### PR TITLE
feat(lsp): track workspace folder lifecycle

### DIFF
--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -413,10 +413,9 @@ pub struct LanguageServerPool {
     /// Passed to downstream servers during LSP handshake so they can provide
     /// workspace-aware features (diagnostics, go-to-definition, etc.).
     root_uri: OnceLock<Option<String>>,
-    /// Workspace folders forwarded from upstream client.
-    ///
-    /// Set once via `set_workspace_folders()` after receiving the upstream initialize request.
-    /// Passed to downstream servers during LSP handshake.
+    /// Current workspace folders from the upstream client. Seeded during
+    /// initialize, then updated by `workspace/didChangeWorkspaceFolders` and
+    /// snapshotted for each later downstream handshake.
     workspace_folders: super::WorkspaceFolderSet,
     /// Client capabilities forwarded from upstream client.
     ///
@@ -635,8 +634,7 @@ impl LanguageServerPool {
 
     /// Set the workspace folders.
     ///
-    /// Called once during upstream initialize to forward workspace folders to downstream servers.
-    /// Subsequent calls are ignored (OnceLock semantics).
+    /// Called during upstream initialize to seed the workspace-folder snapshot.
     pub(crate) fn set_workspace_folders(
         &self,
         folders: Option<Vec<tower_lsp_server::ls_types::WorkspaceFolder>>,

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -3391,6 +3391,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn workspace_folder_change_arms_every_recycled_connection_for_reopen() {
+        // Dropping the connection is only half the repair: its replacement
+        // starts with nothing open, and only an armed key gets a re-open
+        // dispatched when that replacement goes Ready. Arming unconditionally
+        // is what the settings-reload purge does, and for the same reason — a
+        // connection recycled mid-handshake holds no documents to report, yet
+        // its replacement still has to be brought up to date.
+        let pool = LanguageServerPool::new();
+        let capable_key = ConnectionKey::for_server("capable");
+        let incapable_key = ConnectionKey::for_server("incapable");
+        let initializing_key = ConnectionKey::for_server("initializing");
+        let capable = create_handle_with_key(ConnectionState::Ready, capable_key.clone()).await;
+        capable.set_server_capabilities(capable_workspace_folders_caps());
+        let incapable = create_handle_with_key(ConnectionState::Ready, incapable_key.clone()).await;
+        incapable.set_server_capabilities(Default::default());
+        let initializing =
+            create_handle_with_key(ConnectionState::Initializing, initializing_key.clone()).await;
+        pool.insert_connection(capable).await;
+        pool.insert_connection(incapable).await;
+        pool.insert_connection(initializing).await;
+        let added = tower_lsp_server::ls_types::WorkspaceFolder {
+            uri: "file:///added".parse().unwrap(),
+            name: "added".to_string(),
+        };
+
+        pool.apply_workspace_folder_change(vec![added], &[]).await;
+
+        assert!(
+            pool.pending_reopen.claim(&incapable_key).is_some(),
+            "a fallback recycled for lacking the capability owes a re-open"
+        );
+        assert!(
+            pool.pending_reopen.claim(&initializing_key).is_some(),
+            "a connection recycled mid-handshake owes one even though it held nothing"
+        );
+        assert!(
+            pool.pending_reopen.claim(&capable_key).is_none(),
+            "a connection that took the notification keeps its documents open"
+        );
+    }
+
+    #[tokio::test]
     async fn workspace_folder_change_does_not_touch_marker_owned_connection() {
         let pool = LanguageServerPool::new();
         let key = ConnectionKey::new("marker", Some("file:///marker".to_string()));

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -663,9 +663,20 @@ impl LanguageServerPool {
 
         let mut connections = self.connections.lock().await;
         let mut invalidated = Vec::new();
-        for (key, handle) in connections.iter().filter(|(_, handle)| {
-            handle.state() == ConnectionState::Ready && handle.supports_workspace_folder_changes()
-        }) {
+        for (key, handle) in connections.iter() {
+            if handle.state() == ConnectionState::Initializing {
+                // Its initialize request captured the old snapshot and an LSP
+                // notification cannot be sent until after `initialized`.
+                // Recycle it so the next acquisition handshakes with the
+                // committed snapshot instead of retaining stale folders.
+                invalidated.push(key.clone());
+                continue;
+            }
+            if handle.state() != ConnectionState::Ready
+                || !handle.supports_workspace_folder_changes()
+            {
+                continue;
+            }
             let notification =
                 build_did_change_workspace_folders_notification(added.clone(), removed.to_vec());
             if handle.send_notification(notification) == NotificationSendResult::Queued {
@@ -3347,6 +3358,25 @@ mod tests {
 
         assert_eq!(capable.workspace_folders().snapshot(), Some(vec![added]));
         assert_eq!(incapable.workspace_folders().snapshot(), None);
+    }
+
+    #[tokio::test]
+    async fn workspace_folder_change_recycles_initializing_connection() {
+        let pool = LanguageServerPool::new();
+        let key = ConnectionKey::for_server("initializing");
+        let handle = create_handle_with_key(ConnectionState::Initializing, key.clone()).await;
+        pool.insert_connection(handle).await;
+        let added = tower_lsp_server::ls_types::WorkspaceFolder {
+            uri: "file:///added".parse().unwrap(),
+            name: "added".to_string(),
+        };
+
+        pool.apply_workspace_folder_change(vec![added], &[]).await;
+
+        assert!(
+            !pool.connections.lock().await.contains_key(&key),
+            "a handshake seeded from the old snapshot must not remain reusable"
+        );
     }
 
     fn shared_config() -> crate::config::settings::BridgeServerConfig {

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -661,8 +661,9 @@ impl LanguageServerPool {
                 .and_then(|folders| folders.first().map(|folder| folder.uri.to_string())),
         );
 
-        let connections = self.connections.lock().await;
-        for handle in connections.values().filter(|handle| {
+        let mut connections = self.connections.lock().await;
+        let mut invalidated = Vec::new();
+        for (key, handle) in connections.iter().filter(|(_, handle)| {
             handle.state() == ConnectionState::Ready && handle.supports_workspace_folder_changes()
         }) {
             let notification =
@@ -671,7 +672,28 @@ impl LanguageServerPool {
                 handle
                     .workspace_folders()
                     .apply_change(added.clone(), removed);
+            } else {
+                invalidated.push(key.clone());
             }
+        }
+        let mut stale_handles = Vec::new();
+        for key in invalidated {
+            if let Some(handle) = connections.get(&key) {
+                handle.begin_shutdown();
+            }
+            self.host_documents
+                .lock()
+                .await
+                .retain(|(_, connection_key), _| connection_key != &key);
+            self.document_tracker.purge_connection(&key).await;
+            self.purge_open_transition_locks(&key).await;
+            if let Some(handle) = connections.remove(&key) {
+                stale_handles.push((key, handle));
+            }
+        }
+        drop(connections);
+        for (key, handle) in stale_handles {
+            shutdown_invalidated_connection(key, handle);
         }
     }
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -409,10 +409,10 @@ pub struct LanguageServerPool {
     consecutive_panic_counts: std::sync::Mutex<HashMap<ConnectionKey, u32>>,
     /// Workspace root URI forwarded from upstream client.
     ///
-    /// Set once via `set_root_uri()` after receiving the upstream initialize request.
+    /// Seeded during initialize and updated when the primary workspace folder changes.
     /// Passed to downstream servers during LSP handshake so they can provide
     /// workspace-aware features (diagnostics, go-to-definition, etc.).
-    root_uri: OnceLock<Option<String>>,
+    root_uri: arc_swap::ArcSwap<Option<String>>,
     /// Current workspace folders from the upstream client. Seeded during
     /// initialize, then updated by `workspace/didChangeWorkspaceFolders` and
     /// snapshotted for each later downstream handshake.
@@ -514,7 +514,7 @@ impl LanguageServerPool {
             upstream_request_registry: std::sync::Mutex::new(HashMap::new()),
             cancel_metrics: CancelForwardingMetrics::default(),
             consecutive_panic_counts: std::sync::Mutex::new(HashMap::new()),
-            root_uri: OnceLock::new(),
+            root_uri: arc_swap::ArcSwap::new(Arc::new(None)),
             workspace_folders: super::WorkspaceFolderSet::new(None),
             client_capabilities: OnceLock::new(),
             log_message_level: AtomicU8::new(
@@ -621,15 +621,14 @@ impl LanguageServerPool {
 
     /// Set the workspace root URI.
     ///
-    /// Called once during upstream initialize to forward the root URI to downstream servers.
-    /// Subsequent calls are ignored (OnceLock semantics).
+    /// Called during initialize and when the primary workspace folder changes.
     pub(crate) fn set_root_uri(&self, uri: Option<String>) {
-        let _ = self.root_uri.set(uri);
+        self.root_uri.store(Arc::new(uri));
     }
 
     /// Get the workspace root URI.
     fn root_uri(&self) -> Option<String> {
-        self.root_uri.get().and_then(|v| v.clone())
+        self.root_uri.load().as_ref().clone()
     }
 
     /// Set the workspace folders.
@@ -643,18 +642,37 @@ impl LanguageServerPool {
     }
 
     /// Get the workspace folders.
-    fn workspace_folders(&self) -> Option<Vec<tower_lsp_server::ls_types::WorkspaceFolder>> {
+    pub(crate) fn workspace_folders(
+        &self,
+    ) -> Option<Vec<tower_lsp_server::ls_types::WorkspaceFolder>> {
         self.workspace_folders.snapshot()
     }
 
     /// Update the upstream client workspace snapshot used by future
     /// client-fallback downstream connections.
-    pub(crate) fn apply_workspace_folder_change(
+    pub(crate) async fn apply_workspace_folder_change(
         &self,
         added: Vec<tower_lsp_server::ls_types::WorkspaceFolder>,
         removed: &[tower_lsp_server::ls_types::WorkspaceFolder],
     ) {
-        self.workspace_folders.apply_change(added, removed);
+        self.workspace_folders.apply_change(added.clone(), removed);
+        self.set_root_uri(
+            self.workspace_folders()
+                .and_then(|folders| folders.first().map(|folder| folder.uri.to_string())),
+        );
+
+        let connections = self.connections.lock().await;
+        for handle in connections.values().filter(|handle| {
+            handle.state() == ConnectionState::Ready && handle.supports_workspace_folder_changes()
+        }) {
+            let notification =
+                build_did_change_workspace_folders_notification(added.clone(), removed.to_vec());
+            if handle.send_notification(notification) == NotificationSendResult::Queued {
+                handle
+                    .workspace_folders()
+                    .apply_change(added.clone(), removed);
+            }
+        }
     }
 
     /// Set the upstream client capabilities.
@@ -2162,9 +2180,11 @@ impl LanguageServerPool {
         let announced = handle
             .workspace_folders()
             .add_and_announce(folder.clone(), || {
-                let result = handle.send_notification(
-                    build_did_change_workspace_folders_notification(vec![folder.clone()]),
-                );
+                let result =
+                    handle.send_notification(build_did_change_workspace_folders_notification(
+                        vec![folder.clone()],
+                        Vec::new(),
+                    ));
                 send_outcome = result;
                 if result == NotificationSendResult::Queued {
                     log::debug!(
@@ -3259,6 +3279,52 @@ mod tests {
             }),
             ..Default::default()
         }
+    }
+
+    #[tokio::test]
+    async fn workspace_folder_change_updates_primary_root_for_future_spawns() {
+        let pool = LanguageServerPool::new();
+        let folder = |uri: &str| tower_lsp_server::ls_types::WorkspaceFolder {
+            uri: uri.parse().unwrap(),
+            name: uri.to_string(),
+        };
+        let original = folder("file:///original");
+        let replacement = folder("file:///replacement");
+        pool.set_root_uri(Some(original.uri.to_string()));
+        pool.set_workspace_folders(Some(vec![original.clone()]));
+
+        pool.apply_workspace_folder_change(vec![replacement.clone()], &[original])
+            .await;
+
+        assert_eq!(pool.root_uri().as_deref(), Some("file:///replacement"));
+        assert_eq!(pool.workspace_folders(), Some(vec![replacement]));
+    }
+
+    #[tokio::test]
+    async fn workspace_folder_change_forwards_only_to_capable_ready_connections() {
+        let pool = LanguageServerPool::new();
+        let capable =
+            create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("capable"))
+                .await;
+        capable.set_server_capabilities(capable_workspace_folders_caps());
+        let incapable = create_handle_with_key(
+            ConnectionState::Ready,
+            ConnectionKey::for_server("incapable"),
+        )
+        .await;
+        incapable.set_server_capabilities(Default::default());
+        pool.insert_connection(Arc::clone(&capable)).await;
+        pool.insert_connection(Arc::clone(&incapable)).await;
+        let added = tower_lsp_server::ls_types::WorkspaceFolder {
+            uri: "file:///added".parse().unwrap(),
+            name: "added".to_string(),
+        };
+
+        pool.apply_workspace_folder_change(vec![added.clone()], &[])
+            .await;
+
+        assert_eq!(capable.workspace_folders().snapshot(), Some(vec![added]));
+        assert_eq!(incapable.workspace_folders().snapshot(), None);
     }
 
     fn shared_config() -> crate::config::settings::BridgeServerConfig {

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -639,9 +639,7 @@ impl LanguageServerPool {
         &self,
         folders: Option<Vec<tower_lsp_server::ls_types::WorkspaceFolder>>,
     ) {
-        if let Some(folders) = folders {
-            self.workspace_folders.apply_change(folders, &[]);
-        }
+        self.workspace_folders.replace(folders);
     }
 
     /// Get the workspace folders.

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -665,7 +665,12 @@ impl LanguageServerPool {
         let mut invalidated = Vec::new();
         for (key, handle) in connections.iter() {
             let follows_client_workspace = key.is_client_fallback() || key.is_shared();
-            if follows_client_workspace && handle.state() == ConnectionState::Initializing {
+            if !follows_client_workspace {
+                // Marker-owned connections derive their workspace from the
+                // marker root, not the upstream client-folder snapshot.
+                continue;
+            }
+            if handle.state() == ConnectionState::Initializing {
                 // Its initialize request captured the old snapshot and an LSP
                 // notification cannot be sent until after `initialized`.
                 // Recycle it so the next acquisition handshakes with the
@@ -677,9 +682,7 @@ impl LanguageServerPool {
                 continue;
             }
             if !handle.supports_workspace_folder_changes() {
-                if follows_client_workspace {
-                    invalidated.push(key.clone());
-                }
+                invalidated.push(key.clone());
                 continue;
             }
             let notification =
@@ -3385,6 +3388,27 @@ mod tests {
             !pool.connections.lock().await.contains_key(&key),
             "a handshake seeded from the old snapshot must not remain reusable"
         );
+    }
+
+    #[tokio::test]
+    async fn workspace_folder_change_does_not_touch_marker_owned_connection() {
+        let pool = LanguageServerPool::new();
+        let key = ConnectionKey::new("marker", Some("file:///marker".to_string()));
+        let handle = create_handle_with_key(ConnectionState::Ready, key.clone()).await;
+        handle.set_server_capabilities(capable_workspace_folders_caps());
+        pool.insert_connection(Arc::clone(&handle)).await;
+
+        pool.apply_workspace_folder_change(
+            vec![tower_lsp_server::ls_types::WorkspaceFolder {
+                uri: "file:///client".parse().unwrap(),
+                name: "client".to_string(),
+            }],
+            &[],
+        )
+        .await;
+
+        assert!(pool.connections.lock().await.contains_key(&key));
+        assert_eq!(handle.workspace_folders().snapshot(), None);
     }
 
     fn shared_config() -> crate::config::settings::BridgeServerConfig {

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -664,7 +664,8 @@ impl LanguageServerPool {
         let mut connections = self.connections.lock().await;
         let mut invalidated = Vec::new();
         for (key, handle) in connections.iter() {
-            if handle.state() == ConnectionState::Initializing {
+            let follows_client_workspace = key.is_client_fallback() || key.is_shared();
+            if follows_client_workspace && handle.state() == ConnectionState::Initializing {
                 // Its initialize request captured the old snapshot and an LSP
                 // notification cannot be sent until after `initialized`.
                 // Recycle it so the next acquisition handshakes with the
@@ -672,9 +673,13 @@ impl LanguageServerPool {
                 invalidated.push(key.clone());
                 continue;
             }
-            if handle.state() != ConnectionState::Ready
-                || !handle.supports_workspace_folder_changes()
-            {
+            if handle.state() != ConnectionState::Ready {
+                continue;
+            }
+            if !handle.supports_workspace_folder_changes() {
+                if follows_client_workspace {
+                    invalidated.push(key.clone());
+                }
                 continue;
             }
             let notification =
@@ -3334,7 +3339,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn workspace_folder_change_forwards_only_to_capable_ready_connections() {
+    async fn workspace_folder_change_forwards_to_capable_and_recycles_incapable_fallback() {
         let pool = LanguageServerPool::new();
         let capable =
             create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("capable"))
@@ -3357,7 +3362,10 @@ mod tests {
             .await;
 
         assert_eq!(capable.workspace_folders().snapshot(), Some(vec![added]));
-        assert_eq!(incapable.workspace_folders().snapshot(), None);
+        assert!(
+            !pool.connections.lock().await.contains_key(incapable.key()),
+            "an incapable fallback must respawn with the current workspace snapshot"
+        );
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -417,7 +417,7 @@ pub struct LanguageServerPool {
     ///
     /// Set once via `set_workspace_folders()` after receiving the upstream initialize request.
     /// Passed to downstream servers during LSP handshake.
-    workspace_folders: OnceLock<Option<Vec<tower_lsp_server::ls_types::WorkspaceFolder>>>,
+    workspace_folders: super::WorkspaceFolderSet,
     /// Client capabilities forwarded from upstream client.
     ///
     /// Set once via `set_client_capabilities()` after receiving the upstream initialize request.
@@ -516,7 +516,7 @@ impl LanguageServerPool {
             cancel_metrics: CancelForwardingMetrics::default(),
             consecutive_panic_counts: std::sync::Mutex::new(HashMap::new()),
             root_uri: OnceLock::new(),
-            workspace_folders: OnceLock::new(),
+            workspace_folders: super::WorkspaceFolderSet::new(None),
             client_capabilities: OnceLock::new(),
             log_message_level: AtomicU8::new(
                 crate::config::settings::LogMessageLevel::Info.as_u8(),
@@ -641,12 +641,24 @@ impl LanguageServerPool {
         &self,
         folders: Option<Vec<tower_lsp_server::ls_types::WorkspaceFolder>>,
     ) {
-        let _ = self.workspace_folders.set(folders);
+        if let Some(folders) = folders {
+            self.workspace_folders.apply_change(folders, &[]);
+        }
     }
 
     /// Get the workspace folders.
     fn workspace_folders(&self) -> Option<Vec<tower_lsp_server::ls_types::WorkspaceFolder>> {
-        self.workspace_folders.get().and_then(|v| v.clone())
+        self.workspace_folders.snapshot()
+    }
+
+    /// Update the upstream client workspace snapshot used by future
+    /// client-fallback downstream connections.
+    pub(crate) fn apply_workspace_folder_change(
+        &self,
+        added: Vec<tower_lsp_server::ls_types::WorkspaceFolder>,
+        removed: &[tower_lsp_server::ls_types::WorkspaceFolder],
+    ) {
+        self.workspace_folders.apply_change(added, removed);
     }
 
     /// Set the upstream client capabilities.

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -664,10 +664,10 @@ impl LanguageServerPool {
         let mut connections = self.connections.lock().await;
         let mut invalidated = Vec::new();
         for (key, handle) in connections.iter() {
-            let follows_client_workspace = key.is_client_fallback() || key.is_shared();
+            let follows_client_workspace = key.is_client_fallback();
             if !follows_client_workspace {
-                // Marker-owned connections derive their workspace from the
-                // marker root, not the upstream client-folder snapshot.
+                // Marker-owned and shared connections derive their folders
+                // from marker-root acquisition, not this client snapshot.
                 continue;
             }
             if handle.state() == ConnectionState::Initializing {
@@ -3409,6 +3409,37 @@ mod tests {
 
         assert!(pool.connections.lock().await.contains_key(&key));
         assert_eq!(handle.workspace_folders().snapshot(), None);
+    }
+
+    #[tokio::test]
+    async fn workspace_folder_change_does_not_touch_shared_marker_folders() {
+        let pool = LanguageServerPool::new();
+        let key = ConnectionKey::shared("shared");
+        let handle = create_handle_with_key(ConnectionState::Ready, key.clone()).await;
+        handle.set_server_capabilities(capable_workspace_folders_caps());
+        let marker = tower_lsp_server::ls_types::WorkspaceFolder {
+            uri: "file:///repo/pkg".parse().unwrap(),
+            name: "pkg".to_string(),
+        };
+        handle
+            .workspace_folders()
+            .replace(Some(vec![marker.clone()]));
+        pool.insert_connection(Arc::clone(&handle)).await;
+
+        pool.apply_workspace_folder_change(
+            vec![tower_lsp_server::ls_types::WorkspaceFolder {
+                uri: "file:///other".parse().unwrap(),
+                name: "other".to_string(),
+            }],
+            &[tower_lsp_server::ls_types::WorkspaceFolder {
+                uri: "file:///repo".parse().unwrap(),
+                name: "repo".to_string(),
+            }],
+        )
+        .await;
+
+        assert!(pool.connections.lock().await.contains_key(&key));
+        assert_eq!(handle.workspace_folders().snapshot(), Some(vec![marker]));
     }
 
     fn shared_config() -> crate::config::settings::BridgeServerConfig {

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -705,6 +705,11 @@ impl LanguageServerPool {
                 .await
                 .retain(|(_, connection_key), _| connection_key != &key);
             self.document_tracker.purge_connection(&key).await;
+            // Arm before the replacement can claim: what this connection held
+            // is irrelevant, only that it owes a re-open. A connection dropped
+            // mid-handshake held nothing at all, which is exactly the case a
+            // host-list-shaped record would have skipped.
+            self.pending_reopen.arm(&key);
             self.purge_open_transition_locks(&key).await;
             if let Some(handle) = connections.remove(&key) {
                 stale_handles.push((key, handle));

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -105,12 +105,10 @@ pub(crate) fn build_didclose_notification(
 /// separate follow-up.
 pub(crate) fn build_did_change_workspace_folders_notification(
     added: Vec<WorkspaceFolder>,
+    removed: Vec<WorkspaceFolder>,
 ) -> JsonRpcNotification<DidChangeWorkspaceFoldersParams> {
     let params = DidChangeWorkspaceFoldersParams {
-        event: WorkspaceFoldersChangeEvent {
-            added,
-            removed: Vec::new(),
-        },
+        event: WorkspaceFoldersChangeEvent { added, removed },
     };
     JsonRpcNotification::new("workspace/didChangeWorkspaceFolders", params)
 }

--- a/src/lsp/bridge/workspace/folder_set.rs
+++ b/src/lsp/bridge/workspace/folder_set.rs
@@ -50,6 +50,15 @@ impl WorkspaceFolderSet {
             .clone()
     }
 
+    /// Replace the complete set, preserving the protocol distinction between
+    /// `None` (`null`) and `Some(vec![])` (an explicitly empty folder list).
+    pub(crate) fn replace(&self, folders: Option<Vec<WorkspaceFolder>>) {
+        *self
+            .inner
+            .lock()
+            .recover_poison("WorkspaceFolderSet::replace") = folders;
+    }
+
     /// Whether a folder with `folder`'s URI is already in the set.
     pub(crate) fn contains(&self, folder: &WorkspaceFolder) -> bool {
         self.inner
@@ -207,5 +216,14 @@ mod tests {
         set.apply_change(Vec::new(), &[folder("file:///absent")]);
 
         assert_eq!(set.snapshot(), None);
+    }
+
+    #[test]
+    fn replace_preserves_an_explicit_empty_set() {
+        let set = WorkspaceFolderSet::new(None);
+
+        set.replace(Some(Vec::new()));
+
+        assert_eq!(set.snapshot(), Some(Vec::new()));
     }
 }

--- a/src/lsp/bridge/workspace/folder_set.rs
+++ b/src/lsp/bridge/workspace/folder_set.rs
@@ -41,17 +41,16 @@ impl WorkspaceFolderSet {
         }
     }
 
-    fn deduplicate(mut folders: Option<Vec<WorkspaceFolder>>) -> Option<Vec<WorkspaceFolder>> {
-        if let Some(folders) = folders.as_mut() {
+    fn deduplicate(folders: Option<Vec<WorkspaceFolder>>) -> Option<Vec<WorkspaceFolder>> {
+        folders.map(|folders| {
             let mut unique = Vec::<WorkspaceFolder>::with_capacity(folders.len());
-            for folder in folders.drain(..) {
+            for folder in folders {
                 if !unique.iter().any(|existing| existing.uri == folder.uri) {
                     unique.push(folder);
                 }
             }
-            *folders = unique;
-        }
-        folders
+            unique
+        })
     }
 
     /// Snapshot the current folders for answering a `workspace/workspaceFolders`
@@ -93,7 +92,7 @@ impl WorkspaceFolderSet {
             return;
         }
         let folders = guard.get_or_insert_with(Vec::new);
-        folders.retain(|existing| !removed.iter().any(|removed| removed.uri == existing.uri));
+        folders.retain(|existing| !removed.iter().any(|item| item.uri == existing.uri));
         for folder in added {
             if !folders.iter().any(|existing| existing.uri == folder.uri) {
                 folders.push(folder);
@@ -233,6 +232,15 @@ mod tests {
             set.snapshot(),
             Some(vec![folder("file:///b"), folder("file:///c")])
         );
+    }
+
+    #[test]
+    fn add_to_none_materializes_folder_set() {
+        let set = WorkspaceFolderSet::new(None);
+
+        set.apply_change(vec![folder("file:///a")], &[]);
+
+        assert_eq!(set.snapshot(), Some(vec![folder("file:///a")]));
     }
 
     #[test]

--- a/src/lsp/bridge/workspace/folder_set.rs
+++ b/src/lsp/bridge/workspace/folder_set.rs
@@ -67,6 +67,9 @@ impl WorkspaceFolderSet {
             .inner
             .lock()
             .recover_poison("WorkspaceFolderSet::apply_change");
+        if guard.is_none() && added.is_empty() {
+            return;
+        }
         let folders = guard.get_or_insert_with(Vec::new);
         folders.retain(|existing| !removed.iter().any(|removed| removed.uri == existing.uri));
         for folder in added {
@@ -195,5 +198,14 @@ mod tests {
             set.snapshot(),
             Some(vec![folder("file:///b"), folder("file:///c")])
         );
+    }
+
+    #[test]
+    fn removal_only_change_preserves_a_none_set() {
+        let set = WorkspaceFolderSet::new(None);
+
+        set.apply_change(Vec::new(), &[folder("file:///absent")]);
+
+        assert_eq!(set.snapshot(), None);
     }
 }

--- a/src/lsp/bridge/workspace/folder_set.rs
+++ b/src/lsp/bridge/workspace/folder_set.rs
@@ -37,8 +37,21 @@ impl WorkspaceFolderSet {
     /// the connection has no folders to advertise).
     pub(crate) fn new(initial: Option<Vec<WorkspaceFolder>>) -> Self {
         Self {
-            inner: Arc::new(Mutex::new(initial)),
+            inner: Arc::new(Mutex::new(Self::deduplicate(initial))),
         }
+    }
+
+    fn deduplicate(mut folders: Option<Vec<WorkspaceFolder>>) -> Option<Vec<WorkspaceFolder>> {
+        if let Some(folders) = folders.as_mut() {
+            let mut unique = Vec::<WorkspaceFolder>::with_capacity(folders.len());
+            for folder in folders.drain(..) {
+                if !unique.iter().any(|existing| existing.uri == folder.uri) {
+                    unique.push(folder);
+                }
+            }
+            *folders = unique;
+        }
+        folders
     }
 
     /// Snapshot the current folders for answering a `workspace/workspaceFolders`
@@ -56,7 +69,7 @@ impl WorkspaceFolderSet {
         *self
             .inner
             .lock()
-            .recover_poison("WorkspaceFolderSet::replace") = folders;
+            .recover_poison("WorkspaceFolderSet::replace") = Self::deduplicate(folders);
     }
 
     /// Whether a folder with `folder`'s URI is already in the set.
@@ -145,6 +158,19 @@ mod tests {
 
         let empty = WorkspaceFolderSet::new(None);
         assert_eq!(empty.snapshot(), None);
+    }
+
+    #[test]
+    fn initial_and_replacement_snapshots_are_uri_unique() {
+        let renamed_a = WorkspaceFolder {
+            uri: folder("file:///a").uri,
+            name: "renamed".to_string(),
+        };
+        let set = WorkspaceFolderSet::new(Some(vec![folder("file:///a"), renamed_a.clone()]));
+        assert_eq!(set.snapshot(), Some(vec![folder("file:///a")]));
+
+        set.replace(Some(vec![renamed_a.clone(), folder("file:///a")]));
+        assert_eq!(set.snapshot(), Some(vec![renamed_a]));
     }
 
     #[test]

--- a/src/lsp/bridge/workspace/folder_set.rs
+++ b/src/lsp/bridge/workspace/folder_set.rs
@@ -59,6 +59,23 @@ impl WorkspaceFolderSet {
             .is_some_and(|folders| folders.iter().any(|existing| existing.uri == folder.uri))
     }
 
+    /// Apply an upstream workspace-folder change atomically. Removals match by
+    /// URI (folder names are display metadata), then additions append in event
+    /// order while preserving URI uniqueness.
+    pub(crate) fn apply_change(&self, added: Vec<WorkspaceFolder>, removed: &[WorkspaceFolder]) {
+        let mut guard = self
+            .inner
+            .lock()
+            .recover_poison("WorkspaceFolderSet::apply_change");
+        let folders = guard.get_or_insert_with(Vec::new);
+        folders.retain(|existing| !removed.iter().any(|removed| removed.uri == existing.uri));
+        for folder in added {
+            if !folders.iter().any(|existing| existing.uri == folder.uri) {
+                folders.push(folder);
+            }
+        }
+    }
+
     /// Atomically add `folder` and announce it, returning whether the set now
     /// contains it. If `folder` is already present, returns `true` without
     /// calling `announce`. Otherwise `announce` runs **while the set lock is
@@ -163,5 +180,20 @@ mod tests {
         let set = WorkspaceFolderSet::new(None);
         assert!(set.add_and_announce(folder("file:///a"), || true));
         assert_eq!(set.snapshot(), Some(vec![folder("file:///a")]));
+    }
+
+    #[test]
+    fn apply_change_removes_by_uri_and_adds_without_duplicates() {
+        let set = WorkspaceFolderSet::new(Some(vec![folder("file:///a"), folder("file:///b")]));
+
+        set.apply_change(
+            vec![folder("file:///b"), folder("file:///c")],
+            &[folder("file:///a")],
+        );
+
+        assert_eq!(
+            set.snapshot(),
+            Some(vec![folder("file:///b"), folder("file:///c")])
+        );
     }
 }

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -317,6 +317,10 @@ pub struct Kakehashi {
     cache: std::sync::Arc<CacheCoordinator>,
     /// Consolidated settings, capabilities, and workspace root management
     settings_manager: std::sync::Arc<SettingsManager>,
+    /// Client-supplied settings kept separate from the merged effective
+    /// snapshot so a workspace-root change can reload project configuration
+    /// without carrying values from the previous project forward.
+    client_settings_override: arc_swap::ArcSwapOption<RawWorkspaceSettings>,
     /// Isolated coordinator for parser auto-installation
     auto_install: AutoInstallManager,
     /// Bridge coordinator for downstream LS pool and node tracking
@@ -462,6 +466,7 @@ impl Kakehashi {
             documents: std::sync::Arc::new(DocumentStore::new()),
             cache: std::sync::Arc::new(CacheCoordinator::new()),
             settings_manager: std::sync::Arc::new(SettingsManager::new()),
+            client_settings_override: arc_swap::ArcSwapOption::empty(),
             auto_install,
             bridge: std::sync::Arc::new(bridge),
             synthetic_diagnostics: std::sync::Arc::new(SyntheticDiagnosticsManager::new()),

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -22,19 +22,19 @@ use tower_lsp_server::ls_types::request::{
 use tower_lsp_server::ls_types::{
     CodeAction, CodeActionParams, CodeActionResponse, CodeLens, CodeLensParams, CompletionItem,
     CompletionParams, CompletionResponse, DidChangeConfigurationParams,
-    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-    DidSaveTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReportResult,
-    DocumentFormattingParams, DocumentHighlight, DocumentHighlightParams, DocumentLink,
-    DocumentLinkParams, DocumentOnTypeFormattingParams, DocumentRangeFormattingParams,
-    DocumentSymbolParams, DocumentSymbolResponse, ExecuteCommandParams, FoldingRange,
-    FoldingRangeParams, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams,
-    InitializeParams, InitializeResult, InitializedParams, InlayHint, InlayHintParams,
-    LinkedEditingRangeParams, LinkedEditingRanges, Location, Moniker, MonikerParams,
-    PrepareRenameResponse, ReferenceParams, RenameParams, SelectionRange, SelectionRangeParams,
-    SemanticTokensDeltaParams, SemanticTokensFullDeltaResult, SemanticTokensParams,
-    SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult, SignatureHelp,
-    SignatureHelpParams, TextDocumentPositionParams, TextEdit, Uri, WillSaveTextDocumentParams,
-    WorkspaceEdit,
+    DidChangeTextDocumentParams, DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentDiagnosticParams,
+    DocumentDiagnosticReportResult, DocumentFormattingParams, DocumentHighlight,
+    DocumentHighlightParams, DocumentLink, DocumentLinkParams, DocumentOnTypeFormattingParams,
+    DocumentRangeFormattingParams, DocumentSymbolParams, DocumentSymbolResponse,
+    ExecuteCommandParams, FoldingRange, FoldingRangeParams, GotoDefinitionParams,
+    GotoDefinitionResponse, Hover, HoverParams, InitializeParams, InitializeResult,
+    InitializedParams, InlayHint, InlayHintParams, LinkedEditingRangeParams, LinkedEditingRanges,
+    Location, Moniker, MonikerParams, PrepareRenameResponse, ReferenceParams, RenameParams,
+    SelectionRange, SelectionRangeParams, SemanticTokensDeltaParams, SemanticTokensFullDeltaResult,
+    SemanticTokensParams, SemanticTokensRangeParams, SemanticTokensRangeResult,
+    SemanticTokensResult, SignatureHelp, SignatureHelpParams, TextDocumentPositionParams, TextEdit,
+    Uri, WillSaveTextDocumentParams, WorkspaceEdit,
 };
 use tower_lsp_server::ls_types::{
     ColorInformation, ColorPresentation, ColorPresentationParams, DocumentColorParams,
@@ -823,6 +823,10 @@ impl LanguageServer for Kakehashi {
 
     async fn did_change_configuration(&self, params: DidChangeConfigurationParams) {
         self.did_change_configuration_impl(params).await
+    }
+
+    async fn did_change_workspace_folders(&self, params: DidChangeWorkspaceFoldersParams) {
+        self.did_change_workspace_folders_impl(params).await
     }
 
     async fn semantic_tokens_full(

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -19,6 +19,7 @@ use tower_lsp_server::ls_types::{
     SemanticTokensServerCapabilities, ServerCapabilities, ServerInfo, SignatureHelpOptions,
     TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
     TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, Uri, WorkDoneProgressOptions,
+    WorkspaceFoldersServerCapabilities, WorkspaceServerCapabilities,
 };
 use url::Url;
 
@@ -221,6 +222,16 @@ fn bridge_workspace_folders(
             }])
         })
     })
+}
+
+fn workspace_server_capabilities() -> WorkspaceServerCapabilities {
+    WorkspaceServerCapabilities {
+        workspace_folders: Some(WorkspaceFoldersServerCapabilities {
+            supported: Some(true),
+            change_notifications: Some(OneOf::Left(true)),
+        }),
+        file_operations: None,
+    }
 }
 
 impl Kakehashi {
@@ -616,6 +627,7 @@ impl Kakehashi {
                         ..Default::default()
                     },
                 )),
+                workspace: Some(workspace_server_capabilities()),
                 experimental: Some(serde_json::json!({
                     "kakehashi": {
                         "wrappedDidChangeConfigurationSettings": true,
@@ -2388,6 +2400,16 @@ mod tests {
         .expect("valid initialize params");
 
         assert_eq!(bridge_root_uri(&params).as_deref(), Some(expected.as_str()));
+    }
+
+    #[test]
+    fn workspace_capabilities_request_folder_change_notifications() {
+        let workspace = workspace_server_capabilities();
+        let folders = workspace
+            .workspace_folders
+            .expect("workspace folder capability");
+        assert_eq!(folders.supported, Some(true));
+        assert_eq!(folders.change_notifications, Some(OneOf::Left(true)));
     }
 
     /// A throwaway cancel context for tests that don't exercise cancellation.

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -332,10 +332,11 @@ impl Kakehashi {
         }
 
         let root_path = self.settings_manager.root_path().as_ref().clone();
+        let initialization_options = params.initialization_options;
         let settings_outcome = load_settings(
             root_path.as_deref(),
-            params
-                .initialization_options
+            initialization_options
+                .clone()
                 .map(|options| (SettingsSource::InitializationOptions, options)),
             self.home_dir.as_deref(),
             |var| std::env::var(var).ok(),
@@ -404,6 +405,11 @@ impl Kakehashi {
             };
             (raw_settings, settings)
         };
+        self.client_settings_override.store(
+            initialization_options
+                .and_then(|value| serde_json::from_value(value).ok())
+                .map(std::sync::Arc::new),
+        );
         // Derive the onTypeFormatting trigger union before settings move into
         // apply_raw_settings: kakehashi cannot know downstream trigger
         // characters at initialize time (servers spawn lazily), so the

--- a/src/lsp/lsp_impl/workspace.rs
+++ b/src/lsp/lsp_impl/workspace.rs
@@ -1,4 +1,5 @@
 //! Workspace related LSP methods.
 
 mod did_change_configuration;
+mod did_change_workspace_folders;
 mod execute_command;

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -184,7 +184,8 @@ impl Kakehashi {
         let current_ts = self.settings_manager.load_raw_settings();
         // SAFETY: merge_workspace_settings(Some, Some) always returns Some, so unwrap_or_return is
         // defensive only — the None branch is unreachable under the current implementation.
-        let Some(merged_ts) = merge_workspace_settings(Some((*current_ts).clone()), Some(parsed))
+        let Some(merged_ts) =
+            merge_workspace_settings(Some((*current_ts).clone()), Some(parsed.clone()))
         else {
             log::warn!(
                 "merge_workspace_settings returned None despite two Some inputs; skipping configuration update"
@@ -198,6 +199,14 @@ impl Kakehashi {
             crate::config::expand::with_kakehashi_defaults(|var| std::env::var(var).ok()),
         ) {
             Ok(settings) => {
+                // Remembered under the same reload transaction that publishes
+                // the merged settings, so a concurrent workspace-root change
+                // cannot rebuild the layers from a half-updated override.
+                let client_override = self.client_settings_override.load_full();
+                let merged_override =
+                    merge_workspace_settings(client_override.as_deref().cloned(), Some(parsed));
+                self.client_settings_override
+                    .store(merged_override.map(std::sync::Arc::new));
                 let warnings = Self::misconfigured_settings_warnings(&settings);
                 self.apply_raw_settings_locked(&reload, merged_ts, settings)
                     .await;

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -1,0 +1,16 @@
+//! Upstream `workspace/didChangeWorkspaceFolders` lifecycle handling.
+
+use tower_lsp_server::ls_types::DidChangeWorkspaceFoldersParams;
+
+use super::super::Kakehashi;
+
+impl Kakehashi {
+    pub(crate) async fn did_change_workspace_folders_impl(
+        &self,
+        params: DidChangeWorkspaceFoldersParams,
+    ) {
+        self.bridge
+            .pool()
+            .apply_workspace_folder_change(params.event.added, &params.event.removed);
+    }
+}

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -2,7 +2,7 @@
 
 use tower_lsp_server::ls_types::DidChangeWorkspaceFoldersParams;
 
-use crate::config::{WorkspaceSettings, merge_workspace_settings};
+use crate::config::WorkspaceSettings;
 use crate::lsp::{SettingsSource, load_settings};
 
 use super::super::{Kakehashi, lock_settings_reload};
@@ -48,24 +48,23 @@ impl Kakehashi {
         }
 
         let root_path = self.settings_manager.root_path().as_ref().clone();
+        let client_override = self.client_settings_override.load_full();
         let outcome = load_settings(
             root_path.as_deref(),
-            None::<(SettingsSource, serde_json::Value)>,
+            client_override.as_deref().and_then(|settings| {
+                serde_json::to_value(settings)
+                    .ok()
+                    .map(|value| (SettingsSource::InitializationOptions, value))
+            }),
             self.home_dir.as_deref(),
             |var| std::env::var(var).ok(),
             // The branch above returned for every session that has one.
             None,
         );
         self.notifier().log_settings_events(&outcome.events).await;
-        let root_settings = outcome
+        let raw = outcome
             .raw_settings
             .unwrap_or_else(crate::config::defaults::default_settings);
-        let active_settings = self.settings_manager.load_raw_settings();
-        let Some(raw) =
-            merge_workspace_settings(Some(root_settings), Some((*active_settings).clone()))
-        else {
-            return;
-        };
         match WorkspaceSettings::try_from_settings(
             &raw,
             self.home_dir.as_deref(),

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -2,6 +2,9 @@
 
 use tower_lsp_server::ls_types::DidChangeWorkspaceFoldersParams;
 
+use crate::config::WorkspaceSettings;
+use crate::lsp::{SettingsSource, load_settings};
+
 use super::super::Kakehashi;
 
 impl Kakehashi {
@@ -9,8 +12,60 @@ impl Kakehashi {
         &self,
         params: DidChangeWorkspaceFoldersParams,
     ) {
+        let added = params.event.added;
+        let removed = params.event.removed;
         self.bridge
             .pool()
-            .apply_workspace_folder_change(params.event.added, &params.event.removed);
+            .apply_workspace_folder_change(added, &removed)
+            .await;
+        let root_path = self
+            .bridge
+            .pool()
+            .workspace_folders()
+            .and_then(|folders| folders.first().cloned())
+            .and_then(|folder| super::super::uri_to_url(&folder.uri).ok())
+            .and_then(|url| url.to_file_path().ok());
+        self.settings_manager.set_root_path(root_path);
+
+        // An explicit `--config-file` replaces the whole config-file stack, so
+        // the project layer at the workspace root is never consulted and no
+        // file layer can change when the root does. Those files are also read
+        // exactly once by contract, which leaves this reload nothing to read
+        // and only initialize's settings events to re-emit. Refreshing the root
+        // — which still anchors relative paths — and stopping there is the whole
+        // of it; #746 covers reloading the project layer for the sessions that
+        // do have one.
+        if crate::config::expand::config_file_override().is_some() {
+            return;
+        }
+
+        let root_path = self.settings_manager.root_path().as_ref().clone();
+        let outcome = load_settings(
+            root_path.as_deref(),
+            None::<(SettingsSource, serde_json::Value)>,
+            self.home_dir.as_deref(),
+            |var| std::env::var(var).ok(),
+            // The branch above returned for every session that has one.
+            None,
+        );
+        self.notifier().log_settings_events(&outcome.events).await;
+        let (raw, settings) = if let Some(settings) = outcome.settings {
+            (
+                outcome
+                    .raw_settings
+                    .unwrap_or_else(|| crate::config::RawWorkspaceSettings::from(&settings)),
+                settings,
+            )
+        } else {
+            let raw = crate::config::defaults::default_settings();
+            let settings = WorkspaceSettings::try_from_settings(
+                &raw,
+                self.home_dir.as_deref(),
+                crate::config::expand::with_kakehashi_defaults(|var| std::env::var(var).ok()),
+            )
+            .unwrap_or_default();
+            (raw, settings)
+        };
+        self.apply_initial_settings(raw, settings).await;
     }
 }

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -2,10 +2,10 @@
 
 use tower_lsp_server::ls_types::DidChangeWorkspaceFoldersParams;
 
-use crate::config::WorkspaceSettings;
+use crate::config::{WorkspaceSettings, merge_workspace_settings};
 use crate::lsp::{SettingsSource, load_settings};
 
-use super::super::Kakehashi;
+use super::super::{Kakehashi, lock_settings_reload};
 
 impl Kakehashi {
     pub(crate) async fn did_change_workspace_folders_impl(
@@ -18,6 +18,14 @@ impl Kakehashi {
             .pool()
             .apply_workspace_folder_change(added, &removed)
             .await;
+
+        // Reading the settings in effect, merging the reloaded root onto them,
+        // and publishing the result share the one reload transaction
+        // `workspace/didChangeConfiguration` uses. Without it a configuration
+        // push racing this notification can publish a merge derived from the
+        // snapshot the other has already replaced.
+        let reload = lock_settings_reload().await;
+
         let root_path = self
             .bridge
             .pool()
@@ -49,23 +57,34 @@ impl Kakehashi {
             None,
         );
         self.notifier().log_settings_events(&outcome.events).await;
-        let (raw, settings) = if let Some(settings) = outcome.settings {
-            (
-                outcome
-                    .raw_settings
-                    .unwrap_or_else(|| crate::config::RawWorkspaceSettings::from(&settings)),
-                settings,
-            )
-        } else {
-            let raw = crate::config::defaults::default_settings();
-            let settings = WorkspaceSettings::try_from_settings(
-                &raw,
-                self.home_dir.as_deref(),
-                crate::config::expand::with_kakehashi_defaults(|var| std::env::var(var).ok()),
-            )
-            .unwrap_or_default();
-            (raw, settings)
+        let root_settings = outcome
+            .raw_settings
+            .unwrap_or_else(crate::config::defaults::default_settings);
+        let active_settings = self.settings_manager.load_raw_settings();
+        let Some(raw) =
+            merge_workspace_settings(Some(root_settings), Some((*active_settings).clone()))
+        else {
+            return;
         };
-        self.apply_initial_settings(raw, settings).await;
+        match WorkspaceSettings::try_from_settings(
+            &raw,
+            self.home_dir.as_deref(),
+            crate::config::expand::with_kakehashi_defaults(|var| std::env::var(var).ok()),
+        ) {
+            Ok(settings) => {
+                let warnings = Self::misconfigured_settings_warnings(&settings);
+                self.apply_raw_settings_locked(&reload, raw, settings).await;
+                drop(reload);
+                self.warn_on_misconfigured_settings(&warnings).await;
+            }
+            Err(error) => {
+                drop(reload);
+                self.notifier()
+                    .log_warning(format!(
+                        "Workspace root changed, but reloaded settings were invalid: {error}"
+                    ))
+                    .await;
+            }
+        }
     }
 }

--- a/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
+++ b/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/e2e_lsp_protocol.rs
-assertion_line: 46
 expression: capabilities
 ---
 {
@@ -58,6 +57,12 @@ expression: capabilities
   "foldingRangeProvider": true,
   "declarationProvider": {
     "workDoneProgress": true
+  },
+  "workspace": {
+    "workspaceFolders": {
+      "supported": true,
+      "changeNotifications": true
+    }
   },
   "semanticTokensProvider": {
     "legend": {


### PR DESCRIPTION
## Summary

- advertise upstream `workspaceFolders` support and change notifications
- consume `workspace/didChangeWorkspaceFolders` and maintain an ordered, URI-unique current snapshot
- use the updated snapshot for downstream client-fallback connections spawned after the change
- snapshot the wire-visible capability

Part of #733.

## Bounded follow-ups

- #746: primary-root project config reload while preserving configuration layers
- #747: provenance-safe propagation to already-running downstream connections

Those concerns are intentionally separate: a marker-derived shared root can share a URI with an upstream folder, so live removal needs source ownership rather than deleting from a flat set; project-root reload must replace only the file layer without losing initialization/runtime settings.

## Validation

- `cargo test --lib -q lsp::bridge::workspace::folder_set`
- `cargo test --lib -q workspace_capabilities_request_folder_change_notifications`
- `INSTA_UPDATE=always cargo test --features e2e --test e2e_lsp_protocol -q test_initialize_returns_capabilities`
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --check`

## Review status

Draft until the revise pipeline converges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for workspace folder change notifications with accurate added and removed folder reporting.
  * Workspace changes now update the effective project root and reload applicable settings without restarting.
  * Workspace folder support and change notifications are advertised during initialization.
* **Bug Fixes**
  * Prevented duplicate workspace folders and improved replacement and incremental updates.
  * Recycled connections unable to process workspace folder changes.
* **Tests**
  * Added coverage for workspace propagation, settings updates, deduplication, and connection handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->