### PR TITLE
fix(cli): reject special-file paths

### DIFF
--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -40,7 +40,7 @@ use std::time::Duration;
 use tower_lsp_server::LspService;
 use tower_lsp_server::ls_types::{Diagnostic, DiagnosticSeverity, NumberOrString};
 
-use crate::cli::files::collect_files;
+use crate::cli::files::{collect_files, read_regular_file_to_string};
 use crate::cli::terminal::{escape_terminal_controls, is_bidi_control, is_line_separator};
 use crate::lsp::Kakehashi;
 
@@ -272,7 +272,7 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &DiagnoseOptions) ->
         // Collected paths are absolute; report them cwd-relative so the output
         // stays readable (and editor-openable) in deep trees.
         let display = file.strip_prefix(cwd).unwrap_or(file).display().to_string();
-        let text = match std::fs::read_to_string(file) {
+        let text = match read_regular_file_to_string(file) {
             Ok(text) => text,
             Err(e) => {
                 elnln!(

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -41,6 +41,13 @@ pub(crate) fn read_regular_file_to_string(path: &Path) -> std::io::Result<String
             "path is not a regular file",
         ));
     }
+    #[cfg(unix)]
+    {
+        use nix::fcntl::{FcntlArg, OFlag, fcntl};
+
+        let flags = OFlag::from_bits_truncate(fcntl(&file, FcntlArg::F_GETFL)?);
+        fcntl(&file, FcntlArg::F_SETFL(flags - OFlag::O_NONBLOCK))?;
+    }
     let mut text = String::new();
     file.read_to_string(&mut text)?;
     Ok(text)

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -469,7 +469,6 @@ mod tests {
     fn read_rejects_fifo_replacing_a_collected_file() {
         use nix::sys::stat::Mode;
         use nix::unistd::mkfifo;
-        use std::io::Write as _;
 
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("input.md");
@@ -477,22 +476,17 @@ mod tests {
         let collected = collect_paths(tmp.path(), std::slice::from_ref(&path), &[], &markdown_only);
         std::fs::remove_file(&path).unwrap();
         mkfifo(&path, Mode::S_IRUSR | Mode::S_IWUSR).unwrap();
-        let writer_path = path.clone();
-        let (ready_tx, ready_rx) = std::sync::mpsc::channel();
-        let writer = std::thread::spawn(move || {
-            let mut fifo = std::fs::File::options()
-                .read(true)
-                .write(true)
-                .open(writer_path)
+        let collected_path = collected[0].clone();
+        let (result_tx, result_rx) = std::sync::mpsc::channel();
+        let reader = std::thread::spawn(move || {
+            result_tx
+                .send(read_regular_file_to_string(&collected_path))
                 .unwrap();
-            fifo.write_all(b"replacement").unwrap();
-            ready_tx.send(()).unwrap();
-            std::thread::sleep(std::time::Duration::from_millis(50));
         });
-        ready_rx.recv().unwrap();
-
-        let result = read_regular_file_to_string(&collected[0]);
-        writer.join().unwrap();
+        let result = result_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("reading a FIFO without a writer must not block");
+        reader.join().unwrap();
 
         assert!(result.is_err());
     }

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -23,6 +23,29 @@ fn format_walk_error(error: &str) -> String {
     format!("error: skipping unreadable entry (will exit 2): {error}")
 }
 
+/// Read a collected path as UTF-8 text.
+pub(crate) fn read_regular_file_to_string(path: &Path) -> std::io::Result<String> {
+    use std::io::Read as _;
+
+    let mut options = std::fs::File::options();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(nix::libc::O_NONBLOCK);
+    }
+    let mut file = options.open(path)?;
+    if !file.metadata()?.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "path is not a regular file",
+        ));
+    }
+    let mut text = String::new();
+    file.read_to_string(&mut text)?;
+    Ok(text)
+}
+
 /// Files collected from CLI paths plus any non-fatal directory walk errors
 /// encountered while discovering them.
 pub(crate) struct CollectedFiles {
@@ -437,6 +460,39 @@ mod tests {
         let _listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
 
         let result = collect_files(tmp.path(), &[socket], &[], &markdown_only);
+
+        assert!(result.is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_rejects_fifo_replacing_a_collected_file() {
+        use nix::sys::stat::Mode;
+        use nix::unistd::mkfifo;
+        use std::io::Write as _;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("input.md");
+        write(&path, "regular");
+        let collected = collect_paths(tmp.path(), std::slice::from_ref(&path), &[], &markdown_only);
+        std::fs::remove_file(&path).unwrap();
+        mkfifo(&path, Mode::S_IRUSR | Mode::S_IWUSR).unwrap();
+        let writer_path = path.clone();
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            let mut fifo = std::fs::File::options()
+                .read(true)
+                .write(true)
+                .open(writer_path)
+                .unwrap();
+            fifo.write_all(b"replacement").unwrap();
+            ready_tx.send(()).unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        });
+        ready_rx.recv().unwrap();
+
+        let result = read_regular_file_to_string(&collected[0]);
+        writer.join().unwrap();
 
         assert!(result.is_err());
     }

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -79,11 +79,16 @@ pub(crate) fn collect_files(
                 continue;
             }
             walk_errors += walk_directory(&path, &exclude_matcher, is_supported, &mut files);
-        } else {
+        } else if metadata.is_file() {
             if is_excluded(&exclude_matcher, base, &path, false) {
                 continue;
             }
             files.push(path);
+        } else {
+            return Err(format!(
+                "cannot access '{}': path is not a regular file or directory",
+                path.display()
+            ));
         }
     }
     files.sort();
@@ -421,6 +426,18 @@ mod tests {
             &[],
             &markdown_only,
         );
+        assert!(result.is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explicit_special_file_is_an_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let socket = tmp.path().join("input.md");
+        let _listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
+
+        let result = collect_files(tmp.path(), &[socket], &[], &markdown_only);
+
         assert!(result.is_err());
     }
 

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -116,7 +116,7 @@ pub(crate) fn collect_files(
             files.push(path);
         } else {
             return Err(format!(
-                "cannot access '{}': path is not a regular file or directory",
+                "unsupported path '{}': not a regular file or directory",
                 path.display()
             ));
         }
@@ -468,7 +468,11 @@ mod tests {
 
         let result = collect_files(tmp.path(), &[socket], &[], &markdown_only);
 
-        assert!(result.is_err());
+        let error = match result {
+            Ok(_) => panic!("special file must be rejected"),
+            Err(error) => error,
+        };
+        assert!(error.starts_with("unsupported path '"), "{error}");
     }
 
     #[cfg(unix)]

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 
 use tower_lsp_server::LspService;
 
-use crate::cli::files::collect_files;
+use crate::cli::files::{collect_files, read_regular_file_to_string};
 use crate::cli::terminal::{escape_terminal_controls, escape_terminal_controls_keeping_newlines};
 use crate::lsp::Kakehashi;
 
@@ -278,7 +278,7 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
         // lines are a stream the user greps, one record per file.
         let relative = file.strip_prefix(cwd).unwrap_or(file).display().to_string();
         let display = escape_terminal_controls(&relative);
-        let text = match std::fs::read_to_string(file) {
+        let text = match read_regular_file_to_string(file) {
             Ok(text) => text,
             Err(e) => {
                 elnln!("error: cannot read '{display}': {e}");


### PR DESCRIPTION
## Summary

- reject explicitly named filesystem objects that are neither regular files nor directories
- open Unix inputs nonblocking, validate the opened descriptor, and read from that same descriptor to close the collection/read TOCTOU window
- cover both static special-file input and regular-file-to-FIFO replacement

Closes #752

## Validation

- `make test` (2,870 library tests)
- `make check`
- continued Codex review clean after one TOCTOU fix
- fresh Codex review clean

## Risk

Symlinks resolving to regular files or directories remain accepted because both pathname and descriptor metadata follow symlink targets. On Unix, `O_NONBLOCK` is ignored for regular files but prevents FIFO open from waiting for a peer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file handling for diagnostic and formatting commands.
  * Special files, such as sockets and named pipes, are now rejected safely instead of being processed or causing commands to block.
  * Unsupported file types now produce clear errors, while regular files continue to be read and processed normally.
  * File operations now avoid unintended blocking when provided with non-regular files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->