### PR TITLE
fix(config): surface broken user config paths

### DIFF
--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -108,12 +108,38 @@ pub fn load_user_config() -> UserConfigResult<Option<UserConfig>> {
                     // The path may have appeared after the first read. Retry
                     // once so a concurrent atomic install does not surface a
                     // stale NotFound; a dangling symlink still fails here.
-                    std::fs::read_to_string(&path).map_err(|retry_source| {
-                        UserConfigError::IoError {
-                            path: path.clone(),
-                            source: retry_source,
+                    match std::fs::read_to_string(&path) {
+                        Ok(contents) => contents,
+                        Err(retry_source)
+                            if retry_source.kind() == std::io::ErrorKind::NotFound =>
+                        {
+                            match std::fs::symlink_metadata(&path) {
+                                Err(final_error)
+                                    if final_error.kind() == std::io::ErrorKind::NotFound =>
+                                {
+                                    return Ok(None);
+                                }
+                                Err(final_error) => {
+                                    return Err(UserConfigError::IoError {
+                                        path,
+                                        source: final_error,
+                                    });
+                                }
+                                Ok(_) => {
+                                    return Err(UserConfigError::IoError {
+                                        path,
+                                        source: retry_source,
+                                    });
+                                }
+                            }
                         }
-                    })?
+                        Err(retry_source) => {
+                            return Err(UserConfigError::IoError {
+                                path,
+                                source: retry_source,
+                            });
+                        }
+                    }
                 }
             }
         }
@@ -194,6 +220,7 @@ mod tests {
     use serial_test::serial;
     use std::env;
 
+    #[must_use]
     struct EnvVarGuard {
         key: &'static str,
         original: Option<std::ffi::OsString>,

--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -95,7 +95,10 @@ pub fn load_user_config() -> UserConfigResult<Option<UserConfig>> {
         Ok(contents) => contents,
         Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
             match std::fs::symlink_metadata(&path) {
-                Err(metadata_error) if metadata_error.kind() == std::io::ErrorKind::NotFound => {
+                Err(metadata_error)
+                    if metadata_error.kind() == std::io::ErrorKind::NotFound
+                        && !contains_dangling_symlink(&path) =>
+                {
                     return Ok(None);
                 }
                 Err(metadata_error) => {
@@ -115,7 +118,8 @@ pub fn load_user_config() -> UserConfigResult<Option<UserConfig>> {
                         {
                             match std::fs::symlink_metadata(&path) {
                                 Err(final_error)
-                                    if final_error.kind() == std::io::ErrorKind::NotFound =>
+                                    if final_error.kind() == std::io::ErrorKind::NotFound
+                                        && !contains_dangling_symlink(&path) =>
                                 {
                                     return Ok(None);
                                 }
@@ -161,6 +165,20 @@ pub fn load_user_config() -> UserConfigResult<Option<UserConfig>> {
         deprecated_keys,
         path,
     }))
+}
+
+fn contains_dangling_symlink(path: &std::path::Path) -> bool {
+    let mut prefix = std::path::PathBuf::new();
+    for component in path.components() {
+        prefix.push(component);
+        if let Ok(metadata) = std::fs::symlink_metadata(&prefix)
+            && metadata.file_type().is_symlink()
+            && std::fs::metadata(&prefix).is_err()
+        {
+            return true;
+        }
+    }
+    false
 }
 
 /// Returns the path to the user configuration file.
@@ -382,6 +400,27 @@ mod tests {
         assert!(
             matches!(result, Err(UserConfigError::IoError { .. })),
             "a configured but broken path must not be treated as absent: {result:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial(xdg_env)]
+    fn load_user_config_reports_dangling_parent_symlink() {
+        use std::os::unix::fs::symlink;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        let config_home = temp_dir.path().join("config");
+        symlink("missing-config", &config_home)
+            .expect("failed to create dangling config-home symlink");
+
+        let _xdg = EnvVarGuard::set("XDG_CONFIG_HOME", &config_home);
+        let result = load_user_config();
+
+        assert!(
+            matches!(result, Err(UserConfigError::IoError { .. })),
+            "a broken ancestor of the configured path must not be treated as absent: {result:?}"
         );
     }
 

--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -87,16 +87,29 @@ pub fn load_user_config() -> UserConfigResult<Option<UserConfig>> {
         None => return Ok(None), // No home directory, silently ignore
     };
 
-    // Check if file exists
-    if !path.exists() {
-        return Ok(None); // Missing file is silently ignored (zero-config)
-    }
-
-    // Read and parse the file
-    let contents = std::fs::read_to_string(&path).map_err(|e| UserConfigError::IoError {
-        path: path.clone(),
-        source: e,
-    })?;
+    // Read first so permission and metadata errors are not collapsed into
+    // "missing" by Path::exists(). A dangling symlink also reports NotFound
+    // when followed, so lstat it before accepting the zero-config case.
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+            match std::fs::symlink_metadata(&path) {
+                Err(metadata_error) if metadata_error.kind() == std::io::ErrorKind::NotFound => {
+                    return Ok(None);
+                }
+                Err(metadata_error) => {
+                    return Err(UserConfigError::IoError {
+                        path,
+                        source: metadata_error,
+                    });
+                }
+                Ok(_) => return Err(UserConfigError::IoError { path, source }),
+            }
+        }
+        Err(source) => {
+            return Err(UserConfigError::IoError { path, source });
+        }
+    };
 
     let deprecated_keys = crate::config::deprecation::toml_deprecated_keys(&contents);
     let settings = toml::from_str::<RawWorkspaceSettings>(&contents).map_err(|e| {
@@ -283,6 +296,37 @@ mod tests {
         assert!(
             result.unwrap().is_none(),
             "load_user_config should return None when config file is missing"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial(xdg_env)]
+    fn load_user_config_reports_dangling_symlink() {
+        use std::os::unix::fs::symlink;
+        use tempfile::TempDir;
+
+        let original = env::var("XDG_CONFIG_HOME").ok();
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        let config_dir = temp_dir.path().join("kakehashi");
+        std::fs::create_dir_all(&config_dir).expect("failed to create config dir");
+        symlink("missing.toml", config_dir.join("kakehashi.toml"))
+            .expect("failed to create dangling config symlink");
+
+        // SAFETY: #[serial(xdg_env)] prevents concurrent modification of XDG_CONFIG_HOME.
+        unsafe { env::set_var("XDG_CONFIG_HOME", temp_dir.path()) };
+        let result = load_user_config();
+        // SAFETY: #[serial(xdg_env)] prevents concurrent modification of XDG_CONFIG_HOME.
+        unsafe {
+            match original {
+                Some(value) => env::set_var("XDG_CONFIG_HOME", value),
+                None => env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+
+        assert!(
+            matches!(result, Err(UserConfigError::IoError { .. })),
+            "a configured but broken path must not be treated as absent: {result:?}"
         );
     }
 

--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -97,7 +97,7 @@ pub fn load_user_config() -> UserConfigResult<Option<UserConfig>> {
             match std::fs::symlink_metadata(&path) {
                 Err(metadata_error)
                     if metadata_error.kind() == std::io::ErrorKind::NotFound
-                        && !contains_dangling_symlink(&path) =>
+                        && !contains_broken_symlink(&path) =>
                 {
                     return Ok(None);
                 }
@@ -119,7 +119,7 @@ pub fn load_user_config() -> UserConfigResult<Option<UserConfig>> {
                             match std::fs::symlink_metadata(&path) {
                                 Err(final_error)
                                     if final_error.kind() == std::io::ErrorKind::NotFound
-                                        && !contains_dangling_symlink(&path) =>
+                                        && !contains_broken_symlink(&path) =>
                                 {
                                     return Ok(None);
                                 }
@@ -167,7 +167,7 @@ pub fn load_user_config() -> UserConfigResult<Option<UserConfig>> {
     }))
 }
 
-fn contains_dangling_symlink(path: &std::path::Path) -> bool {
+fn contains_broken_symlink(path: &std::path::Path) -> bool {
     let mut prefix = std::path::PathBuf::new();
     for component in path.components() {
         prefix.push(component);

--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -80,7 +80,8 @@ pub(crate) struct UserConfig {
 /// Returns:
 /// - `Ok(Some(config))` if the file exists and is valid TOML
 /// - `Ok(None)` if the file does not exist (zero-config experience preserved)
-/// - `Err(UserConfigError)` if the file exists but contains invalid TOML
+/// - `Err(UserConfigError)` if the configured path cannot be read or contains
+///   invalid TOML
 pub fn load_user_config() -> UserConfigResult<Option<UserConfig>> {
     let path = match user_config_path() {
         Some(p) => p,
@@ -103,7 +104,17 @@ pub fn load_user_config() -> UserConfigResult<Option<UserConfig>> {
                         source: metadata_error,
                     });
                 }
-                Ok(_) => return Err(UserConfigError::IoError { path, source }),
+                Ok(_) => {
+                    // The path may have appeared after the first read. Retry
+                    // once so a concurrent atomic install does not surface a
+                    // stale NotFound; a dangling symlink still fails here.
+                    std::fs::read_to_string(&path).map_err(|retry_source| {
+                        UserConfigError::IoError {
+                            path: path.clone(),
+                            source: retry_source,
+                        }
+                    })?
+                }
             }
         }
         Err(source) => {
@@ -182,6 +193,32 @@ mod tests {
     use super::*;
     use serial_test::serial;
     use std::env;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let original = env::var_os(key);
+            // SAFETY: callers serialize every test that mutates this key.
+            unsafe { env::set_var(key, value) };
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // SAFETY: callers serialize every test that mutates this key.
+            unsafe {
+                match &self.original {
+                    Some(value) => env::set_var(self.key, value),
+                    None => env::remove_var(self.key),
+                }
+            }
+        }
+    }
 
     #[test]
     #[serial(xdg_env)]
@@ -306,23 +343,14 @@ mod tests {
         use std::os::unix::fs::symlink;
         use tempfile::TempDir;
 
-        let original = env::var("XDG_CONFIG_HOME").ok();
         let temp_dir = TempDir::new().expect("failed to create temp dir");
         let config_dir = temp_dir.path().join("kakehashi");
         std::fs::create_dir_all(&config_dir).expect("failed to create config dir");
         symlink("missing.toml", config_dir.join("kakehashi.toml"))
             .expect("failed to create dangling config symlink");
 
-        // SAFETY: #[serial(xdg_env)] prevents concurrent modification of XDG_CONFIG_HOME.
-        unsafe { env::set_var("XDG_CONFIG_HOME", temp_dir.path()) };
+        let _xdg = EnvVarGuard::set("XDG_CONFIG_HOME", temp_dir.path());
         let result = load_user_config();
-        // SAFETY: #[serial(xdg_env)] prevents concurrent modification of XDG_CONFIG_HOME.
-        unsafe {
-            match original {
-                Some(value) => env::set_var("XDG_CONFIG_HOME", value),
-                None => env::remove_var("XDG_CONFIG_HOME"),
-            }
-        }
 
         assert!(
             matches!(result, Err(UserConfigError::IoError { .. })),


### PR DESCRIPTION
Closes #785.

## Summary
- read the user config directly instead of prechecking with `Path::exists()`
- treat `NotFound` as zero-config only when `symlink_metadata` confirms the path itself is absent
- report dangling config symlinks and other metadata failures as `UserConfigError::IoError`

## Validation
- `cargo test --lib config::user::tests::load_user_config_`
- `cargo fmt --check`
- `cargo clippy --lib -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user configuration loading to distinguish missing configuration from broken symbolic links and other access errors.
  * Configuration paths affected by dangling links or unreadable locations now return clear errors instead of being treated as absent.
  * Added a retry for transient “not found” results to better handle stale filesystem state.

* **Tests**
  * Added coverage for dangling links in both configuration files and parent directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->