### PR TITLE
fix(config): surface broken workspace config paths

### DIFF
--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -620,7 +620,8 @@ fn read_workspace_toml_contents(
                 }
                 Err(metadata_error) => {
                     events.push(SettingsEvent::warning(format!(
-                        "Failed to read kakehashi.toml: {metadata_error}"
+                        "Failed to read {}: {metadata_error}",
+                        config_path.display()
                     )));
                     None
                 }
@@ -630,7 +631,8 @@ fn read_workspace_toml_contents(
                     Ok(contents) => Some(contents),
                     Err(retry_error) => {
                         events.push(SettingsEvent::warning(format!(
-                            "Failed to read kakehashi.toml: {retry_error}"
+                            "Failed to read {}: {retry_error}",
+                            config_path.display()
                         )));
                         None
                     }
@@ -639,7 +641,8 @@ fn read_workspace_toml_contents(
         }
         Err(err) => {
             events.push(SettingsEvent::warning(format!(
-                "Failed to read kakehashi.toml: {}",
+                "Failed to read {}: {}",
+                config_path.display(),
                 err
             )));
             None
@@ -1855,7 +1858,8 @@ mod tests {
         assert!(
             events.iter().any(|event| {
                 event.kind == SettingsEventKind::Warning
-                    && event.message.contains("Failed to read kakehashi.toml")
+                    && event.message.contains("Failed to read")
+                    && event.message.contains(&dir.path().display().to_string())
             }),
             "a configured but broken workspace path must emit a read warning: {events:?}"
         );

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -1848,7 +1848,8 @@ mod tests {
         use std::os::unix::fs::symlink;
 
         let dir = TempDir::new().unwrap();
-        symlink("missing.toml", dir.path().join("kakehashi.toml")).unwrap();
+        let config_path = dir.path().join("kakehashi.toml");
+        symlink("missing.toml", &config_path).unwrap();
 
         let mut events = Vec::new();
         let mut deprecated_keys = DeprecatedKeysSeen::default();
@@ -1859,7 +1860,7 @@ mod tests {
             events.iter().any(|event| {
                 event.kind == SettingsEventKind::Warning
                     && event.message.contains("Failed to read")
-                    && event.message.contains(&dir.path().display().to_string())
+                    && event.message.contains(&config_path.display().to_string())
             }),
             "a configured but broken workspace path must emit a read warning: {events:?}"
         );

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -614,35 +614,56 @@ fn load_toml_settings(
 ) -> Option<RawWorkspaceSettings> {
     let root = root_path?;
     let config_path = root.join("kakehashi.toml");
-    if !config_path.exists() {
-        return None;
-    }
-
-    events.push(SettingsEvent::info(format!(
-        "Found config file: {}",
-        config_path.display()
-    )));
-
-    match fs::read_to_string(&config_path) {
+    let contents = match fs::read_to_string(&config_path) {
         Ok(contents) => {
-            deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
-            match toml::from_str::<RawWorkspaceSettings>(&contents) {
-                Ok(settings) => {
-                    events.push(SettingsEvent::info("Successfully loaded kakehashi.toml"));
-                    Some(settings)
+            events.push(SettingsEvent::info(format!(
+                "Found config file: {}",
+                config_path.display()
+            )));
+            contents
+        }
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+            match fs::symlink_metadata(&config_path) {
+                Err(metadata_error) if metadata_error.kind() == std::io::ErrorKind::NotFound => {
+                    return None;
                 }
-                Err(err) => {
+                Err(metadata_error) => {
                     events.push(SettingsEvent::warning(format!(
-                        "Failed to parse kakehashi.toml: {}",
-                        err
+                        "Failed to read kakehashi.toml: {metadata_error}"
                     )));
-                    None
+                    return None;
                 }
+                // The path may have appeared after the first read. Retry once;
+                // a dangling symlink remains a read error on the retry.
+                Ok(_) => match fs::read_to_string(&config_path) {
+                    Ok(contents) => contents,
+                    Err(retry_error) => {
+                        events.push(SettingsEvent::warning(format!(
+                            "Failed to read kakehashi.toml: {retry_error}"
+                        )));
+                        return None;
+                    }
+                },
             }
         }
         Err(err) => {
             events.push(SettingsEvent::warning(format!(
                 "Failed to read kakehashi.toml: {}",
+                err
+            )));
+            return None;
+        }
+    };
+
+    deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
+    match toml::from_str::<RawWorkspaceSettings>(&contents) {
+        Ok(settings) => {
+            events.push(SettingsEvent::info("Successfully loaded kakehashi.toml"));
+            Some(settings)
+        }
+        Err(err) => {
+            events.push(SettingsEvent::warning(format!(
+                "Failed to parse kakehashi.toml: {}",
                 err
             )));
             None
@@ -1810,6 +1831,28 @@ mod tests {
         assert!(
             used_deprecated.root_markers,
             "rootMarkers should set the flag"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_toml_settings_reports_dangling_workspace_config() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TempDir::new().unwrap();
+        symlink("missing.toml", dir.path().join("kakehashi.toml")).unwrap();
+
+        let mut events = Vec::new();
+        let mut deprecated_keys = DeprecatedKeysSeen::default();
+        let result = load_toml_settings(Some(dir.path()), &mut events, &mut deprecated_keys);
+
+        assert!(result.is_none());
+        assert!(
+            events.iter().any(|event| {
+                event.kind == SettingsEventKind::Warning
+                    && event.message.contains("Failed to read kakehashi.toml")
+            }),
+            "a configured but broken workspace path must emit a read warning: {events:?}"
         );
     }
 }

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -607,41 +607,32 @@ fn load_toml_file(
     Ok(Some(settings))
 }
 
-fn load_toml_settings(
-    root_path: Option<&Path>,
+fn read_workspace_toml_contents(
+    config_path: &Path,
     events: &mut Vec<SettingsEvent>,
-    deprecated_keys: &mut DeprecatedKeysSeen,
-) -> Option<RawWorkspaceSettings> {
-    let root = root_path?;
-    let config_path = root.join("kakehashi.toml");
-    let contents = match fs::read_to_string(&config_path) {
-        Ok(contents) => {
-            events.push(SettingsEvent::info(format!(
-                "Found config file: {}",
-                config_path.display()
-            )));
-            contents
-        }
+) -> Option<String> {
+    match fs::read_to_string(config_path) {
+        Ok(contents) => Some(contents),
         Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
-            match fs::symlink_metadata(&config_path) {
+            match fs::symlink_metadata(config_path) {
                 Err(metadata_error) if metadata_error.kind() == std::io::ErrorKind::NotFound => {
-                    return None;
+                    None
                 }
                 Err(metadata_error) => {
                     events.push(SettingsEvent::warning(format!(
                         "Failed to read kakehashi.toml: {metadata_error}"
                     )));
-                    return None;
+                    None
                 }
                 // The path may have appeared after the first read. Retry once;
                 // a dangling symlink remains a read error on the retry.
-                Ok(_) => match fs::read_to_string(&config_path) {
-                    Ok(contents) => contents,
+                Ok(_) => match fs::read_to_string(config_path) {
+                    Ok(contents) => Some(contents),
                     Err(retry_error) => {
                         events.push(SettingsEvent::warning(format!(
                             "Failed to read kakehashi.toml: {retry_error}"
                         )));
-                        return None;
+                        None
                     }
                 },
             }
@@ -651,9 +642,23 @@ fn load_toml_settings(
                 "Failed to read kakehashi.toml: {}",
                 err
             )));
-            return None;
+            None
         }
-    };
+    }
+}
+
+fn load_toml_settings(
+    root_path: Option<&Path>,
+    events: &mut Vec<SettingsEvent>,
+    deprecated_keys: &mut DeprecatedKeysSeen,
+) -> Option<RawWorkspaceSettings> {
+    let root = root_path?;
+    let config_path = root.join("kakehashi.toml");
+    let contents = read_workspace_toml_contents(&config_path, events)?;
+    events.push(SettingsEvent::info(format!(
+        "Found config file: {}",
+        config_path.display()
+    )));
 
     deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
     match toml::from_str::<RawWorkspaceSettings>(&contents) {


### PR DESCRIPTION
Closes #794.

## Summary
- read workspace-local `kakehashi.toml` directly instead of prechecking with `Path::exists()`
- ignore only a genuinely absent config path
- preserve the existing read-warning event for dangling symlinks and metadata failures
- retry once if a config appears concurrently between the first read and metadata check
- add a dangling-workspace-config regression test

## Validation
- `cargo test --lib lsp::settings::tests::load_toml_settings`
- `cargo fmt --check`
- `cargo clippy --lib -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing, unreadable, and broken `kakehashi.toml` paths by distinguishing truly absent configs from transient/dangling symlink states.
  * Added warning notifications when the settings file can’t be read, including a single retry to recover from broken links.
  * Preserved silent behavior when the config is definitively not found.

* **Tests**
  * Added Unix-only test coverage for dangling symlinks and the resulting warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->