### PR TITLE
fix(diagnostics): scope coverage to document lifetime

### DIFF
--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -400,8 +400,9 @@ pub(crate) struct DiagnosticAggregator {
     /// [`Self::mark_served`], [`Self::is_dirty`]; forgotten on `didClose`.
     coverage: Mutex<HashMap<Url, HostCoverage>>,
     /// Mints a distinct lifetime for each newly-created coverage entry. A pull
-    /// captures this with `current`; after `didClose` removes the entry, its
-    /// completion must not advance a later reopened lifetime's `served` value.
+    /// captures this epoch and the current version in [`Self::coverage_stamp`];
+    /// after `didClose` removes the entry, its completion must not advance a
+    /// later reopened lifetime's `served` value.
     next_coverage_epoch: AtomicU64,
     /// Hosts whose LAST pull was answered degraded — the bounded parse wait
     /// lapsed while the aggregator held live region pushes, so the response

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -398,6 +398,10 @@ pub(crate) struct DiagnosticAggregator {
     /// `served`) sends no redundant nudge. Drives [`Self::bump_current`],
     /// [`Self::mark_served`], [`Self::is_dirty`]; forgotten on `didClose`.
     coverage: Mutex<HashMap<Url, HostCoverage>>,
+    /// Mints a distinct lifetime for each newly-created coverage entry. A pull
+    /// captures this with `current`; after `didClose` removes the entry, its
+    /// completion must not advance a later reopened lifetime's `served` value.
+    next_coverage_epoch: AtomicU64,
     /// Hosts whose LAST pull was answered degraded — the bounded parse wait
     /// lapsed while the aggregator held live region pushes, so the response
     /// was missing the region fold and deliberately did not `mark_served`.
@@ -582,11 +586,19 @@ impl Eq for WireAdmit {}
 /// Per-host coverage versions for the refresh gate (#497, commit 2).
 #[derive(Default, Clone, Copy)]
 struct HostCoverage {
+    epoch: u64,
     /// Bumped on each set-changing republish for this host.
     current: u64,
     /// The `current` value a pull was last answered against (a lower bound — read
     /// before the pull's fold, so never ahead of what the editor actually received).
     served: u64,
+}
+
+/// The diagnostic coverage observed when a pull begins.
+#[derive(Clone, Copy)]
+pub(crate) struct DiagnosticCoverageStamp {
+    epoch: u64,
+    version: u64,
 }
 
 /// Always-on diagnostic-path counters (#533). The four counts trace the refresh
@@ -1259,6 +1271,7 @@ impl DiagnosticAggregator {
             coverage.insert(
                 host.clone(),
                 HostCoverage {
+                    epoch: self.next_coverage_epoch.fetch_add(1, Ordering::Relaxed),
                     current: 1,
                     served: 0,
                 },
@@ -1266,9 +1279,10 @@ impl DiagnosticAggregator {
         }
     }
 
-    /// Read a host's current coverage version (`0` if it has never changed). A pull
-    /// captures this *before* its fold and later passes it to [`Self::mark_served`],
-    /// so `served` is a lower bound (never ahead of the set the editor received).
+    /// Read a host's current coverage version (`0` if it has never changed).
+    /// Test-only numeric view; production pulls use [`Self::coverage_stamp`] so
+    /// close/reopen lifetimes cannot be confused (#745).
+    #[cfg(test)]
     pub(crate) fn current_version(&self, host: &Url) -> u64 {
         self.coverage
             .lock()
@@ -1277,21 +1291,37 @@ impl DiagnosticAggregator {
             .map_or(0, |c| c.current)
     }
 
+    /// Capture both the current version and the coverage-entry lifetime.
+    pub(crate) fn coverage_stamp(&self, host: &Url) -> Option<DiagnosticCoverageStamp> {
+        self.coverage
+            .lock()
+            .recover_poison("DiagnosticAggregator::coverage")
+            .get(host)
+            .map(|coverage| DiagnosticCoverageStamp {
+                epoch: coverage.epoch,
+                version: coverage.current,
+            })
+    }
+
     /// Record that a pull was answered for `host` against coverage version
-    /// `version` (#497): the editor now has the set as of `version`, so it is no
+    /// `stamp` (#497): the editor now has the set as of its version, so it is no
     /// longer dirty up to there. Pure bookkeeping — it must **never** bump `current`
     /// or republish, so a refresh→pull→`mark_served` cannot beget another refresh
     /// (keeps #496/#499 loop-safety). Monotonic via `max`, so a slower concurrent
-    /// pull can't regress `served`. No-op for a host with no coverage entry (nothing
-    /// was ever pushed → nothing to be dirty about).
-    pub(crate) fn mark_served(&self, host: &Url, version: u64) {
+    /// pull can't regress `served`. A missing stamp or one from a closed document
+    /// lifetime is a no-op (#745).
+    pub(crate) fn mark_served(&self, host: &Url, stamp: Option<DiagnosticCoverageStamp>) {
+        let Some(stamp) = stamp else {
+            return;
+        };
         if let Some(cov) = self
             .coverage
             .lock()
             .recover_poison("DiagnosticAggregator::coverage")
             .get_mut(host)
+            && cov.epoch == stamp.epoch
         {
-            cov.served = cov.served.max(version);
+            cov.served = cov.served.max(stamp.version);
         }
     }
 
@@ -3771,7 +3801,8 @@ mod tests {
         agg.bump_current(&h); // current=2
         assert!(!agg.try_begin_refresh(false), "in-flight → pending");
         // The editor pulls and is answered against the latest version → not dirty.
-        agg.mark_served(&h, 2);
+        let stamp = agg.coverage_stamp(&h);
+        agg.mark_served(&h, stamp);
         assert!(!agg.is_dirty(), "the pull covered both changes");
         // Completion: pending was set, but nothing is dirty and it wasn't forced →
         // the trailing is suppressed.
@@ -3829,8 +3860,15 @@ mod tests {
         agg.bump_current(&h);
         assert_eq!(agg.current_version(&h), 2);
         // `served` is monotonic: a stale (lower) mark can't regress it.
-        agg.mark_served(&h, 2);
-        agg.mark_served(&h, 1);
+        let current = agg.coverage_stamp(&h).expect("coverage exists");
+        agg.mark_served(&h, Some(current));
+        agg.mark_served(
+            &h,
+            Some(DiagnosticCoverageStamp {
+                version: 1,
+                ..current
+            }),
+        );
         assert!(
             !agg.is_dirty(),
             "served caught up and a stale mark didn't regress it"
@@ -3844,6 +3882,24 @@ mod tests {
             "a closed host no longer keeps the workspace dirty"
         );
         assert_eq!(agg.current_version(&h), 0, "re-open starts fresh");
+    }
+
+    #[test]
+    fn stale_pull_does_not_mark_reopened_coverage_served() {
+        let agg = DiagnosticAggregator::new();
+        let h = host();
+        agg.bump_current(&h);
+        agg.bump_current(&h);
+        let stale = agg.coverage_stamp(&h);
+
+        agg.forget_coverage(&h);
+        agg.bump_current(&h);
+        agg.mark_served(&h, stale);
+
+        assert!(
+            agg.is_dirty(),
+            "a pull from the closed lifetime must not cover the reopened host"
+        );
     }
 
     #[test]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -47,7 +47,7 @@
 //! version gate was evaluated and rejected (it converts a self-healing stale-overwrite
 //! into a reopen-resurrection hide); the stale-overwrite is left self-healing.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -409,8 +409,10 @@ pub(crate) struct DiagnosticAggregator {
     /// predecessor" problem one map over. They are not interchangeable: a cache
     /// revision advances on every mutation and orders wire snapshots, while
     /// this is minted once per coverage lifetime and only ever compared for
-    /// equality. Sharing one counter would tie the coverage gate's correctness
-    /// to the cadence of cache writes.
+    /// equality. A shared allocator would work, but it would couple two
+    /// unrelated concepts and their allocation cadences for nothing; reusing
+    /// the cache REVISIONS themselves as lifetime identity would be wrong,
+    /// since a revision changes repeatedly within one coverage lifetime.
     next_coverage_epoch: AtomicU64,
     /// Hosts whose LAST pull was answered degraded — the bounded parse wait
     /// lapsed while the aggregator held live region pushes, so the response
@@ -420,9 +422,18 @@ pub(crate) struct DiagnosticAggregator {
     /// `workspace/diagnostic/refresh` for exactly the hosts that owe one —
     /// keying the recovery on this instead of the workspace-wide coverage
     /// dirtiness keeps unrelated stale hosts from turning every edit's parse
-    /// pass into a refresh trigger. A later non-degraded pull clears the debt
-    /// (it marks served); `didClose` forgets it.
-    degraded_pulls: Mutex<HashSet<Url>>,
+    /// pass into a refresh trigger. A later non-degraded pull FROM THE SAME
+    /// coverage lifetime clears the debt (it marks served); `didClose` forgets
+    /// it outright.
+    ///
+    /// The stored value is the coverage epoch the debt was recorded under, for
+    /// the same reason `served` carries one: a pull that started before a
+    /// close+reopen must not settle the reopened lifetime's state. Without it
+    /// such a pull would be correctly refused by `mark_served` and still erase
+    /// a debt a NEWER degraded pull had just recorded, so the post-parse
+    /// backstop would find nothing and the editor would keep a region-less
+    /// answer (#745).
+    degraded_pulls: Mutex<HashMap<Url, Option<u64>>>,
     /// Per-host coalescing state for the editor-facing `publishDiagnostics`
     /// wire sends (the quiet window): see [`WireGate`] and
     /// [`Self::wire_gate_admit`]. Mutated under the host's republish lock
@@ -1358,14 +1369,20 @@ impl DiagnosticAggregator {
     }
 
     /// Record that a pull for `host` was answered degraded (see the
-    /// `degraded_pulls` field doc). Clones the key only on first insert.
-    pub(crate) fn record_degraded_pull(&self, host: &Url) {
+    /// `degraded_pulls` field doc), under the coverage lifetime the answering
+    /// pull observed. Clones the key only on first insert.
+    pub(crate) fn record_degraded_pull(&self, host: &Url, stamp: Option<DiagnosticCoverageStamp>) {
+        let epoch = stamp.map(|stamp| stamp.epoch);
         let mut degraded = self
             .degraded_pulls
             .lock()
             .recover_poison("DiagnosticAggregator::degraded_pulls");
-        if !degraded.contains(host) {
-            degraded.insert(host.clone());
+        // A repeat debt from a NEWER lifetime must overwrite the epoch, or the
+        // clear below would key on a lifetime that no longer owes anything.
+        if let Some(recorded) = degraded.get_mut(host) {
+            *recorded = epoch;
+        } else {
+            degraded.insert(host.clone(), epoch);
         }
     }
 
@@ -1376,16 +1393,44 @@ impl DiagnosticAggregator {
             .lock()
             .recover_poison("DiagnosticAggregator::degraded_pulls")
             .remove(host)
+            .is_some()
     }
 
-    /// Forget `host`'s degraded-pull debt without acting on it: a later
-    /// non-degraded pull covered the host (it marked served), or the host
-    /// closed.
+    /// Forget `host`'s degraded-pull debt outright — the host CLOSED, so it
+    /// owes no recovery refresh whichever lifetime recorded the debt.
     pub(crate) fn forget_degraded_pull(&self, host: &Url) {
         self.degraded_pulls
             .lock()
             .recover_poison("DiagnosticAggregator::degraded_pulls")
             .remove(host);
+    }
+
+    /// Forget `host`'s degraded-pull debt because a covering pull answered it —
+    /// but only if that pull belongs to the lifetime that recorded it.
+    ///
+    /// The lifetime check is what keeps this in step with [`Self::mark_served`].
+    /// A pull that started before a close+reopen is refused there, and clearing
+    /// the debt unconditionally would still let it erase a debt a newer
+    /// degraded pull recorded — the post-parse backstop would then find nothing
+    /// to recover and the editor would keep the region-less answer. A mismatch
+    /// leaves the debt, costing at most one extra forced refresh, which is the
+    /// direction that cannot lose a needed one.
+    pub(crate) fn forget_degraded_pull_from(
+        &self,
+        host: &Url,
+        stamp: Option<DiagnosticCoverageStamp>,
+    ) {
+        let epoch = stamp.map(|stamp| stamp.epoch);
+        let mut degraded = self
+            .degraded_pulls
+            .lock()
+            .recover_poison("DiagnosticAggregator::degraded_pulls");
+        if degraded
+            .get(host)
+            .is_some_and(|recorded| *recorded == epoch)
+        {
+            degraded.remove(host);
+        }
     }
 
     /// Decide whether a wire `publishDiagnostics` for `host` may be written
@@ -3913,6 +3958,54 @@ mod tests {
         assert!(
             agg.is_dirty(),
             "a pull from the closed lifetime must not cover the reopened host"
+        );
+    }
+
+    /// The debt half of the lifetime guard. A pull that started before a
+    /// close+reopen is refused by `mark_served`, but if it could still clear
+    /// the debt a NEWER degraded pull recorded, the post-parse backstop would
+    /// find nothing to recover and the editor would keep a region-less answer.
+    #[test]
+    fn a_stale_covering_pull_does_not_clear_a_reopened_lifetimes_debt() {
+        let agg = DiagnosticAggregator::new();
+        let h = host();
+        agg.bump_current(&h);
+        let stale = agg
+            .coverage_stamp(&h)
+            .expect("coverage exists before close");
+
+        // Close and reopen, then a degraded pull in the NEW lifetime owes a
+        // recovery refresh.
+        agg.forget_coverage(&h);
+        agg.bump_current(&h);
+        let reopened = agg.coverage_stamp(&h).expect("reopened coverage");
+        agg.record_degraded_pull(&h, Some(reopened));
+
+        // The pull from the closed lifetime finally answers.
+        agg.forget_degraded_pull_from(&h, Some(stale));
+
+        assert!(
+            agg.take_degraded_pull(&h),
+            "a pull from the closed lifetime must not settle the reopened one's debt"
+        );
+    }
+
+    /// The other direction: the lifetime that recorded the debt does clear it,
+    /// or every covering pull would leave a debt behind and fire a needless
+    /// forced refresh on the next parse.
+    #[test]
+    fn a_covering_pull_clears_its_own_lifetimes_debt() {
+        let agg = DiagnosticAggregator::new();
+        let h = host();
+        agg.bump_current(&h);
+        let stamp = agg.coverage_stamp(&h).expect("coverage exists");
+        agg.record_degraded_pull(&h, Some(stamp));
+
+        agg.forget_degraded_pull_from(&h, Some(stamp));
+
+        assert!(
+            !agg.take_degraded_pull(&h),
+            "a covering pull from the recording lifetime clears the debt"
         );
     }
 

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -699,6 +699,30 @@ impl DiagnosticMetricsSnapshot {
     }
 }
 
+/// Fold a newly-recorded debt lifetime into the one already stored.
+///
+/// Two rules, and the second is the one that is easy to get wrong.
+///
+/// Between two KNOWN lifetimes, keep the newer: epochs come from a monotonic
+/// counter, so a stale degraded pull landing after a reopened one must not
+/// re-key the debt to the closed lifetime, where a stale covering pull could
+/// then clear it.
+///
+/// An UNKNOWN lifetime (`None`) is ABSORBING, not merely inferior. A pull
+/// captures its stamp before its awaited work, and coverage entries are created
+/// lazily, so a reopened lifetime's degraded pull can genuinely carry `None`.
+/// Ordering `None` against `Some` either way loses that debt: preferring the
+/// stored `Some` lets a stale covering pull clear the newer unidentified debt,
+/// and preferring the incoming `Some` re-keys it to the stale lifetime so the
+/// same clear succeeds. Once any part of the debt is unidentified, only
+/// `take_degraded_pull` or the close path may remove it.
+fn merge_debt_lifetime(stored: Option<u64>, incoming: Option<u64>) -> Option<u64> {
+    match (stored, incoming) {
+        (Some(stored), Some(incoming)) => Some(stored.max(incoming)),
+        _ => None,
+    }
+}
+
 impl DiagnosticAggregator {
     /// Record downstream refresh activity and claim the single debounce task.
     /// The returned generation is the activity snapshot that task should wait
@@ -1377,27 +1401,9 @@ impl DiagnosticAggregator {
             .degraded_pulls
             .lock()
             .recover_poison("DiagnosticAggregator::degraded_pulls");
-        // A repeat debt from a NEWER lifetime must overwrite the epoch, or the
-        // clear below would key on a lifetime that no longer owes anything.
-        // But it must never REWIND: a stale degraded pull landing after the
-        // reopened one would otherwise re-key the debt to the closed lifetime,
-        // and a stale covering pull from that same lifetime could then clear
-        // it — losing the reopened host's recovery refresh, which is the whole
-        // failure this scoping exists to prevent. Epochs are minted by a
-        // monotonic counter, so `>=` is genuinely "not older".
         match degraded.get_mut(host) {
             Some(recorded) => {
-                let replace = match (*recorded, epoch) {
-                    (Some(stored), Some(new)) => new >= stored,
-                    // An identified lifetime is strictly better than none.
-                    (None, Some(_)) => true,
-                    // ...and going back to unidentified is not an improvement.
-                    (Some(_), None) => false,
-                    (None, None) => true,
-                };
-                if replace {
-                    *recorded = epoch;
-                }
+                *recorded = merge_debt_lifetime(*recorded, epoch);
             }
             None => {
                 degraded.insert(host.clone(), epoch);
@@ -4085,6 +4091,40 @@ mod tests {
         agg.record_degraded_pull(&h, Some(stamp));
         agg.forget_degraded_pull_from(&h, None);
         assert!(agg.take_degraded_pull(&h));
+    }
+
+    /// Mixed identities, both orderings. An unknown lifetime must ABSORB, not
+    /// lose to a known one — either direction of preference lets a stale
+    /// covering pull clear a debt the reopened lifetime recorded.
+    #[test]
+    fn an_unknown_debt_lifetime_absorbs_a_known_one() {
+        // record(Some(old)) -> record(None) -> clear(Some(old))
+        let agg = DiagnosticAggregator::new();
+        let h = host();
+        agg.bump_current(&h);
+        let old = agg.coverage_stamp(&h).expect("coverage exists");
+        agg.record_degraded_pull(&h, Some(old));
+        agg.record_degraded_pull(&h, None);
+        agg.forget_degraded_pull_from(&h, Some(old));
+        assert!(
+            agg.take_degraded_pull(&h),
+            "an unidentified debt recorded later must not be clearable by the \
+             lifetime it replaced"
+        );
+
+        // record(None) -> record(Some(old)) -> clear(Some(old))
+        let agg = DiagnosticAggregator::new();
+        let h = host();
+        agg.bump_current(&h);
+        let old = agg.coverage_stamp(&h).expect("coverage exists");
+        agg.record_degraded_pull(&h, None);
+        agg.record_degraded_pull(&h, Some(old));
+        agg.forget_degraded_pull_from(&h, Some(old));
+        assert!(
+            agg.take_degraded_pull(&h),
+            "a known lifetime must not re-key an unidentified debt into being \
+             clearable"
+        );
     }
 
     #[test]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -403,6 +403,14 @@ pub(crate) struct DiagnosticAggregator {
     /// captures this epoch and the current version in [`Self::coverage_stamp`];
     /// after `didClose` removes the entry, its completion must not advance a
     /// later reopened lifetime's `served` value.
+    ///
+    /// Deliberately separate from [`Self::next_cache_revision`], which solves
+    /// the structurally similar "a reopened URI must not be confused with its
+    /// predecessor" problem one map over. They are not interchangeable: a cache
+    /// revision advances on every mutation and orders wire snapshots, while
+    /// this is minted once per coverage lifetime and only ever compared for
+    /// equality. Sharing one counter would tie the coverage gate's correctness
+    /// to the cadence of cache writes.
     next_coverage_epoch: AtomicU64,
     /// Hosts whose LAST pull was answered degraded — the bounded parse wait
     /// lapsed while the aggregator held live region pushes, so the response

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -3894,11 +3894,13 @@ mod tests {
         let h = host();
         agg.bump_current(&h);
         agg.bump_current(&h);
-        let stale = agg.coverage_stamp(&h);
+        let stale = agg
+            .coverage_stamp(&h)
+            .expect("coverage exists before close");
 
         agg.forget_coverage(&h);
         agg.bump_current(&h);
-        agg.mark_served(&h, stale);
+        agg.mark_served(&h, Some(stale));
 
         assert!(
             agg.is_dirty(),

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -586,7 +586,7 @@ impl PartialEq for WireAdmit {
 impl Eq for WireAdmit {}
 
 /// Per-host coverage versions for the refresh gate (#497, commit 2).
-#[derive(Default, Clone, Copy)]
+#[derive(Clone, Copy)]
 struct HostCoverage {
     epoch: u64,
     /// Bumped on each set-changing republish for this host.
@@ -597,7 +597,7 @@ struct HostCoverage {
 }
 
 /// The diagnostic coverage observed when a pull begins.
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct DiagnosticCoverageStamp {
     epoch: u64,
     version: u64,

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1379,10 +1379,29 @@ impl DiagnosticAggregator {
             .recover_poison("DiagnosticAggregator::degraded_pulls");
         // A repeat debt from a NEWER lifetime must overwrite the epoch, or the
         // clear below would key on a lifetime that no longer owes anything.
-        if let Some(recorded) = degraded.get_mut(host) {
-            *recorded = epoch;
-        } else {
-            degraded.insert(host.clone(), epoch);
+        // But it must never REWIND: a stale degraded pull landing after the
+        // reopened one would otherwise re-key the debt to the closed lifetime,
+        // and a stale covering pull from that same lifetime could then clear
+        // it — losing the reopened host's recovery refresh, which is the whole
+        // failure this scoping exists to prevent. Epochs are minted by a
+        // monotonic counter, so `>=` is genuinely "not older".
+        match degraded.get_mut(host) {
+            Some(recorded) => {
+                let replace = match (*recorded, epoch) {
+                    (Some(stored), Some(new)) => new >= stored,
+                    // An identified lifetime is strictly better than none.
+                    (None, Some(_)) => true,
+                    // ...and going back to unidentified is not an improvement.
+                    (Some(_), None) => false,
+                    (None, None) => true,
+                };
+                if replace {
+                    *recorded = epoch;
+                }
+            }
+            None => {
+                degraded.insert(host.clone(), epoch);
+            }
         }
     }
 
@@ -1415,19 +1434,28 @@ impl DiagnosticAggregator {
     /// to recover and the editor would keep the region-less answer. A mismatch
     /// leaves the debt, costing at most one extra forced refresh, which is the
     /// direction that cannot lose a needed one.
+    ///
+    /// A stampless pull clears NOTHING. Coverage entries are created lazily, so
+    /// a pull can observe none and still answer degraded once a push creates
+    /// slots during its awaits — meaning an old covering pull and a reopened
+    /// degraded pull can both carry `None`. Treating those as the same lifetime
+    /// would delete the reopened debt on exactly the evidence that proves
+    /// nothing: absence of an identity is not a matching identity.
     pub(crate) fn forget_degraded_pull_from(
         &self,
         host: &Url,
         stamp: Option<DiagnosticCoverageStamp>,
     ) {
-        let epoch = stamp.map(|stamp| stamp.epoch);
+        let Some(stamp) = stamp else {
+            return;
+        };
         let mut degraded = self
             .degraded_pulls
             .lock()
             .recover_poison("DiagnosticAggregator::degraded_pulls");
         if degraded
             .get(host)
-            .is_some_and(|recorded| *recorded == epoch)
+            .is_some_and(|recorded| *recorded == Some(stamp.epoch))
         {
             degraded.remove(host);
         }
@@ -4007,6 +4035,56 @@ mod tests {
             !agg.take_degraded_pull(&h),
             "a covering pull from the recording lifetime clears the debt"
         );
+    }
+
+    /// A degraded pull from the CLOSED lifetime landing after the reopened one
+    /// must not re-key the debt backwards, or a covering pull from that same
+    /// closed lifetime could then clear it.
+    #[test]
+    fn a_stale_degraded_pull_does_not_rewind_the_debts_lifetime() {
+        let agg = DiagnosticAggregator::new();
+        let h = host();
+        agg.bump_current(&h);
+        let stale = agg.coverage_stamp(&h).expect("coverage before close");
+
+        agg.forget_coverage(&h);
+        agg.bump_current(&h);
+        let reopened = agg.coverage_stamp(&h).expect("reopened coverage");
+
+        // The reopened lifetime owes a recovery...
+        agg.record_degraded_pull(&h, Some(reopened));
+        // ...then a degraded pull from the closed lifetime finally lands.
+        agg.record_degraded_pull(&h, Some(stale));
+        // A covering pull from the closed lifetime must still not settle it.
+        agg.forget_degraded_pull_from(&h, Some(stale));
+
+        assert!(
+            agg.take_degraded_pull(&h),
+            "a stale degraded pull must not re-key the debt to its own lifetime"
+        );
+    }
+
+    /// Coverage entries are lazy, so two pulls from DIFFERENT lifetimes can
+    /// both observe none. Absence of an identity is not a matching identity.
+    #[test]
+    fn a_stampless_covering_pull_clears_nothing() {
+        let agg = DiagnosticAggregator::new();
+        let h = host();
+
+        // A degraded pull that saw no coverage entry.
+        agg.record_degraded_pull(&h, None);
+        agg.forget_degraded_pull_from(&h, None);
+        assert!(
+            agg.take_degraded_pull(&h),
+            "a pull with no lifetime cannot prove it owns the debt"
+        );
+
+        // And it cannot clear an identified lifetime's debt either.
+        agg.bump_current(&h);
+        let stamp = agg.coverage_stamp(&h).expect("coverage exists");
+        agg.record_degraded_pull(&h, Some(stamp));
+        agg.forget_degraded_pull_from(&h, None);
+        assert!(agg.take_degraded_pull(&h));
     }
 
     #[test]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1292,6 +1292,8 @@ impl DiagnosticAggregator {
     }
 
     /// Capture both the current version and the coverage-entry lifetime.
+    /// Returns `None` when the host has no active coverage entry, including
+    /// after `didClose`; passing that through to [`Self::mark_served`] is a no-op.
     pub(crate) fn coverage_stamp(&self, host: &Url) -> Option<DiagnosticCoverageStamp> {
         self.coverage
             .lock()

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -414,17 +414,23 @@ pub(crate) struct DiagnosticAggregator {
     /// the cache REVISIONS themselves as lifetime identity would be wrong,
     /// since a revision changes repeatedly within one coverage lifetime.
     next_coverage_epoch: AtomicU64,
-    /// Hosts whose LAST pull was answered degraded — the bounded parse wait
-    /// lapsed while the aggregator held live region pushes, so the response
-    /// was missing the region fold and deliberately did not `mark_served`.
+    /// Hosts with OUTSTANDING degraded-pull recovery debt — some pull's bounded
+    /// parse wait lapsed while the aggregator held live region pushes, so that
+    /// response was missing the region fold and deliberately did not
+    /// `mark_served`.
+    ///
+    /// Deliberately not "hosts whose LAST pull was degraded": unknown-lifetime
+    /// debt survives a later covering pull (see the absorbing rule below), so
+    /// an entry can outlive the answer that would otherwise have settled it.
+    ///
     /// The reparse loop's post-parse backstop consumes an entry
     /// ([`Self::take_degraded_pull`]) to request the recovery
     /// `workspace/diagnostic/refresh` for exactly the hosts that owe one —
     /// keying the recovery on this instead of the workspace-wide coverage
     /// dirtiness keeps unrelated stale hosts from turning every edit's parse
-    /// pass into a refresh trigger. A later non-degraded pull FROM THE SAME
-    /// coverage lifetime clears the debt (it marks served); `didClose` forgets
-    /// it outright.
+    /// pass into a refresh trigger. A non-degraded pull carrying a stamp whose
+    /// epoch MATCHES clears known debt (it marks served); unknown debt waits for
+    /// `take_degraded_pull`; `didClose` forgets either outright.
     ///
     /// The stored value is the coverage epoch the debt was recorded under, for
     /// the same reason `served` carries one: a pull that started before a

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -392,7 +392,8 @@ pub(crate) struct DiagnosticAggregator {
     forwarded_refresh_debounce: Mutex<ForwardedRefreshDebounce>,
     /// Per-host coverage versions for the refresh **coverage gate** (#497, commit 2).
     /// `current` bumps on every set-changing republish (the editor's pulled view is
-    /// now stale); `served` records the `current` a pull was answered against. A
+    /// now stale); a pull captures the epoch plus `current` version through
+    /// [`Self::coverage_stamp`], and `served` records that version. A
     /// gated refresh fires only when some host has `current > served` ("dirty") — so
     /// a change the editor already re-pulled (its own `didChange` pull advances
     /// `served`) sends no redundant nudge. Drives [`Self::bump_current`],

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1884,7 +1884,7 @@ mod tests {
         );
 
         // The editor pulls and is answered against the current version → clean.
-        let v = server.diagnostics.current_version(&uri);
+        let v = server.diagnostics.coverage_stamp(&uri);
         server.diagnostics.mark_served(&uri, v);
         assert!(
             !server.diagnostics.is_dirty(),

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1884,8 +1884,8 @@ mod tests {
         );
 
         // The editor pulls and is answered against the current version → clean.
-        let v = server.diagnostics.coverage_stamp(&uri);
-        server.diagnostics.mark_served(&uri, v);
+        let stamp = server.diagnostics.coverage_stamp(&uri);
+        server.diagnostics.mark_served(&uri, stamp);
         assert!(
             !server.diagnostics.is_dirty(),
             "a covering pull clears dirty"

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -28,7 +28,9 @@ use crate::lsp::aggregation::server::{
     dispatch_host_preferred, dispatch_preferred,
 };
 use crate::lsp::bridge::{LanguageServerPool, RegionOffset};
-use crate::lsp::diagnostic_cache::{DiagnosticSource, cached_push_diagnostics, push_slot_servers};
+use crate::lsp::diagnostic_cache::{
+    DiagnosticCoverageStamp, DiagnosticSource, cached_push_diagnostics, push_slot_servers,
+};
 use crate::lsp::lsp_impl::bridge_context::{
     DocumentRequestContext, HostRequestContext, resolve_aggregation_config_from_settings,
 };
@@ -128,12 +130,12 @@ impl Kakehashi {
         // and reopens while the pull is in flight, the eventual `mark_served` is a
         // no-op against the new lifetime rather than poisoning it with a stale-high
         // version (#745).
-        let served_version = self.diagnostics.coverage_stamp(&uri);
+        let coverage_stamp = self.diagnostics.coverage_stamp(&uri);
 
         // Get the language for this document
         let Some(language_name) = self.document_language(&uri) else {
             log::debug!(target: "kakehashi::diagnostic", "No language detected");
-            self.mark_pull_covered(&uri, served_version);
+            self.mark_pull_covered(&uri, coverage_stamp);
             return Ok(empty_diagnostic_report());
         };
 
@@ -154,7 +156,7 @@ impl Kakehashi {
                 "no diagnostic layer enabled for {} (layers.aggregation priorities / bridge._self)",
                 language_name
             );
-            self.mark_pull_covered(&uri, served_version);
+            self.mark_pull_covered(&uri, coverage_stamp);
             return Ok(empty_diagnostic_report());
         }
 
@@ -398,7 +400,7 @@ impl Kakehashi {
                     .request_pull_diagnostic_refresh(true);
             }
         } else {
-            self.mark_pull_covered(&uri, served_version);
+            self.mark_pull_covered(&uri, coverage_stamp);
         }
 
         let items = combine_layer_diagnostics(&layer_cfg, virt_items, host_items);
@@ -420,8 +422,8 @@ impl Kakehashi {
     /// coverage `served` marker and clear any earlier degraded-pull debt —
     /// every covering exit must do both, or a stale debt would later fire an
     /// unnecessary (though coverage-gated) recovery refresh.
-    fn mark_pull_covered(&self, uri: &Url, served_version: u64) {
-        self.diagnostics.mark_served(uri, served_version);
+    fn mark_pull_covered(&self, uri: &Url, coverage_stamp: Option<DiagnosticCoverageStamp>) {
+        self.diagnostics.mark_served(uri, coverage_stamp);
         self.diagnostics.forget_degraded_pull(uri);
     }
 

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -124,15 +124,11 @@ impl Kakehashi {
         // refresh redundant, never skips a needed one. Recorded only on the paths
         // that return a report for this open doc (not the cancel path).
         //
-        // Known limitation (deferred epoch class, like `did_close.rs`): if this doc
-        // is closed and re-opened while this pull is in flight, `forget_coverage`
-        // resets the entry to 0 and this captured version becomes stale-HIGH for the
-        // re-opened incarnation. `mark_served` then sets `served` above the re-opened
-        // `current`, leaving the gate briefly stuck-clean → a needed refresh can be
-        // skipped (narrow staleness) until `current` catches back up. Closing this
-        // fully needs a per-incarnation epoch; the editor's own re-open pull
-        // self-heals it.
-        let served_version = self.diagnostics.current_version(&uri);
+        // The stamp includes the coverage-entry lifetime: if this document closes
+        // and reopens while the pull is in flight, the eventual `mark_served` is a
+        // no-op against the new lifetime rather than poisoning it with a stale-high
+        // version (#745).
+        let served_version = self.diagnostics.coverage_stamp(&uri);
 
         // Get the language for this document
         let Some(language_name) = self.document_language(&uri) else {

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -373,7 +373,7 @@ impl Kakehashi {
         if degraded_virt {
             // The debt drives the post-parse recovery refresh (see
             // `DiagnosticAggregator::degraded_pulls`).
-            self.diagnostics.record_degraded_pull(&uri);
+            self.diagnostics.record_degraded_pull(&uri, coverage_stamp);
             // TOCTOU guard: `snapshot` was captured before the fan-out/fold
             // awaits above, so the parse may have landed — and the post-parse
             // debt consumer already run — in between, leaving this
@@ -421,10 +421,17 @@ impl Kakehashi {
     /// A pull answered with a covering (non-degraded) report: advance the
     /// coverage `served` marker and clear any earlier degraded-pull debt —
     /// every covering exit must do both, or a stale debt would later fire an
-    /// unnecessary (though coverage-gated) recovery refresh.
+    /// unnecessary recovery refresh. Not coverage-gated: both recovery paths
+    /// pass `forced`, so the debt is the only thing standing between a stale
+    /// entry and a refresh.
+    ///
+    /// Both halves are scoped to the coverage lifetime this pull observed. A
+    /// pull that started before a close+reopen may neither mark the reopened
+    /// lifetime served nor clear a debt recorded within it (#745).
     fn mark_pull_covered(&self, uri: &Url, coverage_stamp: Option<DiagnosticCoverageStamp>) {
         self.diagnostics.mark_served(uri, coverage_stamp);
-        self.diagnostics.forget_degraded_pull(uri);
+        self.diagnostics
+            .forget_degraded_pull_from(uri, coverage_stamp);
     }
 
     /// pushFallback fold (Path B, #425): append push-driven servers' cached


### PR DESCRIPTION
## Summary

- attach an epoch to each per-host diagnostic coverage lifetime
- make pulls carry an epoch-stamped coverage snapshot
- ignore completions from a document lifetime that has since closed

## Why

An in-flight `textDocument/diagnostic` pull could complete after `didClose` and poison a reopened host's refresh gate with the old lifetime's higher served version. That could suppress a required `workspace/diagnostic/refresh` until another editor pull self-healed the state.

Closes #745.

## Validation

- `cargo test --lib coverage_` (7 passed)
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --check`
- revise local review: no actionable findings
- Codex continued review: no comments
- Codex fresh review: no actionable findings

## Risk

Low and isolated to diagnostic refresh bookkeeping. The new atomic increments only when a coverage entry is first created; steady-state push/pull paths retain the existing per-host coverage mutex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic refresh tracking across document reopenings and host lifetime changes.
  * Prevented stale or in-flight diagnostic requests from incorrectly marking coverage as served.
  * Improved recovery handling for incomplete diagnostic pulls, including documents without detected languages.
* **Tests**
  * Added regression coverage for stale diagnostic results and lifetime transitions.
  * Updated diagnostic coverage tests to validate matching request lifetimes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->