### PR TITLE
fix(text): recognize lone CR line endings

### DIFF
--- a/src/lsp/text_sync.rs
+++ b/src/lsp/text_sync.rs
@@ -179,6 +179,24 @@ mod tests {
     }
 
     #[test]
+    fn test_incremental_change_resolves_line_after_lone_cr() {
+        let changes = vec![TextDocumentContentChangeEvent {
+            range: Some(Range::new(Position::new(1, 0), Position::new(1, 5))),
+            range_length: Some(5),
+            text: "rust".to_string(),
+        }];
+
+        let (new_text, edits) = apply_content_changes_with_edits("hello\rworld", changes);
+        let edit = edits.first().expect("one edit");
+
+        assert_eq!(new_text, "hello\rrust");
+        assert_eq!((edit.start_byte, edit.old_end_byte), (6, 11));
+        // tree-sitter still sees the lone CR as a column byte, not a row break.
+        assert_eq!(edit.start_position, Point::new(0, 6));
+        assert_eq!(edit.old_end_position, Point::new(0, 11));
+    }
+
+    #[test]
     fn test_apply_content_changes_out_of_range_does_not_panic() {
         // Regression: a change whose range extends past the current text must not
         // panic in `replace_range`. This happens under concurrent `didChange`

--- a/src/text/position.rs
+++ b/src/text/position.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use line_index::{LineIndex, WideEncoding, WideLineCol};
 use tower_lsp_server::ls_types::Position;
 
@@ -7,8 +9,9 @@ use super::char_boundary::floor_char_boundary;
 pub struct PositionMapper<'text> {
     /// LSP line index, including lone-CR line boundaries.
     line_index: LineIndex,
-    /// tree-sitter counts only LF as a row boundary.
-    tree_line_index: LineIndex,
+    /// Only needed for lone-CR documents: tree-sitter counts only LF as a row
+    /// boundary, while `line_index` above follows LSP semantics in that case.
+    tree_line_index: Option<LineIndex>,
     text: &'text str,
 }
 
@@ -21,8 +24,8 @@ impl<'text> PositionMapper<'text> {
         // width, allowing the dependency's logarithmic lookups to implement
         // the full LSP line-ending contract without altering document text.
         let indexed_text = normalize_lone_carriage_returns(text);
+        let tree_line_index = matches!(indexed_text, Cow::Owned(_)).then(|| LineIndex::new(text));
         let line_index = LineIndex::new(&indexed_text);
-        let tree_line_index = LineIndex::new(text);
         Self {
             line_index,
             tree_line_index,
@@ -31,14 +34,14 @@ impl<'text> PositionMapper<'text> {
     }
 }
 
-fn normalize_lone_carriage_returns(text: &str) -> std::borrow::Cow<'_, str> {
+fn normalize_lone_carriage_returns(text: &str) -> Cow<'_, str> {
     let bytes = text.as_bytes();
     let has_lone_cr = bytes
         .iter()
         .enumerate()
         .any(|(index, byte)| *byte == b'\r' && bytes.get(index + 1) != Some(&b'\n'));
     if !has_lone_cr {
-        return std::borrow::Cow::Borrowed(text);
+        return Cow::Borrowed(text);
     }
 
     let mut normalized = bytes.to_vec();
@@ -47,9 +50,7 @@ fn normalize_lone_carriage_returns(text: &str) -> std::borrow::Cow<'_, str> {
             normalized[index] = b'\n';
         }
     }
-    std::borrow::Cow::Owned(
-        String::from_utf8(normalized).expect("replacing ASCII bytes preserves valid UTF-8"),
-    )
+    Cow::Owned(String::from_utf8(normalized).expect("replacing ASCII bytes preserves valid UTF-8"))
 }
 
 impl PositionMapper<'_> {
@@ -133,12 +134,13 @@ impl PositionMapper<'_> {
     /// length, so `try_line_col` resolves for every input; the `None` arm is
     /// unreachable and degrades to the document start.
     pub fn byte_to_point(&self, offset: usize) -> tree_sitter::Point {
-        let len: usize = self.tree_line_index.len().into();
+        let line_index = self.tree_line_index.as_ref().unwrap_or(&self.line_index);
+        let len: usize = line_index.len().into();
         let offset = offset.min(len);
         match offset
             .try_into()
             .ok()
-            .and_then(|o| self.tree_line_index.try_line_col(o))
+            .and_then(|o| line_index.try_line_col(o))
         {
             Some(line_col) => {
                 tree_sitter::Point::new(line_col.line as usize, line_col.col as usize)

--- a/src/text/position.rs
+++ b/src/text/position.rs
@@ -99,7 +99,7 @@ impl PositionMapper<'_> {
                 let content = line
                     .strip_suffix('\n')
                     .map(|line| line.strip_suffix('\r').unwrap_or(line))
-                    .unwrap_or(line);
+                    .unwrap_or_else(|| line.strip_suffix('\r').unwrap_or(line));
                 let line_end = line_start + content.len();
                 let byte = self
                     .position_to_byte(position)
@@ -477,6 +477,13 @@ mod tests {
         // the valid LSP end position is byte 5, before `\n`. A far-past column
         // clamps there, not to the start of line 1 or the document end.
         let text = "hello\nworld\n";
+        let mapper = PositionMapper::new(text);
+        assert_eq!(mapper.position_to_byte_clamped(Position::new(0, 999)), 5);
+    }
+
+    #[test]
+    fn clamped_snaps_overlong_character_before_lone_carriage_return() {
+        let text = "hello\rworld";
         let mapper = PositionMapper::new(text);
         assert_eq!(mapper.position_to_byte_clamped(Position::new(0, 999)), 5);
     }

--- a/src/text/position.rs
+++ b/src/text/position.rs
@@ -49,7 +49,10 @@ fn normalize_lone_carriage_returns(text: &str) -> Cow<'_, str> {
             normalized[index] = b'\n';
         }
     }
-    Cow::Owned(String::from_utf8(normalized).expect("replacing ASCII bytes preserves valid UTF-8"))
+    // SAFETY: `normalized` came from valid UTF-8 and only ASCII CR bytes were
+    // replaced with ASCII LF bytes, so every UTF-8 code-unit boundary remains
+    // unchanged.
+    Cow::Owned(unsafe { String::from_utf8_unchecked(normalized) })
 }
 
 impl PositionMapper<'_> {

--- a/src/text/position.rs
+++ b/src/text/position.rs
@@ -445,6 +445,19 @@ mod tests {
     }
 
     #[test]
+    fn mixed_line_endings_have_one_boundary_each() {
+        let text = "a\rb\r\nc\nd";
+        let mapper = PositionMapper::new(text);
+
+        for (line, byte) in [(0, 0), (1, 2), (2, 5), (3, 7)] {
+            let position = Position::new(line, 0);
+            assert_eq!(mapper.position_to_byte(position), Some(byte));
+            assert_eq!(mapper.byte_to_position(byte), Some(position));
+        }
+        assert_eq!(mapper.position_to_byte(Position::new(4, 0)), None);
+    }
+
+    #[test]
     fn clamped_maps_in_bounds_position_exactly() {
         let text = "hello\nworld\n";
         let mapper = PositionMapper::new(text);

--- a/src/text/position.rs
+++ b/src/text/position.rs
@@ -5,16 +5,51 @@ use super::char_boundary::floor_char_boundary;
 
 /// Position mapper for converting between LSP positions and byte offsets
 pub struct PositionMapper<'text> {
+    /// LSP line index, including lone-CR line boundaries.
     line_index: LineIndex,
+    /// tree-sitter counts only LF as a row boundary.
+    tree_line_index: LineIndex,
     text: &'text str,
 }
 
 impl<'text> PositionMapper<'text> {
     /// Create a new PositionMapper with pre-computed line starts
     pub fn new(text: &'text str) -> Self {
-        let line_index = LineIndex::new(text);
-        Self { line_index, text }
+        // `line-index` recognizes LF (and therefore CRLF) boundaries, while
+        // the LSP position model also treats a lone CR as a line terminator.
+        // Replacing only lone CR bytes preserves every byte offset and UTF-16
+        // width, allowing the dependency's logarithmic lookups to implement
+        // the full LSP line-ending contract without altering document text.
+        let indexed_text = normalize_lone_carriage_returns(text);
+        let line_index = LineIndex::new(&indexed_text);
+        let tree_line_index = LineIndex::new(text);
+        Self {
+            line_index,
+            tree_line_index,
+            text,
+        }
     }
+}
+
+fn normalize_lone_carriage_returns(text: &str) -> std::borrow::Cow<'_, str> {
+    let bytes = text.as_bytes();
+    let has_lone_cr = bytes
+        .iter()
+        .enumerate()
+        .any(|(index, byte)| *byte == b'\r' && bytes.get(index + 1) != Some(&b'\n'));
+    if !has_lone_cr {
+        return std::borrow::Cow::Borrowed(text);
+    }
+
+    let mut normalized = bytes.to_vec();
+    for index in 0..normalized.len() {
+        if normalized[index] == b'\r' && normalized.get(index + 1) != Some(&b'\n') {
+            normalized[index] = b'\n';
+        }
+    }
+    std::borrow::Cow::Owned(
+        String::from_utf8(normalized).expect("replacing ASCII bytes preserves valid UTF-8"),
+    )
 }
 
 impl PositionMapper<'_> {
@@ -98,12 +133,12 @@ impl PositionMapper<'_> {
     /// length, so `try_line_col` resolves for every input; the `None` arm is
     /// unreachable and degrades to the document start.
     pub fn byte_to_point(&self, offset: usize) -> tree_sitter::Point {
-        let len: usize = self.line_index.len().into();
+        let len: usize = self.tree_line_index.len().into();
         let offset = offset.min(len);
         match offset
             .try_into()
             .ok()
-            .and_then(|o| self.line_index.try_line_col(o))
+            .and_then(|o| self.tree_line_index.try_line_col(o))
         {
             Some(line_col) => {
                 tree_sitter::Point::new(line_col.line as usize, line_col.col as usize)
@@ -394,6 +429,19 @@ mod tests {
         let line1_start = text.find("local").unwrap();
         let p = mapper.byte_to_point(line1_start);
         assert_eq!((p.row, p.column), (1, 0));
+    }
+
+    #[test]
+    fn lone_carriage_return_starts_a_new_line() {
+        let text = "hello\rworld";
+        let mapper = PositionMapper::new(text);
+
+        assert_eq!(mapper.position_to_byte(Position::new(1, 0)), Some(6));
+        assert_eq!(mapper.byte_to_position(6), Some(Position::new(1, 0)));
+        // tree-sitter's Point contract differs: its lexer advances rows only
+        // for LF, so a lone CR remains one byte on row 0 there.
+        let point = mapper.byte_to_point(6);
+        assert_eq!((point.row, point.column), (0, 6));
     }
 
     #[test]

--- a/src/text/position.rs
+++ b/src/text/position.rs
@@ -36,16 +36,15 @@ impl<'text> PositionMapper<'text> {
 
 fn normalize_lone_carriage_returns(text: &str) -> Cow<'_, str> {
     let bytes = text.as_bytes();
-    let has_lone_cr = bytes
-        .iter()
-        .enumerate()
-        .any(|(index, byte)| *byte == b'\r' && bytes.get(index + 1) != Some(&b'\n'));
-    if !has_lone_cr {
+    let Some(first_lone_cr) = bytes.iter().enumerate().find_map(|(index, byte)| {
+        (*byte == b'\r' && bytes.get(index + 1) != Some(&b'\n')).then_some(index)
+    }) else {
         return Cow::Borrowed(text);
-    }
+    };
 
     let mut normalized = bytes.to_vec();
-    for index in 0..normalized.len() {
+    normalized[first_lone_cr] = b'\n';
+    for index in first_lone_cr + 1..normalized.len() {
         if normalized[index] == b'\r' && normalized.get(index + 1) != Some(&b'\n') {
             normalized[index] = b'\n';
         }


### PR DESCRIPTION
## Summary

- index lone carriage returns as LSP line boundaries without changing document byte offsets
- preserve tree-sitter’s distinct LF-only `Point` coordinate model
- avoid duplicate line indexing for ordinary LF/CRLF documents
- cover mixed CR/LF/CRLF round trips and incremental `didChange` edits

## Validation

- `cargo test --lib text::position::tests`
- `cargo test --lib lsp::text_sync::tests`
- `make check`
- Codex review: continued and fresh sessions both clean

Full `make test` was also run; the changed tests passed, while two unrelated bridge unique-ID tests failed under concurrent test activity from other worktrees. CI will provide an isolated full-suite result.

Fixes #710