### PR TITLE
fix(lsp): retain immediate request cancellation

### DIFF
--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -2690,7 +2690,7 @@ impl LanguageServerPool {
             let registry = self
                 .upstream_request_registry
                 .lock()
-                .recover_poison("LanguageServerPool::forward_cancel_by_upstream_id");
+                .recover_poison("LanguageServerPool::forward_cancel_by_upstream_id_if_current");
             if !is_current() {
                 return Ok(());
             }

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -2660,9 +2660,24 @@ impl LanguageServerPool {
     /// first atomically marks queued work for writer-side skipping and captures
     /// only already-writing/sent IDs that still need a FIFO cancel notification;
     /// the later cleanup is then harmless.
+    #[cfg(test)]
     pub(crate) async fn forward_cancel_by_upstream_id_with_notify(
         &self,
         upstream_id: UpstreamId,
+        notify: impl FnOnce(),
+    ) -> io::Result<()> {
+        self.forward_cancel_by_upstream_id_if_current(upstream_id, || true, notify)
+            .await
+    }
+
+    /// Generation-aware cancellation used by the upstream middleware. The
+    /// validity check runs while the upstream registry is locked, so request-ID
+    /// reuse cannot replace the old request's downstream mappings between the
+    /// check and target capture.
+    pub(crate) async fn forward_cancel_by_upstream_id_if_current(
+        &self,
+        upstream_id: UpstreamId,
+        is_current: impl FnOnce() -> bool,
         notify: impl FnOnce(),
     ) -> io::Result<()> {
         // 1. Snapshot the connections registered for this upstream id.
@@ -2671,6 +2686,9 @@ impl LanguageServerPool {
                 .upstream_request_registry
                 .lock()
                 .recover_poison("LanguageServerPool::forward_cancel_by_upstream_id");
+            if !is_current() {
+                return Ok(());
+            }
             match registry.get(&upstream_id) {
                 Some(connections) => connections.keys().cloned().collect(),
                 None => {

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -2641,11 +2641,11 @@ impl LanguageServerPool {
         }
     }
 
-    /// Fan out `$/cancelRequest` to every server registered for `upstream_id`,
-    /// invoking `notify` after every `(connection, downstream ids)` target has
-    /// been captured and before any cancel is sent. Invoked by
-    /// `RequestIdCapture` (via `CancelForwarder::forward_cancel`) when the
-    /// client cancels.
+    /// Test-only compatibility wrapper that fans out `$/cancelRequest` to
+    /// every server registered for `upstream_id`, invoking `notify` after every
+    /// `(connection, downstream ids)` target has been captured and before any
+    /// cancel is sent. Production `RequestIdCapture` uses the generation-aware
+    /// [`Self::forward_cancel_by_upstream_id_if_current`] path instead.
     ///
     /// LSP cancel is best-effort, so we silently return `Ok(())` (rather than
     /// erroring) when: the ID is unknown, the connection is still initializing,

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -2680,8 +2680,13 @@ impl LanguageServerPool {
         is_current: impl FnOnce() -> bool,
         notify: impl FnOnce(),
     ) -> io::Result<()> {
-        // 1. Snapshot the connections registered for this upstream id.
-        let connection_keys: Vec<ConnectionKey> = {
+        // Acquire the async connections lock first, then keep the synchronous
+        // upstream registry locked from generation validation through router
+        // target capture. Registration/unregistration uses that registry lock,
+        // so an ID cannot change request lifetime in the middle of this block.
+        let connections = self.connections().await;
+        let mut targets: Vec<(ConnectionKey, Arc<ConnectionHandle>, Vec<RequestId>)> = Vec::new();
+        let registered = {
             let registry = self
                 .upstream_request_registry
                 .lock()
@@ -2689,61 +2694,55 @@ impl LanguageServerPool {
             if !is_current() {
                 return Ok(());
             }
-            match registry.get(&upstream_id) {
-                Some(connections) => connections.keys().cloned().collect(),
-                None => {
-                    // Request not registered yet (still initializing) or already completed.
-                    // This is expected - silently drop the cancel per best-effort semantics.
-                    self.cancel_metrics.record_not_in_registry();
-                    log::debug!(
-                        target: "kakehashi::bridge::cancel",
-                        "Cancel dropped: upstream ID {} not in registry (expected during init or after completion)",
-                        upstream_id
-                    );
-                    notify();
-                    return Ok(());
+            if let Some(connection_counts) = registry.get(&upstream_id) {
+                for connection_key in connection_counts.keys() {
+                    let Some(handle) = self.ready_handle_for_cancel_in(
+                        &connections,
+                        connection_key,
+                        &format!("upstream_id: {upstream_id}"),
+                    ) else {
+                        continue;
+                    };
+                    let (known, downstream_ids) =
+                        handle.router().prepare_cancel_by_upstream(&upstream_id);
+                    if !known {
+                        // Request already completed or ID never registered.
+                        // Silently drop per best-effort semantics.
+                        self.cancel_metrics.record_unknown_id();
+                        log::debug!(
+                            target: "kakehashi::bridge::cancel",
+                            "Cancel dropped: upstream ID {} not found for '{}' (request may have completed)",
+                            upstream_id,
+                            connection_key
+                        );
+                        continue;
+                    }
+                    if !downstream_ids.is_empty() {
+                        targets.push((connection_key.clone(), handle, downstream_ids));
+                    }
                 }
+                true
+            } else {
+                false
             }
         };
+        drop(connections);
 
-        // 2. Capture each server's connection handle and atomically classify its
-        //    downstream ids under one connections-lock acquisition. Queued requests
-        //    are marked for writer-side skipping before `notify`, and the time to
-        //    wake the handler is bounded by one lock wait rather than one per server
-        //    (PR #359 review).
-        let mut targets: Vec<(ConnectionKey, Arc<ConnectionHandle>, Vec<RequestId>)> = Vec::new();
-        {
-            let connections = self.connections().await;
-            for connection_key in connection_keys {
-                let Some(handle) = self.ready_handle_for_cancel_in(
-                    &connections,
-                    &connection_key,
-                    &format!("upstream_id: {upstream_id}"),
-                ) else {
-                    continue;
-                };
-                let (known, downstream_ids) =
-                    handle.router().prepare_cancel_by_upstream(&upstream_id);
-                if !known {
-                    // Request already completed or ID never registered.
-                    // Silently drop per best-effort semantics.
-                    self.cancel_metrics.record_unknown_id();
-                    log::debug!(
-                        target: "kakehashi::bridge::cancel",
-                        "Cancel dropped: upstream ID {} not found for '{}' (request may have completed)",
-                        upstream_id,
-                        connection_key
-                    );
-                    continue;
-                }
-                if !downstream_ids.is_empty() {
-                    targets.push((connection_key, handle, downstream_ids));
-                }
-            }
-            // Lock dropped here — notify and the sends below run without it.
+        if !registered {
+            // Request not registered yet (still initializing) or already completed.
+            // This is expected - silently drop the downstream cancel, but still
+            // notify the active local handler.
+            self.cancel_metrics.record_not_in_registry();
+            log::debug!(
+                target: "kakehashi::bridge::cancel",
+                "Cancel dropped: upstream ID {} not in registry (expected during init or after completion)",
+                upstream_id
+            );
+            notify();
+            return Ok(());
         }
 
-        // 3. Wake the upstream handler only now that targets are captured.
+        // Wake the upstream handler only now that targets are captured.
         notify();
 
         // 4. Send the cancels (best-effort, log I/O errors).

--- a/src/lsp/request_id.rs
+++ b/src/lsp/request_id.rs
@@ -264,8 +264,20 @@ impl CancelForwarder {
             sender
         };
         if let Some(tx) = sender {
-            // Send notification (ignore if receiver dropped)
-            let _ = tx.send(());
+            if tx.send(()).is_err()
+                && let Some(generation) = generation
+            {
+                let mut subscribers = self
+                    .subscribers
+                    .lock()
+                    .recover_poison("CancelForwarder::retain_failed_cancel_delivery");
+                if subscribers.active_requests.get(upstream_id) == Some(&generation) {
+                    subscribers.delivered_cancellations.remove(upstream_id);
+                    subscribers
+                        .pending_cancellations
+                        .insert(upstream_id.clone(), generation);
+                }
+            }
             true
         } else {
             false
@@ -772,6 +784,30 @@ mod tests {
             .recover_poison("repeated cancel test");
         assert!(!state.pending_cancellations.contains_key(&upstream_id));
         drop(state);
+        drop(request_future);
+    }
+
+    #[tokio::test]
+    async fn cancelled_dropped_receiver_can_resubscribe_in_same_generation() {
+        let mock = MockService::new();
+        let pool = Arc::new(LanguageServerPool::new());
+        let forwarder = CancelForwarder::new(pool);
+        let mut service = RequestIdCapture::with_cancel_forwarder(mock, forwarder.clone());
+        let upstream_id = UpstreamId::Number(123);
+        let request = Request::build("textDocument/hover")
+            .params(serde_json::json!({}))
+            .id(123i64)
+            .finish();
+        let request_future = service.call(request);
+
+        drop(forwarder.subscribe(upstream_id.clone()).unwrap());
+        assert!(forwarder.notify_cancel(&upstream_id));
+        forwarder
+            .subscribe(upstream_id.clone())
+            .expect("failed delivery must be retained")
+            .await
+            .expect("retained cancellation is delivered");
+
         drop(request_future);
     }
 

--- a/src/lsp/request_id.rs
+++ b/src/lsp/request_id.rs
@@ -6,8 +6,8 @@
 //! `CancelForwarder::subscribe()` via a oneshot so it can abort and return
 //! `RequestCancelled`.
 
+use std::collections::HashMap;
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -64,9 +64,10 @@ impl std::error::Error for AlreadySubscribedError {}
 /// in the short interval between those two events.
 #[derive(Default)]
 struct CancelSubscriberState {
-    subscribers: HashMap<UpstreamId, oneshot::Sender<()>>,
-    active_requests: HashSet<UpstreamId>,
-    pending_cancellations: HashSet<UpstreamId>,
+    subscribers: HashMap<UpstreamId, (Option<u64>, oneshot::Sender<()>)>,
+    active_requests: HashMap<UpstreamId, u64>,
+    pending_cancellations: HashMap<UpstreamId, u64>,
+    next_generation: u64,
 }
 
 type CancelSubscriberRegistry = std::sync::Mutex<CancelSubscriberState>;
@@ -113,11 +114,30 @@ impl CancelForwarder {
     /// forwarding pass reads, so notifying first could silently drop the
     /// downstream `$/cancelRequest` (capture-before-notify; see
     /// `forward_cancel_by_upstream_id_with_notify`).
+    #[cfg(test)]
     pub(crate) async fn forward_cancel(&self, upstream_id: UpstreamId) -> std::io::Result<()> {
+        let generation = self.request_generation(&upstream_id);
+        self.forward_cancel_for_generation(upstream_id, generation)
+            .await
+    }
+
+    async fn forward_cancel_for_generation(
+        &self,
+        upstream_id: UpstreamId,
+        generation: Option<u64>,
+    ) -> std::io::Result<()> {
+        let validate_forwarder = self.clone();
+        let notify_forwarder = self.clone();
+        let validate_id = upstream_id.clone();
+        let notify_id = upstream_id.clone();
         self.pool
-            .forward_cancel_by_upstream_id_with_notify(upstream_id.clone(), || {
-                self.notify_cancel(&upstream_id);
-            })
+            .forward_cancel_by_upstream_id_if_current(
+                upstream_id,
+                move || validate_forwarder.request_generation(&validate_id) == generation,
+                move || {
+                    notify_forwarder.notify_cancel_for_generation(&notify_id, generation);
+                },
+            )
             .await
     }
 
@@ -147,14 +167,18 @@ impl CancelForwarder {
                 .subscribers
                 .lock()
                 .recover_poison("CancelForwarder::subscribe");
-            if subscribers.pending_cancellations.remove(&upstream_id) {
+            let generation = subscribers.active_requests.get(&upstream_id).copied();
+            if generation.is_some()
+                && subscribers.pending_cancellations.get(&upstream_id).copied() == generation
+            {
+                subscribers.pending_cancellations.remove(&upstream_id);
                 let _ = tx.send(());
                 return Ok(rx);
             }
             match subscribers.subscribers.entry(upstream_id) {
                 Entry::Occupied(entry) => return Err(AlreadySubscribedError(entry.key().clone())),
                 Entry::Vacant(entry) => {
-                    entry.insert(tx);
+                    entry.insert((generation, tx));
                 }
             }
         }
@@ -176,17 +200,36 @@ impl CancelForwarder {
     /// Notify a subscriber that its request was cancelled, or retain the signal
     /// while an accepted request has not subscribed yet. Returns whether the ID
     /// belongs to an active request or subscriber.
+    #[cfg(test)]
     pub(crate) fn notify_cancel(&self, upstream_id: &UpstreamId) -> bool {
+        let generation = self.request_generation(upstream_id);
+        self.notify_cancel_for_generation(upstream_id, generation)
+    }
+
+    fn notify_cancel_for_generation(
+        &self,
+        upstream_id: &UpstreamId,
+        generation: Option<u64>,
+    ) -> bool {
         let sender = {
             let mut subscribers = self
                 .subscribers
                 .lock()
                 .recover_poison("CancelForwarder::notify_cancel");
-            let sender = subscribers.subscribers.remove(upstream_id);
-            if sender.is_none() && subscribers.active_requests.contains(upstream_id) {
+            if subscribers.active_requests.get(upstream_id).copied() != generation {
+                return false;
+            }
+            let sender = subscribers
+                .subscribers
+                .remove(upstream_id)
+                .filter(|(subscriber_generation, _)| *subscriber_generation == generation)
+                .map(|(_, sender)| sender);
+            if sender.is_none()
+                && let Some(generation) = generation
+            {
                 subscribers
                     .pending_cancellations
-                    .insert(upstream_id.clone());
+                    .insert(upstream_id.clone(), generation);
                 return true;
             }
             sender
@@ -200,43 +243,60 @@ impl CancelForwarder {
         }
     }
 
-    fn register_request(&self, upstream_id: UpstreamId) {
-        self.subscribers
+    fn register_request(&self, upstream_id: UpstreamId) -> u64 {
+        let mut state = self
+            .subscribers
             .lock()
-            .recover_poison("CancelForwarder::register_request")
-            .active_requests
-            .insert(upstream_id);
+            .recover_poison("CancelForwarder::register_request");
+        let generation = state.next_generation;
+        state.next_generation = state.next_generation.wrapping_add(1);
+        state.active_requests.insert(upstream_id, generation);
+        generation
     }
 
-    fn unregister_request(&self, upstream_id: &UpstreamId) {
+    fn unregister_request(&self, upstream_id: &UpstreamId, generation: u64) {
         let mut state = self
             .subscribers
             .lock()
             .recover_poison("CancelForwarder::unregister_request");
-        state.active_requests.remove(upstream_id);
-        state.pending_cancellations.remove(upstream_id);
-        state.subscribers.remove(upstream_id);
+        if state.active_requests.get(upstream_id) == Some(&generation) {
+            state.active_requests.remove(upstream_id);
+            state.pending_cancellations.remove(upstream_id);
+            state.subscribers.remove(upstream_id);
+        }
+    }
+
+    fn request_generation(&self, upstream_id: &UpstreamId) -> Option<u64> {
+        self.subscribers
+            .lock()
+            .recover_poison("CancelForwarder::request_generation")
+            .active_requests
+            .get(upstream_id)
+            .copied()
     }
 }
 
 struct ActiveRequestGuard {
     cancel_forwarder: CancelForwarder,
     upstream_id: UpstreamId,
+    generation: u64,
 }
 
 impl ActiveRequestGuard {
     fn new(cancel_forwarder: CancelForwarder, upstream_id: UpstreamId) -> Self {
-        cancel_forwarder.register_request(upstream_id.clone());
+        let generation = cancel_forwarder.register_request(upstream_id.clone());
         Self {
             cancel_forwarder,
             upstream_id,
+            generation,
         }
     }
 }
 
 impl Drop for ActiveRequestGuard {
     fn drop(&mut self) {
-        self.cancel_forwarder.unregister_request(&self.upstream_id);
+        self.cancel_forwarder
+            .unregister_request(&self.upstream_id, self.generation);
     }
 }
 
@@ -344,6 +404,7 @@ where
                 });
 
             if let Some(upstream_id) = id_to_cancel {
+                let generation = forwarder.request_generation(&upstream_id);
                 let forwarder = forwarder.clone();
                 // Fire-and-forget: spawn without tracking JoinHandle.
                 //
@@ -359,7 +420,10 @@ where
                 // let the woken handler tear down the registry/router state the
                 // forwarding pass is about to read (capture-before-notify).
                 tokio::spawn(async move {
-                    if let Err(e) = forwarder.forward_cancel(upstream_id.clone()).await {
+                    if let Err(e) = forwarder
+                        .forward_cancel_for_generation(upstream_id.clone(), generation)
+                        .await
+                    {
                         // Log the error but don't fail - cancel forwarding is best-effort
                         log::debug!(
                             target: "kakehashi::cancel",
@@ -640,6 +704,38 @@ mod tests {
             ),
             "dropping the accepted request must not poison later reuse of its ID"
         );
+    }
+
+    #[tokio::test]
+    async fn delayed_cancel_does_not_hit_reused_request_id() {
+        let mock = MockService::new();
+        let pool = Arc::new(LanguageServerPool::new());
+        let forwarder = CancelForwarder::new(pool);
+        let mut service = RequestIdCapture::with_cancel_forwarder(mock, forwarder.clone());
+        let upstream_id = UpstreamId::Number(123);
+        let request = || {
+            Request::build("textDocument/hover")
+                .params(serde_json::json!({}))
+                .id(123i64)
+                .finish()
+        };
+
+        let old_request = service.call(request());
+        let old_generation = forwarder.request_generation(&upstream_id);
+        drop(old_request);
+
+        let new_request = service.call(request());
+        let mut new_request_cancel = forwarder.subscribe(upstream_id.clone()).unwrap();
+        forwarder
+            .forward_cancel_for_generation(upstream_id, old_generation)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            new_request_cancel.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        ));
+        drop(new_request);
     }
 
     #[tokio::test]

--- a/src/lsp/request_id.rs
+++ b/src/lsp/request_id.rs
@@ -67,6 +67,7 @@ struct CancelSubscriberState {
     subscribers: HashMap<UpstreamId, (Option<u64>, oneshot::Sender<()>)>,
     active_requests: HashMap<UpstreamId, u64>,
     pending_cancellations: HashMap<UpstreamId, u64>,
+    delivered_cancellations: HashMap<UpstreamId, u64>,
     next_generation: u64,
 }
 
@@ -169,9 +170,21 @@ impl CancelForwarder {
                 .recover_poison("CancelForwarder::subscribe");
             let generation = subscribers.active_requests.get(&upstream_id).copied();
             if generation.is_some()
-                && subscribers.pending_cancellations.get(&upstream_id).copied() == generation
+                && subscribers
+                    .delivered_cancellations
+                    .get(&upstream_id)
+                    .copied()
+                    == generation
+            {
+                return Err(AlreadySubscribedError(upstream_id));
+            }
+            if let Some(generation) = generation
+                && subscribers.pending_cancellations.get(&upstream_id).copied() == Some(generation)
             {
                 subscribers.pending_cancellations.remove(&upstream_id);
+                subscribers
+                    .delivered_cancellations
+                    .insert(upstream_id, generation);
                 let _ = tx.send(());
                 return Ok(rx);
             }
@@ -224,6 +237,13 @@ impl CancelForwarder {
                 .remove(upstream_id)
                 .filter(|(subscriber_generation, _)| *subscriber_generation == generation)
                 .map(|(_, sender)| sender);
+            if sender.is_some()
+                && let Some(generation) = generation
+            {
+                subscribers
+                    .delivered_cancellations
+                    .insert(upstream_id.clone(), generation);
+            }
             if sender.is_none()
                 && let Some(generation) = generation
             {
@@ -262,6 +282,7 @@ impl CancelForwarder {
         if state.active_requests.get(upstream_id) == Some(&generation) {
             state.active_requests.remove(upstream_id);
             state.pending_cancellations.remove(upstream_id);
+            state.delivered_cancellations.remove(upstream_id);
             state.subscribers.remove(upstream_id);
         }
     }
@@ -676,6 +697,32 @@ mod tests {
             .await
             .expect("retained cancellation should be delivered on subscribe")
             .expect("cancel sender should signal rather than drop");
+
+        drop(request_future);
+    }
+
+    #[tokio::test]
+    async fn retained_cancel_rejects_a_second_subscription_in_same_request() {
+        let mock = MockService::new();
+        let pool = Arc::new(LanguageServerPool::new());
+        let forwarder = CancelForwarder::new(pool);
+        let mut service = RequestIdCapture::with_cancel_forwarder(mock, forwarder.clone());
+        let upstream_id = UpstreamId::Number(123);
+        let request = Request::build("textDocument/hover")
+            .params(serde_json::json!({}))
+            .id(123i64)
+            .finish();
+        let request_future = service.call(request);
+
+        assert!(forwarder.notify_cancel(&upstream_id));
+        let cancel = forwarder.subscribe(upstream_id.clone()).unwrap();
+        cancel.await.expect("retained cancel is delivered");
+
+        let duplicate = forwarder.subscribe(upstream_id.clone());
+        assert!(
+            matches!(duplicate, Err(AlreadySubscribedError(id)) if id == upstream_id),
+            "a cancelled active generation must not create a fresh receiver"
+        );
 
         drop(request_future);
     }

--- a/src/lsp/request_id.rs
+++ b/src/lsp/request_id.rs
@@ -228,7 +228,7 @@ impl CancelForwarder {
             let mut subscribers = self
                 .subscribers
                 .lock()
-                .recover_poison("CancelForwarder::notify_cancel");
+                .recover_poison("CancelForwarder::notify_cancel_for_generation");
             if subscribers.active_requests.get(upstream_id).copied() != generation {
                 return false;
             }

--- a/src/lsp/request_id.rs
+++ b/src/lsp/request_id.rs
@@ -409,14 +409,22 @@ where
         // Check if this is a $/cancelRequest notification and forward to downstream
         // Per LSP spec, cancel params.id can be either integer or string
         let cancel_forwarder = self.cancel_forwarder.clone();
-        let active_request = cancel_forwarder.clone().and_then(|forwarder| {
-            let upstream_id = match request_id.as_ref()? {
-                Id::Number(id) => UpstreamId::Number(*id),
-                Id::String(id) => UpstreamId::String(id.clone()),
-                Id::Null => return None,
-            };
-            Some(ActiveRequestGuard::new(forwarder, upstream_id))
-        });
+        let is_cancel_notification = matches!(
+            req.method(),
+            "$/cancelRequest" | "window/workDoneProgress/cancel"
+        );
+        let active_request = if is_cancel_notification {
+            None
+        } else {
+            cancel_forwarder.clone().and_then(|forwarder| {
+                let upstream_id = match request_id.as_ref()? {
+                    Id::Number(id) => UpstreamId::Number(*id),
+                    Id::String(id) => UpstreamId::String(id.clone()),
+                    Id::Null => return None,
+                };
+                Some(ActiveRequestGuard::new(forwarder, upstream_id))
+            })
+        };
         if req.method() == "$/cancelRequest"
             && let Some(forwarder) = cancel_forwarder.as_ref()
             && let Some(params) = req.params()
@@ -914,6 +922,24 @@ mod tests {
         // Should not crash, just skip forwarding
         let result = service.call(request).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn malformed_cancel_message_id_does_not_replace_active_generation() {
+        let mock = MockService::new();
+        let pool = Arc::new(LanguageServerPool::new());
+        let forwarder = CancelForwarder::new(pool);
+        let upstream_id = UpstreamId::Number(123);
+        let generation = forwarder.register_request(upstream_id.clone());
+        let mut service = RequestIdCapture::with_cancel_forwarder(mock.clone(), forwarder.clone());
+
+        let request = Request::build("$/cancelRequest")
+            .id(123i64)
+            .params(serde_json::json!({ "id": 123 }))
+            .finish();
+        service.call(request).await.unwrap();
+
+        assert_eq!(forwarder.request_generation(&upstream_id), Some(generation));
     }
 
     #[tokio::test]

--- a/src/lsp/request_id.rs
+++ b/src/lsp/request_id.rs
@@ -224,7 +224,16 @@ impl CancelForwarder {
         upstream_id: &UpstreamId,
         generation: Option<u64>,
     ) -> bool {
-        let sender = {
+        self.notify_cancel_for_generation_with_hook(upstream_id, generation, || {})
+    }
+
+    fn notify_cancel_for_generation_with_hook(
+        &self,
+        upstream_id: &UpstreamId,
+        generation: Option<u64>,
+        after_registry: impl FnOnce(),
+    ) -> bool {
+        let handled = {
             let mut subscribers = self
                 .subscribers
                 .lock()
@@ -246,42 +255,28 @@ impl CancelForwarder {
                 .remove(upstream_id)
                 .filter(|(subscriber_generation, _)| *subscriber_generation == generation)
                 .map(|(_, sender)| sender);
-            if sender.is_some()
-                && let Some(generation) = generation
-            {
-                subscribers
-                    .delivered_cancellations
-                    .insert(upstream_id.clone(), generation);
-            }
-            if sender.is_none()
-                && let Some(generation) = generation
-            {
+            if let Some(tx) = sender {
+                let delivered = tx.send(()).is_ok();
+                if let Some(generation) = generation {
+                    let cancellations = if delivered {
+                        &mut subscribers.delivered_cancellations
+                    } else {
+                        &mut subscribers.pending_cancellations
+                    };
+                    cancellations.insert(upstream_id.clone(), generation);
+                }
+                true
+            } else if let Some(generation) = generation {
                 subscribers
                     .pending_cancellations
                     .insert(upstream_id.clone(), generation);
-                return true;
+                true
+            } else {
+                false
             }
-            sender
         };
-        if let Some(tx) = sender {
-            if tx.send(()).is_err()
-                && let Some(generation) = generation
-            {
-                let mut subscribers = self
-                    .subscribers
-                    .lock()
-                    .recover_poison("CancelForwarder::retain_failed_cancel_delivery");
-                if subscribers.active_requests.get(upstream_id) == Some(&generation) {
-                    subscribers.delivered_cancellations.remove(upstream_id);
-                    subscribers
-                        .pending_cancellations
-                        .insert(upstream_id.clone(), generation);
-                }
-            }
-            true
-        } else {
-            false
-        }
+        after_registry();
+        handled
     }
 
     fn register_request(&self, upstream_id: UpstreamId) -> u64 {
@@ -807,6 +802,51 @@ mod tests {
             .expect("failed delivery must be retained")
             .await
             .expect("retained cancellation is delivered");
+
+        drop(request_future);
+    }
+
+    #[tokio::test]
+    async fn failed_delivery_recovery_is_atomic_with_resubscription() {
+        let mock = MockService::new();
+        let pool = Arc::new(LanguageServerPool::new());
+        let forwarder = CancelForwarder::new(pool);
+        let mut service = RequestIdCapture::with_cancel_forwarder(mock, forwarder.clone());
+        let upstream_id = UpstreamId::Number(123);
+        let request = Request::build("textDocument/hover")
+            .params(serde_json::json!({}))
+            .id(123i64)
+            .finish();
+        let request_future = service.call(request);
+        let generation = forwarder.request_generation(&upstream_id);
+
+        drop(forwarder.subscribe(upstream_id.clone()).unwrap());
+        let replacement = std::thread::scope(|scope| {
+            let (registry_done_tx, registry_done_rx) = std::sync::mpsc::sync_channel(0);
+            let (resume_tx, resume_rx) = std::sync::mpsc::sync_channel(0);
+            let notify_id = upstream_id.clone();
+            let notify_forwarder = forwarder.clone();
+            let notify = scope.spawn(move || {
+                notify_forwarder.notify_cancel_for_generation_with_hook(
+                    &notify_id,
+                    generation,
+                    || {
+                        registry_done_tx.send(()).unwrap();
+                        resume_rx.recv().unwrap();
+                    },
+                )
+            });
+
+            registry_done_rx.recv().unwrap();
+            let replacement = forwarder.subscribe(upstream_id.clone());
+            resume_tx.send(()).unwrap();
+            assert!(notify.join().unwrap());
+            replacement
+        })
+        .expect("failed delivery must become pending before resubscription");
+        replacement
+            .await
+            .expect("replacement observes cancellation");
 
         drop(request_future);
     }

--- a/src/lsp/request_id.rs
+++ b/src/lsp/request_id.rs
@@ -232,6 +232,15 @@ impl CancelForwarder {
             if subscribers.active_requests.get(upstream_id).copied() != generation {
                 return false;
             }
+            if let Some(generation) = generation
+                && subscribers
+                    .delivered_cancellations
+                    .get(upstream_id)
+                    .copied()
+                    == Some(generation)
+            {
+                return true;
+            }
             let sender = subscribers
                 .subscribers
                 .remove(upstream_id)
@@ -725,6 +734,36 @@ mod tests {
             "a cancelled active generation must not create a fresh receiver"
         );
 
+        drop(request_future);
+    }
+
+    #[tokio::test]
+    async fn repeated_cancel_does_not_recreate_pending_state_after_delivery() {
+        let mock = MockService::new();
+        let pool = Arc::new(LanguageServerPool::new());
+        let forwarder = CancelForwarder::new(pool);
+        let mut service = RequestIdCapture::with_cancel_forwarder(mock, forwarder.clone());
+        let upstream_id = UpstreamId::Number(123);
+        let request = Request::build("textDocument/hover")
+            .params(serde_json::json!({}))
+            .id(123i64)
+            .finish();
+        let request_future = service.call(request);
+
+        assert!(forwarder.notify_cancel(&upstream_id));
+        forwarder
+            .subscribe(upstream_id.clone())
+            .unwrap()
+            .await
+            .unwrap();
+        assert!(forwarder.notify_cancel(&upstream_id));
+
+        let state = forwarder
+            .subscribers
+            .lock()
+            .recover_poison("repeated cancel test");
+        assert!(!state.pending_cancellations.contains_key(&upstream_id));
+        drop(state);
         drop(request_future);
     }
 

--- a/src/lsp/request_id.rs
+++ b/src/lsp/request_id.rs
@@ -424,8 +424,9 @@ where
                         .map(|s| UpstreamId::String(s.to_string()))
                 });
 
-            if let Some(upstream_id) = id_to_cancel {
-                let generation = forwarder.request_generation(&upstream_id);
+            if let Some(upstream_id) = id_to_cancel
+                && let Some(generation) = forwarder.request_generation(&upstream_id)
+            {
                 let forwarder = forwarder.clone();
                 // Fire-and-forget: spawn without tracking JoinHandle.
                 //
@@ -442,7 +443,7 @@ where
                 // forwarding pass is about to read (capture-before-notify).
                 tokio::spawn(async move {
                     if let Err(e) = forwarder
-                        .forward_cancel_for_generation(upstream_id.clone(), generation)
+                        .forward_cancel_for_generation(upstream_id.clone(), Some(generation))
                         .await
                     {
                         // Log the error but don't fail - cancel forwarding is best-effort

--- a/src/lsp/request_id.rs
+++ b/src/lsp/request_id.rs
@@ -6,8 +6,8 @@
 //! `CancelForwarder::subscribe()` via a oneshot so it can abort and return
 //! `RequestCancelled`.
 
-use std::collections::HashMap;
 use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -60,9 +60,16 @@ impl std::error::Error for AlreadySubscribedError {}
 
 /// Registry of cancel notification subscribers.
 ///
-/// Maps upstream request IDs to oneshot senders that notify handlers when
-/// a `$/cancelRequest` arrives.
-type CancelSubscriberRegistry = std::sync::Mutex<HashMap<UpstreamId, oneshot::Sender<()>>>;
+/// Tracks accepted requests, handler subscribers, and cancellations that arrived
+/// in the short interval between those two events.
+#[derive(Default)]
+struct CancelSubscriberState {
+    subscribers: HashMap<UpstreamId, oneshot::Sender<()>>,
+    active_requests: HashSet<UpstreamId>,
+    pending_cancellations: HashSet<UpstreamId>,
+}
+
+type CancelSubscriberRegistry = std::sync::Mutex<CancelSubscriberState>;
 
 /// Forwards cancel requests to downstream language servers.
 ///
@@ -91,7 +98,7 @@ impl CancelForwarder {
     pub fn new(pool: Arc<LanguageServerPool>) -> Self {
         Self {
             pool,
-            subscribers: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            subscribers: Arc::new(std::sync::Mutex::new(CancelSubscriberState::default())),
         }
     }
 
@@ -140,7 +147,11 @@ impl CancelForwarder {
                 .subscribers
                 .lock()
                 .recover_poison("CancelForwarder::subscribe");
-            match subscribers.entry(upstream_id) {
+            if subscribers.pending_cancellations.remove(&upstream_id) {
+                let _ = tx.send(());
+                return Ok(rx);
+            }
+            match subscribers.subscribers.entry(upstream_id) {
                 Entry::Occupied(entry) => return Err(AlreadySubscribedError(entry.key().clone())),
                 Entry::Vacant(entry) => {
                     entry.insert(tx);
@@ -159,19 +170,26 @@ impl CancelForwarder {
             .subscribers
             .lock()
             .recover_poison("CancelForwarder::unsubscribe");
-        subscribers.remove(upstream_id);
+        subscribers.subscribers.remove(upstream_id);
     }
 
-    /// Notify a subscriber that their request was cancelled, returning whether one
-    /// existed. Called by `RequestIdCapture` on `$/cancelRequest`; a matched
-    /// subscriber is notified and removed from the registry.
+    /// Notify a subscriber that its request was cancelled, or retain the signal
+    /// while an accepted request has not subscribed yet. Returns whether the ID
+    /// belongs to an active request or subscriber.
     pub(crate) fn notify_cancel(&self, upstream_id: &UpstreamId) -> bool {
         let sender = {
             let mut subscribers = self
                 .subscribers
                 .lock()
                 .recover_poison("CancelForwarder::notify_cancel");
-            subscribers.remove(upstream_id)
+            let sender = subscribers.subscribers.remove(upstream_id);
+            if sender.is_none() && subscribers.active_requests.contains(upstream_id) {
+                subscribers
+                    .pending_cancellations
+                    .insert(upstream_id.clone());
+                return true;
+            }
+            sender
         };
         if let Some(tx) = sender {
             // Send notification (ignore if receiver dropped)
@@ -180,6 +198,45 @@ impl CancelForwarder {
         } else {
             false
         }
+    }
+
+    fn register_request(&self, upstream_id: UpstreamId) {
+        self.subscribers
+            .lock()
+            .recover_poison("CancelForwarder::register_request")
+            .active_requests
+            .insert(upstream_id);
+    }
+
+    fn unregister_request(&self, upstream_id: &UpstreamId) {
+        let mut state = self
+            .subscribers
+            .lock()
+            .recover_poison("CancelForwarder::unregister_request");
+        state.active_requests.remove(upstream_id);
+        state.pending_cancellations.remove(upstream_id);
+        state.subscribers.remove(upstream_id);
+    }
+}
+
+struct ActiveRequestGuard {
+    cancel_forwarder: CancelForwarder,
+    upstream_id: UpstreamId,
+}
+
+impl ActiveRequestGuard {
+    fn new(cancel_forwarder: CancelForwarder, upstream_id: UpstreamId) -> Self {
+        cancel_forwarder.register_request(upstream_id.clone());
+        Self {
+            cancel_forwarder,
+            upstream_id,
+        }
+    }
+}
+
+impl Drop for ActiveRequestGuard {
+    fn drop(&mut self) {
+        self.cancel_forwarder.unregister_request(&self.upstream_id);
     }
 }
 
@@ -262,6 +319,14 @@ where
         // Check if this is a $/cancelRequest notification and forward to downstream
         // Per LSP spec, cancel params.id can be either integer or string
         let cancel_forwarder = self.cancel_forwarder.clone();
+        let active_request = cancel_forwarder.clone().and_then(|forwarder| {
+            let upstream_id = match request_id.as_ref()? {
+                Id::Number(id) => UpstreamId::Number(*id),
+                Id::String(id) => UpstreamId::String(id.clone()),
+                Id::Null => return None,
+            };
+            Some(ActiveRequestGuard::new(forwarder, upstream_id))
+        });
         if req.method() == "$/cancelRequest"
             && let Some(forwarder) = cancel_forwarder.as_ref()
             && let Some(params) = req.params()
@@ -329,6 +394,7 @@ where
         let inner_fut = self.inner.call(req);
 
         Box::pin(async move {
+            let _active_request = active_request;
             // Set the task-local request ID and await the inner future
             CURRENT_REQUEST_ID.scope(request_id, inner_fut).await
         })
@@ -519,6 +585,35 @@ mod tests {
 
         // Note: We can't verify the forward happened without a real pool setup,
         // but we've verified the middleware processes the cancel notification.
+    }
+
+    #[tokio::test]
+    async fn cancel_before_handler_subscription_is_delivered() {
+        let mock = MockService::new();
+        let pool = Arc::new(LanguageServerPool::new());
+        let forwarder = CancelForwarder::new(pool);
+        let mut service = RequestIdCapture::with_cancel_forwarder(mock, forwarder.clone());
+        let upstream_id = UpstreamId::Number(123);
+
+        // `call` means the middleware has accepted this request, but deliberately
+        // leave its future unpolled so the handler cannot have subscribed yet.
+        let request = Request::build("textDocument/hover")
+            .params(serde_json::json!({}))
+            .id(123i64)
+            .finish();
+        let request_future = service.call(request);
+
+        assert!(
+            forwarder.notify_cancel(&upstream_id),
+            "an accepted request must retain cancellation until its handler subscribes"
+        );
+        let cancel = forwarder.subscribe(upstream_id).unwrap();
+        tokio::time::timeout(std::time::Duration::from_millis(50), cancel)
+            .await
+            .expect("retained cancellation should be delivered on subscribe")
+            .expect("cancel sender should signal rather than drop");
+
+        drop(request_future);
     }
 
     #[tokio::test]

--- a/src/lsp/request_id.rs
+++ b/src/lsp/request_id.rs
@@ -617,6 +617,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dropped_request_clears_retained_cancellation() {
+        let mock = MockService::new();
+        let pool = Arc::new(LanguageServerPool::new());
+        let forwarder = CancelForwarder::new(pool);
+        let mut service = RequestIdCapture::with_cancel_forwarder(mock, forwarder.clone());
+        let upstream_id = UpstreamId::Number(123);
+        let request = Request::build("textDocument/hover")
+            .params(serde_json::json!({}))
+            .id(123i64)
+            .finish();
+        let request_future = service.call(request);
+
+        assert!(forwarder.notify_cancel(&upstream_id));
+        drop(request_future);
+
+        let mut reused_id_cancel = forwarder.subscribe(upstream_id).unwrap();
+        assert!(
+            matches!(
+                reused_id_cancel.try_recv(),
+                Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+            ),
+            "dropping the accepted request must not poison later reuse of its ID"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_for_unknown_id_is_not_retained() {
+        let pool = Arc::new(LanguageServerPool::new());
+        let forwarder = CancelForwarder::new(pool);
+        let upstream_id = UpstreamId::String("not-active".to_string());
+
+        assert!(!forwarder.notify_cancel(&upstream_id));
+        let mut later_subscription = forwarder.subscribe(upstream_id).unwrap();
+        assert!(matches!(
+            later_subscription.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
     async fn work_done_progress_cancel_is_intercepted() {
         let mock = MockService::new();
         let pool = Arc::new(LanguageServerPool::new());


### PR DESCRIPTION
## Summary

- retain `$/cancelRequest` delivered after middleware acceptance but before handler subscription
- scope retained signals to a per-request generation so delayed cancellation cannot affect a reused JSON-RPC ID
- validate the generation and capture downstream router targets atomically with respect to unregister/re-register
- clear active, pending, and subscribed cancellation state through an RAII request guard

Closes #755.

## Validation

- `cargo test --lib -q lsp::request_id::tests` (18 passed)
- `cargo test --lib -q lsp::bridge::pool::tests::forward_cancel` (9 passed)
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --check`
- full `cargo test --lib -q`: 2,862 passed; 5 unrelated latest-main fixture/lifecycle failures (`process_injection_sync_returns_incomplete_on_mid_region_cancel` and four `src/lsp/bridge.rs` tests whose fixtures do not open the host document, tracked by existing issues)

## Revise status

- local multi-perspective review: converged after adding cleanup and unknown/reused-ID coverage
- Codex MCP: fixed two high-severity request-reuse races in commits `52d15032c` and `42ac50e67`; continuation is temporarily blocked by the Codex usage limit
- Copilot/Gemini: requested after draft creation; keep draft until all current-head reviews and CI converge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cancellation delivery for language-server requests and work-progress cancellation.
  - Prevented stale or delayed cancellations from impacting reused request IDs.
  - Ensured cancels received before a handler subscribes are delivered once subscribed.
  - Suppressed duplicate cancellation notifications within the same request lifecycle.
  - Better handling for malformed cancels, unknown targets, and cancels arriving after completion.
- **Tests**
  - Expanded coverage for generation-aware behavior, late subscription delivery, duplicate handling, repeated cancels, resubscription scenarios, and malformed messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->