### PR TITLE
fix(query): confine runtime asset lookup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -258,17 +258,22 @@ keeps a language name taken from document text — an injected code fence, say �
 from reaching outside `parser/` and `queries/`. It is a check on the name only;
 a component that is a symlink still leads wherever it points.
 
-For an asset that cannot follow this layout, set
-[`languages[*].parser`](#languages) to an explicit path. That is required, not
-merely an alternative: no queries are loaded for a language whose parser fails
-to load. Then list each kind you need under `languages[*].queries[*].path` —
-supplying `queries` at all disables the implicit lookup for the kinds you leave
-out, and only `highlights`, `injections`, and `bindings` can be given an
-explicit path.
+For an asset that cannot follow this layout, give the language an explicit
+parser — either [`languages[*].parser`](#languages) as a path, or
+[`languages[*].base`](#languagesbase) to reuse another language's parser. One of
+the two is needed, not optional: no queries are loaded for a language whose
+parser fails to load, so `queries` alone will not rescue a name the implicit
+lookup rejects.
 
-A `; inherits:` parent is resolved by language name at runtime and cannot be
-given an explicit path, so a parent query must always follow the implicit
-layout.
+Then list each kind you need under `languages[*].queries[*].path`. Supplying
+`queries` at all disables the implicit lookup for the kinds you leave out, and
+only `highlights`, `injections`, and `bindings` can be given an explicit path.
+
+`; inherits:` is resolved only for implicitly located queries. A query file
+given an explicit path is loaded as-is, so an `; inherits:` line in it is inert
+— tree-sitter reads it as a comment and the parent's patterns are silently
+absent. Inherit only from queries that follow the implicit layout, whose parent
+is itself resolved by language name and so must follow it too.
 
 #### `autoInstall` (deprecated)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -251,6 +251,10 @@ Array of base directories to search for parsers and queries. If not specified, u
 
 Parsers are searched as `{searchPath}/parser/{language}.{so,dylib,dll}`.
 Queries are searched as `{searchPath}/queries/{language}/{query_type}.scm`.
+For implicit lookup, `{language}` must be one normal path component; values
+containing path separators, `.`/`..` components, or platform path prefixes do
+not resolve. Use an explicit `languages[*].parser` or `languages[*].queries`
+path when an asset cannot follow this layout.
 
 #### `autoInstall` (deprecated)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -254,7 +254,9 @@ Queries are searched as `{searchPath}/queries/{language}/{query_type}.scm`.
 For implicit lookup, `{language}` must be one normal path component; values
 containing path separators, `.`/`..` components, or platform path prefixes do
 not resolve. Use an explicit `languages[*].parser` or `languages[*].queries`
-path when an asset cannot follow this layout.
+path for the configured parser and query kinds when an asset cannot follow this
+layout. Runtime-named queries (including capture kinds and inherited parents)
+must use the implicit layout.
 
 #### `autoInstall` (deprecated)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -251,12 +251,24 @@ Array of base directories to search for parsers and queries. If not specified, u
 
 Parsers are searched as `{searchPath}/parser/{language}.{so,dylib,dll}`.
 Queries are searched as `{searchPath}/queries/{language}/{query_type}.scm`.
-For implicit lookup, `{language}` must be one normal path component; values
-containing path separators, `.`/`..` components, or platform path prefixes do
-not resolve. Use an explicit `languages[*].parser` or `languages[*].queries`
-path for the configured parser and query kinds when an asset cannot follow this
-layout. Runtime-named queries (including capture kinds and inherited parents)
-must use the implicit layout.
+For implicit lookup, `{language}` must be one normal path component: values
+containing a path separator or a `.`/`..` component do not resolve, and on
+Windows neither do drive (`C:\…`) or UNC (`\\server\share\…`) prefixes. This
+keeps a language name taken from document text — an injected code fence, say —
+from reaching outside `parser/` and `queries/`. It is a check on the name only;
+a component that is a symlink still leads wherever it points.
+
+For an asset that cannot follow this layout, set
+[`languages[*].parser`](#languages) to an explicit path. That is required, not
+merely an alternative: no queries are loaded for a language whose parser fails
+to load. Then list each kind you need under `languages[*].queries[*].path` —
+supplying `queries` at all disables the implicit lookup for the kinds you leave
+out, and only `highlights`, `injections`, and `bindings` can be given an
+explicit path.
+
+A `; inherits:` parent is resolved by language name at runtime and cannot be
+given an explicit path, so a parent query must always follow the implicit
+layout.
 
 #### `autoInstall` (deprecated)
 

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -3,7 +3,7 @@ use log::warn;
 use path_clean::PathClean;
 use std::fmt::Write;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use tree_sitter::{Language, Query};
 
 /// Parser library file extensions for different platforms
@@ -88,8 +88,9 @@ pub(crate) fn format_search_paths<P: AsRef<Path>>(paths: &[P]) -> String {
 pub(crate) struct QueryLoader;
 
 impl QueryLoader {
-    fn query_file_path(base: &Path, lang_name: &str, file_name: &str) -> PathBuf {
-        base.join("queries").join(lang_name).join(file_name).clean()
+    fn query_file_path(base: &Path, lang_name: &str, file_name: &str) -> Option<PathBuf> {
+        is_single_path_component(lang_name)
+            .then(|| base.join("queries").join(lang_name).join(file_name).clean())
     }
 
     fn parser_library_path(base: &Path, language: &str, ext: &str) -> PathBuf {
@@ -210,7 +211,7 @@ impl QueryLoader {
         file_name: &str,
     ) -> Option<PathBuf> {
         for base in runtime_bases {
-            let candidate = Self::query_file_path(base.as_ref(), lang_name, file_name);
+            let candidate = Self::query_file_path(base.as_ref(), lang_name, file_name)?;
             if candidate.exists() {
                 return Some(candidate);
             }
@@ -410,6 +411,11 @@ impl QueryLoader {
     }
 }
 
+fn is_single_path_component(value: &str) -> bool {
+    let mut components = Path::new(value).components();
+    matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none()
+}
+
 fn normalize_inherited_language_name(name: &str) -> String {
     name.strip_prefix('(')
         .and_then(|name| name.strip_suffix(')'))
@@ -482,6 +488,30 @@ mod tests {
         // Test not finding a non-existent file
         let result = QueryLoader::find_query_file(NO_SEARCH_PATHS, "rust", "highlights.scm");
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn find_query_file_rejects_language_path_traversal() {
+        let dir = tempdir().unwrap();
+        let runtime = dir.path().join("runtime");
+        let outside = dir.path().join("outside");
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join("highlights.scm"), "(identifier) @variable").unwrap();
+
+        let result = QueryLoader::find_query_file(&[runtime], "../../outside", "highlights.scm");
+
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn implicit_asset_language_must_be_one_normal_component() {
+        assert!(is_single_path_component("typescript-react"));
+        assert!(!is_single_path_component(""));
+        assert!(!is_single_path_component("."));
+        assert!(!is_single_path_component(".."));
+        assert!(!is_single_path_component("../rust"));
+        assert!(!is_single_path_component("rust/query"));
+        assert!(!is_single_path_component("/rust"));
     }
 
     #[test]

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -415,7 +415,8 @@ impl QueryLoader {
 
 fn is_single_path_component(value: &str) -> bool {
     let mut components = Path::new(value).components();
-    matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none()
+    matches!(components.next(), Some(Component::Normal(name)) if name == value)
+        && components.next().is_none()
 }
 
 fn normalize_inherited_language_name(name: &str) -> String {
@@ -513,6 +514,8 @@ mod tests {
         assert!(!is_single_path_component(".."));
         assert!(!is_single_path_component("../rust"));
         assert!(!is_single_path_component("rust/query"));
+        assert!(!is_single_path_component("rust/"));
+        assert!(!is_single_path_component("rust/."));
         assert!(!is_single_path_component("/rust"));
     }
 

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -517,6 +517,15 @@ mod tests {
         assert!(!is_single_path_component("rust/"));
         assert!(!is_single_path_component("rust/."));
         assert!(!is_single_path_component("/rust"));
+        assert!(!is_single_path_component(&format!(
+            "rust{}query",
+            std::path::MAIN_SEPARATOR
+        )));
+        #[cfg(windows)]
+        {
+            assert!(!is_single_path_component(r"C:\rust"));
+            assert!(!is_single_path_component(r"\\server\share\rust"));
+        }
     }
 
     #[test]

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -93,10 +93,12 @@ impl QueryLoader {
             .then(|| base.join("queries").join(lang_name).join(file_name).clean())
     }
 
-    fn parser_library_path(base: &Path, language: &str, ext: &str) -> PathBuf {
-        base.join("parser")
-            .join(format!("{language}.{ext}"))
-            .clean()
+    fn parser_library_path(base: &Path, language: &str, ext: &str) -> Option<PathBuf> {
+        is_single_path_component(language).then(|| {
+            base.join("parser")
+                .join(format!("{language}.{ext}"))
+                .clean()
+        })
     }
 
     /// Resolve query inheritance and return the combined query content.
@@ -400,7 +402,7 @@ impl QueryLoader {
         // Otherwise, search in searchPaths: <base>/parser/
         for path in search_paths {
             for ext in PARSER_EXTENSIONS {
-                let parser_path = Self::parser_library_path(path.as_ref(), language, ext);
+                let parser_path = Self::parser_library_path(path.as_ref(), language, ext)?;
                 if parser_path.exists() {
                     return Some(parser_path);
                 }
@@ -512,6 +514,20 @@ mod tests {
         assert!(!is_single_path_component("../rust"));
         assert!(!is_single_path_component("rust/query"));
         assert!(!is_single_path_component("/rust"));
+    }
+
+    #[test]
+    fn resolve_library_path_rejects_language_path_traversal() {
+        let dir = tempdir().unwrap();
+        let runtime = dir.path().join("runtime");
+        fs::create_dir_all(&runtime).unwrap();
+        for ext in PARSER_EXTENSIONS {
+            fs::write(dir.path().join(format!("outside.{ext}")), "not a parser").unwrap();
+        }
+
+        let result = QueryLoader::resolve_library_path(None, "../../outside", &[runtime]);
+
+        assert_eq!(result, None);
     }
 
     #[test]

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -547,9 +547,63 @@ mod tests {
         fs::create_dir_all(&outside).unwrap();
         fs::write(outside.join("highlights.scm"), "(identifier) @variable").unwrap();
 
-        let result = QueryLoader::find_query_file(&[runtime], "../../outside", "highlights.scm");
+        // `runtime/queries` sits two components below the tempdir root, so the
+        // pre-fix join cleaned to exactly the file planted above.
+        let result =
+            QueryLoader::find_query_file(&[runtime.clone()], "../../outside", "highlights.scm");
 
         assert_eq!(result, None);
+
+        // An absolute name is the worse variant: `join` discards the base
+        // outright, so no `..` arithmetic is needed to escape.
+        let result = QueryLoader::find_query_file(
+            &[runtime.clone()],
+            outside.to_str().unwrap(),
+            "highlights.scm",
+        );
+
+        assert_eq!(result, None);
+
+        // Positive control on the same base: an ordinary name still resolves,
+        // so the assertions above pin the gate rather than a broken fixture.
+        let inside = runtime.join("queries").join("rust");
+        fs::create_dir_all(&inside).unwrap();
+        fs::write(inside.join("highlights.scm"), "(identifier) @variable").unwrap();
+
+        let result = QueryLoader::find_query_file(&[runtime], "rust", "highlights.scm");
+
+        assert_eq!(result, Some(inside.join("highlights.scm")));
+    }
+
+    #[test]
+    fn resolve_query_rejects_traversing_inherits_parent() {
+        // The parent language name comes from the first line of an on-disk query
+        // file, so it is the content-driven route into find_query_file -- and
+        // parse_inherits_directive, unlike its install-side twin, applies no
+        // filter of its own.
+        let dir = tempdir().unwrap();
+        let runtime = dir.path().join("runtime");
+
+        let outside = dir.path().join("outside");
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join("highlights.scm"), "(identifier) @smuggled").unwrap();
+
+        let child = runtime.join("queries").join("child");
+        fs::create_dir_all(&child).unwrap();
+        fs::write(
+            child.join("highlights.scm"),
+            "; inherits: ../../outside\n(string_literal) @string\n",
+        )
+        .unwrap();
+
+        let result = resolve_query(&[runtime], "child", "highlights.scm");
+
+        // An unresolvable parent fails the whole child query; what matters is
+        // that the smuggled content never reaches the combined output.
+        assert!(
+            result.is_err(),
+            "expected traversal to fail, got {result:?}"
+        );
     }
 
     #[test]
@@ -571,6 +625,12 @@ mod tests {
         {
             assert!(!is_single_path_component(r"C:\rust"));
             assert!(!is_single_path_component(r"\\server\share\rust"));
+            // Drive-relative: a prefix needs no following separator, so this
+            // parses as Prefix(Disk) + Normal("rust").
+            assert!(!is_single_path_component(r"C:rust"));
+            // Windows accepts `/` as a separator too, so the unix-looking case
+            // above is not redundant here.
+            assert!(!is_single_path_component("rust/query"));
         }
     }
 

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -88,17 +88,23 @@ pub(crate) fn format_search_paths<P: AsRef<Path>>(paths: &[P]) -> String {
 pub(crate) struct QueryLoader;
 
 impl QueryLoader {
-    fn query_file_path(base: &Path, lang_name: &str, file_name: &str) -> Option<PathBuf> {
-        is_single_path_component(lang_name)
-            .then(|| base.join("queries").join(lang_name).join(file_name).clean())
+    /// Build `<base>/queries/<lang_name>/<file_name>`.
+    ///
+    /// Callers must reject a `lang_name` that is not a single normal path
+    /// component before calling this; `file_name` is likewise caller-validated
+    /// (see `is_single_path_component`).
+    fn query_file_path(base: &Path, lang_name: &str, file_name: &str) -> PathBuf {
+        base.join("queries").join(lang_name).join(file_name).clean()
     }
 
-    fn parser_library_path(base: &Path, language: &str, ext: &str) -> Option<PathBuf> {
-        is_single_path_component(language).then(|| {
-            base.join("parser")
-                .join(format!("{language}.{ext}"))
-                .clean()
-        })
+    /// Build `<base>/parser/<language>.<ext>`.
+    ///
+    /// Callers must reject a `language` that is not a single normal path
+    /// component before calling this.
+    fn parser_library_path(base: &Path, language: &str, ext: &str) -> PathBuf {
+        base.join("parser")
+            .join(format!("{language}.{ext}"))
+            .clean()
     }
 
     /// Resolve query inheritance and return the combined query content.
@@ -207,13 +213,21 @@ impl QueryLoader {
     /// `pub(crate)` so the captures handler can distinguish "kind file absent"
     /// (expected, debug log) from "file exists but failed to load" (asset
     /// trouble, warn) — captures-protocol §"Null vs. error semantics".
+    ///
+    /// Returns `None` without touching the filesystem when `lang_name` is not a
+    /// single normal path component, so a document-controlled injection language
+    /// cannot escape `<base>/queries/`.
     pub(crate) fn find_query_file<P: AsRef<Path>>(
         runtime_bases: &[P],
         lang_name: &str,
         file_name: &str,
     ) -> Option<PathBuf> {
+        // Name-only, so it cannot vary per base: reject once, before the search.
+        if !is_single_path_component(lang_name) {
+            return None;
+        }
         for base in runtime_bases {
-            let candidate = Self::query_file_path(base.as_ref(), lang_name, file_name)?;
+            let candidate = Self::query_file_path(base.as_ref(), lang_name, file_name);
             if candidate.exists() {
                 return Some(candidate);
             }
@@ -388,21 +402,33 @@ impl QueryLoader {
     /// because it comes from `LanguageSettings.parser: Option<String>`; `search_paths`
     /// is generic over `AsRef<Path>` to accept both `PathBuf` (from `ConfigStore`)
     /// and `String` (from `WorkspaceSettings`).
+    ///
+    /// The implicit search is skipped entirely when `language` is not a single
+    /// normal path component. An explicit `library` is exempt: it comes from
+    /// config rather than from document text.
     pub(crate) fn resolve_library_path<P: AsRef<Path>>(
         library: Option<&str>,
         language: &str,
         search_paths: &[P],
     ) -> Option<PathBuf> {
-        // If explicit library path is provided, normalize and use it
+        // If explicit library path is provided, normalize and use it.
+        // Stays ahead of the name gate: this is the documented escape hatch for
+        // assets that cannot follow the implicit layout.
         if let Some(lib) = library {
             let normalized = PathBuf::from(lib).clean();
             return Some(normalized);
         }
 
+        // Name-only, so it cannot vary per base or extension: reject once here
+        // rather than inside the search below.
+        if !is_single_path_component(language) {
+            return None;
+        }
+
         // Otherwise, search in searchPaths: <base>/parser/
         for path in search_paths {
             for ext in PARSER_EXTENSIONS {
-                let parser_path = Self::parser_library_path(path.as_ref(), language, ext)?;
+                let parser_path = Self::parser_library_path(path.as_ref(), language, ext);
                 if parser_path.exists() {
                     return Some(parser_path);
                 }
@@ -413,6 +439,26 @@ impl QueryLoader {
     }
 }
 
+/// Whether `value` names exactly one ordinary path component.
+///
+/// Gates the language half of implicit asset lookup so a document-controlled
+/// injection language cannot leave `<base>/queries` or `<base>/parser`. The
+/// query-kind half is gated separately, by `is_valid_kind` in the captures
+/// handler; every other `file_name` is a `QueryKind::filename()` constant.
+///
+/// The `name == value` comparison is load-bearing, not a formality:
+/// `Components` silently normalizes away trailing separators and interior `.`,
+/// so `"rust/"` and `"rust/."` both yield a lone `Normal("rust")`. Requiring
+/// the component to span the whole input rejects them. Every normalization
+/// `Components` performs shortens the rendered form, so equality can only hold
+/// when none occurred — which is why this cannot be reduced to a
+/// `components().count() == 1` check.
+///
+/// Deliberately laxer than `is_safe_language_name` (`[a-z0-9_]+`), which gates
+/// installs: names like `typescript-react` are legal to place by hand and must
+/// stay readable, whereas the write side may be stricter because the name also
+/// becomes a URL segment. Rejection here is a path-shape decision only; it is
+/// not a charset filter and must not be relied on as one.
 fn is_single_path_component(value: &str) -> bool {
     let mut components = Path::new(value).components();
     matches!(components.next(), Some(Component::Normal(name)) if name == value)

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -543,6 +543,24 @@ mod tests {
     }
 
     #[test]
+    fn resolve_library_path_honors_explicit_path_for_rejected_language() {
+        // The name gate guards implicit `<base>/parser/<language>.<ext>` lookup only.
+        // An explicit `languages[*].parser` comes from config, not from a document,
+        // and is the documented escape hatch for assets that cannot follow the
+        // implicit layout -- so it must resolve even for a name the gate rejects.
+        let dir = tempdir().unwrap();
+        let runtime = dir.path().join("runtime");
+
+        let result = QueryLoader::resolve_library_path(
+            Some("explicit/path.so"),
+            "../../outside",
+            &[runtime],
+        );
+
+        assert_eq!(result, Some(PathBuf::from("explicit/path.so")));
+    }
+
+    #[test]
     fn test_resolve_library_path() {
         // Test explicit library path
         let explicit = Some("explicit/path.so");


### PR DESCRIPTION
## Summary

Confine implicit runtime asset lookup so a document-controlled language identifier cannot leave the configured asset roots.

Implicit lookup builds `{searchPath}/queries/{language}/{kind}.scm` and `{searchPath}/parser/{language}.{so,dylib,dll}`, then cleans the path *lexically*. `{language}` can come from document text — a Markdown fence info string consumed by an injection query — so `../../outside` resolved outside the root. On the query side that reads a foreign `.scm` and loads it as if it belonged to the injected language; on the parser side the resolved path is handed to `dlopen`.

The fix rejects any language identifier that is not exactly one normal path component, before any path is built.

## What changed

- **The gate.** `is_single_path_component()` in `src/language/query_loader.rs`. The `name == value` comparison is load-bearing: `Components` normalizes away trailing separators and interior `.`, so `"rust/"` and `"rust/."` both yield a lone `Normal("rust")`; requiring the component to span the whole input rejects them. This is why it cannot be reduced to `components().count() == 1`.
- **Placement.** The gate is name-only, so it runs once per call rather than inside the per-base / per-extension search loops. In `resolve_library_path` it sits *after* the explicit-`library` branch, not at the top: an explicit `languages[*].parser` comes from config, not from document text, and is the documented escape hatch. That exemption is pinned by its own test, landed before the hoist so it proves the property rather than the refactor.
- **Tests.** Both escape tests were confirmed RED against the pre-fix code. Coverage added for the `; inherits: <parent>` route (the parent name is read from an on-disk query file, making it the genuinely content-driven input, and `parse_inherits_directive` applies no filter of its own), for absolute names via the public API (`join` discards the base outright — no `..` needed), for the explicit-parser exemption, and for `C:rust` / `/`-as-separator on Windows.
- **Docs.** The `searchPaths` paragraph was rewritten: an explicit `parser` is *required* rather than an alternative to `queries` (queries never load for a language whose parser fails to load); `queries[*].path` is the correct spelling and only the three `QueryKind` variants can take one; the platform-prefix claim is scoped to Windows, since `C:\rust` is an ordinary component on Unix.

## Deliberately not in this PR

- **Distinguishing "name refused" from "file not found"** in error messages. The honest message can't land until document-derived names are escaped at the LSP log boundary, or it becomes a second injection site. Filed as #942.
- **Rejecting control characters in the gate** (suggested by Qodo). Wrong layer — it would only change which message carries the bytes, since the raw name is formatted either way at `coordinator.rs:928` and `query_loader.rs:239`. Same issue.
- **Symlinks and NTFS alternate data streams.** Both are contained: they require write access to the search root, which is the same access needed to drop a malicious `.so` there directly under an ordinary accepted name. The threat model here is document-controlled *names* within trusted roots. The README now says outright that the gate checks the name only.

## Validation

- `make check` (cargo check, clippy `-D warnings`, fmt, dead_code ban) — green
- `cargo test --lib` — 3,245 passed, 0 failed, 2 ignored
- `make test_e2e`
- Every commit gate-green individually.

## Follow-ups filed

#939 (project-local `kakehashi.toml` trust boundary — pre-existing, strictly stronger than this issue), #940, #941 (virtual-URI defects), #942 (log escaping + refusal wording), #943 (loader/installer name-validator divergence), #944 (`parser_file_exists` hardening).

Closes #764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security and reliability when locating language parsers and query assets.
  - Invalid language or library names containing path separators, traversal components, or platform-specific prefixes are no longer treated as valid implicit paths.
  - Assets using nonstandard layouts must now be configured with explicit parser and query paths.
  - Runtime query inheritance now enforces the expected implicit asset layout.

- **Documentation**
  - Clarified supported naming rules and configuration requirements for implicit asset lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->