### PR TITLE
fix(cli): fail incomplete uninstall scans

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -483,7 +483,13 @@ fn installed_query_language_name(path: &Path) -> Option<String> {
 fn read_optional_install_dir(path: &Path, kind: &str) -> Result<Option<std::fs::ReadDir>, String> {
     match std::fs::read_dir(path) {
         Ok(entries) => Ok(Some(entries)),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e)
+            if e.kind() == std::io::ErrorKind::NotFound
+                && std::fs::symlink_metadata(path)
+                    .is_err_and(|metadata_error| metadata_error.kind() == e.kind()) =>
+        {
+            Ok(None)
+        }
         Err(e) => Err(format!(
             "cannot read {kind} directory '{}': {e}",
             path.display()

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -575,13 +575,19 @@ fn collect_installed_languages_for_uninstall(
                 )
             })?;
             let path = entry.path();
-            entry
+            let file_type = entry
                 .file_type()
                 .map_err(|e| format!("cannot inspect parser entry '{}': {e}", path.display()))?;
             let is_parser = path
                 .extension()
                 .map(|ext| ext == std::env::consts::DLL_EXTENSION)
                 .unwrap_or(false);
+            if is_parser && !(file_type.is_file() || file_type.is_symlink()) {
+                return Err(format!(
+                    "parser entry '{}' is not a file or symlink",
+                    path.display()
+                ));
+            }
             if is_parser && let Some(stem) = path.file_stem() {
                 languages.insert(stem.to_string_lossy().to_string());
             }
@@ -700,6 +706,17 @@ fn run_language_uninstall(
             continue;
         }
 
+        // Inspect the parser entry before mutating queries. Targeted uninstall
+        // does not run bulk discovery, so this is its per-language preflight;
+        // bulk uninstall repeats the check to close races after discovery.
+        let parser_path = match find_parser_file_for_uninstall(&parser_dir, lang) {
+            Ok(path) => path,
+            Err(e) => {
+                eprintln!("✗ Failed to inspect parser for '{}': {e}", lang);
+                any_failed = true;
+                continue;
+            }
+        };
         let mut removed_something = false;
 
         // Remove queries directory and any kakehashi-created backups under the
@@ -726,14 +743,6 @@ fn run_language_uninstall(
         }
 
         // Remove parser file only after query removal completed.
-        let parser_path = match find_parser_file_for_uninstall(&parser_dir, lang) {
-            Ok(path) => path,
-            Err(e) => {
-                eprintln!("✗ Failed to inspect parser for '{}': {e}", lang);
-                any_failed = true;
-                continue;
-            }
-        };
         if let Some(parser_path) = parser_path {
             match fs::remove_file(&parser_path) {
                 Ok(()) => {
@@ -781,7 +790,11 @@ fn find_parser_file_for_uninstall(
 ) -> Result<Option<PathBuf>, String> {
     let path = parser_dir.join(format!("{}.{}", lang, std::env::consts::DLL_EXTENSION));
     match std::fs::symlink_metadata(&path) {
-        Ok(_) => Ok(Some(path)),
+        Ok(metadata) if metadata.is_file() || metadata.file_type().is_symlink() => Ok(Some(path)),
+        Ok(_) => Err(format!(
+            "parser entry '{}' is not a file or symlink",
+            path.display()
+        )),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(format!("cannot inspect '{}': {e}", path.display())),
     }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -522,7 +522,11 @@ fn installed_query_language_name_for_uninstall(
     // make the kakehashi-owned namespace impossible to clean.
     let is_dir = file_type.is_dir() || file_type.is_symlink();
     let language = installed_query_language_name_if_dir(&path, is_dir);
-    if language.is_some() && file_type.is_dir() {
+    // Hidden staging/backup directories are skipped as installed languages,
+    // but recovery can mutate them into canonical installs. Validate every
+    // real directory before recovery so an unreadable candidate cannot be
+    // renamed first and fail only on the post-recovery scan.
+    if file_type.is_dir() {
         preflight_query_install_tree(&path)?;
     }
     Ok(language)

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -480,13 +480,77 @@ fn installed_query_language_name(path: &Path) -> Option<String> {
     Some(name.to_string())
 }
 
+fn collect_installed_languages_for_uninstall(
+    parser_dir: &Path,
+    queries_dir: &Path,
+) -> Result<std::collections::BTreeSet<String>, String> {
+    use std::fs;
+    use std::io::ErrorKind;
+
+    let mut languages = std::collections::BTreeSet::new();
+
+    let parser_entries = match fs::read_dir(parser_dir) {
+        Ok(entries) => Some(entries),
+        Err(e) if e.kind() == ErrorKind::NotFound => None,
+        Err(e) => {
+            return Err(format!(
+                "cannot read parser directory '{}': {e}",
+                parser_dir.display()
+            ));
+        }
+    };
+    if let Some(entries) = parser_entries {
+        for entry in entries {
+            let entry = entry.map_err(|e| {
+                format!(
+                    "cannot read an entry in parser directory '{}': {e}",
+                    parser_dir.display()
+                )
+            })?;
+            let path = entry.path();
+            let is_parser = path
+                .extension()
+                .map(|ext| ext == std::env::consts::DLL_EXTENSION)
+                .unwrap_or(false);
+            if is_parser && let Some(stem) = path.file_stem() {
+                languages.insert(stem.to_string_lossy().to_string());
+            }
+        }
+    }
+
+    let query_entries = match fs::read_dir(queries_dir) {
+        Ok(entries) => Some(entries),
+        Err(e) if e.kind() == ErrorKind::NotFound => None,
+        Err(e) => {
+            return Err(format!(
+                "cannot read queries directory '{}': {e}",
+                queries_dir.display()
+            ));
+        }
+    };
+    if let Some(entries) = query_entries {
+        for entry in entries {
+            let entry = entry.map_err(|e| {
+                format!(
+                    "cannot read an entry in queries directory '{}': {e}",
+                    queries_dir.display()
+                )
+            })?;
+            if let Some(name) = installed_query_language_name(&entry.path()) {
+                languages.insert(name);
+            }
+        }
+    }
+
+    Ok(languages)
+}
+
 /// Run the language uninstall command
 fn run_language_uninstall(
     language: Option<String>,
     force: bool,
     all: bool,
 ) -> Result<(), ExitCode> {
-    use std::collections::BTreeSet;
     use std::fs;
     use std::io::{self, Write};
 
@@ -503,31 +567,13 @@ fn run_language_uninstall(
 
     // Determine which languages to uninstall
     let languages_to_uninstall: Vec<String> = if all {
-        // Collect all installed languages
-        let mut languages = BTreeSet::new();
-
-        if let Ok(entries) = fs::read_dir(&parser_dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                let is_parser = path
-                    .extension()
-                    .map(|ext| ext == std::env::consts::DLL_EXTENSION)
-                    .unwrap_or(false);
-                if is_parser && let Some(stem) = path.file_stem() {
-                    languages.insert(stem.to_string_lossy().to_string());
-                }
-            }
-        }
-
-        if let Ok(entries) = fs::read_dir(&queries_dir) {
-            for entry in entries.flatten() {
-                if let Some(name) = installed_query_language_name(&entry.path()) {
-                    languages.insert(name);
-                }
-            }
-        }
-
-        languages.into_iter().collect()
+        collect_installed_languages_for_uninstall(&parser_dir, &queries_dir)
+            .map_err(|e| {
+                eprintln!("Failed to scan installed languages: {e}");
+                ExitCode::FAILURE
+            })?
+            .into_iter()
+            .collect()
     } else {
         vec![language.expect("language required when --all not specified")]
     };

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -486,29 +486,19 @@ fn installed_query_language_name_if_dir(path: &Path, is_dir: bool) -> Option<Str
 
 fn installed_query_language_name_for_uninstall(
     entry: &std::fs::DirEntry,
-    queries_dir: &Path,
 ) -> Result<Option<String>, String> {
-    let file_type = entry.file_type().map_err(|e| {
-        format!(
-            "cannot inspect an entry in queries directory '{}': {e}",
-            queries_dir.display()
-        )
-    })?;
+    let path = entry.path();
+    let file_type = entry
+        .file_type()
+        .map_err(|e| format!("cannot inspect query entry '{}': {e}", path.display()))?;
     let is_dir = if file_type.is_symlink() {
-        entry
-            .path()
-            .metadata()
-            .map_err(|e| {
-                format!(
-                    "cannot resolve query entry '{}': {e}",
-                    entry.path().display()
-                )
-            })?
+        path.metadata()
+            .map_err(|e| format!("cannot resolve query entry '{}': {e}", path.display()))?
             .is_dir()
     } else {
         file_type.is_dir()
     };
-    Ok(installed_query_language_name_if_dir(&entry.path(), is_dir))
+    Ok(installed_query_language_name_if_dir(&path, is_dir))
 }
 
 fn read_optional_install_dir(path: &Path, kind: &str) -> Result<Option<std::fs::ReadDir>, String> {
@@ -561,7 +551,7 @@ fn collect_installed_languages_for_uninstall(
                     queries_dir.display()
                 )
             })?;
-            if let Some(name) = installed_query_language_name_for_uninstall(&entry, queries_dir)? {
+            if let Some(name) = installed_query_language_name_for_uninstall(&entry)? {
                 languages.insert(name);
             }
         }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -484,6 +484,32 @@ fn installed_query_language_name_if_dir(path: &Path, is_dir: bool) -> Option<Str
     Some(name.to_string())
 }
 
+fn preflight_query_install_tree(root: &Path) -> Result<(), String> {
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(dir) = pending.pop() {
+        let entries = std::fs::read_dir(&dir)
+            .map_err(|e| format!("cannot read query directory '{}': {e}", dir.display()))?;
+        for entry in entries {
+            let entry = entry.map_err(|e| {
+                format!(
+                    "cannot read an entry in query directory '{}': {e}",
+                    dir.display()
+                )
+            })?;
+            let path = entry.path();
+            let file_type = entry
+                .file_type()
+                .map_err(|e| format!("cannot inspect query entry '{}': {e}", path.display()))?;
+            // remove_dir_all does not follow symlinks, so only real child
+            // directories need traversal preflight.
+            if file_type.is_dir() {
+                pending.push(path);
+            }
+        }
+    }
+    Ok(())
+}
+
 fn installed_query_language_name_for_uninstall(
     entry: &std::fs::DirEntry,
 ) -> Result<Option<String>, String> {
@@ -495,7 +521,11 @@ fn installed_query_language_name_for_uninstall(
     // query-root entry. Do not follow it: a dangling target or loop must not
     // make the kakehashi-owned namespace impossible to clean.
     let is_dir = file_type.is_dir() || file_type.is_symlink();
-    Ok(installed_query_language_name_if_dir(&path, is_dir))
+    let language = installed_query_language_name_if_dir(&path, is_dir);
+    if language.is_some() && file_type.is_dir() {
+        preflight_query_install_tree(&path)?;
+    }
+    Ok(language)
 }
 
 fn read_optional_install_dir(path: &Path, kind: &str) -> Result<Option<std::fs::ReadDir>, String> {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -529,20 +529,31 @@ fn installed_query_language_name_for_uninstall(
 }
 
 fn read_optional_install_dir(path: &Path, kind: &str) -> Result<Option<std::fs::ReadDir>, String> {
-    match std::fs::read_dir(path) {
-        Ok(entries) => Ok(Some(entries)),
-        Err(e)
-            if e.kind() == std::io::ErrorKind::NotFound
-                && std::fs::symlink_metadata(path)
-                    .is_err_and(|metadata_error| metadata_error.kind() == e.kind()) =>
-        {
-            Ok(None)
+    match std::fs::symlink_metadata(path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(format!(
+                "cannot inspect {kind} directory '{}': {e}",
+                path.display()
+            ));
         }
-        Err(e) => Err(format!(
-            "cannot read {kind} directory '{}': {e}",
-            path.display()
-        )),
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(format!(
+                "{kind} directory '{}' must not be a symlink",
+                path.display()
+            ));
+        }
+        Ok(metadata) if !metadata.is_dir() => {
+            return Err(format!(
+                "{kind} path '{}' is not a directory",
+                path.display()
+            ));
+        }
+        Ok(_) => {}
     }
+    std::fs::read_dir(path)
+        .map(Some)
+        .map_err(|e| format!("cannot read {kind} directory '{}': {e}", path.display()))
 }
 
 fn collect_installed_languages_for_uninstall(

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -575,9 +575,14 @@ fn read_optional_install_dir(path: &Path, kind: &str) -> Result<Option<std::fs::
         }
         Ok(_) => {}
     }
-    std::fs::read_dir(path)
-        .map(Some)
-        .map_err(|e| format!("cannot read {kind} directory '{}': {e}", path.display()))
+    match std::fs::read_dir(path) {
+        Ok(entries) => Ok(Some(entries)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(format!(
+            "cannot read {kind} directory '{}': {e}",
+            path.display()
+        )),
+    }
 }
 
 fn collect_installed_languages_for_uninstall(

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -688,7 +688,30 @@ fn run_language_uninstall(
 
         let mut removed_something = false;
 
-        // Remove parser file
+        // Remove queries directory and any kakehashi-created backups under the
+        // same lock used by install replacement, so uninstall cannot race a
+        // concurrent install into resurrecting queries after reporting success.
+        // Do this before the parser: query removal recursively traverses a tree
+        // and has more ways to fail than deleting one parser entry. If it fails,
+        // preserve the parser rather than leaving the language half-uninstalled.
+        match queries::remove_query_install_and_backups(&queries_dir, lang) {
+            Ok(removal) => {
+                if removal.removed_queries {
+                    eprintln!("✓ Removed queries: {}", queries_dir.join(lang).display());
+                }
+                if removal.removed_backups {
+                    eprintln!("✓ Removed query backups for '{}'", lang);
+                }
+                removed_something |= removal.removed_anything();
+            }
+            Err(e) => {
+                eprintln!("✗ Failed to remove queries for '{}': {}", lang, e);
+                any_failed = true;
+                continue;
+            }
+        }
+
+        // Remove parser file only after query removal completed.
         let parser_path = match find_parser_file_for_uninstall(&parser_dir, lang) {
             Ok(path) => path,
             Err(e) => {
@@ -707,25 +730,6 @@ fn run_language_uninstall(
                     eprintln!("✗ Failed to remove parser {}: {}", parser_path.display(), e);
                     any_failed = true;
                 }
-            }
-        }
-
-        // Remove queries directory and any kakehashi-created backups under the
-        // same lock used by install replacement, so uninstall cannot race a
-        // concurrent install into resurrecting queries after reporting success.
-        match queries::remove_query_install_and_backups(&queries_dir, lang) {
-            Ok(removal) => {
-                if removal.removed_queries {
-                    eprintln!("✓ Removed queries: {}", queries_dir.join(lang).display());
-                }
-                if removal.removed_backups {
-                    eprintln!("✓ Removed query backups for '{}'", lang);
-                }
-                removed_something |= removal.removed_anything();
-            }
-            Err(e) => {
-                eprintln!("✗ Failed to remove queries for '{}': {}", lang, e);
-                any_failed = true;
             }
         }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -487,19 +487,38 @@ fn installed_query_language_name_if_dir(path: &Path, is_dir: bool) -> Option<Str
 fn preflight_query_install_tree(root: &Path) -> Result<(), String> {
     let mut pending = vec![root.to_path_buf()];
     while let Some(dir) = pending.pop() {
-        let entries = std::fs::read_dir(&dir)
-            .map_err(|e| format!("cannot read query directory '{}': {e}", dir.display()))?;
-        for entry in entries {
-            let entry = entry.map_err(|e| {
-                format!(
-                    "cannot read an entry in query directory '{}': {e}",
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                return Err(format!(
+                    "cannot read query directory '{}': {e}",
                     dir.display()
-                )
-            })?;
+                ));
+            }
+        };
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => {
+                    return Err(format!(
+                        "cannot read an entry in query directory '{}': {e}",
+                        dir.display()
+                    ));
+                }
+            };
             let path = entry.path();
-            let file_type = entry
-                .file_type()
-                .map_err(|e| format!("cannot inspect query entry '{}': {e}", path.display()))?;
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => {
+                    return Err(format!(
+                        "cannot inspect query entry '{}': {e}",
+                        path.display()
+                    ));
+                }
+            };
             // remove_dir_all does not follow symlinks, so only real child
             // directories need traversal preflight.
             if file_type.is_dir() {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -491,13 +491,10 @@ fn installed_query_language_name_for_uninstall(
     let file_type = entry
         .file_type()
         .map_err(|e| format!("cannot inspect query entry '{}': {e}", path.display()))?;
-    let is_dir = if file_type.is_symlink() {
-        path.metadata()
-            .map_err(|e| format!("cannot resolve query entry '{}': {e}", path.display()))?
-            .is_dir()
-    } else {
-        file_type.is_dir()
-    };
+    // A safe-named symlink directly under queries/ is itself an uninstallable
+    // query-root entry. Do not follow it: a dangling target or loop must not
+    // make the kakehashi-owned namespace impossible to clean.
+    let is_dir = file_type.is_dir() || file_type.is_symlink();
     Ok(installed_query_language_name_if_dir(&path, is_dir))
 }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -523,10 +523,14 @@ fn installed_query_language_name_for_uninstall(
     let is_dir = file_type.is_dir() || file_type.is_symlink();
     let language = installed_query_language_name_if_dir(&path, is_dir);
     // Hidden staging/backup directories are skipped as installed languages,
-    // but recovery can mutate them into canonical installs. Validate every
-    // real directory before recovery so an unreadable candidate cannot be
-    // renamed first and fail only on the post-recovery scan.
-    if file_type.is_dir() {
+    // but recovery can mutate recognized ones into canonical installs. Avoid
+    // traversing unrelated hidden directories that neither recovery nor
+    // uninstall owns.
+    let is_recovery_dir = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(queries::is_recovery_directory_name);
+    if file_type.is_dir() && (language.is_some() || is_recovery_dir) {
         preflight_query_install_tree(&path)?;
     }
     Ok(language)

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -597,6 +597,10 @@ fn run_language_uninstall(
         })?;
     }
     if let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {
+        if all {
+            eprintln!("Failed to recover interrupted query installs: {e}");
+            return Err(ExitCode::FAILURE);
+        }
         eprintln!("Warning: failed to recover interrupted query installs: {e}");
     }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -586,6 +586,16 @@ fn run_language_uninstall(
 
     let parser_dir = data_dir.join("parser");
     let queries_dir = data_dir.join("queries");
+    // `--all` promises to discover the complete install before removing it.
+    // Validate both roots before recovery, which may delete stale staging
+    // directories or restore backups. Discard this first snapshot and rescan
+    // after recovery so restored languages are included in the uninstall set.
+    if all {
+        collect_installed_languages_for_uninstall(&parser_dir, &queries_dir).map_err(|e| {
+            eprintln!("Failed to scan installed languages: {e}");
+            ExitCode::FAILURE
+        })?;
+    }
     if let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {
         eprintln!("Warning: failed to recover interrupted query installs: {e}");
     }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -661,7 +661,7 @@ fn preflight_targeted_query_state(queries_dir: &Path, language: &str) -> Result<
             .file_type()
             .map_err(|e| format!("cannot inspect query entry '{}': {e}", path.display()))?;
         let is_target = name == language;
-        let is_recovery = queries::is_recovery_directory_name(name);
+        let is_recovery = queries::recovery_directory_language(name) == Some(language);
         if is_target && !(file_type.is_dir() || file_type.is_symlink()) {
             return Err(format!(
                 "query entry '{}' is not a directory or symlink",

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -467,7 +467,11 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
 }
 
 fn installed_query_language_name(path: &Path) -> Option<String> {
-    if !path.is_dir() {
+    installed_query_language_name_if_dir(path, path.is_dir())
+}
+
+fn installed_query_language_name_if_dir(path: &Path, is_dir: bool) -> Option<String> {
+    if !is_dir {
         return None;
     }
     let name = path.file_name()?.to_string_lossy();
@@ -478,6 +482,33 @@ fn installed_query_language_name(path: &Path) -> Option<String> {
         return None;
     }
     Some(name.to_string())
+}
+
+fn installed_query_language_name_for_uninstall(
+    entry: &std::fs::DirEntry,
+    queries_dir: &Path,
+) -> Result<Option<String>, String> {
+    let file_type = entry.file_type().map_err(|e| {
+        format!(
+            "cannot inspect an entry in queries directory '{}': {e}",
+            queries_dir.display()
+        )
+    })?;
+    let is_dir = if file_type.is_symlink() {
+        entry
+            .path()
+            .metadata()
+            .map_err(|e| {
+                format!(
+                    "cannot resolve query entry '{}': {e}",
+                    entry.path().display()
+                )
+            })?
+            .is_dir()
+    } else {
+        file_type.is_dir()
+    };
+    Ok(installed_query_language_name_if_dir(&entry.path(), is_dir))
 }
 
 fn read_optional_install_dir(path: &Path, kind: &str) -> Result<Option<std::fs::ReadDir>, String> {
@@ -530,7 +561,7 @@ fn collect_installed_languages_for_uninstall(
                     queries_dir.display()
                 )
             })?;
-            if let Some(name) = installed_query_language_name(&entry.path()) {
+            if let Some(name) = installed_query_language_name_for_uninstall(&entry, queries_dir)? {
                 languages.insert(name);
             }
         }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -521,6 +521,16 @@ fn installed_query_language_name_for_uninstall(
     // query-root entry. Do not follow it: a dangling target or loop must not
     // make the kakehashi-owned namespace impossible to clean.
     let is_dir = file_type.is_dir() || file_type.is_symlink();
+    let safe_name = path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .filter(|name| !name.starts_with('.') && queries::is_safe_language_name(name));
+    if safe_name.is_some() && !is_dir {
+        return Err(format!(
+            "query entry '{}' is not a directory or symlink",
+            path.display()
+        ));
+    }
     let language = installed_query_language_name_if_dir(&path, is_dir);
     // Hidden staging/backup directories are skipped as installed languages,
     // but recovery can mutate recognized ones into canonical installs. Avoid

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -540,6 +540,12 @@ fn installed_query_language_name_for_uninstall(
         .file_name()
         .and_then(|name| name.to_str())
         .is_some_and(queries::is_recovery_directory_name);
+    if is_recovery_dir && file_type.is_symlink() {
+        return Err(format!(
+            "query recovery entry '{}' must not be a symlink",
+            path.display()
+        ));
+    }
     if file_type.is_dir() && (language.is_some() || is_recovery_dir) {
         preflight_query_install_tree(&path)?;
     }
@@ -655,13 +661,20 @@ fn preflight_targeted_query_state(queries_dir: &Path, language: &str) -> Result<
             .file_type()
             .map_err(|e| format!("cannot inspect query entry '{}': {e}", path.display()))?;
         let is_target = name == language;
+        let is_recovery = queries::is_recovery_directory_name(name);
         if is_target && !(file_type.is_dir() || file_type.is_symlink()) {
             return Err(format!(
                 "query entry '{}' is not a directory or symlink",
                 path.display()
             ));
         }
-        if file_type.is_dir() && (is_target || queries::is_recovery_directory_name(name)) {
+        if is_recovery && file_type.is_symlink() {
+            return Err(format!(
+                "query recovery entry '{}' must not be a symlink",
+                path.display()
+            ));
+        }
+        if file_type.is_dir() && (is_target || is_recovery) {
             preflight_query_install_tree(&path)?;
         }
     }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -592,8 +592,20 @@ fn collect_installed_languages_for_uninstall(
                     path.display()
                 ));
             }
-            if is_parser && let Some(stem) = path.file_stem() {
-                languages.insert(stem.to_string_lossy().to_string());
+            if is_parser {
+                let language =
+                    path.file_stem()
+                        .and_then(|stem| stem.to_str())
+                        .ok_or_else(|| {
+                            format!("parser entry '{}' has a non-UTF-8 name", path.display())
+                        })?;
+                if !queries::is_safe_language_name(language) {
+                    return Err(format!(
+                        "parser entry '{}' has an invalid language name",
+                        path.display()
+                    ));
+                }
+                languages.insert(language.to_string());
             }
         }
     }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -697,6 +697,18 @@ fn run_language_uninstall(
 
     let parser_dir = data_dir.join("parser");
     let queries_dir = data_dir.join("queries");
+    let targeted_language = if all {
+        None
+    } else {
+        let language = language
+            .as_deref()
+            .expect("targeted uninstall has a language");
+        if !queries::is_safe_language_name(language) {
+            eprintln!("✗ Invalid language name {:?}", language);
+            return Err(ExitCode::FAILURE);
+        }
+        Some(language)
+    };
     // `--all` promises to discover the complete install before removing it.
     // Validate both roots before recovery, which may delete stale staging
     // directories or restore backups. Discard this first snapshot and rescan
@@ -714,20 +726,15 @@ fn run_language_uninstall(
             eprintln!("Failed to validate install roots: {e}");
             ExitCode::FAILURE
         })?;
-        let language = language
-            .as_deref()
-            .expect("targeted uninstall has a language");
+        let language = targeted_language.expect("targeted uninstall has a language");
         preflight_targeted_query_state(&queries_dir, language).map_err(|e| {
             eprintln!("Failed to preflight targeted query state: {e}");
             ExitCode::FAILURE
         })?;
     }
-    if let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {
-        if all {
-            eprintln!("Failed to recover interrupted query installs: {e}");
-            return Err(ExitCode::FAILURE);
-        }
-        eprintln!("Warning: failed to recover interrupted query installs: {e}");
+    if all && let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {
+        eprintln!("Failed to recover interrupted query installs: {e}");
+        return Err(ExitCode::FAILURE);
     }
 
     // Determine which languages to uninstall
@@ -740,7 +747,11 @@ fn run_language_uninstall(
             .into_iter()
             .collect()
     } else {
-        vec![language.expect("language required when --all not specified")]
+        vec![
+            targeted_language
+                .expect("targeted uninstall has a language")
+                .to_string(),
+        ]
     };
 
     if languages_to_uninstall.is_empty() {
@@ -765,6 +776,17 @@ fn run_language_uninstall(
             eprintln!("Cancelled.");
             return Ok(());
         }
+    }
+
+    // Targeted recovery is deliberately after confirmation and scoped to the
+    // requested language: cancellation and invalid input must not mutate any
+    // recovery state, especially not another language's artifacts.
+    if let Some(language) = targeted_language
+        && let Err(e) =
+            queries::recover_interrupted_query_installs_for_language(&queries_dir, language)
+    {
+        eprintln!("Failed to recover interrupted query installs for '{language}': {e}");
+        return Err(ExitCode::FAILURE);
     }
 
     // Uninstall each language

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -480,26 +480,24 @@ fn installed_query_language_name(path: &Path) -> Option<String> {
     Some(name.to_string())
 }
 
+fn read_optional_install_dir(path: &Path, kind: &str) -> Result<Option<std::fs::ReadDir>, String> {
+    match std::fs::read_dir(path) {
+        Ok(entries) => Ok(Some(entries)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(format!(
+            "cannot read {kind} directory '{}': {e}",
+            path.display()
+        )),
+    }
+}
+
 fn collect_installed_languages_for_uninstall(
     parser_dir: &Path,
     queries_dir: &Path,
 ) -> Result<std::collections::BTreeSet<String>, String> {
-    use std::fs;
-    use std::io::ErrorKind;
-
     let mut languages = std::collections::BTreeSet::new();
 
-    let parser_entries = match fs::read_dir(parser_dir) {
-        Ok(entries) => Some(entries),
-        Err(e) if e.kind() == ErrorKind::NotFound => None,
-        Err(e) => {
-            return Err(format!(
-                "cannot read parser directory '{}': {e}",
-                parser_dir.display()
-            ));
-        }
-    };
-    if let Some(entries) = parser_entries {
+    if let Some(entries) = read_optional_install_dir(parser_dir, "parser")? {
         for entry in entries {
             let entry = entry.map_err(|e| {
                 format!(
@@ -518,17 +516,7 @@ fn collect_installed_languages_for_uninstall(
         }
     }
 
-    let query_entries = match fs::read_dir(queries_dir) {
-        Ok(entries) => Some(entries),
-        Err(e) if e.kind() == ErrorKind::NotFound => None,
-        Err(e) => {
-            return Err(format!(
-                "cannot read queries directory '{}': {e}",
-                queries_dir.display()
-            ));
-        }
-    };
-    if let Some(entries) = query_entries {
+    if let Some(entries) = read_optional_install_dir(queries_dir, "queries")? {
         for entry in entries {
             let entry = entry.map_err(|e| {
                 format!(

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -533,6 +533,9 @@ fn collect_installed_languages_for_uninstall(
                 )
             })?;
             let path = entry.path();
+            entry
+                .file_type()
+                .map_err(|e| format!("cannot inspect parser entry '{}': {e}", path.display()))?;
             let is_parser = path
                 .extension()
                 .map(|ext| ext == std::env::consts::DLL_EXTENSION)
@@ -648,7 +651,15 @@ fn run_language_uninstall(
         let mut removed_something = false;
 
         // Remove parser file
-        if let Some(parser_path) = find_parser_file(&parser_dir, lang) {
+        let parser_path = match find_parser_file_for_uninstall(&parser_dir, lang) {
+            Ok(path) => path,
+            Err(e) => {
+                eprintln!("✗ Failed to inspect parser for '{}': {e}", lang);
+                any_failed = true;
+                continue;
+            }
+        };
+        if let Some(parser_path) = parser_path {
             match fs::remove_file(&parser_path) {
                 Ok(()) => {
                     eprintln!("✓ Removed parser: {}", parser_path.display());
@@ -706,6 +717,18 @@ fn run_language_uninstall(
 fn find_parser_file(parser_dir: &std::path::Path, lang: &str) -> Option<PathBuf> {
     let path = parser_dir.join(format!("{}.{}", lang, std::env::consts::DLL_EXTENSION));
     if path.exists() { Some(path) } else { None }
+}
+
+fn find_parser_file_for_uninstall(
+    parser_dir: &Path,
+    lang: &str,
+) -> Result<Option<PathBuf>, String> {
+    let path = parser_dir.join(format!("{}.{}", lang, std::env::consts::DLL_EXTENSION));
+    match std::fs::symlink_metadata(&path) {
+        Ok(_) => Ok(Some(path)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(format!("cannot inspect '{}': {e}", path.display())),
+    }
 }
 
 /// Write content to stdout or a file, with --force / --output semantics.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -627,6 +627,37 @@ fn collect_installed_languages_for_uninstall(
     Ok(languages)
 }
 
+fn preflight_targeted_query_state(queries_dir: &Path, language: &str) -> Result<(), String> {
+    let Some(entries) = read_optional_install_dir(queries_dir, "queries")? else {
+        return Ok(());
+    };
+    for entry in entries {
+        let entry = entry.map_err(|e| {
+            format!(
+                "cannot read an entry in queries directory '{}': {e}",
+                queries_dir.display()
+            )
+        })?;
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_str().unwrap_or_default();
+        let file_type = entry
+            .file_type()
+            .map_err(|e| format!("cannot inspect query entry '{}': {e}", path.display()))?;
+        let is_target = name == language;
+        if is_target && !(file_type.is_dir() || file_type.is_symlink()) {
+            return Err(format!(
+                "query entry '{}' is not a directory or symlink",
+                path.display()
+            ));
+        }
+        if file_type.is_dir() && (is_target || queries::is_recovery_directory_name(name)) {
+            preflight_query_install_tree(&path)?;
+        }
+    }
+    Ok(())
+}
+
 /// Run the language uninstall command
 fn run_language_uninstall(
     language: Option<String>,
@@ -656,12 +687,17 @@ fn run_language_uninstall(
         // Targeted uninstall does not need to enumerate every entry, but it
         // still builds removal paths beneath both roots. Reject a symlinked or
         // non-directory root before recovery/removal can escape data_dir.
-        for (path, kind) in [(&parser_dir, "parser"), (&queries_dir, "queries")] {
-            read_optional_install_dir(path, kind).map_err(|e| {
-                eprintln!("Failed to validate install roots: {e}");
-                ExitCode::FAILURE
-            })?;
-        }
+        read_optional_install_dir(&parser_dir, "parser").map_err(|e| {
+            eprintln!("Failed to validate install roots: {e}");
+            ExitCode::FAILURE
+        })?;
+        let language = language
+            .as_deref()
+            .expect("targeted uninstall has a language");
+        preflight_targeted_query_state(&queries_dir, language).map_err(|e| {
+            eprintln!("Failed to preflight targeted query state: {e}");
+            ExitCode::FAILURE
+        })?;
     }
     if let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {
         if all {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -630,6 +630,16 @@ fn run_language_uninstall(
             eprintln!("Failed to scan installed languages: {e}");
             ExitCode::FAILURE
         })?;
+    } else {
+        // Targeted uninstall does not need to enumerate every entry, but it
+        // still builds removal paths beneath both roots. Reject a symlinked or
+        // non-directory root before recovery/removal can escape data_dir.
+        for (path, kind) in [(&parser_dir, "parser"), (&queries_dir, "queries")] {
+            read_optional_install_dir(path, kind).map_err(|e| {
+                eprintln!("Failed to validate install roots: {e}");
+                ExitCode::FAILURE
+            })?;
+        }
     }
     if let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {
         if all {

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -842,6 +842,29 @@ fn backup_is_owned(path: &Path) -> bool {
     backup_ownership_sidecar(path).is_file()
 }
 
+fn backup_is_complete_and_owned(path: &Path) -> Result<bool, QueryInstallError> {
+    let regular_file_or_absent = |path: &Path| match fs::metadata(path) {
+        Ok(metadata) => Ok(Some(metadata)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(QueryInstallError::IoError(e)),
+    };
+
+    let Some(ownership) = regular_file_or_absent(&backup_ownership_sidecar(path))? else {
+        return Ok(false);
+    };
+    if !ownership.is_file() {
+        return Ok(false);
+    }
+    let Some(highlights) = regular_file_or_absent(&path.join("highlights.scm"))? else {
+        return Ok(false);
+    };
+    if !highlights.is_file() {
+        return Ok(false);
+    }
+    let marker = regular_file_or_absent(&path.join(QUERY_INSTALL_COMPLETE_MARKER))?;
+    Ok(marker.is_some_and(|metadata| metadata.is_file()) || highlights.len() > 0)
+}
+
 fn newest_complete_backup_dir(
     queries_parent: &Path,
     language: &str,
@@ -868,13 +891,10 @@ fn newest_complete_backup_dir(
         if !generated_backup_matches_language(name, language) {
             continue;
         }
-        if !backup_is_owned(&path) || !query_install_is_complete(&path) {
+        if !backup_is_complete_and_owned(&path)? {
             continue;
         }
-        let modified = entry
-            .metadata()
-            .and_then(|metadata| metadata.modified())
-            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        let modified = entry.metadata()?.modified()?;
         if newest
             .as_ref()
             .is_none_or(|(current, _)| modified > *current)
@@ -1313,6 +1333,33 @@ mod tests {
         assert!(!queries_parent.join("lua").exists());
         assert!(fs::symlink_metadata(&backup).is_ok());
         assert!(outside.join("highlights.scm").exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn recover_interrupted_query_install_propagates_unreadable_backup_metadata() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let backup = queries_parent.join(".lua.4294967295.0.backup");
+        fs::create_dir_all(&backup).unwrap();
+        fs::write(backup.join("highlights.scm"), "(comment) @comment").unwrap();
+        fs::write(backup_ownership_sidecar(&backup), b"owned\n").unwrap();
+        fs::set_permissions(&backup, fs::Permissions::from_mode(0o000)).unwrap();
+        if fs::metadata(backup.join("highlights.scm")).is_ok() {
+            fs::set_permissions(&backup, fs::Permissions::from_mode(0o700)).unwrap();
+            return;
+        }
+
+        let result = recover_interrupted_query_install(&queries_parent, "lua");
+
+        fs::set_permissions(&backup, fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(
+            matches!(result, Err(QueryInstallError::IoError(_))),
+            "backup inspection errors must not be treated as an incomplete backup: {result:?}"
+        );
+        assert!(!queries_parent.join("lua").exists());
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -656,6 +656,14 @@ fn generated_temp_parts(name: &str) -> Option<(&str, &str, &str)> {
     }
 }
 
+/// Whether a directory name belongs to the staging/backup namespace that
+/// [`recover_interrupted_query_installs`] may mutate.
+pub fn is_recovery_directory_name(name: &str) -> bool {
+    generated_backup_parts(name).is_some_and(|(language, _, _)| is_safe_language_name(language))
+        || generated_temp_parts(name)
+            .is_some_and(|(language, _, _)| is_safe_language_name(language))
+}
+
 fn remove_interrupted_temp_query_install(
     queries_parent: &Path,
     language: &str,

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -488,12 +488,21 @@ pub fn recover_interrupted_query_installs(queries_parent: &Path) -> Result<(), Q
     // same scan and lock acquisition for each stranded backup.
     let mut recovered_languages = std::collections::HashSet::new();
     for entry in entries {
-        let entry = entry?;
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(QueryInstallError::IoError(e)),
+        };
         let path = entry.path();
         // Recovery artifacts must be real directories. Do not follow a
         // staging/backup symlink outside the queries root, and propagate
         // entry-type errors instead of silently treating them as absent.
-        if !entry.file_type()?.is_dir() {
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(QueryInstallError::IoError(e)),
+        };
+        if !file_type.is_dir() {
             continue;
         }
         if let Some(language) = backup_language_name(&path) {
@@ -882,12 +891,21 @@ fn newest_complete_backup_dir(
     let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
 
     for entry in entries {
-        let entry = entry?;
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(QueryInstallError::IoError(e)),
+        };
         let path = entry.path();
         // This helper is also called independently of the outer recovery scan.
         // Never follow a generated-name backup symlink or suppress entry-type
         // errors while selecting a directory to rename into the canonical path.
-        if !entry.file_type()?.is_dir() {
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(QueryInstallError::IoError(e)),
+        };
+        if !file_type.is_dir() {
             continue;
         }
         let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
@@ -896,10 +914,21 @@ fn newest_complete_backup_dir(
         if !generated_backup_matches_language(name, language) {
             continue;
         }
-        if !backup_is_complete_and_owned(&path)? {
+        let complete = match backup_is_complete_and_owned(&path) {
+            Ok(complete) => complete,
+            Err(QueryInstallError::IoError(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+                continue;
+            }
+            Err(e) => return Err(e),
+        };
+        if !complete {
             continue;
         }
-        let modified = entry.metadata()?.modified()?;
+        let modified = match entry.metadata().and_then(|metadata| metadata.modified()) {
+            Ok(modified) => modified,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(QueryInstallError::IoError(e)),
+        };
         if newest
             .as_ref()
             .is_none_or(|(current, _)| modified > *current)

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -843,7 +843,7 @@ fn backup_is_owned(path: &Path) -> bool {
 }
 
 fn backup_is_complete_and_owned(path: &Path) -> Result<bool, QueryInstallError> {
-    let regular_file_or_absent = |path: &Path| match fs::metadata(path) {
+    let regular_file_or_absent = |path: &Path| match fs::symlink_metadata(path) {
         Ok(metadata) => Ok(Some(metadata)),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(QueryInstallError::IoError(e)),

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -508,6 +508,35 @@ pub fn recover_interrupted_query_installs(queries_parent: &Path) -> Result<(), Q
     Ok(())
 }
 
+/// Recover only artifacts belonging to `language`.
+///
+/// Targeted uninstall uses this after confirmation so it neither mutates
+/// unrelated languages nor performs recovery when the user cancels.
+pub fn recover_interrupted_query_installs_for_language(
+    queries_parent: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    validate_safe_language_name(language)?;
+    let entries = match fs::read_dir(queries_parent) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(QueryInstallError::IoError(e)),
+    };
+    for entry in entries {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let path = entry.path();
+        if let Some((temp_language, _)) = temp_language_name_and_pid(&path)
+            && temp_language == language
+        {
+            remove_interrupted_temp_query_install(queries_parent, language, &path)?;
+        }
+    }
+    recover_interrupted_query_install(queries_parent, language)
+}
+
 pub struct QueryRemoval {
     pub removed_queries: bool,
     pub removed_backups: bool,

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -855,8 +855,13 @@ fn backup_is_complete_and_owned(path: &Path) -> Result<bool, QueryInstallError> 
     if !ownership.is_file() {
         return Ok(false);
     }
-    let Some(highlights) = regular_file_or_absent(&path.join("highlights.scm"))? else {
-        return Ok(false);
+    // Query files may intentionally be user-managed symlinks; completeness
+    // follows the same semantics as the installed query directory.
+    let highlights_path = path.join("highlights.scm");
+    let highlights = match fs::metadata(&highlights_path) {
+        Ok(metadata) => metadata,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(QueryInstallError::IoError(e)),
     };
     if !highlights.is_file() {
         return Ok(false);

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -631,6 +631,8 @@ fn generated_backup_parts(name: &str) -> Option<(&str, &str, &str)> {
     let pid = parts.next()?;
     let counter = parts.next()?;
     if parts.next().is_none()
+        && !pid.is_empty()
+        && !counter.is_empty()
         && pid.bytes().all(|b| b.is_ascii_digit())
         && counter.bytes().all(|b| b.is_ascii_digit())
     {
@@ -647,6 +649,8 @@ fn generated_temp_parts(name: &str) -> Option<(&str, &str, &str)> {
     let pid = parts.next()?;
     let counter = parts.next()?;
     if parts.next().is_none()
+        && !pid.is_empty()
+        && !counter.is_empty()
         && pid.bytes().all(|b| b.is_ascii_digit())
         && counter.bytes().all(|b| b.is_ascii_digit())
     {
@@ -990,6 +994,14 @@ fn download_file(url: &str, http_policy: QueryHttpPolicy) -> Result<String, Quer
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn recovery_directory_names_require_numeric_fields() {
+        assert!(is_recovery_directory_name(".lua.123.0.tmp"));
+        assert!(is_recovery_directory_name(".lua.123.0.backup"));
+        assert!(!is_recovery_directory_name(".lua...tmp"));
+        assert!(!is_recovery_directory_name(".lua...backup"));
+    }
     use tempfile::TempDir;
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -487,9 +487,13 @@ pub fn recover_interrupted_query_installs(queries_parent: &Path) -> Result<(), Q
     // rescans the parent), so running it per backup directory would redo the
     // same scan and lock acquisition for each stranded backup.
     let mut recovered_languages = std::collections::HashSet::new();
-    for entry in entries.flatten() {
+    for entry in entries {
+        let entry = entry?;
         let path = entry.path();
-        if !path.is_dir() {
+        // Recovery artifacts must be real directories. Do not follow a
+        // staging/backup symlink outside the queries root, and propagate
+        // entry-type errors instead of silently treating them as absent.
+        if !entry.file_type()?.is_dir() {
             continue;
         }
         if let Some(language) = backup_language_name(&path) {
@@ -1245,6 +1249,28 @@ mod tests {
             tmp.exists(),
             "generated staging dirs from live installers must not be collected"
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn recover_interrupted_query_installs_does_not_follow_backup_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(&queries_parent).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join("highlights.scm"), "(comment) @comment\n").unwrap();
+        let backup = queries_parent.join(".lua.4294967295.0.backup");
+        symlink(&outside, &backup).unwrap();
+        write_backup_ownership_marker(&backup).unwrap();
+
+        recover_interrupted_query_installs(&queries_parent).unwrap();
+
+        assert!(!queries_parent.join("lua").exists());
+        assert!(fs::symlink_metadata(&backup).is_ok());
+        assert!(outside.join("highlights.scm").exists());
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -696,9 +696,15 @@ fn generated_temp_parts(name: &str) -> Option<(&str, &str, &str)> {
 /// Whether a directory name belongs to the staging/backup namespace that
 /// [`recover_interrupted_query_installs`] may mutate.
 pub fn is_recovery_directory_name(name: &str) -> bool {
-    generated_backup_parts(name).is_some_and(|(language, _, _)| is_safe_language_name(language))
-        || generated_temp_parts(name)
-            .is_some_and(|(language, _, _)| is_safe_language_name(language))
+    recovery_directory_language(name).is_some()
+}
+
+/// Returns the language owned by a valid staging/backup directory name.
+pub fn recovery_directory_language(name: &str) -> Option<&str> {
+    generated_backup_parts(name)
+        .or_else(|| generated_temp_parts(name))
+        .map(|(language, _, _)| language)
+        .filter(|language| is_safe_language_name(language))
 }
 
 fn remove_interrupted_temp_query_install(

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -818,8 +818,15 @@ fn newest_complete_backup_dir(
     };
     let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
 
-    for entry in entries.flatten() {
+    for entry in entries {
+        let entry = entry?;
         let path = entry.path();
+        // This helper is also called independently of the outer recovery scan.
+        // Never follow a generated-name backup symlink or suppress entry-type
+        // errors while selecting a directory to rename into the canonical path.
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
         let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
             continue;
         };
@@ -1267,6 +1274,28 @@ mod tests {
         write_backup_ownership_marker(&backup).unwrap();
 
         recover_interrupted_query_installs(&queries_parent).unwrap();
+
+        assert!(!queries_parent.join("lua").exists());
+        assert!(fs::symlink_metadata(&backup).is_ok());
+        assert!(outside.join("highlights.scm").exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn per_language_recovery_does_not_follow_backup_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(&queries_parent).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join("highlights.scm"), "(comment) @comment\n").unwrap();
+        let backup = queries_parent.join(".lua.4294967295.0.backup");
+        symlink(&outside, &backup).unwrap();
+        write_backup_ownership_marker(&backup).unwrap();
+
+        recover_interrupted_query_install(&queries_parent, "lua").unwrap();
 
         assert!(!queries_parent.join("lua").exists());
         assert!(fs::symlink_metadata(&backup).is_ok());

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1492,6 +1492,49 @@ fn test_language_uninstall_all_rejects_invalid_parser_name_before_removal() {
 
 #[cfg(unix)]
 #[test]
+fn test_language_uninstall_all_rejects_non_directory_query_entries() {
+    use std::fs;
+    use std::os::unix::net::UnixListener;
+
+    for entry_kind in ["file", "socket"] {
+        let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let queries_dir = test_dir.path().join("queries");
+        fs::create_dir_all(&queries_dir).expect("Failed to create queries dir");
+        let query_entry = queries_dir.join("lua");
+        let _socket = if entry_kind == "file" {
+            fs::write(&query_entry, "not a query directory")
+                .expect("Failed to write query-shaped file");
+            None
+        } else {
+            Some(UnixListener::bind(&query_entry).expect("Failed to create query-shaped socket"))
+        };
+
+        let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+            .args([
+                "language",
+                "uninstall",
+                "--all",
+                "--data-dir",
+                test_dir.path().to_str().unwrap(),
+                "--force",
+            ])
+            .output()
+            .expect("Failed to execute command");
+
+        assert!(
+            !output.status.success(),
+            "safe-named query {entry_kind} must fail preflight; stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            fs::symlink_metadata(&query_entry).is_ok(),
+            "malformed query entry must remain for repair"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
 fn test_language_uninstall_all_removes_dangling_parser_entry() {
     use std::fs;
     use std::os::unix::fs::symlink;

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1342,7 +1342,7 @@ fn test_language_uninstall_all_removes_dangling_parser_entry() {
 
 #[cfg(unix)]
 #[test]
-fn test_language_uninstall_all_fails_before_removal_for_query_symlink_loop() {
+fn test_language_uninstall_all_removes_query_symlink_entry() {
     use std::fs;
     use std::os::unix::fs::symlink;
 
@@ -1368,11 +1368,16 @@ fn test_language_uninstall_all_fails_before_removal_for_query_symlink_loop() {
         .expect("Failed to execute command");
 
     assert!(
-        !output.status.success(),
-        "an unreadable query entry must fail; stderr: {}",
+        output.status.success(),
+        "query symlink should be removable without resolving its target; stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-    assert!(parser.exists(), "preflight failure must not remove parsers");
+    assert!(!parser.exists(), "the discovered parser must be removed");
+    assert!(
+        fs::symlink_metadata(queries_dir.join("loop"))
+            .is_err_and(|e| e.kind() == std::io::ErrorKind::NotFound),
+        "query symlink entry must be removed"
+    );
 }
 
 #[cfg(unix)]

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1762,6 +1762,50 @@ fn test_language_uninstall_all_preflights_recovery_backups_before_restore() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn test_language_uninstall_all_ignores_unrelated_hidden_query_dirs() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let parser_dir = test_dir.path().join("parser");
+    let cache_dir = test_dir.path().join("queries/.cache");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    fs::create_dir_all(&cache_dir).expect("Failed to create unrelated cache dir");
+    let parser = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+    fs::write(&parser, "fake").expect("Failed to write parser");
+    fs::set_permissions(&cache_dir, fs::Permissions::from_mode(0o000))
+        .expect("Failed to make unrelated cache unreadable");
+    if fs::read_dir(&cache_dir).is_ok() {
+        fs::set_permissions(&cache_dir, fs::Permissions::from_mode(0o700))
+            .expect("Failed to restore cache permissions");
+        return;
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    fs::set_permissions(&cache_dir, fs::Permissions::from_mode(0o700))
+        .expect("Failed to restore cache permissions");
+    assert!(
+        output.status.success(),
+        "unrelated hidden directories must not block uninstall: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!parser.exists(), "valid parser must be removed");
+    assert!(cache_dir.exists(), "unrelated hidden directory must remain");
+}
+
 /// Test that language uninstall --all ignores internal query staging directories
 #[test]
 fn test_language_uninstall_all_ignores_internal_query_dirs() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1602,6 +1602,68 @@ fn test_language_uninstall_all_query_removal_failure_preserves_parser() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn test_language_uninstall_all_preflights_recovery_backups_before_restore() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let queries_dir = test_dir.path().join("queries");
+    let backup = queries_dir.join(".lua.4294967295.0.backup");
+    let nested = backup.join("nested");
+    fs::create_dir_all(&nested).expect("Failed to create backup tree");
+    fs::write(backup.join("highlights.scm"), "(comment) @comment")
+        .expect("Failed to write backup query");
+    fs::write(nested.join("query.scm"), "(comment) @comment")
+        .expect("Failed to write nested backup query");
+    fs::write(backup.join(".kakehashi-install-complete"), "ok\n")
+        .expect("Failed to mark backup complete");
+    fs::write(
+        queries_dir.join(".lua.4294967295.0.backup.kakehashi-backup"),
+        "ok\n",
+    )
+    .expect("Failed to mark backup ownership");
+    fs::set_permissions(&nested, fs::Permissions::from_mode(0o000))
+        .expect("Failed to make backup subtree unreadable");
+    if fs::read_dir(&nested).is_ok() {
+        fs::set_permissions(&nested, fs::Permissions::from_mode(0o700))
+            .expect("Failed to restore backup permissions");
+        return;
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let restored_nested = queries_dir.join("lua/nested");
+    let nested_to_restore = if nested.exists() {
+        &nested
+    } else {
+        &restored_nested
+    };
+    fs::set_permissions(nested_to_restore, fs::Permissions::from_mode(0o700))
+        .expect("Failed to restore backup subtree permissions");
+    assert!(
+        !output.status.success(),
+        "unreadable backup must fail preflight; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(backup.exists(), "preflight must not restore the backup");
+    assert!(
+        !queries_dir.join("lua").exists(),
+        "failed preflight must not revive the canonical install"
+    );
+}
+
 /// Test that language uninstall --all ignores internal query staging directories
 #[test]
 fn test_language_uninstall_all_ignores_internal_query_dirs() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1695,6 +1695,53 @@ fn test_language_uninstall_all_preflights_query_contents_before_parser_removal()
 
 #[cfg(unix)]
 #[test]
+fn test_language_uninstall_preflights_target_query_contents() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let parser_dir = test_dir.path().join("parser");
+    let query_dir = test_dir.path().join("queries/lua");
+    let nested = query_dir.join("nested");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    fs::create_dir_all(&nested).expect("Failed to create nested query dir");
+    let parser = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+    fs::write(&parser, "fake").expect("Failed to write parser");
+    fs::write(nested.join("query.scm"), "(comment) @comment")
+        .expect("Failed to write nested query");
+    fs::set_permissions(&nested, fs::Permissions::from_mode(0o000))
+        .expect("Failed to make nested query unreadable");
+    if fs::read_dir(&nested).is_ok() {
+        fs::set_permissions(&nested, fs::Permissions::from_mode(0o700))
+            .expect("Failed to restore nested query permissions");
+        return;
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "lua",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    fs::set_permissions(&nested, fs::Permissions::from_mode(0o700))
+        .expect("Failed to restore nested query permissions");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "unreadable target tree must fail");
+    assert!(
+        stderr.contains("Failed to preflight targeted query state"),
+        "failure must occur during preflight, before removal: {stderr}"
+    );
+    assert!(parser.exists(), "preflight failure must preserve parser");
+}
+
+#[cfg(unix)]
+#[test]
 fn test_language_uninstall_all_query_removal_failure_preserves_parser() {
     use std::fs;
     use std::os::unix::fs::PermissionsExt;

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1785,6 +1785,46 @@ fn test_language_uninstall_preflights_target_query_contents() {
 
 #[cfg(unix)]
 #[test]
+fn test_language_uninstall_cancel_does_not_recover_unrelated_languages() {
+    use std::fs;
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let unrelated_tmp = test_dir.path().join("queries/.python.4294967295.0.tmp");
+    fs::create_dir_all(&unrelated_tmp).expect("Failed to create unrelated recovery temp");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "lua",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn command");
+    child
+        .stdin
+        .take()
+        .expect("child stdin")
+        .write_all(b"n\n")
+        .expect("Failed to cancel uninstall");
+    let output = child
+        .wait_with_output()
+        .expect("Failed to wait for command");
+
+    assert!(output.status.success(), "cancellation should succeed");
+    assert!(
+        unrelated_tmp.exists(),
+        "cancellation must not mutate another language's recovery state"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn test_language_uninstall_all_query_removal_failure_preserves_parser() {
     use std::fs;
     use std::os::unix::fs::PermissionsExt;

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1825,6 +1825,50 @@ fn test_language_uninstall_cancel_does_not_recover_unrelated_languages() {
 
 #[cfg(unix)]
 #[test]
+fn test_language_uninstall_ignores_unrelated_unreadable_recovery_state() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let unrelated_tmp = test_dir.path().join("queries/.python.4294967295.0.tmp");
+    fs::create_dir_all(&unrelated_tmp).expect("Failed to create unrelated recovery temp");
+    fs::write(unrelated_tmp.join("query.scm"), "(comment) @comment")
+        .expect("Failed to write unrelated recovery query");
+    fs::set_permissions(&unrelated_tmp, fs::Permissions::from_mode(0o000))
+        .expect("Failed to make unrelated recovery state unreadable");
+    if fs::read_dir(&unrelated_tmp).is_ok() {
+        fs::set_permissions(&unrelated_tmp, fs::Permissions::from_mode(0o700))
+            .expect("Failed to restore recovery permissions");
+        return;
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "lua",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    fs::set_permissions(&unrelated_tmp, fs::Permissions::from_mode(0o700))
+        .expect("Failed to restore recovery permissions");
+    assert!(
+        output.status.success(),
+        "unrelated recovery state must not block targeted uninstall: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        unrelated_tmp.exists(),
+        "unrelated recovery state must remain"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn test_language_uninstall_all_query_removal_failure_preserves_parser() {
     use std::fs;
     use std::os::unix::fs::PermissionsExt;

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1556,6 +1556,52 @@ fn test_language_uninstall_all_preflights_query_contents_before_parser_removal()
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn test_language_uninstall_all_query_removal_failure_preserves_parser() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let parser_dir = test_dir.path().join("parser");
+    let query_dir = test_dir.path().join("queries/lua");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    fs::create_dir_all(&query_dir).expect("Failed to create query dir");
+    let parser = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+    fs::write(&parser, "fake").expect("Failed to write parser");
+    fs::write(query_dir.join("highlights.scm"), "(comment) @comment")
+        .expect("Failed to write query");
+    fs::set_permissions(&query_dir, fs::Permissions::from_mode(0o500))
+        .expect("Failed to make query dir non-writable");
+    let probe = query_dir.join("permission-probe");
+    if fs::write(&probe, "probe").is_ok() {
+        let _ = fs::remove_file(probe);
+        fs::set_permissions(&query_dir, fs::Permissions::from_mode(0o700))
+            .expect("Failed to restore query dir permissions");
+        return;
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    fs::set_permissions(&query_dir, fs::Permissions::from_mode(0o700))
+        .expect("Failed to restore query dir permissions");
+    assert!(!output.status.success(), "query removal must fail");
+    assert!(
+        parser.exists(),
+        "query removal must finish before the parser is deleted"
+    );
+}
+
 /// Test that language uninstall --all ignores internal query staging directories
 #[test]
 fn test_language_uninstall_all_ignores_internal_query_dirs() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1209,29 +1209,36 @@ fn test_language_uninstall_all() {
     assert!(queries.is_empty(), "All queries should be removed");
 }
 
-/// `--all` must not claim success when it cannot enumerate installed parsers.
 #[cfg(unix)]
-#[test]
-fn test_language_uninstall_all_fails_for_unreadable_parser_dir() {
+fn assert_uninstall_all_fails_for_unreadable_dir(dir_name: &str) {
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
 
     let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
-    let parser_dir = test_dir.path().join("parser");
-    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
-    fs::write(
-        parser_dir.join(format!("testlang.{}", std::env::consts::DLL_EXTENSION)),
-        "fake",
-    )
-    .expect("Failed to write parser");
-    fs::set_permissions(&parser_dir, fs::Permissions::from_mode(0o000))
-        .expect("Failed to make parser dir unreadable");
+    let install_dir = test_dir.path().join(dir_name);
+    if dir_name == "parser" {
+        fs::create_dir_all(&install_dir).expect("Failed to create parser dir");
+        fs::write(
+            install_dir.join(format!("testlang.{}", std::env::consts::DLL_EXTENSION)),
+            "fake",
+        )
+        .expect("Failed to write parser");
+    } else {
+        fs::create_dir_all(install_dir.join("testlang")).expect("Failed to create queries dir");
+        fs::write(
+            install_dir.join("testlang/highlights.scm"),
+            "(comment) @comment",
+        )
+        .expect("Failed to write query");
+    }
+    fs::set_permissions(&install_dir, fs::Permissions::from_mode(0o000))
+        .expect("Failed to make install dir unreadable");
 
     // Elevated test environments may retain permission to read mode-000 paths.
     // Skip there rather than asserting a failure the OS cannot produce.
-    if fs::read_dir(&parser_dir).is_ok() {
-        fs::set_permissions(&parser_dir, fs::Permissions::from_mode(0o700))
-            .expect("Failed to restore parser dir permissions");
+    if fs::read_dir(&install_dir).is_ok() {
+        fs::set_permissions(&install_dir, fs::Permissions::from_mode(0o700))
+            .expect("Failed to restore install dir permissions");
         return;
     }
 
@@ -1247,8 +1254,8 @@ fn test_language_uninstall_all_fails_for_unreadable_parser_dir() {
         .output()
         .expect("Failed to execute command");
 
-    fs::set_permissions(&parser_dir, fs::Permissions::from_mode(0o700))
-        .expect("Failed to restore parser dir permissions");
+    fs::set_permissions(&install_dir, fs::Permissions::from_mode(0o700))
+        .expect("Failed to restore install dir permissions");
 
     assert!(
         !output.status.success(),
@@ -1260,6 +1267,14 @@ fn test_language_uninstall_all_fails_for_unreadable_parser_dir() {
         "stderr should identify the failed install scan: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+/// `--all` must not claim success when either asset root cannot be enumerated.
+#[cfg(unix)]
+#[test]
+fn test_language_uninstall_all_fails_for_unreadable_install_dirs() {
+    assert_uninstall_all_fails_for_unreadable_dir("parser");
+    assert_uninstall_all_fails_for_unreadable_dir("queries");
 }
 
 /// Test that language uninstall --all ignores internal query staging directories

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1340,6 +1340,46 @@ fn test_language_uninstall_all_fails_before_removal_for_query_symlink_loop() {
     assert!(parser.exists(), "preflight failure must not remove parsers");
 }
 
+#[cfg(unix)]
+#[test]
+fn test_language_uninstall_all_preflights_before_query_recovery() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let parser_dir = test_dir.path().join("parser");
+    let stranded_tmp = test_dir.path().join("queries/.lua.4294967295.0.tmp");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    fs::create_dir_all(&stranded_tmp).expect("Failed to create stranded query temp dir");
+    fs::set_permissions(&parser_dir, fs::Permissions::from_mode(0o000))
+        .expect("Failed to make parser dir unreadable");
+    if fs::read_dir(&parser_dir).is_ok() {
+        fs::set_permissions(&parser_dir, fs::Permissions::from_mode(0o700))
+            .expect("Failed to restore parser dir permissions");
+        return;
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    fs::set_permissions(&parser_dir, fs::Permissions::from_mode(0o700))
+        .expect("Failed to restore parser dir permissions");
+    assert!(!output.status.success(), "unreadable preflight must fail");
+    assert!(
+        stranded_tmp.exists(),
+        "query recovery must not mutate state before all install roots pass preflight"
+    );
+}
+
 /// Test that language uninstall --all ignores internal query staging directories
 #[test]
 fn test_language_uninstall_all_ignores_internal_query_dirs() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -3,6 +3,18 @@
 
 use std::process::Command;
 
+#[cfg(unix)]
+fn directory_is_enumerable(path: &std::path::Path) -> bool {
+    std::fs::read_dir(path)
+        .and_then(|entries| {
+            for entry in entries {
+                entry?;
+            }
+            Ok(())
+        })
+        .is_ok()
+}
+
 /// Test that --help flag shows help message with program description
 #[test]
 fn test_help_flag_shows_help_message() {
@@ -1236,7 +1248,7 @@ fn assert_uninstall_all_fails_for_unreadable_dir(dir_name: &str) {
 
     // Elevated test environments may retain permission to read mode-000 paths.
     // Skip there rather than asserting a failure the OS cannot produce.
-    if fs::read_dir(&install_dir).is_ok() {
+    if directory_is_enumerable(&install_dir) {
         fs::set_permissions(&install_dir, fs::Permissions::from_mode(0o700))
             .expect("Failed to restore install dir permissions");
         return;
@@ -1621,7 +1633,7 @@ fn test_language_uninstall_all_preflights_before_query_recovery() {
     fs::create_dir_all(&stranded_tmp).expect("Failed to create stranded query temp dir");
     fs::set_permissions(&parser_dir, fs::Permissions::from_mode(0o000))
         .expect("Failed to make parser dir unreadable");
-    if fs::read_dir(&parser_dir).is_ok() {
+    if directory_is_enumerable(&parser_dir) {
         fs::set_permissions(&parser_dir, fs::Permissions::from_mode(0o700))
             .expect("Failed to restore parser dir permissions");
         return;
@@ -1709,7 +1721,7 @@ fn test_language_uninstall_all_preflights_query_contents_before_parser_removal()
         .expect("Failed to write query");
     fs::set_permissions(&query_dir, fs::Permissions::from_mode(0o000))
         .expect("Failed to make query dir unreadable");
-    if fs::read_dir(&query_dir).is_ok() {
+    if directory_is_enumerable(&query_dir) {
         fs::set_permissions(&query_dir, fs::Permissions::from_mode(0o700))
             .expect("Failed to restore query dir permissions");
         return;
@@ -1754,7 +1766,7 @@ fn test_language_uninstall_preflights_target_query_contents() {
         .expect("Failed to write nested query");
     fs::set_permissions(&nested, fs::Permissions::from_mode(0o000))
         .expect("Failed to make nested query unreadable");
-    if fs::read_dir(&nested).is_ok() {
+    if directory_is_enumerable(&nested) {
         fs::set_permissions(&nested, fs::Permissions::from_mode(0o700))
             .expect("Failed to restore nested query permissions");
         return;
@@ -1836,7 +1848,7 @@ fn test_language_uninstall_ignores_unrelated_unreadable_recovery_state() {
         .expect("Failed to write unrelated recovery query");
     fs::set_permissions(&unrelated_tmp, fs::Permissions::from_mode(0o000))
         .expect("Failed to make unrelated recovery state unreadable");
-    if fs::read_dir(&unrelated_tmp).is_ok() {
+    if directory_is_enumerable(&unrelated_tmp) {
         fs::set_permissions(&unrelated_tmp, fs::Permissions::from_mode(0o700))
             .expect("Failed to restore recovery permissions");
         return;
@@ -1937,7 +1949,7 @@ fn test_language_uninstall_all_preflights_recovery_backups_before_restore() {
     .expect("Failed to mark backup ownership");
     fs::set_permissions(&nested, fs::Permissions::from_mode(0o000))
         .expect("Failed to make backup subtree unreadable");
-    if fs::read_dir(&nested).is_ok() {
+    if directory_is_enumerable(&nested) {
         fs::set_permissions(&nested, fs::Permissions::from_mode(0o700))
             .expect("Failed to restore backup permissions");
         return;
@@ -2038,7 +2050,7 @@ fn test_language_uninstall_all_ignores_unrelated_hidden_query_dirs() {
     fs::write(&parser, "fake").expect("Failed to write parser");
     fs::set_permissions(&cache_dir, fs::Permissions::from_mode(0o000))
         .expect("Failed to make unrelated cache unreadable");
-    if fs::read_dir(&cache_dir).is_ok() {
+    if directory_is_enumerable(&cache_dir) {
         fs::set_permissions(&cache_dir, fs::Permissions::from_mode(0o700))
             .expect("Failed to restore cache permissions");
         return;

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1209,6 +1209,59 @@ fn test_language_uninstall_all() {
     assert!(queries.is_empty(), "All queries should be removed");
 }
 
+/// `--all` must not claim success when it cannot enumerate installed parsers.
+#[cfg(unix)]
+#[test]
+fn test_language_uninstall_all_fails_for_unreadable_parser_dir() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let parser_dir = test_dir.path().join("parser");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    fs::write(
+        parser_dir.join(format!("testlang.{}", std::env::consts::DLL_EXTENSION)),
+        "fake",
+    )
+    .expect("Failed to write parser");
+    fs::set_permissions(&parser_dir, fs::Permissions::from_mode(0o000))
+        .expect("Failed to make parser dir unreadable");
+
+    // Elevated test environments may retain permission to read mode-000 paths.
+    // Skip there rather than asserting a failure the OS cannot produce.
+    if fs::read_dir(&parser_dir).is_ok() {
+        fs::set_permissions(&parser_dir, fs::Permissions::from_mode(0o700))
+            .expect("Failed to restore parser dir permissions");
+        return;
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    fs::set_permissions(&parser_dir, fs::Permissions::from_mode(0o700))
+        .expect("Failed to restore parser dir permissions");
+
+    assert!(
+        !output.status.success(),
+        "unreadable install state must fail instead of reporting success; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Failed to scan installed languages"),
+        "stderr should identify the failed install scan: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 /// Test that language uninstall --all ignores internal query staging directories
 #[test]
 fn test_language_uninstall_all_ignores_internal_query_dirs() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1451,6 +1451,45 @@ fn test_language_uninstall_rejects_non_file_parser_entries_before_query_removal(
     }
 }
 
+#[test]
+fn test_language_uninstall_all_rejects_invalid_parser_name_before_removal() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let parser_dir = test_dir.path().join("parser");
+    let query_dir = test_dir.path().join("queries/a_valid");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    fs::create_dir_all(&query_dir).expect("Failed to create query dir");
+    let valid_parser = parser_dir.join(format!("a_valid.{}", std::env::consts::DLL_EXTENSION));
+    fs::write(&valid_parser, "fake").expect("Failed to write valid parser");
+    fs::write(
+        parser_dir.join(format!("z.bad.{}", std::env::consts::DLL_EXTENSION)),
+        "fake",
+    )
+    .expect("Failed to write invalid parser");
+    fs::write(query_dir.join("highlights.scm"), "(comment) @comment")
+        .expect("Failed to write query");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(!output.status.success(), "invalid parser name must fail");
+    assert!(
+        valid_parser.exists(),
+        "bulk preflight must reject every invalid name before removing valid installs"
+    );
+    assert!(query_dir.exists(), "valid queries must remain untouched");
+}
+
 #[cfg(unix)]
 #[test]
 fn test_language_uninstall_all_removes_dangling_parser_entry() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1893,6 +1893,54 @@ fn test_language_uninstall_all_preflights_recovery_backups_before_restore() {
 
 #[cfg(unix)]
 #[test]
+fn test_language_uninstall_all_rejects_symlinked_recovery_entries() {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let queries_dir = test_dir.path().join("queries");
+    let outside = test_dir.path().join("outside-backup");
+    fs::create_dir_all(&queries_dir).expect("Failed to create queries dir");
+    fs::create_dir_all(&outside).expect("Failed to create outside backup");
+    let outside_query = outside.join("highlights.scm");
+    fs::write(&outside_query, "(comment) @comment").expect("Failed to write outside query");
+    let backup_name = ".lua.4294967295.0.backup";
+    symlink(&outside, queries_dir.join(backup_name)).expect("Failed to link recovery backup");
+    fs::write(
+        queries_dir.join(format!("{backup_name}.kakehashi-backup")),
+        "ok\n",
+    )
+    .expect("Failed to mark backup ownership");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(
+        !output.status.success(),
+        "recovery symlink must fail before recovery; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        outside_query.exists(),
+        "outside recovery target must remain untouched"
+    );
+    assert!(
+        fs::symlink_metadata(queries_dir.join(backup_name)).is_ok(),
+        "recovery symlink must remain for explicit repair"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn test_language_uninstall_all_ignores_unrelated_hidden_query_dirs() {
     use std::fs;
     use std::os::unix::fs::PermissionsExt;

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1464,6 +1464,50 @@ fn test_language_uninstall_all_fails_when_query_recovery_fails() {
     assert!(stranded_tmp.exists(), "failed recovery must stay visible");
 }
 
+#[cfg(unix)]
+#[test]
+fn test_language_uninstall_all_preflights_query_contents_before_parser_removal() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let parser_dir = test_dir.path().join("parser");
+    let query_dir = test_dir.path().join("queries/lua");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    fs::create_dir_all(&query_dir).expect("Failed to create query dir");
+    let parser = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+    fs::write(&parser, "fake").expect("Failed to write parser");
+    fs::write(query_dir.join("highlights.scm"), "(comment) @comment")
+        .expect("Failed to write query");
+    fs::set_permissions(&query_dir, fs::Permissions::from_mode(0o000))
+        .expect("Failed to make query dir unreadable");
+    if fs::read_dir(&query_dir).is_ok() {
+        fs::set_permissions(&query_dir, fs::Permissions::from_mode(0o700))
+            .expect("Failed to restore query dir permissions");
+        return;
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    fs::set_permissions(&query_dir, fs::Permissions::from_mode(0o700))
+        .expect("Failed to restore query dir permissions");
+    assert!(!output.status.success(), "unreadable query tree must fail");
+    assert!(
+        parser.exists(),
+        "query preflight failure must happen before parser removal"
+    );
+}
+
 /// Test that language uninstall --all ignores internal query staging directories
 #[test]
 fn test_language_uninstall_all_ignores_internal_query_dirs() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1305,6 +1305,41 @@ fn test_language_uninstall_all_fails_for_dangling_install_dir() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn test_language_uninstall_all_fails_before_removal_for_query_symlink_loop() {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let parser_dir = test_dir.path().join("parser");
+    let queries_dir = test_dir.path().join("queries");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    fs::create_dir_all(&queries_dir).expect("Failed to create queries dir");
+    let parser = parser_dir.join(format!("testlang.{}", std::env::consts::DLL_EXTENSION));
+    fs::write(&parser, "fake").expect("Failed to write parser");
+    symlink("loop", queries_dir.join("loop")).expect("Failed to create query symlink loop");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(
+        !output.status.success(),
+        "an unreadable query entry must fail; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(parser.exists(), "preflight failure must not remove parsers");
+}
+
 /// Test that language uninstall --all ignores internal query staging directories
 #[test]
 fn test_language_uninstall_all_ignores_internal_query_dirs() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1403,6 +1403,56 @@ fn test_language_uninstall_rejects_symlinked_install_roots() {
 
 #[cfg(unix)]
 #[test]
+fn test_language_uninstall_rejects_non_file_parser_entries_before_query_removal() {
+    use std::fs;
+    use std::os::unix::net::UnixListener;
+
+    for all in [false, true] {
+        for entry_kind in ["directory", "socket"] {
+            let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+            let parser_dir = test_dir.path().join("parser");
+            let query_dir = test_dir.path().join("queries/lua");
+            fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+            fs::create_dir_all(&query_dir).expect("Failed to create query dir");
+            fs::write(query_dir.join("highlights.scm"), "(comment) @comment")
+                .expect("Failed to write query");
+            let parser = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+            let _socket = if entry_kind == "directory" {
+                fs::create_dir(&parser).expect("Failed to create parser-shaped directory");
+                None
+            } else {
+                Some(UnixListener::bind(&parser).expect("Failed to create parser-shaped socket"))
+            };
+
+            let mut command = Command::new(env!("CARGO_BIN_EXE_kakehashi"));
+            command.arg("language").arg("uninstall");
+            if all {
+                command.arg("--all");
+            } else {
+                command.arg("lua");
+            }
+            let output = command
+                .arg("--data-dir")
+                .arg(test_dir.path())
+                .arg("--force")
+                .output()
+                .expect("Failed to execute command");
+
+            assert!(
+                !output.status.success(),
+                "{entry_kind} parser entry must fail before mutation; stderr: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(
+                query_dir.exists(),
+                "invalid parser entry must be rejected before query removal"
+            );
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
 fn test_language_uninstall_all_removes_dangling_parser_entry() {
     use std::fs;
     use std::os::unix::fs::symlink;

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1277,6 +1277,34 @@ fn test_language_uninstall_all_fails_for_unreadable_install_dirs() {
     assert_uninstall_all_fails_for_unreadable_dir("queries");
 }
 
+#[cfg(unix)]
+#[test]
+fn test_language_uninstall_all_fails_for_dangling_install_dir() {
+    use std::os::unix::fs::symlink;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    symlink("missing-parser-target", test_dir.path().join("parser"))
+        .expect("Failed to create dangling parser link");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(
+        !output.status.success(),
+        "a present but unreadable install root must fail; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 /// Test that language uninstall --all ignores internal query staging directories
 #[test]
 fn test_language_uninstall_all_ignores_internal_query_dirs() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1307,6 +1307,41 @@ fn test_language_uninstall_all_fails_for_dangling_install_dir() {
 
 #[cfg(unix)]
 #[test]
+fn test_language_uninstall_all_removes_dangling_parser_entry() {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let parser_dir = test_dir.path().join("parser");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    let parser = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+    symlink("missing-parser-library", &parser).expect("Failed to create dangling parser link");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(
+        output.status.success(),
+        "dangling parser entry should be removable; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        fs::symlink_metadata(&parser).is_err_and(|e| e.kind() == std::io::ErrorKind::NotFound),
+        "dangling parser entry must be removed"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn test_language_uninstall_all_fails_before_removal_for_query_symlink_loop() {
     use std::fs;
     use std::os::unix::fs::symlink;

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1355,6 +1355,54 @@ fn test_language_uninstall_all_rejects_symlinked_install_roots() {
 
 #[cfg(unix)]
 #[test]
+fn test_language_uninstall_rejects_symlinked_install_roots() {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    for root_name in ["parser", "queries"] {
+        let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let data_dir = test_dir.path().join("data");
+        let outside = test_dir.path().join("outside");
+        fs::create_dir_all(&data_dir).expect("Failed to create data dir");
+        let asset = if root_name == "parser" {
+            fs::create_dir_all(&outside).expect("Failed to create outside parser dir");
+            let path = outside.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+            fs::write(&path, "fake").expect("Failed to write outside parser");
+            path
+        } else {
+            let path = outside.join("lua/highlights.scm");
+            fs::create_dir_all(path.parent().unwrap()).expect("Failed to create outside query dir");
+            fs::write(&path, "(comment) @comment").expect("Failed to write outside query");
+            path
+        };
+        symlink(&outside, data_dir.join(root_name)).expect("Failed to link install root");
+
+        let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+            .args([
+                "language",
+                "uninstall",
+                "lua",
+                "--data-dir",
+                data_dir.to_str().unwrap(),
+                "--force",
+            ])
+            .output()
+            .expect("Failed to execute command");
+
+        assert!(
+            !output.status.success(),
+            "targeted uninstall must reject symlinked {root_name}; stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            asset.exists(),
+            "outside {root_name} asset must remain untouched"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
 fn test_language_uninstall_all_removes_dangling_parser_entry() {
     use std::fs;
     use std::os::unix::fs::symlink;

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1307,6 +1307,54 @@ fn test_language_uninstall_all_fails_for_dangling_install_dir() {
 
 #[cfg(unix)]
 #[test]
+fn test_language_uninstall_all_rejects_symlinked_install_roots() {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    for root_name in ["parser", "queries"] {
+        let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let data_dir = test_dir.path().join("data");
+        let outside = test_dir.path().join("outside");
+        fs::create_dir_all(&data_dir).expect("Failed to create data dir");
+        let asset = if root_name == "parser" {
+            fs::create_dir_all(&outside).expect("Failed to create outside parser dir");
+            let path = outside.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+            fs::write(&path, "fake").expect("Failed to write outside parser");
+            path
+        } else {
+            let path = outside.join("lua/highlights.scm");
+            fs::create_dir_all(path.parent().unwrap()).expect("Failed to create outside query dir");
+            fs::write(&path, "(comment) @comment").expect("Failed to write outside query");
+            path
+        };
+        symlink(&outside, data_dir.join(root_name)).expect("Failed to link install root");
+
+        let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+            .args([
+                "language",
+                "uninstall",
+                "--all",
+                "--data-dir",
+                data_dir.to_str().unwrap(),
+                "--force",
+            ])
+            .output()
+            .expect("Failed to execute command");
+
+        assert!(
+            !output.status.success(),
+            "symlinked {root_name} root must fail; stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            asset.exists(),
+            "outside {root_name} asset must remain untouched"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
 fn test_language_uninstall_all_removes_dangling_parser_entry() {
     use std::fs;
     use std::os::unix::fs::symlink;

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1380,6 +1380,50 @@ fn test_language_uninstall_all_preflights_before_query_recovery() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn test_language_uninstall_all_fails_when_query_recovery_fails() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let queries_dir = test_dir.path().join("queries");
+    let stranded_tmp = queries_dir.join(".lua.4294967295.0.tmp");
+    fs::create_dir_all(&stranded_tmp).expect("Failed to create stranded query temp dir");
+    fs::set_permissions(&queries_dir, fs::Permissions::from_mode(0o500))
+        .expect("Failed to make queries dir read-only");
+
+    // Elevated environments may still create the recovery lock.
+    let probe = queries_dir.join("permission-probe");
+    if fs::write(&probe, "probe").is_ok() {
+        let _ = fs::remove_file(probe);
+        fs::set_permissions(&queries_dir, fs::Permissions::from_mode(0o700))
+            .expect("Failed to restore queries dir permissions");
+        return;
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    fs::set_permissions(&queries_dir, fs::Permissions::from_mode(0o700))
+        .expect("Failed to restore queries dir permissions");
+    assert!(
+        !output.status.success(),
+        "failed recovery must fail --all; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(stranded_tmp.exists(), "failed recovery must stay visible");
+}
+
 /// Test that language uninstall --all ignores internal query staging directories
 #[test]
 fn test_language_uninstall_all_ignores_internal_query_dirs() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1300,7 +1300,7 @@ fn test_language_uninstall_all_fails_for_dangling_install_dir() {
 
     assert!(
         !output.status.success(),
-        "a present but unreadable install root must fail; stderr: {}",
+        "a dangling install root must fail; stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
 }


### PR DESCRIPTION
## Summary

- treat only genuinely missing parser/query roots as an empty install during `language uninstall`
- propagate directory-open, per-entry, metadata, symlink, and query-recovery errors before removal
- preflight both roots before bulk recovery; scope targeted recovery/preflight to the requested language
- recover only complete, owned backups and preserve idempotent behavior when roots vanish concurrently

## User impact

`language uninstall` no longer reports success while unreadable or malformed install state remains behind, and scan/recovery failures cannot partially delete already-discovered parsers or unrelated language state.

## Validation

- RED regressions cover unreadable and dangling roots, malformed entries, symlinked roots/recovery entries, recovery failure ordering, targeted recovery scope, and unreadable backup metadata
- `cargo test --test test_cli` (61 passed)
- `cargo test --lib install::queries::tests` (27 passed)
- `cargo clippy --bin kakehashi --lib -- -D warnings`
- `cargo fmt --check`
- fresh exact-head Codex review: no actionable findings

## Follow-up

- #774 tracks global coordination when installs race `uninstall --all`; it requires an operation-wide protocol beyond this static filesystem scan fix.

Closes #767

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened language uninstall with stronger preflight checks of parser/query paths, including handling unreadable, dangling, and unsafe symlink scenarios.
  * Improved recovery of interrupted query installs, including targeted recovery for a single language and safer `--all` recovery/rescanning so recovered items are included.
  * Updated removal sequencing to attempt query/backup removal before parser deletion, preserving parser data if query removal fails.
  * Added stricter validation for recovery/backup directory naming and completeness.
* **Tests**
  * Expanded Unix integration tests covering uninstall `--all`/targeted edge cases, permission failures, symlinks/dangling entries, and recovery sequencing rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->