### PR TITLE
fix(install): serialize bulk uninstall snapshots

### DIFF
--- a/docs/architecture-decisions/language-install-operation-locking.md
+++ b/docs/architecture-decisions/language-install-operation-locking.md
@@ -1,0 +1,73 @@
+# Coordinate Language Mutations with a Data-Directory Lock
+
+## Context
+
+Parser and query installs already serialize same-language replacement, but
+`language uninstall --all` first discovers a set of names and then removes that
+snapshot. A different process can publish another language after discovery, so
+the command can report that everything was removed while an install remains.
+The protocol must cover CLI and LSP auto-install processes without preventing
+independent language installs from running concurrently.
+
+## Decision
+
+Each data directory owns a persistent advisory operation-lock file.
+
+- Parser install and top-level query install phases acquire a shared lock.
+- Targeted uninstall holds a shared lock across query and parser removal.
+- `uninstall --all` asks for confirmation before locking, then acquires the
+  exclusive lock, repeats recovery and discovery, and holds the lock through
+  every removal and the final verification.
+- The global operation lock is always acquired before any per-language parser
+  or query replacement lock. Code holding a per-language lock must never try to
+  acquire the global lock.
+
+The successful bulk uninstall linearizes at its verified-empty state while the
+exclusive lock is held. An install phase that acquires its shared lock after
+that point is ordered after the uninstall and may legitimately create a new
+artifact.
+
+## Considered Options
+
+1. A shared/exclusive advisory lock per data directory.
+2. Repeated unlocked discovery/removal until a scan happens to be empty.
+3. A persistent uninstall generation/tombstone checked by every installer.
+
+Option 1 is chosen. It gives an explicit cross-process order and composes with
+the existing filesystem locks. Option 2 can starve and never proves that an
+installer is not between its own check and publish. Option 3 can encode order,
+but requires transactional generation metadata and recovery in every parser
+and query publication path.
+
+## Consequences
+
+### Positive
+
+- Successful `uninstall --all` has a precise, testable linearization point.
+- Separate language installs retain shared-lock concurrency.
+- The protocol works across CLI and LSP server processes.
+
+### Negative
+
+- Bulk uninstall waits for every in-flight install phase and temporarily blocks
+  new ones.
+- All new filesystem mutation entry points must participate and preserve the
+  global-before-language lock order.
+- Advisory locks only coordinate cooperating kakehashi processes; arbitrary
+  external filesystem writers remain outside the guarantee.
+
+### Neutral
+
+- The lock file remains in the data directory and is not an installed-language
+  artifact.
+
+## Confirmation
+
+- Cross-process tests prove an exclusive bulk operation waits for shared
+  installers and prevents new shared publishers until it releases.
+- CLI regression coverage pauses after the preliminary snapshot, starts a
+  cooperating install, and proves the authoritative locked rescan removes it
+  or orders its publication after the uninstall.
+- Review verifies every parser/query install and targeted/bulk uninstall path
+  follows the documented lock order.
+

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1069,6 +1069,16 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
         ExitCode::FAILURE
     })?;
 
+    // Tombstone clearing, parser publication, and query publication form one
+    // install operation relative to bulk uninstall.
+    let _operation_lock = kakehashi::install::operation_lock::LanguageOperationGuard::shared(
+        &data_dir,
+    )
+    .map_err(|e| {
+        eprintln!("✗ Failed to coordinate language installation: {e}");
+        ExitCode::FAILURE
+    })?;
+
     // Track success/failure for exit code
     let mut parser_success = true;
     let mut queries_success = true;
@@ -1091,7 +1101,7 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
         compile: parser::ParserCompile::KillableSubprocess,
     };
 
-    match parser::install_parser(language, &options) {
+    match parser::install_parser_under_operation_lock(language, &options) {
         Ok(result) => {
             eprintln!("✓ Parser installed: {}", result.install_path.display());
             if verbose {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -733,6 +733,16 @@ fn run_language_uninstall(
         }
         Some(language)
     };
+    // Discovery and recovery may mutate stranded query state, so even the
+    // preliminary snapshot participates in the operation protocol. Release
+    // this shared lock before asking for input.
+    let preliminary_lock = kakehashi::install::operation_lock::LanguageOperationGuard::shared(
+        &data_dir,
+    )
+    .map_err(|e| {
+        eprintln!("Failed to coordinate language uninstall: {e}");
+        ExitCode::FAILURE
+    })?;
     // `--all` promises to discover the complete install before removing it.
     // Validate both roots before recovery, which may delete stale staging
     // directories or restore backups. Discard this first snapshot and rescan
@@ -762,7 +772,7 @@ fn run_language_uninstall(
     }
 
     // Determine which languages to uninstall
-    let languages_to_uninstall: Vec<String> = if all {
+    let mut languages_to_uninstall: Vec<String> = if all {
         collect_installed_languages_for_uninstall(&parser_dir, &queries_dir)
             .map_err(|e| {
                 eprintln!("Failed to scan installed languages: {e}");
@@ -778,7 +788,9 @@ fn run_language_uninstall(
         ]
     };
 
-    if languages_to_uninstall.is_empty() {
+    drop(preliminary_lock);
+
+    if languages_to_uninstall.is_empty() && !all {
         eprintln!("No languages installed to uninstall.");
         return Ok(());
     }
@@ -786,11 +798,17 @@ fn run_language_uninstall(
     // Confirmation prompt unless --force
     if !force {
         if all {
-            eprint!(
-                "Uninstall all {} languages? [y/N] ",
-                languages_to_uninstall.len()
-            );
-        } else {
+            if languages_to_uninstall.is_empty() {
+                // The exclusive post-confirmation snapshot may still find an
+                // install that begins after this preliminary empty snapshot.
+                eprint!("Uninstall all currently installed languages? [y/N] ");
+            } else {
+                eprint!(
+                    "Uninstall all {} languages? [y/N] ",
+                    languages_to_uninstall.len()
+                );
+            }
+        } else if !all {
             eprint!("Uninstall '{}'? [y/N] ", languages_to_uninstall[0]);
         }
         io::stderr().flush().unwrap();
@@ -802,10 +820,43 @@ fn run_language_uninstall(
         }
     }
 
-    // Targeted recovery is deliberately after confirmation and scoped to the
-    // requested language: cancellation and invalid input must not mutate any
-    // recovery state, especially not another language's artifacts.
-    if let Some(language) = targeted_language
+    // Confirmation is intentionally outside the lock. Once confirmed, take
+    // the operation-wide lock and rebuild the authoritative uninstall set.
+    // An install that held a shared lock is ordered before this snapshot; a
+    // later install cannot publish until the verified-empty point below.
+    let _operation_lock = if all {
+        kakehashi::install::operation_lock::LanguageOperationGuard::exclusive(&data_dir)
+    } else {
+        kakehashi::install::operation_lock::LanguageOperationGuard::shared(&data_dir)
+    }
+    .map_err(|e| {
+        eprintln!("Failed to coordinate language uninstall: {e}");
+        ExitCode::FAILURE
+    })?;
+
+    if all {
+        collect_installed_languages_for_uninstall(&parser_dir, &queries_dir).map_err(|e| {
+            eprintln!("Failed to scan installed languages: {e}");
+            ExitCode::FAILURE
+        })?;
+        queries::recover_interrupted_query_installs(&queries_dir).map_err(|e| {
+            eprintln!("Failed to recover interrupted query installs: {e}");
+            ExitCode::FAILURE
+        })?;
+        languages_to_uninstall =
+            collect_installed_languages_for_uninstall(&parser_dir, &queries_dir)
+                .map_err(|e| {
+                    eprintln!("Failed to scan installed languages: {e}");
+                    ExitCode::FAILURE
+                })?
+                .into_iter()
+                .collect();
+
+        if languages_to_uninstall.is_empty() {
+            eprintln!("No languages installed to uninstall.");
+            return Ok(());
+        }
+    } else if let Some(language) = targeted_language
         && let Err(e) =
             queries::recover_interrupted_query_installs_for_language(&queries_dir, language)
     {
@@ -885,6 +936,18 @@ fn run_language_uninstall(
     }
 
     if any_failed {
+        return Err(ExitCode::FAILURE);
+    }
+
+    if all
+        && !collect_installed_languages_for_uninstall(&parser_dir, &queries_dir)
+            .map_err(|e| {
+                eprintln!("Failed to verify language uninstall: {e}");
+                ExitCode::FAILURE
+            })?
+            .is_empty()
+    {
+        eprintln!("Failed to verify that all languages were uninstalled.");
         return Err(ExitCode::FAILURE);
     }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -398,17 +398,26 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
     // Status recovery can restore backups or remove interrupted staging
     // directories. Coordinate that mutation and the following snapshot with
     // bulk uninstall's exclusive operation guard.
-    let _operation_lock = kakehashi::install::operation_lock::LanguageOperationGuard::shared(
-        &data_dir,
-    )
-    .map_err(|e| {
-        eprintln!("Failed to coordinate language status: {e}");
-        ExitCode::FAILURE
-    })?;
+    let operation_lock = if data_dir.exists() {
+        match kakehashi::install::operation_lock::LanguageOperationGuard::shared(&data_dir) {
+            Ok(lock) => Some(lock),
+            Err(e) => {
+                // Status remains a read-only inspection when its storage is
+                // not writable. Without coordination, skip recovery below so
+                // this process does not mutate outside the operation protocol.
+                eprintln!("Warning: cannot coordinate language status; skipping recovery: {e}");
+                None
+            }
+        }
+    } else {
+        None
+    };
 
     let parser_dir = data_dir.join("parser");
     let queries_dir = data_dir.join("queries");
-    if let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {
+    if operation_lock.is_some()
+        && let Err(e) = queries::recover_interrupted_query_installs(&queries_dir)
+    {
         eprintln!("Warning: failed to recover interrupted query installs: {e}");
     }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -744,10 +744,23 @@ fn run_language_uninstall(
         }
         Some(language)
     };
+    // Bulk discovery must be exclusive to avoid observing install renames,
+    // but never make installers wait while the command is awaiting consent.
+    // The authoritative locked snapshot below determines the actual set.
+    if all && !force {
+        eprint!("Uninstall all currently installed languages? [y/N] ");
+        io::stderr().flush().unwrap();
+
+        let mut input = String::new();
+        if io::stdin().read_line(&mut input).is_err() || !input.trim().eq_ignore_ascii_case("y") {
+            eprintln!("Cancelled.");
+            return Ok(());
+        }
+    }
     // Discovery and recovery may mutate stranded query state, so even the
     // preliminary snapshot participates in the operation protocol. A short
     // exclusive phase prevents strict recursive scans from observing install
-    // renames mid-flight. Release it before asking for input.
+    // renames mid-flight. Interactive bulk consent was obtained above.
     let preliminary_lock = kakehashi::install::operation_lock::LanguageOperationGuard::exclusive(
         &data_dir,
     )
@@ -808,21 +821,8 @@ fn run_language_uninstall(
     }
 
     // Confirmation prompt unless --force
-    if !force {
-        if all {
-            if languages_to_uninstall.is_empty() {
-                // The exclusive post-confirmation snapshot may still find an
-                // install that begins after this preliminary empty snapshot.
-                eprint!("Uninstall all currently installed languages? [y/N] ");
-            } else {
-                eprint!(
-                    "Uninstall all {} languages? [y/N] ",
-                    languages_to_uninstall.len()
-                );
-            }
-        } else if !all {
-            eprint!("Uninstall '{}'? [y/N] ", languages_to_uninstall[0]);
-        }
+    if !force && !all {
+        eprint!("Uninstall '{}'? [y/N] ", languages_to_uninstall[0]);
         io::stderr().flush().unwrap();
 
         let mut input = String::new();

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -870,12 +870,24 @@ fn run_language_uninstall(
             eprintln!("No languages installed to uninstall.");
             return Ok(());
         }
-    } else if let Some(language) = targeted_language
-        && let Err(e) =
+    } else {
+        // Confirmation happens outside the lock, so validate roots again at
+        // the mutation point to close filesystem TOCTOU windows.
+        read_optional_install_dir(&parser_dir, "parser").map_err(|e| {
+            eprintln!("Failed to validate install roots: {e}");
+            ExitCode::FAILURE
+        })?;
+        let language = targeted_language.expect("targeted uninstall has a language");
+        preflight_targeted_query_state(&queries_dir, language).map_err(|e| {
+            eprintln!("Failed to preflight targeted query state: {e}");
+            ExitCode::FAILURE
+        })?;
+        if let Err(e) =
             queries::recover_interrupted_query_installs_for_language(&queries_dir, language)
-    {
-        eprintln!("Failed to recover interrupted query installs for '{language}': {e}");
-        return Err(ExitCode::FAILURE);
+        {
+            eprintln!("Failed to recover interrupted query installs for '{language}': {e}");
+            return Err(ExitCode::FAILURE);
+        }
     }
 
     // Uninstall each language

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -740,10 +740,8 @@ fn run_language_uninstall(
     })?;
 
     match std::fs::symlink_metadata(&data_dir) {
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            if all {
-                eprintln!("No languages installed to uninstall.");
-            } else if let Some(language) = language.as_deref() {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound && !all => {
+            if let Some(language) = language.as_deref() {
                 eprintln!("Language '{}' is not installed.", language);
             }
             return Ok(());

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -739,18 +739,6 @@ fn run_language_uninstall(
         ExitCode::FAILURE
     })?;
 
-    match std::fs::symlink_metadata(&data_dir) {
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound && !all => {
-            if let Some(language) = language.as_deref() {
-                eprintln!("Language '{}' is not installed.", language);
-            }
-            return Ok(());
-        }
-        _ => {}
-    }
-
-    let parser_dir = data_dir.join("parser");
-    let queries_dir = data_dir.join("queries");
     let targeted_language = if all {
         None
     } else {
@@ -763,6 +751,19 @@ fn run_language_uninstall(
         }
         Some(language)
     };
+
+    match std::fs::symlink_metadata(&data_dir) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound && !all => {
+            if let Some(language) = language.as_deref() {
+                eprintln!("Language '{}' is not installed.", language);
+            }
+            return Ok(());
+        }
+        _ => {}
+    }
+
+    let parser_dir = data_dir.join("parser");
+    let queries_dir = data_dir.join("queries");
     // Bulk discovery must be exclusive to avoid observing install renames,
     // but never make installers wait while the command is awaiting consent.
     // The authoritative locked snapshot below determines the actual set.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -745,9 +745,10 @@ fn run_language_uninstall(
         Some(language)
     };
     // Discovery and recovery may mutate stranded query state, so even the
-    // preliminary snapshot participates in the operation protocol. Release
-    // this shared lock before asking for input.
-    let preliminary_lock = kakehashi::install::operation_lock::LanguageOperationGuard::shared(
+    // preliminary snapshot participates in the operation protocol. A short
+    // exclusive phase prevents strict recursive scans from observing install
+    // renames mid-flight. Release it before asking for input.
+    let preliminary_lock = kakehashi::install::operation_lock::LanguageOperationGuard::exclusive(
         &data_dir,
     )
     .map_err(|e| {
@@ -1117,7 +1118,7 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
     // Install queries (with inherited dependencies)
     eprintln!("Installing queries for '{}' to {:?}...", language, data_dir);
 
-    match queries::install_queries_with_dependencies_after_install_started(
+    match queries::install_queries_with_dependencies_after_install_started_under_operation_lock(
         language, &data_dir, force,
     ) {
         Ok(result) => {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -395,6 +395,17 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
         ExitCode::FAILURE
     })?;
 
+    // Status recovery can restore backups or remove interrupted staging
+    // directories. Coordinate that mutation and the following snapshot with
+    // bulk uninstall's exclusive operation guard.
+    let _operation_lock = kakehashi::install::operation_lock::LanguageOperationGuard::shared(
+        &data_dir,
+    )
+    .map_err(|e| {
+        eprintln!("Failed to coordinate language status: {e}");
+        ExitCode::FAILURE
+    })?;
+
     let parser_dir = data_dir.join("parser");
     let queries_dir = data_dir.join("queries");
     if let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -739,6 +739,18 @@ fn run_language_uninstall(
         ExitCode::FAILURE
     })?;
 
+    match std::fs::symlink_metadata(&data_dir) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            if all {
+                eprintln!("No languages installed to uninstall.");
+            } else if let Some(language) = language.as_deref() {
+                eprintln!("Language '{}' is not installed.", language);
+            }
+            return Ok(());
+        }
+        _ => {}
+    }
+
     let parser_dir = data_dir.join("parser");
     let queries_dir = data_dir.join("queries");
     let targeted_language = if all {
@@ -1059,6 +1071,11 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
         eprintln!("Error: Could not determine data directory. Please specify --data-dir.");
         ExitCode::FAILURE
     })?;
+
+    if !queries::is_safe_language_name(language) {
+        eprintln!("✗ Invalid language name {:?}", language);
+        return Err(ExitCode::FAILURE);
+    }
 
     // Tombstone clearing, parser publication, and query publication form one
     // install operation relative to bulk uninstall.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -766,27 +766,22 @@ fn run_language_uninstall(
             return Ok(());
         }
     }
-    // Discovery and recovery may mutate stranded query state, so even the
-    // preliminary snapshot participates in the operation protocol. A short
-    // exclusive phase prevents strict recursive scans from observing install
-    // renames mid-flight. Interactive bulk consent was obtained above.
-    let preliminary_lock = kakehashi::install::operation_lock::LanguageOperationGuard::exclusive(
-        &data_dir,
-    )
-    .map_err(|e| {
-        eprintln!("Failed to coordinate language uninstall: {e}");
-        ExitCode::FAILURE
-    })?;
-    // `--all` promises to discover the complete install before removing it.
-    // Validate both roots before recovery, which may delete stale staging
-    // directories or restore backups. Discard this first snapshot and rescan
-    // after recovery so restored languages are included in the uninstall set.
-    if all {
-        collect_installed_languages_for_uninstall(&parser_dir, &queries_dir).map_err(|e| {
-            eprintln!("Failed to scan installed languages: {e}");
-            ExitCode::FAILURE
-        })?;
+    // Targeted preflight happens before its language-specific prompt. Bulk
+    // consent was already obtained above, so it goes directly to the single
+    // authoritative exclusive phase below.
+    let preliminary_lock = if all {
+        None
     } else {
+        Some(
+            kakehashi::install::operation_lock::LanguageOperationGuard::shared(&data_dir).map_err(
+                |e| {
+                    eprintln!("Failed to coordinate language uninstall: {e}");
+                    ExitCode::FAILURE
+                },
+            )?,
+        )
+    };
+    if !all {
         // Targeted uninstall does not need to enumerate every entry, but it
         // still builds removal paths beneath both roots. Reject a symlinked or
         // non-directory root before recovery/removal can escape data_dir.
@@ -800,20 +795,9 @@ fn run_language_uninstall(
             ExitCode::FAILURE
         })?;
     }
-    if all && let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {
-        eprintln!("Failed to recover interrupted query installs: {e}");
-        return Err(ExitCode::FAILURE);
-    }
-
     // Determine which languages to uninstall
     let mut languages_to_uninstall: Vec<String> = if all {
-        collect_installed_languages_for_uninstall(&parser_dir, &queries_dir)
-            .map_err(|e| {
-                eprintln!("Failed to scan installed languages: {e}");
-                ExitCode::FAILURE
-            })?
-            .into_iter()
-            .collect()
+        Vec::new()
     } else {
         vec![
             targeted_language
@@ -823,11 +807,6 @@ fn run_language_uninstall(
     };
 
     drop(preliminary_lock);
-
-    if languages_to_uninstall.is_empty() && !all {
-        eprintln!("No languages installed to uninstall.");
-        return Ok(());
-    }
 
     // Confirmation prompt unless --force
     if !force && !all {
@@ -856,6 +835,8 @@ fn run_language_uninstall(
     })?;
 
     if all {
+        // Validate the complete tree before recovery mutates stranded staging
+        // state. The post-recovery scan below is the authoritative set.
         collect_installed_languages_for_uninstall(&parser_dir, &queries_dir).map_err(|e| {
             eprintln!("Failed to scan installed languages: {e}");
             ExitCode::FAILURE

--- a/src/install.rs
+++ b/src/install.rs
@@ -6,6 +6,8 @@
 pub(crate) mod cache;
 pub(crate) mod http;
 pub mod metadata;
+#[doc(hidden)]
+pub mod operation_lock;
 pub mod parser;
 pub mod queries;
 pub(crate) mod support_check;

--- a/src/install.rs
+++ b/src/install.rs
@@ -247,7 +247,7 @@ fn install_language_blocking(
         force,
         queries_base_url,
         compile,
-        queries::install_queries_with_dependencies_from,
+        queries::install_queries_with_dependencies_from_under_operation_lock,
     )
 }
 
@@ -281,6 +281,18 @@ fn install_language_blocking_with_query_installer(
         return result;
     }
 
+    // Cover tombstone preparation and both artifact publications as one
+    // install operation. Bulk uninstall must not linearize between them.
+    let _operation_lock = match operation_lock::LanguageOperationGuard::shared(data_dir) {
+        Ok(lock) => lock,
+        Err(e) => {
+            let reason = e.to_string();
+            result.parser_error = Some(reason.clone());
+            result.queries_error = Some(reason);
+            return result;
+        }
+    };
+
     if let Err(e) = queries::clear_uninstall_tombstone_for_install(data_dir, language) {
         let reason = e.to_string();
         result.queries_error = Some(reason);
@@ -303,7 +315,7 @@ fn install_language_blocking_with_query_installer(
     // AlreadyExists means the artifact is present and usable — success,
     // not failure; treating it as an error made the auto-install manager
     // degrade a fully-installed language to "installed but with warnings".
-    match parser::install_parser(language, &parser_options) {
+    match parser::install_parser_under_operation_lock(language, &parser_options) {
         Ok(parser_result) => {
             result.parser_path = Some(parser_result.install_path);
         }
@@ -375,7 +387,7 @@ fn install_language_blocking_allowing_http_queries_for_tests(
         force,
         queries_base_url,
         compile,
-        queries::install_queries_with_dependencies_from_allowing_http_for_tests,
+        queries::install_queries_with_dependencies_from_allowing_http_for_tests_under_operation_lock,
     )
 }
 

--- a/src/install/operation_lock.rs
+++ b/src/install/operation_lock.rs
@@ -1,0 +1,65 @@
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::Path;
+
+use fs4::fs_std::FileExt as _;
+
+const OPERATION_LOCK_FILE: &str = ".language-operations.lock";
+
+/// Holds one advisory data-directory operation lock until drop.
+pub struct LanguageOperationGuard {
+    _file: File,
+}
+
+impl LanguageOperationGuard {
+    pub fn shared(data_dir: &Path) -> io::Result<Self> {
+        let file = open_lock_file(data_dir)?;
+        file.lock_shared()?;
+        Ok(Self { _file: file })
+    }
+
+    pub fn exclusive(data_dir: &Path) -> io::Result<Self> {
+        let file = open_lock_file(data_dir)?;
+        file.lock_exclusive()?;
+        Ok(Self { _file: file })
+    }
+}
+
+fn open_lock_file(data_dir: &Path) -> io::Result<File> {
+    std::fs::create_dir_all(data_dir)?;
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(data_dir.join(OPERATION_LOCK_FILE))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    #[test]
+    fn exclusive_waits_for_shared_operation() {
+        let temp = tempfile::tempdir().unwrap();
+        let shared = LanguageOperationGuard::shared(temp.path()).unwrap();
+        let path = temp.path().to_path_buf();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+
+        let waiter = std::thread::spawn(move || {
+            let exclusive = LanguageOperationGuard::exclusive(&path).unwrap();
+            acquired_tx.send(()).unwrap();
+            exclusive
+        });
+
+        assert_eq!(
+            acquired_rx.recv_timeout(Duration::from_millis(50)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        );
+        drop(shared);
+        acquired_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        drop(waiter.join().unwrap());
+    }
+}

--- a/src/install/operation_lock.rs
+++ b/src/install/operation_lock.rs
@@ -13,7 +13,12 @@ pub struct LanguageOperationGuard {
 
 impl LanguageOperationGuard {
     pub fn shared(data_dir: &Path) -> io::Result<Self> {
-        let file = open_lock_file(data_dir)?;
+        let path = data_dir.join(OPERATION_LOCK_FILE);
+        let file = match OpenOptions::new().read(true).open(&path) {
+            Ok(file) => file,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => open_lock_file(data_dir)?,
+            Err(e) => return Err(e),
+        };
         file.lock_shared()?;
         Ok(Self { _file: file })
     }
@@ -64,5 +69,19 @@ mod tests {
         drop(shared);
         acquired_rx.recv_timeout(Duration::from_secs(2)).unwrap();
         drop(waiter.join().unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_opens_existing_lock_without_write_access() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        drop(LanguageOperationGuard::exclusive(temp.path()).unwrap());
+        let lock_path = temp.path().join(OPERATION_LOCK_FILE);
+        std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o444)).unwrap();
+
+        let shared = LanguageOperationGuard::shared(temp.path()).unwrap();
+        drop(shared);
     }
 }

--- a/src/install/operation_lock.rs
+++ b/src/install/operation_lock.rs
@@ -46,14 +46,17 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let shared = LanguageOperationGuard::shared(temp.path()).unwrap();
         let path = temp.path().to_path_buf();
+        let (started_tx, started_rx) = mpsc::channel();
         let (acquired_tx, acquired_rx) = mpsc::channel();
 
         let waiter = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
             let exclusive = LanguageOperationGuard::exclusive(&path).unwrap();
             acquired_tx.send(()).unwrap();
             exclusive
         });
 
+        started_rx.recv_timeout(Duration::from_secs(2)).unwrap();
         assert_eq!(
             acquired_rx.recv_timeout(Duration::from_millis(50)),
             Err(mpsc::RecvTimeoutError::Timeout)

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -266,6 +266,16 @@ pub fn install_parser(
     language: &str,
     options: &InstallOptions,
 ) -> Result<ParserInstallResult, ParserInstallError> {
+    let _operation_lock = super::operation_lock::LanguageOperationGuard::shared(&options.data_dir)?;
+    install_parser_under_operation_lock(language, options)
+}
+
+/// Install a parser while the caller holds the data-directory operation lock.
+#[doc(hidden)]
+pub fn install_parser_under_operation_lock(
+    language: &str,
+    options: &InstallOptions,
+) -> Result<ParserInstallResult, ParserInstallError> {
     // `language` becomes path segments (`parser/<language>.<ext>` and the temp
     // file) and a URL/metadata key, so reject traversal-capable names before
     // touching the filesystem. Higher-level callers (auto-install) already gate
@@ -277,12 +287,6 @@ pub fn install_parser(
             format!("unsafe language name '{}'", language.escape_default()),
         )));
     }
-
-    // Operation locks are always acquired before any artifact-specific lock.
-    // Bulk uninstall takes the exclusive side of this lock, so an install
-    // phase either publishes completely before its snapshot or starts after
-    // the uninstall has established an empty state.
-    let _operation_lock = super::operation_lock::LanguageOperationGuard::shared(&options.data_dir)?;
 
     let parser_dir = options.data_dir.join("parser");
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -278,6 +278,12 @@ pub fn install_parser(
         )));
     }
 
+    // Operation locks are always acquired before any artifact-specific lock.
+    // Bulk uninstall takes the exclusive side of this lock, so an install
+    // phase either publishes completely before its snapshot or starts after
+    // the uninstall has established an empty state.
+    let _operation_lock = super::operation_lock::LanguageOperationGuard::shared(&options.data_dir)?;
+
     let parser_dir = options.data_dir.join("parser");
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -266,6 +266,12 @@ pub fn install_parser(
     language: &str,
     options: &InstallOptions,
 ) -> Result<ParserInstallResult, ParserInstallError> {
+    if !super::queries::is_safe_language_name(language) {
+        return Err(ParserInstallError::IoError(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("unsafe language name '{}'", language.escape_default()),
+        )));
+    }
     let _operation_lock = super::operation_lock::LanguageOperationGuard::shared(&options.data_dir)?;
     install_parser_under_operation_lock(language, options)
 }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -180,6 +180,7 @@ pub fn install_queries_with_dependencies_after_install_started(
 }
 
 /// Like [`install_queries_with_dependencies`] but downloading from `base_url`.
+#[cfg(test)]
 pub(crate) fn install_queries_with_dependencies_from(
     base_url: &str,
     language: &str,

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -170,6 +170,19 @@ pub fn install_queries_with_dependencies_after_install_started(
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
+    let _operation_lock = super::operation_lock::LanguageOperationGuard::shared(data_dir)?;
+    install_queries_with_dependencies_after_install_started_under_operation_lock(
+        language, data_dir, force,
+    )
+}
+
+/// Continue query installation while the caller holds the operation lock.
+#[doc(hidden)]
+pub fn install_queries_with_dependencies_after_install_started_under_operation_lock(
+    language: &str,
+    data_dir: &Path,
+    force: bool,
+) -> Result<QueryInstallResult, QueryInstallError> {
     install_queries_with_dependencies_from_with_http_policy_under_operation_lock(
         NVIM_TREESITTER_QUERIES_URL,
         language,

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -185,6 +185,7 @@ pub fn install_queries_with_dependencies_after_install_started_under_operation_l
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
+    validate_safe_language_name(language)?;
     install_queries_with_dependencies_from_with_http_policy_under_operation_lock(
         NVIM_TREESITTER_QUERIES_URL,
         language,
@@ -1287,6 +1288,23 @@ mod tests {
             "keep",
             "unsafe tombstone cleanup must not escape queries/"
         );
+    }
+
+    #[test]
+    fn under_operation_lock_install_rejects_unsafe_language_before_path_use() {
+        let temp = TempDir::new().unwrap();
+
+        let result = install_queries_with_dependencies_after_install_started_under_operation_lock(
+            "../../evil",
+            temp.path(),
+            false,
+        );
+
+        assert!(matches!(
+            result,
+            Err(QueryInstallError::InvalidLanguageName(_))
+        ));
+        assert!(!temp.path().join("queries").exists());
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -226,6 +226,10 @@ fn install_queries_with_dependencies_from_with_http_policy(
     force: bool,
     http_policy: QueryHttpPolicy,
 ) -> Result<QueryInstallResult, QueryInstallError> {
+    // Acquire the data-directory lock before recursive installation takes any
+    // per-language replacement locks. This order prevents a bulk uninstall
+    // from deadlocking with inherited-query installation.
+    let _operation_lock = super::operation_lock::LanguageOperationGuard::shared(data_dir)?;
     let mut installed = std::collections::HashSet::new();
     install_queries_recursive(
         base_url,

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -154,6 +154,7 @@ pub fn install_queries_with_dependencies(
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
+    validate_safe_language_name(language)?;
     let _operation_lock = super::operation_lock::LanguageOperationGuard::shared(data_dir)?;
     clear_uninstall_tombstone_for_install(data_dir, language)?;
     install_queries_with_dependencies_from_with_http_policy_under_operation_lock(
@@ -170,6 +171,7 @@ pub fn install_queries_with_dependencies_after_install_started(
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
+    validate_safe_language_name(language)?;
     let _operation_lock = super::operation_lock::LanguageOperationGuard::shared(data_dir)?;
     install_queries_with_dependencies_after_install_started_under_operation_lock(
         language, data_dir, force,
@@ -200,6 +202,7 @@ pub(crate) fn install_queries_with_dependencies_from(
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
+    validate_safe_language_name(language)?;
     let _operation_lock = super::operation_lock::LanguageOperationGuard::shared(data_dir)?;
     install_queries_with_dependencies_from_under_operation_lock(base_url, language, data_dir, force)
 }
@@ -228,6 +231,7 @@ pub(crate) fn install_queries_with_dependencies_from_allowing_http_for_tests(
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
+    validate_safe_language_name(language)?;
     let _operation_lock = super::operation_lock::LanguageOperationGuard::shared(data_dir)?;
     install_queries_with_dependencies_from_allowing_http_for_tests_under_operation_lock(
         base_url, language, data_dir, force,

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -154,8 +154,9 @@ pub fn install_queries_with_dependencies(
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
+    let _operation_lock = super::operation_lock::LanguageOperationGuard::shared(data_dir)?;
     clear_uninstall_tombstone_for_install(data_dir, language)?;
-    install_queries_with_dependencies_from_with_http_policy(
+    install_queries_with_dependencies_from_with_http_policy_under_operation_lock(
         NVIM_TREESITTER_QUERIES_URL,
         language,
         data_dir,
@@ -169,7 +170,7 @@ pub fn install_queries_with_dependencies_after_install_started(
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
-    install_queries_with_dependencies_from_with_http_policy(
+    install_queries_with_dependencies_from_with_http_policy_under_operation_lock(
         NVIM_TREESITTER_QUERIES_URL,
         language,
         data_dir,
@@ -185,7 +186,17 @@ pub(crate) fn install_queries_with_dependencies_from(
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
-    install_queries_with_dependencies_from_with_http_policy(
+    let _operation_lock = super::operation_lock::LanguageOperationGuard::shared(data_dir)?;
+    install_queries_with_dependencies_from_under_operation_lock(base_url, language, data_dir, force)
+}
+
+pub(crate) fn install_queries_with_dependencies_from_under_operation_lock(
+    base_url: &str,
+    language: &str,
+    data_dir: &Path,
+    force: bool,
+) -> Result<QueryInstallResult, QueryInstallError> {
+    install_queries_with_dependencies_from_with_http_policy_under_operation_lock(
         base_url,
         language,
         data_dir,
@@ -203,7 +214,20 @@ pub(crate) fn install_queries_with_dependencies_from_allowing_http_for_tests(
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
-    install_queries_with_dependencies_from_with_http_policy(
+    let _operation_lock = super::operation_lock::LanguageOperationGuard::shared(data_dir)?;
+    install_queries_with_dependencies_from_allowing_http_for_tests_under_operation_lock(
+        base_url, language, data_dir, force,
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn install_queries_with_dependencies_from_allowing_http_for_tests_under_operation_lock(
+    base_url: &str,
+    language: &str,
+    data_dir: &Path,
+    force: bool,
+) -> Result<QueryInstallResult, QueryInstallError> {
+    install_queries_with_dependencies_from_with_http_policy_under_operation_lock(
         base_url,
         language,
         data_dir,
@@ -219,17 +243,13 @@ enum QueryHttpPolicy {
     AllowHttpForTests,
 }
 
-fn install_queries_with_dependencies_from_with_http_policy(
+fn install_queries_with_dependencies_from_with_http_policy_under_operation_lock(
     base_url: &str,
     language: &str,
     data_dir: &Path,
     force: bool,
     http_policy: QueryHttpPolicy,
 ) -> Result<QueryInstallResult, QueryInstallError> {
-    // Acquire the data-directory lock before recursive installation takes any
-    // per-language replacement locks. This order prevents a bulk uninstall
-    // from deadlocking with inherited-query installation.
-    let _operation_lock = super::operation_lock::LanguageOperationGuard::shared(data_dir)?;
     let mut installed = std::collections::HashSet::new();
     install_queries_recursive(
         base_url,

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -687,6 +687,25 @@ fn test_language_status_help() {
     );
 }
 
+#[test]
+fn test_language_status_does_not_create_missing_data_dir() {
+    let parent = tempfile::tempdir().unwrap();
+    let data_dir = parent.path().join("missing");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(!data_dir.exists(), "status must remain read-only");
+}
+
 /// Test that language status shows installed languages
 #[test]
 fn test_language_status_shows_installed() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1240,6 +1240,50 @@ fn test_language_uninstall_all() {
     assert!(queries.is_empty(), "All queries should be removed");
 }
 
+#[test]
+fn test_language_uninstall_does_not_create_missing_data_dir() {
+    let parent = tempfile::tempdir().unwrap();
+
+    for args in [vec!["--all"], vec!["testlang"]] {
+        let data_dir = parent.path().join(args[0].trim_start_matches('-'));
+        let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+            .arg("language")
+            .arg("uninstall")
+            .args(&args)
+            .arg("--data-dir")
+            .arg(&data_dir)
+            .arg("--force")
+            .output()
+            .unwrap();
+
+        assert!(output.status.success());
+        assert!(!data_dir.exists(), "uninstall must remain a no-op");
+    }
+}
+
+#[test]
+fn test_language_install_rejects_unsafe_name_before_creating_data_dir() {
+    let parent = tempfile::tempdir().unwrap();
+    let data_dir = parent.path().join("missing");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "install",
+            "../../evil",
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(
+        !data_dir.exists(),
+        "invalid input must not create lock state"
+    );
+}
+
 /// A bulk uninstall must include an install that starts after confirmation is
 /// requested but completes before its exclusive snapshot.
 #[test]
@@ -1248,6 +1292,8 @@ fn test_language_uninstall_all_includes_install_completed_before_exclusive_lock(
     use std::fs;
     use std::io::{Read, Write};
     use std::process::Stdio;
+    use std::sync::mpsc;
+    use std::time::Duration;
 
     let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
     fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
@@ -1266,12 +1312,28 @@ fn test_language_uninstall_all_includes_install_completed_before_exclusive_lock(
         .spawn()
         .expect("Failed to start uninstall command");
 
-    let mut prompt = Vec::new();
-    let stderr = uninstall.stderr.as_mut().unwrap();
-    while !prompt.ends_with(b"[y/N] ") {
-        let mut byte = [0];
-        assert_eq!(stderr.read(&mut byte).unwrap(), 1, "prompt ended early");
-        prompt.push(byte[0]);
+    let mut stderr = uninstall.stderr.take().unwrap();
+    let (prompt_tx, prompt_rx) = mpsc::channel();
+    let prompt_reader = std::thread::spawn(move || {
+        let mut prompt = Vec::new();
+        while !prompt.ends_with(b"[y/N] ") {
+            let mut byte = [0];
+            if stderr.read(&mut byte)? == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "prompt ended early",
+                ));
+            }
+            prompt.push(byte[0]);
+        }
+        prompt_tx.send(()).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "prompt receiver dropped")
+        })?;
+        Ok::<_, std::io::Error>(stderr)
+    });
+    if prompt_rx.recv_timeout(Duration::from_secs(2)).is_err() {
+        let _ = uninstall.kill();
+        panic!("timed out waiting for uninstall confirmation prompt");
     }
 
     // This install starts after the prompt and holds the shared side while it
@@ -1287,6 +1349,7 @@ fn test_language_uninstall_all_includes_install_completed_before_exclusive_lock(
     let status = uninstall
         .wait()
         .expect("Failed to wait for uninstall command");
+    prompt_reader.join().unwrap().unwrap();
     assert!(status.success(), "Uninstall --all should succeed");
     assert!(
         !parser.exists(),

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1221,6 +1221,50 @@ fn test_language_uninstall_all() {
     assert!(queries.is_empty(), "All queries should be removed");
 }
 
+/// A bulk uninstall must rebuild its snapshot after waiting for an install
+/// operation that began while its preliminary discovery was in progress.
+#[test]
+fn test_language_uninstall_all_includes_install_completed_before_exclusive_lock() {
+    use kakehashi::install::operation_lock::LanguageOperationGuard;
+    use std::fs;
+    use std::time::Duration;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
+    fs::create_dir_all(test_dir.path().join("queries")).expect("Failed to create queries dir");
+
+    // Model an install phase already in flight. Shared holders do not block
+    // preliminary discovery, but they do block the authoritative exclusive
+    // snapshot used by `--all`.
+    let install = LanguageOperationGuard::shared(test_dir.path()).unwrap();
+    let mut uninstall = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .spawn()
+        .expect("Failed to start uninstall command");
+
+    std::thread::sleep(Duration::from_millis(100));
+    let ext = std::env::consts::DLL_EXTENSION;
+    let parser = test_dir.path().join(format!("parser/concurrent.{ext}"));
+    fs::write(&parser, "fake").expect("Failed to publish concurrent parser");
+    drop(install);
+
+    let status = uninstall
+        .wait()
+        .expect("Failed to wait for uninstall command");
+    assert!(status.success(), "Uninstall --all should succeed");
+    assert!(
+        !parser.exists(),
+        "the authoritative snapshot must include the completed install"
+    );
+}
+
 #[cfg(unix)]
 fn assert_uninstall_all_fails_for_unreadable_dir(dir_name: &str) {
     use std::fs;

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1256,6 +1256,21 @@ fn test_language_uninstall_does_not_create_missing_data_dir() {
 }
 
 #[test]
+fn test_language_uninstall_rejects_unsafe_name_when_data_dir_is_missing() {
+    let parent = tempfile::tempdir().unwrap();
+    let data_dir = parent.path().join("missing");
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args(["language", "uninstall", "../../evil", "--data-dir"])
+        .arg(&data_dir)
+        .arg("--force")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(!data_dir.exists());
+}
+
+#[test]
 fn test_language_uninstall_all_coordinates_missing_data_dir() {
     use kakehashi::install::operation_lock::LanguageOperationGuard;
     use std::fs;

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1284,6 +1284,53 @@ fn test_language_install_rejects_unsafe_name_before_creating_data_dir() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn test_targeted_uninstall_revalidates_roots_after_confirmation() {
+    use std::fs;
+    use std::io::{Read, Write};
+    use std::os::unix::fs::symlink;
+    use std::process::Stdio;
+
+    let test_dir = tempfile::tempdir().unwrap();
+    let external = tempfile::tempdir().unwrap();
+    fs::create_dir_all(test_dir.path().join("parser")).unwrap();
+    fs::create_dir_all(test_dir.path().join("queries/lua")).unwrap();
+    let parser_name = format!("lua.{}", std::env::consts::DLL_EXTENSION);
+    fs::write(external.path().join(&parser_name), "keep").unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "lua",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let mut stderr = child.stderr.take().unwrap();
+    let mut prompt = Vec::new();
+    while !prompt.ends_with(b"[y/N] ") {
+        let mut byte = [0];
+        stderr.read_exact(&mut byte).unwrap();
+        prompt.push(byte[0]);
+    }
+
+    fs::remove_dir(test_dir.path().join("parser")).unwrap();
+    symlink(external.path(), test_dir.path().join("parser")).unwrap();
+    child.stdin.take().unwrap().write_all(b"y\n").unwrap();
+
+    assert!(!child.wait().unwrap().success());
+    assert_eq!(
+        fs::read_to_string(external.path().join(parser_name)).unwrap(),
+        "keep"
+    );
+}
+
 /// A bulk uninstall must include an install that starts after confirmation is
 /// requested but completes before its exclusive snapshot.
 #[test]

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1221,22 +1221,19 @@ fn test_language_uninstall_all() {
     assert!(queries.is_empty(), "All queries should be removed");
 }
 
-/// A bulk uninstall must rebuild its snapshot after waiting for an install
-/// operation that began while its preliminary discovery was in progress.
+/// A bulk uninstall must include an install that starts after confirmation is
+/// requested but completes before its exclusive snapshot.
 #[test]
 fn test_language_uninstall_all_includes_install_completed_before_exclusive_lock() {
     use kakehashi::install::operation_lock::LanguageOperationGuard;
     use std::fs;
-    use std::time::Duration;
+    use std::io::{Read, Write};
+    use std::process::Stdio;
 
     let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
     fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
     fs::create_dir_all(test_dir.path().join("queries")).expect("Failed to create queries dir");
 
-    // Model an install phase already in flight. Shared holders do not block
-    // preliminary discovery, but they do block the authoritative exclusive
-    // snapshot used by `--all`.
-    let install = LanguageOperationGuard::shared(test_dir.path()).unwrap();
     let mut uninstall = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
         .args([
             "language",
@@ -1244,15 +1241,28 @@ fn test_language_uninstall_all_includes_install_completed_before_exclusive_lock(
             "--all",
             "--data-dir",
             test_dir.path().to_str().unwrap(),
-            "--force",
         ])
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .expect("Failed to start uninstall command");
 
-    std::thread::sleep(Duration::from_millis(100));
+    let mut prompt = Vec::new();
+    let stderr = uninstall.stderr.as_mut().unwrap();
+    while !prompt.ends_with(b"[y/N] ") {
+        let mut byte = [0];
+        assert_eq!(stderr.read(&mut byte).unwrap(), 1, "prompt ended early");
+        prompt.push(byte[0]);
+    }
+
+    // This install starts after the prompt and holds the shared side while it
+    // publishes. After consent, uninstall must wait and include it in the
+    // authoritative exclusive snapshot.
+    let install = LanguageOperationGuard::shared(test_dir.path()).unwrap();
     let ext = std::env::consts::DLL_EXTENSION;
     let parser = test_dir.path().join(format!("parser/concurrent.{ext}"));
     fs::write(&parser, "fake").expect("Failed to publish concurrent parser");
+    uninstall.stdin.as_mut().unwrap().write_all(b"y\n").unwrap();
     drop(install);
 
     let status = uninstall

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1400,7 +1400,7 @@ fn test_language_uninstall_all_includes_install_completed_before_exclusive_lock(
         })?;
         Ok::<_, std::io::Error>(stderr)
     });
-    if prompt_rx.recv_timeout(Duration::from_secs(2)).is_err() {
+    if prompt_rx.recv_timeout(Duration::from_secs(30)).is_err() {
         let _ = uninstall.kill();
         panic!("timed out waiting for uninstall confirmation prompt");
     }

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1243,22 +1243,44 @@ fn test_language_uninstall_all() {
 #[test]
 fn test_language_uninstall_does_not_create_missing_data_dir() {
     let parent = tempfile::tempdir().unwrap();
+    let data_dir = parent.path().join("testlang");
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args(["language", "uninstall", "testlang", "--data-dir"])
+        .arg(&data_dir)
+        .arg("--force")
+        .output()
+        .unwrap();
 
-    for args in [vec!["--all"], vec!["testlang"]] {
-        let data_dir = parent.path().join(args[0].trim_start_matches('-'));
-        let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
-            .arg("language")
-            .arg("uninstall")
-            .args(&args)
-            .arg("--data-dir")
-            .arg(&data_dir)
-            .arg("--force")
-            .output()
-            .unwrap();
+    assert!(output.status.success());
+    assert!(!data_dir.exists(), "targeted uninstall must remain a no-op");
+}
 
-        assert!(output.status.success());
-        assert!(!data_dir.exists(), "uninstall must remain a no-op");
-    }
+#[test]
+fn test_language_uninstall_all_coordinates_missing_data_dir() {
+    use kakehashi::install::operation_lock::LanguageOperationGuard;
+    use std::fs;
+
+    let parent = tempfile::tempdir().unwrap();
+    let data_dir = parent.path().join("missing");
+    let install = LanguageOperationGuard::shared(&data_dir).unwrap();
+    fs::create_dir_all(data_dir.join("parser")).unwrap();
+    let parser = data_dir
+        .join("parser")
+        .join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+    fs::write(&parser, "parser").unwrap();
+
+    let mut uninstall = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args(["language", "uninstall", "--all", "--data-dir"])
+        .arg(&data_dir)
+        .arg("--force")
+        .spawn()
+        .unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    assert!(uninstall.try_wait().unwrap().is_none());
+
+    drop(install);
+    assert!(uninstall.wait().unwrap().success());
+    assert!(!parser.exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add a data-directory shared/exclusive operation lock and document its ordering contract
- make parser/query install phases and targeted uninstall use shared coordination
- make `language uninstall --all` recover, rescan, remove, and verify under an exclusive lock
- avoid holding the operation lock while waiting for confirmation

## Why

`language uninstall --all` previously removed a discovery snapshot. An install for another language could finish after discovery and remain even though the command reported success. The exclusive authoritative snapshot gives the operation a precise verified-empty linearization point.

## Testing

- `cargo test --test test_cli test_language_uninstall_all -- --nocapture`
- `cargo test --lib install::operation_lock::tests -- --nocapture`
- `make check`

Closes #774

## Stack

Draft and stacked on #772 because that PR defines the strict uninstall discovery/recovery behavior this operation synchronizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved coordination between language installation, status checks, and uninstallation when operations run concurrently.
  - `language uninstall --all` now reliably removes languages installed during the operation and verifies that no languages remain afterward.
  - Added safeguards to prevent conflicting install and uninstall actions from producing inconsistent results.

- **Documentation**
  - Added architecture documentation describing operation locking, concurrency behavior, and validation expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->