### PR TITLE
fix(format): reject multiply linked targets

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -872,9 +872,10 @@ kakehashi format . --tab-size 2 --insert-spaces false
 
 Exit codes: `0` nothing to change (or changes written without
 `--fail-on-change`), `1` changes detected under `--check`/`--fail-on-change`,
-`2` usage error, I/O error, a configuration file given with `--config-file`
-that could not be loaded, or downstream formatter failure (a configured
-server failed to start, errored on the request, timed out, or returned a
+`2` usage error, I/O error, a refused write (see below), a configuration
+file given with `--config-file` that could not be loaded, or downstream
+formatter failure (a configured server failed to start, errored on the
+request, timed out, or returned a
 protocol-invalid response). Only *request-time* failures are strategy-aware:
 under `preferred` — the bridge-level default for formatting, where several
 servers of one target produce competing whole-document edits — the winner is
@@ -882,6 +883,17 @@ authoritative, so a non-winning server's failed request does not count, while
 `concatenated` counts every server's. A server that fails to **start** always
 counts, whichever strategy is in force and even if a fallback then formatted
 the document.
+
+In-place writes go through a temporary file and an atomic rename, so a crash
+mid-write cannot leave a truncated source file behind. Two consequences: a
+symlinked path stays a symlink (the file it resolves to is rewritten), and a
+target reachable under more than one **hard link** is *refused* rather than
+written — the rename moves only the named entry onto the new content, so the
+other names would silently keep the old. Such a file is reported per file and
+counted as a write error (exit `2`); the rest of the run continues. The
+detection is Unix-only, so on Windows a hard-linked file is still rewritten
+and its other names keep the old content. `--check` is unaffected: it answers
+whether the content would change, not whether the write would succeed.
 
 A configuration failure exits `2` before anything is written, so stdout stays
 empty in `--stdin-filename` mode. A *downstream* failure does not: the content

--- a/docs/README.md
+++ b/docs/README.md
@@ -875,27 +875,31 @@ Exit codes: `0` nothing to change (or changes written without
 `2` usage error, I/O error, a refused write (see below), a configuration
 file given with `--config-file` that could not be loaded, or downstream
 formatter failure (a configured server failed to start, errored on the
-request, timed out, or returned a
-protocol-invalid response). Only *request-time* failures are strategy-aware:
-under `preferred` — the bridge-level default for formatting, where several
-servers of one target produce competing whole-document edits — the winner is
-authoritative, so a non-winning server's failed request does not count, while
-`concatenated` counts every server's. A server that fails to **start** always
-counts, whichever strategy is in force and even if a fallback then formatted
-the document.
+request, timed out, or returned a protocol-invalid response). Only
+*request-time* failures are strategy-aware: under `preferred` — the
+bridge-level default for formatting, where several servers of one target
+produce competing whole-document edits — the winner is authoritative, so a
+non-winning server's failed request does not count, while `concatenated`
+counts every server's. A server that fails to **start** always counts,
+whichever strategy is in force and even if a fallback then formatted the
+document.
 
 In-place writes go through a temporary file and an atomic rename, so a crash
 mid-write cannot leave a truncated source file behind. Two consequences: a
 symlinked path stays a symlink (the file it resolves to is rewritten), and a
 target reachable under more than one **hard link** is *refused* rather than
 written — the rename moves only the named entry onto the new content, so the
-other names would silently keep the old. Such a file is reported per file and
-counted as a write error (exit `2`); the rest of the run continues. Detection
-depends on the filesystem reporting a true link count, and is Unix-only — on
-Windows, and on mounts that under-report link counts (some FUSE
-backends, `cifs` without UNIX extensions), a hard-linked file is still
-rewritten and its other names keep the old content. `--check` is unaffected: it answers
-whether the content would change, not whether the write would succeed.
+other names would silently keep the old. Such a file is reported per file
+and counted as a write error (exit `2`); the rest of the run continues.
+
+That refusal is a best-effort guard, not a guarantee. It rests on the
+link count the filesystem reports, so a mount that under-reports (some
+FUSE backends, `cifs` without UNIX extensions) still splits the file
+silently, as does Windows, where the count is not read at all. The count
+is also checked immediately before the rename rather than atomically with
+it, so a link created in that window is still split. `--check` is
+unaffected either way: it answers whether the content would change, not
+whether the write would succeed.
 
 A configuration failure exits `2` before anything is written, so stdout stays
 empty in `--stdin-filename` mode. A *downstream* failure does not: the content

--- a/docs/README.md
+++ b/docs/README.md
@@ -892,7 +892,7 @@ written — the rename moves only the named entry onto the new content, so the
 other names would silently keep the old. Such a file is reported per file and
 counted as a write error (exit `2`); the rest of the run continues. Detection
 depends on the filesystem reporting a true link count, and is Unix-only — on
-Windows, and on mounts that report link counts inaccurately (some FUSE
+Windows, and on mounts that under-report link counts (some FUSE
 backends, `cifs` without UNIX extensions), a hard-linked file is still
 rewritten and its other names keep the old content. `--check` is unaffected: it answers
 whether the content would change, not whether the write would succeed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -890,9 +890,11 @@ symlinked path stays a symlink (the file it resolves to is rewritten), and a
 target reachable under more than one **hard link** is *refused* rather than
 written — the rename moves only the named entry onto the new content, so the
 other names would silently keep the old. Such a file is reported per file and
-counted as a write error (exit `2`); the rest of the run continues. The
-detection is Unix-only, so on Windows a hard-linked file is still rewritten
-and its other names keep the old content. `--check` is unaffected: it answers
+counted as a write error (exit `2`); the rest of the run continues. Detection
+depends on the filesystem reporting a true link count, and is Unix-only — on
+Windows, and on mounts that report link counts inaccurately (some FUSE
+backends, `cifs` without UNIX extensions), a hard-linked file is still
+rewritten and its other names keep the old content. `--check` is unaffected: it answers
 whether the content would change, not whether the write would succeed.
 
 A configuration failure exits `2` before anything is written, so stdout stays

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -403,7 +403,14 @@ fn write_atomically(path: &Path, content: &str) -> std::io::Result<()> {
 fn reject_multiple_hard_links(target: &Path) -> std::io::Result<()> {
     use std::os::unix::fs::MetadataExt as _;
 
-    let links = std::fs::metadata(target)?.nlink();
+    // `symlink_metadata`, not `metadata`: `rename(2)` never follows a final
+    // symlink, so the count has to come from the same inode the rename will
+    // unlink. On the pre-create call the two are identical — `target` is
+    // canonical, so its last component cannot be a symlink — but the
+    // pre-persist call re-reads a path that may have changed underneath, and
+    // there a symlink (which can itself carry links on Linux) must be judged
+    // by its own count rather than its pointee's.
+    let links = std::fs::symlink_metadata(target)?.nlink();
     if links > 1 {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -383,8 +383,8 @@ fn write_atomically(path: &Path, content: &str) -> std::io::Result<()> {
     // over — after writing, so a read-only target mode can't block the write.
     tmp.as_file()
         .set_permissions(std::fs::metadata(&target)?.permissions())?;
-    // A link can be added while the replacement is prepared. Narrow that race
-    // by checking again immediately before persist would split the new alias.
+    // A link can be added while the replacement is prepared. Check again
+    // immediately before persist, which would otherwise split the new alias.
     reject_multiple_hard_links(&target)?;
     tmp.persist(&target).map_err(|e| e.error)?;
     // Best-effort directory fsync: on some filesystems the rename's

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -383,8 +383,8 @@ fn write_atomically(path: &Path, content: &str) -> std::io::Result<()> {
     // over — after writing, so a read-only target mode can't block the write.
     tmp.as_file()
         .set_permissions(std::fs::metadata(&target)?.permissions())?;
-    // A link can be added while the replacement is prepared. Check again at
-    // the last point before persist would split that new alias from `target`.
+    // A link can be added while the replacement is prepared. Narrow that race
+    // by checking again immediately before persist would split the new alias.
     reject_multiple_hard_links(&target)?;
     tmp.persist(&target).map_err(|e| e.error)?;
     // Best-effort directory fsync: on some filesystems the rename's
@@ -417,6 +417,8 @@ fn reject_multiple_hard_links(target: &Path) -> std::io::Result<()> {
 
 #[cfg(not(unix))]
 fn reject_multiple_hard_links(_target: &Path) -> std::io::Result<()> {
+    // Stable std currently exposes link counts only on Unix. In particular,
+    // Windows MetadataExt::number_of_links is still a nightly-only API.
     Ok(())
 }
 

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -415,7 +415,7 @@ fn reject_multiple_hard_links(target: &Path) -> std::io::Result<()> {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             format!(
-                "refusing atomic replacement of a file with {links} hard links; remove the aliases first"
+                "target has {links} hard links; an atomic replacement updates only this name and would leave the other names on the old content (list them with `find . -samefile <path>`)"
             ),
         ));
     }

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -420,10 +420,15 @@ fn write_atomically(path: &Path, content: &str) -> std::io::Result<()> {
 /// [`write_atomically`]'s rename can only move one of them onto the new
 /// content (#760).
 ///
-/// A false negative is the safe direction, and there are two: mounts that do
-/// not report real link counts (some FUSE backends, `cifs` without UNIX
-/// extensions) and non-Unix platforms. Both degrade to the pre-#760 behavior
-/// rather than to a wrong refusal.
+/// The verdict is only as good as the filesystem's `st_nlink`, and it can be
+/// wrong in either direction — neither of which is "safe":
+/// - A false negative (some FUSE backends hardcode 1; `cifs` without UNIX
+///   extensions) silently restores the pre-#760 split, i.e. the data loss
+///   this guard exists to prevent. Non-Unix platforms sit here too (#933).
+/// - A false positive costs a spurious refusal, which at least says so and
+///   leaves the file intact.
+///
+/// Neither is detectable from here, so the guard reports what it is told.
 #[cfg(unix)]
 fn reject_multiple_hard_links(target: &Path) -> std::io::Result<()> {
     use std::os::unix::fs::MetadataExt as _;

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -504,6 +504,9 @@ mod tests {
         );
     }
 
+    /// Before #760 this write *succeeded*: the target took `"new\n"` on a
+    /// fresh inode and the alias silently stayed behind on the old one. Both
+    /// names, and the inode that carries them, must survive the refusal.
     #[cfg(unix)]
     #[test]
     fn write_atomically_rejects_multiply_linked_target_without_changes() {
@@ -515,19 +518,124 @@ mod tests {
         std::fs::write(&target, "old\n").unwrap();
         std::fs::hard_link(&target, &alias).unwrap();
         let inode = std::fs::metadata(&target).unwrap().ino();
-        let entries_before = std::fs::read_dir(dir.path()).unwrap().count();
 
         let error = write_atomically(&target, "new\n").unwrap_err();
 
-        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
-        assert!(error.to_string().contains("hard link"));
-        assert_eq!(std::fs::read_to_string(&target).unwrap(), "old\n");
-        assert_eq!(std::fs::read_to_string(&alias).unwrap(), "old\n");
-        assert_eq!(std::fs::metadata(&target).unwrap().ino(), inode);
-        assert_eq!(std::fs::metadata(&alias).unwrap().ino(), inode);
         assert_eq!(
-            std::fs::read_dir(dir.path()).unwrap().count(),
-            entries_before
+            error.kind(),
+            std::io::ErrorKind::InvalidInput,
+            "a policy refusal, not an I/O failure: {error}"
         );
+        assert!(
+            error.to_string().contains("hard link"),
+            "the refusal must name its cause: {error}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            "old\n",
+            "the target must not be rewritten"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&alias).unwrap(),
+            "old\n",
+            "the alias must not be left on stale content"
+        );
+        assert_eq!(
+            std::fs::metadata(&target).unwrap().ino(),
+            inode,
+            "the target must keep its inode, or the link is already split"
+        );
+        assert_eq!(
+            std::fs::metadata(&alias).unwrap().ino(),
+            inode,
+            "both names must still resolve to the one inode"
+        );
+        assert_eq!(
+            sorted_entry_names(dir.path()),
+            ["alias.lua", "source.lua"],
+            "the refusal must leave no temp file behind"
+        );
+    }
+
+    /// The refusal must not cost the normal case. This is the only test of a
+    /// *successful* `write_atomically` that CI compiles — `tests/` is gated
+    /// behind the `e2e` feature — so without it, inverting the guard to
+    /// `links >= 1` would refuse every write and still pass the gate.
+    #[cfg(unix)]
+    #[test]
+    fn write_atomically_replaces_a_single_link_file_keeping_its_mode() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("source.lua");
+        std::fs::write(&target, "old\n").unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o754)).unwrap();
+
+        write_atomically(&target, "new\n").expect("a singly linked file must stay writable");
+
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "new\n");
+        assert_eq!(
+            std::fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+            0o754,
+            "the rename must carry the target's own mode over"
+        );
+        assert_eq!(
+            sorted_entry_names(dir.path()),
+            ["source.lua"],
+            "the temp file must not survive the write"
+        );
+    }
+
+    /// Canonicalization writes *through* a symlink instead of replacing it,
+    /// and the link count that decides the refusal is therefore the resolved
+    /// file's — a symlink does not count as a hard link to it.
+    #[cfg(unix)]
+    #[test]
+    fn write_atomically_writes_through_a_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real.lua");
+        let link = dir.path().join("link.lua");
+        std::fs::write(&real, "old\n").unwrap();
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        write_atomically(&link, "new\n").expect("writing through a symlink must succeed");
+
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the symlink must survive the replacement"
+        );
+        assert_eq!(std::fs::read_to_string(&real).unwrap(), "new\n");
+    }
+
+    /// Pins the predicate both call sites rest on. The pre-persist one is
+    /// only reachable by racing a concurrent `link(2)`, so this is the only
+    /// coverage it can get.
+    #[cfg(unix)]
+    #[test]
+    fn reject_multiple_hard_links_only_rejects_aliased_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let lone = dir.path().join("lone.lua");
+        let aliased = dir.path().join("aliased.lua");
+        std::fs::write(&lone, "x").unwrap();
+        std::fs::write(&aliased, "x").unwrap();
+        std::fs::hard_link(&aliased, dir.path().join("alias.lua")).unwrap();
+
+        reject_multiple_hard_links(&lone).expect("a single name is not an alias");
+        let error = reject_multiple_hard_links(&aliased).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[cfg(unix)]
+    fn sorted_entry_names(dir: &Path) -> Vec<String> {
+        let mut names: Vec<String> = std::fs::read_dir(dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        names
     }
 }

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -315,9 +315,9 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
                     // Deliberately not mirroring `write_atomically`'s
                     // refusals (hard links) here: `--check` answers "would
                     // the content change", not "would the write succeed",
-                    // and it resolves no paths at all today. A read-only
-                    // target has always passed `--check` and failed the
-                    // apply run the same way.
+                    // and it resolves no paths at all today. A target in a
+                    // read-only directory has always passed `--check` and
+                    // failed the apply run the same way.
                     elnln!("Would reformat: {display}");
                 } else {
                     match write_atomically(file, &formatted) {
@@ -445,7 +445,7 @@ fn reject_multiple_hard_links(target: &Path) -> std::io::Result<()> {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             format!(
-                "target has {links} hard links; an atomic replacement updates only this name and would leave the other names on the old content (list them with `find . -samefile <path>`)"
+                "target has {links} hard links; an atomic replacement updates only this name and would leave every other name on the old content (`find -samefile` lists them)"
             ),
         ));
     }
@@ -457,10 +457,11 @@ fn reject_multiple_hard_links(_target: &Path) -> std::io::Result<()> {
     // Not implemented rather than impossible, and NTFS does have hard links,
     // so #760 stays live on Windows. Stable std cannot express the check —
     // `windows::fs::MetadataExt::number_of_links` is unstable behind
-    // `windows_by_handle` — but `winapi-util` and `windows-sys` are both
-    // already in the lockfile on Windows and expose
-    // `GetFileInformationByHandle`. Tracked in #933, together with the CI
-    // gap that leaves this arm uncompiled until a release build.
+    // `windows_by_handle` — but `winapi-util` and `windows-sys` both reach
+    // Windows builds transitively already and expose
+    // `GetFileInformationByHandle`, so the implementation costs a direct
+    // dependency entry rather than a new crate. Tracked in #933, together
+    // with the CI gap that leaves this arm uncompiled until a release build.
     Ok(())
 }
 
@@ -558,14 +559,14 @@ mod tests {
         assert_eq!(
             sorted_entry_names(dir.path()),
             ["alias.lua", "source.lua"],
-            "the refusal must leave no temp file behind"
+            "the refusal must land before a temp file is even created"
         );
     }
 
-    /// The refusal must not cost the normal case. This is the only test of a
-    /// *successful* `write_atomically` that CI compiles — `tests/` is gated
-    /// behind the `e2e` feature — so without it, inverting the guard to
-    /// `links >= 1` would refuse every write and still pass the gate.
+    /// The refusal must not cost the normal case. Every *successful*
+    /// `write_atomically` test used to live in `tests/`, which is gated
+    /// behind the `e2e` feature that CI does not enable — so inverting the
+    /// guard to `links >= 1`, refusing every write, passed the whole gate.
     #[cfg(unix)]
     #[test]
     fn write_atomically_replaces_a_single_link_file_keeping_its_mode() {
@@ -632,6 +633,25 @@ mod tests {
         let error = reject_multiple_hard_links(&aliased).unwrap_err();
 
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    /// The count must come from the link itself, not from what it points at,
+    /// because `rename(2)` replaces the link rather than following it.
+    /// `write_atomically` canonicalizes before it ever gets here, so only the
+    /// pre-persist re-check can be handed a symlink — and only after the path
+    /// changed underneath it. Reverting to `metadata` refuses this case.
+    #[cfg(unix)]
+    #[test]
+    fn reject_multiple_hard_links_judges_a_symlink_by_its_own_count() {
+        let dir = tempfile::tempdir().unwrap();
+        let aliased = dir.path().join("aliased.lua");
+        let link = dir.path().join("link.lua");
+        std::fs::write(&aliased, "x").unwrap();
+        std::fs::hard_link(&aliased, dir.path().join("alias.lua")).unwrap();
+        std::os::unix::fs::symlink(&aliased, &link).unwrap();
+
+        reject_multiple_hard_links(&link)
+            .expect("a symlink carries one name, whatever its target carries");
     }
 
     #[cfg(unix)]

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -312,6 +312,12 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
             Some(formatted) if formatted != text => {
                 changed += 1;
                 if options.check {
+                    // Deliberately not mirroring `write_atomically`'s
+                    // refusals (hard links) here: `--check` answers "would
+                    // the content change", not "would the write succeed",
+                    // and it resolves no paths at all today. A read-only
+                    // target has always passed `--check` and failed the
+                    // apply run the same way.
                     elnln!("Would reformat: {display}");
                 } else {
                     match write_atomically(file, &formatted) {
@@ -364,6 +370,12 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
 /// The path is canonicalized first so a symlinked source file keeps being a
 /// symlink — renaming over the link itself would silently replace it with a
 /// regular file and leave the link's target stale (chezmoi/stow setups).
+///
+/// Not every target can be served this way: a file with more than one hard
+/// link is *refused* (`InvalidInput`) rather than written, because the rename
+/// moves only the named directory entry onto the new inode and every other
+/// name would silently keep the old content. That is a policy refusal, not an
+/// I/O failure, and it is Unix-only — see [`reject_multiple_hard_links`].
 fn write_atomically(path: &Path, content: &str) -> std::io::Result<()> {
     use std::io::Write as _;
 
@@ -383,8 +395,13 @@ fn write_atomically(path: &Path, content: &str) -> std::io::Result<()> {
     // over — after writing, so a read-only target mode can't block the write.
     tmp.as_file()
         .set_permissions(std::fs::metadata(&target)?.permissions())?;
-    // A link can be added while the replacement is prepared. Check again
-    // immediately before persist, which would otherwise split the new alias.
+    // A link can be added while the replacement is prepared, so check again
+    // here. This *narrows* the race, it does not close it: a link created
+    // between this check and the `rename(2)` inside `persist` is still split.
+    // Nothing closes it — no stable API renames conditionally on a link
+    // count, `RENAME_EXCHANGE` only reshapes the split, and the one true fix
+    // (truncate-and-write in place) forfeits the crash safety this function
+    // exists to provide.
     reject_multiple_hard_links(&target)?;
     tmp.persist(&target).map_err(|e| e.error)?;
     // Best-effort directory fsync: on some filesystems the rename's
@@ -399,6 +416,14 @@ fn write_atomically(path: &Path, content: &str) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Refuse a target that is reachable under more than one name, because
+/// [`write_atomically`]'s rename can only move one of them onto the new
+/// content (#760).
+///
+/// A false negative is the safe direction, and there are two: mounts that do
+/// not report real link counts (some FUSE backends, `cifs` without UNIX
+/// extensions) and non-Unix platforms. Both degrade to the pre-#760 behavior
+/// rather than to a wrong refusal.
 #[cfg(unix)]
 fn reject_multiple_hard_links(target: &Path) -> std::io::Result<()> {
     use std::os::unix::fs::MetadataExt as _;
@@ -424,8 +449,13 @@ fn reject_multiple_hard_links(target: &Path) -> std::io::Result<()> {
 
 #[cfg(not(unix))]
 fn reject_multiple_hard_links(_target: &Path) -> std::io::Result<()> {
-    // Stable std currently exposes link counts only on Unix. In particular,
-    // Windows MetadataExt::number_of_links is still a nightly-only API.
+    // Not implemented rather than impossible, and NTFS does have hard links,
+    // so #760 stays live on Windows. Stable std cannot express the check —
+    // `windows::fs::MetadataExt::number_of_links` is unstable behind
+    // `windows_by_handle` — but `winapi-util` and `windows-sys` are both
+    // already in the lockfile on Windows and expose
+    // `GetFileInformationByHandle`. Tracked in #933, together with the CI
+    // gap that leaves this arm uncompiled until a release build.
     Ok(())
 }
 

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -368,6 +368,7 @@ fn write_atomically(path: &Path, content: &str) -> std::io::Result<()> {
     use std::io::Write as _;
 
     let target = std::fs::canonicalize(path)?;
+    reject_multiple_hard_links(&target)?;
     let dir = target.parent().filter(|p| !p.as_os_str().is_empty());
     let mut tmp = tempfile::NamedTempFile::new_in(dir.unwrap_or(Path::new(".")))?;
     tmp.write_all(content.as_bytes())?;
@@ -382,6 +383,9 @@ fn write_atomically(path: &Path, content: &str) -> std::io::Result<()> {
     // over — after writing, so a read-only target mode can't block the write.
     tmp.as_file()
         .set_permissions(std::fs::metadata(&target)?.permissions())?;
+    // A link can be added while the replacement is prepared. Check again at
+    // the last point before persist would split that new alias from `target`.
+    reject_multiple_hard_links(&target)?;
     tmp.persist(&target).map_err(|e| e.error)?;
     // Best-effort directory fsync: on some filesystems the rename's
     // directory-entry update is itself buffered, so without this a power
@@ -392,6 +396,27 @@ fn write_atomically(path: &Path, content: &str) -> std::io::Result<()> {
     {
         let _ = dir_handle.sync_all();
     }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn reject_multiple_hard_links(target: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::MetadataExt as _;
+
+    let links = std::fs::metadata(target)?.nlink();
+    if links > 1 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "refusing atomic replacement of a file with {links} hard links; remove the aliases first"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn reject_multiple_hard_links(_target: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
@@ -437,6 +462,33 @@ mod tests {
             escaped.lines().count(),
             4,
             "the caret diagram must survive escaping: {escaped:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_atomically_rejects_multiply_linked_target_without_changes() {
+        use std::os::unix::fs::MetadataExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("source.lua");
+        let alias = dir.path().join("alias.lua");
+        std::fs::write(&target, "old\n").unwrap();
+        std::fs::hard_link(&target, &alias).unwrap();
+        let inode = std::fs::metadata(&target).unwrap().ino();
+        let entries_before = std::fs::read_dir(dir.path()).unwrap().count();
+
+        let error = write_atomically(&target, "new\n").unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("hard link"));
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "old\n");
+        assert_eq!(std::fs::read_to_string(&alias).unwrap(), "old\n");
+        assert_eq!(std::fs::metadata(&target).unwrap().ino(), inode);
+        assert_eq!(std::fs::metadata(&alias).unwrap().ino(), inode);
+        assert_eq!(
+            std::fs::read_dir(dir.path()).unwrap().count(),
+            entries_before
         );
     }
 }

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -701,6 +701,44 @@ fn e2e_format_preserves_file_permissions() {
     );
 }
 
+/// A refused write must be reported and counted like any other write error,
+/// not swallowed — and the summary must not claim the file was reformatted.
+/// This is the cheapest deterministic way to reach that branch at all.
+#[cfg(unix)]
+#[test]
+fn e2e_hard_linked_file_is_refused_and_counted_as_an_error() {
+    let ws = workspace_with(&[("doc.md", MARKDOWN)]);
+    std::fs::hard_link(ws.path().join("doc.md"), ws.path().join("alias.md"))
+        .expect("hard link the document");
+
+    let output = run_format(ws.path(), &["doc.md"]);
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "a refused write exits 2; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("cannot write") && stderr.contains("hard link"),
+        "the refusal must name its cause; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("0 file(s) reformatted"),
+        "a refused write must not be summarised as reformatted; stderr: {stderr}"
+    );
+    assert_eq!(
+        read(ws.path(), "doc.md"),
+        MARKDOWN,
+        "the target must be untouched"
+    );
+    assert_eq!(
+        read(ws.path(), "alias.md"),
+        MARKDOWN,
+        "the alias must not be left on stale content"
+    );
+}
+
 #[test]
 fn e2e_excludes_filters_directory_walk() {
     let ws = workspace_with(&[("kept.md", MARKDOWN), ("vendor/dep.md", MARKDOWN)]);

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -707,9 +707,13 @@ fn e2e_format_preserves_file_permissions() {
 #[cfg(unix)]
 #[test]
 fn e2e_hard_linked_file_is_refused_and_counted_as_an_error() {
+    use std::os::unix::fs::MetadataExt as _;
+
     let ws = workspace_with(&[("doc.md", MARKDOWN)]);
-    std::fs::hard_link(ws.path().join("doc.md"), ws.path().join("alias.md"))
-        .expect("hard link the document");
+    let target = ws.path().join("doc.md");
+    let alias = ws.path().join("alias.md");
+    std::fs::hard_link(&target, &alias).expect("hard link the document");
+    let inode = std::fs::metadata(&target).expect("stat target").ino();
 
     let output = run_format(ws.path(), &["doc.md"]);
 
@@ -736,6 +740,18 @@ fn e2e_hard_linked_file_is_refused_and_counted_as_an_error() {
         read(ws.path(), "alias.md"),
         MARKDOWN,
         "the alias must not be left on stale content"
+    );
+    // Equal bytes are not equal files: the split this guards against produces
+    // two inodes that happen to agree until the next edit. Pin the identity.
+    assert_eq!(
+        std::fs::metadata(&target).expect("stat target").ino(),
+        inode,
+        "the target must keep its inode"
+    );
+    assert_eq!(
+        std::fs::metadata(&alias).expect("stat alias").ino(),
+        inode,
+        "both names must still resolve to the one inode"
     );
 }
 


### PR DESCRIPTION
## Summary

`kakehashi format` rewrites files by writing a temp file and renaming it over
the target. That is crash-safe, but it gives the target a new inode — so a file
reachable under several hard links keeps only the formatted name up to date and
strands every other name on the old content, silently.

- refuse a target whose link count is greater than one, before the temp file is
  created and again immediately before `persist`
- count the refusal as a per-file write error (exit 2) and keep formatting the
  rest of the run
- preserve target content, inode identity, and directory contents on rejection

The count comes from `symlink_metadata`, not `metadata`: `rename(2)` never
follows a final symlink, so the number has to describe the inode the rename will
actually unlink.

## What this does not promise

The refusal is best-effort, and the code and docs now say so rather than
implying a guarantee:

- **Timing.** The count is read immediately before the rename, not atomically
  with it. A link created in that window is still split. Nothing closes this —
  no stable API renames conditionally on a link count, `RENAME_EXCHANGE` only
  reshapes the split, and truncate-in-place would forfeit the crash safety
  `write_atomically` exists to provide.
- **Filesystem.** The verdict is only as good as `st_nlink`. A mount that
  under-reports (some FUSE backends, `cifs` without UNIX extensions) still
  splits silently.
- **Platform.** Non-Unix is a no-op: `windows::fs::MetadataExt::number_of_links`
  is unstable behind `windows_by_handle`. NTFS does have hard links, so #760
  stays live on Windows — tracked in #933, which also records that the crates
  needed (`winapi-util`, `windows-sys`) already reach Windows builds
  transitively, and that Ubuntu-only CI leaves the `cfg(not(unix))` arm
  uncompiled until a release build.

`--check` is deliberately unchanged: it answers whether the content would
change, not whether the write would succeed, and it resolves no paths today.

## Tests

- `cargo test --lib` — 3240 passed, 0 failed
- `cargo test --features e2e --test e2e_cli_format` — 20 passed, 0 failed
- `cargo clippy --lib -- -D warnings`, `cargo fmt --check`

New coverage:

- the refusal leaves both names, their shared inode, and the directory
  untouched (this test fails against pre-fix code: the write *succeeded* there)
- a singly linked file is still replaced, carrying its mode over — the only
  CI-compiled proof the guard did not break the write path, since `tests/` is
  gated behind the `e2e` feature that CI does not enable
- a symlinked path is still written *through* rather than replaced
- the predicate judges a symlink by its own count, not its target's (reverting
  to `metadata` fails exactly this test)
- e2e: a refused write exits 2, names its cause on stderr, and is not counted
  as reformatted in the summary

Closes #760