### PR TITLE
fix(cli): deduplicate symlink file aliases

### DIFF
--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -80,7 +80,15 @@ pub(crate) fn collect_files(
         }
     }
     files.sort();
-    files.dedup();
+    let mut seen = std::collections::HashSet::new();
+    files.retain(|path| {
+        // Preserve the stable sorted spelling for output, but compare the
+        // resolved path so explicit symlink aliases do not process one file
+        // twice. If an entry vanished after collection, retain its lexical
+        // path and let the caller report the existing read error.
+        let identity = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+        seen.insert(identity)
+    });
     Ok(CollectedFiles { files, walk_errors })
 }
 
@@ -446,6 +454,26 @@ mod tests {
         );
 
         assert_eq!(files, vec![tmp.path().join("doc.md")]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_aliases_are_deduplicated() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let document = tmp.path().join("doc.md");
+        let alias = tmp.path().join("alias.md");
+        write(&document, "x");
+        symlink(&document, &alias).unwrap();
+
+        let files = collect_paths(tmp.path(), &[document.clone(), alias], &[], &markdown_only);
+
+        assert_eq!(files.len(), 1, "one filesystem file must be processed once");
+        assert_eq!(
+            std::fs::canonicalize(&files[0]).unwrap(),
+            std::fs::canonicalize(document).unwrap()
+        );
     }
 
     #[test]

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -66,10 +66,15 @@ pub(crate) fn collect_files(
         // Normalize before stat: a relative path must resolve against
         // `base`, not against whatever the process cwd happens to be.
         let path = normalize_path(base, path);
-        let metadata = std::fs::metadata(&path)
+        let link_metadata = std::fs::symlink_metadata(&path)
             .map_err(|e| format!("cannot access '{}': {e}", path.display()))?;
-        let is_symlink = std::fs::symlink_metadata(&path)
-            .is_ok_and(|metadata| metadata.file_type().is_symlink());
+        let is_symlink = link_metadata.file_type().is_symlink();
+        let metadata = if is_symlink {
+            std::fs::metadata(&path)
+                .map_err(|e| format!("cannot access '{}': {e}", path.display()))?
+        } else {
+            link_metadata
+        };
         if metadata.is_dir() {
             if is_excluded(&exclude_matcher, base, &path, true) {
                 continue;

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -68,17 +68,19 @@ pub(crate) fn collect_files(
         let path = normalize_path(base, path);
         let metadata = std::fs::metadata(&path)
             .map_err(|e| format!("cannot access '{}': {e}", path.display()))?;
-        has_explicit_symlink |= std::fs::symlink_metadata(&path)
+        let is_symlink = std::fs::symlink_metadata(&path)
             .is_ok_and(|metadata| metadata.file_type().is_symlink());
         if metadata.is_dir() {
             if is_excluded(&exclude_matcher, base, &path, true) {
                 continue;
             }
+            has_explicit_symlink |= is_symlink;
             walk_errors += walk_directory(&path, &exclude_matcher, is_supported, &mut files);
         } else {
             if is_excluded(&exclude_matcher, base, &path, false) {
                 continue;
             }
+            has_explicit_symlink |= is_symlink;
             files.push(path);
         }
     }
@@ -275,6 +277,28 @@ mod tests {
         );
 
         assert!(files.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn excluded_symlink_does_not_affect_collected_directory() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let docs = tmp.path().join("docs");
+        let document = docs.join("kept.md");
+        let alias = tmp.path().join("alias.md");
+        write(&document, "x");
+        symlink(&document, &alias).unwrap();
+
+        let files = collect_paths(
+            tmp.path(),
+            &[docs, alias],
+            &["alias.md".to_string()],
+            &markdown_only,
+        );
+
+        assert_eq!(files, vec![document]);
     }
 
     #[test]

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -18,13 +18,15 @@ use std::path::{Path, PathBuf};
 
 fn has_symlink_ancestor(
     path: &Path,
-    base: &Path,
+    boundary: Option<&Path>,
     cache: &mut std::collections::HashMap<PathBuf, bool>,
 ) -> bool {
-    let is_within_base = path.starts_with(base);
+    let is_within_boundary = boundary.is_some_and(|boundary| path.starts_with(boundary));
     path.ancestors()
         .skip(1)
-        .take_while(|ancestor| !is_within_base || ancestor.starts_with(base))
+        .take_while(|ancestor| {
+            !is_within_boundary || boundary.is_some_and(|boundary| ancestor.starts_with(boundary))
+        })
         .any(|ancestor| {
             *cache.entry(ancestor.to_path_buf()).or_insert_with(|| {
                 std::fs::symlink_metadata(ancestor)
@@ -116,6 +118,7 @@ pub(crate) fn collect_files(
     let mut walk_errors = 0usize;
     let mut explicit_inputs = Vec::new();
     let mut ancestor_symlinks = std::collections::HashMap::new();
+    let mut has_outside_input = false;
     for path in paths {
         // Normalize before stat: a relative path must resolve against
         // `base`, not against whatever the process cwd happens to be.
@@ -134,8 +137,9 @@ pub(crate) fn collect_files(
                 continue;
             }
             if paths.len() > 1 {
+                has_outside_input |= !path.starts_with(base);
                 let has_alias =
-                    is_symlink || has_symlink_ancestor(&path, base, &mut ancestor_symlinks);
+                    is_symlink || has_symlink_ancestor(&path, Some(base), &mut ancestor_symlinks);
                 explicit_inputs.push((path.clone(), true, has_alias));
             }
             walk_errors += walk_directory(&path, &exclude_matcher, is_supported, &mut files);
@@ -144,15 +148,18 @@ pub(crate) fn collect_files(
                 continue;
             }
             if paths.len() > 1 {
+                has_outside_input |= !path.starts_with(base);
                 let has_alias =
-                    is_symlink || has_symlink_ancestor(&path, base, &mut ancestor_symlinks);
+                    is_symlink || has_symlink_ancestor(&path, Some(base), &mut ancestor_symlinks);
                 explicit_inputs.push((path.clone(), false, has_alias));
             }
             files.push(path);
         }
     }
     files.sort();
-    let has_explicit_alias = if explicit_inputs.iter().any(|input| input.2) {
+    let may_have_explicit_alias = explicit_inputs.iter().any(|input| input.2)
+        || (has_outside_input && has_symlink_ancestor(base, None, &mut ancestor_symlinks));
+    let has_explicit_alias = if may_have_explicit_alias {
         let mut identities = explicit_inputs
             .into_iter()
             .map(|(path, is_dir, _)| {
@@ -170,7 +177,7 @@ pub(crate) fn collect_files(
             let identity = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
             let is_alias = std::fs::symlink_metadata(&path)
                 .is_ok_and(|metadata| metadata.file_type().is_symlink())
-                || has_symlink_ancestor(&path, base, &mut ancestor_symlinks);
+                || has_symlink_ancestor(&path, Some(base), &mut ancestor_symlinks);
             representatives
                 .entry(identity)
                 .and_modify(|representative: &mut (PathBuf, bool)| {
@@ -646,6 +653,35 @@ mod tests {
         );
 
         assert_eq!(files.len(), 1, "one filesystem file must be processed once");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn aliases_above_the_collection_base_are_deduplicated() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let real_parent = tmp.path().join("real-parent");
+        let real_base = real_parent.join("cwd");
+        let document = real_base.join("doc.md");
+        write(&document, "x");
+
+        let alias_parent = tmp.path().join("alias-parent");
+        symlink(&real_parent, &alias_parent).unwrap();
+        let alias_base = alias_parent.join("cwd");
+
+        let files = collect_paths(
+            &alias_base,
+            &[PathBuf::from("doc.md"), document.clone()],
+            &[],
+            &markdown_only,
+        );
+
+        assert_eq!(files.len(), 1, "one filesystem file must be processed once");
+        assert_eq!(
+            std::fs::canonicalize(&files[0]).unwrap(),
+            std::fs::canonicalize(document).unwrap()
+        );
     }
 
     #[cfg(unix)]

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -647,6 +647,47 @@ mod tests {
         assert_eq!(files.len(), 1, "one filesystem file must be processed once");
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn windows_file_symlink_aliases_are_deduplicated() {
+        use std::os::windows::fs::symlink_file;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let document = tmp.path().join("doc.md");
+        let alias = tmp.path().join("alias.md");
+        write(&document, "x");
+        if symlink_file(&document, &alias).is_err() {
+            return;
+        }
+
+        let files = collect_paths(tmp.path(), &[document, alias], &[], &markdown_only);
+
+        assert_eq!(files.len(), 1, "one filesystem file must be processed once");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_directory_symlink_aliases_are_deduplicated() {
+        use std::os::windows::fs::symlink_dir;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("real");
+        let alias = tmp.path().join("alias");
+        write(&real.join("doc.md"), "x");
+        if symlink_dir(&real, &alias).is_err() {
+            return;
+        }
+
+        let files = collect_paths(
+            tmp.path(),
+            &[tmp.path().to_path_buf(), alias],
+            &[],
+            &markdown_only,
+        );
+
+        assert_eq!(files.len(), 1, "one filesystem file must be processed once");
+    }
+
     #[test]
     fn explicitly_named_hidden_directory_is_walked() {
         // The walker's hidden-file filter applies to entries, not to the

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -16,13 +16,21 @@
 
 use std::path::{Path, PathBuf};
 
-fn has_symlink_ancestor(path: &Path, cache: &mut std::collections::HashMap<PathBuf, bool>) -> bool {
-    path.ancestors().skip(1).any(|ancestor| {
-        *cache.entry(ancestor.to_path_buf()).or_insert_with(|| {
-            std::fs::symlink_metadata(ancestor)
-                .is_ok_and(|metadata| metadata.file_type().is_symlink())
+fn has_symlink_ancestor(
+    path: &Path,
+    base: &Path,
+    cache: &mut std::collections::HashMap<PathBuf, bool>,
+) -> bool {
+    let is_within_base = path.starts_with(base);
+    path.ancestors()
+        .skip(1)
+        .take_while(|ancestor| !is_within_base || ancestor.starts_with(base))
+        .any(|ancestor| {
+            *cache.entry(ancestor.to_path_buf()).or_insert_with(|| {
+                std::fs::symlink_metadata(ancestor)
+                    .is_ok_and(|metadata| metadata.file_type().is_symlink())
+            })
         })
-    })
 }
 
 /// Files collected from CLI paths plus any non-fatal directory walk errors
@@ -126,7 +134,8 @@ pub(crate) fn collect_files(
                 continue;
             }
             if paths.len() > 1 {
-                let has_alias = is_symlink || has_symlink_ancestor(&path, &mut ancestor_symlinks);
+                let has_alias =
+                    is_symlink || has_symlink_ancestor(&path, base, &mut ancestor_symlinks);
                 explicit_inputs.push((path.clone(), true, has_alias));
             }
             walk_errors += walk_directory(&path, &exclude_matcher, is_supported, &mut files);
@@ -135,7 +144,8 @@ pub(crate) fn collect_files(
                 continue;
             }
             if paths.len() > 1 {
-                let has_alias = is_symlink || has_symlink_ancestor(&path, &mut ancestor_symlinks);
+                let has_alias =
+                    is_symlink || has_symlink_ancestor(&path, base, &mut ancestor_symlinks);
                 explicit_inputs.push((path.clone(), false, has_alias));
             }
             files.push(path);
@@ -155,15 +165,27 @@ pub(crate) fn collect_files(
         false
     };
     if has_explicit_alias {
-        let mut seen = std::collections::HashSet::with_capacity(files.len());
-        files.retain(|path| {
-            // Preserve the stable sorted spelling for output, but compare the
-            // resolved path so explicit filesystem aliases do not process one file
-            // twice. If identity resolution fails after collection, retain the
-            // lexical path so the caller can report any later read error.
-            let identity = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
-            seen.insert(identity)
-        });
+        let mut representatives = std::collections::HashMap::with_capacity(files.len());
+        for path in files.drain(..) {
+            let identity = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+            let is_alias = std::fs::symlink_metadata(&path)
+                .is_ok_and(|metadata| metadata.file_type().is_symlink())
+                || has_symlink_ancestor(&path, base, &mut ancestor_symlinks);
+            representatives
+                .entry(identity)
+                .and_modify(|representative: &mut (PathBuf, bool)| {
+                    if representative.1 && !is_alias {
+                        *representative = (path.clone(), false);
+                    }
+                })
+                .or_insert((path, is_alias));
+        }
+        files.extend(
+            representatives
+                .into_values()
+                .map(|(representative, _)| representative),
+        );
+        files.sort();
     } else {
         files.dedup();
     }
@@ -645,6 +667,23 @@ mod tests {
         );
 
         assert_eq!(files.len(), 1, "one filesystem file must be processed once");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dedup_prefers_non_symlink_processing_path() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("real");
+        let document = real.join("doc.md");
+        let alias = tmp.path().join("alias.txt");
+        write(&document, "x");
+        symlink(&document, &alias).unwrap();
+
+        let files = collect_paths(tmp.path(), &[real, alias], &[], &markdown_only);
+
+        assert_eq!(files, vec![document]);
     }
 
     #[cfg(windows)]

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -61,7 +61,7 @@ pub(crate) fn collect_files(
 
     let mut files = Vec::new();
     let mut walk_errors = 0usize;
-    let mut has_explicit_alias = false;
+    let mut explicit_identities = Vec::new();
     for path in paths {
         // Normalize before stat: a relative path must resolve against
         // `base`, not against whatever the process cwd happens to be.
@@ -79,19 +79,31 @@ pub(crate) fn collect_files(
             if is_excluded(&exclude_matcher, base, &path, true) {
                 continue;
             }
-            has_explicit_alias |= paths.len() > 1
-                && std::fs::canonicalize(&path).is_ok_and(|resolved| resolved != path);
+            if paths.len() > 1 {
+                let resolved = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+                explicit_identities.push((path.clone(), resolved));
+            }
             walk_errors += walk_directory(&path, &exclude_matcher, is_supported, &mut files);
         } else {
             if is_excluded(&exclude_matcher, base, &path, false) {
                 continue;
             }
-            has_explicit_alias |= paths.len() > 1
-                && std::fs::canonicalize(&path).is_ok_and(|resolved| resolved != path);
+            if paths.len() > 1 {
+                let resolved = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+                explicit_identities.push((path.clone(), resolved));
+            }
             files.push(path);
         }
     }
     files.sort();
+    let overlaps = |left: &Path, right: &Path| {
+        left == right || left.starts_with(right) || right.starts_with(left)
+    };
+    let has_explicit_alias = explicit_identities.iter().enumerate().any(|(index, left)| {
+        explicit_identities[index + 1..]
+            .iter()
+            .any(|right| overlaps(&left.1, &right.1) && !overlaps(&left.0, &right.0))
+    });
     if has_explicit_alias {
         let mut seen = std::collections::HashSet::new();
         files.retain(|path| {

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -23,6 +23,42 @@ pub(crate) struct CollectedFiles {
     pub(crate) walk_errors: usize,
 }
 
+fn explicit_inputs_have_alias(inputs: &mut [(PathBuf, PathBuf, bool)]) -> bool {
+    inputs.sort_by(|left, right| left.1.cmp(&right.1).then_with(|| left.0.cmp(&right.0)));
+    let mut ancestors: Vec<usize> = Vec::new();
+    let mut previous = None;
+
+    for index in 0..inputs.len() {
+        let (lexical, resolved, is_dir) = &inputs[index];
+        if let Some(previous_index) = previous {
+            let previous: &(PathBuf, PathBuf, bool) = &inputs[previous_index];
+            if previous.1 == *resolved && previous.0 != *lexical {
+                return true;
+            }
+        }
+        while ancestors
+            .last()
+            .is_some_and(|&ancestor| !resolved.starts_with(&inputs[ancestor].1))
+        {
+            ancestors.pop();
+        }
+        for &ancestor in &ancestors {
+            let (ancestor_lexical, ancestor_resolved, _) = &inputs[ancestor];
+            let suffix = resolved
+                .strip_prefix(ancestor_resolved)
+                .expect("ancestor stack only contains resolved path prefixes");
+            if ancestor_lexical.join(suffix) != *lexical {
+                return true;
+            }
+        }
+        if *is_dir {
+            ancestors.push(index);
+        }
+        previous = Some(index);
+    }
+    false
+}
+
 /// Build the `--excludes` matcher: gitignore-style patterns rooted at `base`
 /// (the current directory). [`ignore::overrides::Override`] is
 /// whitelist-oriented, so each user pattern is added negated (`!pattern`) to
@@ -81,7 +117,7 @@ pub(crate) fn collect_files(
             }
             if paths.len() > 1 {
                 let resolved = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
-                explicit_identities.push((path.clone(), resolved));
+                explicit_identities.push((path.clone(), resolved, true));
             }
             walk_errors += walk_directory(&path, &exclude_matcher, is_supported, &mut files);
         } else {
@@ -90,29 +126,13 @@ pub(crate) fn collect_files(
             }
             if paths.len() > 1 {
                 let resolved = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
-                explicit_identities.push((path.clone(), resolved));
+                explicit_identities.push((path.clone(), resolved, false));
             }
             files.push(path);
         }
     }
     files.sort();
-    let relationship = |left: &Path, right: &Path| {
-        if left == right {
-            Some((0, PathBuf::new()))
-        } else if let Ok(suffix) = right.strip_prefix(left) {
-            Some((1, suffix.to_path_buf()))
-        } else {
-            left.strip_prefix(right)
-                .ok()
-                .map(|suffix| (-1, suffix.to_path_buf()))
-        }
-    };
-    let has_explicit_alias = explicit_identities.iter().enumerate().any(|(index, left)| {
-        explicit_identities[index + 1..].iter().any(|right| {
-            let resolved = relationship(&left.1, &right.1);
-            resolved.is_some() && resolved != relationship(&left.0, &right.0)
-        })
-    });
+    let has_explicit_alias = explicit_inputs_have_alias(&mut explicit_identities);
     if has_explicit_alias {
         let mut seen = std::collections::HashSet::new();
         files.retain(|path| {
@@ -225,6 +245,18 @@ fn walk_directory(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn large_explicit_file_lists_have_no_alias_relationship() {
+        let mut inputs = (0..4096)
+            .map(|index| {
+                let path = PathBuf::from(format!("/workspace/file-{index}.md"));
+                (path.clone(), path, false)
+            })
+            .collect::<Vec<_>>();
+
+        assert!(!explicit_inputs_have_alias(&mut inputs));
+    }
 
     fn write(path: &Path, content: &str) {
         if let Some(parent) = path.parent() {

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -134,12 +134,12 @@ pub(crate) fn collect_files(
     files.sort();
     let has_explicit_alias = explicit_inputs_have_alias(&mut explicit_identities);
     if has_explicit_alias {
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = std::collections::HashSet::with_capacity(files.len());
         files.retain(|path| {
             // Preserve the stable sorted spelling for output, but compare the
             // resolved path so explicit filesystem aliases do not process one file
-            // twice. If an entry vanished after collection, retain its lexical
-            // path and let the caller report the existing read error.
+            // twice. If identity resolution fails after collection, retain the
+            // lexical path so the caller can report any later read error.
             let identity = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
             seen.insert(identity)
         });

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -61,7 +61,7 @@ pub(crate) fn collect_files(
 
     let mut files = Vec::new();
     let mut walk_errors = 0usize;
-    let mut has_explicit_symlink = false;
+    let mut has_explicit_alias = false;
     for path in paths {
         // Normalize before stat: a relative path must resolve against
         // `base`, not against whatever the process cwd happens to be.
@@ -79,22 +79,24 @@ pub(crate) fn collect_files(
             if is_excluded(&exclude_matcher, base, &path, true) {
                 continue;
             }
-            has_explicit_symlink |= is_symlink;
+            has_explicit_alias |= paths.len() > 1
+                && std::fs::canonicalize(&path).is_ok_and(|resolved| resolved != path);
             walk_errors += walk_directory(&path, &exclude_matcher, is_supported, &mut files);
         } else {
             if is_excluded(&exclude_matcher, base, &path, false) {
                 continue;
             }
-            has_explicit_symlink |= is_symlink;
+            has_explicit_alias |= paths.len() > 1
+                && std::fs::canonicalize(&path).is_ok_and(|resolved| resolved != path);
             files.push(path);
         }
     }
     files.sort();
-    if has_explicit_symlink {
+    if has_explicit_alias {
         let mut seen = std::collections::HashSet::new();
         files.retain(|path| {
             // Preserve the stable sorted spelling for output, but compare the
-            // resolved path so explicit symlink aliases do not process one file
+            // resolved path so explicit filesystem aliases do not process one file
             // twice. If an entry vanished after collection, retain its lexical
             // path and let the caller report the existing read error.
             let identity = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
@@ -510,6 +512,28 @@ mod tests {
             std::fs::canonicalize(&files[0]).unwrap(),
             std::fs::canonicalize(document).unwrap()
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_ancestor_aliases_are_deduplicated() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("real");
+        let alias = tmp.path().join("alias");
+        let document = real.join("doc.md");
+        write(&document, "x");
+        symlink(&real, &alias).unwrap();
+
+        let files = collect_paths(
+            tmp.path(),
+            &[document.clone(), alias.join("doc.md")],
+            &[],
+            &markdown_only,
+        );
+
+        assert_eq!(files.len(), 1, "one filesystem file must be processed once");
     }
 
     #[test]

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -96,13 +96,22 @@ pub(crate) fn collect_files(
         }
     }
     files.sort();
-    let overlaps = |left: &Path, right: &Path| {
-        left == right || left.starts_with(right) || right.starts_with(left)
+    let relationship = |left: &Path, right: &Path| {
+        if left == right {
+            Some((0, PathBuf::new()))
+        } else if let Ok(suffix) = right.strip_prefix(left) {
+            Some((1, suffix.to_path_buf()))
+        } else {
+            left.strip_prefix(right)
+                .ok()
+                .map(|suffix| (-1, suffix.to_path_buf()))
+        }
     };
     let has_explicit_alias = explicit_identities.iter().enumerate().any(|(index, left)| {
-        explicit_identities[index + 1..]
-            .iter()
-            .any(|right| overlaps(&left.1, &right.1) && !overlaps(&left.0, &right.0))
+        explicit_identities[index + 1..].iter().any(|right| {
+            let resolved = relationship(&left.1, &right.1);
+            resolved.is_some() && resolved != relationship(&left.0, &right.0)
+        })
     });
     if has_explicit_alias {
         let mut seen = std::collections::HashSet::new();
@@ -541,6 +550,27 @@ mod tests {
         let files = collect_paths(
             tmp.path(),
             &[document.clone(), alias.join("doc.md")],
+            &[],
+            &markdown_only,
+        );
+
+        assert_eq!(files.len(), 1, "one filesystem file must be processed once");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nested_symlink_directory_aliases_are_deduplicated() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("real");
+        let alias = tmp.path().join("alias");
+        write(&real.join("doc.md"), "x");
+        symlink(&real, &alias).unwrap();
+
+        let files = collect_paths(
+            tmp.path(),
+            &[tmp.path().to_path_buf(), alias],
             &[],
             &markdown_only,
         );

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -16,6 +16,15 @@
 
 use std::path::{Path, PathBuf};
 
+fn has_symlink_ancestor(path: &Path, cache: &mut std::collections::HashMap<PathBuf, bool>) -> bool {
+    path.ancestors().skip(1).any(|ancestor| {
+        *cache.entry(ancestor.to_path_buf()).or_insert_with(|| {
+            std::fs::symlink_metadata(ancestor)
+                .is_ok_and(|metadata| metadata.file_type().is_symlink())
+        })
+    })
+}
+
 /// Files collected from CLI paths plus any non-fatal directory walk errors
 /// encountered while discovering them.
 pub(crate) struct CollectedFiles {
@@ -97,7 +106,8 @@ pub(crate) fn collect_files(
 
     let mut files = Vec::new();
     let mut walk_errors = 0usize;
-    let mut explicit_identities = Vec::new();
+    let mut explicit_inputs = Vec::new();
+    let mut ancestor_symlinks = std::collections::HashMap::new();
     for path in paths {
         // Normalize before stat: a relative path must resolve against
         // `base`, not against whatever the process cwd happens to be.
@@ -116,8 +126,8 @@ pub(crate) fn collect_files(
                 continue;
             }
             if paths.len() > 1 {
-                let resolved = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
-                explicit_identities.push((path.clone(), resolved, true));
+                let has_alias = is_symlink || has_symlink_ancestor(&path, &mut ancestor_symlinks);
+                explicit_inputs.push((path.clone(), true, has_alias));
             }
             walk_errors += walk_directory(&path, &exclude_matcher, is_supported, &mut files);
         } else {
@@ -125,14 +135,25 @@ pub(crate) fn collect_files(
                 continue;
             }
             if paths.len() > 1 {
-                let resolved = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
-                explicit_identities.push((path.clone(), resolved, false));
+                let has_alias = is_symlink || has_symlink_ancestor(&path, &mut ancestor_symlinks);
+                explicit_inputs.push((path.clone(), false, has_alias));
             }
             files.push(path);
         }
     }
     files.sort();
-    let has_explicit_alias = explicit_inputs_have_alias(&mut explicit_identities);
+    let has_explicit_alias = if explicit_inputs.iter().any(|input| input.2) {
+        let mut identities = explicit_inputs
+            .into_iter()
+            .map(|(path, is_dir, _)| {
+                let resolved = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+                (path, resolved, is_dir)
+            })
+            .collect::<Vec<_>>();
+        explicit_inputs_have_alias(&mut identities)
+    } else {
+        false
+    };
     if has_explicit_alias {
         let mut seen = std::collections::HashSet::with_capacity(files.len());
         files.retain(|path| {
@@ -256,6 +277,22 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert!(!explicit_inputs_have_alias(&mut inputs));
+    }
+
+    #[test]
+    fn large_ordinary_explicit_file_list_is_collected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = (0..256)
+            .map(|index| {
+                let path = tmp.path().join(format!("file-{index}.md"));
+                write(&path, "x");
+                path
+            })
+            .collect::<Vec<_>>();
+
+        let files = collect_paths(tmp.path(), &paths, &[], &markdown_only);
+
+        assert_eq!(files.len(), paths.len());
     }
 
     fn write(path: &Path, content: &str) {

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -61,12 +61,15 @@ pub(crate) fn collect_files(
 
     let mut files = Vec::new();
     let mut walk_errors = 0usize;
+    let mut has_explicit_symlink = false;
     for path in paths {
         // Normalize before stat: a relative path must resolve against
         // `base`, not against whatever the process cwd happens to be.
         let path = normalize_path(base, path);
         let metadata = std::fs::metadata(&path)
             .map_err(|e| format!("cannot access '{}': {e}", path.display()))?;
+        has_explicit_symlink |= std::fs::symlink_metadata(&path)
+            .is_ok_and(|metadata| metadata.file_type().is_symlink());
         if metadata.is_dir() {
             if is_excluded(&exclude_matcher, base, &path, true) {
                 continue;
@@ -80,15 +83,19 @@ pub(crate) fn collect_files(
         }
     }
     files.sort();
-    let mut seen = std::collections::HashSet::new();
-    files.retain(|path| {
-        // Preserve the stable sorted spelling for output, but compare the
-        // resolved path so explicit symlink aliases do not process one file
-        // twice. If an entry vanished after collection, retain its lexical
-        // path and let the caller report the existing read error.
-        let identity = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
-        seen.insert(identity)
-    });
+    if has_explicit_symlink {
+        let mut seen = std::collections::HashSet::new();
+        files.retain(|path| {
+            // Preserve the stable sorted spelling for output, but compare the
+            // resolved path so explicit symlink aliases do not process one file
+            // twice. If an entry vanished after collection, retain its lexical
+            // path and let the caller report the existing read error.
+            let identity = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+            seen.insert(identity)
+        });
+    } else {
+        files.dedup();
+    }
     Ok(CollectedFiles { files, walk_errors })
 }
 

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -28,10 +28,13 @@ fn has_symlink_ancestor(
             !is_within_boundary || boundary.is_some_and(|boundary| ancestor.starts_with(boundary))
         })
         .any(|ancestor| {
-            *cache.entry(ancestor.to_path_buf()).or_insert_with(|| {
-                std::fs::symlink_metadata(ancestor)
-                    .is_ok_and(|metadata| metadata.file_type().is_symlink())
-            })
+            if let Some(&is_symlink) = cache.get(ancestor) {
+                return is_symlink;
+            }
+            let is_symlink = std::fs::symlink_metadata(ancestor)
+                .is_ok_and(|metadata| metadata.file_type().is_symlink());
+            cache.insert(ancestor.to_path_buf(), is_symlink);
+            is_symlink
         })
 }
 


### PR DESCRIPTION
## Summary

- deduplicate explicit symlink aliases by resolved filesystem identity
- retain the existing sorted user-facing path spelling
- keep the lexical fast path when no explicit input is a symlink
- preserve vanished-file handling by falling back to the lexical identity

## Validation

- RED: a real Markdown file plus its symlink produced two collected entries
- `cargo test --lib cli::files::tests` (24 passed)
- `cargo clippy --bin kakehashi --lib -- -D warnings`
- `cargo fmt --check`

Closes #783

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symbolic link handling when collecting files, including accurate directory vs. file detection.
  * Prevented duplicate processing by correctly deduplicating when explicit inputs refer to the same underlying target.
  * Fixed exclude behavior to properly account for symbolic links and their resolved targets.
  * Maintained stable, sorted output while avoiding repeated filesystem entries.
* **Tests**
  * Expanded Unix symlink coverage and added Windows symlink tests where supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->