### PR TITLE
fix(diagnose): escape terminal controls

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -686,12 +686,13 @@ kakehashi diagnose . --fail-on-warning
 cat README.md | kakehashi diagnose --stdin-filename README.md
 ```
 
-The default format is presentation-oriented and intentionally lossy: in its
-file, message, and source fields, whitespace runs become single spaces and
-terminal/bidirectional control characters render as visible Rust-style escapes
-(for example, `\u{1b}`). Use `--output-format jsonl` when consumers need the
-original field values. JSON escapes controls on the wire, but parsing each
-JSONL record recovers the exact path, message, and source strings.
+The default format is presentation-oriented and intentionally lossy. The file
+field preserves ordinary characters but renders terminal/bidirectional controls
+as visible Rust-style escapes (for example, `\u{1b}`). In message and source
+fields, whitespace runs become single spaces before remaining controls are
+escaped. Use `--output-format jsonl` when consumers need the original field
+values. JSON escapes controls on the wire, but parsing each JSONL record
+recovers the exact path, message, and source strings.
 
 Diagnostics go to stdout; the one-line summary, any errors, and `RUST_LOG`
 output go to stderr — so stdout stays a clean data channel for `| jq` / `| head`

--- a/docs/README.md
+++ b/docs/README.md
@@ -693,8 +693,9 @@ fields, whitespace runs become single spaces before remaining controls are
 escaped. Use `--output-format jsonl` when consumers need the original field
 values. JSON escapes controls on the wire, but parsing each JSONL record
 recovers the exact emitted Unicode field values. In path mode, `file` is
-cwd-relative and uses Rust's display representation, which can be lossy for a
-non-UTF-8 filename.
+cwd-relative when it is under the current directory and absolute otherwise. It
+uses Rust's display representation, which can be lossy for a non-UTF-8
+filename.
 
 Diagnostics go to stdout; the one-line summary, any errors, and `RUST_LOG`
 output go to stderr — so stdout stays a clean data channel for `| jq` / `| head`

--- a/docs/README.md
+++ b/docs/README.md
@@ -692,7 +692,9 @@ as visible Rust-style escapes (for example, `\u{1b}`). In message and source
 fields, whitespace runs become single spaces before remaining controls are
 escaped. Use `--output-format jsonl` when consumers need the original field
 values. JSON escapes controls on the wire, but parsing each JSONL record
-recovers the exact path, message, and source strings.
+recovers the exact emitted Unicode field values. In path mode, `file` is
+cwd-relative and uses Rust's display representation, which can be lossy for a
+non-UTF-8 filename.
 
 Diagnostics go to stdout; the one-line summary, any errors, and `RUST_LOG`
 output go to stderr — so stdout stays a clean data channel for `| jq` / `| head`

--- a/docs/README.md
+++ b/docs/README.md
@@ -686,6 +686,13 @@ kakehashi diagnose . --fail-on-warning
 cat README.md | kakehashi diagnose --stdin-filename README.md
 ```
 
+The default format is presentation-oriented and intentionally lossy: in its
+file, message, and source fields, whitespace runs become single spaces and
+terminal/bidirectional control characters render as visible Rust-style escapes
+(for example, `\u{1b}`). Use `--output-format jsonl` when consumers need the
+original field values. JSON escapes controls on the wire, but parsing each
+JSONL record recovers the exact path, message, and source strings.
+
 Diagnostics go to stdout; the one-line summary, any errors, and `RUST_LOG`
 output go to stderr — so stdout stays a clean data channel for `| jq` / `| head`
 (redirect or ignore stderr in CI if the summary is unwanted).

--- a/docs/README.md
+++ b/docs/README.md
@@ -689,13 +689,13 @@ cat README.md | kakehashi diagnose --stdin-filename README.md
 The default format is presentation-oriented and intentionally lossy. The file
 field preserves ordinary characters but renders terminal/bidirectional controls
 as visible Rust-style escapes (for example, `\u{1b}`). In message and source
-fields, whitespace runs become single spaces before remaining controls are
-escaped. Use `--output-format jsonl` when consumers need the original field
-values. JSON escapes controls on the wire, but parsing each JSONL record
-recovers the exact emitted Unicode field values. In path mode, `file` is
-cwd-relative when it is under the current directory and absolute otherwise. It
-uses Rust's display representation, which can be lossy for a non-UTF-8
-filename.
+fields, leading and trailing whitespace is removed and internal runs become
+single spaces before remaining controls are escaped. Use
+`--output-format jsonl` when consumers need the original field values. JSON
+escapes controls on the wire, but parsing each JSONL record recovers the exact
+emitted Unicode field values. In path mode, `file` is cwd-relative when it is
+under the current directory and absolute otherwise. It uses Rust's display
+representation, which can be lossy for a non-UTF-8 filename.
 
 Diagnostics go to stdout; the one-line summary, any errors, and `RUST_LOG`
 output go to stderr — so stdout stays a clean data channel for `| jq` / `| head`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,7 @@
 pub mod diagnose;
 pub(crate) mod files;
 pub mod format;
+pub(crate) mod terminal;
 
 /// Drain server→client traffic so `Client` calls never block while a CLI
 /// command drives the LSP handlers in-process: notifications (logMessage etc.)

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -467,7 +467,23 @@ fn format_diagnostic(format: OutputFormat, display: &str, diagnostic: &Diagnosti
 /// Make an untrusted diagnostic field safe for the line-oriented `default`
 /// format: collapse whitespace runs and visibly escape terminal controls.
 /// Single-pass, with no intermediate collection.
-fn one_line(message: &str) -> String {
+fn one_line(message: &str) -> std::borrow::Cow<'_, str> {
+    let mut previous_whitespace = false;
+    let mut needs_rewrite = false;
+    for (index, ch) in message.chars().enumerate() {
+        if ch.is_whitespace() {
+            needs_rewrite |= ch != ' ' || index == 0 || previous_whitespace;
+            previous_whitespace = true;
+        } else {
+            needs_rewrite |= ch.is_control();
+            previous_whitespace = false;
+        }
+    }
+    needs_rewrite |= previous_whitespace;
+    if !needs_rewrite {
+        return std::borrow::Cow::Borrowed(message);
+    }
+
     let mut out = String::with_capacity(message.len());
     let mut pending_space = false;
     for ch in message.chars() {
@@ -485,7 +501,7 @@ fn one_line(message: &str) -> String {
             out.push(ch);
         }
     }
-    out
+    std::borrow::Cow::Owned(out)
 }
 
 /// The lower-case severity word. Both an absent severity and an out-of-spec

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -422,6 +422,7 @@ fn format_diagnostic(format: OutputFormat, display: &str, diagnostic: &Diagnosti
     let col = diagnostic.range.start.character.saturating_add(1);
     match format {
         OutputFormat::Default => {
+            let display = one_line(display);
             let severity = severity_word(diagnostic.severity);
             let message = one_line(&diagnostic.message);
             // Branch on the source rather than building a separate ` [src]`
@@ -633,6 +634,16 @@ mod tests {
         assert_eq!(
             format_diagnostic(OutputFormat::Default, "a.md", &d),
             "a.md:1:1: hint: hint here"
+        );
+    }
+
+    #[test]
+    fn default_format_escapes_controls_in_display_path() {
+        let d = diag(0, 0, Some(DiagnosticSeverity::ERROR), "boom");
+
+        assert_eq!(
+            format_diagnostic(OutputFormat::Default, "dir/\u{1b}[2Jfile\nname", &d),
+            "dir/\\u{1b}[2Jfile name:1:1: error: boom"
         );
     }
 

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -189,8 +189,9 @@ impl Report {
         // position, then tie-break by severity, source, code, and message so
         // two findings at the same spot always print in the same order.
         diagnostics.sort_by(|a, b| sort_key(a).cmp(&sort_key(b)));
+        let display = prepare_display(format, display);
         for diagnostic in &diagnostics {
-            out.push_str(&format_diagnostic(format, display, diagnostic));
+            out.push_str(&format_diagnostic_prepared(format, &display, diagnostic));
             out.push('\n');
             self.tally(diagnostic, fail_on_warning);
         }
@@ -421,9 +422,20 @@ fn format_server_failure(display: &str, failure: &str) -> String {
     format!("error: {display}: {failure}")
 }
 
-/// Render one diagnostic in the requested format. `display` is the
-/// already-formatted (cwd-relative or stdin) path.
-fn format_diagnostic(format: OutputFormat, display: &str, diagnostic: &Diagnostic) -> String {
+fn prepare_display(format: OutputFormat, display: &str) -> std::borrow::Cow<'_, str> {
+    match format {
+        OutputFormat::Default => escape_terminal_controls(display),
+        OutputFormat::Jsonl => std::borrow::Cow::Borrowed(display),
+    }
+}
+
+/// Render one diagnostic in the requested format. `display` has already been
+/// prepared for the selected format so callers can reuse it across a file.
+fn format_diagnostic_prepared(
+    format: OutputFormat,
+    display: &str,
+    diagnostic: &Diagnostic,
+) -> String {
     // LSP positions are 0-based; editors and quickfix consumers expect 1-based
     // line and column. `character` is a UTF-16 offset — presenting it as a
     // column is the same approximation grep/ripgrep make.
@@ -431,7 +443,6 @@ fn format_diagnostic(format: OutputFormat, display: &str, diagnostic: &Diagnosti
     let col = diagnostic.range.start.character.saturating_add(1);
     match format {
         OutputFormat::Default => {
-            let display = escape_terminal_controls(display);
             let severity = severity_word(diagnostic.severity);
             let message = one_line(&diagnostic.message);
             // Branch on the source rather than building a separate ` [src]`
@@ -467,6 +478,12 @@ fn format_diagnostic(format: OutputFormat, display: &str, diagnostic: &Diagnosti
             escape_jsonl_terminal_controls(value.to_string())
         }
     }
+}
+
+#[cfg(test)]
+fn format_diagnostic(format: OutputFormat, display: &str, diagnostic: &Diagnostic) -> String {
+    let display = prepare_display(format, display);
+    format_diagnostic_prepared(format, &display, diagnostic)
 }
 
 /// Make an untrusted diagnostic field safe for the line-oriented `default`

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -231,7 +231,7 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &DiagnoseOptions) ->
     }) {
         Ok(collected) => collected,
         Err(e) => {
-            elnln!("error: {e}");
+            elnln!("error: {}", escape_terminal_controls(&e.to_string()));
             return EXIT_ERROR;
         }
     };
@@ -262,7 +262,10 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &DiagnoseOptions) ->
         let text = match std::fs::read_to_string(file) {
             Ok(text) => text,
             Err(e) => {
-                elnln!("error: cannot read '{display}': {e}");
+                elnln!(
+                    "error: cannot read '{}': {e}",
+                    escape_terminal_controls(&display)
+                );
                 report.operational_error = true;
                 continue;
             }
@@ -413,6 +416,8 @@ fn summarize(report: &Report, file_count: usize) -> u8 {
 }
 
 fn format_server_failure(display: &str, failure: &str) -> String {
+    let display = escape_terminal_controls(display);
+    let failure = escape_terminal_controls(failure);
     format!("error: {display}: {failure}")
 }
 
@@ -723,6 +728,14 @@ mod tests {
         assert_eq!(
             format_diagnostic(OutputFormat::Default, " dir/a  b.rs ", &d),
             " dir/a  b.rs :1:1: error: boom"
+        );
+    }
+
+    #[test]
+    fn server_failure_escapes_untrusted_fields() {
+        assert_eq!(
+            format_server_failure(" dir/\u{1b}  f ", "server\nspoof\u{1b}"),
+            "error:  dir/\\u{1b}  f : server\\nspoof\\u{1b}"
         );
     }
 

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -463,16 +463,26 @@ fn format_diagnostic(format: OutputFormat, display: &str, diagnostic: &Diagnosti
     }
 }
 
-/// Collapse a (possibly multi-line) diagnostic message onto one line so it
-/// stays parseable in the line-oriented `default` format. Single-pass: no
-/// intermediate `Vec` of words.
+/// Make an untrusted diagnostic field safe for the line-oriented `default`
+/// format: collapse whitespace runs and visibly escape terminal controls.
+/// Single-pass, with no intermediate collection.
 fn one_line(message: &str) -> String {
     let mut out = String::with_capacity(message.len());
-    for word in message.split_whitespace() {
-        if !out.is_empty() {
-            out.push(' ');
+    let mut pending_space = false;
+    for ch in message.chars() {
+        if ch.is_whitespace() {
+            pending_space = !out.is_empty();
+            continue;
         }
-        out.push_str(word);
+        if pending_space {
+            out.push(' ');
+            pending_space = false;
+        }
+        if ch.is_control() {
+            out.extend(ch.escape_default());
+        } else {
+            out.push(ch);
+        }
     }
     out
 }
@@ -684,6 +694,14 @@ mod tests {
         assert_eq!(
             format_diagnostic(OutputFormat::Default, "f", &d),
             "f:1:1: error: line one line two"
+        );
+    }
+
+    #[test]
+    fn default_fields_escape_non_whitespace_controls() {
+        assert_eq!(
+            one_line("before\u{1b}[31mred\u{7f}\u{009b}after"),
+            "before\\u{1b}[31mred\\u{7f}\\u{9b}after"
         );
     }
 

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -422,7 +422,7 @@ fn format_diagnostic(format: OutputFormat, display: &str, diagnostic: &Diagnosti
     let col = diagnostic.range.start.character.saturating_add(1);
     match format {
         OutputFormat::Default => {
-            let display = one_line(display);
+            let display = escape_terminal_controls(display);
             let severity = severity_word(diagnostic.severity);
             let message = one_line(&diagnostic.message);
             // Branch on the source rather than building a separate ` [src]`
@@ -501,6 +501,31 @@ fn one_line(message: &str) -> std::borrow::Cow<'_, str> {
         }
     }
     std::borrow::Cow::Owned(out)
+}
+
+/// Visibly escape terminal and bidirectional controls without changing other
+/// characters. Paths use this instead of [`one_line`] because spaces and other
+/// non-control whitespace are valid filename characters and must retain their
+/// identity in diagnostic locations.
+fn escape_terminal_controls(text: &str) -> std::borrow::Cow<'_, str> {
+    if !text
+        .chars()
+        .any(|ch| ch.is_control() || is_bidi_control(ch))
+    {
+        return std::borrow::Cow::Borrowed(text);
+    }
+
+    let mut escaped = String::with_capacity(text.len());
+    for ch in text.chars() {
+        if is_bidi_control(ch) {
+            escaped.extend(ch.escape_unicode());
+        } else if ch.is_control() {
+            escaped.extend(ch.escape_default());
+        } else {
+            escaped.push(ch);
+        }
+    }
+    std::borrow::Cow::Owned(escaped)
 }
 
 fn is_bidi_control(ch: char) -> bool {
@@ -683,7 +708,17 @@ mod tests {
 
         assert_eq!(
             format_diagnostic(OutputFormat::Default, "dir/\u{1b}[2Jfile\nname", &d),
-            "dir/\\u{1b}[2Jfile name:1:1: error: boom"
+            "dir/\\u{1b}[2Jfile\\nname:1:1: error: boom"
+        );
+    }
+
+    #[test]
+    fn default_format_preserves_spaces_in_display_path() {
+        let d = diag(0, 0, Some(DiagnosticSeverity::ERROR), "boom");
+
+        assert_eq!(
+            format_diagnostic(OutputFormat::Default, " dir/a  b.rs ", &d),
+            " dir/a  b.rs :1:1: error: boom"
         );
     }
 

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -430,11 +430,7 @@ fn format_diagnostic(format: OutputFormat, display: &str, diagnostic: &Diagnosti
             // source.
             match diagnostic.source.as_deref() {
                 Some(source) => {
-                    let source = if source.chars().any(char::is_whitespace) {
-                        std::borrow::Cow::Owned(one_line(source))
-                    } else {
-                        std::borrow::Cow::Borrowed(source)
-                    };
+                    let source = one_line(source);
                     format!("{display}:{line}:{col}: {severity}: {message} [{source}]")
                 }
                 None => format!("{display}:{line}:{col}: {severity}: {message}"),

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -677,6 +677,23 @@ mod tests {
     }
 
     #[test]
+    fn jsonl_format_preserves_control_characters() {
+        let mut d = diag(0, 0, Some(DiagnosticSeverity::ERROR), "boom\u{1b}[31m");
+        d.source = Some("tool\u{009b}".to_string());
+
+        let value: serde_json::Value = serde_json::from_str(&format_diagnostic(
+            OutputFormat::Jsonl,
+            "dir/\u{1b}[2Jfile",
+            &d,
+        ))
+        .unwrap();
+
+        assert_eq!(value["file"], "dir/\u{1b}[2Jfile");
+        assert_eq!(value["message"], "boom\u{1b}[31m");
+        assert_eq!(value["source"], "tool\u{009b}");
+    }
+
+    #[test]
     fn jsonl_numeric_code_stays_numeric() {
         let mut d = diag(0, 0, Some(DiagnosticSeverity::ERROR), "m");
         d.code = Some(NumberOrString::Number(42));

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -466,7 +466,8 @@ fn format_diagnostic(format: OutputFormat, display: &str, diagnostic: &Diagnosti
 
 /// Make an untrusted diagnostic field safe for the line-oriented `default`
 /// format: collapse whitespace runs and visibly escape terminal controls.
-/// Single-pass, with no intermediate collection.
+/// A validation pass borrows already-safe text; only rewritten fields need a
+/// second pass and an allocation.
 fn one_line(message: &str) -> std::borrow::Cow<'_, str> {
     let mut previous_whitespace = false;
     let mut needs_rewrite = false;
@@ -747,6 +748,18 @@ mod tests {
             one_line("before\u{1b}[31mred\u{7f}\u{009b}after"),
             "before\\u{1b}[31mred\\u{7f}\\u{9b}after"
         );
+    }
+
+    #[test]
+    fn safe_default_fields_stay_borrowed() {
+        assert!(matches!(
+            one_line("ordinary Unicode: 日本語"),
+            std::borrow::Cow::Borrowed(_)
+        ));
+        assert!(matches!(
+            one_line("unsafe\u{1b}"),
+            std::borrow::Cow::Owned(_)
+        ));
     }
 
     #[test]

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -40,6 +40,7 @@ use tower_lsp_server::LspService;
 use tower_lsp_server::ls_types::{Diagnostic, DiagnosticSeverity, NumberOrString};
 
 use crate::cli::files::collect_files;
+use crate::cli::terminal::{escape_terminal_controls, is_bidi_control, is_line_separator};
 use crate::lsp::Kakehashi;
 
 /// Write one line to stderr, tolerating a closed pipe.
@@ -528,42 +529,6 @@ fn one_line(message: &str) -> std::borrow::Cow<'_, str> {
         }
     }
     std::borrow::Cow::Owned(out)
-}
-
-/// Visibly escape terminal and bidirectional controls without changing other
-/// characters. Paths use this instead of [`one_line`] because spaces and other
-/// non-control whitespace are valid filename characters and must retain their
-/// identity in diagnostic locations.
-fn escape_terminal_controls(text: &str) -> std::borrow::Cow<'_, str> {
-    if !text
-        .chars()
-        .any(|ch| ch.is_control() || is_bidi_control(ch) || is_line_separator(ch))
-    {
-        return std::borrow::Cow::Borrowed(text);
-    }
-
-    let mut escaped = String::with_capacity(text.len());
-    for ch in text.chars() {
-        if is_bidi_control(ch) || is_line_separator(ch) {
-            escaped.extend(ch.escape_unicode());
-        } else if ch.is_control() {
-            escaped.extend(ch.escape_default());
-        } else {
-            escaped.push(ch);
-        }
-    }
-    std::borrow::Cow::Owned(escaped)
-}
-
-fn is_bidi_control(ch: char) -> bool {
-    matches!(
-        ch,
-        '\u{061c}' | '\u{200e}' | '\u{200f}' | '\u{202a}'..='\u{202e}' | '\u{2066}'..='\u{2069}'
-    )
-}
-
-fn is_line_separator(ch: char) -> bool {
-    matches!(ch, '\u{2028}' | '\u{2029}')
 }
 
 fn escape_jsonl_terminal_controls(json: String) -> String {

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -470,7 +470,8 @@ fn format_diagnostic(format: OutputFormat, display: &str, diagnostic: &Diagnosti
 }
 
 /// Make an untrusted diagnostic field safe for the line-oriented `default`
-/// format: collapse whitespace runs and visibly escape terminal controls.
+/// format: collapse whitespace runs and visibly escape remaining terminal
+/// controls.
 /// A validation pass borrows already-safe text; only rewritten fields need a
 /// second pass and an allocation.
 fn one_line(message: &str) -> std::borrow::Cow<'_, str> {

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -271,7 +271,7 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &DiagnoseOptions) ->
             .cli_diagnose_text(file, &text, SERVER_READY_TIMEOUT)
             .await;
         for failure in &outcome.server_failures {
-            elnln!("error: {display}: {failure}");
+            elnln!("{}", format_server_failure(&display, failure));
             report.operational_error = true;
         }
         if pipe_closed {
@@ -339,7 +339,7 @@ async fn run_stdin(server: &Kakehashi, cwd: &Path, options: &DiagnoseOptions) ->
     let mut report = Report::default();
     let display = name.display().to_string();
     for failure in &outcome.server_failures {
-        elnln!("error: {display}: {failure}");
+        elnln!("{}", format_server_failure(&display, failure));
         report.operational_error = true;
     }
     let mut buf = String::new();
@@ -410,6 +410,10 @@ fn summarize(report: &Report, file_count: usize) -> u8 {
     elnln!("{} {diag_label} in {file_count} {file_label}", report.total);
 
     report.exit_code()
+}
+
+fn format_server_failure(display: &str, failure: &str) -> String {
+    format!("error: {display}: {failure}")
 }
 
 /// Render one diagnostic in the requested format. `display` is the

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -476,7 +476,7 @@ fn one_line(message: &str) -> std::borrow::Cow<'_, str> {
             needs_rewrite |= ch != ' ' || index == 0 || previous_whitespace;
             previous_whitespace = true;
         } else {
-            needs_rewrite |= ch.is_control();
+            needs_rewrite |= ch.is_control() || is_bidi_control(ch);
             previous_whitespace = false;
         }
     }
@@ -496,13 +496,22 @@ fn one_line(message: &str) -> std::borrow::Cow<'_, str> {
             out.push(' ');
             pending_space = false;
         }
-        if ch.is_control() {
+        if is_bidi_control(ch) {
+            out.extend(ch.escape_unicode());
+        } else if ch.is_control() {
             out.extend(ch.escape_default());
         } else {
             out.push(ch);
         }
     }
     std::borrow::Cow::Owned(out)
+}
+
+fn is_bidi_control(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{061c}' | '\u{200e}' | '\u{200f}' | '\u{202a}'..='\u{202e}' | '\u{2066}'..='\u{2069}'
+    )
 }
 
 /// The lower-case severity word. Both an absent severity and an out-of-spec
@@ -695,8 +704,13 @@ mod tests {
 
     #[test]
     fn jsonl_format_preserves_control_characters() {
-        let mut d = diag(0, 0, Some(DiagnosticSeverity::ERROR), "boom\u{1b}[31m");
-        d.source = Some("tool\u{009b}".to_string());
+        let mut d = diag(
+            0,
+            0,
+            Some(DiagnosticSeverity::ERROR),
+            "boom\u{1b}[31m\u{202e}",
+        );
+        d.source = Some("tool\u{009b}\u{2066}".to_string());
 
         let value: serde_json::Value = serde_json::from_str(&format_diagnostic(
             OutputFormat::Jsonl,
@@ -706,8 +720,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(value["file"], "dir/\u{1b}[2Jfile");
-        assert_eq!(value["message"], "boom\u{1b}[31m");
-        assert_eq!(value["source"], "tool\u{009b}");
+        assert_eq!(value["message"], "boom\u{1b}[31m\u{202e}");
+        assert_eq!(value["source"], "tool\u{009b}\u{2066}");
     }
 
     #[test]
@@ -745,8 +759,8 @@ mod tests {
     #[test]
     fn default_fields_escape_non_whitespace_controls() {
         assert_eq!(
-            one_line("before\u{1b}[31mred\u{7f}\u{009b}after"),
-            "before\\u{1b}[31mred\\u{7f}\\u{9b}after"
+            one_line("before\u{1b}[31mred\u{7f}\u{009b}\u{202e}\u{2066}after"),
+            "before\\u{1b}[31mred\\u{7f}\\u{9b}\\u{202e}\\u{2066}after"
         );
     }
 

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -537,14 +537,14 @@ fn one_line(message: &str) -> std::borrow::Cow<'_, str> {
 fn escape_terminal_controls(text: &str) -> std::borrow::Cow<'_, str> {
     if !text
         .chars()
-        .any(|ch| ch.is_control() || is_bidi_control(ch))
+        .any(|ch| ch.is_control() || is_bidi_control(ch) || is_line_separator(ch))
     {
         return std::borrow::Cow::Borrowed(text);
     }
 
     let mut escaped = String::with_capacity(text.len());
     for ch in text.chars() {
-        if is_bidi_control(ch) {
+        if is_bidi_control(ch) || is_line_separator(ch) {
             escaped.extend(ch.escape_unicode());
         } else if ch.is_control() {
             escaped.extend(ch.escape_default());
@@ -562,11 +562,13 @@ fn is_bidi_control(ch: char) -> bool {
     )
 }
 
+fn is_line_separator(ch: char) -> bool {
+    matches!(ch, '\u{2028}' | '\u{2029}')
+}
+
 fn escape_jsonl_terminal_controls(json: String) -> String {
     let requires_escape = |ch: char| {
-        (ch.is_control() && ch >= '\u{7f}')
-            || is_bidi_control(ch)
-            || matches!(ch, '\u{2028}' | '\u{2029}')
+        (ch.is_control() && ch >= '\u{7f}') || is_bidi_control(ch) || is_line_separator(ch)
     };
     if !json.chars().any(requires_escape) {
         return json;
@@ -756,8 +758,8 @@ mod tests {
     #[test]
     fn server_failure_escapes_untrusted_fields() {
         assert_eq!(
-            format_server_failure(" dir/\u{1b}  f ", "server\nspoof\u{1b}"),
-            "error:  dir/\\u{1b}  f : server\\nspoof\\u{1b}"
+            format_server_failure(" dir/\u{1b}\u{2028} f ", "server\nspoof\u{1b}\u{2029}"),
+            "error:  dir/\\u{1b}\\u{2028} f : server\\nspoof\\u{1b}\\u{2029}"
         );
     }
 

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -459,7 +459,7 @@ fn format_diagnostic(format: OutputFormat, display: &str, diagnostic: &Diagnosti
                 "source": diagnostic.source.as_deref(),
                 "message": diagnostic.message.as_str(),
             });
-            value.to_string()
+            escape_jsonl_terminal_controls(value.to_string())
         }
     }
 }
@@ -512,6 +512,24 @@ fn is_bidi_control(ch: char) -> bool {
         ch,
         '\u{061c}' | '\u{200e}' | '\u{200f}' | '\u{202a}'..='\u{202e}' | '\u{2066}'..='\u{2069}'
     )
+}
+
+fn escape_jsonl_terminal_controls(json: String) -> String {
+    let requires_escape = |ch: char| (ch.is_control() && ch >= '\u{80}') || is_bidi_control(ch);
+    if !json.chars().any(requires_escape) {
+        return json;
+    }
+
+    use std::fmt::Write as _;
+    let mut escaped = String::with_capacity(json.len());
+    for ch in json.chars() {
+        if requires_escape(ch) {
+            write!(escaped, "\\u{:04x}", ch as u32).expect("writing to String cannot fail");
+        } else {
+            escaped.push(ch);
+        }
+    }
+    escaped
 }
 
 /// The lower-case severity word. Both an absent severity and an out-of-spec
@@ -712,12 +730,11 @@ mod tests {
         );
         d.source = Some("tool\u{009b}\u{2066}".to_string());
 
-        let value: serde_json::Value = serde_json::from_str(&format_diagnostic(
-            OutputFormat::Jsonl,
-            "dir/\u{1b}[2Jfile",
-            &d,
-        ))
-        .unwrap();
+        let rendered = format_diagnostic(OutputFormat::Jsonl, "dir/\u{1b}[2Jfile", &d);
+        assert!(rendered.contains("\\u009b"), "rendered: {rendered}");
+        assert!(rendered.contains("\\u202e"), "rendered: {rendered}");
+        assert!(rendered.contains("\\u2066"), "rendered: {rendered}");
+        let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
 
         assert_eq!(value["file"], "dir/\u{1b}[2Jfile");
         assert_eq!(value["message"], "boom\u{1b}[31m\u{202e}");

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -545,7 +545,11 @@ fn is_bidi_control(ch: char) -> bool {
 }
 
 fn escape_jsonl_terminal_controls(json: String) -> String {
-    let requires_escape = |ch: char| (ch.is_control() && ch >= '\u{7f}') || is_bidi_control(ch);
+    let requires_escape = |ch: char| {
+        (ch.is_control() && ch >= '\u{7f}')
+            || is_bidi_control(ch)
+            || matches!(ch, '\u{2028}' | '\u{2029}')
+    };
     if !json.chars().any(requires_escape) {
         return json;
     }
@@ -788,6 +792,22 @@ mod tests {
         assert_eq!(value["file"], "dir/\u{1b}[2Jfile");
         assert_eq!(value["message"], "boom\u{1b}[31m\u{202e}");
         assert_eq!(value["source"], "tool\u{7f}\u{009b}\u{2066}");
+    }
+
+    #[test]
+    fn jsonl_escapes_unicode_line_separators() {
+        let d = diag(
+            0,
+            0,
+            Some(DiagnosticSeverity::ERROR),
+            "before\u{2028}middle\u{2029}after",
+        );
+
+        let rendered = format_diagnostic(OutputFormat::Jsonl, "x", &d);
+        assert!(rendered.contains("\\u2028"), "rendered: {rendered}");
+        assert!(rendered.contains("\\u2029"), "rendered: {rendered}");
+        let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(value["message"], "before\u{2028}middle\u{2029}after");
     }
 
     #[test]

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -511,7 +511,7 @@ fn is_bidi_control(ch: char) -> bool {
 }
 
 fn escape_jsonl_terminal_controls(json: String) -> String {
-    let requires_escape = |ch: char| (ch.is_control() && ch >= '\u{80}') || is_bidi_control(ch);
+    let requires_escape = |ch: char| (ch.is_control() && ch >= '\u{7f}') || is_bidi_control(ch);
     if !json.chars().any(requires_escape) {
         return json;
     }
@@ -724,9 +724,10 @@ mod tests {
             Some(DiagnosticSeverity::ERROR),
             "boom\u{1b}[31m\u{202e}",
         );
-        d.source = Some("tool\u{009b}\u{2066}".to_string());
+        d.source = Some("tool\u{7f}\u{009b}\u{2066}".to_string());
 
         let rendered = format_diagnostic(OutputFormat::Jsonl, "dir/\u{1b}[2Jfile", &d);
+        assert!(rendered.contains("\\u007f"), "rendered: {rendered}");
         assert!(rendered.contains("\\u009b"), "rendered: {rendered}");
         assert!(rendered.contains("\\u202e"), "rendered: {rendered}");
         assert!(rendered.contains("\\u2066"), "rendered: {rendered}");
@@ -734,7 +735,7 @@ mod tests {
 
         assert_eq!(value["file"], "dir/\u{1b}[2Jfile");
         assert_eq!(value["message"], "boom\u{1b}[31m\u{202e}");
-        assert_eq!(value["source"], "tool\u{009b}\u{2066}");
+        assert_eq!(value["source"], "tool\u{7f}\u{009b}\u{2066}");
     }
 
     #[test]

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -16,7 +16,10 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::cli::terminal::escape_terminal_controls;
+
 fn format_walk_error(error: &str) -> String {
+    let error = escape_terminal_controls(error);
     format!("error: skipping unreadable entry (will exit 2): {error}")
 }
 
@@ -191,6 +194,14 @@ mod tests {
 
     fn markdown_only(path: &Path) -> bool {
         path.extension().is_some_and(|e| e == "md")
+    }
+
+    #[test]
+    fn walk_errors_escape_terminal_controls() {
+        assert_eq!(
+            format_walk_error("dir/\u{1b}\u{2028}entry: denied"),
+            "error: skipping unreadable entry (will exit 2): dir/\\u{1b}\\u{2028}entry: denied"
+        );
     }
 
     fn collect_paths(

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -16,6 +16,10 @@
 
 use std::path::{Path, PathBuf};
 
+fn format_walk_error(error: &str) -> String {
+    format!("error: skipping unreadable entry (will exit 2): {error}")
+}
+
 /// Files collected from CLI paths plus any non-fatal directory walk errors
 /// encountered while discovering them.
 pub(crate) struct CollectedFiles {
@@ -166,10 +170,7 @@ fn walk_directory(
                 // closed stderr (`… 2>&1 | head`) would panic (exit 101).
                 // There is nowhere to report a failed error message, so drop it.
                 use std::io::Write as _;
-                let _ = writeln!(
-                    std::io::stderr(),
-                    "error: skipping unreadable entry (will exit 2): {e}"
-                );
+                let _ = writeln!(std::io::stderr(), "{}", format_walk_error(&e.to_string()));
                 errors += 1;
             }
         }

--- a/src/cli/terminal.rs
+++ b/src/cli/terminal.rs
@@ -1,0 +1,35 @@
+//! Terminal-safe rendering for untrusted CLI fields.
+
+/// Visibly escape terminal, bidirectional, and Unicode line-separator
+/// characters without changing ordinary text.
+pub(crate) fn escape_terminal_controls(text: &str) -> std::borrow::Cow<'_, str> {
+    if !text
+        .chars()
+        .any(|ch| ch.is_control() || is_bidi_control(ch) || is_line_separator(ch))
+    {
+        return std::borrow::Cow::Borrowed(text);
+    }
+
+    let mut escaped = String::with_capacity(text.len());
+    for ch in text.chars() {
+        if is_bidi_control(ch) || is_line_separator(ch) {
+            escaped.extend(ch.escape_unicode());
+        } else if ch.is_control() {
+            escaped.extend(ch.escape_default());
+        } else {
+            escaped.push(ch);
+        }
+    }
+    std::borrow::Cow::Owned(escaped)
+}
+
+pub(crate) fn is_bidi_control(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{061c}' | '\u{200e}' | '\u{200f}' | '\u{202a}'..='\u{202e}' | '\u{2066}'..='\u{2069}'
+    )
+}
+
+pub(crate) fn is_line_separator(ch: char) -> bool {
+    matches!(ch, '\u{2028}' | '\u{2029}')
+}


### PR DESCRIPTION
## Summary

- escape terminal, bidirectional, and Unicode line-separator characters in default diagnostic paths and operational errors without changing ordinary path spaces
- preserve exact decoded values in JSONL while escaping terminal-unsafe characters on the wire
- sanitize shared directory-walk errors and avoid repeated path sanitization across a file's diagnostics
- document the lossy default format and emitted-path fidelity

## Tests

- cargo test --lib -q cli::diagnose
- cargo test --lib -q cli::files
- make check

Closes #771

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer terminal rendering for diagnostic output, including escaping control characters and bidirectional text.
  * Added JSONL output handling that preserves original Unicode field values while safely escaping output.
* **Bug Fixes**
  * Prevented broken pipes and unreadable-file errors from causing crashes or unsafe terminal output.
  * Improved path, source, and error-message formatting for clearer, safer display.
* **Documentation**
  * Documented formatting behavior and data preservation differences between default and JSONL output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->