### PR TITLE
fix(lsp): replace runtime configuration layer

### DIFF
--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -7,7 +7,8 @@ kakehashi needs to support multiple configuration sources to accommodate differe
 1. **Programmed defaults**: Built-in defaults for zero-config usage
 2. **User-wide defaults**: Settings that apply across all projects for a user
 3. **Project-specific settings**: Configuration local to a specific project/directory
-4. **Session-specific overrides**: Settings passed directly from the LSP client at initialization
+4. **Initialization overrides**: Settings passed directly from the LSP client at initialization
+5. **Runtime overrides**: The client's current configuration section, replaced on each notification
 
 The limitations of the current system are:
 
@@ -19,7 +20,7 @@ The standard pattern in many language servers and CLI tools is layered configura
 
 ## Decision
 
-**Implement a four-layer configuration system with "later sources override earlier ones" semantics.**
+**Implement a five-layer configuration system with "later sources override earlier ones" semantics.**
 
 ### Query Configuration Schema
 
@@ -73,12 +74,20 @@ queries = [
    - `--config-file` CLI option to specify alternative path(s)
    - Purpose: Project-specific settings, version-controlled with the project
 
-4. **Session-specific overrides** (highest precedence)
-   - Sources:
-     - `initializationOptions` in the LSP `initialize` request (at startup)
-     - `workspace/didChangeConfiguration` notification (at runtime)
-   - Purpose: Per-session overrides from the editor/client configuration
-   - Note: Runtime changes via `didChangeConfiguration` re-trigger the merge process
+4. **Initialization overrides**
+   - Source: `initializationOptions` in the LSP `initialize` request
+   - Purpose: Startup-only per-session overrides from the editor/client
+
+5. **Runtime overrides** (highest precedence)
+   - Source: the current kakehashi section in each
+     `workspace/didChangeConfiguration` notification
+   - Purpose: Live editor/client configuration
+   - Replacement semantics: each accepted notification replaces the previous
+     runtime layer; it is not merged onto the previous effective snapshot
+   - Omitting a previously supplied key restores its value from the startup
+     layers (defaults, files, and `initializationOptions`)
+   - An explicit wrapped `{ "kakehashi": {} }` section clears the runtime layer
+     completely, while unrelated flat editor settings are ignored
 
 ### Merge Algorithm
 
@@ -93,7 +102,15 @@ Configs are applied in order (earlier = lower precedence, later = higher precede
 ```
 final_config = [defaults, user_config, project_config, InitializationOptions]
     .into_iter().reduce(merge_workspace_settings).flatten()
+
+effective_config = merge_workspace_settings(final_config, current_runtime_section)
 ```
+
+`final_config` is retained as the stable startup base. On every accepted
+`didChangeConfiguration`, kakehashi merges only the notification's current
+runtime section onto that base. Parser data directories discovered by successful
+installs are then re-applied as a process-local operational layer so a later
+runtime replacement cannot make a newly installed parser unreachable.
 
 **Scalar values and Option types** (`searchPaths`, `autoInstall`):
 - Later sources completely replace earlier values (via `overlay.or(base)`)

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -495,7 +495,6 @@ impl Kakehashi {
         .await
         .into_iter()
         .for_each(|uri| self.schedule_reparse(uri, None));
-        self.warn_on_misconfigured_settings().await;
     }
 
     async fn apply_initial_settings(

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -509,7 +509,7 @@ impl Kakehashi {
         raw_settings: RawWorkspaceSettings,
         settings: WorkspaceSettings,
     ) {
-        let warning_settings = settings.clone();
+        let warnings = Self::misconfigured_settings_warnings(&settings);
         apply_shared_settings(
             &self.client,
             ReloadLanguageState {
@@ -529,7 +529,7 @@ impl Kakehashi {
         .await
         .into_iter()
         .for_each(|uri| self.schedule_reparse(uri, None));
-        self.warn_on_misconfigured_settings(&warning_settings).await;
+        self.warn_on_misconfigured_settings(&warnings).await;
     }
 
     /// Emit a single client-visible warning summarizing all (host, injection)
@@ -544,14 +544,22 @@ impl Kakehashi {
     /// Previously this emitted one notification per pair, which floods the
     /// editor log on `didChangeConfiguration` reloads for workspaces with
     /// many bridge entries.
-    async fn warn_on_misconfigured_settings(&self, settings: &WorkspaceSettings) {
+    fn misconfigured_settings_warnings(settings: &WorkspaceSettings) -> Vec<String> {
+        let mut warnings = Vec::new();
         let pairs = bridge_context::concatenated_formatting_pairs(settings);
         if let Some(msg) = bridge_context::format_concatenated_formatting_warning(&pairs) {
-            self.notifier().log_warning(msg).await;
+            warnings.push(msg);
         }
         let unspawnable = bridge_context::unspawnable_language_servers(settings);
         if let Some(msg) = bridge_context::format_unspawnable_servers_warning(&unspawnable) {
-            self.notifier().log_warning(msg).await;
+            warnings.push(msg);
+        }
+        warnings
+    }
+
+    async fn warn_on_misconfigured_settings(&self, warnings: &[String]) {
+        for warning in warnings {
+            self.notifier().log_warning(warning).await;
         }
     }
 

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -510,6 +510,8 @@ impl Kakehashi {
         settings: WorkspaceSettings,
     ) {
         let warnings = Self::misconfigured_settings_warnings(&settings);
+        self.settings_manager
+            .set_base_raw_settings(raw_settings.clone());
         apply_shared_settings(
             &self.client,
             ReloadLanguageState {

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -502,6 +502,7 @@ impl Kakehashi {
         raw_settings: RawWorkspaceSettings,
         settings: WorkspaceSettings,
     ) {
+        let warning_settings = settings.clone();
         apply_shared_settings(
             &self.client,
             ReloadLanguageState {
@@ -520,7 +521,7 @@ impl Kakehashi {
         .await
         .into_iter()
         .for_each(|uri| self.schedule_reparse(uri, None));
-        self.warn_on_misconfigured_settings().await;
+        self.warn_on_misconfigured_settings(&warning_settings).await;
     }
 
     /// Emit a single client-visible warning summarizing all (host, injection)
@@ -535,13 +536,12 @@ impl Kakehashi {
     /// Previously this emitted one notification per pair, which floods the
     /// editor log on `didChangeConfiguration` reloads for workspaces with
     /// many bridge entries.
-    async fn warn_on_misconfigured_settings(&self) {
-        let settings = self.settings_manager.load_settings();
-        let pairs = bridge_context::concatenated_formatting_pairs(&settings);
+    async fn warn_on_misconfigured_settings(&self, settings: &WorkspaceSettings) {
+        let pairs = bridge_context::concatenated_formatting_pairs(settings);
         if let Some(msg) = bridge_context::format_concatenated_formatting_warning(&pairs) {
             self.notifier().log_warning(msg).await;
         }
-        let unspawnable = bridge_context::unspawnable_language_servers(&settings);
+        let unspawnable = bridge_context::unspawnable_language_servers(settings);
         if let Some(msg) = bridge_context::format_unspawnable_servers_warning(&unspawnable) {
             self.notifier().log_warning(msg).await;
         }

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -100,6 +100,7 @@ pub(super) struct ReloadLanguageState<'a> {
     documents: &'a DocumentStore,
     invalidate_documents: bool,
     request_semantic_refresh: bool,
+    settings_transaction: Option<tokio::sync::MutexGuard<'a, ()>>,
 }
 
 /// One server process owns one effective workspace settings snapshot. Keep the
@@ -133,7 +134,7 @@ impl Drop for ParserReloadGuard<'_> {
 
 pub(super) async fn apply_shared_settings(
     client: &Client,
-    language_state: ReloadLanguageState<'_>,
+    mut language_state: ReloadLanguageState<'_>,
     settings_manager: &SettingsManager,
     cache: &CacheCoordinator,
     bridge: &BridgeCoordinator,
@@ -178,6 +179,10 @@ pub(super) async fn apply_shared_settings(
         Some(raw_settings) => settings_manager.apply_settings_with_raw(raw_settings, settings),
         None => settings_manager.apply_settings(settings),
     }
+    // Snapshot derivation and publication are now atomic. Release the outer
+    // read-modify-write guard before downstream/client I/O; SETTINGS_RELOAD_LOCK
+    // continues to serialize the remaining propagation work.
+    drop(language_state.settings_transaction.take());
     let settings = settings_manager.load_settings();
     // Path c: apply downstream config at this single reload choke point
     // (initialize, didChangeConfiguration, auto-install reload): push runtime
@@ -476,6 +481,7 @@ impl Kakehashi {
         &self,
         raw_settings: RawWorkspaceSettings,
         settings: WorkspaceSettings,
+        settings_transaction: tokio::sync::MutexGuard<'_, ()>,
     ) {
         apply_shared_settings(
             &self.client,
@@ -485,6 +491,7 @@ impl Kakehashi {
                 documents: &self.documents,
                 invalidate_documents: true,
                 request_semantic_refresh: true,
+                settings_transaction: Some(settings_transaction),
             },
             &self.settings_manager,
             &self.cache,
@@ -511,6 +518,7 @@ impl Kakehashi {
                 documents: &self.documents,
                 invalidate_documents: false,
                 request_semantic_refresh: false,
+                settings_transaction: None,
             },
             &self.settings_manager,
             &self.cache,
@@ -955,11 +963,17 @@ mod tests {
             .unwrap()
             .release("stale".to_string(), tree_sitter::Parser::new());
 
+        let transaction = service
+            .inner()
+            .settings_manager
+            .begin_settings_transaction()
+            .await;
         service
             .inner()
             .apply_raw_settings(
                 RawWorkspaceSettings::default(),
                 WorkspaceSettings::default(),
+                transaction,
             )
             .await;
 
@@ -989,11 +1003,17 @@ mod tests {
             }
         };
 
+        let transaction = service
+            .inner()
+            .settings_manager
+            .begin_settings_transaction()
+            .await;
         service
             .inner()
             .apply_raw_settings(
                 RawWorkspaceSettings::default(),
                 WorkspaceSettings::default(),
+                transaction,
             )
             .await;
         let parser_is_current = service

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -26,7 +26,12 @@ fn updated_settings_after_install(
     let mut updated_settings = settings.clone();
     let mut updated_raw_settings = raw_settings.clone();
     let data_dir_str = data_dir.clean().to_string_lossy().into_owned();
-    if !updated_settings.search_paths.contains(&data_dir_str) {
+    let cleaned_data_dir = std::path::Path::new(&data_dir_str);
+    if !updated_settings
+        .search_paths
+        .iter()
+        .any(|existing| std::path::Path::new(existing).clean() == cleaned_data_dir)
+    {
         updated_settings.search_paths.push(data_dir_str.clone());
 
         let raw_search_paths = updated_raw_settings
@@ -376,6 +381,24 @@ mod tests {
             &settings,
             Path::new("/tmp/parent/../installed"),
         );
+
+        assert_eq!(updated_raw.search_paths, raw_settings.search_paths);
+        assert_eq!(updated_settings.search_paths, settings.search_paths);
+    }
+
+    #[test]
+    fn reload_after_install_deduplicates_lexical_existing_path_variants() {
+        let raw_settings = RawWorkspaceSettings {
+            search_paths: Some(vec!["/tmp/parent/../installed".to_string()]),
+            ..Default::default()
+        };
+        let settings = WorkspaceSettings {
+            search_paths: vec!["/tmp/parent/../installed".to_string()],
+            ..Default::default()
+        };
+
+        let (updated_raw, updated_settings) =
+            updated_settings_after_install(&raw_settings, &settings, Path::new("/tmp/installed"));
 
         assert_eq!(updated_raw.search_paths, raw_settings.search_paths);
         assert_eq!(updated_settings.search_paths, settings.search_paths);

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -197,7 +197,7 @@ impl InstallCoordinator {
         // Keep the post-install search-path derivation in the same transaction
         // domain as runtime configuration pushes, or either update can overwrite
         // the other after deriving from a shared stale snapshot.
-        let _settings_transaction = self.settings_manager.begin_settings_transaction().await;
+        let settings_transaction = self.settings_manager.begin_settings_transaction().await;
         let settings_snapshot = self.settings_manager.load_settings_pair();
         let (updated_raw_settings, updated_settings) = updated_settings_after_install(
             &settings_snapshot.raw_settings,
@@ -205,12 +205,8 @@ impl InstallCoordinator {
             data_dir,
         );
 
-        self.apply_raw_settings(
-            updated_raw_settings,
-            updated_settings,
-            _settings_transaction,
-        )
-        .await;
+        self.apply_raw_settings(updated_raw_settings, updated_settings, settings_transaction)
+            .await;
 
         let load_result = self.language.ensure_language_loaded_async(language).await;
         self.notifier()

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -198,6 +198,7 @@ impl InstallCoordinator {
         // domain as runtime configuration pushes, or either update can overwrite
         // the other after deriving from a shared stale snapshot.
         let settings_transaction = self.settings_manager.begin_settings_transaction().await;
+        self.settings_manager.record_installed_search_path(data_dir);
         let settings_snapshot = self.settings_manager.load_settings_pair();
         let (updated_raw_settings, updated_settings) = updated_settings_after_install(
             &settings_snapshot.raw_settings,

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -25,8 +25,8 @@ fn updated_settings_after_install(
 ) -> (crate::config::RawWorkspaceSettings, WorkspaceSettings) {
     let mut updated_settings = settings.clone();
     let mut updated_raw_settings = raw_settings.clone();
-    let data_dir_str = data_dir.clean().to_string_lossy().into_owned();
-    let cleaned_data_dir = std::path::Path::new(&data_dir_str);
+    let cleaned_data_dir = data_dir.clean();
+    let data_dir_str = cleaned_data_dir.to_string_lossy().into_owned();
     if !updated_settings
         .search_paths
         .iter()

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -194,6 +194,10 @@ impl InstallCoordinator {
         uri: Url,
         is_injection: bool,
     ) {
+        // Keep the post-install search-path derivation in the same transaction
+        // domain as runtime configuration pushes, or either update can overwrite
+        // the other after deriving from a shared stale snapshot.
+        let _settings_transaction = self.settings_manager.begin_settings_transaction().await;
         let settings_snapshot = self.settings_manager.load_settings_pair();
         let (updated_raw_settings, updated_settings) = updated_settings_after_install(
             &settings_snapshot.raw_settings,

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -12,6 +12,7 @@ use crate::lsp::lsp_impl::{
     Kakehashi, ReloadLanguageState, apply_shared_settings, build_notifier, detect_document_language,
 };
 use crate::lsp::settings_manager::SettingsManager;
+use path_clean::PathClean;
 use tower_lsp_server::Client;
 
 use super::ParseCoordinator;
@@ -24,7 +25,7 @@ fn updated_settings_after_install(
 ) -> (crate::config::RawWorkspaceSettings, WorkspaceSettings) {
     let mut updated_settings = settings.clone();
     let mut updated_raw_settings = raw_settings.clone();
-    let data_dir_str = data_dir.to_string_lossy().to_string();
+    let data_dir_str = data_dir.clean().to_string_lossy().into_owned();
     if !updated_settings.search_paths.contains(&data_dir_str) {
         updated_settings.search_paths.push(data_dir_str.clone());
 
@@ -357,6 +358,27 @@ mod tests {
             updated_settings.search_paths,
             vec!["/installed".to_string()]
         );
+    }
+
+    #[test]
+    fn reload_after_install_deduplicates_lexical_data_dir_variants() {
+        let raw_settings = RawWorkspaceSettings {
+            search_paths: Some(vec!["/tmp/installed".to_string()]),
+            ..Default::default()
+        };
+        let settings = WorkspaceSettings {
+            search_paths: vec!["/tmp/installed".to_string()],
+            ..Default::default()
+        };
+
+        let (updated_raw, updated_settings) = updated_settings_after_install(
+            &raw_settings,
+            &settings,
+            Path::new("/tmp/parent/../installed"),
+        );
+
+        assert_eq!(updated_raw.search_paths, raw_settings.search_paths);
+        assert_eq!(updated_settings.search_paths, settings.search_paths);
     }
 
     #[test]

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -207,6 +207,7 @@ impl InstallCoordinator {
 
         self.apply_raw_settings(updated_raw_settings, updated_settings)
             .await;
+        drop(_settings_transaction);
 
         let load_result = self.language.ensure_language_loaded_async(language).await;
         self.notifier()

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -205,9 +205,12 @@ impl InstallCoordinator {
             data_dir,
         );
 
-        self.apply_raw_settings(updated_raw_settings, updated_settings)
-            .await;
-        drop(_settings_transaction);
+        self.apply_raw_settings(
+            updated_raw_settings,
+            updated_settings,
+            _settings_transaction,
+        )
+        .await;
 
         let load_result = self.language.ensure_language_loaded_async(language).await;
         self.notifier()
@@ -231,6 +234,7 @@ impl InstallCoordinator {
         &self,
         raw_settings: crate::config::RawWorkspaceSettings,
         settings: WorkspaceSettings,
+        settings_transaction: tokio::sync::MutexGuard<'_, ()>,
     ) {
         let _reparse_uris = apply_shared_settings(
             &self.client,
@@ -240,6 +244,7 @@ impl InstallCoordinator {
                 documents: &self.documents,
                 invalidate_documents: false,
                 request_semantic_refresh: true,
+                settings_transaction: Some(settings_transaction),
             },
             &self.settings_manager,
             &self.cache,

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -404,7 +404,7 @@ impl Kakehashi {
         let base_ts = self.settings_manager.load_base_raw_settings();
         // SAFETY: merge_workspace_settings(Some, Some) always returns Some, so unwrap_or_return is
         // defensive only — the None branch is unreachable under the current implementation.
-        let Some(merged_ts) = merge_workspace_settings(Some((*base_ts).clone()), Some(parsed))
+        let Some(mut merged_ts) = merge_workspace_settings(Some((*base_ts).clone()), Some(parsed))
         else {
             log::warn!(
                 "merge_workspace_settings returned None despite two Some inputs; skipping configuration update"
@@ -417,7 +417,9 @@ impl Kakehashi {
             self.home_dir.as_deref(),
             crate::config::expand::with_kakehashi_defaults(|var| std::env::var(var).ok()),
         ) {
-            Ok(settings) => {
+            Ok(mut settings) => {
+                self.settings_manager
+                    .apply_installed_search_paths(&mut merged_ts, &mut settings);
                 let warnings = Self::misconfigured_settings_warnings(&settings);
                 self.apply_raw_settings(merged_ts, settings, settings_transaction)
                     .await;

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -391,7 +391,7 @@ impl Kakehashi {
         // Serialize the snapshot read and publication as one transaction. The
         // reload lock inside apply_shared_settings starts too late to prevent
         // two callers deriving replacements from the same old snapshot.
-        let _settings_transaction = self.settings_manager.begin_settings_transaction().await;
+        let settings_transaction = self.settings_manager.begin_settings_transaction().await;
 
         // Merge onto current effective settings (not from scratch).
         // The current settings already reflect defaults < user < project < initializationOptions,
@@ -414,13 +414,13 @@ impl Kakehashi {
         ) {
             Ok(settings) => {
                 let warnings = Self::misconfigured_settings_warnings(&settings);
-                self.apply_raw_settings(merged_ts, settings, _settings_transaction)
+                self.apply_raw_settings(merged_ts, settings, settings_transaction)
                     .await;
                 self.warn_on_misconfigured_settings(&warnings).await;
                 self.notifier().log_info("Configuration updated!").await;
             }
             Err(errs) => {
-                drop(_settings_transaction);
+                drop(settings_transaction);
                 let event = crate::lsp::SettingsEvent::error(format!(
                     "Path expansion failed: {errs}. \
                      This configuration has been discarded; previous settings remain in effect. \

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -388,6 +388,11 @@ impl Kakehashi {
             }
         };
 
+        // Serialize the snapshot read and publication as one transaction. The
+        // reload lock inside apply_shared_settings starts too late to prevent
+        // two callers deriving replacements from the same old snapshot.
+        let _settings_transaction = self.settings_manager.begin_settings_transaction().await;
+
         // Merge onto current effective settings (not from scratch).
         // The current settings already reflect defaults < user < project < initializationOptions,
         // so merging preserves languages and other fields set during initialize.

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -413,10 +413,10 @@ impl Kakehashi {
             crate::config::expand::with_kakehashi_defaults(|var| std::env::var(var).ok()),
         ) {
             Ok(settings) => {
-                let warning_settings = settings.clone();
+                let warnings = Self::misconfigured_settings_warnings(&settings);
                 self.apply_raw_settings(merged_ts, settings, _settings_transaction)
                     .await;
-                self.warn_on_misconfigured_settings(&warning_settings).await;
+                self.warn_on_misconfigured_settings(&warnings).await;
                 self.notifier().log_info("Configuration updated!").await;
             }
             Err(errs) => {

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -414,9 +414,11 @@ impl Kakehashi {
         ) {
             Ok(settings) => {
                 self.apply_raw_settings(merged_ts, settings).await;
+                drop(_settings_transaction);
                 self.notifier().log_info("Configuration updated!").await;
             }
             Err(errs) => {
+                drop(_settings_transaction);
                 let event = crate::lsp::SettingsEvent::error(format!(
                     "Path expansion failed: {errs}. \
                      This configuration has been discarded; previous settings remain in effect. \

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -413,9 +413,10 @@ impl Kakehashi {
             crate::config::expand::with_kakehashi_defaults(|var| std::env::var(var).ok()),
         ) {
             Ok(settings) => {
+                let warning_settings = settings.clone();
                 self.apply_raw_settings(merged_ts, settings).await;
                 drop(_settings_transaction);
-                self.warn_on_misconfigured_settings().await;
+                self.warn_on_misconfigured_settings(&warning_settings).await;
                 self.notifier().log_info("Configuration updated!").await;
             }
             Err(errs) => {

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -415,6 +415,7 @@ impl Kakehashi {
             Ok(settings) => {
                 self.apply_raw_settings(merged_ts, settings).await;
                 drop(_settings_transaction);
+                self.warn_on_misconfigured_settings().await;
                 self.notifier().log_info("Configuration updated!").await;
             }
             Err(errs) => {

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -414,8 +414,8 @@ impl Kakehashi {
         ) {
             Ok(settings) => {
                 let warning_settings = settings.clone();
-                self.apply_raw_settings(merged_ts, settings).await;
-                drop(_settings_transaction);
+                self.apply_raw_settings(merged_ts, settings, _settings_transaction)
+                    .await;
                 self.warn_on_misconfigured_settings(&warning_settings).await;
                 self.notifier().log_info("Configuration updated!").await;
             }

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -332,6 +332,10 @@ fn append_unknown_layers_keys(
 impl Kakehashi {
     /// Handle workspace/didChangeConfiguration notification.
     pub(crate) async fn did_change_configuration_impl(&self, params: DidChangeConfigurationParams) {
+        let has_kakehashi_wrapper = params
+            .settings
+            .as_object()
+            .is_some_and(|settings| settings.contains_key("kakehashi"));
         let uses_deprecated_unwrapped_shape =
             uses_deprecated_unwrapped_didchange_shape(&params.settings);
         let (settings_value, unknown_keys) = settings_payload(params.settings);
@@ -370,9 +374,10 @@ impl Kakehashi {
             return;
         }
 
-        if settings_value
-            .as_object()
-            .is_some_and(serde_json::Map::is_empty)
+        if !has_kakehashi_wrapper
+            && settings_value
+                .as_object()
+                .is_some_and(serde_json::Map::is_empty)
         {
             return;
         }

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -393,13 +393,13 @@ impl Kakehashi {
         // two callers deriving replacements from the same old snapshot.
         let settings_transaction = self.settings_manager.begin_settings_transaction().await;
 
-        // Merge onto current effective settings (not from scratch).
-        // The current settings already reflect defaults < user < project < initializationOptions,
-        // so merging preserves languages and other fields set during initialize.
-        let current_ts = self.settings_manager.load_raw_settings();
+        // Each accepted notification replaces the previous runtime layer. Merge
+        // it onto the stable startup layers rather than the prior effective
+        // snapshot, so omitted keys revert to files/initialization options.
+        let base_ts = self.settings_manager.load_base_raw_settings();
         // SAFETY: merge_workspace_settings(Some, Some) always returns Some, so unwrap_or_return is
         // defensive only — the None branch is unreachable under the current implementation.
-        let Some(merged_ts) = merge_workspace_settings(Some((*current_ts).clone()), Some(parsed))
+        let Some(merged_ts) = merge_workspace_settings(Some((*base_ts).clone()), Some(parsed))
         else {
             log::warn!(
                 "merge_workspace_settings returned None despite two Some inputs; skipping configuration update"

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -26,6 +26,9 @@ pub(crate) struct SettingsSnapshot {
 pub(crate) struct SettingsManager {
     root_path: ArcSwap<Option<PathBuf>>,
     settings_snapshot: ArcSwap<SettingsSnapshot>,
+    /// Serializes read-modify-write settings transactions from runtime config
+    /// pushes and post-install search-path updates.
+    settings_transaction: tokio::sync::Mutex<()>,
     /// Client capabilities from initialize() - immutable after initialization.
     /// Uses OnceLock to enforce "set once, read many" semantics per LSP protocol.
     client_capabilities: OnceLock<ClientCapabilities>,
@@ -79,10 +82,19 @@ impl SettingsManager {
                 raw_settings: Arc::new(raw_settings),
                 settings: Arc::new(settings),
             })),
+            settings_transaction: tokio::sync::Mutex::new(()),
             client_capabilities: OnceLock::new(),
             root_markers_deprecation_warned: AtomicBool::new(false),
             unwrapped_didchange_deprecation_warned: AtomicBool::new(false),
         }
+    }
+
+    /// Begin a settings read-modify-write transaction.
+    ///
+    /// Callers must acquire this before loading the snapshot they intend to
+    /// derive from and retain it until the derived snapshot is published.
+    pub(crate) async fn begin_settings_transaction(&self) -> tokio::sync::MutexGuard<'_, ()> {
+        self.settings_transaction.lock().await
     }
 
     /// Claim the one-per-session slot for the `rootMarkers` deprecation notice.
@@ -304,6 +316,51 @@ mod tests {
         DocumentSymbolClientCapabilities, SemanticTokensWorkspaceClientCapabilities,
         TextDocumentClientCapabilities, WorkspaceClientCapabilities,
     };
+
+    #[tokio::test]
+    async fn settings_transaction_serializes_snapshot_derivation_and_publication() {
+        let manager = Arc::new(SettingsManager::new());
+        let first_guard = manager.begin_settings_transaction().await;
+        let first_base = manager.load_raw_settings();
+
+        let second_started = Arc::new(tokio::sync::Notify::new());
+        let second_manager = Arc::clone(&manager);
+        let second_started_task = Arc::clone(&second_started);
+        let second = tokio::spawn(async move {
+            second_started_task.notify_one();
+            let _guard = second_manager.begin_settings_transaction().await;
+            let base = second_manager.load_raw_settings();
+            let merged = crate::config::merge_workspace_settings(
+                Some((*base).clone()),
+                Some(RawWorkspaceSettings {
+                    search_paths: Some(vec!["/installed".to_string()]),
+                    ..Default::default()
+                }),
+            )
+            .expect("two settings snapshots merge");
+            second_manager.apply_settings_with_raw(merged, WorkspaceSettings::default());
+        });
+
+        second_started.notified().await;
+        let first = crate::config::merge_workspace_settings(
+            Some((*first_base).clone()),
+            Some(RawWorkspaceSettings {
+                auto_install: Some(false),
+                ..Default::default()
+            }),
+        )
+        .expect("two settings snapshots merge");
+        manager.apply_settings_with_raw(first, WorkspaceSettings::default());
+        drop(first_guard);
+        second.await.expect("second transaction completes");
+
+        let final_settings = manager.load_raw_settings();
+        assert_eq!(final_settings.auto_install, Some(false));
+        assert_eq!(
+            final_settings.search_paths.as_deref(),
+            Some(["/installed".to_string()].as_slice())
+        );
+    }
 
     #[test]
     fn test_new_creates_default_state() {

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -210,10 +210,10 @@ impl SettingsManager {
         for path in paths.iter() {
             if !settings.search_paths.contains(path) {
                 settings.search_paths.push(path.clone());
-            }
-            let raw_paths = raw_settings.search_paths.get_or_insert_with(Vec::new);
-            if !raw_paths.contains(path) {
-                raw_paths.push(path.clone());
+                let raw_paths = raw_settings.search_paths.get_or_insert_with(Vec::new);
+                if !raw_paths.contains(path) {
+                    raw_paths.push(path.clone());
+                }
             }
         }
     }
@@ -631,6 +631,33 @@ mod tests {
         assert_eq!(
             effective_settings.search_paths,
             vec!["/runtime".to_string(), "/installed".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_installed_search_path_does_not_duplicate_expanded_raw_path() {
+        let manager = SettingsManager::new();
+        manager.record_installed_search_path(std::path::Path::new("/installed"));
+
+        let mut raw_settings = RawWorkspaceSettings {
+            search_paths: Some(vec!["${DATA_DIR}".to_string()]),
+            ..Default::default()
+        };
+        let mut effective_settings =
+            WorkspaceSettings::try_from_settings(&raw_settings, None, |var| {
+                (var == "DATA_DIR").then(|| "/installed".to_string())
+            })
+            .unwrap();
+
+        manager.apply_installed_search_paths(&mut raw_settings, &mut effective_settings);
+
+        assert_eq!(
+            raw_settings.search_paths,
+            Some(vec!["${DATA_DIR}".to_string()])
+        );
+        assert_eq!(
+            effective_settings.search_paths,
+            vec!["/installed".to_string()]
         );
     }
 

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -324,11 +324,13 @@ mod tests {
         assert!(manager.settings_transaction.try_lock().is_err());
         let first_base = manager.load_raw_settings();
 
-        let second_started = Arc::new(tokio::sync::Notify::new());
+        let (second_attempted_tx, second_attempted_rx) = tokio::sync::oneshot::channel();
         let second_manager = Arc::clone(&manager);
-        let second_started_task = Arc::clone(&second_started);
         let second = tokio::spawn(async move {
-            second_started_task.notify_one();
+            assert!(second_manager.settings_transaction.try_lock().is_err());
+            second_attempted_tx
+                .send(())
+                .expect("first transaction still receives attempt signal");
             let _guard = second_manager.begin_settings_transaction().await;
             let base = second_manager.load_raw_settings();
             let merged = crate::config::merge_workspace_settings(
@@ -348,7 +350,9 @@ mod tests {
             second_manager.apply_settings_with_raw(merged, effective);
         });
 
-        second_started.notified().await;
+        second_attempted_rx
+            .await
+            .expect("second transaction attempts lock acquisition");
         let first = crate::config::merge_workspace_settings(
             Some((*first_base).clone()),
             Some(RawWorkspaceSettings {

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -208,7 +208,7 @@ impl SettingsManager {
             .lock()
             .recover_poison("SettingsManager::apply_installed_search_paths");
         for path in paths.iter() {
-            let cleaned_path = std::path::Path::new(path);
+            let cleaned_path = std::path::Path::new(path).clean();
             if !settings
                 .search_paths
                 .iter()
@@ -216,7 +216,10 @@ impl SettingsManager {
             {
                 settings.search_paths.push(path.clone());
                 let raw_paths = raw_settings.search_paths.get_or_insert_with(Vec::new);
-                if !raw_paths.contains(path) {
+                if !raw_paths
+                    .iter()
+                    .any(|existing| std::path::Path::new(existing).clean() == cleaned_path)
+                {
                     raw_paths.push(path.clone());
                 }
             }

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -2,6 +2,7 @@
 //! `apply_settings`) plus initialize-only state — `client_capabilities` and
 //! `root_path` (both `OnceLock`, set once during `initialize()`).
 
+use crate::error::LockResultExt;
 use arc_swap::ArcSwap;
 use path_clean::PathClean;
 use std::path::PathBuf;
@@ -28,6 +29,9 @@ pub(crate) struct SettingsManager {
     /// Startup layers (defaults, config files, and initialization options),
     /// before any replaceable didChangeConfiguration layer is applied.
     base_raw_settings: ArcSwap<RawWorkspaceSettings>,
+    /// Parser data directories discovered by successful installs. These form
+    /// a durable layer above replaceable client settings for this process.
+    installed_search_paths: std::sync::Mutex<Vec<String>>,
     settings_snapshot: ArcSwap<SettingsSnapshot>,
     /// Serializes read-modify-write settings transactions from runtime config
     /// pushes and post-install search-path updates.
@@ -82,6 +86,7 @@ impl SettingsManager {
         Self {
             root_path: ArcSwap::new(Arc::new(None)),
             base_raw_settings: ArcSwap::new(Arc::new(raw_settings.clone())),
+            installed_search_paths: std::sync::Mutex::new(Vec::new()),
             settings_snapshot: ArcSwap::new(Arc::new(SettingsSnapshot {
                 raw_settings: Arc::new(raw_settings),
                 settings: Arc::new(settings),
@@ -178,6 +183,39 @@ impl SettingsManager {
     /// Replace the startup layers during the initialize handshake.
     pub(crate) fn set_base_raw_settings(&self, raw_settings: RawWorkspaceSettings) {
         self.base_raw_settings.store(Arc::new(raw_settings));
+    }
+
+    /// Remember a parser data directory for subsequent runtime-layer rebuilds.
+    pub(crate) fn record_installed_search_path(&self, data_dir: &std::path::Path) {
+        let data_dir = data_dir.to_string_lossy().into_owned();
+        let mut paths = self
+            .installed_search_paths
+            .lock()
+            .recover_poison("SettingsManager::record_installed_search_path");
+        if !paths.contains(&data_dir) {
+            paths.push(data_dir);
+        }
+    }
+
+    /// Reapply parser data directories added after the startup layers loaded.
+    pub(crate) fn apply_installed_search_paths(
+        &self,
+        raw_settings: &mut RawWorkspaceSettings,
+        settings: &mut WorkspaceSettings,
+    ) {
+        let paths = self
+            .installed_search_paths
+            .lock()
+            .recover_poison("SettingsManager::apply_installed_search_paths");
+        for path in paths.iter() {
+            if !settings.search_paths.contains(path) {
+                settings.search_paths.push(path.clone());
+            }
+            let raw_paths = raw_settings.search_paths.get_or_insert_with(Vec::new);
+            if !raw_paths.contains(path) {
+                raw_paths.push(path.clone());
+            }
+        }
     }
 
     /// Load the current raw and effective workspace settings from one snapshot.
@@ -570,6 +608,30 @@ mod tests {
             raw_settings.auto_install
         );
         assert_eq!(&*snapshot.settings, &effective_settings);
+    }
+
+    #[test]
+    fn test_installed_search_paths_survive_rebuilt_runtime_settings() {
+        let manager = SettingsManager::new();
+        manager.record_installed_search_path(std::path::Path::new("/installed"));
+
+        let mut raw_settings = RawWorkspaceSettings {
+            search_paths: Some(vec!["/runtime".to_string()]),
+            ..Default::default()
+        };
+        let mut effective_settings =
+            WorkspaceSettings::try_from_settings(&raw_settings, None, |_| None).unwrap();
+
+        manager.apply_installed_search_paths(&mut raw_settings, &mut effective_settings);
+
+        assert_eq!(
+            raw_settings.search_paths,
+            Some(vec!["/runtime".to_string(), "/installed".to_string()])
+        );
+        assert_eq!(
+            effective_settings.search_paths,
+            vec!["/runtime".to_string(), "/installed".to_string()]
+        );
     }
 
     /// Tests for supports_semantic_tokens_refresh capability checking.

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -208,9 +208,12 @@ impl SettingsManager {
             .lock()
             .recover_poison("SettingsManager::apply_installed_search_paths");
         for path in paths.iter() {
-            if !settings.search_paths.iter().any(|existing| {
-                std::path::Path::new(existing).clean() == std::path::Path::new(path)
-            }) {
+            let cleaned_path = std::path::Path::new(path);
+            if !settings
+                .search_paths
+                .iter()
+                .any(|existing| std::path::Path::new(existing).clean() == cleaned_path)
+            {
                 settings.search_paths.push(path.clone());
                 let raw_paths = raw_settings.search_paths.get_or_insert_with(Vec::new);
                 if !raw_paths.contains(path) {

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -187,7 +187,7 @@ impl SettingsManager {
 
     /// Remember a parser data directory for subsequent runtime-layer rebuilds.
     pub(crate) fn record_installed_search_path(&self, data_dir: &std::path::Path) {
-        let data_dir = data_dir.to_string_lossy().into_owned();
+        let data_dir = data_dir.clean().to_string_lossy().into_owned();
         let mut paths = self
             .installed_search_paths
             .lock()
@@ -208,7 +208,9 @@ impl SettingsManager {
             .lock()
             .recover_poison("SettingsManager::apply_installed_search_paths");
         for path in paths.iter() {
-            if !settings.search_paths.contains(path) {
+            if !settings.search_paths.iter().any(|existing| {
+                std::path::Path::new(existing).clean() == std::path::Path::new(path)
+            }) {
                 settings.search_paths.push(path.clone());
                 let raw_paths = raw_settings.search_paths.get_or_insert_with(Vec::new);
                 if !raw_paths.contains(path) {
@@ -658,6 +660,30 @@ mod tests {
         assert_eq!(
             effective_settings.search_paths,
             vec!["/installed".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_installed_search_path_deduplicates_lexical_variants() {
+        let manager = SettingsManager::new();
+        manager.record_installed_search_path(std::path::Path::new("/tmp/parent/../installed"));
+
+        let mut raw_settings = RawWorkspaceSettings {
+            search_paths: Some(vec!["/tmp/installed".to_string()]),
+            ..Default::default()
+        };
+        let mut effective_settings =
+            WorkspaceSettings::try_from_settings(&raw_settings, None, |_| None).unwrap();
+
+        manager.apply_installed_search_paths(&mut raw_settings, &mut effective_settings);
+
+        assert_eq!(
+            raw_settings.search_paths,
+            Some(vec!["/tmp/installed".to_string()])
+        );
+        assert_eq!(
+            effective_settings.search_paths,
+            vec!["/tmp/installed".to_string()]
         );
     }
 

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -25,6 +25,9 @@ pub(crate) struct SettingsSnapshot {
 
 pub(crate) struct SettingsManager {
     root_path: ArcSwap<Option<PathBuf>>,
+    /// Startup layers (defaults, config files, and initialization options),
+    /// before any replaceable didChangeConfiguration layer is applied.
+    base_raw_settings: ArcSwap<RawWorkspaceSettings>,
     settings_snapshot: ArcSwap<SettingsSnapshot>,
     /// Serializes read-modify-write settings transactions from runtime config
     /// pushes and post-install search-path updates.
@@ -78,6 +81,7 @@ impl SettingsManager {
 
         Self {
             root_path: ArcSwap::new(Arc::new(None)),
+            base_raw_settings: ArcSwap::new(Arc::new(raw_settings.clone())),
             settings_snapshot: ArcSwap::new(Arc::new(SettingsSnapshot {
                 raw_settings: Arc::new(raw_settings),
                 settings: Arc::new(settings),
@@ -164,6 +168,16 @@ impl SettingsManager {
     /// Load the current raw workspace settings.
     pub(crate) fn load_raw_settings(&self) -> Arc<RawWorkspaceSettings> {
         Arc::clone(&self.settings_snapshot.load().raw_settings)
+    }
+
+    /// Load the immutable startup layers used beneath runtime client settings.
+    pub(crate) fn load_base_raw_settings(&self) -> Arc<RawWorkspaceSettings> {
+        self.base_raw_settings.load_full()
+    }
+
+    /// Replace the startup layers during the initialize handshake.
+    pub(crate) fn set_base_raw_settings(&self, raw_settings: RawWorkspaceSettings) {
+        self.base_raw_settings.store(Arc::new(raw_settings));
     }
 
     /// Load the current raw and effective workspace settings from one snapshot.

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -321,6 +321,7 @@ mod tests {
     async fn settings_transaction_serializes_snapshot_derivation_and_publication() {
         let manager = Arc::new(SettingsManager::new());
         let first_guard = manager.begin_settings_transaction().await;
+        assert!(manager.settings_transaction.try_lock().is_err());
         let first_base = manager.load_raw_settings();
 
         let second_started = Arc::new(tokio::sync::Notify::new());
@@ -338,7 +339,13 @@ mod tests {
                 }),
             )
             .expect("two settings snapshots merge");
-            second_manager.apply_settings_with_raw(merged, WorkspaceSettings::default());
+            let effective = WorkspaceSettings::try_from_settings(
+                &merged,
+                None,
+                with_kakehashi_defaults(|_| None),
+            )
+            .expect("merged settings expand");
+            second_manager.apply_settings_with_raw(merged, effective);
         });
 
         second_started.notified().await;
@@ -350,7 +357,10 @@ mod tests {
             }),
         )
         .expect("two settings snapshots merge");
-        manager.apply_settings_with_raw(first, WorkspaceSettings::default());
+        let first_effective =
+            WorkspaceSettings::try_from_settings(&first, None, with_kakehashi_defaults(|_| None))
+                .expect("merged settings expand");
+        manager.apply_settings_with_raw(first, first_effective);
         drop(first_guard);
         second.await.expect("second transaction completes");
 

--- a/tests/e2e_config_file.rs
+++ b/tests/e2e_config_file.rs
@@ -953,7 +953,7 @@ fn test_did_change_configuration_preserves_config_file_settings() {
 
     client.send_notification(
         "workspace/didChangeConfiguration",
-        json!({ "settings": { "autoInstall": false } }),
+        json!({ "settings": { "kakehashi": { "autoInstall": false } } }),
     );
 
     let settings = poll_effective_settings(
@@ -996,7 +996,7 @@ fn test_did_change_configuration_removed_key_reverts_to_config_file() {
 
     client.send_notification(
         "workspace/didChangeConfiguration",
-        json!({ "settings": { "searchPaths": ["/replacement"] } }),
+        json!({ "settings": { "kakehashi": { "searchPaths": ["/replacement"] } } }),
     );
     let settings = poll_effective_settings(
         &mut client,

--- a/tests/e2e_config_file.rs
+++ b/tests/e2e_config_file.rs
@@ -719,9 +719,9 @@ fn test_did_change_configuration_skips_unrelated_flat_settings() {
     );
 }
 
-/// didChangeConfiguration does not report success for empty kakehashi sections.
+/// An empty wrapped section clears the complete runtime layer.
 #[test]
-fn test_did_change_configuration_skips_empty_kakehashi_section() {
+fn test_did_change_configuration_empty_kakehashi_section_restores_base() {
     let dir = TempDir::new().unwrap();
     let config = dir.path().join("base.toml");
     std::fs::write(&config, "autoInstall = false\n").unwrap();
@@ -737,6 +737,16 @@ fn test_did_change_configuration_skips_empty_kakehashi_section() {
 
     client.send_notification(
         "workspace/didChangeConfiguration",
+        json!({ "settings": { "kakehashi": { "autoInstall": true } } }),
+    );
+    poll_effective_settings(
+        &mut client,
+        |s| s["autoInstall"] == json!(true),
+        "runtime layer should override the config-file layer",
+    );
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
         json!({
             "settings": {
                 "kakehashi": {},
@@ -747,21 +757,21 @@ fn test_did_change_configuration_skips_empty_kakehashi_section() {
         }),
     );
 
-    let unexpected_success = client.wait_for_notification_where(
+    let success = client.wait_for_notification_where(
         &["window/logMessage"],
-        Duration::from_millis(250),
+        Duration::from_secs(5),
         is_config_updated,
     );
     assert!(
-        unexpected_success.is_none(),
-        "empty kakehashi section must not log success; got: {unexpected_success:?}"
+        success.is_some(),
+        "empty kakehashi section should apply the cleared runtime layer"
     );
 
     let settings = query_effective_settings(&mut client);
     assert_eq!(
         settings["autoInstall"],
         json!(false),
-        "empty kakehashi section should leave settings unchanged"
+        "empty kakehashi section should restore config-file settings"
     );
 }
 

--- a/tests/e2e_config_file.rs
+++ b/tests/e2e_config_file.rs
@@ -958,6 +958,48 @@ fn test_did_change_configuration_preserves_config_file_settings() {
     );
 }
 
+/// Each didChangeConfiguration payload replaces the previous runtime layer.
+#[test]
+fn test_did_change_configuration_removed_key_reverts_to_config_file() {
+    let dir = TempDir::new().unwrap();
+    let config = dir.path().join("base.toml");
+    std::fs::write(&config, "autoInstall = true\n").unwrap();
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config.to_str().unwrap())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let settings = get_effective_settings(&mut client);
+    assert_eq!(settings["autoInstall"], json!(true), "precondition");
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": { "autoInstall": false } }),
+    );
+    poll_effective_settings(
+        &mut client,
+        |s| s["autoInstall"] == json!(false),
+        "first runtime layer should override the config file",
+    );
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": { "searchPaths": ["/replacement"] } }),
+    );
+    let settings = poll_effective_settings(
+        &mut client,
+        |s| s["searchPaths"] == json!(["/replacement"]),
+        "second runtime layer should be applied",
+    );
+    assert_eq!(
+        settings["autoInstall"],
+        json!(true),
+        "omitted runtime key should fall back to the config-file layer"
+    );
+}
+
 /// didChangeConfiguration adds languageServers to a config-file that only had languages.
 #[test]
 fn test_did_change_configuration_adds_language_servers_to_config_file_base() {


### PR DESCRIPTION
## Summary

- retain the startup settings layers separately from client-pushed runtime settings
- treat each accepted `workspace/didChangeConfiguration` section as a replacement of the previous runtime layer
- let an explicit empty wrapped section restore startup settings while continuing to ignore unrelated flat editor settings
- preserve parser data directories added after successful installs across runtime-layer rebuilds

## User-visible impact

Removing a setting, language, server, or mapping from the editor configuration now takes effect immediately instead of remaining stuck until restart. Sending `settings.kakehashi = {}` clears the runtime layer and restores defaults/config files/initialization options.

## Base

This is stacked on #714 because runtime replacement must derive and publish under the per-server settings transaction added there. Retarget to `main` after #714 merges.

## Validation

- `cargo test --features e2e --test e2e_config_file -- --test-threads=1` (51 passed)
- `cargo test --lib lsp::settings_manager::tests -q`
- `cargo test --lib lsp::lsp_impl::coordinator::install::tests -q`
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --all -- --check`

Fixes #734

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Runtime configuration updates now replace the previous runtime layer, while omitted settings revert to startup configuration values.
  - Sending an empty `kakehashi` configuration clears all runtime overrides.
  - Newly installed parser locations remain available after configuration changes.

- **Bug Fixes**
  - Configuration updates now correctly preserve installed parser discovery paths.
  - Empty and partial runtime updates are processed reliably.

- **Documentation**
  - Updated configuration precedence and merging guidance to describe initialization and runtime overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->