### PR TITLE
fix(cli): fail status on query recovery errors

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -412,9 +412,10 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
 
     let parser_dir = data_dir.join("parser");
     let queries_dir = data_dir.join("queries");
-    if let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {
-        eprintln!("Warning: failed to recover interrupted query installs: {e}");
-    }
+    queries::recover_interrupted_query_installs(&queries_dir).map_err(|e| {
+        eprintln!("Error: failed to recover interrupted query installs: {e}");
+        ExitCode::FAILURE
+    })?;
 
     // Collect all installed languages from both parser and queries directories
     let mut languages = BTreeSet::new();

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1256,6 +1256,46 @@ fn test_language_status_recovers_internal_query_backup() {
     );
 }
 
+#[test]
+fn test_language_status_fails_when_query_recovery_fails() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let queries_dir = test_dir.path().join("queries");
+    let backup = queries_dir.join(".lua.4294967295.0.backup");
+    fs::create_dir_all(&backup).expect("Failed to create recovery backup");
+    fs::write(backup.join("highlights.scm"), "(comment) @comment")
+        .expect("Failed to write recovery query");
+    fs::write(
+        queries_dir.join(".lua.4294967295.0.backup.kakehashi-owned"),
+        "owned\n",
+    )
+    .expect("Failed to write recovery ownership marker");
+    fs::create_dir(queries_dir.join(".lua.replace.lock"))
+        .expect("Failed to block recovery lock creation");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("failed to recover interrupted query installs"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("No languages installed"),
+        "status must not report an empty install after recovery failed: {stderr}"
+    );
+}
+
 /// Test that status recovery does not delete an incomplete canonical query dir
 #[test]
 fn test_language_status_preserves_incomplete_query_dir_when_backup_exists() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1292,9 +1292,10 @@ fn test_language_status_fails_when_query_recovery_fails() {
         stderr.contains("failed to recover interrupted query installs"),
         "stderr: {stderr}"
     );
+    let combined = format!("{}{}", String::from_utf8_lossy(&output.stdout), stderr);
     assert!(
-        !stderr.contains("No languages installed"),
-        "status must not report an empty install after recovery failed: {stderr}"
+        !combined.contains("No languages installed"),
+        "status must not report an empty install after recovery failed: {combined}"
     );
 }
 

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1266,8 +1266,10 @@ fn test_language_status_fails_when_query_recovery_fails() {
     fs::create_dir_all(&backup).expect("Failed to create recovery backup");
     fs::write(backup.join("highlights.scm"), "(comment) @comment")
         .expect("Failed to write recovery query");
+    fs::write(backup.join(".kakehashi-install-complete"), "ok\n")
+        .expect("Failed to write recovery completion marker");
     fs::write(
-        queries_dir.join(".lua.4294967295.0.backup.kakehashi-owned"),
+        queries_dir.join(".lua.4294967295.0.backup.kakehashi-backup"),
         "owned\n",
     )
     .expect("Failed to write recovery ownership marker");


### PR DESCRIPTION
## Summary

- make `language status` fail when interrupted-query recovery fails
- stop before scanning so hidden recovery artifacts cannot be misreported as an empty installation
- add a deterministic regression using a directory-shaped replacement lock

## Validation

- RED: status warned about recovery failure, printed `No languages installed`, and exited 0
- `cargo test --test test_cli` (43 passed)
- `cargo test --lib install::queries::tests` (23 passed)
- `cargo clippy --bin kakehashi --lib -- -D warnings`
- `cargo fmt --check`

Closes #780

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `language status` now treats interrupted query install recovery failures as fatal, logging an error and exiting with failure.
  * Prevents misleading output that could incorrectly suggest no languages are installed after a recovery failure.
  * Added a CLI integration test covering the recovery-failure scenario to ensure the correct exit code and error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->