### PR TITLE
fix(install): preserve parser uninstall order

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -854,7 +854,7 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
     // Install queries (with inherited dependencies)
     eprintln!("Installing queries for '{}' to {:?}...", language, data_dir);
 
-    match queries::install_queries_with_dependencies_after_install_started(
+    match queries::install_queries_with_dependencies_after_install_started_with_permit(
         language,
         &data_dir,
         force,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -483,14 +483,39 @@ fn installed_query_language_name(path: &Path) -> Option<String> {
     Some(name.to_string())
 }
 
+fn collect_installed_languages(parser_dir: &Path, queries_dir: &Path) -> Vec<String> {
+    use std::collections::BTreeSet;
+    use std::fs;
+
+    let mut languages = BTreeSet::new();
+    if let Ok(entries) = fs::read_dir(parser_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let is_parser = path
+                .extension()
+                .map(|ext| ext == std::env::consts::DLL_EXTENSION)
+                .unwrap_or(false);
+            if is_parser && let Some(stem) = path.file_stem() {
+                languages.insert(stem.to_string_lossy().to_string());
+            }
+        }
+    }
+    if let Ok(entries) = fs::read_dir(queries_dir) {
+        for entry in entries.flatten() {
+            if let Some(name) = installed_query_language_name(&entry.path()) {
+                languages.insert(name);
+            }
+        }
+    }
+    languages.into_iter().collect()
+}
+
 /// Run the language uninstall command
 fn run_language_uninstall(
     language: Option<String>,
     force: bool,
     all: bool,
 ) -> Result<(), ExitCode> {
-    use std::collections::BTreeSet;
-    use std::fs;
     use std::io::{self, Write};
 
     let data_dir = default_data_dir().ok_or_else(|| {
@@ -501,9 +526,9 @@ fn run_language_uninstall(
     // Acquire before discovery: an install that is still compiling has no
     // parser/query artifact to enumerate. Waiting for every active language
     // operation makes its publication visible before the --all snapshot, and
-    // retaining the lock through confirmation prevents a new language from
-    // appearing outside that snapshot before removal completes.
-    let _all_operations_lock = if all {
+    // retaining the lock through removal prevents a new language from
+    // appearing outside that snapshot before the command completes.
+    let mut all_operations_lock = if all {
         Some(
             AllLanguageOperationsLockGuard::acquire(&data_dir).map_err(|error| {
                 eprintln!("Error: failed to lock uninstall --all: {error}");
@@ -521,32 +546,8 @@ fn run_language_uninstall(
     }
 
     // Determine which languages to uninstall
-    let languages_to_uninstall: Vec<String> = if all {
-        // Collect all installed languages
-        let mut languages = BTreeSet::new();
-
-        if let Ok(entries) = fs::read_dir(&parser_dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                let is_parser = path
-                    .extension()
-                    .map(|ext| ext == std::env::consts::DLL_EXTENSION)
-                    .unwrap_or(false);
-                if is_parser && let Some(stem) = path.file_stem() {
-                    languages.insert(stem.to_string_lossy().to_string());
-                }
-            }
-        }
-
-        if let Ok(entries) = fs::read_dir(&queries_dir) {
-            for entry in entries.flatten() {
-                if let Some(name) = installed_query_language_name(&entry.path()) {
-                    languages.insert(name);
-                }
-            }
-        }
-
-        languages.into_iter().collect()
+    let mut languages_to_uninstall = if all {
+        collect_installed_languages(&parser_dir, &queries_dir)
     } else {
         vec![language.expect("language required when --all not specified")]
     };
@@ -556,18 +557,48 @@ fn run_language_uninstall(
         return Ok(());
     }
 
-    // Confirmation prompt unless --force
-    if !force {
-        if all {
+    // Confirmation prompt unless --force. Do not hold the global lock while
+    // waiting for input; if the installed set changes, reacquire, rediscover,
+    // and ask again so the displayed count remains the exact removal set.
+    if !force && all {
+        loop {
+            drop(all_operations_lock.take());
             eprint!(
                 "Uninstall all {} languages? [y/N] ",
                 languages_to_uninstall.len()
             );
-        } else {
-            eprint!("Uninstall '{}'? [y/N] ", languages_to_uninstall[0]);
-        }
-        io::stderr().flush().unwrap();
+            io::stderr().flush().unwrap();
 
+            let mut input = String::new();
+            if io::stdin().read_line(&mut input).is_err() || !input.trim().eq_ignore_ascii_case("y")
+            {
+                eprintln!("Cancelled.");
+                return Ok(());
+            }
+
+            all_operations_lock = Some(
+                AllLanguageOperationsLockGuard::acquire(&data_dir).map_err(|error| {
+                    eprintln!("Error: failed to lock uninstall --all: {error}");
+                    ExitCode::FAILURE
+                })?,
+            );
+            if let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {
+                eprintln!("Warning: failed to recover interrupted query installs: {e}");
+            }
+            let refreshed = collect_installed_languages(&parser_dir, &queries_dir);
+            if refreshed == languages_to_uninstall {
+                break;
+            }
+            languages_to_uninstall = refreshed;
+            if languages_to_uninstall.is_empty() {
+                eprintln!("No languages installed to uninstall.");
+                return Ok(());
+            }
+            eprintln!("Installed languages changed while awaiting confirmation; retrying.");
+        }
+    } else if !force {
+        eprint!("Uninstall '{}'? [y/N] ", languages_to_uninstall[0]);
+        io::stderr().flush().unwrap();
         let mut input = String::new();
         if io::stdin().read_line(&mut input).is_err() || !input.trim().eq_ignore_ascii_case("y") {
             eprintln!("Cancelled.");

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -643,7 +643,8 @@ fn run_language_uninstall(
         // Remove queries directory and any kakehashi-created backups under the
         // same lock used by install replacement, so uninstall cannot race a
         // concurrent install into resurrecting queries after reporting success.
-        match queries::remove_query_install_and_backups(&queries_dir, lang) {
+        match queries::remove_query_install_and_backups_after_operation_started(&queries_dir, lang)
+        {
             Ok(removal) => {
                 if removal.removed_queries {
                     eprintln!("✓ Removed queries: {}", queries_dir.join(lang).display());
@@ -663,7 +664,7 @@ fn run_language_uninstall(
         // lock with parser publication, its operation marker must be written after
         // query cleanup so an installer that starts during that cleanup cannot
         // publish a parser after this command reports success.
-        match parser::remove_parser_install(&parser_dir, lang) {
+        match parser::remove_parser_install_after_operation_started(&parser_dir, lang) {
             Ok(true) => {
                 eprintln!(
                     "✓ Removed parser: {}",

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -808,7 +808,7 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
 
     let _operation_lock =
         LanguageOperationLockGuard::acquire(&data_dir, language).map_err(|e| {
-            eprintln!("✗ Failed to lock installation for '{}': {}", language, e);
+            eprintln!("✗ Failed to lock installation for {:?}: {}", language, e);
             ExitCode::FAILURE
         })?;
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,5 +1,8 @@
 use clap::{Parser, Subcommand};
-use kakehashi::install::{LanguageOperationLockGuard, default_data_dir, metadata, parser, queries};
+use kakehashi::install::{
+    AllLanguageOperationsLockGuard, LanguageOperationLockGuard, default_data_dir, metadata, parser,
+    queries,
+};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
@@ -495,6 +498,22 @@ fn run_language_uninstall(
         ExitCode::FAILURE
     })?;
 
+    // Acquire before discovery: an install that is still compiling has no
+    // parser/query artifact to enumerate. Waiting for every active language
+    // operation makes its publication visible before the --all snapshot, and
+    // retaining the lock through confirmation prevents a new language from
+    // appearing outside that snapshot before removal completes.
+    let _all_operations_lock = if all {
+        Some(
+            AllLanguageOperationsLockGuard::acquire(&data_dir).map_err(|error| {
+                eprintln!("Error: failed to lock uninstall --all: {error}");
+                ExitCode::FAILURE
+            })?,
+        )
+    } else {
+        None
+    };
+
     let parser_dir = data_dir.join("parser");
     let queries_dir = data_dir.join("queries");
     if let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {
@@ -573,12 +592,18 @@ fn run_language_uninstall(
         // Parser and query locks protect their own artifacts, but only this
         // outer lock prevents their phases from interleaving with a complete
         // install in another process.
-        let _operation_lock = match LanguageOperationLockGuard::acquire(&data_dir, lang) {
-            Ok(lock) => lock,
-            Err(error) => {
-                eprintln!("✗ Failed to lock uninstall for '{}': {}", lang, error);
-                any_failed = true;
-                continue;
+        let _operation_lock = if all {
+            // The exclusive all-language lock already excludes every install
+            // and uninstall. Acquiring its shared side again would deadlock.
+            None
+        } else {
+            match LanguageOperationLockGuard::acquire(&data_dir, lang) {
+                Ok(lock) => Some(lock),
+                Err(error) => {
+                    eprintln!("✗ Failed to lock uninstall for '{}': {}", lang, error);
+                    any_failed = true;
+                    continue;
+                }
             }
         };
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -561,8 +561,8 @@ fn run_language_uninstall(
     let mut any_failed = false;
     for lang in &languages_to_uninstall {
         // Reject unsafe names before building any path from them: `lang` is
-        // user input and feeds fs::remove_file via find_parser_file, so a
-        // separator-carrying name must not escape the data dir.
+        // user input and feeds both removal APIs, so a separator-carrying name
+        // must not escape the data dir.
         if !queries::is_safe_language_name(lang) {
             // Debug-format: untrusted input could smuggle ANSI escapes.
             eprintln!("✗ Invalid language name {:?}", lang);
@@ -571,20 +571,6 @@ fn run_language_uninstall(
         }
 
         let mut removed_something = false;
-
-        // Remove parser file
-        if let Some(parser_path) = find_parser_file(&parser_dir, lang) {
-            match fs::remove_file(&parser_path) {
-                Ok(()) => {
-                    eprintln!("✓ Removed parser: {}", parser_path.display());
-                    removed_something = true;
-                }
-                Err(e) => {
-                    eprintln!("✗ Failed to remove parser {}: {}", parser_path.display(), e);
-                    any_failed = true;
-                }
-            }
-        }
 
         // Remove queries directory and any kakehashi-created backups under the
         // same lock used by install replacement, so uninstall cannot race a
@@ -601,6 +587,27 @@ fn run_language_uninstall(
             }
             Err(e) => {
                 eprintln!("✗ Failed to remove queries for '{}': {}", lang, e);
+                any_failed = true;
+            }
+        }
+
+        // Make parser removal the final artifact operation. Besides sharing a
+        // lock with parser publication, its tombstone must be written after
+        // query cleanup so an installer that starts during that cleanup cannot
+        // publish a parser after this command reports success.
+        match parser::remove_parser_install(&parser_dir, lang) {
+            Ok(true) => {
+                eprintln!(
+                    "✓ Removed parser: {}",
+                    parser_dir
+                        .join(format!("{}.{}", lang, std::env::consts::DLL_EXTENSION))
+                        .display()
+                );
+                removed_something = true;
+            }
+            Ok(false) => {}
+            Err(e) => {
+                eprintln!("✗ Failed to remove parser for '{}': {}", lang, e);
                 any_failed = true;
             }
         }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use kakehashi::install::{default_data_dir, metadata, parser, queries};
+use kakehashi::install::{LanguageOperationLockGuard, default_data_dir, metadata, parser, queries};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
@@ -570,6 +570,18 @@ fn run_language_uninstall(
             continue;
         }
 
+        // Parser and query locks protect their own artifacts, but only this
+        // outer lock prevents their phases from interleaving with a complete
+        // install in another process.
+        let _operation_lock = match LanguageOperationLockGuard::acquire(&data_dir, lang) {
+            Ok(lock) => lock,
+            Err(error) => {
+                eprintln!("✗ Failed to lock uninstall for '{}': {}", lang, error);
+                any_failed = true;
+                continue;
+            }
+        };
+
         let mut removed_something = false;
 
         // Remove queries directory and any kakehashi-created backups under the
@@ -713,6 +725,12 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
         eprintln!("Error: Could not determine data directory. Please specify --data-dir.");
         ExitCode::FAILURE
     })?;
+
+    let _operation_lock =
+        LanguageOperationLockGuard::acquire(&data_dir, language).map_err(|e| {
+            eprintln!("✗ Failed to lock installation for '{}': {}", language, e);
+            ExitCode::FAILURE
+        })?;
 
     // Track success/failure for exit code
     let mut parser_success = true;

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -541,7 +541,14 @@ fn run_language_uninstall(
 
     let parser_dir = data_dir.join("parser");
     let queries_dir = data_dir.join("queries");
-    if let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {
+    let recovery = match all_operations_lock.as_ref() {
+        Some(lock) => queries::recover_interrupted_query_installs_with_permit(
+            &queries_dir,
+            LanguageOperationPermit::All(lock),
+        ),
+        None => queries::recover_interrupted_query_installs(&queries_dir),
+    };
+    if let Err(e) = recovery {
         eprintln!("Warning: failed to recover interrupted query installs: {e}");
     }
 
@@ -582,7 +589,14 @@ fn run_language_uninstall(
                     ExitCode::FAILURE
                 })?,
             );
-            if let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {
+            if let Err(e) = queries::recover_interrupted_query_installs_with_permit(
+                &queries_dir,
+                LanguageOperationPermit::All(
+                    all_operations_lock
+                        .as_ref()
+                        .expect("--all reacquired its exclusive operation lock"),
+                ),
+            ) {
                 eprintln!("Warning: failed to recover interrupted query installs: {e}");
             }
             let refreshed = collect_installed_languages(&parser_dir, &queries_dir);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -416,7 +416,10 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
                 .map(|ext| ext == std::env::consts::DLL_EXTENSION)
                 .unwrap_or(false);
             if is_parser && let Some(stem) = path.file_stem() {
-                languages.insert(stem.to_string_lossy().to_string());
+                let stem = stem.to_string_lossy();
+                if queries::is_safe_language_name(&stem) {
+                    languages.insert(stem.to_string());
+                }
             }
         }
     }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -499,7 +499,10 @@ fn collect_installed_languages(parser_dir: &Path, queries_dir: &Path) -> Vec<Str
                 .map(|ext| ext == std::env::consts::DLL_EXTENSION)
                 .unwrap_or(false);
             if is_parser && let Some(stem) = path.file_stem() {
-                languages.insert(stem.to_string_lossy().to_string());
+                let stem = stem.to_string_lossy();
+                if queries::is_safe_language_name(&stem) {
+                    languages.insert(stem.to_string());
+                }
             }
         }
     }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -779,7 +779,7 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
         compile: parser::ParserCompile::KillableSubprocess,
     };
 
-    match parser::install_parser(language, &options) {
+    match parser::install_parser_after_operation_started(language, &options) {
         Ok(result) => {
             eprintln!("✓ Parser installed: {}", result.install_path.display());
             if verbose {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 use kakehashi::install::{
-    AllLanguageOperationsLockGuard, LanguageOperationLockGuard, default_data_dir, metadata, parser,
-    queries,
+    AllLanguageOperationsLockGuard, LanguageOperationLockGuard, LanguageOperationPermit,
+    default_data_dir, metadata, parser, queries,
 };
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -643,8 +643,19 @@ fn run_language_uninstall(
         // Remove queries directory and any kakehashi-created backups under the
         // same lock used by install replacement, so uninstall cannot race a
         // concurrent install into resurrecting queries after reporting success.
-        match queries::remove_query_install_and_backups_after_operation_started(&queries_dir, lang)
-        {
+        let operation_permit = match &_operation_lock {
+            Some(lock) => LanguageOperationPermit::Language(lock),
+            None => LanguageOperationPermit::All(
+                all_operations_lock
+                    .as_ref()
+                    .expect("--all retains its exclusive operation lock"),
+            ),
+        };
+        match queries::remove_query_install_and_backups_after_operation_started(
+            &queries_dir,
+            lang,
+            operation_permit,
+        ) {
             Ok(removal) => {
                 if removal.removed_queries {
                     eprintln!("✓ Removed queries: {}", queries_dir.join(lang).display());
@@ -664,7 +675,19 @@ fn run_language_uninstall(
         // lock with parser publication, its operation marker must be written after
         // query cleanup so an installer that starts during that cleanup cannot
         // publish a parser after this command reports success.
-        match parser::remove_parser_install_after_operation_started(&parser_dir, lang) {
+        let operation_permit = match &_operation_lock {
+            Some(lock) => LanguageOperationPermit::Language(lock),
+            None => LanguageOperationPermit::All(
+                all_operations_lock
+                    .as_ref()
+                    .expect("--all retains its exclusive operation lock"),
+            ),
+        };
+        match parser::remove_parser_install_after_operation_started(
+            &parser_dir,
+            lang,
+            operation_permit,
+        ) {
             Ok(true) => {
                 eprintln!(
                     "✓ Removed parser: {}",
@@ -811,7 +834,11 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
         compile: parser::ParserCompile::KillableSubprocess,
     };
 
-    match parser::install_parser_after_operation_started(language, &options) {
+    match parser::install_parser_after_operation_started(
+        language,
+        &options,
+        LanguageOperationPermit::Language(&_operation_lock),
+    ) {
         Ok(result) => {
             eprintln!("✓ Parser installed: {}", result.install_path.display());
             if verbose {
@@ -828,7 +855,10 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
     eprintln!("Installing queries for '{}' to {:?}...", language, data_dir);
 
     match queries::install_queries_with_dependencies_after_install_started(
-        language, &data_dir, force,
+        language,
+        &data_dir,
+        force,
+        LanguageOperationPermit::Language(&_operation_lock),
     ) {
         Ok(result) => {
             eprintln!("✓ Queries installed: {}", result.install_path.display());

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -604,7 +604,7 @@ fn run_language_uninstall(
         }
 
         // Make parser removal the final artifact operation. Besides sharing a
-        // lock with parser publication, its tombstone must be written after
+        // lock with parser publication, its operation marker must be written after
         // query cleanup so an installer that starts during that cleanup cannot
         // publish a parser after this command reports success.
         match parser::remove_parser_install(&parser_dir, lang) {

--- a/src/install.rs
+++ b/src/install.rs
@@ -28,7 +28,38 @@ pub mod test_helpers {
 
 pub(crate) use parser::parser_file_exists;
 
+use fs4::fs_std::FileExt;
+use std::fs;
 use std::path::PathBuf;
+
+/// Cross-process lock that makes parser and query changes one language operation.
+pub struct LanguageOperationLockGuard {
+    _file: fs::File,
+}
+
+impl LanguageOperationLockGuard {
+    /// Serialize install and uninstall for one language across processes.
+    pub fn acquire(
+        data_dir: &std::path::Path,
+        language: &str,
+    ) -> std::io::Result<LanguageOperationLockGuard> {
+        if !queries::is_safe_language_name(language) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("unsafe language name '{}'", language.escape_default()),
+            ));
+        }
+        let lock_dir = data_dir.join(".operation-locks");
+        fs::create_dir_all(&lock_dir)?;
+        let file = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(lock_dir.join(format!("{language}.lock")))?;
+        file.lock_exclusive()?;
+        Ok(Self { _file: file })
+    }
+}
 
 /// Get the default data directory for kakehashi.
 ///
@@ -279,6 +310,16 @@ fn install_language_blocking_with_query_installer(
         return result;
     }
 
+    let _operation_lock = match LanguageOperationLockGuard::acquire(data_dir, language) {
+        Ok(lock) => lock,
+        Err(error) => {
+            let reason = format!("Failed to lock language operation: {error}");
+            result.parser_error = Some(reason.clone());
+            result.queries_error = Some(reason);
+            return result;
+        }
+    };
+
     if let Err(e) = queries::clear_uninstall_tombstone_for_install(data_dir, language) {
         let reason = e.to_string();
         result.queries_error = Some(reason);
@@ -380,6 +421,33 @@ fn install_language_blocking_allowing_http_queries_for_tests(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn language_operation_lock_serializes_the_same_language() {
+        let temp = tempfile::tempdir().unwrap();
+        let first = LanguageOperationLockGuard::acquire(temp.path(), "lua").unwrap();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let data_dir = temp.path().to_path_buf();
+        let waiter = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            let _second = LanguageOperationLockGuard::acquire(&data_dir, "lua").unwrap();
+            acquired_tx.send(()).unwrap();
+        });
+        started_rx.recv().unwrap();
+
+        assert!(
+            acquired_rx
+                .recv_timeout(std::time::Duration::from_millis(100))
+                .is_err(),
+            "a same-language operation must wait for the current one"
+        );
+        drop(first);
+        acquired_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("the waiter acquires after release");
+        waiter.join().unwrap();
+    }
 
     #[test]
     fn test_default_data_dir_returns_some() {

--- a/src/install.rs
+++ b/src/install.rs
@@ -426,27 +426,18 @@ mod tests {
     fn language_operation_lock_serializes_the_same_language() {
         let temp = tempfile::tempdir().unwrap();
         let first = LanguageOperationLockGuard::acquire(temp.path(), "lua").unwrap();
-        let (started_tx, started_rx) = std::sync::mpsc::channel();
-        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
-        let data_dir = temp.path().to_path_buf();
-        let waiter = std::thread::spawn(move || {
-            started_tx.send(()).unwrap();
-            let _second = LanguageOperationLockGuard::acquire(&data_dir, "lua").unwrap();
-            acquired_tx.send(()).unwrap();
-        });
-        started_rx.recv().unwrap();
-
+        let second = fs::OpenOptions::new()
+            .write(true)
+            .open(temp.path().join(".operation-locks/lua.lock"))
+            .unwrap();
         assert!(
-            acquired_rx
-                .recv_timeout(std::time::Duration::from_millis(100))
-                .is_err(),
-            "a same-language operation must wait for the current one"
+            second.try_lock_exclusive().is_err(),
+            "the same-language lock must be unavailable while held"
         );
         drop(first);
-        acquired_rx
-            .recv_timeout(std::time::Duration::from_secs(5))
-            .expect("the waiter acquires after release");
-        waiter.join().unwrap();
+        second
+            .try_lock_exclusive()
+            .expect("the same-language lock becomes available after release");
     }
 
     #[test]

--- a/src/install.rs
+++ b/src/install.rs
@@ -54,6 +54,9 @@ pub enum LanguageOperationPermit<'a> {
 
 impl LanguageOperationPermit<'_> {
     pub(crate) fn covers(&self, data_dir: &std::path::Path, language: &str) -> bool {
+        let Ok(data_dir) = fs::canonicalize(data_dir) else {
+            return false;
+        };
         match self {
             Self::Language(guard) => guard.data_dir == data_dir && guard.language == language,
             Self::All(guard) => guard.data_dir == data_dir,
@@ -78,7 +81,7 @@ impl AllLanguageOperationsLockGuard {
         file.lock_exclusive()?;
         Ok(Self {
             _file: file,
-            data_dir: data_dir.to_path_buf(),
+            data_dir: fs::canonicalize(data_dir)?,
         })
     }
 }
@@ -107,7 +110,7 @@ impl LanguageOperationLockGuard {
         Ok(Self {
             _all_file: all_file,
             _file: file,
-            data_dir: data_dir.to_path_buf(),
+            data_dir: fs::canonicalize(data_dir)?,
             language: language.to_string(),
         })
     }
@@ -527,6 +530,22 @@ mod tests {
         assert!(permit.covers(temp.path(), "lua"));
         assert!(permit.covers(temp.path(), "python"));
         assert!(!permit.covers(other.path(), "lua"));
+    }
+
+    #[test]
+    fn operation_permit_uses_canonical_directory_identity() {
+        let temp = tempfile::tempdir().unwrap();
+        let data_dir = temp.path().join("data");
+        fs::create_dir_all(&data_dir).unwrap();
+        let equivalent = data_dir.join("nested/..");
+        fs::create_dir_all(data_dir.join("nested")).unwrap();
+
+        let language = LanguageOperationLockGuard::acquire(&equivalent, "lua").unwrap();
+        let permit = LanguageOperationPermit::Language(&language);
+        assert!(
+            permit.covers(&data_dir, "lua"),
+            "equivalent path spellings must identify the same locked directory"
+        );
     }
 
     #[test]

--- a/src/install.rs
+++ b/src/install.rs
@@ -62,6 +62,13 @@ impl LanguageOperationPermit<'_> {
             Self::All(guard) => guard.data_dir == data_dir,
         }
     }
+
+    pub(crate) fn covers_all(&self, data_dir: &std::path::Path) -> bool {
+        let Ok(data_dir) = fs::canonicalize(data_dir) else {
+            return false;
+        };
+        matches!(self, Self::All(guard) if guard.data_dir == data_dir)
+    }
 }
 
 fn open_all_language_operations_lock(data_dir: &std::path::Path) -> std::io::Result<fs::File> {

--- a/src/install.rs
+++ b/src/install.rs
@@ -371,7 +371,7 @@ fn install_language_blocking_with_query_installer(
     // AlreadyExists means the artifact is present and usable — success,
     // not failure; treating it as an error made the auto-install manager
     // degrade a fully-installed language to "installed but with warnings".
-    match parser::install_parser(language, &parser_options) {
+    match parser::install_parser_after_operation_started(language, &parser_options) {
         Ok(parser_result) => {
             result.parser_path = Some(parser_result.install_path);
         }

--- a/src/install.rs
+++ b/src/install.rs
@@ -36,11 +36,29 @@ use std::path::PathBuf;
 pub struct LanguageOperationLockGuard {
     _all_file: fs::File,
     _file: fs::File,
+    data_dir: PathBuf,
+    language: String,
 }
 
 /// Cross-process exclusive lock for operations that affect every language.
 pub struct AllLanguageOperationsLockGuard {
     _file: fs::File,
+    data_dir: PathBuf,
+}
+
+/// Proof that the caller holds an operation lock covering one language.
+pub enum LanguageOperationPermit<'a> {
+    Language(&'a LanguageOperationLockGuard),
+    All(&'a AllLanguageOperationsLockGuard),
+}
+
+impl LanguageOperationPermit<'_> {
+    pub(crate) fn covers(&self, data_dir: &std::path::Path, language: &str) -> bool {
+        match self {
+            Self::Language(guard) => guard.data_dir == data_dir && guard.language == language,
+            Self::All(guard) => guard.data_dir == data_dir,
+        }
+    }
 }
 
 fn open_all_language_operations_lock(data_dir: &std::path::Path) -> std::io::Result<fs::File> {
@@ -58,7 +76,10 @@ impl AllLanguageOperationsLockGuard {
     pub fn acquire(data_dir: &std::path::Path) -> std::io::Result<AllLanguageOperationsLockGuard> {
         let file = open_all_language_operations_lock(data_dir)?;
         file.lock_exclusive()?;
-        Ok(Self { _file: file })
+        Ok(Self {
+            _file: file,
+            data_dir: data_dir.to_path_buf(),
+        })
     }
 }
 
@@ -86,6 +107,8 @@ impl LanguageOperationLockGuard {
         Ok(Self {
             _all_file: all_file,
             _file: file,
+            data_dir: data_dir.to_path_buf(),
+            language: language.to_string(),
         })
     }
 }
@@ -371,7 +394,11 @@ fn install_language_blocking_with_query_installer(
     // AlreadyExists means the artifact is present and usable — success,
     // not failure; treating it as an error made the auto-install manager
     // degrade a fully-installed language to "installed but with warnings".
-    match parser::install_parser_after_operation_started(language, &parser_options) {
+    match parser::install_parser_after_operation_started(
+        language,
+        &parser_options,
+        LanguageOperationPermit::Language(&_operation_lock),
+    ) {
         Ok(parser_result) => {
             result.parser_path = Some(parser_result.install_path);
         }
@@ -482,6 +509,24 @@ mod tests {
         all_file
             .try_lock_exclusive()
             .expect("the all-language lock becomes available after the language operation");
+    }
+
+    #[test]
+    fn operation_permit_is_bound_to_its_scope() {
+        let temp = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let language = LanguageOperationLockGuard::acquire(temp.path(), "lua").unwrap();
+        let permit = LanguageOperationPermit::Language(&language);
+        assert!(permit.covers(temp.path(), "lua"));
+        assert!(!permit.covers(temp.path(), "python"));
+        assert!(!permit.covers(other.path(), "lua"));
+        drop(language);
+
+        let all = AllLanguageOperationsLockGuard::acquire(temp.path()).unwrap();
+        let permit = LanguageOperationPermit::All(&all);
+        assert!(permit.covers(temp.path(), "lua"));
+        assert!(permit.covers(temp.path(), "python"));
+        assert!(!permit.covers(other.path(), "lua"));
     }
 
     #[test]

--- a/src/install.rs
+++ b/src/install.rs
@@ -34,7 +34,32 @@ use std::path::PathBuf;
 
 /// Cross-process lock that makes parser and query changes one language operation.
 pub struct LanguageOperationLockGuard {
+    _all_file: fs::File,
     _file: fs::File,
+}
+
+/// Cross-process exclusive lock for operations that affect every language.
+pub struct AllLanguageOperationsLockGuard {
+    _file: fs::File,
+}
+
+fn open_all_language_operations_lock(data_dir: &std::path::Path) -> std::io::Result<fs::File> {
+    let lock_dir = data_dir.join(".operation-locks");
+    fs::create_dir_all(&lock_dir)?;
+    fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(lock_dir.join(".all.lock"))
+}
+
+impl AllLanguageOperationsLockGuard {
+    /// Exclude every per-language operation while an all-language operation runs.
+    pub fn acquire(data_dir: &std::path::Path) -> std::io::Result<AllLanguageOperationsLockGuard> {
+        let file = open_all_language_operations_lock(data_dir)?;
+        file.lock_exclusive()?;
+        Ok(Self { _file: file })
+    }
 }
 
 impl LanguageOperationLockGuard {
@@ -49,15 +74,19 @@ impl LanguageOperationLockGuard {
                 format!("unsafe language name '{}'", language.escape_default()),
             ));
         }
+        let all_file = open_all_language_operations_lock(data_dir)?;
+        all_file.lock_shared()?;
         let lock_dir = data_dir.join(".operation-locks");
-        fs::create_dir_all(&lock_dir)?;
         let file = fs::OpenOptions::new()
             .create(true)
             .write(true)
             .truncate(false)
             .open(lock_dir.join(format!("{language}.lock")))?;
         file.lock_exclusive()?;
-        Ok(Self { _file: file })
+        Ok(Self {
+            _all_file: all_file,
+            _file: file,
+        })
     }
 }
 
@@ -438,6 +467,21 @@ mod tests {
         second
             .try_lock_exclusive()
             .expect("the same-language lock becomes available after release");
+    }
+
+    #[test]
+    fn all_language_lock_excludes_per_language_operations() {
+        let temp = tempfile::tempdir().unwrap();
+        let language = LanguageOperationLockGuard::acquire(temp.path(), "lua").unwrap();
+        let all_file = open_all_language_operations_lock(temp.path()).unwrap();
+        assert!(
+            all_file.try_lock_exclusive().is_err(),
+            "an all-language operation must wait for an active language operation"
+        );
+        drop(language);
+        all_file
+            .try_lock_exclusive()
+            .expect("the all-language lock becomes available after the language operation");
     }
 
     #[test]

--- a/src/install.rs
+++ b/src/install.rs
@@ -372,7 +372,10 @@ fn install_language_blocking_with_query_installer(
         return result;
     }
 
-    let _operation_lock = match LanguageOperationLockGuard::acquire(data_dir, language) {
+    // Query inheritance can publish multiple languages. Hold the all-language
+    // operation lock across parser and query publication so every inherited
+    // parent is ordered against targeted uninstall without lock-order cycles.
+    let _operation_lock = match AllLanguageOperationsLockGuard::acquire(data_dir) {
         Ok(lock) => lock,
         Err(error) => {
             let reason = format!("Failed to lock language operation: {error}");
@@ -407,7 +410,7 @@ fn install_language_blocking_with_query_installer(
     match parser::install_parser_after_operation_started(
         language,
         &parser_options,
-        LanguageOperationPermit::Language(&_operation_lock),
+        LanguageOperationPermit::All(&_operation_lock),
     ) {
         Ok(parser_result) => {
             result.parser_path = Some(parser_result.install_path);

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -20,7 +20,7 @@ use super::metadata::{FetchOptions, MetadataError, fetch_parser_metadata};
 
 /// HTTP timeout for archive downloads.
 const ARCHIVE_HTTP_TIMEOUT: Duration = Duration::from_secs(120);
-const PARSER_UNINSTALL_TOMBSTONE_SUFFIX: &str = ".uninstalled";
+const PARSER_OPERATION_MARKER_SUFFIX: &str = ".operation";
 
 /// Error types for parser installation.
 #[derive(Debug)]
@@ -284,8 +284,8 @@ impl ParserReplaceLockGuard {
     }
 }
 
-fn parser_uninstall_tombstone_path(parser_dir: &Path, language: &str) -> PathBuf {
-    parser_dir.join(format!(".{language}{PARSER_UNINSTALL_TOMBSTONE_SUFFIX}"))
+fn parser_operation_marker_path(parser_dir: &Path, language: &str) -> PathBuf {
+    parser_dir.join(format!(".{language}{PARSER_OPERATION_MARKER_SUFFIX}"))
 }
 
 fn unsafe_language_name_error(language: &str) -> ParserInstallError {
@@ -306,7 +306,7 @@ fn begin_parser_install(
         return Err(ParserInstallError::AlreadyExists(parser_file.to_path_buf()));
     }
     let token = format!("install:{}", ulid::Ulid::new());
-    let mut marker = fs::File::create(parser_uninstall_tombstone_path(parser_dir, language))?;
+    let mut marker = fs::File::create(parser_operation_marker_path(parser_dir, language))?;
     marker.write_all(token.as_bytes())?;
     Ok(token)
 }
@@ -321,12 +321,12 @@ fn publish_compiled_parser(
         ParserInstallError::IoError(std::io::Error::other("parser path has no parent"))
     })?;
     let _replace_lock = ParserReplaceLockGuard::acquire(parser_dir, language)?;
-    let current_token =
-        match fs::read_to_string(parser_uninstall_tombstone_path(parser_dir, language)) {
-            Ok(token) => Some(token),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
-            Err(error) => return Err(ParserInstallError::IoError(error)),
-        };
+    let current_token = match fs::read_to_string(parser_operation_marker_path(parser_dir, language))
+    {
+        Ok(token) => Some(token),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(ParserInstallError::IoError(error)),
+    };
     if current_token.as_deref() != Some(install_token) {
         let _ = fs::remove_file(tmp_file);
         return Err(ParserInstallError::IoError(std::io::Error::new(
@@ -354,8 +354,8 @@ pub fn remove_parser_install(
     language: &str,
 ) -> Result<bool, ParserInstallError> {
     let _replace_lock = ParserReplaceLockGuard::acquire(parser_dir, language)?;
-    let mut tombstone = fs::File::create(parser_uninstall_tombstone_path(parser_dir, language))?;
-    writeln!(tombstone, "uninstall:{}", ulid::Ulid::new())?;
+    let mut marker = fs::File::create(parser_operation_marker_path(parser_dir, language))?;
+    writeln!(marker, "uninstall:{}", ulid::Ulid::new())?;
     let parser_file = parser_dir.join(format!("{language}.{}", std::env::consts::DLL_EXTENSION));
     match fs::remove_file(parser_file) {
         Ok(()) => Ok(true),
@@ -1492,21 +1492,21 @@ mod tests {
             matches!(result, Err(ParserInstallError::AlreadyExists(path)) if path == parser_file)
         );
         assert_eq!(
-            fs::read_to_string(parser_uninstall_tombstone_path(&parser_dir, "lua")).unwrap(),
+            fs::read_to_string(parser_operation_marker_path(&parser_dir, "lua")).unwrap(),
             first_token,
             "a no-op install must not cancel the in-flight force install"
         );
     }
 
     #[test]
-    fn uninstall_tombstone_prevents_staged_parser_publication() {
+    fn uninstall_marker_prevents_staged_parser_publication() {
         let temp = tempdir().expect("temp dir");
         let parser_dir = temp.path().join("parser");
         fs::create_dir_all(&parser_dir).expect("create parser dir");
         let parser_file = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
         let tmp_file = parser_dir.join(".lua.staged.tmp");
         fs::write(&tmp_file, b"compiled parser").expect("write staged parser");
-        fs::write(parser_uninstall_tombstone_path(&parser_dir, "lua"), b"ok\n")
+        fs::write(parser_operation_marker_path(&parser_dir, "lua"), b"ok\n")
             .expect("record later uninstall");
 
         let result = publish_compiled_parser(&tmp_file, &parser_file, "lua", "install:first");
@@ -1564,7 +1564,7 @@ mod tests {
 
         assert_eq!(fs::read(parser_file).unwrap(), b"compiled parser");
         assert_eq!(
-            fs::read_to_string(parser_uninstall_tombstone_path(&parser_dir, "lua")).unwrap(),
+            fs::read_to_string(parser_operation_marker_path(&parser_dir, "lua")).unwrap(),
             install_token
         );
     }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -369,6 +369,19 @@ pub fn install_parser(
     language: &str,
     options: &InstallOptions,
 ) -> Result<ParserInstallResult, ParserInstallError> {
+    let _operation_lock = super::LanguageOperationLockGuard::acquire(&options.data_dir, language)?;
+    install_parser_after_operation_started(language, options)
+}
+
+/// Install a parser while the caller holds this language's operation lock.
+///
+/// Most callers should use [`install_parser`]. This entry point exists for a
+/// combined parser-and-query operation that must retain one lock across both.
+#[doc(hidden)]
+pub fn install_parser_after_operation_started(
+    language: &str,
+    options: &InstallOptions,
+) -> Result<ParserInstallResult, ParserInstallError> {
     // `language` becomes path segments (`parser/<language>.<ext>` and the temp
     // file) and a URL/metadata key, so reject traversal-capable names before
     // touching the filesystem. Higher-level callers (auto-install) already gate

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -323,7 +323,7 @@ fn publish_compiled_parser(
         let _ = fs::remove_file(tmp_file);
         return Err(ParserInstallError::IoError(std::io::Error::new(
             std::io::ErrorKind::Interrupted,
-            format!("Parser install for {language} was superseded by uninstall"),
+            format!("Parser install for {language} was superseded by a newer parser operation"),
         )));
     }
     // On unix `rename` atomically replaces an existing parser. Windows

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -295,28 +295,31 @@ fn unsafe_language_name_error(language: &str) -> ParserInstallError {
     ))
 }
 
-fn clear_parser_uninstall_tombstone(
-    parser_dir: &Path,
-    language: &str,
-) -> Result<(), ParserInstallError> {
+fn begin_parser_install(parser_dir: &Path, language: &str) -> Result<String, ParserInstallError> {
     let _replace_lock = ParserReplaceLockGuard::acquire(parser_dir, language)?;
-    match fs::remove_file(parser_uninstall_tombstone_path(parser_dir, language)) {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(ParserInstallError::IoError(error)),
-    }
+    let token = format!("install:{}", ulid::Ulid::new());
+    let mut marker = fs::File::create(parser_uninstall_tombstone_path(parser_dir, language))?;
+    marker.write_all(token.as_bytes())?;
+    Ok(token)
 }
 
 fn publish_compiled_parser(
     tmp_file: &Path,
     parser_file: &Path,
     language: &str,
+    install_token: &str,
 ) -> Result<(), ParserInstallError> {
     let parser_dir = parser_file.parent().ok_or_else(|| {
         ParserInstallError::IoError(std::io::Error::other("parser path has no parent"))
     })?;
     let _replace_lock = ParserReplaceLockGuard::acquire(parser_dir, language)?;
-    if parser_uninstall_tombstone_path(parser_dir, language).is_file() {
+    let current_token =
+        match fs::read_to_string(parser_uninstall_tombstone_path(parser_dir, language)) {
+            Ok(token) => Some(token),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(ParserInstallError::IoError(error)),
+        };
+    if current_token.as_deref() != Some(install_token) {
         let _ = fs::remove_file(tmp_file);
         return Err(ParserInstallError::IoError(std::io::Error::new(
             std::io::ErrorKind::Interrupted,
@@ -344,7 +347,7 @@ pub fn remove_parser_install(
 ) -> Result<bool, ParserInstallError> {
     let _replace_lock = ParserReplaceLockGuard::acquire(parser_dir, language)?;
     let mut tombstone = fs::File::create(parser_uninstall_tombstone_path(parser_dir, language))?;
-    tombstone.write_all(b"ok\n")?;
+    writeln!(tombstone, "uninstall:{}", ulid::Ulid::new())?;
     let parser_file = parser_dir.join(format!("{language}.{}", std::env::consts::DLL_EXTENSION));
     match fs::remove_file(parser_file) {
         Ok(()) => Ok(true),
@@ -369,7 +372,7 @@ pub fn install_parser(
 
     let parser_dir = options.data_dir.join("parser");
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
-    clear_parser_uninstall_tombstone(&parser_dir, language)?;
+    let install_token = begin_parser_install(&parser_dir, language)?;
 
     // Check if parser already exists
     if parser_file.exists() && !options.force {
@@ -436,7 +439,7 @@ pub fn install_parser(
         ParserCompile::InProcess => compile_parser_inprocess(&source_dir, &tmp_file),
     };
     match compiled {
-        Ok(()) => publish_compiled_parser(&tmp_file, &parser_file, language)?,
+        Ok(()) => publish_compiled_parser(&tmp_file, &parser_file, language, &install_token)?,
         Err(e) => {
             let _ = fs::remove_file(&tmp_file);
             return Err(e);
@@ -1473,7 +1476,7 @@ mod tests {
         fs::write(&tmp_file, b"compiled parser").expect("write staged parser");
         fs::write(parser_dir.join(".lua.uninstalled"), b"ok\n").expect("record later uninstall");
 
-        let result = publish_compiled_parser(&tmp_file, &parser_file, "lua");
+        let result = publish_compiled_parser(&tmp_file, &parser_file, "lua", "install:first");
 
         assert!(
             matches!(
@@ -1495,9 +1498,10 @@ mod tests {
         let tmp_file = parser_dir.join(".lua.staged.tmp");
         fs::create_dir_all(&parser_dir).expect("create parser dir");
         fs::write(&tmp_file, b"compiled parser").expect("write staged parser");
+        let install_token = begin_parser_install(&parser_dir, "lua").expect("start install");
 
         assert!(!remove_parser_install(&parser_dir, "lua").expect("uninstall succeeds"));
-        let publish = publish_compiled_parser(&tmp_file, &parser_file, "lua");
+        let publish = publish_compiled_parser(&tmp_file, &parser_file, "lua", &install_token);
 
         assert!(
             matches!(
@@ -1517,12 +1521,38 @@ mod tests {
         let parser_file = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
         let tmp_file = parser_dir.join(".lua.staged.tmp");
         remove_parser_install(&parser_dir, "lua").expect("record uninstall");
-        clear_parser_uninstall_tombstone(&parser_dir, "lua").expect("start later install");
+        let install_token = begin_parser_install(&parser_dir, "lua").expect("start later install");
         fs::write(&tmp_file, b"compiled parser").expect("write staged parser");
 
-        publish_compiled_parser(&tmp_file, &parser_file, "lua").expect("later install may publish");
+        publish_compiled_parser(&tmp_file, &parser_file, "lua", &install_token)
+            .expect("later install may publish");
 
         assert_eq!(fs::read(parser_file).unwrap(), b"compiled parser");
+    }
+
+    #[test]
+    fn a_later_install_does_not_authorize_an_older_staged_parser() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        let parser_file = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        let first_token = begin_parser_install(&parser_dir, "lua").expect("start first install");
+        remove_parser_install(&parser_dir, "lua").expect("superseding uninstall");
+        begin_parser_install(&parser_dir, "lua").expect("start second install");
+        let first_tmp_file = parser_dir.join(".lua.first.staged.tmp");
+        fs::write(&first_tmp_file, b"first parser").expect("stage first parser");
+
+        let first_publish =
+            publish_compiled_parser(&first_tmp_file, &parser_file, "lua", &first_token);
+
+        assert!(
+            matches!(
+                first_publish,
+                Err(ParserInstallError::IoError(ref error))
+                    if error.kind() == std::io::ErrorKind::Interrupted
+            ),
+            "the second install must not clear the first install's supersession: {first_publish:?}"
+        );
+        assert!(!parser_file.exists(), "the stale parser must not publish");
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -295,8 +295,16 @@ fn unsafe_language_name_error(language: &str) -> ParserInstallError {
     ))
 }
 
-fn begin_parser_install(parser_dir: &Path, language: &str) -> Result<String, ParserInstallError> {
+fn begin_parser_install(
+    parser_dir: &Path,
+    parser_file: &Path,
+    language: &str,
+    force: bool,
+) -> Result<String, ParserInstallError> {
     let _replace_lock = ParserReplaceLockGuard::acquire(parser_dir, language)?;
+    if parser_file.exists() && !force {
+        return Err(ParserInstallError::AlreadyExists(parser_file.to_path_buf()));
+    }
     let token = format!("install:{}", ulid::Ulid::new());
     let mut marker = fs::File::create(parser_uninstall_tombstone_path(parser_dir, language))?;
     marker.write_all(token.as_bytes())?;
@@ -372,12 +380,7 @@ pub fn install_parser(
 
     let parser_dir = options.data_dir.join("parser");
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
-    let install_token = begin_parser_install(&parser_dir, language)?;
-
-    // Check if parser already exists
-    if parser_file.exists() && !options.force {
-        return Err(ParserInstallError::AlreadyExists(parser_file));
-    }
+    let install_token = begin_parser_install(&parser_dir, &parser_file, language, options.force)?;
 
     // Fetch metadata (with caching support)
     if options.verbose {
@@ -1467,6 +1470,35 @@ mod tests {
     }
 
     #[test]
+    fn an_already_installed_parser_does_not_supersede_an_inflight_force_install() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let parser_file = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        fs::write(&parser_file, b"installed parser").expect("write installed parser");
+        let first_token = begin_parser_install(&parser_dir, &parser_file, "lua", true)
+            .expect("start force install");
+        let options = InstallOptions {
+            data_dir: temp.path().to_path_buf(),
+            force: false,
+            verbose: false,
+            no_cache: false,
+            compile: ParserCompile::InProcess,
+        };
+
+        let result = install_parser("lua", &options);
+
+        assert!(
+            matches!(result, Err(ParserInstallError::AlreadyExists(path)) if path == parser_file)
+        );
+        assert_eq!(
+            fs::read_to_string(parser_uninstall_tombstone_path(&parser_dir, "lua")).unwrap(),
+            first_token,
+            "a no-op install must not cancel the in-flight force install"
+        );
+    }
+
+    #[test]
     fn uninstall_tombstone_prevents_staged_parser_publication() {
         let temp = tempdir().expect("temp dir");
         let parser_dir = temp.path().join("parser");
@@ -1498,7 +1530,8 @@ mod tests {
         let tmp_file = parser_dir.join(".lua.staged.tmp");
         fs::create_dir_all(&parser_dir).expect("create parser dir");
         fs::write(&tmp_file, b"compiled parser").expect("write staged parser");
-        let install_token = begin_parser_install(&parser_dir, "lua").expect("start install");
+        let install_token =
+            begin_parser_install(&parser_dir, &parser_file, "lua", true).expect("start install");
 
         assert!(!remove_parser_install(&parser_dir, "lua").expect("uninstall succeeds"));
         let publish = publish_compiled_parser(&tmp_file, &parser_file, "lua", &install_token);
@@ -1521,7 +1554,8 @@ mod tests {
         let parser_file = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
         let tmp_file = parser_dir.join(".lua.staged.tmp");
         remove_parser_install(&parser_dir, "lua").expect("record uninstall");
-        let install_token = begin_parser_install(&parser_dir, "lua").expect("start later install");
+        let install_token = begin_parser_install(&parser_dir, &parser_file, "lua", true)
+            .expect("start later install");
         fs::write(&tmp_file, b"compiled parser").expect("write staged parser");
 
         publish_compiled_parser(&tmp_file, &parser_file, "lua", &install_token)
@@ -1535,9 +1569,10 @@ mod tests {
         let temp = tempdir().expect("temp dir");
         let parser_dir = temp.path().join("parser");
         let parser_file = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
-        let first_token = begin_parser_install(&parser_dir, "lua").expect("start first install");
+        let first_token = begin_parser_install(&parser_dir, &parser_file, "lua", true)
+            .expect("start first install");
         remove_parser_install(&parser_dir, "lua").expect("superseding uninstall");
-        begin_parser_install(&parser_dir, "lua").expect("start second install");
+        begin_parser_install(&parser_dir, &parser_file, "lua", true).expect("start second install");
         let first_tmp_file = parser_dir.join(".lua.first.staged.tmp");
         fs::write(&first_tmp_file, b"first parser").expect("stage first parser");
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -4,12 +4,14 @@
 //! compiling them with tree-sitter-loader, and installing the resulting shared library.
 
 use std::fs;
+use std::io::Write;
 use std::path::Component;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
 use flate2::read::GzDecoder;
+use fs4::fs_std::FileExt;
 use tar::Archive;
 use tree_sitter_loader::Loader;
 
@@ -18,6 +20,7 @@ use super::metadata::{FetchOptions, MetadataError, fetch_parser_metadata};
 
 /// HTTP timeout for archive downloads.
 const ARCHIVE_HTTP_TIMEOUT: Duration = Duration::from_secs(120);
+const PARSER_UNINSTALL_TOMBSTONE_SUFFIX: &str = ".uninstalled";
 
 /// Error types for parser installation.
 #[derive(Debug)]
@@ -261,7 +264,65 @@ fn compile_parser(grammar_path: &Path, output_path: &Path) -> Result<(), ParserI
     Ok(())
 }
 
-fn publish_compiled_parser(tmp_file: &Path, parser_file: &Path) -> Result<(), ParserInstallError> {
+struct ParserReplaceLockGuard {
+    _file: fs::File,
+}
+
+impl ParserReplaceLockGuard {
+    fn acquire(parser_dir: &Path, language: &str) -> Result<Self, ParserInstallError> {
+        if !super::queries::is_safe_language_name(language) {
+            return Err(unsafe_language_name_error(language));
+        }
+        fs::create_dir_all(parser_dir)?;
+        let file = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(parser_dir.join(format!(".{language}.replace.lock")))?;
+        file.lock_exclusive()?;
+        Ok(Self { _file: file })
+    }
+}
+
+fn parser_uninstall_tombstone_path(parser_dir: &Path, language: &str) -> PathBuf {
+    parser_dir.join(format!(".{language}{PARSER_UNINSTALL_TOMBSTONE_SUFFIX}"))
+}
+
+fn unsafe_language_name_error(language: &str) -> ParserInstallError {
+    ParserInstallError::IoError(std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        format!("unsafe language name '{}'", language.escape_default()),
+    ))
+}
+
+fn clear_parser_uninstall_tombstone(
+    parser_dir: &Path,
+    language: &str,
+) -> Result<(), ParserInstallError> {
+    let _replace_lock = ParserReplaceLockGuard::acquire(parser_dir, language)?;
+    match fs::remove_file(parser_uninstall_tombstone_path(parser_dir, language)) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(ParserInstallError::IoError(error)),
+    }
+}
+
+fn publish_compiled_parser(
+    tmp_file: &Path,
+    parser_file: &Path,
+    language: &str,
+) -> Result<(), ParserInstallError> {
+    let parser_dir = parser_file.parent().ok_or_else(|| {
+        ParserInstallError::IoError(std::io::Error::other("parser path has no parent"))
+    })?;
+    let _replace_lock = ParserReplaceLockGuard::acquire(parser_dir, language)?;
+    if parser_uninstall_tombstone_path(parser_dir, language).is_file() {
+        let _ = fs::remove_file(tmp_file);
+        return Err(ParserInstallError::IoError(std::io::Error::new(
+            std::io::ErrorKind::Interrupted,
+            format!("Parser install for {language} was superseded by uninstall"),
+        )));
+    }
     // On unix `rename` atomically replaces an existing parser. Windows
     // `rename` instead fails if the destination exists, which would make a
     // `force` reinstall fail after a good compile — remove the old file
@@ -276,6 +337,22 @@ fn publish_compiled_parser(tmp_file: &Path, parser_file: &Path) -> Result<(), Pa
     Ok(())
 }
 
+/// Remove a parser while preventing an already-running install from publishing later.
+pub fn remove_parser_install(
+    parser_dir: &Path,
+    language: &str,
+) -> Result<bool, ParserInstallError> {
+    let _replace_lock = ParserReplaceLockGuard::acquire(parser_dir, language)?;
+    let mut tombstone = fs::File::create(parser_uninstall_tombstone_path(parser_dir, language))?;
+    tombstone.write_all(b"ok\n")?;
+    let parser_file = parser_dir.join(format!("{language}.{}", std::env::consts::DLL_EXTENSION));
+    match fs::remove_file(parser_file) {
+        Ok(()) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(ParserInstallError::IoError(error)),
+    }
+}
+
 /// Install a Tree-sitter parser for a language.
 pub fn install_parser(
     language: &str,
@@ -287,14 +364,12 @@ pub fn install_parser(
     // this, but `install_parser` is a public entry point and must be safe on its
     // own — a name like `../../evil` would otherwise write outside the data dir.
     if !super::queries::is_safe_language_name(language) {
-        return Err(ParserInstallError::IoError(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("unsafe language name '{}'", language.escape_default()),
-        )));
+        return Err(unsafe_language_name_error(language));
     }
 
     let parser_dir = options.data_dir.join("parser");
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
+    clear_parser_uninstall_tombstone(&parser_dir, language)?;
 
     // Check if parser already exists
     if parser_file.exists() && !options.force {
@@ -361,7 +436,7 @@ pub fn install_parser(
         ParserCompile::InProcess => compile_parser_inprocess(&source_dir, &tmp_file),
     };
     match compiled {
-        Ok(()) => publish_compiled_parser(&tmp_file, &parser_file)?,
+        Ok(()) => publish_compiled_parser(&tmp_file, &parser_file, language)?,
         Err(e) => {
             let _ = fs::remove_file(&tmp_file);
             return Err(e);
@@ -1386,6 +1461,68 @@ mod tests {
         let result = parser_file_exists("lua", temp.path());
         assert!(result.is_some());
         assert_eq!(result.unwrap(), parser_file);
+    }
+
+    #[test]
+    fn uninstall_tombstone_prevents_staged_parser_publication() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let parser_file = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        let tmp_file = parser_dir.join(".lua.staged.tmp");
+        fs::write(&tmp_file, b"compiled parser").expect("write staged parser");
+        fs::write(parser_dir.join(".lua.uninstalled"), b"ok\n").expect("record later uninstall");
+
+        let result = publish_compiled_parser(&tmp_file, &parser_file, "lua");
+
+        assert!(
+            matches!(
+                result,
+                Err(ParserInstallError::IoError(ref error))
+                    if error.kind() == std::io::ErrorKind::Interrupted
+            ),
+            "a later uninstall must supersede staged publication: {result:?}"
+        );
+        assert!(!parser_file.exists(), "the parser must remain uninstalled");
+        assert!(!tmp_file.exists(), "the superseded staging file is cleaned");
+    }
+
+    #[test]
+    fn removing_a_missing_parser_still_supersedes_an_inflight_install() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        let parser_file = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        let tmp_file = parser_dir.join(".lua.staged.tmp");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        fs::write(&tmp_file, b"compiled parser").expect("write staged parser");
+
+        assert!(!remove_parser_install(&parser_dir, "lua").expect("uninstall succeeds"));
+        let publish = publish_compiled_parser(&tmp_file, &parser_file, "lua");
+
+        assert!(
+            matches!(
+                publish,
+                Err(ParserInstallError::IoError(ref error))
+                    if error.kind() == std::io::ErrorKind::Interrupted
+            ),
+            "uninstall must win even when no old parser existed: {publish:?}"
+        );
+        assert!(!parser_file.exists(), "the parser must remain absent");
+    }
+
+    #[test]
+    fn a_later_install_clears_the_parser_uninstall_tombstone() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        let parser_file = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        let tmp_file = parser_dir.join(".lua.staged.tmp");
+        remove_parser_install(&parser_dir, "lua").expect("record uninstall");
+        clear_parser_uninstall_tombstone(&parser_dir, "lua").expect("start later install");
+        fs::write(&tmp_file, b"compiled parser").expect("write staged parser");
+
+        publish_compiled_parser(&tmp_file, &parser_file, "lua").expect("later install may publish");
+
+        assert_eq!(fs::read(parser_file).unwrap(), b"compiled parser");
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -261,6 +261,21 @@ fn compile_parser(grammar_path: &Path, output_path: &Path) -> Result<(), ParserI
     Ok(())
 }
 
+fn publish_compiled_parser(tmp_file: &Path, parser_file: &Path) -> Result<(), ParserInstallError> {
+    // On unix `rename` atomically replaces an existing parser. Windows
+    // `rename` instead fails if the destination exists, which would make a
+    // `force` reinstall fail after a good compile — remove the old file
+    // first there (a small non-atomic window, acceptable on the
+    // non-primary platform).
+    #[cfg(windows)]
+    let _ = fs::remove_file(parser_file);
+    if let Err(e) = fs::rename(tmp_file, parser_file) {
+        let _ = fs::remove_file(tmp_file);
+        return Err(ParserInstallError::IoError(e));
+    }
+    Ok(())
+}
+
 /// Install a Tree-sitter parser for a language.
 pub fn install_parser(
     language: &str,
@@ -346,19 +361,7 @@ pub fn install_parser(
         ParserCompile::InProcess => compile_parser_inprocess(&source_dir, &tmp_file),
     };
     match compiled {
-        Ok(()) => {
-            // On unix `rename` atomically replaces an existing parser. Windows
-            // `rename` instead fails if the destination exists, which would make a
-            // `force` reinstall fail after a good compile — remove the old file
-            // first there (a small non-atomic window, acceptable on the
-            // non-primary platform).
-            #[cfg(windows)]
-            let _ = fs::remove_file(&parser_file);
-            if let Err(e) = fs::rename(&tmp_file, &parser_file) {
-                let _ = fs::remove_file(&tmp_file);
-                return Err(ParserInstallError::IoError(e));
-            }
-        }
+        Ok(()) => publish_compiled_parser(&tmp_file, &parser_file)?,
         Err(e) => {
             let _ = fs::remove_file(&tmp_file);
             return Err(e);

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -1548,7 +1548,7 @@ mod tests {
     }
 
     #[test]
-    fn a_later_install_clears_the_parser_uninstall_tombstone() {
+    fn a_later_install_replaces_the_uninstall_marker_with_its_token() {
         let temp = tempdir().expect("temp dir");
         let parser_dir = temp.path().join("parser");
         let parser_file = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
@@ -1562,6 +1562,10 @@ mod tests {
             .expect("later install may publish");
 
         assert_eq!(fs::read(parser_file).unwrap(), b"compiled parser");
+        assert_eq!(
+            fs::read_to_string(parser_uninstall_tombstone_path(&parser_dir, "lua")).unwrap(),
+            install_token
+        );
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -363,7 +363,11 @@ pub fn remove_parser_install(
         ))
     })?;
     let _operation_lock = super::LanguageOperationLockGuard::acquire(data_dir, language)?;
-    remove_parser_install_after_operation_started(parser_dir, language)
+    remove_parser_install_after_operation_started(
+        parser_dir,
+        language,
+        super::LanguageOperationPermit::Language(&_operation_lock),
+    )
 }
 
 /// Remove a parser while the caller holds this language's operation lock.
@@ -371,7 +375,20 @@ pub fn remove_parser_install(
 pub fn remove_parser_install_after_operation_started(
     parser_dir: &Path,
     language: &str,
+    permit: super::LanguageOperationPermit<'_>,
 ) -> Result<bool, ParserInstallError> {
+    let Some(data_dir) = parser_dir.parent() else {
+        return Err(ParserInstallError::IoError(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "parser directory must have a data-directory parent",
+        )));
+    };
+    if !permit.covers(data_dir, language) {
+        return Err(ParserInstallError::IoError(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "operation permit does not cover this parser removal",
+        )));
+    }
     let _replace_lock = ParserReplaceLockGuard::acquire(parser_dir, language)?;
     let mut marker = fs::File::create(parser_operation_marker_path(parser_dir, language))?;
     writeln!(marker, "uninstall:{}", ulid::Ulid::new())?;
@@ -392,7 +409,11 @@ pub fn install_parser(
         return Err(unsafe_language_name_error(language));
     }
     let _operation_lock = super::LanguageOperationLockGuard::acquire(&options.data_dir, language)?;
-    install_parser_after_operation_started(language, options)
+    install_parser_after_operation_started(
+        language,
+        options,
+        super::LanguageOperationPermit::Language(&_operation_lock),
+    )
 }
 
 /// Install a parser while the caller holds this language's operation lock.
@@ -403,7 +424,14 @@ pub fn install_parser(
 pub fn install_parser_after_operation_started(
     language: &str,
     options: &InstallOptions,
+    permit: super::LanguageOperationPermit<'_>,
 ) -> Result<ParserInstallResult, ParserInstallError> {
+    if !permit.covers(&options.data_dir, language) {
+        return Err(ParserInstallError::IoError(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "operation permit does not cover this parser install",
+        )));
+    }
     // `language` becomes path segments (`parser/<language>.<ext>` and the temp
     // file) and a URL/metadata key, so reject traversal-capable names before
     // touching the filesystem. Higher-level callers (auto-install) already gate

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -353,6 +353,25 @@ pub fn remove_parser_install(
     parser_dir: &Path,
     language: &str,
 ) -> Result<bool, ParserInstallError> {
+    if !super::queries::is_safe_language_name(language) {
+        return Err(unsafe_language_name_error(language));
+    }
+    let data_dir = parser_dir.parent().ok_or_else(|| {
+        ParserInstallError::IoError(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "parser directory must have a data-directory parent",
+        ))
+    })?;
+    let _operation_lock = super::LanguageOperationLockGuard::acquire(data_dir, language)?;
+    remove_parser_install_after_operation_started(parser_dir, language)
+}
+
+/// Remove a parser while the caller holds this language's operation lock.
+#[doc(hidden)]
+pub fn remove_parser_install_after_operation_started(
+    parser_dir: &Path,
+    language: &str,
+) -> Result<bool, ParserInstallError> {
     let _replace_lock = ParserReplaceLockGuard::acquire(parser_dir, language)?;
     let mut marker = fs::File::create(parser_operation_marker_path(parser_dir, language))?;
     writeln!(marker, "uninstall:{}", ulid::Ulid::new())?;
@@ -369,6 +388,9 @@ pub fn install_parser(
     language: &str,
     options: &InstallOptions,
 ) -> Result<ParserInstallResult, ParserInstallError> {
+    if !super::queries::is_safe_language_name(language) {
+        return Err(unsafe_language_name_error(language));
+    }
     let _operation_lock = super::LanguageOperationLockGuard::acquire(&options.data_dir, language)?;
     install_parser_after_operation_started(language, options)
 }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -1506,7 +1506,8 @@ mod tests {
         let parser_file = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
         let tmp_file = parser_dir.join(".lua.staged.tmp");
         fs::write(&tmp_file, b"compiled parser").expect("write staged parser");
-        fs::write(parser_dir.join(".lua.uninstalled"), b"ok\n").expect("record later uninstall");
+        fs::write(parser_uninstall_tombstone_path(&parser_dir, "lua"), b"ok\n")
+            .expect("record later uninstall");
 
         let result = publish_compiled_parser(&tmp_file, &parser_file, "lua", "install:first");
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -509,6 +509,11 @@ pub fn recover_interrupted_query_installs(queries_parent: &Path) -> Result<(), Q
             "queries directory must have a data-directory parent",
         )));
     };
+    match fs::metadata(queries_parent) {
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(QueryInstallError::IoError(error)),
+    }
     let all_lock = super::AllLanguageOperationsLockGuard::acquire(data_dir)?;
     recover_interrupted_query_installs_with_permit(
         queries_parent,
@@ -1342,6 +1347,19 @@ mod tests {
         assert!(
             tmp.exists(),
             "generated staging dirs from live installers must not be collected"
+        );
+    }
+
+    #[test]
+    fn recover_interrupted_query_installs_does_not_create_locks_when_absent() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+
+        recover_interrupted_query_installs(&queries_parent).unwrap();
+
+        assert!(
+            !temp.path().join(".operation-locks").exists(),
+            "no-op recovery must not mutate a fresh data directory"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -503,6 +503,37 @@ fn unique_backup_query_dir(queries_dir: &Path, language: &str) -> PathBuf {
 
 /// Recover query directories stranded by a process exit during replacement.
 pub fn recover_interrupted_query_installs(queries_parent: &Path) -> Result<(), QueryInstallError> {
+    let Some(data_dir) = queries_parent.parent() else {
+        return Err(QueryInstallError::IoError(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "queries directory must have a data-directory parent",
+        )));
+    };
+    let all_lock = super::AllLanguageOperationsLockGuard::acquire(data_dir)?;
+    recover_interrupted_query_installs_with_permit(
+        queries_parent,
+        super::LanguageOperationPermit::All(&all_lock),
+    )
+}
+
+/// Recover all query installs while the caller holds the all-language lock.
+#[doc(hidden)]
+pub fn recover_interrupted_query_installs_with_permit(
+    queries_parent: &Path,
+    permit: super::LanguageOperationPermit<'_>,
+) -> Result<(), QueryInstallError> {
+    let Some(data_dir) = queries_parent.parent() else {
+        return Err(QueryInstallError::IoError(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "queries directory must have a data-directory parent",
+        )));
+    };
+    if !permit.covers_all(data_dir) {
+        return Err(QueryInstallError::IoError(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "operation permit does not cover all-language query recovery",
+        )));
+    }
     let entries = match fs::read_dir(queries_parent) {
         Ok(entries) => entries,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -154,6 +154,7 @@ pub fn install_queries_with_dependencies(
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
+    validate_safe_language_name(language)?;
     let _operation_lock = super::LanguageOperationLockGuard::acquire(data_dir, language)?;
     clear_uninstall_tombstone_for_install(data_dir, language)?;
     install_queries_with_dependencies_from_with_http_policy(
@@ -517,6 +518,23 @@ impl QueryRemoval {
 }
 
 pub fn remove_query_install_and_backups(
+    queries_parent: &Path,
+    language: &str,
+) -> Result<QueryRemoval, QueryInstallError> {
+    validate_safe_language_name(language)?;
+    let data_dir = queries_parent.parent().ok_or_else(|| {
+        QueryInstallError::IoError(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "queries directory must have a data-directory parent",
+        ))
+    })?;
+    let _operation_lock = super::LanguageOperationLockGuard::acquire(data_dir, language)?;
+    remove_query_install_and_backups_after_operation_started(queries_parent, language)
+}
+
+/// Remove queries while the caller holds this language's operation lock.
+#[doc(hidden)]
+pub fn remove_query_install_and_backups_after_operation_started(
     queries_parent: &Path,
     language: &str,
 ) -> Result<QueryRemoval, QueryInstallError> {

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -154,6 +154,7 @@ pub fn install_queries_with_dependencies(
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
+    let _operation_lock = super::LanguageOperationLockGuard::acquire(data_dir, language)?;
     clear_uninstall_tombstone_for_install(data_dir, language)?;
     install_queries_with_dependencies_from_with_http_policy(
         NVIM_TREESITTER_QUERIES_URL,

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -170,7 +170,14 @@ pub fn install_queries_with_dependencies_after_install_started(
     language: &str,
     data_dir: &Path,
     force: bool,
+    permit: super::LanguageOperationPermit<'_>,
 ) -> Result<QueryInstallResult, QueryInstallError> {
+    if !permit.covers(data_dir, language) {
+        return Err(QueryInstallError::IoError(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "operation permit does not cover this query install",
+        )));
+    }
     install_queries_with_dependencies_from_with_http_policy(
         NVIM_TREESITTER_QUERIES_URL,
         language,
@@ -529,7 +536,11 @@ pub fn remove_query_install_and_backups(
         ))
     })?;
     let _operation_lock = super::LanguageOperationLockGuard::acquire(data_dir, language)?;
-    remove_query_install_and_backups_after_operation_started(queries_parent, language)
+    remove_query_install_and_backups_after_operation_started(
+        queries_parent,
+        language,
+        super::LanguageOperationPermit::Language(&_operation_lock),
+    )
 }
 
 /// Remove queries while the caller holds this language's operation lock.
@@ -537,7 +548,20 @@ pub fn remove_query_install_and_backups(
 pub fn remove_query_install_and_backups_after_operation_started(
     queries_parent: &Path,
     language: &str,
+    permit: super::LanguageOperationPermit<'_>,
 ) -> Result<QueryRemoval, QueryInstallError> {
+    let Some(data_dir) = queries_parent.parent() else {
+        return Err(QueryInstallError::IoError(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "queries directory must have a data-directory parent",
+        )));
+    };
+    if !permit.covers(data_dir, language) {
+        return Err(QueryInstallError::IoError(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "operation permit does not cover this query removal",
+        )));
+    }
     validate_safe_language_name(language)?;
     fs::create_dir_all(queries_parent)?;
     let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -170,6 +170,23 @@ pub fn install_queries_with_dependencies_after_install_started(
     language: &str,
     data_dir: &Path,
     force: bool,
+) -> Result<QueryInstallResult, QueryInstallError> {
+    validate_safe_language_name(language)?;
+    let _operation_lock = super::LanguageOperationLockGuard::acquire(data_dir, language)?;
+    install_queries_with_dependencies_after_install_started_with_permit(
+        language,
+        data_dir,
+        force,
+        super::LanguageOperationPermit::Language(&_operation_lock),
+    )
+}
+
+/// Continue query installation while the caller holds the operation lock.
+#[doc(hidden)]
+pub fn install_queries_with_dependencies_after_install_started_with_permit(
+    language: &str,
+    data_dir: &Path,
+    force: bool,
     permit: super::LanguageOperationPermit<'_>,
 ) -> Result<QueryInstallResult, QueryInstallError> {
     if !permit.covers(data_dir, language) {

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -579,7 +579,6 @@ pub fn remove_query_install_and_backups_after_operation_started(
             "operation permit does not cover this query removal",
         )));
     }
-    validate_safe_language_name(language)?;
     fs::create_dir_all(queries_parent)?;
     let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
     write_uninstall_tombstone(queries_parent, language)?;

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -155,7 +155,7 @@ pub fn install_queries_with_dependencies(
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
     validate_safe_language_name(language)?;
-    let _operation_lock = super::LanguageOperationLockGuard::acquire(data_dir, language)?;
+    let _operation_lock = super::AllLanguageOperationsLockGuard::acquire(data_dir)?;
     clear_uninstall_tombstone_for_install(data_dir, language)?;
     install_queries_with_dependencies_from_with_http_policy(
         NVIM_TREESITTER_QUERIES_URL,
@@ -172,13 +172,13 @@ pub fn install_queries_with_dependencies_after_install_started(
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
     validate_safe_language_name(language)?;
-    let _operation_lock = super::LanguageOperationLockGuard::acquire(data_dir, language)?;
+    let _operation_lock = super::AllLanguageOperationsLockGuard::acquire(data_dir)?;
     clear_uninstall_tombstone_for_install(data_dir, language)?;
     install_queries_with_dependencies_after_install_started_with_permit(
         language,
         data_dir,
         force,
-        super::LanguageOperationPermit::Language(&_operation_lock),
+        super::LanguageOperationPermit::All(&_operation_lock),
     )
 }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -173,6 +173,7 @@ pub fn install_queries_with_dependencies_after_install_started(
 ) -> Result<QueryInstallResult, QueryInstallError> {
     validate_safe_language_name(language)?;
     let _operation_lock = super::LanguageOperationLockGuard::acquire(data_dir, language)?;
+    clear_uninstall_tombstone_for_install(data_dir, language)?;
     install_queries_with_dependencies_after_install_started_with_permit(
         language,
         data_dir,
@@ -1183,6 +1184,33 @@ mod tests {
             fs::read_to_string(data_dir.join("victim.uninstalled")).unwrap(),
             "keep",
             "unsafe tombstone cleanup must not escape queries/"
+        );
+    }
+
+    #[test]
+    fn compatibility_install_restarts_intent_under_operation_lock() {
+        let temp = TempDir::new().unwrap();
+        let data_dir = temp.path();
+        let queries_parent = data_dir.join("queries");
+        let queries_dir = queries_parent.join("lua");
+        fs::create_dir_all(&queries_dir).unwrap();
+        fs::write(
+            queries_dir.join("highlights.scm"),
+            "(identifier) @variable\n",
+        )
+        .unwrap();
+        write_install_marker_for_tests(&queries_dir).unwrap();
+        write_uninstall_tombstone(&queries_parent, "lua").unwrap();
+
+        let result =
+            install_queries_with_dependencies_after_install_started("lua", data_dir, false);
+
+        assert!(
+            matches!(result, Err(QueryInstallError::AlreadyExists(path)) if path == queries_dir)
+        );
+        assert!(
+            !uninstall_tombstone_path(&queries_parent, "lua").exists(),
+            "the compatibility entry point must establish a new install intent after locking"
         );
     }
 

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1185,7 +1185,7 @@ fn test_language_uninstall_all() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    // All parser shared libraries should be removed; internal lock/tombstone
+    // All parser shared libraries should be removed; internal lock/operation-marker
     // files may remain hidden under parser/.
     let parsers: Vec<_> = fs::read_dir(test_dir.path().join("parser"))
         .map(|entries| {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1185,7 +1185,8 @@ fn test_language_uninstall_all() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    // All parsers should be removed
+    // All parser shared libraries should be removed; internal lock/tombstone
+    // files may remain hidden under parser/.
     let parsers: Vec<_> = fs::read_dir(test_dir.path().join("parser"))
         .map(|entries| {
             entries

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1187,7 +1187,17 @@ fn test_language_uninstall_all() {
 
     // All parsers should be removed
     let parsers: Vec<_> = fs::read_dir(test_dir.path().join("parser"))
-        .map(|entries| entries.filter_map(|e| e.ok()).collect())
+        .map(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .filter(|entry| {
+                    entry
+                        .file_name()
+                        .to_str()
+                        .is_none_or(|name| !name.starts_with('.'))
+                })
+                .collect()
+        })
         .unwrap_or_default();
     assert!(parsers.is_empty(), "All parsers should be removed");
 


### PR DESCRIPTION
## Summary

- serialize complete parser/query language operations with a per-language cross-process lock
- serialize parser publication/removal and record unique parser install/uninstall intents
- publish a compiled parser only while its exact install intent remains current
- perform parser removal last during language uninstall so an older install cannot resurrect it afterward
- keep non-force `AlreadyExists` calls from superseding an active force reinstall

## Validation

- focused parser intent, tombstone, and publication unit tests
- `cargo test --lib -q install::tests::language_operation_lock_serializes_the_same_language`
- `cargo test --test test_cli -q test_language_uninstall_all`
- `cargo check -q`
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --check`

## Follow-up

- inherited parent-query operation ordering is tracked separately in #719

Closes #715.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when installing or uninstalling languages concurrently using stricter locking/intent tracking.
  * Prevented overlapping operations from leaving outdated or incomplete parser and query files.
  * Improved recovery from interrupted installations during both install and uninstall.
  * Ensured “uninstall all” reflects the latest installed languages after confirmation changes during the prompt.
  * Added safer handling for hidden operational files during uninstall verification.

* **Tests**
  * Added coverage for concurrent operations, interrupted installs, and installation replacement scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->