### PR TITLE
fix(language): canonicalize bridge aliases before parser load

### DIFF
--- a/docs/architecture-decisions/base-language-inheritance.md
+++ b/docs/architecture-decisions/base-language-inheritance.md
@@ -116,7 +116,12 @@ The language detection fallback chain from language-detection-fallback-chain cha
 
 The key difference: with `base`, the language `rmd` is a first-class entry in the config, not a reverse lookup in an alias map. Detection finds `rmd` directly, and the base chain handles parser resolution. This also applies to injection language resolution — injected language identifiers are looked up directly in the config, and the base chain handles parser fallback.
 
-Syntect-based token normalization (e.g., `py` -> `python`) remains unchanged — it operates before the base chain.
+Parser-loading detection retains its documented fallback chain. Bridge/URI
+canonicalization is intentionally different: it first honors an explicit
+configured base for the raw identifier, then applies Syntect token or
+first-line normalization with base fallback. This keeps configured injection
+keys authoritative while still canonicalizing unconfigured aliases such as
+`py` -> `python` without requiring a parser to be loaded.
 
 ### Removed: `aliases` Field
 

--- a/docs/architecture-decisions/language-detection-fallback-chain.md
+++ b/docs/architecture-decisions/language-detection-fallback-chain.md
@@ -31,18 +31,18 @@ parser-independent canonical injection candidate. Parser loading remains a
 later, separate decision.
 
 ```
-1. LSP languageId  →  Try direct  →  Try alias  →  If available: use it
+1. LSP languageId  →  Try direct  →  Try base   →  If available: use it
                                                 →  If no: continue
-2. Token detection →  syntect     →  Try alias  →  If available: use it
-                  →  raw token   →  Try alias  →  If available: use it
+2. Token detection →  syntect     →  Try base   →  If available: use it
+                  →  raw token   →  Try base   →  If available: use it
                                                 →  If no: continue
-3. First line      →  Try direct  →  Try alias  →  If available: use it
+3. First line      →  Try direct  →  Try base   →  If available: use it
                                                 →  If no: return None
 ```
 
 ### Priority Order Rationale
 
-Each detection method follows the **detect → alias resolution → availability check** pattern:
+Each detection method follows the **detect → base resolution → availability check** pattern:
 
 1. **LSP languageId (highest priority)**
    - Client has full context: file path, content, user preferences, workspace settings
@@ -59,9 +59,9 @@ Each detection method follows the **detect → alias resolution → availability
    - `py` → `python`, `js` → `javascript`, `rs` → `rust`
    - `Makefile` → `make`, `.bashrc` → `bash`
 
-   If syntect doesn't recognize the token, it's tried directly as an alias candidate.
+   If syntect doesn't recognize the token, it's tried directly as a base candidate.
    This handles extensions like `jsx`, `tsx` that syntect doesn't know but may be
-   configured as aliases (e.g., `jsx` → `javascript`).
+   configured with a base (e.g., `jsx.base = "javascript"`).
 
 3. **First-line detection (lowest priority)**
    - Shebang detection: `#!/usr/bin/env python` → python
@@ -69,35 +69,36 @@ Each detection method follows the **detect → alias resolution → availability
    - Implementation: syntect's `find_syntax_by_first_line`
    - Fallback when token detection fails (e.g., extensionless files without special names)
 
-### Alias Resolution as Sub-step
+### Base Resolution as Sub-step
 
-Alias resolution is applied **after each detection method**, not as a separate step in the chain. This is configured via the `aliases` field in language config:
+Base resolution is applied **after each detection method**, not as a separate
+step in the chain. This is configured via the `base` field:
 
 ```toml
-[languages.markdown]
-aliases = ["rmd", "qmd"]
+[languages.rmd]
+base = "markdown"
 ```
 
 This ensures:
-- **Consistent behavior**: All detection paths apply the same alias logic
+- **Consistent behavior**: All detection paths apply the same base logic
 - **User control**: Users can define mappings that work at any detection level
 - **Alignment with injection**: Document-level and injection-level detection behave the same way
 
 Example scenarios:
-- Editor sends `languageId: "rmd"` → alias resolves to `markdown` → parser found
+- Editor sends `languageId: "rmd"` → base resolves to `markdown` → parser found
 - Token `py` (from code fence or `.py` extension) → syntect normalizes to `python` → parser found
-- Token `jsx` (from `.jsx` extension) → syntect unknown → direct alias to `javascript` → parser found
+- Token `jsx` (from `.jsx` extension) → syntect unknown → configured base `javascript` → parser found
 - Shebang `#!/usr/bin/env python3` → syntect returns `python` → parser found
 
 ### Availability Check
 
-Each detection method tries direct match first, then alias resolution:
+Each detection method tries a direct match first, then base resolution:
 
 ```
 detect_language(path, content, token, language_id):
     // 1. Try languageId (skip "plaintext")
     if language_id exists and != "plaintext":
-        if try_with_alias_fallback(language_id) succeeds:
+        if try_with_base_fallback(language_id) succeeds:
             return result
 
     // 2. Token-based detection
@@ -105,31 +106,31 @@ detect_language(path, content, token, language_id):
     if effective_token exists:
         // Try syntect normalization (py → python, Makefile → make)
         if syntect recognizes token:
-            if try_with_alias_fallback(normalized) succeeds:
+            if try_with_base_fallback(normalized) succeeds:
                 return result
-        // Try raw token as alias (handles jsx, tsx that syntect doesn't know)
-        if try_with_alias_fallback(raw_token) succeeds:
+        // Try raw token with base fallback (handles jsx, tsx)
+        if try_with_base_fallback(raw_token) succeeds:
             return result
 
     // 3. First-line detection (shebang, mode line)
     if syntect detects from first line:
-        if try_with_alias_fallback(detected) succeeds:
+        if try_with_base_fallback(detected) succeeds:
             return result
 
     return None
 
-try_with_alias_fallback(candidate):
+try_with_base_fallback(candidate):
     if parser_available(candidate):
         return candidate
-    if alias_configured(candidate) AND parser_available(alias):
-        return alias
+    if base_configured(candidate) AND parser_available(base):
+        return base
     return None
 ```
 
 This means:
-- If client sends `languageId: "rmd"` and alias maps `rmd` → `markdown`, use the markdown parser
+- If client sends `languageId: "rmd"` and its base is `markdown`, use the markdown parser
 - If token `py` is normalized by syntect to `python`, use the python parser
-- If token `jsx` is not recognized by syntect but alias maps `jsx` → `javascript`, use the javascript parser
+- If token `jsx` is not recognized by syntect but its base is `javascript`, use the javascript parser
 - If no match, continue to the next detection method
 
 ### Language Injection

--- a/docs/architecture-decisions/language-detection-fallback-chain.md
+++ b/docs/architecture-decisions/language-detection-fallback-chain.md
@@ -146,8 +146,9 @@ For example, a Markdown code fence with ` ```py ` provides the identifier
 
 - **Bridge canonicalization** produces a stable language key even when no
   parser exists yet. It checks an explicit configured base, then syntect token
-  normalization, then first-line detection, and finally the raw identifier.
-  Thus `py` remains `python` before and after parser installation.
+  normalization (and that candidate's base), then first-line detection (and
+  that candidate's base), and finally the raw identifier. Thus `py` remains
+  `python` before and after parser installation.
 - **Parser resolution** may then load or select the canonical language/base and
   can still fail when no grammar is available.
 

--- a/docs/architecture-decisions/language-detection-fallback-chain.md
+++ b/docs/architecture-decisions/language-detection-fallback-chain.md
@@ -30,7 +30,7 @@ For bridge routing and virtual-document identity, first derive a
 parser-independent canonical injection candidate. Parser loading remains a
 later, separate decision.
 
-```
+```text
 1. LSP languageId  →  Try direct  →  Try base   →  If available: use it
                                                 →  If no: continue
 2. Token detection →  syntect     →  Try base   →  If available: use it
@@ -96,7 +96,7 @@ Example scenarios:
 
 Each detection method tries a direct match first, then base resolution:
 
-```
+```text
 detect_language(path, content, token, language_id):
     // 1. Try languageId (skip "plaintext")
     if language_id exists and != "plaintext":
@@ -139,7 +139,7 @@ This means:
 
 The fallback chain also applies to **injected languages** (e.g., code blocks in Markdown, JavaScript inside HTML). Injection queries extract a language identifier, but this identifier needs resolution:
 
-```
+```text
 Document (markdown) ──parse──▶ AST ──injection query──▶ "py" ──detect──▶ python
                                                       ▶ "sh" ──detect──▶ bash
 ```

--- a/docs/architecture-decisions/language-detection-fallback-chain.md
+++ b/docs/architecture-decisions/language-detection-fallback-chain.md
@@ -98,7 +98,7 @@ Each detection method tries a direct match first, then base resolution:
 detect_language(path, content, token, language_id):
     // 1. Try languageId (skip "plaintext")
     if language_id exists and != "plaintext":
-        if try_with_base_fallback(language_id) succeeds:
+        if result = try_with_base_fallback(language_id):
             return result
 
     // 2. Token-based detection
@@ -106,15 +106,15 @@ detect_language(path, content, token, language_id):
     if effective_token exists:
         // Try syntect normalization (py → python, Makefile → make)
         if normalized = syntect_detect(effective_token):
-            if try_with_base_fallback(normalized) succeeds:
+            if result = try_with_base_fallback(normalized):
                 return result
         // Try raw token with base fallback (handles jsx, tsx)
-        if try_with_base_fallback(effective_token) succeeds:
+        if result = try_with_base_fallback(effective_token):
             return result
 
     // 3. First-line detection (shebang, mode line)
     if detected = syntect_detect_first_line(content):
-        if try_with_base_fallback(detected) succeeds:
+        if result = try_with_base_fallback(detected):
             return result
 
     return None
@@ -122,7 +122,7 @@ detect_language(path, content, token, language_id):
 try_with_base_fallback(candidate):
     if parser_available(candidate):
         return candidate
-    if base_configured(candidate) AND parser_available(base):
+    if base = configured_base(candidate) AND parser_available(base):
         return base
     return None
 ```

--- a/docs/architecture-decisions/language-detection-fallback-chain.md
+++ b/docs/architecture-decisions/language-detection-fallback-chain.md
@@ -82,7 +82,9 @@ base = "markdown"
 This ensures:
 - **Consistent behavior**: All detection paths apply the same base logic
 - **User control**: Users can define mappings that work at any detection level
-- **Alignment with injection**: Document-level and injection-level detection behave the same way
+- **Shared base semantics**: Document parser resolution and injection bridge
+  canonicalization both honor eligible bases, while their surrounding fallback
+  chains intentionally differ as described below (including explicit `plaintext`).
 
 Example scenarios:
 - Editor sends `languageId: "rmd"` → base resolves to `markdown` → parser found

--- a/docs/architecture-decisions/language-detection-fallback-chain.md
+++ b/docs/architecture-decisions/language-detection-fallback-chain.md
@@ -105,7 +105,7 @@ detect_language(path, content, token, language_id):
     effective_token = token OR extract_token_from_path(path)
     if effective_token exists:
         // Try syntect normalization (py → python, Makefile → make)
-        if syntect recognizes effective_token:
+        if normalized = syntect_detect(effective_token):
             if try_with_base_fallback(normalized) succeeds:
                 return result
         // Try raw token with base fallback (handles jsx, tsx)

--- a/docs/architecture-decisions/language-detection-fallback-chain.md
+++ b/docs/architecture-decisions/language-detection-fallback-chain.md
@@ -153,9 +153,12 @@ For example, a Markdown code fence with ` ```py ` provides the identifier
 
 Parser resolution follows this fallback pattern:
 
-1. **Try the identifier directly**: Check if a parser named `"py"` is available
-2. **Normalize via syntect**: Use `detect_from_token("py")` which returns `"python"`
-3. **Try config-based alias**: If syntect doesn't recognize it, check user-configured aliases
+1. **Try identifier then configured base**: Load `"py"` directly, then its
+   configured base before considering generic normalization
+2. **Normalize via syntect, then try its base**: Use `detect_from_token("py")`
+   which returns `"python"`, and load that candidate or its configured base
+3. **Try first-line candidate then its base**: Use shebang/mode-line detection
+   only after the explicit identifier paths fail
 4. **Skip parser-backed analysis if unavailable**: Bridge routing can still use
    the canonical candidate, but semantic/parser work skips the region when no
    parser matches

--- a/docs/architecture-decisions/language-detection-fallback-chain.md
+++ b/docs/architecture-decisions/language-detection-fallback-chain.md
@@ -105,11 +105,11 @@ detect_language(path, content, token, language_id):
     effective_token = token OR extract_token_from_path(path)
     if effective_token exists:
         // Try syntect normalization (py → python, Makefile → make)
-        if syntect recognizes token:
+        if syntect recognizes effective_token:
             if try_with_base_fallback(normalized) succeeds:
                 return result
         // Try raw token with base fallback (handles jsx, tsx)
-        if try_with_base_fallback(raw_token) succeeds:
+        if try_with_base_fallback(effective_token) succeeds:
             return result
 
     // 3. First-line detection (shebang, mode line)

--- a/docs/architecture-decisions/language-detection-fallback-chain.md
+++ b/docs/architecture-decisions/language-detection-fallback-chain.md
@@ -14,7 +14,10 @@ Additionally, PBI-061 removed the `filetypes` configuration field entirely, elim
 
 The key insight is: **detection should find an *available* Tree-sitter parser, not just identify a language name**. If the detected language has no parser loaded, detection should continue to the next method.
 
-This applies to both document-level language detection and injected language resolution (e.g., code blocks in Markdown).
+This applies to parser selection for both document-level language detection and
+injected-language analysis. Bridge selection has a separate stability
+constraint: its canonical language key and virtual URI must be known before a
+parser is installed and must not change when parser availability changes.
 
 ## Decision
 
@@ -22,6 +25,10 @@ This applies to both document-level language detection and injected language res
 
 1. **Document-level**: Detecting the primary language when a file is opened
 2. **Injection-level**: Resolving embedded languages within a parsed document
+
+For bridge routing and virtual-document identity, first derive a
+parser-independent canonical injection candidate. Parser loading remains a
+later, separate decision.
 
 ```
 1. LSP languageId  →  Try direct  →  Try alias  →  If available: use it
@@ -134,12 +141,24 @@ Document (markdown) ──parse──▶ AST ──injection query──▶ "py"
                                                       ▶ "sh" ──detect──▶ bash
 ```
 
-For example, a Markdown code fence with ` ```py ` provides the identifier `"py"`, which must be resolved to an available parser. This resolution follows a fallback pattern:
+For example, a Markdown code fence with ` ```py ` provides the identifier
+`"py"`. Two related operations intentionally have different acceptance rules:
+
+- **Bridge canonicalization** produces a stable language key even when no
+  parser exists yet. It checks an explicit configured base, then syntect token
+  normalization, then first-line detection, and finally the raw identifier.
+  Thus `py` remains `python` before and after parser installation.
+- **Parser resolution** may then load or select the canonical language/base and
+  can still fail when no grammar is available.
+
+Parser resolution follows this fallback pattern:
 
 1. **Try the identifier directly**: Check if a parser named `"py"` is available
 2. **Normalize via syntect**: Use `detect_from_token("py")` which returns `"python"`
 3. **Try config-based alias**: If syntect doesn't recognize it, check user-configured aliases
-4. **Skip if unavailable**: If no parser matches, the region is skipped
+4. **Skip parser-backed analysis if unavailable**: Bridge routing can still use
+   the canonical candidate, but semantic/parser work skips the region when no
+   parser matches
 
 This means:
 - Injected languages benefit from the same graceful degradation
@@ -159,14 +178,16 @@ This means:
 ### Negative
 
 - **Heuristic overhead**: Reading file content for shebang detection adds I/O
-- **Non-deterministic**: Same file might use different parsers on different systems (based on available parsers)
+- **Parser selection can vary**: Same file might use different parsers on
+  different systems, while bridge language keys and virtual URIs remain stable
 - **Heuristic maintenance**: Shebang patterns need ongoing updates
 - **languageId naming variance**: Clients may send languageIds that differ from parser names (e.g., `shellscript` vs `bash`); normalization may be needed later
 
 ### Neutral
 
 - **Token-based detection includes extensions**: Extensions are treated as tokens, not a separate detection step
-- **Parser availability matters**: Detection result depends on what's installed
+- **Parser availability is scoped**: Parser-backed detection depends on what's
+  installed; bridge canonicalization does not
 - **Auto-install interaction**: Detection completes first (returning None if no parser found); auto-install runs asynchronously afterward, making the parser available for subsequent requests
 - **Caching**: Detection result is stored per-document; cache invalidates on content change or `languageId` change from client
 - **syntect dependency**: Uses syntect's Sublime Text syntax definitions for token normalization and first-line detection

--- a/docs/architecture-decisions/language-detection-fallback-chain.md
+++ b/docs/architecture-decisions/language-detection-fallback-chain.md
@@ -113,7 +113,7 @@ detect_language(path, content, token, language_id):
             return result
 
     // 3. First-line detection (shebang, mode line)
-    if syntect detects from first line:
+    if detected = syntect_detect_first_line(content):
         if try_with_base_fallback(detected) succeeds:
             return result
 

--- a/docs/architecture-decisions/language-detection-fallback-chain.md
+++ b/docs/architecture-decisions/language-detection-fallback-chain.md
@@ -148,8 +148,8 @@ For example, a Markdown code fence with ` ```py ` provides the identifier
 - **Bridge canonicalization** produces a stable language key even when no
   parser exists yet. It checks an explicit configured base, then syntect token
   normalization (and that candidate's base), then first-line detection (and
-  that candidate's base), and finally the raw identifier. Thus `py` remains
-  `python` before and after parser installation.
+  that candidate's base), and finally the raw identifier. Without an explicit
+  `py` base override, `py` remains `python` before and after parser installation.
 - **Parser resolution** may then load or select the canonical language/base and
   can still fail when no grammar is available.
 

--- a/docs/architecture-decisions/language-detection-fallback-chain.md
+++ b/docs/architecture-decisions/language-detection-fallback-chain.md
@@ -146,10 +146,13 @@ For example, a Markdown code fence with ` ```py ` provides the identifier
 `"py"`. Two related operations intentionally have different acceptance rules:
 
 - **Bridge canonicalization** produces a stable language key even when no
-  parser exists yet. It checks an explicit configured base, then syntect token
-  normalization (and that candidate's base), then first-line detection (and
-  that candidate's base), and finally the raw identifier. Without an explicit
-  `py` base override, `py` remains `python` before and after parser installation.
+  parser exists yet. It checks an eligible configured base mapping first. An
+  explicit unconfigured `plaintext` identifier then remains `plaintext` rather
+  than acquiring language features from its content. Other identifiers proceed
+  through syntect token normalization (and that candidate's base), then
+  first-line detection (and that candidate's base), and finally the raw
+  identifier. Without an eligible `py` base override, `py` remains `python`
+  before and after parser installation.
 - **Parser resolution** may then load or select the canonical language/base and
   can still fail when no grammar is available.
 

--- a/docs/architecture-decisions/language-detection-fallback-chain.md
+++ b/docs/architecture-decisions/language-detection-fallback-chain.md
@@ -61,7 +61,7 @@ Each detection method follows the **detect → base resolution → availability 
 
    If syntect doesn't recognize the token, it's tried directly as a base candidate.
    This handles extensions like `jsx`, `tsx` that syntect doesn't know but may be
-   configured with a base (e.g., `jsx.base = "javascript"`).
+   configured with a base (e.g., `[languages.jsx] base = "javascript"`).
 
 3. **First-line detection (lowest priority)**
    - Shebang detection: `#!/usr/bin/env python` → python

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1230,11 +1230,12 @@ impl LanguageCoordinator {
     /// Candidate selection deliberately does not inspect parser state: eager
     /// bridge selection and virtual URIs must stay stable before and after a
     /// parser loads. An eligible configured base mapping for the explicit
-    /// identifier takes precedence over syntect token normalization, followed by
-    /// first-line fallback. Consequently, registering a parser under a
-    /// non-canonical key such as `py` or `js` does not change bridge keys/URIs:
-    /// bridge configuration uses `python`/`javascript` unless that key has a
-    /// registered base mapping.
+    /// identifier takes precedence. An otherwise unconfigured explicit
+    /// `plaintext` remains `plaintext`; other identifiers proceed through syntect
+    /// token normalization and then first-line fallback. Consequently,
+    /// registering a parser under a non-canonical key such as `py` or `js` does
+    /// not change bridge keys/URIs: bridge configuration uses
+    /// `python`/`javascript` unless that key has a registered base mapping.
     pub(crate) fn canonical_injection_language(&self, identifier: &str, content: &str) -> String {
         if let Some(base) = self.resolve_base(identifier) {
             return base;

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1233,9 +1233,7 @@ impl LanguageCoordinator {
     /// does not change bridge keys/URIs: bridge configuration uses the canonical
     /// `python`/`javascript` name unless that alias has an explicit base.
     pub(crate) fn canonical_injection_language(&self, identifier: &str, content: &str) -> String {
-        if identifier != "plaintext"
-            && let Some(base) = self.resolve_base(identifier)
-        {
+        if let Some(base) = self.resolve_base(identifier) {
             return base;
         }
         if let Some(candidate) = super::heuristic::detect_from_token(identifier) {

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1370,12 +1370,14 @@ impl LanguageCoordinator {
         (None, "none", last_candidate)
     }
 
-    /// language-detection-fallback-chain injection-language detection. Same chain as `detect_language`
+    /// language-detection-fallback-chain injection-language detection. Normally uses the same chain as `detect_language`
     /// (1: direct id, 2: syntect normalisation `py→python`, `js→javascript`,
     /// 3: first-line shebang/mode-line) but *loads* the parser instead of
     /// only checking availability — injection discovery runs before we know
     /// which parsers are needed. Each step runs through `try_load_with_base`
-    /// for config-based base resolution (e.g. `rmd→markdown`).
+    /// for config-based base resolution (e.g. `rmd→markdown`). Explicit
+    /// `plaintext` is the exception: only an eligible configured base is loaded,
+    /// otherwise it remains featureless and returns `None` without heuristics.
     pub(crate) fn resolve_injection_language(
         &self,
         identifier: &str,

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -778,8 +778,10 @@ impl LanguageCoordinator {
 
     /// Resolve a derived languageId to its base language name.
     ///
-    /// Returns the base name if the input has a base declaration, otherwise None.
-    /// Example: "rmd" → Some("markdown") if rmd has `base = "markdown"`
+    /// Returns the registered base mapping, otherwise `None`. A declaration is
+    /// intentionally not registered when the derived language owns a distinct
+    /// parser; see [`Self::build_base_map`].
+    /// Example: "rmd" → Some("markdown") when its base mapping is eligible.
     fn resolve_base(&self, language_id: &str) -> Option<String> {
         let base_map = self
             .base_map
@@ -1227,11 +1229,12 @@ impl LanguageCoordinator {
     ///
     /// Candidate selection deliberately does not inspect parser state: eager
     /// bridge selection and virtual URIs must stay stable before and after a
-    /// parser loads. A configured base for the explicit identifier takes
-    /// precedence over syntect token normalization, followed by first-line
-    /// fallback. Consequently, registering a parser under a non-canonical key
-    /// such as `py` or `js` does not change bridge keys/URIs: bridge configuration
-    /// uses `python`/`javascript` unless that key has an explicit base.
+    /// parser loads. An eligible configured base mapping for the explicit
+    /// identifier takes precedence over syntect token normalization, followed by
+    /// first-line fallback. Consequently, registering a parser under a
+    /// non-canonical key such as `py` or `js` does not change bridge keys/URIs:
+    /// bridge configuration uses `python`/`javascript` unless that key has a
+    /// registered base mapping.
     pub(crate) fn canonical_injection_language(&self, identifier: &str, content: &str) -> String {
         if let Some(base) = self.resolve_base(identifier) {
             return base;

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1391,10 +1391,20 @@ impl LanguageCoordinator {
             content.len()
         );
 
-        // 1. Try direct identifier first (skip "plaintext")
-        if identifier != "plaintext"
-            && let Some(found) = self.try_load_with_base(identifier)
-        {
+        // 1. Try the identifier first. Explicit plaintext remains featureless
+        // unless it has an eligible configured base mapping; loading plaintext
+        // itself or applying content heuristics would violate that explicit key.
+        if identifier == "plaintext" {
+            let base = self.resolve_base(identifier)?;
+            let found = self.try_load_with_base(&base)?;
+            log::trace!(
+                target: "kakehashi::language_detection",
+                "Resolved injection '{}' -> '{}' via configured plaintext base",
+                identifier, found.0
+            );
+            return Some(found);
+        }
+        if let Some(found) = self.try_load_with_base(identifier) {
             log::trace!(
                 target: "kakehashi::language_detection",
                 "Resolved injection '{}' -> '{}' via identifier (direct or base)",
@@ -1939,6 +1949,42 @@ mod tests {
         let (resolved, load_result) = result.unwrap();
         assert_eq!(resolved, "markdown");
         assert!(load_result.success);
+    }
+
+    #[test]
+    fn test_injection_plaintext_uses_eligible_config_base() {
+        let coordinator = LanguageCoordinator::new();
+        coordinator
+            .language_registry_for_parallel()
+            .register("python".to_string(), tree_sitter_rust::LANGUAGE.into());
+        coordinator.build_base_map(&HashMap::from([(
+            "plaintext".to_string(),
+            crate::config::settings::LanguageSettings {
+                base: Some("python".to_string()),
+                ..Default::default()
+            },
+        )]));
+
+        let (resolved, load_result) = coordinator
+            .resolve_injection_language("plaintext", "#!/usr/bin/env ruby")
+            .expect("eligible plaintext base must drive parser resolution");
+
+        assert_eq!(resolved, "python");
+        assert!(load_result.success);
+    }
+
+    #[test]
+    fn test_injection_plaintext_without_base_stays_featureless() {
+        let coordinator = LanguageCoordinator::new();
+        coordinator
+            .language_registry_for_parallel()
+            .register("python".to_string(), tree_sitter_rust::LANGUAGE.into());
+
+        assert!(
+            coordinator
+                .resolve_injection_language("plaintext", "#!/usr/bin/env python")
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1235,7 +1235,8 @@ impl LanguageCoordinator {
     /// token normalization and then first-line fallback. Consequently,
     /// registering a parser under a non-canonical key such as `py` or `js` does
     /// not change bridge keys/URIs: bridge configuration uses
-    /// `python`/`javascript` unless that key has a registered base mapping.
+    /// `python`/`javascript` unless the explicit identifier itself has an
+    /// eligible base mapping (for example, `py.base`).
     pub(crate) fn canonical_injection_language(&self, identifier: &str, content: &str) -> String {
         if let Some(base) = self.resolve_base(identifier) {
             return base;
@@ -1884,7 +1885,7 @@ mod tests {
         // Register "python" parser
         coordinator
             .language_registry_for_parallel()
-            .register("python".to_string(), tree_sitter_rust::LANGUAGE.into());
+            .register("python".to_string(), tree_sitter_python::LANGUAGE.into());
 
         // Direct identifier "python" should work
         let result = coordinator.resolve_injection_language("python", "print('hello')");
@@ -1900,7 +1901,7 @@ mod tests {
         // Register "python" parser (not "py")
         coordinator
             .language_registry_for_parallel()
-            .register("python".to_string(), tree_sitter_rust::LANGUAGE.into());
+            .register("python".to_string(), tree_sitter_python::LANGUAGE.into());
 
         // Token "py" should resolve to "python" via syntect's detect_from_token
         let result = coordinator.resolve_injection_language("py", "print('hello')");

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1981,7 +1981,7 @@ mod tests {
         let coordinator = LanguageCoordinator::new();
         coordinator
             .language_registry_for_parallel()
-            .register("python".to_string(), tree_sitter_rust::LANGUAGE.into());
+            .register("python".to_string(), tree_sitter_python::LANGUAGE.into());
 
         assert!(
             coordinator
@@ -2017,7 +2017,7 @@ mod tests {
         // Register "python" parser
         coordinator
             .language_registry_for_parallel()
-            .register("python".to_string(), tree_sitter_rust::LANGUAGE.into());
+            .register("python".to_string(), tree_sitter_python::LANGUAGE.into());
 
         // Injection with unknown identifier but Python shebang in content
         let content = "#!/usr/bin/env python\nprint('hello')";

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1959,7 +1959,7 @@ mod tests {
         let coordinator = LanguageCoordinator::new();
         coordinator
             .language_registry_for_parallel()
-            .register("python".to_string(), tree_sitter_rust::LANGUAGE.into());
+            .register("python".to_string(), tree_sitter_python::LANGUAGE.into());
         coordinator.build_base_map(&HashMap::from([(
             "plaintext".to_string(),
             crate::config::settings::LanguageSettings {

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1236,6 +1236,9 @@ impl LanguageCoordinator {
         if let Some(base) = self.resolve_base(identifier) {
             return base;
         }
+        if identifier == "plaintext" {
+            return identifier.to_string();
+        }
         if let Some(candidate) = super::heuristic::detect_from_token(identifier) {
             return self.resolve_base(&candidate).unwrap_or(candidate);
         }

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1228,10 +1228,10 @@ impl LanguageCoordinator {
     /// Candidate selection deliberately does not inspect parser state: eager
     /// bridge selection and virtual URIs must stay stable before and after a
     /// parser loads. A configured base for the explicit identifier takes
-    /// precedence over generic token aliases, followed by first-line fallback.
-    /// Consequently, registering a parser under an alias such as `py` or `js`
-    /// does not change bridge keys/URIs: bridge configuration uses the canonical
-    /// `python`/`javascript` name unless that alias has an explicit base.
+    /// precedence over syntect token normalization, followed by first-line
+    /// fallback. Consequently, registering a parser under a non-canonical key
+    /// such as `py` or `js` does not change bridge keys/URIs: bridge configuration
+    /// uses `python`/`javascript` unless that key has an explicit base.
     pub(crate) fn canonical_injection_language(&self, identifier: &str, content: &str) -> String {
         if let Some(base) = self.resolve_base(identifier) {
             return base;

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1212,9 +1212,7 @@ impl LanguageCoordinator {
     /// (1) LSP `languageId` (if not `"plaintext"`); (2) heuristics — explicit
     /// token (`"py"`, `"js"`), path token via `extract_token_from_path`, then
     /// first-line content (shebang, mode line, Emacs markers).
-    /// Host call: `detect_language(path, content, None, language_id)`;
-    /// injection call: `detect_language_hot(token, content, Some(token),
-    /// Some(token))` — the per-region hot path logs at TRACE.
+    /// Host call: `detect_language(path, content, None, language_id)`.
     pub(crate) fn detect_language(
         &self,
         path: &str,
@@ -1225,39 +1223,23 @@ impl LanguageCoordinator {
         self.detect_language_logged(path, content, token, language_id, log::Level::Debug)
     }
 
-    /// Hot-path variant of [`Self::detect_language`] that logs at TRACE.
-    ///
-    /// Per-injection-region resolution runs this once per region per walk —
-    /// thousands of calls per second during a typing storm — and per-call
-    /// DEBUG formatting/writes flood stderr (measured ~16k lines/sec, dwarfing
-    /// the detection chain itself). The chain is identical; only the log level
-    /// differs, matching `resolve_injection_language`'s TRACE convention.
-    pub(crate) fn detect_language_hot(
-        &self,
-        path: &str,
-        content: &str,
-        token: Option<&str>,
-        language_id: Option<&str>,
-    ) -> Option<String> {
-        self.detect_language_logged(path, content, token, language_id, log::Level::Trace)
-    }
-
     /// Canonical injection language for bridge selection and virtual URIs.
     ///
-    /// Prefer the established parser-aware detection result. When no parser is
-    /// available yet, retain a normalized token, configured base, or first-line
-    /// candidate so eager bridge selection does not fall back to a raw alias.
+    /// Candidate selection deliberately does not inspect parser state: eager
+    /// bridge selection and virtual URIs must stay stable before and after a
+    /// parser loads. A configured base for the explicit identifier takes
+    /// precedence over generic token aliases, followed by first-line fallback.
+    /// Consequently, registering a parser under an alias such as `py` or `js`
+    /// does not change bridge keys/URIs: bridge configuration uses the canonical
+    /// `python`/`javascript` name unless that alias has an explicit base.
     pub(crate) fn canonical_injection_language(&self, identifier: &str, content: &str) -> String {
-        if let Some(language) =
-            self.detect_language_hot(identifier, content, Some(identifier), Some(identifier))
+        if identifier != "plaintext"
+            && let Some(base) = self.resolve_base(identifier)
         {
-            return language;
+            return base;
         }
         if let Some(candidate) = super::heuristic::detect_from_token(identifier) {
             return self.resolve_base(&candidate).unwrap_or(candidate);
-        }
-        if let Some(base) = self.resolve_base(identifier) {
-            return base;
         }
         if let Some(candidate) = super::heuristic::detect_from_first_line(content) {
             return self.resolve_base(&candidate).unwrap_or(candidate);

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1206,8 +1206,8 @@ impl LanguageCoordinator {
             && self.has_current_parser_registration(language_name, generation)
     }
 
-    /// language-detection-fallback-chain unified detection chain for host docs and injections; returns
-    /// the first language with an available parser. Each stage is
+    /// Parser-aware language-detection fallback chain for host documents;
+    /// returns the first language with an available parser. Each stage is
     /// detect → base resolution → availability:
     /// (1) LSP `languageId` (if not `"plaintext"`); (2) heuristics — explicit
     /// token (`"py"`, `"js"`), path token via `extract_token_from_path`, then

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1242,6 +1242,29 @@ impl LanguageCoordinator {
         self.detect_language_logged(path, content, token, language_id, log::Level::Trace)
     }
 
+    /// Canonical injection language for bridge selection and virtual URIs.
+    ///
+    /// Prefer the established parser-aware detection result. When no parser is
+    /// available yet, retain a normalized token, configured base, or first-line
+    /// candidate so eager bridge selection does not fall back to a raw alias.
+    pub(crate) fn canonical_injection_language(&self, identifier: &str, content: &str) -> String {
+        if let Some(language) =
+            self.detect_language_hot(identifier, content, Some(identifier), Some(identifier))
+        {
+            return language;
+        }
+        if let Some(candidate) = super::heuristic::detect_from_token(identifier) {
+            return self.resolve_base(&candidate).unwrap_or(candidate);
+        }
+        if let Some(base) = self.resolve_base(identifier) {
+            return base;
+        }
+        if let Some(candidate) = super::heuristic::detect_from_first_line(content) {
+            return self.resolve_base(&candidate).unwrap_or(candidate);
+        }
+        identifier.to_string()
+    }
+
     fn detect_language_logged(
         &self,
         path: &str,

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -511,8 +511,8 @@ impl InjectionResolver {
     /// Derive a parser-independent canonical injection language for bridge
     /// selection and stable virtual-document identity.
     ///
-    /// This normalizes raw fence identifiers (e.g., "py") to canonical language names
-    /// (e.g., "python") that match bridge server configurations.
+    /// This derives the stable bridge key from an explicit configured base or
+    /// heuristic normalization (for example, `py` to `python`).
     ///
     /// Falls back to the raw identifier when no configured or heuristic
     /// canonical candidate exists; bridge matching then uses that explicit key.

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -728,6 +728,26 @@ mod tests {
         );
     }
 
+    #[test]
+    fn configured_plaintext_base_is_canonical_for_bridge() {
+        let coordinator = LanguageCoordinator::new();
+        coordinator.load_settings(&crate::config::WorkspaceSettings {
+            languages: std::collections::HashMap::from([(
+                "plaintext".to_string(),
+                crate::config::settings::LanguageSettings {
+                    base: Some("python".to_string()),
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            InjectionResolver::resolve_language(&coordinator, "plaintext", ""),
+            "python"
+        );
+    }
+
     /// Helper: parse `text` with tree-sitter Rust, match `string_content` nodes
     /// via injection query, and return the `CacheableInjectionRegion` for the first match.
     fn cacheable_from_first_injection(text: &str) -> CacheableInjectionRegion {

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -520,14 +520,7 @@ impl InjectionResolver {
         raw_identifier: &str,
         content: &str,
     ) -> String {
-        coordinator
-            .detect_language_hot(
-                raw_identifier, // Use identifier as path for token extraction
-                content,
-                Some(raw_identifier), // Explicit token
-                Some(raw_identifier), // Also try as languageId
-            )
-            .unwrap_or_else(|| raw_identifier.to_string())
+        coordinator.canonical_injection_language(raw_identifier, content)
     }
 
     /// Build a [`ResolvedInjection`] from a raw injection region.
@@ -664,6 +657,16 @@ mod tests {
 
     fn test_coordinator() -> LanguageCoordinator {
         LanguageCoordinator::new()
+    }
+
+    #[test]
+    fn canonicalizes_token_without_loaded_parser() {
+        let coordinator = LanguageCoordinator::new();
+
+        assert_eq!(
+            InjectionResolver::resolve_language(&coordinator, "py", "print('hello')"),
+            "python"
+        );
     }
 
     /// Helper: parse `text` with tree-sitter Rust, match `string_content` nodes

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -696,7 +696,7 @@ mod tests {
     }
 
     #[test]
-    fn configured_base_beats_generic_token_alias_without_parser() {
+    fn configured_base_beats_syntect_token_normalization_without_parser() {
         let coordinator = LanguageCoordinator::new();
         coordinator.load_settings(&crate::config::WorkspaceSettings {
             languages: std::collections::HashMap::from([(

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -508,13 +508,14 @@ impl InjectionResolver {
         )
     }
 
-    /// Resolve injection language using the unified detection chain (language-detection-fallback-chain).
+    /// Derive a parser-independent canonical injection language for bridge
+    /// selection and stable virtual-document identity.
     ///
     /// This normalizes raw fence identifiers (e.g., "py") to canonical language names
     /// (e.g., "python") that match bridge server configurations.
     ///
-    /// Falls back to the raw identifier if no resolution is found, allowing the
-    /// bridge lookup to fail gracefully with a clear error message.
+    /// Falls back to the raw identifier when no configured or heuristic
+    /// canonical candidate exists; bridge matching then uses that explicit key.
     fn resolve_language(
         coordinator: &LanguageCoordinator,
         raw_identifier: &str,

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -660,11 +660,70 @@ mod tests {
     }
 
     #[test]
-    fn canonicalizes_token_without_loaded_parser() {
+    fn canonicalizes_token_independently_of_parser_availability() {
         let coordinator = LanguageCoordinator::new();
 
         assert_eq!(
             InjectionResolver::resolve_language(&coordinator, "py", "print('hello')"),
+            "python"
+        );
+
+        coordinator
+            .language_registry_for_parallel()
+            .register("py".to_string(), tree_sitter_python::LANGUAGE.into());
+        assert_eq!(
+            InjectionResolver::resolve_language(&coordinator, "py", "print('hello')"),
+            "python"
+        );
+    }
+
+    #[test]
+    fn explicit_token_beats_loaded_first_line_language() {
+        let coordinator = LanguageCoordinator::new();
+        coordinator
+            .language_registry_for_parallel()
+            .register("lua".to_string(), tree_sitter_lua::LANGUAGE.into());
+
+        assert_eq!(
+            InjectionResolver::resolve_language(
+                &coordinator,
+                "py",
+                "#!/usr/bin/env lua\nprint('hello')",
+            ),
+            "python"
+        );
+    }
+
+    #[test]
+    fn configured_base_beats_generic_token_alias_without_parser() {
+        let coordinator = LanguageCoordinator::new();
+        coordinator.load_settings(&crate::config::WorkspaceSettings {
+            languages: std::collections::HashMap::from([(
+                "py".to_string(),
+                crate::config::settings::LanguageSettings {
+                    base: Some("custom-python".to_string()),
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            InjectionResolver::resolve_language(&coordinator, "py", ""),
+            "custom-python"
+        );
+    }
+
+    #[test]
+    fn canonicalizes_first_line_without_loaded_parser() {
+        let coordinator = LanguageCoordinator::new();
+
+        assert_eq!(
+            InjectionResolver::resolve_language(
+                &coordinator,
+                "unknown",
+                "#!/usr/bin/env python\nprint('hello')",
+            ),
             "python"
         );
     }

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -749,6 +749,20 @@ mod tests {
         );
     }
 
+    #[test]
+    fn explicit_plaintext_ignores_first_line_heuristics() {
+        let coordinator = LanguageCoordinator::new();
+
+        assert_eq!(
+            InjectionResolver::resolve_language(
+                &coordinator,
+                "plaintext",
+                "#!/usr/bin/env python\nprint('hello')",
+            ),
+            "plaintext"
+        );
+    }
+
     /// Helper: parse `text` with tree-sitter Rust, match `string_content` nodes
     /// via injection query, and return the `CacheableInjectionRegion` for the first match.
     fn cacheable_from_first_injection(text: &str) -> CacheableInjectionRegion {

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -406,8 +406,8 @@ impl InjectionCoordinator {
 }
 
 fn parser_enabled_injection_language(language: &str) -> bool {
-    // Explicit, unconfigured plaintext is deliberately featureless. A configured
-    // plaintext base is canonicalized to that base before reaching this loop.
+    // Explicit, unconfigured plaintext is deliberately featureless. An eligible
+    // configured plaintext base is canonicalized before reaching this loop.
     language != "plaintext"
 }
 

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -311,7 +311,10 @@ impl InjectionCoordinator {
         // an already-registered language returns no events).
         let mut load_events: Vec<LanguageEvent> = Vec::new();
 
-        for lang in languages {
+        for lang in languages
+            .iter()
+            .filter(|lang| parser_enabled_injection_language(lang))
+        {
             let resolved_lang = if self.language.has_parser_available(lang) {
                 lang.clone()
             } else if let Some(normalized) = crate::language::heuristic::detect_from_token(lang) {
@@ -402,9 +405,21 @@ impl InjectionCoordinator {
     }
 }
 
+fn parser_enabled_injection_language(language: &str) -> bool {
+    // Explicit, unconfigured plaintext is deliberately featureless. A configured
+    // plaintext base is canonicalized to that base before reaching this loop.
+    language != "plaintext"
+}
+
 #[cfg(test)]
 mod tests {
-    use super::InjectionResolver;
+    use super::{InjectionResolver, parser_enabled_injection_language};
+
+    #[test]
+    fn explicit_plaintext_does_not_request_a_parser() {
+        assert!(!parser_enabled_injection_language("plaintext"));
+        assert!(parser_enabled_injection_language("python"));
+    }
     use std::sync::Arc;
     use tokio::sync::Notify;
     use tower_lsp_server::LspService;


### PR DESCRIPTION
## Stack dependency

This PR is intentionally stacked on #692 (`fix/issue-687-canonical-injection-language`). #692 establishes the shared `ResolvedInjection` path used by eager and interactive bridge dispatch; this PR changes that shared resolver policy. Review only the commits/diff relative to the #692 branch. Merge #692 first, then retarget this PR to `main`.

## Summary

- canonicalize bridge injection tokens, configured bases, and first-line candidates without consulting parser availability
- keep bridge language keys and virtual-document URIs stable before and after parser installation
- preserve configured base priority over generic syntect aliases
- document the separate bridge-canonicalization and parser-resolution contracts in the language-detection ADR

## Regression coverage

- `py` resolves to `python` before and after registering a parser under raw alias `py`
- explicit `py` beats a conflicting loaded shebang language
- configured `py.base` overrides generic token normalization without a parser
- unknown identifier uses Python shebang without a loaded parser
- configured `plaintext.base` is honored for bridge identity

## Validation

- `TREE_SITTER_GRAMMARS=/Users/atusy/ghq/github.com/atusy/kakehashi___main/deps/tree-sitter cargo test --lib -q` — 2799 passed, 2 ignored
- focused alias/base/first-line regressions
- `make check`

Closes #691

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated migration guidance from `aliases` to `base`, including language inheritance and canonicalization behavior.
  * Reworked language detection fallback documentation to reflect parser-availability-aware selection while keeping stable canonical identity.

* **Bug Fixes**
  * Improved injected-language canonicalization with clearer precedence across configured `base`, explicit tokens, and heuristics.
  * Tightened `plaintext` handling so it resolves only via eligible configured mappings; otherwise it stays unresolved.
  * Prevented injected-language auto-install/load when injection parsing is disabled.

* **Tests**
  * Expanded injected-language canonicalization and `plaintext` edge-case coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->