### PR TITLE
fix(install): clean stale parser staging files

### DIFF
--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -394,8 +394,14 @@ fn reserve_parser_staging_file(
             Ok(file) => {
                 #[cfg(unix)]
                 {
-                    file.lock_exclusive()?;
-                    return Ok((candidate, Some(file)));
+                    return match file.lock_exclusive() {
+                        Ok(()) => Ok((candidate, Some(file))),
+                        // Locking is an ownership optimization for cleanup,
+                        // not a prerequisite for compilation. On filesystems
+                        // without advisory locks, cleanup also declines to
+                        // claim unlocked artifacts conservatively.
+                        Err(_) => Ok((candidate, None)),
+                    };
                 }
                 #[cfg(not(unix))]
                 {
@@ -478,8 +484,7 @@ fn claim_and_unlink_stale_parser_file(
     }
     match file.try_lock_exclusive() {
         Ok(()) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => return Ok(None),
-        Err(error) => return Err(ParserInstallError::IoError(error)),
+        Err(_) => return Ok(None),
     }
     let opened = file.metadata()?;
     let current = match fs::metadata(path) {

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -497,7 +497,10 @@ fn claim_and_unlink_stale_parser_file(
             }
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            Err(error) => return Err(ParserInstallError::IoError(error)),
+            // Cleanup is opportunistic. Some Unix-backed data directories do
+            // not support hard links; leaving a stale artifact is preferable
+            // to making every future parser install fail there.
+            Err(_) => return Ok(None),
         }
     }
 }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -441,12 +441,30 @@ fn claim_and_unlink_stale_parser_file(
     path: &Path,
 ) -> Result<Option<PathBuf>, ParserInstallError> {
     use std::os::unix::fs::MetadataExt;
+    use std::os::unix::fs::OpenOptionsExt;
 
-    let file = match fs::OpenOptions::new().read(true).open(path) {
+    let initial = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(ParserInstallError::IoError(error)),
+    };
+    if !initial.file_type().is_file() {
+        return Ok(None);
+    }
+    let file = match fs::OpenOptions::new()
+        .read(true)
+        // The pathname can be replaced after symlink_metadata. Never block if
+        // an external actor swaps in a FIFO before open.
+        .custom_flags(nix::libc::O_NONBLOCK)
+        .open(path)
+    {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(ParserInstallError::IoError(error)),
     };
+    if !file.metadata()?.file_type().is_file() {
+        return Ok(None);
+    }
     match file.try_lock_exclusive() {
         Ok(()) => {}
         Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => return Ok(None),
@@ -1200,6 +1218,27 @@ mod tests {
         cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup succeeds");
 
         assert!(staged.exists(), "another cleaner owns the staging file");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_skips_non_file_staging_path() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let mut pid = std::process::id().saturating_add(100_000);
+        while process_is_running(pid) {
+            pid = pid.saturating_add(1);
+        }
+        let staged = parser_dir.join(format!(
+            ".lua.{pid}.0.{}.tmp",
+            std::env::consts::DLL_EXTENSION
+        ));
+        fs::create_dir(&staged).expect("create impostor directory");
+
+        cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup succeeds");
+
+        assert!(staged.is_dir(), "non-file staging path is preserved");
     }
 
     const TREE_SITTER_JSON_URL: &str =

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -542,6 +542,21 @@ fn claim_and_unlink_stale_parser_file(
         ));
         match fs::hard_link(path, &candidate) {
             Ok(()) => {
+                // The directory entry is the authority for unlink. Re-check
+                // after creating the claim so a pathname replacement cannot
+                // make us delete an inode other than the one we locked.
+                let current = match fs::symlink_metadata(path) {
+                    Ok(metadata) => metadata,
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                        let _ = fs::remove_file(&candidate);
+                        return Ok(None);
+                    }
+                    Err(error) => return Err(ParserInstallError::IoError(error)),
+                };
+                if opened.dev() != current.dev() || opened.ino() != current.ino() {
+                    let _ = fs::remove_file(&candidate);
+                    return Ok(None);
+                }
                 match fs::remove_file(path) {
                     Ok(()) => {}
                     Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -616,12 +616,18 @@ fn remove_stale_cleanup_claim(path: &Path) {
     let Ok(marker_fd) = openat(
         &dir,
         "owner",
-        OFlag::O_RDONLY | OFlag::O_NOFOLLOW,
+        OFlag::O_RDONLY | OFlag::O_NOFOLLOW | OFlag::O_NONBLOCK,
         Mode::empty(),
     ) else {
         return;
     };
     let file = fs::File::from(marker_fd);
+    if !file
+        .metadata()
+        .is_ok_and(|metadata| metadata.file_type().is_file())
+    {
+        return;
+    }
     let mut contents = Vec::with_capacity(PARSER_CLEANUP_MARKER.len() + 1);
     if file
         .take(PARSER_CLEANUP_MARKER.len() as u64 + 1)
@@ -1418,6 +1424,11 @@ mod tests {
         fs::write(owned.join("owner"), PARSER_CLEANUP_MARKER).expect("write ownership marker");
         fs::write(owned.join("artifact"), b"stale parser").expect("write stale artifact");
         fs::create_dir(&unowned).expect("create unowned lookalike");
+        nix::unistd::mkfifo(
+            &unowned.join("owner"),
+            nix::sys::stat::Mode::S_IRUSR | nix::sys::stat::Mode::S_IWUSR,
+        )
+        .expect("create marker-shaped FIFO");
         fs::write(unowned.join("artifact"), b"user data").expect("write user data");
 
         cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup succeeds");

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -1312,8 +1312,8 @@ mod tests {
         let path = temp.path().join("staging");
         let lock = fs::File::create(&path).expect("create staging file");
         lock.lock_exclusive().expect("lock staging file");
-        let mut cmd = Command::new("sh");
-        cmd.arg("-c").arg("sleep 30");
+        let mut cmd = Command::new("sleep");
+        cmd.arg("30");
         inherit_staging_lock(&mut cmd, &lock);
         let mut child = cmd.spawn().expect("spawn lock inheritor");
         drop(lock);

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -485,7 +485,8 @@ fn cleanup_claim_pid(path: &Path) -> Option<u32> {
     if parts.next().is_some() || !is_canonical_decimal(pid) || !is_canonical_decimal(counter) {
         return None;
     }
-    pid.parse().ok()
+    let pid = pid.parse().ok()?;
+    (1..=i32::MAX as u32).contains(&pid).then_some(pid)
 }
 
 #[cfg(unix)]
@@ -1378,12 +1379,18 @@ mod tests {
             std::env::consts::DLL_EXTENSION
         ));
         let noncanonical_claim = parser_dir.join(".parser-cleanup.000123.0");
+        let zero_claim = parser_dir.join(".parser-cleanup.0.0");
+        let oversized_claim = parser_dir.join(format!(".parser-cleanup.{}.0", i32::MAX as u32 + 1));
         fs::write(&empty_counter, b"user file").expect("write user file");
         fs::write(&leading_zero, b"user file").expect("write user file");
         fs::write(&leading_zero_pid, b"user file").expect("write user file");
         fs::write(&zero_pid, b"user file").expect("write user file");
         fs::write(&oversized_pid, b"user file").expect("write user file");
         fs::write(&noncanonical_claim, b"user file").expect("write user file");
+        fs::create_dir(&zero_claim).expect("create zero-PID claim lookalike");
+        fs::write(zero_claim.join("owner"), PARSER_CLEANUP_MARKER).expect("write marker");
+        fs::create_dir(&oversized_claim).expect("create oversized-PID claim lookalike");
+        fs::write(oversized_claim.join("owner"), PARSER_CLEANUP_MARKER).expect("write marker");
 
         cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup succeeds");
 
@@ -1395,6 +1402,11 @@ mod tests {
         assert!(
             noncanonical_claim.exists(),
             "leading-zero cleanup claim PID is preserved"
+        );
+        assert!(zero_claim.exists(), "zero-PID cleanup claim is preserved");
+        assert!(
+            oversized_claim.exists(),
+            "oversized-PID cleanup claim is preserved"
         );
     }
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -564,6 +564,13 @@ fn claim_and_unlink_stale_parser_file(
             return Err(ParserInstallError::IoError(error));
         }
         let claimed = candidate.join("artifact");
+        // Among cooperating installers, `path` cannot change here: its
+        // create_new reservation remains present until this atomic rename, and
+        // every cleaner follows this same lock/claim protocol. A same-UID actor
+        // deliberately rewriting the private data directory can also delete an
+        // installed parser directly and is outside this filesystem protocol's
+        // trust boundary. The post-rename inode check still fail-closes without
+        // deleting an unexpected inode.
         match fs::rename(path, &claimed) {
             Ok(()) => {
                 let current = fs::symlink_metadata(&claimed)?;
@@ -697,7 +704,9 @@ fn cleanup_interrupted_parser_installs(parser_dir: &Path) -> Result<(), ParserIn
             // installer reserves staging paths with create_new, so after this
             // claim it may safely reuse the old PID/counter name without our
             // cleanup deleting its newly-created output.
-            let Some(claimed) = claim_and_unlink_stale_parser_file(parser_dir, &path)? else {
+            // Recovery is best-effort. An unreadable or otherwise unclaimable
+            // lookalike must not prevent installation from proceeding.
+            let Ok(Some(claimed)) = claim_and_unlink_stale_parser_file(parser_dir, &path) else {
                 continue;
             };
             remove_stale_cleanup_claim(&claimed);
@@ -1456,6 +1465,28 @@ mod tests {
 
         assert!(staged.is_dir(), "non-file staging path is preserved");
         assert!(claim.is_dir(), "non-file cleanup claim is preserved");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_skips_unreadable_staging_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let staged = parser_dir.join(format!(
+            ".lua.{}.0.{}.tmp",
+            terminated_child_pid(),
+            std::env::consts::DLL_EXTENSION
+        ));
+        fs::write(&staged, b"unreadable lookalike").expect("write staging file");
+        fs::set_permissions(&staged, fs::Permissions::from_mode(0o000))
+            .expect("remove read permission");
+
+        cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup remains best-effort");
+
+        assert!(staged.exists(), "unreadable staging file is preserved");
     }
 
     #[cfg(unix)]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -568,12 +568,10 @@ fn claim_and_unlink_stale_parser_file(
             Ok(()) => {
                 let current = fs::symlink_metadata(&claimed)?;
                 if opened.dev() != current.dev() || opened.ino() != current.ino() {
-                    // A non-cooperating actor replaced the pathname just before
-                    // the atomic claim. Restore it when the original name is
-                    // still free; never delete the unexpected inode.
-                    let _ = fs::rename(&claimed, path);
+                    // Never restore with rename: Unix rename would overwrite a
+                    // new entry created at the original pathname. Invalidate
+                    // provenance and retain the unexpected inode in the claim.
                     let _ = fs::remove_file(&marker);
-                    let _ = fs::remove_dir(&candidate);
                     return Ok(None);
                 }
                 return Ok(Some(candidate));
@@ -597,16 +595,33 @@ const PARSER_CLEANUP_MARKER: &[u8] = b"kakehashi parser cleanup v1\n";
 #[cfg(unix)]
 fn remove_stale_cleanup_claim(path: &Path) {
     use std::io::Read;
-    use std::os::unix::fs::OpenOptionsExt;
+    use std::os::unix::fs::MetadataExt;
 
-    let marker = path.join("owner");
-    let Ok(file) = fs::OpenOptions::new()
-        .read(true)
-        .custom_flags(nix::libc::O_NOFOLLOW)
-        .open(&marker)
-    else {
+    use nix::fcntl::{OFlag, open, openat};
+    use nix::sys::stat::Mode;
+    use nix::unistd::{UnlinkatFlags, unlinkat};
+
+    let Ok(dir_fd) = open(
+        path,
+        OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW,
+        Mode::empty(),
+    ) else {
         return;
     };
+    let dir = fs::File::from(dir_fd);
+    let Ok(opened) = dir.metadata() else {
+        return;
+    };
+
+    let Ok(marker_fd) = openat(
+        &dir,
+        "owner",
+        OFlag::O_RDONLY | OFlag::O_NOFOLLOW,
+        Mode::empty(),
+    ) else {
+        return;
+    };
+    let file = fs::File::from(marker_fd);
     let mut contents = Vec::with_capacity(PARSER_CLEANUP_MARKER.len() + 1);
     if file
         .take(PARSER_CLEANUP_MARKER.len() as u64 + 1)
@@ -616,9 +631,19 @@ fn remove_stale_cleanup_claim(path: &Path) {
     {
         return;
     }
-    // The private, marker-bearing directory is the durable ownership record.
-    // remove_dir_all does not traverse a directory symlink swapped into `path`.
-    let _ = fs::remove_dir_all(path);
+    // Remove only the two protocol-owned entries through the opened directory
+    // descriptor. A rename-and-replace of `path` cannot redirect these unlinks.
+    let _ = unlinkat(&dir, "artifact", UnlinkatFlags::NoRemoveDir);
+    let _ = unlinkat(&dir, "owner", UnlinkatFlags::NoRemoveDir);
+
+    // The remaining directory is empty. Verify the pathname still names the
+    // opened directory before removing it; never recurse through the pathname.
+    let Ok(current) = fs::symlink_metadata(path) else {
+        return;
+    };
+    if opened.dev() == current.dev() && opened.ino() == current.ino() {
+        let _ = fs::remove_dir(path);
+    }
 }
 
 #[cfg(unix)]
@@ -669,7 +694,7 @@ fn cleanup_interrupted_parser_installs(parser_dir: &Path) -> Result<(), ParserIn
             let Some(claimed) = claim_and_unlink_stale_parser_file(parser_dir, &path)? else {
                 continue;
             };
-            let _ = fs::remove_dir_all(claimed);
+            remove_stale_cleanup_claim(&claimed);
         }
     }
     Ok(())

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -284,13 +284,13 @@ pub fn install_parser(
     let parser_dir = options.data_dir.join("parser");
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
 
-    fs::create_dir_all(&parser_dir)?;
-    cleanup_interrupted_parser_installs(&parser_dir)?;
-
     // Check if parser already exists
     if parser_file.exists() && !options.force {
         return Err(ParserInstallError::AlreadyExists(parser_file));
     }
+
+    fs::create_dir_all(&parser_dir)?;
+    cleanup_interrupted_parser_installs(&parser_dir)?;
 
     // Fetch metadata (with caching support)
     if options.verbose {
@@ -1328,6 +1328,36 @@ mod tests {
             "staging-shaped symlink is preserved"
         );
         assert_eq!(fs::read(&target).expect("read target"), b"user data");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn existing_parser_returns_before_stale_cleanup() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let installed = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        fs::write(&installed, b"installed parser").expect("write installed parser");
+        let stale = parser_dir.join(format!(
+            ".json.{}.0.{}.tmp",
+            terminated_child_pid(),
+            std::env::consts::DLL_EXTENSION
+        ));
+        fs::write(&stale, b"stale parser").expect("write stale parser");
+        let options = InstallOptions {
+            data_dir: temp.path().to_path_buf(),
+            force: false,
+            verbose: false,
+            no_cache: false,
+            compile: ParserCompile::InProcess,
+        };
+
+        let result = install_parser("lua", &options);
+
+        assert!(
+            matches!(result, Err(ParserInstallError::AlreadyExists(path)) if path == installed)
+        );
+        assert!(stale.exists(), "no cleanup runs for a rejected install");
     }
 
     const TREE_SITTER_JSON_URL: &str =

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -493,6 +493,8 @@ fn claim_and_unlink_stale_parser_file(
     parser_dir: &Path,
     path: &Path,
 ) -> Result<Option<PathBuf>, ParserInstallError> {
+    use std::io::Write;
+    use std::os::unix::fs::DirBuilderExt;
     use std::os::unix::fs::MetadataExt;
     use std::os::unix::fs::OpenOptionsExt;
 
@@ -540,80 +542,83 @@ fn claim_and_unlink_stale_parser_file(
             std::process::id(),
             PARSER_TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
         ));
-        match fs::hard_link(path, &candidate) {
+        let mut builder = fs::DirBuilder::new();
+        builder.mode(0o700);
+        match builder.create(&candidate) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(ParserInstallError::IoError(error)),
+        }
+        let marker = candidate.join("owner");
+        let marker_result = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .custom_flags(nix::libc::O_NOFOLLOW)
+            .open(&marker)
+            .and_then(|mut file| {
+                file.write_all(PARSER_CLEANUP_MARKER)?;
+                file.sync_all()
+            });
+        if let Err(error) = marker_result {
+            let _ = fs::remove_dir(&candidate);
+            return Err(ParserInstallError::IoError(error));
+        }
+        let claimed = candidate.join("artifact");
+        match fs::rename(path, &claimed) {
             Ok(()) => {
-                // The directory entry is the authority for unlink. Re-check
-                // after creating the claim so a pathname replacement cannot
-                // make us delete an inode other than the one we locked.
-                let current = match fs::symlink_metadata(path) {
-                    Ok(metadata) => metadata,
-                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                        let _ = fs::remove_file(&candidate);
-                        return Ok(None);
-                    }
-                    Err(error) => return Err(ParserInstallError::IoError(error)),
-                };
+                let current = fs::symlink_metadata(&claimed)?;
                 if opened.dev() != current.dev() || opened.ino() != current.ino() {
-                    let _ = fs::remove_file(&candidate);
+                    // A non-cooperating actor replaced the pathname just before
+                    // the atomic claim. Restore it when the original name is
+                    // still free; never delete the unexpected inode.
+                    let _ = fs::rename(&claimed, path);
+                    let _ = fs::remove_file(&marker);
+                    let _ = fs::remove_dir(&candidate);
                     return Ok(None);
-                }
-                match fs::remove_file(path) {
-                    Ok(()) => {}
-                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(error) => return Err(ParserInstallError::IoError(error)),
                 }
                 return Ok(Some(candidate));
             }
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            // Cleanup is opportunistic. Some Unix-backed data directories do
-            // not support hard links; leaving a stale artifact is preferable
-            // to making every future parser install fail there.
-            Err(_) => return Ok(None),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let _ = fs::remove_file(&marker);
+                let _ = fs::remove_dir(&candidate);
+                return Ok(None);
+            }
+            Err(_) => {
+                let _ = fs::remove_file(&marker);
+                let _ = fs::remove_dir(&candidate);
+                return Ok(None);
+            }
         }
     }
 }
 
-#[cfg(unix)]
-fn unlink_stale_cleanup_claim(path: &Path) -> Result<(), ParserInstallError> {
-    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+const PARSER_CLEANUP_MARKER: &[u8] = b"kakehashi parser cleanup v1\n";
 
-    let file = match fs::OpenOptions::new()
+#[cfg(unix)]
+fn remove_stale_cleanup_claim(path: &Path) {
+    use std::io::Read;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let marker = path.join("owner");
+    let Ok(file) = fs::OpenOptions::new()
         .read(true)
-        .custom_flags(nix::libc::O_NONBLOCK | nix::libc::O_NOFOLLOW)
-        .open(path)
+        .custom_flags(nix::libc::O_NOFOLLOW)
+        .open(&marker)
+    else {
+        return;
+    };
+    let mut contents = Vec::with_capacity(PARSER_CLEANUP_MARKER.len() + 1);
+    if file
+        .take(PARSER_CLEANUP_MARKER.len() as u64 + 1)
+        .read_to_end(&mut contents)
+        .is_err()
+        || contents != PARSER_CLEANUP_MARKER
     {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(error) if error.raw_os_error() == Some(nix::libc::ELOOP) => return Ok(()),
-        Err(_) => return Ok(()),
-    };
-    if !file.metadata()?.file_type().is_file() || file.try_lock_exclusive().is_err() {
-        return Ok(());
+        return;
     }
-    let opened = file.metadata()?;
-    let current = match fs::symlink_metadata(path) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(_) => return Ok(()),
-    };
-    if opened.dev() != current.dev() || opened.ino() != current.ino() {
-        return Ok(());
-    }
-    match fs::remove_file(path) {
-        Ok(()) => Ok(()),
-        Err(error)
-            if matches!(
-                error.kind(),
-                std::io::ErrorKind::NotFound | std::io::ErrorKind::IsADirectory
-            ) =>
-        {
-            Ok(())
-        }
-        // Recovery is best-effort; an undeletable abandoned claim must not
-        // prevent an otherwise valid parser installation.
-        Err(_) => Ok(()),
-    }
+    // The private, marker-bearing directory is the durable ownership record.
+    // remove_dir_all does not traverse a directory symlink swapped into `path`.
+    let _ = fs::remove_dir_all(path);
 }
 
 #[cfg(unix)]
@@ -649,7 +654,7 @@ fn cleanup_interrupted_parser_installs(parser_dir: &Path) -> Result<(), ParserIn
         let path = entry.path();
         if let Some(pid) = cleanup_claim_pid(&path) {
             if !process_is_running(pid) {
-                unlink_stale_cleanup_claim(&path)?;
+                remove_stale_cleanup_claim(&path);
             }
             continue;
         }
@@ -664,11 +669,7 @@ fn cleanup_interrupted_parser_installs(parser_dir: &Path) -> Result<(), ParserIn
             let Some(claimed) = claim_and_unlink_stale_parser_file(parser_dir, &path)? else {
                 continue;
             };
-            match fs::remove_file(claimed) {
-                Ok(()) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) => return Err(ParserInstallError::IoError(error)),
-            }
+            let _ = fs::remove_dir_all(claimed);
         }
     }
     Ok(())
@@ -1381,20 +1382,23 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn cleanup_preserves_cleanup_claim_locked_by_live_cleaner() {
+    fn cleanup_only_removes_proven_cleanup_claims() {
         let temp = tempdir().expect("temp dir");
         let parser_dir = temp.path().join("parser");
         fs::create_dir_all(&parser_dir).expect("create parser dir");
-        let claim = parser_dir.join(format!(".parser-cleanup.{}.0", terminated_child_pid()));
-        fs::write(&claim, b"claimed parser").expect("write cleanup claim");
-        let claimed_elsewhere = fs::File::open(&claim).expect("open cleanup claim");
-        claimed_elsewhere
-            .lock_exclusive()
-            .expect("simulate live cleaner's claim");
+        let pid = terminated_child_pid();
+        let owned = parser_dir.join(format!(".parser-cleanup.{pid}.0"));
+        let unowned = parser_dir.join(format!(".parser-cleanup.{pid}.1"));
+        fs::create_dir(&owned).expect("create owned cleanup claim");
+        fs::write(owned.join("owner"), PARSER_CLEANUP_MARKER).expect("write ownership marker");
+        fs::write(owned.join("artifact"), b"stale parser").expect("write stale artifact");
+        fs::create_dir(&unowned).expect("create unowned lookalike");
+        fs::write(unowned.join("artifact"), b"user data").expect("write user data");
 
         cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup succeeds");
 
-        assert!(claim.exists(), "live cleaner retains its cleanup claim");
+        assert!(!owned.exists(), "proven abandoned claim is removed");
+        assert!(unowned.exists(), "unmarked lookalike is preserved");
     }
 
     #[cfg(unix)]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -18,6 +18,7 @@ use super::metadata::{FetchOptions, MetadataError, fetch_parser_metadata};
 
 /// HTTP timeout for archive downloads.
 const ARCHIVE_HTTP_TIMEOUT: Duration = Duration::from_secs(120);
+static PARSER_TMP_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
 /// Error types for parser installation.
 #[derive(Debug)]
@@ -335,14 +336,7 @@ pub fn install_parser(
     // install dedup. (Windows caveat: replacing a parser that is *currently loaded*
     // by this process still fails at the rename — a loaded DLL can't be removed — a
     // pre-existing platform limitation this scheme doesn't change.)
-    static TMP_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-    let tmp_file = parser_dir.join(format!(
-        ".{}.{}.{}.{}.tmp",
-        language,
-        std::process::id(),
-        TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
-        std::env::consts::DLL_EXTENSION
-    ));
+    let tmp_file = reserve_parser_staging_file(&parser_dir, language)?;
     let compiled = match options.compile {
         ParserCompile::KillableSubprocess => compile_parser(&source_dir, &tmp_file),
         ParserCompile::InProcess => compile_parser_inprocess(&source_dir, &tmp_file),
@@ -378,6 +372,30 @@ pub fn install_parser(
     })
 }
 
+fn reserve_parser_staging_file(
+    parser_dir: &Path,
+    language: &str,
+) -> Result<PathBuf, ParserInstallError> {
+    loop {
+        let candidate = parser_dir.join(format!(
+            ".{}.{}.{}.{}.tmp",
+            language,
+            std::process::id(),
+            PARSER_TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            std::env::consts::DLL_EXTENSION
+        ));
+        match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+        {
+            Ok(_) => return Ok(candidate),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(ParserInstallError::IoError(error)),
+        }
+    }
+}
+
 fn staged_parser_pid(path: &Path) -> Option<u32> {
     let name = path.file_name()?.to_str()?;
     let rest = name.strip_prefix('.')?.strip_suffix(".tmp")?;
@@ -388,6 +406,7 @@ fn staged_parser_pid(path: &Path) -> Option<u32> {
     let extension = parts.next()?;
     if parts.next().is_some()
         || !super::queries::is_safe_language_name(language)
+        || counter.is_empty()
         || !counter.bytes().all(|byte| byte.is_ascii_digit())
         || extension != std::env::consts::DLL_EXTENSION
     {
@@ -420,7 +439,21 @@ fn cleanup_interrupted_parser_installs(parser_dir: &Path) -> Result<(), ParserIn
             continue;
         };
         if !process_is_running(pid) {
-            match fs::remove_file(path) {
+            // Claim the stale pathname atomically before deleting it. A new
+            // installer reserves staging paths with create_new, so after this
+            // rename it may safely reuse the old PID/counter name without our
+            // cleanup deleting its newly-created output.
+            let claimed = parser_dir.join(format!(
+                ".parser-cleanup.{}.{}",
+                std::process::id(),
+                PARSER_TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            ));
+            match fs::rename(&path, &claimed) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(ParserInstallError::IoError(error)),
+            }
+            match fs::remove_file(claimed) {
                 Ok(()) => {}
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
                 Err(error) => return Err(ParserInstallError::IoError(error)),
@@ -1037,6 +1070,20 @@ mod tests {
         cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup succeeds");
 
         assert!(staged.exists(), "live process staging file is preserved");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_preserves_noncanonical_staging_name() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let staged = parser_dir.join(format!(".lua.123..{}.tmp", std::env::consts::DLL_EXTENSION));
+        fs::write(&staged, b"user file").expect("write user file");
+
+        cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup succeeds");
+
+        assert!(staged.exists(), "noncanonical staging name is preserved");
     }
 
     const TREE_SITTER_JSON_URL: &str =

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -243,7 +243,11 @@ fn self_exe_for_reexec() -> Result<PathBuf, ParserInstallError> {
 /// subprocess") and bound it with [`PARSER_COMPILE_TIMEOUT`]. Re-exec rather than
 /// `fork`: forking a multithreaded process is unsafe past the child's first
 /// non-async-signal-safe call.
-fn compile_parser(grammar_path: &Path, output_path: &Path) -> Result<(), ParserInstallError> {
+fn compile_parser(
+    grammar_path: &Path,
+    output_path: &Path,
+    staging_lock: Option<&fs::File>,
+) -> Result<(), ParserInstallError> {
     let mut cmd = Command::new(self_exe_for_reexec()?);
     cmd.arg("__compile-parser")
         .arg(grammar_path)
@@ -253,6 +257,9 @@ fn compile_parser(grammar_path: &Path, output_path: &Path) -> Result<(), ParserI
         // inherited so `cc` diagnostics land in the logs.
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null());
+    if let Some(staging_lock) = staging_lock {
+        inherit_staging_lock(&mut cmd, staging_lock);
+    }
     let status = run_killable_subprocess(cmd, PARSER_COMPILE_TIMEOUT, "parser compile")?;
     if !status.success() {
         return Err(ParserInstallError::CompileError(format!(
@@ -263,6 +270,32 @@ fn compile_parser(grammar_path: &Path, output_path: &Path) -> Result<(), ParserI
     }
     Ok(())
 }
+
+#[cfg(unix)]
+fn inherit_staging_lock(cmd: &mut Command, staging_lock: &fs::File) {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::process::CommandExt;
+
+    let fd = staging_lock.as_raw_fd();
+    // Only the forked child clears CLOEXEC on its copy. The descriptor then
+    // keeps the advisory lock alive through our re-exec and the compiler it
+    // launches if the installer process exits unexpectedly.
+    unsafe {
+        cmd.pre_exec(move || {
+            let flags = nix::libc::fcntl(fd, nix::libc::F_GETFD);
+            if flags == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if nix::libc::fcntl(fd, nix::libc::F_SETFD, flags & !nix::libc::FD_CLOEXEC) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+}
+
+#[cfg(not(unix))]
+fn inherit_staging_lock(_cmd: &mut Command, _staging_lock: &fs::File) {}
 
 /// Install a Tree-sitter parser for a language.
 pub fn install_parser(
@@ -338,9 +371,11 @@ pub fn install_parser(
     // install dedup. (Windows caveat: replacing a parser that is *currently loaded*
     // by this process still fails at the rename — a loaded DLL can't be removed — a
     // pre-existing platform limitation this scheme doesn't change.)
-    let (tmp_file, _tmp_lock) = reserve_parser_staging_file(&parser_dir, language)?;
+    let (tmp_file, tmp_lock) = reserve_parser_staging_file(&parser_dir, language)?;
     let compiled = match options.compile {
-        ParserCompile::KillableSubprocess => compile_parser(&source_dir, &tmp_file),
+        ParserCompile::KillableSubprocess => {
+            compile_parser(&source_dir, &tmp_file, tmp_lock.as_ref())
+        }
         ParserCompile::InProcess => compile_parser_inprocess(&source_dir, &tmp_file),
     };
     match compiled {
@@ -1177,6 +1212,29 @@ mod tests {
         child.wait().expect("wait for short-lived child");
         assert!(!process_is_running(pid), "reaped child PID is not running");
         pid
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn staging_lock_is_inherited_through_exec() {
+        let temp = tempdir().expect("temp dir");
+        let path = temp.path().join("staging");
+        let lock = fs::File::create(&path).expect("create staging file");
+        lock.lock_exclusive().expect("lock staging file");
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("sleep 30");
+        inherit_staging_lock(&mut cmd, &lock);
+        let mut child = cmd.spawn().expect("spawn lock inheritor");
+        drop(lock);
+
+        let contender = fs::File::open(&path).expect("open staging file");
+        assert!(
+            contender.try_lock_exclusive().is_err(),
+            "exec child retains the staging lock after the parent drops it"
+        );
+
+        child.kill().expect("kill lock inheritor");
+        child.wait().expect("reap lock inheritor");
     }
 
     #[cfg(unix)]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -406,13 +406,50 @@ fn staged_parser_pid(path: &Path) -> Option<u32> {
     let extension = parts.next()?;
     if parts.next().is_some()
         || !super::queries::is_safe_language_name(language)
-        || counter.is_empty()
-        || !counter.bytes().all(|byte| byte.is_ascii_digit())
+        || !is_canonical_decimal(counter)
         || extension != std::env::consts::DLL_EXTENSION
     {
         return None;
     }
     pid.parse().ok()
+}
+
+fn is_canonical_decimal(value: &str) -> bool {
+    !value.is_empty()
+        && value.bytes().all(|byte| byte.is_ascii_digit())
+        && (value == "0" || !value.starts_with('0'))
+}
+
+fn cleanup_claim_pid(path: &Path) -> Option<u32> {
+    let name = path.file_name()?.to_str()?;
+    let rest = name.strip_prefix(".parser-cleanup.")?;
+    let mut parts = rest.split('.');
+    let pid = parts.next()?;
+    let counter = parts.next()?;
+    if parts.next().is_some() || !is_canonical_decimal(counter) {
+        return None;
+    }
+    pid.parse().ok()
+}
+
+#[cfg(unix)]
+fn claim_stale_parser_file(
+    parser_dir: &Path,
+    path: &Path,
+) -> Result<Option<PathBuf>, ParserInstallError> {
+    loop {
+        let candidate = parser_dir.join(format!(
+            ".parser-cleanup.{}.{}",
+            std::process::id(),
+            PARSER_TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        match fs::hard_link(path, &candidate) {
+            Ok(()) => return Ok(Some(candidate)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(ParserInstallError::IoError(error)),
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -435,22 +472,30 @@ fn cleanup_interrupted_parser_installs(parser_dir: &Path) -> Result<(), ParserIn
     for entry in fs::read_dir(parser_dir)? {
         let entry = entry?;
         let path = entry.path();
+        if let Some(pid) = cleanup_claim_pid(&path) {
+            if !process_is_running(pid) {
+                match fs::remove_file(path) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => return Err(ParserInstallError::IoError(error)),
+                }
+            }
+            continue;
+        }
         let Some(pid) = staged_parser_pid(&path) else {
             continue;
         };
         if !process_is_running(pid) {
             // Claim the stale pathname atomically before deleting it. A new
             // installer reserves staging paths with create_new, so after this
-            // rename it may safely reuse the old PID/counter name without our
+            // claim it may safely reuse the old PID/counter name without our
             // cleanup deleting its newly-created output.
-            let claimed = parser_dir.join(format!(
-                ".parser-cleanup.{}.{}",
-                std::process::id(),
-                PARSER_TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ));
-            match fs::rename(&path, &claimed) {
+            let Some(claimed) = claim_stale_parser_file(parser_dir, &path)? else {
+                continue;
+            };
+            match fs::remove_file(&path) {
                 Ok(()) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
                 Err(error) => return Err(ParserInstallError::IoError(error)),
             }
             match fs::remove_file(claimed) {
@@ -1078,12 +1123,19 @@ mod tests {
         let temp = tempdir().expect("temp dir");
         let parser_dir = temp.path().join("parser");
         fs::create_dir_all(&parser_dir).expect("create parser dir");
-        let staged = parser_dir.join(format!(".lua.123..{}.tmp", std::env::consts::DLL_EXTENSION));
-        fs::write(&staged, b"user file").expect("write user file");
+        let empty_counter =
+            parser_dir.join(format!(".lua.123..{}.tmp", std::env::consts::DLL_EXTENSION));
+        let leading_zero = parser_dir.join(format!(
+            ".lua.123.01.{}.tmp",
+            std::env::consts::DLL_EXTENSION
+        ));
+        fs::write(&empty_counter, b"user file").expect("write user file");
+        fs::write(&leading_zero, b"user file").expect("write user file");
 
         cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup succeeds");
 
-        assert!(staged.exists(), "noncanonical staging name is preserved");
+        assert!(empty_counter.exists(), "empty counter name is preserved");
+        assert!(leading_zero.exists(), "leading-zero name is preserved");
     }
 
     const TREE_SITTER_JSON_URL: &str =

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -338,7 +338,7 @@ pub fn install_parser(
     // install dedup. (Windows caveat: replacing a parser that is *currently loaded*
     // by this process still fails at the rename — a loaded DLL can't be removed — a
     // pre-existing platform limitation this scheme doesn't change.)
-    let tmp_file = reserve_parser_staging_file(&parser_dir, language)?;
+    let (tmp_file, _tmp_lock) = reserve_parser_staging_file(&parser_dir, language)?;
     let compiled = match options.compile {
         ParserCompile::KillableSubprocess => compile_parser(&source_dir, &tmp_file),
         ParserCompile::InProcess => compile_parser_inprocess(&source_dir, &tmp_file),
@@ -377,7 +377,7 @@ pub fn install_parser(
 fn reserve_parser_staging_file(
     parser_dir: &Path,
     language: &str,
-) -> Result<PathBuf, ParserInstallError> {
+) -> Result<(PathBuf, Option<fs::File>), ParserInstallError> {
     loop {
         let candidate = parser_dir.join(format!(
             ".{}.{}.{}.{}.tmp",
@@ -391,7 +391,18 @@ fn reserve_parser_staging_file(
             .create_new(true)
             .open(&candidate)
         {
-            Ok(_) => return Ok(candidate),
+            Ok(file) => {
+                #[cfg(unix)]
+                {
+                    file.lock_exclusive()?;
+                    return Ok((candidate, Some(file)));
+                }
+                #[cfg(not(unix))]
+                {
+                    drop(file);
+                    return Ok((candidate, None));
+                }
+            }
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(error) => return Err(ParserInstallError::IoError(error)),
         }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -561,6 +561,9 @@ fn claim_and_unlink_stale_parser_file(
                 file.sync_all()
             });
         if let Err(error) = marker_result {
+            // `write_all` or `sync_all` may fail after creating a partial
+            // marker. Remove it before the now-empty claim directory.
+            let _ = fs::remove_file(&marker);
             let _ = fs::remove_dir(&candidate);
             return Err(ParserInstallError::IoError(error));
         }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -10,6 +10,8 @@ use std::process::Command;
 use std::time::Duration;
 
 use flate2::read::GzDecoder;
+#[cfg(unix)]
+use fs4::fs_std::FileExt;
 use tar::Archive;
 use tree_sitter_loader::Loader;
 
@@ -406,6 +408,7 @@ fn staged_parser_pid(path: &Path) -> Option<u32> {
     let extension = parts.next()?;
     if parts.next().is_some()
         || !super::queries::is_safe_language_name(language)
+        || !is_canonical_decimal(pid)
         || !is_canonical_decimal(counter)
         || extension != std::env::consts::DLL_EXTENSION
     {
@@ -426,17 +429,39 @@ fn cleanup_claim_pid(path: &Path) -> Option<u32> {
     let mut parts = rest.split('.');
     let pid = parts.next()?;
     let counter = parts.next()?;
-    if parts.next().is_some() || !is_canonical_decimal(counter) {
+    if parts.next().is_some() || !is_canonical_decimal(pid) || !is_canonical_decimal(counter) {
         return None;
     }
     pid.parse().ok()
 }
 
 #[cfg(unix)]
-fn claim_stale_parser_file(
+fn claim_and_unlink_stale_parser_file(
     parser_dir: &Path,
     path: &Path,
 ) -> Result<Option<PathBuf>, ParserInstallError> {
+    use std::os::unix::fs::MetadataExt;
+
+    let file = match fs::OpenOptions::new().read(true).open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(ParserInstallError::IoError(error)),
+    };
+    match file.try_lock_exclusive() {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => return Ok(None),
+        Err(error) => return Err(ParserInstallError::IoError(error)),
+    }
+    let opened = file.metadata()?;
+    let current = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(ParserInstallError::IoError(error)),
+    };
+    if opened.dev() != current.dev() || opened.ino() != current.ino() {
+        return Ok(None);
+    }
+
     loop {
         let candidate = parser_dir.join(format!(
             ".parser-cleanup.{}.{}",
@@ -444,7 +469,14 @@ fn claim_stale_parser_file(
             PARSER_TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
         ));
         match fs::hard_link(path, &candidate) {
-            Ok(()) => return Ok(Some(candidate)),
+            Ok(()) => {
+                match fs::remove_file(path) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => return Err(ParserInstallError::IoError(error)),
+                }
+                return Ok(Some(candidate));
+            }
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(error) => return Err(ParserInstallError::IoError(error)),
@@ -490,14 +522,9 @@ fn cleanup_interrupted_parser_installs(parser_dir: &Path) -> Result<(), ParserIn
             // installer reserves staging paths with create_new, so after this
             // claim it may safely reuse the old PID/counter name without our
             // cleanup deleting its newly-created output.
-            let Some(claimed) = claim_stale_parser_file(parser_dir, &path)? else {
+            let Some(claimed) = claim_and_unlink_stale_parser_file(parser_dir, &path)? else {
                 continue;
             };
-            match fs::remove_file(&path) {
-                Ok(()) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) => return Err(ParserInstallError::IoError(error)),
-            }
             match fs::remove_file(claimed) {
                 Ok(()) => {}
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
@@ -1129,13 +1156,50 @@ mod tests {
             ".lua.123.01.{}.tmp",
             std::env::consts::DLL_EXTENSION
         ));
+        let leading_zero_pid = parser_dir.join(format!(
+            ".lua.000123.0.{}.tmp",
+            std::env::consts::DLL_EXTENSION
+        ));
+        let noncanonical_claim = parser_dir.join(".parser-cleanup.000123.0");
         fs::write(&empty_counter, b"user file").expect("write user file");
         fs::write(&leading_zero, b"user file").expect("write user file");
+        fs::write(&leading_zero_pid, b"user file").expect("write user file");
+        fs::write(&noncanonical_claim, b"user file").expect("write user file");
 
         cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup succeeds");
 
         assert!(empty_counter.exists(), "empty counter name is preserved");
         assert!(leading_zero.exists(), "leading-zero name is preserved");
+        assert!(leading_zero_pid.exists(), "leading-zero PID is preserved");
+        assert!(
+            noncanonical_claim.exists(),
+            "leading-zero cleanup claim PID is preserved"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_preserves_staging_file_claimed_by_another_cleaner() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let mut pid = std::process::id().saturating_add(100_000);
+        while process_is_running(pid) {
+            pid = pid.saturating_add(1);
+        }
+        let staged = parser_dir.join(format!(
+            ".lua.{pid}.0.{}.tmp",
+            std::env::consts::DLL_EXTENSION
+        ));
+        fs::write(&staged, b"partial parser").expect("write staged parser");
+        let claimed_elsewhere = fs::File::open(&staged).expect("open staged parser");
+        claimed_elsewhere
+            .lock_exclusive()
+            .expect("simulate another cleaner's claim");
+
+        cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup succeeds");
+
+        assert!(staged.exists(), "another cleaner owns the staging file");
     }
 
     const TREE_SITTER_JSON_URL: &str =

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -281,6 +281,9 @@ pub fn install_parser(
     let parser_dir = options.data_dir.join("parser");
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
 
+    fs::create_dir_all(&parser_dir)?;
+    cleanup_interrupted_parser_installs(&parser_dir)?;
+
     // Check if parser already exists
     if parser_file.exists() && !options.force {
         return Err(ParserInstallError::AlreadyExists(parser_file));
@@ -332,7 +335,6 @@ pub fn install_parser(
     // install dedup. (Windows caveat: replacing a parser that is *currently loaded*
     // by this process still fails at the rename — a loaded DLL can't be removed — a
     // pre-existing platform limitation this scheme doesn't change.)
-    fs::create_dir_all(&parser_dir)?;
     static TMP_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let tmp_file = parser_dir.join(format!(
         ".{}.{}.{}.{}.tmp",
@@ -374,6 +376,65 @@ pub fn install_parser(
         install_path: parser_file,
         revision: metadata.revision,
     })
+}
+
+fn staged_parser_pid(path: &Path) -> Option<u32> {
+    let name = path.file_name()?.to_str()?;
+    let rest = name.strip_prefix('.')?.strip_suffix(".tmp")?;
+    let mut parts = rest.split('.');
+    let language = parts.next()?;
+    let pid = parts.next()?;
+    let counter = parts.next()?;
+    let extension = parts.next()?;
+    if parts.next().is_some()
+        || !super::queries::is_safe_language_name(language)
+        || !counter.bytes().all(|byte| byte.is_ascii_digit())
+        || extension != std::env::consts::DLL_EXTENSION
+    {
+        return None;
+    }
+    pid.parse().ok()
+}
+
+#[cfg(unix)]
+fn process_is_running(pid: u32) -> bool {
+    let Ok(pid) = i32::try_from(pid) else {
+        return false;
+    };
+    if pid <= 0 {
+        return false;
+    }
+    match nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None) {
+        Ok(()) | Err(nix::errno::Errno::EPERM) => true,
+        Err(nix::errno::Errno::ESRCH) => false,
+        Err(_) => true,
+    }
+}
+
+#[cfg(unix)]
+fn cleanup_interrupted_parser_installs(parser_dir: &Path) -> Result<(), ParserInstallError> {
+    for entry in fs::read_dir(parser_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let Some(pid) = staged_parser_pid(&path) else {
+            continue;
+        };
+        if !process_is_running(pid) {
+            match fs::remove_file(path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(ParserInstallError::IoError(error)),
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn cleanup_interrupted_parser_installs(_parser_dir: &Path) -> Result<(), ParserInstallError> {
+    // There is no portable process-liveness API. Keep possibly live staging
+    // files instead of risking deletion of another installer process's output.
+    Ok(())
 }
 
 /// Construct a GitHub archive download URL from a repository URL and revision.
@@ -938,6 +999,45 @@ fn invalid_metadata(message: String) -> ParserInstallError {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_removes_staged_parser_from_dead_process() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let mut pid = std::process::id().saturating_add(100_000);
+        while process_is_running(pid) {
+            pid = pid.saturating_add(1);
+        }
+        let staged = parser_dir.join(format!(
+            ".lua.{pid}.0.{}.tmp",
+            std::env::consts::DLL_EXTENSION
+        ));
+        fs::write(&staged, b"partial parser").expect("write staged parser");
+
+        cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup succeeds");
+
+        assert!(!staged.exists(), "dead process staging file is removed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_preserves_staged_parser_from_live_process() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let staged = parser_dir.join(format!(
+            ".lua.{}.0.{}.tmp",
+            std::process::id(),
+            std::env::consts::DLL_EXTENSION
+        ));
+        fs::write(&staged, b"active parser").expect("write staged parser");
+
+        cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup succeeds");
+
+        assert!(staged.exists(), "live process staging file is preserved");
+    }
 
     const TREE_SITTER_JSON_URL: &str =
         "https://github.com/tree-sitter/tree-sitter-json/archive/v0.24.8.tar.gz";

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -575,6 +575,48 @@ fn claim_and_unlink_stale_parser_file(
 }
 
 #[cfg(unix)]
+fn unlink_stale_cleanup_claim(path: &Path) -> Result<(), ParserInstallError> {
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+    let file = match fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(nix::libc::O_NONBLOCK | nix::libc::O_NOFOLLOW)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) if error.raw_os_error() == Some(nix::libc::ELOOP) => return Ok(()),
+        Err(_) => return Ok(()),
+    };
+    if !file.metadata()?.file_type().is_file() || file.try_lock_exclusive().is_err() {
+        return Ok(());
+    }
+    let opened = file.metadata()?;
+    let current = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(_) => return Ok(()),
+    };
+    if opened.dev() != current.dev() || opened.ino() != current.ino() {
+        return Ok(());
+    }
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::IsADirectory
+            ) =>
+        {
+            Ok(())
+        }
+        // Recovery is best-effort; an undeletable abandoned claim must not
+        // prevent an otherwise valid parser installation.
+        Err(_) => Ok(()),
+    }
+}
+
+#[cfg(unix)]
 fn process_is_running(pid: u32) -> bool {
     let Ok(pid) = i32::try_from(pid) else {
         return false;
@@ -607,23 +649,7 @@ fn cleanup_interrupted_parser_installs(parser_dir: &Path) -> Result<(), ParserIn
         let path = entry.path();
         if let Some(pid) = cleanup_claim_pid(&path) {
             if !process_is_running(pid) {
-                let is_file = match fs::symlink_metadata(&path) {
-                    Ok(metadata) => metadata.file_type().is_file(),
-                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
-                    Err(error) => return Err(ParserInstallError::IoError(error)),
-                };
-                if !is_file {
-                    continue;
-                }
-                match fs::remove_file(path) {
-                    Ok(()) => {}
-                    Err(error)
-                        if matches!(
-                            error.kind(),
-                            std::io::ErrorKind::NotFound | std::io::ErrorKind::IsADirectory
-                        ) => {}
-                    Err(error) => return Err(ParserInstallError::IoError(error)),
-                }
+                unlink_stale_cleanup_claim(&path)?;
             }
             continue;
         }
@@ -1351,6 +1377,24 @@ mod tests {
         cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup succeeds");
 
         assert!(staged.exists(), "another cleaner owns the staging file");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_preserves_cleanup_claim_locked_by_live_cleaner() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let claim = parser_dir.join(format!(".parser-cleanup.{}.0", terminated_child_pid()));
+        fs::write(&claim, b"claimed parser").expect("write cleanup claim");
+        let claimed_elsewhere = fs::File::open(&claim).expect("open cleanup claim");
+        claimed_elsewhere
+            .lock_exclusive()
+            .expect("simulate live cleaner's claim");
+
+        cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup succeeds");
+
+        assert!(claim.exists(), "live cleaner retains its cleanup claim");
     }
 
     #[cfg(unix)]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -1291,9 +1291,12 @@ mod tests {
 
     #[cfg(unix)]
     fn terminated_child_pid() -> u32 {
-        let mut child = std::process::Command::new("true")
-            .spawn()
-            .expect("spawn short-lived child");
+        let mut child = std::process::Command::new(
+            std::env::current_exe().expect("resolve current test executable"),
+        )
+        .arg("--help")
+        .spawn()
+        .expect("spawn short-lived child");
         let pid = child.id();
         child.wait().expect("wait for short-lived child");
         assert!(!process_is_running(pid), "reaped child PID is not running");

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -317,13 +317,13 @@ pub fn install_parser(
     let parser_dir = options.data_dir.join("parser");
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
 
+    fs::create_dir_all(&parser_dir)?;
+    cleanup_interrupted_parser_installs(&parser_dir)?;
+
     // Check if parser already exists
     if parser_file.exists() && !options.force {
         return Err(ParserInstallError::AlreadyExists(parser_file));
     }
-
-    fs::create_dir_all(&parser_dir)?;
-    cleanup_interrupted_parser_installs(&parser_dir)?;
 
     // Fetch metadata (with caching support)
     if options.verbose {
@@ -1532,7 +1532,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn existing_parser_returns_before_stale_cleanup() {
+    fn existing_parser_still_cleans_stale_artifacts() {
         let temp = tempdir().expect("temp dir");
         let parser_dir = temp.path().join("parser");
         fs::create_dir_all(&parser_dir).expect("create parser dir");
@@ -1557,7 +1557,10 @@ mod tests {
         assert!(
             matches!(result, Err(ParserInstallError::AlreadyExists(path)) if path == installed)
         );
-        assert!(stale.exists(), "no cleanup runs for a rejected install");
+        assert!(
+            !stale.exists(),
+            "recovery runs even when the install is rejected"
+        );
     }
 
     const TREE_SITTER_JSON_URL: &str =

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -1295,6 +1295,8 @@ mod tests {
             std::env::current_exe().expect("resolve current test executable"),
         )
         .arg("--help")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
         .spawn()
         .expect("spawn short-lived child");
         let pid = child.id();

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -431,7 +431,8 @@ fn staged_parser_pid(path: &Path) -> Option<u32> {
     {
         return None;
     }
-    pid.parse().ok()
+    let pid = pid.parse().ok()?;
+    (1..=i32::MAX as u32).contains(&pid).then_some(pid)
 }
 
 fn is_canonical_decimal(value: &str) -> bool {
@@ -1155,15 +1156,23 @@ mod tests {
     use tempfile::tempdir;
 
     #[cfg(unix)]
+    fn terminated_child_pid() -> u32 {
+        let mut child = std::process::Command::new("true")
+            .spawn()
+            .expect("spawn short-lived child");
+        let pid = child.id();
+        child.wait().expect("wait for short-lived child");
+        assert!(!process_is_running(pid), "reaped child PID is not running");
+        pid
+    }
+
+    #[cfg(unix)]
     #[test]
     fn cleanup_removes_staged_parser_from_dead_process() {
         let temp = tempdir().expect("temp dir");
         let parser_dir = temp.path().join("parser");
         fs::create_dir_all(&parser_dir).expect("create parser dir");
-        let mut pid = std::process::id().saturating_add(100_000);
-        while process_is_running(pid) {
-            pid = pid.saturating_add(1);
-        }
+        let pid = terminated_child_pid();
         let staged = parser_dir.join(format!(
             ".lua.{pid}.0.{}.tmp",
             std::env::consts::DLL_EXTENSION
@@ -1209,10 +1218,18 @@ mod tests {
             ".lua.000123.0.{}.tmp",
             std::env::consts::DLL_EXTENSION
         ));
+        let zero_pid = parser_dir.join(format!(".lua.0.0.{}.tmp", std::env::consts::DLL_EXTENSION));
+        let oversized_pid = parser_dir.join(format!(
+            ".lua.{}.0.{}.tmp",
+            i32::MAX as u32 + 1,
+            std::env::consts::DLL_EXTENSION
+        ));
         let noncanonical_claim = parser_dir.join(".parser-cleanup.000123.0");
         fs::write(&empty_counter, b"user file").expect("write user file");
         fs::write(&leading_zero, b"user file").expect("write user file");
         fs::write(&leading_zero_pid, b"user file").expect("write user file");
+        fs::write(&zero_pid, b"user file").expect("write user file");
+        fs::write(&oversized_pid, b"user file").expect("write user file");
         fs::write(&noncanonical_claim, b"user file").expect("write user file");
 
         cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup succeeds");
@@ -1220,6 +1237,8 @@ mod tests {
         assert!(empty_counter.exists(), "empty counter name is preserved");
         assert!(leading_zero.exists(), "leading-zero name is preserved");
         assert!(leading_zero_pid.exists(), "leading-zero PID is preserved");
+        assert!(zero_pid.exists(), "zero PID is preserved");
+        assert!(oversized_pid.exists(), "oversized PID is preserved");
         assert!(
             noncanonical_claim.exists(),
             "leading-zero cleanup claim PID is preserved"
@@ -1232,10 +1251,7 @@ mod tests {
         let temp = tempdir().expect("temp dir");
         let parser_dir = temp.path().join("parser");
         fs::create_dir_all(&parser_dir).expect("create parser dir");
-        let mut pid = std::process::id().saturating_add(100_000);
-        while process_is_running(pid) {
-            pid = pid.saturating_add(1);
-        }
+        let pid = terminated_child_pid();
         let staged = parser_dir.join(format!(
             ".lua.{pid}.0.{}.tmp",
             std::env::consts::DLL_EXTENSION
@@ -1257,10 +1273,7 @@ mod tests {
         let temp = tempdir().expect("temp dir");
         let parser_dir = temp.path().join("parser");
         fs::create_dir_all(&parser_dir).expect("create parser dir");
-        let mut pid = std::process::id().saturating_add(100_000);
-        while process_is_running(pid) {
-            pid = pid.saturating_add(1);
-        }
+        let pid = terminated_child_pid();
         let staged = parser_dir.join(format!(
             ".lua.{pid}.0.{}.tmp",
             std::env::consts::DLL_EXTENSION

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -472,12 +472,14 @@ fn claim_and_unlink_stale_parser_file(
     let file = match fs::OpenOptions::new()
         .read(true)
         // The pathname can be replaced after symlink_metadata. Never block if
-        // an external actor swaps in a FIFO before open.
-        .custom_flags(nix::libc::O_NONBLOCK)
+        // an external actor swaps in a FIFO before open, and never follow a
+        // symlink swapped into the final path component.
+        .custom_flags(nix::libc::O_NONBLOCK | nix::libc::O_NOFOLLOW)
         .open(path)
     {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) if error.raw_os_error() == Some(nix::libc::ELOOP) => return Ok(None),
         Err(error) => return Err(ParserInstallError::IoError(error)),
     };
     if !file.metadata()?.file_type().is_file() {
@@ -488,7 +490,7 @@ fn claim_and_unlink_stale_parser_file(
         Err(_) => return Ok(None),
     }
     let opened = file.metadata()?;
-    let current = match fs::metadata(path) {
+    let current = match fs::symlink_metadata(path) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(ParserInstallError::IoError(error)),
@@ -539,8 +541,19 @@ fn process_is_running(pid: u32) -> bool {
 
 #[cfg(unix)]
 fn cleanup_interrupted_parser_installs(parser_dir: &Path) -> Result<(), ParserInstallError> {
-    for entry in fs::read_dir(parser_dir)? {
-        let entry = entry?;
+    let entries = match fs::read_dir(parser_dir) {
+        Ok(entries) => entries,
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied
+            ) =>
+        {
+            return Ok(());
+        }
+        Err(error) => return Err(ParserInstallError::IoError(error)),
+    };
+    for entry in entries.flatten() {
         let path = entry.path();
         if let Some(pid) = cleanup_claim_pid(&path) {
             if !process_is_running(pid) {
@@ -1286,6 +1299,35 @@ mod tests {
 
         assert!(staged.is_dir(), "non-file staging path is preserved");
         assert!(claim.is_dir(), "non-file cleanup claim is preserved");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_preserves_staging_symlink_and_target() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let target = temp.path().join("user-file");
+        fs::write(&target, b"user data").expect("write target");
+        let staged = parser_dir.join(format!(
+            ".lua.{}.0.{}.tmp",
+            terminated_child_pid(),
+            std::env::consts::DLL_EXTENSION
+        ));
+        symlink(&target, &staged).expect("create staging-shaped symlink");
+
+        cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup succeeds");
+
+        assert!(
+            fs::symlink_metadata(&staged)
+                .expect("symlink remains")
+                .file_type()
+                .is_symlink(),
+            "staging-shaped symlink is preserved"
+        );
+        assert_eq!(fs::read(&target).expect("read target"), b"user data");
     }
 
     const TREE_SITTER_JSON_URL: &str =

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -524,9 +524,21 @@ fn cleanup_interrupted_parser_installs(parser_dir: &Path) -> Result<(), ParserIn
         let path = entry.path();
         if let Some(pid) = cleanup_claim_pid(&path) {
             if !process_is_running(pid) {
+                let is_file = match fs::symlink_metadata(&path) {
+                    Ok(metadata) => metadata.file_type().is_file(),
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+                    Err(error) => return Err(ParserInstallError::IoError(error)),
+                };
+                if !is_file {
+                    continue;
+                }
                 match fs::remove_file(path) {
                     Ok(()) => {}
-                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error)
+                        if matches!(
+                            error.kind(),
+                            std::io::ErrorKind::NotFound | std::io::ErrorKind::IsADirectory
+                        ) => {}
                     Err(error) => return Err(ParserInstallError::IoError(error)),
                 }
             }
@@ -1234,11 +1246,14 @@ mod tests {
             ".lua.{pid}.0.{}.tmp",
             std::env::consts::DLL_EXTENSION
         ));
+        let claim = parser_dir.join(format!(".parser-cleanup.{pid}.0"));
         fs::create_dir(&staged).expect("create impostor directory");
+        fs::create_dir(&claim).expect("create impostor claim directory");
 
         cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup succeeds");
 
         assert!(staged.is_dir(), "non-file staging path is preserved");
+        assert!(claim.is_dir(), "non-file cleanup claim is preserved");
     }
 
     const TREE_SITTER_JSON_URL: &str =

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -462,6 +462,7 @@ fn staged_parser_pid(path: &Path) -> Option<u32> {
         || !super::queries::is_safe_language_name(language)
         || !is_canonical_decimal(pid)
         || !is_canonical_decimal(counter)
+        || counter.parse::<u64>().is_err()
         || extension != std::env::consts::DLL_EXTENSION
     {
         return None;
@@ -482,7 +483,11 @@ fn cleanup_claim_pid(path: &Path) -> Option<u32> {
     let mut parts = rest.split('.');
     let pid = parts.next()?;
     let counter = parts.next()?;
-    if parts.next().is_some() || !is_canonical_decimal(pid) || !is_canonical_decimal(counter) {
+    if parts.next().is_some()
+        || !is_canonical_decimal(pid)
+        || !is_canonical_decimal(counter)
+        || counter.parse::<u64>().is_err()
+    {
         return None;
     }
     let pid = pid.parse().ok()?;
@@ -601,6 +606,7 @@ fn claim_and_unlink_stale_parser_file(
     }
 }
 
+#[cfg(unix)]
 const PARSER_CLEANUP_MARKER: &[u8] = b"kakehashi parser cleanup v1\n";
 
 #[cfg(unix)]
@@ -1503,6 +1509,12 @@ mod tests {
         fs::write(&staged, b"unreadable lookalike").expect("write staging file");
         fs::set_permissions(&staged, fs::Permissions::from_mode(0o000))
             .expect("remove read permission");
+
+        if fs::File::open(&staged).is_ok() {
+            fs::set_permissions(&staged, fs::Permissions::from_mode(0o600))
+                .expect("restore staging permissions");
+            return;
+        }
 
         cleanup_interrupted_parser_installs(&parser_dir).expect("cleanup remains best-effort");
 


### PR DESCRIPTION
Closes #716.

## Problem

A killed parser installer can leave its compiled `.LANG.PID.COUNTER.EXT.tmp` artifact permanently in the persistent parser directory. Normal error cleanup never runs after a crash or `SIGKILL`, and later installs did not recover those artifacts.

## Change

- recognize only the exact kakehashi-owned parser staging filename shape
- on Unix, remove artifacts whose owner PID is no longer alive
- preserve artifacts belonging to live concurrent installers
- conservatively leave staging files untouched on platforms without a portable process-liveness check
- run recovery before the ordinary already-installed early return

## Verification

- `cargo test --lib install::parser::tests` (48 passed)
- `cargo fmt --check`
- `cargo clippy --lib --tests -- -D warnings` reaches only the two pre-existing `clippy::single_range_in_vec_init` failures in `src/language/injection/discovery.rs:1576,1586`; this PR does not touch that file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from interrupted parser installations by cleaning only verifiable stale staging artifacts.
  * Prevented active or unrelated installation outputs from being removed during cleanup.
  * Improved reliability of separate-process parser compilation by safely inheriting staging locks on Unix.
* **Tests**
  * Expanded Unix test coverage for staging-lock inheritance and cleanup correctness across live vs dead processes and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->