### PR TITLE
fix(query): preserve broken asset presence

### DIFF
--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -998,11 +998,22 @@ impl LanguageCoordinator {
             filename,
         ) {
             Ok(r) => r,
-            Err(_) => {
-                debug!(
-                    "Query file {}/{} not found in search paths (this is normal if not provided)",
-                    ctx.language_id, filename
-                );
+            Err(err) => {
+                if QueryLoader::find_query_file(paths, ctx.language_id, filename).is_none() {
+                    debug!(
+                        "Query file {}/{} not found in search paths (this is normal if not provided)",
+                        ctx.language_id, filename
+                    );
+                } else {
+                    events.push(LanguageEvent::log(
+                        LanguageLogLevel::Warning,
+                        format!(
+                            "Failed to load {} query for {}: {err}",
+                            ctx.query_kind.name(),
+                            ctx.language_id
+                        ),
+                    ));
+                }
                 return;
             }
         };

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -998,22 +998,22 @@ impl LanguageCoordinator {
             filename,
         ) {
             Ok(r) => r,
+            Err(crate::language::query_loader::QueryLoadError::NotFound) => {
+                debug!(
+                    "Query file {}/{} not found in search paths (this is normal if not provided)",
+                    ctx.language_id, filename
+                );
+                return;
+            }
             Err(err) => {
-                if QueryLoader::find_query_file(paths, ctx.language_id, filename).is_none() {
-                    debug!(
-                        "Query file {}/{} not found in search paths (this is normal if not provided)",
-                        ctx.language_id, filename
-                    );
-                } else {
-                    events.push(LanguageEvent::log(
-                        LanguageLogLevel::Warning,
-                        format!(
-                            "Failed to load {} query for {}: {err}",
-                            ctx.query_kind.name(),
-                            ctx.language_id
-                        ),
-                    ));
-                }
+                events.push(LanguageEvent::log(
+                    LanguageLogLevel::Warning,
+                    format!(
+                        "Failed to load {} query for {}: {err}",
+                        ctx.query_kind.name(),
+                        ctx.language_id
+                    ),
+                ));
                 return;
             }
         };

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -560,6 +560,12 @@ mod tests {
             Some(query_file),
             "a broken configured asset must not be classified as ordinary absence"
         );
+
+        let error = QueryLoader::load_query_file(&[dir.path()], "rust", "highlights.scm")
+            .expect_err("the present-but-broken asset must surface its read failure");
+        let message = error.to_string();
+        assert!(message.contains("Failed to read query file"), "{message}");
+        assert!(message.contains("highlights.scm"), "{message}");
     }
 
     #[test]

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -228,8 +228,13 @@ impl QueryLoader {
         }
         for base in runtime_bases {
             let candidate = Self::query_file_path(base.as_ref(), lang_name, file_name);
-            if candidate.exists() {
-                return Some(candidate);
+            match fs::symlink_metadata(&candidate) {
+                Ok(_) => return Some(candidate),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                // Presence probing must not downgrade inaccessible/broken
+                // assets to an ordinary optional-kind absence. Return the
+                // candidate so the real read reports its concrete I/O error.
+                Err(_) => return Some(candidate),
             }
         }
         None

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -67,6 +67,14 @@ pub(crate) struct ParseResult {
     pub used_inheritance: bool,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum QueryLoadError {
+    #[error("query file not found")]
+    NotFound,
+    #[error(transparent)]
+    Other(#[from] LspError),
+}
+
 /// Format search paths for display in error messages.
 pub(crate) fn format_search_paths<P: AsRef<Path>>(paths: &[P]) -> String {
     if paths.is_empty() {
@@ -384,9 +392,18 @@ impl QueryLoader {
         runtime_bases: &[P],
         lang_name: &str,
         file_name: &str,
-    ) -> LspResult<ParseResult> {
+    ) -> Result<ParseResult, QueryLoadError> {
         // Load the original file once and pass to resolver to avoid double-loading
-        let original_content = Self::load_query_file(runtime_bases, lang_name, file_name)?;
+        let Some(path) = Self::find_query_file(runtime_bases, lang_name, file_name) else {
+            return Err(QueryLoadError::NotFound);
+        };
+        let original_content = fs::read_to_string(&path).map_err(|e| {
+            LspError::query(format!(
+                "Failed to read query file {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
         let used_inheritance = !Self::parse_inherits_directive(&original_content).is_empty();
 
         let mut visited = std::collections::HashSet::new();

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -539,6 +539,24 @@ mod tests {
         assert!(result.is_none());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn find_query_file_treats_dangling_symlink_as_present_asset() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let query_dir = dir.path().join("queries/rust");
+        fs::create_dir_all(&query_dir).unwrap();
+        let query_file = query_dir.join("highlights.scm");
+        symlink("missing-target.scm", &query_file).unwrap();
+
+        assert_eq!(
+            QueryLoader::find_query_file(&[dir.path()], "rust", "highlights.scm"),
+            Some(query_file),
+            "a broken configured asset must not be classified as ordinary absence"
+        );
+    }
+
     #[test]
     fn find_query_file_rejects_language_path_traversal() {
         let dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary

- detect query directory entries without following their symlink targets
- keep dangling or inaccessible configured assets distinct from genuinely absent optional query kinds
- add a focused dangling-symlink regression

## Why

`Path::exists()` returned false for a dangling query symlink. Captures therefore classified a broken configured asset as expected absence and suppressed the normal asset-trouble warning.

## Testing

- `cargo test --lib language::query_loader::tests::find_query_file_treats_dangling_symlink_as_present_asset -- --exact`
- `cargo test --lib language::query_loader::tests::test_find_query_file -- --exact`
- `make check`

Closes #779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of broken or inaccessible query-file candidates so the underlying filesystem/read error is preserved instead of being treated as “not found.”
  * Enhanced runtime reporting when a query file is detected but fails to load, including clearer warnings tied to the specific query kind/id.
* **Tests**
  * Added Unix-only coverage to confirm dangling symbolic links are treated as present, and that loading fails with the expected “Failed to read query file” error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->