### PR TITLE
fix(parser): persist crash recovery markers

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -42,7 +42,7 @@ pub fn default_data_dir() -> Option<PathBuf> {
     // persistent dir under `deps/` so the developer's real
     // `~/.local/share/kakehashi/` is never read or written. The dir is
     // shared across the test process to keep parser/query installs
-    // cached between runs; transient crash-recovery files
+    // cached between runs; legacy transient crash-recovery files
     // (`parsing_in_progress`, `failed_parsers`) are cleared once per
     // process at first call so a prior E2E shutdown can't taint this run.
     #[cfg(test)]
@@ -63,7 +63,7 @@ pub fn default_data_dir() -> Option<PathBuf> {
 /// Project-local persistent data directory used by unit tests.
 ///
 /// Lives under `deps/` (already gitignored). Parser/query installs persist
-/// across runs to avoid re-downloading, while crash-recovery state files
+/// across runs to avoid re-downloading, while legacy crash-recovery state files
 /// are cleared once per test process so a previous test's leftovers
 /// (typically from an E2E binary that exited mid-parse) don't poison this
 /// run. Returns the same path every call within a process via `OnceLock`.

--- a/src/install.rs
+++ b/src/install.rs
@@ -37,9 +37,9 @@ use std::path::PathBuf;
 /// - macOS: ~/Library/Application Support/kakehashi/
 /// - Windows: %APPDATA%/kakehashi/
 pub fn default_data_dir() -> Option<PathBuf> {
-    // In `cfg(test)`, redirect every caller (Kakehashi::new -> failed
-    // parser registry, search-path defaulting, etc.) to a project-local
-    // persistent dir under `deps/` so the developer's real
+    // In `cfg(test)`, redirect install assets, search-path defaults, and
+    // other persistent data callers to a project-local dir under `deps/`
+    // so the developer's real
     // `~/.local/share/kakehashi/` is never read or written. The dir is
     // shared across test processes to keep parser/query installs cached
     // between runs. Crash-recovery state is stored separately in the

--- a/src/install.rs
+++ b/src/install.rs
@@ -90,6 +90,11 @@ pub(crate) fn test_data_dir() -> PathBuf {
 #[cfg(test)]
 pub(crate) fn test_state_dir() -> PathBuf {
     use std::sync::OnceLock;
+    // Rust does not drop statics, so this small directory intentionally remains
+    // in the OS temp tree after the test process exits. Keeping the `TempDir`
+    // guard (rather than only its path) prevents premature cleanup while tests
+    // are still using the shared process-local registry state; this matches the
+    // E2E helpers' accepted lifetime policy.
     static DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
     DIR.get_or_init(|| tempfile::tempdir().expect("create unit-test crash state directory"))
         .path()

--- a/src/install.rs
+++ b/src/install.rs
@@ -41,10 +41,9 @@ pub fn default_data_dir() -> Option<PathBuf> {
     // parser registry, search-path defaulting, etc.) to a project-local
     // persistent dir under `deps/` so the developer's real
     // `~/.local/share/kakehashi/` is never read or written. The dir is
-    // shared across the test process to keep parser/query installs
-    // cached between runs; legacy transient crash-recovery files
-    // (`parsing_in_progress`, `failed_parsers`) are cleared once per
-    // process at first call so a prior E2E shutdown can't taint this run.
+    // shared across test processes to keep parser/query installs cached
+    // between runs. Crash-recovery state is stored separately in the
+    // process-local `test_state_dir`.
     #[cfg(test)]
     {
         return Some(test_data_dir());
@@ -63,10 +62,8 @@ pub fn default_data_dir() -> Option<PathBuf> {
 /// Project-local persistent data directory used by unit tests.
 ///
 /// Lives under `deps/` (already gitignored). Parser/query installs persist
-/// across runs to avoid re-downloading, while legacy crash-recovery state files
-/// are cleared once per test process so a previous test's leftovers
-/// (typically from an E2E binary that exited mid-parse) don't poison this
-/// run. Returns the same path every call within a process via `OnceLock`.
+/// across runs to avoid re-downloading. Returns the same path every call
+/// within a process via `OnceLock`.
 #[cfg(test)]
 pub(crate) fn test_data_dir() -> PathBuf {
     use std::sync::OnceLock;
@@ -74,11 +71,6 @@ pub(crate) fn test_data_dir() -> PathBuf {
     DIR.get_or_init(|| {
         let dir = test_support::test_data_dir_path();
         let _ = std::fs::create_dir_all(&dir);
-        // Crash-recovery state can be left over from a previous E2E
-        // shutdown; clear it once per test process so init() doesn't
-        // pre-mark languages as failed.
-        let _ = std::fs::remove_file(dir.join("parsing_in_progress"));
-        let _ = std::fs::remove_file(dir.join("failed_parsers"));
         // Auto-install required parsers + queries on first call per
         // process. Cached on disk via the `.installed` marker so
         // subsequent test processes are fast.
@@ -86,6 +78,22 @@ pub(crate) fn test_data_dir() -> PathBuf {
         dir
     })
     .clone()
+}
+
+/// Process-local crash-recovery directory used by unit-test builds.
+///
+/// Parser/query assets remain shared in [`test_data_dir`], but marker files
+/// must not: deleting stale-looking markers from that shared directory can
+/// unlink a concurrently running test process's live, locked marker. A temp
+/// directory owned for the lifetime of this process gives recovery tests a
+/// stable location without environment-variable mutation or peer cleanup.
+#[cfg(test)]
+pub(crate) fn test_state_dir() -> PathBuf {
+    use std::sync::OnceLock;
+    static DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
+    DIR.get_or_init(|| tempfile::tempdir().expect("create unit-test crash state directory"))
+        .path()
+        .to_path_buf()
 }
 
 /// Test-support helpers exposed to integration tests under `tests/`.

--- a/src/language/failed_parsers.rs
+++ b/src/language/failed_parsers.rs
@@ -323,9 +323,9 @@ impl FailedParserRegistry {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
 
-        // Build and flush a replacement inode without touching the currently
-        // locked marker. Any create/write/sync failure therefore leaves the
-        // prior active-language evidence intact.
+        // Build a replacement inode without touching the currently locked
+        // marker. Any create/write failure therefore leaves the prior
+        // active-language evidence intact.
         let next_path = self.session_marker_path();
         let temp_path = self
             .state_dir
@@ -338,7 +338,6 @@ impl FailedParserRegistry {
                 .open(&temp_path)?;
             file.lock_exclusive()?;
             file.write_all(contents.as_bytes())?;
-            file.sync_data()?;
             fs::rename(&temp_path, &next_path)?;
             Ok(file)
         })();
@@ -350,9 +349,9 @@ impl FailedParserRegistry {
             }
         };
 
-        // The replacement is now visible with flushed contents and already
-        // locked. Swap ownership before releasing the old lock, so startup
-        // scanning can never observe a gap with no live marker.
+        // The replacement is now visible and already locked. Swap ownership
+        // before releasing the old lock, so startup scanning can never observe
+        // a gap with no live marker.
         let old_path = std::mem::replace(&mut current.path, next_path);
         let old_file = std::mem::replace(&mut current.file, replacement);
         if let Err(remove_error) = fs::remove_file(&old_path) {
@@ -361,7 +360,7 @@ impl FailedParserRegistry {
             // If either operation fails, retain the lock for this session;
             // safety prefers a later false quarantine over a live peer reading
             // stale evidence now.
-            let cleared = old_file.set_len(0).and_then(|()| old_file.sync_data());
+            let cleared = old_file.set_len(0);
             if cleared.is_ok() {
                 drop(old_file);
                 if let Err(error) = fs::remove_file(&old_path) {

--- a/src/language/failed_parsers.rs
+++ b/src/language/failed_parsers.rs
@@ -227,7 +227,11 @@ impl FailedParserRegistry {
             .entry(language.to_string())
             .and_modify(|count| *count += 1)
             .or_insert(1);
-        self.persist_current_state()
+        if let Err(error) = self.persist_current_state() {
+            self.decrement_parsing_count(language);
+            return Err(error);
+        }
+        Ok(())
     }
 
     /// Record that parsing completed successfully for a language.
@@ -238,7 +242,11 @@ impl FailedParserRegistry {
             .persistence_lock
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        // Decrement the parsing count for this language
+        self.decrement_parsing_count(language);
+        self.persist_current_state()
+    }
+
+    fn decrement_parsing_count(&self, language: &str) {
         if let Some(mut entry) = self.parsing_counts.get_mut(language) {
             *entry -= 1;
             if *entry == 0 {
@@ -247,7 +255,6 @@ impl FailedParserRegistry {
                 self.parsing_counts.remove(language);
             }
         }
-        self.persist_current_state()
     }
 
     /// Persist current parsing state to disk.

--- a/src/language/failed_parsers.rs
+++ b/src/language/failed_parsers.rs
@@ -69,7 +69,7 @@ impl FailedParserRegistry {
         }
     }
 
-    /// Path to the "parsing in progress" state file.
+    /// Path to the legacy single-session marker used by older versions.
     fn parsing_state_path(&self) -> PathBuf {
         self.state_dir.join("parsing_in_progress")
     }
@@ -269,11 +269,10 @@ impl FailedParserRegistry {
         }
     }
 
-    /// Persist current parsing state to disk.
+    /// Force the current active-parser set into this session's durable marker.
     ///
-    /// This should be called on graceful shutdown to enable crash detection
-    /// across process restarts. If parsers are currently being parsed, write
-    /// their names to the parsing_in_progress file (one per line).
+    /// Begin/end transitions already persist this state synchronously. This
+    /// explicit flush remains available to lifecycle paths such as shutdown.
     pub fn persist_state(&self) -> io::Result<()> {
         let _guard = self
             .persistence_lock

--- a/src/language/failed_parsers.rs
+++ b/src/language/failed_parsers.rs
@@ -225,8 +225,8 @@ impl FailedParserRegistry {
 
     /// Record that parsing is starting for a language.
     ///
-    /// The durable marker is updated before returning, so an uncatchable crash
-    /// in the native parser still leaves recovery evidence for the next run.
+    /// The marker is persisted before returning, so an uncatchable process
+    /// crash in the native parser still leaves recovery evidence for restart.
     ///
     /// Supports concurrent parsing by tracking a counter per language.
     pub fn begin_parsing(&self, language: &str) -> io::Result<()> {
@@ -269,7 +269,7 @@ impl FailedParserRegistry {
         }
     }
 
-    /// Force the current active-parser set into this session's durable marker.
+    /// Force the current active-parser set into this session's crash marker.
     ///
     /// Begin/end transitions already persist this state synchronously. This
     /// explicit flush remains available to lifecycle paths such as shutdown.
@@ -298,9 +298,9 @@ impl FailedParserRegistry {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
 
-        // Build and durably flush a replacement inode without touching the
-        // currently locked marker. Any create/write/sync failure therefore
-        // leaves the prior active-language evidence intact.
+        // Build and flush a replacement inode without touching the currently
+        // locked marker. Any create/write/sync failure therefore leaves the
+        // prior active-language evidence intact.
         let next_path = self.session_marker_path();
         let temp_path = self
             .state_dir
@@ -325,9 +325,9 @@ impl FailedParserRegistry {
             }
         };
 
-        // The replacement is now visible, durable, and already locked. Swap
-        // ownership before releasing the old lock, so startup scanning can
-        // never observe a gap with no live marker.
+        // The replacement is now visible with flushed contents and already
+        // locked. Swap ownership before releasing the old lock, so startup
+        // scanning can never observe a gap with no live marker.
         let old_path = std::mem::replace(&mut current.path, next_path);
         let old_file = std::mem::replace(&mut current.file, replacement);
         if let Err(remove_error) = fs::remove_file(&old_path) {

--- a/src/language/failed_parsers.rs
+++ b/src/language/failed_parsers.rs
@@ -517,6 +517,33 @@ mod tests {
     }
 
     #[test]
+    fn test_abort_releases_marker_lock_for_crash_recovery() {
+        const CHILD_STATE_DIR: &str = "KAKEHASHI_ABORT_TEST_STATE_DIR";
+        if let Some(state_dir) = std::env::var_os(CHILD_STATE_DIR) {
+            let registry = FailedParserRegistry::new(Path::new(&state_dir));
+            registry.init().unwrap();
+            registry.begin_parsing("lua").unwrap();
+            std::process::abort();
+        }
+
+        let temp = tempdir().unwrap();
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "language::failed_parsers::tests::test_abort_releases_marker_lock_for_crash_recovery",
+                "--nocapture",
+            ])
+            .env(CHILD_STATE_DIR, temp.path())
+            .status()
+            .unwrap();
+        assert!(!status.success(), "child must terminate via abort");
+
+        let restarted = FailedParserRegistry::new(temp.path());
+        restarted.init().unwrap();
+        assert!(restarted.is_failed("lua"));
+    }
+
+    #[test]
     fn test_live_peer_marker_is_not_treated_as_a_crash() {
         let temp = tempdir().unwrap();
         let first = FailedParserRegistry::new(temp.path());

--- a/src/language/failed_parsers.rs
+++ b/src/language/failed_parsers.rs
@@ -13,10 +13,17 @@
 //! Supports concurrent parsing by tracking per-language parsing counts.
 
 use dashmap::{DashMap, DashSet};
+use fs4::fs_std::FileExt;
 use std::fs;
-use std::io;
+use std::io::{self, Read, Seek, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+
+const PARSING_MARKER_PREFIX: &str = "parsing_in_progress.";
+
+struct SessionMarker {
+    file: std::sync::Mutex<fs::File>,
+}
 
 /// Registry for tracking failed parsers.
 ///
@@ -33,6 +40,9 @@ pub(crate) struct FailedParserRegistry {
     parsing_counts: Arc<DashMap<String, usize>>,
     /// Serializes count transitions with their durable marker update.
     persistence_lock: Arc<std::sync::Mutex<()>>,
+    /// This session's exclusively locked marker. A peer can distinguish this
+    /// live owner from an unlocked marker left by a crashed process.
+    session_marker: Arc<OnceLock<Arc<SessionMarker>>>,
 }
 
 impl FailedParserRegistry {
@@ -43,12 +53,18 @@ impl FailedParserRegistry {
             state_dir: state_dir.to_path_buf(),
             parsing_counts: Arc::new(DashMap::new()),
             persistence_lock: Arc::new(std::sync::Mutex::new(())),
+            session_marker: Arc::new(OnceLock::new()),
         }
     }
 
     /// Path to the "parsing in progress" state file.
     fn parsing_state_path(&self) -> PathBuf {
         self.state_dir.join("parsing_in_progress")
+    }
+
+    fn session_marker_path(&self) -> PathBuf {
+        self.state_dir
+            .join(format!("{PARSING_MARKER_PREFIX}{}", ulid::Ulid::new()))
     }
 
     /// Path to the "failed parsers" list file.
@@ -67,7 +83,18 @@ impl FailedParserRegistry {
         // Load previously failed parsers
         self.load_failed_parsers()?;
 
-        // Check for crash recovery
+        // Serialize recovery scanning with marker creation. Otherwise a peer
+        // could observe a newly-created marker before its owner locks it and
+        // misclassify the live session as crashed.
+        let init_lock = fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(self.state_dir.join("crash_recovery.lock"))?;
+        init_lock.lock_exclusive()?;
+
+        // Recover the legacy single marker written by older versions.
         let parsing_state = self.parsing_state_path();
         if parsing_state.exists() {
             // Previous parsing was interrupted - crash detected!
@@ -88,6 +115,60 @@ impl FailedParserRegistry {
             let _ = fs::remove_file(&parsing_state);
         }
 
+        // Recover only unlocked per-session markers. A locked marker belongs
+        // to another live kakehashi process sharing this state directory.
+        for entry in fs::read_dir(&self.state_dir)? {
+            let entry = entry?;
+            let name = entry.file_name();
+            if !name.to_string_lossy().starts_with(PARSING_MARKER_PREFIX) {
+                continue;
+            }
+            let mut file = fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(entry.path())?;
+            match file.try_lock_exclusive() {
+                Ok(()) => {
+                    let mut content = String::new();
+                    file.read_to_string(&mut content)?;
+                    self.mark_languages_failed(&content)?;
+                    drop(file);
+                    let _ = fs::remove_file(entry.path());
+                }
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+                Err(error) => return Err(error),
+            }
+        }
+
+        if self.session_marker.get().is_none() {
+            let path = self.session_marker_path();
+            let file = fs::OpenOptions::new()
+                .create_new(true)
+                .read(true)
+                .write(true)
+                .open(&path)?;
+            file.lock_exclusive()?;
+            let marker = Arc::new(SessionMarker {
+                file: std::sync::Mutex::new(file),
+            });
+            let _ = self.session_marker.set(marker);
+        }
+
+        Ok(())
+    }
+
+    fn mark_languages_failed(&self, content: &str) -> io::Result<()> {
+        for line in content.lines() {
+            let language = line.trim();
+            if !language.is_empty() {
+                log::error!(
+                    target: "kakehashi::crash_recovery",
+                    "Detected crash during parsing of '{}'. Marking as failed.",
+                    language
+                );
+                self.mark_failed(language)?;
+            }
+        }
         Ok(())
     }
 
@@ -183,16 +264,24 @@ impl FailedParserRegistry {
             .map(|entry| entry.key().clone())
             .collect();
 
-        if !parsing_languages.is_empty() {
-            fs::create_dir_all(&self.state_dir)?;
-            fs::write(self.parsing_state_path(), parsing_languages.join("\n"))?;
-        } else {
-            match fs::remove_file(self.parsing_state_path()) {
-                Ok(()) => {}
-                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-                Err(error) => return Err(error),
-            }
-        }
+        let marker = self
+            .session_marker
+            .get()
+            .ok_or_else(|| io::Error::other("crash recovery registry is not initialized"))?;
+        let mut file = marker
+            .file
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        file.seek(std::io::SeekFrom::Start(0))?;
+        let contents = parsing_languages.join("\n");
+        // Write and flush the new evidence before shortening an older, longer
+        // value. A crash between these operations may retain an extra stale
+        // language (safe over-quarantine), but cannot erase every currently
+        // active language and recreate the crash loop #725 prevents.
+        file.write_all(contents.as_bytes())?;
+        file.sync_data()?;
+        file.set_len(contents.len() as u64)?;
+        file.sync_data()?;
         Ok(())
     }
 }
@@ -217,6 +306,20 @@ impl FailedParserRegistry {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    fn session_marker_contents(state_dir: &Path) -> Vec<String> {
+        fs::read_dir(state_dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(PARSING_MARKER_PREFIX)
+            })
+            .map(|entry| fs::read_to_string(entry.path()).unwrap())
+            .collect()
+    }
 
     impl FailedParserRegistry {
         /// Get the currently parsing languages (test helper).
@@ -316,6 +419,23 @@ mod tests {
     }
 
     #[test]
+    fn test_live_peer_marker_is_not_treated_as_a_crash() {
+        let temp = tempdir().unwrap();
+        let first = FailedParserRegistry::new(temp.path());
+        first.init().unwrap();
+        first.begin_parsing("lua").unwrap();
+
+        let second = FailedParserRegistry::new(temp.path());
+        second.init().unwrap();
+
+        assert!(
+            !second.is_failed("lua"),
+            "a live peer's active parser must not be quarantined"
+        );
+        first.end_parsing_language("lua").unwrap();
+    }
+
+    #[test]
     fn test_successful_parsing_does_not_mark_failed() {
         let temp = tempdir().unwrap();
 
@@ -395,11 +515,7 @@ mod tests {
         registry.begin_parsing("lua").unwrap();
 
         // Verify that crash evidence is durable before native parsing begins.
-        let parsing_state_path = temp.path().join("parsing_in_progress");
-        assert!(
-            parsing_state_path.exists(),
-            "begin_parsing should write parsing_in_progress to disk"
-        );
+        assert_eq!(session_marker_contents(temp.path()), vec!["lua"]);
 
         // Verify that in-memory state is updated (we'll add accessor for this)
         assert_eq!(
@@ -433,11 +549,7 @@ mod tests {
         );
 
         // Successful completion removes the recovery evidence.
-        let parsing_state_path = temp.path().join("parsing_in_progress");
-        assert!(
-            !parsing_state_path.exists(),
-            "end_parsing_language should remove the crash marker"
-        );
+        assert_eq!(session_marker_contents(temp.path()), vec![""]);
     }
 
     #[test]

--- a/src/language/failed_parsers.rs
+++ b/src/language/failed_parsers.rs
@@ -84,9 +84,6 @@ impl FailedParserRegistry {
         // Ensure state directory exists
         fs::create_dir_all(&self.state_dir)?;
 
-        // Load previously failed parsers
-        self.load_failed_parsers()?;
-
         // Serialize recovery scanning with marker creation. Otherwise a peer
         // could observe a newly-created marker before its owner locks it and
         // misclassify the live session as crashed.
@@ -97,6 +94,11 @@ impl FailedParserRegistry {
             .write(true)
             .open(self.state_dir.join("crash_recovery.lock"))?;
         init_lock.lock_exclusive()?;
+
+        // Load only after acquiring the cross-process lock. A peer may have
+        // recovered another marker while this process waited; loading earlier
+        // would let our later save overwrite and forget that quarantine.
+        self.load_failed_parsers()?;
 
         // Recover the legacy single marker written by older versions.
         let parsing_state = self.parsing_state_path();
@@ -437,6 +439,26 @@ mod tests {
             "a live peer's active parser must not be quarantined"
         );
         first.end_parsing_language("lua").unwrap();
+    }
+
+    #[test]
+    fn test_recovery_preserves_failures_recorded_by_a_peer() {
+        let temp = tempdir().unwrap();
+        fs::write(temp.path().join("failed_parsers"), "lua").unwrap();
+        fs::write(
+            temp.path().join(format!("{PARSING_MARKER_PREFIX}stale")),
+            "rust",
+        )
+        .unwrap();
+
+        let registry = FailedParserRegistry::new(temp.path());
+        registry.init().unwrap();
+
+        assert!(registry.is_failed("lua"));
+        assert!(registry.is_failed("rust"));
+        let persisted = fs::read_to_string(temp.path().join("failed_parsers")).unwrap();
+        assert!(persisted.lines().any(|language| language == "lua"));
+        assert!(persisted.lines().any(|language| language == "rust"));
     }
 
     #[test]

--- a/src/language/failed_parsers.rs
+++ b/src/language/failed_parsers.rs
@@ -15,7 +15,7 @@
 use dashmap::{DashMap, DashSet};
 use fs4::fs_std::FileExt;
 use std::fs;
-use std::io::{self, Read, Seek, Write};
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
@@ -26,7 +26,15 @@ fn is_lock_contended(error: &io::Error) -> bool {
 }
 
 struct SessionMarker {
-    file: std::sync::Mutex<fs::File>,
+    state: std::sync::Mutex<MarkerState>,
+}
+
+struct MarkerState {
+    path: PathBuf,
+    file: fs::File,
+    /// Old markers whose cleanup failed stay locked so live peers never
+    /// misclassify their stale contents as a crash.
+    retired: Vec<(PathBuf, fs::File)>,
 }
 
 /// Registry for tracking failed parsers.
@@ -155,7 +163,11 @@ impl FailedParserRegistry {
                 .open(&path)?;
             file.lock_exclusive()?;
             let marker = Arc::new(SessionMarker {
-                file: std::sync::Mutex::new(file),
+                state: std::sync::Mutex::new(MarkerState {
+                    path,
+                    file,
+                    retired: Vec::new(),
+                }),
             });
             let _ = self.session_marker.set(marker);
         }
@@ -281,20 +293,70 @@ impl FailedParserRegistry {
             .session_marker
             .get()
             .ok_or_else(|| io::Error::other("crash recovery registry is not initialized"))?;
-        let mut file = marker
-            .file
+        let contents = parsing_languages.join("\n");
+        let mut current = marker
+            .state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        file.seek(std::io::SeekFrom::Start(0))?;
-        let contents = parsing_languages.join("\n");
-        // Write and flush the new evidence before shortening an older, longer
-        // value. A crash between these operations may retain an extra stale
-        // language (safe over-quarantine), but cannot erase every currently
-        // active language and recreate the crash loop #725 prevents.
-        file.write_all(contents.as_bytes())?;
-        file.sync_data()?;
-        file.set_len(contents.len() as u64)?;
-        file.sync_data()?;
+
+        // Build and durably flush a replacement inode without touching the
+        // currently locked marker. Any create/write/sync failure therefore
+        // leaves the prior active-language evidence intact.
+        let next_path = self.session_marker_path();
+        let temp_path = self
+            .state_dir
+            .join(format!(".parsing_marker_next.{}", ulid::Ulid::new()));
+        let replacement = (|| -> io::Result<fs::File> {
+            let mut file = fs::OpenOptions::new()
+                .create_new(true)
+                .read(true)
+                .write(true)
+                .open(&temp_path)?;
+            file.lock_exclusive()?;
+            file.write_all(contents.as_bytes())?;
+            file.sync_data()?;
+            fs::rename(&temp_path, &next_path)?;
+            Ok(file)
+        })();
+        let replacement = match replacement {
+            Ok(file) => file,
+            Err(error) => {
+                let _ = fs::remove_file(&temp_path);
+                return Err(error);
+            }
+        };
+
+        // The replacement is now visible, durable, and already locked. Swap
+        // ownership before releasing the old lock, so startup scanning can
+        // never observe a gap with no live marker.
+        let old_path = std::mem::replace(&mut current.path, next_path);
+        let old_file = std::mem::replace(&mut current.file, replacement);
+        if let Err(remove_error) = fs::remove_file(&old_path) {
+            // Windows normally cannot unlink an open locked file. Clear its
+            // stale contents while it is still locked, then retry after close.
+            // If either operation fails, retain the lock for this session;
+            // safety prefers a later false quarantine over a live peer reading
+            // stale evidence now.
+            let cleared = old_file.set_len(0).and_then(|()| old_file.sync_data());
+            if cleared.is_ok() {
+                drop(old_file);
+                if let Err(error) = fs::remove_file(&old_path) {
+                    log::warn!(
+                        target: "kakehashi::crash_recovery",
+                        "Failed to remove retired parser marker after clearing it: {}",
+                        error
+                    );
+                }
+            } else {
+                log::warn!(
+                    target: "kakehashi::crash_recovery",
+                    "Failed to retire parser marker (unlink: {}; clear: {:?}); retaining lock",
+                    remove_error,
+                    cleared.err()
+                );
+                current.retired.push((old_path, old_file));
+            }
+        }
         Ok(())
     }
 }
@@ -466,6 +528,25 @@ mod tests {
         let persisted = fs::read_to_string(temp.path().join("failed_parsers")).unwrap();
         assert!(persisted.lines().any(|language| language == "lua"));
         assert!(persisted.lines().any(|language| language == "rust"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_failed_replacement_preserves_existing_active_evidence() {
+        let temp = tempdir().unwrap();
+        let state_dir = temp.path().join("state");
+        let moved_dir = temp.path().join("moved-state");
+        let registry = FailedParserRegistry::new(&state_dir);
+        registry.init().unwrap();
+        registry.begin_parsing("rust").unwrap();
+
+        // Make creation of the transactional replacement fail without touching
+        // the already-open marker inode.
+        fs::rename(&state_dir, &moved_dir).unwrap();
+        assert!(registry.begin_parsing("lua").is_err());
+
+        assert_eq!(session_marker_contents(&moved_dir), vec!["rust"]);
+        assert_eq!(registry.current_parsing_language().as_deref(), Some("rust"));
     }
 
     #[test]

--- a/src/language/failed_parsers.rs
+++ b/src/language/failed_parsers.rs
@@ -33,7 +33,7 @@ struct SessionMarker {
 struct MarkerState {
     path: PathBuf,
     file: fs::File,
-    /// Old markers whose cleanup failed stay locked so live peers never
+    /// Old markers that cannot be cleared stay locked so live peers never
     /// misclassify their stale contents as a crash.
     retired: Vec<(PathBuf, fs::File)>,
 }

--- a/src/language/failed_parsers.rs
+++ b/src/language/failed_parsers.rs
@@ -31,6 +31,8 @@ pub(crate) struct FailedParserRegistry {
     /// Per-language parsing counts for concurrent crash detection
     /// Key: language name, Value: number of concurrent parses
     parsing_counts: Arc<DashMap<String, usize>>,
+    /// Serializes count transitions with their durable marker update.
+    persistence_lock: Arc<std::sync::Mutex<()>>,
 }
 
 impl FailedParserRegistry {
@@ -40,6 +42,7 @@ impl FailedParserRegistry {
             failed: Arc::new(DashSet::new()),
             state_dir: state_dir.to_path_buf(),
             parsing_counts: Arc::new(DashMap::new()),
+            persistence_lock: Arc::new(std::sync::Mutex::new(())),
         }
     }
 
@@ -123,23 +126,31 @@ impl FailedParserRegistry {
 
     /// Record that parsing is starting for a language.
     ///
-    /// This updates in-memory state only. Crash detection happens by checking
-    /// this state on restart (via init()).
+    /// The durable marker is updated before returning, so an uncatchable crash
+    /// in the native parser still leaves recovery evidence for the next run.
     ///
     /// Supports concurrent parsing by tracking a counter per language.
     pub fn begin_parsing(&self, language: &str) -> io::Result<()> {
+        let _guard = self
+            .persistence_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         // Increment the parsing count for this language
         self.parsing_counts
             .entry(language.to_string())
             .and_modify(|count| *count += 1)
             .or_insert(1);
-        Ok(())
+        self.persist_current_state()
     }
 
     /// Record that parsing completed successfully for a language.
     ///
-    /// This clears in-memory state only (no disk I/O).
+    /// This updates or clears the durable marker after the in-memory count.
     pub fn end_parsing_language(&self, language: &str) -> io::Result<()> {
+        let _guard = self
+            .persistence_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         // Decrement the parsing count for this language
         if let Some(mut entry) = self.parsing_counts.get_mut(language) {
             *entry -= 1;
@@ -149,7 +160,7 @@ impl FailedParserRegistry {
                 self.parsing_counts.remove(language);
             }
         }
-        Ok(())
+        self.persist_current_state()
     }
 
     /// Persist current parsing state to disk.
@@ -158,6 +169,14 @@ impl FailedParserRegistry {
     /// across process restarts. If parsers are currently being parsed, write
     /// their names to the parsing_in_progress file (one per line).
     pub fn persist_state(&self) -> io::Result<()> {
+        let _guard = self
+            .persistence_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        self.persist_current_state()
+    }
+
+    fn persist_current_state(&self) -> io::Result<()> {
         let parsing_languages: Vec<String> = self
             .parsing_counts
             .iter()
@@ -167,6 +186,12 @@ impl FailedParserRegistry {
         if !parsing_languages.is_empty() {
             fs::create_dir_all(&self.state_dir)?;
             fs::write(self.parsing_state_path(), parsing_languages.join("\n"))?;
+        } else {
+            match fs::remove_file(self.parsing_state_path()) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
         }
         Ok(())
     }
@@ -270,6 +295,27 @@ mod tests {
     }
 
     #[test]
+    fn test_crash_detection_does_not_require_shutdown_persistence() {
+        let temp = tempdir().unwrap();
+
+        {
+            let registry = FailedParserRegistry::new(temp.path());
+            registry.init().unwrap();
+            registry.begin_parsing("lua").unwrap();
+            // Simulate an uncatchable parser crash: neither normal parse cleanup
+            // nor the process lifecycle's graceful-shutdown hook can run.
+        }
+
+        let restarted = FailedParserRegistry::new(temp.path());
+        restarted.init().unwrap();
+
+        assert!(
+            restarted.is_failed("lua"),
+            "an active parser must be recoverable without graceful shutdown"
+        );
+    }
+
+    #[test]
     fn test_successful_parsing_does_not_mark_failed() {
         let temp = tempdir().unwrap();
 
@@ -340,7 +386,7 @@ mod tests {
     }
 
     #[test]
-    fn test_begin_parsing_does_not_write_to_disk() {
+    fn test_begin_parsing_writes_crash_marker() {
         let temp = tempdir().unwrap();
         let registry = FailedParserRegistry::new(temp.path());
         registry.init().unwrap();
@@ -348,12 +394,11 @@ mod tests {
         // Call begin_parsing
         registry.begin_parsing("lua").unwrap();
 
-        // Verify that parsing_in_progress file does NOT exist
-        // (begin_parsing should only update in-memory state)
+        // Verify that crash evidence is durable before native parsing begins.
         let parsing_state_path = temp.path().join("parsing_in_progress");
         assert!(
-            !parsing_state_path.exists(),
-            "begin_parsing should not write parsing_in_progress file to disk"
+            parsing_state_path.exists(),
+            "begin_parsing should write parsing_in_progress to disk"
         );
 
         // Verify that in-memory state is updated (we'll add accessor for this)
@@ -365,7 +410,7 @@ mod tests {
     }
 
     #[test]
-    fn test_end_parsing_only_clears_memory() {
+    fn test_end_parsing_clears_crash_marker() {
         let temp = tempdir().unwrap();
         let registry = FailedParserRegistry::new(temp.path());
         registry.init().unwrap();
@@ -387,11 +432,11 @@ mod tests {
             "end_parsing_language should clear in-memory state"
         );
 
-        // Verify no disk I/O happened
+        // Successful completion removes the recovery evidence.
         let parsing_state_path = temp.path().join("parsing_in_progress");
         assert!(
             !parsing_state_path.exists(),
-            "end_parsing_language should not create or modify files"
+            "end_parsing_language should remove the crash marker"
         );
     }
 

--- a/src/language/failed_parsers.rs
+++ b/src/language/failed_parsers.rs
@@ -20,6 +20,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
 const PARSING_MARKER_PREFIX: &str = "parsing_in_progress.";
+const NEXT_MARKER_PREFIX: &str = ".parsing_marker_next.";
 
 fn is_lock_contended(error: &io::Error) -> bool {
     error.raw_os_error() == fs4::lock_contended_error().raw_os_error()
@@ -79,6 +80,15 @@ impl FailedParserRegistry {
             .join(format!("{PARSING_MARKER_PREFIX}{}", ulid::Ulid::new()))
     }
 
+    fn crash_recovery_lock(&self) -> io::Result<fs::File> {
+        fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(self.state_dir.join("crash_recovery.lock"))
+    }
+
     /// Path to the "failed parsers" list file.
     fn failed_parsers_path(&self) -> PathBuf {
         self.state_dir.join("failed_parsers")
@@ -95,12 +105,7 @@ impl FailedParserRegistry {
         // Serialize recovery scanning with marker creation. Otherwise a peer
         // could observe a newly-created marker before its owner locks it and
         // misclassify the live session as crashed.
-        let init_lock = fs::OpenOptions::new()
-            .create(true)
-            .truncate(false)
-            .read(true)
-            .write(true)
-            .open(self.state_dir.join("crash_recovery.lock"))?;
+        let init_lock = self.crash_recovery_lock()?;
         init_lock.lock_exclusive()?;
 
         // Load only after acquiring the cross-process lock. A peer may have
@@ -134,6 +139,21 @@ impl FailedParserRegistry {
         for entry in fs::read_dir(&self.state_dir)? {
             let entry = entry?;
             let name = entry.file_name();
+            if name.to_string_lossy().starts_with(NEXT_MARKER_PREFIX) {
+                let file = fs::OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(entry.path())?;
+                match file.try_lock_exclusive() {
+                    Ok(()) => {
+                        drop(file);
+                        let _ = fs::remove_file(entry.path());
+                    }
+                    Err(error) if is_lock_contended(&error) => {}
+                    Err(error) => return Err(error),
+                }
+                continue;
+            }
             if !name.to_string_lossy().starts_with(PARSING_MARKER_PREFIX) {
                 continue;
             }
@@ -282,6 +302,11 @@ impl FailedParserRegistry {
     }
 
     fn persist_current_state(&self) -> io::Result<()> {
+        // Serialize temporary-file publication with startup cleanup. Without
+        // this lock, init could see the file between create and file locking.
+        let recovery_lock = self.crash_recovery_lock()?;
+        recovery_lock.lock_exclusive()?;
+
         let parsing_languages: Vec<String> = self
             .parsing_counts
             .iter()
@@ -304,7 +329,7 @@ impl FailedParserRegistry {
         let next_path = self.session_marker_path();
         let temp_path = self
             .state_dir
-            .join(format!(".parsing_marker_next.{}", ulid::Ulid::new()));
+            .join(format!("{NEXT_MARKER_PREFIX}{}", ulid::Ulid::new()));
         let replacement = (|| -> io::Result<fs::File> {
             let mut file = fs::OpenOptions::new()
                 .create_new(true)
@@ -507,6 +532,18 @@ mod tests {
             "a live peer's active parser must not be quarantined"
         );
         first.end_parsing_language("lua").unwrap();
+    }
+
+    #[test]
+    fn test_init_removes_abandoned_replacement_marker() {
+        let temp = tempdir().unwrap();
+        let abandoned = temp.path().join(".parsing_marker_next.abandoned");
+        fs::write(&abandoned, "partial").unwrap();
+
+        let registry = FailedParserRegistry::new(temp.path());
+        registry.init().unwrap();
+
+        assert!(!abandoned.exists());
     }
 
     #[test]

--- a/src/language/failed_parsers.rs
+++ b/src/language/failed_parsers.rs
@@ -140,10 +140,15 @@ impl FailedParserRegistry {
             let entry = entry?;
             let name = entry.file_name();
             if name.to_string_lossy().starts_with(NEXT_MARKER_PREFIX) {
-                let file = fs::OpenOptions::new()
+                let file = match fs::OpenOptions::new()
                     .read(true)
                     .write(true)
-                    .open(entry.path())?;
+                    .open(entry.path())
+                {
+                    Ok(file) => file,
+                    Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                    Err(error) => return Err(error),
+                };
                 match file.try_lock_exclusive() {
                     Ok(()) => {
                         drop(file);
@@ -157,10 +162,15 @@ impl FailedParserRegistry {
             if !name.to_string_lossy().starts_with(PARSING_MARKER_PREFIX) {
                 continue;
             }
-            let mut file = fs::OpenOptions::new()
+            let mut file = match fs::OpenOptions::new()
                 .read(true)
                 .write(true)
-                .open(entry.path())?;
+                .open(entry.path())
+            {
+                Ok(file) => file,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error),
+            };
             match file.try_lock_exclusive() {
                 Ok(()) => {
                     let mut content = String::new();
@@ -275,7 +285,14 @@ impl FailedParserRegistry {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         self.decrement_parsing_count(language);
-        self.persist_current_state()
+        if let Err(error) = self.persist_current_state() {
+            self.parsing_counts
+                .entry(language.to_string())
+                .and_modify(|count| *count += 1)
+                .or_insert(1);
+            return Err(error);
+        }
+        Ok(())
     }
 
     fn decrement_parsing_count(&self, language: &str) {
@@ -322,6 +339,16 @@ impl FailedParserRegistry {
             .state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // Retry bounded cleanup of previously unremovable marker handles on
+        // every state transition instead of allowing the retired set to grow.
+        current.retired.retain_mut(|(path, file)| {
+            if file.set_len(0).is_err() {
+                return true;
+            }
+            let _ = fs::remove_file(path);
+            false
+        });
 
         // Build a replacement inode without touching the currently locked
         // marker. Any create/write failure therefore leaves the prior

--- a/src/language/failed_parsers.rs
+++ b/src/language/failed_parsers.rs
@@ -21,6 +21,10 @@ use std::sync::{Arc, OnceLock};
 
 const PARSING_MARKER_PREFIX: &str = "parsing_in_progress.";
 
+fn is_lock_contended(error: &io::Error) -> bool {
+    error.raw_os_error() == fs4::lock_contended_error().raw_os_error()
+}
+
 struct SessionMarker {
     file: std::sync::Mutex<fs::File>,
 }
@@ -135,7 +139,7 @@ impl FailedParserRegistry {
                     drop(file);
                     let _ = fs::remove_file(entry.path());
                 }
-                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+                Err(error) if is_lock_contended(&error) => {}
                 Err(error) => return Err(error),
             }
         }

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -173,7 +173,8 @@ impl AutoInstallManager {
     ///
     /// State storage location: `KAKEHASHI_STATE_DIR` if set, else the default
     /// data directory, falling back to a `kakehashi` dir under the OS temp dir
-    /// if neither resolves. Crash-recovery state (`parsing_in_progress`,
+    /// if neither resolves. Unit-test builds instead use a stable process-owned
+    /// temp directory, independent of the shared parser assets. Crash-recovery state (`parsing_in_progress`,
     /// `failed_parsers`) is ephemeral and conceptually distinct from the
     /// persistent parser/query install assets in the data dir; the override
     /// lets it live elsewhere — e.g. so concurrent test processes that share one

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -535,6 +535,13 @@ mod tests {
 
     #[test]
     fn unit_test_crash_state_is_separate_from_shared_install_assets() {
+        const PARENT_STATE_DIR: &str = "KAKEHASHI_TEST_PARENT_CRASH_STATE_DIR";
+
+        if let Some(parent_state_dir) = std::env::var_os(PARENT_STATE_DIR) {
+            assert_ne!(failed_parser_state_dir(), PathBuf::from(parent_state_dir));
+            return;
+        }
+
         let shared_install_dir = crate::install::test_support::test_data_dir_path();
         let state_dir = failed_parser_state_dir();
         let _registry = AutoInstallManager::init_failed_parser_registry();
@@ -542,6 +549,21 @@ mod tests {
         assert_ne!(state_dir, shared_install_dir);
         assert_eq!(state_dir, failed_parser_state_dir());
         assert!(state_dir.join("crash_recovery.lock").is_file());
+
+        let child_status = std::process::Command::new(
+            std::env::current_exe().expect("resolve current test executable"),
+        )
+        .arg(stringify!(
+            unit_test_crash_state_is_separate_from_shared_install_assets
+        ))
+        .env(PARENT_STATE_DIR, &state_dir)
+        .status()
+        .expect("run crash-state isolation test in child process");
+
+        assert!(
+            child_status.success(),
+            "child test process must use a different crash-state directory"
+        );
     }
 
     fn create_test_manager() -> (AutoInstallManager, tempfile::TempDir) {

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -159,9 +159,10 @@ impl AutoInstallManager {
     /// persistent parser/query install assets in the data dir; the override
     /// lets it live elsewhere — e.g. so concurrent test processes that share one
     /// read-only install dir can isolate their crash state and not poison each
-    /// other (a leftover `parsing_in_progress` from another process is otherwise
-    /// read as a crash and marks that parser failed).
-    /// If initialization fails, returns an empty registry.
+    /// other (an unlocked marker from another process is otherwise read as a
+    /// crash and marks that parser failed).
+    /// If initialization fails, returns an uninitialized registry whose
+    /// `begin_parsing` calls fail closed before entering native parser code.
     pub fn init_failed_parser_registry() -> FailedParserRegistry {
         let state_dir = std::env::var_os("KAKEHASHI_STATE_DIR")
             // An empty value resolves to the process cwd (writing crash files

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -174,8 +174,9 @@ impl AutoInstallManager {
     /// State storage location: `KAKEHASHI_STATE_DIR` if set, else the default
     /// data directory, falling back to a `kakehashi` dir under the OS temp dir
     /// if neither resolves. Unit-test builds instead use a stable process-owned
-    /// temp directory, independent of the shared parser assets. Crash-recovery state (`parsing_in_progress`,
-    /// `failed_parsers`) is ephemeral and conceptually distinct from the
+    /// temp directory, independent of the shared parser assets. Crash-recovery
+    /// state (`parsing_in_progress`, `failed_parsers`) is ephemeral and
+    /// conceptually distinct from the
     /// persistent parser/query install assets in the data dir; the override
     /// lets it live elsewhere — e.g. so concurrent test processes that share one
     /// read-only install dir can isolate their crash state and not poison each

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -534,7 +534,7 @@ mod tests {
 
     #[test]
     fn unit_test_crash_state_is_separate_from_shared_install_assets() {
-        let shared_install_dir = crate::install::test_data_dir();
+        let shared_install_dir = crate::install::test_support::test_data_dir_path();
 
         let state_dir = failed_parser_state_dir();
 

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -536,11 +536,8 @@ mod tests {
     #[test]
     fn unit_test_crash_state_is_separate_from_shared_install_assets() {
         const PARENT_STATE_DIR: &str = "KAKEHASHI_TEST_PARENT_CRASH_STATE_DIR";
-
-        if let Some(parent_state_dir) = std::env::var_os(PARENT_STATE_DIR) {
-            assert_ne!(failed_parser_state_dir(), PathBuf::from(parent_state_dir));
-            return;
-        }
+        const CHILD_TEST: &str =
+            "lsp::auto_install::manager::tests::child_process_uses_distinct_crash_state";
 
         let shared_install_dir = crate::install::test_support::test_data_dir_path();
         let state_dir = failed_parser_state_dir();
@@ -553,9 +550,7 @@ mod tests {
         let child_status = std::process::Command::new(
             std::env::current_exe().expect("resolve current test executable"),
         )
-        .arg(stringify!(
-            unit_test_crash_state_is_separate_from_shared_install_assets
-        ))
+        .args(["--ignored", "--exact", CHILD_TEST])
         .env(PARENT_STATE_DIR, &state_dir)
         .status()
         .expect("run crash-state isolation test in child process");
@@ -564,6 +559,15 @@ mod tests {
             child_status.success(),
             "child test process must use a different crash-state directory"
         );
+    }
+
+    #[test]
+    #[ignore = "run only as a child of the crash-state isolation test"]
+    fn child_process_uses_distinct_crash_state() {
+        let parent_state_dir = std::env::var_os("KAKEHASHI_TEST_PARENT_CRASH_STATE_DIR")
+            .expect("parent crash-state directory must be provided");
+
+        assert_ne!(failed_parser_state_dir(), PathBuf::from(parent_state_dir));
     }
 
     fn create_test_manager() -> (AutoInstallManager, tempfile::TempDir) {

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -541,7 +541,6 @@ mod tests {
         assert_ne!(state_dir, shared_install_dir);
         assert_eq!(state_dir, failed_parser_state_dir());
         assert!(state_dir.join("crash_recovery.lock").is_file());
-        assert!(!shared_install_dir.join("crash_recovery.lock").exists());
     }
 
     fn create_test_manager() -> (AutoInstallManager, tempfile::TempDir) {

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -535,11 +535,13 @@ mod tests {
     #[test]
     fn unit_test_crash_state_is_separate_from_shared_install_assets() {
         let shared_install_dir = crate::install::test_support::test_data_dir_path();
-
         let state_dir = failed_parser_state_dir();
+        let _registry = AutoInstallManager::init_failed_parser_registry();
 
         assert_ne!(state_dir, shared_install_dir);
         assert_eq!(state_dir, failed_parser_state_dir());
+        assert!(state_dir.join("crash_recovery.lock").is_file());
+        assert!(!shared_install_dir.join("crash_recovery.lock").exists());
     }
 
     fn create_test_manager() -> (AutoInstallManager, tempfile::TempDir) {

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -138,6 +138,25 @@ impl Drop for InstallMarkerGuard {
     }
 }
 
+#[cfg(test)]
+fn failed_parser_state_dir() -> PathBuf {
+    crate::install::test_state_dir()
+}
+
+#[cfg(not(test))]
+fn failed_parser_state_dir() -> PathBuf {
+    std::env::var_os("KAKEHASHI_STATE_DIR")
+        // An empty value resolves to the process cwd (writing crash files
+        // wherever it was started), so treat it as unset — matching how
+        // `resolve_data_dir` handles an empty `KAKEHASHI_DATA_DIR`.
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .or_else(crate::install::default_data_dir)
+        // Platform-aware last resort (not a hard-coded `/tmp`, which doesn't
+        // exist on Windows); only reached if the data dir can't resolve.
+        .unwrap_or_else(|| std::env::temp_dir().join("kakehashi"))
+}
+
 impl AutoInstallManager {
     /// Create a new `AutoInstallManager`.
     pub fn new(
@@ -164,16 +183,7 @@ impl AutoInstallManager {
     /// If initialization fails, returns an uninitialized registry whose
     /// `begin_parsing` calls fail closed before entering native parser code.
     pub fn init_failed_parser_registry() -> FailedParserRegistry {
-        let state_dir = std::env::var_os("KAKEHASHI_STATE_DIR")
-            // An empty value resolves to the process cwd (writing crash files
-            // wherever it was started), so treat it as unset — matching how
-            // `resolve_data_dir` handles an empty `KAKEHASHI_DATA_DIR`.
-            .filter(|v| !v.is_empty())
-            .map(PathBuf::from)
-            .or_else(crate::install::default_data_dir)
-            // Platform-aware last resort (not a hard-coded `/tmp`, which doesn't
-            // exist on Windows); only reached if the data dir can't resolve.
-            .unwrap_or_else(|| std::env::temp_dir().join("kakehashi"));
+        let state_dir = failed_parser_state_dir();
 
         let registry = FailedParserRegistry::new(&state_dir);
 
@@ -520,6 +530,16 @@ impl AutoInstallManager {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn unit_test_crash_state_is_separate_from_shared_install_assets() {
+        let shared_install_dir = crate::install::test_data_dir();
+
+        let state_dir = failed_parser_state_dir();
+
+        assert_ne!(state_dir, shared_install_dir);
+        assert_eq!(state_dir, failed_parser_state_dir());
+    }
 
     fn create_test_manager() -> (AutoInstallManager, tempfile::TempDir) {
         let temp = tempdir().expect("Failed to create temp dir");

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -533,9 +533,11 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
+    const PARENT_STATE_DIR: &str = "KAKEHASHI_TEST_PARENT_CRASH_STATE_DIR";
+    const CHILD_HANDSHAKE_PATH: &str = "KAKEHASHI_TEST_CRASH_STATE_HANDSHAKE_PATH";
+
     #[test]
     fn unit_test_crash_state_is_separate_from_shared_install_assets() {
-        const PARENT_STATE_DIR: &str = "KAKEHASHI_TEST_PARENT_CRASH_STATE_DIR";
         const CHILD_TEST: &str =
             "lsp::auto_install::manager::tests::child_process_uses_distinct_crash_state";
 
@@ -547,11 +549,14 @@ mod tests {
         assert_eq!(state_dir, failed_parser_state_dir());
         assert!(state_dir.join("crash_recovery.lock").is_file());
 
+        let handshake_dir = tempdir().expect("create crash-state handshake directory");
+        let handshake_path = handshake_dir.path().join("child-ran");
         let child_status = std::process::Command::new(
             std::env::current_exe().expect("resolve current test executable"),
         )
         .args(["--ignored", "--exact", CHILD_TEST])
         .env(PARENT_STATE_DIR, &state_dir)
+        .env(CHILD_HANDSHAKE_PATH, &handshake_path)
         .status()
         .expect("run crash-state isolation test in child process");
 
@@ -559,15 +564,25 @@ mod tests {
             child_status.success(),
             "child test process must use a different crash-state directory"
         );
+        assert!(
+            handshake_path.is_file(),
+            "child test process must execute the isolation assertion"
+        );
     }
 
     #[test]
     #[ignore = "run only as a child of the crash-state isolation test"]
     fn child_process_uses_distinct_crash_state() {
-        let parent_state_dir = std::env::var_os("KAKEHASHI_TEST_PARENT_CRASH_STATE_DIR")
-            .expect("parent crash-state directory must be provided");
+        let (Some(parent_state_dir), Some(handshake_path)) = (
+            std::env::var_os(PARENT_STATE_DIR),
+            std::env::var_os(CHILD_HANDSHAKE_PATH),
+        ) else {
+            return;
+        };
 
         assert_ne!(failed_parser_state_dir(), PathBuf::from(parent_state_dir));
+        std::fs::write(handshake_path, b"child assertion passed")
+            .expect("write crash-state child handshake");
     }
 
     fn create_test_manager() -> (AutoInstallManager, tempfile::TempDir) {

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -60,6 +60,34 @@ fn parse_text_with_deadline(
     crate::language::injection::parse_with_deadline(parser, text, old_tree, deadline)
 }
 
+/// Run native parser code only after its crash marker is durable. Failing open
+/// would recreate the restart loop the marker exists to prevent.
+fn run_crash_tracked_parse<T>(
+    auto_install: &AutoInstallManager,
+    language: &str,
+    parse: impl FnOnce() -> T,
+) -> Option<T> {
+    if let Err(error) = auto_install.begin_parsing(language) {
+        log::error!(
+            target: "kakehashi::crash_recovery",
+            "Skipping parser '{}': failed to persist crash marker: {}",
+            language,
+            error
+        );
+        return None;
+    }
+    let result = parse();
+    if let Err(error) = auto_install.end_parsing(language) {
+        log::warn!(
+            target: "kakehashi::crash_recovery",
+            "Failed to clear crash marker for parser '{}': {}",
+            language,
+            error
+        );
+    }
+    Some(result)
+}
+
 /// The settled+stale gate for the parse loop's `semanticTokens/refresh`
 /// emission (its full rationale lives at the call site): emit only when the
 /// published parse is still the LIVE content version (settled — mid-burst
@@ -565,10 +593,16 @@ impl ParseCoordinator {
                     &uri,
                     text.len(),
                     move |mut parser, deadline, _generation_retry| {
-                        let _ = auto_install.begin_parsing(&language_name_clone);
                         let parse_result =
-                            parse_text_with_deadline(&mut parser, &text_for_parse, None, deadline);
-                        let _ = auto_install.end_parsing(&language_name_clone);
+                            run_crash_tracked_parse(&auto_install, &language_name_clone, || {
+                                parse_text_with_deadline(
+                                    &mut parser,
+                                    &text_for_parse,
+                                    None,
+                                    deadline,
+                                )
+                            })
+                            .flatten();
                         (parser, parse_result)
                     },
                 )
@@ -837,10 +871,16 @@ impl ParseCoordinator {
                     &uri,
                     text_len,
                     move |mut parser, deadline, _generation_retry| {
-                        let _ = auto_install.begin_parsing(&language_name_clone);
                         let result =
-                            parse_text_with_deadline(&mut parser, &text_for_parse, None, deadline);
-                        let _ = auto_install.end_parsing(&language_name_clone);
+                            run_crash_tracked_parse(&auto_install, &language_name_clone, || {
+                                parse_text_with_deadline(
+                                    &mut parser,
+                                    &text_for_parse,
+                                    None,
+                                    deadline,
+                                )
+                            })
+                            .flatten();
                         (parser, result)
                     },
                 )
@@ -1039,18 +1079,20 @@ impl ParseCoordinator {
                 uri,
                 text_len,
                 move |mut parser, deadline, generation_retry| {
-                    let _ = auto_install.begin_parsing(&language_name_clone);
-                    let result = parse_text_with_deadline(
-                        &mut parser,
-                        &text_for_parse,
-                        if generation_retry {
-                            None
-                        } else {
-                            seed.as_ref()
-                        },
-                        deadline,
-                    );
-                    let _ = auto_install.end_parsing(&language_name_clone);
+                    let result =
+                        run_crash_tracked_parse(&auto_install, &language_name_clone, || {
+                            parse_text_with_deadline(
+                                &mut parser,
+                                &text_for_parse,
+                                if generation_retry {
+                                    None
+                                } else {
+                                    seed.as_ref()
+                                },
+                                deadline,
+                            )
+                        })
+                        .flatten();
                     (parser, result)
                 },
             )
@@ -1164,6 +1206,26 @@ impl ParseCoordinator {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn crash_marker_failure_skips_native_parser() {
+        let temp = tempfile::tempdir().unwrap();
+        // Deliberately do not initialize the registry: begin_parsing must fail
+        // before the parser closure can execute.
+        let manager = AutoInstallManager::new(
+            crate::lsp::auto_install::InstallingLanguages::new(),
+            crate::language::FailedParserRegistry::new(temp.path()),
+        );
+        let parser_called = std::cell::Cell::new(false);
+
+        let result = run_crash_tracked_parse(&manager, "lua", || {
+            parser_called.set(true);
+            42
+        });
+
+        assert_eq!(result, None);
+        assert!(!parser_called.get());
+    }
 
     /// The four documented invariants of the settle-refresh gate.
     #[test]

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -62,6 +62,24 @@ fn parse_text_with_deadline(
 
 /// Run native parser code only after its crash marker is durable. Failing open
 /// would recreate the restart loop the marker exists to prevent.
+struct CrashMarkerGuard<'a> {
+    auto_install: &'a AutoInstallManager,
+    language: &'a str,
+}
+
+impl Drop for CrashMarkerGuard<'_> {
+    fn drop(&mut self) {
+        if let Err(error) = self.auto_install.end_parsing(self.language) {
+            log::warn!(
+                target: "kakehashi::crash_recovery",
+                "Failed to clear crash marker for parser '{}': {}",
+                self.language,
+                error
+            );
+        }
+    }
+}
+
 fn run_crash_tracked_parse<T>(
     auto_install: &AutoInstallManager,
     language: &str,
@@ -76,15 +94,12 @@ fn run_crash_tracked_parse<T>(
         );
         return None;
     }
+    let guard = CrashMarkerGuard {
+        auto_install,
+        language,
+    };
     let result = parse();
-    if let Err(error) = auto_install.end_parsing(language) {
-        log::warn!(
-            target: "kakehashi::crash_recovery",
-            "Failed to clear crash marker for parser '{}': {}",
-            language,
-            error
-        );
-    }
+    drop(guard);
     Some(result)
 }
 
@@ -1225,6 +1240,35 @@ mod tests {
 
         assert_eq!(result, None);
         assert!(!parser_called.get());
+    }
+
+    #[test]
+    fn panic_unwind_clears_crash_marker() {
+        let temp = tempfile::tempdir().unwrap();
+        let registry = crate::language::FailedParserRegistry::new(temp.path());
+        registry.init().unwrap();
+        let manager = AutoInstallManager::new(
+            crate::lsp::auto_install::InstallingLanguages::new(),
+            registry,
+        );
+
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            run_crash_tracked_parse(&manager, "lua", || panic!("parse panic"));
+        }));
+
+        assert!(panic.is_err());
+        let marker_contents: Vec<String> = std::fs::read_dir(temp.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("parsing_in_progress.")
+            })
+            .map(|entry| std::fs::read_to_string(entry.path()).unwrap())
+            .collect();
+        assert_eq!(marker_contents, vec![""]);
     }
 
     /// The four documented invariants of the settle-refresh gate.

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -540,8 +540,8 @@ impl Kakehashi {
     /// are orphaned — observed live as a `with-logging emmylua_ls` wrapper
     /// re-parented to launchd and running for hours, because not every
     /// downstream exits on stdin EOF. On SIGTERM/SIGHUP this persists the
-    /// crash-detection marker (`parsing_in_progress` — a kill mid-parse is
-    /// precisely what that marker detects) and runs the same bounded
+    /// crash-detection marker (the locked per-session marker — a kill mid-parse
+    /// is precisely what that marker detects) and runs the same bounded
     /// `shutdown_all` as the graceful path (LSP handshake, then
     /// SIGTERM→SIGKILL escalation, global timeout), then exits with the
     /// conventional 128+signal status. Unlike `shutdown_impl` it does NOT
@@ -587,7 +587,7 @@ impl Kakehashi {
             };
             log::info!("received signal {signum}: reaping downstream servers before exit");
             // Crash-detection parity with `shutdown_impl`: a kill mid-parse is
-            // exactly the case the `parsing_in_progress` marker exists for, so
+            // exactly the case the per-session marker exists for, so
             // persist it before the (comparatively slow) downstream reap.
             if let Err(e) = failed_parsers.persist_state() {
                 log::warn!(

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -56,8 +56,8 @@ fn test_data_dir() -> &'static Path {
 /// `KAKEHASHI_STATE_DIR`.
 ///
 /// Kept OUT of the shared [`test_data_dir`] so servers never poison each other:
-/// the server's `FailedParserRegistry::init()` reads a leftover
-/// an unlocked parsing marker as a crash and marks that parser failed. A
+/// the server's `FailedParserRegistry::init()` reads an unlocked parsing marker
+/// as evidence of a crash and marks that parser failed. A
 /// per-SPAWN (not per-process) dir is what makes the test suite safe under both
 /// cross-process AND intra-process concurrency (parallel test threads in one
 /// binary): no two concurrently-running servers ever share these files, so a

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -52,12 +52,13 @@ fn test_data_dir() -> &'static Path {
 }
 
 /// A fresh, unique directory for ONE spawned server's crash-recovery state
-/// (`parsing_in_progress`, `failed_parsers`), passed via `KAKEHASHI_STATE_DIR`.
+/// (per-session parsing markers and `failed_parsers`), passed via
+/// `KAKEHASHI_STATE_DIR`.
 ///
 /// Kept OUT of the shared [`test_data_dir`] so servers never poison each other:
 /// the server's `FailedParserRegistry::init()` reads a leftover
-/// `parsing_in_progress` as a crash and marks that parser failed. A per-SPAWN
-/// (not per-process) dir is what makes the test suite safe under both
+/// an unlocked parsing marker as a crash and marks that parser failed. A
+/// per-SPAWN (not per-process) dir is what makes the test suite safe under both
 /// cross-process AND intra-process concurrency (parallel test threads in one
 /// binary): no two concurrently-running servers ever share these files, so a
 /// server that persists state on a shutdown-while-parsing can't be read as a


### PR DESCRIPTION
## Summary

- persist the complete active parser set before entering native tree-sitter code
- keep one exclusively locked marker per kakehashi session so concurrent editor processes are not mistaken for crashed peers
- recover only unlocked markers and retain compatibility with the legacy single marker
- replace markers transactionally so an interrupted write cannot combine new and stale language names
- clean abandoned unlocked replacement artifacts on startup without racing live writers
- clear markers during recoverable Rust panic unwinding while retaining evidence after aborts
- avoid synchronous disk flushes that are unnecessary for the process-failure recovery contract

Closes #725.
Closes #726.

## Validation

- `cargo test --lib language::failed_parsers::tests` (17 passed, including a real child-process abort/restart)
- `cargo test --lib crash_marker` (4 passed)
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --check`
- full `cargo test --lib`: 2867 passed; 5 unrelated current-main failures (`process_injection_sync_returns_incomplete_on_mid_region_cancel` missing its rust fixture and four bridge tests reporting a closed host document)

## Risk

This restores synchronous marker publication around native parser entry/exit. Those calls run inside the existing blocking compute-pool closure, not on the Tokio request runtime. Kernel-visible write-before-rename ordering preserves recovery evidence after uncatchable process failures such as abort/SIGABRT without paying for machine-power-loss durability on every parse transition.

The broader test-only separation of crash state from shared parser assets is tracked in #730.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash recovery for native language parsing using reliable per-session tracking.
  * Preserved parser failure information across unexpected crashes and concurrent server processes.
  * Prevented parsing from running when crash-recovery tracking can’t be initialized safely.
  * Ensured crash-recovery markers are durably updated and cleared correctly, including after panics.
  * Isolated crash-recovery state used during tests from shared install assets.

* **Documentation**
  * Clarified crash-recovery state behavior and marker semantics across installation, lifecycle, and test documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->