### PR TITLE
fix(cli): detect shebang files in directory walks

### DIFF
--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -240,7 +240,7 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &DiagnoseOptions) ->
     }
 
     let collected = match collect_files(cwd, &options.paths, &options.excludes, &|path| {
-        server.cli_can_handle_path(path)
+        server.cli_can_handle_discovered_file(path)
     }) {
         Ok(collected) => collected,
         Err(e) => {

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -82,8 +82,8 @@ fn build_exclude_matcher(
 ///   it.
 /// - A directory is walked respecting `.gitignore` (even outside a git
 ///   repository), hidden-file filtering, and `--excludes`; only files for
-///   which `is_supported` returns true (language detectable from the path)
-///   are kept.
+///   which `is_supported` returns true are kept. The callback may inspect file
+///   content when support cannot be determined from the path alone.
 /// - A path that does not exist is an error.
 ///
 /// The files are sorted and deduplicated for deterministic processing order.
@@ -178,7 +178,8 @@ fn is_excluded(
 }
 
 /// Walk `dir` respecting `.gitignore` and `--excludes`, appending every
-/// supported file to `out`. Unreadable entries are reported and counted so
+/// supported file to `out`. Support checks may inspect file content. Unreadable
+/// walker entries are reported and counted so
 /// callers can surface an operational-error exit code after processing the
 /// files that were still discoverable.
 fn walk_directory(

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -253,7 +253,7 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
     }
 
     let collected = match collect_files(cwd, &options.paths, &options.excludes, &|path| {
-        server.cli_can_handle_path(path)
+        server.cli_can_handle_discovered_file(path)
     }) {
         Ok(collected) => collected,
         Err(e) => {

--- a/src/language/heuristic.rs
+++ b/src/language/heuristic.rs
@@ -107,6 +107,7 @@ mod tests {
     #[case::shebang_node("#!/usr/bin/env node\nconsole.log('hello')", Some("javascript"))]
     #[case::shebang_ruby("#!/usr/bin/env ruby\nputs 'hello'", Some("ruby"))]
     #[case::shebang_perl("#!/usr/bin/perl\nprint 'hello';", Some("perl"))]
+    #[case::cpp_mode_line("    -*- C++ -*-", Some("cpp"))]
     #[case::no_shebang_code("print('hello')", None)]
     #[case::no_shebang_empty("", None)]
     fn test_detect_from_first_line(#[case] content: &str, #[case] expected: Option<&str>) {

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -72,7 +72,9 @@ impl Kakehashi {
     /// Whether a file discovered during a directory walk identifies a known
     /// language by path or by its first line. Only path misses read content,
     /// and only the first line is materialized, matching explicit-file shebang
-    /// and mode-line detection without reading the full document.
+    /// and mode-line detection without reading the full document. Files whose
+    /// first-line I/O fails are retained so the command's normal read path can
+    /// report the operational error; invalid UTF-8 is filtered as non-text.
     pub(crate) fn cli_can_handle_discovered_file(&self, path: &Path) -> bool {
         use std::io::BufRead as _;
 

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -70,14 +70,14 @@ impl Kakehashi {
     }
 
     /// Whether a file discovered during a directory walk identifies a known
-    /// language by path or by a bounded first-line probe. Only path misses read
-    /// content. Files whose probe is truncated are retained for authoritative
-    /// detection during normal processing, preserving explicit-file parity
-    /// without unbounded allocation during discovery. Files whose
+    /// language by path or by a memory-bounded streaming scan of its first
+    /// line. Only path misses read content. The scan keeps overlapping windows
+    /// so shebangs and mode markers beyond the first buffer remain detectable
+    /// without retaining an arbitrarily long line. Files whose
     /// first-line I/O fails are retained so the command's normal read path can
     /// report the operational error; invalid UTF-8 is filtered as non-text.
     pub(crate) fn cli_can_handle_discovered_file(&self, path: &Path) -> bool {
-        use std::io::{BufRead as _, Read as _};
+        use std::io::Read as _;
 
         if self.cli_can_handle_path(path) {
             return true;
@@ -88,36 +88,51 @@ impl Kakehashi {
             // unsupported language.
             return true;
         };
-        const MAX_FIRST_LINE_BYTES: usize = 8 * 1024;
-        let mut first_line = Vec::new();
-        if std::io::BufReader::new(file)
-            .take((MAX_FIRST_LINE_BYTES + 1) as u64)
-            .read_until(b'\n', &mut first_line)
-            .is_err()
-        {
-            return true;
-        }
-        let truncated = first_line.len() > MAX_FIRST_LINE_BYTES;
-        let probe = &first_line[..first_line.len().min(MAX_FIRST_LINE_BYTES)];
-        let first_line = match std::str::from_utf8(probe) {
-            Ok(line) => line,
-            // A valid multibyte character may straddle the hard probe boundary.
-            Err(error) if truncated && error.error_len().is_none() => {
-                std::str::from_utf8(&probe[..error.valid_up_to()])
-                    .expect("valid_up_to always identifies valid UTF-8")
+        const READ_CHUNK_BYTES: usize = 4 * 1024;
+        const WINDOW_BYTES: usize = 8 * 1024;
+        let path = path.to_string_lossy();
+        let mut reader = std::io::BufReader::new(file);
+        let mut chunk = [0; READ_CHUNK_BYTES];
+        let mut window = Vec::with_capacity(WINDOW_BYTES + READ_CHUNK_BYTES);
+        loop {
+            let read = match reader.read(&mut chunk) {
+                Ok(0) => return false,
+                Ok(read) => read,
+                Err(_) => return true,
+            };
+            let line_end = chunk[..read]
+                .iter()
+                .position(|byte| *byte == b'\n')
+                .map_or(read, |index| index + 1);
+            window.extend_from_slice(&chunk[..line_end]);
+
+            let valid = match std::str::from_utf8(&window) {
+                Ok(valid) => valid,
+                Err(error) if error.error_len().is_none() => {
+                    std::str::from_utf8(&window[..error.valid_up_to()])
+                        .expect("valid_up_to always identifies valid UTF-8")
+                }
+                Err(_) => return false,
+            };
+            if self
+                .language
+                .loadable_language_for_document(&path, valid)
+                .is_some()
+            {
+                return true;
             }
-            // Unknown extensionless binary content cannot participate in text
-            // language detection.
-            Err(_) => return false,
-        };
-        if truncated {
-            // Syntect mode markers can occur after the probe. Keep valid text
-            // so the normal full-document path makes the authoritative choice.
-            return true;
+            if line_end < read || chunk[..line_end].ends_with(b"\n") {
+                return false;
+            }
+
+            if window.len() > WINDOW_BYTES {
+                let mut keep_from = window.len() - WINDOW_BYTES;
+                while keep_from < window.len() && (window[keep_from] & 0b1100_0000) == 0b1000_0000 {
+                    keep_from += 1;
+                }
+                window.drain(..keep_from);
+            }
         }
-        self.language
-            .loadable_language_for_document(&path.to_string_lossy(), first_line)
-            .is_some()
     }
 
     /// Gracefully shut down downstream language servers (LSP shutdown/exit

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -77,10 +77,13 @@ impl Kakehashi {
     /// first-line I/O fails are retained so the command's normal read path can
     /// report the operational error; invalid UTF-8 is filtered as non-text.
     pub(crate) fn cli_can_handle_discovered_file(&self, path: &Path) -> bool {
-        use std::io::Read as _;
+        use std::io::{BufRead as _, Read as _};
 
         if self.cli_can_handle_path(path) {
             return true;
+        }
+        if path.extension().is_some() {
+            return false;
         }
         let Ok(file) = std::fs::File::open(path) else {
             // Keep the candidate so the command's normal read path reports
@@ -93,7 +96,7 @@ impl Kakehashi {
         let mut probe = Vec::with_capacity(MAX_FIRST_LINE_BYTES + 1);
         if std::io::BufReader::new(file)
             .take((MAX_FIRST_LINE_BYTES + 1) as u64)
-            .read_to_end(&mut probe)
+            .read_until(b'\n', &mut probe)
             .is_err()
         {
             return true;

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -70,10 +70,10 @@ impl Kakehashi {
     }
 
     /// Whether a file discovered during a directory walk identifies a known
-    /// language by path or by a bounded prefix of its first line. Content is
-    /// read only when path-based detection fails. The hard cap keeps traversal
-    /// from scanning arbitrarily large extensionless files; explicitly named
-    /// files remain authoritative for mode markers beyond the cap. Files whose
+    /// language by path or, for an extensionless path, by a bounded prefix of
+    /// its first line. Content is read only when path-based detection fails.
+    /// The hard cap keeps traversal from scanning arbitrarily large files;
+    /// explicitly named files remain authoritative for markers beyond the cap. Files whose
     /// first-line I/O fails are retained so the command's normal read path can
     /// report the operational error; invalid UTF-8 is filtered as non-text.
     pub(crate) fn cli_can_handle_discovered_file(&self, path: &Path) -> bool {

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -78,7 +78,7 @@ impl Kakehashi {
         if self.cli_can_handle_path(path) {
             return true;
         }
-        const MAX_FIRST_LINE_BYTES: u64 = 8 * 1024;
+        const MAX_FIRST_LINE_BYTES: usize = 8 * 1024;
         let Ok(file) = std::fs::File::open(path) else {
             // Keep the candidate so the command's normal read path reports
             // the operational error instead of silently treating it as an
@@ -87,10 +87,16 @@ impl Kakehashi {
         };
         let mut first_line = Vec::new();
         if std::io::BufReader::new(file)
-            .take(MAX_FIRST_LINE_BYTES)
+            .take((MAX_FIRST_LINE_BYTES + 1) as u64)
             .read_until(b'\n', &mut first_line)
             .is_err()
         {
+            return true;
+        }
+        if first_line.len() > MAX_FIRST_LINE_BYTES {
+            // Preserve exact explicit-file semantics without making directory
+            // filtering allocate an unbounded line: let normal processing read
+            // the full document and perform its existing content detection.
             return true;
         }
         let first_line = String::from_utf8_lossy(&first_line);

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -70,8 +70,8 @@ impl Kakehashi {
     }
 
     /// Whether a file discovered during a directory walk identifies a known
-    /// language by path or by a bounded prefix of its first line. Only path
-    /// misses read content. The hard cap keeps ordinary directory traversal
+    /// language by path or by a bounded prefix of its first line. Content is
+    /// read only when path-based detection fails. The hard cap keeps traversal
     /// from scanning arbitrarily large extensionless files; explicitly named
     /// files remain authoritative for mode markers beyond the cap. Files whose
     /// first-line I/O fails are retained so the command's normal read path can

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -70,15 +70,15 @@ impl Kakehashi {
     }
 
     /// Whether a file discovered during a directory walk identifies a known
-    /// language by path or by its first line. The bounded read keeps filtering
-    /// cheap while matching explicit-file shebang and mode-line detection.
+    /// language by path or by its first line. Only path misses read content,
+    /// and only the first line is materialized, matching explicit-file shebang
+    /// and mode-line detection without reading the full document.
     pub(crate) fn cli_can_handle_discovered_file(&self, path: &Path) -> bool {
-        use std::io::{BufRead as _, Read as _};
+        use std::io::BufRead as _;
 
         if self.cli_can_handle_path(path) {
             return true;
         }
-        const MAX_FIRST_LINE_BYTES: usize = 8 * 1024;
         let Ok(file) = std::fs::File::open(path) else {
             // Keep the candidate so the command's normal read path reports
             // the operational error instead of silently treating it as an
@@ -87,21 +87,18 @@ impl Kakehashi {
         };
         let mut first_line = Vec::new();
         if std::io::BufReader::new(file)
-            .take((MAX_FIRST_LINE_BYTES + 1) as u64)
             .read_until(b'\n', &mut first_line)
             .is_err()
         {
             return true;
         }
-        if first_line.len() > MAX_FIRST_LINE_BYTES {
-            // Preserve exact explicit-file semantics without making directory
-            // filtering allocate an unbounded line: let normal processing read
-            // the full document and perform its existing content detection.
-            return true;
-        }
-        let first_line = String::from_utf8_lossy(&first_line);
+        let Ok(first_line) = std::str::from_utf8(&first_line) else {
+            // An unknown extensionless binary is not an operational read
+            // failure and cannot participate in text language detection.
+            return false;
+        };
         self.language
-            .loadable_language_for_document(&path.to_string_lossy(), &first_line)
+            .loadable_language_for_document(&path.to_string_lossy(), first_line)
             .is_some()
     }
 

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -69,6 +69,32 @@ impl Kakehashi {
             .is_some()
     }
 
+    /// Whether a file discovered during a directory walk identifies a known
+    /// language by path or by its first line. The bounded read keeps filtering
+    /// cheap while matching explicit-file shebang and mode-line detection.
+    pub(crate) fn cli_can_handle_discovered_file(&self, path: &Path) -> bool {
+        use std::io::{BufRead as _, Read as _};
+
+        if self.cli_can_handle_path(path) {
+            return true;
+        }
+        const MAX_FIRST_LINE_BYTES: u64 = 8 * 1024;
+        let Ok(file) = std::fs::File::open(path) else {
+            return false;
+        };
+        let mut first_line = String::new();
+        if std::io::BufReader::new(file)
+            .take(MAX_FIRST_LINE_BYTES)
+            .read_line(&mut first_line)
+            .is_err()
+        {
+            return false;
+        }
+        self.language
+            .loadable_language_for_document(&path.to_string_lossy(), &first_line)
+            .is_some()
+    }
+
     /// Gracefully shut down downstream language servers (LSP shutdown/exit
     /// handshake, escalating for unresponsive ones).
     pub(crate) async fn cli_shutdown(&self) {

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -94,8 +94,7 @@ impl Kakehashi {
         const MAX_FIRST_LINE_BYTES: usize = 8 * 1024;
         let path_text = path.to_string_lossy();
         let mut probe = Vec::with_capacity(MAX_FIRST_LINE_BYTES + 1);
-        if std::io::BufReader::new(file)
-            .take((MAX_FIRST_LINE_BYTES + 1) as u64)
+        if std::io::BufReader::new(file.take((MAX_FIRST_LINE_BYTES + 1) as u64))
             .read_until(b'\n', &mut probe)
             .is_err()
         {

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -85,14 +85,15 @@ impl Kakehashi {
             // unsupported language.
             return true;
         };
-        let mut first_line = String::new();
+        let mut first_line = Vec::new();
         if std::io::BufReader::new(file)
             .take(MAX_FIRST_LINE_BYTES)
-            .read_line(&mut first_line)
+            .read_until(b'\n', &mut first_line)
             .is_err()
         {
             return true;
         }
+        let first_line = String::from_utf8_lossy(&first_line);
         self.language
             .loadable_language_for_document(&path.to_string_lossy(), &first_line)
             .is_some()

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -89,7 +89,7 @@ impl Kakehashi {
             return true;
         };
         const MAX_FIRST_LINE_BYTES: usize = 8 * 1024;
-        let path = path.to_string_lossy();
+        let path_text = path.to_string_lossy();
         let mut probe = Vec::with_capacity(MAX_FIRST_LINE_BYTES + 1);
         if std::io::BufReader::new(file)
             .take((MAX_FIRST_LINE_BYTES + 1) as u64)
@@ -109,7 +109,7 @@ impl Kakehashi {
             Err(_) => return false,
         };
         self.language
-            .loadable_language_for_document(&path, valid)
+            .loadable_language_for_document(&path_text, valid)
             .is_some()
     }
 

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -86,6 +86,11 @@ impl Kakehashi {
             return true;
         };
         let mut first_line = Vec::new();
+        // Intentionally read the complete first line: syntect's first-line
+        // rules include mode markers that may occur near its end, and applying
+        // a different cutoff here would recreate explicit-vs-directory drift.
+        // This runs only for path-detection misses, one file at a time, and
+        // retains less data than normal processing (which reads the full file).
         if std::io::BufReader::new(file)
             .read_until(b'\n', &mut first_line)
             .is_err()

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -80,7 +80,10 @@ impl Kakehashi {
         }
         const MAX_FIRST_LINE_BYTES: u64 = 8 * 1024;
         let Ok(file) = std::fs::File::open(path) else {
-            return false;
+            // Keep the candidate so the command's normal read path reports
+            // the operational error instead of silently treating it as an
+            // unsupported language.
+            return true;
         };
         let mut first_line = String::new();
         if std::io::BufReader::new(file)
@@ -88,7 +91,7 @@ impl Kakehashi {
             .read_line(&mut first_line)
             .is_err()
         {
-            return false;
+            return true;
         }
         self.language
             .loadable_language_for_document(&path.to_string_lossy(), &first_line)

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -70,10 +70,10 @@ impl Kakehashi {
     }
 
     /// Whether a file discovered during a directory walk identifies a known
-    /// language by path or by a memory-bounded streaming scan of its first
-    /// line. Only path misses read content. The scan keeps overlapping windows
-    /// so shebangs and mode markers beyond the first buffer remain detectable
-    /// without retaining an arbitrarily long line. Files whose
+    /// language by path or by a bounded prefix of its first line. Only path
+    /// misses read content. The hard cap keeps ordinary directory traversal
+    /// from scanning arbitrarily large extensionless files; explicitly named
+    /// files remain authoritative for mode markers beyond the cap. Files whose
     /// first-line I/O fails are retained so the command's normal read path can
     /// report the operational error; invalid UTF-8 is filtered as non-text.
     pub(crate) fn cli_can_handle_discovered_file(&self, path: &Path) -> bool {
@@ -88,51 +88,29 @@ impl Kakehashi {
             // unsupported language.
             return true;
         };
-        const READ_CHUNK_BYTES: usize = 4 * 1024;
-        const WINDOW_BYTES: usize = 8 * 1024;
+        const MAX_FIRST_LINE_BYTES: usize = 8 * 1024;
         let path = path.to_string_lossy();
-        let mut reader = std::io::BufReader::new(file);
-        let mut chunk = [0; READ_CHUNK_BYTES];
-        let mut window = Vec::with_capacity(WINDOW_BYTES + READ_CHUNK_BYTES);
-        loop {
-            let read = match reader.read(&mut chunk) {
-                Ok(0) => return false,
-                Ok(read) => read,
-                Err(_) => return true,
-            };
-            let line_end = chunk[..read]
-                .iter()
-                .position(|byte| *byte == b'\n')
-                .map_or(read, |index| index + 1);
-            window.extend_from_slice(&chunk[..line_end]);
-
-            let valid = match std::str::from_utf8(&window) {
-                Ok(valid) => valid,
-                Err(error) if error.error_len().is_none() => {
-                    std::str::from_utf8(&window[..error.valid_up_to()])
-                        .expect("valid_up_to always identifies valid UTF-8")
-                }
-                Err(_) => return false,
-            };
-            if self
-                .language
-                .loadable_language_for_document(&path, valid)
-                .is_some()
-            {
-                return true;
-            }
-            if line_end < read || chunk[..line_end].ends_with(b"\n") {
-                return false;
-            }
-
-            if window.len() > WINDOW_BYTES {
-                let mut keep_from = window.len() - WINDOW_BYTES;
-                while keep_from < window.len() && (window[keep_from] & 0b1100_0000) == 0b1000_0000 {
-                    keep_from += 1;
-                }
-                window.drain(..keep_from);
-            }
+        let mut probe = Vec::with_capacity(MAX_FIRST_LINE_BYTES + 1);
+        if std::io::BufReader::new(file)
+            .take((MAX_FIRST_LINE_BYTES + 1) as u64)
+            .read_to_end(&mut probe)
+            .is_err()
+        {
+            return true;
         }
+        let truncated = probe.len() > MAX_FIRST_LINE_BYTES;
+        probe.truncate(MAX_FIRST_LINE_BYTES);
+        let valid = match std::str::from_utf8(&probe) {
+            Ok(valid) => valid,
+            Err(error) if truncated && error.error_len().is_none() => {
+                std::str::from_utf8(&probe[..error.valid_up_to()])
+                    .expect("valid_up_to always identifies valid UTF-8")
+            }
+            Err(_) => return false,
+        };
+        self.language
+            .loadable_language_for_document(&path, valid)
+            .is_some()
     }
 
     /// Gracefully shut down downstream language servers (LSP shutdown/exit

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -70,13 +70,14 @@ impl Kakehashi {
     }
 
     /// Whether a file discovered during a directory walk identifies a known
-    /// language by path or by its first line. Only path misses read content,
-    /// and only the first line is materialized, matching explicit-file shebang
-    /// and mode-line detection without reading the full document. Files whose
+    /// language by path or by a bounded first-line probe. Only path misses read
+    /// content. Files whose probe is truncated are retained for authoritative
+    /// detection during normal processing, preserving explicit-file parity
+    /// without unbounded allocation during discovery. Files whose
     /// first-line I/O fails are retained so the command's normal read path can
     /// report the operational error; invalid UTF-8 is filtered as non-text.
     pub(crate) fn cli_can_handle_discovered_file(&self, path: &Path) -> bool {
-        use std::io::BufRead as _;
+        use std::io::{BufRead as _, Read as _};
 
         if self.cli_can_handle_path(path) {
             return true;
@@ -87,23 +88,33 @@ impl Kakehashi {
             // unsupported language.
             return true;
         };
+        const MAX_FIRST_LINE_BYTES: usize = 8 * 1024;
         let mut first_line = Vec::new();
-        // Intentionally read the complete first line: syntect's first-line
-        // rules include mode markers that may occur near its end, and applying
-        // a different cutoff here would recreate explicit-vs-directory drift.
-        // This runs only for path-detection misses, one file at a time, and
-        // retains less data than normal processing (which reads the full file).
         if std::io::BufReader::new(file)
+            .take((MAX_FIRST_LINE_BYTES + 1) as u64)
             .read_until(b'\n', &mut first_line)
             .is_err()
         {
             return true;
         }
-        let Ok(first_line) = std::str::from_utf8(&first_line) else {
-            // An unknown extensionless binary is not an operational read
-            // failure and cannot participate in text language detection.
-            return false;
+        let truncated = first_line.len() > MAX_FIRST_LINE_BYTES;
+        let probe = &first_line[..first_line.len().min(MAX_FIRST_LINE_BYTES)];
+        let first_line = match std::str::from_utf8(probe) {
+            Ok(line) => line,
+            // A valid multibyte character may straddle the hard probe boundary.
+            Err(error) if truncated && error.error_len().is_none() => {
+                std::str::from_utf8(&probe[..error.valid_up_to()])
+                    .expect("valid_up_to always identifies valid UTF-8")
+            }
+            // Unknown extensionless binary content cannot participate in text
+            // language detection.
+            Err(_) => return false,
         };
+        if truncated {
+            // Syntect mode markers can occur after the probe. Keep valid text
+            // so the normal full-document path makes the authoritative choice.
+            return true;
+        }
         self.language
             .loadable_language_for_document(&path.to_string_lossy(), first_line)
             .is_some()

--- a/tests/e2e_cli_diagnose.rs
+++ b/tests/e2e_cli_diagnose.rs
@@ -594,3 +594,26 @@ fn e2e_diagnose_directory_walk_respects_gitignore_but_explicit_path_wins() {
         stdout_of(&output)
     );
 }
+
+#[test]
+fn e2e_diagnose_directory_walk_includes_extensionless_shebang_file() {
+    let config = config_toml().replace("languages = [\"lua\"]", "languages = [\"python\"]");
+    let ws = workspace_with(
+        &config,
+        &[("tool", "#!/usr/bin/env python\nvalue = 1\n")],
+    );
+
+    let output = run_diagnose(ws.path(), &[".", "--fail-on-warning"]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "directory walk should diagnose the shebang file; stderr: {}",
+        stderr_of(&output)
+    );
+    assert!(
+        stdout_of(&output).contains("tool:1:1: warning:"),
+        "diagnostic should name the extensionless file; stdout: {}",
+        stdout_of(&output)
+    );
+}

--- a/tests/e2e_cli_diagnose.rs
+++ b/tests/e2e_cli_diagnose.rs
@@ -598,10 +598,7 @@ fn e2e_diagnose_directory_walk_respects_gitignore_but_explicit_path_wins() {
 #[test]
 fn e2e_diagnose_directory_walk_includes_extensionless_shebang_file() {
     let config = config_toml().replace("languages = [\"lua\"]", "languages = [\"python\"]");
-    let ws = workspace_with(
-        &config,
-        &[("tool", "#!/usr/bin/env python\nvalue = 1\n")],
-    );
+    let ws = workspace_with(&config, &[("tool", "#!/usr/bin/env python\nvalue = 1\n")]);
 
     let output = run_diagnose(ws.path(), &[".", "--fail-on-warning"]);
 

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -349,9 +349,7 @@ fn e2e_directory_walk_formats_extensionless_shebang_file() {
     std::fs::write(ws.path().join("unknown"), &unknown).expect("write unknown text file");
     let sparse_path = ws.path().join("binary");
     let sparse = std::fs::File::create(&sparse_path).expect("create extensionless sparse binary");
-    sparse
-        .set_len(64 * 1024 * 1024)
-        .expect("size sparse binary");
+    sparse.set_len(16 * 1024).expect("size sparse binary");
     drop(sparse);
     use std::io::{Seek as _, Write as _};
     let mut sparse = std::fs::OpenOptions::new()

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -346,8 +346,21 @@ fn e2e_directory_walk_formats_extensionless_shebang_file() {
     let ws = workspace_with(&[("tool", &source)]);
     let unknown = "x".repeat(9 * 1024);
     std::fs::write(ws.path().join("unknown"), &unknown).expect("write unknown text file");
-    std::fs::write(ws.path().join("binary"), vec![0xff; 9 * 1024])
-        .expect("write extensionless binary");
+    let sparse_path = ws.path().join("binary");
+    let sparse = std::fs::File::create(&sparse_path).expect("create extensionless sparse binary");
+    sparse
+        .set_len(64 * 1024 * 1024)
+        .expect("size sparse binary");
+    drop(sparse);
+    use std::io::{Seek as _, Write as _};
+    let mut sparse = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&sparse_path)
+        .expect("open sparse binary");
+    sparse
+        .seek(std::io::SeekFrom::Start(0))
+        .expect("seek sparse binary");
+    sparse.write_all(&[0xff]).expect("mark sparse as binary");
     std::fs::write(
         ws.path().join("kakehashi.toml"),
         config_toml().replace("languages = [\"lua\"]", "languages = [\"python\"]"),

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -336,6 +336,31 @@ fn e2e_directory_walk_respects_gitignore_but_explicit_path_wins() {
 }
 
 #[test]
+fn e2e_directory_walk_formats_extensionless_shebang_file() {
+    let source = "#!/usr/bin/env python\nvalue = 1\n";
+    let ws = workspace_with(&[("tool", source)]);
+    std::fs::write(
+        ws.path().join("kakehashi.toml"),
+        config_toml().replace("languages = [\"lua\"]", "languages = [\"python\"]"),
+    )
+    .expect("write Python formatter config");
+
+    let output = run_format(ws.path(), &["."]);
+
+    assert!(
+        output.status.success(),
+        "directory format should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        read(ws.path(), "tool").starts_with("#!/USR/BIN/ENV PYTHON"),
+        "directory walk should use shebang detection; content: {:?}; stderr: {}",
+        read(ws.path(), "tool"),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn e2e_tab_size_and_insert_spaces_reach_the_downstream_server() {
     // Workspace whose mock server echoes the FormattingOptions it received.
     let ws = workspace_with(&[("doc.md", MARKDOWN)]);

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -344,6 +344,10 @@ fn e2e_directory_walk_formats_extensionless_shebang_file() {
     // or silently skipping the valid UTF-8 file.
     let source = format!("{prefix}{padding}é\nvalue = 1\n");
     let ws = workspace_with(&[("tool", &source)]);
+    let unknown = "x".repeat(9 * 1024);
+    std::fs::write(ws.path().join("unknown"), &unknown).expect("write unknown text file");
+    std::fs::write(ws.path().join("binary"), vec![0xff; 9 * 1024])
+        .expect("write extensionless binary");
     std::fs::write(
         ws.path().join("kakehashi.toml"),
         config_toml().replace("languages = [\"lua\"]", "languages = [\"python\"]"),
@@ -363,6 +367,7 @@ fn e2e_directory_walk_formats_extensionless_shebang_file() {
         read(ws.path(), "tool"),
         String::from_utf8_lossy(&output.stderr)
     );
+    assert_eq!(read(ws.path(), "unknown"), unknown);
 }
 
 #[test]

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -337,8 +337,13 @@ fn e2e_directory_walk_respects_gitignore_but_explicit_path_wins() {
 
 #[test]
 fn e2e_directory_walk_formats_extensionless_shebang_file() {
-    let source = "#!/usr/bin/env python\nvalue = 1\n";
-    let ws = workspace_with(&[("tool", source)]);
+    let prefix = "#!/usr/bin/env python ";
+    let padding = " ".repeat(8191 - prefix.len());
+    // Byte 8192 cuts through this multibyte character. Directory discovery
+    // must fall back to normal full-document detection instead of rejecting
+    // or silently skipping the valid UTF-8 file.
+    let source = format!("{prefix}{padding}é\nvalue = 1\n");
+    let ws = workspace_with(&[("tool", &source)]);
     std::fs::write(
         ws.path().join("kakehashi.toml"),
         config_toml().replace("languages = [\"lua\"]", "languages = [\"python\"]"),

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -339,9 +339,9 @@ fn e2e_directory_walk_respects_gitignore_but_explicit_path_wins() {
 fn e2e_directory_walk_formats_extensionless_shebang_file() {
     let prefix = "#!/usr/bin/env python ";
     let padding = " ".repeat(8191 - prefix.len());
-    // BufReader's 8 KiB internal read boundary cuts through this multibyte
-    // character. Discovery must continue assembling the complete valid UTF-8
-    // first line and still detect its shebang language.
+    // The hard 8 KiB probe boundary cuts through this multibyte character.
+    // Discovery must validate the complete prefix and still detect the
+    // shebang language without treating the split code point as binary.
     let source = format!("{prefix}{padding}é\nvalue = 1\n");
     let late_mode_line = format!("{}-*- C++ -*-\nvalue = 2\n", " ".repeat(12 * 1024));
     let ws = workspace_with(&[("tool", &source), ("modeline", &late_mode_line)]);
@@ -387,11 +387,19 @@ fn e2e_directory_walk_formats_extensionless_shebang_file() {
     );
     assert_eq!(read(ws.path(), "modeline"), late_mode_line);
     assert!(
-        String::from_utf8_lossy(&output.stderr).contains("1 unchanged"),
-        "the late mode-line file should be collected even though no formatter applies; stderr: {}",
+        String::from_utf8_lossy(&output.stderr).contains("0 unchanged"),
+        "directory discovery should skip markers beyond its bounded prefix; stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
     assert_eq!(read(ws.path(), "unknown"), unknown);
+
+    let explicit = run_format(ws.path(), &["modeline"]);
+    assert!(explicit.status.success());
+    assert!(
+        String::from_utf8_lossy(&explicit.stderr).contains("1 unchanged"),
+        "an explicit path must still use full first-line detection; stderr: {}",
+        String::from_utf8_lossy(&explicit.stderr)
+    );
 }
 
 #[test]

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -339,9 +339,9 @@ fn e2e_directory_walk_respects_gitignore_but_explicit_path_wins() {
 fn e2e_directory_walk_formats_extensionless_shebang_file() {
     let prefix = "#!/usr/bin/env python ";
     let padding = " ".repeat(8191 - prefix.len());
-    // Byte 8192 cuts through this multibyte character. Directory discovery
-    // must fall back to normal full-document detection instead of rejecting
-    // or silently skipping the valid UTF-8 file.
+    // BufReader's 8 KiB internal read boundary cuts through this multibyte
+    // character. Discovery must continue assembling the complete valid UTF-8
+    // first line and still detect its shebang language.
     let source = format!("{prefix}{padding}é\nvalue = 1\n");
     let ws = workspace_with(&[("tool", &source)]);
     let unknown = "x".repeat(9 * 1024);

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -365,8 +365,11 @@ fn e2e_directory_walk_formats_extensionless_shebang_file() {
     std::fs::write(
         ws.path().join("kakehashi.toml"),
         format!(
-            "{}\n[languages.cpp]\nbase = \"lua\"\n",
-            config_toml().replace("languages = [\"lua\"]", "languages = [\"python\", \"lua\"]")
+            "{}\n[languages.cpp]\nbase = \"lua\"\n\n[languages.cpp.bridge._self]\nenabled = true\n",
+            config_toml().replace(
+                "languages = [\"lua\"]",
+                "languages = [\"python\", \"lua\", \"cpp\"]"
+            )
         ),
     )
     .expect("write Python formatter config");
@@ -396,8 +399,8 @@ fn e2e_directory_walk_formats_extensionless_shebang_file() {
     let explicit = run_format(ws.path(), &["modeline"]);
     assert!(explicit.status.success());
     assert!(
-        String::from_utf8_lossy(&explicit.stderr).contains("1 unchanged"),
-        "an explicit path must still use full first-line detection; stderr: {}",
+        read(ws.path(), "modeline").contains("-*- C++ -*-\nVALUE = 2"),
+        "an explicit path must use full first-line detection and formatting; stderr: {}",
         String::from_utf8_lossy(&explicit.stderr)
     );
 }

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -361,10 +361,11 @@ fn e2e_directory_walk_formats_extensionless_shebang_file() {
         "directory format should succeed; stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+    let formatted = read(ws.path(), "tool");
     assert!(
-        read(ws.path(), "tool").starts_with("#!/USR/BIN/ENV PYTHON"),
+        formatted.starts_with("#!/USR/BIN/ENV PYTHON"),
         "directory walk should use shebang detection; content: {:?}; stderr: {}",
-        read(ws.path(), "tool"),
+        formatted,
         String::from_utf8_lossy(&output.stderr)
     );
     assert_eq!(read(ws.path(), "unknown"), unknown);

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -343,7 +343,8 @@ fn e2e_directory_walk_formats_extensionless_shebang_file() {
     // character. Discovery must continue assembling the complete valid UTF-8
     // first line and still detect its shebang language.
     let source = format!("{prefix}{padding}é\nvalue = 1\n");
-    let ws = workspace_with(&[("tool", &source)]);
+    let late_mode_line = format!("{}-*- C++ -*-\nvalue = 2\n", " ".repeat(12 * 1024));
+    let ws = workspace_with(&[("tool", &source), ("modeline", &late_mode_line)]);
     let unknown = "x".repeat(9 * 1024);
     std::fs::write(ws.path().join("unknown"), &unknown).expect("write unknown text file");
     let sparse_path = ws.path().join("binary");
@@ -363,7 +364,10 @@ fn e2e_directory_walk_formats_extensionless_shebang_file() {
     sparse.write_all(&[0xff]).expect("mark sparse as binary");
     std::fs::write(
         ws.path().join("kakehashi.toml"),
-        config_toml().replace("languages = [\"lua\"]", "languages = [\"python\"]"),
+        format!(
+            "{}\n[languages.cpp]\nbase = \"lua\"\n",
+            config_toml().replace("languages = [\"lua\"]", "languages = [\"python\", \"lua\"]")
+        ),
     )
     .expect("write Python formatter config");
 
@@ -379,6 +383,12 @@ fn e2e_directory_walk_formats_extensionless_shebang_file() {
         formatted.starts_with("#!/USR/BIN/ENV PYTHON"),
         "directory walk should use shebang detection; content: {:?}; stderr: {}",
         formatted,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(read(ws.path(), "modeline"), late_mode_line);
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("1 unchanged"),
+        "the late mode-line file should be collected even though no formatter applies; stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
     assert_eq!(read(ws.path(), "unknown"), unknown);


### PR DESCRIPTION
Closes #777.

## Summary
- let directory walks detect extensionless scripts from a bounded first-line prefix
- keep path-detectable files on the fast path and retain actual probe I/O failures for normal error reporting
- cap content discovery at 8 KiB so large newline-free extensionless files cannot cause unbounded discovery I/O or allocation
- preserve full-document first-line detection for explicitly named files, including mode markers beyond the directory-discovery cap
- cover format and diagnose directory shebang behavior, split UTF-8 boundaries, long unknown text, sparse binary input, and explicit late-marker fallback

## Contract
Directory discovery is intentionally bounded and may skip an extensionless file whose only language marker starts beyond 8 KiB. Explicit paths are a stronger signal and retain authoritative full-content detection.

## Validation
- `cargo test --lib language::heuristic::tests::test_detect_from_first_line::case_08_cpp_mode_line`
- `cargo test --features e2e --test e2e_cli_format e2e_directory_walk_formats_extensionless_shebang_file`
- `cargo test --features e2e --test e2e_cli_diagnose e2e_diagnose_directory_walk_includes_extensionless_shebang_file`
- `cargo clippy --lib -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI directory walking to detect supported extensionless files using first-line content, including shebangs.
  * Improved handling of UTF-8 boundaries and preserved error reporting for unreadable entries.
  * Refined directory formatting and diagnosis to skip unsupported, unknown, and binary files while recognizing valid modelines.

* **Documentation**
  * Clarified when file support checks may inspect file contents.

* **Tests**
  * Added coverage for extensionless files, boundary conditions, and C++ modeline detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->