### PR TITLE
fix(install): preserve parser on Windows publish failure

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -509,6 +509,7 @@ fn collect_installed_languages(
             }
         }
     }
+    #[cfg(windows)]
     languages.extend(parser::owned_parser_backup_languages(parser_dir)?);
     if let Ok(entries) = fs::read_dir(queries_dir) {
         for entry in entries.flatten() {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -876,8 +876,8 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
                 eprintln!("  Revision: {}", result.revision);
             }
         }
-        Err(parser::ParserInstallError::Recovered(path)) => {
-            eprintln!("✓ Parser recovered: {}", path.display());
+        Err(parser::ParserInstallError::AlreadyExists(path)) => {
+            eprintln!("✓ Parser available: {}", path.display());
         }
         Err(e) => {
             eprintln!("✗ Parser installation failed: {}", e);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -865,7 +865,7 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
         compile: parser::ParserCompile::KillableSubprocess,
     };
 
-    match parser::install_parser_after_operation_started(
+    match parser::install_parser_with_outcome_after_operation_started(
         language,
         &options,
         LanguageOperationPermit::Language(&_operation_lock),

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -725,12 +725,7 @@ fn run_language_uninstall(
             operation_permit,
         ) {
             Ok(true) => {
-                eprintln!(
-                    "✓ Removed parser: {}",
-                    parser_dir
-                        .join(format!("{}.{}", lang, std::env::consts::DLL_EXTENSION))
-                        .display()
-                );
+                eprintln!("✓ Removed parser installation for '{}'", lang);
                 removed_something = true;
             }
             Ok(false) => {}

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -877,8 +877,8 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
     ) {
         Ok(result) => {
             eprintln!("✓ Parser installed: {}", result.install_path.display());
-            if verbose {
-                eprintln!("  Revision: {}", result.revision);
+            if verbose && let Some(revision) = result.revision {
+                eprintln!("  Revision: {revision}");
             }
         }
         Err(e) => {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -872,9 +872,12 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
     ) {
         Ok(result) => {
             eprintln!("✓ Parser installed: {}", result.install_path.display());
-            if verbose && !result.revision.is_empty() {
+            if verbose {
                 eprintln!("  Revision: {}", result.revision);
             }
+        }
+        Err(parser::ParserInstallError::Recovered(path)) => {
+            eprintln!("✓ Parser recovered: {}", path.display());
         }
         Err(e) => {
             eprintln!("✗ Parser installation failed: {}", e);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -870,14 +870,14 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
         &options,
         LanguageOperationPermit::Language(&_operation_lock),
     ) {
-        Ok(result) => {
+        Ok(parser::ParserInstallOutcome::Installed(result)) => {
             eprintln!("✓ Parser installed: {}", result.install_path.display());
             if verbose {
                 eprintln!("  Revision: {}", result.revision);
             }
         }
-        Err(parser::ParserInstallError::AlreadyExists(path)) => {
-            eprintln!("✓ Parser available: {}", path.display());
+        Ok(parser::ParserInstallOutcome::Recovered(path)) => {
+            eprintln!("✓ Parser recovered: {}", path.display());
         }
         Err(e) => {
             eprintln!("✗ Parser installation failed: {}", e);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -877,8 +877,8 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
     ) {
         Ok(result) => {
             eprintln!("✓ Parser installed: {}", result.install_path.display());
-            if verbose && let Some(revision) = result.revision {
-                eprintln!("  Revision: {revision}");
+            if verbose && !result.revision.is_empty() {
+                eprintln!("  Revision: {}", result.revision);
             }
         }
         Err(e) => {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -486,7 +486,10 @@ fn installed_query_language_name(path: &Path) -> Option<String> {
     Some(name.to_string())
 }
 
-fn collect_installed_languages(parser_dir: &Path, queries_dir: &Path) -> Vec<String> {
+fn collect_installed_languages(
+    parser_dir: &Path,
+    queries_dir: &Path,
+) -> std::io::Result<Vec<String>> {
     use std::collections::BTreeSet;
     use std::fs;
 
@@ -506,9 +509,7 @@ fn collect_installed_languages(parser_dir: &Path, queries_dir: &Path) -> Vec<Str
             }
         }
     }
-    if let Ok(backup_languages) = parser::owned_parser_backup_languages(parser_dir) {
-        languages.extend(backup_languages);
-    }
+    languages.extend(parser::owned_parser_backup_languages(parser_dir)?);
     if let Ok(entries) = fs::read_dir(queries_dir) {
         for entry in entries.flatten() {
             if let Some(name) = installed_query_language_name(&entry.path()) {
@@ -516,7 +517,7 @@ fn collect_installed_languages(parser_dir: &Path, queries_dir: &Path) -> Vec<Str
             }
         }
     }
-    languages.into_iter().collect()
+    Ok(languages.into_iter().collect())
 }
 
 /// Run the language uninstall command
@@ -563,7 +564,13 @@ fn run_language_uninstall(
 
     // Determine which languages to uninstall
     let mut languages_to_uninstall = if all {
-        collect_installed_languages(&parser_dir, &queries_dir)
+        match collect_installed_languages(&parser_dir, &queries_dir) {
+            Ok(languages) => languages,
+            Err(error) => {
+                eprintln!("Error: failed to inspect parser backups: {error}");
+                return Err(ExitCode::FAILURE);
+            }
+        }
     } else {
         vec![language.expect("language required when --all not specified")]
     };
@@ -608,7 +615,13 @@ fn run_language_uninstall(
             ) {
                 eprintln!("Warning: failed to recover interrupted query installs: {e}");
             }
-            let refreshed = collect_installed_languages(&parser_dir, &queries_dir);
+            let refreshed = match collect_installed_languages(&parser_dir, &queries_dir) {
+                Ok(languages) => languages,
+                Err(error) => {
+                    eprintln!("Error: failed to inspect parser backups: {error}");
+                    return Err(ExitCode::FAILURE);
+                }
+            };
             if refreshed == languages_to_uninstall {
                 break;
             }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -506,6 +506,9 @@ fn collect_installed_languages(parser_dir: &Path, queries_dir: &Path) -> Vec<Str
             }
         }
     }
+    if let Ok(backup_languages) = parser::owned_parser_backup_languages(parser_dir) {
+        languages.extend(backup_languages);
+    }
     if let Ok(entries) = fs::read_dir(queries_dir) {
         for entry in entries.flatten() {
             if let Some(name) = installed_query_language_name(&entry.path()) {

--- a/src/install.rs
+++ b/src/install.rs
@@ -407,7 +407,7 @@ fn install_language_blocking_with_query_installer(
     // AlreadyExists means the artifact is present and usable — success,
     // not failure; treating it as an error made the auto-install manager
     // degrade a fully-installed language to "installed but with warnings".
-    match parser::install_parser_after_operation_started(
+    match parser::install_parser_with_outcome_after_operation_started(
         language,
         &parser_options,
         LanguageOperationPermit::All(&_operation_lock),

--- a/src/install.rs
+++ b/src/install.rs
@@ -412,8 +412,11 @@ fn install_language_blocking_with_query_installer(
         &parser_options,
         LanguageOperationPermit::All(&_operation_lock),
     ) {
-        Ok(parser_result) => {
+        Ok(parser::ParserInstallOutcome::Installed(parser_result)) => {
             result.parser_path = Some(parser_result.install_path);
+        }
+        Ok(parser::ParserInstallOutcome::Recovered(path)) => {
+            result.parser_path = Some(path);
         }
         Err(parser::ParserInstallError::AlreadyExists(path)) => {
             result.parser_path = Some(path);

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -186,9 +186,6 @@ fn write_marker_atomically(marker_path: &Path, content: &[u8]) -> std::io::Resul
         let _ = fs::remove_file(marker_tmp);
         return Err(error);
     }
-    // A crash or unlink failure leaves only a content-validated staging alias,
-    // which recovery removes by its exact ULID shape.
-    let _ = fs::remove_file(marker_tmp);
     Ok(())
 }
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -115,6 +115,16 @@ fn generated_parser_backup_matches_language(name: &str, language: &str) -> bool 
         && counter.bytes().all(|byte| byte.is_ascii_digit())
 }
 
+fn parser_backup_ownership_sidecar(backup: &Path) -> PathBuf {
+    backup.with_file_name(format!(
+        "{}.owner",
+        backup
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(".parser.backup")
+    ))
+}
+
 fn parser_backup_files(parser_dir: &Path, language: &str) -> std::io::Result<Vec<PathBuf>> {
     let entries = match fs::read_dir(parser_dir) {
         Ok(entries) => entries,
@@ -128,12 +138,27 @@ fn parser_backup_files(parser_dir: &Path, language: &str) -> std::io::Result<Vec
         let Some(name) = name.to_str() else {
             continue;
         };
-        if entry.file_type()?.is_file() && generated_parser_backup_matches_language(name, language)
+        if entry.file_type()?.is_file()
+            && generated_parser_backup_matches_language(name, language)
+            && parser_backup_ownership_sidecar(&entry.path()).is_file()
         {
             backups.push(entry.path());
         }
     }
     Ok(backups)
+}
+
+fn remove_owned_parser_backup(backup: &Path) -> std::io::Result<()> {
+    match fs::remove_file(backup) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+    match fs::remove_file(parser_backup_ownership_sidecar(backup)) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
 }
 
 #[cfg(any(windows, test))]
@@ -148,7 +173,7 @@ fn recover_parser_backups(
     }
     if parser_file.is_file() {
         for backup in backups {
-            fs::remove_file(backup)?;
+            remove_owned_parser_backup(&backup)?;
         }
         return Ok(());
     }
@@ -159,8 +184,9 @@ fn recover_parser_backups(
     });
     let restore = backups.pop().expect("non-empty parser backup list");
     fs::rename(&restore, parser_file)?;
+    fs::remove_file(parser_backup_ownership_sidecar(&restore))?;
     for obsolete in backups {
-        fs::remove_file(obsolete)?;
+        remove_owned_parser_backup(&obsolete)?;
     }
     Ok(())
 }
@@ -183,11 +209,8 @@ pub fn remove_parser_install_and_backups(
         Err(error) => return Err(error),
     };
     for backup in parser_backup_files(parser_dir, language)? {
-        match fs::remove_file(backup) {
-            Ok(()) => removed = true,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => return Err(error),
-        }
+        remove_owned_parser_backup(&backup)?;
+        removed = true;
     }
     Ok(removed)
 }
@@ -1456,11 +1479,19 @@ mod tests {
         fs::create_dir_all(&parser_dir).expect("create parser dir");
         let canonical = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
         let owned = parser_dir.join(generated_backup_name("lua", 123, 4));
+        let unowned_exact_shape = parser_dir.join(generated_backup_name("lua", 123, 5));
         let other_language = parser_dir.join(generated_backup_name("rust", 123, 4));
         let user_file = parser_dir.join(".lua.manual.backup");
-        for path in [&canonical, &owned, &other_language, &user_file] {
+        for path in [
+            &canonical,
+            &owned,
+            &unowned_exact_shape,
+            &other_language,
+            &user_file,
+        ] {
             fs::write(path, b"parser").expect("write parser fixture");
         }
+        fs::write(parser_backup_ownership_sidecar(&owned), b"ok\n").expect("mark owned backup");
 
         assert!(
             remove_parser_install_and_backups(&parser_dir, "lua").expect("remove parser files")
@@ -1468,6 +1499,7 @@ mod tests {
 
         assert!(!canonical.exists());
         assert!(!owned.exists());
+        assert!(unowned_exact_shape.exists());
         assert!(other_language.exists());
         assert!(user_file.exists());
     }
@@ -1480,6 +1512,7 @@ mod tests {
         let canonical = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
         let backup = parser_dir.join(generated_backup_name("lua", 123, 4));
         fs::write(&backup, b"working parser").expect("write backup");
+        fs::write(parser_backup_ownership_sidecar(&backup), b"ok\n").expect("mark owned backup");
 
         recover_parser_backups(&parser_dir, &canonical, "lua").expect("recover parser backup");
 
@@ -1499,11 +1532,27 @@ mod tests {
         let backup = parser_dir.join(generated_backup_name("lua", 123, 4));
         fs::write(&canonical, b"new parser").expect("write canonical");
         fs::write(&backup, b"old parser").expect("write backup");
+        fs::write(parser_backup_ownership_sidecar(&backup), b"ok\n").expect("mark owned backup");
 
         recover_parser_backups(&parser_dir, &canonical, "lua").expect("clean parser backup");
 
         assert_eq!(fs::read(&canonical).expect("read canonical"), b"new parser");
         assert!(!backup.exists());
+    }
+
+    #[test]
+    fn parser_recovery_ignores_exact_shape_backup_without_ownership_marker() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let canonical = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        let unowned = parser_dir.join(generated_backup_name("lua", 123, 4));
+        fs::write(&unowned, b"user file").expect("write user file");
+
+        recover_parser_backups(&parser_dir, &canonical, "lua").expect("scan parser backups");
+
+        assert!(!canonical.exists());
+        assert_eq!(fs::read(unowned).expect("read user file"), b"user file");
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -146,26 +146,26 @@ impl ParserFileOps for StdParserFileOps {
 }
 
 fn generated_parser_backup_matches_language(name: &str, language: &str) -> bool {
-    let Some(stem) = name
+    parser_backup_language(name).is_some_and(|backup_language| backup_language == language)
+}
+
+fn parser_backup_language(name: &str) -> Option<&str> {
+    let stem = name
         .strip_prefix('.')
-        .and_then(|name| name.strip_suffix(".backup"))
-    else {
-        return false;
-    };
-    let Some(stem) = stem.strip_suffix(&format!(".{}", std::env::consts::DLL_EXTENSION)) else {
-        return false;
-    };
-    let Some((prefix, counter)) = stem.rsplit_once('.') else {
-        return false;
-    };
-    let Some((backup_language, pid)) = prefix.rsplit_once('.') else {
-        return false;
-    };
-    backup_language == language
+        .and_then(|name| name.strip_suffix(".backup"))?;
+    let stem = stem.strip_suffix(&format!(".{}", std::env::consts::DLL_EXTENSION))?;
+    let (prefix, counter) = stem.rsplit_once('.')?;
+    let (backup_language, pid) = prefix.rsplit_once('.')?;
+    if super::queries::is_safe_language_name(backup_language)
         && !pid.is_empty()
         && pid.bytes().all(|byte| byte.is_ascii_digit())
         && !counter.is_empty()
         && counter.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        Some(backup_language)
+    } else {
+        None
+    }
 }
 
 fn parser_backup_ownership_sidecar(backup: &Path) -> PathBuf {
@@ -214,6 +214,36 @@ fn parser_backup_files(parser_dir: &Path, language: &str) -> std::io::Result<Vec
         }
     }
     Ok(backups)
+}
+
+/// Return languages with kakehashi-owned transactional backups.
+pub fn owned_parser_backup_languages(parser_dir: &Path) -> std::io::Result<Vec<String>> {
+    let entries = match fs::read_dir(parser_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error),
+    };
+    let mut languages = std::collections::BTreeSet::new();
+    for entry in entries {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let name = entry.file_name();
+        let Some(language) = name.to_str().and_then(parser_backup_language) else {
+            continue;
+        };
+        let marker = parser_backup_ownership_sidecar(&entry.path());
+        match fs::read(marker) {
+            Ok(content) if content == PARSER_BACKUP_MARKER_CONTENT => {
+                languages.insert(language.to_owned());
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(languages.into_iter().collect())
 }
 
 fn cleanup_orphan_parser_backup_markers(parser_dir: &Path, language: &str) -> std::io::Result<()> {
@@ -1698,6 +1728,31 @@ mod tests {
             "lua.123.4.dylib.backup",
             "lua"
         ));
+    }
+
+    #[test]
+    fn owned_parser_backup_languages_require_exact_marker_and_shape() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let owned = parser_dir.join(generated_backup_name("lua", 123, 4));
+        let unowned = parser_dir.join(generated_backup_name("rust", 123, 5));
+        let unsafe_name = parser_dir.join(generated_backup_name("Lua", 123, 6));
+        for backup in [&owned, &unowned, &unsafe_name] {
+            fs::write(backup, b"parser").expect("write backup");
+        }
+        fs::write(
+            parser_backup_ownership_sidecar(&owned),
+            PARSER_BACKUP_MARKER_CONTENT,
+        )
+        .expect("mark owned backup");
+        fs::write(parser_backup_ownership_sidecar(&unowned), b"user marker")
+            .expect("write unowned marker");
+
+        assert_eq!(
+            owned_parser_backup_languages(&parser_dir).expect("discover backups"),
+            vec!["lua"]
+        );
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -302,14 +302,18 @@ pub fn remove_parser_install_and_backups(
     }
     cleanup_orphan_parser_backup_markers(parser_dir, language)?;
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
-    let mut removed = match fs::remove_file(parser_file) {
-        Ok(()) => true,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
-        Err(error) => return Err(error),
-    };
+    // Remove recovery copies first. If uninstall is interrupted, leaving the
+    // canonical parser is an incomplete uninstall that can be retried; deleting
+    // canonical first could let the next install resurrect an old backup.
+    let mut removed = false;
     for backup in parser_backup_files(parser_dir, language)? {
         remove_owned_parser_backup(&backup)?;
         removed = true;
+    }
+    match fs::remove_file(parser_file) {
+        Ok(()) => removed = true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
     }
     Ok(removed)
 }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -89,7 +89,8 @@ fn publish_parser_transactionally(
                         return Err(std::io::Error::new(
                             publish_error.kind(),
                             format!(
-                                "failed to publish parser: {publish_error}; restored parser but failed to remove backup marker: {marker_error}"
+                                "failed to publish parser: {publish_error}; restored parser but failed to remove backup marker '{}': {marker_error}",
+                                parser_backup_ownership_sidecar(backup_file).display()
                             ),
                         ));
                     }
@@ -1406,6 +1407,7 @@ mod tests {
         backup_markers: HashSet<PathBuf>,
         fail_marker_creation: bool,
         fail_marker_write_after_create: bool,
+        fail_marker_removal: bool,
         backup_claim_observed_marker: bool,
     }
 
@@ -1478,6 +1480,12 @@ mod tests {
         }
 
         fn remove_backup_marker(&mut self, backup: &Path) -> std::io::Result<()> {
+            if self.fail_marker_removal {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "injected marker cleanup failure",
+                ));
+            }
             self.backup_markers.remove(backup);
             Ok(())
         }
@@ -1499,6 +1507,26 @@ mod tests {
         assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
         assert_eq!(ops.files.get(&parser), Some(&"old"));
         assert!(!ops.files.contains_key(&backup));
+    }
+
+    #[test]
+    fn transactional_publish_identifies_marker_left_after_rollback() {
+        let tmp = PathBuf::from("parser.tmp");
+        let parser = PathBuf::from("parser.dll");
+        let backup = PathBuf::from("parser.backup");
+        let mut ops = FakeParserFileOps::default();
+        ops.files.insert(tmp.clone(), "new");
+        ops.files.insert(parser.clone(), "old");
+        ops.failed_renames.push((tmp.clone(), parser.clone()));
+        ops.fail_marker_removal = true;
+
+        let error = publish_parser_transactionally(&mut ops, &tmp, &parser, &backup)
+            .expect_err("marker cleanup failure must identify the leftover");
+
+        assert!(
+            error.to_string().contains("parser.backup.owner"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -304,6 +304,9 @@ pub fn remove_parser_install_and_backups(
             "unsafe parser language name",
         ));
     }
+    if !parser_dir.try_exists()? {
+        return Ok(false);
+    }
     cleanup_orphan_parser_backup_markers(parser_dir, language)?;
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
     // Remove recovery copies first. If uninstall is interrupted, leaving the
@@ -1703,6 +1706,18 @@ mod tests {
         assert!(unowned_exact_shape.exists());
         assert!(other_language.exists());
         assert!(user_file.exists());
+    }
+
+    #[test]
+    fn parser_uninstall_does_not_create_missing_parser_directory() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+
+        assert!(
+            !remove_parser_install_and_backups(&parser_dir, "lua")
+                .expect("missing parser install is a no-op")
+        );
+        assert!(!parser_dir.exists());
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -459,11 +459,9 @@ fn parser_backup_files(parser_dir: &Path, language: &str) -> std::io::Result<Vec
         {
             continue;
         }
-        if parser_backup_marker_is_owned(
-            &parser_backup_ownership_sidecar(&entry.path()),
-            &entry.path(),
-        )? {
-            backups.push(entry.path());
+        let path = entry.path();
+        if parser_backup_marker_is_owned(&parser_backup_ownership_sidecar(&path), &path)? {
+            backups.push(path);
         }
     }
     Ok(backups)
@@ -480,14 +478,12 @@ fn parser_backup_intent_files(parser_dir: &Path, language: &str) -> std::io::Res
         let entry = entry?;
         let name = entry.file_name();
         let Some(name) = name.to_str() else { continue };
+        let path = entry.path();
         if entry.file_type()?.is_file()
             && generated_parser_backup_matches_language(name, language)
-            && parser_backup_marker_is_intent(
-                &parser_backup_intent_sidecar(&entry.path()),
-                &entry.path(),
-            )?
+            && parser_backup_marker_is_intent(&parser_backup_intent_sidecar(&path), &path)?
         {
-            backups.push(entry.path());
+            backups.push(path);
         }
     }
     Ok(backups)
@@ -510,15 +506,13 @@ pub fn owned_parser_backup_languages(parser_dir: &Path) -> std::io::Result<Vec<S
         let Some(language) = name.to_str().and_then(parser_backup_language) else {
             continue;
         };
-        let marker = parser_backup_ownership_sidecar(&entry.path());
+        let path = entry.path();
+        let marker = parser_backup_ownership_sidecar(&path);
         let canonical =
             parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
-        if parser_backup_marker_is_owned(&marker, &entry.path())?
+        if parser_backup_marker_is_owned(&marker, &path)?
             || (!path_entry_exists(&canonical)?
-                && parser_backup_marker_is_intent(
-                    &parser_backup_intent_sidecar(&entry.path()),
-                    &entry.path(),
-                )?)
+                && parser_backup_marker_is_intent(&parser_backup_intent_sidecar(&path), &path)?)
         {
             languages.insert(language.to_owned());
         }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -79,7 +79,13 @@ fn publish_parser_transactionally(
 
     if had_old_parser && let Err(finalize_error) = ops.finalize_backup_marker(backup_file) {
         let rollback = ops.rename(backup_file, parser_file);
-        let cleanup = ops.remove_backup_marker(backup_file);
+        let cleanup = if rollback.is_ok() {
+            Some(ops.remove_backup_marker(backup_file))
+        } else {
+            // Keep intent/final ownership discoverable when the working parser
+            // remains stranded at the backup path.
+            None
+        };
         return Err(std::io::Error::new(
             finalize_error.kind(),
             format!(
@@ -1693,6 +1699,7 @@ mod tests {
         fail_marker_creation: bool,
         fail_marker_write_after_create: bool,
         fail_marker_removal: bool,
+        fail_marker_finalization: bool,
         backup_claim_observed_marker: bool,
     }
 
@@ -1780,6 +1787,12 @@ mod tests {
         }
 
         fn finalize_backup_marker(&mut self, backup: &Path) -> std::io::Result<()> {
+            if self.fail_marker_finalization {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "injected marker finalization failure",
+                ));
+            }
             if !self.backup_markers.remove(backup) {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::NotFound,
@@ -1899,6 +1912,25 @@ mod tests {
         assert!(error.to_string().contains("failed to restore backup"));
         assert_eq!(ops.files.get(&backup), Some(&"old"));
         assert_eq!(ops.files.get(&tmp), Some(&"new"));
+        assert!(!ops.files.contains_key(&parser));
+    }
+
+    #[test]
+    fn transactional_publish_keeps_intent_when_finalization_and_rollback_fail() {
+        let tmp = PathBuf::from("parser.tmp");
+        let parser = PathBuf::from("parser.dll");
+        let backup = PathBuf::from("parser.backup");
+        let mut ops = FakeParserFileOps::default();
+        ops.files.insert(tmp.clone(), "new");
+        ops.files.insert(parser.clone(), "old");
+        ops.fail_marker_finalization = true;
+        ops.failed_renames.push((backup.clone(), parser.clone()));
+
+        publish_parser_transactionally(&mut ops, &tmp, &parser, &backup)
+            .expect_err("finalization and rollback failure must abort");
+
+        assert_eq!(ops.files.get(&backup), Some(&"old"));
+        assert!(ops.backup_markers.contains(&backup));
         assert!(!ops.files.contains_key(&parser));
     }
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -204,12 +204,32 @@ fn remove_parser_backup_marker(backup: &Path) -> std::io::Result<()> {
 }
 
 fn parser_backup_marker_is_owned(marker: &Path) -> std::io::Result<bool> {
-    let file = match fs::File::open(marker) {
-        Ok(file) => file,
+    let metadata = match fs::symlink_metadata(marker) {
+        Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
         Err(error) => return Err(error),
     };
-    if file.metadata()?.len() != PARSER_BACKUP_MARKER_CONTENT.len() as u64 {
+    if !metadata.file_type().is_file() {
+        return Ok(false);
+    }
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(nix::libc::O_NONBLOCK | nix::libc::O_NOFOLLOW);
+    }
+    let file = match options.open(marker) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        #[cfg(unix)]
+        Err(error) if error.raw_os_error() == Some(nix::libc::ELOOP) => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    let metadata = file.metadata()?;
+    if !metadata.file_type().is_file()
+        || metadata.len() != PARSER_BACKUP_MARKER_CONTENT.len() as u64
+    {
         return Ok(false);
     }
     let mut content = Vec::with_capacity(PARSER_BACKUP_MARKER_CONTENT.len() + 1);
@@ -1827,7 +1847,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn owned_parser_backup_languages_propagates_marker_read_error() {
+    fn owned_parser_backup_languages_ignores_marker_symlink() {
         use std::os::unix::fs::symlink;
         let temp = tempdir().expect("temp dir");
         let parser_dir = temp.path().join("parser");
@@ -1837,8 +1857,31 @@ mod tests {
         fs::write(&backup, b"parser").expect("write backup");
         symlink(&marker, &marker).expect("create marker symlink loop");
 
-        owned_parser_backup_languages(&parser_dir)
-            .expect_err("uninspectable ownership marker must abort discovery");
+        assert!(
+            owned_parser_backup_languages(&parser_dir)
+                .expect("symlink marker is unowned")
+                .is_empty()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owned_parser_backup_languages_ignores_marker_fifo() {
+        use nix::sys::stat::Mode;
+        use nix::unistd::mkfifo;
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let backup = parser_dir.join(generated_backup_name("lua", 123, 4));
+        let marker = parser_backup_ownership_sidecar(&backup);
+        fs::write(&backup, b"parser").expect("write backup");
+        mkfifo(&marker, Mode::S_IRUSR | Mode::S_IWUSR).expect("create marker fifo");
+
+        assert!(
+            owned_parser_backup_languages(&parser_dir)
+                .expect("fifo marker is unowned")
+                .is_empty()
+        );
     }
 
     #[test]
@@ -1982,7 +2025,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn parser_recovery_propagates_ownership_marker_read_error() {
+    fn parser_recovery_ignores_ownership_marker_symlink() {
         use std::os::unix::fs::symlink;
         let temp = tempdir().expect("temp dir");
         let parser_dir = temp.path().join("parser");
@@ -1993,8 +2036,10 @@ mod tests {
         fs::write(&backup, b"working parser").expect("write backup");
         symlink(&marker, &marker).expect("create marker symlink loop");
 
-        recover_parser_backups(&parser_dir, &canonical, "lua")
-            .expect_err("marker read error must abort recovery");
+        assert!(
+            !recover_parser_backups(&parser_dir, &canonical, "lua")
+                .expect("symlink marker is unowned")
+        );
 
         assert!(backup.exists());
         assert!(!canonical.exists());

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -47,7 +47,7 @@ fn publish_parser_transactionally(
                 if let Err(cleanup_error) = ops.remove_file(backup_file) {
                     if let Err(unpublish_error) = ops.rename(parser_file, tmp_file) {
                         return Err(std::io::Error::new(
-                            unpublish_error.kind(),
+                            cleanup_error.kind(),
                             format!(
                                 "failed to remove parser backup '{}': {cleanup_error}; failed to unpublish replacement: {unpublish_error}",
                                 backup_file.display()
@@ -56,7 +56,7 @@ fn publish_parser_transactionally(
                     }
                     if let Err(rollback_error) = ops.rename(backup_file, parser_file) {
                         return Err(std::io::Error::new(
-                            rollback_error.kind(),
+                            cleanup_error.kind(),
                             format!(
                                 "failed to remove parser backup '{}': {cleanup_error}; failed to restore backup: {rollback_error}",
                                 backup_file.display()
@@ -75,7 +75,7 @@ fn publish_parser_transactionally(
             match ops.rename(backup_file, parser_file) {
                 Ok(()) => Err(publish_error),
                 Err(rollback_error) => Err(std::io::Error::new(
-                    rollback_error.kind(),
+                    publish_error.kind(),
                     format!(
                         "failed to publish parser: {publish_error}; failed to restore backup '{}': {rollback_error}",
                         backup_file.display()
@@ -1172,6 +1172,7 @@ mod tests {
     struct FakeParserFileOps {
         files: HashMap<PathBuf, &'static str>,
         failed_renames: Vec<(PathBuf, PathBuf)>,
+        rollback_error_kind: Option<std::io::ErrorKind>,
         failed_removals: Vec<PathBuf>,
     }
 
@@ -1183,7 +1184,9 @@ mod tests {
                 .any(|(fail_from, fail_to)| fail_from == from && fail_to == to)
             {
                 return Err(std::io::Error::new(
-                    std::io::ErrorKind::PermissionDenied,
+                    self.rollback_error_kind
+                        .filter(|_| from.extension().is_some_and(|ext| ext == "backup"))
+                        .unwrap_or(std::io::ErrorKind::PermissionDenied),
                     "injected publish failure",
                 ));
             }
@@ -1261,6 +1264,24 @@ mod tests {
         assert_eq!(ops.files.get(&backup), Some(&"old"));
         assert_eq!(ops.files.get(&tmp), Some(&"new"));
         assert!(!ops.files.contains_key(&parser));
+    }
+
+    #[test]
+    fn transactional_publish_reports_primary_error_kind_when_rollback_differs() {
+        let tmp = PathBuf::from("parser.tmp");
+        let parser = PathBuf::from("parser.dll");
+        let backup = PathBuf::from("parser.backup");
+        let mut ops = FakeParserFileOps::default();
+        ops.files.insert(tmp.clone(), "new");
+        ops.files.insert(parser.clone(), "old");
+        ops.failed_renames.push((tmp.clone(), parser.clone()));
+        ops.failed_renames.push((backup.clone(), parser.clone()));
+        ops.rollback_error_kind = Some(std::io::ErrorKind::NotFound);
+
+        let error = publish_parser_transactionally(&mut ops, &tmp, &parser, &backup)
+            .expect_err("publish and rollback failures must be reported");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -92,6 +92,106 @@ impl ParserFileOps for StdParserFileOps {
     }
 }
 
+fn generated_parser_backup_matches_language(name: &str, language: &str) -> bool {
+    let Some(stem) = name
+        .strip_prefix('.')
+        .and_then(|name| name.strip_suffix(".backup"))
+    else {
+        return false;
+    };
+    let Some(stem) = stem.strip_suffix(&format!(".{}", std::env::consts::DLL_EXTENSION)) else {
+        return false;
+    };
+    let Some((prefix, counter)) = stem.rsplit_once('.') else {
+        return false;
+    };
+    let Some((backup_language, pid)) = prefix.rsplit_once('.') else {
+        return false;
+    };
+    backup_language == language
+        && !pid.is_empty()
+        && pid.bytes().all(|byte| byte.is_ascii_digit())
+        && !counter.is_empty()
+        && counter.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn parser_backup_files(parser_dir: &Path, language: &str) -> std::io::Result<Vec<PathBuf>> {
+    let entries = match fs::read_dir(parser_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error),
+    };
+    let mut backups = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if entry.file_type()?.is_file() && generated_parser_backup_matches_language(name, language)
+        {
+            backups.push(entry.path());
+        }
+    }
+    Ok(backups)
+}
+
+#[cfg(any(windows, test))]
+fn recover_parser_backups(
+    parser_dir: &Path,
+    parser_file: &Path,
+    language: &str,
+) -> std::io::Result<()> {
+    let mut backups = parser_backup_files(parser_dir, language)?;
+    if backups.is_empty() {
+        return Ok(());
+    }
+    if parser_file.is_file() {
+        for backup in backups {
+            fs::remove_file(backup)?;
+        }
+        return Ok(());
+    }
+    backups.sort_by_key(|path| {
+        fs::metadata(path)
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+    });
+    let restore = backups.pop().expect("non-empty parser backup list");
+    fs::rename(&restore, parser_file)?;
+    for obsolete in backups {
+        fs::remove_file(obsolete)?;
+    }
+    Ok(())
+}
+
+/// Remove the canonical parser and every kakehashi-generated replacement backup.
+pub fn remove_parser_install_and_backups(
+    parser_dir: &Path,
+    language: &str,
+) -> std::io::Result<bool> {
+    if !super::queries::is_safe_language_name(language) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "unsafe parser language name",
+        ));
+    }
+    let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
+    let mut removed = match fs::remove_file(parser_file) {
+        Ok(()) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => return Err(error),
+    };
+    for backup in parser_backup_files(parser_dir, language)? {
+        match fs::remove_file(backup) {
+            Ok(()) => removed = true,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(removed)
+}
+
 /// Error types for parser installation.
 #[derive(Debug)]
 pub enum ParserInstallError {
@@ -513,6 +613,10 @@ pub fn install_parser_after_operation_started(
 
     let parser_dir = options.data_dir.join("parser");
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
+
+    fs::create_dir_all(&parser_dir)?;
+    #[cfg(windows)]
+    recover_parser_backups(&parser_dir, &parser_file, language)?;
     let install_token = begin_parser_install(&parser_dir, &parser_file, language, options.force)?;
 
     // Fetch metadata (with caching support)
@@ -561,7 +665,6 @@ pub fn install_parser_after_operation_started(
     // install dedup. (Windows caveat: replacing a parser that is *currently loaded*
     // by this process still fails at the rename — a loaded DLL can't be removed — a
     // pre-existing platform limitation this scheme doesn't change.)
-    fs::create_dir_all(&parser_dir)?;
     static TMP_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let tmp_file = parser_dir.join(format!(
         ".{}.{}.{}.{}.tmp",
@@ -1322,6 +1425,85 @@ mod tests {
 
         assert_eq!(ops.files.get(&parser), Some(&"new"));
         assert!(!ops.files.contains_key(&backup));
+    }
+
+    fn generated_backup_name(language: &str, pid: u32, counter: usize) -> String {
+        format!(
+            ".{language}.{pid}.{counter}.{}.backup",
+            std::env::consts::DLL_EXTENSION
+        )
+    }
+
+    #[test]
+    fn parser_backup_matching_rejects_other_or_user_files() {
+        let owned = generated_backup_name("lua", 123, 4);
+        assert!(generated_parser_backup_matches_language(&owned, "lua"));
+        assert!(!generated_parser_backup_matches_language(&owned, "rust"));
+        assert!(!generated_parser_backup_matches_language(
+            ".lua.manual.dylib.backup",
+            "lua"
+        ));
+        assert!(!generated_parser_backup_matches_language(
+            "lua.123.4.dylib.backup",
+            "lua"
+        ));
+    }
+
+    #[test]
+    fn parser_uninstall_removes_owned_backups_only() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let canonical = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        let owned = parser_dir.join(generated_backup_name("lua", 123, 4));
+        let other_language = parser_dir.join(generated_backup_name("rust", 123, 4));
+        let user_file = parser_dir.join(".lua.manual.backup");
+        for path in [&canonical, &owned, &other_language, &user_file] {
+            fs::write(path, b"parser").expect("write parser fixture");
+        }
+
+        assert!(
+            remove_parser_install_and_backups(&parser_dir, "lua").expect("remove parser files")
+        );
+
+        assert!(!canonical.exists());
+        assert!(!owned.exists());
+        assert!(other_language.exists());
+        assert!(user_file.exists());
+    }
+
+    #[test]
+    fn parser_recovery_restores_backup_when_canonical_is_missing() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let canonical = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        let backup = parser_dir.join(generated_backup_name("lua", 123, 4));
+        fs::write(&backup, b"working parser").expect("write backup");
+
+        recover_parser_backups(&parser_dir, &canonical, "lua").expect("recover parser backup");
+
+        assert_eq!(
+            fs::read(&canonical).expect("read restored parser"),
+            b"working parser"
+        );
+        assert!(!backup.exists());
+    }
+
+    #[test]
+    fn parser_recovery_removes_obsolete_backup_when_canonical_exists() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let canonical = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        let backup = parser_dir.join(generated_backup_name("lua", 123, 4));
+        fs::write(&canonical, b"new parser").expect("write canonical");
+        fs::write(&backup, b"old parser").expect("write backup");
+
+        recover_parser_backups(&parser_dir, &canonical, "lua").expect("clean parser backup");
+
+        assert_eq!(fs::read(&canonical).expect("read canonical"), b"new parser");
+        assert!(!backup.exists());
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -147,7 +147,7 @@ fn publish_parser_transactionally(
 #[cfg(windows)]
 struct StdParserFileOps;
 
-#[cfg(windows)]
+#[cfg(any(windows, test))]
 fn write_marker_atomically(marker_path: &Path, content: &[u8]) -> std::io::Result<()> {
     let marker_tmp = marker_staging_path(marker_path, ulid::Ulid::new());
     let mut marker = fs::OpenOptions::new()
@@ -160,10 +160,16 @@ fn write_marker_atomically(marker_path: &Path, content: &[u8]) -> std::io::Resul
         return Err(error);
     }
     drop(marker);
-    if let Err(error) = fs::rename(&marker_tmp, &marker_path) {
+    // Linking publishes the already-complete inode and atomically fails when
+    // the destination exists; unlike Windows rename, it never replaces a
+    // colliding user or prior-process sidecar.
+    if let Err(error) = fs::hard_link(&marker_tmp, marker_path) {
         let _ = fs::remove_file(marker_tmp);
         return Err(error);
     }
+    // A crash or unlink failure leaves only a content-validated staging alias,
+    // which recovery removes by its exact ULID shape.
+    let _ = fs::remove_file(marker_tmp);
     Ok(())
 }
 
@@ -1686,6 +1692,19 @@ mod tests {
 
     const TREE_SITTER_JSON_URL: &str =
         "https://github.com/tree-sitter/tree-sitter-json/archive/v0.24.8.tar.gz";
+
+    #[test]
+    fn atomic_marker_publish_preserves_existing_destination() {
+        let temp = tempdir().expect("temp dir");
+        let marker = temp.path().join("backup.owner");
+        fs::write(&marker, b"unrelated").expect("write collision");
+
+        write_marker_atomically(&marker, PARSER_BACKUP_INTENT_CONTENT)
+            .expect_err("atomic publication must reject collision");
+
+        assert_eq!(fs::read(&marker).expect("read collision"), b"unrelated");
+        assert_eq!(fs::read_dir(temp.path()).expect("list temp").count(), 1);
+    }
 
     #[derive(Default)]
     struct FakeParserFileOps {

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -285,8 +285,13 @@ fn cleanup_orphan_parser_backup_markers(parser_dir: &Path, language: &str) -> st
             continue;
         }
         let backup = parser_dir.join(backup_name);
-        if !backup.try_exists()? && fs::read(&marker)? == PARSER_BACKUP_MARKER_CONTENT {
-            fs::remove_file(marker)?;
+        let marker_content = match fs::read(&marker) {
+            Ok(content) => content,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error),
+        };
+        if !backup.try_exists()? && marker_content == PARSER_BACKUP_MARKER_CONTENT {
+            remove_parser_backup_marker(&backup)?;
         }
     }
     Ok(())

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -44,26 +44,18 @@ fn publish_parser_transactionally(
     match ops.rename(tmp_file, parser_file) {
         Ok(()) => {
             if had_old_parser {
-                if let Err(cleanup_error) = ops.remove_file(backup_file) {
-                    if let Err(unpublish_error) = ops.rename(parser_file, tmp_file) {
+                match ops.remove_file(backup_file) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => {
                         return Err(std::io::Error::new(
-                            cleanup_error.kind(),
+                            error.kind(),
                             format!(
-                                "failed to remove parser backup '{}': {cleanup_error}; failed to unpublish replacement: {unpublish_error}",
+                                "published parser but failed to remove backup '{}': {error}",
                                 backup_file.display()
                             ),
                         ));
                     }
-                    if let Err(rollback_error) = ops.rename(backup_file, parser_file) {
-                        return Err(std::io::Error::new(
-                            cleanup_error.kind(),
-                            format!(
-                                "failed to remove parser backup '{}': {cleanup_error}; failed to restore backup: {rollback_error}",
-                                backup_file.display()
-                            ),
-                        ));
-                    }
-                    return Err(cleanup_error);
                 }
             }
             Ok(())
@@ -1174,6 +1166,7 @@ mod tests {
         failed_renames: Vec<(PathBuf, PathBuf)>,
         rollback_error_kind: Option<std::io::ErrorKind>,
         failed_removals: Vec<PathBuf>,
+        vanished_removals: Vec<PathBuf>,
     }
 
     impl ParserFileOps for FakeParserFileOps {
@@ -1198,6 +1191,17 @@ mod tests {
         }
 
         fn remove_file(&mut self, path: &Path) -> std::io::Result<()> {
+            if self
+                .vanished_removals
+                .iter()
+                .any(|vanished| vanished == path)
+            {
+                self.files.remove(path);
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "injected external removal",
+                ));
+            }
             if self.failed_removals.iter().any(|failed| failed == path) {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::PermissionDenied,
@@ -1285,7 +1289,7 @@ mod tests {
     }
 
     #[test]
-    fn transactional_publish_restores_old_parser_when_backup_cleanup_fails() {
+    fn transactional_publish_preserves_both_copies_when_backup_cleanup_fails() {
         let tmp = PathBuf::from("parser.tmp");
         let parser = PathBuf::from("parser.dll");
         let backup = PathBuf::from("parser.backup");
@@ -1298,8 +1302,25 @@ mod tests {
             .expect_err("backup cleanup failure must fail the transaction");
 
         assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
-        assert_eq!(ops.files.get(&parser), Some(&"old"));
-        assert_eq!(ops.files.get(&tmp), Some(&"new"));
+        assert_eq!(ops.files.get(&parser), Some(&"new"));
+        assert!(!ops.files.contains_key(&tmp));
+        assert_eq!(ops.files.get(&backup), Some(&"old"));
+    }
+
+    #[test]
+    fn transactional_publish_accepts_backup_that_vanished_during_cleanup() {
+        let tmp = PathBuf::from("parser.tmp");
+        let parser = PathBuf::from("parser.dll");
+        let backup = PathBuf::from("parser.backup");
+        let mut ops = FakeParserFileOps::default();
+        ops.files.insert(tmp.clone(), "new");
+        ops.files.insert(parser.clone(), "old");
+        ops.vanished_removals.push(backup.clone());
+
+        publish_parser_transactionally(&mut ops, &tmp, &parser, &backup)
+            .expect("a vanished backup is already cleaned up");
+
+        assert_eq!(ops.files.get(&parser), Some(&"new"));
         assert!(!ops.files.contains_key(&backup));
     }
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -139,14 +139,8 @@ impl ParserFileOps for StdParserFileOps {
     }
 
     fn create_backup_marker(&mut self, backup: &Path) -> std::io::Result<()> {
-        static MARKER_COUNTER: std::sync::atomic::AtomicUsize =
-            std::sync::atomic::AtomicUsize::new(0);
         let marker_path = parser_backup_ownership_sidecar(backup);
-        let marker_tmp = marker_path.with_extension(format!(
-            "owner.{}.{}.tmp",
-            std::process::id(),
-            MARKER_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-        ));
+        let marker_tmp = marker_path.with_extension(format!("owner.{}.tmp", ulid::Ulid::new()));
         let mut marker = fs::OpenOptions::new()
             .write(true)
             .create_new(true)

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -834,14 +834,11 @@ pub fn install_parser(
         return Err(unsafe_language_name_error(language));
     }
     let _operation_lock = super::LanguageOperationLockGuard::acquire(&options.data_dir, language)?;
-    match install_parser_after_operation_started(
+    install_parser_after_operation_started(
         language,
         options,
         super::LanguageOperationPermit::Language(&_operation_lock),
-    )? {
-        ParserInstallOutcome::Installed(result) => Ok(result),
-        ParserInstallOutcome::Recovered(path) => Err(ParserInstallError::AlreadyExists(path)),
-    }
+    )
 }
 
 /// Install a parser while the caller holds this language's operation lock.
@@ -850,6 +847,19 @@ pub fn install_parser(
 /// combined parser-and-query operation that must retain one lock across both.
 #[doc(hidden)]
 pub fn install_parser_after_operation_started(
+    language: &str,
+    options: &InstallOptions,
+    permit: super::LanguageOperationPermit<'_>,
+) -> Result<ParserInstallResult, ParserInstallError> {
+    match install_parser_with_outcome_after_operation_started(language, options, permit)? {
+        ParserInstallOutcome::Installed(result) => Ok(result),
+        ParserInstallOutcome::Recovered(path) => Err(ParserInstallError::AlreadyExists(path)),
+    }
+}
+
+/// Install a parser while retaining the recovery-specific outcome.
+#[doc(hidden)]
+pub fn install_parser_with_outcome_after_operation_started(
     language: &str,
     options: &InstallOptions,
     permit: super::LanguageOperationPermit<'_>,

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -173,13 +173,35 @@ fn write_marker_atomically(marker_path: &Path, content: &[u8]) -> std::io::Resul
 
 #[cfg(windows)]
 fn publish_marker_no_replace(from: &Path, to: &Path) -> std::io::Result<()> {
+    move_file_no_replace(from, to)
+}
+
+#[cfg(windows)]
+fn windows_verbatim_path(path: &Path) -> std::io::Result<Vec<u16>> {
     use std::os::windows::ffi::OsStrExt;
+    let absolute = std::path::absolute(path)?;
+    let text = absolute.as_os_str().to_string_lossy();
+    let verbatim = if text.starts_with(r"\\?\") {
+        text.into_owned()
+    } else if let Some(unc) = text.strip_prefix(r"\\") {
+        format!(r"\\?\UNC\{unc}")
+    } else {
+        format!(r"\\?\{text}")
+    };
+    Ok(std::ffi::OsStr::new(&verbatim)
+        .encode_wide()
+        .chain(Some(0))
+        .collect())
+}
+
+#[cfg(windows)]
+fn move_file_no_replace(from: &Path, to: &Path) -> std::io::Result<()> {
     #[link(name = "kernel32")]
     unsafe extern "system" {
         fn MoveFileExW(existing: *const u16, new: *const u16, flags: u32) -> i32;
     }
-    let from: Vec<u16> = from.as_os_str().encode_wide().chain(Some(0)).collect();
-    let to: Vec<u16> = to.as_os_str().encode_wide().chain(Some(0)).collect();
+    let from = windows_verbatim_path(from)?;
+    let to = windows_verbatim_path(to)?;
     // Flags 0 is an atomic same-volume move that fails when `to` exists.
     if unsafe { MoveFileExW(from.as_ptr(), to.as_ptr(), 0) } == 0 {
         Err(std::io::Error::last_os_error())
@@ -217,7 +239,7 @@ fn path_entry_exists(path: &Path) -> std::io::Result<bool> {
 #[cfg(windows)]
 impl ParserFileOps for StdParserFileOps {
     fn rename(&mut self, from: &Path, to: &Path) -> std::io::Result<()> {
-        fs::rename(from, to)
+        move_file_no_replace(from, to)
     }
 
     fn remove_file(&mut self, path: &Path) -> std::io::Result<()> {
@@ -1738,6 +1760,26 @@ mod tests {
         assert_eq!(fs::read_dir(temp.path()).expect("list temp").count(), 1);
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn atomic_marker_publish_supports_long_windows_paths() {
+        let temp = tempdir().expect("temp dir");
+        let mut directory = temp.path().to_path_buf();
+        while directory.as_os_str().len() < 280 {
+            directory.push("long-parser-marker-segment");
+        }
+        fs::create_dir_all(&directory).expect("create long directory");
+        let marker = directory.join("backup.owner");
+
+        write_marker_atomically(&marker, PARSER_BACKUP_INTENT_CONTENT)
+            .expect("publish long marker");
+
+        assert_eq!(
+            fs::read(marker).expect("read long marker"),
+            PARSER_BACKUP_INTENT_CONTENT
+        );
+    }
+
     #[derive(Default)]
     struct FakeParserFileOps {
         files: HashMap<PathBuf, &'static str>,
@@ -1761,6 +1803,12 @@ mod tests {
                 .is_some_and(|extension| extension == "backup")
             {
                 self.backup_claim_observed_marker = self.backup_markers.contains(to);
+            }
+            if self.files.contains_key(to) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    "destination exists",
+                ));
             }
             if self
                 .failed_renames

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -272,15 +272,18 @@ fn recover_parser_backups(
         }
         return Ok(());
     }
-    backups.sort_by_key(|path| {
-        fs::metadata(path)
-            .and_then(|metadata| metadata.modified())
-            .unwrap_or(std::time::SystemTime::UNIX_EPOCH)
-    });
-    let restore = backups.pop().expect("non-empty parser backup list");
+    let mut timed_backups = backups
+        .into_iter()
+        .map(|path| {
+            let modified = fs::metadata(&path)?.modified()?;
+            Ok((modified, path))
+        })
+        .collect::<std::io::Result<Vec<_>>>()?;
+    timed_backups.sort_by_key(|(modified, _)| *modified);
+    let (_, restore) = timed_backups.pop().expect("non-empty parser backup list");
     fs::rename(&restore, parser_file)?;
     fs::remove_file(parser_backup_ownership_sidecar(&restore))?;
-    for obsolete in backups {
+    for (_, obsolete) in timed_backups {
         remove_owned_parser_backup(&obsolete)?;
     }
     Ok(())

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -691,14 +691,16 @@ fn publish_compiled_parser(
             format!("Parser install for {language} was superseded by a newer parser operation"),
         )));
     }
-    // On unix `rename` atomically replaces an existing parser. Windows
-    // `rename` instead fails if the destination exists, which would make a
-    // `force` reinstall fail after a good compile — remove the old file
-    // first there (a small non-atomic window, acceptable on the
-    // non-primary platform).
+    // Unix atomically replaces the destination. Windows needs the same-directory
+    // owned backup so a failed publication can restore the working parser.
+    #[cfg(not(windows))]
+    let published = fs::rename(tmp_file, parser_file);
     #[cfg(windows)]
-    let _ = fs::remove_file(parser_file);
-    if let Err(e) = fs::rename(tmp_file, parser_file) {
+    let published = {
+        let backup_file = tmp_file.with_extension("backup");
+        publish_parser_transactionally(&mut StdParserFileOps, tmp_file, parser_file, &backup_file)
+    };
+    if let Err(e) = published {
         let _ = fs::remove_file(tmp_file);
         return Err(ParserInstallError::IoError(e));
     }
@@ -749,10 +751,18 @@ pub fn remove_parser_install_after_operation_started(
     let _replace_lock = ParserReplaceLockGuard::acquire(parser_dir, language)?;
     let mut marker = fs::File::create(parser_operation_marker_path(parser_dir, language))?;
     writeln!(marker, "uninstall:{}", ulid::Ulid::new())?;
+    cleanup_orphan_parser_backup_markers(parser_dir, language)?;
+    // Delete recovery copies first so an interrupted uninstall cannot leave a
+    // backup that a later install would restore after canonical removal.
+    let mut removed = false;
+    for backup in parser_backup_files(parser_dir, language)? {
+        remove_owned_parser_backup(&backup)?;
+        removed = true;
+    }
     let parser_file = parser_dir.join(format!("{language}.{}", std::env::consts::DLL_EXTENSION));
     match fs::remove_file(parser_file) {
         Ok(()) => Ok(true),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(removed),
         Err(error) => Err(ParserInstallError::IoError(error)),
     }
 }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -26,6 +26,8 @@ const PARSER_OPERATION_MARKER_SUFFIX: &str = ".operation";
 trait ParserFileOps {
     fn rename(&mut self, from: &Path, to: &Path) -> std::io::Result<()>;
     fn remove_file(&mut self, path: &Path) -> std::io::Result<()>;
+    fn create_backup_marker(&mut self, backup: &Path) -> std::io::Result<()>;
+    fn remove_backup_marker(&mut self, backup: &Path) -> std::io::Result<()>;
 }
 
 #[cfg(any(windows, test))]
@@ -36,7 +38,21 @@ fn publish_parser_transactionally(
     backup_file: &Path,
 ) -> std::io::Result<()> {
     let had_old_parser = match ops.rename(parser_file, backup_file) {
-        Ok(()) => true,
+        Ok(()) => {
+            if let Err(marker_error) = ops.create_backup_marker(backup_file) {
+                return match ops.rename(backup_file, parser_file) {
+                    Ok(()) => Err(marker_error),
+                    Err(rollback_error) => Err(std::io::Error::new(
+                        marker_error.kind(),
+                        format!(
+                            "failed to mark parser backup: {marker_error}; failed to restore backup '{}': {rollback_error}",
+                            backup_file.display()
+                        ),
+                    )),
+                };
+            }
+            true
+        }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
         Err(error) => return Err(error),
     };
@@ -45,8 +61,10 @@ fn publish_parser_transactionally(
         Ok(()) => {
             if had_old_parser {
                 match ops.remove_file(backup_file) {
-                    Ok(()) => {}
-                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Ok(()) => ops.remove_backup_marker(backup_file)?,
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                        ops.remove_backup_marker(backup_file)?;
+                    }
                     Err(error) => {
                         return Err(std::io::Error::new(
                             error.kind(),
@@ -65,7 +83,17 @@ fn publish_parser_transactionally(
                 return Err(publish_error);
             }
             match ops.rename(backup_file, parser_file) {
-                Ok(()) => Err(publish_error),
+                Ok(()) => {
+                    if let Err(marker_error) = ops.remove_backup_marker(backup_file) {
+                        return Err(std::io::Error::new(
+                            publish_error.kind(),
+                            format!(
+                                "failed to publish parser: {publish_error}; restored parser but failed to remove backup marker: {marker_error}"
+                            ),
+                        ));
+                    }
+                    Err(publish_error)
+                }
                 Err(rollback_error) => Err(std::io::Error::new(
                     publish_error.kind(),
                     format!(
@@ -89,6 +117,23 @@ impl ParserFileOps for StdParserFileOps {
 
     fn remove_file(&mut self, path: &Path) -> std::io::Result<()> {
         fs::remove_file(path)
+    }
+
+    fn create_backup_marker(&mut self, backup: &Path) -> std::io::Result<()> {
+        use std::io::Write;
+        let mut marker = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(parser_backup_ownership_sidecar(backup))?;
+        marker.write_all(b"ok\n")
+    }
+
+    fn remove_backup_marker(&mut self, backup: &Path) -> std::io::Result<()> {
+        match fs::remove_file(parser_backup_ownership_sidecar(backup)) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
     }
 }
 
@@ -1280,7 +1325,7 @@ fn invalid_metadata(message: String) -> ParserInstallError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use tempfile::tempdir;
 
     const TREE_SITTER_JSON_URL: &str =
@@ -1293,6 +1338,8 @@ mod tests {
         rollback_error_kind: Option<std::io::ErrorKind>,
         failed_removals: Vec<PathBuf>,
         vanished_removals: Vec<PathBuf>,
+        backup_markers: HashSet<PathBuf>,
+        fail_marker_creation: bool,
     }
 
     impl ParserFileOps for FakeParserFileOps {
@@ -1338,6 +1385,21 @@ mod tests {
                 .remove(path)
                 .map(|_| ())
                 .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "missing file"))
+        }
+
+        fn create_backup_marker(&mut self, backup: &Path) -> std::io::Result<()> {
+            if self.fail_marker_creation || !self.backup_markers.insert(backup.to_path_buf()) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    "injected marker collision",
+                ));
+            }
+            Ok(())
+        }
+
+        fn remove_backup_marker(&mut self, backup: &Path) -> std::io::Result<()> {
+            self.backup_markers.remove(backup);
+            Ok(())
         }
     }
 
@@ -1448,6 +1510,43 @@ mod tests {
 
         assert_eq!(ops.files.get(&parser), Some(&"new"));
         assert!(!ops.files.contains_key(&backup));
+    }
+
+    #[test]
+    fn transactional_publish_does_not_claim_colliding_backup() {
+        let tmp = PathBuf::from("parser.tmp");
+        let parser = PathBuf::from("parser.dll");
+        let backup = PathBuf::from("parser.backup");
+        let mut ops = FakeParserFileOps::default();
+        ops.files.insert(tmp.clone(), "new");
+        ops.files.insert(parser.clone(), "old");
+        ops.files.insert(backup.clone(), "user");
+        ops.failed_renames.push((parser.clone(), backup.clone()));
+
+        publish_parser_transactionally(&mut ops, &tmp, &parser, &backup)
+            .expect_err("backup collision must abort publication");
+
+        assert_eq!(ops.files.get(&parser), Some(&"old"));
+        assert_eq!(ops.files.get(&backup), Some(&"user"));
+        assert!(!ops.backup_markers.contains(&backup));
+    }
+
+    #[test]
+    fn transactional_publish_preserves_colliding_sidecar() {
+        let tmp = PathBuf::from("parser.tmp");
+        let parser = PathBuf::from("parser.dll");
+        let backup = PathBuf::from("parser.backup");
+        let mut ops = FakeParserFileOps::default();
+        ops.files.insert(tmp.clone(), "new");
+        ops.files.insert(parser.clone(), "old");
+        ops.backup_markers.insert(backup.clone());
+
+        publish_parser_transactionally(&mut ops, &tmp, &parser, &backup)
+            .expect_err("sidecar collision must abort publication");
+
+        assert_eq!(ops.files.get(&parser), Some(&"old"));
+        assert!(!ops.files.contains_key(&backup));
+        assert!(ops.backup_markers.contains(&backup));
     }
 
     fn generated_backup_name(language: &str, pid: u32, counter: usize) -> String {

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -21,13 +21,15 @@ use super::metadata::{FetchOptions, MetadataError, fetch_parser_metadata};
 /// HTTP timeout for archive downloads.
 const ARCHIVE_HTTP_TIMEOUT: Duration = Duration::from_secs(120);
 const PARSER_OPERATION_MARKER_SUFFIX: &str = ".operation";
-const PARSER_BACKUP_MARKER_CONTENT: &[u8] = b"kakehashi parser backup v1\n";
+const PARSER_BACKUP_INTENT_CONTENT: &[u8] = b"kakehashi parser backup intent v1\n";
+const PARSER_BACKUP_MARKER_CONTENT: &[u8] = b"kakehashi parser backup owned v1\n";
 
 #[cfg(any(windows, test))]
 trait ParserFileOps {
     fn rename(&mut self, from: &Path, to: &Path) -> std::io::Result<()>;
     fn remove_file(&mut self, path: &Path) -> std::io::Result<()>;
     fn create_backup_marker(&mut self, backup: &Path) -> std::io::Result<()>;
+    fn finalize_backup_marker(&mut self, backup: &Path) -> std::io::Result<()>;
     fn remove_backup_marker(&mut self, backup: &Path) -> std::io::Result<()>;
 }
 
@@ -74,6 +76,17 @@ fn publish_parser_transactionally(
             return Err(error);
         }
     };
+
+    if had_old_parser && let Err(finalize_error) = ops.finalize_backup_marker(backup_file) {
+        let rollback = ops.rename(backup_file, parser_file);
+        let cleanup = ops.remove_backup_marker(backup_file);
+        return Err(std::io::Error::new(
+            finalize_error.kind(),
+            format!(
+                "failed to finalize parser backup ownership: {finalize_error}; rollback: {rollback:?}; marker cleanup: {cleanup:?}"
+            ),
+        ));
+    }
 
     match ops.rename(tmp_file, parser_file) {
         Ok(()) => {
@@ -129,6 +142,26 @@ fn publish_parser_transactionally(
 struct StdParserFileOps;
 
 #[cfg(windows)]
+fn write_marker_atomically(marker_path: &Path, content: &[u8]) -> std::io::Result<()> {
+    let marker_tmp = marker_path.with_extension(format!("owner.{}.tmp", ulid::Ulid::new()));
+    let mut marker = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&marker_tmp)?;
+    if let Err(error) = marker.write_all(content).and_then(|()| marker.sync_all()) {
+        drop(marker);
+        let _ = fs::remove_file(marker_tmp);
+        return Err(error);
+    }
+    drop(marker);
+    if let Err(error) = fs::rename(&marker_tmp, &marker_path) {
+        let _ = fs::remove_file(marker_tmp);
+        return Err(error);
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
 impl ParserFileOps for StdParserFileOps {
     fn rename(&mut self, from: &Path, to: &Path) -> std::io::Result<()> {
         fs::rename(from, to)
@@ -149,36 +182,32 @@ impl ParserFileOps for StdParserFileOps {
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
             Err(error) => return Err(error),
         }
-        let marker_path = parser_backup_ownership_sidecar(backup);
-        let marker_tmp = marker_path.with_extension(format!("owner.{}.tmp", ulid::Ulid::new()));
-        let mut marker = fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&marker_tmp)?;
-        if let Err(error) = marker.write_all(PARSER_BACKUP_MARKER_CONTENT) {
-            drop(marker);
-            let _ = fs::remove_file(marker_tmp);
-            return Err(error);
-        }
-        if let Err(error) = marker.sync_all() {
-            drop(marker);
-            let _ = fs::remove_file(marker_tmp);
-            return Err(error);
-        }
-        drop(marker);
-        if let Err(error) = fs::rename(&marker_tmp, &marker_path) {
-            let _ = fs::remove_file(marker_tmp);
-            return Err(error);
-        }
-        Ok(())
+        write_marker_atomically(
+            &parser_backup_intent_sidecar(backup),
+            PARSER_BACKUP_INTENT_CONTENT,
+        )
+    }
+
+    fn finalize_backup_marker(&mut self, backup: &Path) -> std::io::Result<()> {
+        write_marker_atomically(
+            &parser_backup_ownership_sidecar(backup),
+            PARSER_BACKUP_MARKER_CONTENT,
+        )?;
+        fs::remove_file(parser_backup_intent_sidecar(backup))
     }
 
     fn remove_backup_marker(&mut self, backup: &Path) -> std::io::Result<()> {
-        match fs::remove_file(parser_backup_ownership_sidecar(backup)) {
-            Ok(()) => Ok(()),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(error) => Err(error),
+        for marker in [
+            parser_backup_ownership_sidecar(backup),
+            parser_backup_intent_sidecar(backup),
+        ] {
+            match fs::remove_file(marker) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
         }
+        Ok(())
     }
 }
 
@@ -215,15 +244,31 @@ fn parser_backup_ownership_sidecar(backup: &Path) -> PathBuf {
     ))
 }
 
-fn remove_parser_backup_marker(backup: &Path) -> std::io::Result<()> {
-    match fs::remove_file(parser_backup_ownership_sidecar(backup)) {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(error),
-    }
+fn parser_backup_intent_sidecar(backup: &Path) -> PathBuf {
+    backup.with_file_name(format!(
+        "{}.owner.intent",
+        backup
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(".parser.backup")
+    ))
 }
 
-fn parser_backup_marker_is_owned(marker: &Path) -> std::io::Result<bool> {
+fn remove_parser_backup_marker(backup: &Path) -> std::io::Result<()> {
+    for marker in [
+        parser_backup_ownership_sidecar(backup),
+        parser_backup_intent_sidecar(backup),
+    ] {
+        match fs::remove_file(marker) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+fn parser_backup_marker_has_content(marker: &Path, expected: &[u8]) -> std::io::Result<bool> {
     let metadata = match fs::symlink_metadata(marker) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
@@ -255,15 +300,21 @@ fn parser_backup_marker_is_owned(marker: &Path) -> std::io::Result<bool> {
         Err(error) => return Err(error),
     };
     let metadata = file.metadata()?;
-    if !metadata.file_type().is_file()
-        || metadata.len() != PARSER_BACKUP_MARKER_CONTENT.len() as u64
-    {
+    if !metadata.file_type().is_file() || metadata.len() != expected.len() as u64 {
         return Ok(false);
     }
-    let mut content = Vec::with_capacity(PARSER_BACKUP_MARKER_CONTENT.len() + 1);
-    file.take((PARSER_BACKUP_MARKER_CONTENT.len() + 1) as u64)
+    let mut content = Vec::with_capacity(expected.len() + 1);
+    file.take((expected.len() + 1) as u64)
         .read_to_end(&mut content)?;
-    Ok(content == PARSER_BACKUP_MARKER_CONTENT)
+    Ok(content == expected)
+}
+
+fn parser_backup_marker_is_owned(marker: &Path) -> std::io::Result<bool> {
+    parser_backup_marker_has_content(marker, PARSER_BACKUP_MARKER_CONTENT)
+}
+
+fn parser_backup_marker_is_intent(marker: &Path) -> std::io::Result<bool> {
+    parser_backup_marker_has_content(marker, PARSER_BACKUP_INTENT_CONTENT)
 }
 
 fn parser_backup_files(parser_dir: &Path, language: &str) -> std::io::Result<Vec<PathBuf>> {
@@ -285,6 +336,27 @@ fn parser_backup_files(parser_dir: &Path, language: &str) -> std::io::Result<Vec
             continue;
         }
         if parser_backup_marker_is_owned(&parser_backup_ownership_sidecar(&entry.path()))? {
+            backups.push(entry.path());
+        }
+    }
+    Ok(backups)
+}
+
+fn parser_backup_intent_files(parser_dir: &Path, language: &str) -> std::io::Result<Vec<PathBuf>> {
+    let entries = match fs::read_dir(parser_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error),
+    };
+    let mut backups = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if entry.file_type()?.is_file()
+            && generated_parser_backup_matches_language(name, language)
+            && parser_backup_marker_is_intent(&parser_backup_intent_sidecar(&entry.path()))?
+        {
             backups.push(entry.path());
         }
     }
@@ -377,8 +449,9 @@ fn recover_parser_backups(
     language: &str,
 ) -> std::io::Result<bool> {
     cleanup_orphan_parser_backup_markers(parser_dir, language)?;
-    let backups = parser_backup_files(parser_dir, language)?;
-    if backups.is_empty() {
+    let mut backups = parser_backup_files(parser_dir, language)?;
+    let intent_backups = parser_backup_intent_files(parser_dir, language)?;
+    if backups.is_empty() && intent_backups.is_empty() {
         return Ok(false);
     }
     if parser_file.try_exists()? {
@@ -391,8 +464,14 @@ fn recover_parser_backups(
         for backup in backups {
             remove_owned_parser_backup(&backup)?;
         }
+        // An intent beside an existing canonical parser never proves ownership:
+        // the backup claim may have collided before rename. Preserve that file.
+        for backup in intent_backups {
+            remove_parser_backup_marker(&backup)?;
+        }
         return Ok(false);
     }
+    backups.extend(intent_backups);
     let mut timed_backups = backups
         .into_iter()
         .map(|path| {
@@ -424,10 +503,19 @@ fn remove_parser_install_and_backups(parser_dir: &Path, language: &str) -> std::
     }
     cleanup_orphan_parser_backup_markers(parser_dir, language)?;
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
+    let canonical_exists = parser_file.try_exists()?;
     // Remove recovery copies first. If uninstall is interrupted, leaving the
     // canonical parser is an incomplete uninstall that can be retried; deleting
     // canonical first could let the next install resurrect an old backup.
     let mut removed = false;
+    for backup in parser_backup_intent_files(parser_dir, language)? {
+        if canonical_exists {
+            remove_parser_backup_marker(&backup)?;
+        } else {
+            remove_owned_parser_backup(&backup)?;
+            removed = true;
+        }
+    }
     for backup in parser_backup_files(parser_dir, language)? {
         remove_owned_parser_backup(&backup)?;
         removed = true;
@@ -820,14 +908,23 @@ pub fn remove_parser_install_after_operation_started(
     let mut marker = fs::File::create(parser_operation_marker_path(parser_dir, language))?;
     writeln!(marker, "uninstall:{}", ulid::Ulid::new())?;
     cleanup_orphan_parser_backup_markers(parser_dir, language)?;
+    let parser_file = parser_dir.join(format!("{language}.{}", std::env::consts::DLL_EXTENSION));
+    let canonical_exists = parser_file.try_exists()?;
     // Delete recovery copies first so an interrupted uninstall cannot leave a
     // backup that a later install would restore after canonical removal.
     let mut removed = false;
+    for backup in parser_backup_intent_files(parser_dir, language)? {
+        if canonical_exists {
+            remove_parser_backup_marker(&backup)?;
+        } else {
+            remove_owned_parser_backup(&backup)?;
+            removed = true;
+        }
+    }
     for backup in parser_backup_files(parser_dir, language)? {
         remove_owned_parser_backup(&backup)?;
         removed = true;
     }
-    let parser_file = parser_dir.join(format!("{language}.{}", std::env::consts::DLL_EXTENSION));
     match fs::remove_file(parser_file) {
         Ok(()) => Ok(true),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(removed),
@@ -1555,6 +1652,7 @@ mod tests {
         failed_removals: Vec<PathBuf>,
         vanished_removals: Vec<PathBuf>,
         backup_markers: HashSet<PathBuf>,
+        finalized_backup_markers: HashSet<PathBuf>,
         fail_marker_creation: bool,
         fail_marker_write_after_create: bool,
         fail_marker_removal: bool,
@@ -1640,6 +1738,18 @@ mod tests {
                 ));
             }
             self.backup_markers.remove(backup);
+            self.finalized_backup_markers.remove(backup);
+            Ok(())
+        }
+
+        fn finalize_backup_marker(&mut self, backup: &Path) -> std::io::Result<()> {
+            if !self.backup_markers.remove(backup) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "missing intent marker",
+                ));
+            }
+            self.finalized_backup_markers.insert(backup.to_path_buf());
             Ok(())
         }
     }
@@ -2022,6 +2132,48 @@ mod tests {
             b"working parser"
         );
         assert!(!backup.exists());
+    }
+
+    #[test]
+    fn parser_recovery_restores_intent_backup_when_canonical_is_missing() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let canonical = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        let backup = parser_dir.join(generated_backup_name("lua", 123, 7));
+        fs::write(&backup, b"working parser").expect("write backup");
+        fs::write(
+            parser_backup_intent_sidecar(&backup),
+            PARSER_BACKUP_INTENT_CONTENT,
+        )
+        .expect("write intent marker");
+
+        assert!(recover_parser_backups(&parser_dir, &canonical, "lua").expect("recover intent"));
+        assert_eq!(
+            fs::read(&canonical).expect("read canonical"),
+            b"working parser"
+        );
+        assert!(!parser_backup_intent_sidecar(&backup).exists());
+    }
+
+    #[test]
+    fn parser_recovery_preserves_colliding_intent_backup_when_canonical_exists() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let canonical = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        let backup = parser_dir.join(generated_backup_name("lua", 123, 8));
+        fs::write(&canonical, b"canonical").expect("write canonical");
+        fs::write(&backup, b"unrelated").expect("write colliding backup");
+        fs::write(
+            parser_backup_intent_sidecar(&backup),
+            PARSER_BACKUP_INTENT_CONTENT,
+        )
+        .expect("write intent marker");
+
+        assert!(!recover_parser_backups(&parser_dir, &canonical, "lua").expect("clean intent"));
+        assert_eq!(fs::read(&backup).expect("preserve collision"), b"unrelated");
+        assert!(!parser_backup_intent_sidecar(&backup).exists());
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -139,15 +139,31 @@ impl ParserFileOps for StdParserFileOps {
     }
 
     fn create_backup_marker(&mut self, backup: &Path) -> std::io::Result<()> {
-        use std::io::Write;
+        static MARKER_COUNTER: std::sync::atomic::AtomicUsize =
+            std::sync::atomic::AtomicUsize::new(0);
         let marker_path = parser_backup_ownership_sidecar(backup);
+        let marker_tmp = marker_path.with_extension(format!(
+            "owner.{}.{}.tmp",
+            std::process::id(),
+            MARKER_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
         let mut marker = fs::OpenOptions::new()
             .write(true)
             .create_new(true)
-            .open(&marker_path)?;
+            .open(&marker_tmp)?;
         if let Err(error) = marker.write_all(PARSER_BACKUP_MARKER_CONTENT) {
             drop(marker);
-            let _ = fs::remove_file(marker_path);
+            let _ = fs::remove_file(marker_tmp);
+            return Err(error);
+        }
+        if let Err(error) = marker.sync_all() {
+            drop(marker);
+            let _ = fs::remove_file(marker_tmp);
+            return Err(error);
+        }
+        drop(marker);
+        if let Err(error) = fs::rename(&marker_tmp, &marker_path) {
+            let _ = fs::remove_file(marker_tmp);
             return Err(error);
         }
         Ok(())

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -22,6 +22,64 @@ use super::metadata::{FetchOptions, MetadataError, fetch_parser_metadata};
 const ARCHIVE_HTTP_TIMEOUT: Duration = Duration::from_secs(120);
 const PARSER_OPERATION_MARKER_SUFFIX: &str = ".operation";
 
+#[cfg(any(windows, test))]
+trait ParserFileOps {
+    fn rename(&mut self, from: &Path, to: &Path) -> std::io::Result<()>;
+    fn remove_file(&mut self, path: &Path) -> std::io::Result<()>;
+}
+
+#[cfg(any(windows, test))]
+fn publish_parser_transactionally(
+    ops: &mut impl ParserFileOps,
+    tmp_file: &Path,
+    parser_file: &Path,
+    backup_file: &Path,
+) -> std::io::Result<()> {
+    let had_old_parser = match ops.rename(parser_file, backup_file) {
+        Ok(()) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => return Err(error),
+    };
+
+    match ops.rename(tmp_file, parser_file) {
+        Ok(()) => {
+            if had_old_parser {
+                ops.remove_file(backup_file)?;
+            }
+            Ok(())
+        }
+        Err(publish_error) => {
+            if !had_old_parser {
+                return Err(publish_error);
+            }
+            match ops.rename(backup_file, parser_file) {
+                Ok(()) => Err(publish_error),
+                Err(rollback_error) => Err(std::io::Error::new(
+                    rollback_error.kind(),
+                    format!(
+                        "failed to publish parser: {publish_error}; failed to restore backup '{}': {rollback_error}",
+                        backup_file.display()
+                    ),
+                )),
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+struct StdParserFileOps;
+
+#[cfg(windows)]
+impl ParserFileOps for StdParserFileOps {
+    fn rename(&mut self, from: &Path, to: &Path) -> std::io::Result<()> {
+        fs::rename(from, to)
+    }
+
+    fn remove_file(&mut self, path: &Path) -> std::io::Result<()> {
+        fs::remove_file(path)
+    }
+}
+
 /// Error types for parser installation.
 #[derive(Debug)]
 pub enum ParserInstallError {
@@ -1084,10 +1142,62 @@ fn invalid_metadata(message: String) -> ParserInstallError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use tempfile::tempdir;
 
     const TREE_SITTER_JSON_URL: &str =
         "https://github.com/tree-sitter/tree-sitter-json/archive/v0.24.8.tar.gz";
+
+    #[derive(Default)]
+    struct FakeParserFileOps {
+        files: HashMap<PathBuf, &'static str>,
+        fail_rename: Option<(PathBuf, PathBuf)>,
+    }
+
+    impl ParserFileOps for FakeParserFileOps {
+        fn rename(&mut self, from: &Path, to: &Path) -> std::io::Result<()> {
+            if self
+                .fail_rename
+                .as_ref()
+                .is_some_and(|(fail_from, fail_to)| fail_from == from && fail_to == to)
+            {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "injected publish failure",
+                ));
+            }
+            let value = self.files.remove(from).ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::NotFound, "missing source")
+            })?;
+            self.files.insert(to.to_path_buf(), value);
+            Ok(())
+        }
+
+        fn remove_file(&mut self, path: &Path) -> std::io::Result<()> {
+            self.files
+                .remove(path)
+                .map(|_| ())
+                .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "missing file"))
+        }
+    }
+
+    #[test]
+    fn transactional_publish_restores_old_parser_when_publish_fails() {
+        let tmp = PathBuf::from("parser.tmp");
+        let parser = PathBuf::from("parser.dll");
+        let backup = PathBuf::from("parser.backup");
+        let mut ops = FakeParserFileOps::default();
+        ops.files.insert(tmp.clone(), "new");
+        ops.files.insert(parser.clone(), "old");
+        ops.fail_rename = Some((tmp.clone(), parser.clone()));
+
+        let error = publish_parser_transactionally(&mut ops, &tmp, &parser, &backup)
+            .expect_err("injected publish failure must be reported");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert_eq!(ops.files.get(&parser), Some(&"old"));
+        assert!(!ops.files.contains_key(&backup));
+    }
 
     #[test]
     fn install_parser_rejects_unsafe_language_name() {

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -44,7 +44,27 @@ fn publish_parser_transactionally(
     match ops.rename(tmp_file, parser_file) {
         Ok(()) => {
             if had_old_parser {
-                ops.remove_file(backup_file)?;
+                if let Err(cleanup_error) = ops.remove_file(backup_file) {
+                    if let Err(unpublish_error) = ops.rename(parser_file, tmp_file) {
+                        return Err(std::io::Error::new(
+                            unpublish_error.kind(),
+                            format!(
+                                "failed to remove parser backup '{}': {cleanup_error}; failed to unpublish replacement: {unpublish_error}",
+                                backup_file.display()
+                            ),
+                        ));
+                    }
+                    if let Err(rollback_error) = ops.rename(backup_file, parser_file) {
+                        return Err(std::io::Error::new(
+                            rollback_error.kind(),
+                            format!(
+                                "failed to remove parser backup '{}': {cleanup_error}; failed to restore backup: {rollback_error}",
+                                backup_file.display()
+                            ),
+                        ));
+                    }
+                    return Err(cleanup_error);
+                }
             }
             Ok(())
         }
@@ -1152,6 +1172,7 @@ mod tests {
     struct FakeParserFileOps {
         files: HashMap<PathBuf, &'static str>,
         failed_renames: Vec<(PathBuf, PathBuf)>,
+        failed_removals: Vec<PathBuf>,
     }
 
     impl ParserFileOps for FakeParserFileOps {
@@ -1174,6 +1195,12 @@ mod tests {
         }
 
         fn remove_file(&mut self, path: &Path) -> std::io::Result<()> {
+            if self.failed_removals.iter().any(|failed| failed == path) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "injected cleanup failure",
+                ));
+            }
             self.files
                 .remove(path)
                 .map(|_| ())
@@ -1234,6 +1261,25 @@ mod tests {
         assert_eq!(ops.files.get(&backup), Some(&"old"));
         assert_eq!(ops.files.get(&tmp), Some(&"new"));
         assert!(!ops.files.contains_key(&parser));
+    }
+
+    #[test]
+    fn transactional_publish_restores_old_parser_when_backup_cleanup_fails() {
+        let tmp = PathBuf::from("parser.tmp");
+        let parser = PathBuf::from("parser.dll");
+        let backup = PathBuf::from("parser.backup");
+        let mut ops = FakeParserFileOps::default();
+        ops.files.insert(tmp.clone(), "new");
+        ops.files.insert(parser.clone(), "old");
+        ops.failed_removals.push(backup.clone());
+
+        let error = publish_parser_transactionally(&mut ops, &tmp, &parser, &backup)
+            .expect_err("backup cleanup failure must fail the transaction");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert_eq!(ops.files.get(&parser), Some(&"old"));
+        assert_eq!(ops.files.get(&tmp), Some(&"new"));
+        assert!(!ops.files.contains_key(&backup));
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -139,6 +139,16 @@ impl ParserFileOps for StdParserFileOps {
     }
 
     fn create_backup_marker(&mut self, backup: &Path) -> std::io::Result<()> {
+        match fs::symlink_metadata(backup) {
+            Ok(_) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    format!("parser backup '{}' already exists", backup.display()),
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
         let marker_path = parser_backup_ownership_sidecar(backup);
         let marker_tmp = marker_path.with_extension(format!("owner.{}.tmp", ulid::Ulid::new()));
         let mut marker = fs::OpenOptions::new()
@@ -1603,7 +1613,10 @@ mod tests {
         }
 
         fn create_backup_marker(&mut self, backup: &Path) -> std::io::Result<()> {
-            if self.fail_marker_creation || !self.backup_markers.insert(backup.to_path_buf()) {
+            if self.files.contains_key(backup)
+                || self.fail_marker_creation
+                || !self.backup_markers.insert(backup.to_path_buf())
+            {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::AlreadyExists,
                     "injected marker collision",

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -32,6 +32,22 @@ trait ParserFileOps {
 }
 
 #[cfg(any(windows, test))]
+fn remove_published_backup_marker(
+    ops: &mut impl ParserFileOps,
+    backup_file: &Path,
+) -> std::io::Result<()> {
+    ops.remove_backup_marker(backup_file).map_err(|error| {
+        std::io::Error::new(
+            error.kind(),
+            format!(
+                "published parser but failed to remove backup marker '{}': {error}",
+                parser_backup_ownership_sidecar(backup_file).display()
+            ),
+        )
+    })
+}
+
+#[cfg(any(windows, test))]
 fn publish_parser_transactionally(
     ops: &mut impl ParserFileOps,
     tmp_file: &Path,
@@ -62,9 +78,9 @@ fn publish_parser_transactionally(
         Ok(()) => {
             if had_old_parser {
                 match ops.remove_file(backup_file) {
-                    Ok(()) => ops.remove_backup_marker(backup_file)?,
+                    Ok(()) => remove_published_backup_marker(ops, backup_file)?,
                     Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                        ops.remove_backup_marker(backup_file)?;
+                        remove_published_backup_marker(ops, backup_file)?;
                     }
                     Err(error) => {
                         return Err(std::io::Error::new(
@@ -1557,6 +1573,23 @@ mod tests {
             error.to_string().contains("parser.backup.owner"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn transactional_publish_identifies_marker_left_after_success() {
+        let tmp = PathBuf::from("parser.tmp");
+        let parser = PathBuf::from("parser.dll");
+        let backup = PathBuf::from("parser.backup");
+        let mut ops = FakeParserFileOps::default();
+        ops.files.insert(tmp.clone(), "new");
+        ops.files.insert(parser.clone(), "old");
+        ops.fail_marker_removal = true;
+
+        let error = publish_parser_transactionally(&mut ops, &tmp, &parser, &backup)
+            .expect_err("marker cleanup failure must identify published state");
+
+        assert!(error.to_string().contains("published parser"));
+        assert!(error.to_string().contains("parser.backup.owner"));
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -66,7 +66,8 @@ fn publish_parser_transactionally(
                 return Err(std::io::Error::new(
                     error.kind(),
                     format!(
-                        "failed to claim parser backup: {error}; failed to remove new ownership marker: {marker_error}"
+                        "failed to claim parser backup: {error}; failed to remove new ownership marker '{}': {marker_error}",
+                        parser_backup_ownership_sidecar(backup_file).display()
                     ),
                 ));
             }
@@ -1589,6 +1590,23 @@ mod tests {
             .expect_err("marker cleanup failure must identify published state");
 
         assert!(error.to_string().contains("published parser"));
+        assert!(error.to_string().contains("parser.backup.owner"));
+    }
+
+    #[test]
+    fn transactional_publish_identifies_marker_left_after_failed_claim() {
+        let tmp = PathBuf::from("parser.tmp");
+        let parser = PathBuf::from("parser.dll");
+        let backup = PathBuf::from("parser.backup");
+        let mut ops = FakeParserFileOps::default();
+        ops.files.insert(tmp.clone(), "new");
+        ops.files.insert(parser.clone(), "old");
+        ops.failed_renames.push((parser.clone(), backup.clone()));
+        ops.fail_marker_removal = true;
+
+        let error = publish_parser_transactionally(&mut ops, &tmp, &parser, &backup)
+            .expect_err("claim cleanup failure must identify marker");
+
         assert!(error.to_string().contains("parser.backup.owner"));
     }
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -568,11 +568,11 @@ fn cleanup_orphan_parser_backup_markers(parser_dir: &Path, language: &str) -> st
             }
         } else if kind == 1 {
             if parser_backup_marker_is_intent(&marker, &backup)?
-                && (!backup.try_exists()? || path_entry_exists(&canonical)?)
+                && (!path_entry_exists(&backup)? || path_entry_exists(&canonical)?)
             {
                 remove_parser_backup_marker(&backup)?;
             }
-        } else if parser_backup_marker_is_owned(&marker, &backup)? && !backup.try_exists()? {
+        } else if parser_backup_marker_is_owned(&marker, &backup)? && !path_entry_exists(&backup)? {
             remove_parser_backup_marker(&backup)?;
         }
     }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -311,11 +311,11 @@ fn recover_parser_backups(
     parser_dir: &Path,
     parser_file: &Path,
     language: &str,
-) -> std::io::Result<()> {
+) -> std::io::Result<bool> {
     cleanup_orphan_parser_backup_markers(parser_dir, language)?;
     let backups = parser_backup_files(parser_dir, language)?;
     if backups.is_empty() {
-        return Ok(());
+        return Ok(false);
     }
     if parser_file.try_exists()? {
         if !fs::metadata(parser_file)?.is_file() {
@@ -327,7 +327,7 @@ fn recover_parser_backups(
         for backup in backups {
             remove_owned_parser_backup(&backup)?;
         }
-        return Ok(());
+        return Ok(false);
     }
     let mut timed_backups = backups
         .into_iter()
@@ -343,7 +343,7 @@ fn recover_parser_backups(
     for (_, obsolete) in timed_backups {
         remove_owned_parser_backup(&obsolete)?;
     }
-    Ok(())
+    Ok(true)
 }
 
 /// Remove the canonical parser and every kakehashi-generated replacement backup.
@@ -435,8 +435,9 @@ pub struct ParserInstallResult {
     pub language: String,
     /// Path where parser was installed.
     pub install_path: PathBuf,
-    /// Git revision that was used.
-    pub revision: String,
+    /// Git revision that was used, or `None` when an interrupted replacement
+    /// was recovered without rebuilding from source.
+    pub revision: Option<String>,
 }
 
 /// How the parser source is compiled.
@@ -802,7 +803,17 @@ pub fn install_parser_after_operation_started(
 
     fs::create_dir_all(&parser_dir)?;
     #[cfg(windows)]
-    recover_parser_backups(&parser_dir, &parser_file, language)?;
+    let recovered = recover_parser_backups(&parser_dir, &parser_file, language)?;
+
+    #[cfg(windows)]
+    if recovered && !options.force {
+        return Ok(ParserInstallResult {
+            language: language.to_string(),
+            install_path: parser_file,
+            revision: None,
+        });
+    }
+
     let install_token = begin_parser_install(&parser_dir, &parser_file, language, options.force)?;
 
     // Fetch metadata (with caching support)
@@ -878,7 +889,7 @@ pub fn install_parser_after_operation_started(
     Ok(ParserInstallResult {
         language: language.to_string(),
         install_path: parser_file,
-        revision: metadata.revision,
+        revision: Some(metadata.revision),
     })
 }
 
@@ -1889,7 +1900,9 @@ mod tests {
         )
         .expect("mark owned backup");
 
-        recover_parser_backups(&parser_dir, &canonical, "lua").expect("recover parser backup");
+        assert!(
+            recover_parser_backups(&parser_dir, &canonical, "lua").expect("recover parser backup")
+        );
 
         assert_eq!(
             fs::read(&canonical).expect("read restored parser"),
@@ -1913,7 +1926,9 @@ mod tests {
         )
         .expect("mark owned backup");
 
-        recover_parser_backups(&parser_dir, &canonical, "lua").expect("clean parser backup");
+        assert!(
+            !recover_parser_backups(&parser_dir, &canonical, "lua").expect("clean parser backup")
+        );
 
         assert_eq!(fs::read(&canonical).expect("read canonical"), b"new parser");
         assert!(!backup.exists());

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -143,7 +143,7 @@ struct StdParserFileOps;
 
 #[cfg(windows)]
 fn write_marker_atomically(marker_path: &Path, content: &[u8]) -> std::io::Result<()> {
-    let marker_tmp = marker_path.with_extension(format!("owner.{}.tmp", ulid::Ulid::new()));
+    let marker_tmp = marker_staging_path(marker_path, ulid::Ulid::new());
     let mut marker = fs::OpenOptions::new()
         .write(true)
         .create_new(true)
@@ -159,6 +159,26 @@ fn write_marker_atomically(marker_path: &Path, content: &[u8]) -> std::io::Resul
         return Err(error);
     }
     Ok(())
+}
+
+#[cfg(any(windows, test))]
+fn marker_staging_path(marker: &Path, nonce: ulid::Ulid) -> PathBuf {
+    marker.with_file_name(format!(
+        "{}.{}.tmp",
+        marker
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(".parser.backup.owner"),
+        nonce
+    ))
+}
+
+fn path_entry_exists(path: &Path) -> std::io::Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
 }
 
 #[cfg(windows)]
@@ -384,7 +404,7 @@ pub fn owned_parser_backup_languages(parser_dir: &Path) -> std::io::Result<Vec<S
         let canonical =
             parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
         if parser_backup_marker_is_owned(&marker)?
-            || (!canonical.try_exists()?
+            || (!path_entry_exists(&canonical)?
                 && parser_backup_marker_is_intent(&parser_backup_intent_sidecar(&entry.path()))?)
         {
             languages.insert(language.to_owned());
@@ -412,10 +432,13 @@ fn cleanup_orphan_parser_backup_markers(parser_dir: &Path, language: &str) -> st
             (backup_name, 0_u8)
         } else if let Some(backup_name) = marker_name.strip_suffix(".owner.intent") {
             (backup_name, 1_u8)
-        } else if let Some((backup_name, nonce)) = marker_name
+        } else if let Some((prefix, nonce)) = marker_name
             .strip_suffix(".tmp")
-            .and_then(|name| name.rsplit_once(".owner."))
+            .and_then(|name| name.rsplit_once('.'))
             && ulid::Ulid::from_string(nonce).is_ok()
+            && let Some(backup_name) = prefix
+                .strip_suffix(".owner.intent")
+                .or_else(|| prefix.strip_suffix(".owner"))
         {
             (backup_name, 2_u8)
         } else {
@@ -436,7 +459,7 @@ fn cleanup_orphan_parser_backup_markers(parser_dir: &Path, language: &str) -> st
             }
         } else if kind == 1 {
             if parser_backup_marker_is_intent(&marker)?
-                && (!backup.try_exists()? || canonical.try_exists()?)
+                && (!backup.try_exists()? || path_entry_exists(&canonical)?)
             {
                 remove_parser_backup_marker(&backup)?;
             }
@@ -468,7 +491,7 @@ fn recover_parser_backups(
     if backups.is_empty() && intent_backups.is_empty() {
         return Ok(false);
     }
-    if parser_file.try_exists()? {
+    if path_entry_exists(parser_file)? {
         if !fs::metadata(parser_file)?.is_file() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
@@ -517,7 +540,7 @@ fn remove_parser_install_and_backups(parser_dir: &Path, language: &str) -> std::
     }
     cleanup_orphan_parser_backup_markers(parser_dir, language)?;
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
-    let canonical_exists = parser_file.try_exists()?;
+    let canonical_exists = path_entry_exists(&parser_file)?;
     // Remove recovery copies first. If uninstall is interrupted, leaving the
     // canonical parser is an incomplete uninstall that can be retried; deleting
     // canonical first could let the next install resurrect an old backup.
@@ -923,7 +946,7 @@ pub fn remove_parser_install_after_operation_started(
     writeln!(marker, "uninstall:{}", ulid::Ulid::new())?;
     cleanup_orphan_parser_backup_markers(parser_dir, language)?;
     let parser_file = parser_dir.join(format!("{language}.{}", std::env::consts::DLL_EXTENSION));
-    let canonical_exists = parser_file.try_exists()?;
+    let canonical_exists = path_entry_exists(&parser_file)?;
     // Delete recovery copies first so an interrupted uninstall cannot leave a
     // backup that a later install would restore after canonical removal.
     let mut removed = false;
@@ -2219,6 +2242,31 @@ mod tests {
         assert!(!parser_backup_intent_sidecar(&backup).exists());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn parser_recovery_preserves_intent_backup_beside_dangling_canonical_symlink() {
+        use std::os::unix::fs::symlink;
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let canonical = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        let backup = parser_dir.join(generated_backup_name("lua", 123, 11));
+        symlink(parser_dir.join("missing-target"), &canonical).expect("create dangling canonical");
+        fs::write(&backup, b"unrelated").expect("write colliding backup");
+        fs::write(
+            parser_backup_intent_sidecar(&backup),
+            PARSER_BACKUP_INTENT_CONTENT,
+        )
+        .expect("write intent");
+
+        assert!(
+            !recover_parser_backups(&parser_dir, &canonical, "lua")
+                .expect("dangling canonical entry preserves collision")
+        );
+        assert_eq!(fs::read(&backup).expect("preserve collision"), b"unrelated");
+        assert!(!parser_backup_intent_sidecar(&backup).exists());
+    }
+
     #[test]
     fn parser_recovery_removes_obsolete_backup_when_canonical_exists() {
         let temp = tempdir().expect("temp dir");
@@ -2275,17 +2323,26 @@ mod tests {
         let owned_marker = parser_backup_ownership_sidecar(&owned_backup);
         let user_backup = parser_dir.join(generated_backup_name("lua", 123, 5));
         let user_marker = parser_backup_ownership_sidecar(&user_backup);
-        let staged_marker = parser_backup_ownership_sidecar(&owned_backup)
-            .with_extension(format!("owner.{}.tmp", ulid::Ulid::new()));
+        let staged_marker = marker_staging_path(
+            &parser_backup_ownership_sidecar(&owned_backup),
+            ulid::Ulid::new(),
+        );
         let malformed_staging =
-            parser_backup_ownership_sidecar(&owned_backup).with_extension("owner.not-a-ulid.tmp");
+            parser_backup_ownership_sidecar(&owned_backup).with_file_name(format!(
+                "{}.not-a-ulid.tmp",
+                owned_marker.file_name().unwrap().to_string_lossy()
+            ));
         let colliding_backup = parser_dir.join(generated_backup_name("lua", 123, 6));
-        let colliding_staging = parser_backup_ownership_sidecar(&colliding_backup)
-            .with_extension(format!("owner.{}.tmp", ulid::Ulid::new()));
+        let colliding_staging = marker_staging_path(
+            &parser_backup_ownership_sidecar(&colliding_backup),
+            ulid::Ulid::new(),
+        );
         let orphan_intent_backup = parser_dir.join(generated_backup_name("lua", 123, 10));
         let orphan_intent = parser_backup_intent_sidecar(&orphan_intent_backup);
-        let staged_intent = parser_backup_ownership_sidecar(&owned_backup)
-            .with_extension(format!("owner.{}.tmp", ulid::Ulid::new()));
+        let staged_intent = marker_staging_path(
+            &parser_backup_intent_sidecar(&owned_backup),
+            ulid::Ulid::new(),
+        );
         fs::write(&owned_marker, PARSER_BACKUP_MARKER_CONTENT).expect("write owned marker");
         fs::write(&user_marker, b"user marker").expect("write user marker");
         fs::write(&staged_marker, PARSER_BACKUP_MARKER_CONTENT).expect("write staged marker");

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -313,7 +313,15 @@ fn cleanup_orphan_parser_backup_markers(parser_dir: &Path, language: &str) -> st
         let Some(marker_name) = marker.file_name().and_then(|name| name.to_str()) else {
             continue;
         };
-        let Some(backup_name) = marker_name.strip_suffix(".owner") else {
+        let (backup_name, staged) = if let Some(backup_name) = marker_name.strip_suffix(".owner") {
+            (backup_name, false)
+        } else if let Some((backup_name, nonce)) = marker_name
+            .strip_suffix(".tmp")
+            .and_then(|name| name.rsplit_once(".owner."))
+            && ulid::Ulid::from_string(nonce).is_ok()
+        {
+            (backup_name, true)
+        } else {
             continue;
         };
         if !generated_parser_backup_matches_language(backup_name, language) {
@@ -321,7 +329,15 @@ fn cleanup_orphan_parser_backup_markers(parser_dir: &Path, language: &str) -> st
         }
         let backup = parser_dir.join(backup_name);
         if !backup.try_exists()? && parser_backup_marker_is_owned(&marker)? {
-            remove_parser_backup_marker(&backup)?;
+            if staged {
+                match fs::remove_file(marker) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => return Err(error),
+                }
+            } else {
+                remove_parser_backup_marker(&backup)?;
+            }
         }
     }
     Ok(())
@@ -2023,12 +2039,21 @@ mod tests {
         let owned_marker = parser_backup_ownership_sidecar(&owned_backup);
         let user_backup = parser_dir.join(generated_backup_name("lua", 123, 5));
         let user_marker = parser_backup_ownership_sidecar(&user_backup);
+        let staged_marker = parser_backup_ownership_sidecar(&owned_backup)
+            .with_extension(format!("owner.{}.tmp", ulid::Ulid::new()));
+        let malformed_staging =
+            parser_backup_ownership_sidecar(&owned_backup).with_extension("owner.not-a-ulid.tmp");
         fs::write(&owned_marker, PARSER_BACKUP_MARKER_CONTENT).expect("write owned marker");
         fs::write(&user_marker, b"user marker").expect("write user marker");
+        fs::write(&staged_marker, PARSER_BACKUP_MARKER_CONTENT).expect("write staged marker");
+        fs::write(&malformed_staging, PARSER_BACKUP_MARKER_CONTENT)
+            .expect("write malformed staging marker");
 
         recover_parser_backups(&parser_dir, &canonical, "lua").expect("clean orphan markers");
 
         assert!(!owned_marker.exists());
+        assert!(!staged_marker.exists());
+        assert!(malformed_staging.exists());
         assert!(user_marker.exists());
         assert!(!canonical.exists());
     }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -328,14 +328,14 @@ fn cleanup_orphan_parser_backup_markers(parser_dir: &Path, language: &str) -> st
             continue;
         }
         let backup = parser_dir.join(backup_name);
-        if !backup.try_exists()? && parser_backup_marker_is_owned(&marker)? {
+        if parser_backup_marker_is_owned(&marker)? {
             if staged {
                 match fs::remove_file(marker) {
                     Ok(()) => {}
                     Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
                     Err(error) => return Err(error),
                 }
-            } else {
+            } else if !backup.try_exists()? {
                 remove_parser_backup_marker(&backup)?;
             }
         }
@@ -2043,16 +2043,24 @@ mod tests {
             .with_extension(format!("owner.{}.tmp", ulid::Ulid::new()));
         let malformed_staging =
             parser_backup_ownership_sidecar(&owned_backup).with_extension("owner.not-a-ulid.tmp");
+        let colliding_backup = parser_dir.join(generated_backup_name("lua", 123, 6));
+        let colliding_staging = parser_backup_ownership_sidecar(&colliding_backup)
+            .with_extension(format!("owner.{}.tmp", ulid::Ulid::new()));
         fs::write(&owned_marker, PARSER_BACKUP_MARKER_CONTENT).expect("write owned marker");
         fs::write(&user_marker, b"user marker").expect("write user marker");
         fs::write(&staged_marker, PARSER_BACKUP_MARKER_CONTENT).expect("write staged marker");
         fs::write(&malformed_staging, PARSER_BACKUP_MARKER_CONTENT)
             .expect("write malformed staging marker");
+        fs::write(&colliding_backup, b"user backup").expect("write colliding backup");
+        fs::write(&colliding_staging, PARSER_BACKUP_MARKER_CONTENT)
+            .expect("write colliding staging marker");
 
         recover_parser_backups(&parser_dir, &canonical, "lua").expect("clean orphan markers");
 
         assert!(!owned_marker.exists());
         assert!(!staged_marker.exists());
+        assert!(!colliding_staging.exists());
+        assert!(colliding_backup.exists());
         assert!(malformed_staging.exists());
         assert!(user_marker.exists());
         assert!(!canonical.exists());

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -30,6 +30,7 @@ trait ParserFileOps {
     fn remove_file(&mut self, path: &Path) -> std::io::Result<()>;
     fn create_backup_marker(&mut self, backup: &Path) -> std::io::Result<()>;
     fn finalize_backup_marker(&mut self, backup: &Path) -> std::io::Result<()>;
+    fn remove_intent_marker(&mut self, backup: &Path) -> std::io::Result<()>;
     fn remove_backup_marker(&mut self, backup: &Path) -> std::io::Result<()>;
 }
 
@@ -60,11 +61,11 @@ fn publish_parser_transactionally(
     let had_old_parser = match ops.rename(parser_file, backup_file) {
         Ok(()) => true,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            ops.remove_backup_marker(backup_file)?;
+            ops.remove_intent_marker(backup_file)?;
             false
         }
         Err(error) => {
-            if let Err(marker_error) = ops.remove_backup_marker(backup_file) {
+            if let Err(marker_error) = ops.remove_intent_marker(backup_file) {
                 return Err(std::io::Error::new(
                     error.kind(),
                     format!(
@@ -80,7 +81,7 @@ fn publish_parser_transactionally(
     if had_old_parser && let Err(finalize_error) = ops.finalize_backup_marker(backup_file) {
         let rollback = ops.rename(backup_file, parser_file);
         let cleanup = if rollback.is_ok() {
-            Some(ops.remove_backup_marker(backup_file))
+            Some(ops.remove_intent_marker(backup_file))
         } else {
             // Keep intent/final ownership discoverable when the working parser
             // remains stranded at the backup path.
@@ -245,21 +246,32 @@ impl ParserFileOps for StdParserFileOps {
             &parser_backup_ownership_sidecar(backup),
             PARSER_BACKUP_MARKER_CONTENT,
         )?;
-        fs::remove_file(parser_backup_intent_sidecar(backup))
+        if let Err(error) = fs::remove_file(parser_backup_intent_sidecar(backup)) {
+            let final_cleanup = fs::remove_file(parser_backup_ownership_sidecar(backup));
+            return Err(std::io::Error::new(
+                error.kind(),
+                format!(
+                    "failed to remove backup intent: {error}; finalized marker cleanup: {final_cleanup:?}"
+                ),
+            ));
+        }
+        Ok(())
     }
 
     fn remove_backup_marker(&mut self, backup: &Path) -> std::io::Result<()> {
-        for marker in [
-            parser_backup_ownership_sidecar(backup),
-            parser_backup_intent_sidecar(backup),
-        ] {
-            match fs::remove_file(marker) {
-                Ok(()) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) => return Err(error),
-            }
+        match fs::remove_file(parser_backup_ownership_sidecar(backup)) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
         }
-        Ok(())
+    }
+
+    fn remove_intent_marker(&mut self, backup: &Path) -> std::io::Result<()> {
+        match fs::remove_file(parser_backup_intent_sidecar(backup)) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
     }
 }
 
@@ -1820,8 +1832,18 @@ mod tests {
                     "injected marker cleanup failure",
                 ));
             }
-            self.backup_markers.remove(backup);
             self.finalized_backup_markers.remove(backup);
+            Ok(())
+        }
+
+        fn remove_intent_marker(&mut self, backup: &Path) -> std::io::Result<()> {
+            if self.fail_marker_removal {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "injected marker cleanup failure",
+                ));
+            }
+            self.backup_markers.remove(backup);
             Ok(())
         }
 
@@ -1830,6 +1852,12 @@ mod tests {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::PermissionDenied,
                     "injected marker finalization failure",
+                ));
+            }
+            if self.finalized_backup_markers.contains(backup) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    "injected finalized marker collision",
                 ));
             }
             if !self.backup_markers.remove(backup) {
@@ -2062,6 +2090,25 @@ mod tests {
         assert_eq!(ops.files.get(&parser), Some(&"old"));
         assert!(!ops.files.contains_key(&backup));
         assert!(ops.backup_markers.contains(&backup));
+    }
+
+    #[test]
+    fn transactional_publish_preserves_colliding_finalized_sidecar() {
+        let tmp = PathBuf::from("parser.tmp");
+        let parser = PathBuf::from("parser.dll");
+        let backup = PathBuf::from("parser.backup");
+        let mut ops = FakeParserFileOps::default();
+        ops.files.insert(tmp.clone(), "new");
+        ops.files.insert(parser.clone(), "old");
+        ops.finalized_backup_markers.insert(backup.clone());
+
+        publish_parser_transactionally(&mut ops, &tmp, &parser, &backup)
+            .expect_err("finalized sidecar collision must abort");
+
+        assert_eq!(ops.files.get(&parser), Some(&"old"));
+        assert!(!ops.files.contains_key(&backup));
+        assert!(ops.finalized_backup_markers.contains(&backup));
+        assert!(!ops.backup_markers.contains(&backup));
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -1755,6 +1755,22 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn owned_parser_backup_languages_propagates_marker_read_error() {
+        use std::os::unix::fs::symlink;
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let backup = parser_dir.join(generated_backup_name("lua", 123, 4));
+        let marker = parser_backup_ownership_sidecar(&backup);
+        fs::write(&backup, b"parser").expect("write backup");
+        symlink(&marker, &marker).expect("create marker symlink loop");
+
+        owned_parser_backup_languages(&parser_dir)
+            .expect_err("uninspectable ownership marker must abort discovery");
+    }
+
     #[test]
     fn parser_uninstall_removes_owned_backups_only() {
         let temp = tempdir().expect("temp dir");

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -24,6 +24,27 @@ const PARSER_OPERATION_MARKER_SUFFIX: &str = ".operation";
 const PARSER_BACKUP_INTENT_CONTENT: &[u8] = b"kakehashi parser backup intent v1\n";
 const PARSER_BACKUP_MARKER_CONTENT: &[u8] = b"kakehashi parser backup owned v1\n";
 
+fn parser_backup_transaction_id(backup: &Path) -> Option<&str> {
+    backup
+        .file_name()?
+        .to_str()?
+        .strip_suffix(".backup")?
+        .rsplit_once('.')
+        .and_then(|(_, nonce)| ulid::Ulid::from_string(nonce).ok().map(|_| nonce))
+}
+
+fn parser_backup_marker_content(backup: &Path, finalized: bool) -> Vec<u8> {
+    match parser_backup_transaction_id(backup) {
+        Some(transaction) => format!(
+            "kakehashi parser backup {} v2 {transaction}\n",
+            if finalized { "owned" } else { "intent" }
+        )
+        .into_bytes(),
+        None if finalized => PARSER_BACKUP_MARKER_CONTENT.to_vec(),
+        None => PARSER_BACKUP_INTENT_CONTENT.to_vec(),
+    }
+}
+
 #[cfg(any(windows, test))]
 trait ParserFileOps {
     fn rename(&mut self, from: &Path, to: &Path) -> std::io::Result<()>;
@@ -219,6 +240,17 @@ fn publish_marker_no_replace(from: &Path, to: &Path) -> std::io::Result<()> {
     fs::remove_file(from)
 }
 
+#[cfg(windows)]
+fn restore_backup_no_replace(from: &Path, to: &Path) -> std::io::Result<()> {
+    move_file_no_replace(from, to)
+}
+
+#[cfg(all(test, not(windows)))]
+fn restore_backup_no_replace(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::hard_link(from, to)?;
+    fs::remove_file(from)
+}
+
 #[cfg(any(windows, test))]
 fn marker_staging_path(marker: &Path, nonce: ulid::Ulid) -> PathBuf {
     marker.with_file_name(format!(
@@ -262,14 +294,14 @@ impl ParserFileOps for StdParserFileOps {
         }
         write_marker_atomically(
             &parser_backup_intent_sidecar(backup),
-            PARSER_BACKUP_INTENT_CONTENT,
+            &parser_backup_marker_content(backup, false),
         )
     }
 
     fn finalize_backup_marker(&mut self, backup: &Path) -> std::io::Result<()> {
         write_marker_atomically(
             &parser_backup_ownership_sidecar(backup),
-            PARSER_BACKUP_MARKER_CONTENT,
+            &parser_backup_marker_content(backup, true),
         )?;
         if let Err(error) = fs::remove_file(parser_backup_intent_sidecar(backup)) {
             let final_cleanup = fs::remove_file(parser_backup_ownership_sidecar(backup));
@@ -308,6 +340,12 @@ fn parser_backup_language(name: &str) -> Option<&str> {
     let stem = name
         .strip_prefix('.')
         .and_then(|name| name.strip_suffix(".backup"))?;
+    // Current backups carry an unpredictable transaction identity. Continue
+    // accepting the legacy PID/counter shape so upgrades can recover it.
+    let stem = stem
+        .rsplit_once('.')
+        .filter(|(_, nonce)| ulid::Ulid::from_string(nonce).is_ok())
+        .map_or(stem, |(prefix, _)| prefix);
     let stem = stem.strip_suffix(&format!(".{}", std::env::consts::DLL_EXTENSION))?;
     let (prefix, counter) = stem.rsplit_once('.')?;
     let (backup_language, pid) = prefix.rsplit_once('.')?;
@@ -398,12 +436,12 @@ fn parser_backup_marker_has_content(marker: &Path, expected: &[u8]) -> std::io::
     Ok(content == expected)
 }
 
-fn parser_backup_marker_is_owned(marker: &Path) -> std::io::Result<bool> {
-    parser_backup_marker_has_content(marker, PARSER_BACKUP_MARKER_CONTENT)
+fn parser_backup_marker_is_owned(marker: &Path, backup: &Path) -> std::io::Result<bool> {
+    parser_backup_marker_has_content(marker, &parser_backup_marker_content(backup, true))
 }
 
-fn parser_backup_marker_is_intent(marker: &Path) -> std::io::Result<bool> {
-    parser_backup_marker_has_content(marker, PARSER_BACKUP_INTENT_CONTENT)
+fn parser_backup_marker_is_intent(marker: &Path, backup: &Path) -> std::io::Result<bool> {
+    parser_backup_marker_has_content(marker, &parser_backup_marker_content(backup, false))
 }
 
 fn parser_backup_files(parser_dir: &Path, language: &str) -> std::io::Result<Vec<PathBuf>> {
@@ -424,7 +462,10 @@ fn parser_backup_files(parser_dir: &Path, language: &str) -> std::io::Result<Vec
         {
             continue;
         }
-        if parser_backup_marker_is_owned(&parser_backup_ownership_sidecar(&entry.path()))? {
+        if parser_backup_marker_is_owned(
+            &parser_backup_ownership_sidecar(&entry.path()),
+            &entry.path(),
+        )? {
             backups.push(entry.path());
         }
     }
@@ -444,7 +485,10 @@ fn parser_backup_intent_files(parser_dir: &Path, language: &str) -> std::io::Res
         let Some(name) = name.to_str() else { continue };
         if entry.file_type()?.is_file()
             && generated_parser_backup_matches_language(name, language)
-            && parser_backup_marker_is_intent(&parser_backup_intent_sidecar(&entry.path()))?
+            && parser_backup_marker_is_intent(
+                &parser_backup_intent_sidecar(&entry.path()),
+                &entry.path(),
+            )?
         {
             backups.push(entry.path());
         }
@@ -472,9 +516,12 @@ pub fn owned_parser_backup_languages(parser_dir: &Path) -> std::io::Result<Vec<S
         let marker = parser_backup_ownership_sidecar(&entry.path());
         let canonical =
             parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
-        if parser_backup_marker_is_owned(&marker)?
+        if parser_backup_marker_is_owned(&marker, &entry.path())?
             || (!path_entry_exists(&canonical)?
-                && parser_backup_marker_is_intent(&parser_backup_intent_sidecar(&entry.path()))?)
+                && parser_backup_marker_is_intent(
+                    &parser_backup_intent_sidecar(&entry.path()),
+                    &entry.path(),
+                )?)
         {
             languages.insert(language.to_owned());
         }
@@ -519,7 +566,9 @@ fn cleanup_orphan_parser_backup_markers(parser_dir: &Path, language: &str) -> st
         let backup = parser_dir.join(backup_name);
         let canonical = parser_dir.join(format!("{language}.{}", std::env::consts::DLL_EXTENSION));
         if kind == 2 {
-            if parser_backup_marker_is_owned(&marker)? || parser_backup_marker_is_intent(&marker)? {
+            if parser_backup_marker_is_owned(&marker, &backup)?
+                || parser_backup_marker_is_intent(&marker, &backup)?
+            {
                 match fs::remove_file(marker) {
                     Ok(()) => {}
                     Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
@@ -527,12 +576,12 @@ fn cleanup_orphan_parser_backup_markers(parser_dir: &Path, language: &str) -> st
                 }
             }
         } else if kind == 1 {
-            if parser_backup_marker_is_intent(&marker)?
+            if parser_backup_marker_is_intent(&marker, &backup)?
                 && (!backup.try_exists()? || path_entry_exists(&canonical)?)
             {
                 remove_parser_backup_marker(&backup)?;
             }
-        } else if parser_backup_marker_is_owned(&marker)? && !backup.try_exists()? {
+        } else if parser_backup_marker_is_owned(&marker, &backup)? && !backup.try_exists()? {
             remove_parser_backup_marker(&backup)?;
         }
     }
@@ -554,6 +603,8 @@ fn recover_parser_backups(
     parser_file: &Path,
     language: &str,
 ) -> std::io::Result<bool> {
+    let _replace_lock = ParserReplaceLockGuard::acquire(parser_dir, language)
+        .map_err(|error| std::io::Error::other(error.to_string()))?;
     cleanup_orphan_parser_backup_markers(parser_dir, language)?;
     let mut backups = parser_backup_files(parser_dir, language)?;
     let intent_backups = parser_backup_intent_files(parser_dir, language)?;
@@ -587,7 +638,7 @@ fn recover_parser_backups(
         .collect::<std::io::Result<Vec<_>>>()?;
     timed_backups.sort_by_key(|(modified, _)| *modified);
     let (_, restore) = timed_backups.pop().expect("non-empty parser backup list");
-    fs::rename(&restore, parser_file)?;
+    restore_backup_no_replace(&restore, parser_file)?;
     remove_parser_backup_marker(&restore)?;
     for (_, obsolete) in timed_backups {
         remove_owned_parser_backup(&obsolete)?;
@@ -959,7 +1010,7 @@ fn publish_compiled_parser(
     let published = fs::rename(tmp_file, parser_file);
     #[cfg(windows)]
     let published = {
-        let backup_file = tmp_file.with_extension("backup");
+        let backup_file = tmp_file.with_extension(format!("{}.backup", ulid::Ulid::new()));
         publish_parser_transactionally(&mut StdParserFileOps, tmp_file, parser_file, &backup_file)
     };
     if let Err(e) = published {
@@ -1763,6 +1814,21 @@ mod tests {
         assert_eq!(fs::read_dir(temp.path()).expect("list temp").count(), 1);
     }
 
+    #[test]
+    fn backup_restore_preserves_new_canonical_destination() {
+        let temp = tempdir().expect("temp dir");
+        let backup = temp.path().join("backup.dll");
+        let canonical = temp.path().join("canonical.dll");
+        fs::write(&backup, b"old").expect("write backup");
+        fs::write(&canonical, b"new").expect("write canonical");
+
+        restore_backup_no_replace(&backup, &canonical)
+            .expect_err("restore must reject new canonical");
+
+        assert_eq!(fs::read(&backup).expect("read backup"), b"old");
+        assert_eq!(fs::read(&canonical).expect("read canonical"), b"new");
+    }
+
     #[cfg(windows)]
     #[test]
     fn atomic_marker_publish_supports_long_windows_paths() {
@@ -2213,10 +2279,28 @@ mod tests {
         )
     }
 
+    fn generated_backup_name_with_transaction(
+        language: &str,
+        pid: u32,
+        counter: usize,
+        transaction: ulid::Ulid,
+    ) -> String {
+        format!(
+            ".{language}.{pid}.{counter}.{}.{transaction}.backup",
+            std::env::consts::DLL_EXTENSION
+        )
+    }
+
     #[test]
     fn parser_backup_matching_rejects_other_or_user_files() {
         let owned = generated_backup_name("lua", 123, 4);
+        let transactional =
+            generated_backup_name_with_transaction("lua", 123, 4, ulid::Ulid::new());
         assert!(generated_parser_backup_matches_language(&owned, "lua"));
+        assert!(generated_parser_backup_matches_language(
+            &transactional,
+            "lua"
+        ));
         assert!(!generated_parser_backup_matches_language(&owned, "rust"));
         assert!(!generated_parser_backup_matches_language(
             ".lua.manual.dylib.backup",
@@ -2278,6 +2362,37 @@ mod tests {
         assert!(
             owned_parser_backup_languages(&parser_dir)
                 .expect("collision is not owned")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn owned_parser_backup_languages_rejects_stale_transaction_marker() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let stale = parser_dir.join(generated_backup_name_with_transaction(
+            "lua",
+            123,
+            1,
+            ulid::Ulid::new(),
+        ));
+        let replacement = parser_dir.join(generated_backup_name_with_transaction(
+            "lua",
+            123,
+            1,
+            ulid::Ulid::new(),
+        ));
+        fs::write(&replacement, b"replacement").expect("write replacement");
+        fs::write(
+            parser_backup_ownership_sidecar(&replacement),
+            parser_backup_marker_content(&stale, true),
+        )
+        .expect("write stale marker");
+
+        assert!(
+            owned_parser_backup_languages(&parser_dir)
+                .expect("inspect stale marker")
                 .is_empty()
         );
     }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -256,7 +256,7 @@ fn recover_parser_backups(
     language: &str,
 ) -> std::io::Result<()> {
     cleanup_orphan_parser_backup_markers(parser_dir, language)?;
-    let mut backups = parser_backup_files(parser_dir, language)?;
+    let backups = parser_backup_files(parser_dir, language)?;
     if backups.is_empty() {
         return Ok(());
     }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -180,18 +180,21 @@ fn publish_marker_no_replace(from: &Path, to: &Path) -> std::io::Result<()> {
 fn windows_verbatim_path(path: &Path) -> std::io::Result<Vec<u16>> {
     use std::os::windows::ffi::OsStrExt;
     let absolute = std::path::absolute(path)?;
-    let text = absolute.as_os_str().to_string_lossy();
-    let verbatim = if text.starts_with(r"\\?\") {
-        text.into_owned()
-    } else if let Some(unc) = text.strip_prefix(r"\\") {
-        format!(r"\\?\UNC\{unc}")
-    } else {
-        format!(r"\\?\{text}")
-    };
-    Ok(std::ffi::OsStr::new(&verbatim)
-        .encode_wide()
-        .chain(Some(0))
-        .collect())
+    let encoded: Vec<u16> = absolute.as_os_str().encode_wide().collect();
+    let mut verbatim =
+        if encoded.starts_with(&[b'\\' as u16, b'\\' as u16, b'?' as u16, b'\\' as u16]) {
+            encoded
+        } else if encoded.starts_with(&[b'\\' as u16, b'\\' as u16]) {
+            let mut path: Vec<u16> = r"\\?\UNC\".encode_utf16().collect();
+            path.extend_from_slice(&encoded[2..]);
+            path
+        } else {
+            let mut path: Vec<u16> = r"\\?\".encode_utf16().collect();
+            path.extend(encoded);
+            path
+        };
+    verbatim.push(0);
+    Ok(verbatim)
 }
 
 #[cfg(windows)]
@@ -1776,6 +1779,31 @@ mod tests {
 
         assert_eq!(
             fs::read(marker).expect("read long marker"),
+            PARSER_BACKUP_INTENT_CONTENT
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn atomic_marker_publish_preserves_non_unicode_windows_path() {
+        use std::os::windows::ffi::OsStringExt;
+        let temp = tempdir().expect("temp dir");
+        let component = std::ffi::OsString::from_wide(&[
+            b'm' as u16,
+            b'a' as u16,
+            b'r' as u16,
+            b'k' as u16,
+            0xD800,
+        ]);
+        let directory = temp.path().join(component);
+        fs::create_dir(&directory).expect("create non-Unicode directory");
+        let marker = directory.join("backup.owner");
+
+        write_marker_atomically(&marker, PARSER_BACKUP_INTENT_CONTENT)
+            .expect("publish non-Unicode marker");
+
+        assert_eq!(
+            fs::read(marker).expect("read marker"),
             PARSER_BACKUP_INTENT_CONTENT
         );
     }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -612,7 +612,8 @@ fn recover_parser_backups(
         return Ok(false);
     }
     if path_entry_exists(parser_file)? {
-        if !fs::metadata(parser_file)?.is_file() {
+        let canonical_is_file = fs::symlink_metadata(parser_file)?.file_type().is_file();
+        if !canonical_is_file && !backups.is_empty() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!("parser path '{}' is not a file", parser_file.display()),
@@ -2568,12 +2569,17 @@ mod tests {
         let parser_dir = temp.path().join("parser");
         fs::create_dir_all(&parser_dir).expect("create parser dir");
         let canonical = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
-        let backup = parser_dir.join(generated_backup_name("lua", 123, 11));
+        let backup = parser_dir.join(generated_backup_name_with_transaction(
+            "lua",
+            123,
+            11,
+            ulid::Ulid::new(),
+        ));
         symlink(parser_dir.join("missing-target"), &canonical).expect("create dangling canonical");
         fs::write(&backup, b"unrelated").expect("write colliding backup");
         fs::write(
             parser_backup_intent_sidecar(&backup),
-            PARSER_BACKUP_INTENT_CONTENT,
+            parser_backup_marker_content(&backup, false),
         )
         .expect("write intent");
 
@@ -2583,6 +2589,12 @@ mod tests {
         );
         assert_eq!(fs::read(&backup).expect("preserve collision"), b"unrelated");
         assert!(!parser_backup_intent_sidecar(&backup).exists());
+        assert!(
+            fs::symlink_metadata(&canonical)
+                .expect("preserve dangling canonical entry")
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -346,11 +346,9 @@ fn recover_parser_backups(
     Ok(true)
 }
 
-/// Remove the canonical parser and every kakehashi-generated replacement backup.
-pub fn remove_parser_install_and_backups(
-    parser_dir: &Path,
-    language: &str,
-) -> std::io::Result<bool> {
+/// Remove parser artifacts without operation coordination for focused unit tests.
+#[cfg(test)]
+fn remove_parser_install_and_backups(parser_dir: &Path, language: &str) -> std::io::Result<bool> {
     if !super::queries::is_safe_language_name(language) {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
@@ -393,6 +391,8 @@ pub enum ParserInstallError {
     IoError(std::io::Error),
     /// Parser already exists.
     AlreadyExists(PathBuf),
+    /// An interrupted replacement was recovered instead of rebuilding.
+    Recovered(PathBuf),
 }
 
 impl std::fmt::Display for ParserInstallError {
@@ -410,6 +410,7 @@ impl std::fmt::Display for ParserInstallError {
                     path.display()
                 )
             }
+            Self::Recovered(path) => write!(f, "Recovered parser at {}", path.display()),
         }
     }
 }
@@ -435,8 +436,7 @@ pub struct ParserInstallResult {
     pub language: String,
     /// Path where parser was installed.
     pub install_path: PathBuf,
-    /// Git revision that was used. Empty when an interrupted replacement was
-    /// recovered without rebuilding from source.
+    /// Git revision that was used.
     pub revision: String,
 }
 
@@ -817,11 +817,7 @@ pub fn install_parser_after_operation_started(
 
     #[cfg(windows)]
     if recovered && !options.force {
-        return Ok(ParserInstallResult {
-            language: language.to_string(),
-            install_path: parser_file,
-            revision: String::new(),
-        });
+        return Err(ParserInstallError::Recovered(parser_file));
     }
 
     let install_token = begin_parser_install(&parser_dir, &parser_file, language, options.force)?;

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -391,8 +391,6 @@ pub enum ParserInstallError {
     IoError(std::io::Error),
     /// Parser already exists.
     AlreadyExists(PathBuf),
-    /// An interrupted replacement was recovered instead of rebuilding.
-    Recovered(PathBuf),
 }
 
 impl std::fmt::Display for ParserInstallError {
@@ -410,7 +408,6 @@ impl std::fmt::Display for ParserInstallError {
                     path.display()
                 )
             }
-            Self::Recovered(path) => write!(f, "Recovered parser at {}", path.display()),
         }
     }
 }
@@ -817,7 +814,7 @@ pub fn install_parser_after_operation_started(
 
     #[cfg(windows)]
     if recovered && !options.force {
-        return Err(ParserInstallError::Recovered(parser_file));
+        return Err(ParserInstallError::AlreadyExists(parser_file));
     }
 
     let install_token = begin_parser_install(&parser_dir, &parser_file, language, options.force)?;

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -190,10 +190,17 @@ fn parser_backup_files(parser_dir: &Path, language: &str) -> std::io::Result<Vec
         let Some(name) = name.to_str() else {
             continue;
         };
-        if entry.file_type()?.is_file()
-            && generated_parser_backup_matches_language(name, language)
-            && parser_backup_ownership_sidecar(&entry.path()).is_file()
+        if !entry.file_type()?.is_file()
+            || !generated_parser_backup_matches_language(name, language)
         {
+            continue;
+        }
+        let marker_content = match fs::read(parser_backup_ownership_sidecar(&entry.path())) {
+            Ok(content) => content,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error),
+        };
+        if marker_content == PARSER_BACKUP_MARKER_CONTENT {
             backups.push(entry.path());
         }
     }
@@ -222,7 +229,7 @@ fn cleanup_orphan_parser_backup_markers(parser_dir: &Path, language: &str) -> st
             continue;
         }
         let backup = parser_dir.join(backup_name);
-        if !backup.exists() && fs::read(&marker)? == PARSER_BACKUP_MARKER_CONTENT {
+        if !backup.try_exists()? && fs::read(&marker)? == PARSER_BACKUP_MARKER_CONTENT {
             fs::remove_file(marker)?;
         }
     }
@@ -253,7 +260,13 @@ fn recover_parser_backups(
     if backups.is_empty() {
         return Ok(());
     }
-    if parser_file.is_file() {
+    if parser_file.try_exists()? {
+        if !fs::metadata(parser_file)?.is_file() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("parser path '{}' is not a file", parser_file.display()),
+            ));
+        }
         for backup in backups {
             remove_owned_parser_backup(&backup)?;
         }
@@ -1758,6 +1771,49 @@ mod tests {
         assert!(!owned_marker.exists());
         assert!(user_marker.exists());
         assert!(!canonical.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parser_recovery_propagates_ownership_marker_read_error() {
+        use std::os::unix::fs::symlink;
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let canonical = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        let backup = parser_dir.join(generated_backup_name("lua", 123, 4));
+        let marker = parser_backup_ownership_sidecar(&backup);
+        fs::write(&backup, b"working parser").expect("write backup");
+        symlink(&marker, &marker).expect("create marker symlink loop");
+
+        recover_parser_backups(&parser_dir, &canonical, "lua")
+            .expect_err("marker read error must abort recovery");
+
+        assert!(backup.exists());
+        assert!(!canonical.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parser_recovery_propagates_canonical_metadata_error() {
+        use std::os::unix::fs::symlink;
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let canonical = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        let backup = parser_dir.join(generated_backup_name("lua", 123, 4));
+        fs::write(&backup, b"working parser").expect("write backup");
+        fs::write(
+            parser_backup_ownership_sidecar(&backup),
+            PARSER_BACKUP_MARKER_CONTENT,
+        )
+        .expect("mark owned backup");
+        symlink(&canonical, &canonical).expect("create canonical symlink loop");
+
+        recover_parser_backups(&parser_dir, &canonical, "lua")
+            .expect_err("canonical metadata error must abort recovery");
+
+        assert!(backup.exists());
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -229,6 +229,14 @@ fn parser_backup_marker_is_owned(marker: &Path) -> std::io::Result<bool> {
         use std::os::unix::fs::OpenOptionsExt;
         options.custom_flags(nix::libc::O_NONBLOCK | nix::libc::O_NOFOLLOW);
     }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        // Open the reparse point itself so a swap after `symlink_metadata`
+        // cannot redirect ownership validation outside the parser directory.
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    }
     let file = match options.open(marker) {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -4,7 +4,7 @@
 //! compiling them with tree-sitter-loader, and installing the resulting shared library.
 
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::Component;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -203,6 +203,21 @@ fn remove_parser_backup_marker(backup: &Path) -> std::io::Result<()> {
     }
 }
 
+fn parser_backup_marker_is_owned(marker: &Path) -> std::io::Result<bool> {
+    let file = match fs::File::open(marker) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    if file.metadata()?.len() != PARSER_BACKUP_MARKER_CONTENT.len() as u64 {
+        return Ok(false);
+    }
+    let mut content = Vec::with_capacity(PARSER_BACKUP_MARKER_CONTENT.len() + 1);
+    file.take((PARSER_BACKUP_MARKER_CONTENT.len() + 1) as u64)
+        .read_to_end(&mut content)?;
+    Ok(content == PARSER_BACKUP_MARKER_CONTENT)
+}
+
 fn parser_backup_files(parser_dir: &Path, language: &str) -> std::io::Result<Vec<PathBuf>> {
     let entries = match fs::read_dir(parser_dir) {
         Ok(entries) => entries,
@@ -221,12 +236,7 @@ fn parser_backup_files(parser_dir: &Path, language: &str) -> std::io::Result<Vec
         {
             continue;
         }
-        let marker_content = match fs::read(parser_backup_ownership_sidecar(&entry.path())) {
-            Ok(content) => content,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(error) => return Err(error),
-        };
-        if marker_content == PARSER_BACKUP_MARKER_CONTENT {
+        if parser_backup_marker_is_owned(&parser_backup_ownership_sidecar(&entry.path()))? {
             backups.push(entry.path());
         }
     }
@@ -251,13 +261,8 @@ pub fn owned_parser_backup_languages(parser_dir: &Path) -> std::io::Result<Vec<S
             continue;
         };
         let marker = parser_backup_ownership_sidecar(&entry.path());
-        match fs::read(marker) {
-            Ok(content) if content == PARSER_BACKUP_MARKER_CONTENT => {
-                languages.insert(language.to_owned());
-            }
-            Ok(_) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => return Err(error),
+        if parser_backup_marker_is_owned(&marker)? {
+            languages.insert(language.to_owned());
         }
     }
     Ok(languages.into_iter().collect())
@@ -285,12 +290,7 @@ fn cleanup_orphan_parser_backup_markers(parser_dir: &Path, language: &str) -> st
             continue;
         }
         let backup = parser_dir.join(backup_name);
-        let marker_content = match fs::read(&marker) {
-            Ok(content) => content,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(error) => return Err(error),
-        };
-        if !backup.try_exists()? && marker_content == PARSER_BACKUP_MARKER_CONTENT {
+        if !backup.try_exists()? && parser_backup_marker_is_owned(&marker)? {
             remove_parser_backup_marker(&backup)?;
         }
     }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -1151,15 +1151,15 @@ mod tests {
     #[derive(Default)]
     struct FakeParserFileOps {
         files: HashMap<PathBuf, &'static str>,
-        fail_rename: Option<(PathBuf, PathBuf)>,
+        failed_renames: Vec<(PathBuf, PathBuf)>,
     }
 
     impl ParserFileOps for FakeParserFileOps {
         fn rename(&mut self, from: &Path, to: &Path) -> std::io::Result<()> {
             if self
-                .fail_rename
-                .as_ref()
-                .is_some_and(|(fail_from, fail_to)| fail_from == from && fail_to == to)
+                .failed_renames
+                .iter()
+                .any(|(fail_from, fail_to)| fail_from == from && fail_to == to)
             {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::PermissionDenied,
@@ -1189,7 +1189,7 @@ mod tests {
         let mut ops = FakeParserFileOps::default();
         ops.files.insert(tmp.clone(), "new");
         ops.files.insert(parser.clone(), "old");
-        ops.fail_rename = Some((tmp.clone(), parser.clone()));
+        ops.failed_renames.push((tmp.clone(), parser.clone()));
 
         let error = publish_parser_transactionally(&mut ops, &tmp, &parser, &backup)
             .expect_err("injected publish failure must be reported");
@@ -1197,6 +1197,43 @@ mod tests {
         assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
         assert_eq!(ops.files.get(&parser), Some(&"old"));
         assert!(!ops.files.contains_key(&backup));
+    }
+
+    #[test]
+    fn transactional_publish_removes_backup_after_success() {
+        let tmp = PathBuf::from("parser.tmp");
+        let parser = PathBuf::from("parser.dll");
+        let backup = PathBuf::from("parser.backup");
+        let mut ops = FakeParserFileOps::default();
+        ops.files.insert(tmp.clone(), "new");
+        ops.files.insert(parser.clone(), "old");
+
+        publish_parser_transactionally(&mut ops, &tmp, &parser, &backup).expect("publish succeeds");
+
+        assert_eq!(ops.files.get(&parser), Some(&"new"));
+        assert!(!ops.files.contains_key(&tmp));
+        assert!(!ops.files.contains_key(&backup));
+    }
+
+    #[test]
+    fn transactional_publish_keeps_backup_when_rollback_fails() {
+        let tmp = PathBuf::from("parser.tmp");
+        let parser = PathBuf::from("parser.dll");
+        let backup = PathBuf::from("parser.backup");
+        let mut ops = FakeParserFileOps::default();
+        ops.files.insert(tmp.clone(), "new");
+        ops.files.insert(parser.clone(), "old");
+        ops.failed_renames.push((tmp.clone(), parser.clone()));
+        ops.failed_renames.push((backup.clone(), parser.clone()));
+
+        let error = publish_parser_transactionally(&mut ops, &tmp, &parser, &backup)
+            .expect_err("publish and rollback failures must be reported");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(error.to_string().contains("failed to restore backup"));
+        assert_eq!(ops.files.get(&backup), Some(&"old"));
+        assert_eq!(ops.files.get(&tmp), Some(&"new"));
+        assert!(!ops.files.contains_key(&parser));
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -435,9 +435,9 @@ pub struct ParserInstallResult {
     pub language: String,
     /// Path where parser was installed.
     pub install_path: PathBuf,
-    /// Git revision that was used, or `None` when an interrupted replacement
-    /// was recovered without rebuilding from source.
-    pub revision: Option<String>,
+    /// Git revision that was used. Empty when an interrupted replacement was
+    /// recovered without rebuilding from source.
+    pub revision: String,
 }
 
 /// How the parser source is compiled.
@@ -810,7 +810,7 @@ pub fn install_parser_after_operation_started(
         return Ok(ParserInstallResult {
             language: language.to_string(),
             install_path: parser_file,
-            revision: None,
+            revision: String::new(),
         });
     }
 
@@ -889,7 +889,7 @@ pub fn install_parser_after_operation_started(
     Ok(ParserInstallResult {
         language: language.to_string(),
         install_path: parser_file,
-        revision: Some(metadata.revision),
+        revision: metadata.revision,
     })
 }
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -90,8 +90,8 @@ fn publish_parser_transactionally(
                 return Err(std::io::Error::new(
                     error.kind(),
                     format!(
-                        "failed to claim parser backup: {error}; failed to remove new ownership marker '{}': {marker_error}",
-                        parser_backup_ownership_sidecar(backup_file).display()
+                        "failed to claim parser backup: {error}; failed to remove new intent marker '{}': {marker_error}",
+                        parser_backup_intent_sidecar(backup_file).display()
                     ),
                 ));
             }
@@ -2082,7 +2082,16 @@ mod tests {
         let error = publish_parser_transactionally(&mut ops, &tmp, &parser, &backup)
             .expect_err("claim cleanup failure must identify marker");
 
-        assert!(error.to_string().contains("parser.backup.owner"));
+        assert!(
+            error
+                .to_string()
+                .contains(&parser_backup_intent_sidecar(&backup).display().to_string()),
+            "unexpected error: {error}"
+        );
+        assert!(
+            error.to_string().contains("new intent marker"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -160,10 +160,7 @@ fn write_marker_atomically(marker_path: &Path, content: &[u8]) -> std::io::Resul
         return Err(error);
     }
     drop(marker);
-    // Linking publishes the already-complete inode and atomically fails when
-    // the destination exists; unlike Windows rename, it never replaces a
-    // colliding user or prior-process sidecar.
-    if let Err(error) = fs::hard_link(&marker_tmp, marker_path) {
+    if let Err(error) = publish_marker_no_replace(&marker_tmp, marker_path) {
         let _ = fs::remove_file(marker_tmp);
         return Err(error);
     }
@@ -171,6 +168,29 @@ fn write_marker_atomically(marker_path: &Path, content: &[u8]) -> std::io::Resul
     // which recovery removes by its exact ULID shape.
     let _ = fs::remove_file(marker_tmp);
     Ok(())
+}
+
+#[cfg(windows)]
+fn publish_marker_no_replace(from: &Path, to: &Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn MoveFileExW(existing: *const u16, new: *const u16, flags: u32) -> i32;
+    }
+    let from: Vec<u16> = from.as_os_str().encode_wide().chain(Some(0)).collect();
+    let to: Vec<u16> = to.as_os_str().encode_wide().chain(Some(0)).collect();
+    // Flags 0 is an atomic same-volume move that fails when `to` exists.
+    if unsafe { MoveFileExW(from.as_ptr(), to.as_ptr(), 0) } == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(all(test, not(windows)))]
+fn publish_marker_no_replace(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::hard_link(from, to)?;
+    fs::remove_file(from)
 }
 
 #[cfg(any(windows, test))]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -37,24 +37,24 @@ fn publish_parser_transactionally(
     parser_file: &Path,
     backup_file: &Path,
 ) -> std::io::Result<()> {
+    ops.create_backup_marker(backup_file)?;
     let had_old_parser = match ops.rename(parser_file, backup_file) {
-        Ok(()) => {
-            if let Err(marker_error) = ops.create_backup_marker(backup_file) {
-                return match ops.rename(backup_file, parser_file) {
-                    Ok(()) => Err(marker_error),
-                    Err(rollback_error) => Err(std::io::Error::new(
-                        marker_error.kind(),
-                        format!(
-                            "failed to mark parser backup: {marker_error}; failed to restore backup '{}': {rollback_error}",
-                            backup_file.display()
-                        ),
-                    )),
-                };
-            }
-            true
+        Ok(()) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            ops.remove_backup_marker(backup_file)?;
+            false
         }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
-        Err(error) => return Err(error),
+        Err(error) => {
+            if let Err(marker_error) = ops.remove_backup_marker(backup_file) {
+                return Err(std::io::Error::new(
+                    error.kind(),
+                    format!(
+                        "failed to claim parser backup: {error}; failed to remove new ownership marker: {marker_error}"
+                    ),
+                ));
+            }
+            return Err(error);
+        }
     };
 
     match ops.rename(tmp_file, parser_file) {
@@ -121,11 +121,17 @@ impl ParserFileOps for StdParserFileOps {
 
     fn create_backup_marker(&mut self, backup: &Path) -> std::io::Result<()> {
         use std::io::Write;
+        let marker_path = parser_backup_ownership_sidecar(backup);
         let mut marker = fs::OpenOptions::new()
             .write(true)
             .create_new(true)
-            .open(parser_backup_ownership_sidecar(backup))?;
-        marker.write_all(b"ok\n")
+            .open(&marker_path)?;
+        if let Err(error) = marker.write_all(b"ok\n") {
+            drop(marker);
+            let _ = fs::remove_file(marker_path);
+            return Err(error);
+        }
+        Ok(())
     }
 
     fn remove_backup_marker(&mut self, backup: &Path) -> std::io::Result<()> {
@@ -1340,10 +1346,18 @@ mod tests {
         vanished_removals: Vec<PathBuf>,
         backup_markers: HashSet<PathBuf>,
         fail_marker_creation: bool,
+        fail_marker_write_after_create: bool,
+        backup_claim_observed_marker: bool,
     }
 
     impl ParserFileOps for FakeParserFileOps {
         fn rename(&mut self, from: &Path, to: &Path) -> std::io::Result<()> {
+            if to
+                .extension()
+                .is_some_and(|extension| extension == "backup")
+            {
+                self.backup_claim_observed_marker = self.backup_markers.contains(to);
+            }
             if self
                 .failed_renames
                 .iter()
@@ -1394,6 +1408,13 @@ mod tests {
                     "injected marker collision",
                 ));
             }
+            if self.fail_marker_write_after_create {
+                self.backup_markers.remove(backup);
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::WriteZero,
+                    "injected marker write failure",
+                ));
+            }
             Ok(())
         }
 
@@ -1435,6 +1456,8 @@ mod tests {
         assert_eq!(ops.files.get(&parser), Some(&"new"));
         assert!(!ops.files.contains_key(&tmp));
         assert!(!ops.files.contains_key(&backup));
+        assert!(ops.backup_claim_observed_marker);
+        assert!(!ops.backup_markers.contains(&backup));
     }
 
     #[test]
@@ -1547,6 +1570,25 @@ mod tests {
         assert_eq!(ops.files.get(&parser), Some(&"old"));
         assert!(!ops.files.contains_key(&backup));
         assert!(ops.backup_markers.contains(&backup));
+    }
+
+    #[test]
+    fn transactional_publish_cleans_marker_after_marker_write_failure() {
+        let tmp = PathBuf::from("parser.tmp");
+        let parser = PathBuf::from("parser.dll");
+        let backup = PathBuf::from("parser.backup");
+        let mut ops = FakeParserFileOps::default();
+        ops.files.insert(tmp.clone(), "new");
+        ops.files.insert(parser.clone(), "old");
+        ops.fail_marker_write_after_create = true;
+
+        publish_parser_transactionally(&mut ops, &tmp, &parser, &backup)
+            .expect_err("marker write failure must abort before moving parser");
+
+        assert_eq!(ops.files.get(&parser), Some(&"old"));
+        assert_eq!(ops.files.get(&tmp), Some(&"new"));
+        assert!(!ops.files.contains_key(&backup));
+        assert!(!ops.backup_markers.contains(&backup));
     }
 
     fn generated_backup_name(language: &str, pid: u32, counter: usize) -> String {

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -381,7 +381,12 @@ pub fn owned_parser_backup_languages(parser_dir: &Path) -> std::io::Result<Vec<S
             continue;
         };
         let marker = parser_backup_ownership_sidecar(&entry.path());
-        if parser_backup_marker_is_owned(&marker)? {
+        let canonical =
+            parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
+        if parser_backup_marker_is_owned(&marker)?
+            || (!canonical.try_exists()?
+                && parser_backup_marker_is_intent(&parser_backup_intent_sidecar(&entry.path()))?)
+        {
             languages.insert(language.to_owned());
         }
     }
@@ -403,14 +408,16 @@ fn cleanup_orphan_parser_backup_markers(parser_dir: &Path, language: &str) -> st
         let Some(marker_name) = marker.file_name().and_then(|name| name.to_str()) else {
             continue;
         };
-        let (backup_name, staged) = if let Some(backup_name) = marker_name.strip_suffix(".owner") {
-            (backup_name, false)
+        let (backup_name, kind) = if let Some(backup_name) = marker_name.strip_suffix(".owner") {
+            (backup_name, 0_u8)
+        } else if let Some(backup_name) = marker_name.strip_suffix(".owner.intent") {
+            (backup_name, 1_u8)
         } else if let Some((backup_name, nonce)) = marker_name
             .strip_suffix(".tmp")
             .and_then(|name| name.rsplit_once(".owner."))
             && ulid::Ulid::from_string(nonce).is_ok()
         {
-            (backup_name, true)
+            (backup_name, 2_u8)
         } else {
             continue;
         };
@@ -418,16 +425,23 @@ fn cleanup_orphan_parser_backup_markers(parser_dir: &Path, language: &str) -> st
             continue;
         }
         let backup = parser_dir.join(backup_name);
-        if parser_backup_marker_is_owned(&marker)? {
-            if staged {
+        let canonical = parser_dir.join(format!("{language}.{}", std::env::consts::DLL_EXTENSION));
+        if kind == 2 {
+            if parser_backup_marker_is_owned(&marker)? || parser_backup_marker_is_intent(&marker)? {
                 match fs::remove_file(marker) {
                     Ok(()) => {}
                     Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
                     Err(error) => return Err(error),
                 }
-            } else if !backup.try_exists()? {
+            }
+        } else if kind == 1 {
+            if parser_backup_marker_is_intent(&marker)?
+                && (!backup.try_exists()? || canonical.try_exists()?)
+            {
                 remove_parser_backup_marker(&backup)?;
             }
+        } else if parser_backup_marker_is_owned(&marker)? && !backup.try_exists()? {
+            remove_parser_backup_marker(&backup)?;
         }
     }
     Ok(())
@@ -2022,6 +2036,35 @@ mod tests {
         );
     }
 
+    #[test]
+    fn owned_parser_backup_languages_discovers_crash_intent_only_without_canonical() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let backup = parser_dir.join(generated_backup_name("lua", 123, 9));
+        fs::write(&backup, b"working parser").expect("write backup");
+        fs::write(
+            parser_backup_intent_sidecar(&backup),
+            PARSER_BACKUP_INTENT_CONTENT,
+        )
+        .expect("write intent");
+
+        assert_eq!(
+            owned_parser_backup_languages(&parser_dir).expect("discover intent"),
+            vec!["lua"]
+        );
+        fs::write(
+            parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION)),
+            b"canonical",
+        )
+        .expect("write canonical");
+        assert!(
+            owned_parser_backup_languages(&parser_dir)
+                .expect("collision is not owned")
+                .is_empty()
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn owned_parser_backup_languages_ignores_marker_symlink() {
@@ -2239,6 +2282,10 @@ mod tests {
         let colliding_backup = parser_dir.join(generated_backup_name("lua", 123, 6));
         let colliding_staging = parser_backup_ownership_sidecar(&colliding_backup)
             .with_extension(format!("owner.{}.tmp", ulid::Ulid::new()));
+        let orphan_intent_backup = parser_dir.join(generated_backup_name("lua", 123, 10));
+        let orphan_intent = parser_backup_intent_sidecar(&orphan_intent_backup);
+        let staged_intent = parser_backup_ownership_sidecar(&owned_backup)
+            .with_extension(format!("owner.{}.tmp", ulid::Ulid::new()));
         fs::write(&owned_marker, PARSER_BACKUP_MARKER_CONTENT).expect("write owned marker");
         fs::write(&user_marker, b"user marker").expect("write user marker");
         fs::write(&staged_marker, PARSER_BACKUP_MARKER_CONTENT).expect("write staged marker");
@@ -2247,12 +2294,16 @@ mod tests {
         fs::write(&colliding_backup, b"user backup").expect("write colliding backup");
         fs::write(&colliding_staging, PARSER_BACKUP_MARKER_CONTENT)
             .expect("write colliding staging marker");
+        fs::write(&orphan_intent, PARSER_BACKUP_INTENT_CONTENT).expect("write orphan intent");
+        fs::write(&staged_intent, PARSER_BACKUP_INTENT_CONTENT).expect("write staged intent");
 
         recover_parser_backups(&parser_dir, &canonical, "lua").expect("clean orphan markers");
 
         assert!(!owned_marker.exists());
         assert!(!staged_marker.exists());
         assert!(!colliding_staging.exists());
+        assert!(!orphan_intent.exists());
+        assert!(!staged_intent.exists());
         assert!(colliding_backup.exists());
         assert!(malformed_staging.exists());
         assert!(user_marker.exists());

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -21,6 +21,7 @@ use super::metadata::{FetchOptions, MetadataError, fetch_parser_metadata};
 /// HTTP timeout for archive downloads.
 const ARCHIVE_HTTP_TIMEOUT: Duration = Duration::from_secs(120);
 const PARSER_OPERATION_MARKER_SUFFIX: &str = ".operation";
+const PARSER_BACKUP_MARKER_CONTENT: &[u8] = b"kakehashi parser backup v1\n";
 
 #[cfg(any(windows, test))]
 trait ParserFileOps {
@@ -126,7 +127,7 @@ impl ParserFileOps for StdParserFileOps {
             .write(true)
             .create_new(true)
             .open(&marker_path)?;
-        if let Err(error) = marker.write_all(b"ok\n") {
+        if let Err(error) = marker.write_all(PARSER_BACKUP_MARKER_CONTENT) {
             drop(marker);
             let _ = fs::remove_file(marker_path);
             return Err(error);
@@ -199,6 +200,35 @@ fn parser_backup_files(parser_dir: &Path, language: &str) -> std::io::Result<Vec
     Ok(backups)
 }
 
+fn cleanup_orphan_parser_backup_markers(parser_dir: &Path, language: &str) -> std::io::Result<()> {
+    let entries = match fs::read_dir(parser_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    for entry in entries {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let marker = entry.path();
+        let Some(marker_name) = marker.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        let Some(backup_name) = marker_name.strip_suffix(".owner") else {
+            continue;
+        };
+        if !generated_parser_backup_matches_language(backup_name, language) {
+            continue;
+        }
+        let backup = parser_dir.join(backup_name);
+        if !backup.exists() && fs::read(&marker)? == PARSER_BACKUP_MARKER_CONTENT {
+            fs::remove_file(marker)?;
+        }
+    }
+    Ok(())
+}
+
 fn remove_owned_parser_backup(backup: &Path) -> std::io::Result<()> {
     match fs::remove_file(backup) {
         Ok(()) => {}
@@ -218,6 +248,7 @@ fn recover_parser_backups(
     parser_file: &Path,
     language: &str,
 ) -> std::io::Result<()> {
+    cleanup_orphan_parser_backup_markers(parser_dir, language)?;
     let mut backups = parser_backup_files(parser_dir, language)?;
     if backups.is_empty() {
         return Ok(());
@@ -253,6 +284,7 @@ pub fn remove_parser_install_and_backups(
             "unsafe parser language name",
         ));
     }
+    cleanup_orphan_parser_backup_markers(parser_dir, language)?;
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
     let mut removed = match fs::remove_file(parser_file) {
         Ok(()) => true,
@@ -1632,7 +1664,11 @@ mod tests {
         ] {
             fs::write(path, b"parser").expect("write parser fixture");
         }
-        fs::write(parser_backup_ownership_sidecar(&owned), b"ok\n").expect("mark owned backup");
+        fs::write(
+            parser_backup_ownership_sidecar(&owned),
+            PARSER_BACKUP_MARKER_CONTENT,
+        )
+        .expect("mark owned backup");
 
         assert!(
             remove_parser_install_and_backups(&parser_dir, "lua").expect("remove parser files")
@@ -1653,7 +1689,11 @@ mod tests {
         let canonical = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
         let backup = parser_dir.join(generated_backup_name("lua", 123, 4));
         fs::write(&backup, b"working parser").expect("write backup");
-        fs::write(parser_backup_ownership_sidecar(&backup), b"ok\n").expect("mark owned backup");
+        fs::write(
+            parser_backup_ownership_sidecar(&backup),
+            PARSER_BACKUP_MARKER_CONTENT,
+        )
+        .expect("mark owned backup");
 
         recover_parser_backups(&parser_dir, &canonical, "lua").expect("recover parser backup");
 
@@ -1673,7 +1713,11 @@ mod tests {
         let backup = parser_dir.join(generated_backup_name("lua", 123, 4));
         fs::write(&canonical, b"new parser").expect("write canonical");
         fs::write(&backup, b"old parser").expect("write backup");
-        fs::write(parser_backup_ownership_sidecar(&backup), b"ok\n").expect("mark owned backup");
+        fs::write(
+            parser_backup_ownership_sidecar(&backup),
+            PARSER_BACKUP_MARKER_CONTENT,
+        )
+        .expect("mark owned backup");
 
         recover_parser_backups(&parser_dir, &canonical, "lua").expect("clean parser backup");
 
@@ -1694,6 +1738,26 @@ mod tests {
 
         assert!(!canonical.exists());
         assert_eq!(fs::read(unowned).expect("read user file"), b"user file");
+    }
+
+    #[test]
+    fn parser_recovery_cleans_owned_orphan_marker_only() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let canonical = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        let owned_backup = parser_dir.join(generated_backup_name("lua", 123, 4));
+        let owned_marker = parser_backup_ownership_sidecar(&owned_backup);
+        let user_backup = parser_dir.join(generated_backup_name("lua", 123, 5));
+        let user_marker = parser_backup_ownership_sidecar(&user_backup);
+        fs::write(&owned_marker, PARSER_BACKUP_MARKER_CONTENT).expect("write owned marker");
+        fs::write(&user_marker, b"user marker").expect("write user marker");
+
+        recover_parser_backups(&parser_dir, &canonical, "lua").expect("clean orphan markers");
+
+        assert!(!owned_marker.exists());
+        assert!(user_marker.exists());
+        assert!(!canonical.exists());
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -177,6 +177,14 @@ fn parser_backup_ownership_sidecar(backup: &Path) -> PathBuf {
     ))
 }
 
+fn remove_parser_backup_marker(backup: &Path) -> std::io::Result<()> {
+    match fs::remove_file(parser_backup_ownership_sidecar(backup)) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
 fn parser_backup_files(parser_dir: &Path, language: &str) -> std::io::Result<Vec<PathBuf>> {
     let entries = match fs::read_dir(parser_dir) {
         Ok(entries) => entries,
@@ -242,11 +250,7 @@ fn remove_owned_parser_backup(backup: &Path) -> std::io::Result<()> {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(error) => return Err(error),
     }
-    match fs::remove_file(parser_backup_ownership_sidecar(backup)) {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(error),
-    }
+    remove_parser_backup_marker(backup)
 }
 
 #[cfg(any(windows, test))]
@@ -282,7 +286,7 @@ fn recover_parser_backups(
     timed_backups.sort_by_key(|(modified, _)| *modified);
     let (_, restore) = timed_backups.pop().expect("non-empty parser backup list");
     fs::rename(&restore, parser_file)?;
-    fs::remove_file(parser_backup_ownership_sidecar(&restore))?;
+    remove_parser_backup_marker(&restore)?;
     for (_, obsolete) in timed_backups {
         remove_owned_parser_backup(&obsolete)?;
     }
@@ -1758,6 +1762,14 @@ mod tests {
 
         assert!(!canonical.exists());
         assert_eq!(fs::read(unowned).expect("read user file"), b"user file");
+    }
+
+    #[test]
+    fn parser_backup_marker_removal_accepts_concurrent_disappearance() {
+        let temp = tempdir().expect("temp dir");
+        let backup = temp.path().join(generated_backup_name("lua", 123, 4));
+
+        remove_parser_backup_marker(&backup).expect("already removed marker is clean");
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -483,6 +483,13 @@ pub struct ParserInstallResult {
     pub revision: String,
 }
 
+/// Internal outcome for callers that coordinate parser and query operations.
+#[doc(hidden)]
+pub enum ParserInstallOutcome {
+    Installed(ParserInstallResult),
+    Recovered(PathBuf),
+}
+
 /// How the parser source is compiled.
 ///
 /// The killable path re-execs **this** binary's `__compile-parser` subcommand, so
@@ -819,11 +826,14 @@ pub fn install_parser(
         return Err(unsafe_language_name_error(language));
     }
     let _operation_lock = super::LanguageOperationLockGuard::acquire(&options.data_dir, language)?;
-    install_parser_after_operation_started(
+    match install_parser_after_operation_started(
         language,
         options,
         super::LanguageOperationPermit::Language(&_operation_lock),
-    )
+    )? {
+        ParserInstallOutcome::Installed(result) => Ok(result),
+        ParserInstallOutcome::Recovered(path) => Err(ParserInstallError::AlreadyExists(path)),
+    }
 }
 
 /// Install a parser while the caller holds this language's operation lock.
@@ -835,7 +845,7 @@ pub fn install_parser_after_operation_started(
     language: &str,
     options: &InstallOptions,
     permit: super::LanguageOperationPermit<'_>,
-) -> Result<ParserInstallResult, ParserInstallError> {
+) -> Result<ParserInstallOutcome, ParserInstallError> {
     if !permit.covers(&options.data_dir, language) {
         return Err(ParserInstallError::IoError(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
@@ -860,7 +870,7 @@ pub fn install_parser_after_operation_started(
 
     #[cfg(windows)]
     if recovered && !options.force {
-        return Err(ParserInstallError::AlreadyExists(parser_file));
+        return Ok(ParserInstallOutcome::Recovered(parser_file));
     }
 
     let install_token = begin_parser_install(&parser_dir, &parser_file, language, options.force)?;
@@ -935,11 +945,11 @@ pub fn install_parser_after_operation_started(
         eprintln!("Installed to: {}", parser_file.display());
     }
 
-    Ok(ParserInstallResult {
+    Ok(ParserInstallOutcome::Installed(ParserInstallResult {
         language: language.to_string(),
         install_path: parser_file,
         revision: metadata.revision,
-    })
+    }))
 }
 
 /// Construct a GitHub archive download URL from a repository URL and revision.

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1195,7 +1195,10 @@ fn test_language_uninstall_all() {
                     entry.file_name().to_str().is_none_or(|name| {
                         !name
                             .strip_prefix('.')
-                            .and_then(|name| name.strip_suffix(".parser-backup.lock"))
+                            .and_then(|name| {
+                                name.strip_suffix(".replace.lock")
+                                    .or_else(|| name.strip_suffix(".operation"))
+                            })
                             .is_some_and(kakehashi::install::queries::is_safe_language_name)
                     })
                 })

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1192,10 +1192,19 @@ fn test_language_uninstall_all() {
             entries
                 .filter_map(|e| e.ok())
                 .filter(|entry| {
-                    entry
-                        .file_name()
-                        .to_str()
-                        .is_none_or(|name| !name.starts_with('.'))
+                    entry.file_name().to_str().is_none_or(|name| {
+                        !name
+                            .strip_prefix('.')
+                            .and_then(|name| name.strip_suffix(".parser-backup.lock"))
+                            .is_some_and(|language| {
+                                !language.is_empty()
+                                    && language.bytes().all(|byte| {
+                                        byte.is_ascii_lowercase()
+                                            || byte.is_ascii_digit()
+                                            || byte == b'_'
+                                    })
+                            })
+                    })
                 })
                 .collect()
         })

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1196,14 +1196,7 @@ fn test_language_uninstall_all() {
                         !name
                             .strip_prefix('.')
                             .and_then(|name| name.strip_suffix(".parser-backup.lock"))
-                            .is_some_and(|language| {
-                                !language.is_empty()
-                                    && language.bytes().all(|byte| {
-                                        byte.is_ascii_lowercase()
-                                            || byte.is_ascii_digit()
-                                            || byte == b'_'
-                                    })
-                            })
+                            .is_some_and(kakehashi::install::queries::is_safe_language_name)
                     })
                 })
                 .collect()


### PR DESCRIPTION
## Summary

- publish Windows parser replacements through a same-directory backup
- restore the working parser if publishing the staged DLL fails
- preserve and report the backup path if rollback itself fails
- cover successful cleanup, successful rollback, and failed rollback through a portable filesystem seam

Closes #728

## Validation

- `cargo test --lib transactional_publish -q`
- `cargo test --lib install::parser::tests -q` (39 passed)
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --check`
- `cargo xwin check --lib --target x86_64-pc-windows-msvc` (in progress at PR creation)

## Risk

The new transactional helper is selected only on Windows. Unix keeps its existing atomic single-rename publication path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows parser library installation reliability using safe, transactional replacement.
  * Existing parser libraries are preserved during updates, with automatic rollback if publishing fails.
  * Better error reporting now retains the original failure details and adds rollback failure context when applicable.
  * Updates and uninstalls now clean up owned temporary backups and recover missing parser libraries more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->