### PR TITLE
fix(bridge): reject malformed initialize capabilities

### DIFF
--- a/src/lsp/bridge/pool/handshake.rs
+++ b/src/lsp/bridge/pool/handshake.rs
@@ -90,3 +90,59 @@ pub(super) async fn perform_lsp_handshake(
 
     Ok(capabilities)
 }
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::lsp::bridge::actor::{ResponseRouter, spawn_reader_task};
+    use crate::lsp::bridge::connection::AsyncBridgeConnection;
+
+    #[tokio::test]
+    async fn malformed_capabilities_stop_before_initialized() {
+        for capabilities in [
+            serde_json::json!("not-an-object"),
+            serde_json::json!({"hoverProvider": 42}),
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let output = temp.path().join("messages");
+            let mut connection = AsyncBridgeConnection::spawn(vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "cat > \"$1\"".to_string(),
+                "sh".to_string(),
+                output.display().to_string(),
+            ])
+            .await
+            .unwrap();
+            let (writer, reader) = connection.split();
+            let router = Arc::new(ResponseRouter::new());
+            let reader_handle = spawn_reader_task(reader, Arc::clone(&router));
+            let handle = ConnectionHandle::new(writer, router, reader_handle);
+            let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+            response_tx
+                .send(serde_json::json!({"result": {"capabilities": capabilities}}))
+                .unwrap();
+
+            let error = perform_lsp_handshake(
+                &handle,
+                RequestId::new(1),
+                response_rx,
+                None,
+                None,
+                None,
+                None,
+                false,
+            )
+            .await
+            .expect_err("malformed capabilities must stop the handshake");
+            assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+
+            drop(handle);
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            let messages = std::fs::read_to_string(&output).unwrap_or_default();
+            assert!(!messages.contains("initialized"));
+        }
+    }
+}

--- a/src/lsp/bridge/pool/handshake.rs
+++ b/src/lsp/bridge/pool/handshake.rs
@@ -20,7 +20,7 @@ use super::ConnectionHandle;
 use super::connection_handle::NotificationSendResult;
 use crate::lsp::bridge::protocol::{
     RequestId, build_initialize_request, build_initialized_notification,
-    validate_initialize_response,
+    parse_initialize_response_capabilities,
 };
 
 /// Send `initialize`, await the response, send `initialized`, return the typed
@@ -62,13 +62,7 @@ pub(super) async fn perform_lsp_handshake(
         .map_err(|_| io::Error::other("bridge: initialize response channel closed"))?;
 
     // 3. Validate response and extract typed capabilities
-    validate_initialize_response(&response)?;
-    let caps_value = response
-        .get("result")
-        .and_then(|r| r.get("capabilities"))
-        .cloned()
-        .unwrap_or_default();
-    let capabilities = serde_json::from_value::<ServerCapabilities>(caps_value).unwrap_or_default();
+    let capabilities = parse_initialize_response_capabilities(&response)?;
 
     // 4. Send initialized notification via the single-writer loop
     let initialized = build_initialized_notification();

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -130,12 +130,14 @@ pub(crate) fn build_did_change_configuration_notification(
     )
 }
 
-/// Validates a JSON-RPC initialize response.
+/// Validates a JSON-RPC initialize response and extracts its capabilities.
 ///
 /// Uses lenient interpretation to maximize compatibility with non-conformant
 /// servers: a non-null `error` field is prioritized, a null `error` alongside a
 /// result is accepted, and a null/missing result is rejected.
-pub(crate) fn validate_initialize_response(response: &serde_json::Value) -> std::io::Result<()> {
+pub(crate) fn parse_initialize_response_capabilities(
+    response: &serde_json::Value,
+) -> std::io::Result<ServerCapabilities> {
     // 1. Check for error response (prioritize error if present)
     if let Some(error) = response.get("error").filter(|e| !e.is_null()) {
         // Error field is non-null: treat as error regardless of result
@@ -152,23 +154,11 @@ pub(crate) fn validate_initialize_response(response: &serde_json::Value) -> std:
     }
 
     // 2. Reject if result is absent or null
-    let Some(result) = response.get("result").filter(|r| !r.is_null()) else {
+    let Some(result) = response.get("result").filter(|result| !result.is_null()) else {
         return Err(std::io::Error::other(
             "bridge: initialize response missing valid result",
         ));
     };
-
-    if let Some(capabilities) = result
-        .get("capabilities")
-        .filter(|capabilities| !capabilities.is_null())
-    {
-        serde_json::from_value::<ServerCapabilities>(capabilities.clone()).map_err(|error| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("bridge: invalid initialize capabilities: {error}"),
-            )
-        })?;
-    }
 
     validate_utf16_encoding(
         result
@@ -178,7 +168,19 @@ pub(crate) fn validate_initialize_response(response: &serde_json::Value) -> std:
     )?;
     validate_utf16_encoding(result.get("offsetEncoding"), "offsetEncoding")?;
 
-    Ok(())
+    let capabilities = result
+        .get("capabilities")
+        .filter(|capabilities| !capabilities.is_null());
+
+    match capabilities {
+        Some(capabilities) => serde_json::from_value(capabilities.clone()).map_err(|error| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("bridge: invalid initialize capabilities: {error}"),
+            )
+        }),
+        None => Ok(ServerCapabilities::default()),
+    }
 }
 
 fn validate_utf16_encoding(
@@ -189,8 +191,6 @@ fn validate_utf16_encoding(
         return Ok(());
     };
     if announced.is_null() {
-        // Optional JSON-RPC fields are commonly serialized as explicit null;
-        // like absence, that announces no alternative to the UTF-16 default.
         return Ok(());
     }
     let Some(encoding) = announced.as_str() else {
@@ -433,7 +433,7 @@ mod tests {
         assert_eq!(json["params"]["textDocument"]["uri"], uri);
     }
 
-    // Tests for validate_initialize_response
+    // Tests for parse_initialize_response_capabilities
 
     #[rstest]
     #[case::valid_result_without_error(
@@ -442,27 +442,23 @@ mod tests {
     #[case::valid_result_with_null_error(
         serde_json::json!({"result": {"capabilities": {}}, "error": null})
     )]
-    #[case::omitted_capabilities(serde_json::json!({"result": {}}))]
-    #[case::null_capabilities(serde_json::json!({"result": {"capabilities": null}}))]
     #[case::explicit_utf16_position_encoding(
-        serde_json::json!({
-            "result": {"capabilities": {"positionEncoding": "utf-16"}}
-        })
+        serde_json::json!({"result": {"capabilities": {"positionEncoding": "utf-16"}}})
     )]
     #[case::legacy_utf16_offset_encoding(
-        serde_json::json!({
-            "result": {"capabilities": {}, "offsetEncoding": "utf-16"}
-        })
+        serde_json::json!({"result": {"capabilities": {}, "offsetEncoding": "utf-16"}})
     )]
     #[case::null_standard_encoding(
-        serde_json::json!({
-            "result": {"capabilities": {"positionEncoding": null}}
-        })
+        serde_json::json!({"result": {"capabilities": {"positionEncoding": null}}})
     )]
     #[case::null_legacy_encoding(
-        serde_json::json!({
-            "result": {"capabilities": {}, "offsetEncoding": null}
-        })
+        serde_json::json!({"result": {"capabilities": {}, "offsetEncoding": null}})
+    )]
+    #[case::omitted_capabilities(
+        serde_json::json!({"result": {}})
+    )]
+    #[case::null_capabilities(
+        serde_json::json!({"result": {"capabilities": null}})
     )]
     #[case::complex_result_object(
         serde_json::json!({
@@ -483,19 +479,19 @@ mod tests {
     #[trace]
     fn validate_accepts_valid_response(#[case] response: serde_json::Value) {
         assert!(
-            validate_initialize_response(&response).is_ok(),
+            parse_initialize_response_capabilities(&response).is_ok(),
             "Expected valid response to be accepted: {:?}",
             response
         );
     }
 
-    #[test]
-    fn validate_rejects_non_object_capabilities() {
-        let response = serde_json::json!({
-            "result": { "capabilities": "not-an-object" }
-        });
+    #[rstest]
+    #[case::non_object(serde_json::json!("not-an-object"))]
+    #[case::invalid_known_field(serde_json::json!({"hoverProvider": 42}))]
+    fn validate_rejects_malformed_capabilities(#[case] capabilities: serde_json::Value) {
+        let response = serde_json::json!({ "result": { "capabilities": capabilities } });
 
-        let error = validate_initialize_response(&response)
+        let error = parse_initialize_response_capabilities(&response)
             .expect_err("non-object server capabilities must fail the handshake");
 
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
@@ -520,7 +516,7 @@ mod tests {
         #[case] response: serde_json::Value,
         #[case] expected_error: &str,
     ) {
-        let result = validate_initialize_response(&response);
+        let result = parse_initialize_response_capabilities(&response);
         assert!(result.is_err(), "Expected rejection for: {:?}", response);
         let err_msg = result.unwrap_err().to_string();
         assert!(
@@ -529,41 +525,6 @@ mod tests {
             expected_error,
             err_msg
         );
-    }
-
-    #[rstest]
-    #[case::standard_utf8(
-        serde_json::json!({
-            "result": {"capabilities": {"positionEncoding": "utf-8"}}
-        }),
-        "positionEncoding",
-        "utf-8",
-    )]
-    #[case::legacy_utf8(
-        serde_json::json!({
-            "result": {"capabilities": {}, "offsetEncoding": "utf-8"}
-        }),
-        "offsetEncoding",
-        "utf-8",
-    )]
-    #[case::malformed_standard_encoding(
-        serde_json::json!({
-            "result": {"capabilities": {"positionEncoding": 16}}
-        }),
-        "positionEncoding",
-        "non-string",
-    )]
-    #[trace]
-    fn validate_rejects_non_utf16_position_encoding(
-        #[case] response: serde_json::Value,
-        #[case] field: &str,
-        #[case] announced: &str,
-    ) {
-        let error = validate_initialize_response(&response)
-            .expect_err("non-UTF-16 downstream encoding must fail initialization");
-        let message = error.to_string();
-        assert!(message.contains(field), "unexpected error: {message}");
-        assert!(message.contains(announced), "unexpected error: {message}");
     }
 
     #[rstest]
@@ -627,7 +588,7 @@ mod tests {
         #[case] expected_code: &str,
         #[case] expected_message: &str,
     ) {
-        let result = validate_initialize_response(&response);
+        let result = parse_initialize_response_capabilities(&response);
         assert!(result.is_err(), "Expected rejection for: {:?}", response);
         let err_msg = result.unwrap_err().to_string();
         assert!(

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -442,6 +442,8 @@ mod tests {
     #[case::valid_result_with_null_error(
         serde_json::json!({"result": {"capabilities": {}}, "error": null})
     )]
+    #[case::omitted_capabilities(serde_json::json!({"result": {}}))]
+    #[case::null_capabilities(serde_json::json!({"result": {"capabilities": null}}))]
     #[case::explicit_utf16_position_encoding(
         serde_json::json!({
             "result": {"capabilities": {"positionEncoding": "utf-16"}}

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -7,8 +7,8 @@ use std::str::FromStr;
 
 use tower_lsp_server::ls_types::{
     ClientCapabilities, DidChangeConfigurationParams, DidChangeWorkspaceFoldersParams,
-    DidCloseTextDocumentParams, InitializeParams, InitializedParams, TextDocumentIdentifier, Uri,
-    WorkspaceFolder, WorkspaceFoldersChangeEvent,
+    DidCloseTextDocumentParams, InitializeParams, InitializedParams, ServerCapabilities,
+    TextDocumentIdentifier, Uri, WorkspaceFolder, WorkspaceFoldersChangeEvent,
 };
 
 use super::client_capabilities::build_bridge_client_capabilities;
@@ -157,6 +157,18 @@ pub(crate) fn validate_initialize_response(response: &serde_json::Value) -> std:
             "bridge: initialize response missing valid result",
         ));
     };
+
+    if let Some(capabilities) = result
+        .get("capabilities")
+        .filter(|capabilities| !capabilities.is_null())
+    {
+        serde_json::from_value::<ServerCapabilities>(capabilities.clone()).map_err(|error| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("bridge: invalid initialize capabilities: {error}"),
+            )
+        })?;
+    }
 
     validate_utf16_encoding(
         result
@@ -473,6 +485,19 @@ mod tests {
             "Expected valid response to be accepted: {:?}",
             response
         );
+    }
+
+    #[test]
+    fn validate_rejects_non_object_capabilities() {
+        let response = serde_json::json!({
+            "result": { "capabilities": "not-an-object" }
+        });
+
+        let error = validate_initialize_response(&response)
+            .expect_err("non-object server capabilities must fail the handshake");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("initialize capabilities"));
     }
 
     #[rstest]

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -492,6 +492,27 @@ mod tests {
         );
     }
 
+    #[test]
+    fn validate_returns_advertised_capabilities() {
+        let response = serde_json::json!({
+            "result": {
+                "capabilities": {
+                    "textDocumentSync": 1,
+                    "completionProvider": { "triggerCharacters": ["."] }
+                }
+            }
+        });
+
+        let capabilities = parse_initialize_response_capabilities(&response)
+            .expect("valid capabilities must be returned");
+
+        assert!(capabilities.text_document_sync.is_some());
+        let completion = capabilities
+            .completion_provider
+            .expect("completion capability must be preserved");
+        assert_eq!(completion.trigger_characters, Some(vec![".".to_string()]));
+    }
+
     #[rstest]
     #[case::non_object(serde_json::json!("not-an-object"))]
     #[case::invalid_known_field(serde_json::json!({"hoverProvider": 42}))]

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -160,6 +160,13 @@ pub(crate) fn parse_initialize_response_capabilities(
         ));
     };
 
+    let result = result.as_object().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "bridge: invalid initialize result: expected an object",
+        )
+    })?;
+
     validate_utf16_encoding(
         result
             .get("capabilities")
@@ -167,7 +174,6 @@ pub(crate) fn parse_initialize_response_capabilities(
         "capabilities.positionEncoding",
     )?;
     validate_utf16_encoding(result.get("offsetEncoding"), "offsetEncoding")?;
-
     let capabilities = result
         .get("capabilities")
         .filter(|capabilities| !capabilities.is_null());
@@ -496,6 +502,19 @@ mod tests {
 
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
         assert!(error.to_string().contains("initialize capabilities"));
+    }
+
+    #[rstest]
+    #[case::scalar(serde_json::json!(42))]
+    #[case::array(serde_json::json!([]))]
+    fn validate_rejects_non_object_result(#[case] result: serde_json::Value) {
+        let response = serde_json::json!({ "result": result });
+
+        let error = parse_initialize_response_capabilities(&response)
+            .expect_err("initialize result must be an object");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("initialize result"));
     }
 
     #[rstest]

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -155,7 +155,8 @@ pub(crate) fn parse_initialize_response_capabilities(
 
     // 2. Reject if result is absent or null
     let Some(result) = response.get("result").filter(|result| !result.is_null()) else {
-        return Err(std::io::Error::other(
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
             "bridge: initialize response missing valid result",
         ));
     };
@@ -537,7 +538,9 @@ mod tests {
     ) {
         let result = parse_initialize_response_capabilities(&response);
         assert!(result.is_err(), "Expected rejection for: {:?}", response);
-        let err_msg = result.unwrap_err().to_string();
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        let err_msg = error.to_string();
         assert!(
             err_msg.contains(expected_error),
             "Expected error containing {:?}, got: {}",


### PR DESCRIPTION
## Summary

- reject downstream `initialize` responses whose non-null capabilities cannot deserialize as `ServerCapabilities`
- reject scalar and array initialize results before applying compatibility defaults
- preserve the existing compatibility behavior for omitted or null capabilities
- parse capabilities once and propagate actionable `InvalidData` errors instead of silently disabling all downstream features

Closes #721

## Validation

- `make test` (2,872 library tests)
- `make check`
- focused initialize response validation tests (18 cases)
- Codex continued review clean
- fresh Codex review clean

## Risk

The only newly rejected inputs are malformed non-null result/capabilities payloads. Servers that omit capabilities or send `capabilities: null` continue to initialize with empty capabilities.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Language Server Protocol (LSP) startup validation for server capability responses.
  * Malformed or incorrectly formatted capability data is now rejected safely with a clear error.
  * Prevented the client from marking a language server as initialized when its startup response is invalid.
  * Improved handling of missing, empty, and error responses during language server initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->