### PR TITLE
fix(config): aim explicit config-file strictness at real mistakes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -719,6 +719,13 @@ When `--config-file` is specified:
   is silent there.
 - A path whose metadata cannot be read at all — an ancestor directory denying
   traversal, say — counts as unusable, not absent.
+- A key kakehashi does not recognise is **reported but not fatal**. Serde would
+  otherwise drop `autoInstal = false` silently and leave you wondering why the
+  default applied. It stays a warning because an unrecognised key may equally be
+  one a newer kakehashi understands, and refusing to start would version-lock
+  the file. (`workspace/didChangeConfiguration` is stricter and rejects the
+  whole update — that one is a live edit, not a file you may share across
+  versions.)
 - Cross-field invariants (e.g. `debounceMs` ≤ `maxWaitMs`) are judged on the
   merged explicit configuration, so splitting the two halves across two files is
   fine — but a combination that is invalid only once merged still aborts.

--- a/docs/README.md
+++ b/docs/README.md
@@ -723,10 +723,12 @@ When `--config-file` is specified:
   merged explicit configuration, so splitting the two halves across two files is
   fine — but a combination that is invalid only once merged still aborts.
 - `initializationOptions` from the LSP client still apply on top, and keep their
-  ordinary non-fatal behavior. Note what "non-fatal" means here: the server
-  starts, but the *whole* merged configuration is discarded in favour of
-  programmed defaults — the config files do not survive a bad override. Only
-  the abort is avoided, not the loss.
+  ordinary non-fatal behavior — but "non-fatal" covers two different outcomes.
+  An override that fails to *parse* is warned about and dropped, leaving the
+  config files in effect. An override that parses and then makes the merged
+  configuration invalid — an unexpandable path, a violated invariant — discards
+  the *whole* merge in favour of programmed defaults, so the config files do not
+  survive it either. Only the abort is avoided, not the loss.
 
 Implicitly discovered configuration is deliberately laxer. A
 `~/.config/kakehashi/kakehashi.toml` or `./kakehashi.toml` that fails to parse

--- a/docs/README.md
+++ b/docs/README.md
@@ -208,7 +208,7 @@ Path fields support environment variable expansion and tilde (`~`) expansion, ma
 - `languages[*].parser`
 - `languages[*].queries[*].path`
 
-**Behavior on undefined variables:** If a referenced environment variable is not defined, configuration loading fails with an error notification and falls back to previous settings (or defaults). The exception is `KAKEHASHI_DATA_DIR`, which automatically falls back to the platform-specific default when unset (see [Default Data Directories](#default-data-directories)).
+**Behavior on undefined variables:** If a referenced environment variable is not defined during ordinary startup loading, the merged configuration is discarded and programmed defaults are used. A runtime `workspace/didChangeConfiguration` update is discarded while the previous settings remain active. Explicit `--config-file` inputs are stricter: an expansion failure rejects LSP initialization or makes the CLI command exit with status 2. The exception is `KAKEHASHI_DATA_DIR`, which automatically falls back to the platform-specific default when unset (see [Default Data Directories](#default-data-directories)).
 
 ### Option Reference
 
@@ -698,7 +698,10 @@ kakehashi --config-file /path/to/empty.toml
 When `--config-file` is specified:
 - Default user config (`~/.config/kakehashi/kakehashi.toml`) is **skipped**
 - Default project config (`./kakehashi.toml`) is **skipped**
-- Non-existent files produce an error
+- Every explicit file is validated before merging, so a missing or unreadable
+  file, malformed TOML, or path-expansion failure aborts startup even when a
+  later layer would override the invalid value. LSP initialization returns a
+  `RequestFailed` error; `format` and `diagnose` exit with status 2.
 - `initializationOptions` from the LSP client still apply on top
 
 ## CLI Commands

--- a/docs/README.md
+++ b/docs/README.md
@@ -707,11 +707,15 @@ When `--config-file` is specified:
 - A path that expands badly is judged **per file**, so a later layer cannot mask
   an earlier layer's undefined variable — the merged result would never mention
   the mistake, because a later layer replaces path fields wholesale.
-- A file that is **absent** is skipped with a warning, not an error, so
+- A file that is **absent** is skipped rather than treated as an error, so
   `--config-file base.toml --config-file overrides.toml` works in a repository
   that has no overlay. Note that a relative path resolves against the process
   working directory, which for an editor-spawned server is the editor's rather
-  than the workspace root.
+  than the workspace root. The skip is reported to the LSP client as a warning;
+  `format` and `diagnose` report only the hard errors above, so a mistyped path
+  is silent there.
+- A path whose metadata cannot be read at all — an ancestor directory denying
+  traversal, say — counts as unusable, not absent.
 - Cross-field invariants (e.g. `debounceMs` ≤ `maxWaitMs`) are judged on the
   merged explicit configuration, so splitting the two halves across two files is
   fine — but a combination that is invalid only once merged still aborts.

--- a/docs/README.md
+++ b/docs/README.md
@@ -208,7 +208,7 @@ Path fields support environment variable expansion and tilde (`~`) expansion, ma
 - `languages[*].parser`
 - `languages[*].queries[*].path`
 
-**Behavior on undefined variables:** If a referenced environment variable is not defined during ordinary startup loading, the merged configuration is discarded and programmed defaults are used. A runtime `workspace/didChangeConfiguration` update is discarded while the previous settings remain active. Explicit `--config-file` inputs are stricter: an expansion failure rejects LSP initialization or makes the CLI command exit with status 2. The exception is `KAKEHASHI_DATA_DIR`, which automatically falls back to the platform-specific default when unset (see [Default Data Directories](#default-data-directories)).
+**Behavior on undefined variables:** If a referenced environment variable is not defined during ordinary startup loading, the merged configuration is discarded and programmed defaults are used. A runtime `workspace/didChangeConfiguration` update is discarded while the previous settings remain active. Explicit `--config-file` inputs are stricter: an expansion failure in one of them rejects LSP initialization or makes the CLI command exit with status 2, rather than falling back to defaults. `initializationOptions` sent by the client keep the ordinary non-fatal behavior even in a `--config-file` session. The exception is `KAKEHASHI_DATA_DIR`, which automatically falls back to the platform-specific default when unset (see [Default Data Directories](#default-data-directories)).
 
 ### Option Reference
 
@@ -698,11 +698,30 @@ kakehashi --config-file /path/to/empty.toml
 When `--config-file` is specified:
 - Default user config (`~/.config/kakehashi/kakehashi.toml`) is **skipped**
 - Default project config (`./kakehashi.toml`) is **skipped**
-- Every explicit file is validated before merging, so a missing or unreadable
-  file, malformed TOML, or path-expansion failure aborts startup even when a
-  later layer would override the invalid value. LSP initialization returns a
-  `RequestFailed` error; `format` and `diagnose` exit with status 2.
-- `initializationOptions` from the LSP client still apply on top
+- A file that is **present but unusable** aborts startup: unreadable, malformed
+  TOML, or a path that cannot be expanded. LSP initialization returns a
+  `RequestFailed` error naming the first such file; `format` and `diagnose`
+  print it to stderr and exit with status 2. Correcting the file requires
+  restarting the server (`:LspRestart`, or reloading the window) — kakehashi
+  does not re-read configuration after a rejected initialization.
+- A path that expands badly is judged **per file**, so a later layer cannot mask
+  an earlier layer's undefined variable — the merged result would never mention
+  the mistake, because a later layer replaces path fields wholesale.
+- A file that is **absent** is skipped with a warning, not an error, so
+  `--config-file base.toml --config-file overrides.toml` works in a repository
+  that has no overlay. Note that a relative path resolves against the process
+  working directory, which for an editor-spawned server is the editor's rather
+  than the workspace root.
+- Cross-field invariants (e.g. `debounceMs` ≤ `maxWaitMs`) are judged on the
+  merged explicit configuration, so splitting the two halves across two files is
+  fine — but a combination that is invalid only once merged still aborts.
+- `initializationOptions` from the LSP client still apply on top, and keep their
+  ordinary non-fatal behavior: an invalid override is discarded, not fatal.
+
+Implicitly discovered configuration is deliberately laxer. A
+`~/.config/kakehashi/kakehashi.toml` or `./kakehashi.toml` that fails to parse
+is reported as a warning and skipped, so a stray file cannot stop the server
+from starting. Only paths you name explicitly are strict.
 
 ## CLI Commands
 
@@ -798,10 +817,12 @@ kakehashi format . --tab-size 2 --insert-spaces false
 
 Exit codes: `0` nothing to change (or changes written without
 `--fail-on-change`), `1` changes detected under `--check`/`--fail-on-change`,
-`2` usage error, I/O error, or downstream formatter failure (a configured
+`2` usage error, I/O error, a configuration file given with `--config-file`
+that could not be loaded, or downstream formatter failure (a configured
 server failed to start, errored on the request, timed out, or returned a
 protocol-invalid response — even when a fallback server still produced
-output).
+output). On exit `2` stdout stays empty, including in `--stdin-filename` mode:
+a failed run never hands its caller content to write back.
 
 ### Diagnostics
 
@@ -851,7 +872,8 @@ Line and column are 1-based; a diagnostic with no severity is treated as an
 error (so it can never silently slip past the gate). Exit codes: `0` no failing
 diagnostic; `1` a failing diagnostic — any error always, plus warnings with
 `--fail-on-warning` (info/hint never fail); `2` an operational error (a file
-could not be read, a path could not be opened or fully enumerated, or a
+could not be read, a path could not be opened or fully enumerated, a
+configuration file given with `--config-file` could not be loaded, or a
 configured downstream server failed — including one that answered the
 `textDocument/diagnostic` pull with an error response or a
 present-but-malformed payload, matching `kakehashi format`'s strictness) —

--- a/docs/README.md
+++ b/docs/README.md
@@ -718,7 +718,10 @@ When `--config-file` is specified:
   `format` and `diagnose` report only the hard errors above, so a mistyped path
   is silent there.
 - A path whose metadata cannot be read at all — an ancestor directory denying
-  traversal, say — counts as unusable, not absent.
+  traversal, say — counts as unusable, not absent. So does a symlink whose
+  target is gone: the path you named exists, it just does not lead to a config.
+  A path *beneath* a broken symlink is a different case — nothing is there at
+  all, so it is treated as absent, like any other missing directory.
 - A key kakehashi does not recognise is **reported but not fatal**, so a file
   can carry a key a newer version understands without the older one refusing to
   start. Serde would otherwise drop `autoInstal = false` silently and leave you

--- a/docs/README.md
+++ b/docs/README.md
@@ -699,7 +699,7 @@ When `--config-file` is specified:
 - Default user config (`~/.config/kakehashi/kakehashi.toml`) is **skipped**
 - Default project config (`./kakehashi.toml`) is **skipped**
 - A file that is **present but unusable** aborts startup: unreadable, malformed
-  TOML, or a path that cannot be expanded. LSP initialization returns a
+  TOML, larger than 8 MiB, or carrying a path that cannot be expanded. LSP initialization returns a
   `RequestFailed` error naming the first such file; `format` and `diagnose`
   print it to stderr and exit with status 2. Nothing is re-read while the
   session runs, so correcting the file means restarting the server
@@ -830,10 +830,12 @@ Exit codes: `0` nothing to change (or changes written without
 `2` usage error, I/O error, a configuration file given with `--config-file`
 that could not be loaded, or downstream formatter failure (a configured
 server failed to start, errored on the request, timed out, or returned a
-protocol-invalid response). Under the default `concatenated` aggregation that
-holds even when another server still produced output; under `preferred` the
-winning formatter is authoritative, so a *non-winning* server's failure does
-not count — mirroring `diagnose` below.
+protocol-invalid response). Which failures count depends on the aggregation
+strategy in force: under `preferred` — the bridge-level default for formatting,
+where several servers of one target produce competing whole-document edits —
+the winner is authoritative, so a *non-winning* server's failure does not
+count; under `concatenated` every server's failure does. Same rule as
+`diagnose` below.
 
 A configuration failure exits `2` before anything is written, so stdout stays
 empty in `--stdin-filename` mode. A *downstream* failure does not: the content

--- a/docs/README.md
+++ b/docs/README.md
@@ -719,13 +719,15 @@ When `--config-file` is specified:
   is silent there.
 - A path whose metadata cannot be read at all — an ancestor directory denying
   traversal, say — counts as unusable, not absent.
-- A key kakehashi does not recognise is **reported but not fatal**. Serde would
-  otherwise drop `autoInstal = false` silently and leave you wondering why the
-  default applied. It stays a warning because an unrecognised key may equally be
-  one a newer kakehashi understands, and refusing to start would version-lock
-  the file. (`workspace/didChangeConfiguration` is stricter and rejects the
-  whole update — that one is a live edit, not a file you may share across
-  versions.)
+- A key kakehashi does not recognise is **reported but not fatal**, so a file
+  can carry a key a newer version understands without the older one refusing to
+  start. Serde would otherwise drop `autoInstal = false` silently and leave you
+  wondering why the default applied. Two caveats: keys inside `features` are an
+  exception — the parser rejects them outright, so an unknown one there *is*
+  fatal — and in `format`/`diagnose` the warning has nowhere to go, since CLI
+  mode surfaces only hard errors. (`workspace/didChangeConfiguration` is
+  stricter still and rejects the whole update — that one is a live edit, not a
+  file you may share across versions.)
 - Cross-field invariants (e.g. `debounceMs` ≤ `maxWaitMs`) are judged on the
   merged explicit configuration, so splitting the two halves across two files is
   fine — but a combination that is invalid only once merged still aborts.

--- a/docs/README.md
+++ b/docs/README.md
@@ -830,9 +830,16 @@ Exit codes: `0` nothing to change (or changes written without
 `2` usage error, I/O error, a configuration file given with `--config-file`
 that could not be loaded, or downstream formatter failure (a configured
 server failed to start, errored on the request, timed out, or returned a
-protocol-invalid response — even when a fallback server still produced
-output). On exit `2` stdout stays empty, including in `--stdin-filename` mode:
-a failed run never hands its caller content to write back.
+protocol-invalid response). Under the default `concatenated` aggregation that
+holds even when another server still produced output; under `preferred` the
+winning formatter is authoritative, so a *non-winning* server's failure does
+not count — mirroring `diagnose` below.
+
+A configuration failure exits `2` before anything is written, so stdout stays
+empty in `--stdin-filename` mode. A *downstream* failure does not: the content
+is written first and the exit code reports the failure afterwards, so a caller
+that pipes stdin through `format` must check the status rather than assume
+empty output means failure.
 
 ### Diagnostics
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -830,12 +830,13 @@ Exit codes: `0` nothing to change (or changes written without
 `2` usage error, I/O error, a configuration file given with `--config-file`
 that could not be loaded, or downstream formatter failure (a configured
 server failed to start, errored on the request, timed out, or returned a
-protocol-invalid response). Which failures count depends on the aggregation
-strategy in force: under `preferred` — the bridge-level default for formatting,
-where several servers of one target produce competing whole-document edits —
-the winner is authoritative, so a *non-winning* server's failure does not
-count; under `concatenated` every server's failure does. Same rule as
-`diagnose` below.
+protocol-invalid response). Only *request-time* failures are strategy-aware:
+under `preferred` — the bridge-level default for formatting, where several
+servers of one target produce competing whole-document edits — the winner is
+authoritative, so a non-winning server's failed request does not count, while
+`concatenated` counts every server's. A server that fails to **start** always
+counts, whichever strategy is in force and even if a fallback then formatted
+the document.
 
 A configuration failure exits `2` before anything is written, so stdout stays
 empty in `--stdin-filename` mode. A *downstream* failure does not: the content

--- a/docs/README.md
+++ b/docs/README.md
@@ -701,9 +701,12 @@ When `--config-file` is specified:
 - A file that is **present but unusable** aborts startup: unreadable, malformed
   TOML, or a path that cannot be expanded. LSP initialization returns a
   `RequestFailed` error naming the first such file; `format` and `diagnose`
-  print it to stderr and exit with status 2. Correcting the file requires
-  restarting the server (`:LspRestart`, or reloading the window) — kakehashi
-  does not re-read configuration after a rejected initialization.
+  print it to stderr and exit with status 2. Nothing is re-read while the
+  session runs, so correcting the file means restarting the server
+  (`:LspRestart`, or reloading the window). A client that responds to the
+  rejected handshake by sending `initialize` again is also served correctly —
+  the retry re-reads the files and is not contaminated by the failed attempt —
+  but most editors do not, so treat restart as the recovery path.
 - A path that expands badly is judged **per file**, so a later layer cannot mask
   an earlier layer's undefined variable — the merged result would never mention
   the mistake, because a later layer replaces path fields wholesale.

--- a/docs/README.md
+++ b/docs/README.md
@@ -720,7 +720,10 @@ When `--config-file` is specified:
   merged explicit configuration, so splitting the two halves across two files is
   fine — but a combination that is invalid only once merged still aborts.
 - `initializationOptions` from the LSP client still apply on top, and keep their
-  ordinary non-fatal behavior: an invalid override is discarded, not fatal.
+  ordinary non-fatal behavior. Note what "non-fatal" means here: the server
+  starts, but the *whole* merged configuration is discarded in favour of
+  programmed defaults — the config files do not survive a bad override. Only
+  the abort is avoided, not the loss.
 
 Implicitly discovered configuration is deliberately laxer. A
 `~/.config/kakehashi/kakehashi.toml` or `./kakehashi.toml` that fails to parse

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -244,8 +244,10 @@ path the user typed carries intent; a path kakehashi went looking for does not.
      `initialize` would otherwise get the corrected settings alongside the
      failed attempt's capabilities and workspace folders.
    - Each `--config-file` is read exactly once and the result carried into the
-     merge. A path may name a stream, and a file swapped between two reads
-     would slip past whichever check ran first.
+     merge: a file swapped between two reads would slip past whichever check
+     ran first. Reads are bounded, so a path naming an endless source fails
+     instead of exhausting memory; a path naming a stream with no writer still
+     blocks, which is the failure mode of the path the user chose.
 
 ### Implementation Notes
 

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -192,18 +192,40 @@ silently shadow every user-supplied top-level opt-out.
 
 ### File Loading Behavior
 
-1. **Missing files are silently ignored**
+Strictness follows *how the path was chosen*, not what went wrong with it. A
+path the user typed carries intent; a path kakehashi went looking for does not.
+
+1. **Implicitly discovered files degrade quietly**
    - User config doesn't exist: proceed with empty user config
-   - Project config doesn't exist (and `--config-file` not specified): proceed with empty project config
-   - No error, no warning—this enables zero-config startup
+   - Project config doesn't exist: proceed with empty project config
+   - Either one exists but fails to parse: warn and skip that layer
+   - This is what keeps zero-config startup working: a stray or half-edited
+     `kakehashi.toml` must never leave the user without a server
 
-2. **Invalid files cause startup failure**
-   - Parse errors in any config file should fail fast with a clear error message
-   - Users should know immediately if their config is malformed
+2. **An explicit `--config-file` that is present but unusable fails startup**
+   - Unreadable, malformed TOML, or carrying a path that cannot be expanded
+   - LSP `initialize` returns `RequestFailed` (-32803) naming the first such
+     file; `format` and `diagnose` print it and exit 2
+   - Silently dropping the layer and continuing on defaults is what hides
+     configuration mistakes, and an explicit path is where the user is most
+     entitled to be told
 
-3. **`--config-file` option with missing file**
-   - If user explicitly specifies `--config-file /path/to/config.toml` and file doesn't exist: error
-   - Explicit paths should be validated; implicit defaults can be missing
+3. **An explicit `--config-file` that is absent is skipped with a warning**
+   - Layered invocations (`--config-file base.toml --config-file overrides.toml`)
+     depend on the overlay being allowed not to exist, and a relative path
+     resolves against the process working directory — for an editor-spawned
+     server, the editor's rather than the workspace root. Absence is too easily
+     accidental to be worth refusing to start over; being unusable is not.
+
+4. **Where each class of failure is judged**
+   - Path expansion: per file, because a later layer replaces path fields
+     wholesale, so the merged result would never mention an earlier layer's
+     undefined variable
+   - Cross-field invariants (e.g. `debounceMs` ≤ `maxWaitMs`): on the merged
+     explicit configuration only, because their operands merge independently —
+     one file may legitimately supply just one half
+   - `initializationOptions`: never fatal. A client-supplied override that fails
+     to expand is discarded, as it is outside a `--config-file` session
 
 ### Implementation Notes
 
@@ -274,7 +296,8 @@ fn load_configuration(cli_config_path: Option<&Path>) -> Option<RawWorkspaceSett
 ### Phase 4: Project Configuration (Completed)
 - [x] Load project config from `./kakehashi.toml`
 - [x] `--config-file` CLI option for alternative path(s)
-- [x] Error on missing file when explicitly specified
+- [x] Fail startup on an explicit file that is present but unusable; skip an
+      absent one with a warning
 
 ### Phase 5: Testing
 - [ ] Unit tests for `QueryItem` parsing and type inference

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -203,7 +203,8 @@ path the user typed carries intent; a path kakehashi went looking for does not.
      `kakehashi.toml` must never leave the user without a server
 
 2. **An explicit `--config-file` that is present but unusable fails startup**
-   - Unreadable, malformed TOML, or carrying a path that cannot be expanded
+   - Unreadable, malformed TOML, larger than the 8 MiB read ceiling, or
+     carrying a path that cannot be expanded
    - LSP `initialize` returns `RequestFailed` (-32803) naming the first such
      file; `format` and `diagnose` print it and exit 2
    - Silently dropping the layer and continuing on defaults is what hides

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -210,12 +210,19 @@ path the user typed carries intent; a path kakehashi went looking for does not.
      configuration mistakes, and an explicit path is where the user is most
      entitled to be told
 
-3. **An explicit `--config-file` that is absent is skipped with a warning**
+3. **An explicit `--config-file` that is absent is skipped**
    - Layered invocations (`--config-file base.toml --config-file overrides.toml`)
      depend on the overlay being allowed not to exist, and a relative path
      resolves against the process working directory — for an editor-spawned
      server, the editor's rather than the workspace root. Absence is too easily
      accidental to be worth refusing to start over; being unusable is not.
+   - A path whose metadata cannot be read at all counts as unusable, not
+     absent: `exists()` answers "no" to both, and only one of them is the
+     optional-overlay case.
+   - The skip is a `SettingsEvent::warning`, so an editor sees it as
+     `window/logMessage`. `format` and `diagnose` show nothing: CLI mode has no
+     channel for non-fatal settings events at all (the stub client pump
+     discards them), which is a pre-existing gap rather than a decision here.
 
 4. **Where each class of failure is judged**
    - Path expansion: per file, because a later layer replaces path fields

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -232,12 +232,18 @@ path the user typed carries intent; a path kakehashi went looking for does not.
    - Cross-field invariants (e.g. `debounceMs` ≤ `maxWaitMs`): on the merged
      explicit configuration only, because their operands merge independently —
      one file may legitimately supply just one half
-   - Unrecognised key names: reported as a warning on an explicit file, never
+   - Unrecognised key names: reported as a warning on an explicit file, not
      fatal. Serde drops an unknown field silently, so a typo otherwise reads as
      "not specified"; but a key this version does not know may be one the next
      one does, and rejecting the file would version-lock it.
      `workspace/didChangeConfiguration` rejects the whole update instead —
      a live edit is not a file shared across versions.
+   - Two known inconsistencies, both pre-existing and both worth closing
+     separately: `FeatureSettings` and its children carry
+     `deny_unknown_fields`, so an unknown key *inside* `features` fails typed
+     deserialization and is fatal before the warning walker ever sees it; and
+     CLI mode has no channel for non-fatal settings events at all, so
+     `format`/`diagnose` users never see these warnings.
    - `initializationOptions`: never fatal, and judged last. A client-supplied
      override that fails to expand does not abort — but "non-fatal" only means
      the session starts: the *whole* merged configuration is discarded in

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -250,14 +250,27 @@ path the user typed carries intent; a path kakehashi went looking for does not.
 ### Implementation Notes
 
 **Config loading order:**
-```rust
-fn load_configuration(cli_config_path: Option<&Path>) -> Option<RawWorkspaceSettings> {
-    let defaults = Some(default_settings());  // from src/config/defaults.rs
-    let user_config = load_optional(xdg_config_path());
-    let project_config = load_optional_project_config(cli_config_path);
-    // InitializationOptions applied later in LSP initialize handler
 
-    [defaults, user_config, project_config].into_iter().reduce(merge_workspace_settings).flatten()
+`--config-file` is not an alternative *path* for the project layer — it replaces
+the whole implicit pair, and accepts any number of files that merge in flag
+order. It is also the only layer with a verdict of its own, reached before
+`initialize` stores anything, so the files are read once and carried into the
+merge rather than re-read:
+
+```rust
+// `initialize`, before any request-derived state is stored:
+let explicit = load_explicit_config(home, env_fn);   // None when the flag is absent
+if let Some(error) = explicit.as_ref().and_then(|c| c.fatal_error.clone()) {
+    return Err(configuration_load_error(error));
+}
+
+fn load_settings(root, override_settings, home, env_fn, explicit) -> SettingsLoadOutcome {
+    let defaults = Some(default_settings());          // src/config/defaults.rs
+    let files = match explicit {
+        Some(explicit) => explicit.layers,            // --config-file, in order
+        None => vec![load_user_config(), load_project_config(root)],
+    };
+    // initializationOptions merge last, and are never fatal
 }
 ```
 
@@ -283,7 +296,7 @@ fn load_configuration(cli_config_path: Option<&Path>) -> Option<RawWorkspaceSett
 - **Complexity increase**: Four config sources to understand and debug
 - **Arrays replace, not merge**: `queries` arrays are replaced entirely, not concatenated; overriding one query type requires repeating all
 - **No "unset" mechanism**: Cannot explicitly remove a field inherited from earlier layers (would need `null` support)
-- **File I/O at startup**: Reading up to two config files adds latency (minimal in practice)
+- **File I/O at startup**: Reading the config files adds latency (minimal in practice) — two implicit files, or however many `--config-file` arguments were given
 - **Infrastructure-integration gap**: Phases 1-3 (Sprints 118-120) built infrastructure (schema, merging, user config loading) but delivered ZERO user value until Sprint 124 wired APIs into application. Lesson: infrastructure sprints must be followed by integration sprints within 1-2 sprints to realize value.
 
 ### Neutral

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -231,8 +231,21 @@ path the user typed carries intent; a path kakehashi went looking for does not.
    - Cross-field invariants (e.g. `debounceMs` ≤ `maxWaitMs`): on the merged
      explicit configuration only, because their operands merge independently —
      one file may legitimately supply just one half
-   - `initializationOptions`: never fatal. A client-supplied override that fails
-     to expand is discarded, as it is outside a `--config-file` session
+   - `initializationOptions`: never fatal, and judged last. A client-supplied
+     override that fails to expand does not abort — but "non-fatal" only means
+     the session starts: the *whole* merged configuration is discarded in
+     favour of programmed defaults, explicit files included. Only the abort is
+     avoided, not the loss.
+
+5. **When the strict gate runs**
+   - Before `initialize` stores anything derived from the request. Several of
+     those stores are first-write-wins and `tower-lsp-server` accepts a retry
+     after an error response, so a client that fixes the file and re-sends
+     `initialize` would otherwise get the corrected settings alongside the
+     failed attempt's capabilities and workspace folders.
+   - Each `--config-file` is read exactly once and the result carried into the
+     merge. A path may name a stream, and a file swapped between two reads
+     would slip past whichever check ran first.
 
 ### Implementation Notes
 

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -232,6 +232,12 @@ path the user typed carries intent; a path kakehashi went looking for does not.
    - Cross-field invariants (e.g. `debounceMs` ≤ `maxWaitMs`): on the merged
      explicit configuration only, because their operands merge independently —
      one file may legitimately supply just one half
+   - Unrecognised key names: reported as a warning on an explicit file, never
+     fatal. Serde drops an unknown field silently, so a typo otherwise reads as
+     "not specified"; but a key this version does not know may be one the next
+     one does, and rejecting the file would version-lock it.
+     `workspace/didChangeConfiguration` rejects the whole update instead —
+     a live edit is not a file shared across versions.
    - `initializationOptions`: never fatal, and judged last. A client-supplied
      override that fails to expand does not abort — but "non-fatal" only means
      the session starts: the *whole* merged configuration is discarded in

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -18,10 +18,10 @@ struct Cli {
     /// specified multiple times; files merge in order.
     /// Skips ~/.config/kakehashi/kakehashi.toml and ./kakehashi.toml.
     /// For those commands, a file that is present but unreadable, malformed,
-    /// or carrying an unexpandable path is a hard error (CLI exit 2); one that
-    /// is absent is skipped (warned about over LSP; the CLI reports only hard
-    /// errors). Relative paths resolve against the working directory of the
-    /// kakehashi process.
+    /// larger than 8 MiB, or carrying an unexpandable path is a hard error
+    /// (CLI exit 2); one that is absent is skipped (warned about over LSP; the
+    /// CLI reports only hard errors). Relative paths resolve against the
+    /// working directory of the kakehashi process.
     #[arg(long, global = true)]
     config_file: Vec<PathBuf>,
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -16,7 +16,8 @@ struct Cli {
     /// Config file(s) to use instead of default locations, for the commands
     /// that load settings (LSP server mode, format, diagnose). Can be
     /// specified multiple times; files merge in order.
-    /// Skips ~/.config/kakehashi/kakehashi.toml and ./kakehashi.toml.
+    /// Skips both default locations: the user config under $XDG_CONFIG_HOME
+    /// (~/.config/kakehashi/kakehashi.toml when unset) and ./kakehashi.toml.
     /// For those commands, a file that is present but unreadable, malformed,
     /// larger than 8 MiB, or carrying an unexpandable path is a hard error:
     /// format and diagnose exit 2, and LSP initialization is rejected with

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -18,8 +18,9 @@ struct Cli {
     /// Skips ~/.config/kakehashi/kakehashi.toml and ./kakehashi.toml.
     /// A file that is present but unreadable, malformed, or carrying an
     /// unexpandable path is a hard error (CLI exit 2); one that is absent is
-    /// skipped with a warning. Relative paths resolve against the working
-    /// directory of the kakehashi process.
+    /// skipped (warned about over LSP; the CLI reports only hard errors).
+    /// Relative paths resolve against the working directory of the kakehashi
+    /// process.
     #[arg(long, global = true)]
     config_file: Vec<PathBuf>,
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -18,9 +18,10 @@ struct Cli {
     /// specified multiple times; files merge in order.
     /// Skips ~/.config/kakehashi/kakehashi.toml and ./kakehashi.toml.
     /// For those commands, a file that is present but unreadable, malformed,
-    /// larger than 8 MiB, or carrying an unexpandable path is a hard error
-    /// (CLI exit 2); one that is absent is skipped (warned about over LSP; the
-    /// CLI reports only hard errors). Relative paths resolve against the
+    /// larger than 8 MiB, or carrying an unexpandable path is a hard error:
+    /// format and diagnose exit 2, and LSP initialization is rejected with
+    /// RequestFailed. A file that is absent is skipped (warned about over LSP;
+    /// the CLI reports only hard errors). Relative paths resolve against the
     /// working directory of the kakehashi process.
     #[arg(long, global = true)]
     config_file: Vec<PathBuf>,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -13,14 +13,15 @@ struct Cli {
     #[arg(long, global = true)]
     data_dir: Option<PathBuf>,
 
-    /// Config file(s) to use instead of default locations. Can be specified
-    /// multiple times; files merge in order.
+    /// Config file(s) to use instead of default locations, for the commands
+    /// that load settings (LSP server mode, format, diagnose). Can be
+    /// specified multiple times; files merge in order.
     /// Skips ~/.config/kakehashi/kakehashi.toml and ./kakehashi.toml.
-    /// A file that is present but unreadable, malformed, or carrying an
-    /// unexpandable path is a hard error (CLI exit 2); one that is absent is
-    /// skipped (warned about over LSP; the CLI reports only hard errors).
-    /// Relative paths resolve against the working directory of the kakehashi
-    /// process.
+    /// For those commands, a file that is present but unreadable, malformed,
+    /// or carrying an unexpandable path is a hard error (CLI exit 2); one that
+    /// is absent is skipped (warned about over LSP; the CLI reports only hard
+    /// errors). Relative paths resolve against the working directory of the
+    /// kakehashi process.
     #[arg(long, global = true)]
     config_file: Vec<PathBuf>,
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -13,9 +13,13 @@ struct Cli {
     #[arg(long, global = true)]
     data_dir: Option<PathBuf>,
 
-    /// Config file(s) to use instead of default locations (LSP and format
-    /// modes). Can be specified multiple times; files merge in order.
+    /// Config file(s) to use instead of default locations. Can be specified
+    /// multiple times; files merge in order.
     /// Skips ~/.config/kakehashi/kakehashi.toml and ./kakehashi.toml.
+    /// A file that is present but unreadable, malformed, or carrying an
+    /// unexpandable path is a hard error (CLI exit 2); one that is absent is
+    /// skipped with a warning. Relative paths resolve against the working
+    /// directory of the kakehashi process.
     #[arg(long, global = true)]
     config_file: Vec<PathBuf>,
 
@@ -94,8 +98,8 @@ enum Commands {
     /// Exit codes: 0 = no failing diagnostics; 1 = a failing diagnostic (any
     /// error, plus warnings with --fail-on-warning; info/hint never fail —
     /// append `|| true` to never fail); 2 = an operational error (unreadable
-    /// file, path open/enumeration failure, downstream server failure),
-    /// independent of the diagnostics.
+    /// file, path open/enumeration failure, an unloadable --config-file,
+    /// downstream server failure), independent of the diagnostics.
     Diagnose {
         /// Files or directories to diagnose ("-" for stdin with --stdin-filename)
         paths: Vec<PathBuf>,

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -138,7 +138,13 @@ async fn run_async(options: DiagnoseOptions) -> u8 {
     crate::cli::spawn_client_pump(socket);
     let server = service.inner();
     if let Err(error) = server.cli_initialize(&cwd).await {
-        elnln!("error: failed to initialize: {}", error.message);
+        // The message quotes config-file content (a TOML parse error echoes the
+        // offending source line), so it is untrusted text on a line-oriented
+        // stderr — escaped like every other field this module emits.
+        elnln!(
+            "error: failed to initialize: {}",
+            escape_terminal_controls(&error.message)
+        );
         return EXIT_ERROR;
     }
 

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -137,7 +137,10 @@ async fn run_async(options: DiagnoseOptions) -> u8 {
     let (service, socket) = LspService::new(Kakehashi::new);
     crate::cli::spawn_client_pump(socket);
     let server = service.inner();
-    server.cli_initialize(&cwd).await;
+    if let Err(error) = server.cli_initialize(&cwd).await {
+        elnln!("error: failed to initialize: {}", error.message);
+        return EXIT_ERROR;
+    }
 
     let code = if options.stdin_filename.is_some() {
         run_stdin(server, &cwd, &options).await

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -22,7 +22,8 @@
 //!   `--fail-on-warning`. Info/hint never fail. To never fail on diagnostics,
 //!   append `|| true`.
 //! - `2`: an operational error (a file could not be read, a path could not be
-//!   opened or fully enumerated, or a configured downstream server failed).
+//!   opened or fully enumerated, a file given with `--config-file` could not be
+//!   loaded, or a configured downstream server failed).
 //!   Independent of the diagnostics — a tool that could not even read a file
 //!   must not look "clean" to CI, so it surfaces as `2` regardless.
 //!
@@ -100,7 +101,8 @@ pub const EXIT_OK: u8 = 0;
 /// A failing diagnostic (an error, or a warning under `--fail-on-warning`).
 pub const EXIT_DIAGNOSTICS: u8 = 1;
 /// An operational error (unreadable file, path open/enumeration failure,
-/// downstream server failure). Independent of the diagnostics.
+/// an unloadable `--config-file`, downstream server failure). Independent of
+/// the diagnostics.
 pub const EXIT_ERROR: u8 = 2;
 
 /// Per-server bound for waiting on cold downstream language servers, matching

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -25,6 +25,19 @@ use tower_lsp_server::LspService;
 use crate::cli::files::collect_files;
 use crate::lsp::Kakehashi;
 
+/// Write one diagnostic line without turning a closed stderr pipe into panic
+/// exit 101. Format mode deliberately ignores SIGPIPE so every stderr write
+/// must tolerate `BrokenPipe`, just like its stdout path does.
+fn write_line_lossy(mut writer: impl std::io::Write, args: std::fmt::Arguments<'_>) {
+    let _ = writeln!(writer, "{args}");
+}
+
+macro_rules! eprintln {
+    ($($arg:tt)*) => {
+        write_line_lossy(std::io::stderr(), format_args!($($arg)*))
+    };
+}
+
 /// Options for the `format` subcommand, mirroring its CLI flags.
 pub struct FormatOptions {
     /// Files or directories to format. With `--stdin-filename`, must be
@@ -347,4 +360,26 @@ fn write_atomically(path: &Path, content: &str) -> std::io::Result<()> {
         let _ = dir_handle.sync_all();
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct ClosedPipe;
+
+    impl std::io::Write for ClosedPipe {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::from(std::io::ErrorKind::BrokenPipe))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn diagnostic_write_tolerates_closed_stderr() {
+        write_line_lossy(ClosedPipe, format_args!("initialization failed"));
+    }
 }

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -108,7 +108,10 @@ async fn run_async(options: FormatOptions) -> u8 {
     let (service, socket) = LspService::new(Kakehashi::new);
     crate::cli::spawn_client_pump(socket);
     let server = service.inner();
-    server.cli_initialize(&cwd).await;
+    if let Err(error) = server.cli_initialize(&cwd).await {
+        eprintln!("error: failed to initialize: {}", error.message);
+        return EXIT_ERROR;
+    }
 
     let code = if options.stdin_filename.is_some() {
         run_stdin(server, &cwd, &options).await

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 use tower_lsp_server::LspService;
 
 use crate::cli::files::collect_files;
-use crate::cli::terminal::escape_terminal_controls_keeping_newlines;
+use crate::cli::terminal::{escape_terminal_controls, escape_terminal_controls_keeping_newlines};
 use crate::lsp::Kakehashi;
 
 /// Write one diagnostic line without turning a closed stderr pipe into panic
@@ -199,7 +199,7 @@ async fn run_stdin(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
         )
         .await;
     for failure in &outcome.server_failures {
-        elnln!("error: {failure}");
+        elnln!("error: {}", escape_terminal_controls(&failure.to_string()));
     }
     let changed = outcome.formatted.as_deref().is_some_and(|f| f != text);
 
@@ -208,7 +208,10 @@ async fn run_stdin(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
             return EXIT_ERROR;
         }
         if changed {
-            elnln!("Would reformat: {}", name.display());
+            elnln!(
+                "Would reformat: {}",
+                escape_terminal_controls(&name.display().to_string())
+            );
             return EXIT_CHANGED;
         }
         return EXIT_OK;
@@ -254,7 +257,7 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
     }) {
         Ok(collected) => collected,
         Err(e) => {
-            elnln!("error: {e}");
+            elnln!("error: {}", escape_terminal_controls(&e.to_string()));
             return EXIT_ERROR;
         }
     };
@@ -269,7 +272,12 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
     for file in &files {
         // Collected paths are absolute (normalize_path); report them
         // cwd-relative so the output stays readable in deep trees.
-        let display = file.strip_prefix(cwd).unwrap_or(file).display();
+        // Escaped once here rather than at each use: a path comes from a
+        // directory walk, so it is untrusted text on a line-oriented stream.
+        // Newlines are escaped too — unlike the initialization error, these
+        // lines are a stream the user greps, one record per file.
+        let relative = file.strip_prefix(cwd).unwrap_or(file).display().to_string();
+        let display = escape_terminal_controls(&relative);
         let text = match std::fs::read_to_string(file) {
             Ok(text) => text,
             Err(e) => {
@@ -291,7 +299,10 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
         // "unchanged" (docs: I/O errors exit 2). Any partial output another
         // server produced is still applied below.
         for failure in &outcome.server_failures {
-            elnln!("error: {display}: {failure}");
+            elnln!(
+                "error: {display}: {}",
+                escape_terminal_controls(&failure.to_string())
+            );
         }
         let server_failed = !outcome.server_failures.is_empty();
         if server_failed {

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -23,16 +23,31 @@ use std::time::Duration;
 use tower_lsp_server::LspService;
 
 use crate::cli::files::collect_files;
+use crate::cli::terminal::escape_terminal_controls_keeping_newlines;
 use crate::lsp::Kakehashi;
 
 /// Write one diagnostic line without turning a closed stderr pipe into panic
-/// exit 101. Format mode deliberately ignores SIGPIPE so every stderr write
-/// must tolerate `BrokenPipe`, just like its stdout path does.
+/// exit 101. Format mode deliberately ignores SIGPIPE, so a consumer that
+/// stops reading (`kakehashi format … 2>&1 | head`) surfaces as a write error
+/// rather than a signal, and `std::eprintln!` panics on one.
+///
+/// The write result is dropped unconditionally, including for failures that
+/// are not `BrokenPipe`: unlike the stdout path — which distinguishes them and
+/// returns [`EXIT_ERROR`] — there is nowhere left to report a failure to
+/// report. `--check` sends its report here, so a stderr that fails for another
+/// reason (a full disk under `2>report.txt`) yields the exit code without the
+/// report.
 fn write_line_lossy(mut writer: impl std::io::Write, args: std::fmt::Arguments<'_>) {
     let _ = writeln!(writer, "{args}");
 }
 
-macro_rules! eprintln {
+/// `eprintln!` that tolerates a closed stderr pipe — see [`write_line_lossy`].
+///
+/// Deliberately *not* named `eprintln`: shadowing the std macro would silently
+/// change every call site in the module, and any future one written above the
+/// definition would quietly get the panicking version back. Mirrors
+/// `diagnose::elnln!`.
+macro_rules! elnln {
     ($($arg:tt)*) => {
         write_line_lossy(std::io::stderr(), format_args!($($arg)*))
     };
@@ -100,7 +115,7 @@ pub fn run(options: FormatOptions) -> u8 {
     {
         Ok(runtime) => runtime,
         Err(e) => {
-            eprintln!("error: failed to start async runtime: {e}");
+            elnln!("error: failed to start async runtime: {e}");
             return EXIT_ERROR;
         }
     };
@@ -111,7 +126,7 @@ async fn run_async(options: FormatOptions) -> u8 {
     let cwd = match std::env::current_dir() {
         Ok(dir) => dir,
         Err(e) => {
-            eprintln!("error: cannot determine current directory: {e}");
+            elnln!("error: cannot determine current directory: {e}");
             return EXIT_ERROR;
         }
     };
@@ -122,7 +137,14 @@ async fn run_async(options: FormatOptions) -> u8 {
     crate::cli::spawn_client_pump(socket);
     let server = service.inner();
     if let Err(error) = server.cli_initialize(&cwd).await {
-        eprintln!("error: failed to initialize: {}", error.message);
+        // The message quotes config-file content (a TOML parse error echoes the
+        // offending source line), so escape it before it reaches a terminal.
+        // Newlines survive: unlike `diagnose`, this output is prose, and the
+        // caret diagram is the useful part of a parse error.
+        elnln!(
+            "error: failed to initialize: {}",
+            escape_terminal_controls_keeping_newlines(&error.message)
+        );
         return EXIT_ERROR;
     }
 
@@ -152,14 +174,14 @@ async fn run_stdin(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
     let stdin_paths_ok = options.paths.is_empty()
         || (options.paths.len() == 1 && options.paths[0].as_os_str() == "-");
     if !stdin_paths_ok {
-        eprintln!("error: --stdin-filename accepts no paths (optionally a single \"-\")");
+        elnln!("error: --stdin-filename accepts no paths (optionally a single \"-\")");
         return EXIT_ERROR;
     }
 
     let mut text = String::new();
     use std::io::Read as _;
     if let Err(e) = std::io::stdin().lock().read_to_string(&mut text) {
-        eprintln!("error: failed to read stdin: {e}");
+        elnln!("error: failed to read stdin: {e}");
         return EXIT_ERROR;
     }
 
@@ -177,7 +199,7 @@ async fn run_stdin(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
         )
         .await;
     for failure in &outcome.server_failures {
-        eprintln!("error: {failure}");
+        elnln!("error: {failure}");
     }
     let changed = outcome.formatted.as_deref().is_some_and(|f| f != text);
 
@@ -186,7 +208,7 @@ async fn run_stdin(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
             return EXIT_ERROR;
         }
         if changed {
-            eprintln!("Would reformat: {}", name.display());
+            elnln!("Would reformat: {}", name.display());
             return EXIT_CHANGED;
         }
         return EXIT_OK;
@@ -207,7 +229,7 @@ async fn run_stdin(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
         .and_then(|()| stdout.flush())
         && e.kind() != std::io::ErrorKind::BrokenPipe
     {
-        eprintln!("error: failed to write stdout: {e}");
+        elnln!("error: failed to write stdout: {e}");
         return EXIT_ERROR;
     }
 
@@ -223,7 +245,7 @@ async fn run_stdin(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
 /// File mode: expand `paths`, format each file, and write/report per flags.
 async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u8 {
     if options.paths.is_empty() {
-        eprintln!("error: no paths given; pass files/directories or use --stdin-filename");
+        elnln!("error: no paths given; pass files/directories or use --stdin-filename");
         return EXIT_ERROR;
     }
 
@@ -232,7 +254,7 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
     }) {
         Ok(collected) => collected,
         Err(e) => {
-            eprintln!("error: {e}");
+            elnln!("error: {e}");
             return EXIT_ERROR;
         }
     };
@@ -251,7 +273,7 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
         let text = match std::fs::read_to_string(file) {
             Ok(text) => text,
             Err(e) => {
-                eprintln!("error: cannot read '{display}': {e}");
+                elnln!("error: cannot read '{display}': {e}");
                 read_errors += 1;
                 continue;
             }
@@ -269,7 +291,7 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
         // "unchanged" (docs: I/O errors exit 2). Any partial output another
         // server produced is still applied below.
         for failure in &outcome.server_failures {
-            eprintln!("error: {display}: {failure}");
+            elnln!("error: {display}: {failure}");
         }
         let server_failed = !outcome.server_failures.is_empty();
         if server_failed {
@@ -279,12 +301,12 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
             Some(formatted) if formatted != text => {
                 changed += 1;
                 if options.check {
-                    eprintln!("Would reformat: {display}");
+                    elnln!("Would reformat: {display}");
                 } else {
                     match write_atomically(file, &formatted) {
-                        Ok(()) => eprintln!("Reformatted: {display}"),
+                        Ok(()) => elnln!("Reformatted: {display}"),
                         Err(e) => {
-                            eprintln!("error: cannot write '{display}': {e}");
+                            elnln!("error: cannot write '{display}': {e}");
                             write_errors += 1;
                         }
                     }
@@ -304,14 +326,14 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
         String::new()
     };
     if options.check {
-        eprintln!(
+        elnln!(
             "{changed} file(s) would be reformatted, {unchanged} already formatted{error_suffix}"
         );
     } else {
         // Write failures stay in `changed` for exit-code purposes, but the
         // summary must not claim a file was reformatted when its write failed.
         let reformatted = changed - write_errors;
-        eprintln!("{reformatted} file(s) reformatted, {unchanged} unchanged{error_suffix}");
+        elnln!("{reformatted} file(s) reformatted, {unchanged} unchanged{error_suffix}");
     }
 
     if errors > 0 {
@@ -381,5 +403,29 @@ mod tests {
     #[test]
     fn diagnostic_write_tolerates_closed_stderr() {
         write_line_lossy(ClosedPipe, format_args!("initialization failed"));
+    }
+
+    /// Tolerating a closed pipe must not degrade into writing nothing at all —
+    /// every stderr line in this module goes through the same helper.
+    #[test]
+    fn diagnostic_write_emits_the_line_on_a_healthy_writer() {
+        let mut sink = Vec::new();
+        write_line_lossy(&mut sink, format_args!("initialization failed"));
+        assert_eq!(sink, b"initialization failed\n");
+    }
+
+    #[test]
+    fn initialization_failure_text_is_escaped_but_keeps_its_caret_diagram() {
+        let toml_error = "TOML parse error at line 1\n  |\n1 | bad = \u{1b}]0;x\u{7}\n  |       ^";
+        let escaped = escape_terminal_controls_keeping_newlines(toml_error);
+        assert!(
+            !escaped.contains('\u{1b}') && !escaped.contains('\u{7}'),
+            "terminal controls must not reach the terminal: {escaped:?}"
+        );
+        assert_eq!(
+            escaped.lines().count(),
+            4,
+            "the caret diagram must survive escaping: {escaped:?}"
+        );
     }
 }

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -96,9 +96,9 @@ pub const EXIT_OK: u8 = 0;
 /// At least one file changed (with `--fail-on-change`) or would change
 /// (with `--check`).
 pub const EXIT_CHANGED: u8 = 1;
-/// Usage error, I/O error, or downstream formatter failure (a configured
-/// server failed to start, errored on the request, timed out, or returned a
-/// protocol-invalid response).
+/// Usage error, I/O error, an unloadable `--config-file`, or downstream
+/// formatter failure (a configured server failed to start, errored on the
+/// request, timed out, or returned a protocol-invalid response).
 pub const EXIT_ERROR: u8 = 2;
 
 /// Per-server bound for waiting on cold downstream language servers. Spawning

--- a/src/cli/terminal.rs
+++ b/src/cli/terminal.rs
@@ -1,5 +1,19 @@
 //! Terminal-safe rendering for untrusted CLI fields.
 
+/// Visibly escape terminal controls while keeping real line breaks intact.
+///
+/// Use this where the text is meant to be read across several lines — a TOML
+/// parse error draws a caret diagram under the offending source line, and
+/// collapsing it costs more than the escaping saves. Line-oriented output,
+/// where a stray newline would break the one-record-per-line contract, wants
+/// [`escape_terminal_controls`] instead.
+pub(crate) fn escape_terminal_controls_keeping_newlines(text: &str) -> String {
+    text.split('\n')
+        .map(|line| escape_terminal_controls(line))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Visibly escape terminal, bidirectional, and Unicode line-separator
 /// characters without changing ordinary text.
 pub(crate) fn escape_terminal_controls(text: &str) -> std::borrow::Cow<'_, str> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ pub(crate) mod deprecation;
 pub(crate) mod expand;
 pub(crate) mod merge;
 pub mod settings;
+pub(crate) mod unknown_keys;
 
 use std::collections::HashMap;
 

--- a/src/config/expand.rs
+++ b/src/config/expand.rs
@@ -76,6 +76,33 @@ impl fmt::Display for ExpandError {
 #[derive(Debug)]
 pub struct ExpandErrors(pub(crate) Vec<ExpandError>);
 
+impl ExpandErrors {
+    /// Render only the errors that make a path unusable on its own.
+    ///
+    /// `InvalidSetting` is deliberately excluded: it reports a cross-field
+    /// invariant (e.g. `debounceMs <= maxWaitMs`) whose operands merge
+    /// independently across config layers, so a layer that supplies only one
+    /// side of the pair is legitimately invalid in isolation and valid once
+    /// merged. Path values, in contrast, are replaced wholesale by a later
+    /// layer, which is why they are worth judging per layer.
+    ///
+    /// Returns `None` when every error is a cross-field invariant violation.
+    pub(crate) fn path_error_summary(&self) -> Option<String> {
+        let details: Vec<String> = self
+            .0
+            .iter()
+            .filter(|error| {
+                matches!(
+                    error,
+                    ExpandError::UndefinedVar { .. } | ExpandError::NoHomeDir { .. }
+                )
+            })
+            .map(|error| error.to_string())
+            .collect();
+        (!details.is_empty()).then(|| details.join("; "))
+    }
+}
+
 impl fmt::Display for ExpandErrors {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let details: Vec<String> = self.0.iter().map(|e| e.to_string()).collect();

--- a/src/config/unknown_keys.rs
+++ b/src/config/unknown_keys.rs
@@ -1,0 +1,386 @@
+//! Recognising configuration keys kakehashi does not know.
+//!
+//! Serde ignores an unknown field silently, so a typo in a configuration file
+//! reads as "this setting was not specified" rather than as a mistake. Both the
+//! runtime `workspace/didChangeConfiguration` path and explicit `--config-file`
+//! loading walk the incoming value against these known-key sets so the user
+//! hears about it; what each does with the answer is that caller's policy.
+
+use serde_json::Value;
+
+pub(crate) const KNOWN_WORKSPACE_SETTING_KEYS: &[&str] = &[
+    "searchPaths",
+    "languages",
+    "captureMappings",
+    "autoInstall",
+    "diagnosticsDebounceMs",
+    "features",
+    "languageServers",
+];
+
+pub(crate) const KNOWN_FEATURE_SETTING_KEYS: &[&str] = &[
+    "textDocument/publishDiagnostics",
+    "window/logMessage",
+    "workspace/diagnostic/refresh",
+];
+
+pub(crate) const KNOWN_AGGREGATION_SETTING_KEYS: &[&str] = &[
+    "maxFanOut",
+    "priorities",
+    "pullFallback",
+    "pushFallback",
+    "strategy",
+];
+
+pub(crate) const KNOWN_BRIDGE_LANGUAGE_SETTING_KEYS: &[&str] = &["aggregation", "enabled"];
+
+pub(crate) const KNOWN_BRIDGE_SERVER_SETTING_KEYS: &[&str] = &[
+    "cmd",
+    "enabled",
+    "initializationOptions",
+    "languages",
+    "onTypeFormattingTriggers",
+    "preferSharedInstance",
+    "rootMarkers",
+    "settings",
+    "workspaceMarkers",
+];
+
+pub(crate) const KNOWN_CAPTURE_MAPPINGS_SETTING_KEYS: &[&str] = &["folds", "highlights"];
+
+pub(crate) const KNOWN_LANGUAGE_SETTING_KEYS: &[&str] =
+    &["aliases", "base", "bridge", "layers", "parser", "queries"];
+
+pub(crate) const KNOWN_LAYER_AGGREGATION_SETTING_KEYS: &[&str] = &["priorities", "strategy"];
+
+pub(crate) const KNOWN_LAYERS_SETTING_KEYS: &[&str] = &["aggregation"];
+
+pub(crate) const KNOWN_QUERY_ITEM_SETTING_KEYS: &[&str] = &["kind", "path"];
+
+pub(crate) fn sort_and_dedup_unknown_keys(unknown_keys: &mut Vec<String>) {
+    unknown_keys.sort();
+    unknown_keys.dedup();
+}
+
+fn unknown_object_keys(path: &str, value: &Value, known_keys: &[&str]) -> Vec<String> {
+    let Some(object) = value.as_object() else {
+        return Vec::new();
+    };
+
+    object
+        .keys()
+        .filter(|key| !known_keys.contains(&key.as_str()))
+        .map(|key| format!("{path}.{key}"))
+        .collect()
+}
+
+pub(crate) fn is_workspace_setting_key_or_typo(key: &str) -> bool {
+    KNOWN_WORKSPACE_SETTING_KEYS.contains(&key)
+        || KNOWN_WORKSPACE_SETTING_KEYS
+            .iter()
+            .any(|known_key| is_one_edit_apart(key, known_key))
+}
+
+fn is_one_edit_apart(candidate: &str, known: &str) -> bool {
+    let candidate = candidate.as_bytes();
+    let known = known.as_bytes();
+    let len_diff = candidate.len().abs_diff(known.len());
+    if len_diff > 1 {
+        return false;
+    }
+
+    if len_diff == 0 {
+        return candidate
+            .iter()
+            .zip(known.iter())
+            .filter(|(candidate, known)| candidate != known)
+            .count()
+            == 1;
+    }
+
+    let (shorter, longer) = if candidate.len() < known.len() {
+        (candidate, known)
+    } else {
+        (known, candidate)
+    };
+    let mut short_index = 0;
+    let mut long_index = 0;
+    let mut edits = 0;
+    while short_index < shorter.len() && long_index < longer.len() {
+        if shorter[short_index] == longer[long_index] {
+            short_index += 1;
+        } else {
+            edits += 1;
+            if edits > 1 {
+                return false;
+            }
+        }
+        long_index += 1;
+    }
+
+    true
+}
+
+pub(crate) fn unknown_workspace_setting_keys(settings: &Value) -> Vec<String> {
+    let Some(object) = settings.as_object() else {
+        return Vec::new();
+    };
+
+    let mut unknown_keys = object
+        .keys()
+        .filter(|key| !KNOWN_WORKSPACE_SETTING_KEYS.contains(&key.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    append_unknown_bridge_server_setting_keys(object, &mut unknown_keys);
+    append_unknown_capture_mappings_setting_keys(object, &mut unknown_keys);
+    append_unknown_language_setting_keys(object, &mut unknown_keys);
+
+    unknown_keys
+}
+
+fn append_unknown_bridge_server_setting_keys(
+    object: &serde_json::Map<String, Value>,
+    unknown_keys: &mut Vec<String>,
+) {
+    let Some(servers) = object.get("languageServers").and_then(Value::as_object) else {
+        return;
+    };
+
+    for (server_name, server) in servers {
+        unknown_keys.extend(unknown_object_keys(
+            &format!("languageServers.{server_name}"),
+            server,
+            KNOWN_BRIDGE_SERVER_SETTING_KEYS,
+        ));
+    }
+}
+
+fn append_unknown_capture_mappings_setting_keys(
+    object: &serde_json::Map<String, Value>,
+    unknown_keys: &mut Vec<String>,
+) {
+    let Some(capture_mappings) = object.get("captureMappings").and_then(Value::as_object) else {
+        return;
+    };
+
+    for (scope, query_type_mappings) in capture_mappings {
+        unknown_keys.extend(unknown_object_keys(
+            &format!("captureMappings.{scope}"),
+            query_type_mappings,
+            KNOWN_CAPTURE_MAPPINGS_SETTING_KEYS,
+        ));
+    }
+}
+
+fn append_unknown_language_setting_keys(
+    object: &serde_json::Map<String, Value>,
+    unknown_keys: &mut Vec<String>,
+) {
+    let Some(languages) = object.get("languages").and_then(Value::as_object) else {
+        return;
+    };
+
+    for (language_name, language) in languages {
+        let language_path = format!("languages.{language_name}");
+        unknown_keys.extend(unknown_object_keys(
+            &language_path,
+            language,
+            KNOWN_LANGUAGE_SETTING_KEYS,
+        ));
+
+        let Some(language) = language.as_object() else {
+            continue;
+        };
+
+        append_unknown_query_item_keys(&language_path, language, unknown_keys);
+        append_unknown_bridge_language_keys(&language_path, language, unknown_keys);
+        append_unknown_layers_keys(&language_path, language, unknown_keys);
+    }
+}
+
+fn append_unknown_query_item_keys(
+    language_path: &str,
+    language: &serde_json::Map<String, Value>,
+    unknown_keys: &mut Vec<String>,
+) {
+    let Some(queries) = language.get("queries").and_then(Value::as_array) else {
+        return;
+    };
+
+    for (query_index, query) in queries.iter().enumerate() {
+        unknown_keys.extend(unknown_object_keys(
+            &format!("{language_path}.queries.{query_index}"),
+            query,
+            KNOWN_QUERY_ITEM_SETTING_KEYS,
+        ));
+    }
+}
+
+fn append_unknown_bridge_language_keys(
+    language_path: &str,
+    language: &serde_json::Map<String, Value>,
+    unknown_keys: &mut Vec<String>,
+) {
+    let Some(bridge) = language.get("bridge").and_then(Value::as_object) else {
+        return;
+    };
+
+    for (bridge_name, bridge) in bridge {
+        let bridge_path = format!("{language_path}.bridge.{bridge_name}");
+        unknown_keys.extend(unknown_object_keys(
+            &bridge_path,
+            bridge,
+            KNOWN_BRIDGE_LANGUAGE_SETTING_KEYS,
+        ));
+
+        let Some(bridge) = bridge.as_object() else {
+            continue;
+        };
+        let Some(aggregation) = bridge.get("aggregation").and_then(Value::as_object) else {
+            continue;
+        };
+
+        for (method, config) in aggregation {
+            unknown_keys.extend(unknown_object_keys(
+                &format!("{bridge_path}.aggregation.{method}"),
+                config,
+                KNOWN_AGGREGATION_SETTING_KEYS,
+            ));
+        }
+    }
+}
+
+fn append_unknown_layers_keys(
+    language_path: &str,
+    language: &serde_json::Map<String, Value>,
+    unknown_keys: &mut Vec<String>,
+) {
+    let Some(layers) = language.get("layers") else {
+        return;
+    };
+
+    let layers_path = format!("{language_path}.layers");
+    unknown_keys.extend(unknown_object_keys(
+        &layers_path,
+        layers,
+        KNOWN_LAYERS_SETTING_KEYS,
+    ));
+
+    let Some(aggregation) = layers.get("aggregation").and_then(Value::as_object) else {
+        return;
+    };
+
+    for (method, config) in aggregation {
+        unknown_keys.extend(unknown_object_keys(
+            &format!("{layers_path}.aggregation.{method}"),
+            config,
+            KNOWN_LAYER_AGGREGATION_SETTING_KEYS,
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::settings::{
+        AggregationConfig, BridgeLanguageConfig, BridgeServerConfig, FeatureSettings,
+        LanguageSettings, LayerAggregationConfig, LayersConfig, QueryItem, QueryTypeMappings,
+        RawWorkspaceSettings,
+    };
+    use std::collections::BTreeSet;
+
+    fn assert_known_keys_match_schema<T: schemars::JsonSchema>(
+        known_keys: &[&str],
+        aliases: &[&str],
+    ) {
+        let schema = schemars::schema_for!(T);
+        let value = serde_json::to_value(schema).expect("schema should serialize");
+        let properties = value["properties"]
+            .as_object()
+            .expect("schema should have properties");
+
+        let mut schema_keys = properties.keys().cloned().collect::<BTreeSet<_>>();
+        schema_keys.extend(aliases.iter().map(|alias| (*alias).to_string()));
+        let known_keys = known_keys
+            .iter()
+            .map(|key| (*key).to_string())
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(known_keys, schema_keys);
+    }
+
+    #[test]
+    fn known_workspace_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<RawWorkspaceSettings>(KNOWN_WORKSPACE_SETTING_KEYS, &[]);
+    }
+
+    #[test]
+    fn known_feature_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<FeatureSettings>(KNOWN_FEATURE_SETTING_KEYS, &[]);
+    }
+
+    #[test]
+    fn section_sibling_filter_matches_workspace_keys_and_typos_only() {
+        assert!(is_workspace_setting_key_or_typo("autoInstall"));
+        assert!(is_workspace_setting_key_or_typo("autoInstal"));
+        assert!(is_workspace_setting_key_or_typo("languageServers"));
+        assert!(!is_workspace_setting_key_or_typo("autXInstal"));
+
+        assert!(!is_workspace_setting_key_or_typo("editor"));
+        assert!(!is_workspace_setting_key_or_typo("files"));
+        assert!(!is_workspace_setting_key_or_typo("workbench"));
+    }
+
+    #[test]
+    fn known_bridge_server_setting_keys_match_schema_properties_and_aliases() {
+        assert_known_keys_match_schema::<BridgeServerConfig>(
+            KNOWN_BRIDGE_SERVER_SETTING_KEYS,
+            &["rootMarkers"],
+        );
+    }
+
+    #[test]
+    fn known_capture_mappings_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<QueryTypeMappings>(
+            KNOWN_CAPTURE_MAPPINGS_SETTING_KEYS,
+            &[],
+        );
+    }
+
+    #[test]
+    fn known_language_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<LanguageSettings>(KNOWN_LANGUAGE_SETTING_KEYS, &[]);
+    }
+
+    #[test]
+    fn known_query_item_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<QueryItem>(KNOWN_QUERY_ITEM_SETTING_KEYS, &[]);
+    }
+
+    #[test]
+    fn known_bridge_language_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<BridgeLanguageConfig>(
+            KNOWN_BRIDGE_LANGUAGE_SETTING_KEYS,
+            &[],
+        );
+    }
+
+    #[test]
+    fn known_aggregation_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<AggregationConfig>(KNOWN_AGGREGATION_SETTING_KEYS, &[]);
+    }
+
+    #[test]
+    fn known_layers_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<LayersConfig>(KNOWN_LAYERS_SETTING_KEYS, &[]);
+    }
+
+    #[test]
+    fn known_layer_aggregation_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<LayerAggregationConfig>(
+            KNOWN_LAYER_AGGREGATION_SETTING_KEYS,
+            &[],
+        );
+    }
+}

--- a/src/config/unknown_keys.rs
+++ b/src/config/unknown_keys.rs
@@ -3,8 +3,14 @@
 //! Serde ignores an unknown field silently, so a typo in a configuration file
 //! reads as "this setting was not specified" rather than as a mistake. Both the
 //! runtime `workspace/didChangeConfiguration` path and explicit `--config-file`
-//! loading walk the incoming value against these known-key sets so the user
-//! hears about it; what each does with the answer is that caller's policy.
+//! loading walk the incoming value against these known-key sets; what each does
+//! with the answer is that caller's policy — the former rejects the update, the
+//! latter warns.
+//!
+//! The walk does not cover `features`: `FeatureSettings` and its children carry
+//! `deny_unknown_fields`, so an unknown key there fails typed deserialization
+//! before any of this runs. That makes it fatal on a config file, unlike every
+//! other unknown key, which is a wrinkle worth removing rather than a design.
 
 use serde_json::Value;
 

--- a/src/config/unknown_keys.rs
+++ b/src/config/unknown_keys.rs
@@ -54,8 +54,15 @@ pub(crate) const KNOWN_BRIDGE_SERVER_SETTING_KEYS: &[&str] = &[
 
 pub(crate) const KNOWN_CAPTURE_MAPPINGS_SETTING_KEYS: &[&str] = &["folds", "highlights"];
 
-pub(crate) const KNOWN_LANGUAGE_SETTING_KEYS: &[&str] =
-    &["aliases", "base", "bridge", "layers", "parser", "queries"];
+pub(crate) const KNOWN_LANGUAGE_SETTING_KEYS: &[&str] = &[
+    "aliases",
+    "autoInstall",
+    "base",
+    "bridge",
+    "layers",
+    "parser",
+    "queries",
+];
 
 pub(crate) const KNOWN_LAYER_AGGREGATION_SETTING_KEYS: &[&str] = &["priorities", "strategy"];
 

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -22,7 +22,10 @@ impl Kakehashi {
     /// Run the LSP initialize/initialized lifecycle for CLI mode, loading
     /// configuration from `root` (typically the current directory) exactly
     /// like an editor session rooted there would.
-    pub(crate) async fn cli_initialize(&self, root: &Path) {
+    pub(crate) async fn cli_initialize(
+        &self,
+        root: &Path,
+    ) -> tower_lsp_server::jsonrpc::Result<()> {
         // One-shot CLI: no editor consumes proactive publishDiagnostics, so
         // did_open_impl skips the synthetic diagnostic task (#489).
         self.mark_cli_mode();
@@ -42,10 +45,9 @@ impl Kakehashi {
             workspace_folders,
             ..Default::default()
         };
-        if let Err(e) = self.initialize_impl(params).await {
-            log::warn!(target: "kakehashi::cli", "initialize failed: {e}");
-        }
+        self.initialize_impl(params).await?;
         self.initialized_impl(InitializedParams {}).await;
+        Ok(())
     }
 
     /// Whether the path alone identifies a known language (loading the

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -22,6 +22,13 @@ impl Kakehashi {
     /// Run the LSP initialize/initialized lifecycle for CLI mode, loading
     /// configuration from `root` (typically the current directory) exactly
     /// like an editor session rooted there would.
+    ///
+    /// # Errors
+    ///
+    /// Returns the `initialize` error when a file given with `--config-file`
+    /// is present but cannot be loaded. Callers must surface it and exit with
+    /// their error code rather than continuing on programmed defaults;
+    /// `initialized` is deliberately not sent in that case.
     pub(crate) async fn cli_initialize(
         &self,
         root: &Path,

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -228,10 +228,10 @@ impl Kakehashi {
             explicit_config,
         );
 
-        // `settings_outcome.fatal_error` is deliberately not consulted here: it
-        // can only be set by the explicit layers, which the pre-flight above
-        // already judged on exactly the same inputs. Re-checking would be a
-        // guard no input can reach.
+        // There is deliberately no second fatal check here. Every verdict on
+        // the explicit configuration was reached above, before any of the
+        // stores in between — and the files must not be read again to reach
+        // one, since a `--config-file` may name a stream.
         let settings_events = settings_outcome.events;
         let mut default_settings_warning = None;
 

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -235,9 +235,10 @@ impl Kakehashi {
         let settings_events = settings_outcome.events;
         let mut default_settings_warning = None;
 
-        // Nudge users off the deprecated `rootMarkers` config key. The claim
-        // guard latches session-wide so a later didChangeConfiguration carrying
-        // `rootMarkers` does not warn a second time (and vice versa).
+        // Nudge users off deprecated config keys. Each claim guard latches
+        // session-wide so a later didChangeConfiguration carrying the same key
+        // does not warn a second time (and vice versa). The two keys claim
+        // independently: seeing one must not suppress the other.
         if settings_outcome.deprecated_keys.root_markers
             && self
                 .settings_manager

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -192,10 +192,13 @@ impl Kakehashi {
         let settings_events = settings_outcome.events;
         let mut default_settings_warning = None;
 
-        // Nudge users off deprecated config keys. Each claim guard latches
-        // session-wide so a later didChangeConfiguration carrying the same key
-        // does not warn a second time (and vice versa). The two keys claim
-        // independently: seeing one must not suppress the other.
+        if let Some(error) = settings_outcome.fatal_error {
+            return Err(tower_lsp_server::jsonrpc::Error::invalid_params(error));
+        }
+
+        // Nudge users off the deprecated `rootMarkers` config key. The claim
+        // guard latches session-wide so a later didChangeConfiguration carrying
+        // `rootMarkers` does not warn a second time (and vice versa).
         if settings_outcome.deprecated_keys.root_markers
             && self
                 .settings_manager

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -89,10 +89,17 @@ impl Kakehashi {
         // the same text are never sent, so the client does not also get a
         // `window/showMessage` popup on top of a handshake it already failed.
         // Pinned by `test_config_file_fatal_error_is_not_also_shown_as_a_message`.
-        if let Some(error) =
-            crate::lsp::settings::explicit_config_fatal_error(self.home_dir.as_deref(), |var| {
+        //
+        // The files are read here and the result carried into `load_settings`
+        // below, never re-read: a `--config-file` may name a stream, and a file
+        // swapped between two reads would slip past whichever check ran first.
+        let explicit_config =
+            crate::lsp::settings::load_explicit_config(self.home_dir.as_deref(), |var| {
                 std::env::var(var).ok()
-            })
+            });
+        if let Some(error) = explicit_config
+            .as_ref()
+            .and_then(|config| config.fatal_error.clone())
         {
             return Err(configuration_load_error(error));
         }
@@ -218,6 +225,7 @@ impl Kakehashi {
                 .map(|options| (SettingsSource::InitializationOptions, options)),
             self.home_dir.as_deref(),
             |var| std::env::var(var).ok(),
+            explicit_config,
         );
 
         // `settings_outcome.fatal_error` is deliberately not consulted here: it

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -200,12 +200,17 @@ impl Kakehashi {
             self.home_dir.as_deref(),
             |var| std::env::var(var).ok(),
         );
-        let settings_events = settings_outcome.events;
-        let mut default_settings_warning = None;
 
+        // Report the fatal explicit-config failure only through the initialize
+        // response: returning before the settings events are logged keeps the
+        // error from also arriving as a window/logMessage duplicate.
         if let Some(error) = settings_outcome.fatal_error {
+            log::error!(target: "kakehashi::config", "{error}");
             return Err(configuration_load_error(error));
         }
+
+        let settings_events = settings_outcome.events;
+        let mut default_settings_warning = None;
 
         // Nudge users off the deprecated `rootMarkers` config key. The claim
         // guard latches session-wide so a later didChangeConfiguration carrying

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use tower_lsp_server::Client;
-use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::jsonrpc::{Error, ErrorCode, Result};
 use tower_lsp_server::ls_types::ColorProviderCapability;
 use tower_lsp_server::ls_types::{
     ClientCapabilities, CodeActionOptions, CodeActionProviderCapability, CodeLensOptions,
@@ -30,6 +30,17 @@ use crate::lsp::{SettingsSource, load_settings};
 use super::apply_edit_translation::ApplyEditTranslator;
 use super::show_document_translation::ShowDocumentTranslator;
 use super::{Kakehashi, uri_to_url};
+
+// LSP `RequestFailed`; ls-types does not currently expose this error code.
+const REQUEST_FAILED_ERROR_CODE: i64 = -32803;
+
+fn configuration_load_error(message: String) -> Error {
+    Error {
+        code: ErrorCode::ServerError(REQUEST_FAILED_ERROR_CODE),
+        message: message.into(),
+        data: None,
+    }
+}
 
 /// Translators for downstream-initiated request payloads that carry
 /// virtual-document coordinates, bundled so the forwarding loop threads one
@@ -193,7 +204,7 @@ impl Kakehashi {
         let mut default_settings_warning = None;
 
         if let Some(error) = settings_outcome.fatal_error {
-            return Err(tower_lsp_server::jsonrpc::Error::invalid_params(error));
+            return Err(configuration_load_error(error));
         }
 
         // Nudge users off the deprecated `rootMarkers` config key. The claim

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -205,7 +205,6 @@ impl Kakehashi {
         // response: returning before the settings events are logged keeps the
         // error from also arriving as a window/logMessage duplicate.
         if let Some(error) = settings_outcome.fatal_error {
-            log::error!(target: "kakehashi::config", "{error}");
             return Err(configuration_load_error(error));
         }
 

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -78,6 +78,25 @@ impl Kakehashi {
         &self,
         params: InitializeParams,
     ) -> Result<InitializeResult> {
+        // Reject an unusable `--config-file` before anything from `params` is
+        // latched. Several of the stores below are first-write-wins, and
+        // tower-lsp-server resets to `Uninitialized` after an error response,
+        // so a client may fix the file and retry: without this, the retry would
+        // load the corrected settings while downstream servers kept the failed
+        // attempt's capabilities, root URI, and workspace folders.
+        //
+        // Reported only through this response — the settings events carrying
+        // the same text are never sent, so the client does not also get a
+        // `window/showMessage` popup on top of a handshake it already failed.
+        // Pinned by `test_config_file_fatal_error_is_not_also_shown_as_a_message`.
+        if let Some(error) =
+            crate::lsp::settings::explicit_config_fatal_error(self.home_dir.as_deref(), |var| {
+                std::env::var(var).ok()
+            })
+        {
+            return Err(configuration_load_error(error));
+        }
+
         let position_encoding = host_position_encoding(&params.capabilities);
         // Store client capabilities for LSP compliance checks (e.g., refresh support).
         // Uses SettingsManager which wraps OnceLock for "set once, read many" semantics.
@@ -201,16 +220,10 @@ impl Kakehashi {
             |var| std::env::var(var).ok(),
         );
 
-        // Report the fatal explicit-config failure only through the initialize
-        // response. Returning before the settings events are logged keeps it
-        // from also arriving as a `window/showMessage` popup — the channel
-        // `SettingsEventKind::Error` normally uses — on top of a handshake the
-        // client already failed. Pinned by
-        // `test_config_file_fatal_error_is_not_also_shown_as_a_message`.
-        if let Some(error) = settings_outcome.fatal_error {
-            return Err(configuration_load_error(error));
-        }
-
+        // `settings_outcome.fatal_error` is deliberately not consulted here: it
+        // can only be set by the explicit layers, which the pre-flight above
+        // already judged on exactly the same inputs. Re-checking would be a
+        // guard no input can reach.
         let settings_events = settings_outcome.events;
         let mut default_settings_warning = None;
 

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -202,8 +202,11 @@ impl Kakehashi {
         );
 
         // Report the fatal explicit-config failure only through the initialize
-        // response: returning before the settings events are logged keeps the
-        // error from also arriving as a window/logMessage duplicate.
+        // response. Returning before the settings events are logged keeps it
+        // from also arriving as a `window/showMessage` popup — the channel
+        // `SettingsEventKind::Error` normally uses — on top of a handshake the
+        // client already failed. Pinned by
+        // `test_config_file_fatal_error_is_not_also_shown_as_a_message`.
         if let Some(error) = settings_outcome.fatal_error {
             return Err(configuration_load_error(error));
         }

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -11,7 +11,6 @@ use crate::config::{RawWorkspaceSettings, WorkspaceSettings, merge_workspace_set
 
 use super::super::{Kakehashi, lock_settings_reload};
 
-
 fn settings_payload(settings: Value) -> (Value, Vec<String>) {
     let Value::Object(mut object) = settings else {
         return (settings, Vec::new());

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -1,5 +1,9 @@
 //! didChangeConfiguration notification handler for Kakehashi.
 
+use crate::config::unknown_keys::{
+    KNOWN_FEATURE_SETTING_KEYS, is_workspace_setting_key_or_typo, sort_and_dedup_unknown_keys,
+    unknown_workspace_setting_keys,
+};
 use serde_json::Value;
 use tower_lsp_server::ls_types::DidChangeConfigurationParams;
 
@@ -7,61 +11,6 @@ use crate::config::{RawWorkspaceSettings, WorkspaceSettings, merge_workspace_set
 
 use super::super::{Kakehashi, lock_settings_reload};
 
-const KNOWN_WORKSPACE_SETTING_KEYS: &[&str] = &[
-    "searchPaths",
-    "languages",
-    "captureMappings",
-    "autoInstall",
-    "diagnosticsDebounceMs",
-    "features",
-    "languageServers",
-];
-
-const KNOWN_FEATURE_SETTING_KEYS: &[&str] = &[
-    "textDocument/publishDiagnostics",
-    "window/logMessage",
-    "workspace/diagnostic/refresh",
-];
-
-const KNOWN_AGGREGATION_SETTING_KEYS: &[&str] = &[
-    "maxFanOut",
-    "priorities",
-    "pullFallback",
-    "pushFallback",
-    "strategy",
-];
-
-const KNOWN_BRIDGE_LANGUAGE_SETTING_KEYS: &[&str] = &["aggregation", "enabled"];
-
-const KNOWN_BRIDGE_SERVER_SETTING_KEYS: &[&str] = &[
-    "cmd",
-    "enabled",
-    "initializationOptions",
-    "languages",
-    "onTypeFormattingTriggers",
-    "preferSharedInstance",
-    "rootMarkers",
-    "settings",
-    "workspaceMarkers",
-];
-
-const KNOWN_CAPTURE_MAPPINGS_SETTING_KEYS: &[&str] = &["folds", "highlights"];
-
-const KNOWN_LANGUAGE_SETTING_KEYS: &[&str] = &[
-    "aliases",
-    "autoInstall",
-    "base",
-    "bridge",
-    "layers",
-    "parser",
-    "queries",
-];
-
-const KNOWN_LAYER_AGGREGATION_SETTING_KEYS: &[&str] = &["priorities", "strategy"];
-
-const KNOWN_LAYERS_SETTING_KEYS: &[&str] = &["aggregation"];
-
-const KNOWN_QUERY_ITEM_SETTING_KEYS: &[&str] = &["kind", "path"];
 
 fn settings_payload(settings: Value) -> (Value, Vec<String>) {
     let Value::Object(mut object) = settings else {
@@ -89,11 +38,6 @@ fn settings_payload(settings: Value) -> (Value, Vec<String>) {
     let mut unknown_keys = unknown_workspace_setting_keys(&settings);
     sort_and_dedup_unknown_keys(&mut unknown_keys);
     (settings, unknown_keys)
-}
-
-fn sort_and_dedup_unknown_keys(unknown_keys: &mut Vec<String>) {
-    unknown_keys.sort();
-    unknown_keys.dedup();
 }
 
 fn uses_deprecated_unwrapped_didchange_shape(settings: &Value) -> bool {
@@ -135,25 +79,6 @@ fn format_rejected_keys(keys: &[String]) -> String {
         .join(", ")
 }
 
-fn unknown_object_keys(path: &str, value: &Value, known_keys: &[&str]) -> Vec<String> {
-    let Some(object) = value.as_object() else {
-        return Vec::new();
-    };
-
-    object
-        .keys()
-        .filter(|key| !known_keys.contains(&key.as_str()))
-        .map(|key| format!("{path}.{key}"))
-        .collect()
-}
-
-fn is_workspace_setting_key_or_typo(key: &str) -> bool {
-    KNOWN_WORKSPACE_SETTING_KEYS.contains(&key)
-        || KNOWN_WORKSPACE_SETTING_KEYS
-            .iter()
-            .any(|known_key| is_one_edit_apart(key, known_key))
-}
-
 fn is_kakehashi_workspace_entry(key: &str, value: &Value) -> bool {
     if key == "features" {
         return value.as_object().is_some_and(|features| {
@@ -163,205 +88,6 @@ fn is_kakehashi_workspace_entry(key: &str, value: &Value) -> bool {
         });
     }
     is_workspace_setting_key_or_typo(key)
-}
-
-fn is_one_edit_apart(candidate: &str, known: &str) -> bool {
-    let candidate = candidate.as_bytes();
-    let known = known.as_bytes();
-    let len_diff = candidate.len().abs_diff(known.len());
-    if len_diff > 1 {
-        return false;
-    }
-
-    if len_diff == 0 {
-        return candidate
-            .iter()
-            .zip(known.iter())
-            .filter(|(candidate, known)| candidate != known)
-            .count()
-            == 1;
-    }
-
-    let (shorter, longer) = if candidate.len() < known.len() {
-        (candidate, known)
-    } else {
-        (known, candidate)
-    };
-    let mut short_index = 0;
-    let mut long_index = 0;
-    let mut edits = 0;
-    while short_index < shorter.len() && long_index < longer.len() {
-        if shorter[short_index] == longer[long_index] {
-            short_index += 1;
-        } else {
-            edits += 1;
-            if edits > 1 {
-                return false;
-            }
-        }
-        long_index += 1;
-    }
-
-    true
-}
-
-fn unknown_workspace_setting_keys(settings: &Value) -> Vec<String> {
-    let Some(object) = settings.as_object() else {
-        return Vec::new();
-    };
-
-    let mut unknown_keys = object
-        .keys()
-        .filter(|key| !KNOWN_WORKSPACE_SETTING_KEYS.contains(&key.as_str()))
-        .cloned()
-        .collect::<Vec<_>>();
-
-    append_unknown_bridge_server_setting_keys(object, &mut unknown_keys);
-    append_unknown_capture_mappings_setting_keys(object, &mut unknown_keys);
-    append_unknown_language_setting_keys(object, &mut unknown_keys);
-
-    unknown_keys
-}
-
-fn append_unknown_bridge_server_setting_keys(
-    object: &serde_json::Map<String, Value>,
-    unknown_keys: &mut Vec<String>,
-) {
-    let Some(servers) = object.get("languageServers").and_then(Value::as_object) else {
-        return;
-    };
-
-    for (server_name, server) in servers {
-        unknown_keys.extend(unknown_object_keys(
-            &format!("languageServers.{server_name}"),
-            server,
-            KNOWN_BRIDGE_SERVER_SETTING_KEYS,
-        ));
-    }
-}
-
-fn append_unknown_capture_mappings_setting_keys(
-    object: &serde_json::Map<String, Value>,
-    unknown_keys: &mut Vec<String>,
-) {
-    let Some(capture_mappings) = object.get("captureMappings").and_then(Value::as_object) else {
-        return;
-    };
-
-    for (scope, query_type_mappings) in capture_mappings {
-        unknown_keys.extend(unknown_object_keys(
-            &format!("captureMappings.{scope}"),
-            query_type_mappings,
-            KNOWN_CAPTURE_MAPPINGS_SETTING_KEYS,
-        ));
-    }
-}
-
-fn append_unknown_language_setting_keys(
-    object: &serde_json::Map<String, Value>,
-    unknown_keys: &mut Vec<String>,
-) {
-    let Some(languages) = object.get("languages").and_then(Value::as_object) else {
-        return;
-    };
-
-    for (language_name, language) in languages {
-        let language_path = format!("languages.{language_name}");
-        unknown_keys.extend(unknown_object_keys(
-            &language_path,
-            language,
-            KNOWN_LANGUAGE_SETTING_KEYS,
-        ));
-
-        let Some(language) = language.as_object() else {
-            continue;
-        };
-
-        append_unknown_query_item_keys(&language_path, language, unknown_keys);
-        append_unknown_bridge_language_keys(&language_path, language, unknown_keys);
-        append_unknown_layers_keys(&language_path, language, unknown_keys);
-    }
-}
-
-fn append_unknown_query_item_keys(
-    language_path: &str,
-    language: &serde_json::Map<String, Value>,
-    unknown_keys: &mut Vec<String>,
-) {
-    let Some(queries) = language.get("queries").and_then(Value::as_array) else {
-        return;
-    };
-
-    for (query_index, query) in queries.iter().enumerate() {
-        unknown_keys.extend(unknown_object_keys(
-            &format!("{language_path}.queries.{query_index}"),
-            query,
-            KNOWN_QUERY_ITEM_SETTING_KEYS,
-        ));
-    }
-}
-
-fn append_unknown_bridge_language_keys(
-    language_path: &str,
-    language: &serde_json::Map<String, Value>,
-    unknown_keys: &mut Vec<String>,
-) {
-    let Some(bridge) = language.get("bridge").and_then(Value::as_object) else {
-        return;
-    };
-
-    for (bridge_name, bridge) in bridge {
-        let bridge_path = format!("{language_path}.bridge.{bridge_name}");
-        unknown_keys.extend(unknown_object_keys(
-            &bridge_path,
-            bridge,
-            KNOWN_BRIDGE_LANGUAGE_SETTING_KEYS,
-        ));
-
-        let Some(bridge) = bridge.as_object() else {
-            continue;
-        };
-        let Some(aggregation) = bridge.get("aggregation").and_then(Value::as_object) else {
-            continue;
-        };
-
-        for (method, config) in aggregation {
-            unknown_keys.extend(unknown_object_keys(
-                &format!("{bridge_path}.aggregation.{method}"),
-                config,
-                KNOWN_AGGREGATION_SETTING_KEYS,
-            ));
-        }
-    }
-}
-
-fn append_unknown_layers_keys(
-    language_path: &str,
-    language: &serde_json::Map<String, Value>,
-    unknown_keys: &mut Vec<String>,
-) {
-    let Some(layers) = language.get("layers") else {
-        return;
-    };
-
-    let layers_path = format!("{language_path}.layers");
-    unknown_keys.extend(unknown_object_keys(
-        &layers_path,
-        layers,
-        KNOWN_LAYERS_SETTING_KEYS,
-    ));
-
-    let Some(aggregation) = layers.get("aggregation").and_then(Value::as_object) else {
-        return;
-    };
-
-    for (method, config) in aggregation {
-        unknown_keys.extend(unknown_object_keys(
-            &format!("{layers_path}.aggregation.{method}"),
-            config,
-            KNOWN_LAYER_AGGREGATION_SETTING_KEYS,
-        ));
-    }
 }
 
 impl Kakehashi {
@@ -482,56 +208,10 @@ impl Kakehashi {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::settings::{
-        AggregationConfig, BridgeLanguageConfig, BridgeServerConfig, FeatureSettings,
-        LanguageSettings, LayerAggregationConfig, LayersConfig, QueryItem, QueryTypeMappings,
-    };
-    use std::collections::BTreeSet;
+
     use std::future::Future;
     use std::task::Poll;
     use tower_lsp_server::LspService;
-
-    fn assert_known_keys_match_schema<T: schemars::JsonSchema>(
-        known_keys: &[&str],
-        aliases: &[&str],
-    ) {
-        let schema = schemars::schema_for!(T);
-        let value = serde_json::to_value(schema).expect("schema should serialize");
-        let properties = value["properties"]
-            .as_object()
-            .expect("schema should have properties");
-
-        let mut schema_keys = properties.keys().cloned().collect::<BTreeSet<_>>();
-        schema_keys.extend(aliases.iter().map(|alias| (*alias).to_string()));
-        let known_keys = known_keys
-            .iter()
-            .map(|key| (*key).to_string())
-            .collect::<BTreeSet<_>>();
-
-        assert_eq!(known_keys, schema_keys);
-    }
-
-    #[test]
-    fn known_workspace_setting_keys_match_schema_properties() {
-        assert_known_keys_match_schema::<RawWorkspaceSettings>(KNOWN_WORKSPACE_SETTING_KEYS, &[]);
-    }
-
-    #[test]
-    fn known_feature_setting_keys_match_schema_properties() {
-        assert_known_keys_match_schema::<FeatureSettings>(KNOWN_FEATURE_SETTING_KEYS, &[]);
-    }
-
-    #[test]
-    fn section_sibling_filter_matches_workspace_keys_and_typos_only() {
-        assert!(is_workspace_setting_key_or_typo("autoInstall"));
-        assert!(is_workspace_setting_key_or_typo("autoInstal"));
-        assert!(is_workspace_setting_key_or_typo("languageServers"));
-        assert!(!is_workspace_setting_key_or_typo("autXInstal"));
-
-        assert!(!is_workspace_setting_key_or_typo("editor"));
-        assert!(!is_workspace_setting_key_or_typo("files"));
-        assert!(!is_workspace_setting_key_or_typo("workbench"));
-    }
 
     #[test]
     fn settings_payload_ignores_unrelated_features_section_sibling() {
@@ -656,58 +336,6 @@ mod tests {
         }));
 
         assert_eq!(unknown_keys, ["autoInstal"]);
-    }
-
-    #[test]
-    fn known_bridge_server_setting_keys_match_schema_properties_and_aliases() {
-        assert_known_keys_match_schema::<BridgeServerConfig>(
-            KNOWN_BRIDGE_SERVER_SETTING_KEYS,
-            &["rootMarkers"],
-        );
-    }
-
-    #[test]
-    fn known_capture_mappings_setting_keys_match_schema_properties() {
-        assert_known_keys_match_schema::<QueryTypeMappings>(
-            KNOWN_CAPTURE_MAPPINGS_SETTING_KEYS,
-            &[],
-        );
-    }
-
-    #[test]
-    fn known_language_setting_keys_match_schema_properties() {
-        assert_known_keys_match_schema::<LanguageSettings>(KNOWN_LANGUAGE_SETTING_KEYS, &[]);
-    }
-
-    #[test]
-    fn known_query_item_setting_keys_match_schema_properties() {
-        assert_known_keys_match_schema::<QueryItem>(KNOWN_QUERY_ITEM_SETTING_KEYS, &[]);
-    }
-
-    #[test]
-    fn known_bridge_language_setting_keys_match_schema_properties() {
-        assert_known_keys_match_schema::<BridgeLanguageConfig>(
-            KNOWN_BRIDGE_LANGUAGE_SETTING_KEYS,
-            &[],
-        );
-    }
-
-    #[test]
-    fn known_aggregation_setting_keys_match_schema_properties() {
-        assert_known_keys_match_schema::<AggregationConfig>(KNOWN_AGGREGATION_SETTING_KEYS, &[]);
-    }
-
-    #[test]
-    fn known_layers_setting_keys_match_schema_properties() {
-        assert_known_keys_match_schema::<LayersConfig>(KNOWN_LAYERS_SETTING_KEYS, &[]);
-    }
-
-    #[test]
-    fn known_layer_aggregation_setting_keys_match_schema_properties() {
-        assert_known_keys_match_schema::<LayerAggregationConfig>(
-            KNOWN_LAYER_AGGREGATION_SETTING_KEYS,
-            &[],
-        );
     }
 
     #[tokio::test]

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -224,7 +224,9 @@ fn read_explicit_layers(
         if let Some(raw_settings) = merged.as_ref()
             && let Err(errs) = WorkspaceSettings::try_from_settings(raw_settings, home, &env_fn)
         {
-            fatal_error = Some(format!("Invalid configuration from --config-file: {errs}"));
+            let message = format!("Invalid configuration from --config-file: {errs}");
+            events.push(SettingsEvent::error(message.clone()));
+            fatal_error = Some(message);
         }
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -451,6 +451,12 @@ fn load_toml_file(
     // Warn rather than reject: a key kakehashi does not recognise may be a
     // typo, but it may equally be one this version has not learned yet, and
     // refusing to start over it would make the file version-locked.
+    //
+    // Not reached for a key inside `features`: those structs carry
+    // `deny_unknown_fields`, so the parse above already failed and this file is
+    // fatal. Inconsistent with the rule stated here, pre-existing, and pinned
+    // by `test_load_toml_file_unknown_feature_key_is_fatal_today` so a future
+    // change to it is a deliberate one.
     for key in unknown_config_keys(&contents) {
         events.push(SettingsEvent::warning(format!(
             "Unknown configuration key in {}: {key}",
@@ -1075,6 +1081,33 @@ mod tests {
                     && event.message.contains("autoInstal")
                     && event.message.contains(&path.display().to_string())),
             "the typo and its file must both be named: {events:?}"
+        );
+    }
+
+    /// Records, rather than endorses, an inconsistency: `FeatureSettings` and
+    /// its children carry `deny_unknown_fields`, so an unknown key *inside*
+    /// `features` fails typed deserialization and is fatal — while the same
+    /// mistake anywhere else is a warning. Pinned so that changing it is a
+    /// deliberate act with a test to update, not a silent drift.
+    #[test]
+    fn test_load_toml_file_unknown_feature_key_is_fatal_today() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("feature-typo.toml");
+        std::fs::write(
+            &path,
+            "[features.\"textDocument/publishDiagnostics\"]\nfutureOption = 1\n",
+        )
+        .unwrap();
+
+        let mut events = Vec::new();
+        let mut ignored_deprecation = false;
+        let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
+
+        let message = result
+            .expect_err("today an unknown key under `features` is fatal, unlike anywhere else");
+        assert!(
+            message.contains("futureOption"),
+            "the rejected key must be named: {message}"
         );
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -186,8 +186,16 @@ fn read_explicit_layers(
     // every `try_from_settings` re-resolves language `base` chains, whose cycle
     // detector logs as it goes.
     if fatal_error.is_none() {
-        let merged = std::iter::once(Some(default_settings()))
-            .chain(layers.iter().cloned())
+        // Only the explicit layers. Programmed defaults carry
+        // `${KAKEHASHI_DATA_DIR}`, which cannot expand on a host with no
+        // discoverable data directory — blaming the user's file for that would
+        // reject a session over a valid, even empty, config. Their absence
+        // costs nothing here: `FeatureSettings::resolve` already fills an
+        // unset half of a timing pair from the same defaults, so a lone
+        // `debounceMs` is still judged against the default `maxWaitMs`.
+        let merged = layers
+            .iter()
+            .cloned()
             .reduce(merge_workspace_settings)
             .flatten();
         if let Some(raw_settings) = merged.as_ref()
@@ -358,14 +366,24 @@ fn load_toml_file(
             // misreported — a config loader does not serialize against the
             // filesystem, and the alternative (probe first) only moves the
             // window.
-            if path
-                .symlink_metadata()
-                .is_ok_and(|metadata| metadata.file_type().is_symlink())
-            {
-                return Err(format!(
-                    "Failed to read {}: broken symbolic link",
-                    path.display()
-                ));
+            match path.symlink_metadata() {
+                Ok(metadata) if metadata.file_type().is_symlink() => {
+                    return Err(format!(
+                        "Failed to read {}: broken symbolic link",
+                        path.display()
+                    ));
+                }
+                // Something appeared between the failed open and this probe.
+                // Nothing was read, so report the absence the open saw rather
+                // than guessing at what is there now.
+                Ok(_) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                // The probe itself failed — a denied parent, an I/O error.
+                // That is a path the user named and cannot use, not an absent
+                // one, and falling through would skip it silently.
+                Err(err) => {
+                    return Err(format!("Failed to read {}: {}", path.display(), err));
+                }
             }
             events.push(SettingsEvent::warning(format!(
                 "Config file not found, skipping: {}",
@@ -994,6 +1012,30 @@ mod tests {
                 .any(|event| event.message.contains(&second.display().to_string())),
             "the second file must be read: {:?}",
             explicit.events
+        );
+    }
+
+    /// A programmed default that cannot expand is not the explicit file's
+    /// fault. `${KAKEHASHI_DATA_DIR}` has no value on a host with no
+    /// discoverable data directory, and rejecting a session over that would
+    /// turn a valid — even empty — `--config-file` into a startup failure.
+    #[test]
+    fn read_explicit_layers_does_not_blame_a_file_for_the_defaults() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("empty.toml");
+        std::fs::write(&path, "").unwrap();
+
+        // An environment where the data-directory fallback is unavailable, so
+        // the default `searchPaths` entry cannot expand.
+        let explicit = read_explicit_layers(&[path], None, |var| match var {
+            "KAKEHASHI_DATA_DIR" => None,
+            _ => std::env::var(var).ok(),
+        });
+
+        assert!(
+            explicit.fatal_error.is_none(),
+            "a valid explicit file must not inherit the defaults' failure: {:?}",
+            explicit.fatal_error
         );
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -116,6 +116,12 @@ pub fn load_settings(
                     None
                 }
             };
+            // Judging a layer in isolation also resolves its language `base`
+            // chains, so a cycle an overlay later removes is still warned about
+            // once here. Accepted: the alternative is threading a "stay quiet"
+            // flag through base resolution to silence a warning that names a
+            // real cycle in a file the user wrote.
+            //
             // Judge each layer's *paths* on its own so a later layer cannot
             // mask an earlier one's undefined variable: path fields are
             // replaced wholesale by the overlay, so the merged result would

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -86,30 +86,48 @@ pub fn load_settings(
     let env_fn = crate::config::expand::with_kakehashi_defaults(env_fn);
     let mut events = Vec::new();
     let mut deprecated_keys = DeprecatedKeysSeen::default();
+    let mut fatal_error = None;
     let explicit_config_requested = crate::config::expand::config_file_override().is_some();
 
     // Layer 1: Programmed defaults (configuration-merging-strategy: lowest precedence)
     let defaults = Some(default_settings());
 
     // Layers 2+3: config files (either explicit --config-file or default locations)
-    let config_layers: Vec<Option<RawWorkspaceSettings>> =
-        if let Some(files) = crate::config::expand::config_file_override() {
-            events.push(SettingsEvent::info(format!(
-                "Using {} explicit config file(s); default config locations skipped",
-                files.len()
-            )));
-            files
-                .iter()
-                .map(|p| load_toml_file(p, &mut events, &mut deprecated_keys))
-                .collect()
-        } else {
-            vec![
-                // Layer 2: User config from XDG_CONFIG_HOME (~/.config/kakehashi/kakehashi.toml)
-                load_user_config_with_events(&mut events, &mut deprecated_keys),
-                // Layer 3: Project config from root_path/kakehashi.toml
-                load_toml_settings(root_path, &mut events, &mut deprecated_keys),
-            ]
-        };
+    let config_layers: Vec<Option<RawWorkspaceSettings>> = if let Some(files) =
+        crate::config::expand::config_file_override()
+    {
+        events.push(SettingsEvent::info(format!(
+            "Using {} explicit config file(s); default config locations skipped",
+            files.len()
+        )));
+        let mut layers = Vec::with_capacity(files.len());
+        for path in files {
+            let event_start = events.len();
+            let layer = load_toml_file(path, &mut events, &mut deprecated_keys);
+            if fatal_error.is_none() {
+                fatal_error = events[event_start..]
+                    .iter()
+                    .find(|event| event.kind == SettingsEventKind::Error)
+                    .map(|event| event.message.clone());
+            }
+            if let Some(raw_settings) = layer.as_ref()
+                && let Err(errs) = WorkspaceSettings::try_from_settings(raw_settings, home, &env_fn)
+            {
+                let message = format!("Path expansion failed in {}: {errs}", path.display());
+                events.push(SettingsEvent::error(message.clone()));
+                fatal_error.get_or_insert(message);
+            }
+            layers.push(layer);
+        }
+        layers
+    } else {
+        vec![
+            // Layer 2: User config from XDG_CONFIG_HOME (~/.config/kakehashi/kakehashi.toml)
+            load_user_config_with_events(&mut events, &mut deprecated_keys),
+            // Layer 3: Project config from root_path/kakehashi.toml
+            load_toml_settings(root_path, &mut events, &mut deprecated_keys),
+        ]
+    };
 
     // Layer 4: Override settings from initialization options or client configuration
     let override_settings = override_settings.and_then(|(source, value)| {
@@ -139,15 +157,6 @@ pub fn load_settings(
                 }
             },
         );
-
-    let fatal_error = explicit_config_requested
-        .then(|| {
-            events
-                .iter()
-                .find(|event| event.kind == SettingsEventKind::Error)
-                .map(|event| event.message.clone())
-        })
-        .flatten();
 
     SettingsLoadOutcome {
         settings,

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -352,7 +352,10 @@ fn load_toml_file(
             // path the user named does exist, it just does not lead to a
             // config. `symlink_metadata` does not follow, so it still sees the
             // link itself.
-            if path.symlink_metadata().is_ok() {
+            if path
+                .symlink_metadata()
+                .is_ok_and(|metadata| metadata.file_type().is_symlink())
+            {
                 return Err(format!(
                     "Failed to read {}: broken symbolic link",
                     path.display()
@@ -375,19 +378,23 @@ fn load_toml_file(
     )));
 
     // Read one byte past the ceiling so hitting it is distinguishable from a
-    // file that merely ends there.
-    let mut contents = String::new();
+    // file that merely ends there. Bytes, then length, then decoding: the
+    // cutoff can land mid-character, and an oversized file should be reported
+    // as oversized rather than as invalid UTF-8 the truncation invented.
+    let mut bytes = Vec::new();
     use std::io::Read as _;
     file.take(MAX_CONFIG_FILE_BYTES + 1)
-        .read_to_string(&mut contents)
+        .read_to_end(&mut bytes)
         .map_err(|err| format!("Failed to read {}: {}", path.display(), err))?;
-    if contents.len() as u64 > MAX_CONFIG_FILE_BYTES {
+    if bytes.len() as u64 > MAX_CONFIG_FILE_BYTES {
         return Err(format!(
             "Failed to read {}: larger than the {} MiB configuration limit",
             path.display(),
             MAX_CONFIG_FILE_BYTES / (1024 * 1024)
         ));
     }
+    let contents = String::from_utf8(bytes)
+        .map_err(|err| format!("Failed to read {}: {}", path.display(), err))?;
     deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
     let settings = toml::from_str::<RawWorkspaceSettings>(&contents)
         .map_err(|err| format!("Failed to parse {}: {}", path.display(), err))?;
@@ -877,13 +884,13 @@ mod tests {
     /// error, so a layered invocation whose overlay does not exist still starts.
     #[test]
     fn test_load_toml_file_missing() {
+        // A child of a fresh temp dir, so "absent" cannot depend on what the
+        // host happens to have at a fixed absolute path.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
         let mut events = Vec::new();
         let mut ignored_deprecation = DeprecatedKeysSeen::default();
-        let result = load_toml_file(
-            Path::new("/nonexistent/config.toml"),
-            &mut events,
-            &mut ignored_deprecation,
-        );
+        let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
 
         assert!(
             matches!(result, Ok(None)),
@@ -1043,6 +1050,29 @@ mod tests {
             message.contains("configuration limit")
                 && message.contains(&path.display().to_string()),
             "the limit must be named, and so must the file: {message}"
+        );
+    }
+
+    /// The size check runs before decoding, so a file whose oversize happens to
+    /// put a multi-byte character across the cutoff is still reported as
+    /// oversized rather than as invalid UTF-8 the truncation itself created.
+    #[test]
+    fn test_load_toml_file_over_size_limit_reports_size_not_encoding() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("huge-utf8.toml");
+        let mut oversized = String::from("# ");
+        oversized.extend(std::iter::repeat_n('a', MAX_CONFIG_FILE_BYTES as usize - 2));
+        oversized.push('é'); // straddles the ceiling
+        std::fs::write(&path, &oversized).unwrap();
+
+        let mut events = Vec::new();
+        let mut ignored_deprecation = false;
+        let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
+
+        let message = result.expect_err("an oversized explicit file must be fatal");
+        assert!(
+            message.contains("configuration limit"),
+            "size must outrank the encoding error the cutoff invented: {message}"
         );
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -117,6 +117,22 @@ pub(crate) fn load_explicit_config(
     Some(read_explicit_layers(files, home, env_fn))
 }
 
+/// Keys in a TOML config file that kakehashi does not recognise.
+///
+/// Reuses the walker the `workspace/didChangeConfiguration` path uses, via a
+/// JSON round-trip, so both routes judge a key by the same schema. An empty
+/// result when the TOML cannot be re-read as a generic value is deliberate:
+/// this only ever *reports*, so a limitation of the conversion must not be
+/// louder than the settings it is describing.
+fn unknown_config_keys(contents: &str) -> Vec<String> {
+    let Ok(value) = toml::from_str::<Value>(contents) else {
+        return Vec::new();
+    };
+    let mut keys = crate::config::unknown_keys::unknown_workspace_setting_keys(&value);
+    crate::config::unknown_keys::sort_and_dedup_unknown_keys(&mut keys);
+    keys
+}
+
 /// The explicit layers merged with nothing beneath them — the subject of the
 /// strict gate.
 ///
@@ -429,6 +445,18 @@ fn load_toml_file(
     deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
     let settings = toml::from_str::<RawWorkspaceSettings>(&contents)
         .map_err(|err| format!("Failed to parse {}: {}", path.display(), err))?;
+
+    // Serde drops an unrecognised field silently, so `autoInstal = false` reads
+    // as "not specified" and the user gets defaults without being told why.
+    // Warn rather than reject: a key kakehashi does not recognise may be a
+    // typo, but it may equally be one this version has not learned yet, and
+    // refusing to start over it would make the file version-locked.
+    for key in unknown_config_keys(&contents) {
+        events.push(SettingsEvent::warning(format!(
+            "Unknown configuration key in {}: {key}",
+            path.display()
+        )));
+    }
 
     events.push(SettingsEvent::info(format!(
         "Successfully loaded {}",
@@ -1019,6 +1047,58 @@ mod tests {
                 .any(|event| event.message.contains(&second.display().to_string())),
             "the second file must be read: {:?}",
             explicit.events
+        );
+    }
+
+    /// A typo is reported rather than silently read as "not specified", which
+    /// is what serde does with an unrecognised field. It stays a warning: an
+    /// unrecognised key may be a mistake, or may be one a newer kakehashi
+    /// understands, and rejecting the file would version-lock it.
+    #[test]
+    fn test_load_toml_file_warns_about_unknown_keys() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("typo.toml");
+        std::fs::write(&path, "autoInstal = false\n").unwrap();
+
+        let mut events = Vec::new();
+        let mut ignored_deprecation = false;
+        let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
+
+        assert!(
+            matches!(result, Ok(Some(_))),
+            "an unknown key must not reject the file: {result:?}"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| event.kind == SettingsEventKind::Warning
+                    && event.message.contains("autoInstal")
+                    && event.message.contains(&path.display().to_string())),
+            "the typo and its file must both be named: {events:?}"
+        );
+    }
+
+    /// The recognised spelling must stay silent, or the warning is noise.
+    #[test]
+    fn test_load_toml_file_accepts_known_keys_without_warning() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("fine.toml");
+        std::fs::write(
+            &path,
+            "autoInstall = false\n[languages.rust]\nparser = \"/p.so\"\n",
+        )
+        .unwrap();
+
+        let mut events = Vec::new();
+        let mut ignored_deprecation = false;
+        let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
+
+        assert!(matches!(result, Ok(Some(_))), "{result:?}");
+        assert!(
+            events
+                .iter()
+                .all(|event| !event.message.contains("Unknown configuration key")),
+            "a well-formed file must not warn: {events:?}"
         );
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -84,6 +84,27 @@ pub struct SettingsLoadOutcome {
     pub(crate) fatal_error: Option<String>,
 }
 
+/// The reason an explicitly requested configuration is unusable, if it is.
+///
+/// `initialize` calls this *before* it latches any once-only state from the
+/// request. `tower-lsp-server` resets to `Uninitialized` after an error
+/// response, so a client may fix the file and retry — and a retry carrying
+/// different capabilities or workspace folders would otherwise be served with
+/// the failed attempt's values, since those are first-write-wins.
+///
+/// Passing no root path and no override settings is not a simplification: when
+/// `--config-file` is set the workspace-relative layer is skipped entirely, and
+/// `initializationOptions` are deliberately outside the strict gate. So this
+/// sees exactly what the gate judges, which is why it can run this early.
+/// Returns `None` when nothing was requested explicitly.
+pub(crate) fn explicit_config_fatal_error(
+    home: Option<&str>,
+    env_fn: impl Fn(&str) -> Option<String>,
+) -> Option<String> {
+    crate::config::expand::config_file_override()?;
+    load_settings(None, None, home, env_fn).fatal_error
+}
+
 pub fn load_settings(
     root_path: Option<&Path>,
     override_settings: Option<(SettingsSource, Value)>,
@@ -108,6 +129,13 @@ pub fn load_settings(
         )));
         let mut layers = Vec::with_capacity(files.len());
         for path in files {
+            // The verdict cannot change once a layer has failed, and reading on
+            // is not free: a later path could be a FIFO that blocks forever, so
+            // an already-doomed session would hang instead of reporting the
+            // failure it already knows about.
+            if fatal_error.is_some() {
+                break;
+            }
             let layer = match load_toml_file(path, &mut events, &mut deprecated_keys) {
                 Ok(layer) => layer,
                 Err(message) => {
@@ -279,6 +307,18 @@ fn load_toml_file(
     match path.try_exists() {
         Ok(true) => {}
         Ok(false) => {
+            // `try_exists` follows symlinks, so a link whose target is gone
+            // also answers "no". That is not the optional-overlay case: the
+            // path the user named does exist, it just does not lead to a
+            // config, and silently ignoring it would hide exactly the broken
+            // setup this is strict about. `symlink_metadata` does not follow,
+            // so it still sees the link itself.
+            if path.symlink_metadata().is_ok() {
+                return Err(format!(
+                    "Failed to read {}: broken symbolic link",
+                    path.display()
+                ));
+            }
             events.push(SettingsEvent::warning(format!(
                 "Config file not found, skipping: {}",
                 path.display()
@@ -835,12 +875,43 @@ mod tests {
         std::fs::set_permissions(&locked_parent, std::fs::Permissions::from_mode(0o755)).unwrap();
 
         if !permissions_enforced {
+            // Running as root (common in container CI): the bits do not apply,
+            // so there is no denial to observe. Still assert the path is not
+            // misread as absent, which is the regression this guards.
+            assert!(
+                matches!(result, Ok(Some(_))),
+                "a reachable file must load: {result:?}"
+            );
             return;
         }
         let message = result.expect_err("an unreachable explicit file must be fatal");
         assert!(
             message.contains(&path.display().to_string()) && !message.contains("not found"),
             "an unreachable path must not be reported as merely absent: {message}"
+        );
+    }
+
+    /// load_toml_file: a symlink whose target is gone is present-but-unusable,
+    /// not absent. `try_exists` follows the link and reports the *target*, so
+    /// the two cases look identical without an explicit check.
+    #[cfg(unix)]
+    #[test]
+    fn test_load_toml_file_broken_symlink() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("generated.toml");
+        let link = dir.path().join("config.toml");
+        std::fs::write(&target, "autoInstall = false\n").unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        std::fs::remove_file(&target).unwrap();
+
+        let mut events = Vec::new();
+        let mut ignored_deprecation = false;
+        let result = load_toml_file(&link, &mut events, &mut ignored_deprecation);
+
+        let message = result.expect_err("a dangling explicit symlink must be fatal");
+        assert!(
+            message.contains(&link.display().to_string()) && !message.contains("not found"),
+            "a dangling symlink must not be reported as merely absent: {message}"
         );
     }
 
@@ -866,6 +937,12 @@ mod tests {
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
 
         if !permissions_enforced {
+            // Running as root: the bits do not apply. Assert the file still
+            // loads rather than being misclassified as absent.
+            assert!(
+                matches!(result, Ok(Some(_))),
+                "a readable file must load: {result:?}"
+            );
             return;
         }
         let message = result.expect_err("an unreadable explicit file must be fatal");

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -62,9 +62,19 @@ pub struct SettingsLoadOutcome {
     pub settings: Option<WorkspaceSettings>,
     pub raw_settings: Option<RawWorkspaceSettings>,
     pub events: Vec<SettingsEvent>,
-    /// Which deprecated keys the loaded layers spelled — see
-    /// [`DeprecatedKeysSeen`] for why this is not an `events` entry.
-    pub(crate) deprecated_keys: DeprecatedKeysSeen,
+    /// True if any loaded config layer used the deprecated `rootMarkers` key
+    /// (superseded by `workspaceMarkers`). Serde's alias erases which spelling
+    /// was written, so this is detected from the raw config value. The
+    /// `initialize` handler reads this field and surfaces a one-per-session
+    /// deprecation notice (gated by `SettingsManager`'s claim guard, shared
+    /// with the didChangeConfiguration path); it is intentionally kept out of
+    /// `events` so the many callers that re-load settings do not re-warn.
+    pub deprecated_keys: DeprecatedKeysSeen,
+    /// Fatal error from an explicitly requested configuration source.
+    ///
+    /// Missing implicit user/project files remain optional, but a path passed
+    /// through `--config-file` represents user intent and must not be skipped.
+    pub fatal_error: Option<String>,
 }
 
 pub fn load_settings(
@@ -76,6 +86,7 @@ pub fn load_settings(
     let env_fn = crate::config::expand::with_kakehashi_defaults(env_fn);
     let mut events = Vec::new();
     let mut deprecated_keys = DeprecatedKeysSeen::default();
+    let mut fatal_error = None;
 
     // Layer 1: Programmed defaults (configuration-merging-strategy: lowest precedence)
     let defaults = Some(default_settings());
@@ -87,10 +98,15 @@ pub fn load_settings(
                 "Using {} explicit config file(s); default config locations skipped",
                 files.len()
             )));
-            files
+            let layers = files
                 .iter()
                 .map(|p| load_toml_file(p, &mut events, &mut deprecated_keys))
-                .collect()
+                .collect();
+            fatal_error = events
+                .iter()
+                .find(|event| event.kind == SettingsEventKind::Error)
+                .map(|event| event.message.clone());
+            layers
         } else {
             vec![
                 // Layer 2: User config from XDG_CONFIG_HOME (~/.config/kakehashi/kakehashi.toml)
@@ -134,6 +150,7 @@ pub fn load_settings(
         raw_settings,
         events,
         deprecated_keys,
+        fatal_error,
     }
 }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -117,6 +117,24 @@ pub(crate) fn load_explicit_config(
     Some(read_explicit_layers(files, home, env_fn))
 }
 
+/// The explicit layers merged with nothing beneath them — the subject of the
+/// strict gate.
+///
+/// Programmed defaults are deliberately absent. They carry
+/// `${KAKEHASHI_DATA_DIR}`, which cannot expand on a host with no discoverable
+/// data directory, and blaming the user's file for that would reject a session
+/// over a valid — even empty — config. Their absence costs the gate nothing:
+/// `FeatureSettings::resolve` already fills an unset half of a timing pair from
+/// the same defaults, so a lone `debounceMs` is still judged against the
+/// default `maxWaitMs`.
+fn merge_explicit_layers(layers: &[Option<RawWorkspaceSettings>]) -> Option<RawWorkspaceSettings> {
+    layers
+        .iter()
+        .cloned()
+        .reduce(merge_workspace_settings)
+        .flatten()
+}
+
 /// The body of [`load_explicit_config`], taking the paths directly so it can be
 /// exercised without the process-global `--config-file` override.
 fn read_explicit_layers(
@@ -186,18 +204,7 @@ fn read_explicit_layers(
     // every `try_from_settings` re-resolves language `base` chains, whose cycle
     // detector logs as it goes.
     if fatal_error.is_none() {
-        // Only the explicit layers. Programmed defaults carry
-        // `${KAKEHASHI_DATA_DIR}`, which cannot expand on a host with no
-        // discoverable data directory — blaming the user's file for that would
-        // reject a session over a valid, even empty, config. Their absence
-        // costs nothing here: `FeatureSettings::resolve` already fills an
-        // unset half of a timing pair from the same defaults, so a lone
-        // `debounceMs` is still judged against the default `maxWaitMs`.
-        let merged = layers
-            .iter()
-            .cloned()
-            .reduce(merge_workspace_settings)
-            .flatten();
+        let merged = merge_explicit_layers(&layers);
         if let Some(raw_settings) = merged.as_ref()
             && let Err(errs) = WorkspaceSettings::try_from_settings(raw_settings, home, &env_fn)
         {
@@ -1015,27 +1022,35 @@ mod tests {
         );
     }
 
-    /// A programmed default that cannot expand is not the explicit file's
-    /// fault. `${KAKEHASHI_DATA_DIR}` has no value on a host with no
-    /// discoverable data directory, and rejecting a session over that would
-    /// turn a valid — even empty — `--config-file` into a startup failure.
+    /// The strict gate judges the user's files, not the defaults beneath them.
+    /// Programmed defaults carry `${KAKEHASHI_DATA_DIR}`, which has no value on
+    /// a host with no discoverable data directory; merging them in would reject
+    /// a session over a valid — even empty — `--config-file`.
+    ///
+    /// Asserted on the merge rather than on a verdict: whether the default
+    /// expands depends on the host, so a test that ran the gate would pass on
+    /// any developer machine even with the defaults merged back in.
     #[test]
-    fn read_explicit_layers_does_not_blame_a_file_for_the_defaults() {
-        let dir = TempDir::new().unwrap();
-        let path = dir.path().join("empty.toml");
-        std::fs::write(&path, "").unwrap();
+    fn merge_explicit_layers_excludes_the_programmed_defaults() {
+        let layers = vec![
+            Some(RawWorkspaceSettings {
+                auto_install: Some(false),
+                ..Default::default()
+            }),
+            None,
+        ];
 
-        // An environment where the data-directory fallback is unavailable, so
-        // the default `searchPaths` entry cannot expand.
-        let explicit = read_explicit_layers(&[path], None, |var| match var {
-            "KAKEHASHI_DATA_DIR" => None,
-            _ => std::env::var(var).ok(),
-        });
+        let merged = merge_explicit_layers(&layers).expect("the explicit layer should survive");
 
+        assert_eq!(merged.auto_install, Some(false));
         assert!(
-            explicit.fatal_error.is_none(),
-            "a valid explicit file must not inherit the defaults' failure: {:?}",
-            explicit.fatal_error
+            merged.search_paths.is_none(),
+            "the defaults' searchPaths must not join the subject of the gate: {:?}",
+            merged.search_paths
+        );
+        assert!(
+            default_settings().search_paths.is_some(),
+            "this test is only meaningful while the defaults do carry searchPaths"
         );
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -76,12 +76,22 @@ pub struct SettingsLoadOutcome {
     pub deprecated_keys: DeprecatedKeysSeen,
 }
 
+/// Ceiling on a single config file read.
+///
+/// A kakehashi configuration is a hand-written TOML file; megabytes of one is a
+/// mistake, not a use case. Without a bound, a `--config-file` naming an
+/// endless source — `/dev/zero`, most obviously — would allocate until the
+/// process died rather than reporting a bad path.
+const MAX_CONFIG_FILE_BYTES: u64 = 8 * 1024 * 1024;
+
 /// The `--config-file` inputs, read and judged exactly once.
 ///
-/// Read *once* is a contract, not an optimisation. A `--config-file` may name a
-/// stream (`/dev/fd/N`), which a second read would find empty, and a file
-/// replaced between two reads would have its second verdict either ignored or
-/// discovered too late to matter.
+/// Read *once* is a contract, not an optimisation. A file replaced between two
+/// reads would have its second verdict either ignored or discovered too late to
+/// matter, and a path that happens to name a stream would be found empty the
+/// second time. (Naming a stream is not a supported workflow — one with no
+/// writer will simply block initialization — but reading once is what keeps the
+/// failure mode that of the path the user chose.)
 pub(crate) struct ExplicitConfig {
     layers: Vec<Option<RawWorkspaceSettings>>,
     events: Vec<SettingsEvent>,
@@ -328,21 +338,20 @@ fn load_toml_file(
     events: &mut Vec<SettingsEvent>,
     deprecated_keys: &mut DeprecatedKeysSeen,
 ) -> Result<Option<RawWorkspaceSettings>, String> {
-    // `try_exists`, not `exists`: the latter answers "no" both for a path that
-    // is genuinely absent and for one whose metadata cannot be read at all
-    // (an ancestor directory denying traversal, say). Only the first is the
-    // optional-overlay case; collapsing them would let a file the user cannot
-    // reach be silently skipped, which is exactly the class this is strict
-    // about.
-    match path.try_exists() {
-        Ok(true) => {}
-        Ok(false) => {
-            // `try_exists` follows symlinks, so a link whose target is gone
-            // also answers "no". That is not the optional-overlay case: the
+    // Classify by opening, not by probing first: a separate `exists` check
+    // would answer for a different moment than the open, and would have to
+    // decide what "no" means without the kernel's reason for it. `NotFound` is
+    // the only answer that can mean the optional-overlay case; everything else
+    // — a denied ancestor directory, a path that is a directory — is a file the
+    // user named and cannot use.
+    let file = match fs::File::open(path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            // Opening follows symlinks, so a link whose target is gone also
+            // reports `NotFound`. That is not the optional-overlay case: the
             // path the user named does exist, it just does not lead to a
-            // config, and silently ignoring it would hide exactly the broken
-            // setup this is strict about. `symlink_metadata` does not follow,
-            // so it still sees the link itself.
+            // config. `symlink_metadata` does not follow, so it still sees the
+            // link itself.
             if path.symlink_metadata().is_ok() {
                 return Err(format!(
                     "Failed to read {}: broken symbolic link",
@@ -356,17 +365,29 @@ fn load_toml_file(
             return Ok(None);
         }
         Err(err) => {
-            return Err(format!("Failed to access {}: {}", path.display(), err));
+            return Err(format!("Failed to read {}: {}", path.display(), err));
         }
-    }
+    };
 
     events.push(SettingsEvent::info(format!(
         "Loading config file: {}",
         path.display()
     )));
 
-    let contents = fs::read_to_string(path)
+    // Read one byte past the ceiling so hitting it is distinguishable from a
+    // file that merely ends there.
+    let mut contents = String::new();
+    use std::io::Read as _;
+    file.take(MAX_CONFIG_FILE_BYTES + 1)
+        .read_to_string(&mut contents)
         .map_err(|err| format!("Failed to read {}: {}", path.display(), err))?;
+    if contents.len() as u64 > MAX_CONFIG_FILE_BYTES {
+        return Err(format!(
+            "Failed to read {}: larger than the {} MiB configuration limit",
+            path.display(),
+            MAX_CONFIG_FILE_BYTES / (1024 * 1024)
+        ));
+    }
     deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
     let settings = toml::from_str::<RawWorkspaceSettings>(&contents)
         .map_err(|err| format!("Failed to parse {}: {}", path.display(), err))?;
@@ -996,6 +1017,32 @@ mod tests {
                 .all(|event| !event.message.contains(&later.display().to_string())),
             "nothing after the failure may be read: {:?}",
             explicit.events
+        );
+    }
+
+    /// load_toml_file: a file past the size ceiling fails instead of being read
+    /// to exhaustion. The ceiling is what keeps `--config-file /dev/zero` from
+    /// allocating until the process dies.
+    #[test]
+    fn test_load_toml_file_over_size_limit() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("huge.toml");
+        // A comment body, so the file is only rejected for its size — a valid
+        // parse would otherwise be indistinguishable from a missing check.
+        let mut oversized = String::with_capacity(MAX_CONFIG_FILE_BYTES as usize + 16);
+        oversized.push_str("# ");
+        oversized.extend(std::iter::repeat_n('a', MAX_CONFIG_FILE_BYTES as usize));
+        std::fs::write(&path, &oversized).unwrap();
+
+        let mut events = Vec::new();
+        let mut ignored_deprecation = false;
+        let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
+
+        let message = result.expect_err("an oversized explicit file must be fatal");
+        assert!(
+            message.contains("configuration limit")
+                && message.contains(&path.display().to_string()),
+            "the limit must be named, and so must the file: {message}"
         );
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -66,14 +66,9 @@ pub struct SettingsLoadOutcome {
     pub settings: Option<WorkspaceSettings>,
     pub raw_settings: Option<RawWorkspaceSettings>,
     pub events: Vec<SettingsEvent>,
-    /// True if any loaded config layer used the deprecated `rootMarkers` key
-    /// (superseded by `workspaceMarkers`). Serde's alias erases which spelling
-    /// was written, so this is detected from the raw config value. The
-    /// `initialize` handler reads this field and surfaces a one-per-session
-    /// deprecation notice (gated by `SettingsManager`'s claim guard, shared
-    /// with the didChangeConfiguration path); it is intentionally kept out of
-    /// `events` so the many callers that re-load settings do not re-warn.
-    pub deprecated_keys: DeprecatedKeysSeen,
+    /// Which deprecated keys the loaded layers spelled — see
+    /// [`DeprecatedKeysSeen`] for why this is not an `events` entry.
+    pub(crate) deprecated_keys: DeprecatedKeysSeen,
 }
 
 /// Ceiling on a single config file read.
@@ -163,7 +158,7 @@ fn read_explicit_layers(
         "Using {} explicit config file(s); default config locations skipped",
         files.len()
     ))];
-    let mut used_deprecated_root_markers = false;
+    let mut deprecated_keys = DeprecatedKeysSeen::default();
     let mut fatal_error = None;
     let mut layers = Vec::with_capacity(files.len());
 
@@ -175,7 +170,7 @@ fn read_explicit_layers(
         if fatal_error.is_some() {
             break;
         }
-        let layer = match load_toml_file(path, &mut events, &mut used_deprecated_root_markers) {
+        let layer = match load_toml_file(path, &mut events, &mut deprecated_keys) {
             Ok(layer) => layer,
             Err(message) => {
                 events.push(SettingsEvent::error(message.clone()));
@@ -233,7 +228,7 @@ fn read_explicit_layers(
     ExplicitConfig {
         layers,
         events,
-        used_deprecated_root_markers,
+        deprecated_keys,
         fatal_error,
     }
 }
@@ -255,7 +250,6 @@ pub fn load_settings(
     let env_fn = crate::config::expand::with_kakehashi_defaults(env_fn);
     let mut events = Vec::new();
     let mut deprecated_keys = DeprecatedKeysSeen::default();
-    let explicit_config_requested = crate::config::expand::config_file_override().is_some();
 
     // Layer 1: Programmed defaults (configuration-merging-strategy: lowest precedence)
     let defaults = Some(default_settings());
@@ -1012,7 +1006,7 @@ mod tests {
         std::fs::set_permissions(&locked_parent, std::fs::Permissions::from_mode(0o000)).unwrap();
 
         let mut events = Vec::new();
-        let mut ignored_deprecation = false;
+        let mut ignored_deprecation = DeprecatedKeysSeen::default();
         // root ignores the permission bits, so probe before deciding to assert.
         let permissions_enforced = std::fs::read_to_string(&path).is_err();
         let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
@@ -1076,7 +1070,7 @@ mod tests {
         std::fs::write(&path, "autoInstal = false\n").unwrap();
 
         let mut events = Vec::new();
-        let mut ignored_deprecation = false;
+        let mut ignored_deprecation = DeprecatedKeysSeen::default();
         let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
 
         assert!(
@@ -1109,7 +1103,7 @@ mod tests {
         .unwrap();
 
         let mut events = Vec::new();
-        let mut ignored_deprecation = false;
+        let mut ignored_deprecation = DeprecatedKeysSeen::default();
         let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
 
         let message = result
@@ -1132,7 +1126,7 @@ mod tests {
         .unwrap();
 
         let mut events = Vec::new();
-        let mut ignored_deprecation = false;
+        let mut ignored_deprecation = DeprecatedKeysSeen::default();
         let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
 
         assert!(matches!(result, Ok(Some(_))), "{result:?}");
@@ -1227,7 +1221,7 @@ mod tests {
         std::fs::write(&path, &oversized).unwrap();
 
         let mut events = Vec::new();
-        let mut ignored_deprecation = false;
+        let mut ignored_deprecation = DeprecatedKeysSeen::default();
         let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
 
         let message = result.expect_err("an oversized explicit file must be fatal");
@@ -1251,7 +1245,7 @@ mod tests {
         std::fs::write(&path, &oversized).unwrap();
 
         let mut events = Vec::new();
-        let mut ignored_deprecation = false;
+        let mut ignored_deprecation = DeprecatedKeysSeen::default();
         let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
 
         let message = result.expect_err("an oversized explicit file must be fatal");
@@ -1275,7 +1269,7 @@ mod tests {
         std::fs::remove_file(&target).unwrap();
 
         let mut events = Vec::new();
-        let mut ignored_deprecation = false;
+        let mut ignored_deprecation = DeprecatedKeysSeen::default();
         let result = load_toml_file(&link, &mut events, &mut ignored_deprecation);
 
         let message = result.expect_err("a dangling explicit symlink must be fatal");
@@ -1298,7 +1292,7 @@ mod tests {
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
 
         let mut events = Vec::new();
-        let mut ignored_deprecation = false;
+        let mut ignored_deprecation = DeprecatedKeysSeen::default();
         // root ignores the permission bits, so probe before deciding to assert.
         let permissions_enforced = std::fs::read_to_string(&path).is_err();
         let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
@@ -1339,7 +1333,10 @@ mod tests {
             matches!(result, Ok(Some(_))),
             "valid TOML should parse: {result:?}"
         );
-        assert!(used_deprecated.root_markers, "rootMarkers should set the flag");
+        assert!(
+            used_deprecated.root_markers,
+            "rootMarkers should set the flag"
+        );
     }
 
     /// load_toml_settings (the project kakehashi.toml layer) sets the flag when

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -150,7 +150,7 @@ pub fn load_settings(
                 Err(errs) => {
                     events.push(SettingsEvent::error(format!(
                         "Invalid configuration: {errs}. \
-                     This configuration has been discarded; previous settings remain in effect. \
+                     This configuration has been discarded. \
                      Please correct the invalid settings or remove them from your config.",
                     )));
                     None
@@ -585,6 +585,13 @@ mod tests {
                 .iter()
                 .map(|e| format!("{:?}: {}", e.kind, &e.message))
                 .collect::<Vec<_>>()
+        );
+        assert!(
+            outcome
+                .events
+                .iter()
+                .all(|event| !event.message.contains("previous settings")),
+            "initialization-time errors must not claim that previous settings exist"
         );
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -158,13 +158,17 @@ pub fn load_settings(
         .flatten();
 
     // An explicit configuration has to be valid on its own terms, or startup
-    // would silently continue on programmed defaults. This is judged before
+    // would silently continue on programmed defaults. Skipped once a layer has
+    // already failed: the verdict cannot change, and every `try_from_settings`
+    // re-resolves language `base` chains, whose cycle detector logs as it goes.
+    // This is judged before
     // `initializationOptions` join the merge, because those keep a non-fatal
     // policy of their own — a client sending a bad override must not be
     // reported as a mistake in the user's file. It is also the only place a
     // cross-layer invariant can be judged: one file supplying `debounceMs` and
     // another `maxWaitMs` is valid in neither file alone.
     if explicit_files.is_some()
+        && fatal_error.is_none()
         && let Some(raw_settings) = merged_files.as_ref()
         && let Err(errs) = WorkspaceSettings::try_from_settings(raw_settings, home, &env_fn)
     {
@@ -260,12 +264,24 @@ fn load_toml_file(
     events: &mut Vec<SettingsEvent>,
     deprecated_keys: &mut DeprecatedKeysSeen,
 ) -> Result<Option<RawWorkspaceSettings>, String> {
-    if !path.exists() {
-        events.push(SettingsEvent::warning(format!(
-            "Config file not found, skipping: {}",
-            path.display()
-        )));
-        return Ok(None);
+    // `try_exists`, not `exists`: the latter answers "no" both for a path that
+    // is genuinely absent and for one whose metadata cannot be read at all
+    // (an ancestor directory denying traversal, say). Only the first is the
+    // optional-overlay case; collapsing them would let a file the user cannot
+    // reach be silently skipped, which is exactly the class this is strict
+    // about.
+    match path.try_exists() {
+        Ok(true) => {}
+        Ok(false) => {
+            events.push(SettingsEvent::warning(format!(
+                "Config file not found, skipping: {}",
+                path.display()
+            )));
+            return Ok(None);
+        }
+        Err(err) => {
+            return Err(format!("Failed to access {}: {}", path.display(), err));
+        }
     }
 
     events.push(SettingsEvent::info(format!(
@@ -785,6 +801,40 @@ mod tests {
         assert!(
             message.contains("Failed to parse") && message.contains(&path.display().to_string()),
             "the fatal message must name the offending file: {message}"
+        );
+    }
+
+    /// load_toml_file: a path whose metadata cannot even be reached is fatal,
+    /// not "absent". `Path::exists()` answers `false` for both, which would
+    /// silently skip a file the user cannot traverse to.
+    #[cfg(unix)]
+    #[test]
+    fn test_load_toml_file_unreachable_parent() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let locked_parent = dir.path().join("locked");
+        std::fs::create_dir(&locked_parent).unwrap();
+        let path = locked_parent.join("config.toml");
+        std::fs::write(&path, "autoInstall = false\n").unwrap();
+        std::fs::set_permissions(&locked_parent, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let mut events = Vec::new();
+        let mut ignored_deprecation = false;
+        // root ignores the permission bits, so probe before deciding to assert.
+        let permissions_enforced = std::fs::read_to_string(&path).is_err();
+        let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
+
+        // Restore before asserting so a failure cannot leave an unremovable dir.
+        std::fs::set_permissions(&locked_parent, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        if !permissions_enforced {
+            return;
+        }
+        let message = result.expect_err("an unreachable explicit file must be fatal");
+        assert!(
+            message.contains(&path.display().to_string()) && !message.contains("not found"),
+            "an unreachable path must not be reported as merely absent: {message}"
         );
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -86,7 +86,7 @@ pub fn load_settings(
     let env_fn = crate::config::expand::with_kakehashi_defaults(env_fn);
     let mut events = Vec::new();
     let mut deprecated_keys = DeprecatedKeysSeen::default();
-    let mut fatal_error = None;
+    let explicit_config_requested = crate::config::expand::config_file_override().is_some();
 
     // Layer 1: Programmed defaults (configuration-merging-strategy: lowest precedence)
     let defaults = Some(default_settings());
@@ -98,15 +98,10 @@ pub fn load_settings(
                 "Using {} explicit config file(s); default config locations skipped",
                 files.len()
             )));
-            let layers = files
+            files
                 .iter()
                 .map(|p| load_toml_file(p, &mut events, &mut deprecated_keys))
-                .collect();
-            fatal_error = events
-                .iter()
-                .find(|event| event.kind == SettingsEventKind::Error)
-                .map(|event| event.message.clone());
-            layers
+                .collect()
         } else {
             vec![
                 // Layer 2: User config from XDG_CONFIG_HOME (~/.config/kakehashi/kakehashi.toml)
@@ -144,6 +139,15 @@ pub fn load_settings(
                 }
             },
         );
+
+    let fatal_error = explicit_config_requested
+        .then(|| {
+            events
+                .iter()
+                .find(|event| event.kind == SettingsEventKind::Error)
+                .map(|event| event.message.clone())
+        })
+        .flatten();
 
     SettingsLoadOutcome {
         settings,

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -144,19 +144,7 @@ pub fn load_settings(
         .flatten();
     let raw_settings = merged.clone();
     let settings =
-        merged.and_then(
-            |m| match WorkspaceSettings::try_from_settings(&m, home, &env_fn) {
-                Ok(ws) => Some(ws),
-                Err(errs) => {
-                    events.push(SettingsEvent::error(format!(
-                        "Invalid configuration: {errs}. \
-                     This configuration has been discarded. \
-                     Please correct the invalid settings or remove them from your config.",
-                    )));
-                    None
-                }
-            },
-        );
+        expand_merged_settings(merged, home, &env_fn, &mut events, fatal_error.is_some());
 
     SettingsLoadOutcome {
         settings,
@@ -165,6 +153,32 @@ pub fn load_settings(
         deprecated_keys,
         fatal_error,
     }
+}
+
+fn expand_merged_settings(
+    merged: Option<RawWorkspaceSettings>,
+    home: Option<&str>,
+    env_fn: impl Fn(&str) -> Option<String>,
+    events: &mut Vec<SettingsEvent>,
+    skip_due_to_fatal_error: bool,
+) -> Option<WorkspaceSettings> {
+    if skip_due_to_fatal_error {
+        return None;
+    }
+
+    merged.and_then(|settings| {
+        match WorkspaceSettings::try_from_settings(&settings, home, env_fn) {
+            Ok(settings) => Some(settings),
+            Err(errs) => {
+                events.push(SettingsEvent::error(format!(
+                    "Invalid configuration: {errs}. \
+                     This configuration has been discarded. \
+                     Please correct the invalid settings or remove them from your config.",
+                )));
+                None
+            }
+        }
+    })
 }
 
 /// Load user config and add appropriate events to the events vector.
@@ -593,6 +607,28 @@ mod tests {
                 .all(|event| !event.message.contains("previous settings")),
             "initialization-time errors must not claim that previous settings exist"
         );
+    }
+
+    #[test]
+    fn fatal_explicit_error_skips_duplicate_merged_expansion_event() {
+        let merged = RawWorkspaceSettings {
+            search_paths: Some(vec!["$UNDEFINED_VAR/parsers".to_string()]),
+            ..Default::default()
+        };
+        let mut events = vec![SettingsEvent::error(
+            "Path expansion failed in explicit.toml",
+        )];
+
+        let settings = expand_merged_settings(
+            Some(merged),
+            None,
+            crate::config::make_env(&[]),
+            &mut events,
+            true,
+        );
+
+        assert!(settings.is_none());
+        assert_eq!(events.len(), 1, "fatal error must be reported only once");
     }
 
     /// A config layer using the deprecated `rootMarkers` key sets the outcome

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -152,20 +152,31 @@ pub fn load_settings(
     // Merge all layers: defaults < config_layers < override (later layers override earlier)
     let mut layers = vec![defaults];
     layers.extend(config_layers);
-    layers.push(override_settings);
-    let merged = layers
+    let merged_files = layers
+        .into_iter()
+        .reduce(merge_workspace_settings)
+        .flatten();
+
+    // An explicit configuration has to be valid on its own terms, or startup
+    // would silently continue on programmed defaults. This is judged before
+    // `initializationOptions` join the merge, because those keep a non-fatal
+    // policy of their own — a client sending a bad override must not be
+    // reported as a mistake in the user's file. It is also the only place a
+    // cross-layer invariant can be judged: one file supplying `debounceMs` and
+    // another `maxWaitMs` is valid in neither file alone.
+    if explicit_files.is_some()
+        && let Some(raw_settings) = merged_files.as_ref()
+        && let Err(errs) = WorkspaceSettings::try_from_settings(raw_settings, home, &env_fn)
+    {
+        fatal_error.get_or_insert(format!("Invalid configuration from --config-file: {errs}"));
+    }
+
+    let merged = [merged_files, override_settings]
         .into_iter()
         .reduce(merge_workspace_settings)
         .flatten();
     let raw_settings = merged.clone();
-    let settings = expand_merged_settings(
-        merged,
-        home,
-        &env_fn,
-        &mut events,
-        &mut fatal_error,
-        explicit_files.is_some(),
-    );
+    let settings = expand_merged_settings(merged, home, &env_fn, &mut events);
 
     SettingsLoadOutcome {
         settings,
@@ -176,35 +187,28 @@ pub fn load_settings(
     }
 }
 
-/// Expand and validate the fully merged configuration.
+/// Expand and validate the fully merged configuration, `initializationOptions`
+/// included.
 ///
-/// `explicit_config` marks a session driven by `--config-file`. Those paths
-/// represent user intent, so a merged configuration that cannot be expanded is
-/// fatal rather than silently degrading to programmed defaults. This is also
-/// the only place a cross-layer invariant violation can be caught — one file
-/// supplying `debounceMs` and another `maxWaitMs` is valid in neither file
-/// alone, yet the pair must still be checked once merged.
+/// Failure here is never fatal on its own: it is the last, most permissive
+/// gate, and the layers that *are* strict have already been judged by the
+/// caller. Discarding the merge leaves `initialize` to start on programmed
+/// defaults, which is the documented policy for a client-supplied override.
 fn expand_merged_settings(
     merged: Option<RawWorkspaceSettings>,
     home: Option<&str>,
     env_fn: impl Fn(&str) -> Option<String>,
     events: &mut Vec<SettingsEvent>,
-    fatal_error: &mut Option<String>,
-    explicit_config: bool,
 ) -> Option<WorkspaceSettings> {
     merged.and_then(|settings| {
         match WorkspaceSettings::try_from_settings(&settings, home, env_fn) {
             Ok(settings) => Some(settings),
             Err(errs) => {
-                let message = format!(
+                events.push(SettingsEvent::error(format!(
                     "Invalid configuration: {errs}. \
                      This configuration has been discarded. \
                      Please correct the invalid settings or remove them from your config.",
-                );
-                events.push(SettingsEvent::error(message.clone()));
-                if explicit_config {
-                    fatal_error.get_or_insert(message);
-                }
+                )));
                 None
             }
         }
@@ -629,49 +633,30 @@ mod tests {
         );
     }
 
-    /// A merged configuration that fails expansion is fatal only when the user
-    /// named the files explicitly; implicit discovery keeps degrading to
-    /// defaults so the zero-config experience survives a stray config file.
+    /// The last expansion gate stays non-fatal: it also carries
+    /// `initializationOptions`, whose failures must not abort startup.
     #[test]
-    fn merged_expansion_failure_is_fatal_only_for_explicit_config() {
-        let broken = || RawWorkspaceSettings {
+    fn merged_expansion_failure_discards_settings_without_aborting() {
+        let merged = RawWorkspaceSettings {
             search_paths: Some(vec!["$UNDEFINED_VAR/parsers".to_string()]),
             ..Default::default()
         };
+        let mut events = Vec::new();
 
-        let mut explicit_events = Vec::new();
-        let mut explicit_fatal = None;
-        let explicit = expand_merged_settings(
-            Some(broken()),
+        let settings = expand_merged_settings(
+            Some(merged),
             None,
             crate::config::make_env(&[]),
-            &mut explicit_events,
-            &mut explicit_fatal,
-            true,
+            &mut events,
         );
 
-        let mut implicit_events = Vec::new();
-        let mut implicit_fatal = None;
-        let implicit = expand_merged_settings(
-            Some(broken()),
-            None,
-            crate::config::make_env(&[]),
-            &mut implicit_events,
-            &mut implicit_fatal,
-            false,
-        );
-
-        assert!(explicit.is_none());
-        assert!(implicit.is_none());
+        assert!(settings.is_none());
         assert!(
-            explicit_fatal
-                .as_deref()
-                .is_some_and(|message| message.contains("UNDEFINED_VAR")),
-            "explicit config must abort startup: {explicit_fatal:?}"
-        );
-        assert!(
-            implicit_fatal.is_none(),
-            "implicit config must keep falling back to defaults: {implicit_fatal:?}"
+            events
+                .iter()
+                .any(|event| event.kind == SettingsEventKind::Error
+                    && event.message.contains("UNDEFINED_VAR")),
+            "the discarded configuration must still be reported: {events:?}"
         );
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -76,9 +76,12 @@ pub struct SettingsLoadOutcome {
     pub deprecated_keys: DeprecatedKeysSeen,
     /// Fatal error from an explicitly requested configuration source.
     ///
-    /// Missing implicit user/project files remain optional, but a path passed
-    /// through `--config-file` represents user intent and must not be skipped.
-    pub fatal_error: Option<String>,
+    /// A `--config-file` path that is *present* but unusable — unreadable,
+    /// malformed, or carrying a path that cannot be expanded — represents a
+    /// user mistake that must not be papered over with defaults. An *absent*
+    /// explicit file stays optional (see `load_toml_file`), as do all
+    /// implicitly discovered user/project files.
+    pub(crate) fatal_error: Option<String>,
 }
 
 pub fn load_settings(
@@ -97,27 +100,35 @@ pub fn load_settings(
     let defaults = Some(default_settings());
 
     // Layers 2+3: config files (either explicit --config-file or default locations)
-    let config_layers: Vec<Option<RawWorkspaceSettings>> = if let Some(files) =
-        crate::config::expand::config_file_override()
-    {
+    let explicit_files = crate::config::expand::config_file_override();
+    let config_layers: Vec<Option<RawWorkspaceSettings>> = if let Some(files) = explicit_files {
         events.push(SettingsEvent::info(format!(
             "Using {} explicit config file(s); default config locations skipped",
             files.len()
         )));
         let mut layers = Vec::with_capacity(files.len());
         for path in files {
-            let event_start = events.len();
-            let layer = load_toml_file(path, &mut events, &mut deprecated_keys);
-            if fatal_error.is_none() {
-                fatal_error = events[event_start..]
-                    .iter()
-                    .find(|event| event.kind == SettingsEventKind::Error)
-                    .map(|event| event.message.clone());
-            }
+            let layer = match load_toml_file(path, &mut events, &mut deprecated_keys) {
+                Ok(layer) => layer,
+                Err(message) => {
+                    events.push(SettingsEvent::error(message.clone()));
+                    fatal_error.get_or_insert(message);
+                    None
+                }
+            };
+            // Judge each layer's *paths* on its own so a later layer cannot
+            // mask an earlier one's undefined variable: path fields are
+            // replaced wholesale by the overlay, so the merged result would
+            // never mention the mistake. Cross-field invariants are excluded
+            // here (see `ExpandErrors::path_error_summary`) — their operands
+            // merge independently, so they are only meaningful once every
+            // layer has been folded together, and `expand_merged_settings`
+            // catches them there.
             if let Some(raw_settings) = layer.as_ref()
                 && let Err(errs) = WorkspaceSettings::try_from_settings(raw_settings, home, &env_fn)
+                && let Some(details) = errs.path_error_summary()
             {
-                let message = format!("Path expansion failed in {}: {errs}", path.display());
+                let message = format!("Path expansion failed in {}: {details}", path.display());
                 events.push(SettingsEvent::error(message.clone()));
                 fatal_error.get_or_insert(message);
             }
@@ -147,8 +158,14 @@ pub fn load_settings(
         .reduce(merge_workspace_settings)
         .flatten();
     let raw_settings = merged.clone();
-    let settings =
-        expand_merged_settings(merged, home, &env_fn, &mut events, fatal_error.is_some());
+    let settings = expand_merged_settings(
+        merged,
+        home,
+        &env_fn,
+        &mut events,
+        &mut fatal_error,
+        explicit_files.is_some(),
+    );
 
     SettingsLoadOutcome {
         settings,
@@ -159,26 +176,35 @@ pub fn load_settings(
     }
 }
 
+/// Expand and validate the fully merged configuration.
+///
+/// `explicit_config` marks a session driven by `--config-file`. Those paths
+/// represent user intent, so a merged configuration that cannot be expanded is
+/// fatal rather than silently degrading to programmed defaults. This is also
+/// the only place a cross-layer invariant violation can be caught — one file
+/// supplying `debounceMs` and another `maxWaitMs` is valid in neither file
+/// alone, yet the pair must still be checked once merged.
 fn expand_merged_settings(
     merged: Option<RawWorkspaceSettings>,
     home: Option<&str>,
     env_fn: impl Fn(&str) -> Option<String>,
     events: &mut Vec<SettingsEvent>,
-    skip_due_to_fatal_error: bool,
+    fatal_error: &mut Option<String>,
+    explicit_config: bool,
 ) -> Option<WorkspaceSettings> {
-    if skip_due_to_fatal_error {
-        return None;
-    }
-
     merged.and_then(|settings| {
         match WorkspaceSettings::try_from_settings(&settings, home, env_fn) {
             Ok(settings) => Some(settings),
             Err(errs) => {
-                events.push(SettingsEvent::error(format!(
+                let message = format!(
                     "Invalid configuration: {errs}. \
                      This configuration has been discarded. \
                      Please correct the invalid settings or remove them from your config.",
-                )));
+                );
+                events.push(SettingsEvent::error(message.clone()));
+                if explicit_config {
+                    fatal_error.get_or_insert(message);
+                }
                 None
             }
         }
@@ -214,19 +240,28 @@ fn load_user_config_with_events(
 
 /// Load a TOML config file from an explicit path (used with `--config-file`).
 ///
-/// Unlike `load_toml_settings`, non-existent files are treated as errors
-/// because explicit paths represent user intent (configuration-merging-strategy).
+/// Every `Err` returned here is fatal to the session: unlike
+/// `load_toml_settings`, a file the user named explicitly and that is actually
+/// present must not be skipped in favour of defaults
+/// (configuration-merging-strategy).
+///
+/// An absent file is `Ok(None)`, not an error. Layered invocations
+/// (`--config-file base.toml --config-file overrides.toml`) rely on the overlay
+/// being optional, and a relative path resolves against the process working
+/// directory — for an editor-spawned server that is the editor's, not the
+/// workspace root — so absence is too easily accidental to be worth aborting
+/// over. It is still reported as a warning so the skip is visible.
 fn load_toml_file(
     path: &Path,
     events: &mut Vec<SettingsEvent>,
     deprecated_keys: &mut DeprecatedKeysSeen,
-) -> Option<RawWorkspaceSettings> {
+) -> Result<Option<RawWorkspaceSettings>, String> {
     if !path.exists() {
-        events.push(SettingsEvent::error(format!(
-            "Config file not found: {}",
+        events.push(SettingsEvent::warning(format!(
+            "Config file not found, skipping: {}",
             path.display()
         )));
-        return None;
+        return Ok(None);
     }
 
     events.push(SettingsEvent::info(format!(
@@ -234,36 +269,17 @@ fn load_toml_file(
         path.display()
     )));
 
-    match fs::read_to_string(path) {
-        Ok(contents) => {
-            deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
-            match toml::from_str::<RawWorkspaceSettings>(&contents) {
-                Ok(settings) => {
-                    events.push(SettingsEvent::info(format!(
-                        "Successfully loaded {}",
-                        path.display()
-                    )));
-                    Some(settings)
-                }
-                Err(err) => {
-                    events.push(SettingsEvent::error(format!(
-                        "Failed to parse {}: {}",
-                        path.display(),
-                        err
-                    )));
-                    None
-                }
-            }
-        }
-        Err(err) => {
-            events.push(SettingsEvent::error(format!(
-                "Failed to read {}: {}",
-                path.display(),
-                err
-            )));
-            None
-        }
-    }
+    let contents = fs::read_to_string(path)
+        .map_err(|err| format!("Failed to read {}: {}", path.display(), err))?;
+    deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
+    let settings = toml::from_str::<RawWorkspaceSettings>(&contents)
+        .map_err(|err| format!("Failed to parse {}: {}", path.display(), err))?;
+
+    events.push(SettingsEvent::info(format!(
+        "Successfully loaded {}",
+        path.display()
+    )));
+    Ok(Some(settings))
 }
 
 fn load_toml_settings(
@@ -613,26 +629,50 @@ mod tests {
         );
     }
 
+    /// A merged configuration that fails expansion is fatal only when the user
+    /// named the files explicitly; implicit discovery keeps degrading to
+    /// defaults so the zero-config experience survives a stray config file.
     #[test]
-    fn fatal_explicit_error_skips_duplicate_merged_expansion_event() {
-        let merged = RawWorkspaceSettings {
+    fn merged_expansion_failure_is_fatal_only_for_explicit_config() {
+        let broken = || RawWorkspaceSettings {
             search_paths: Some(vec!["$UNDEFINED_VAR/parsers".to_string()]),
             ..Default::default()
         };
-        let mut events = vec![SettingsEvent::error(
-            "Path expansion failed in explicit.toml",
-        )];
 
-        let settings = expand_merged_settings(
-            Some(merged),
+        let mut explicit_events = Vec::new();
+        let mut explicit_fatal = None;
+        let explicit = expand_merged_settings(
+            Some(broken()),
             None,
             crate::config::make_env(&[]),
-            &mut events,
+            &mut explicit_events,
+            &mut explicit_fatal,
             true,
         );
 
-        assert!(settings.is_none());
-        assert_eq!(events.len(), 1, "fatal error must be reported only once");
+        let mut implicit_events = Vec::new();
+        let mut implicit_fatal = None;
+        let implicit = expand_merged_settings(
+            Some(broken()),
+            None,
+            crate::config::make_env(&[]),
+            &mut implicit_events,
+            &mut implicit_fatal,
+            false,
+        );
+
+        assert!(explicit.is_none());
+        assert!(implicit.is_none());
+        assert!(
+            explicit_fatal
+                .as_deref()
+                .is_some_and(|message| message.contains("UNDEFINED_VAR")),
+            "explicit config must abort startup: {explicit_fatal:?}"
+        );
+        assert!(
+            implicit_fatal.is_none(),
+            "implicit config must keep falling back to defaults: {implicit_fatal:?}"
+        );
     }
 
     /// A config layer using the deprecated `rootMarkers` key sets the outcome
@@ -705,8 +745,13 @@ mod tests {
         let mut ignored_deprecation = DeprecatedKeysSeen::default();
         let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
 
-        assert!(result.is_some(), "valid TOML should parse");
-        assert_eq!(result.unwrap().auto_install, Some(false));
+        let settings = result.expect("valid TOML should parse");
+        assert_eq!(
+            settings
+                .expect("present file should yield a layer")
+                .auto_install,
+            Some(false)
+        );
         assert!(
             events
                 .iter()
@@ -716,7 +761,8 @@ mod tests {
         );
     }
 
-    /// load_toml_file: non-existent path returns None + error event (configuration-merging-strategy).
+    /// load_toml_file: an absent explicit path is an optional layer, not an
+    /// error, so a layered invocation whose overlay does not exist still starts.
     #[test]
     fn test_load_toml_file_missing() {
         let mut events = Vec::new();
@@ -727,16 +773,19 @@ mod tests {
             &mut ignored_deprecation,
         );
 
-        assert!(result.is_none(), "missing file should return None");
+        assert!(
+            matches!(result, Ok(None)),
+            "missing file should be skipped, not fatal: {result:?}"
+        );
         assert!(
             events
                 .iter()
-                .any(|e| e.kind == SettingsEventKind::Error && e.message.contains("not found")),
-            "should emit error event for missing file"
+                .any(|e| e.kind == SettingsEventKind::Warning && e.message.contains("not found")),
+            "the skip must still be visible as a warning"
         );
     }
 
-    /// load_toml_file: invalid TOML returns None + warning event.
+    /// load_toml_file: a present file with invalid TOML is fatal.
     #[test]
     fn test_load_toml_file_invalid_toml() {
         let dir = TempDir::new().unwrap();
@@ -747,12 +796,41 @@ mod tests {
         let mut ignored_deprecation = DeprecatedKeysSeen::default();
         let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
 
-        assert!(result.is_none(), "invalid TOML should return None");
+        let message = result.expect_err("invalid TOML in an explicit file must be fatal");
         assert!(
-            events.iter().any(
-                |e| e.kind == SettingsEventKind::Error && e.message.contains("Failed to parse")
-            ),
-            "should emit error for invalid TOML in explicit config file"
+            message.contains("Failed to parse") && message.contains(&path.display().to_string()),
+            "the fatal message must name the offending file: {message}"
+        );
+    }
+
+    /// load_toml_file: a file that exists but cannot be read is fatal, and is
+    /// reported differently from a file that is simply absent.
+    #[cfg(unix)]
+    #[test]
+    fn test_load_toml_file_unreadable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("locked.toml");
+        std::fs::write(&path, "autoInstall = false\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let mut events = Vec::new();
+        let mut ignored_deprecation = false;
+        // root ignores the permission bits, so probe before deciding to assert.
+        let permissions_enforced = std::fs::read_to_string(&path).is_err();
+        let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
+
+        // Restore before asserting so a failure cannot leave an unremovable dir.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        if !permissions_enforced {
+            return;
+        }
+        let message = result.expect_err("an unreadable explicit file must be fatal");
+        assert!(
+            message.contains("Failed to read") && message.contains(&path.display().to_string()),
+            "the fatal message must name the offending file: {message}"
         );
     }
 
@@ -769,11 +847,11 @@ mod tests {
         let mut used_deprecated = DeprecatedKeysSeen::default();
         let result = load_toml_file(&path, &mut events, &mut used_deprecated);
 
-        assert!(result.is_some(), "valid TOML should parse");
         assert!(
-            used_deprecated.root_markers,
-            "rootMarkers should set the flag"
+            matches!(result, Ok(Some(_))),
+            "valid TOML should parse: {result:?}"
         );
+        assert!(used_deprecated.root_markers, "rootMarkers should set the flag");
     }
 
     /// load_toml_settings (the project kakehashi.toml layer) sets the flag when

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -74,101 +74,154 @@ pub struct SettingsLoadOutcome {
     /// with the didChangeConfiguration path); it is intentionally kept out of
     /// `events` so the many callers that re-load settings do not re-warn.
     pub deprecated_keys: DeprecatedKeysSeen,
-    /// Fatal error from an explicitly requested configuration source.
-    ///
-    /// A `--config-file` path that is *present* but unusable — unreadable,
-    /// malformed, or carrying a path that cannot be expanded — represents a
-    /// user mistake that must not be papered over with defaults. An *absent*
-    /// explicit file stays optional (see `load_toml_file`), as do all
-    /// implicitly discovered user/project files.
+}
+
+/// The `--config-file` inputs, read and judged exactly once.
+///
+/// Read *once* is a contract, not an optimisation. A `--config-file` may name a
+/// stream (`/dev/fd/N`), which a second read would find empty, and a file
+/// replaced between two reads would have its second verdict either ignored or
+/// discovered too late to matter.
+pub(crate) struct ExplicitConfig {
+    layers: Vec<Option<RawWorkspaceSettings>>,
+    events: Vec<SettingsEvent>,
+    deprecated_keys: DeprecatedKeysSeen,
+    /// Why this configuration cannot be used, if it cannot. `initialize` must
+    /// reject the session when this is set.
     pub(crate) fatal_error: Option<String>,
 }
 
-/// The reason an explicitly requested configuration is unusable, if it is.
+/// Read and judge the `--config-file` inputs, or `None` if there are none.
 ///
 /// `initialize` calls this *before* it latches any once-only state from the
 /// request. `tower-lsp-server` resets to `Uninitialized` after an error
 /// response, so a client may fix the file and retry — and a retry carrying
 /// different capabilities or workspace folders would otherwise be served with
-/// the failed attempt's values, since those are first-write-wins.
-///
-/// Passing no root path and no override settings is not a simplification: when
-/// `--config-file` is set the workspace-relative layer is skipped entirely, and
-/// `initializationOptions` are deliberately outside the strict gate. So this
-/// sees exactly what the gate judges, which is why it can run this early.
-/// Returns `None` when nothing was requested explicitly.
-pub(crate) fn explicit_config_fatal_error(
+/// the failed attempt's values, since those are first-write-wins. The result is
+/// then handed to [`load_settings`], so the files are not read again.
+pub(crate) fn load_explicit_config(
     home: Option<&str>,
     env_fn: impl Fn(&str) -> Option<String>,
-) -> Option<String> {
-    crate::config::expand::config_file_override()?;
-    load_settings(None, None, home, env_fn).fatal_error
+) -> Option<ExplicitConfig> {
+    let files = crate::config::expand::config_file_override()?;
+    Some(read_explicit_layers(files, home, env_fn))
 }
 
+/// The body of [`load_explicit_config`], taking the paths directly so it can be
+/// exercised without the process-global `--config-file` override.
+fn read_explicit_layers(
+    files: &[std::path::PathBuf],
+    home: Option<&str>,
+    env_fn: impl Fn(&str) -> Option<String>,
+) -> ExplicitConfig {
+    let env_fn = crate::config::expand::with_kakehashi_defaults(env_fn);
+    let mut events = vec![SettingsEvent::info(format!(
+        "Using {} explicit config file(s); default config locations skipped",
+        files.len()
+    ))];
+    let mut used_deprecated_root_markers = false;
+    let mut fatal_error = None;
+    let mut layers = Vec::with_capacity(files.len());
+
+    for path in files {
+        // The verdict cannot change once a layer has failed, and reading on is
+        // not free: a later path could be a FIFO that blocks forever, so an
+        // already-doomed session would hang instead of reporting the failure it
+        // already knows about.
+        if fatal_error.is_some() {
+            break;
+        }
+        let layer = match load_toml_file(path, &mut events, &mut used_deprecated_root_markers) {
+            Ok(layer) => layer,
+            Err(message) => {
+                events.push(SettingsEvent::error(message.clone()));
+                fatal_error.get_or_insert(message);
+                None
+            }
+        };
+        // Judging a layer in isolation also resolves its language `base`
+        // chains, so a cycle an overlay later removes is still warned about
+        // once here. Accepted: the alternative is threading a "stay quiet"
+        // flag through base resolution to silence a warning that names a
+        // real cycle in a file the user wrote.
+        //
+        // Judge each layer's *paths* on its own so a later layer cannot
+        // mask an earlier one's undefined variable: path fields are
+        // replaced wholesale by the overlay, so the merged result would
+        // never mention the mistake. Cross-field invariants are excluded
+        // here (see `ExpandErrors::path_error_summary`) — their operands
+        // merge independently, so they are only meaningful once every
+        // layer has been folded together, and `expand_merged_settings`
+        // catches them there.
+        if let Some(raw_settings) = layer.as_ref()
+            && let Err(errs) = WorkspaceSettings::try_from_settings(raw_settings, home, &env_fn)
+            && let Some(details) = errs.path_error_summary()
+        {
+            let message = format!("Path expansion failed in {}: {details}", path.display());
+            events.push(SettingsEvent::error(message.clone()));
+            fatal_error.get_or_insert(message);
+        }
+        layers.push(layer);
+    }
+
+    // An explicit configuration also has to be valid *as a whole*, or startup
+    // would silently continue on programmed defaults. This is the only place a
+    // cross-layer invariant can be judged: one file supplying `debounceMs` and
+    // another `maxWaitMs` is valid in neither file alone. It is judged without
+    // `initializationOptions`, which keep a non-fatal policy of their own — a
+    // client sending a bad override must not be reported as a mistake in the
+    // user's file.
+    //
+    // Skipped once a layer has already failed: the verdict cannot change, and
+    // every `try_from_settings` re-resolves language `base` chains, whose cycle
+    // detector logs as it goes.
+    if fatal_error.is_none() {
+        let merged = std::iter::once(Some(default_settings()))
+            .chain(layers.iter().cloned())
+            .reduce(merge_workspace_settings)
+            .flatten();
+        if let Some(raw_settings) = merged.as_ref()
+            && let Err(errs) = WorkspaceSettings::try_from_settings(raw_settings, home, &env_fn)
+        {
+            fatal_error = Some(format!("Invalid configuration from --config-file: {errs}"));
+        }
+    }
+
+    ExplicitConfig {
+        layers,
+        events,
+        used_deprecated_root_markers,
+        fatal_error,
+    }
+}
+
+/// Merge every configuration layer into the settings the session will use.
+///
+/// `explicit` carries the already-read `--config-file` inputs; when it is
+/// `Some`, the implicitly discovered user and project files are skipped and the
+/// strict gate applies. Callers must obtain it from [`load_explicit_config`]
+/// rather than reading the files themselves — passing `None` while
+/// `--config-file` is set would silently fall back to implicit discovery.
 pub fn load_settings(
     root_path: Option<&Path>,
     override_settings: Option<(SettingsSource, Value)>,
     home: Option<&str>,
     env_fn: impl Fn(&str) -> Option<String>,
+    explicit: Option<ExplicitConfig>,
 ) -> SettingsLoadOutcome {
     let env_fn = crate::config::expand::with_kakehashi_defaults(env_fn);
     let mut events = Vec::new();
     let mut deprecated_keys = DeprecatedKeysSeen::default();
-    let mut fatal_error = None;
     let explicit_config_requested = crate::config::expand::config_file_override().is_some();
 
     // Layer 1: Programmed defaults (configuration-merging-strategy: lowest precedence)
     let defaults = Some(default_settings());
 
     // Layers 2+3: config files (either explicit --config-file or default locations)
-    let explicit_files = crate::config::expand::config_file_override();
-    let config_layers: Vec<Option<RawWorkspaceSettings>> = if let Some(files) = explicit_files {
-        events.push(SettingsEvent::info(format!(
-            "Using {} explicit config file(s); default config locations skipped",
-            files.len()
-        )));
-        let mut layers = Vec::with_capacity(files.len());
-        for path in files {
-            // The verdict cannot change once a layer has failed, and reading on
-            // is not free: a later path could be a FIFO that blocks forever, so
-            // an already-doomed session would hang instead of reporting the
-            // failure it already knows about.
-            if fatal_error.is_some() {
-                break;
-            }
-            let layer = match load_toml_file(path, &mut events, &mut deprecated_keys) {
-                Ok(layer) => layer,
-                Err(message) => {
-                    events.push(SettingsEvent::error(message.clone()));
-                    fatal_error.get_or_insert(message);
-                    None
-                }
-            };
-            // Judging a layer in isolation also resolves its language `base`
-            // chains, so a cycle an overlay later removes is still warned about
-            // once here. Accepted: the alternative is threading a "stay quiet"
-            // flag through base resolution to silence a warning that names a
-            // real cycle in a file the user wrote.
-            //
-            // Judge each layer's *paths* on its own so a later layer cannot
-            // mask an earlier one's undefined variable: path fields are
-            // replaced wholesale by the overlay, so the merged result would
-            // never mention the mistake. Cross-field invariants are excluded
-            // here (see `ExpandErrors::path_error_summary`) — their operands
-            // merge independently, so they are only meaningful once every
-            // layer has been folded together, and `expand_merged_settings`
-            // catches them there.
-            if let Some(raw_settings) = layer.as_ref()
-                && let Err(errs) = WorkspaceSettings::try_from_settings(raw_settings, home, &env_fn)
-                && let Some(details) = errs.path_error_summary()
-            {
-                let message = format!("Path expansion failed in {}: {details}", path.display());
-                events.push(SettingsEvent::error(message.clone()));
-                fatal_error.get_or_insert(message);
-            }
-            layers.push(layer);
-        }
-        layers
+    let config_layers: Vec<Option<RawWorkspaceSettings>> = if let Some(explicit) = explicit {
+        events.extend(explicit.events);
+        deprecated_keys.merge(explicit.deprecated_keys);
+        explicit.layers
     } else {
         vec![
             // Layer 2: User config from XDG_CONFIG_HOME (~/.config/kakehashi/kakehashi.toml)
@@ -186,30 +239,8 @@ pub fn load_settings(
     // Merge all layers: defaults < config_layers < override (later layers override earlier)
     let mut layers = vec![defaults];
     layers.extend(config_layers);
-    let merged_files = layers
-        .into_iter()
-        .reduce(merge_workspace_settings)
-        .flatten();
-
-    // An explicit configuration has to be valid on its own terms, or startup
-    // would silently continue on programmed defaults. Skipped once a layer has
-    // already failed: the verdict cannot change, and every `try_from_settings`
-    // re-resolves language `base` chains, whose cycle detector logs as it goes.
-    // This is judged before
-    // `initializationOptions` join the merge, because those keep a non-fatal
-    // policy of their own — a client sending a bad override must not be
-    // reported as a mistake in the user's file. It is also the only place a
-    // cross-layer invariant can be judged: one file supplying `debounceMs` and
-    // another `maxWaitMs` is valid in neither file alone.
-    if explicit_files.is_some()
-        && fatal_error.is_none()
-        && let Some(raw_settings) = merged_files.as_ref()
-        && let Err(errs) = WorkspaceSettings::try_from_settings(raw_settings, home, &env_fn)
-    {
-        fatal_error.get_or_insert(format!("Invalid configuration from --config-file: {errs}"));
-    }
-
-    let merged = [merged_files, override_settings]
+    layers.push(override_settings);
+    let merged = layers
         .into_iter()
         .reduce(merge_workspace_settings)
         .flatten();
@@ -221,7 +252,6 @@ pub fn load_settings(
         raw_settings,
         events,
         deprecated_keys,
-        fatal_error,
     }
 }
 
@@ -469,9 +499,13 @@ mod tests {
 
         // Load settings with project path
         let home = dirs::home_dir().map(|p| p.to_string_lossy().into_owned());
-        let outcome = load_settings(Some(project_dir.path()), None, home.as_deref(), |var| {
-            std::env::var(var).ok()
-        });
+        let outcome = load_settings(
+            Some(project_dir.path()),
+            None,
+            home.as_deref(),
+            |var| std::env::var(var).ok(),
+            None,
+        );
 
         // Restore original XDG_CONFIG_HOME
         // SAFETY: #[serial(xdg_env)] prevents concurrent modification of XDG_CONFIG_HOME
@@ -560,6 +594,7 @@ mod tests {
             Some((SettingsSource::InitializationOptions, override_json)),
             home.as_deref(),
             |var| std::env::var(var).ok(),
+            None,
         );
 
         // Restore original XDG_CONFIG_HOME
@@ -618,7 +653,13 @@ mod tests {
 
         // Load settings (no project path, just user config)
         let home = dirs::home_dir().map(|p| p.to_string_lossy().into_owned());
-        let outcome = load_settings(None, None, home.as_deref(), |var| std::env::var(var).ok());
+        let outcome = load_settings(
+            None,
+            None,
+            home.as_deref(),
+            |var| std::env::var(var).ok(),
+            None,
+        );
 
         // Restore original XDG_CONFIG_HOME
         // SAFETY: #[serial(xdg_env)] prevents concurrent modification of XDG_CONFIG_HOME
@@ -664,6 +705,7 @@ mod tests {
             Some((SettingsSource::InitializationOptions, override_json)),
             None,
             env,
+            None,
         );
 
         assert!(
@@ -747,6 +789,7 @@ mod tests {
             Some((SettingsSource::InitializationOptions, deprecated)),
             None,
             make_env(&[]),
+            None,
         )
         .deprecated_keys
         .root_markers;
@@ -759,6 +802,7 @@ mod tests {
             Some((SettingsSource::InitializationOptions, canonical)),
             None,
             make_env(&[]),
+            None,
         )
         .deprecated_keys
         .root_markers;
@@ -888,6 +932,70 @@ mod tests {
         assert!(
             message.contains(&path.display().to_string()) && !message.contains("not found"),
             "an unreachable path must not be reported as merely absent: {message}"
+        );
+    }
+
+    /// Every explicit layer is read, in order, while the configuration is
+    /// still usable.
+    #[test]
+    fn read_explicit_layers_reads_each_file_in_order() {
+        let dir = TempDir::new().unwrap();
+        let first = dir.path().join("first.toml");
+        let second = dir.path().join("second.toml");
+        std::fs::write(&first, "autoInstall = false\n").unwrap();
+        std::fs::write(&second, "autoInstall = true\n").unwrap();
+
+        let explicit = read_explicit_layers(
+            &[first.clone(), second.clone()],
+            None,
+            crate::config::make_env(&[]),
+        );
+
+        assert!(explicit.fatal_error.is_none());
+        assert_eq!(explicit.layers.len(), 2);
+        assert!(
+            explicit
+                .events
+                .iter()
+                .any(|event| event.message.contains(&second.display().to_string())),
+            "the second file must be read: {:?}",
+            explicit.events
+        );
+    }
+
+    /// Once a layer has failed the verdict is settled, so later paths are not
+    /// touched at all. This is what keeps a `--config-file` naming a FIFO from
+    /// hanging a session over a failure already known — a property no
+    /// finite-file test can observe, hence the assertion on the events.
+    #[test]
+    fn read_explicit_layers_stops_at_the_first_failure() {
+        let dir = TempDir::new().unwrap();
+        let broken = dir.path().join("broken.toml");
+        let later = dir.path().join("later.toml");
+        std::fs::write(&broken, "this is not [valid toml").unwrap();
+        std::fs::write(&later, "autoInstall = true\n").unwrap();
+
+        let explicit = read_explicit_layers(
+            &[broken.clone(), later.clone()],
+            None,
+            crate::config::make_env(&[]),
+        );
+
+        assert!(
+            explicit
+                .fatal_error
+                .as_deref()
+                .is_some_and(|message| message.contains(&broken.display().to_string())),
+            "the first failure must be reported: {:?}",
+            explicit.fatal_error
+        );
+        assert!(
+            explicit
+                .events
+                .iter()
+                .all(|event| !event.message.contains(&later.display().to_string())),
+            "nothing after the failure may be read: {:?}",
+            explicit.events
         );
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -352,6 +352,12 @@ fn load_toml_file(
             // path the user named does exist, it just does not lead to a
             // config. `symlink_metadata` does not follow, so it still sees the
             // link itself.
+            //
+            // This describes the path as of the probe, which is a moment after
+            // the failed open. Something appearing there in between is
+            // misreported — a config loader does not serialize against the
+            // filesystem, and the alternative (probe first) only moves the
+            // window.
             if path
                 .symlink_metadata()
                 .is_ok_and(|metadata| metadata.file_type().is_symlink())

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -11,7 +11,11 @@ use std::path::Path;
 pub enum SettingsEventKind {
     Info,
     Warning,
-    /// Hard error surfaced via `window/showMessage` so the user cannot miss it.
+    /// Hard error normally surfaced via `window/showMessage`.
+    ///
+    /// Fatal explicit-config errors instead reject initialization before
+    /// settings events are sent, so the initialize response is their sole
+    /// client-facing report.
     Error,
 }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -386,6 +386,13 @@ fn load_toml_file(
             // config. `symlink_metadata` does not follow, so it still sees the
             // link itself.
             //
+            // Only the final component is inspected. A path whose *ancestor*
+            // is a dangling link resolves to nothing at all, so nothing is
+            // there to call unusable — that is the absent case, the same as a
+            // missing directory. The line is "does the path the user named
+            // exist?", and a link does while a path beneath a broken one does
+            // not.
+            //
             // This describes the path as of the probe, which is a moment after
             // the failed open. Something appearing there in between is
             // misreported — a config loader does not serialize against the

--- a/tests/e2e_cli_diagnose.rs
+++ b/tests/e2e_cli_diagnose.rs
@@ -94,10 +94,11 @@ fn e2e_diagnose_missing_explicit_config_exits_error() {
     let output = run_diagnose(ws.path(), &["doc.md"]);
 
     assert_eq!(output.status.code(), Some(2));
-    assert!(
-        stderr_of(&output).contains("Config file not found"),
-        "stderr should report the missing explicit config: {}",
-        stderr_of(&output)
+    let stderr = stderr_of(&output);
+    assert_eq!(
+        stderr.matches("Config file not found").count(),
+        1,
+        "stderr should report the missing explicit config exactly once: {stderr}"
     );
 }
 

--- a/tests/e2e_cli_diagnose.rs
+++ b/tests/e2e_cli_diagnose.rs
@@ -87,6 +87,21 @@ fn stderr_of(output: &Output) -> String {
 }
 
 #[test]
+fn e2e_diagnose_missing_explicit_config_exits_error() {
+    let ws = tempfile::tempdir().expect("create workspace tempdir");
+    std::fs::write(ws.path().join("doc.md"), PLAIN_MARKDOWN).expect("write document");
+
+    let output = run_diagnose(ws.path(), &["doc.md"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        stderr_of(&output).contains("Config file not found"),
+        "stderr should report the missing explicit config: {}",
+        stderr_of(&output)
+    );
+}
+
+#[test]
 fn e2e_diagnose_default_format_reports_transformed_position() {
     let ws = workspace_with(&config_toml(), &[("doc.md", MARKDOWN)]);
 

--- a/tests/e2e_cli_diagnose.rs
+++ b/tests/e2e_cli_diagnose.rs
@@ -86,19 +86,50 @@ fn stderr_of(output: &Output) -> String {
     String::from_utf8_lossy(&output.stderr).into_owned()
 }
 
+/// A `--config-file` that exists but cannot be parsed aborts the run, and
+/// stdout stays empty so a caller parsing the report cannot mistake a failed
+/// run for a clean one.
 #[test]
-fn e2e_diagnose_missing_explicit_config_exits_error() {
+fn e2e_diagnose_invalid_explicit_config_exits_error() {
+    let ws = tempfile::tempdir().expect("create workspace tempdir");
+    std::fs::write(ws.path().join("doc.md"), PLAIN_MARKDOWN).expect("write document");
+    std::fs::write(ws.path().join("kakehashi.toml"), "searchPaths = [\"/x\"\n")
+        .expect("write malformed config");
+
+    let output = run_diagnose(ws.path(), &["doc.md"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        output.stdout.is_empty(),
+        "a failed run must not emit a report: {}",
+        stdout_of(&output)
+    );
+    let stderr = stderr_of(&output);
+    assert_eq!(
+        stderr.matches("error: failed to initialize").count(),
+        1,
+        "stderr should report the initialization failure exactly once: {stderr}"
+    );
+    assert!(
+        stderr.contains("Failed to parse"),
+        "stderr should name the failure: {stderr}"
+    );
+}
+
+/// The mirror image: an explicit config file that is merely absent is an
+/// optional layer, so the run proceeds on defaults.
+#[test]
+fn e2e_diagnose_missing_explicit_config_still_runs() {
     let ws = tempfile::tempdir().expect("create workspace tempdir");
     std::fs::write(ws.path().join("doc.md"), PLAIN_MARKDOWN).expect("write document");
 
     let output = run_diagnose(ws.path(), &["doc.md"]);
 
-    assert_eq!(output.status.code(), Some(2));
-    let stderr = stderr_of(&output);
     assert_eq!(
-        stderr.matches("Config file not found").count(),
-        1,
-        "stderr should report the missing explicit config exactly once: {stderr}"
+        output.status.code(),
+        Some(0),
+        "a missing explicit config must be skipped, not fatal; stderr: {}",
+        stderr_of(&output)
     );
 }
 

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -86,10 +86,11 @@ fn e2e_format_missing_explicit_config_exits_error() {
     let output = run_format(ws.path(), &["doc.md"]);
 
     assert_eq!(output.status.code(), Some(2));
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains("Config file not found"),
-        "stderr should report the missing explicit config: {}",
-        String::from_utf8_lossy(&output.stderr)
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stderr.matches("Config file not found").count(),
+        1,
+        "stderr should report the missing explicit config exactly once: {stderr}"
     );
 }
 

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -78,10 +78,11 @@ fn read(workspace: &Path, name: &str) -> String {
     std::fs::read_to_string(workspace.join(name)).expect("read workspace file")
 }
 
-/// A `--config-file` that exists but cannot be parsed aborts the run. stdout
-/// stays empty: a formatter that exits non-zero must not hand its caller
-/// content, or `kakehashi format --stdin-filename f.md < f.md > f.md` and
-/// editor filters would replace the buffer with partial output.
+/// A `--config-file` that exists but cannot be parsed aborts the run before
+/// anything is written, so stdout stays empty. This is specific to a
+/// configuration failure: a *downstream* formatter failure writes its content
+/// first and reports the failure through the exit code afterwards, so empty
+/// stdout is not a general property of exit 2.
 #[test]
 fn e2e_format_invalid_explicit_config_exits_error() {
     let ws = tempfile::tempdir().expect("create workspace tempdir");

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -79,6 +79,21 @@ fn read(workspace: &Path, name: &str) -> String {
 }
 
 #[test]
+fn e2e_format_missing_explicit_config_exits_error() {
+    let ws = tempfile::tempdir().expect("create workspace tempdir");
+    std::fs::write(ws.path().join("doc.md"), MARKDOWN).expect("write document");
+
+    let output = run_format(ws.path(), &["doc.md"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Config file not found"),
+        "stderr should report the missing explicit config: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn e2e_format_rewrites_file_in_place_and_is_idempotent() {
     let ws = workspace_with(&[("doc.md", MARKDOWN)]);
 

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -78,19 +78,51 @@ fn read(workspace: &Path, name: &str) -> String {
     std::fs::read_to_string(workspace.join(name)).expect("read workspace file")
 }
 
+/// A `--config-file` that exists but cannot be parsed aborts the run. stdout
+/// stays empty: a formatter that exits non-zero must not hand its caller
+/// content, or `kakehashi format --stdin-filename f.md < f.md > f.md` and
+/// editor filters would replace the buffer with partial output.
 #[test]
-fn e2e_format_missing_explicit_config_exits_error() {
+fn e2e_format_invalid_explicit_config_exits_error() {
+    let ws = tempfile::tempdir().expect("create workspace tempdir");
+    std::fs::write(ws.path().join("doc.md"), MARKDOWN).expect("write document");
+    std::fs::write(ws.path().join("kakehashi.toml"), "searchPaths = [\"/x\"\n")
+        .expect("write malformed config");
+
+    let output = run_format(ws.path(), &["doc.md"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        output.stdout.is_empty(),
+        "a failed run must not emit content: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stderr.matches("error: failed to initialize").count(),
+        1,
+        "stderr should report the initialization failure exactly once: {stderr}"
+    );
+    assert!(
+        stderr.contains("Failed to parse"),
+        "stderr should name the failure: {stderr}"
+    );
+}
+
+/// The mirror image: an explicit config file that is merely absent is an
+/// optional layer, so the run proceeds on defaults.
+#[test]
+fn e2e_format_missing_explicit_config_still_runs() {
     let ws = tempfile::tempdir().expect("create workspace tempdir");
     std::fs::write(ws.path().join("doc.md"), MARKDOWN).expect("write document");
 
     let output = run_format(ws.path(), &["doc.md"]);
 
-    assert_eq!(output.status.code(), Some(2));
-    let stderr = String::from_utf8_lossy(&output.stderr);
     assert_eq!(
-        stderr.matches("Config file not found").count(),
-        1,
-        "stderr should report the missing explicit config exactly once: {stderr}"
+        output.status.code(),
+        Some(0),
+        "a missing explicit config must be skipped, not fatal; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
 }
 

--- a/tests/e2e_config_file.rs
+++ b/tests/e2e_config_file.rs
@@ -161,9 +161,11 @@ fn test_config_file_two_files_merge_in_order() {
 /// falling back to defaults.
 #[test]
 fn test_config_file_nonexistent_fails_initialization() {
+    let dir = TempDir::new().unwrap();
+    let config_path = dir.path().join("missing.toml");
     let mut client = LspClient::builder()
         .arg("--config-file")
-        .arg("/nonexistent/kakehashi-test-config.toml")
+        .arg(config_path.to_str().unwrap())
         .env_remove("KAKEHASHI_DATA_DIR")
         .build();
 

--- a/tests/e2e_config_file.rs
+++ b/tests/e2e_config_file.rs
@@ -183,9 +183,10 @@ fn test_config_file_nonexistent_fails_initialization() {
         .expect("missing explicit config file should reject initialize");
     assert_eq!(error["code"], json!(-32803));
     assert!(
-        error["message"]
-            .as_str()
-            .is_some_and(|message| message.contains("Config file not found")),
+        error["message"].as_str().is_some_and(|message| {
+            message.contains("Config file not found")
+                && message.contains(&config_path.display().to_string())
+        }),
         "initialize error should identify the missing config file: {error}"
     );
 }
@@ -215,9 +216,10 @@ fn test_config_file_invalid_toml_fails_initialization() {
         .expect("invalid explicit config file should reject initialize");
     assert_eq!(error["code"], json!(-32803));
     assert!(
-        error["message"]
-            .as_str()
-            .is_some_and(|message| message.contains("Failed to parse")),
+        error["message"].as_str().is_some_and(|message| {
+            message.contains("Failed to parse")
+                && message.contains(&config_path.display().to_string())
+        }),
         "initialize error should identify the parse failure: {error}"
     );
 }

--- a/tests/e2e_config_file.rs
+++ b/tests/e2e_config_file.rs
@@ -220,6 +220,43 @@ fn test_config_file_invalid_toml_fails_initialization() {
     );
 }
 
+#[test]
+fn test_config_file_invalid_path_expansion_fails_initialization() {
+    let dir = TempDir::new().unwrap();
+    let config_path = dir.path().join("invalid-path.toml");
+    std::fs::write(
+        &config_path,
+        "searchPaths = [\"$KAKEHASHI_TEST_UNDEFINED/path\"]\n",
+    )
+    .unwrap();
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().unwrap())
+        .env_remove("KAKEHASHI_TEST_UNDEFINED")
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {}
+        }),
+    );
+
+    let error = response
+        .get("error")
+        .expect("invalid explicit path expansion should reject initialize");
+    assert_eq!(error["code"], json!(-32602));
+    assert!(
+        error["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("Path expansion failed")),
+        "initialize error should identify the expansion failure: {error}"
+    );
+}
+
 /// --config-file with an empty temp file gives defaults only (test isolation pattern).
 #[test]
 fn test_config_file_empty_file_gives_defaults() {

--- a/tests/e2e_config_file.rs
+++ b/tests/e2e_config_file.rs
@@ -157,23 +157,66 @@ fn test_config_file_two_files_merge_in_order() {
     );
 }
 
-/// --config-file with non-existent path: the file load fails with an error,
-/// and the configuration layer is skipped, so effective settings fall back to defaults.
+/// --config-file with non-existent path fails initialization instead of silently
+/// falling back to defaults.
 #[test]
-fn test_config_file_nonexistent_falls_back_to_defaults() {
+fn test_config_file_nonexistent_fails_initialization() {
     let mut client = LspClient::builder()
         .arg("--config-file")
         .arg("/nonexistent/kakehashi-test-config.toml")
         .env_remove("KAKEHASHI_DATA_DIR")
         .build();
 
-    let settings = get_effective_settings(&mut client);
+    let response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {}
+        }),
+    );
 
-    // The missing file produces None in the merge, so only defaults apply
-    assert_eq!(
-        settings["autoInstall"],
-        json!(true),
-        "missing config file should fall back to default autoInstall=true"
+    let error = response
+        .get("error")
+        .expect("missing explicit config file should reject initialize");
+    assert_eq!(error["code"], json!(-32602));
+    assert!(
+        error["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("Config file not found")),
+        "initialize error should identify the missing config file: {error}"
+    );
+}
+
+#[test]
+fn test_config_file_invalid_toml_fails_initialization() {
+    let dir = TempDir::new().unwrap();
+    let config_path = dir.path().join("invalid.toml");
+    std::fs::write(&config_path, "searchPaths = [\"/unterminated\"\n").unwrap();
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().unwrap())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {}
+        }),
+    );
+
+    let error = response
+        .get("error")
+        .expect("invalid explicit config file should reject initialize");
+    assert_eq!(error["code"], json!(-32602));
+    assert!(
+        error["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("Failed to parse")),
+        "initialize error should identify the parse failure: {error}"
     );
 }
 

--- a/tests/e2e_config_file.rs
+++ b/tests/e2e_config_file.rs
@@ -181,7 +181,7 @@ fn test_config_file_nonexistent_fails_initialization() {
     let error = response
         .get("error")
         .expect("missing explicit config file should reject initialize");
-    assert_eq!(error["code"], json!(-32602));
+    assert_eq!(error["code"], json!(-32803));
     assert!(
         error["message"]
             .as_str()
@@ -213,7 +213,7 @@ fn test_config_file_invalid_toml_fails_initialization() {
     let error = response
         .get("error")
         .expect("invalid explicit config file should reject initialize");
-    assert_eq!(error["code"], json!(-32602));
+    assert_eq!(error["code"], json!(-32803));
     assert!(
         error["message"]
             .as_str()
@@ -250,7 +250,7 @@ fn test_config_file_invalid_path_expansion_fails_initialization() {
     let error = response
         .get("error")
         .expect("invalid explicit path expansion should reject initialize");
-    assert_eq!(error["code"], json!(-32602));
+    assert_eq!(error["code"], json!(-32803));
     assert!(
         error["message"]
             .as_str()

--- a/tests/e2e_config_file.rs
+++ b/tests/e2e_config_file.rs
@@ -259,6 +259,71 @@ fn test_config_file_invalid_path_expansion_fails_initialization() {
     );
 }
 
+#[test]
+fn test_config_file_masked_invalid_path_expansion_fails_initialization() {
+    let dir = TempDir::new().unwrap();
+    let invalid = dir.path().join("invalid.toml");
+    let valid = dir.path().join("valid.toml");
+    std::fs::write(
+        &invalid,
+        "searchPaths = [\"$KAKEHASHI_TEST_UNDEFINED/path\"]\n",
+    )
+    .unwrap();
+    std::fs::write(&valid, "searchPaths = [\"/valid\"]\n").unwrap();
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(invalid.to_str().unwrap())
+        .arg("--config-file")
+        .arg(valid.to_str().unwrap())
+        .env_remove("KAKEHASHI_TEST_UNDEFINED")
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {}
+        }),
+    );
+
+    assert!(
+        response.get("error").is_some(),
+        "a later explicit layer must not mask an earlier layer's invalid path: {response}"
+    );
+}
+
+#[test]
+fn test_config_file_does_not_make_invalid_initialization_options_fatal() {
+    let dir = TempDir::new().unwrap();
+    let config_path = dir.path().join("valid.toml");
+    std::fs::write(&config_path, "autoInstall = false\n").unwrap();
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().unwrap())
+        .env_remove("KAKEHASHI_TEST_UNDEFINED")
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "initializationOptions": {
+                "searchPaths": ["$KAKEHASHI_TEST_UNDEFINED/path"]
+            }
+        }),
+    );
+
+    assert!(
+        response.get("result").is_some(),
+        "initializationOptions keep their existing non-fatal policy: {response}"
+    );
+}
+
 /// --config-file with an empty temp file gives defaults only (test isolation pattern).
 #[test]
 fn test_config_file_empty_file_gives_defaults() {

--- a/tests/e2e_config_file.rs
+++ b/tests/e2e_config_file.rs
@@ -256,8 +256,9 @@ fn test_config_file_invalid_path_expansion_fails_initialization() {
     assert!(
         error["message"]
             .as_str()
-            .is_some_and(|message| message.contains("Path expansion failed")),
-        "initialize error should identify the expansion failure: {error}"
+            .is_some_and(|message| message.contains("Path expansion failed")
+                && message.contains(config_path.to_str().unwrap())),
+        "initialize error should identify the expansion failure and file: {error}"
     );
 }
 

--- a/tests/e2e_config_file.rs
+++ b/tests/e2e_config_file.rs
@@ -174,7 +174,7 @@ fn test_config_file_nonexistent_is_optional() {
         .env_remove("KAKEHASHI_DATA_DIR")
         .build();
 
-    let response = client.send_request(
+    let id = client.send_request_async(
         "initialize",
         json!({
             "processId": std::process::id(),
@@ -182,10 +182,35 @@ fn test_config_file_nonexistent_is_optional() {
             "capabilities": {}
         }),
     );
+    let (response, watched) = client.receive_response_for_id_watching_notifications(
+        id,
+        &["window/showMessage", "window/logMessage"],
+    );
 
     assert!(
         response.get("result").is_some(),
         "a missing explicit layer must be skipped, not fatal: {response}"
+    );
+    // The skip has to be visible, and visible as a warning rather than the
+    // error popup a genuinely unusable file gets. MessageType: 1 = Error,
+    // 2 = Warning.
+    let reports: Vec<_> = watched
+        .iter()
+        .filter(|(_, params)| {
+            params["message"]
+                .as_str()
+                .is_some_and(|message| message.contains(missing.to_str().unwrap()))
+        })
+        .collect();
+    assert!(
+        !reports.is_empty(),
+        "the skipped layer must be reported: {watched:?}"
+    );
+    assert!(
+        reports
+            .iter()
+            .all(|(method, params)| method == "window/logMessage" && params["type"] == json!(2)),
+        "a skipped optional layer is a warning, not an error popup: {reports:?}"
     );
     // The surviving layer must still apply, so the skip is a skip and not a
     // wholesale fallback to programmed defaults.

--- a/tests/e2e_config_file.rs
+++ b/tests/e2e_config_file.rs
@@ -470,6 +470,62 @@ fn test_config_file_merged_only_invalid_fails_initialization() {
     );
 }
 
+/// A rejected `initialize` does not poison the session: correcting the file and
+/// sending `initialize` again is served from the corrected file. `tower-lsp`
+/// resets to `Uninitialized` after an error response, so this is a path clients
+/// can genuinely take, and it is why the configuration verdict is reached
+/// before `initialize` stores anything from the request.
+///
+/// What this cannot observe is the state that a stale latch would corrupt —
+/// downstream servers keeping the failed attempt's capabilities and workspace
+/// folders — which needs a mock downstream server to see.
+#[test]
+fn test_config_file_retry_after_repair_uses_the_corrected_file() {
+    let dir = TempDir::new().unwrap();
+    let config_path = dir.path().join("config.toml");
+    std::fs::write(&config_path, "searchPaths = [\"/unterminated\"\n").unwrap();
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().unwrap())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let rejected = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {}
+        }),
+    );
+    assert!(
+        rejected.get("error").is_some(),
+        "the malformed file should reject the first attempt: {rejected}"
+    );
+
+    std::fs::write(&config_path, "autoInstall = false\n").unwrap();
+    let accepted = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {}
+        }),
+    );
+    assert!(
+        accepted.get("result").is_some(),
+        "a retry after repairing the file must be accepted: {accepted}"
+    );
+
+    client.send_notification("initialized", json!({}));
+    let settings = query_effective_settings(&mut client);
+    assert_eq!(
+        settings["autoInstall"],
+        json!(false),
+        "the retry must read the corrected file, not the rejected one: {settings}"
+    );
+}
+
 /// Implicitly discovered configuration keeps its optional, warning-only policy:
 /// only paths the user named explicitly are strict. Pinning this stops a future
 /// unification of the two loaders from turning a typo in a project

--- a/tests/e2e_config_file.rs
+++ b/tests/e2e_config_file.rs
@@ -157,15 +157,20 @@ fn test_config_file_two_files_merge_in_order() {
     );
 }
 
-/// --config-file with non-existent path fails initialization instead of silently
-/// falling back to defaults.
+/// An absent explicit config file is an optional layer, not a startup failure:
+/// layered invocations rely on the overlay being allowed to not exist, and a
+/// relative path resolves against the editor's working directory.
 #[test]
-fn test_config_file_nonexistent_fails_initialization() {
+fn test_config_file_nonexistent_is_optional() {
     let dir = TempDir::new().unwrap();
-    let config_path = dir.path().join("missing.toml");
+    let present = dir.path().join("present.toml");
+    let missing = dir.path().join("missing.toml");
+    std::fs::write(&present, "autoInstall = false\n").unwrap();
     let mut client = LspClient::builder()
         .arg("--config-file")
-        .arg(config_path.to_str().unwrap())
+        .arg(present.to_str().unwrap())
+        .arg("--config-file")
+        .arg(missing.to_str().unwrap())
         .env_remove("KAKEHASHI_DATA_DIR")
         .build();
 
@@ -178,16 +183,18 @@ fn test_config_file_nonexistent_fails_initialization() {
         }),
     );
 
-    let error = response
-        .get("error")
-        .expect("missing explicit config file should reject initialize");
-    assert_eq!(error["code"], json!(-32803));
     assert!(
-        error["message"].as_str().is_some_and(|message| {
-            message.contains("Config file not found")
-                && message.contains(&config_path.display().to_string())
-        }),
-        "initialize error should identify the missing config file: {error}"
+        response.get("result").is_some(),
+        "a missing explicit layer must be skipped, not fatal: {response}"
+    );
+    // The surviving layer must still apply, so the skip is a skip and not a
+    // wholesale fallback to programmed defaults.
+    client.send_notification("initialized", json!({}));
+    let settings = query_effective_settings(&mut client);
+    assert_eq!(
+        settings["autoInstall"],
+        json!(false),
+        "the layer that does exist must still apply: {settings}"
     );
 }
 
@@ -291,9 +298,224 @@ fn test_config_file_masked_invalid_path_expansion_fails_initialization() {
         }),
     );
 
+    let error = response
+        .get("error")
+        .expect("a later explicit layer must not mask an earlier layer's invalid path");
+    assert_eq!(error["code"], json!(-32803));
+    assert!(
+        error["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("Path expansion failed")
+                && message.contains(invalid.to_str().unwrap())),
+        "the masked failure, not some other error, must be reported — and it must \
+         name the file the bad path came from: {error}"
+    );
+}
+
+/// Every explicit layer is validated, not just the first: a failure in the
+/// second file must be reported and must name that file.
+#[test]
+fn test_config_file_validates_every_explicit_layer() {
+    let dir = TempDir::new().unwrap();
+    let first = dir.path().join("first.toml");
+    let second = dir.path().join("second.toml");
+    std::fs::write(&first, "autoInstall = false\n").unwrap();
+    std::fs::write(&second, "searchPaths = [\"/unterminated\"\n").unwrap();
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(first.to_str().unwrap())
+        .arg("--config-file")
+        .arg(second.to_str().unwrap())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {}
+        }),
+    );
+
+    let error = response
+        .get("error")
+        .expect("a failure in a later explicit layer must reject initialize");
+    assert!(
+        error["message"].as_str().is_some_and(|message| {
+            message.contains("Failed to parse") && message.contains(second.to_str().unwrap())
+        }),
+        "the error must name the second file, not stop at the first: {error}"
+    );
+}
+
+/// A cross-field invariant whose operands are split across two explicit layers
+/// is valid once merged, so neither layer may be rejected on its own.
+#[test]
+fn test_config_file_split_cross_field_invariant_is_not_fatal() {
+    let dir = TempDir::new().unwrap();
+    let debounce = dir.path().join("debounce.toml");
+    let max_wait = dir.path().join("max-wait.toml");
+    // 3000ms alone exceeds the default maxWaitMs of 1000ms; the overlay lifts
+    // the ceiling, so the merged configuration is valid.
+    std::fs::write(
+        &debounce,
+        "[features.\"textDocument/publishDiagnostics\"]\ndebounceMs = 3000\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &max_wait,
+        "[features.\"textDocument/publishDiagnostics\"]\nmaxWaitMs = 5000\n",
+    )
+    .unwrap();
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(debounce.to_str().unwrap())
+        .arg("--config-file")
+        .arg(max_wait.to_str().unwrap())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {}
+        }),
+    );
+
+    assert!(
+        response.get("result").is_some(),
+        "a layer must not be judged against defaults its sibling layer replaces: {response}"
+    );
+    client.send_notification("initialized", json!({}));
+    let settings = query_effective_settings(&mut client);
+    let timing = &settings["features"]["textDocument/publishDiagnostics"];
+    assert_eq!(timing["debounceMs"], json!(3000), "settings: {settings}");
+    assert_eq!(timing["maxWaitMs"], json!(5000), "settings: {settings}");
+}
+
+/// The mirror image: layers that are each valid alone but invalid once merged
+/// must still abort, rather than silently discarding the explicit configuration
+/// and starting on programmed defaults.
+#[test]
+fn test_config_file_merged_only_invalid_fails_initialization() {
+    let dir = TempDir::new().unwrap();
+    let max_wait = dir.path().join("max-wait.toml");
+    let debounce = dir.path().join("debounce.toml");
+    // Each file is valid in isolation (120 <= default 1000; 500 >= default 100),
+    // but merged they violate debounceMs <= maxWaitMs.
+    std::fs::write(
+        &max_wait,
+        "[features.\"textDocument/publishDiagnostics\"]\nmaxWaitMs = 120\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &debounce,
+        "[features.\"textDocument/publishDiagnostics\"]\ndebounceMs = 500\n",
+    )
+    .unwrap();
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(max_wait.to_str().unwrap())
+        .arg("--config-file")
+        .arg(debounce.to_str().unwrap())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {}
+        }),
+    );
+
+    let error = response
+        .get("error")
+        .expect("an explicit configuration that is invalid only once merged must abort");
+    assert_eq!(error["code"], json!(-32803));
+    assert!(
+        error["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("Invalid configuration")),
+        "initialize error should describe the invalid merged configuration: {error}"
+    );
+}
+
+/// Implicitly discovered configuration keeps its optional, warning-only policy:
+/// only paths the user named explicitly are strict. Pinning this stops a future
+/// unification of the two loaders from turning a typo in a project
+/// `kakehashi.toml` into a server that refuses to start.
+#[test]
+fn test_implicit_project_config_parse_failure_is_not_fatal() {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(dir.path().join("kakehashi.toml"), "autoInstall = \n").unwrap();
+    let mut client = LspClient::builder()
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let root_uri = format!("file://{}", dir.path().display());
+    let response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": root_uri,
+            "capabilities": {}
+        }),
+    );
+
+    assert!(
+        response.get("result").is_some(),
+        "a malformed implicit project config must not reject initialize: {response}"
+    );
+}
+
+/// The initialize error is the *only* client-facing report of a fatal config
+/// failure. Without this the early return in `initialize_impl` could drift back
+/// below `log_settings_events` and the user would get a `window/showMessage`
+/// popup on top of a failed handshake, with nothing failing in CI.
+#[test]
+fn test_config_file_fatal_error_is_not_also_shown_as_a_message() {
+    let dir = TempDir::new().unwrap();
+    let config_path = dir.path().join("invalid.toml");
+    std::fs::write(&config_path, "searchPaths = [\"/unterminated\"\n").unwrap();
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().unwrap())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let id = client.send_request_async(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {}
+        }),
+    );
+    let (response, watched) = client.receive_response_for_id_watching_notifications(
+        id,
+        &["window/showMessage", "window/logMessage"],
+    );
+
     assert!(
         response.get("error").is_some(),
-        "a later explicit layer must not mask an earlier layer's invalid path: {response}"
+        "invalid explicit config file should reject initialize: {response}"
+    );
+    let duplicated: Vec<_> = watched
+        .iter()
+        .filter(|(_, params)| {
+            params["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("Failed to parse"))
+        })
+        .collect();
+    assert!(
+        duplicated.is_empty(),
+        "the initialize error must be the sole report of the failure: {duplicated:?}"
     );
 }
 
@@ -324,6 +546,21 @@ fn test_config_file_does_not_make_invalid_initialization_options_fatal() {
     assert!(
         response.get("result").is_some(),
         "initializationOptions keep their existing non-fatal policy: {response}"
+    );
+    // Prove the expansion really failed rather than quietly succeeding. The
+    // merged configuration is discarded wholesale and programmed defaults take
+    // over, so the file's `autoInstall = false` is gone too — without a failure
+    // it would have survived.
+    client.send_notification("initialized", json!({}));
+    let settings = query_effective_settings(&mut client);
+    assert_eq!(
+        settings["autoInstall"],
+        json!(true),
+        "the failed expansion should discard the merge in favour of defaults: {settings}"
+    );
+    assert!(
+        !settings.to_string().contains("KAKEHASHI_TEST_UNDEFINED"),
+        "no unexpanded value may leak into the effective configuration: {settings}"
     );
 }
 


### PR DESCRIPTION
## Summary

Configuration named with `--config-file` becomes strict, but only where strictness is warranted. The organising rule: **strictness follows how the path was chosen, not what went wrong with it.** A path the user typed carries intent; a path kakehashi went looking for does not.

- **present but unusable** → rejects LSP initialization (`RequestFailed`, -32803) and exits `format` / `diagnose` with 2: unreadable, malformed TOML, larger than 8 MiB, or carrying a path that cannot be expanded
- **absent** → skipped with a warning, so `--config-file base.toml --config-file overrides.toml` still works where the overlay does not exist, and a relative path resolving against the editor's working directory does not produce a dead server
- **unreachable** (an ancestor directory denying traversal, a dangling symlink) counts as unusable, not absent — `exists()` answers "no" to both, and only one of them is the optional-overlay case
- **unrecognised key** → reported as a warning, so a typo is not silently read as "not specified" while a key a newer version understands does not version-lock the file
- path expansion is judged **per file**, so a later layer cannot mask an earlier one's undefined variable — path fields are replaced wholesale, so the merged result would never mention the mistake
- cross-field invariants (`debounceMs` ≤ `maxWaitMs`) are judged on the **merged** explicit configuration, so splitting the halves across two files is fine, while a combination invalid only once merged still aborts
- the whole verdict is reached **before `initialize` stores anything from the request**, and each file is read **exactly once**
- `initializationOptions` keep their non-fatal policy; implicit user/project discovery is untouched, so a malformed `./kakehashi.toml` is still a warning and cannot stop the server starting

## Why

Silently dropping a layer the user named and continuing on defaults hides configuration mistakes. But strictness has to be aimed: an absent overlay and an invalid setting are different mistakes, and a rule that cannot tell them apart breaks the documented layering pattern instead of protecting it.

## Tests

`cargo test --lib` (3120) · `--test e2e_config_file` (60) · `--test e2e_cli_format` (19) · `--test e2e_cli_diagnose` (18) · full e2e suite (1710 across 57 binaries) · `make check`

Coverage pins what the behaviour rests on: every explicit layer is validated and nothing after a failed one is read; a split invariant is valid once merged while a merge invalid only in combination aborts; an absent layer is skipped without losing the layer that does exist, and is reported as a warning rather than an error popup; an unreadable file, an unreachable parent, and a dangling symlink are each distinguished from absence; size is judged before decoding; the initialize error is the sole client-facing report; a repaired file is re-read on retry; a failed CLI run leaves stdout empty; and implicit config keeps its warning-only policy.

## Known gaps, named rather than implied

- **Unknown keys inside `features` are fatal**, unlike everywhere else, because `FeatureSettings` carries `deny_unknown_fields` and fails before the warning walker runs. Pinned by a test so removing the inconsistency is deliberate; changing it reaches further than this PR should.
- **CLI mode has no channel for non-fatal settings events** — the stub client pump discards them — so a skipped layer or an unknown key is invisible to `format`/`diagnose`. Pre-existing, unchanged here.
- **The retry-state invariant is not mutation-pinned.** The verdict is reached before the first-write-wins capability/root/workspace stores; observing a stale latch needs a mock downstream server plus differing workspace folders across two attempts. Stated at the call site and in the test.
- **`InitializeError { retry }`** is not sent in the initialize error's `data`. Reviewers disagreed on the right value, so it should not ride along here.

Refs #731. This addresses the explicit-path half. The issue's headline case — a malformed *implicitly discovered* `kakehashi.toml` being ignored — is deliberately left open: making it fatal would cost the zero-config guarantee, and deserves its own decision.
