### PR TITLE
fix(bridge): preserve no-workspace initialization

### DIFF
--- a/docs/architecture-decisions/workspace-resolver.md
+++ b/docs/architecture-decisions/workspace-resolver.md
@@ -57,7 +57,8 @@ workspaceResolver = """
 --- first return  — attach? if false, do not attach this document to this server.
 --- second return — workspace folder, a filesystem path (ignored when first is false):
 ---   nil:    attach using the client-supplied workspace fallback — the upstream
----           rootUri/workspaceFolders (the ClientFallback root), not "no folder".
+---           rootUri/workspaceFolders (the ClientFallback root). That fallback
+---           is itself "no folder" when the client opened no workspace.
 ---   string: attach rooted at the given folder (becomes the connection's root).
 --- To resolve a folder from markers, call kakehashi.fs.find_ancestor and return
 --- its result, e.g. `return true, kakehashi.fs.find_ancestor(document_info.path, {"deno.json"})`.
@@ -161,7 +162,8 @@ async-friendliness is achieved at the Rust↔Lua boundary, not inside Lua.
     with the workspace seeding `InitializeParams` via `build_initialize_request`
     (`protocol/lifecycle.rs`). A `nil` workspace maps to the `ClientFallback`
     key — which `workspace_from_marker`'s fallback roots at the **upstream
-    client's** `rootUri`/`workspaceFolders`, not at "no folder".
+    client's** `rootUri`/`workspaceFolders`, and therefore at no folder at all
+    when the client supplied neither (#742).
   - **Shared instance (`preferSharedInstance`, #391).** Marker-rooted documents
     join one `Shared` connection via `workspace/didChangeWorkspaceFolders` (the
     `WorkspaceFolderSet`, defined in `workspace/folder_set.rs`, driven from

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -77,6 +77,7 @@ fn host_position_encoding(capabilities: &ClientCapabilities) -> Option<PositionE
 /// initialization. Kakehashi may use its process CWD internally for config
 /// discovery, but forwarding that fallback would turn a no-workspace session
 /// into an unrelated workspace for every bridged server.
+#[allow(deprecated)]
 fn bridge_root_uri(params: &InitializeParams) -> Option<String> {
     #[allow(deprecated)]
     let primary_uri = params
@@ -85,7 +86,13 @@ fn bridge_root_uri(params: &InitializeParams) -> Option<String> {
         .and_then(|folders| folders.first())
         .map(|folder| &folder.uri)
         .or(params.root_uri.as_ref());
-    primary_uri.map(|uri| uri.as_str().to_string())
+    primary_uri.map(|uri| uri.as_str().to_string()).or_else(|| {
+        params
+            .root_path
+            .as_ref()
+            .and_then(|path| Url::from_file_path(path).ok())
+            .map(|uri| uri.to_string())
+    })
 }
 
 fn bridge_workspace_folders(
@@ -182,9 +189,9 @@ impl Kakehashi {
         let root_uri_for_bridge = bridge_root_uri(&params);
 
         // Forward root_uri and workspace_folders to bridge pool for downstream server initialization
-        self.bridge.pool().set_root_uri(root_uri_for_bridge.clone());
         let workspace_folders_for_bridge =
             bridge_workspace_folders(&params, root_uri_for_bridge.as_deref());
+        self.bridge.pool().set_root_uri(root_uri_for_bridge);
         self.bridge
             .pool()
             .set_workspace_folders(workspace_folders_for_bridge);
@@ -2063,6 +2070,22 @@ mod tests {
         let root_uri = bridge_root_uri(&params);
         assert_eq!(root_uri, None);
         assert_eq!(bridge_workspace_folders(&params, root_uri.as_deref()), None);
+    }
+
+    #[test]
+    fn bridge_root_uri_preserves_legacy_root_path() {
+        let params: InitializeParams = serde_json::from_value(serde_json::json!({
+            "capabilities": {},
+            "rootUri": null,
+            "rootPath": "/tmp/legacy-workspace",
+            "workspaceFolders": null
+        }))
+        .expect("valid initialize params");
+
+        assert_eq!(
+            bridge_root_uri(&params).as_deref(),
+            Some("file:///tmp/legacy-workspace")
+        );
     }
 
     /// A throwaway cancel context for tests that don't exercise cancellation.

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -123,6 +123,17 @@ impl ClientRoot<'_> {
 }
 
 /// Pick the root from the workspace inputs the upstream client actually sent.
+///
+/// An empty `workspaceFolders` does not suppress the deprecated fields, so
+/// `{workspaceFolders: [], rootUri: X}` still roots at `X`. Reviewers read that
+/// pair as contradictory and propose making the empty list authoritative;
+/// it costs more than it looks. LSP gives `[]` no meaning distinct from `null`
+/// ("supports folders, none configured"), while `rootUri` is documented as null
+/// when no folder is open — so a client that meant "no workspace" left the field
+/// that says it unused. And because this ladder also feeds config discovery,
+/// suppressing `X` would not leave that root empty: it would fall through to the
+/// process CWD, trading a location the client named for the launch directory
+/// #742 exists to stop depending on.
 #[allow(deprecated)]
 fn client_root(params: &InitializeParams) -> Option<ClientRoot<'_>> {
     if let Some(folder) = params

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -149,6 +149,17 @@ fn bridge_root_uri(params: &InitializeParams) -> Option<String> {
     }
 }
 
+/// Forward the client's `workspaceFolders` verbatim — including an empty list,
+/// which says "no folders" as deliberately as a missing one — and otherwise
+/// synthesize the single folder that folder-only downstream servers expect from
+/// `root_uri`. Synthesizing translates a root the client did supply; it never
+/// invents one, so a no-workspace session still forwards nothing.
+///
+/// `root_uri` must be [`bridge_root_uri`]'s result for the same `params`.
+///
+/// The folder name mirrors `root_markers::workspace_at_root`, except that this
+/// falls back to a fixed name where that one falls back to the whole URI: the
+/// name here is only ever shown to a downstream server.
 fn bridge_workspace_folders(
     params: &InitializeParams,
     root_uri: Option<&str>,

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -73,27 +73,80 @@ fn host_position_encoding(capabilities: &ClientCapabilities) -> Option<PositionE
         .map(|_| PositionEncodingKind::UTF16)
 }
 
-/// Derive a root URI only from workspace inputs the upstream client supplied
-/// (`workspaceFolders`, `rootUri`, or legacy `rootPath`) for downstream
-/// initialization. Kakehashi may use its process CWD internally for config
-/// discovery, but forwarding that fallback would turn a no-workspace session
-/// into an unrelated workspace for every bridged server.
+/// The workspace root the upstream client supplied, in the precedence order LSP
+/// defines: `workspaceFolders[0]`, then the deprecated `rootUri`, then the
+/// deprecated `rootPath`.
+///
+/// `None` means the client opened no workspace at all. That is a state clients
+/// choose deliberately — single-file sessions, embedded clients — so neither
+/// the forwarded handshake nor config discovery may invent a root for it.
+/// The two consumers still differ in what they do with a root once found,
+/// which is why this shares the ladder and not the conversion.
+enum ClientRoot<'a> {
+    /// The first entry of `workspaceFolders`.
+    WorkspaceFolder(&'a Uri),
+    /// The deprecated `rootUri`.
+    RootUri(&'a Uri),
+    /// The deprecated `rootPath`, which is a filesystem path and not a URI.
+    LegacyPath(&'a str),
+}
+
+impl ClientRoot<'_> {
+    /// How this root's origin reads in the startup log.
+    fn source(&self) -> &'static str {
+        match self {
+            Self::WorkspaceFolder(_) => "workspace folders",
+            Self::RootUri(_) => "root_uri (deprecated)",
+            Self::LegacyPath(_) => "root_path (deprecated)",
+        }
+    }
+
+    /// The root as a filesystem path, for Kakehashi's own config discovery.
+    fn to_file_path(&self) -> Option<std::path::PathBuf> {
+        match self {
+            Self::WorkspaceFolder(uri) | Self::RootUri(uri) => {
+                uri_to_url(uri).ok().and_then(|url| url.to_file_path().ok())
+            }
+            // Only an absolute `rootPath` can anchor relative config paths; a
+            // relative one would resolve against the launch directory, which is
+            // the dependence this handshake exists to avoid.
+            Self::LegacyPath(path) => {
+                let path = std::path::Path::new(path);
+                path.is_absolute().then(|| path.to_path_buf())
+            }
+        }
+    }
+}
+
+/// Pick the root from the workspace inputs the upstream client actually sent.
 #[allow(deprecated)]
-fn bridge_root_uri(params: &InitializeParams) -> Option<String> {
-    #[allow(deprecated)]
-    let primary_uri = params
+fn client_root(params: &InitializeParams) -> Option<ClientRoot<'_>> {
+    if let Some(folder) = params
         .workspace_folders
         .as_ref()
         .and_then(|folders| folders.first())
-        .map(|folder| &folder.uri)
-        .or(params.root_uri.as_ref());
-    primary_uri.map(|uri| uri.as_str().to_string()).or_else(|| {
-        params
-            .root_path
-            .as_ref()
-            .and_then(|path| Url::from_file_path(path).ok())
-            .map(|uri| uri.to_string())
-    })
+    {
+        return Some(ClientRoot::WorkspaceFolder(&folder.uri));
+    }
+    if let Some(uri) = params.root_uri.as_ref() {
+        return Some(ClientRoot::RootUri(uri));
+    }
+    params.root_path.as_deref().map(ClientRoot::LegacyPath)
+}
+
+/// Derive a root URI only from workspace inputs the upstream client supplied,
+/// for downstream initialization. Kakehashi may use its process CWD internally
+/// for config discovery, but forwarding that fallback would turn a
+/// no-workspace session into an unrelated workspace for every bridged server.
+fn bridge_root_uri(params: &InitializeParams) -> Option<String> {
+    match client_root(params)? {
+        ClientRoot::WorkspaceFolder(uri) | ClientRoot::RootUri(uri) => {
+            Some(uri.as_str().to_string())
+        }
+        // `Url::from_file_path` rejects a relative path, so an unanchorable
+        // `rootPath` forwards no workspace rather than one built from the CWD.
+        ClientRoot::LegacyPath(path) => Url::from_file_path(path).ok().map(|uri| uri.to_string()),
+    }
 }
 
 fn bridge_workspace_folders(
@@ -178,16 +231,14 @@ impl Kakehashi {
             "Received initialization request".to_string(),
         )];
 
-        // Extract first workspace folder for reuse
-        let first_folder = params.workspace_folders.as_ref().and_then(|f| f.first());
-
-        // Determine primary URI from workspace folders or deprecated root_uri
-        #[allow(deprecated)]
-        let primary_uri: Option<&Uri> = first_folder.map(|f| &f.uri).or(params.root_uri.as_ref());
-
         // Preserve the upstream workspace contract for downstream servers. The
-        // separate internal root-path fallback below may still use the CWD.
+        // separate internal root path below may still fall back to the CWD.
         let root_uri_for_bridge = bridge_root_uri(&params);
+
+        // Resolved here, into owned values, because `params.capabilities` is
+        // moved into the pool below and that ends any borrow of `params`.
+        let client_root_path: Option<(std::path::PathBuf, &'static str)> =
+            client_root(&params).and_then(|root| root.to_file_path().map(|p| (p, root.source())));
 
         // Forward root_uri and workspace_folders to bridge pool for downstream server initialization
         let workspace_folders_for_bridge =
@@ -213,23 +264,20 @@ impl Kakehashi {
             .pool()
             .set_client_capabilities(params.capabilities);
 
-        // Get root path from primary URI, falling back to current directory
-        let uri_to_path = |uri: &Uri| uri_to_url(uri).ok().and_then(|url| url.to_file_path().ok());
-        let root_path = primary_uri
-            .and_then(uri_to_path)
-            .or_else(|| std::env::current_dir().ok());
+        // Get root path from the client-supplied root, falling back to the
+        // current directory. Unlike the forwarded handshake, config discovery
+        // keeps that fallback: it anchors Kakehashi's own relative paths and
+        // never reaches a downstream server.
+        let (root_path, source) = match client_root_path {
+            Some((path, source)) => (Some(path), source),
+            None => (
+                std::env::current_dir().ok(),
+                "current working directory (fallback)",
+            ),
+        };
 
         // Store root path for later use and log the source
-        #[allow(deprecated)]
         if let Some(ref path) = root_path {
-            let source = if params.workspace_folders.is_some() {
-                "workspace folders"
-            } else if params.root_uri.is_some() {
-                "root_uri (deprecated)"
-            } else {
-                "current working directory (fallback)"
-            };
-
             startup_logs.push((
                 tower_lsp_server::ls_types::MessageType::INFO,
                 format!("Using workspace root from {}: {}", source, path.display()),
@@ -2056,6 +2104,88 @@ mod tests {
             host_position_encoding(&ClientCapabilities::default()),
             None,
             "omitted capability uses the protocol's UTF-16 default",
+        );
+    }
+
+    /// Initialize params carrying only the fields a test names.
+    fn params_with(workspace: serde_json::Value) -> InitializeParams {
+        let mut value = serde_json::json!({ "capabilities": {} });
+        let object = value.as_object_mut().expect("an object");
+        for (key, field) in workspace.as_object().expect("an object") {
+            object.insert(key.clone(), field.clone());
+        }
+        serde_json::from_value(value).expect("valid initialize params")
+    }
+
+    #[test]
+    fn client_root_anchors_config_discovery_to_a_legacy_root_path() {
+        // The forwarded handshake and config discovery read one ladder, so a
+        // client that names its workspace only through the deprecated
+        // `rootPath` still gets its own `kakehashi.toml` — not the launch
+        // directory's.
+        let root_path = std::env::current_dir()
+            .expect("current directory")
+            .join("legacy-workspace");
+        let params = params_with(serde_json::json!({
+            "rootUri": null,
+            "rootPath": root_path,
+            "workspaceFolders": null
+        }));
+
+        let root = client_root(&params).expect("a client-supplied root");
+        assert_eq!(root.to_file_path(), Some(root_path));
+        assert_eq!(root.source(), "root_path (deprecated)");
+    }
+
+    #[test]
+    fn client_root_rejects_a_relative_legacy_root_path() {
+        // A relative `rootPath` resolves against the launch directory, so it
+        // cannot anchor config paths; falling through to the CWD fallback keeps
+        // that dependence named in the startup log instead of hidden.
+        let params = params_with(serde_json::json!({
+            "rootUri": null,
+            "rootPath": "relative/workspace",
+            "workspaceFolders": null
+        }));
+
+        let root = client_root(&params).expect("a client-supplied root");
+        assert_eq!(root.to_file_path(), None);
+        assert_eq!(bridge_root_uri(&params), None);
+    }
+
+    #[test]
+    fn client_root_prefers_workspace_folders_over_the_deprecated_fields() {
+        let params = params_with(serde_json::json!({
+            "rootUri": "file:///from-root-uri",
+            "rootPath": "/from-root-path",
+            "workspaceFolders": [{ "uri": "file:///from-folders", "name": "folders" }]
+        }));
+
+        assert_eq!(
+            bridge_root_uri(&params).as_deref(),
+            Some("file:///from-folders")
+        );
+        assert_eq!(
+            client_root(&params).expect("a root").source(),
+            "workspace folders"
+        );
+    }
+
+    #[test]
+    fn client_root_prefers_root_uri_over_the_legacy_root_path() {
+        let params = params_with(serde_json::json!({
+            "rootUri": "file:///from-root-uri",
+            "rootPath": "/from-root-path",
+            "workspaceFolders": null
+        }));
+
+        assert_eq!(
+            bridge_root_uri(&params).as_deref(),
+            Some("file:///from-root-uri")
+        );
+        assert_eq!(
+            client_root(&params).expect("a root").source(),
+            "root_uri (deprecated)"
         );
     }
 

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -2075,7 +2075,14 @@ mod tests {
 
     #[test]
     fn bridge_root_uri_preserves_legacy_root_path() {
-        let root_path = std::env::current_dir().expect("current directory");
+        // A directory the process is NOT running in: the removed fallback
+        // forwarded the CWD, so a CWD-valued fixture would pass under both the
+        // old and the new derivation and pin nothing. Built from the CWD rather
+        // than a literal so the path stays absolute on Windows too.
+        let root_path = std::env::current_dir()
+            .expect("current directory")
+            .join("legacy-workspace");
+        let expected = Url::from_file_path(&root_path).expect("an absolute root path");
         let params: InitializeParams = serde_json::from_value(serde_json::json!({
             "capabilities": {},
             "rootUri": null,
@@ -2084,13 +2091,7 @@ mod tests {
         }))
         .expect("valid initialize params");
 
-        assert_eq!(
-            bridge_root_uri(&params).as_deref(),
-            Url::from_file_path(&root_path)
-                .ok()
-                .as_ref()
-                .map(Url::as_str)
-        );
+        assert_eq!(bridge_root_uri(&params).as_deref(), Some(expected.as_str()));
     }
 
     /// A throwaway cancel context for tests that don't exercise cancellation.

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -77,11 +77,15 @@ fn host_position_encoding(capabilities: &ClientCapabilities) -> Option<PositionE
 /// defines: `workspaceFolders[0]`, then the deprecated `rootUri`, then the
 /// deprecated `rootPath`.
 ///
-/// `None` means the client opened no workspace at all. That is a state clients
-/// choose deliberately — single-file sessions, embedded clients — so neither
-/// the forwarded handshake nor config discovery may invent a root for it.
-/// The two consumers still differ in what they do with a root once found,
-/// which is why this shares the ladder and not the conversion.
+/// `None` means the client opened no workspace at all — a state clients choose
+/// deliberately (single-file sessions, embedded clients). The forwarded
+/// handshake must preserve it: inventing a root there is what #742 reported.
+/// Config discovery may still fall back to the process CWD for its own root,
+/// which the startup log names, because that root anchors Kakehashi's relative
+/// paths and never reaches a downstream server.
+///
+/// The two consumers differ in what they do with a root once found, which is
+/// why this shares the ladder and not the conversion.
 enum ClientRoot<'a> {
     /// The first entry of `workspaceFolders`.
     WorkspaceFolder(&'a Uri),

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -73,7 +73,8 @@ fn host_position_encoding(capabilities: &ClientCapabilities) -> Option<PositionE
         .map(|_| PositionEncodingKind::UTF16)
 }
 
-/// Derive only the root URI the upstream client supplied for downstream
+/// Derive a root URI only from workspace inputs the upstream client supplied
+/// (`workspaceFolders`, `rootUri`, or legacy `rootPath`) for downstream
 /// initialization. Kakehashi may use its process CWD internally for config
 /// discovery, but forwarding that fallback would turn a no-workspace session
 /// into an unrelated workspace for every bridged server.
@@ -2074,17 +2075,21 @@ mod tests {
 
     #[test]
     fn bridge_root_uri_preserves_legacy_root_path() {
+        let root_path = std::env::current_dir().expect("current directory");
         let params: InitializeParams = serde_json::from_value(serde_json::json!({
             "capabilities": {},
             "rootUri": null,
-            "rootPath": "/tmp/legacy-workspace",
+            "rootPath": root_path,
             "workspaceFolders": null
         }))
         .expect("valid initialize params");
 
         assert_eq!(
             bridge_root_uri(&params).as_deref(),
-            Some("file:///tmp/legacy-workspace")
+            Url::from_file_path(&root_path)
+                .ok()
+                .as_ref()
+                .map(Url::as_str)
         );
     }
 

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -2044,7 +2044,7 @@ mod tests {
     }
 
     #[test]
-    fn bridge_workspace_context_preserves_no_workspace_initialize() {
+    fn bridge_root_uri_preserves_no_workspace_initialize() {
         let params: InitializeParams = serde_json::from_value(serde_json::json!({
             "capabilities": {},
             "rootUri": null,

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -73,6 +73,21 @@ fn host_position_encoding(capabilities: &ClientCapabilities) -> Option<PositionE
         .map(|_| PositionEncodingKind::UTF16)
 }
 
+/// Derive only the root URI the upstream client supplied for downstream
+/// initialization. Kakehashi may use its process CWD internally for config
+/// discovery, but forwarding that fallback would turn a no-workspace session
+/// into an unrelated workspace for every bridged server.
+fn bridge_root_uri(params: &InitializeParams) -> Option<String> {
+    #[allow(deprecated)]
+    let primary_uri = params
+        .workspace_folders
+        .as_ref()
+        .and_then(|folders| folders.first())
+        .map(|folder| &folder.uri)
+        .or(params.root_uri.as_ref());
+    primary_uri.map(|uri| uri.as_str().to_string())
+}
+
 impl Kakehashi {
     pub(crate) async fn initialize_impl(
         &self,
@@ -131,18 +146,12 @@ impl Kakehashi {
         #[allow(deprecated)]
         let primary_uri: Option<&Uri> = first_folder.map(|f| &f.uri).or(params.root_uri.as_ref());
 
-        // Get root URI string for downstream servers, falling back to current directory
-        let root_uri_for_bridge: Option<String> =
-            primary_uri.map(|uri| uri.to_string()).or_else(|| {
-                std::env::current_dir()
-                    .ok()
-                    .and_then(|p| Url::from_file_path(p).ok())
-                    .map(|u| u.to_string())
-            });
+        // Preserve the upstream workspace contract for downstream servers. The
+        // separate internal root-path fallback below may still use the CWD.
+        let root_uri_for_bridge = bridge_root_uri(&params);
 
         // Forward root_uri and workspace_folders to bridge pool for downstream server initialization
         self.bridge.pool().set_root_uri(root_uri_for_bridge.clone());
-
         use std::str::FromStr as _;
         let workspace_folders_for_bridge = params.workspace_folders.clone().or_else(|| {
             root_uri_for_bridge.as_ref().and_then(|uri| {
@@ -2032,6 +2041,18 @@ mod tests {
             None,
             "omitted capability uses the protocol's UTF-16 default",
         );
+    }
+
+    #[test]
+    fn bridge_workspace_context_preserves_no_workspace_initialize() {
+        let params: InitializeParams = serde_json::from_value(serde_json::json!({
+            "capabilities": {},
+            "rootUri": null,
+            "workspaceFolders": null
+        }))
+        .expect("valid initialize params");
+
+        assert_eq!(bridge_root_uri(&params), None);
     }
 
     /// A throwaway cancel context for tests that don't exercise cancellation.

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -88,6 +88,37 @@ fn bridge_root_uri(params: &InitializeParams) -> Option<String> {
     primary_uri.map(|uri| uri.as_str().to_string())
 }
 
+fn bridge_workspace_folders(
+    params: &InitializeParams,
+    root_uri: Option<&str>,
+) -> Option<Vec<tower_lsp_server::ls_types::WorkspaceFolder>> {
+    use std::str::FromStr as _;
+    params.workspace_folders.clone().or_else(|| {
+        root_uri.and_then(|uri| {
+            let name = Url::parse(uri)
+                .ok()
+                .and_then(|url| {
+                    url.to_file_path()
+                        .ok()
+                        .and_then(|path| {
+                            path.file_name().and_then(|s| s.to_str().map(String::from))
+                        })
+                        .or_else(|| {
+                            url.path_segments()
+                                .and_then(|mut seg| seg.next_back().map(|s| s.to_string()))
+                        })
+                })
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "workspace".to_string());
+            let folder_uri = Uri::from_str(uri).ok()?;
+            Some(vec![tower_lsp_server::ls_types::WorkspaceFolder {
+                uri: folder_uri,
+                name,
+            }])
+        })
+    })
+}
+
 impl Kakehashi {
     pub(crate) async fn initialize_impl(
         &self,
@@ -152,31 +183,8 @@ impl Kakehashi {
 
         // Forward root_uri and workspace_folders to bridge pool for downstream server initialization
         self.bridge.pool().set_root_uri(root_uri_for_bridge.clone());
-        use std::str::FromStr as _;
-        let workspace_folders_for_bridge = params.workspace_folders.clone().or_else(|| {
-            root_uri_for_bridge.as_ref().and_then(|uri| {
-                let name = Url::parse(uri)
-                    .ok()
-                    .and_then(|url| {
-                        url.to_file_path()
-                            .ok()
-                            .and_then(|path| {
-                                path.file_name().and_then(|s| s.to_str().map(String::from))
-                            })
-                            .or_else(|| {
-                                url.path_segments()
-                                    .and_then(|mut seg| seg.next_back().map(|s| s.to_string()))
-                            })
-                    })
-                    .filter(|s| !s.is_empty())
-                    .unwrap_or_else(|| "workspace".to_string());
-                let folder_uri = tower_lsp_server::ls_types::Uri::from_str(uri).ok()?;
-                Some(vec![tower_lsp_server::ls_types::WorkspaceFolder {
-                    uri: folder_uri,
-                    name,
-                }])
-            })
-        });
+        let workspace_folders_for_bridge =
+            bridge_workspace_folders(&params, root_uri_for_bridge.as_deref());
         self.bridge
             .pool()
             .set_workspace_folders(workspace_folders_for_bridge);
@@ -2052,7 +2060,9 @@ mod tests {
         }))
         .expect("valid initialize params");
 
-        assert_eq!(bridge_root_uri(&params), None);
+        let root_uri = bridge_root_uri(&params);
+        assert_eq!(root_uri, None);
+        assert_eq!(bridge_workspace_folders(&params, root_uri.as_deref()), None);
     }
 
     /// A throwaway cancel context for tests that don't exercise cancellation.

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -149,6 +149,23 @@ fn client_root(params: &InitializeParams) -> Option<ClientRoot<'_>> {
     params.root_path.as_deref().map(ClientRoot::LegacyPath)
 }
 
+/// Kakehashi's own root, paired with the origin the startup log reports: the
+/// client's root when it named an anchorable one, else the process CWD.
+///
+/// This is the fallback the bridge side deliberately does not have. It anchors
+/// relative config paths and `kakehashi.toml` discovery and never reaches a
+/// downstream server, so a no-workspace session forwards nothing while still
+/// resolving Kakehashi's own configuration.
+fn config_root_path(root: Option<ClientRoot<'_>>) -> (Option<std::path::PathBuf>, &'static str) {
+    match root.and_then(|root| root.to_file_path().map(|path| (path, root.source()))) {
+        Some((path, source)) => (Some(path), source),
+        None => (
+            std::env::current_dir().ok(),
+            "current working directory (fallback)",
+        ),
+    }
+}
+
 /// Derive a root URI only from workspace inputs the upstream client supplied,
 /// for downstream initialization. Kakehashi may use its process CWD internally
 /// for config discovery, but forwarding that fallback would turn a
@@ -263,8 +280,7 @@ impl Kakehashi {
 
         // Resolved here, into owned values, because `params.capabilities` is
         // moved into the pool below and that ends any borrow of `params`.
-        let client_root_path: Option<(std::path::PathBuf, &'static str)> =
-            client_root(&params).and_then(|root| root.to_file_path().map(|p| (p, root.source())));
+        let (root_path, source) = config_root_path(client_root(&params));
 
         // Forward root_uri and workspace_folders to bridge pool for downstream server initialization
         let workspace_folders_for_bridge =
@@ -289,18 +305,6 @@ impl Kakehashi {
         self.bridge
             .pool()
             .set_client_capabilities(params.capabilities);
-
-        // Get root path from the client-supplied root, falling back to the
-        // current directory. Unlike the forwarded handshake, config discovery
-        // keeps that fallback: it anchors Kakehashi's own relative paths and
-        // never reaches a downstream server.
-        let (root_path, source) = match client_root_path {
-            Some((path, source)) => (Some(path), source),
-            None => (
-                std::env::current_dir().ok(),
-                "current working directory (fallback)",
-            ),
-        };
 
         // Store root path for later use and log the source
         if let Some(ref path) = root_path {

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -2168,6 +2168,60 @@ mod tests {
     }
 
     #[test]
+    fn config_root_keeps_the_cwd_when_the_client_opened_no_workspace() {
+        // The asymmetry this change turns on, in one place: the handshake
+        // forwards nothing, while Kakehashi still resolves its own config
+        // against the launch directory. Deleting the surviving fallback for
+        // symmetry with the bridge would break config discovery for exactly
+        // the sessions #742 is about.
+        let params = params_with(serde_json::json!({
+            "rootUri": null,
+            "workspaceFolders": null
+        }));
+
+        assert_eq!(bridge_root_uri(&params), None, "nothing is forwarded");
+
+        let (root_path, source) = config_root_path(client_root(&params));
+        assert_eq!(root_path, std::env::current_dir().ok());
+        assert_eq!(source, "current working directory (fallback)");
+    }
+
+    #[test]
+    fn config_root_reports_the_rung_it_resolved() {
+        let root_path = std::env::current_dir()
+            .expect("current directory")
+            .join("legacy-workspace");
+        let params = params_with(serde_json::json!({
+            "rootUri": null,
+            "rootPath": root_path,
+            "workspaceFolders": null
+        }));
+
+        let (resolved, source) = config_root_path(client_root(&params));
+        assert_eq!(resolved, Some(root_path));
+        assert_eq!(
+            source, "root_path (deprecated)",
+            "the log must not call a client-named root a CWD fallback"
+        );
+    }
+
+    #[test]
+    fn config_root_falls_back_when_the_legacy_root_path_is_unanchorable() {
+        let params = params_with(serde_json::json!({
+            "rootUri": null,
+            "rootPath": "relative/workspace",
+            "workspaceFolders": null
+        }));
+
+        let (root_path, source) = config_root_path(client_root(&params));
+        assert_eq!(root_path, std::env::current_dir().ok());
+        assert_eq!(
+            source, "current working directory (fallback)",
+            "a dropped root must be reported as the fallback it became"
+        );
+    }
+
+    #[test]
     fn client_root_rejects_a_relative_legacy_root_path() {
         // A relative `rootPath` resolves against the launch directory, so it
         // cannot anchor config paths; falling through to the CWD fallback keeps

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -2200,6 +2200,88 @@ mod tests {
         );
     }
 
+    /// The folder `bridge_workspace_folders` forwards for `params`, as
+    /// `(uri, name)` — the shape a downstream server receives.
+    fn forwarded_folders(params: &InitializeParams) -> Option<Vec<(String, String)>> {
+        let root_uri = bridge_root_uri(params);
+        bridge_workspace_folders(params, root_uri.as_deref()).map(|folders| {
+            folders
+                .into_iter()
+                .map(|folder| (folder.uri.as_str().to_string(), folder.name))
+                .collect()
+        })
+    }
+
+    #[test]
+    fn bridge_workspace_folders_names_a_synthesized_folder_after_the_root() {
+        let params = params_with(serde_json::json!({
+            "rootUri": "file:///home/dev/my-project",
+            "workspaceFolders": null
+        }));
+
+        assert_eq!(
+            forwarded_folders(&params),
+            Some(vec![(
+                "file:///home/dev/my-project".to_string(),
+                "my-project".to_string()
+            )])
+        );
+    }
+
+    #[test]
+    fn bridge_workspace_folders_synthesizes_from_a_legacy_root_path() {
+        let root_path = std::env::current_dir()
+            .expect("current directory")
+            .join("legacy-workspace");
+        let expected_uri = Url::from_file_path(&root_path).expect("an absolute root path");
+        let params = params_with(serde_json::json!({
+            "rootUri": null,
+            "rootPath": root_path,
+            "workspaceFolders": null
+        }));
+
+        assert_eq!(
+            forwarded_folders(&params),
+            Some(vec![(
+                expected_uri.as_str().to_string(),
+                "legacy-workspace".to_string()
+            )])
+        );
+    }
+
+    #[test]
+    fn bridge_workspace_folders_falls_back_to_a_fixed_name_without_a_segment() {
+        // A root with no last segment to name: `path_segments` yields the empty
+        // string, which must not become the folder name.
+        let params = params_with(serde_json::json!({
+            "rootUri": "file:///",
+            "workspaceFolders": null
+        }));
+
+        assert_eq!(
+            forwarded_folders(&params),
+            Some(vec![("file:///".to_string(), "workspace".to_string())])
+        );
+    }
+
+    #[test]
+    fn bridge_workspace_folders_forwards_an_empty_list_verbatim() {
+        // `[]` is the client saying it has no folders. Synthesizing one from
+        // `rootUri` here would invent the workspace #742 is about, so the empty
+        // list is forwarded as sent.
+        let params = params_with(serde_json::json!({
+            "rootUri": "file:///home/dev/my-project",
+            "workspaceFolders": []
+        }));
+
+        assert_eq!(forwarded_folders(&params), Some(vec![]));
+        assert_eq!(
+            bridge_root_uri(&params).as_deref(),
+            Some("file:///home/dev/my-project"),
+            "an empty folder list leaves the client's own rootUri untouched"
+        );
+    }
+
     #[test]
     fn bridge_root_uri_preserves_no_workspace_initialize() {
         let params: InitializeParams = serde_json::from_value(serde_json::json!({


### PR DESCRIPTION
## Summary

- preserve an upstream no-workspace initialize state for bridged servers
- keep the process-CWD fallback internal to Kakehashi config discovery
- feed the forwarded handshake and config discovery from one client-root ladder, so a `rootPath`-only client anchors both at the workspace it named
- add regression tests for `rootUri`/`workspaceFolders` null, the legacy `rootPath` rung, and the surviving folder synthesis

Closes #742.

## Behavior

`initialize` params forwarded to bridged servers are now derived only from what the upstream client sent: `workspaceFolders[0]` → `rootUri` → deprecated `rootPath` → nothing. A client that opened no workspace forwards `rootUri: null` and no folders instead of Kakehashi's launch directory.

Kakehashi's own root keeps its CWD fallback — it anchors relative config paths and never reaches a downstream server — but it now reads the same ladder, including the `rootPath` rung the bridge honors. Previously the two agreed only by both falling back to the CWD, so a `rootPath`-only client rooted its language servers correctly while its own `kakehashi.toml` was discovered from the launch directory. The startup log names that rung instead of reporting a CWD fallback.

A relative `rootPath` still falls through to the CWD: it can only resolve against the launch directory, which is the dependence this handshake avoids.

## Scope notes

- An empty `workspaceFolders: []` is forwarded verbatim. It is the client saying it has no folders, as deliberately as a missing list; synthesizing one from `rootUri` would invent the workspace this PR removes.
- `ls_types::InitializeParams::workspace_folders` is `skip_serializing_if = "Option::is_none"`, so no folders means the key is omitted rather than sent as `null`. Both spellings are spec-legal and `rootUri: null` is emitted explicitly; expressing the distinction would need a serialization wrapper, which is out of scope here.
- Downstream servers are still spawned without an explicit `current_dir`, so one that self-falls-back to its process CWD on a null root can still land in the launch directory. That is the remaining half of #742 and needs its own change.

## Validation

- `cargo test --lib` — 3215 passed, 0 failed
- `cargo clippy --lib --tests` — no new warnings (9 pre-existing on `main`, none in the changed files)
- `cargo fmt --check`
- full local integration + e2e tier (`scripts/test_e2e_parallel.sh`) — 58 binaries, 1745 tests, 0 failures; CI does not run this tier

Downstream-side null forwarding is additionally pinned by the pre-existing `initialize_request_has_null_root_uri_when_not_provided` in `src/lsp/bridge/protocol/lifecycle.rs`.
