### PR TITLE
test(bridge): honor host lifecycle in request fixtures

### DIFF
--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -110,6 +110,7 @@ mod tests {
         let server_config = lua_ls_config();
 
         let host_uri = Url::parse("file:///test/doc.md").unwrap();
+        pool.open_host_incarnation(&host_uri, 1).await;
         let host_position = Position {
             line: 3,
             character: 9,
@@ -144,6 +145,7 @@ mod tests {
         let server_config = lua_ls_config();
 
         let host_uri = Url::parse("file:///test/doc.md").unwrap();
+        pool.open_host_incarnation(&host_uri, 1).await;
         let host_position = Position {
             line: 3,
             character: 3,
@@ -185,6 +187,7 @@ mod tests {
         let server_config = lua_ls_config();
 
         let host_uri = Url::parse("file:///test/doc.md").unwrap();
+        pool.open_host_incarnation(&host_uri, 1).await;
         let host_position = Position {
             line: 3,
             character: 9,
@@ -225,6 +228,7 @@ mod tests {
         let server_config = lua_ls_config();
 
         let host_uri = Url::parse("file:///test/doc.md").unwrap();
+        pool.open_host_incarnation(&host_uri, 1).await;
         let host_position = Position {
             line: 3,
             character: 3,
@@ -261,6 +265,7 @@ mod tests {
         let server_config = lua_ls_config();
 
         let host_uri = Url::parse("file:///test/doc.md").unwrap();
+        pool.open_host_incarnation(&host_uri, 1).await;
         // Lua code with require statement - lua-ls may return document links for requires
         let virtual_content = "local mod = require(\"mymodule\")\nprint(mod)";
 


### PR DESCRIPTION
## Summary

- open a host incarnation before real-server hover, completion, and document-link requests
- align bridge integration fixtures with the closed-host request guard
- keep the production lifecycle contract unchanged

Closes #739

## Validation

- reproduced with `cargo test --lib -q lsp::bridge::tests -- --test-threads=16`
- ran the same bridge group successfully three times after the fix
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --check`

## Review status

Draft until revise converges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved language-server integration test setup for hover, completion, and document-link requests.
  * Ensured host sessions are properly initialized before validating each request/response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->