### PR TITLE
feat(lsp): reload config for primary workspace

### DIFF
--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -542,9 +542,7 @@ impl LanguageServerPool {
         &self,
         folders: Option<Vec<tower_lsp_server::ls_types::WorkspaceFolder>>,
     ) {
-        if let Some(folders) = folders {
-            self.workspace_folders.apply_change(folders, &[]);
-        }
+        self.workspace_folders.replace(folders);
     }
 
     /// Get the workspace folders.

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -372,7 +372,7 @@ pub struct LanguageServerPool {
     ///
     /// Set once via `set_workspace_folders()` after receiving the upstream initialize request.
     /// Passed to downstream servers during LSP handshake.
-    workspace_folders: OnceLock<Option<Vec<tower_lsp_server::ls_types::WorkspaceFolder>>>,
+    workspace_folders: super::WorkspaceFolderSet,
     /// Client capabilities forwarded from upstream client.
     ///
     /// Set once via `set_client_capabilities()` after receiving the upstream initialize request.
@@ -459,7 +459,7 @@ impl LanguageServerPool {
             cancel_metrics: CancelForwardingMetrics::default(),
             consecutive_panic_counts: std::sync::Mutex::new(HashMap::new()),
             root_uri: OnceLock::new(),
-            workspace_folders: OnceLock::new(),
+            workspace_folders: super::WorkspaceFolderSet::new(None),
             client_capabilities: OnceLock::new(),
             upstream_tx,
             upstream_rx: std::sync::Mutex::new(Some(upstream_rx)),
@@ -544,12 +544,24 @@ impl LanguageServerPool {
         &self,
         folders: Option<Vec<tower_lsp_server::ls_types::WorkspaceFolder>>,
     ) {
-        let _ = self.workspace_folders.set(folders);
+        if let Some(folders) = folders {
+            self.workspace_folders.apply_change(folders, &[]);
+        }
     }
 
     /// Get the workspace folders.
     fn workspace_folders(&self) -> Option<Vec<tower_lsp_server::ls_types::WorkspaceFolder>> {
-        self.workspace_folders.get().and_then(|v| v.clone())
+        self.workspace_folders.snapshot()
+    }
+
+    /// Update the upstream client workspace snapshot used by future
+    /// client-fallback downstream connections.
+    pub(crate) fn apply_workspace_folder_change(
+        &self,
+        added: Vec<tower_lsp_server::ls_types::WorkspaceFolder>,
+        removed: &[tower_lsp_server::ls_types::WorkspaceFolder],
+    ) {
+        self.workspace_folders.apply_change(added, removed);
     }
 
     /// Set the upstream client capabilities.

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -368,10 +368,9 @@ pub struct LanguageServerPool {
     /// Passed to downstream servers during LSP handshake so they can provide
     /// workspace-aware features (diagnostics, go-to-definition, etc.).
     root_uri: OnceLock<Option<String>>,
-    /// Workspace folders forwarded from upstream client.
-    ///
-    /// Set once via `set_workspace_folders()` after receiving the upstream initialize request.
-    /// Passed to downstream servers during LSP handshake.
+    /// Current workspace folders from the upstream client. Seeded during
+    /// initialize, then updated by `workspace/didChangeWorkspaceFolders` and
+    /// snapshotted for each later downstream handshake.
     workspace_folders: super::WorkspaceFolderSet,
     /// Client capabilities forwarded from upstream client.
     ///
@@ -538,8 +537,7 @@ impl LanguageServerPool {
 
     /// Set the workspace folders.
     ///
-    /// Called once during upstream initialize to forward workspace folders to downstream servers.
-    /// Subsequent calls are ignored (OnceLock semantics).
+    /// Called during upstream initialize to seed the workspace-folder snapshot.
     pub(crate) fn set_workspace_folders(
         &self,
         folders: Option<Vec<tower_lsp_server::ls_types::WorkspaceFolder>>,

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -556,8 +556,8 @@ impl LanguageServerPool {
         &self,
         added: Vec<tower_lsp_server::ls_types::WorkspaceFolder>,
         removed: &[tower_lsp_server::ls_types::WorkspaceFolder],
-    ) {
-        self.workspace_folders.apply_change(added, removed);
+    ) -> Option<Vec<tower_lsp_server::ls_types::WorkspaceFolder>> {
+        self.workspace_folders.apply_change(added, removed)
     }
 
     /// Set the upstream client capabilities.

--- a/src/lsp/bridge/workspace/folder_set.rs
+++ b/src/lsp/bridge/workspace/folder_set.rs
@@ -50,6 +50,15 @@ impl WorkspaceFolderSet {
             .clone()
     }
 
+    /// Replace the complete set, preserving the protocol distinction between
+    /// `None` (`null`) and `Some(vec![])` (an explicitly empty folder list).
+    pub(crate) fn replace(&self, folders: Option<Vec<WorkspaceFolder>>) {
+        *self
+            .inner
+            .lock()
+            .recover_poison("WorkspaceFolderSet::replace") = folders;
+    }
+
     /// Whether a folder with `folder`'s URI is already in the set.
     pub(crate) fn contains(&self, folder: &WorkspaceFolder) -> bool {
         self.inner
@@ -207,5 +216,14 @@ mod tests {
         set.apply_change(Vec::new(), &[folder("file:///absent")]);
 
         assert_eq!(set.snapshot(), None);
+    }
+
+    #[test]
+    fn replace_preserves_an_explicit_empty_set() {
+        let set = WorkspaceFolderSet::new(None);
+
+        set.replace(Some(Vec::new()));
+
+        assert_eq!(set.snapshot(), Some(Vec::new()));
     }
 }

--- a/src/lsp/bridge/workspace/folder_set.rs
+++ b/src/lsp/bridge/workspace/folder_set.rs
@@ -70,14 +70,20 @@ impl WorkspaceFolderSet {
 
     /// Apply an upstream workspace-folder change atomically. Removals match by
     /// URI (folder names are display metadata), then additions append in event
-    /// order while preserving URI uniqueness.
-    pub(crate) fn apply_change(&self, added: Vec<WorkspaceFolder>, removed: &[WorkspaceFolder]) {
+    /// order while preserving URI uniqueness. Returns the resulting snapshot
+    /// from the same lock acquisition so primary-root selection cannot observe
+    /// an interleaved folder event.
+    pub(crate) fn apply_change(
+        &self,
+        added: Vec<WorkspaceFolder>,
+        removed: &[WorkspaceFolder],
+    ) -> Option<Vec<WorkspaceFolder>> {
         let mut guard = self
             .inner
             .lock()
             .recover_poison("WorkspaceFolderSet::apply_change");
         if guard.is_none() && added.is_empty() {
-            return;
+            return None;
         }
         let folders = guard.get_or_insert_with(Vec::new);
         folders.retain(|existing| !removed.iter().any(|removed| removed.uri == existing.uri));
@@ -86,6 +92,7 @@ impl WorkspaceFolderSet {
                 folders.push(folder);
             }
         }
+        guard.clone()
     }
 
     /// Atomically add `folder` and announce it, returning whether the set now

--- a/src/lsp/bridge/workspace/folder_set.rs
+++ b/src/lsp/bridge/workspace/folder_set.rs
@@ -67,6 +67,9 @@ impl WorkspaceFolderSet {
             .inner
             .lock()
             .recover_poison("WorkspaceFolderSet::apply_change");
+        if guard.is_none() && added.is_empty() {
+            return;
+        }
         let folders = guard.get_or_insert_with(Vec::new);
         folders.retain(|existing| !removed.iter().any(|removed| removed.uri == existing.uri));
         for folder in added {
@@ -195,5 +198,14 @@ mod tests {
             set.snapshot(),
             Some(vec![folder("file:///b"), folder("file:///c")])
         );
+    }
+
+    #[test]
+    fn removal_only_change_preserves_a_none_set() {
+        let set = WorkspaceFolderSet::new(None);
+
+        set.apply_change(Vec::new(), &[folder("file:///absent")]);
+
+        assert_eq!(set.snapshot(), None);
     }
 }

--- a/src/lsp/bridge/workspace/folder_set.rs
+++ b/src/lsp/bridge/workspace/folder_set.rs
@@ -59,6 +59,23 @@ impl WorkspaceFolderSet {
             .is_some_and(|folders| folders.iter().any(|existing| existing.uri == folder.uri))
     }
 
+    /// Apply an upstream workspace-folder change atomically. Removals match by
+    /// URI (folder names are display metadata), then additions append in event
+    /// order while preserving URI uniqueness.
+    pub(crate) fn apply_change(&self, added: Vec<WorkspaceFolder>, removed: &[WorkspaceFolder]) {
+        let mut guard = self
+            .inner
+            .lock()
+            .recover_poison("WorkspaceFolderSet::apply_change");
+        let folders = guard.get_or_insert_with(Vec::new);
+        folders.retain(|existing| !removed.iter().any(|removed| removed.uri == existing.uri));
+        for folder in added {
+            if !folders.iter().any(|existing| existing.uri == folder.uri) {
+                folders.push(folder);
+            }
+        }
+    }
+
     /// Atomically add `folder` and announce it, returning whether the set now
     /// contains it. If `folder` is already present, returns `true` without
     /// calling `announce`. Otherwise `announce` runs **while the set lock is
@@ -163,5 +180,20 @@ mod tests {
         let set = WorkspaceFolderSet::new(None);
         assert!(set.add_and_announce(folder("file:///a"), || true));
         assert_eq!(set.snapshot(), Some(vec![folder("file:///a")]));
+    }
+
+    #[test]
+    fn apply_change_removes_by_uri_and_adds_without_duplicates() {
+        let set = WorkspaceFolderSet::new(Some(vec![folder("file:///a"), folder("file:///b")]));
+
+        set.apply_change(
+            vec![folder("file:///b"), folder("file:///c")],
+            &[folder("file:///a")],
+        );
+
+        assert_eq!(
+            set.snapshot(),
+            Some(vec![folder("file:///b"), folder("file:///c")])
+        );
     }
 }

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -102,6 +102,12 @@ pub(super) struct ReloadLanguageState<'a> {
     request_semantic_refresh: bool,
 }
 
+pub(super) struct SettingsUpdate {
+    root_path: Option<Option<std::path::PathBuf>>,
+    raw_settings: Option<RawWorkspaceSettings>,
+    settings: WorkspaceSettings,
+}
+
 /// One server process owns one effective workspace settings snapshot. Keep the
 /// complete async reload transaction ordered across didChangeConfiguration and
 /// post-install reloads, including downstream propagation and SettingsManager
@@ -137,9 +143,13 @@ pub(super) async fn apply_shared_settings(
     settings_manager: &SettingsManager,
     cache: &CacheCoordinator,
     bridge: &BridgeCoordinator,
-    raw_settings: Option<RawWorkspaceSettings>,
-    settings: WorkspaceSettings,
+    update: SettingsUpdate,
 ) -> Vec<Url> {
+    let SettingsUpdate {
+        root_path,
+        raw_settings,
+        settings,
+    } = update;
     let _reload = SETTINGS_RELOAD_LOCK.lock().await;
     // TRANSITIONAL generation bump BEFORE any query/config mutation: from
     // this instant, every generation-stamped product built from the OLD
@@ -174,9 +184,14 @@ pub(super) async fn apply_shared_settings(
     // Publish the settings snapshot before invalidating downstream connections:
     // once propagation exposes a pool miss, a concurrent request must resolve
     // the NEW launch config rather than respawn from the old snapshot (#587).
-    match raw_settings {
-        Some(raw_settings) => settings_manager.apply_settings_with_raw(raw_settings, settings),
-        None => settings_manager.apply_settings(settings),
+    match (root_path, raw_settings) {
+        (Some(root_path), Some(raw_settings)) => {
+            settings_manager.apply_settings_with_raw_at_root(root_path, raw_settings, settings)
+        }
+        (None, Some(raw_settings)) => {
+            settings_manager.apply_settings_with_raw(raw_settings, settings)
+        }
+        (_, None) => settings_manager.apply_settings(settings),
     }
     let settings = settings_manager.load_settings();
     // Path c: apply downstream config at this single reload choke point
@@ -489,8 +504,11 @@ impl Kakehashi {
             &self.settings_manager,
             &self.cache,
             &self.bridge,
-            Some(raw_settings),
-            settings,
+            SettingsUpdate {
+                root_path: None,
+                raw_settings: Some(raw_settings),
+                settings,
+            },
         )
         .await
         .into_iter()
@@ -515,8 +533,41 @@ impl Kakehashi {
             &self.settings_manager,
             &self.cache,
             &self.bridge,
-            Some(raw_settings),
-            settings,
+            SettingsUpdate {
+                root_path: None,
+                raw_settings: Some(raw_settings),
+                settings,
+            },
+        )
+        .await
+        .into_iter()
+        .for_each(|uri| self.schedule_reparse(uri, None));
+        self.warn_on_misconfigured_settings().await;
+    }
+
+    async fn apply_raw_settings_at_root(
+        &self,
+        root_path: Option<std::path::PathBuf>,
+        raw_settings: RawWorkspaceSettings,
+        settings: WorkspaceSettings,
+    ) {
+        apply_shared_settings(
+            &self.client,
+            ReloadLanguageState {
+                language: &self.language,
+                parser_pool: &self.parser_pool,
+                documents: &self.documents,
+                invalidate_documents: true,
+                request_semantic_refresh: true,
+            },
+            &self.settings_manager,
+            &self.cache,
+            &self.bridge,
+            SettingsUpdate {
+                root_path: Some(root_path),
+                raw_settings: Some(raw_settings),
+                settings,
+            },
         )
         .await
         .into_iter()

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -22,19 +22,19 @@ use tower_lsp_server::ls_types::request::{
 use tower_lsp_server::ls_types::{
     CodeAction, CodeActionParams, CodeActionResponse, CodeLens, CodeLensParams, CompletionItem,
     CompletionParams, CompletionResponse, DidChangeConfigurationParams,
-    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-    DidSaveTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReportResult,
-    DocumentFormattingParams, DocumentHighlight, DocumentHighlightParams, DocumentLink,
-    DocumentLinkParams, DocumentOnTypeFormattingParams, DocumentRangeFormattingParams,
-    DocumentSymbolParams, DocumentSymbolResponse, ExecuteCommandParams, FoldingRange,
-    FoldingRangeParams, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams,
-    InitializeParams, InitializeResult, InitializedParams, InlayHint, InlayHintParams,
-    LinkedEditingRangeParams, LinkedEditingRanges, Location, Moniker, MonikerParams,
-    PrepareRenameResponse, ReferenceParams, RenameParams, SelectionRange, SelectionRangeParams,
-    SemanticTokensDeltaParams, SemanticTokensFullDeltaResult, SemanticTokensParams,
-    SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult, SignatureHelp,
-    SignatureHelpParams, TextDocumentPositionParams, TextEdit, Uri, WillSaveTextDocumentParams,
-    WorkspaceEdit,
+    DidChangeTextDocumentParams, DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentDiagnosticParams,
+    DocumentDiagnosticReportResult, DocumentFormattingParams, DocumentHighlight,
+    DocumentHighlightParams, DocumentLink, DocumentLinkParams, DocumentOnTypeFormattingParams,
+    DocumentRangeFormattingParams, DocumentSymbolParams, DocumentSymbolResponse,
+    ExecuteCommandParams, FoldingRange, FoldingRangeParams, GotoDefinitionParams,
+    GotoDefinitionResponse, Hover, HoverParams, InitializeParams, InitializeResult,
+    InitializedParams, InlayHint, InlayHintParams, LinkedEditingRangeParams, LinkedEditingRanges,
+    Location, Moniker, MonikerParams, PrepareRenameResponse, ReferenceParams, RenameParams,
+    SelectionRange, SelectionRangeParams, SemanticTokensDeltaParams, SemanticTokensFullDeltaResult,
+    SemanticTokensParams, SemanticTokensRangeParams, SemanticTokensRangeResult,
+    SemanticTokensResult, SignatureHelp, SignatureHelpParams, TextDocumentPositionParams, TextEdit,
+    Uri, WillSaveTextDocumentParams, WorkspaceEdit,
 };
 use tower_lsp_server::ls_types::{
     ColorInformation, ColorPresentation, ColorPresentationParams, DocumentColorParams,
@@ -733,6 +733,10 @@ impl LanguageServer for Kakehashi {
 
     async fn did_change_configuration(&self, params: DidChangeConfigurationParams) {
         self.did_change_configuration_impl(params).await
+    }
+
+    async fn did_change_workspace_folders(&self, params: DidChangeWorkspaceFoldersParams) {
+        self.did_change_workspace_folders_impl(params).await
     }
 
     async fn semantic_tokens_full(

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -239,8 +239,11 @@ impl InstallCoordinator {
             &self.settings_manager,
             &self.cache,
             &self.bridge,
-            Some(raw_settings),
-            settings,
+            super::super::SettingsUpdate {
+                root_path: None,
+                raw_settings: Some(raw_settings),
+                settings,
+            },
         )
         .await;
     }

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -18,7 +18,7 @@ use tower_lsp_server::ls_types::{
     SemanticTokensOptions, SemanticTokensServerCapabilities, ServerCapabilities, ServerInfo,
     SignatureHelpOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
     TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, Uri,
-    WorkDoneProgressOptions,
+    WorkDoneProgressOptions, WorkspaceFoldersServerCapabilities, WorkspaceServerCapabilities,
 };
 use url::Url;
 
@@ -52,6 +52,16 @@ fn lsp_legend_modifiers() -> Vec<SemanticTokenModifier> {
         .iter()
         .map(|m| SemanticTokenModifier::new(m.as_str()))
         .collect()
+}
+
+fn workspace_server_capabilities() -> WorkspaceServerCapabilities {
+    WorkspaceServerCapabilities {
+        workspace_folders: Some(WorkspaceFoldersServerCapabilities {
+            supported: Some(true),
+            change_notifications: Some(OneOf::Left(true)),
+        }),
+        file_operations: None,
+    }
 }
 
 impl Kakehashi {
@@ -441,6 +451,7 @@ impl Kakehashi {
                         ..Default::default()
                     },
                 )),
+                workspace: Some(workspace_server_capabilities()),
                 experimental: Some(serde_json::json!({
                     "kakehashi": {
                         "wrappedDidChangeConfigurationSettings": true,
@@ -1596,6 +1607,16 @@ async fn upstream_forwarding_loop_with_cancel(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn workspace_capabilities_request_folder_change_notifications() {
+        let workspace = workspace_server_capabilities();
+        let folders = workspace
+            .workspace_folders
+            .expect("workspace folder capability");
+        assert_eq!(folders.supported, Some(true));
+        assert_eq!(folders.change_notifications, Some(OneOf::Left(true)));
+    }
 
     /// A throwaway cancel context for tests that don't exercise cancellation.
     fn test_forwarded_cancel() -> crate::lsp::bridge::ForwardedRequestCancel {

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -149,11 +149,20 @@ impl Kakehashi {
             .pool()
             .set_client_capabilities(params.capabilities);
 
-        // Get root path from primary URI, falling back to current directory
+        // Get root path from the first workspace folder. When no folder remains,
+        // lifecycle updates fall back to initialize-time rootUri, then CWD (#746).
         let uri_to_path = |uri: &Uri| uri_to_url(uri).ok().and_then(|url| url.to_file_path().ok());
-        let root_path = primary_uri
+        #[allow(deprecated)]
+        let fallback_root_path = params
+            .root_uri
+            .as_ref()
             .and_then(uri_to_path)
             .or_else(|| std::env::current_dir().ok());
+        self.settings_manager
+            .set_fallback_root_path(fallback_root_path.clone());
+        let root_path = first_folder
+            .and_then(|folder| uri_to_path(&folder.uri))
+            .or(fallback_root_path);
 
         // Store root path for later use and log the source
         #[allow(deprecated)]
@@ -192,6 +201,8 @@ impl Kakehashi {
         self.notifier()
             .log_settings_events(&settings_outcome.events)
             .await;
+        self.settings_manager
+            .set_session_settings(settings_outcome.override_settings.clone());
 
         // Nudge users off the deprecated `rootMarkers` config key. The claim
         // guard latches session-wide so a later didChangeConfiguration carrying

--- a/src/lsp/lsp_impl/workspace.rs
+++ b/src/lsp/lsp_impl/workspace.rs
@@ -1,4 +1,5 @@
 //! Workspace related LSP methods.
 
 mod did_change_configuration;
+mod did_change_workspace_folders;
 mod execute_command;

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -394,13 +394,18 @@ impl Kakehashi {
         let current_ts = self.settings_manager.load_raw_settings();
         // SAFETY: merge_workspace_settings(Some, Some) always returns Some, so unwrap_or_return is
         // defensive only — the None branch is unreachable under the current implementation.
-        let Some(merged_ts) = merge_workspace_settings(Some((*current_ts).clone()), Some(parsed))
+        let Some(merged_ts) =
+            merge_workspace_settings(Some((*current_ts).clone()), Some(parsed.clone()))
         else {
             log::warn!(
                 "merge_workspace_settings returned None despite two Some inputs; skipping configuration update"
             );
             return;
         };
+        let session_settings = merge_workspace_settings(
+            self.settings_manager.load_session_settings(),
+            Some(parsed.clone()),
+        );
 
         match WorkspaceSettings::try_from_settings(
             &merged_ts,
@@ -409,6 +414,7 @@ impl Kakehashi {
         ) {
             Ok(settings) => {
                 self.apply_raw_settings(merged_ts, settings).await;
+                self.settings_manager.set_session_settings(session_settings);
                 self.notifier().log_info("Configuration updated!").await;
             }
             Err(errs) => {

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -1,0 +1,16 @@
+//! Upstream `workspace/didChangeWorkspaceFolders` lifecycle handling.
+
+use tower_lsp_server::ls_types::DidChangeWorkspaceFoldersParams;
+
+use super::super::Kakehashi;
+
+impl Kakehashi {
+    pub(crate) async fn did_change_workspace_folders_impl(
+        &self,
+        params: DidChangeWorkspaceFoldersParams,
+    ) {
+        self.bridge
+            .pool()
+            .apply_workspace_folder_change(params.event.added, &params.event.removed);
+    }
+}

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -1,16 +1,136 @@
 //! Upstream `workspace/didChangeWorkspaceFolders` lifecycle handling.
 
-use tower_lsp_server::ls_types::DidChangeWorkspaceFoldersParams;
+use std::path::PathBuf;
 
-use super::super::Kakehashi;
+use tower_lsp_server::ls_types::{DidChangeWorkspaceFoldersParams, WorkspaceFolder};
+
+use super::super::{Kakehashi, uri_to_url};
+use crate::lsp::settings::SettingsLoadOutcome;
+use crate::lsp::{SettingsSource, load_settings};
+
+fn primary_root_path(
+    folders: Option<&[WorkspaceFolder]>,
+    fallback: Option<PathBuf>,
+) -> Option<PathBuf> {
+    folders
+        .and_then(|folders| folders.first())
+        .and_then(|folder| uri_to_url(&folder.uri).ok())
+        .and_then(|url| url.to_file_path().ok())
+        .or(fallback)
+}
+
+fn load_primary_root_settings(
+    root_path: Option<&std::path::Path>,
+    session_settings: Option<crate::config::RawWorkspaceSettings>,
+    home: Option<&str>,
+) -> SettingsLoadOutcome {
+    let session_override = session_settings
+        .and_then(|settings| serde_json::to_value(settings).ok())
+        .map(|settings| (SettingsSource::SessionOverrides, settings));
+    load_settings(root_path, session_override, home, |var| {
+        std::env::var(var).ok()
+    })
+}
 
 impl Kakehashi {
     pub(crate) async fn did_change_workspace_folders_impl(
         &self,
         params: DidChangeWorkspaceFoldersParams,
     ) {
-        self.bridge
+        let folders = self
+            .bridge
             .pool()
             .apply_workspace_folder_change(params.event.added, &params.event.removed);
+        let root_path = primary_root_path(
+            folders.as_deref(),
+            self.settings_manager.fallback_root_path(),
+        );
+        if self.settings_manager.root_path().as_ref() == &root_path {
+            return;
+        }
+
+        let outcome = load_primary_root_settings(
+            root_path.as_deref(),
+            self.settings_manager.load_session_settings(),
+            self.home_dir.as_deref(),
+        );
+        self.notifier().log_settings_events(&outcome.events).await;
+
+        let (Some(raw_settings), Some(settings)) = (outcome.raw_settings, outcome.settings) else {
+            self.notifier()
+                .log_warning(
+                    "Workspace root changed, but its configuration could not be applied; \
+                     retaining the previous root and settings",
+                )
+                .await;
+            return;
+        };
+        self.apply_raw_settings_at_root(root_path, raw_settings, settings)
+            .await;
+        self.notifier()
+            .log_info("Primary workspace root configuration updated")
+            .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{RawWorkspaceSettings, merge_workspace_settings};
+    use std::str::FromStr;
+    use tower_lsp_server::ls_types::Uri;
+
+    fn folder(uri: &str, name: &str) -> WorkspaceFolder {
+        WorkspaceFolder {
+            uri: Uri::from_str(uri).expect("valid URI"),
+            name: name.to_string(),
+        }
+    }
+
+    #[test]
+    fn primary_root_uses_first_folder_in_client_order() {
+        let folders = [
+            folder("file:///first", "first"),
+            folder("file:///second", "second"),
+        ];
+
+        assert_eq!(
+            primary_root_path(Some(&folders), Some(PathBuf::from("/fallback"))),
+            Some(PathBuf::from("/first"))
+        );
+    }
+
+    #[test]
+    fn primary_root_falls_back_when_last_folder_is_removed() {
+        assert_eq!(
+            primary_root_path(Some(&[]), Some(PathBuf::from("/fallback"))),
+            Some(PathBuf::from("/fallback"))
+        );
+    }
+
+    #[test]
+    fn root_reload_preserves_initialization_and_runtime_layers() {
+        let root = tempfile::tempdir().expect("temporary root");
+        std::fs::write(
+            root.path().join("kakehashi.toml"),
+            "diagnosticsDebounceMs = 321\n",
+        )
+        .expect("project config");
+        let initialization = RawWorkspaceSettings {
+            auto_install: Some(false),
+            ..Default::default()
+        };
+        let runtime = RawWorkspaceSettings {
+            search_paths: Some(vec!["/runtime/parsers".to_string()]),
+            ..Default::default()
+        };
+        let session = merge_workspace_settings(Some(initialization), Some(runtime));
+
+        let outcome = load_primary_root_settings(Some(root.path()), session, None);
+        let raw = outcome.raw_settings.expect("settings load");
+
+        assert_eq!(raw.diagnostics_debounce_ms, Some(321));
+        assert_eq!(raw.auto_install, Some(false));
+        assert_eq!(raw.search_paths, Some(vec!["/runtime/parsers".to_string()]));
     }
 }

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -46,12 +46,14 @@ impl SettingsEvent {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SettingsSource {
     InitializationOptions,
+    SessionOverrides,
 }
 
 impl SettingsSource {
     fn description(self) -> &'static str {
         match self {
             SettingsSource::InitializationOptions => "initialization options",
+            SettingsSource::SessionOverrides => "retained session overrides",
         }
     }
 }
@@ -60,6 +62,10 @@ impl SettingsSource {
 pub struct SettingsLoadOutcome {
     pub settings: Option<WorkspaceSettings>,
     pub raw_settings: Option<RawWorkspaceSettings>,
+    /// Parsed session override supplied for this load, retained separately from
+    /// the merged result so a later project-root reload can replace only the
+    /// file layer.
+    pub override_settings: Option<RawWorkspaceSettings>,
     pub events: Vec<SettingsEvent>,
     /// True if any loaded config layer used the deprecated `rootMarkers` key
     /// (superseded by `workspaceMarkers`). Serde's alias erases which spelling
@@ -117,7 +123,7 @@ pub fn load_settings(
     // Merge all layers: defaults < config_layers < override (later layers override earlier)
     let mut layers = vec![defaults];
     layers.extend(config_layers);
-    layers.push(override_settings);
+    layers.push(override_settings.clone());
     let merged = layers
         .into_iter()
         .reduce(merge_workspace_settings)
@@ -141,6 +147,7 @@ pub fn load_settings(
     SettingsLoadOutcome {
         settings,
         raw_settings,
+        override_settings,
         events,
         used_deprecated_root_markers,
     }

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -1,6 +1,7 @@
 //! `SettingsManager`: workspace settings (`ArcSwap`, hot-swappable via
-//! `apply_settings`) plus initialize-only state — `client_capabilities` and
-//! `root_path` (both `OnceLock`, set once during `initialize()`).
+//! `apply_settings`) plus client capabilities and primary-root state. The root
+//! shares the same `ArcSwap` snapshot as raw/effective settings so a workspace
+//! folder transition publishes all three atomically (#746).
 
 use arc_swap::ArcSwap;
 use path_clean::PathClean;
@@ -13,19 +14,27 @@ use tower_lsp_server::ls_types::{
 
 use crate::config::expand::with_kakehashi_defaults;
 use crate::config::{RawWorkspaceSettings, WorkspaceSettings};
+use crate::error::LockResultExt;
 #[cfg(test)]
 use crate::lsp::client::check_semantic_tokens_refresh_support;
 
 /// Centralized manager for workspace settings, capabilities, and configuration.
 #[derive(Debug)]
 pub(crate) struct SettingsSnapshot {
+    pub(crate) root_path: Arc<Option<PathBuf>>,
     pub(crate) raw_settings: Arc<RawWorkspaceSettings>,
     pub(crate) settings: Arc<WorkspaceSettings>,
 }
 
 pub(crate) struct SettingsManager {
-    root_path: ArcSwap<Option<PathBuf>>,
     settings_snapshot: ArcSwap<SettingsSnapshot>,
+    /// Session-owned configuration layers (initialization options followed by
+    /// runtime updates), retained separately so a workspace-root change can
+    /// replace only the project-file layer.
+    session_settings: std::sync::Mutex<Option<RawWorkspaceSettings>>,
+    /// Deprecated `rootUri`, or process CWD when absent. Initialize fixes this
+    /// fallback for the session; it is used only when no workspace folder remains.
+    fallback_root_path: OnceLock<Option<PathBuf>>,
     /// Client capabilities from initialize() - immutable after initialization.
     /// Uses OnceLock to enforce "set once, read many" semantics per LSP protocol.
     client_capabilities: OnceLock<ClientCapabilities>,
@@ -42,7 +51,6 @@ pub(crate) struct SettingsManager {
 impl std::fmt::Debug for SettingsManager {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SettingsManager")
-            .field("root_path", &"ArcSwap<Option<PathBuf>>")
             .field("settings_snapshot", &"ArcSwap<SettingsSnapshot>")
             .field("client_capabilities", &"OnceLock<ClientCapabilities>")
             .finish()
@@ -74,11 +82,13 @@ impl SettingsManager {
         });
 
         Self {
-            root_path: ArcSwap::new(Arc::new(None)),
             settings_snapshot: ArcSwap::new(Arc::new(SettingsSnapshot {
+                root_path: Arc::new(None),
                 raw_settings: Arc::new(raw_settings),
                 settings: Arc::new(settings),
             })),
+            session_settings: std::sync::Mutex::new(None),
+            fallback_root_path: OnceLock::new(),
             client_capabilities: OnceLock::new(),
             root_markers_deprecation_warned: AtomicBool::new(false),
             unwrapped_didchange_deprecation_warned: AtomicBool::new(false),
@@ -136,12 +146,25 @@ impl SettingsManager {
     /// `workspace_folders`, `root_uri` (deprecated but supported for backward
     /// compatibility), or the current working directory.
     pub(crate) fn set_root_path(&self, path: Option<PathBuf>) {
-        self.root_path.store(Arc::new(path));
+        let snapshot = self.settings_snapshot.load_full();
+        self.settings_snapshot.store(Arc::new(SettingsSnapshot {
+            root_path: Arc::new(path),
+            raw_settings: Arc::clone(&snapshot.raw_settings),
+            settings: Arc::clone(&snapshot.settings),
+        }));
     }
 
     /// Get the current workspace root path.
     pub(crate) fn root_path(&self) -> Arc<Option<PathBuf>> {
-        self.root_path.load_full()
+        Arc::clone(&self.settings_snapshot.load().root_path)
+    }
+
+    pub(crate) fn set_fallback_root_path(&self, path: Option<PathBuf>) {
+        let _ = self.fallback_root_path.set(path);
+    }
+
+    pub(crate) fn fallback_root_path(&self) -> Option<PathBuf> {
+        self.fallback_root_path.get().cloned().flatten()
     }
 
     /// Load the current workspace settings.
@@ -159,6 +182,20 @@ impl SettingsManager {
         self.settings_snapshot.load_full()
     }
 
+    pub(crate) fn set_session_settings(&self, settings: Option<RawWorkspaceSettings>) {
+        *self
+            .session_settings
+            .lock()
+            .recover_poison("SettingsManager::session_settings") = settings;
+    }
+
+    pub(crate) fn load_session_settings(&self) -> Option<RawWorkspaceSettings> {
+        self.session_settings
+            .lock()
+            .recover_poison("SettingsManager::session_settings")
+            .clone()
+    }
+
     /// Apply new workspace settings for later retrieval via `load_settings()`.
     pub(crate) fn apply_settings(&self, settings: WorkspaceSettings) {
         let raw_settings = RawWorkspaceSettings::from(&settings);
@@ -171,7 +208,19 @@ impl SettingsManager {
         raw_settings: RawWorkspaceSettings,
         settings: WorkspaceSettings,
     ) {
+        let root_path = self.root_path();
+        self.apply_settings_with_raw_at_root(root_path.as_ref().clone(), raw_settings, settings);
+    }
+
+    /// Atomically publish a new primary root with the settings derived from it.
+    pub(crate) fn apply_settings_with_raw_at_root(
+        &self,
+        root_path: Option<PathBuf>,
+        raw_settings: RawWorkspaceSettings,
+        settings: WorkspaceSettings,
+    ) {
         self.settings_snapshot.store(Arc::new(SettingsSnapshot {
+            root_path: Arc::new(root_path),
             raw_settings: Arc::new(raw_settings),
             settings: Arc::new(settings),
         }));
@@ -383,6 +432,47 @@ mod tests {
         let loaded = manager.load_settings();
 
         assert!(!loaded.auto_install);
+    }
+
+    #[test]
+    fn session_settings_preserve_initialization_and_runtime_layers() {
+        let manager = SettingsManager::new();
+        let initialization = RawWorkspaceSettings {
+            auto_install: Some(false),
+            ..Default::default()
+        };
+
+        manager.set_session_settings(Some(initialization.clone()));
+
+        assert_eq!(
+            manager
+                .load_session_settings()
+                .and_then(|settings| settings.auto_install),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn root_and_settings_publish_in_one_snapshot() {
+        let manager = SettingsManager::new();
+        let raw = RawWorkspaceSettings {
+            auto_install: Some(false),
+            ..Default::default()
+        };
+        let settings = WorkspaceSettings {
+            auto_install: false,
+            ..Default::default()
+        };
+
+        manager.apply_settings_with_raw_at_root(Some(PathBuf::from("/new-root")), raw, settings);
+        let snapshot = manager.load_settings_pair();
+
+        assert_eq!(
+            snapshot.root_path.as_ref(),
+            &Some(PathBuf::from("/new-root"))
+        );
+        assert_eq!(snapshot.raw_settings.auto_install, Some(false));
+        assert!(!snapshot.settings.auto_install);
     }
 
     #[test]

--- a/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
+++ b/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/e2e_lsp_protocol.rs
-assertion_line: 46
 expression: capabilities
 ---
 {
@@ -58,6 +57,12 @@ expression: capabilities
   "foldingRangeProvider": true,
   "declarationProvider": {
     "workDoneProgress": true
+  },
+  "workspace": {
+    "workspaceFolders": {
+      "supported": true,
+      "changeNotifications": true
+    }
   },
   "semanticTokensProvider": {
     "legend": {


### PR DESCRIPTION
## Summary

- select the first active workspace folder as the primary project-config root
- fall back to initialize-time `rootUri`, then process CWD, after the last folder is removed
- retain initialization/runtime session overlays separately while replacing only the project-file layer
- publish root, raw settings, and effective settings in one SettingsManager snapshot
- route the reload through the existing language/query/downstream settings transaction

Closes #746.

## Stack

Stacked on #748, which provides the advertised workspace-folder capability and ordered live folder snapshot. Keep this PR draft until #748 merges and this branch is retargeted to `main`.

#714 owns settings-derivation serialization. This PR deliberately does not duplicate that lock. After #714 merges, rebase this branch onto the resulting latest `main` and run the mixed `didChangeConfiguration`/workspace-folder integration checks before marking ready.

## Validation

- `cargo test --lib -q lsp::bridge::workspace::folder_set` (8 passed)
- `cargo test --lib -q did_change_workspace_folders` (3 passed)
- `cargo test --lib -q lsp::settings_manager` (39 passed)
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --check`

## Safety

Folder removals affect only the upstream folder snapshot. This change does not remove marker-derived folders from live downstream shared connections (#747 owns provenance-safe live propagation). A failed root config expansion retains both the previous root and previous settings.