### PR TITLE
fix(install): recover from corrupt metadata cache

### DIFF
--- a/src/install/cache.rs
+++ b/src/install/cache.rs
@@ -4,7 +4,7 @@
 //! when fetching parser metadata from nvim-treesitter.
 
 use std::fs;
-use std::io;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
@@ -65,11 +65,13 @@ impl MetadataCache {
     pub fn write(&self, content: &str) -> io::Result<()> {
         // Ensure cache directory exists
         fs::create_dir_all(&self.cache_dir)?;
-
-        // Write content
-        fs::write(self.cache_path(), content)?;
-
-        Ok(())
+        let mut staged = tempfile::NamedTempFile::new_in(&self.cache_dir)?;
+        staged.write_all(content.as_bytes())?;
+        staged.flush()?;
+        staged
+            .persist(self.cache_path())
+            .map(|_| ())
+            .map_err(|error| error.error)
     }
 }
 

--- a/src/install/cache.rs
+++ b/src/install/cache.rs
@@ -67,11 +67,17 @@ impl MetadataCache {
         fs::create_dir_all(&self.cache_dir)?;
         let mut staged = tempfile::NamedTempFile::new_in(&self.cache_dir)?;
         staged.write_all(content.as_bytes())?;
-        staged.flush()?;
+        staged.as_file().sync_all()?;
         staged
             .persist(self.cache_path())
-            .map(|_| ())
-            .map_err(|error| error.error)
+            .map_err(|error| error.error)?;
+        // A directory sync makes the rename durable on filesystems that
+        // buffer directory-entry updates. Data is already durable, so keep
+        // this best-effort for platforms that cannot sync directories.
+        if let Ok(directory) = fs::File::open(&self.cache_dir) {
+            let _ = directory.sync_all();
+        }
+        Ok(())
     }
 }
 

--- a/src/install/metadata.rs
+++ b/src/install/metadata.rs
@@ -165,7 +165,7 @@ fn fetch_parsers_lua() -> Result<String, MetadataError> {
 fn parse_parsers_lua(content: &str) -> Result<HashMap<String, ParserMetadata>, MetadataError> {
     let mut parsers = HashMap::new();
 
-    let lang_names = top_level_table_keys(content);
+    let lang_names = top_level_table_keys(content)?;
 
     // For each language, find its block and extract metadata
     for (lang, block) in lang_names {
@@ -194,15 +194,18 @@ fn parse_parsers_lua(content: &str) -> Result<HashMap<String, ParserMetadata>, M
     Ok(parsers)
 }
 
-fn top_level_table_keys(s: &str) -> Vec<(String, &str)> {
+fn top_level_table_keys(s: &str) -> Result<Vec<(String, &str)>, MetadataError> {
     let Some(offset) = returned_table_start(s) else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
     table_entries(s, offset)
         .into_iter()
-        .filter_map(|(name, value)| match value {
-            LuaValue::Table(block) if !is_reserved_key(&name) => Some((name, block)),
-            _ => None,
+        .filter_map(|(name, value)| match (is_reserved_key(&name), value) {
+            (true, _) => None,
+            (false, LuaValue::Table(block)) => Some(Ok((name, block))),
+            (false, LuaValue::String(_)) => Some(Err(MetadataError::ParseError(format!(
+                "invalid parser entry for {name}"
+            )))),
         })
         .collect()
 }
@@ -741,6 +744,16 @@ mod tests {
     #[test]
     fn non_table_install_info_invalidates_the_document() {
         let content = "return {\nlua = { install_info = { url = 'https://example/lua', revision = 'ok' } },\nrust = { install_info = 'damaged' },\n}";
+
+        assert!(matches!(
+            parse_complete_parsers_lua(content),
+            Err(MetadataError::ParseError(_))
+        ));
+    }
+
+    #[test]
+    fn non_table_parser_entry_invalidates_the_document() {
+        let content = "return {\nlua = { install_info = { url = 'https://example/lua', revision = 'ok' } },\nrust = 'damaged',\n}";
 
         assert!(matches!(
             parse_complete_parsers_lua(content),

--- a/src/install/metadata.rs
+++ b/src/install/metadata.rs
@@ -104,16 +104,29 @@ fn fetch_parsers_lua_with_options(
         }
     });
 
-    // Try cache first
-    if let Some(ref cache) = cache
+    load_parsers_lua(cache.as_ref(), fetch_parsers_lua)
+}
+
+fn load_parsers_lua(
+    cache: Option<&MetadataCache>,
+    fetch: impl FnOnce() -> Result<String, MetadataError>,
+) -> Result<HashMap<String, ParserMetadata>, MetadataError> {
+    if let Some(cache) = cache
         && let Some(cached_content) = cache.read()
     {
         return parse_parsers_lua(&cached_content);
     }
 
-    // Cache miss or no cache - fetch from network
-    let agent = agent_with_timeout(PARSERS_LUA_HTTP_TIMEOUT);
+    let content = fetch()?;
+    if let Some(cache) = cache {
+        // Ignore cache write errors - caching is best-effort
+        let _ = cache.write(&content);
+    }
+    parse_parsers_lua(&content)
+}
 
+fn fetch_parsers_lua() -> Result<String, MetadataError> {
+    let agent = agent_with_timeout(PARSERS_LUA_HTTP_TIMEOUT);
     let mut response = agent.get(PARSERS_LUA_URL).call().map_err(|e| match e {
         ureq::Error::Timeout(_) => MetadataError::Timeout,
         ureq::Error::StatusCode(code) => {
@@ -122,18 +135,10 @@ fn fetch_parsers_lua_with_options(
         e => MetadataError::HttpError(e.to_string()),
     })?;
 
-    let content = response.body_mut().read_to_string().map_err(|e| match e {
+    response.body_mut().read_to_string().map_err(|e| match e {
         ureq::Error::Timeout(_) => MetadataError::Timeout,
         e => MetadataError::HttpError(e.to_string()),
-    })?;
-
-    // Update cache if available
-    if let Some(cache) = cache {
-        // Ignore cache write errors - caching is best-effort
-        let _ = cache.write(&content);
-    }
-
-    parse_parsers_lua(&content)
+    })
 }
 
 /// Parse the parsers.lua content to extract parser information.

--- a/src/install/metadata.rs
+++ b/src/install/metadata.rs
@@ -166,25 +166,7 @@ fn fetch_parsers_lua() -> Result<String, MetadataError> {
 fn parse_parsers_lua(content: &str) -> Result<HashMap<String, ParserMetadata>, MetadataError> {
     let mut parsers = HashMap::new();
 
-    // Pattern to match parser entries in main branch format: lang = { ... }
-    // The pattern matches language names at the start of a line (with optional indentation)
-    // followed by = {
-    let lang_pattern = Regex::new(r#"(?m)^([ \t]*)([a-zA-Z][a-zA-Z0-9_]*)\s*=\s*\{"#)
-        .expect("valid regex for lang pattern");
-
-    // Language entries share the table's minimum indentation. Restricting to
-    // that level keeps nested install_info fields from looking like languages.
-    let candidates: Vec<(usize, String)> = lang_pattern
-        .captures_iter(content)
-        .filter_map(|cap| Some((cap.get(1)?.as_str().len(), cap.get(2)?.as_str().to_string())))
-        // Filter out non-language keys like "return", "install_info", etc.
-        .filter(|(_, name)| !is_reserved_key(name))
-        .collect();
-    let top_level_indent = candidates.iter().map(|(indent, _)| *indent).min();
-    let lang_names = candidates
-        .into_iter()
-        .filter(|(indent, _)| Some(*indent) == top_level_indent)
-        .map(|(_, name)| name);
+    let lang_names = top_level_table_keys(content);
 
     // For each language, find its block and extract metadata
     for lang in lang_names {
@@ -206,6 +188,118 @@ fn parse_parsers_lua(content: &str) -> Result<HashMap<String, ParserMetadata>, M
     }
 
     Ok(parsers)
+}
+
+fn top_level_table_keys(s: &str) -> Vec<String> {
+    let Some(mut offset) = returned_table_start(s) else {
+        return Vec::new();
+    };
+    let mut keys = Vec::new();
+    let mut depth = 0;
+    let mut quote = None;
+    let mut escaped = false;
+    let mut line_comment = false;
+    let mut long_bracket = None;
+
+    while offset < s.len() {
+        if let Some(equals) = long_bracket {
+            if is_long_bracket_close(&s[offset..], equals) {
+                offset += equals + 2;
+                long_bracket = None;
+            } else if let Some(c) = s[offset..].chars().next() {
+                offset += c.len_utf8();
+            }
+            continue;
+        }
+
+        let Some(c) = s[offset..].chars().next() else {
+            break;
+        };
+        let char_len = c.len_utf8();
+        if line_comment {
+            if c == '\n' {
+                line_comment = false;
+            }
+            offset += char_len;
+            continue;
+        }
+        if let Some(delimiter) = quote {
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == delimiter {
+                quote = None;
+            }
+            offset += char_len;
+            continue;
+        }
+        if s[offset..].starts_with("--") {
+            offset += 2;
+            if let Some(equals) = long_bracket_open(&s[offset..]) {
+                offset += equals + 2;
+                long_bracket = Some(equals);
+            } else {
+                line_comment = true;
+            }
+            continue;
+        }
+        if let Some(equals) = long_bracket_open(&s[offset..]) {
+            offset += equals + 2;
+            long_bracket = Some(equals);
+            continue;
+        }
+
+        if depth == 1
+            && c.is_ascii_alphabetic()
+            && (offset == 0
+                || !s[..offset]
+                    .chars()
+                    .next_back()
+                    .is_some_and(is_lua_identifier_char))
+        {
+            let name_len = s[offset..]
+                .chars()
+                .take_while(|next| is_lua_identifier_char(*next))
+                .map(char::len_utf8)
+                .sum::<usize>();
+            let name_end = offset + name_len;
+            let whitespace = s[name_end..]
+                .chars()
+                .take_while(|next| next.is_whitespace())
+                .map(char::len_utf8)
+                .sum::<usize>();
+            let equals = name_end + whitespace;
+            if s[equals..].starts_with('=') {
+                let after_equals = equals + 1;
+                let whitespace = s[after_equals..]
+                    .chars()
+                    .take_while(|next| next.is_whitespace())
+                    .map(char::len_utf8)
+                    .sum::<usize>();
+                if s[after_equals + whitespace..].starts_with('{') {
+                    let name = &s[offset..name_end];
+                    if !is_reserved_key(name) {
+                        keys.push(name.to_string());
+                    }
+                }
+            }
+        }
+
+        match c {
+            '\'' | '"' => quote = Some(c),
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            _ => {}
+        }
+        offset += char_len;
+    }
+    keys
 }
 
 /// Check if a key is a reserved/internal key (not a language name)
@@ -583,6 +677,16 @@ mod tests {
             parse_complete_parsers_lua(content),
             Err(MetadataError::ParseError(_))
         ));
+    }
+
+    #[test]
+    fn top_level_entries_do_not_depend_on_indentation() {
+        let content = "return {\nlua = { install_info = { url = 'https://example/lua', revision = 'lua-rev' } },\n  rust = { install_info = { url = 'https://example/rust', revision = 'rust-rev' } },\n}";
+        let parsers = parse_complete_parsers_lua(content).expect("complete metadata");
+
+        assert_eq!(parsers.len(), 2);
+        assert!(parsers.contains_key("lua"));
+        assert!(parsers.contains_key("rust"));
     }
 
     #[test]

--- a/src/install/metadata.rs
+++ b/src/install/metadata.rs
@@ -169,14 +169,11 @@ fn parse_parsers_lua(content: &str) -> Result<HashMap<String, ParserMetadata>, M
     let lang_names = top_level_table_keys(content);
 
     // For each language, find its block and extract metadata
-    for lang in lang_names {
-        let block = parser_metadata_block(content, &lang).ok_or_else(|| {
-            MetadataError::ParseError(format!("incomplete parser block for {lang}"))
-        })?;
+    for (lang, block) in lang_names {
         // Query-only entries (for example upstream `ecma`) intentionally have
         // no install_info and are not installable parsers.
         if block.contains("install_info") {
-            let info = extract_parser_metadata(content, &lang).ok_or_else(|| {
+            let info = extract_parser_metadata_from_block(block).ok_or_else(|| {
                 MetadataError::ParseError(format!("incomplete parser metadata for {lang}"))
             })?;
             parsers.insert(lang, info);
@@ -190,7 +187,7 @@ fn parse_parsers_lua(content: &str) -> Result<HashMap<String, ParserMetadata>, M
     Ok(parsers)
 }
 
-fn top_level_table_keys(s: &str) -> Vec<String> {
+fn top_level_table_keys(s: &str) -> Vec<(String, &str)> {
     let Some(mut offset) = returned_table_start(s) else {
         return Vec::new();
     };
@@ -279,8 +276,11 @@ fn top_level_table_keys(s: &str) -> Vec<String> {
                     .sum::<usize>();
                 if s[after_equals + whitespace..].starts_with('{') {
                     let name = &s[offset..name_end];
-                    if !is_reserved_key(name) {
-                        keys.push(name.to_string());
+                    let block_start = after_equals + whitespace;
+                    if !is_reserved_key(name)
+                        && let Some(block) = find_matching_brace(&s[block_start..])
+                    {
+                        keys.push((name.to_string(), block));
                     }
                 }
             }
@@ -317,10 +317,7 @@ fn is_reserved_key(name: &str) -> bool {
     )
 }
 
-/// Extract parser metadata for a specific language from parsers.lua content.
-fn extract_parser_metadata(content: &str, language: &str) -> Option<ParserMetadata> {
-    let block_content = parser_metadata_block(content, language)?;
-
+fn extract_parser_metadata_from_block(block_content: &str) -> Option<ParserMetadata> {
     // Extract URL (required)
     let url_re = Regex::new(r#"url\s*=\s*'([^']+)'"#).ok()?;
     let url = url_re
@@ -347,19 +344,6 @@ fn extract_parser_metadata(content: &str, language: &str) -> Option<ParserMetada
         revision,
         location,
     })
-}
-
-fn parser_metadata_block<'a>(content: &'a str, language: &str) -> Option<&'a str> {
-    // Find the start of this language's block
-    // Use word boundary to avoid matching substrings (e.g., "c" matching "cpp")
-    let block_start_pattern = format!(r#"(?m)^\s*{}\s*=\s*\{{"#, regex::escape(language));
-    let block_start_re = Regex::new(&block_start_pattern).ok()?;
-
-    let block_start = block_start_re.find(content)?;
-    let start_pos = block_start.start();
-
-    // Find the end of this block by counting braces
-    find_matching_brace(&content[start_pos..])
 }
 
 /// Find the content within matching braces starting from the first `{`.
@@ -690,6 +674,15 @@ mod tests {
     }
 
     #[test]
+    fn preamble_examples_do_not_shadow_returned_entries() {
+        let content = "--[=[\nlua = { install_info = { url = 'https://example/wrong', revision = 'wrong' } }\n]=]\nreturn {\nlua = { install_info = { url = 'https://example/lua', revision = 'right' } },\n}";
+        let parsers = parse_complete_parsers_lua(content).expect("complete metadata");
+
+        assert_eq!(parsers["lua"].url, "https://example/lua");
+        assert_eq!(parsers["lua"].revision, "right");
+    }
+
+    #[test]
     fn test_fetch_parser_metadata_with_caching() {
         // This test verifies that FetchOptions can be used to enable caching
         let temp = tempdir().expect("Failed to create temp dir");
@@ -787,7 +780,7 @@ return {
 
     #[test]
     fn test_extract_parser_metadata() {
-        let content = r#"
+        let content = r#"return {
   rust = {
     install_info = {
       revision = 'abc123',
@@ -795,9 +788,11 @@ return {
     },
     tier = 1,
   },
+}
 "#;
 
-        let info = extract_parser_metadata(content, "rust").expect("should extract");
+        let parsers = parse_parsers_lua(content).expect("should parse");
+        let info = parsers.get("rust").expect("should extract");
         assert_eq!(info.url, "https://github.com/tree-sitter/tree-sitter-rust");
         assert_eq!(info.revision, "abc123");
         assert!(info.location.is_none());
@@ -805,7 +800,7 @@ return {
 
     #[test]
     fn test_extract_parser_metadata_with_location() {
-        let content = r#"
+        let content = r#"return {
   markdown = {
     install_info = {
       location = 'tree-sitter-markdown',
@@ -814,9 +809,11 @@ return {
     },
     tier = 2,
   },
+}
 "#;
 
-        let info = extract_parser_metadata(content, "markdown").expect("should extract");
+        let parsers = parse_parsers_lua(content).expect("should parse");
+        let info = parsers.get("markdown").expect("should extract");
         assert_eq!(
             info.url,
             "https://github.com/tree-sitter-grammars/tree-sitter-markdown"

--- a/src/install/metadata.rs
+++ b/src/install/metadata.rs
@@ -6,7 +6,6 @@
 //! The main branch of nvim-treesitter uses a consolidated format where each language
 //! entry contains url, revision, and location all in one place.
 
-use regex::Regex;
 use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
@@ -172,7 +171,7 @@ fn parse_parsers_lua(content: &str) -> Result<HashMap<String, ParserMetadata>, M
     for (lang, block) in lang_names {
         // Query-only entries (for example upstream `ecma`) intentionally have
         // no install_info and are not installable parsers.
-        if block.contains("install_info") {
+        if has_install_info(block) {
             let info = extract_parser_metadata_from_block(block).ok_or_else(|| {
                 MetadataError::ParseError(format!("incomplete parser metadata for {lang}"))
             })?;
@@ -188,9 +187,19 @@ fn parse_parsers_lua(content: &str) -> Result<HashMap<String, ParserMetadata>, M
 }
 
 fn top_level_table_keys(s: &str) -> Vec<(String, &str)> {
-    let Some(mut offset) = returned_table_start(s) else {
+    let Some(offset) = returned_table_start(s) else {
         return Vec::new();
     };
+    table_entries(s, offset)
+        .into_iter()
+        .filter_map(|(name, value)| match value {
+            LuaValue::Table(block) if !is_reserved_key(&name) => Some((name, block)),
+            _ => None,
+        })
+        .collect()
+}
+
+fn table_entries(s: &str, mut offset: usize) -> Vec<(String, LuaValue<'_>)> {
     let mut keys = Vec::new();
     let mut depth = 0;
     let mut quote = None;
@@ -274,14 +283,16 @@ fn top_level_table_keys(s: &str) -> Vec<(String, &str)> {
                     .take_while(|next| next.is_whitespace())
                     .map(char::len_utf8)
                     .sum::<usize>();
-                if s[after_equals + whitespace..].starts_with('{') {
-                    let name = &s[offset..name_end];
-                    let block_start = after_equals + whitespace;
-                    if !is_reserved_key(name)
-                        && let Some(block) = find_matching_brace(&s[block_start..])
-                    {
-                        keys.push((name.to_string(), block));
+                let value_start = after_equals + whitespace;
+                let name = s[offset..name_end].to_string();
+                if s[value_start..].starts_with('{') {
+                    if let Some(block) = find_matching_brace(&s[value_start..]) {
+                        keys.push((name, LuaValue::Table(block)));
                     }
+                } else if matches!(s[value_start..].chars().next(), Some('\'' | '"'))
+                    && let Some(value) = quoted_string(&s[value_start..])
+                {
+                    keys.push((name, LuaValue::String(value)));
                 }
             }
         }
@@ -302,6 +313,26 @@ fn top_level_table_keys(s: &str) -> Vec<(String, &str)> {
     keys
 }
 
+fn quoted_string(s: &str) -> Option<&str> {
+    let delimiter = s.chars().next()?;
+    let mut escaped = false;
+    for (offset, c) in s[delimiter.len_utf8()..].char_indices() {
+        if escaped {
+            escaped = false;
+        } else if c == '\\' {
+            escaped = true;
+        } else if c == delimiter {
+            return Some(&s[delimiter.len_utf8()..delimiter.len_utf8() + offset]);
+        }
+    }
+    None
+}
+
+enum LuaValue<'a> {
+    Table(&'a str),
+    String(&'a str),
+}
+
 /// Check if a key is a reserved/internal key (not a language name)
 fn is_reserved_key(name: &str) -> bool {
     matches!(
@@ -318,32 +349,35 @@ fn is_reserved_key(name: &str) -> bool {
 }
 
 fn extract_parser_metadata_from_block(block_content: &str) -> Option<ParserMetadata> {
-    // Extract URL (required)
-    let url_re = Regex::new(r#"url\s*=\s*'([^']+)'"#).ok()?;
-    let url = url_re
-        .captures(block_content)
-        .and_then(|cap| cap.get(1))
-        .map(|m| m.as_str().to_string())?;
-
-    // Extract revision (required) - in main branch, revision is inside install_info
-    let revision_re = Regex::new(r#"revision\s*=\s*'([^']+)'"#).ok()?;
-    let revision = revision_re
-        .captures(block_content)
-        .and_then(|cap| cap.get(1))
-        .map(|m| m.as_str().to_string())?;
-
-    // Extract location (optional)
-    let location_re = Regex::new(r#"location\s*=\s*'([^']+)'"#).ok()?;
-    let location = location_re
-        .captures(block_content)
-        .and_then(|cap| cap.get(1))
-        .map(|m| m.as_str().to_string());
+    let install_info =
+        table_entries(block_content, 0)
+            .into_iter()
+            .find_map(|(name, value)| match (name.as_str(), value) {
+                ("install_info", LuaValue::Table(table)) => Some(table),
+                _ => None,
+            })?;
+    let fields = table_entries(install_info, 0);
+    let string_field = |key: &str| {
+        fields.iter().find_map(|(name, value)| match value {
+            LuaValue::String(value) if name == key => Some((*value).to_string()),
+            _ => None,
+        })
+    };
+    let url = string_field("url")?;
+    let revision = string_field("revision")?;
+    let location = string_field("location");
 
     Some(ParserMetadata {
         url,
         revision,
         location,
     })
+}
+
+fn has_install_info(block: &str) -> bool {
+    table_entries(block, 0)
+        .into_iter()
+        .any(|(name, value)| name == "install_info" && matches!(value, LuaValue::Table(_)))
 }
 
 /// Find the content within matching braces starting from the first `{`.
@@ -680,6 +714,16 @@ mod tests {
 
         assert_eq!(parsers["lua"].url, "https://example/lua");
         assert_eq!(parsers["lua"].revision, "right");
+    }
+
+    #[test]
+    fn commented_metadata_fields_do_not_validate_an_entry() {
+        let content = "return {\nlua = { install_info = {\n-- url = 'https://example/wrong'\n-- revision = 'wrong'\n} },\n}";
+
+        assert!(matches!(
+            parse_complete_parsers_lua(content),
+            Err(MetadataError::ParseError(_))
+        ));
     }
 
     #[test]

--- a/src/install/metadata.rs
+++ b/src/install/metadata.rs
@@ -298,12 +298,24 @@ fn table_entries(s: &str, mut offset: usize) -> Vec<(String, LuaValue<'_>)> {
                 let name = s[offset..name_end].to_string();
                 if s[value_start..].starts_with('{') {
                     if let Some(block) = find_matching_brace(&s[value_start..]) {
-                        keys.push((name, LuaValue::Table(block)));
+                        if has_valid_field_terminator(&s[value_start + block.len()..]) {
+                            keys.push((name, LuaValue::Table(block)));
+                        } else {
+                            keys.push((name, LuaValue::Other));
+                        }
+                    } else {
+                        keys.push((name, LuaValue::Other));
                     }
                 } else if matches!(s[value_start..].chars().next(), Some('\'' | '"'))
                     && let Some(value) = quoted_string(&s[value_start..])
                 {
-                    keys.push((name, LuaValue::String(value)));
+                    let delimiter_len = s[value_start..].chars().next().unwrap().len_utf8();
+                    let value_end = value_start + delimiter_len + value.len() + delimiter_len;
+                    if has_valid_field_terminator(&s[value_end..]) {
+                        keys.push((name, LuaValue::String(value)));
+                    } else {
+                        keys.push((name, LuaValue::Other));
+                    }
                 } else {
                     keys.push((name, LuaValue::Other));
                 }
@@ -324,6 +336,28 @@ fn table_entries(s: &str, mut offset: usize) -> Vec<(String, LuaValue<'_>)> {
         offset += char_len;
     }
     keys
+}
+
+fn has_valid_field_terminator(mut rest: &str) -> bool {
+    loop {
+        rest = rest.trim_start_matches(char::is_whitespace);
+        if let Some(comment) = rest.strip_prefix("--") {
+            if let Some(equals) = long_bracket_open(comment) {
+                let opener_len = equals + 2;
+                let closer = format!("]{}]", "=".repeat(equals));
+                let Some(close_offset) = comment[opener_len..].find(&closer) else {
+                    return false;
+                };
+                rest = &comment[opener_len + close_offset + closer.len()..];
+            } else if let Some(newline) = comment.find('\n') {
+                rest = &comment[newline + 1..];
+            } else {
+                return false;
+            }
+            continue;
+        }
+        return matches!(rest.chars().next(), Some(',' | ';' | '}'));
+    }
 }
 
 fn quoted_string(s: &str) -> Option<&str> {
@@ -404,14 +438,14 @@ fn install_info(block: &str) -> InstallInfo<'_> {
 
 /// Find the content within matching braces starting from the first `{`.
 fn find_matching_brace(s: &str) -> Option<&str> {
-    let start = s.find('{')?;
+    let mut start = None;
     let mut depth = 0;
-    let mut end = start;
+    let mut end = 0;
     let mut quote = None;
     let mut escaped = false;
     let mut line_comment = false;
     let mut long_bracket = None;
-    let mut offset = start;
+    let mut offset = 0;
 
     while offset < s.len() {
         if let Some(equals) = long_bracket {
@@ -463,7 +497,12 @@ fn find_matching_brace(s: &str) -> Option<&str> {
 
         match c {
             '\'' | '"' => quote = Some(c),
-            '{' => depth += 1,
+            '{' => {
+                if depth == 0 {
+                    start = Some(offset);
+                }
+                depth += 1;
+            }
             '}' => {
                 depth -= 1;
                 if depth == 0 {
@@ -477,7 +516,7 @@ fn find_matching_brace(s: &str) -> Option<&str> {
     }
 
     if depth == 0 {
-        Some(&s[start..end])
+        Some(&s[start?..end])
     } else {
         None
     }
@@ -864,6 +903,28 @@ return {
     }
 
     #[test]
+    fn rejects_unclosed_nested_table() {
+        let content = "return { lua = { install_info = { url = 'x', revision = 'r' } }";
+        assert!(matches!(
+            parse_complete_parsers_lua(content),
+            Err(MetadataError::ParseError(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_table_field_separators() {
+        for content in [
+            "return { lua = { install_info = { url = 'x', revision = 'r' } } rust = { install_info = { url = 'y', revision = 's' } }, }",
+            "return { lua = { install_info = { url = 'x' revision = 'r' }, }, }",
+        ] {
+            assert!(matches!(
+                parse_complete_parsers_lua(content),
+                Err(MetadataError::ParseError(_))
+            ));
+        }
+    }
+
+    #[test]
     fn test_find_matching_brace() {
         let s = "{ foo { bar } baz }";
         let result = find_matching_brace(s);
@@ -872,6 +933,9 @@ return {
         let s2 = "prefix { inner } suffix";
         let result2 = find_matching_brace(s2);
         assert_eq!(result2, Some("{ inner }"));
+
+        let with_comment_brace = "-- { ignored\n{ real }";
+        assert_eq!(find_matching_brace(with_comment_brace), Some("{ real }"));
     }
 
     #[test]

--- a/src/install/metadata.rs
+++ b/src/install/metadata.rs
@@ -203,9 +203,9 @@ fn top_level_table_keys(s: &str) -> Result<Vec<(String, &str)>, MetadataError> {
         .filter_map(|(name, value)| match (is_reserved_key(&name), value) {
             (true, _) => None,
             (false, LuaValue::Table(block)) => Some(Ok((name, block))),
-            (false, LuaValue::String(_)) => Some(Err(MetadataError::ParseError(format!(
-                "invalid parser entry for {name}"
-            )))),
+            (false, LuaValue::String(_) | LuaValue::Other) => Some(Err(MetadataError::ParseError(
+                format!("invalid parser entry for {name}"),
+            ))),
         })
         .collect()
 }
@@ -304,6 +304,8 @@ fn table_entries(s: &str, mut offset: usize) -> Vec<(String, LuaValue<'_>)> {
                     && let Some(value) = quoted_string(&s[value_start..])
                 {
                     keys.push((name, LuaValue::String(value)));
+                } else {
+                    keys.push((name, LuaValue::Other));
                 }
             }
         }
@@ -342,6 +344,7 @@ fn quoted_string(s: &str) -> Option<&str> {
 enum LuaValue<'a> {
     Table(&'a str),
     String(&'a str),
+    Other,
 }
 
 /// Check if a key is a reserved/internal key (not a language name)
@@ -752,8 +755,8 @@ mod tests {
     }
 
     #[test]
-    fn non_table_parser_entry_invalidates_the_document() {
-        let content = "return {\nlua = { install_info = { url = 'https://example/lua', revision = 'ok' } },\nrust = 'damaged',\n}";
+    fn scalar_parser_entry_invalidates_the_document() {
+        let content = "return {\nlua = { install_info = { url = 'https://example/lua', revision = 'ok' } },\nrust = false,\n}";
 
         assert!(matches!(
             parse_complete_parsers_lua(content),

--- a/src/install/metadata.rs
+++ b/src/install/metadata.rs
@@ -171,11 +171,19 @@ fn parse_parsers_lua(content: &str) -> Result<HashMap<String, ParserMetadata>, M
     for (lang, block) in lang_names {
         // Query-only entries (for example upstream `ecma`) intentionally have
         // no install_info and are not installable parsers.
-        if has_install_info(block) {
-            let info = extract_parser_metadata_from_block(block).ok_or_else(|| {
-                MetadataError::ParseError(format!("incomplete parser metadata for {lang}"))
-            })?;
-            parsers.insert(lang, info);
+        match install_info(block) {
+            InstallInfo::Absent => {}
+            InstallInfo::Invalid => {
+                return Err(MetadataError::ParseError(format!(
+                    "invalid install_info for {lang}"
+                )));
+            }
+            InstallInfo::Table(install_info) => {
+                let info = extract_parser_metadata_from_block(install_info).ok_or_else(|| {
+                    MetadataError::ParseError(format!("incomplete parser metadata for {lang}"))
+                })?;
+                parsers.insert(lang, info);
+            }
         }
     }
 
@@ -348,14 +356,7 @@ fn is_reserved_key(name: &str) -> bool {
     )
 }
 
-fn extract_parser_metadata_from_block(block_content: &str) -> Option<ParserMetadata> {
-    let install_info =
-        table_entries(block_content, 0)
-            .into_iter()
-            .find_map(|(name, value)| match (name.as_str(), value) {
-                ("install_info", LuaValue::Table(table)) => Some(table),
-                _ => None,
-            })?;
+fn extract_parser_metadata_from_block(install_info: &str) -> Option<ParserMetadata> {
     let fields = table_entries(install_info, 0);
     let string_field = |key: &str| {
         fields.iter().find_map(|(name, value)| match value {
@@ -374,10 +375,21 @@ fn extract_parser_metadata_from_block(block_content: &str) -> Option<ParserMetad
     })
 }
 
-fn has_install_info(block: &str) -> bool {
-    table_entries(block, 0)
+enum InstallInfo<'a> {
+    Absent,
+    Table(&'a str),
+    Invalid,
+}
+
+fn install_info(block: &str) -> InstallInfo<'_> {
+    match table_entries(block, 0)
         .into_iter()
-        .any(|(name, value)| name == "install_info" && matches!(value, LuaValue::Table(_)))
+        .find(|(name, _)| name == "install_info")
+    {
+        None => InstallInfo::Absent,
+        Some((_, LuaValue::Table(table))) => InstallInfo::Table(table),
+        Some(_) => InstallInfo::Invalid,
+    }
 }
 
 /// Find the content within matching braces starting from the first `{`.
@@ -719,6 +731,16 @@ mod tests {
     #[test]
     fn commented_metadata_fields_do_not_validate_an_entry() {
         let content = "return {\nlua = { install_info = {\n-- url = 'https://example/wrong'\n-- revision = 'wrong'\n} },\n}";
+
+        assert!(matches!(
+            parse_complete_parsers_lua(content),
+            Err(MetadataError::ParseError(_))
+        ));
+    }
+
+    #[test]
+    fn non_table_install_info_invalidates_the_document() {
+        let content = "return {\nlua = { install_info = { url = 'https://example/lua', revision = 'ok' } },\nrust = { install_info = 'damaged' },\n}";
 
         assert!(matches!(
             parse_complete_parsers_lua(content),

--- a/src/install/metadata.rs
+++ b/src/install/metadata.rs
@@ -113,18 +113,32 @@ fn load_parsers_lua(
 ) -> Result<HashMap<String, ParserMetadata>, MetadataError> {
     if let Some(cache) = cache
         && let Some(cached_content) = cache.read()
-        && let Ok(parsers) = parse_parsers_lua(&cached_content)
+        && let Ok(parsers) = parse_complete_parsers_lua(&cached_content)
     {
         return Ok(parsers);
     }
 
     let content = fetch()?;
-    let parsers = parse_parsers_lua(&content)?;
+    let parsers = parse_complete_parsers_lua(&content)?;
     if let Some(cache) = cache {
         // Ignore cache write errors - caching is best-effort
         let _ = cache.write(&content);
     }
     Ok(parsers)
+}
+
+fn parse_complete_parsers_lua(
+    content: &str,
+) -> Result<HashMap<String, ParserMetadata>, MetadataError> {
+    // A prefix ending after one complete language entry can still yield a
+    // non-empty map. Require the outer `return { ... }` table to close before
+    // accepting or publishing metadata.
+    if find_matching_brace(content).is_none() {
+        return Err(MetadataError::ParseError(
+            "incomplete parsers.lua document".to_string(),
+        ));
+    }
+    parse_parsers_lua(content)
 }
 
 fn fetch_parsers_lua() -> Result<String, MetadataError> {
@@ -321,7 +335,10 @@ mod tests {
 
         let parsers = load_parsers_lua(Some(&cache), || {
             fetched.store(true, Ordering::Relaxed);
-            Ok("lua = { url = 'https://example.com/lua', revision = 'abc' }".to_string())
+            Ok(
+                "return {\nlua = { url = 'https://example.com/lua', revision = 'abc' },\n}"
+                    .to_string(),
+            )
         })
         .expect("corrupt cache should be repaired from the source");
 
@@ -334,6 +351,26 @@ mod tests {
                 .is_some_and(|cached| cached.contains_key("lua")),
             "successful recovery must replace the corrupt cache"
         );
+    }
+
+    #[test]
+    fn cache_truncated_after_complete_entry_falls_back_to_fetch() {
+        let temp = tempdir().expect("temp dir");
+        let cache = MetadataCache::with_default_ttl(temp.path());
+        cache
+            .write("return {\nlua = { url = 'https://stale/lua', revision = 'old' },")
+            .expect("write partial cache");
+
+        let parsers = load_parsers_lua(Some(&cache), || {
+            Ok(
+                "return {\nrust = { url = 'https://example.com/rust', revision = 'new' },\n}"
+                    .to_string(),
+            )
+        })
+        .expect("partial document must be refetched");
+
+        assert!(parsers.contains_key("rust"));
+        assert!(!parsers.contains_key("lua"));
     }
 
     #[test]

--- a/src/install/metadata.rs
+++ b/src/install/metadata.rs
@@ -133,7 +133,10 @@ fn parse_complete_parsers_lua(
     // A prefix ending after one complete language entry can still yield a
     // non-empty map. Require the outer `return { ... }` table to close before
     // accepting or publishing metadata.
-    if find_matching_brace(content).is_none() {
+    if returned_table_start(content)
+        .and_then(|start| find_matching_brace(&content[start..]))
+        .is_none()
+    {
         return Err(MetadataError::ParseError(
             "incomplete parsers.lua document".to_string(),
         ));
@@ -346,6 +349,95 @@ fn find_matching_brace(s: &str) -> Option<&str> {
     }
 }
 
+fn returned_table_start(s: &str) -> Option<usize> {
+    let mut quote = None;
+    let mut escaped = false;
+    let mut line_comment = false;
+    let mut long_bracket = None;
+    let mut offset = 0;
+
+    while offset < s.len() {
+        if let Some(equals) = long_bracket {
+            if is_long_bracket_close(&s[offset..], equals) {
+                offset += equals + 2;
+                long_bracket = None;
+            } else {
+                offset += s[offset..].chars().next()?.len_utf8();
+            }
+            continue;
+        }
+
+        let c = s[offset..].chars().next()?;
+        let char_len = c.len_utf8();
+        if line_comment {
+            if c == '\n' {
+                line_comment = false;
+            }
+            offset += char_len;
+            continue;
+        }
+        if let Some(delimiter) = quote {
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == delimiter {
+                quote = None;
+            }
+            offset += char_len;
+            continue;
+        }
+
+        if s[offset..].starts_with("--") {
+            offset += 2;
+            if let Some(equals) = long_bracket_open(&s[offset..]) {
+                offset += equals + 2;
+                long_bracket = Some(equals);
+            } else {
+                line_comment = true;
+            }
+            continue;
+        }
+        if let Some(equals) = long_bracket_open(&s[offset..]) {
+            offset += equals + 2;
+            long_bracket = Some(equals);
+            continue;
+        }
+        if s[offset..].starts_with("return")
+            && (offset == 0
+                || !s[..offset]
+                    .chars()
+                    .next_back()
+                    .is_some_and(is_lua_identifier_char))
+            && !s[offset + "return".len()..]
+                .chars()
+                .next()
+                .is_some_and(is_lua_identifier_char)
+        {
+            let table_start = offset + "return".len();
+            let whitespace = s[table_start..]
+                .chars()
+                .take_while(|next| next.is_whitespace())
+                .map(char::len_utf8)
+                .sum::<usize>();
+            if s[table_start + whitespace..].starts_with('{') {
+                return Some(table_start + whitespace);
+            }
+        }
+
+        match c {
+            '\'' | '"' => quote = Some(c),
+            _ => {}
+        }
+        offset += char_len;
+    }
+    None
+}
+
+fn is_lua_identifier_char(c: char) -> bool {
+    c == '_' || c.is_ascii_alphanumeric()
+}
+
 fn long_bracket_open(s: &str) -> Option<usize> {
     let bytes = s.as_bytes();
     if bytes.first() != Some(&b'[') {
@@ -460,6 +552,15 @@ mod tests {
     #[test]
     fn braces_in_strings_and_comments_do_not_hide_truncation() {
         let partial = "return {\n-- } is not the table end\nlua = { url = 'https://example/}', revision = 'ok' },";
+        assert!(matches!(
+            parse_complete_parsers_lua(partial),
+            Err(MetadataError::ParseError(_))
+        ));
+    }
+
+    #[test]
+    fn braces_in_preamble_comments_do_not_complete_the_document() {
+        let partial = "-- {} is not the returned table\nreturn {\nlua = { install_info = { url = 'https://example/lua', revision = 'ok' } },";
         assert!(matches!(
             parse_complete_parsers_lua(partial),
             Err(MetadataError::ParseError(_))

--- a/src/install/metadata.rs
+++ b/src/install/metadata.rs
@@ -113,16 +113,18 @@ fn load_parsers_lua(
 ) -> Result<HashMap<String, ParserMetadata>, MetadataError> {
     if let Some(cache) = cache
         && let Some(cached_content) = cache.read()
+        && let Ok(parsers) = parse_parsers_lua(&cached_content)
     {
-        return parse_parsers_lua(&cached_content);
+        return Ok(parsers);
     }
 
     let content = fetch()?;
+    let parsers = parse_parsers_lua(&content)?;
     if let Some(cache) = cache {
         // Ignore cache write errors - caching is best-effort
         let _ = cache.write(&content);
     }
-    parse_parsers_lua(&content)
+    Ok(parsers)
 }
 
 fn fetch_parsers_lua() -> Result<String, MetadataError> {
@@ -307,7 +309,25 @@ pub fn is_language_supported(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use tempfile::tempdir;
+
+    #[test]
+    fn corrupt_fresh_cache_falls_back_to_fetch() {
+        let temp = tempdir().expect("temp dir");
+        let cache = MetadataCache::with_default_ttl(temp.path());
+        cache.write("truncated").expect("write corrupt cache");
+        let fetched = AtomicBool::new(false);
+
+        let parsers = load_parsers_lua(Some(&cache), || {
+            fetched.store(true, Ordering::Relaxed);
+            Ok("lua = { url = 'https://example.com/lua', revision = 'abc' }".to_string())
+        })
+        .expect("corrupt cache should be repaired from the source");
+
+        assert!(fetched.load(Ordering::Relaxed));
+        assert!(parsers.contains_key("lua"));
+    }
 
     #[test]
     fn test_fetch_parser_metadata_with_caching() {
@@ -583,22 +603,17 @@ return {
     }
 
     #[test]
-    fn test_is_language_supported_returns_error_for_invalid_metadata() {
+    fn invalid_source_still_returns_metadata_error_after_cache_miss() {
         use crate::install::test_helpers::setup_mock_metadata_cache;
 
         let temp = tempdir().expect("Failed to create temp dir");
-        let options = FetchOptions {
-            data_dir: Some(temp.path()),
-            use_cache: true,
-        };
+        setup_mock_metadata_cache(temp.path(), "truncated cache");
+        let cache = MetadataCache::with_default_ttl(temp.path());
 
-        let mock_parsers_lua = "return {}";
-        setup_mock_metadata_cache(temp.path(), mock_parsers_lua);
-
-        let result = is_language_supported("lua", Some(&options));
+        let result = load_parsers_lua(Some(&cache), || Ok("return {}".to_string()));
         assert!(
             matches!(result, Err(MetadataError::EmptyMetadata)),
-            "Expected empty metadata error for invalid metadata"
+            "invalid fetched metadata must not be cached as a successful result"
         );
     }
 }

--- a/src/install/metadata.rs
+++ b/src/install/metadata.rs
@@ -327,6 +327,13 @@ mod tests {
 
         assert!(fetched.load(Ordering::Relaxed));
         assert!(parsers.contains_key("lua"));
+        assert!(
+            cache
+                .read()
+                .and_then(|content| parse_parsers_lua(&content).ok())
+                .is_some_and(|cached| cached.contains_key("lua")),
+            "successful recovery must replace the corrupt cache"
+        );
     }
 
     #[test]
@@ -615,5 +622,6 @@ return {
             matches!(result, Err(MetadataError::EmptyMetadata)),
             "invalid fetched metadata must not be cached as a successful result"
         );
+        assert_eq!(cache.read().as_deref(), Some("truncated cache"));
     }
 }

--- a/src/install/metadata.rs
+++ b/src/install/metadata.rs
@@ -166,20 +166,34 @@ fn parse_parsers_lua(content: &str) -> Result<HashMap<String, ParserMetadata>, M
     // Pattern to match parser entries in main branch format: lang = { ... }
     // The pattern matches language names at the start of a line (with optional indentation)
     // followed by = {
-    let lang_pattern = Regex::new(r#"(?m)^\s*([a-zA-Z][a-zA-Z0-9_]*)\s*=\s*\{"#)
+    let lang_pattern = Regex::new(r#"(?m)^([ \t]*)([a-zA-Z][a-zA-Z0-9_]*)\s*=\s*\{"#)
         .expect("valid regex for lang pattern");
 
-    // Find all language names first
-    let lang_names: Vec<String> = lang_pattern
+    // Language entries share the table's minimum indentation. Restricting to
+    // that level keeps nested install_info fields from looking like languages.
+    let candidates: Vec<(usize, String)> = lang_pattern
         .captures_iter(content)
-        .filter_map(|cap| cap.get(1).map(|m| m.as_str().to_string()))
+        .filter_map(|cap| Some((cap.get(1)?.as_str().len(), cap.get(2)?.as_str().to_string())))
         // Filter out non-language keys like "return", "install_info", etc.
-        .filter(|name| !is_reserved_key(name))
+        .filter(|(_, name)| !is_reserved_key(name))
         .collect();
+    let top_level_indent = candidates.iter().map(|(indent, _)| *indent).min();
+    let lang_names = candidates
+        .into_iter()
+        .filter(|(indent, _)| Some(*indent) == top_level_indent)
+        .map(|(_, name)| name);
 
     // For each language, find its block and extract metadata
     for lang in lang_names {
-        if let Some(info) = extract_parser_metadata(content, &lang) {
+        let block = parser_metadata_block(content, &lang).ok_or_else(|| {
+            MetadataError::ParseError(format!("incomplete parser block for {lang}"))
+        })?;
+        // Query-only entries (for example upstream `ecma`) intentionally have
+        // no install_info and are not installable parsers.
+        if block.contains("install_info") {
+            let info = extract_parser_metadata(content, &lang).ok_or_else(|| {
+                MetadataError::ParseError(format!("incomplete parser metadata for {lang}"))
+            })?;
             parsers.insert(lang, info);
         }
     }
@@ -208,16 +222,7 @@ fn is_reserved_key(name: &str) -> bool {
 
 /// Extract parser metadata for a specific language from parsers.lua content.
 fn extract_parser_metadata(content: &str, language: &str) -> Option<ParserMetadata> {
-    // Find the start of this language's block
-    // Use word boundary to avoid matching substrings (e.g., "c" matching "cpp")
-    let block_start_pattern = format!(r#"(?m)^\s*{}\s*=\s*\{{"#, regex::escape(language));
-    let block_start_re = Regex::new(&block_start_pattern).ok()?;
-
-    let block_start = block_start_re.find(content)?;
-    let start_pos = block_start.start();
-
-    // Find the end of this block by counting braces
-    let block_content = find_matching_brace(&content[start_pos..])?;
+    let block_content = parser_metadata_block(content, language)?;
 
     // Extract URL (required)
     let url_re = Regex::new(r#"url\s*=\s*'([^']+)'"#).ok()?;
@@ -247,14 +252,53 @@ fn extract_parser_metadata(content: &str, language: &str) -> Option<ParserMetada
     })
 }
 
+fn parser_metadata_block<'a>(content: &'a str, language: &str) -> Option<&'a str> {
+    // Find the start of this language's block
+    // Use word boundary to avoid matching substrings (e.g., "c" matching "cpp")
+    let block_start_pattern = format!(r#"(?m)^\s*{}\s*=\s*\{{"#, regex::escape(language));
+    let block_start_re = Regex::new(&block_start_pattern).ok()?;
+
+    let block_start = block_start_re.find(content)?;
+    let start_pos = block_start.start();
+
+    // Find the end of this block by counting braces
+    find_matching_brace(&content[start_pos..])
+}
+
 /// Find the content within matching braces starting from the first `{`.
 fn find_matching_brace(s: &str) -> Option<&str> {
     let start = s.find('{')?;
     let mut depth = 0;
     let mut end = start;
+    let mut quote = None;
+    let mut escaped = false;
+    let mut line_comment = false;
+    let mut chars = s[start..].char_indices().peekable();
 
-    for (i, c) in s[start..].char_indices() {
+    while let Some((i, c)) = chars.next() {
+        if line_comment {
+            if c == '\n' {
+                line_comment = false;
+            }
+            continue;
+        }
+        if let Some(delimiter) = quote {
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == delimiter {
+                quote = None;
+            }
+            continue;
+        }
+        if c == '-' && chars.peek().is_some_and(|(_, next)| *next == '-') {
+            chars.next();
+            line_comment = true;
+            continue;
+        }
         match c {
+            '\'' | '"' => quote = Some(c),
             '{' => depth += 1,
             '}' => {
                 depth -= 1;
@@ -335,10 +379,8 @@ mod tests {
 
         let parsers = load_parsers_lua(Some(&cache), || {
             fetched.store(true, Ordering::Relaxed);
-            Ok(
-                "return {\nlua = { url = 'https://example.com/lua', revision = 'abc' },\n}"
-                    .to_string(),
-            )
+            Ok("return {\nlua = { install_info = { url = 'https://example.com/lua', revision = 'abc' } },\n}"
+                .to_string())
         })
         .expect("corrupt cache should be repaired from the source");
 
@@ -358,19 +400,35 @@ mod tests {
         let temp = tempdir().expect("temp dir");
         let cache = MetadataCache::with_default_ttl(temp.path());
         cache
-            .write("return {\nlua = { url = 'https://stale/lua', revision = 'old' },")
+            .write("return {\nlua = { install_info = { url = 'https://stale/lua', revision = 'old' } },")
             .expect("write partial cache");
 
         let parsers = load_parsers_lua(Some(&cache), || {
-            Ok(
-                "return {\nrust = { url = 'https://example.com/rust', revision = 'new' },\n}"
-                    .to_string(),
-            )
+            Ok("return {\nrust = { install_info = { url = 'https://example.com/rust', revision = 'new' } },\n}"
+                .to_string())
         })
         .expect("partial document must be refetched");
 
         assert!(parsers.contains_key("rust"));
         assert!(!parsers.contains_key("lua"));
+    }
+
+    #[test]
+    fn braces_in_strings_and_comments_do_not_hide_truncation() {
+        let partial = "return {\n-- } is not the table end\nlua = { url = 'https://example/}', revision = 'ok' },";
+        assert!(matches!(
+            parse_complete_parsers_lua(partial),
+            Err(MetadataError::ParseError(_))
+        ));
+    }
+
+    #[test]
+    fn malformed_top_level_entry_rejects_the_whole_document() {
+        let content = "return {\nlua = { install_info = { url = 'https://example/lua', revision = 'ok' } },\nrust = { install_info = { url = 'https://example/rust' } },\n}";
+        assert!(matches!(
+            parse_complete_parsers_lua(content),
+            Err(MetadataError::ParseError(_))
+        ));
     }
 
     #[test]

--- a/src/install/metadata.rs
+++ b/src/install/metadata.rs
@@ -273,13 +273,27 @@ fn find_matching_brace(s: &str) -> Option<&str> {
     let mut quote = None;
     let mut escaped = false;
     let mut line_comment = false;
-    let mut chars = s[start..].char_indices().peekable();
+    let mut long_bracket = None;
+    let mut offset = start;
 
-    while let Some((i, c)) = chars.next() {
+    while offset < s.len() {
+        if let Some(equals) = long_bracket {
+            if is_long_bracket_close(&s[offset..], equals) {
+                offset += equals + 2;
+                long_bracket = None;
+            } else {
+                offset += s[offset..].chars().next()?.len_utf8();
+            }
+            continue;
+        }
+
+        let c = s[offset..].chars().next()?;
+        let char_len = c.len_utf8();
         if line_comment {
             if c == '\n' {
                 line_comment = false;
             }
+            offset += char_len;
             continue;
         }
         if let Some(delimiter) = quote {
@@ -290,25 +304,39 @@ fn find_matching_brace(s: &str) -> Option<&str> {
             } else if c == delimiter {
                 quote = None;
             }
+            offset += char_len;
             continue;
         }
-        if c == '-' && chars.peek().is_some_and(|(_, next)| *next == '-') {
-            chars.next();
-            line_comment = true;
+
+        if s[offset..].starts_with("--") {
+            offset += 2;
+            if let Some(equals) = long_bracket_open(&s[offset..]) {
+                offset += equals + 2;
+                long_bracket = Some(equals);
+            } else {
+                line_comment = true;
+            }
             continue;
         }
+        if let Some(equals) = long_bracket_open(&s[offset..]) {
+            offset += equals + 2;
+            long_bracket = Some(equals);
+            continue;
+        }
+
         match c {
             '\'' | '"' => quote = Some(c),
             '{' => depth += 1,
             '}' => {
                 depth -= 1;
                 if depth == 0 {
-                    end = start + i + 1;
+                    end = offset + char_len;
                     break;
                 }
             }
             _ => {}
         }
+        offset += char_len;
     }
 
     if depth == 0 {
@@ -316,6 +344,22 @@ fn find_matching_brace(s: &str) -> Option<&str> {
     } else {
         None
     }
+}
+
+fn long_bracket_open(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    if bytes.first() != Some(&b'[') {
+        return None;
+    }
+    let equals = bytes[1..].iter().take_while(|byte| **byte == b'=').count();
+    (bytes.get(equals + 1) == Some(&b'[')).then_some(equals)
+}
+
+fn is_long_bracket_close(s: &str, equals: usize) -> bool {
+    let bytes = s.as_bytes();
+    bytes.first() == Some(&b']')
+        && bytes[1..].iter().take(equals).all(|byte| *byte == b'=')
+        && bytes.get(equals + 1) == Some(&b']')
 }
 
 /// Fetch parser metadata for a language from nvim-treesitter.
@@ -416,6 +460,15 @@ mod tests {
     #[test]
     fn braces_in_strings_and_comments_do_not_hide_truncation() {
         let partial = "return {\n-- } is not the table end\nlua = { url = 'https://example/}', revision = 'ok' },";
+        assert!(matches!(
+            parse_complete_parsers_lua(partial),
+            Err(MetadataError::ParseError(_))
+        ));
+    }
+
+    #[test]
+    fn braces_in_long_strings_and_comments_do_not_hide_truncation() {
+        let partial = "return {\n--[=[ } is not the table end ]=]\nlua = { note = [==[ } is data ]==], install_info = { url = 'https://example/lua', revision = 'ok' } },";
         assert!(matches!(
             parse_complete_parsers_lua(partial),
             Err(MetadataError::ParseError(_))

--- a/src/install/metadata.rs
+++ b/src/install/metadata.rs
@@ -372,7 +372,11 @@ fn extract_parser_metadata_from_block(install_info: &str) -> Option<ParserMetada
     };
     let url = string_field("url")?;
     let revision = string_field("revision")?;
-    let location = string_field("location");
+    let location = match fields.iter().find(|(name, _)| name == "location") {
+        None => None,
+        Some((_, LuaValue::String(value))) => Some((*value).to_string()),
+        Some(_) => return None,
+    };
 
     Some(ParserMetadata {
         url,
@@ -757,6 +761,16 @@ mod tests {
     #[test]
     fn scalar_parser_entry_invalidates_the_document() {
         let content = "return {\nlua = { install_info = { url = 'https://example/lua', revision = 'ok' } },\nrust = false,\n}";
+
+        assert!(matches!(
+            parse_complete_parsers_lua(content),
+            Err(MetadataError::ParseError(_))
+        ));
+    }
+
+    #[test]
+    fn scalar_location_invalidates_the_document() {
+        let content = "return {\nlua = { install_info = { url = 'https://example/lua', revision = 'ok', location = false } },\n}";
 
         assert!(matches!(
             parse_complete_parsers_lua(content),

--- a/src/install/support_check.rs
+++ b/src/install/support_check.rs
@@ -277,24 +277,25 @@ return {
 
     #[tokio::test]
     async fn test_should_skip_unsupported_language_reports_metadata_error() {
-        use crate::install::test_helpers::setup_mock_metadata_cache;
-        use tempfile::tempdir;
-
-        let temp = tempdir().expect("Failed to create temp dir");
-        setup_mock_metadata_cache(temp.path(), "return {}");
-
-        let options = FetchOptions {
-            data_dir: Some(temp.path()),
-            use_cache: true,
-        };
-
-        let result = should_skip_unsupported_language_tracked("lua", Some(&options)).await;
+        let result = should_skip_unsupported_language_with_checker_tracked(
+            "lua",
+            None,
+            Duration::from_secs(1),
+            |_, _| Err(MetadataError::EmptyMetadata),
+        )
+        .await;
         assert!(
             result.should_skip,
             "Metadata errors should prevent auto-install attempts"
         );
         assert!(
-            matches!(result.reason, Some(SkipReason::MetadataUnavailable { .. })),
+            matches!(
+                result.reason,
+                Some(SkipReason::MetadataUnavailable {
+                    language,
+                    error: MetadataError::EmptyMetadata,
+                }) if language == "lua"
+            ),
             "Expected MetadataUnavailable reason"
         );
     }


### PR DESCRIPTION
Closes #709.

## Problem

A fresh truncated/corrupt cached `parsers.lua` was parsed as authoritative. The parse error returned immediately, preventing a healthy network source from repairing installs until the cache TTL expired. Partial or lexically malformed metadata could also be accepted as a complete document.

## Change

- Treat invalid cached metadata as a cache miss and repair it from the authoritative source.
- Validate the fetched document before publishing it, while preserving the previous cache on invalid responses.
- Validate the actual returned Lua table and its parser/install metadata fields without treating comments, strings, indentation, or scalar damage as valid structure.
- Publish replacements atomically and durably via same-directory staging, file sync, rename, and best-effort directory sync.
- Keep query-only entries without `install_info` supported while rejecting present-but-invalid metadata.

## Verification

- `cargo test --lib install::metadata::tests` (23 passed)
- `cargo test --lib install::cache::tests` (4 passed)
- `make check` (passed)
- Full `cargo test --lib` reached 2,880 tests but the environment lacks the installed Rust parser fixture required by `process_injection_sync_returns_incomplete_on_mid_region_cancel`; the exact unrelated test reproduces the same fixture assertion.
- Codex threaded review converged, followed by a fresh independent review with no comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language metadata parsing with Lua-aware scanning, ensuring only complete, well-formed `parsers.lua` data is accepted and preventing partial/incorrect results.
  * Enhanced handling of corrupted or truncated cached metadata by detecting incomplete cache contents and refetching when needed.
  * Improved language support checking behavior and error reporting when metadata is empty or unavailable.
* **Reliability**
  * Increased cache durability by staging updates, flushing/syncing, and performing best-effort directory sync to reduce data loss risk after interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->