### PR TITLE
fix(diagnose): keep diagnostic sources on one line

### DIFF
--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -429,7 +429,11 @@ fn format_diagnostic(format: OutputFormat, display: &str, diagnostic: &Diagnosti
             // source.
             match diagnostic.source.as_deref() {
                 Some(source) => {
-                    let source = one_line(source);
+                    let source = if source.chars().any(char::is_whitespace) {
+                        std::borrow::Cow::Owned(one_line(source))
+                    } else {
+                        std::borrow::Cow::Borrowed(source)
+                    };
                     format!("{display}:{line}:{col}: {severity}: {message} [{source}]")
                 }
                 None => format!("{display}:{line}:{col}: {severity}: {message}"),

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -641,6 +641,17 @@ mod tests {
     }
 
     #[test]
+    fn jsonl_format_preserves_multiline_source() {
+        let mut d = diag(0, 0, Some(DiagnosticSeverity::ERROR), "boom");
+        d.source = Some("lua-ls\nsecond\tfield".to_string());
+
+        let value: serde_json::Value =
+            serde_json::from_str(&format_diagnostic(OutputFormat::Jsonl, "x.lua", &d)).unwrap();
+
+        assert_eq!(value["source"], "lua-ls\nsecond\tfield");
+    }
+
+    #[test]
     fn jsonl_numeric_code_stays_numeric() {
         let mut d = diag(0, 0, Some(DiagnosticSeverity::ERROR), "m");
         d.code = Some(NumberOrString::Number(42));

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -429,6 +429,7 @@ fn format_diagnostic(format: OutputFormat, display: &str, diagnostic: &Diagnosti
             // source.
             match diagnostic.source.as_deref() {
                 Some(source) => {
+                    let source = one_line(source);
                     format!("{display}:{line}:{col}: {severity}: {message} [{source}]")
                 }
                 None => format!("{display}:{line}:{col}: {severity}: {message}"),
@@ -598,6 +599,17 @@ mod tests {
         assert_eq!(
             format_diagnostic(OutputFormat::Default, "a.md", &d),
             "a.md:5:3: error: boom [lua-ls]"
+        );
+    }
+
+    #[test]
+    fn default_format_collapses_multiline_source() {
+        let mut d = diag(4, 2, Some(DiagnosticSeverity::ERROR), "boom");
+        d.source = Some("lua-ls\nspoofed\tfield".to_string());
+
+        assert_eq!(
+            format_diagnostic(OutputFormat::Default, "a.md", &d),
+            "a.md:5:3: error: boom [lua-ls spoofed field]"
         );
     }
 


### PR DESCRIPTION
## Summary

- normalize whitespace in downstream `Diagnostic.source` values for default human output
- preserve the exact source string in structured JSONL output
- keep one diagnostic per line for quickfix/compiler-style consumers

## Tests

- `cargo test --lib cli::diagnose::tests -- --nocapture`
- `cargo fmt --check`
- `cargo clippy --lib -- -D warnings`

Closes #770

Broader terminal control escaping is tracked separately in #771.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default diagnostic output by rendering the diagnostic source in the bracket suffix as a single-line value, collapsing line breaks and tabs when present.
  * Kept JSONL diagnostic output unchanged so multiline diagnostic source content remains verbatim for machine-readable consistency.
* **Tests**
  * Added unit tests to verify single-line collapsing behavior for default output and preservation of multiline/tabs for JSONL output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->