### PR TITLE
fix(lsp): serialize didClose cleanup with fast reopen

### DIFF
--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -687,9 +687,19 @@ impl DocumentStore {
     }
 
     // Lock safety: Single remove() call - no read lock held before or during write
+    #[cfg(test)]
     pub(crate) fn remove(&self, uri: &Url) -> Option<Document> {
-        self.parse_states.remove(uri);
         self.edit_locks.remove(uri);
+        self.remove_preserving_edit_lock(uri)
+    }
+
+    /// Remove a document while retaining its per-URI edit lock entry.
+    ///
+    /// Lifecycle teardown holds that lock across cleanup after the document is
+    /// gone. Keeping the map entry makes a fast reopen wait on the same mutex
+    /// instead of creating a fresh lock and racing the old lifetime's cleanup.
+    pub(crate) fn remove_preserving_edit_lock(&self, uri: &Url) -> Option<Document> {
+        self.parse_states.remove(uri);
         // Dropping the watermark sender wakes any reader still blocked on
         // the watermark for this document, so a reader racing the close
         // proceeds into the empty fallback instead of stalling to the timeout.

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -538,6 +538,7 @@ impl DocumentStore {
     /// lock entry behind forever. Such handlers call this on their miss path to
     /// keep the map bounded. Safe to call while holding the lock's `Arc` guard —
     /// the guard keeps the mutex alive; only the map entry is removed.
+    #[cfg(test)]
     pub(crate) fn remove_edit_lock(&self, uri: &Url) {
         self.edit_locks.remove(uri);
     }

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -543,7 +543,7 @@ impl DocumentStore {
         self.edit_locks.remove(uri);
     }
 
-    /// [`remove_edit_lock`](Self::remove_edit_lock), but only while the map
+    /// Remove the edit-lock entry, but only while the map
     /// still holds the exact `Arc` the caller acquired AND nobody else
     /// holds a clone — for miss paths that probe liveness some time after
     /// their `edit_lock()` call. A close+reopen in that gap can hand the
@@ -565,7 +565,7 @@ impl DocumentStore {
     /// Ensure a watermark channel exists for `uri` carrying the current lifetime's
     /// `incarnation`, created at ticket 0. Called when a document is registered or
     /// edited so the watermark's lifetime tracks the document's — it exists exactly
-    /// while the document is open and is dropped by [`remove`](Self::remove) on close.
+    /// while the document is open and is dropped when the document closes.
     ///
     /// Idempotent **within a lifetime**: an existing channel whose incarnation
     /// already matches is left untouched, so an edit never resets the ticket. But a

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -51,7 +51,8 @@ impl Kakehashi {
                     // We created an edit-lock entry above for a document that
                     // doesn't exist (a stray/reordered notification). Drop it so
                     // the map can't grow unboundedly from such notifications.
-                    self.documents.remove_edit_lock(&uri);
+                    self.documents
+                        .remove_edit_lock_if_unshared(&uri, &edit_lock);
                     return;
                 }
             }

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -81,9 +81,9 @@ impl Kakehashi {
         // document's edit lock first (the same lock `did_change` holds across its
         // reparse). Without it, `remove` could drop the lock entry while an edit
         // still holds the old `Arc`, so a later edit would create a *fresh* lock
-        // and stop serializing with the in-flight one. The guard is held
-        // Keep the retained edit lock through every URI-scoped teardown below;
-        // didOpen takes the same lock before inserting the next lifetime.
+        // and stop serializing with the in-flight one. The retained lock stays
+        // held through every URI-scoped teardown below; didOpen takes the same
+        // lock before inserting the next lifetime.
         self.close_document_lifecycle(&uri, std::future::ready(()))
             .await;
 

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -5,16 +5,23 @@ use tower_lsp_server::ls_types::DidCloseTextDocumentParams;
 use super::super::{Kakehashi, uri_to_url};
 
 impl Kakehashi {
+    #[cfg(test)]
     pub(in crate::lsp::lsp_impl) async fn clear_document_state_on_close(&self, uri: &url::Url) {
         let edit_lock = self.documents.edit_lock(uri);
-        let _edit_guard = edit_lock.lock().await;
+        let edit_guard = edit_lock.lock().await;
+        self.clear_document_state_on_close_locked(uri);
+        drop(edit_guard);
+        self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
+    }
+
+    fn clear_document_state_on_close_locked(&self, uri: &url::Url) {
         // Captures lineage and walk memos are installed under this same lock,
         // so a store that won first is cleared while one arriving later sees
         // the document gone and refuses to install obsolete state.
         self.captures_cache.retain(|key, _| key.0 != *uri);
         self.captures_walk_cache.retain(|key, _| key.0 != *uri);
         self.cancel_captures_walks_for_document(uri);
-        self.documents.remove(uri);
+        self.documents.remove_preserving_edit_lock(uri);
         self.cache.remove_document(uri);
         // The match cache uses insert-then-verify. Clearing after document
         // removal ensures a straggler either inserted before this clear or
@@ -42,7 +49,9 @@ impl Kakehashi {
         // across the whole in-helper teardown (captures/walk cache clears,
         // walk cancellation, document + cache removal); only the cleanups
         // BELOW this call run outside the edit-lock section.
-        self.clear_document_state_on_close(&uri).await;
+        let edit_lock = self.documents.edit_lock(&uri);
+        let edit_guard = edit_lock.lock().await;
+        self.clear_document_state_on_close_locked(&uri);
 
         // Clean up region ID mappings for this document
         // (lazy-node-identity-tracking). This runs AFTER the removal above
@@ -99,6 +108,10 @@ impl Kakehashi {
             .pool_arc()
             .close_host_bridge_document(&uri)
             .await;
+
+        drop(edit_guard);
+        self.documents
+            .remove_edit_lock_if_unshared(&uri, &edit_lock);
 
         self.notifier().log_info("file closed!").await;
     }

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -137,24 +137,29 @@ mod tests {
         cleanup_paused.notified().await;
         assert!(server.documents.get(&uri).is_none());
 
+        let reopen_started = Arc::new(Notify::new());
         let reopen = {
             let service = Arc::clone(&service);
             let uri = uri.clone();
+            let reopen_started = Arc::clone(&reopen_started);
             tokio::spawn(async move {
                 service
                     .inner()
-                    .did_open_impl(DidOpenTextDocumentParams {
-                        text_document: TextDocumentItem {
-                            uri: crate::lsp::lsp_impl::url_to_uri(&uri).unwrap(),
-                            language_id: "plaintext".to_string(),
-                            version: 1,
-                            text: "new".to_string(),
+                    .did_open_impl_with_lock_probe(
+                        DidOpenTextDocumentParams {
+                            text_document: TextDocumentItem {
+                                uri: crate::lsp::lsp_impl::url_to_uri(&uri).unwrap(),
+                                language_id: "plaintext".to_string(),
+                                version: 1,
+                                text: "new".to_string(),
+                            },
                         },
-                    })
+                        async move { reopen_started.notify_one() },
+                    )
                     .await;
             })
         };
-        tokio::task::yield_now().await;
+        reopen_started.notified().await;
         assert!(
             server.documents.get(&uri).is_none(),
             "reopen must not expose new state during old-lifetime cleanup"

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -29,6 +29,42 @@ impl Kakehashi {
         self.captures_match_cache.clear_document(uri);
     }
 
+    async fn close_document_lifecycle(
+        &self,
+        uri: &url::Url,
+        after_remove: impl std::future::Future<Output = ()>,
+    ) {
+        let edit_lock = self.documents.edit_lock(uri);
+        let edit_guard = edit_lock.lock().await;
+        self.clear_document_state_on_close_locked(uri);
+        after_remove.await;
+
+        self.bridge
+            .cleanup(uri, || self.documents.latest_snapshot(uri).is_some());
+        self.synthetic_diagnostics.remove_document(uri);
+        self.debounced_diagnostics.cancel(uri);
+        self.bridge.cancel_eager_open(uri);
+        self.bridge.cancel_host_eager_open(uri);
+
+        let closed_docs = self.bridge.close_host_document(uri).await;
+        if !closed_docs.is_empty() {
+            log::debug!(
+                target: "kakehashi::bridge",
+                "Closed {} virtual documents for host {}",
+                closed_docs.len(),
+                uri
+            );
+        }
+
+        super::super::coordinator::DiagnosticPublisher::new(self)
+            .clear_host(uri)
+            .await;
+        self.bridge.pool_arc().close_host_bridge_document(uri).await;
+
+        drop(edit_guard);
+        self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
+    }
+
     pub(crate) async fn did_close_impl(&self, params: DidCloseTextDocumentParams) {
         let lsp_uri = params.text_document.uri;
 
@@ -46,73 +82,101 @@ impl Kakehashi {
         // reparse). Without it, `remove` could drop the lock entry while an edit
         // still holds the old `Arc`, so a later edit would create a *fresh* lock
         // and stop serializing with the in-flight one. The guard is held
-        // across the whole in-helper teardown (captures/walk cache clears,
-        // walk cancellation, document + cache removal); only the cleanups
-        // BELOW this call run outside the edit-lock section.
-        let edit_lock = self.documents.edit_lock(&uri);
-        let edit_guard = edit_lock.lock().await;
-        self.clear_document_state_on_close_locked(&uri);
-
-        // Clean up region ID mappings for this document
-        // (lazy-node-identity-tracking). This runs AFTER the removal above
-        // and outside the edit-lock section, so a fast reopen's parse may
-        // already have minted the NEW lifetime's ids — the probe (evaluated
-        // under the tracker entry's lock) skips the removal in that case
-        // instead of wiping a live index whose published ids would then
-        // resolve null. See NodeTracker::cleanup.
-        self.bridge
-            .cleanup(&uri, || self.documents.latest_snapshot(&uri).is_some());
-
-        // Abort any in-progress synthetic diagnostic task for this document (pull-first-diagnostic-forwarding Phase 2)
-        self.synthetic_diagnostics.remove_document(&uri);
-
-        // Cancel any pending debounced diagnostic for this document (pull-first-diagnostic-forwarding Phase 3)
-        self.debounced_diagnostics.cancel(&uri);
-
-        // Cancel any eager-open tasks for this document (prevents orphaned didOpen).
-        // Host-layer eager-open is cancelled here too — before `close_host_bridge_document`
-        // (the host-server didClose, further below) — so an in-flight host eager-open
-        // still waiting for server readiness can't open a host doc whose didClose
-        // already ran (#429).
-        self.bridge.cancel_eager_open(&uri);
-        self.bridge.cancel_host_eager_open(&uri);
-
-        // Close all virtual documents associated with this host document
-        // This sends didClose notifications to downstream language servers
-        let closed_docs = self.bridge.close_host_document(&uri).await;
-        if !closed_docs.is_empty() {
-            log::debug!(
-                target: "kakehashi::bridge",
-                "Closed {} virtual documents for host {}",
-                closed_docs.len(),
-                uri
-            );
-        }
-
-        // Drop the proactive diagnostic cache for this host and clear the editor's
-        // diagnostics (push-propagation-diagnostic-forwarding). MUST run AFTER
-        // close_host_document tears down host_to_virtual: a region push dequeued
-        // before that teardown can still resolve its virtual URI and re-create the
-        // cache entry, so clearing first would leave a resurrected, never-cleared
-        // host. (Residual resolve→suspend→record micro-windows remain — both the
-        // region path and the host path, whose `documents.get→record` can race the
-        // `documents.remove()` above — closed only by the deferred tombstone/epoch
-        // gate.)
-        super::super::coordinator::DiagnosticPublisher::new(self)
-            .clear_host(&uri)
+        // Keep the retained edit lock through every URI-scoped teardown below;
+        // didOpen takes the same lock before inserting the next lifetime.
+        self.close_document_lifecycle(&uri, std::future::ready(()))
             .await;
-
-        // Close the host document itself on any servers it was opened on via
-        // the host bridge (host-document-bridge).
-        self.bridge
-            .pool_arc()
-            .close_host_bridge_document(&uri)
-            .await;
-
-        drop(edit_guard);
-        self.documents
-            .remove_edit_lock_if_unshared(&uri, &edit_lock);
 
         self.notifier().log_info("file closed!").await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::config::WorkspaceSettings;
+    use tokio::sync::Notify;
+    use tokio::time::{Duration, timeout};
+    use tower_lsp_server::LspService;
+    use tower_lsp_server::ls_types::{DidOpenTextDocumentParams, TextDocumentItem};
+    use url::Url;
+
+    #[tokio::test]
+    async fn fast_reopen_waits_for_complete_did_close_cleanup() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let service = Arc::new(service);
+        let server = service.inner();
+        server.settings_manager.apply_settings(WorkspaceSettings {
+            auto_install: false,
+            ..Default::default()
+        });
+        let uri = Url::parse("file:///test/close-cleanup-fast-reopen").unwrap();
+        server
+            .documents
+            .insert(uri.clone(), "old".to_string(), None, None);
+
+        let cleanup_paused = Arc::new(Notify::new());
+        let release_cleanup = Arc::new(Notify::new());
+        let close = {
+            let service = Arc::clone(&service);
+            let uri = uri.clone();
+            let cleanup_paused = Arc::clone(&cleanup_paused);
+            let release_cleanup = Arc::clone(&release_cleanup);
+            tokio::spawn(async move {
+                service
+                    .inner()
+                    .close_document_lifecycle(&uri, async move {
+                        cleanup_paused.notify_one();
+                        release_cleanup.notified().await;
+                    })
+                    .await;
+            })
+        };
+        cleanup_paused.notified().await;
+        assert!(server.documents.get(&uri).is_none());
+
+        let reopen = {
+            let service = Arc::clone(&service);
+            let uri = uri.clone();
+            tokio::spawn(async move {
+                service
+                    .inner()
+                    .did_open_impl(DidOpenTextDocumentParams {
+                        text_document: TextDocumentItem {
+                            uri: crate::lsp::lsp_impl::url_to_uri(&uri).unwrap(),
+                            language_id: "plaintext".to_string(),
+                            version: 1,
+                            text: "new".to_string(),
+                        },
+                    })
+                    .await;
+            })
+        };
+        tokio::task::yield_now().await;
+        assert!(
+            server.documents.get(&uri).is_none(),
+            "reopen must not expose new state during old-lifetime cleanup"
+        );
+
+        release_cleanup.notify_one();
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if server
+                    .documents
+                    .get(&uri)
+                    .is_some_and(|doc| doc.text() == "new")
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("reopen should proceed after cleanup releases the lock");
+
+        close.abort();
+        reopen.abort();
     }
 }

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -178,5 +178,10 @@ mod tests {
 
         close.abort();
         reopen.abort();
+        for (name, task) in [("didClose", close), ("didOpen", reopen)] {
+            if let Err(error) = task.await {
+                assert!(error.is_cancelled(), "{name} task panicked: {error}");
+            }
+        }
     }
 }

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -25,11 +25,19 @@ impl Kakehashi {
             Some(language_id.clone())
         };
 
+        // Serialize reopen insertion behind the prior lifetime's complete
+        // didClose cleanup. didClose deliberately retains this map entry while
+        // the document itself is absent, so reopening cannot mint a fresh mutex
+        // and expose new state to URI-scoped old-lifetime teardown.
+        let edit_lock = self.documents.edit_lock(&uri);
+        let edit_guard = edit_lock.lock().await;
+
         // Insert document immediately (without tree) so concurrent requests can find it.
         // This handles race conditions where semanticTokens/full arrives before
         // parse_document completes. The tree will be updated by parse_document.
         self.documents
             .insert(uri.clone(), text.clone(), language_name.clone(), None);
+        drop(edit_guard);
 
         // Host-tier hoist (parse-decoupled-document-lifecycle ADR): attach the real
         // host document to any `_self` host-bridge server *before* the parser load,
@@ -253,6 +261,7 @@ impl Kakehashi {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     use super::*;
     use crate::config::WorkspaceSettings;
@@ -278,6 +287,62 @@ mod tests {
         })
         .await
         .expect("condition should become true");
+    }
+
+    #[tokio::test]
+    async fn did_open_waits_for_prior_lifetime_close_cleanup() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let service = Arc::new(service);
+        let server = service.inner();
+        server.settings_manager.apply_settings(WorkspaceSettings {
+            auto_install: false,
+            ..Default::default()
+        });
+        let uri = Url::parse("file:///test/fast-reopen.md").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "old".to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+
+        let lifecycle = server.documents.edit_lock(&uri);
+        let close_guard = lifecycle.lock().await;
+        server.documents.remove_preserving_edit_lock(&uri);
+
+        let reopen = {
+            let service = Arc::clone(&service);
+            let uri = uri.clone();
+            tokio::spawn(async move {
+                service
+                    .inner()
+                    .did_open_impl(DidOpenTextDocumentParams {
+                        text_document: TextDocumentItem {
+                            uri: crate::lsp::lsp_impl::url_to_uri(&uri).unwrap(),
+                            language_id: "plaintext".to_string(),
+                            version: 1,
+                            text: "new".to_string(),
+                        },
+                    })
+                    .await;
+            })
+        };
+        tokio::task::yield_now().await;
+        assert!(
+            !reopen.is_finished(),
+            "reopen must wait until all old-lifetime cleanup releases the lifecycle lock"
+        );
+
+        drop(close_guard);
+        wait_until(|| {
+            server
+                .documents
+                .get(&uri)
+                .is_some_and(|doc| doc.text() == "new")
+        })
+        .await;
+        reopen.abort();
+        assert_eq!(server.documents.get(&uri).unwrap().text(), "new");
     }
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -261,7 +261,6 @@ impl Kakehashi {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::Arc;
 
     use super::*;
     use crate::config::WorkspaceSettings;
@@ -287,65 +286,6 @@ mod tests {
         })
         .await
         .expect("condition should become true");
-    }
-
-    #[tokio::test]
-    async fn did_open_waits_for_prior_lifetime_close_cleanup() {
-        let (service, _socket) = LspService::new(Kakehashi::new);
-        let service = Arc::new(service);
-        let server = service.inner();
-        server.settings_manager.apply_settings(WorkspaceSettings {
-            auto_install: false,
-            ..Default::default()
-        });
-        let uri = Url::parse("file:///test/fast-reopen.md").unwrap();
-        server.documents.insert(
-            uri.clone(),
-            "old".to_string(),
-            Some("markdown".to_string()),
-            None,
-        );
-
-        let lifecycle = server.documents.edit_lock(&uri);
-        let close_guard = lifecycle.lock().await;
-        server.documents.remove_preserving_edit_lock(&uri);
-
-        let reopen = {
-            let service = Arc::clone(&service);
-            let uri = uri.clone();
-            tokio::spawn(async move {
-                service
-                    .inner()
-                    .did_open_impl(DidOpenTextDocumentParams {
-                        text_document: TextDocumentItem {
-                            uri: crate::lsp::lsp_impl::url_to_uri(&uri).unwrap(),
-                            language_id: "plaintext".to_string(),
-                            version: 1,
-                            text: "new".to_string(),
-                        },
-                    })
-                    .await;
-            })
-        };
-        tokio::task::yield_now().await;
-        assert!(
-            !reopen.is_finished(),
-            "reopen must wait until all old-lifetime cleanup releases the lifecycle lock"
-        );
-
-        drop(close_guard);
-        wait_until(|| {
-            server
-                .documents
-                .get(&uri)
-                .is_some_and(|doc| doc.text() == "new")
-        })
-        .await;
-        reopen.abort();
-        if let Err(error) = reopen.await {
-            assert!(error.is_cancelled(), "didOpen task panicked: {error}");
-        }
-        assert_eq!(server.documents.get(&uri).unwrap().text(), "new");
     }
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -342,6 +342,9 @@ mod tests {
         })
         .await;
         reopen.abort();
+        if let Err(error) = reopen.await {
+            assert!(error.is_cancelled(), "didOpen task panicked: {error}");
+        }
         assert_eq!(server.documents.get(&uri).unwrap().text(), "new");
     }
 

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -11,7 +11,7 @@ impl Kakehashi {
             .await;
     }
 
-    async fn did_open_impl_with_lock_probe(
+    pub(in crate::lsp::lsp_impl) async fn did_open_impl_with_lock_probe(
         &self,
         params: DidOpenTextDocumentParams,
         before_lifecycle_lock: impl std::future::Future<Output = ()>,

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -7,6 +7,15 @@ use crate::language::LanguageEvent;
 
 impl Kakehashi {
     pub(crate) async fn did_open_impl(&self, params: DidOpenTextDocumentParams) {
+        self.did_open_impl_with_lock_probe(params, std::future::ready(()))
+            .await;
+    }
+
+    async fn did_open_impl_with_lock_probe(
+        &self,
+        params: DidOpenTextDocumentParams,
+        before_lifecycle_lock: impl std::future::Future<Output = ()>,
+    ) {
         let text_document = params.text_document;
         let language_id = text_document.language_id;
         let lsp_uri = text_document.uri;
@@ -30,6 +39,7 @@ impl Kakehashi {
         // the document itself is absent, so reopening cannot mint a fresh mutex
         // and expose new state to URI-scoped old-lifetime teardown.
         let edit_lock = self.documents.edit_lock(&uri);
+        before_lifecycle_lock.await;
         let edit_guard = edit_lock.lock().await;
 
         // Insert document immediately (without tree) so concurrent requests can find it.


### PR DESCRIPTION
## Summary
- retain the per-URI edit-lock entry while didClose removes the document and completes URI-scoped cleanup
- make didOpen insertion wait behind that lifecycle lock, then safely reclaim it after close only when unshared
- preserve a shared lifecycle lock on missing-document didChange paths
- add deterministic tests for both the lock primitive and the complete production close lifecycle

## Tests
- `cargo test --lib -q did_open_waits_for_prior_lifetime_close_cleanup`
- `cargo test --lib -q fast_reopen_waits_for_complete_did_close_cleanup`
- `cargo test --lib -q document::store::tests::` (35 passed)
- `make check`

Closes #703.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved per-document edit-lock handling across open, change, and close flows to prevent stale/incorrect lock bookkeeping.
  * Avoided unconditionally removing edit locks when handling out-of-order change notifications, preserving correct lock sharing behavior.
  * Ensured documents remain unavailable during close cleanup so fast reopen won’t expose inconsistent state prematurely.
* **Tests**
  * Updated async coverage to verify fast reopen waits for deferred close cleanup to complete before new state becomes visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->