### PR TITLE
fix(cli): surface language status scan failures

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -402,6 +402,14 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
         ExitCode::FAILURE
     })?;
 
+    validate_install_root(&data_dir).map_err(|e| {
+        eprintln!(
+            "Error: failed to inspect data directory '{}': {e}",
+            data_dir.display()
+        );
+        ExitCode::FAILURE
+    })?;
+
     let parser_dir = data_dir.join("parser");
     let queries_dir = data_dir.join("queries");
     if let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {
@@ -488,6 +496,28 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
     }
 
     Ok(())
+}
+
+fn validate_install_root(path: &Path) -> std::io::Result<()> {
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_dir() => Ok(()),
+        Ok(_) => Err(std::io::Error::new(
+            std::io::ErrorKind::NotADirectory,
+            "install data path is not a directory",
+        )),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            match std::fs::symlink_metadata(path) {
+                // A truly absent root is the normal state before any install.
+                Err(metadata_error) if metadata_error.kind() == std::io::ErrorKind::NotFound => {
+                    Ok(())
+                }
+                // Preserve the original follow failure for a dangling link.
+                Ok(_) => Err(e),
+                Err(metadata_error) => Err(metadata_error),
+            }
+        }
+        Err(e) => Err(e),
+    }
 }
 
 /// Visit every entry in an installation directory.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -396,7 +396,6 @@ const DOC_LINK: &str =
 /// Run the language status command
 fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
     use std::collections::BTreeSet;
-    use std::fs;
 
     let data_dir = default_data_dir().ok_or_else(|| {
         eprintln!("Error: Could not determine data directory. Please specify --data-dir.");
@@ -412,28 +411,40 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
     // Collect all installed languages from both parser and queries directories
     let mut languages = BTreeSet::new();
 
-    // Scan parser directory for .so, .dylib, .dll files
-    if let Ok(entries) = fs::read_dir(&parser_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let is_parser = path
-                .extension()
-                .map(|ext| ext == std::env::consts::DLL_EXTENSION)
-                .unwrap_or(false);
-            if is_parser && let Some(stem) = path.file_stem() {
-                languages.insert(stem.to_string_lossy().to_string());
-            }
+    // Scan parser directory for .so, .dylib, .dll files. A fresh data
+    // directory legitimately has no parser directory yet; every other I/O
+    // failure means status cannot truthfully report the installation as empty.
+    visit_install_directory(&parser_dir, |entry| {
+        let path = entry.path();
+        let is_parser = path
+            .extension()
+            .map(|ext| ext == std::env::consts::DLL_EXTENSION)
+            .unwrap_or(false);
+        if is_parser && let Some(stem) = path.file_stem() {
+            languages.insert(stem.to_string_lossy().to_string());
         }
-    }
+    })
+    .map_err(|e| {
+        eprintln!(
+            "Error: failed to inspect parser directory '{}': {e}",
+            parser_dir.display()
+        );
+        ExitCode::FAILURE
+    })?;
 
     // Also check queries directory for languages that might only have queries
-    if let Ok(entries) = fs::read_dir(&queries_dir) {
-        for entry in entries.flatten() {
-            if let Some(name) = installed_query_language_name(&entry.path()) {
-                languages.insert(name);
-            }
+    visit_install_directory(&queries_dir, |entry| {
+        if let Some(name) = installed_query_language_name(&entry.path()) {
+            languages.insert(name);
         }
-    }
+    })
+    .map_err(|e| {
+        eprintln!(
+            "Error: failed to inspect query directory '{}': {e}",
+            queries_dir.display()
+        );
+        ExitCode::FAILURE
+    })?;
 
     if languages.is_empty() {
         eprintln!("No languages installed in {}", data_dir.display());
@@ -471,6 +482,26 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
         }
     }
 
+    Ok(())
+}
+
+/// Visit every entry in an installation directory.
+///
+/// Missing directories are the normal state before the first install. Other
+/// directory-open errors and per-entry iteration errors mean the caller did
+/// not observe the complete installation and must not report an empty result.
+fn visit_install_directory(
+    path: &Path,
+    mut visit: impl FnMut(std::fs::DirEntry),
+) -> std::io::Result<()> {
+    let entries = match std::fs::read_dir(path) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e),
+    };
+    for entry in entries {
+        visit(entry?);
+    }
     Ok(())
 }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -499,6 +499,12 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
 }
 
 fn validate_install_root(path: &Path) -> std::io::Result<()> {
+    let path = if path.is_absolute() {
+        std::borrow::Cow::Borrowed(path)
+    } else {
+        std::borrow::Cow::Owned(std::env::current_dir()?.join(path))
+    };
+    let path = path.as_ref();
     match std::fs::metadata(path) {
         Ok(metadata) if metadata.is_dir() => Ok(()),
         Ok(_) => Err(std::io::Error::new(
@@ -506,15 +512,32 @@ fn validate_install_root(path: &Path) -> std::io::Result<()> {
             "install data path is not a directory",
         )),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            match std::fs::symlink_metadata(path) {
-                // A truly absent root is the normal state before any install.
-                Err(metadata_error) if metadata_error.kind() == std::io::ErrorKind::NotFound => {
-                    Ok(())
+            for ancestor in path.ancestors() {
+                match std::fs::symlink_metadata(ancestor) {
+                    Err(metadata_error)
+                        if metadata_error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(metadata_error) => return Err(metadata_error),
+                    Ok(metadata) if metadata.file_type().is_symlink() => {
+                        let target = std::fs::metadata(ancestor)?;
+                        return if target.is_dir() {
+                            Ok(())
+                        } else {
+                            Err(std::io::Error::new(
+                                std::io::ErrorKind::NotADirectory,
+                                "install data ancestor is not a directory",
+                            ))
+                        };
+                    }
+                    Ok(metadata) if metadata.is_dir() => return Ok(()),
+                    Ok(_) => {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::NotADirectory,
+                            "install data ancestor is not a directory",
+                        ));
+                    }
                 }
-                // Preserve the original follow failure for a dangling link.
-                Ok(_) => Err(e),
-                Err(metadata_error) => Err(metadata_error),
             }
+            Err(e)
         }
         Err(e) => Err(e),
     }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -428,8 +428,22 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
             .extension()
             .map(|ext| ext == std::env::consts::DLL_EXTENSION)
             .unwrap_or(false);
+        let is_file = match std::fs::metadata(&path) {
+            Ok(metadata) => metadata.is_file(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                match std::fs::symlink_metadata(&path) {
+                    Err(metadata_error)
+                        if metadata_error.kind() == std::io::ErrorKind::NotFound =>
+                    {
+                        return Ok(());
+                    }
+                    _ => return Err(error),
+                }
+            }
+            Err(error) => return Err(error),
+        };
         if is_parser
-            && std::fs::metadata(&path)?.is_file()
+            && is_file
             && let Some(stem) = path.file_stem()
         {
             languages.insert(stem.to_string_lossy().to_string());
@@ -589,7 +603,19 @@ fn installed_query_language_name_checked(path: &Path) -> std::io::Result<Option<
     if !queries::is_safe_language_name(&name) {
         return Ok(None);
     }
-    if !std::fs::metadata(path)?.is_dir() {
+    let is_dir = match std::fs::metadata(path) {
+        Ok(metadata) => metadata.is_dir(),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            match std::fs::symlink_metadata(path) {
+                Err(metadata_error) if metadata_error.kind() == std::io::ErrorKind::NotFound => {
+                    return Ok(None);
+                }
+                _ => return Err(error),
+            }
+        }
+        Err(error) => return Err(error),
+    };
+    if !is_dir {
         return Ok(None);
     }
     Ok(Some(name.to_string()))

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -428,6 +428,9 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
             .extension()
             .map(|ext| ext == std::env::consts::DLL_EXTENSION)
             .unwrap_or(false);
+        if !is_parser {
+            return Ok(());
+        }
         let is_file = match std::fs::metadata(&path) {
             Ok(metadata) => metadata.is_file(),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -442,10 +445,7 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
             }
             Err(error) => return Err(error),
         };
-        if is_parser
-            && is_file
-            && let Some(stem) = path.file_stem()
-        {
+        if is_file && let Some(stem) = path.file_stem() {
             languages.insert(stem.to_string_lossy().to_string());
         }
         Ok(())

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -420,7 +420,10 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
             .extension()
             .map(|ext| ext == std::env::consts::DLL_EXTENSION)
             .unwrap_or(false);
-        if is_parser && let Some(stem) = path.file_stem() {
+        if is_parser
+            && std::fs::metadata(&path)?.is_file()
+            && let Some(stem) = path.file_stem()
+        {
             languages.insert(stem.to_string_lossy().to_string());
         }
         Ok(())

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -496,7 +496,18 @@ fn visit_install_directory(
 ) -> std::io::Result<()> {
     let entries = match std::fs::read_dir(path) {
         Ok(entries) => entries,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            match std::fs::symlink_metadata(path) {
+                // No directory entry is the normal pre-install state.
+                Err(metadata_error) if metadata_error.kind() == std::io::ErrorKind::NotFound => {
+                    return Ok(());
+                }
+                // A dangling symlink (or another entry read_dir could not
+                // follow) exists, so preserve the original scan failure.
+                Ok(_) => return Err(e),
+                Err(metadata_error) => return Err(metadata_error),
+            }
+        }
         Err(e) => return Err(e),
     };
     for entry in entries {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -423,6 +423,7 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
         if is_parser && let Some(stem) = path.file_stem() {
             languages.insert(stem.to_string_lossy().to_string());
         }
+        Ok(())
     })
     .map_err(|e| {
         eprintln!(
@@ -434,9 +435,10 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
 
     // Also check queries directory for languages that might only have queries
     visit_install_directory(&queries_dir, |entry| {
-        if let Some(name) = installed_query_language_name(&entry.path()) {
+        if let Some(name) = installed_query_language_name_checked(&entry.path())? {
             languages.insert(name);
         }
+        Ok(())
     })
     .map_err(|e| {
         eprintln!(
@@ -492,7 +494,7 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
 /// not observe the complete installation and must not report an empty result.
 fn visit_install_directory(
     path: &Path,
-    mut visit: impl FnMut(std::fs::DirEntry),
+    mut visit: impl FnMut(std::fs::DirEntry) -> std::io::Result<()>,
 ) -> std::io::Result<()> {
     let entries = match std::fs::read_dir(path) {
         Ok(entries) => entries,
@@ -511,23 +513,30 @@ fn visit_install_directory(
         Err(e) => return Err(e),
     };
     for entry in entries {
-        visit(entry?);
+        visit(entry?)?;
     }
     Ok(())
 }
 
 fn installed_query_language_name(path: &Path) -> Option<String> {
-    if !path.is_dir() {
-        return None;
+    installed_query_language_name_checked(path).ok().flatten()
+}
+
+fn installed_query_language_name_checked(path: &Path) -> std::io::Result<Option<String>> {
+    if !std::fs::metadata(path)?.is_dir() {
+        return Ok(None);
     }
-    let name = path.file_name()?.to_string_lossy();
+    let Some(file_name) = path.file_name() else {
+        return Ok(None);
+    };
+    let name = file_name.to_string_lossy();
     if name.starts_with('.') {
-        return None;
+        return Ok(None);
     }
     if !queries::is_safe_language_name(&name) {
-        return None;
+        return Ok(None);
     }
-    Some(name.to_string())
+    Ok(Some(name.to_string()))
 }
 
 /// Run the language uninstall command

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -526,9 +526,6 @@ fn installed_query_language_name(path: &Path) -> Option<String> {
 }
 
 fn installed_query_language_name_checked(path: &Path) -> std::io::Result<Option<String>> {
-    if !std::fs::metadata(path)?.is_dir() {
-        return Ok(None);
-    }
     let Some(file_name) = path.file_name() else {
         return Ok(None);
     };
@@ -537,6 +534,9 @@ fn installed_query_language_name_checked(path: &Path) -> std::io::Result<Option<
         return Ok(None);
     }
     if !queries::is_safe_language_name(&name) {
+        return Ok(None);
+    }
+    if !std::fs::metadata(path)?.is_dir() {
         return Ok(None);
     }
     Ok(Some(name.to_string()))

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -908,6 +908,39 @@ fn test_language_status_fails_for_dangling_install_directory_symlink() {
 
 #[cfg(unix)]
 #[test]
+fn test_language_status_fails_for_dangling_parser_entry_symlink() {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let parser_dir = test_dir.path().join("parser");
+    fs::create_dir(&parser_dir).expect("Failed to create parser directory");
+    symlink(
+        "missing-parser",
+        parser_dir.join(format!("rust.{}", std::env::consts::DLL_EXTENSION)),
+    )
+    .expect("Failed to create dangling parser symlink");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("failed to inspect parser directory"),
+        "stderr: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn test_language_status_fails_for_dangling_query_entry_symlink() {
     use std::fs;
     use std::os::unix::fs::symlink;

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -846,7 +846,7 @@ fn test_language_status_shows_installed() {
 
 /// Status must not report an install as empty when it could not inspect it.
 #[test]
-fn test_language_status_fails_when_install_directory_is_unreadable() {
+fn test_language_status_fails_when_install_directory_is_not_a_directory() {
     use std::fs;
 
     let test_dir = tempfile::tempdir().expect("Failed to create temp dir");

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -935,6 +935,34 @@ fn test_language_status_fails_for_dangling_data_directory_symlink() {
 
 #[cfg(unix)]
 #[test]
+fn test_language_status_fails_below_dangling_data_directory_ancestor() {
+    use std::os::unix::fs::symlink;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let dangling = test_dir.path().join("dangling");
+    symlink("missing-data-directory", &dangling).expect("Failed to create dangling data ancestor");
+    let data_dir = dangling.join("nested-data");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("failed to inspect data directory"),
+        "stderr: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn test_language_status_fails_for_dangling_parser_entry_symlink() {
     use std::fs;
     use std::os::unix::fs::symlink;

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1099,6 +1099,36 @@ fn test_language_status_ignores_internal_query_dirs() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn test_language_status_ignores_dangling_internal_query_symlink() {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let queries_dir = test_dir.path().join("queries");
+    fs::create_dir(&queries_dir).expect("Failed to create queries directory");
+    symlink("missing", queries_dir.join(".rust.123.tmp"))
+        .expect("Failed to create internal query symlink");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("No languages installed"),
+        "stderr: {stderr}"
+    );
+}
+
 /// Test that language status recovers a query dir stranded as a hidden backup
 #[test]
 fn test_language_status_recovers_internal_query_backup() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -865,8 +865,10 @@ fn test_language_status_fails_when_install_directory_is_unreadable() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(!output.status.success(), "stderr: {stderr}");
-    assert!(stderr.contains("parser"), "stderr: {stderr}");
-    assert!(stderr.contains("Not a directory"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("failed to inspect parser directory"),
+        "stderr: {stderr}"
+    );
     assert!(
         !stderr.contains("No languages installed"),
         "stderr: {stderr}"

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -844,6 +844,35 @@ fn test_language_status_shows_installed() {
     );
 }
 
+/// Status must not report an install as empty when it could not inspect it.
+#[test]
+fn test_language_status_fails_when_install_directory_is_unreadable() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    fs::write(test_dir.path().join("parser"), "not a directory")
+        .expect("Failed to create invalid parser directory");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "stderr: {stderr}");
+    assert!(stderr.contains("parser"), "stderr: {stderr}");
+    assert!(stderr.contains("Not a directory"), "stderr: {stderr}");
+    assert!(
+        !stderr.contains("No languages installed"),
+        "stderr: {stderr}"
+    );
+}
+
 /// Test that language status shows missing queries
 #[test]
 fn test_language_status_missing_queries() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -906,6 +906,42 @@ fn test_language_status_fails_for_dangling_install_directory_symlink() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn test_language_status_fails_for_dangling_query_entry_symlink() {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    fs::create_dir(test_dir.path().join("queries")).expect("Failed to create queries directory");
+    symlink(
+        "missing-query-directory",
+        test_dir.path().join("queries/rust"),
+    )
+    .expect("Failed to create dangling query symlink");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("failed to inspect query directory"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("No languages installed"),
+        "stderr: {stderr}"
+    );
+}
+
 /// Test that language status shows missing queries
 #[test]
 fn test_language_status_missing_queries() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -875,6 +875,37 @@ fn test_language_status_fails_when_install_directory_is_unreadable() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn test_language_status_fails_for_dangling_install_directory_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    symlink("missing-parser-directory", test_dir.path().join("parser"))
+        .expect("Failed to create dangling parser symlink");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("failed to inspect parser directory"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("No languages installed"),
+        "stderr: {stderr}"
+    );
+}
+
 /// Test that language status shows missing queries
 #[test]
 fn test_language_status_missing_queries() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -908,6 +908,33 @@ fn test_language_status_fails_for_dangling_install_directory_symlink() {
 
 #[cfg(unix)]
 #[test]
+fn test_language_status_fails_for_dangling_data_directory_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let data_dir = test_dir.path().join("data");
+    symlink("missing-data-directory", &data_dir).expect("Failed to create dangling data symlink");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("failed to inspect data directory"),
+        "stderr: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn test_language_status_fails_for_dangling_parser_entry_symlink() {
     use std::fs;
     use std::os::unix::fs::symlink;


### PR DESCRIPTION
## Summary

- fail `language status` when parser/query install directories cannot be inspected
- keep genuinely missing directories as the valid pre-install empty state
- propagate candidate parser/query entry metadata failures while ignoring internal staging names

## User impact

Status no longer exits successfully with `No languages installed` when filesystem errors prevented it from observing the installation.

## Tests

- `cargo test --test test_cli test_language_status_ -- --nocapture`
- `cargo fmt --check`
- `cargo clippy --bin kakehashi --test test_cli -- -D warnings`

Closes #766

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `language status` reliability when installation data contains missing, invalid, unreadable, or symlinked paths.
  * Directory inspection failures now return proper failure results, while normal pre-install conditions remain non-fatal.
  * Dangling internal query entries are ignored instead of causing incorrect installation reports.

* **Tests**
  * Added CLI coverage for invalid directory layouts, dangling symlinks, and pre-install states.
  * Added Unix-only coverage for dangling internal query symlinks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->