### PR TITLE
fix(config): create outputs without clobbering

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -837,6 +837,12 @@ kakehashi config init --output ./kakehashi.toml --force
 
 `--force` only applies when `--output` is used.
 
+Without `--force`, the output path is never touched: the file is created
+exclusively, so *any* existing entry there — a regular file, a directory, or a
+symlink, including a dangling one — makes the command report an error and exit
+non-zero rather than write. With `--force`, a symlink at the output path is
+followed and its target is written; the link itself stays.
+
 ### Formatting
 
 `kakehashi format` formats files through the same downstream language servers

--- a/docs/README.md
+++ b/docs/README.md
@@ -837,11 +837,12 @@ kakehashi config init --output ./kakehashi.toml --force
 
 `--force` only applies when `--output` is used.
 
-Without `--force`, the output path is never touched: the file is created
-exclusively, so *any* existing entry there — a regular file, a directory, or a
-symlink, including a dangling one — makes the command report an error and exit
-non-zero rather than write. With `--force`, a symlink at the output path is
-followed and its target is written; the link itself stays.
+Without `--force`, an entry already at the output path is never touched: the
+file is created exclusively, so *anything* there — a regular file, a
+directory, or a symlink, including a dangling one — makes the command report
+an error and exit non-zero rather than write. With `--force`, a symlink is
+followed rather than replaced, so the write lands on its target when that
+target can be opened as a file.
 
 ### Formatting
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -184,7 +184,7 @@ enum ConfigAction {
         #[arg(long)]
         output: Option<PathBuf>,
 
-        /// Overwrite whatever is at the output path (only applies with --output)
+        /// Write even if the output path already exists (only applies with --output)
         #[arg(long)]
         force: bool,
     },
@@ -197,7 +197,7 @@ enum ConfigAction {
         #[arg(long)]
         output: Option<PathBuf>,
 
-        /// Overwrite whatever is at the output path (only applies with --output)
+        /// Write even if the output path already exists (only applies with --output)
         #[arg(long)]
         force: bool,
     },
@@ -641,21 +641,29 @@ fn find_parser_file(parser_dir: &std::path::Path, lang: &str) -> Option<PathBuf>
     if path.exists() { Some(path) } else { None }
 }
 
-/// What to tell someone whose `--output` path is already taken. Blanket
-/// "use --force to overwrite" advice is wrong for two of the three cases:
-/// `--force` writes *through* a symlink to whatever it points at, and it
-/// cannot write to a directory at all.
+/// What to tell someone whose `--output` path is already taken. A regular
+/// file is the only entry `--force` actually replaces: it writes *through* a
+/// symlink to whatever that points at, cannot write to a directory at all,
+/// and would write *into* a FIFO, socket, or device node — blocking on a
+/// reader, in the FIFO case — rather than replace it. So the advice is only
+/// offered where it holds.
 ///
 /// The entry is inspected only to word the message — the refusal itself was
 /// already decided atomically by `create_new`, so a path that changes between
-/// the two costs at worst a misleading sentence, never a wrong action.
+/// the two costs at worst a misleading sentence, never a wrong action. A
+/// failed inspection falls back to the plain advice for the same reason.
 fn overwrite_advice(path: &Path) -> &'static str {
-    match path.symlink_metadata() {
-        Ok(metadata) if metadata.is_dir() => "It is a directory; --force cannot overwrite it.",
-        Ok(metadata) if metadata.file_type().is_symlink() => {
-            "It is a symbolic link; --force would write through to its target rather than replace the link."
-        }
-        _ => "Use --force to overwrite.",
+    let Ok(metadata) = path.symlink_metadata() else {
+        return "Use --force to overwrite.";
+    };
+    if metadata.is_file() {
+        "Use --force to overwrite."
+    } else if metadata.is_dir() {
+        "It is a directory; --force cannot write to it."
+    } else if metadata.file_type().is_symlink() {
+        "It is a symbolic link; --force would write through to its target rather than replace the link."
+    } else {
+        "It is not a regular file; --force would write into it rather than replace it."
     }
 }
 
@@ -677,8 +685,9 @@ fn write_content_to_output(
         // `exists()` follows symlinks, so a dangling symlink reads as absent
         // and the write lands on its target instead of refusing; and anything
         // created between the check and the write is silently truncated
-        // (#763). `--force` keeps the plain truncating write — replacing what
-        // is already there is exactly what it asks for.
+        // (#763). `--force` keeps the plain truncating write: it asks to
+        // write whatever is already there out of the way, which for a symlink
+        // means following it — see `overwrite_advice`.
         let write_result = if force {
             std::fs::write(path, content)
         } else {
@@ -1230,6 +1239,32 @@ mod tests {
 
         assert!(output.symlink_metadata().unwrap().file_type().is_symlink());
         assert_eq!(std::fs::read_to_string(&redirected).unwrap(), "generated");
+    }
+
+    /// Only a regular file may be told to retry with `--force`; every other
+    /// entry kind would get a promise the flag cannot keep.
+    #[cfg(unix)]
+    #[test]
+    fn overwrite_advice_offers_force_only_where_it_replaces_the_entry() {
+        let temp = tempfile::TempDir::new().unwrap();
+
+        let file = temp.path().join("plain.toml");
+        std::fs::write(&file, "x").unwrap();
+        assert_eq!(overwrite_advice(&file), "Use --force to overwrite.");
+
+        let dir = temp.path().join("adir");
+        std::fs::create_dir(&dir).unwrap();
+        assert!(overwrite_advice(&dir).contains("directory"));
+
+        let link = temp.path().join("link.toml");
+        std::os::unix::fs::symlink(temp.path().join("nowhere.toml"), &link).unwrap();
+        assert!(overwrite_advice(&link).contains("symbolic link"));
+
+        // A socket stands in for the whole special-file family (FIFOs, device
+        // nodes): `--force` would write *into* it, not replace it.
+        let socket = temp.path().join("sock");
+        let _listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
+        assert!(overwrite_advice(&socket).contains("not a regular file"));
     }
 
     /// Guards the `AlreadyExists` mapping rather than the #763 fix itself:

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -654,17 +654,28 @@ fn write_content_to_output(
     }
 
     if let Some(path) = output.as_ref().filter(|p| p.as_os_str() != "-") {
-        if path.exists() && !force {
-            eprintln!(
-                "Error: File '{}' already exists. Use --force to overwrite.",
-                path.display()
-            );
-            return Err(ExitCode::FAILURE);
-        }
+        let write_result = if force {
+            std::fs::write(path, content)
+        } else {
+            use std::io::Write as _;
 
-        match std::fs::write(path, content) {
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(path)
+                .and_then(|mut file| file.write_all(content.as_bytes()))
+        };
+
+        match write_result {
             Ok(()) => {
                 eprintln!("Created {label} file: {}", path.display());
+            }
+            Err(e) if !force && e.kind() == std::io::ErrorKind::AlreadyExists => {
+                eprintln!(
+                    "Error: File '{}' already exists. Use --force to overwrite.",
+                    path.display()
+                );
+                return Err(ExitCode::FAILURE);
             }
             Err(e) => {
                 eprintln!("Failed to write {label} file: {}", e);
@@ -1140,5 +1151,23 @@ mod tests {
         );
         assert_eq!(installed_query_language_name(&unsafe_name), None);
         assert_eq!(installed_query_language_name(&hidden), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn output_without_force_rejects_dangling_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let redirected = temp.path().join("redirected.toml");
+        let output = temp.path().join("config.toml");
+        symlink(&redirected, &output).unwrap();
+
+        let result =
+            write_content_to_output("generated", Some(output.clone()), false, "configuration");
+
+        assert!(result.is_err());
+        assert!(output.symlink_metadata().is_ok());
+        assert!(!redirected.exists());
     }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -643,10 +643,11 @@ fn find_parser_file(parser_dir: &std::path::Path, lang: &str) -> Option<PathBuf>
 
 /// What to tell someone whose `--output` path is already taken. A regular
 /// file is the only entry `--force` actually replaces: it writes *through* a
-/// symlink to whatever that points at, cannot write to a directory at all,
-/// and would write *into* a FIFO, socket, or device node — blocking on a
-/// reader, in the FIFO case — rather than replace it. So the advice is only
-/// offered where it holds.
+/// symlink to whatever that points at, and cannot write to a directory at
+/// all. Nor to the rest: it would write *into* a FIFO or device node —
+/// blocking until a reader appears, in the FIFO case — while a socket path
+/// cannot be opened as a file at all. None of those is a replacement, so the
+/// advice is only offered where it holds.
 ///
 /// The entry is inspected only to word the message — the refusal itself was
 /// already decided atomically by `create_new`, so a path that changes between
@@ -663,7 +664,7 @@ fn overwrite_advice(path: &Path) -> &'static str {
     } else if metadata.file_type().is_symlink() {
         "It is a symbolic link; --force would write through to its target rather than replace the link."
     } else {
-        "It is not a regular file; --force would write into it rather than replace it."
+        "It is not a regular file; --force would not replace it."
     }
 }
 
@@ -686,7 +687,7 @@ fn write_content_to_output(
         // and the write lands on its target instead of refusing; and anything
         // created between the check and the write is silently truncated
         // (#763). `--force` keeps the plain truncating write: it asks to
-        // write whatever is already there out of the way, which for a symlink
+        // write regardless of whatever is already there, which for a symlink
         // means following it — see `overwrite_advice`.
         let write_result = if force {
             std::fs::write(path, content)
@@ -1261,7 +1262,8 @@ mod tests {
         assert!(overwrite_advice(&link).contains("symbolic link"));
 
         // A socket stands in for the whole special-file family (FIFOs, device
-        // nodes): `--force` would write *into* it, not replace it.
+        // nodes). Only the classification is pinned here: what --force does to
+        // each kind differs, and none of it is a replacement.
         let socket = temp.path().join("sock");
         let _listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
         assert!(overwrite_advice(&socket).contains("not a regular file"));

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -642,12 +642,15 @@ fn find_parser_file(parser_dir: &std::path::Path, lang: &str) -> Option<PathBuf>
 }
 
 /// What to tell someone whose `--output` path is already taken. A regular
-/// file is the only entry `--force` actually replaces: it writes *through* a
-/// symlink to whatever that points at, and cannot write to a directory at
-/// all. Nor to the rest: it would write *into* a FIFO or device node —
-/// blocking until a reader appears, in the FIFO case — while a socket path
-/// cannot be opened as a file at all. None of those is a replacement, so the
-/// advice is only offered where it holds.
+/// file is the only entry `--force` overwrites — in place, truncating that
+/// inode rather than replacing the directory entry, so any hard link to it
+/// sees the new content too. Everything else it cannot overwrite at all: it
+/// writes *through* a symlink to whatever that points at, cannot write to a
+/// directory, would write *into* a FIFO or device node (blocking until a
+/// reader appears, in the FIFO case), and cannot open a socket path as a file
+/// at all. So the advice is offered only where `--force` acts on the entry
+/// named — not as a promise that the write then succeeds, which permissions
+/// still decide.
 ///
 /// The entry is inspected only to word the message — the refusal itself was
 /// already decided atomically by `create_new`, so a path that changes between
@@ -1243,11 +1246,11 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&redirected).unwrap(), "generated");
     }
 
-    /// Only a regular file may be told to retry with `--force`; every other
-    /// entry kind would get a promise the flag cannot keep.
+    /// Only a regular file may be told to retry with `--force`; for every
+    /// other entry kind the flag does not act on the entry named at all.
     #[cfg(unix)]
     #[test]
-    fn overwrite_advice_offers_force_only_where_it_replaces_the_entry() {
+    fn overwrite_advice_offers_force_only_where_it_overwrites_the_entry() {
         let temp = tempfile::TempDir::new().unwrap();
 
         let file = temp.path().join("plain.toml");

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -672,7 +672,7 @@ fn write_content_to_output(
             }
             Err(e) if !force && e.kind() == std::io::ErrorKind::AlreadyExists => {
                 eprintln!(
-                    "Error: File '{}' already exists. Use --force to overwrite.",
+                    "Error: An entry already exists at '{}'. Use --force to overwrite.",
                     path.display()
                 );
                 return Err(ExitCode::FAILURE);
@@ -1167,7 +1167,20 @@ mod tests {
             write_content_to_output("generated", Some(output.clone()), false, "configuration");
 
         assert!(result.is_err());
-        assert!(output.symlink_metadata().is_ok());
+        assert!(output.symlink_metadata().unwrap().file_type().is_symlink());
         assert!(!redirected.exists());
+    }
+
+    #[test]
+    fn output_without_force_preserves_existing_file() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let output = temp.path().join("config.toml");
+        std::fs::write(&output, "existing").unwrap();
+
+        let result =
+            write_content_to_output("generated", Some(output.clone()), false, "configuration");
+
+        assert!(result.is_err());
+        assert_eq!(std::fs::read_to_string(output).unwrap(), "existing");
     }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -184,7 +184,7 @@ enum ConfigAction {
         #[arg(long)]
         output: Option<PathBuf>,
 
-        /// Write even if the output path already exists (only applies with --output)
+        /// Skip the refusal when the output path is already taken (only applies with --output)
         #[arg(long)]
         force: bool,
     },
@@ -197,7 +197,7 @@ enum ConfigAction {
         #[arg(long)]
         output: Option<PathBuf>,
 
-        /// Write even if the output path already exists (only applies with --output)
+        /// Skip the refusal when the output path is already taken (only applies with --output)
         #[arg(long)]
         force: bool,
     },
@@ -705,10 +705,11 @@ fn write_content_to_output(
             Ok(()) => {
                 eprintln!("Created {label} file: {}", path.display());
             }
-            // `!force` is unreachable today (a truncating write cannot report
-            // `AlreadyExists`) and stays deliberately: without it, a future
-            // force-path error of this kind would tell someone who already
-            // passed `--force` to pass `--force`.
+            // `AlreadyExists` under `--force` cannot happen today — a truncating
+            // write never reports it — so testing `!force` is redundant. It
+            // stays deliberately: without it, a future force-path error of
+            // that kind would tell someone who already passed `--force` to
+            // pass `--force`.
             Err(e) if !force && e.kind() == std::io::ErrorKind::AlreadyExists => {
                 eprintln!(
                     "Error: An entry already exists at '{}'. {}",

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -184,7 +184,7 @@ enum ConfigAction {
         #[arg(long)]
         output: Option<PathBuf>,
 
-        /// Overwrite existing file (only applies with --output)
+        /// Overwrite whatever is at the output path (only applies with --output)
         #[arg(long)]
         force: bool,
     },
@@ -197,7 +197,7 @@ enum ConfigAction {
         #[arg(long)]
         output: Option<PathBuf>,
 
-        /// Overwrite existing file (only applies with --output)
+        /// Overwrite whatever is at the output path (only applies with --output)
         #[arg(long)]
         force: bool,
     },
@@ -641,6 +641,24 @@ fn find_parser_file(parser_dir: &std::path::Path, lang: &str) -> Option<PathBuf>
     if path.exists() { Some(path) } else { None }
 }
 
+/// What to tell someone whose `--output` path is already taken. Blanket
+/// "use --force to overwrite" advice is wrong for two of the three cases:
+/// `--force` writes *through* a symlink to whatever it points at, and it
+/// cannot write to a directory at all.
+///
+/// The entry is inspected only to word the message — the refusal itself was
+/// already decided atomically by `create_new`, so a path that changes between
+/// the two costs at worst a misleading sentence, never a wrong action.
+fn overwrite_advice(path: &Path) -> &'static str {
+    match path.symlink_metadata() {
+        Ok(metadata) if metadata.is_dir() => "It is a directory; --force cannot overwrite it.",
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            "It is a symbolic link; --force would write through to its target rather than replace the link."
+        }
+        _ => "Use --force to overwrite.",
+    }
+}
+
 /// Write content to stdout or a file, with --force / --output semantics.
 fn write_content_to_output(
     content: &str,
@@ -654,6 +672,13 @@ fn write_content_to_output(
     }
 
     if let Some(path) = output.as_ref().filter(|p| p.as_os_str() != "-") {
+        // `create_new` (O_CREAT|O_EXCL), not an `exists()` check followed by a
+        // write: check-then-write has two holes that one syscall closes.
+        // `exists()` follows symlinks, so a dangling symlink reads as absent
+        // and the write lands on its target instead of refusing; and anything
+        // created between the check and the write is silently truncated
+        // (#763). `--force` keeps the plain truncating write — replacing what
+        // is already there is exactly what it asks for.
         let write_result = if force {
             std::fs::write(path, content)
         } else {
@@ -670,10 +695,15 @@ fn write_content_to_output(
             Ok(()) => {
                 eprintln!("Created {label} file: {}", path.display());
             }
+            // `!force` is unreachable today (a truncating write cannot report
+            // `AlreadyExists`) and stays deliberately: without it, a future
+            // force-path error of this kind would tell someone who already
+            // passed `--force` to pass `--force`.
             Err(e) if !force && e.kind() == std::io::ErrorKind::AlreadyExists => {
                 eprintln!(
-                    "Error: An entry already exists at '{}'. Use --force to overwrite.",
-                    path.display()
+                    "Error: An entry already exists at '{}'. {}",
+                    path.display(),
+                    overwrite_advice(path)
                 );
                 return Err(ExitCode::FAILURE);
             }
@@ -1153,6 +1183,9 @@ mod tests {
         assert_eq!(installed_query_language_name(&hidden), None);
     }
 
+    /// `Path::exists()` follows symlinks, so the old precheck read a dangling
+    /// link as absent and the write clobbered the link's target (#763). The
+    /// entry at the output path must survive as the link it is.
     #[cfg(unix)]
     #[test]
     fn output_without_force_rejects_dangling_symlink() {
@@ -1169,8 +1202,38 @@ mod tests {
         assert!(result.is_err());
         assert!(output.symlink_metadata().unwrap().file_type().is_symlink());
         assert!(!redirected.exists());
+
+        // Positive control: this directory is writable, so the refusal above
+        // came from the dangling link and not from an unwritable fixture.
+        let fresh = temp.path().join("fresh.toml");
+        write_content_to_output("generated", Some(fresh.clone()), false, "configuration")
+            .expect("a free path in the same directory must still be created");
+        assert_eq!(std::fs::read_to_string(fresh).unwrap(), "generated");
     }
 
+    /// `--force` opts out of the no-clobber guard, and that means writing
+    /// *through* a symlink rather than replacing it — the reason the refusal
+    /// message stops advertising `--force` for a link. Pinned so the behavior
+    /// cannot drift silently while #800 decides whether to keep it.
+    #[cfg(unix)]
+    #[test]
+    fn output_with_force_follows_a_symlink_to_its_target() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let redirected = temp.path().join("redirected.toml");
+        let output = temp.path().join("config.toml");
+        symlink(&redirected, &output).unwrap();
+
+        write_content_to_output("generated", Some(output.clone()), true, "configuration")
+            .expect("--force must not be blocked by the link");
+
+        assert!(output.symlink_metadata().unwrap().file_type().is_symlink());
+        assert_eq!(std::fs::read_to_string(&redirected).unwrap(), "generated");
+    }
+
+    /// Guards the `AlreadyExists` mapping rather than the #763 fix itself:
+    /// the old `exists()` precheck already refused a plain file.
     #[test]
     fn output_without_force_preserves_existing_file() {
         let temp = tempfile::TempDir::new().unwrap();

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -448,6 +448,38 @@ fn test_config_init_output_no_overwrite_without_force() {
     assert_eq!(content, "existing", "Original content should be preserved");
 }
 
+/// Test that config init --output refuses a dangling symlink instead of
+/// creating whatever it points at. `Path::exists()` follows symlinks, so the
+/// old precheck read a dangling link as absent and wrote through it (#763).
+#[cfg(unix)]
+#[test]
+fn test_config_init_output_rejects_dangling_symlink() {
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let redirected = test_dir.path().join("redirected.toml");
+    std::os::unix::fs::symlink(&redirected, test_dir.path().join("kakehashi.toml"))
+        .expect("Failed to create dangling symlink");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args(["config", "init", "--output", "kakehashi.toml"])
+        .current_dir(test_dir.path())
+        .output()
+        .expect("Failed to execute command");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "A dangling symlink is an existing entry and must be refused; stderr: {stderr}"
+    );
+    assert!(
+        !redirected.exists(),
+        "The link's target must not be created; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("symbolic link"),
+        "The refusal must not promise that --force replaces the link; stderr: {stderr}"
+    );
+}
+
 /// Test that config init --output --force overwrites existing file
 #[test]
 fn test_config_init_output_force_overwrites() {


### PR DESCRIPTION
## Summary

`kakehashi config init --output PATH` and `config schema --output PATH` checked
`Path::exists()` and then called `std::fs::write`. That is not a no-clobber
operation: `exists()` follows symlinks, so a **dangling** symlink read as absent
and the write created the link's target even without `--force`, and anything
created in the check-to-write window was silently truncated.

- create the output exclusively (`OpenOptions::create_new`) when `--force` is
  absent, so every pre-existing directory entry is refused in one syscall
- keep `--force` on the plain truncating write
- tell the user what `--force` will actually do to the entry that is in the way

## The refusal message

`--force` overwrites a regular file — in place, truncating that inode rather
than replacing the directory entry, so a hard link to it sees the new content.
It does none of that to the other entry kinds the exclusive create now refuses,
so blanket "use --force to overwrite" advice pointed users back into the hole
this PR closes. `overwrite_advice` picks the sentence:

| entry at `--output` | message |
|---|---|
| regular file | `Use --force to overwrite.` |
| directory | `It is a directory; --force cannot write to it.` |
| symlink | `It is a symbolic link; --force would write through to its target rather than replace the link.` |
| FIFO / socket / device node | `It is not a regular file; --force would not replace it.` |

The entry is inspected only to word the message — the refusal itself was already
decided atomically, so a path that changes in between costs a misleading
sentence, never a wrong action.

## Tests

- `cargo test --bin kakehashi` — 5 passed
- `cargo test --test test_cli` — 48 passed
- `cargo test --lib` — 3240 passed
- `cargo clippy --bins --lib -- -D warnings`, `cargo fmt --check`

Coverage:

- the dangling symlink is refused, the link survives as a link, and its target
  is never created (fails against pre-fix code, which returned `Ok`), plus a
  positive control proving the fixture directory was writable
- `--force` write-through to a symlink target is pinned, so it cannot drift
  while #800 decides whether to keep it
- `overwrite_advice` covers all four entry kinds (a `UnixListener` socket stands
  in for the special-file family)
- a CLI-level dangling-symlink test in `tests/test_cli.rs`, which `make test_e2e`
  runs — the bin unit tests are reached by neither `make test` nor `make test_e2e`

## Known gaps, tracked separately

- #799 — a mid-write failure can leave a partially written file
- #800 — `--force` follows a symlink at the output path
- #801 — "Created" is printed even when `--force` overwrote something

The Windows behavior of `create_new` against a dangling symlink is unverified:
the regression test is `#[cfg(unix)]` and CI is Ubuntu-only, while releases ship
`x86_64-pc-windows-msvc`.

Closes #763