### PR TITLE
fix(tests): isolate parser crash state per process

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -37,9 +37,9 @@ use std::path::PathBuf;
 /// - macOS: ~/Library/Application Support/kakehashi/
 /// - Windows: %APPDATA%/kakehashi/
 pub fn default_data_dir() -> Option<PathBuf> {
-    // In `cfg(test)`, redirect every caller (Kakehashi::new -> failed
-    // parser registry, search-path defaulting, etc.) to a project-local
-    // persistent dir under `deps/` so the developer's real
+    // In `cfg(test)`, redirect install assets, search-path defaults, and
+    // other persistent data callers to a project-local dir under `deps/`
+    // so the developer's real
     // `~/.local/share/kakehashi/` is never read or written. The dir is
     // shared across test processes to keep parser/query installs cached
     // between runs. Crash-recovery state is stored separately in the

--- a/src/install.rs
+++ b/src/install.rs
@@ -90,6 +90,11 @@ pub(crate) fn test_data_dir() -> PathBuf {
 #[cfg(test)]
 pub(crate) fn test_state_dir() -> PathBuf {
     use std::sync::OnceLock;
+    // Rust does not drop statics, so this small directory intentionally remains
+    // in the OS temp tree after the test process exits. Keeping the `TempDir`
+    // guard (rather than only its path) prevents premature cleanup while tests
+    // are still using the shared process-local registry state; this matches the
+    // E2E helpers' accepted lifetime policy.
     static DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
     DIR.get_or_init(|| tempfile::tempdir().expect("create unit-test crash state directory"))
         .path()

--- a/src/install.rs
+++ b/src/install.rs
@@ -41,10 +41,9 @@ pub fn default_data_dir() -> Option<PathBuf> {
     // parser registry, search-path defaulting, etc.) to a project-local
     // persistent dir under `deps/` so the developer's real
     // `~/.local/share/kakehashi/` is never read or written. The dir is
-    // shared across the test process to keep parser/query installs
-    // cached between runs; legacy transient crash-recovery files
-    // (`parsing_in_progress`, `failed_parsers`) are cleared once per
-    // process at first call so a prior E2E shutdown can't taint this run.
+    // shared across test processes to keep parser/query installs cached
+    // between runs. Crash-recovery state is stored separately in the
+    // process-local `test_state_dir`.
     #[cfg(test)]
     {
         return Some(test_data_dir());
@@ -63,10 +62,8 @@ pub fn default_data_dir() -> Option<PathBuf> {
 /// Project-local persistent data directory used by unit tests.
 ///
 /// Lives under `deps/` (already gitignored). Parser/query installs persist
-/// across runs to avoid re-downloading, while legacy crash-recovery state files
-/// are cleared once per test process so a previous test's leftovers
-/// (typically from an E2E binary that exited mid-parse) don't poison this
-/// run. Returns the same path every call within a process via `OnceLock`.
+/// across runs to avoid re-downloading. Returns the same path every call
+/// within a process via `OnceLock`.
 #[cfg(test)]
 pub(crate) fn test_data_dir() -> PathBuf {
     use std::sync::OnceLock;
@@ -74,11 +71,6 @@ pub(crate) fn test_data_dir() -> PathBuf {
     DIR.get_or_init(|| {
         let dir = test_support::test_data_dir_path();
         let _ = std::fs::create_dir_all(&dir);
-        // Crash-recovery state can be left over from a previous E2E
-        // shutdown; clear it once per test process so init() doesn't
-        // pre-mark languages as failed.
-        let _ = std::fs::remove_file(dir.join("parsing_in_progress"));
-        let _ = std::fs::remove_file(dir.join("failed_parsers"));
         // Auto-install required parsers + queries on first call per
         // process. Cached on disk via the `.installed` marker so
         // subsequent test processes are fast.
@@ -86,6 +78,22 @@ pub(crate) fn test_data_dir() -> PathBuf {
         dir
     })
     .clone()
+}
+
+/// Process-local crash-recovery directory used by unit-test builds.
+///
+/// Parser/query assets remain shared in [`test_data_dir`], but marker files
+/// must not: deleting stale-looking markers from that shared directory can
+/// unlink a concurrently running test process's live, locked marker. A temp
+/// directory owned for the lifetime of this process gives recovery tests a
+/// stable location without environment-variable mutation or peer cleanup.
+#[cfg(test)]
+pub(crate) fn test_state_dir() -> PathBuf {
+    use std::sync::OnceLock;
+    static DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
+    DIR.get_or_init(|| tempfile::tempdir().expect("create unit-test crash state directory"))
+        .path()
+        .to_path_buf()
 }
 
 /// Test-support helpers exposed to integration tests under `tests/`.

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -173,7 +173,8 @@ impl AutoInstallManager {
     ///
     /// State storage location: `KAKEHASHI_STATE_DIR` if set, else the default
     /// data directory, falling back to a `kakehashi` dir under the OS temp dir
-    /// if neither resolves. Crash-recovery state (`parsing_in_progress`,
+    /// if neither resolves. Unit-test builds instead use a stable process-owned
+    /// temp directory, independent of the shared parser assets. Crash-recovery state (`parsing_in_progress`,
     /// `failed_parsers`) is ephemeral and conceptually distinct from the
     /// persistent parser/query install assets in the data dir; the override
     /// lets it live elsewhere — e.g. so concurrent test processes that share one

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -535,6 +535,13 @@ mod tests {
 
     #[test]
     fn unit_test_crash_state_is_separate_from_shared_install_assets() {
+        const PARENT_STATE_DIR: &str = "KAKEHASHI_TEST_PARENT_CRASH_STATE_DIR";
+
+        if let Some(parent_state_dir) = std::env::var_os(PARENT_STATE_DIR) {
+            assert_ne!(failed_parser_state_dir(), PathBuf::from(parent_state_dir));
+            return;
+        }
+
         let shared_install_dir = crate::install::test_support::test_data_dir_path();
         let state_dir = failed_parser_state_dir();
         let _registry = AutoInstallManager::init_failed_parser_registry();
@@ -542,6 +549,21 @@ mod tests {
         assert_ne!(state_dir, shared_install_dir);
         assert_eq!(state_dir, failed_parser_state_dir());
         assert!(state_dir.join("crash_recovery.lock").is_file());
+
+        let child_status = std::process::Command::new(
+            std::env::current_exe().expect("resolve current test executable"),
+        )
+        .arg(stringify!(
+            unit_test_crash_state_is_separate_from_shared_install_assets
+        ))
+        .env(PARENT_STATE_DIR, &state_dir)
+        .status()
+        .expect("run crash-state isolation test in child process");
+
+        assert!(
+            child_status.success(),
+            "child test process must use a different crash-state directory"
+        );
     }
 
     fn create_test_manager() -> (AutoInstallManager, tempfile::TempDir) {

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -174,8 +174,9 @@ impl AutoInstallManager {
     /// State storage location: `KAKEHASHI_STATE_DIR` if set, else the default
     /// data directory, falling back to a `kakehashi` dir under the OS temp dir
     /// if neither resolves. Unit-test builds instead use a stable process-owned
-    /// temp directory, independent of the shared parser assets. Crash-recovery state (`parsing_in_progress`,
-    /// `failed_parsers`) is ephemeral and conceptually distinct from the
+    /// temp directory, independent of the shared parser assets. Crash-recovery
+    /// state (`parsing_in_progress`, `failed_parsers`) is ephemeral and
+    /// conceptually distinct from the
     /// persistent parser/query install assets in the data dir; the override
     /// lets it live elsewhere — e.g. so concurrent test processes that share one
     /// read-only install dir can isolate their crash state and not poison each

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -534,7 +534,7 @@ mod tests {
 
     #[test]
     fn unit_test_crash_state_is_separate_from_shared_install_assets() {
-        let shared_install_dir = crate::install::test_data_dir();
+        let shared_install_dir = crate::install::test_support::test_data_dir_path();
 
         let state_dir = failed_parser_state_dir();
 

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -536,11 +536,8 @@ mod tests {
     #[test]
     fn unit_test_crash_state_is_separate_from_shared_install_assets() {
         const PARENT_STATE_DIR: &str = "KAKEHASHI_TEST_PARENT_CRASH_STATE_DIR";
-
-        if let Some(parent_state_dir) = std::env::var_os(PARENT_STATE_DIR) {
-            assert_ne!(failed_parser_state_dir(), PathBuf::from(parent_state_dir));
-            return;
-        }
+        const CHILD_TEST: &str =
+            "lsp::auto_install::manager::tests::child_process_uses_distinct_crash_state";
 
         let shared_install_dir = crate::install::test_support::test_data_dir_path();
         let state_dir = failed_parser_state_dir();
@@ -553,9 +550,7 @@ mod tests {
         let child_status = std::process::Command::new(
             std::env::current_exe().expect("resolve current test executable"),
         )
-        .arg(stringify!(
-            unit_test_crash_state_is_separate_from_shared_install_assets
-        ))
+        .args(["--ignored", "--exact", CHILD_TEST])
         .env(PARENT_STATE_DIR, &state_dir)
         .status()
         .expect("run crash-state isolation test in child process");
@@ -564,6 +559,15 @@ mod tests {
             child_status.success(),
             "child test process must use a different crash-state directory"
         );
+    }
+
+    #[test]
+    #[ignore = "run only as a child of the crash-state isolation test"]
+    fn child_process_uses_distinct_crash_state() {
+        let parent_state_dir = std::env::var_os("KAKEHASHI_TEST_PARENT_CRASH_STATE_DIR")
+            .expect("parent crash-state directory must be provided");
+
+        assert_ne!(failed_parser_state_dir(), PathBuf::from(parent_state_dir));
     }
 
     fn create_test_manager() -> (AutoInstallManager, tempfile::TempDir) {

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -541,7 +541,6 @@ mod tests {
         assert_ne!(state_dir, shared_install_dir);
         assert_eq!(state_dir, failed_parser_state_dir());
         assert!(state_dir.join("crash_recovery.lock").is_file());
-        assert!(!shared_install_dir.join("crash_recovery.lock").exists());
     }
 
     fn create_test_manager() -> (AutoInstallManager, tempfile::TempDir) {

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -535,11 +535,13 @@ mod tests {
     #[test]
     fn unit_test_crash_state_is_separate_from_shared_install_assets() {
         let shared_install_dir = crate::install::test_support::test_data_dir_path();
-
         let state_dir = failed_parser_state_dir();
+        let _registry = AutoInstallManager::init_failed_parser_registry();
 
         assert_ne!(state_dir, shared_install_dir);
         assert_eq!(state_dir, failed_parser_state_dir());
+        assert!(state_dir.join("crash_recovery.lock").is_file());
+        assert!(!shared_install_dir.join("crash_recovery.lock").exists());
     }
 
     fn create_test_manager() -> (AutoInstallManager, tempfile::TempDir) {

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -138,6 +138,25 @@ impl Drop for InstallMarkerGuard {
     }
 }
 
+#[cfg(test)]
+fn failed_parser_state_dir() -> PathBuf {
+    crate::install::test_state_dir()
+}
+
+#[cfg(not(test))]
+fn failed_parser_state_dir() -> PathBuf {
+    std::env::var_os("KAKEHASHI_STATE_DIR")
+        // An empty value resolves to the process cwd (writing crash files
+        // wherever it was started), so treat it as unset — matching how
+        // `resolve_data_dir` handles an empty `KAKEHASHI_DATA_DIR`.
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .or_else(crate::install::default_data_dir)
+        // Platform-aware last resort (not a hard-coded `/tmp`, which doesn't
+        // exist on Windows); only reached if the data dir can't resolve.
+        .unwrap_or_else(|| std::env::temp_dir().join("kakehashi"))
+}
+
 impl AutoInstallManager {
     /// Create a new `AutoInstallManager`.
     pub fn new(
@@ -164,16 +183,7 @@ impl AutoInstallManager {
     /// If initialization fails, returns an uninitialized registry whose
     /// `begin_parsing` calls fail closed before entering native parser code.
     pub fn init_failed_parser_registry() -> FailedParserRegistry {
-        let state_dir = std::env::var_os("KAKEHASHI_STATE_DIR")
-            // An empty value resolves to the process cwd (writing crash files
-            // wherever it was started), so treat it as unset — matching how
-            // `resolve_data_dir` handles an empty `KAKEHASHI_DATA_DIR`.
-            .filter(|v| !v.is_empty())
-            .map(PathBuf::from)
-            .or_else(crate::install::default_data_dir)
-            // Platform-aware last resort (not a hard-coded `/tmp`, which doesn't
-            // exist on Windows); only reached if the data dir can't resolve.
-            .unwrap_or_else(|| std::env::temp_dir().join("kakehashi"));
+        let state_dir = failed_parser_state_dir();
 
         let registry = FailedParserRegistry::new(&state_dir);
 
@@ -520,6 +530,16 @@ impl AutoInstallManager {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn unit_test_crash_state_is_separate_from_shared_install_assets() {
+        let shared_install_dir = crate::install::test_data_dir();
+
+        let state_dir = failed_parser_state_dir();
+
+        assert_ne!(state_dir, shared_install_dir);
+        assert_eq!(state_dir, failed_parser_state_dir());
+    }
 
     fn create_test_manager() -> (AutoInstallManager, tempfile::TempDir) {
         let temp = tempdir().expect("Failed to create temp dir");

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -533,9 +533,11 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
+    const PARENT_STATE_DIR: &str = "KAKEHASHI_TEST_PARENT_CRASH_STATE_DIR";
+    const CHILD_HANDSHAKE_PATH: &str = "KAKEHASHI_TEST_CRASH_STATE_HANDSHAKE_PATH";
+
     #[test]
     fn unit_test_crash_state_is_separate_from_shared_install_assets() {
-        const PARENT_STATE_DIR: &str = "KAKEHASHI_TEST_PARENT_CRASH_STATE_DIR";
         const CHILD_TEST: &str =
             "lsp::auto_install::manager::tests::child_process_uses_distinct_crash_state";
 
@@ -547,11 +549,14 @@ mod tests {
         assert_eq!(state_dir, failed_parser_state_dir());
         assert!(state_dir.join("crash_recovery.lock").is_file());
 
+        let handshake_dir = tempdir().expect("create crash-state handshake directory");
+        let handshake_path = handshake_dir.path().join("child-ran");
         let child_status = std::process::Command::new(
             std::env::current_exe().expect("resolve current test executable"),
         )
         .args(["--ignored", "--exact", CHILD_TEST])
         .env(PARENT_STATE_DIR, &state_dir)
+        .env(CHILD_HANDSHAKE_PATH, &handshake_path)
         .status()
         .expect("run crash-state isolation test in child process");
 
@@ -559,15 +564,25 @@ mod tests {
             child_status.success(),
             "child test process must use a different crash-state directory"
         );
+        assert!(
+            handshake_path.is_file(),
+            "child test process must execute the isolation assertion"
+        );
     }
 
     #[test]
     #[ignore = "run only as a child of the crash-state isolation test"]
     fn child_process_uses_distinct_crash_state() {
-        let parent_state_dir = std::env::var_os("KAKEHASHI_TEST_PARENT_CRASH_STATE_DIR")
-            .expect("parent crash-state directory must be provided");
+        let (Some(parent_state_dir), Some(handshake_path)) = (
+            std::env::var_os(PARENT_STATE_DIR),
+            std::env::var_os(CHILD_HANDSHAKE_PATH),
+        ) else {
+            return;
+        };
 
         assert_ne!(failed_parser_state_dir(), PathBuf::from(parent_state_dir));
+        std::fs::write(handshake_path, b"child assertion passed")
+            .expect("write crash-state child handshake");
     }
 
     fn create_test_manager() -> (AutoInstallManager, tempfile::TempDir) {


### PR DESCRIPTION
## Summary

- keep shared parser/query assets under `deps/test/kakehashi`
- derive a process-owned temporary crash-state directory for unit-test builds
- stop deleting legacy crash markers from the shared install directory
- preserve production `KAKEHASHI_STATE_DIR` and fallback behavior unchanged
- prove same-process stability and cross-process uniqueness with a child-test handshake

Closes #730

## Validation

- RED: fixed shared temp paths fail the parent/child uniqueness regression
- RED: ambient probe variables and stale child-test filters are detected
- `cargo test --lib lsp::auto_install::manager::tests::` (13 passed, 1 helper ignored in the parent suite and executed by the regression)
- direct ignored-helper invocation without probe environment passes
- `make check`
- fresh independent Codex review: no comments to provide

## Stack

This PR is based on #727 because per-session crash markers and the state-directory contract are introduced there. It merges into `fix-725-durable-parser-crash-marker`; #727 remains responsible for bringing the combined stack to `main`.