### PR TITLE
fix(bridge): gate virtual content cache by incarnation

### DIFF
--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -792,11 +792,20 @@ impl BridgeCoordinator {
     pub(crate) async fn forward_didchange_to_opened_docs(
         &self,
         uri: &Url,
+        incarnation: u64,
         injections: &[BridgeInjection],
     ) {
         self.pool
-            .forward_didchange_to_opened_docs(uri, injections)
+            .forward_didchange_to_opened_docs(uri, incarnation, injections)
             .await;
+    }
+
+    pub(crate) fn open_host_incarnation(&self, uri: &Url, incarnation: u64) {
+        self.pool.open_host_incarnation(uri, incarnation);
+    }
+
+    pub(crate) fn close_host_incarnation(&self, uri: &Url, incarnation: u64) {
+        self.pool.close_host_incarnation(uri, incarnation);
     }
 
     // ========================================

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -393,7 +393,14 @@ impl BridgeCoordinator {
             return;
         };
         self.pool
-            .eager_open_virtual_documents(server_name, &config, host_uri, &host_uri_lsp, for_server)
+            .eager_open_virtual_documents(
+                server_name,
+                &config,
+                host_uri,
+                &host_uri_lsp,
+                None,
+                for_server,
+            )
             .await;
     }
 
@@ -821,6 +828,7 @@ impl BridgeCoordinator {
         settings: &WorkspaceSettings,
         host_language: &str,
         host_uri: &Url,
+        incarnation: u64,
         injections: Vec<BridgeInjection>,
     ) {
         // Convert host_uri to ls_types::Uri for VirtualDocumentUri construction
@@ -926,6 +934,7 @@ impl BridgeCoordinator {
                         &config,
                         &host_uri_owned,
                         &host_uri_lsp,
+                        Some(incarnation),
                         group_injections,
                     ) => {}
                 }

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -381,6 +381,7 @@ impl BridgeCoordinator {
         settings: &Arc<WorkspaceSettings>,
         host_language: &str,
         host_uri: &Url,
+        host_incarnation: u64,
         injections: Vec<BridgeInjection>,
         server_name: &str,
     ) {
@@ -398,7 +399,7 @@ impl BridgeCoordinator {
                 &config,
                 host_uri,
                 &host_uri_lsp,
-                None,
+                Some(host_incarnation),
                 for_server,
             )
             .await;
@@ -1611,6 +1612,7 @@ mod tests {
                 &settings,
                 "markdown",
                 &host_uri,
+                1,
                 injections,
                 "other-server",
             ),

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -399,7 +399,7 @@ impl BridgeCoordinator {
                 &config,
                 host_uri,
                 &host_uri_lsp,
-                Some(host_incarnation),
+                host_incarnation,
                 for_server,
             )
             .await;
@@ -935,7 +935,7 @@ impl BridgeCoordinator {
                         &config,
                         &host_uri_owned,
                         &host_uri_lsp,
-                        Some(incarnation),
+                        incarnation,
                         group_injections,
                     ) => {}
                 }

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -807,12 +807,12 @@ impl BridgeCoordinator {
             .await;
     }
 
-    pub(crate) fn open_host_incarnation(&self, uri: &Url, incarnation: u64) {
-        self.pool.open_host_incarnation(uri, incarnation);
+    pub(crate) async fn open_host_incarnation(&self, uri: &Url, incarnation: u64) {
+        self.pool.open_host_incarnation(uri, incarnation).await;
     }
 
-    pub(crate) fn close_host_incarnation(&self, uri: &Url, incarnation: u64) {
-        self.pool.close_host_incarnation(uri, incarnation);
+    pub(crate) async fn close_host_incarnation(&self, uri: &Url, incarnation: u64) {
+        self.pool.close_host_incarnation(uri, incarnation).await;
     }
 
     // ========================================

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -260,6 +260,7 @@ struct OpenClaimGuard {
 }
 
 type OpenTransitionLocks = DashMap<(ConnectionKey, String), Arc<tokio::sync::Mutex<()>>>;
+type HostLifecycleLocks = DashMap<Url, Arc<tokio::sync::Mutex<()>>>;
 pub(crate) struct HostVirtualContents {
     // The open lifetime that owns this container. Reopen replaces the whole
     // container, so a stale publisher holding the old DashMap guard can only
@@ -334,6 +335,8 @@ pub struct LanguageServerPool {
     /// Serializes didOpen enqueue/promotion, rollback, and didClose per exact
     /// downstream document so wire order matches tracker state transitions.
     open_transition_locks: Arc<OpenTransitionLocks>,
+    /// Serializes host-lifetime replacement with incarnation-bound eager opens.
+    host_lifecycle_locks: HostLifecycleLocks,
     /// Latest extracted content observed from host didChange for each injection.
     /// Interactive requests may carry an older snapshot while awaiting server
     /// startup; the didOpen path reads this after claiming the transition.
@@ -449,6 +452,7 @@ impl LanguageServerPool {
             shutting_down: AtomicBool::new(false),
             document_tracker: Arc::new(DocumentTracker::new()),
             open_transition_locks: Arc::new(DashMap::new()),
+            host_lifecycle_locks: DashMap::new(),
             latest_virtual_contents: DashMap::new(),
             host_documents: Mutex::new(HashMap::new()),
             upstream_request_registry: std::sync::Mutex::new(HashMap::new()),
@@ -1267,7 +1271,18 @@ impl LanguageServerPool {
         contents.insert(key, Arc::<str>::from(content));
     }
 
-    pub(crate) fn open_host_incarnation(&self, host_uri: &Url, incarnation: u64) {
+    pub(crate) fn host_lifecycle_lock(&self, host_uri: &Url) -> Arc<tokio::sync::Mutex<()>> {
+        Arc::clone(
+            self.host_lifecycle_locks
+                .entry(host_uri.clone())
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                .value(),
+        )
+    }
+
+    pub(crate) async fn open_host_incarnation(&self, host_uri: &Url, incarnation: u64) {
+        let lifecycle = self.host_lifecycle_lock(host_uri);
+        let _guard = lifecycle.lock().await;
         self.latest_virtual_contents.insert(
             host_uri.clone(),
             HostVirtualContents {
@@ -1277,7 +1292,9 @@ impl LanguageServerPool {
         );
     }
 
-    pub(crate) fn close_host_incarnation(&self, host_uri: &Url, incarnation: u64) {
+    pub(crate) async fn close_host_incarnation(&self, host_uri: &Url, incarnation: u64) {
+        let lifecycle = self.host_lifecycle_lock(host_uri);
+        let _guard = lifecycle.lock().await;
         // A delayed close from an older lifetime must not clear a fast reopen's
         // cache container.
         self.latest_virtual_contents
@@ -3624,7 +3641,7 @@ mod tests {
         }];
 
         let start = Instant::now();
-        pool.open_host_incarnation(&host_uri, 1);
+        pool.open_host_incarnation(&host_uri, 1).await;
         pool.forward_didchange_to_opened_docs(&host_uri, 1, &injections)
             .await;
         assert!(
@@ -3706,7 +3723,7 @@ mod tests {
         let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, "lua", TEST_ULID_LUA_0);
         let connection_key = ConnectionKey::for_server("lua");
 
-        pool.open_host_incarnation(&host_uri, 1);
+        pool.open_host_incarnation(&host_uri, 1).await;
         pool.forward_didchange_to_opened_docs(
             &host_uri,
             1,
@@ -3746,9 +3763,9 @@ mod tests {
         let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, "lua", TEST_ULID_LUA_0);
         let connection_key = ConnectionKey::for_server("lua");
 
-        pool.open_host_incarnation(&host_uri, 1);
-        pool.close_host_incarnation(&host_uri, 1);
-        pool.open_host_incarnation(&host_uri, 2);
+        pool.open_host_incarnation(&host_uri, 1).await;
+        pool.close_host_incarnation(&host_uri, 1).await;
+        pool.open_host_incarnation(&host_uri, 2).await;
 
         // An old process_injections task resumes after close + reopen.
         pool.record_latest_virtual_content(
@@ -3800,7 +3817,7 @@ mod tests {
     async fn host_close_reclaims_unopened_latest_virtual_content() {
         let pool = LanguageServerPool::new();
         let host_uri = Url::parse("file:///test/cache-close.md").unwrap();
-        pool.open_host_incarnation(&host_uri, 1);
+        pool.open_host_incarnation(&host_uri, 1).await;
         pool.forward_didchange_to_opened_docs(
             &host_uri,
             1,
@@ -3813,17 +3830,17 @@ mod tests {
         .await;
         assert_eq!(pool.latest_virtual_contents.len(), 1);
 
-        pool.close_host_incarnation(&host_uri, 1);
+        pool.close_host_incarnation(&host_uri, 1).await;
         assert!(pool.close_host_document(&host_uri).await.is_empty());
 
         assert!(pool.latest_virtual_contents.is_empty());
     }
 
-    #[test]
-    fn unchanged_latest_virtual_content_reuses_allocation() {
+    #[tokio::test]
+    async fn unchanged_latest_virtual_content_reuses_allocation() {
         let pool = LanguageServerPool::new();
         let host_uri = Url::parse("file:///test/cache-dedup.md").unwrap();
-        pool.open_host_incarnation(&host_uri, 1);
+        pool.open_host_incarnation(&host_uri, 1).await;
         pool.record_latest_virtual_content(&host_uri, 1, "lua", TEST_ULID_LUA_0, "print('same')");
         let before = Arc::clone(
             pool.latest_virtual_contents
@@ -3853,7 +3870,7 @@ mod tests {
     async fn invalidation_reclaims_only_matching_latest_virtual_content() {
         let pool = LanguageServerPool::new();
         let host_uri = Url::parse("file:///test/cache-invalidation.md").unwrap();
-        pool.open_host_incarnation(&host_uri, 1);
+        pool.open_host_incarnation(&host_uri, 1).await;
         pool.record_latest_virtual_content(&host_uri, 1, "lua", TEST_ULID_LUA_0, "first");
         pool.record_latest_virtual_content(&host_uri, 1, "lua", TEST_ULID_LUA_1, "second");
 
@@ -6092,7 +6109,7 @@ mod tests {
             region_id: TEST_ULID_LUA_0.to_string(),
             content: "print('hello')".to_string(),
         }];
-        pool.open_host_incarnation(&host_uri, 1);
+        pool.open_host_incarnation(&host_uri, 1).await;
         pool.forward_didchange_to_opened_docs(&host_uri, 1, &injections)
             .await;
 
@@ -6164,7 +6181,7 @@ mod tests {
             region_id: TEST_ULID_LUA_0.to_string(),
             content: "print('hello')".to_string(),
         }];
-        pool.open_host_incarnation(&host_uri, 1);
+        pool.open_host_incarnation(&host_uri, 1).await;
         pool.forward_didchange_to_opened_docs(&host_uri, 1, &injections)
             .await;
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1261,19 +1261,17 @@ impl LanguageServerPool {
         if host.incarnation != incarnation {
             return;
         }
-        if let Some(regions) = host.contents.get(language) {
-            if regions
+        if let Some(regions) = host.contents.get(language)
+            && regions
                 .get(region_id)
                 .is_some_and(|cached| cached.as_ref() == content)
-            {
-                return;
-            }
-            regions.insert(region_id.to_string(), Arc::<str>::from(content));
+        {
             return;
         }
-        let regions = DashMap::new();
-        regions.insert(region_id.to_string(), Arc::<str>::from(content));
-        host.contents.insert(language.to_string(), regions);
+        host.contents
+            .entry(language.to_string())
+            .or_default()
+            .insert(region_id.to_string(), Arc::<str>::from(content));
     }
 
     pub(crate) fn host_lifecycle_lock(&self, host_uri: &Url) -> Arc<tokio::sync::Mutex<()>> {

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1304,7 +1304,9 @@ impl LanguageServerPool {
         lifecycle: &Arc<tokio::sync::Mutex<()>>,
     ) {
         self.host_lifecycle_locks.remove_if(host_uri, |_, current| {
-            Arc::ptr_eq(current, lifecycle) && Arc::strong_count(current) == 2
+            Arc::ptr_eq(current, lifecycle)
+                && Arc::strong_count(current) == 2
+                && !self.latest_virtual_contents.contains_key(host_uri)
         });
     }
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1294,11 +1294,18 @@ impl LanguageServerPool {
 
     pub(crate) async fn close_host_incarnation(&self, host_uri: &Url, incarnation: u64) {
         let lifecycle = self.host_lifecycle_lock(host_uri);
-        let _guard = lifecycle.lock().await;
+        let guard = lifecycle.lock().await;
         // A delayed close from an older lifetime must not clear a fast reopen's
         // cache container.
         self.latest_virtual_contents
             .remove_if(host_uri, |_, host| host.incarnation == incarnation);
+        let host_closed = !self.latest_virtual_contents.contains_key(host_uri);
+        drop(guard);
+        if host_closed {
+            self.host_lifecycle_locks.remove_if(host_uri, |_, current| {
+                Arc::ptr_eq(current, &lifecycle) && Arc::strong_count(current) == 2
+            });
+        }
     }
 
     pub(crate) fn clear_invalidated_virtual_contents(
@@ -3834,6 +3841,7 @@ mod tests {
         assert!(pool.close_host_document(&host_uri).await.is_empty());
 
         assert!(pool.latest_virtual_contents.is_empty());
+        assert!(pool.host_lifecycle_locks.is_empty());
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1261,11 +1261,14 @@ impl LanguageServerPool {
         if host.incarnation != incarnation {
             return;
         }
-        if let Some(regions) = host.contents.get(language)
-            && regions
+        if let Some(regions) = host.contents.get(language) {
+            if regions
                 .get(region_id)
                 .is_some_and(|cached| cached.as_ref() == content)
-        {
+            {
+                return;
+            }
+            regions.insert(region_id.to_string(), Arc::<str>::from(content));
             return;
         }
         host.contents

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1336,8 +1336,6 @@ impl LanguageServerPool {
             host.contents
                 .retain(|(_, region_id), _| !invalidated.contains(region_id));
         }
-        self.latest_virtual_contents
-            .remove_if(host_uri, |_, host| host.contents.is_empty());
     }
 
     /// Increment the version of a virtual document and return the new version,
@@ -3933,7 +3931,19 @@ mod tests {
 
         pool.close_invalidated_docs(&host_uri, &[TEST_ULID_LUA_1.parse::<ulid::Ulid>().unwrap()])
             .await;
-        assert!(!pool.latest_virtual_contents.contains_key(&host_uri));
+        let host = pool.latest_virtual_contents.get(&host_uri).unwrap();
+        assert!(host.contents.is_empty());
+        assert_eq!(host.incarnation, 1);
+        drop(host);
+
+        pool.record_latest_virtual_content(&host_uri, 1, "lua", TEST_ULID_LUA_0, "replacement");
+        assert!(
+            pool.latest_virtual_contents
+                .get(&host_uri)
+                .unwrap()
+                .contents
+                .contains_key(&("lua".to_string(), TEST_ULID_LUA_0.to_string()))
+        );
     }
 
     /// Test that ensure_document_opened skips didOpen when document is already opened.

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -260,11 +260,11 @@ struct OpenClaimGuard {
 }
 
 type OpenTransitionLocks = DashMap<(ConnectionKey, String), Arc<tokio::sync::Mutex<()>>>;
-struct HostVirtualContents {
+pub(crate) struct HostVirtualContents {
     // The open lifetime that owns this container. Reopen replaces the whole
     // container, so a stale publisher holding the old DashMap guard can only
     // mutate detached state that current didOpen readers cannot observe.
-    incarnation: u64,
+    pub(crate) incarnation: u64,
     contents: DashMap<(String, String), Arc<str>>,
 }
 
@@ -337,7 +337,7 @@ pub struct LanguageServerPool {
     /// Latest extracted content observed from host didChange for each injection.
     /// Interactive requests may carry an older snapshot while awaiting server
     /// startup; the didOpen path reads this after claiming the transition.
-    latest_virtual_contents: LatestVirtualContents,
+    pub(crate) latest_virtual_contents: LatestVirtualContents,
     /// Host-document sync state per `(uri, connection key)`
     /// (host-document-bridge): the real-URI documents opened on downstream
     /// servers via `bridge._self`, with their version and content
@@ -3758,6 +3758,23 @@ mod tests {
             TEST_ULID_LUA_0,
             "print('old lifetime')",
         );
+
+        let handle = create_handle_with_key(ConnectionState::Ready, connection_key.clone()).await;
+        pool.insert_connection(handle).await;
+        pool.eager_open_virtual_documents(
+            "lua",
+            &devnull_config(),
+            &host_uri,
+            &host_uri_lsp,
+            Some(1),
+            vec![super::super::coordinator::BridgeInjection {
+                language: "lua".to_string(),
+                region_id: TEST_ULID_LUA_0.to_string(),
+                content: "print('old lifetime')".to_string(),
+            }],
+        )
+        .await;
+        assert!(!pool.is_document_opened(&virtual_uri));
 
         let (mut sender, mut rx) = tokio::sync::mpsc::channel::<OutboundMessage>(1);
         pool.ensure_document_opened(

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1289,6 +1289,16 @@ impl LanguageServerPool {
             .map(|entry| Arc::clone(entry.value()))
     }
 
+    pub(crate) fn remove_host_lifecycle_lock_if_unshared(
+        &self,
+        host_uri: &Url,
+        lifecycle: &Arc<tokio::sync::Mutex<()>>,
+    ) {
+        self.host_lifecycle_locks.remove_if(host_uri, |_, current| {
+            Arc::ptr_eq(current, lifecycle) && Arc::strong_count(current) == 2
+        });
+    }
+
     pub(crate) async fn open_host_incarnation(&self, host_uri: &Url, incarnation: u64) {
         let lifecycle = self.host_lifecycle_lock(host_uri);
         let _guard = lifecycle.lock().await;
@@ -1311,9 +1321,7 @@ impl LanguageServerPool {
         let host_closed = !self.latest_virtual_contents.contains_key(host_uri);
         drop(guard);
         if host_closed {
-            self.host_lifecycle_locks.remove_if(host_uri, |_, current| {
-                Arc::ptr_eq(current, &lifecycle) && Arc::strong_count(current) == 2
-            });
+            self.remove_host_lifecycle_lock_if_unshared(host_uri, &lifecycle);
         }
     }
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -3814,6 +3814,7 @@ mod tests {
         )
         .await;
         assert!(!pool.is_document_opened(&virtual_uri));
+        assert!(pool.host_lifecycle_locks.contains_key(&host_uri));
 
         let (mut sender, mut rx) = tokio::sync::mpsc::channel::<OutboundMessage>(1);
         pool.ensure_document_opened(

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1280,6 +1280,15 @@ impl LanguageServerPool {
         )
     }
 
+    pub(crate) fn existing_host_lifecycle_lock(
+        &self,
+        host_uri: &Url,
+    ) -> Option<Arc<tokio::sync::Mutex<()>>> {
+        self.host_lifecycle_locks
+            .get(host_uri)
+            .map(|entry| Arc::clone(entry.value()))
+    }
+
     pub(crate) async fn open_host_incarnation(&self, host_uri: &Url, incarnation: u64) {
         let lifecycle = self.host_lifecycle_lock(host_uri);
         let _guard = lifecycle.lock().await;
@@ -3818,6 +3827,22 @@ mod tests {
             message["params"]["textDocument"]["text"],
             "print('new lifetime')"
         );
+
+        pool.close_host_incarnation(&host_uri, 2).await;
+        pool.eager_open_virtual_documents(
+            "lua",
+            &devnull_config(),
+            &host_uri,
+            &host_uri_lsp,
+            Some(1),
+            vec![super::super::coordinator::BridgeInjection {
+                language: "lua".to_string(),
+                region_id: TEST_ULID_LUA_0.to_string(),
+                content: "print('old lifetime')".to_string(),
+            }],
+        )
+        .await;
+        assert!(pool.host_lifecycle_locks.is_empty());
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -260,7 +260,15 @@ struct OpenClaimGuard {
 }
 
 type OpenTransitionLocks = DashMap<(ConnectionKey, String), Arc<tokio::sync::Mutex<()>>>;
-type LatestVirtualContents = DashMap<Url, DashMap<(String, String), Arc<str>>>;
+struct HostVirtualContents {
+    // The open lifetime that owns this container. Reopen replaces the whole
+    // container, so a stale publisher holding the old DashMap guard can only
+    // mutate detached state that current didOpen readers cannot observe.
+    incarnation: u64,
+    contents: DashMap<(String, String), Arc<str>>,
+}
+
+type LatestVirtualContents = DashMap<Url, HostVirtualContents>;
 
 impl OpenClaimGuard {
     fn disarm(&mut self) {
@@ -1189,17 +1197,14 @@ impl LanguageServerPool {
         // Read as close to enqueue as possible, after pending registration's
         // awaits. If an edit publishes after this read, it observes the open
         // claim and serializes a didChange behind this didOpen transition.
-        let current_content = self
-            .latest_virtual_contents
-            .get(host_uri)
-            .and_then(|contents| {
-                contents
-                    .get(&(
-                        virtual_uri.language().to_string(),
-                        virtual_uri.region_id().to_string(),
-                    ))
-                    .map(|entry| Arc::clone(entry.value()))
-            });
+        let current_content = self.latest_virtual_contents.get(host_uri).and_then(|host| {
+            host.contents
+                .get(&(
+                    virtual_uri.language().to_string(),
+                    virtual_uri.region_id().to_string(),
+                ))
+                .map(|entry| Arc::clone(entry.value()))
+        });
         let virtual_content = current_content.as_deref().unwrap_or(virtual_content);
         let did_open = build_didopen_notification(virtual_uri, virtual_content);
         if let Err(e) = sender.send_notification(did_open).await {
@@ -1240,14 +1245,18 @@ impl LanguageServerPool {
     pub(crate) fn record_latest_virtual_content(
         &self,
         host_uri: &Url,
+        incarnation: u64,
         language: &str,
         region_id: &str,
         content: &str,
     ) {
-        let contents = self
-            .latest_virtual_contents
-            .entry(host_uri.clone())
-            .or_default();
+        let Some(host) = self.latest_virtual_contents.get(host_uri) else {
+            return;
+        };
+        if host.incarnation != incarnation {
+            return;
+        }
+        let contents = &host.contents;
         let key = (language.to_string(), region_id.to_string());
         if contents
             .get(&key)
@@ -1258,8 +1267,21 @@ impl LanguageServerPool {
         contents.insert(key, Arc::<str>::from(content));
     }
 
-    pub(crate) fn clear_latest_virtual_contents(&self, host_uri: &Url) {
-        self.latest_virtual_contents.remove(host_uri);
+    pub(crate) fn open_host_incarnation(&self, host_uri: &Url, incarnation: u64) {
+        self.latest_virtual_contents.insert(
+            host_uri.clone(),
+            HostVirtualContents {
+                incarnation,
+                contents: DashMap::new(),
+            },
+        );
+    }
+
+    pub(crate) fn close_host_incarnation(&self, host_uri: &Url, incarnation: u64) {
+        // A delayed close from an older lifetime must not clear a fast reopen's
+        // cache container.
+        self.latest_virtual_contents
+            .remove_if(host_uri, |_, host| host.incarnation == incarnation);
     }
 
     pub(crate) fn clear_invalidated_virtual_contents(
@@ -1269,11 +1291,12 @@ impl LanguageServerPool {
     ) {
         let invalidated: std::collections::HashSet<String> =
             invalidated_ulids.iter().map(ToString::to_string).collect();
-        if let Some(contents) = self.latest_virtual_contents.get(host_uri) {
-            contents.retain(|(_, region_id), _| !invalidated.contains(region_id));
+        if let Some(host) = self.latest_virtual_contents.get(host_uri) {
+            host.contents
+                .retain(|(_, region_id), _| !invalidated.contains(region_id));
         }
         self.latest_virtual_contents
-            .remove_if(host_uri, |_, contents| contents.is_empty());
+            .remove_if(host_uri, |_, host| host.contents.is_empty());
     }
 
     /// Increment the version of a virtual document and return the new version,
@@ -3601,7 +3624,8 @@ mod tests {
         }];
 
         let start = Instant::now();
-        pool.forward_didchange_to_opened_docs(&host_uri, &injections)
+        pool.open_host_incarnation(&host_uri, 1);
+        pool.forward_didchange_to_opened_docs(&host_uri, 1, &injections)
             .await;
         assert!(
             start.elapsed() < Duration::from_millis(100),
@@ -3682,8 +3706,10 @@ mod tests {
         let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, "lua", TEST_ULID_LUA_0);
         let connection_key = ConnectionKey::for_server("lua");
 
+        pool.open_host_incarnation(&host_uri, 1);
         pool.forward_didchange_to_opened_docs(
             &host_uri,
+            1,
             &[super::super::coordinator::BridgeInjection {
                 language: "lua".to_string(),
                 region_id: TEST_ULID_LUA_0.to_string(),
@@ -3713,11 +3739,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stale_incarnation_cannot_repopulate_latest_virtual_content_after_fast_reopen() {
+        let pool = LanguageServerPool::new();
+        let host_uri = Url::parse("file:///test/cache-fast-reopen.md").unwrap();
+        let host_uri_lsp = url_to_uri(&host_uri);
+        let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, "lua", TEST_ULID_LUA_0);
+        let connection_key = ConnectionKey::for_server("lua");
+
+        pool.open_host_incarnation(&host_uri, 1);
+        pool.close_host_incarnation(&host_uri, 1);
+        pool.open_host_incarnation(&host_uri, 2);
+
+        // An old process_injections task resumes after close + reopen.
+        pool.record_latest_virtual_content(
+            &host_uri,
+            1,
+            "lua",
+            TEST_ULID_LUA_0,
+            "print('old lifetime')",
+        );
+
+        let (mut sender, mut rx) = tokio::sync::mpsc::channel::<OutboundMessage>(1);
+        pool.ensure_document_opened(
+            &mut sender,
+            &host_uri,
+            &virtual_uri,
+            "print('new lifetime')",
+            &connection_key,
+        )
+        .await
+        .unwrap();
+
+        let OutboundMessage::Untracked(message) = rx.try_recv().unwrap() else {
+            panic!("didOpen must be an untracked notification");
+        };
+        assert_eq!(
+            message["params"]["textDocument"]["text"],
+            "print('new lifetime')"
+        );
+    }
+
+    #[tokio::test]
     async fn host_close_reclaims_unopened_latest_virtual_content() {
         let pool = LanguageServerPool::new();
         let host_uri = Url::parse("file:///test/cache-close.md").unwrap();
+        pool.open_host_incarnation(&host_uri, 1);
         pool.forward_didchange_to_opened_docs(
             &host_uri,
+            1,
             &[super::super::coordinator::BridgeInjection {
                 language: "lua".to_string(),
                 region_id: TEST_ULID_LUA_0.to_string(),
@@ -3727,6 +3796,7 @@ mod tests {
         .await;
         assert_eq!(pool.latest_virtual_contents.len(), 1);
 
+        pool.close_host_incarnation(&host_uri, 1);
         assert!(pool.close_host_document(&host_uri).await.is_empty());
 
         assert!(pool.latest_virtual_contents.is_empty());
@@ -3736,22 +3806,25 @@ mod tests {
     fn unchanged_latest_virtual_content_reuses_allocation() {
         let pool = LanguageServerPool::new();
         let host_uri = Url::parse("file:///test/cache-dedup.md").unwrap();
-        pool.record_latest_virtual_content(&host_uri, "lua", TEST_ULID_LUA_0, "print('same')");
+        pool.open_host_incarnation(&host_uri, 1);
+        pool.record_latest_virtual_content(&host_uri, 1, "lua", TEST_ULID_LUA_0, "print('same')");
         let before = Arc::clone(
             pool.latest_virtual_contents
                 .get(&host_uri)
                 .unwrap()
+                .contents
                 .get(&("lua".to_string(), TEST_ULID_LUA_0.to_string()))
                 .unwrap()
                 .value(),
         );
 
-        pool.record_latest_virtual_content(&host_uri, "lua", TEST_ULID_LUA_0, "print('same')");
+        pool.record_latest_virtual_content(&host_uri, 1, "lua", TEST_ULID_LUA_0, "print('same')");
 
         let after = Arc::clone(
             pool.latest_virtual_contents
                 .get(&host_uri)
                 .unwrap()
+                .contents
                 .get(&("lua".to_string(), TEST_ULID_LUA_0.to_string()))
                 .unwrap()
                 .value(),
@@ -3763,15 +3836,24 @@ mod tests {
     async fn invalidation_reclaims_only_matching_latest_virtual_content() {
         let pool = LanguageServerPool::new();
         let host_uri = Url::parse("file:///test/cache-invalidation.md").unwrap();
-        pool.record_latest_virtual_content(&host_uri, "lua", TEST_ULID_LUA_0, "first");
-        pool.record_latest_virtual_content(&host_uri, "lua", TEST_ULID_LUA_1, "second");
+        pool.open_host_incarnation(&host_uri, 1);
+        pool.record_latest_virtual_content(&host_uri, 1, "lua", TEST_ULID_LUA_0, "first");
+        pool.record_latest_virtual_content(&host_uri, 1, "lua", TEST_ULID_LUA_1, "second");
 
         pool.close_invalidated_docs(&host_uri, &[TEST_ULID_LUA_0.parse::<ulid::Ulid>().unwrap()])
             .await;
 
         let contents = pool.latest_virtual_contents.get(&host_uri).unwrap();
-        assert!(!contents.contains_key(&("lua".to_string(), TEST_ULID_LUA_0.to_string())));
-        assert!(contents.contains_key(&("lua".to_string(), TEST_ULID_LUA_1.to_string())));
+        assert!(
+            !contents
+                .contents
+                .contains_key(&("lua".to_string(), TEST_ULID_LUA_0.to_string()))
+        );
+        assert!(
+            contents
+                .contents
+                .contains_key(&("lua".to_string(), TEST_ULID_LUA_1.to_string()))
+        );
         drop(contents);
 
         pool.close_invalidated_docs(&host_uri, &[TEST_ULID_LUA_1.parse::<ulid::Ulid>().unwrap()])
@@ -5920,6 +6002,7 @@ mod tests {
             tokio::spawn(async move {
                 pool.forward_didchange_to_opened_docs(
                     &host_uri,
+                    1,
                     &[crate::lsp::bridge::coordinator::BridgeInjection {
                         language: "lua".to_string(),
                         region_id: TEST_ULID_LUA_0.to_string(),
@@ -5992,7 +6075,8 @@ mod tests {
             region_id: TEST_ULID_LUA_0.to_string(),
             content: "print('hello')".to_string(),
         }];
-        pool.forward_didchange_to_opened_docs(&host_uri, &injections)
+        pool.open_host_incarnation(&host_uri, 1);
+        pool.forward_didchange_to_opened_docs(&host_uri, 1, &injections)
             .await;
 
         // Verify both servers got their versions incremented (1 -> 2)
@@ -6063,7 +6147,8 @@ mod tests {
             region_id: TEST_ULID_LUA_0.to_string(),
             content: "print('hello')".to_string(),
         }];
-        pool.forward_didchange_to_opened_docs(&host_uri, &injections)
+        pool.open_host_incarnation(&host_uri, 1);
+        pool.forward_didchange_to_opened_docs(&host_uri, 1, &injections)
             .await;
 
         // ready_server should have been incremented (1->2)

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -340,7 +340,7 @@ pub struct LanguageServerPool {
     /// Latest extracted content observed from host didChange for each injection.
     /// Interactive requests may carry an older snapshot while awaiting server
     /// startup; the didOpen path reads this after claiming the transition.
-    pub(crate) latest_virtual_contents: LatestVirtualContents,
+    latest_virtual_contents: LatestVirtualContents,
     /// Host-document sync state per `(uri, connection key)`
     /// (host-document-bridge): the real-URI documents opened on downstream
     /// servers via `bridge._self`, with their version and content
@@ -1283,6 +1283,12 @@ impl LanguageServerPool {
                 .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
                 .value(),
         )
+    }
+
+    pub(crate) fn current_host_incarnation(&self, host_uri: &Url) -> Option<u64> {
+        self.latest_virtual_contents
+            .get(host_uri)
+            .map(|host| host.incarnation)
     }
 
     pub(crate) fn existing_host_lifecycle_lock(
@@ -3812,7 +3818,7 @@ mod tests {
             &devnull_config(),
             &host_uri,
             &host_uri_lsp,
-            Some(1),
+            1,
             vec![super::super::coordinator::BridgeInjection {
                 language: "lua".to_string(),
                 region_id: TEST_ULID_LUA_0.to_string(),
@@ -3848,7 +3854,7 @@ mod tests {
             &devnull_config(),
             &host_uri,
             &host_uri_lsp,
-            Some(1),
+            1,
             vec![super::super::coordinator::BridgeInjection {
                 language: "lua".to_string(),
                 region_id: TEST_ULID_LUA_0.to_string(),

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -266,7 +266,7 @@ pub(crate) struct HostVirtualContents {
     // container, so a stale publisher holding the old DashMap guard can only
     // mutate detached state that current didOpen readers cannot observe.
     pub(crate) incarnation: u64,
-    contents: DashMap<(String, String), Arc<str>>,
+    contents: DashMap<String, DashMap<String, Arc<str>>>,
 }
 
 type LatestVirtualContents = DashMap<Url, HostVirtualContents>;
@@ -1203,11 +1203,12 @@ impl LanguageServerPool {
         // claim and serializes a didChange behind this didOpen transition.
         let current_content = self.latest_virtual_contents.get(host_uri).and_then(|host| {
             host.contents
-                .get(&(
-                    virtual_uri.language().to_string(),
-                    virtual_uri.region_id().to_string(),
-                ))
-                .map(|entry| Arc::clone(entry.value()))
+                .get(virtual_uri.language())
+                .and_then(|regions| {
+                    regions
+                        .get(virtual_uri.region_id())
+                        .map(|entry| Arc::clone(entry.value()))
+                })
         });
         let virtual_content = current_content.as_deref().unwrap_or(virtual_content);
         let did_open = build_didopen_notification(virtual_uri, virtual_content);
@@ -1260,15 +1261,19 @@ impl LanguageServerPool {
         if host.incarnation != incarnation {
             return;
         }
-        let contents = &host.contents;
-        let key = (language.to_string(), region_id.to_string());
-        if contents
-            .get(&key)
-            .is_some_and(|cached| cached.as_ref() == content)
-        {
+        if let Some(regions) = host.contents.get(language) {
+            if regions
+                .get(region_id)
+                .is_some_and(|cached| cached.as_ref() == content)
+            {
+                return;
+            }
+            regions.insert(region_id.to_string(), Arc::<str>::from(content));
             return;
         }
-        contents.insert(key, Arc::<str>::from(content));
+        let regions = DashMap::new();
+        regions.insert(region_id.to_string(), Arc::<str>::from(content));
+        host.contents.insert(language.to_string(), regions);
     }
 
     pub(crate) fn host_lifecycle_lock(&self, host_uri: &Url) -> Arc<tokio::sync::Mutex<()>> {
@@ -1333,8 +1338,10 @@ impl LanguageServerPool {
         let invalidated: std::collections::HashSet<String> =
             invalidated_ulids.iter().map(ToString::to_string).collect();
         if let Some(host) = self.latest_virtual_contents.get(host_uri) {
-            host.contents
-                .retain(|(_, region_id), _| !invalidated.contains(region_id));
+            host.contents.retain(|_, regions| {
+                regions.retain(|region_id, _| !invalidated.contains(region_id));
+                !regions.is_empty()
+            });
         }
     }
 
@@ -3882,27 +3889,19 @@ mod tests {
         let host_uri = Url::parse("file:///test/cache-dedup.md").unwrap();
         pool.open_host_incarnation(&host_uri, 1).await;
         pool.record_latest_virtual_content(&host_uri, 1, "lua", TEST_ULID_LUA_0, "print('same')");
-        let before = Arc::clone(
-            pool.latest_virtual_contents
-                .get(&host_uri)
-                .unwrap()
-                .contents
-                .get(&("lua".to_string(), TEST_ULID_LUA_0.to_string()))
-                .unwrap()
-                .value(),
-        );
+        let before = {
+            let host = pool.latest_virtual_contents.get(&host_uri).unwrap();
+            let regions = host.contents.get("lua").unwrap();
+            Arc::clone(regions.get(TEST_ULID_LUA_0).unwrap().value())
+        };
 
         pool.record_latest_virtual_content(&host_uri, 1, "lua", TEST_ULID_LUA_0, "print('same')");
 
-        let after = Arc::clone(
-            pool.latest_virtual_contents
-                .get(&host_uri)
-                .unwrap()
-                .contents
-                .get(&("lua".to_string(), TEST_ULID_LUA_0.to_string()))
-                .unwrap()
-                .value(),
-        );
+        let after = {
+            let host = pool.latest_virtual_contents.get(&host_uri).unwrap();
+            let regions = host.contents.get("lua").unwrap();
+            Arc::clone(regions.get(TEST_ULID_LUA_0).unwrap().value())
+        };
         assert!(Arc::ptr_eq(&before, &after));
     }
 
@@ -3921,12 +3920,14 @@ mod tests {
         assert!(
             !contents
                 .contents
-                .contains_key(&("lua".to_string(), TEST_ULID_LUA_0.to_string()))
+                .get("lua")
+                .is_some_and(|regions| regions.contains_key(TEST_ULID_LUA_0))
         );
         assert!(
             contents
                 .contents
-                .contains_key(&("lua".to_string(), TEST_ULID_LUA_1.to_string()))
+                .get("lua")
+                .is_some_and(|regions| regions.contains_key(TEST_ULID_LUA_1))
         );
         drop(contents);
 
@@ -3943,7 +3944,8 @@ mod tests {
                 .get(&host_uri)
                 .unwrap()
                 .contents
-                .contains_key(&("lua".to_string(), TEST_ULID_LUA_0.to_string()))
+                .get("lua")
+                .is_some_and(|regions| regions.contains_key(TEST_ULID_LUA_0))
         );
     }
 

--- a/src/lsp/bridge/text_document/did_change.rs
+++ b/src/lsp/bridge/text_document/did_change.rs
@@ -34,6 +34,7 @@ impl LanguageServerPool {
     pub(crate) async fn forward_didchange_to_opened_docs(
         &self,
         host_uri: &Url,
+        incarnation: u64,
         injections: &[crate::lsp::bridge::coordinator::BridgeInjection],
     ) {
         // Convert host_uri to lsp_types::Uri for bridge protocol functions
@@ -59,6 +60,7 @@ impl LanguageServerPool {
             // latest host content; unchanged edits avoid replacing it.
             self.record_latest_virtual_content(
                 host_uri,
+                incarnation,
                 &injection.language,
                 &injection.region_id,
                 &injection.content,

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -189,7 +189,6 @@ impl LanguageServerPool {
     /// The connection to downstream language servers remains open — only the
     /// virtual documents are closed.
     pub(crate) async fn close_host_document(&self, host_uri: &Url) -> Vec<OpenedVirtualDoc> {
-        self.clear_latest_virtual_contents(host_uri);
         // 1. Remove and get all virtual docs for this host
         let virtual_docs = self.remove_host_virtual_docs(host_uri).await;
 

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -65,7 +65,7 @@ impl LanguageServerPool {
                 }
                 None => None,
             };
-            let _lifecycle_guard = match &lifecycle {
+            let lifecycle_guard = match &lifecycle {
                 Some(lifecycle) => Some(lifecycle.lock().await),
                 None => None,
             };
@@ -75,6 +75,10 @@ impl LanguageServerPool {
                     .get(host_uri)
                     .is_none_or(|host| host.incarnation != expected)
             {
+                drop(lifecycle_guard);
+                if let Some(lifecycle) = &lifecycle {
+                    self.remove_host_lifecycle_lock_if_unshared(host_uri, lifecycle);
+                }
                 return;
             }
             let virtual_uri =

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -51,20 +51,20 @@ impl LanguageServerPool {
         let connection_key = handle.key().clone();
         let mut sender = ConnectionHandleSender(&handle);
 
-        for injection in &injections {
+        let lifecycle = match expected_incarnation {
+            Some(_) => {
+                let Some(lifecycle) = self.existing_host_lifecycle_lock(host_uri) else {
+                    return;
+                };
+                Some(lifecycle)
+            }
+            None => None,
+        };
+        for injection in injections {
             // Hold the host cache guard through didOpen. didClose/reopen replaces
             // this entry, so it either linearizes after this open (and closes the
             // tracked virtual document) or wins first and makes this stale batch
             // stop without opening old content.
-            let lifecycle = match expected_incarnation {
-                Some(_) => {
-                    let Some(lifecycle) = self.existing_host_lifecycle_lock(host_uri) else {
-                        return;
-                    };
-                    Some(lifecycle)
-                }
-                None => None,
-            };
             let lifecycle_guard = match &lifecycle {
                 Some(lifecycle) => Some(lifecycle.lock().await),
                 None => None,

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -56,12 +56,17 @@ impl LanguageServerPool {
             // this entry, so it either linearizes after this open (and closes the
             // tracked virtual document) or wins first and makes this stale batch
             // stop without opening old content.
-            let host_incarnation_guard = expected_incarnation.and_then(|incarnation| {
-                self.latest_virtual_contents
+            let lifecycle = expected_incarnation.map(|_| self.host_lifecycle_lock(host_uri));
+            let _lifecycle_guard = match &lifecycle {
+                Some(lifecycle) => Some(lifecycle.lock().await),
+                None => None,
+            };
+            if let Some(expected) = expected_incarnation
+                && self
+                    .latest_virtual_contents
                     .get(host_uri)
-                    .filter(|host| host.incarnation == incarnation)
-            });
-            if expected_incarnation.is_some() && host_incarnation_guard.is_none() {
+                    .is_none_or(|host| host.incarnation != expected)
+            {
                 return;
             }
             let virtual_uri =

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -69,14 +69,17 @@ impl LanguageServerPool {
                 Some(lifecycle) => Some(lifecycle.lock().await),
                 None => None,
             };
+            let current_incarnation = self
+                .latest_virtual_contents
+                .get(host_uri)
+                .map(|host| host.incarnation);
             if let Some(expected) = expected_incarnation
-                && self
-                    .latest_virtual_contents
-                    .get(host_uri)
-                    .is_none_or(|host| host.incarnation != expected)
+                && current_incarnation != Some(expected)
             {
                 drop(lifecycle_guard);
-                if let Some(lifecycle) = &lifecycle {
+                if current_incarnation.is_none()
+                    && let Some(lifecycle) = &lifecycle
+                {
                     self.remove_host_lifecycle_lock_if_unshared(host_uri, lifecycle);
                 }
                 return;

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -83,9 +83,6 @@ impl LanguageServerPool {
             let current_incarnation = self.current_host_incarnation(host_uri);
             if current_incarnation != Some(expected_incarnation) {
                 drop(lifecycle_guard);
-                if current_incarnation.is_none() {
-                    self.remove_host_lifecycle_lock_if_unshared(host_uri, &lifecycle);
-                }
                 return;
             }
             let virtual_uri =

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -13,14 +13,14 @@ use super::super::protocol::VirtualDocumentUri;
 struct LifecycleCleanup<'a> {
     pool: &'a LanguageServerPool,
     host_uri: &'a url::Url,
-    lifecycle: Arc<tokio::sync::Mutex<()>>,
+    lifecycle: &'a Arc<tokio::sync::Mutex<()>>,
 }
 
 impl Drop for LifecycleCleanup<'_> {
     fn drop(&mut self) {
         if self.pool.current_host_incarnation(self.host_uri).is_none() {
             self.pool
-                .remove_host_lifecycle_lock_if_unshared(self.host_uri, &self.lifecycle);
+                .remove_host_lifecycle_lock_if_unshared(self.host_uri, self.lifecycle);
         }
     }
 }
@@ -72,7 +72,7 @@ impl LanguageServerPool {
         let _lifecycle_cleanup = LifecycleCleanup {
             pool: self,
             host_uri,
-            lifecycle: Arc::clone(&lifecycle),
+            lifecycle: &lifecycle,
         };
         for injection in injections {
             // Hold the host cache guard through didOpen. didClose/reopen replaces

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -22,6 +22,7 @@ impl LanguageServerPool {
         server_config: &crate::config::settings::BridgeServerConfig,
         host_uri: &url::Url,
         host_uri_lsp: &tower_lsp_server::ls_types::Uri,
+        expected_incarnation: Option<u64>,
         injections: Vec<crate::lsp::bridge::coordinator::BridgeInjection>,
     ) {
         // Wait for the server to be ready (handshake complete)
@@ -51,6 +52,18 @@ impl LanguageServerPool {
         let mut sender = ConnectionHandleSender(&handle);
 
         for injection in &injections {
+            // Hold the host cache guard through didOpen. didClose/reopen replaces
+            // this entry, so it either linearizes after this open (and closes the
+            // tracked virtual document) or wins first and makes this stale batch
+            // stop without opening old content.
+            let host_incarnation_guard = expected_incarnation.and_then(|incarnation| {
+                self.latest_virtual_contents
+                    .get(host_uri)
+                    .filter(|host| host.incarnation == incarnation)
+            });
+            if expected_incarnation.is_some() && host_incarnation_guard.is_none() {
+                return;
+            }
             let virtual_uri =
                 VirtualDocumentUri::new(host_uri_lsp, &injection.language, &injection.region_id);
 
@@ -226,6 +239,7 @@ mod tests {
             &config,
             &host_uri,
             &host_uri_lsp,
+            None,
             injections,
         )
         .await;
@@ -278,6 +292,7 @@ mod tests {
             &config,
             &host_uri,
             &host_uri_lsp,
+            None,
             injections.clone(),
         )
         .await;
@@ -294,6 +309,7 @@ mod tests {
             &config,
             &host_uri,
             &host_uri_lsp,
+            None,
             injections,
         )
         .await;

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -56,7 +56,15 @@ impl LanguageServerPool {
             // this entry, so it either linearizes after this open (and closes the
             // tracked virtual document) or wins first and makes this stale batch
             // stop without opening old content.
-            let lifecycle = expected_incarnation.map(|_| self.host_lifecycle_lock(host_uri));
+            let lifecycle = match expected_incarnation {
+                Some(_) => {
+                    let Some(lifecycle) = self.existing_host_lifecycle_lock(host_uri) else {
+                        return;
+                    };
+                    Some(lifecycle)
+                }
+                None => None,
+            };
             let _lifecycle_guard = match &lifecycle {
                 Some(lifecycle) => Some(lifecycle.lock().await),
                 None => None,

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -10,6 +10,21 @@ use std::time::Duration;
 use super::super::pool::{ConnectionHandleSender, INIT_TIMEOUT_SECS, LanguageServerPool};
 use super::super::protocol::VirtualDocumentUri;
 
+struct LifecycleCleanup<'a> {
+    pool: &'a LanguageServerPool,
+    host_uri: &'a url::Url,
+    lifecycle: Arc<tokio::sync::Mutex<()>>,
+}
+
+impl Drop for LifecycleCleanup<'_> {
+    fn drop(&mut self) {
+        if self.pool.current_host_incarnation(self.host_uri).is_none() {
+            self.pool
+                .remove_host_lifecycle_lock_if_unshared(self.host_uri, &self.lifecycle);
+        }
+    }
+}
+
 impl LanguageServerPool {
     /// Fire `didOpen` for every injection region's virtual URI so the downstream
     /// server starts analyzing immediately instead of waiting for the first
@@ -22,7 +37,7 @@ impl LanguageServerPool {
         server_config: &crate::config::settings::BridgeServerConfig,
         host_uri: &url::Url,
         host_uri_lsp: &tower_lsp_server::ls_types::Uri,
-        expected_incarnation: Option<u64>,
+        expected_incarnation: u64,
         injections: Vec<crate::lsp::bridge::coordinator::BridgeInjection>,
     ) {
         // Wait for the server to be ready (handshake complete)
@@ -51,36 +66,25 @@ impl LanguageServerPool {
         let connection_key = handle.key().clone();
         let mut sender = ConnectionHandleSender(&handle);
 
-        let lifecycle = match expected_incarnation {
-            Some(_) => {
-                let Some(lifecycle) = self.existing_host_lifecycle_lock(host_uri) else {
-                    return;
-                };
-                Some(lifecycle)
-            }
-            None => None,
+        let Some(lifecycle) = self.existing_host_lifecycle_lock(host_uri) else {
+            return;
+        };
+        let _lifecycle_cleanup = LifecycleCleanup {
+            pool: self,
+            host_uri,
+            lifecycle: Arc::clone(&lifecycle),
         };
         for injection in injections {
             // Hold the host cache guard through didOpen. didClose/reopen replaces
             // this entry, so it either linearizes after this open (and closes the
             // tracked virtual document) or wins first and makes this stale batch
             // stop without opening old content.
-            let lifecycle_guard = match &lifecycle {
-                Some(lifecycle) => Some(lifecycle.lock().await),
-                None => None,
-            };
-            let current_incarnation = self
-                .latest_virtual_contents
-                .get(host_uri)
-                .map(|host| host.incarnation);
-            if let Some(expected) = expected_incarnation
-                && current_incarnation != Some(expected)
-            {
+            let lifecycle_guard = lifecycle.lock().await;
+            let current_incarnation = self.current_host_incarnation(host_uri);
+            if current_incarnation != Some(expected_incarnation) {
                 drop(lifecycle_guard);
-                if current_incarnation.is_none()
-                    && let Some(lifecycle) = &lifecycle
-                {
-                    self.remove_host_lifecycle_lock_if_unshared(host_uri, lifecycle);
+                if current_incarnation.is_none() {
+                    self.remove_host_lifecycle_lock_if_unshared(host_uri, &lifecycle);
                 }
                 return;
             }
@@ -239,6 +243,7 @@ mod tests {
 
         let host_uri = test_host_uri("eager_open");
         let host_uri_lsp = url_to_uri(&host_uri);
+        pool.open_host_incarnation(&host_uri, 1).await;
 
         use super::super::super::coordinator::BridgeInjection;
         let injections = vec![
@@ -259,7 +264,7 @@ mod tests {
             &config,
             &host_uri,
             &host_uri_lsp,
-            None,
+            1,
             injections,
         )
         .await;
@@ -298,6 +303,7 @@ mod tests {
 
         let host_uri = test_host_uri("idempotent");
         let host_uri_lsp = url_to_uri(&host_uri);
+        pool.open_host_incarnation(&host_uri, 1).await;
 
         use super::super::super::coordinator::BridgeInjection;
         let injections = vec![BridgeInjection {
@@ -312,7 +318,7 @@ mod tests {
             &config,
             &host_uri,
             &host_uri_lsp,
-            None,
+            1,
             injections.clone(),
         )
         .await;
@@ -329,7 +335,7 @@ mod tests {
             &config,
             &host_uri,
             &host_uri_lsp,
-            None,
+            1,
             injections,
         )
         .await;

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -234,7 +234,7 @@ impl InjectionCoordinator {
         };
         tokio::spawn(install_task);
 
-        self.eager_spawn_bridge_servers(uri, &host_language, injections)
+        self.eager_spawn_bridge_servers(uri, incarnation, &host_language, injections)
             .await;
     }
 
@@ -333,12 +333,13 @@ impl InjectionCoordinator {
     pub(crate) async fn eager_spawn_bridge_servers(
         &self,
         uri: &Url,
+        incarnation: u64,
         host_language: &str,
         injections: Vec<BridgeInjection>,
     ) {
         let settings = self.settings_manager.load_settings();
         self.bridge
-            .eager_spawn_and_open_documents(&settings, host_language, uri, injections)
+            .eager_spawn_and_open_documents(&settings, host_language, uri, incarnation, injections)
             .await;
     }
 

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -186,6 +186,10 @@ impl InjectionCoordinator {
             self.bridge.cancel_eager_open(uri);
             return;
         };
+        let Some(incarnation) = self.documents.get(uri).map(|doc| doc.incarnation()) else {
+            self.bridge.cancel_eager_open(uri);
+            return;
+        };
         let injections = self.resolve_injection_data(uri, &host_language);
         if injections.is_empty() {
             self.bridge.cancel_eager_open(uri);
@@ -194,7 +198,7 @@ impl InjectionCoordinator {
 
         if forward_did_change {
             self.bridge
-                .forward_didchange_to_opened_docs(uri, &injections)
+                .forward_didchange_to_opened_docs(uri, incarnation, &injections)
                 .await;
         }
 

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -19,13 +19,16 @@ impl Kakehashi {
     }
 
     fn clear_document_state_on_close_locked(&self, uri: &url::Url) -> Option<u64> {
+        let closing_incarnation = self.documents.get(uri).map(|doc| doc.incarnation());
+        if let Some(incarnation) = closing_incarnation {
+            self.bridge.close_host_incarnation(uri, incarnation);
+        }
         // Captures lineage and walk memos are installed under this same lock,
         // so a store that won first is cleared while one arriving later sees
         // the document gone and refuses to install obsolete state.
         self.captures_cache.retain(|key, _| key.0 != *uri);
         self.captures_walk_cache.retain(|key, _| key.0 != *uri);
         self.cancel_captures_walks_for_document(uri);
-        let closing_incarnation = self.documents.get(uri).map(|doc| doc.incarnation());
         self.documents.remove_preserving_edit_lock(uri);
         self.cache.remove_document(uri);
         // The match cache uses insert-then-verify. Clearing after document

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -12,16 +12,16 @@ impl Kakehashi {
     ) -> Option<u64> {
         let edit_lock = self.documents.edit_lock(uri);
         let edit_guard = edit_lock.lock().await;
-        let closing_incarnation = self.clear_document_state_on_close_locked(uri);
+        let closing_incarnation = self.clear_document_state_on_close_locked(uri).await;
         drop(edit_guard);
         self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
         closing_incarnation
     }
 
-    fn clear_document_state_on_close_locked(&self, uri: &url::Url) -> Option<u64> {
+    async fn clear_document_state_on_close_locked(&self, uri: &url::Url) -> Option<u64> {
         let closing_incarnation = self.documents.get(uri).map(|doc| doc.incarnation());
         if let Some(incarnation) = closing_incarnation {
-            self.bridge.close_host_incarnation(uri, incarnation);
+            self.bridge.close_host_incarnation(uri, incarnation).await;
         }
         // Captures lineage and walk memos are installed under this same lock,
         // so a store that won first is cleared while one arriving later sees
@@ -45,7 +45,7 @@ impl Kakehashi {
     ) {
         let edit_lock = self.documents.edit_lock(uri);
         let edit_guard = edit_lock.lock().await;
-        let closing_incarnation = self.clear_document_state_on_close_locked(uri);
+        let closing_incarnation = self.clear_document_state_on_close_locked(uri).await;
         after_remove.await;
 
         if let Some(closing_incarnation) = closing_incarnation {

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -49,7 +49,7 @@ impl Kakehashi {
             self.documents
                 .insert(uri.clone(), text.clone(), language_name.clone(), None);
         self.bridge.open_tracker_incarnation(&uri, incarnation);
-        self.bridge.open_host_incarnation(&uri, incarnation);
+        self.bridge.open_host_incarnation(&uri, incarnation).await;
         drop(edit_guard);
 
         // Host-tier hoist (parse-decoupled-document-lifecycle ADR): attach the real

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -49,6 +49,7 @@ impl Kakehashi {
             self.documents
                 .insert(uri.clone(), text.clone(), language_name.clone(), None);
         self.bridge.open_tracker_incarnation(&uri, incarnation);
+        self.bridge.open_host_incarnation(&uri, incarnation);
         drop(edit_guard);
 
         // Host-tier hoist (parse-decoupled-document-lifecycle ADR): attach the real

--- a/src/lsp/lsp_impl/workspace/execute_command.rs
+++ b/src/lsp/lsp_impl/workspace/execute_command.rs
@@ -89,6 +89,13 @@ impl Kakehashi {
         // silently skip the heal (the request paths await the fresh tree the
         // same way).
         self.ensure_document_parsed(&host_url).await;
+        let Some(host_incarnation) = self
+            .documents
+            .get(&host_url)
+            .map(|document| document.incarnation())
+        else {
+            return;
+        };
         let Some((host_language, injections)) =
             self.injection_coordinator().bridge_injections(&host_url)
         else {
@@ -122,6 +129,7 @@ impl Kakehashi {
                     &settings,
                     &host_language_owned,
                     &host_url_owned,
+                    host_incarnation,
                     injections,
                     &origin,
                 )


### PR DESCRIPTION
## Summary
- tag each host virtual-content cache container with its document incarnation
- reject stale post-close publications and stale eager opens across fast reopen
- serialize host lifecycle transitions with incarnation-bound eager opens and safely reclaim lifecycle locks
- retain the current host container across region invalidation so the next parse can republish

## Tests
- `cargo test --lib -q stale_incarnation_cannot_repopulate_latest_virtual_content_after_fast_reopen`
- `cargo test --lib -q invalidation_reclaims_only_matching_latest_virtual_content`
- `cargo test --lib -q bridge::pool::tests::` (87 passed)
- `cargo test --lib -q bridge::text_document::did_open::tests::` (2 passed)
- `make check`

Full `cargo test --lib` was also attempted; one unrelated environment-dependent test fails because the Rust parser fixture is not installed (`process_injection_sync_returns_incomplete_on_mid_region_cancel`).

Closes #696.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rapid reopen/close behavior by making virtual-document open and updates instance-aware.
  - Prevented stale cached virtual-document content from being reused after fast reopen by isolating cache state per active host instance.
  - Kept virtual-document `didOpen`/`didChange` aligned with the currently active host instance to reduce mismatches during quick switching.
- **Reliability**
  - Strengthened lifecycle coordination so eager-open won’t repopulate virtual documents from out-of-date state after a reopen.
  - Ensured host-instance open/close is correctly handled during document teardown and pre-sync before command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->