### PR TITLE
fix(diagnostics): debounce downstream refresh bursts

### DIFF
--- a/docs/architecture-decisions/downstream-diagnostic-refresh-handling.md
+++ b/docs/architecture-decisions/downstream-diagnostic-refresh-handling.md
@@ -200,18 +200,17 @@ keeps the default `true`. kakehashi never guesses the editor's behavior.
 
 ## Decision–Implementation Gap
 
-**Implemented**: rule 1 (accept always) — kakehashi advertises
+**Implemented**: rules 1 and 3. For rule 1 (accept always), kakehashi advertises
 `workspace.diagnostics.refreshSupport = true` to downstream
 (`src/lsp/bridge/protocol/client_capabilities.rs`), and the downstream
 `workspace/diagnostic/refresh` request handler
 (`src/lsp/bridge/workspace/diagnostic_refresh.rs`) acks it with a `null` result
-while emitting `UpstreamNotification::DiagnosticRefresh` to forward the refresh
-toward the editor (the lifecycle arm that performs that forward is where rule 3's
-gate will live).
+while emitting `UpstreamNotification::DiagnosticRefresh`. For rule 3, the
+lifecycle arm routes that notification through the workspace-wide leading +
+trailing scheduler, which checks `workspace.diagnostics.refreshSupport` before
+admission and sends through the existing detached single-flight path.
 
 **Planned** (this decision):
 
-- Rule 3 — gate the editor forward on `check_diagnostic_refresh_support` (today it
-  forwards unconditionally).
 - Rule 2 — add the downstream-refresh → Path A pull trigger (today a downstream
   refresh never re-pulls).

--- a/docs/architecture-decisions/downstream-diagnostic-refresh-handling.md
+++ b/docs/architecture-decisions/downstream-diagnostic-refresh-handling.md
@@ -98,6 +98,16 @@ pull-driven downstream; whether the editor actually re-pulls is its own
 (unadvertised) choice — which is exactly why rule 2's push path is not conditioned
 on it. This gate is orthogonal to rule 2's *pull*.
 
+Forwarding is scheduled once per upstream workspace connection, not once per
+downstream server. The first downstream refresh after idle is the leading edge
+and is forwarded immediately. Further downstream refreshes join one trailing
+debounce cycle: 100 ms of quiet releases the latest activity, while an anchored
+1 s maximum wait prevents a continuously chatty server from postponing it
+forever. If another editor refresh is sent after the latest downstream activity,
+that send already provides the required re-pull nudge and the trailing forward is
+suppressed. This keeps independent downstream servers on the same workspace-wide
+cadence without coupling separate kakehashi workspace connections.
+
 ### Why 2 and 3 are decoupled (not "skip the pull when the editor can pull")
 
 Coupling rule 2 to the editor's refresh capability would save one redundant pull

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -497,7 +497,7 @@ pub(crate) struct ForwardedRefreshWaitSnapshot {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ForwardedRefreshWait {
     Restart(ForwardedRefreshWaitSnapshot),
-    SendTrailing,
+    SendTrailing(ForwardedRefreshWaitSnapshot),
     Settled,
     MaxWait {
         snapshot: ForwardedRefreshWaitSnapshot,
@@ -693,15 +693,43 @@ impl DiagnosticAggregator {
                     .last_activity_at
                     .expect("activity generation has a timestamp"),
             })
+        } else if debounce.covered_generation != Some(debounce.generation)
+            && debounce.refresh_epoch == debounce.refresh_epoch_at_last_activity
+        {
+            ForwardedRefreshWait::SendTrailing(ForwardedRefreshWaitSnapshot {
+                generation: debounce.generation,
+                last_activity_at: debounce
+                    .last_activity_at
+                    .expect("activity generation has a timestamp"),
+            })
         } else {
             debounce.task_scheduled = false;
-            if debounce.covered_generation != Some(debounce.generation)
-                && debounce.refresh_epoch == debounce.refresh_epoch_at_last_activity
-            {
-                ForwardedRefreshWait::SendTrailing
-            } else {
-                ForwardedRefreshWait::Settled
-            }
+            ForwardedRefreshWait::Settled
+        }
+    }
+
+    /// Release a quiet-edge claim after its forced refresh admission. If newer
+    /// activity arrived in the admission gap, keep the same task responsible
+    /// for settling that generation instead of letting it start a second
+    /// leading cycle beside the admitted trailing request.
+    pub(crate) fn finish_forwarded_refresh_admission(
+        &self,
+        admitted_generation: u64,
+    ) -> Option<ForwardedRefreshWaitSnapshot> {
+        let mut debounce = self
+            .forwarded_refresh_debounce
+            .lock()
+            .recover_poison("DiagnosticAggregator::forwarded_refresh_debounce");
+        if debounce.generation == admitted_generation {
+            debounce.task_scheduled = false;
+            None
+        } else {
+            Some(ForwardedRefreshWaitSnapshot {
+                generation: debounce.generation,
+                last_activity_at: debounce
+                    .last_activity_at
+                    .expect("activity generation has a timestamp"),
+            })
         }
     }
 
@@ -2445,10 +2473,15 @@ mod tests {
         else {
             panic!("activity during the wait must restart the settle window");
         };
-        assert_eq!(
-            agg.finish_forwarded_refresh_wait(latest.generation, false),
-            ForwardedRefreshWait::SendTrailing,
-            "activity after the leading send releases exactly one trailing refresh"
+        let ForwardedRefreshWait::SendTrailing(admitted) =
+            agg.finish_forwarded_refresh_wait(latest.generation, false)
+        else {
+            panic!("activity after the leading send releases one trailing refresh");
+        };
+        agg.mark_forwarded_refresh_covered(admitted.generation);
+        assert!(
+            agg.finish_forwarded_refresh_admission(admitted.generation)
+                .is_none()
         );
         assert!(
             agg.begin_forwarded_refresh_debounce().is_some(),
@@ -2550,11 +2583,48 @@ mod tests {
         else {
             panic!("the waiter must observe the newer activity");
         };
-        assert_eq!(
-            agg.finish_forwarded_refresh_wait(newest.generation, false),
-            ForwardedRefreshWait::SendTrailing,
+        assert!(
+            matches!(
+                agg.finish_forwarded_refresh_wait(newest.generation, false),
+                ForwardedRefreshWait::SendTrailing(snapshot)
+                    if snapshot.generation == newest.generation
+            ),
             "an older admission must not suppress the newer generation"
         );
+    }
+
+    #[test]
+    fn quiet_trailing_keeps_the_claim_until_refresh_admission() {
+        let agg = DiagnosticAggregator::new();
+        let first = agg
+            .begin_forwarded_refresh_debounce()
+            .expect("the first refresh schedules the settle task");
+        agg.mark_forwarded_refresh_covered(first.generation);
+        assert!(agg.begin_forwarded_refresh_debounce().is_none());
+        let ForwardedRefreshWait::Restart(latest) =
+            agg.finish_forwarded_refresh_wait(first.generation, false)
+        else {
+            panic!("the waiter must observe post-leading activity");
+        };
+
+        let ForwardedRefreshWait::SendTrailing(admitted) =
+            agg.finish_forwarded_refresh_wait(latest.generation, false)
+        else {
+            panic!("the quiet edge needs a trailing refresh");
+        };
+        assert!(
+            agg.begin_forwarded_refresh_debounce().is_none(),
+            "the trailing edge must retain the claim until admission"
+        );
+        agg.mark_forwarded_refresh_covered(admitted.generation);
+        let newer = agg
+            .finish_forwarded_refresh_admission(admitted.generation)
+            .expect("activity in the admission gap stays owned by this task");
+        assert!(matches!(
+            agg.finish_forwarded_refresh_wait(newer.generation, false),
+            ForwardedRefreshWait::SendTrailing(snapshot)
+                if snapshot.generation == newer.generation
+        ));
     }
 
     #[test]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -715,12 +715,14 @@ impl DiagnosticAggregator {
     /// Record that a forced refresh has been admitted for the latest downstream
     /// activity. Admission is enough: the refresh single-flight guarantees that
     /// an in-flight request will eventually emit its forced pending successor.
-    pub(crate) fn mark_forwarded_refresh_covered(&self) {
+    pub(crate) fn mark_forwarded_refresh_covered(&self, generation: u64) {
         let mut debounce = self
             .forwarded_refresh_debounce
             .lock()
             .recover_poison("DiagnosticAggregator::forwarded_refresh_debounce");
-        debounce.covered_generation = Some(debounce.generation);
+        if debounce.generation == generation {
+            debounce.covered_generation = Some(generation);
+        }
     }
 
     pub(crate) fn new() -> Self {
@@ -2502,7 +2504,7 @@ mod tests {
         let first = agg
             .begin_forwarded_refresh_debounce()
             .expect("the first refresh schedules the settle task");
-        agg.mark_forwarded_refresh_covered();
+        agg.mark_forwarded_refresh_covered(first.generation);
         assert!(agg.begin_forwarded_refresh_debounce().is_none());
 
         let ForwardedRefreshWait::MaxWait {
@@ -2512,12 +2514,46 @@ mod tests {
         else {
             panic!("activity after the leading edge needs a max-wait send");
         };
-        agg.mark_forwarded_refresh_covered();
+        agg.mark_forwarded_refresh_covered(latest.generation);
 
         assert_eq!(
             agg.finish_forwarded_refresh_wait(latest.generation, false),
             ForwardedRefreshWait::Settled,
             "admission must prevent a delayed waiter from scheduling the same trailing edge twice"
+        );
+    }
+
+    #[test]
+    fn an_old_admission_never_covers_a_newer_generation() {
+        let agg = DiagnosticAggregator::new();
+        let first = agg
+            .begin_forwarded_refresh_debounce()
+            .expect("the first refresh schedules the settle task");
+        agg.mark_forwarded_refresh_covered(first.generation);
+        assert!(agg.begin_forwarded_refresh_debounce().is_none());
+        let ForwardedRefreshWait::MaxWait {
+            snapshot: admitted,
+            send_trailing: true,
+        } = agg.finish_forwarded_refresh_wait(first.generation, true)
+        else {
+            panic!("the second generation needs a max-wait send");
+        };
+
+        // The admitted send happens before a newer activity, but its coverage
+        // mark loses the race and runs afterward.
+        agg.record_refresh_sent();
+        assert!(agg.begin_forwarded_refresh_debounce().is_none());
+        agg.mark_forwarded_refresh_covered(admitted.generation);
+
+        let ForwardedRefreshWait::Restart(newest) =
+            agg.finish_forwarded_refresh_wait(admitted.generation, false)
+        else {
+            panic!("the waiter must observe the newer activity");
+        };
+        assert_eq!(
+            agg.finish_forwarded_refresh_wait(newest.generation, false),
+            ForwardedRefreshWait::SendTrailing,
+            "an older admission must not suppress the newer generation"
         );
     }
 

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -418,10 +418,12 @@ pub(crate) struct DiagnosticAggregator {
     /// that window set `pending`, which fires exactly one more refresh on
     /// completion. Drives [`Self::try_begin_refresh`]/[`Self::finish_refresh`].
     refresh_flight: Mutex<RefreshFlight>,
-    /// Trailing-edge debounce for downstream-forwarded diagnostic refreshes
-    /// (#789). Unlike [`Self::refresh_flight`], which only coalesces while the
-    /// editor's acknowledgement is outstanding, this also collapses bursts
-    /// when the editor answers each request immediately.
+    /// Leading + trailing debounce for downstream-forwarded diagnostic
+    /// refreshes (#789). Unlike [`Self::refresh_flight`], which only coalesces
+    /// while the editor's acknowledgement is outstanding, this also collapses
+    /// bursts when the editor answers each request immediately. The first
+    /// activity after idle sends without waiting; later activity produces a
+    /// trailing send only when no refresh from any origin has covered it.
     forwarded_refresh_debounce: Mutex<ForwardedRefreshDebounce>,
     /// Per-host coverage versions for the refresh **coverage gate** (#497, commit 2).
     /// `current` bumps on every set-changing republish (the editor's pulled view is
@@ -480,6 +482,21 @@ struct RefreshFlight {
 struct ForwardedRefreshDebounce {
     generation: u64,
     task_scheduled: bool,
+    last_activity_at: Option<tokio::time::Instant>,
+    refreshes_sent_at_last_activity: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ForwardedRefreshWaitSnapshot {
+    pub(crate) generation: u64,
+    pub(crate) last_activity_at: tokio::time::Instant,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ForwardedRefreshWait {
+    Restart(ForwardedRefreshWaitSnapshot),
+    SendTrailing,
+    Settled,
 }
 
 /// Per-host coalescing state for the editor-facing `publishDiagnostics` wire
@@ -617,33 +634,56 @@ impl DiagnosticAggregator {
     /// Record downstream refresh activity and claim the single debounce task.
     /// The returned generation is the activity snapshot that task should wait
     /// against; `None` means an existing task will observe this activity.
-    pub(crate) fn begin_forwarded_refresh_debounce(&self) -> Option<u64> {
+    pub(crate) fn begin_forwarded_refresh_debounce(&self) -> Option<ForwardedRefreshWaitSnapshot> {
         let mut debounce = self
             .forwarded_refresh_debounce
             .lock()
             .recover_poison("DiagnosticAggregator::forwarded_refresh_debounce");
         debounce.generation = debounce.generation.wrapping_add(1);
+        let last_activity_at = tokio::time::Instant::now();
+        debounce.last_activity_at = Some(last_activity_at);
+        debounce.refreshes_sent_at_last_activity =
+            self.metrics.refreshes_sent.load(Ordering::Relaxed);
         if debounce.task_scheduled {
             None
         } else {
             debounce.task_scheduled = true;
-            Some(debounce.generation)
+            Some(ForwardedRefreshWaitSnapshot {
+                generation: debounce.generation,
+                last_activity_at,
+            })
         }
     }
 
     /// Check whether activity occurred during the debounce wait. A newer
-    /// generation restarts the settle window; `None` releases the task claim
-    /// and tells the caller to forward exactly one refresh.
-    pub(crate) fn finish_forwarded_refresh_wait(&self, observed: u64, force: bool) -> Option<u64> {
+    /// generation restarts the settle window. Once the wait settles, request a
+    /// trailing refresh only when no refresh send has covered the latest
+    /// downstream activity; the leading send or another refresh origin may
+    /// already have done so.
+    pub(crate) fn finish_forwarded_refresh_wait(
+        &self,
+        observed: u64,
+        force: bool,
+    ) -> ForwardedRefreshWait {
         let mut debounce = self
             .forwarded_refresh_debounce
             .lock()
             .recover_poison("DiagnosticAggregator::forwarded_refresh_debounce");
         if !force && debounce.generation != observed {
-            Some(debounce.generation)
+            ForwardedRefreshWait::Restart(ForwardedRefreshWaitSnapshot {
+                generation: debounce.generation,
+                last_activity_at: debounce
+                    .last_activity_at
+                    .expect("activity generation has a timestamp"),
+            })
         } else {
             debounce.task_scheduled = false;
-            None
+            let refreshes_sent = self.metrics.refreshes_sent.load(Ordering::Relaxed);
+            if refreshes_sent == debounce.refreshes_sent_at_last_activity {
+                ForwardedRefreshWait::SendTrailing
+            } else {
+                ForwardedRefreshWait::Settled
+            }
         }
     }
 
@@ -2351,21 +2391,66 @@ mod tests {
         let first = agg
             .begin_forwarded_refresh_debounce()
             .expect("the first refresh schedules the trailing task");
+        agg.record_refresh_sent();
         assert!(
             agg.begin_forwarded_refresh_debounce().is_none(),
             "burst activity must reuse the scheduled task"
         );
-        let latest = agg
-            .finish_forwarded_refresh_wait(first, false)
-            .expect("activity during the wait restarts the settle window");
+        let ForwardedRefreshWait::Restart(latest) =
+            agg.finish_forwarded_refresh_wait(first.generation, false)
+        else {
+            panic!("activity during the wait must restart the settle window");
+        };
         assert_eq!(
-            agg.finish_forwarded_refresh_wait(latest, false),
-            None,
-            "a quiet window releases exactly one refresh"
+            agg.finish_forwarded_refresh_wait(latest.generation, false),
+            ForwardedRefreshWait::SendTrailing,
+            "activity after the leading send releases exactly one trailing refresh"
         );
         assert!(
             agg.begin_forwarded_refresh_debounce().is_some(),
             "new activity after the quiet window schedules the next refresh"
+        );
+    }
+
+    #[test]
+    fn forwarded_refresh_settles_without_a_duplicate_after_the_leading_send() {
+        let agg = DiagnosticAggregator::new();
+        let first = agg
+            .begin_forwarded_refresh_debounce()
+            .expect("the first refresh schedules the settle task");
+
+        agg.record_refresh_sent();
+
+        assert_eq!(
+            agg.finish_forwarded_refresh_wait(first.generation, false),
+            ForwardedRefreshWait::Settled,
+            "the leading send covers the only activity"
+        );
+    }
+
+    #[test]
+    fn another_refresh_after_the_latest_activity_satisfies_the_trailing_edge() {
+        let agg = DiagnosticAggregator::new();
+        let first = agg
+            .begin_forwarded_refresh_debounce()
+            .expect("the first refresh schedules the settle task");
+        agg.record_refresh_sent();
+        assert!(
+            agg.begin_forwarded_refresh_debounce().is_none(),
+            "later downstream activity remains in the same debounce cycle"
+        );
+        let ForwardedRefreshWait::Restart(latest) =
+            agg.finish_forwarded_refresh_wait(first.generation, false)
+        else {
+            panic!("the waiter must observe the later activity");
+        };
+
+        agg.record_refresh_sent();
+
+        assert_eq!(
+            agg.finish_forwarded_refresh_wait(latest.generation, false),
+            ForwardedRefreshWait::Settled,
+            "a refresh sent after the latest activity makes a forced trailing send redundant"
         );
     }
 

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -552,7 +552,8 @@ struct DiagnosticMetrics {
     refreshes_requested: AtomicU64,
     /// `workspace/diagnostic/refresh` requests actually written to the wire (post
     /// forwarded-refresh debounce + single-flight/coverage gates, including
-    /// trailing fires). `requested - sent` is the total coalescing/gate savings.
+    /// trailing fires). `requested - sent` includes coalesced, gated, and
+    /// shutdown-suppressed requests.
     refreshes_sent: AtomicU64,
     /// `textDocument/diagnostic` pulls answered (every return of the LSP handler).
     pulls_answered: AtomicU64,
@@ -2528,7 +2529,7 @@ mod tests {
         assert_eq!(
             m.refreshes_requested.saturating_sub(m.refreshes_sent),
             2,
-            "requested - sent is what coalescing and the gates saved"
+            "requested - sent includes coalesced, gated, and shutdown-suppressed requests"
         );
         assert_eq!(m.pulls_answered, 2);
         assert_eq!(m.pull_micros_total, 400);

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -418,6 +418,11 @@ pub(crate) struct DiagnosticAggregator {
     /// that window set `pending`, which fires exactly one more refresh on
     /// completion. Drives [`Self::try_begin_refresh`]/[`Self::finish_refresh`].
     refresh_flight: Mutex<RefreshFlight>,
+    /// Trailing-edge debounce for downstream-forwarded diagnostic refreshes
+    /// (#789). Unlike [`Self::refresh_flight`], which only coalesces while the
+    /// editor's acknowledgement is outstanding, this also collapses bursts
+    /// when the editor answers each request immediately.
+    forwarded_refresh_debounce: Mutex<ForwardedRefreshDebounce>,
     /// Per-host coverage versions for the refresh **coverage gate** (#497, commit 2).
     /// `current` bumps on every set-changing republish (the editor's pulled view is
     /// now stale); `served` records the `current` a pull was answered against. A
@@ -469,6 +474,12 @@ struct RefreshFlight {
     /// refresh, #521), so the trailing must fire regardless of the coverage gate —
     /// there is no version representing what the downstream asked to refresh.
     pending_forced: bool,
+}
+
+#[derive(Default)]
+struct ForwardedRefreshDebounce {
+    generation: u64,
+    task_scheduled: bool,
 }
 
 /// Per-host coalescing state for the editor-facing `publishDiagnostics` wire
@@ -602,6 +613,39 @@ impl DiagnosticMetricsSnapshot {
 }
 
 impl DiagnosticAggregator {
+    /// Record downstream refresh activity and claim the single debounce task.
+    /// The returned generation is the activity snapshot that task should wait
+    /// against; `None` means an existing task will observe this activity.
+    pub(crate) fn begin_forwarded_refresh_debounce(&self) -> Option<u64> {
+        let mut debounce = self
+            .forwarded_refresh_debounce
+            .lock()
+            .recover_poison("DiagnosticAggregator::forwarded_refresh_debounce");
+        debounce.generation = debounce.generation.wrapping_add(1);
+        if debounce.task_scheduled {
+            None
+        } else {
+            debounce.task_scheduled = true;
+            Some(debounce.generation)
+        }
+    }
+
+    /// Check whether activity occurred during the debounce wait. A newer
+    /// generation restarts the settle window; `None` releases the task claim
+    /// and tells the caller to forward exactly one refresh.
+    pub(crate) fn finish_forwarded_refresh_wait(&self, observed: u64) -> Option<u64> {
+        let mut debounce = self
+            .forwarded_refresh_debounce
+            .lock()
+            .recover_poison("DiagnosticAggregator::forwarded_refresh_debounce");
+        if debounce.generation != observed {
+            Some(debounce.generation)
+        } else {
+            debounce.task_scheduled = false;
+            None
+        }
+    }
+
     pub(crate) fn new() -> Self {
         Self::default()
     }
@@ -2289,6 +2333,31 @@ mod tests {
             "cleared guard → next request sends"
         );
         assert!(!agg.finish_refresh(), "no pending → clears");
+    }
+
+    #[test]
+    fn forwarded_refresh_debounce_waits_for_a_quiet_window() {
+        let agg = DiagnosticAggregator::new();
+
+        let first = agg
+            .begin_forwarded_refresh_debounce()
+            .expect("the first refresh schedules the trailing task");
+        assert!(
+            agg.begin_forwarded_refresh_debounce().is_none(),
+            "burst activity must reuse the scheduled task"
+        );
+        let latest = agg
+            .finish_forwarded_refresh_wait(first)
+            .expect("activity during the wait restarts the settle window");
+        assert_eq!(
+            agg.finish_forwarded_refresh_wait(latest),
+            None,
+            "a quiet window releases exactly one refresh"
+        );
+        assert!(
+            agg.begin_forwarded_refresh_debounce().is_some(),
+            "new activity after the quiet window schedules the next refresh"
+        );
     }
 
     #[test]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -483,7 +483,8 @@ struct ForwardedRefreshDebounce {
     generation: u64,
     task_scheduled: bool,
     last_activity_at: Option<tokio::time::Instant>,
-    refreshes_sent_at_last_activity: u64,
+    refresh_epoch: u64,
+    refresh_epoch_at_last_activity: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -497,6 +498,10 @@ pub(crate) enum ForwardedRefreshWait {
     Restart(ForwardedRefreshWaitSnapshot),
     SendTrailing,
     Settled,
+    MaxWait {
+        snapshot: ForwardedRefreshWaitSnapshot,
+        send_trailing: bool,
+    },
 }
 
 /// Per-host coalescing state for the editor-facing `publishDiagnostics` wire
@@ -642,8 +647,7 @@ impl DiagnosticAggregator {
         debounce.generation = debounce.generation.wrapping_add(1);
         let last_activity_at = tokio::time::Instant::now();
         debounce.last_activity_at = Some(last_activity_at);
-        debounce.refreshes_sent_at_last_activity =
-            self.metrics.refreshes_sent.load(Ordering::Relaxed);
+        debounce.refresh_epoch_at_last_activity = debounce.refresh_epoch;
         if debounce.task_scheduled {
             None
         } else {
@@ -663,13 +667,24 @@ impl DiagnosticAggregator {
     pub(crate) fn finish_forwarded_refresh_wait(
         &self,
         observed: u64,
-        force: bool,
+        max_wait_reached: bool,
     ) -> ForwardedRefreshWait {
         let mut debounce = self
             .forwarded_refresh_debounce
             .lock()
             .recover_poison("DiagnosticAggregator::forwarded_refresh_debounce");
-        if !force && debounce.generation != observed {
+        if max_wait_reached {
+            return ForwardedRefreshWait::MaxWait {
+                snapshot: ForwardedRefreshWaitSnapshot {
+                    generation: debounce.generation,
+                    last_activity_at: debounce
+                        .last_activity_at
+                        .expect("activity generation has a timestamp"),
+                },
+                send_trailing: debounce.refresh_epoch == debounce.refresh_epoch_at_last_activity,
+            };
+        }
+        if debounce.generation != observed {
             ForwardedRefreshWait::Restart(ForwardedRefreshWaitSnapshot {
                 generation: debounce.generation,
                 last_activity_at: debounce
@@ -678,13 +693,19 @@ impl DiagnosticAggregator {
             })
         } else {
             debounce.task_scheduled = false;
-            let refreshes_sent = self.metrics.refreshes_sent.load(Ordering::Relaxed);
-            if refreshes_sent == debounce.refreshes_sent_at_last_activity {
+            if debounce.refresh_epoch == debounce.refresh_epoch_at_last_activity {
                 ForwardedRefreshWait::SendTrailing
             } else {
                 ForwardedRefreshWait::Settled
             }
         }
+    }
+
+    pub(crate) fn cancel_forwarded_refresh_debounce(&self) {
+        self.forwarded_refresh_debounce
+            .lock()
+            .recover_poison("DiagnosticAggregator::forwarded_refresh_debounce")
+            .task_scheduled = false;
     }
 
     pub(crate) fn new() -> Self {
@@ -699,6 +720,12 @@ impl DiagnosticAggregator {
 
     /// Record that a `workspace/diagnostic/refresh` was actually written to the wire.
     pub(crate) fn record_refresh_sent(&self) {
+        let mut debounce = self
+            .forwarded_refresh_debounce
+            .lock()
+            .recover_poison("DiagnosticAggregator::forwarded_refresh_debounce");
+        debounce.refresh_epoch = debounce.refresh_epoch.wrapping_add(1);
+        drop(debounce);
         self.metrics.record_refresh_sent();
     }
 

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -485,6 +485,7 @@ struct ForwardedRefreshDebounce {
     last_activity_at: Option<tokio::time::Instant>,
     refresh_epoch: u64,
     refresh_epoch_at_last_activity: u64,
+    covered_generation: Option<u64>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -681,7 +682,8 @@ impl DiagnosticAggregator {
                         .last_activity_at
                         .expect("activity generation has a timestamp"),
                 },
-                send_trailing: debounce.refresh_epoch == debounce.refresh_epoch_at_last_activity,
+                send_trailing: debounce.covered_generation != Some(debounce.generation)
+                    && debounce.refresh_epoch == debounce.refresh_epoch_at_last_activity,
             };
         }
         if debounce.generation != observed {
@@ -693,7 +695,9 @@ impl DiagnosticAggregator {
             })
         } else {
             debounce.task_scheduled = false;
-            if debounce.refresh_epoch == debounce.refresh_epoch_at_last_activity {
+            if debounce.covered_generation != Some(debounce.generation)
+                && debounce.refresh_epoch == debounce.refresh_epoch_at_last_activity
+            {
                 ForwardedRefreshWait::SendTrailing
             } else {
                 ForwardedRefreshWait::Settled
@@ -706,6 +710,17 @@ impl DiagnosticAggregator {
             .lock()
             .recover_poison("DiagnosticAggregator::forwarded_refresh_debounce")
             .task_scheduled = false;
+    }
+
+    /// Record that a forced refresh has been admitted for the latest downstream
+    /// activity. Admission is enough: the refresh single-flight guarantees that
+    /// an in-flight request will eventually emit its forced pending successor.
+    pub(crate) fn mark_forwarded_refresh_covered(&self) {
+        let mut debounce = self
+            .forwarded_refresh_debounce
+            .lock()
+            .recover_poison("DiagnosticAggregator::forwarded_refresh_debounce");
+        debounce.covered_generation = Some(debounce.generation);
     }
 
     pub(crate) fn new() -> Self {
@@ -2478,6 +2493,31 @@ mod tests {
             agg.finish_forwarded_refresh_wait(latest.generation, false),
             ForwardedRefreshWait::Settled,
             "a refresh sent after the latest activity makes a forced trailing send redundant"
+        );
+    }
+
+    #[test]
+    fn max_wait_admission_covers_the_generation_before_the_wire_task_runs() {
+        let agg = DiagnosticAggregator::new();
+        let first = agg
+            .begin_forwarded_refresh_debounce()
+            .expect("the first refresh schedules the settle task");
+        agg.mark_forwarded_refresh_covered();
+        assert!(agg.begin_forwarded_refresh_debounce().is_none());
+
+        let ForwardedRefreshWait::MaxWait {
+            snapshot: latest,
+            send_trailing: true,
+        } = agg.finish_forwarded_refresh_wait(first.generation, true)
+        else {
+            panic!("activity after the leading edge needs a max-wait send");
+        };
+        agg.mark_forwarded_refresh_covered();
+
+        assert_eq!(
+            agg.finish_forwarded_refresh_wait(latest.generation, false),
+            ForwardedRefreshWait::Settled,
+            "admission must prevent a delayed waiter from scheduling the same trailing edge twice"
         );
     }
 

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -902,6 +902,14 @@ impl DiagnosticAggregator {
         }
     }
 
+    /// Clear refresh work that was admitted before shutdown became observable.
+    pub(crate) fn cancel_refresh_flight(&self) {
+        *self
+            .refresh_flight
+            .lock()
+            .recover_poison("DiagnosticAggregator::refresh_flight") = RefreshFlight::default();
+    }
+
     /// Bump a host's `current` coverage version (#497) — a **push-origin** change the
     /// editor doesn't know about just landed, so its last-pulled view is now stale.
     /// Called only from the push/eviction paths (`publish_recorded_hosts`,

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -455,7 +455,7 @@ pub(crate) struct DiagnosticAggregator {
     wire_gate: Mutex<HashMap<Url, WireGate>>,
     /// Always-on counters for the diagnostic path (#533): push-origin republishes
     /// in, `workspace/diagnostic/refresh` requested vs actually sent (the gap is
-    /// what the #497 single-flight + coverage gate saves), and pulls answered with
+    /// what debounce + the #497 single-flight/coverage gates save), and pulls answered with
     /// coarse latency. Read on shutdown / in tests to quantify refresh amplification
     /// on a real session before/after a change. Relaxed atomics — free on the hot
     /// path, and the counts need no cross-counter ordering.
@@ -547,12 +547,12 @@ struct DiagnosticMetrics {
     /// ingress that can drive a refresh). Counted in [`DiagnosticAggregator::bump_current`].
     push_republishes: AtomicU64,
     /// `workspace/diagnostic/refresh` asks that passed the client capability gate
-    /// (entry to `request_pull_diagnostic_refresh`), *before* the single-flight /
-    /// coverage gate decides whether to actually send.
+    /// before forwarded-refresh debounce and the single-flight/coverage gates
+    /// decide whether to actually send.
     refreshes_requested: AtomicU64,
     /// `workspace/diagnostic/refresh` requests actually written to the wire (post
-    /// single-flight + coverage gate, including trailing fires). `requested - sent`
-    /// is what the #497 gate saves.
+    /// forwarded-refresh debounce + single-flight/coverage gates, including
+    /// trailing fires). `requested - sent` is the total coalescing/gate savings.
     refreshes_sent: AtomicU64,
     /// `textDocument/diagnostic` pulls answered (every return of the LSP handler).
     pulls_answered: AtomicU64,
@@ -2520,7 +2520,7 @@ mod tests {
         assert_eq!(
             m.refreshes_requested.saturating_sub(m.refreshes_sent),
             2,
-            "requested - sent is what the gate saved"
+            "requested - sent is what coalescing and the gates saved"
         );
         assert_eq!(m.pulls_answered, 2);
         assert_eq!(m.pull_micros_total, 400);

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -633,12 +633,12 @@ impl DiagnosticAggregator {
     /// Check whether activity occurred during the debounce wait. A newer
     /// generation restarts the settle window; `None` releases the task claim
     /// and tells the caller to forward exactly one refresh.
-    pub(crate) fn finish_forwarded_refresh_wait(&self, observed: u64) -> Option<u64> {
+    pub(crate) fn finish_forwarded_refresh_wait(&self, observed: u64, force: bool) -> Option<u64> {
         let mut debounce = self
             .forwarded_refresh_debounce
             .lock()
             .recover_poison("DiagnosticAggregator::forwarded_refresh_debounce");
-        if debounce.generation != observed {
+        if !force && debounce.generation != observed {
             Some(debounce.generation)
         } else {
             debounce.task_scheduled = false;
@@ -2347,10 +2347,10 @@ mod tests {
             "burst activity must reuse the scheduled task"
         );
         let latest = agg
-            .finish_forwarded_refresh_wait(first)
+            .finish_forwarded_refresh_wait(first, false)
             .expect("activity during the wait restarts the settle window");
         assert_eq!(
-            agg.finish_forwarded_refresh_wait(latest),
+            agg.finish_forwarded_refresh_wait(latest, false),
             None,
             "a quiet window releases exactly one refresh"
         );

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -88,6 +88,9 @@ impl RepublishOutcome {
 /// chose existing config surfaces over new ones — revisit if a real setup
 /// needs a different cadence.
 const WIRE_PUBLISH_QUIET_WINDOW: std::time::Duration = std::time::Duration::from_secs(1);
+/// Short enough that a downstream re-analysis still prompts a timely editor
+/// pull, but longer than the 1 ms-scale refresh bursts observed in #789.
+const FORWARDED_REFRESH_SETTLE_WINDOW: std::time::Duration = std::time::Duration::from_millis(100);
 
 /// Bundles the state needed to merge the cache and publish for a host, so the
 /// notification feeds (reader push, host-event pull) can trigger a republish
@@ -116,6 +119,30 @@ impl DiagnosticPublisher {
             cache: Arc::clone(&server.cache),
             aggregator: Arc::clone(&server.diagnostics),
         }
+    }
+
+    /// Coalesce a burst of downstream `workspace/diagnostic/refresh` requests
+    /// into one forced upstream refresh after the burst settles (#789).
+    pub(crate) fn request_forwarded_diagnostic_refresh(&self) {
+        let Some(mut generation) = self.aggregator.begin_forwarded_refresh_debounce() else {
+            return;
+        };
+        let publisher = self.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(FORWARDED_REFRESH_SETTLE_WINDOW).await;
+                match publisher
+                    .aggregator
+                    .finish_forwarded_refresh_wait(generation)
+                {
+                    Some(latest) => generation = latest,
+                    None => {
+                        publisher.request_pull_diagnostic_refresh(true);
+                        break;
+                    }
+                }
+            }
+        });
     }
 
     /// Route a downstream `publishDiagnostics` push into the cache, classifying by

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -216,12 +216,17 @@ impl DiagnosticPublisher {
                                 snapshot: latest,
                                 send_trailing,
                             } => {
-                                if send_trailing
-                                    && publisher.request_pull_diagnostic_refresh_inner(true, false)
-                                {
-                                    publisher
-                                        .aggregator
-                                        .mark_forwarded_refresh_covered(latest.generation);
+                                if send_trailing {
+                                    if publisher
+                                        .request_pull_diagnostic_refresh_inner(true, false)
+                                    {
+                                        publisher
+                                            .aggregator
+                                            .mark_forwarded_refresh_covered(latest.generation);
+                                    } else {
+                                        publisher.aggregator.cancel_forwarded_refresh_debounce();
+                                        break;
+                                    }
                                 }
                                 snapshot = latest;
                                 deadline = tokio::time::Instant::now()

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -973,6 +973,7 @@ impl DiagnosticPublisher {
         }
         let client = self.client.clone();
         let aggregator = Arc::clone(&self.aggregator);
+        let shutdown = self.shutdown.clone();
         tokio::spawn(async move {
             loop {
                 // `workspace_diagnostic_refresh()` resolves when the editor answers
@@ -1000,6 +1001,13 @@ impl DiagnosticPublisher {
                 // future change adds a *pre-shutdown* panic source to this task,
                 // revisit — it would wedge the guard (and a drop-guard "fix" would
                 // reopen the `finish_refresh` lost-wakeup, so clear it atomically).
+                // Admission can race shutdown before this detached task first runs.
+                // Do not start a request once cancellation is observable, and clear
+                // the single-flight claim that admission already took.
+                if shutdown.is_cancelled() {
+                    aggregator.cancel_refresh_flight();
+                    break;
+                }
                 // Count each wire send, including trailing fires (#533).
                 aggregator.record_refresh_sent();
                 if let Err(e) = client.workspace_diagnostic_refresh().await {
@@ -1010,6 +1018,10 @@ impl DiagnosticPublisher {
                 }
                 // Fire exactly one more iff a refresh was requested while this one
                 // was in flight; otherwise the guard is now clear and we stop.
+                if shutdown.is_cancelled() {
+                    aggregator.cancel_refresh_flight();
+                    break;
+                }
                 if !aggregator.finish_refresh() {
                     break;
                 }
@@ -1172,6 +1184,32 @@ mod tests {
         let metrics = server.diagnostics.metrics_snapshot();
         assert_eq!(metrics.refreshes_requested, 1);
         assert_eq!(metrics.refreshes_sent, 0, "shutdown must suppress the send");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_cancels_an_admitted_refresh_before_send() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .settings_manager
+            .set_capabilities(ClientCapabilities {
+                workspace: Some(WorkspaceClientCapabilities {
+                    diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
+                        refresh_support: Some(true),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        let publisher = DiagnosticPublisher::new(server);
+
+        publisher.request_pull_diagnostic_refresh(true);
+        server.shutdown_token.cancel();
+        tokio::task::yield_now().await;
+
+        let metrics = server.diagnostics.metrics_snapshot();
+        assert_eq!(metrics.refreshes_requested, 1);
+        assert_eq!(metrics.refreshes_sent, 0, "admitted task must not send");
     }
 
     fn rust_server_config() -> (String, BridgeServerConfig) {

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -160,7 +160,11 @@ impl DiagnosticPublisher {
                 biased;
                 _ = publisher.shutdown.cancelled() => {}
                 _ = wait_for_forwarded_refresh_settle(&publisher.aggregator, generation) => {
-                    publisher.request_pull_diagnostic_refresh_inner(true, false);
+                    // Cancellation can race immediately after `select!` chose the
+                    // timer branch, so re-check at the refresh admission boundary.
+                    if !publisher.shutdown.is_cancelled() {
+                        publisher.request_pull_diagnostic_refresh_inner(true, false);
+                    }
                 }
             }
         });
@@ -949,7 +953,7 @@ impl DiagnosticPublisher {
     }
 
     fn request_pull_diagnostic_refresh_inner(&self, forced: bool, record_request: bool) {
-        if !self.diagnostic_refresh_supported() {
+        if self.shutdown.is_cancelled() || !self.diagnostic_refresh_supported() {
             return;
         }
         // Count the ask before the gates so `requested - sent` measures total

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -125,6 +125,7 @@ pub(crate) struct DiagnosticPublisher {
     settings_manager: Arc<SettingsManager>,
     cache: Arc<crate::lsp::cache::CacheCoordinator>,
     aggregator: Arc<DiagnosticAggregator>,
+    shutdown: tokio_util::sync::CancellationToken,
 }
 
 impl DiagnosticPublisher {
@@ -137,6 +138,7 @@ impl DiagnosticPublisher {
             settings_manager: Arc::clone(&server.settings_manager),
             cache: Arc::clone(&server.cache),
             aggregator: Arc::clone(&server.diagnostics),
+            shutdown: server.shutdown_token.clone(),
         }
     }
 
@@ -154,8 +156,13 @@ impl DiagnosticPublisher {
         };
         let publisher = self.clone();
         tokio::spawn(async move {
-            wait_for_forwarded_refresh_settle(&publisher.aggregator, generation).await;
-            publisher.request_pull_diagnostic_refresh_inner(true, false);
+            tokio::select! {
+                biased;
+                _ = publisher.shutdown.cancelled() => {}
+                _ = wait_for_forwarded_refresh_settle(&publisher.aggregator, generation) => {
+                    publisher.request_pull_diagnostic_refresh_inner(true, false);
+                }
+            }
         });
     }
 
@@ -1134,6 +1141,33 @@ mod tests {
         publisher.request_forwarded_diagnostic_refresh();
 
         assert_eq!(server.diagnostics.metrics_snapshot().refreshes_requested, 3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_cancels_pending_forwarded_refresh() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .settings_manager
+            .set_capabilities(ClientCapabilities {
+                workspace: Some(WorkspaceClientCapabilities {
+                    diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
+                        refresh_support: Some(true),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        let publisher = DiagnosticPublisher::new(server);
+        publisher.request_forwarded_diagnostic_refresh();
+        server.shutdown_token.cancel();
+
+        tokio::time::advance(FORWARDED_REFRESH_MAX_WAIT).await;
+        tokio::task::yield_now().await;
+
+        let metrics = server.diagnostics.metrics_snapshot();
+        assert_eq!(metrics.refreshes_requested, 1);
+        assert_eq!(metrics.refreshes_sent, 0, "shutdown must suppress the send");
     }
 
     fn rust_server_config() -> (String, BridgeServerConfig) {

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -164,7 +164,8 @@ impl DiagnosticPublisher {
             return;
         };
         if self.request_pull_diagnostic_refresh_inner(true, false) {
-            self.aggregator.mark_forwarded_refresh_covered();
+            self.aggregator
+                .mark_forwarded_refresh_covered(snapshot.generation);
         }
         let publisher = self.clone();
         tokio::spawn(async move {
@@ -190,9 +191,7 @@ impl DiagnosticPublisher {
                         }
                         match decision {
                             crate::lsp::diagnostic_cache::ForwardedRefreshWait::SendTrailing => {
-                                if publisher.request_pull_diagnostic_refresh_inner(true, false) {
-                                    publisher.aggregator.mark_forwarded_refresh_covered();
-                                }
+                                publisher.request_pull_diagnostic_refresh_inner(true, false);
                                 break;
                             }
                             crate::lsp::diagnostic_cache::ForwardedRefreshWait::Settled => break,
@@ -203,7 +202,9 @@ impl DiagnosticPublisher {
                                 if send_trailing
                                     && publisher.request_pull_diagnostic_refresh_inner(true, false)
                                 {
-                                    publisher.aggregator.mark_forwarded_refresh_covered();
+                                    publisher
+                                        .aggregator
+                                        .mark_forwarded_refresh_covered(latest.generation);
                                 }
                                 snapshot = latest;
                                 deadline = tokio::time::Instant::now()

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -143,14 +143,27 @@ impl DiagnosticPublisher {
     /// Coalesce a burst of downstream `workspace/diagnostic/refresh` requests
     /// into one forced upstream refresh after the burst settles (#789).
     pub(crate) fn request_forwarded_diagnostic_refresh(&self) {
+        if !self.diagnostic_refresh_supported() {
+            return;
+        }
+        // Preserve the metrics contract: each capability-eligible downstream
+        // ask is counted before this debounce decides how many wire sends survive.
+        self.aggregator.record_refresh_requested();
         let Some(generation) = self.aggregator.begin_forwarded_refresh_debounce() else {
             return;
         };
         let publisher = self.clone();
         tokio::spawn(async move {
             wait_for_forwarded_refresh_settle(&publisher.aggregator, generation).await;
-            publisher.request_pull_diagnostic_refresh(true);
+            publisher.request_pull_diagnostic_refresh_inner(true, false);
         });
+    }
+
+    fn diagnostic_refresh_supported(&self) -> bool {
+        self.settings_manager
+            .client_capabilities_lock()
+            .get()
+            .is_some_and(crate::lsp::client::check_diagnostic_refresh_support)
     }
 
     /// Route a downstream `publishDiagnostics` push into the cache, classifying by
@@ -925,17 +938,18 @@ impl DiagnosticPublisher {
     /// leaking a tower-lsp pending-request entry plus a parked task — the same gate
     /// the `semantic_tokens_refresh` path uses.
     pub(crate) fn request_pull_diagnostic_refresh(&self, forced: bool) {
-        let supported = self
-            .settings_manager
-            .client_capabilities_lock()
-            .get()
-            .is_some_and(crate::lsp::client::check_diagnostic_refresh_support);
-        if !supported {
+        self.request_pull_diagnostic_refresh_inner(forced, true);
+    }
+
+    fn request_pull_diagnostic_refresh_inner(&self, forced: bool, record_request: bool) {
+        if !self.diagnostic_refresh_supported() {
             return;
         }
         // Count the ask before the gate so `requested - sent` measures what the
         // single-flight + coverage gate saves (#533).
-        self.aggregator.record_refresh_requested();
+        if record_request {
+            self.aggregator.record_refresh_requested();
+        }
         // Coalesce against any in-flight refresh and apply the coverage gate (#497):
         // `false` here means either one is already outstanding (recorded as `pending`,
         // so the outstanding task's loop fires the trailing) or — for a non-`forced`
@@ -1085,7 +1099,10 @@ mod tests {
     };
     use std::collections::HashMap;
     use tower_lsp_server::LspService;
-    use tower_lsp_server::ls_types::{Position, Range};
+    use tower_lsp_server::ls_types::{
+        ClientCapabilities, DiagnosticWorkspaceClientCapabilities, Position, Range,
+        WorkspaceClientCapabilities,
+    };
 
     fn diag(message: &str) -> Diagnostic {
         Diagnostic {
@@ -1093,6 +1110,30 @@ mod tests {
             message: message.to_string(),
             ..Default::default()
         }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn forwarded_refresh_metrics_count_inputs_before_debounce() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .settings_manager
+            .set_capabilities(ClientCapabilities {
+                workspace: Some(WorkspaceClientCapabilities {
+                    diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
+                        refresh_support: Some(true),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        let publisher = DiagnosticPublisher::new(server);
+
+        publisher.request_forwarded_diagnostic_refresh();
+        publisher.request_forwarded_diagnostic_refresh();
+        publisher.request_forwarded_diagnostic_refresh();
+
+        assert_eq!(server.diagnostics.metrics_snapshot().refreshes_requested, 3);
     }
 
     fn rust_server_config() -> (String, BridgeServerConfig) {

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1193,6 +1193,17 @@ mod tests {
     async fn shutdown_rejects_new_forwarded_refresh_inputs() {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
+        server
+            .settings_manager
+            .set_capabilities(ClientCapabilities {
+                workspace: Some(WorkspaceClientCapabilities {
+                    diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
+                        refresh_support: Some(true),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
         server.shutdown_token.cancel();
         let publisher = DiagnosticPublisher::new(server);
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -161,7 +161,11 @@ impl DiagnosticPublisher {
         tokio::spawn(async move {
             tokio::select! {
                 biased;
-                _ = publisher.shutdown.cancelled() => {}
+                _ = publisher.shutdown.cancelled() => {
+                    publisher
+                        .aggregator
+                        .finish_forwarded_refresh_wait(generation, true);
+                }
                 _ = wait_for_forwarded_refresh_settle(&publisher.aggregator, generation) => {
                     // Cancellation can race immediately after `select!` chose the
                     // timer branch, so re-check at the refresh admission boundary.
@@ -1187,6 +1191,13 @@ mod tests {
         let metrics = server.diagnostics.metrics_snapshot();
         assert_eq!(metrics.refreshes_requested, 1);
         assert_eq!(metrics.refreshes_sent, 0, "shutdown must suppress the send");
+        assert!(
+            server
+                .diagnostics
+                .begin_forwarded_refresh_debounce()
+                .is_some(),
+            "shutdown must release the debounce task claim"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -945,8 +945,8 @@ impl DiagnosticPublisher {
         if !self.diagnostic_refresh_supported() {
             return;
         }
-        // Count the ask before the gate so `requested - sent` measures what the
-        // single-flight + coverage gate saves (#533).
+        // Count the ask before the gates so `requested - sent` measures total
+        // debounce/single-flight/coverage savings (#533, #789).
         if record_request {
             self.aggregator.record_refresh_requested();
         }

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -96,17 +96,23 @@ const FORWARDED_REFRESH_SETTLE_WINDOW: std::time::Duration = std::time::Duration
 /// from an unbounded rate to at most one refresh per second.
 const FORWARDED_REFRESH_MAX_WAIT: std::time::Duration = std::time::Duration::from_secs(1);
 
-async fn wait_for_forwarded_refresh_settle(aggregator: &DiagnosticAggregator, mut generation: u64) {
-    let deadline = tokio::time::Instant::now() + FORWARDED_REFRESH_MAX_WAIT;
+async fn wait_for_forwarded_refresh_settle(
+    aggregator: &DiagnosticAggregator,
+    mut snapshot: crate::lsp::diagnostic_cache::ForwardedRefreshWaitSnapshot,
+    deadline: tokio::time::Instant,
+) -> bool {
     loop {
         tokio::time::sleep_until(
-            (tokio::time::Instant::now() + FORWARDED_REFRESH_SETTLE_WINDOW).min(deadline),
+            (snapshot.last_activity_at + FORWARDED_REFRESH_SETTLE_WINDOW).min(deadline),
         )
         .await;
         let force = tokio::time::Instant::now() >= deadline;
-        match aggregator.finish_forwarded_refresh_wait(generation, force) {
-            Some(latest) => generation = latest,
-            None => return,
+        match aggregator.finish_forwarded_refresh_wait(snapshot.generation, force) {
+            crate::lsp::diagnostic_cache::ForwardedRefreshWait::Restart(latest) => {
+                snapshot = latest;
+            }
+            crate::lsp::diagnostic_cache::ForwardedRefreshWait::SendTrailing => return true,
+            crate::lsp::diagnostic_cache::ForwardedRefreshWait::Settled => return false,
         }
     }
 }
@@ -142,8 +148,9 @@ impl DiagnosticPublisher {
         }
     }
 
-    /// Coalesce a burst of downstream `workspace/diagnostic/refresh` requests
-    /// into one forced upstream refresh after the burst settles (#789).
+    /// Forward the first downstream `workspace/diagnostic/refresh` immediately,
+    /// then coalesce later burst activity into at most one trailing refresh
+    /// after quiet or the max-wait deadline (#789).
     pub(crate) fn request_forwarded_diagnostic_refresh(&self) {
         if self.shutdown.is_cancelled() {
             return;
@@ -154,9 +161,11 @@ impl DiagnosticPublisher {
         // Preserve the metrics contract: each capability-eligible downstream
         // ask is counted before this debounce decides how many wire sends survive.
         self.aggregator.record_refresh_requested();
-        let Some(generation) = self.aggregator.begin_forwarded_refresh_debounce() else {
+        let Some(snapshot) = self.aggregator.begin_forwarded_refresh_debounce() else {
             return;
         };
+        let deadline = snapshot.last_activity_at + FORWARDED_REFRESH_MAX_WAIT;
+        self.request_pull_diagnostic_refresh_inner(true, false);
         let publisher = self.clone();
         tokio::spawn(async move {
             tokio::select! {
@@ -164,12 +173,16 @@ impl DiagnosticPublisher {
                 _ = publisher.shutdown.cancelled() => {
                     publisher
                         .aggregator
-                        .finish_forwarded_refresh_wait(generation, true);
+                        .finish_forwarded_refresh_wait(snapshot.generation, true);
                 }
-                _ = wait_for_forwarded_refresh_settle(&publisher.aggregator, generation) => {
+                should_send = wait_for_forwarded_refresh_settle(
+                    &publisher.aggregator,
+                    snapshot,
+                    deadline,
+                ) => {
                     // Cancellation can race immediately after `select!` chose the
                     // timer branch, so re-check at the refresh admission boundary.
-                    if !publisher.shutdown.is_cancelled() {
+                    if should_send && !publisher.shutdown.is_cancelled() {
                         publisher.request_pull_diagnostic_refresh_inner(true, false);
                     }
                 }
@@ -1143,6 +1156,39 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn forwarded_refresh_sends_the_leading_edge_immediately() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .settings_manager
+            .set_capabilities(ClientCapabilities {
+                workspace: Some(WorkspaceClientCapabilities {
+                    diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
+                        refresh_support: Some(true),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        let publisher = DiagnosticPublisher::new(server);
+        let before = tokio::time::Instant::now();
+
+        publisher.request_forwarded_diagnostic_refresh();
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            tokio::time::Instant::now(),
+            before,
+            "the leading send must happen without advancing to the debounce timer"
+        );
+        assert_eq!(
+            server.diagnostics.metrics_snapshot().refreshes_sent,
+            1,
+            "the first refresh after idle must not wait for the debounce window"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn forwarded_refresh_metrics_count_inputs_before_debounce() {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
@@ -1643,12 +1689,13 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn forwarded_refresh_stream_is_bounded_by_max_wait() {
         let aggregator = Arc::new(DiagnosticAggregator::new());
-        let generation = aggregator
+        let snapshot = aggregator
             .begin_forwarded_refresh_debounce()
             .expect("first refresh claims the debounce task");
+        let deadline = snapshot.last_activity_at + FORWARDED_REFRESH_MAX_WAIT;
         let waiter_aggregator = Arc::clone(&aggregator);
         let waiter = tokio::spawn(async move {
-            super::wait_for_forwarded_refresh_settle(&waiter_aggregator, generation).await;
+            super::wait_for_forwarded_refresh_settle(&waiter_aggregator, snapshot, deadline).await
         });
         tokio::task::yield_now().await;
 
@@ -1663,7 +1710,10 @@ mod tests {
         // implementation would remain parked until 1090 ms. The anchored
         // one-second deadline must release it after just 10 ms.
         tokio::time::advance(std::time::Duration::from_millis(10)).await;
-        waiter.await.expect("debounce task completes at max wait");
+        assert!(
+            waiter.await.expect("debounce task completes at max wait"),
+            "continuous activity without another send needs a trailing refresh"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -190,8 +190,25 @@ impl DiagnosticPublisher {
                             break;
                         }
                         match decision {
-                            crate::lsp::diagnostic_cache::ForwardedRefreshWait::SendTrailing => {
-                                publisher.request_pull_diagnostic_refresh_inner(true, false);
+                            crate::lsp::diagnostic_cache::ForwardedRefreshWait::SendTrailing(
+                                admitted,
+                            ) => {
+                                if publisher.request_pull_diagnostic_refresh_inner(true, false) {
+                                    publisher
+                                        .aggregator
+                                        .mark_forwarded_refresh_covered(admitted.generation);
+                                    if let Some(latest) = publisher
+                                        .aggregator
+                                        .finish_forwarded_refresh_admission(admitted.generation)
+                                    {
+                                        snapshot = latest;
+                                        deadline = tokio::time::Instant::now()
+                                            + FORWARDED_REFRESH_MAX_WAIT;
+                                        continue;
+                                    }
+                                } else {
+                                    publisher.aggregator.cancel_forwarded_refresh_debounce();
+                                }
                                 break;
                             }
                             crate::lsp::diagnostic_cache::ForwardedRefreshWait::Settled => break,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -163,7 +163,9 @@ impl DiagnosticPublisher {
         let Some(snapshot) = self.aggregator.begin_forwarded_refresh_debounce() else {
             return;
         };
-        self.request_pull_diagnostic_refresh_inner(true, false);
+        if self.request_pull_diagnostic_refresh_inner(true, false) {
+            self.aggregator.mark_forwarded_refresh_covered();
+        }
         let publisher = self.clone();
         tokio::spawn(async move {
             let mut snapshot = snapshot;
@@ -188,7 +190,9 @@ impl DiagnosticPublisher {
                         }
                         match decision {
                             crate::lsp::diagnostic_cache::ForwardedRefreshWait::SendTrailing => {
-                                publisher.request_pull_diagnostic_refresh_inner(true, false);
+                                if publisher.request_pull_diagnostic_refresh_inner(true, false) {
+                                    publisher.aggregator.mark_forwarded_refresh_covered();
+                                }
                                 break;
                             }
                             crate::lsp::diagnostic_cache::ForwardedRefreshWait::Settled => break,
@@ -196,8 +200,10 @@ impl DiagnosticPublisher {
                                 snapshot: latest,
                                 send_trailing,
                             } => {
-                                if send_trailing {
-                                    publisher.request_pull_diagnostic_refresh_inner(true, false);
+                                if send_trailing
+                                    && publisher.request_pull_diagnostic_refresh_inner(true, false)
+                                {
+                                    publisher.aggregator.mark_forwarded_refresh_covered();
                                 }
                                 snapshot = latest;
                                 deadline = tokio::time::Instant::now()
@@ -995,9 +1001,9 @@ impl DiagnosticPublisher {
         self.request_pull_diagnostic_refresh_inner(forced, true);
     }
 
-    fn request_pull_diagnostic_refresh_inner(&self, forced: bool, record_request: bool) {
+    fn request_pull_diagnostic_refresh_inner(&self, forced: bool, record_request: bool) -> bool {
         if self.shutdown.is_cancelled() || !self.diagnostic_refresh_supported() {
-            return;
+            return false;
         }
         // Count the ask before the gates so `requested - sent` measures total
         // debounce/single-flight/coverage savings (#533, #789).
@@ -1012,7 +1018,7 @@ impl DiagnosticPublisher {
         // refresh (#521) and the degraded-pull recovery (whose per-host debt
         // proves a non-covering answer no coverage version represents).
         if !self.aggregator.try_begin_refresh(forced) {
-            return;
+            return forced;
         }
         let client = self.client.clone();
         let aggregator = Arc::clone(&self.aggregator);
@@ -1070,6 +1076,7 @@ impl DiagnosticPublisher {
                 }
             }
         });
+        true
     }
 
     /// Map each currently-resolvable injection region of the host document to its

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1222,7 +1222,7 @@ mod tests {
         let before = tokio::time::Instant::now();
 
         publisher.request_forwarded_diagnostic_refresh();
-        tokio::task::yield_now().await;
+        tokio::time::advance(std::time::Duration::ZERO).await;
 
         assert_eq!(
             tokio::time::Instant::now(),
@@ -1280,7 +1280,7 @@ mod tests {
         server.shutdown_token.cancel();
 
         tokio::time::advance(FORWARDED_REFRESH_MAX_WAIT).await;
-        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 
         let metrics = server.diagnostics.metrics_snapshot();
         assert_eq!(metrics.refreshes_requested, 1);
@@ -1339,7 +1339,7 @@ mod tests {
 
         publisher.request_pull_diagnostic_refresh(true);
         server.shutdown_token.cancel();
-        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 
         let metrics = server.diagnostics.metrics_snapshot();
         assert_eq!(metrics.refreshes_requested, 1);
@@ -1745,7 +1745,7 @@ mod tests {
         let waiter = tokio::spawn(async move {
             super::wait_for_forwarded_refresh_settle(&waiter_aggregator, snapshot, deadline).await
         });
-        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 
         for _ in 0..11 {
             tokio::time::advance(std::time::Duration::from_millis(90)).await;

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1536,14 +1536,17 @@ mod tests {
         });
         tokio::task::yield_now().await;
 
-        for _ in 0..9 {
+        for _ in 0..11 {
             tokio::time::advance(std::time::Duration::from_millis(90)).await;
             assert!(
                 aggregator.begin_forwarded_refresh_debounce().is_none(),
                 "continuous activity reuses the debounce task"
             );
         }
-        tokio::time::advance(std::time::Duration::from_millis(190)).await;
+        // The last activity was at 990 ms, so an unbounded quiet-window-only
+        // implementation would remain parked until 1090 ms. The anchored
+        // one-second deadline must release it after just 10 ms.
+        tokio::time::advance(std::time::Duration::from_millis(10)).await;
         waiter.await.expect("debounce task completes at max wait");
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1204,7 +1204,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn shutdown_cancels_an_admitted_refresh_before_send() {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -91,6 +91,25 @@ const WIRE_PUBLISH_QUIET_WINDOW: std::time::Duration = std::time::Duration::from
 /// Short enough that a downstream re-analysis still prompts a timely editor
 /// pull, but longer than the 1 ms-scale refresh bursts observed in #789.
 const FORWARDED_REFRESH_SETTLE_WINDOW: std::time::Duration = std::time::Duration::from_millis(100);
+/// Bound staleness when a server emits refreshes continuously. This matches the
+/// existing diagnostics publish cadence and still reduces a sustained stream
+/// from an unbounded rate to at most one refresh per second.
+const FORWARDED_REFRESH_MAX_WAIT: std::time::Duration = std::time::Duration::from_secs(1);
+
+async fn wait_for_forwarded_refresh_settle(aggregator: &DiagnosticAggregator, mut generation: u64) {
+    let deadline = tokio::time::Instant::now() + FORWARDED_REFRESH_MAX_WAIT;
+    loop {
+        tokio::time::sleep_until(
+            (tokio::time::Instant::now() + FORWARDED_REFRESH_SETTLE_WINDOW).min(deadline),
+        )
+        .await;
+        let force = tokio::time::Instant::now() >= deadline;
+        match aggregator.finish_forwarded_refresh_wait(generation, force) {
+            Some(latest) => generation = latest,
+            None => return,
+        }
+    }
+}
 
 /// Bundles the state needed to merge the cache and publish for a host, so the
 /// notification feeds (reader push, host-event pull) can trigger a republish
@@ -124,24 +143,13 @@ impl DiagnosticPublisher {
     /// Coalesce a burst of downstream `workspace/diagnostic/refresh` requests
     /// into one forced upstream refresh after the burst settles (#789).
     pub(crate) fn request_forwarded_diagnostic_refresh(&self) {
-        let Some(mut generation) = self.aggregator.begin_forwarded_refresh_debounce() else {
+        let Some(generation) = self.aggregator.begin_forwarded_refresh_debounce() else {
             return;
         };
         let publisher = self.clone();
         tokio::spawn(async move {
-            loop {
-                tokio::time::sleep(FORWARDED_REFRESH_SETTLE_WINDOW).await;
-                match publisher
-                    .aggregator
-                    .finish_forwarded_refresh_wait(generation)
-                {
-                    Some(latest) => generation = latest,
-                    None => {
-                        publisher.request_pull_diagnostic_refresh(true);
-                        break;
-                    }
-                }
-            }
+            wait_for_forwarded_refresh_settle(&publisher.aggregator, generation).await;
+            publisher.request_pull_diagnostic_refresh(true);
         });
     }
 
@@ -1473,6 +1481,29 @@ mod tests {
             RepublishOutcome::Unchanged,
             "the sealed set was recorded as last-published, so a re-merge is unchanged"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn forwarded_refresh_stream_is_bounded_by_max_wait() {
+        let aggregator = Arc::new(DiagnosticAggregator::new());
+        let generation = aggregator
+            .begin_forwarded_refresh_debounce()
+            .expect("first refresh claims the debounce task");
+        let waiter_aggregator = Arc::clone(&aggregator);
+        let waiter = tokio::spawn(async move {
+            super::wait_for_forwarded_refresh_settle(&waiter_aggregator, generation).await;
+        });
+        tokio::task::yield_now().await;
+
+        for _ in 0..9 {
+            tokio::time::advance(std::time::Duration::from_millis(90)).await;
+            assert!(
+                aggregator.begin_forwarded_refresh_debounce().is_none(),
+                "continuous activity reuses the debounce task"
+            );
+        }
+        tokio::time::advance(std::time::Duration::from_millis(190)).await;
+        waiter.await.expect("debounce task completes at max wait");
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -100,7 +100,7 @@ async fn wait_for_forwarded_refresh_settle(
     aggregator: &DiagnosticAggregator,
     mut snapshot: crate::lsp::diagnostic_cache::ForwardedRefreshWaitSnapshot,
     deadline: tokio::time::Instant,
-) -> bool {
+) -> crate::lsp::diagnostic_cache::ForwardedRefreshWait {
     loop {
         tokio::time::sleep_until(
             (snapshot.last_activity_at + FORWARDED_REFRESH_SETTLE_WINDOW).min(deadline),
@@ -111,8 +111,7 @@ async fn wait_for_forwarded_refresh_settle(
             crate::lsp::diagnostic_cache::ForwardedRefreshWait::Restart(latest) => {
                 snapshot = latest;
             }
-            crate::lsp::diagnostic_cache::ForwardedRefreshWait::SendTrailing => return true,
-            crate::lsp::diagnostic_cache::ForwardedRefreshWait::Settled => return false,
+            decision => return decision,
         }
     }
 }
@@ -164,26 +163,50 @@ impl DiagnosticPublisher {
         let Some(snapshot) = self.aggregator.begin_forwarded_refresh_debounce() else {
             return;
         };
-        let deadline = snapshot.last_activity_at + FORWARDED_REFRESH_MAX_WAIT;
         self.request_pull_diagnostic_refresh_inner(true, false);
         let publisher = self.clone();
         tokio::spawn(async move {
-            tokio::select! {
-                biased;
-                _ = publisher.shutdown.cancelled() => {
-                    publisher
-                        .aggregator
-                        .finish_forwarded_refresh_wait(snapshot.generation, true);
-                }
-                should_send = wait_for_forwarded_refresh_settle(
-                    &publisher.aggregator,
-                    snapshot,
-                    deadline,
-                ) => {
-                    // Cancellation can race immediately after `select!` chose the
-                    // timer branch, so re-check at the refresh admission boundary.
-                    if should_send && !publisher.shutdown.is_cancelled() {
-                        publisher.request_pull_diagnostic_refresh_inner(true, false);
+            let mut snapshot = snapshot;
+            let mut deadline = snapshot.last_activity_at + FORWARDED_REFRESH_MAX_WAIT;
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = publisher.shutdown.cancelled() => {
+                        publisher.aggregator.cancel_forwarded_refresh_debounce();
+                        break;
+                    }
+                    decision = wait_for_forwarded_refresh_settle(
+                        &publisher.aggregator,
+                        snapshot,
+                        deadline,
+                    ) => {
+                        // Cancellation can race immediately after `select!` chose the
+                        // timer branch, so re-check at the refresh admission boundary.
+                        if publisher.shutdown.is_cancelled() {
+                            publisher.aggregator.cancel_forwarded_refresh_debounce();
+                            break;
+                        }
+                        match decision {
+                            crate::lsp::diagnostic_cache::ForwardedRefreshWait::SendTrailing => {
+                                publisher.request_pull_diagnostic_refresh_inner(true, false);
+                                break;
+                            }
+                            crate::lsp::diagnostic_cache::ForwardedRefreshWait::Settled => break,
+                            crate::lsp::diagnostic_cache::ForwardedRefreshWait::MaxWait {
+                                snapshot: latest,
+                                send_trailing,
+                            } => {
+                                if send_trailing {
+                                    publisher.request_pull_diagnostic_refresh_inner(true, false);
+                                }
+                                snapshot = latest;
+                                deadline = tokio::time::Instant::now()
+                                    + FORWARDED_REFRESH_MAX_WAIT;
+                            }
+                            crate::lsp::diagnostic_cache::ForwardedRefreshWait::Restart(_) => {
+                                unreachable!("the settle waiter consumes restart decisions")
+                            }
+                        }
                     }
                 }
             }
@@ -1710,9 +1733,16 @@ mod tests {
         // implementation would remain parked until 1090 ms. The anchored
         // one-second deadline must release it after just 10 ms.
         tokio::time::advance(std::time::Duration::from_millis(10)).await;
-        assert!(
+        assert!(matches!(
             waiter.await.expect("debounce task completes at max wait"),
-            "continuous activity without another send needs a trailing refresh"
+            crate::lsp::diagnostic_cache::ForwardedRefreshWait::MaxWait {
+                send_trailing: true,
+                ..
+            }
+        ));
+        assert!(
+            aggregator.begin_forwarded_refresh_debounce().is_none(),
+            "a max-wait fire must keep the cycle active until activity becomes quiet"
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -145,6 +145,9 @@ impl DiagnosticPublisher {
     /// Coalesce a burst of downstream `workspace/diagnostic/refresh` requests
     /// into one forced upstream refresh after the burst settles (#789).
     pub(crate) fn request_forwarded_diagnostic_refresh(&self) {
+        if self.shutdown.is_cancelled() {
+            return;
+        }
         if !self.diagnostic_refresh_supported() {
             return;
         }
@@ -1184,6 +1187,21 @@ mod tests {
         let metrics = server.diagnostics.metrics_snapshot();
         assert_eq!(metrics.refreshes_requested, 1);
         assert_eq!(metrics.refreshes_sent, 0, "shutdown must suppress the send");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_rejects_new_forwarded_refresh_inputs() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server.shutdown_token.cancel();
+        let publisher = DiagnosticPublisher::new(server);
+
+        publisher.request_forwarded_diagnostic_refresh();
+
+        assert_eq!(
+            server.diagnostics.metrics_snapshot(),
+            crate::lsp::diagnostic_cache::DiagnosticMetricsSnapshot::default()
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1435,9 +1435,7 @@ async fn deliver_upstream_notification(
             // settings to gate on, so the forward is dropped; production always has
             // one (#521).
             if let Some(publisher) = diagnostic_publisher {
-                // `forced`: a downstream server explicitly asked for a refresh, which
-                // no coverage version represents, so bypass the coverage gate (#497).
-                publisher.request_pull_diagnostic_refresh(true);
+                publisher.request_forwarded_diagnostic_refresh();
             }
         }
         UpstreamNotification::PublishDiagnostics {

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1427,14 +1427,12 @@ async fn deliver_upstream_notification(
     match notification {
         UpstreamNotification::DiagnosticRefresh => {
             // A downstream server asked the editor to re-pull diagnostics. Route it
-            // through the publisher's `request_pull_diagnostic_refresh` so it reuses
-            // the `workspace.diagnostics.refreshSupport` capability gate (a client
-            // that doesn't support refresh would otherwise leak a tower-lsp
-            // pending-request entry + parked task) and the detached `tokio::spawn`
-            // (an inline `.await` here would block this delivery loop on the client
-            // round-trip — head-of-line). A `None` publisher (test loop) has no
-            // settings to gate on, so the forward is dropped; production always has
-            // one (#521).
+            // through `request_forwarded_diagnostic_refresh`, which debounces
+            // downstream bursts before reusing the capability-gated, detached
+            // forced-refresh path. Detaching avoids blocking this delivery loop on
+            // the editor round-trip (head-of-line). A `None` publisher (test loop)
+            // has no settings to gate on, so the forward is dropped; production
+            // always has one (#521, #789).
             if let Some(publisher) = diagnostic_publisher {
                 publisher.request_forwarded_diagnostic_refresh();
             }

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1427,12 +1427,12 @@ async fn deliver_upstream_notification(
     match notification {
         UpstreamNotification::DiagnosticRefresh => {
             // A downstream server asked the editor to re-pull diagnostics. Route it
-            // through `request_forwarded_diagnostic_refresh`, which debounces
-            // downstream bursts before reusing the capability-gated, detached
-            // forced-refresh path. Detaching avoids blocking this delivery loop on
-            // the editor round-trip (head-of-line). A `None` publisher (test loop)
-            // has no settings to gate on, so the forward is dropped; production
-            // always has one (#521, #789).
+            // through `request_forwarded_diagnostic_refresh`, which forwards the
+            // leading edge immediately and debounces later burst activity before
+            // reusing the capability-gated, detached forced-refresh path. Detaching
+            // avoids blocking this delivery loop on the editor round-trip
+            // (head-of-line). A `None` publisher (test loop) has no settings to gate
+            // on, so the forward is dropped; production always has one (#521, #789).
             if let Some(publisher) = diagnostic_publisher {
                 publisher.request_forwarded_diagnostic_refresh();
             }

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -645,11 +645,12 @@ impl Kakehashi {
 
         // Dump diagnostic-path counters (#533) so a session's refresh amplification
         // (push republishes in → refreshes requested vs sent → pulls answered) is
-        // readable without a profiler. `requested - sent` is what the #497 gate saved.
+        // readable without a profiler. `requested - sent` is the total saved by
+        // forwarded-refresh debounce plus the #497 single-flight/coverage gates.
         let m = self.diagnostics.metrics_snapshot();
         log::info!(
             target: "kakehashi::diagnostic_metrics",
-            "diagnostic path totals: push_republishes={} refreshes_requested={} refreshes_sent={} (gate saved {}) pulls_answered={} mean_pull_us={}",
+            "diagnostic path totals: push_republishes={} refreshes_requested={} refreshes_sent={} (coalescing/gates saved {}) pulls_answered={} mean_pull_us={}",
             m.push_republishes,
             m.refreshes_requested,
             m.refreshes_sent,

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -645,12 +645,12 @@ impl Kakehashi {
 
         // Dump diagnostic-path counters (#533) so a session's refresh amplification
         // (push republishes in → refreshes requested vs sent → pulls answered) is
-        // readable without a profiler. `requested - sent` is the total saved by
-        // forwarded-refresh debounce plus the #497 single-flight/coverage gates.
+        // readable without a profiler. `requested - sent` includes refreshes
+        // coalesced, gated, or suppressed during shutdown.
         let m = self.diagnostics.metrics_snapshot();
         log::info!(
             target: "kakehashi::diagnostic_metrics",
-            "diagnostic path totals: push_republishes={} refreshes_requested={} refreshes_sent={} (coalescing/gates saved {}) pulls_answered={} mean_pull_us={}",
+            "diagnostic path totals: push_republishes={} refreshes_requested={} refreshes_sent={} (not sent: coalesced/gated/shutdown {}) pulls_answered={} mean_pull_us={}",
             m.push_republishes,
             m.refreshes_requested,
             m.refreshes_sent,

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -73,9 +73,10 @@
 //! - `diagnostics-refresh` — sends a `workspace/diagnostic/refresh` server→client
 //!   request on `didOpen`. The bridge forwards it upstream to the editor; used to
 //!   prove that forward is capability-gated (#521).
-//! - `diagnostics-refresh-burst` — advertises pull diagnostics and sends ten
-//!   refresh requests on `didOpen`, so the editor-facing test can verify both
-//!   burst coalescing and the diagnostic result delivered by the induced pull.
+//! - `diagnostics-refresh-burst` — advertises pull diagnostics, sends generation
+//!   1's refresh on `didOpen`, then emits generations 2–10 after the first pull.
+//!   The editor-facing test keeps the leading refresh unacknowledged during that
+//!   pull, so all later refreshes exercise debounce plus refresh single-flight.
 //! - `on-type` — advertises `documentOnTypeFormattingProvider` with `}` and
 //!   `;` as triggers; answers `textDocument/onTypeFormatting` with the
 //!   uppercasing whole-document edit for ANY typed character (bridge-side

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -143,6 +143,7 @@ fn main() {
     let mut last_will_save_uri: Option<String> = None;
     let mut did_save_count: usize = 0;
     let mut last_did_save_uri: Option<String> = None;
+    let mut diagnostic_generation: u64 = 0;
 
     while let Some(message) = read_message(&mut reader) {
         let method = message
@@ -331,9 +332,8 @@ fn main() {
                     if mode == "diagnostics-refresh" {
                         request(&mut writer, json!(1000), "workspace/diagnostic/refresh");
                     } else if mode == "diagnostics-refresh-burst" {
-                        for id in 1000..1010 {
-                            request(&mut writer, json!(id), "workspace/diagnostic/refresh");
-                        }
+                        diagnostic_generation = 1;
+                        request(&mut writer, json!(1000), "workspace/diagnostic/refresh");
                     }
                 }
             }
@@ -836,11 +836,20 @@ fn main() {
                 // but only for documents this server actually received via
                 // didOpen, so the test also proves the host document was
                 // synced before the pull.
+                let diagnostic_message = if mode == "diagnostics-refresh-burst" {
+                    format!("mock-diagnostic-generation:{diagnostic_generation}")
+                } else {
+                    message
+                        .pointer("/params/textDocument/uri")
+                        .and_then(Value::as_str)
+                        .map(|uri| format!("mock-diagnostic:{uri}"))
+                        .unwrap_or_default()
+                };
                 let result = message
                     .pointer("/params/textDocument/uri")
                     .and_then(Value::as_str)
                     .filter(|uri| documents.contains_key(*uri))
-                    .map(|uri| {
+                    .map(|_| {
                         json!({
                             "kind": "full",
                             "items": [{
@@ -849,12 +858,18 @@ fn main() {
                                     "end": { "line": 0, "character": 1 }
                                 },
                                 "severity": 2,
-                                "message": format!("mock-diagnostic:{uri}")
+                                "message": diagnostic_message
                             }]
                         })
                     })
                     .unwrap_or(Value::Null);
                 respond(&mut writer, id, result);
+                if mode == "diagnostics-refresh-burst" && diagnostic_generation == 1 {
+                    for id in 1001..1010 {
+                        diagnostic_generation += 1;
+                        request(&mut writer, json!(id), "workspace/diagnostic/refresh");
+                    }
+                }
             }
             "codeLens/resolve" => {
                 // Materialize the command, echoing the lens's own data back so

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -870,29 +870,30 @@ fn main() {
                         diagnostic_generation += 1;
                         request(&mut writer, json!(id), "workspace/diagnostic/refresh");
                     }
-                    if let Some(uri) = message
-                        .pointer("/params/textDocument/uri")
-                        .and_then(Value::as_str)
-                    {
-                        // This push shares the loss-intolerant upstream FIFO with
-                        // refreshes. Its editor-facing publication is therefore
-                        // an observable barrier after all burst admissions.
-                        notify(
-                            &mut writer,
-                            "textDocument/publishDiagnostics",
-                            json!({
-                                "uri": uri,
-                                "diagnostics": [{
-                                    "range": {
-                                        "start": { "line": 0, "character": 0 },
-                                        "end": { "line": 0, "character": 1 }
-                                    },
-                                    "severity": 3,
-                                    "message": "diagnostic-refresh-burst-admitted"
-                                }]
-                            }),
-                        );
-                    }
+                    // Work-done progress shares the loss-intolerant upstream
+                    // FIFO with refreshes but cannot schedule a diagnostic
+                    // refresh itself. Its editor-facing create request is an
+                    // observable, refresh-neutral admission barrier.
+                    let token = json!("diagnostic-refresh-burst-admitted");
+                    request_with_params(
+                        &mut writer,
+                        json!(2000),
+                        "window/workDoneProgress/create",
+                        json!({ "token": token }),
+                    );
+                    notify(
+                        &mut writer,
+                        "$/progress",
+                        json!({
+                            "token": token,
+                            "value": { "kind": "begin", "title": "refresh burst barrier" }
+                        }),
+                    );
+                    notify(
+                        &mut writer,
+                        "$/progress",
+                        json!({ "token": token, "value": { "kind": "end" } }),
+                    );
                 }
             }
             "codeLens/resolve" => {

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -326,6 +326,10 @@ fn main() {
                     // ignores. A fixed id is fine since nothing awaits the ack.
                     if mode == "diagnostics-refresh" {
                         request(&mut writer, json!(1000), "workspace/diagnostic/refresh");
+                    } else if mode == "diagnostics-refresh-burst" {
+                        for id in 1000..1010 {
+                            request(&mut writer, json!(id), "workspace/diagnostic/refresh");
+                        }
                     }
                 }
             }

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -73,6 +73,9 @@
 //! - `diagnostics-refresh` — sends a `workspace/diagnostic/refresh` server→client
 //!   request on `didOpen`. The bridge forwards it upstream to the editor; used to
 //!   prove that forward is capability-gated (#521).
+//! - `diagnostics-refresh-burst` — advertises pull diagnostics and sends ten
+//!   refresh requests on `didOpen`, so the editor-facing test can verify both
+//!   burst coalescing and the diagnostic result delivered by the induced pull.
 //! - `on-type` — advertises `documentOnTypeFormattingProvider` with `}` and
 //!   `;` as triggers; answers `textDocument/onTypeFormatting` with the
 //!   uppercasing whole-document edit for ANY typed character (bridge-side
@@ -212,6 +215,7 @@ fn main() {
                     "diagnostics"
                     | "diagnostics-fail"
                     | "diagnostics-malformed"
+                    | "diagnostics-refresh-burst"
                     | "diagnostics-push-pullcap" => json!({
                         "diagnosticProvider": {
                             "interFileDependencies": false,

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -870,6 +870,29 @@ fn main() {
                         diagnostic_generation += 1;
                         request(&mut writer, json!(id), "workspace/diagnostic/refresh");
                     }
+                    if let Some(uri) = message
+                        .pointer("/params/textDocument/uri")
+                        .and_then(Value::as_str)
+                    {
+                        // This push shares the loss-intolerant upstream FIFO with
+                        // refreshes. Its editor-facing publication is therefore
+                        // an observable barrier after all burst admissions.
+                        notify(
+                            &mut writer,
+                            "textDocument/publishDiagnostics",
+                            json!({
+                                "uri": uri,
+                                "diagnostics": [{
+                                    "range": {
+                                        "start": { "line": 0, "character": 0 },
+                                        "end": { "line": 0, "character": 1 }
+                                    },
+                                    "severity": 3,
+                                    "message": "diagnostic-refresh-burst-admitted"
+                                }]
+                            }),
+                        );
+                    }
                 }
             }
             "codeLens/resolve" => {

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -910,10 +910,11 @@ fn e2e_downstream_refresh_burst_is_coalesced() {
         "textDocument/diagnostic",
         json!({ "textDocument": { "uri": MD_URI } }),
     );
-    let (leading_pull, refreshes_during_leading_pull) = client
-        .receive_response_for_id_watching_server_requests(
+    let (leading_pull, mut refreshes_before_barrier, mut barrier_pushes) = client
+        .receive_response_for_id_watching_server_requests_and_notification(
             leading_pull_id,
             "workspace/diagnostic/refresh",
+            "textDocument/publishDiagnostics",
         );
     assert!(
         leading_pull["result"]["items"]
@@ -924,29 +925,32 @@ fn e2e_downstream_refresh_burst_is_coalesced() {
         "the leading refresh must expose the first downstream generation: {leading_pull}"
     );
     assert!(
-        refreshes_during_leading_pull.is_empty(),
-        "single-flight must suppress refreshes during the leading pull: {refreshes_during_leading_pull:?}"
+        refreshes_before_barrier.is_empty(),
+        "single-flight must suppress refreshes during the leading pull: {refreshes_before_barrier:?}"
     );
 
-    // A second pull is an ordered post-burst barrier: the mock reads it only
-    // after writing refresh generations 2–10, and its response follows those
-    // refresh frames on the same downstream connection.
-    let barrier_pull_id = client.send_request_async(
-        "textDocument/diagnostic",
-        json!({ "textDocument": { "uri": MD_URI } }),
-    );
-    let (barrier_pull, refreshes_before_barrier) = client
-        .receive_response_for_id_watching_server_requests(
-            barrier_pull_id,
-            "workspace/diagnostic/refresh",
-        );
+    if barrier_pushes.is_empty() {
+        let (barrier, refreshes) = client
+            .wait_for_notification_watching_server_requests(
+                "textDocument/publishDiagnostics",
+                "workspace/diagnostic/refresh",
+                Duration::from_secs(5),
+            )
+            .expect("the upstream FIFO must publish the post-burst barrier");
+        barrier_pushes.push(barrier);
+        refreshes_before_barrier.extend(refreshes);
+    }
     assert!(
-        barrier_pull["result"]["items"]
-            .as_array()
-            .is_some_and(|items| items.iter().any(|diagnostic| {
-                diagnostic["message"] == json!("mock-diagnostic-generation:10")
-            })),
-        "the ordered barrier must observe the complete downstream burst: {barrier_pull}"
+        barrier_pushes
+            .iter()
+            .any(|params| params["diagnostics"]
+                .as_array()
+                .is_some_and(|diagnostics| diagnostics.iter().any(|diagnostic| {
+                    diagnostic["message"].as_str().is_some_and(|message| {
+                        message.ends_with("diagnostic-refresh-burst-admitted")
+                    })
+                }))),
+        "the upstream FIFO must expose the post-burst push barrier: {barrier_pushes:?}"
     );
     assert!(
         refreshes_before_barrier.is_empty(),

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -953,6 +953,12 @@ fn e2e_downstream_refresh_burst_is_coalesced() {
         "expected one progress barrier: {barriers:?}"
     );
     client.send_response(barriers.remove(0).0, json!(null));
+    assert!(
+        client
+            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(250),)
+            .is_none(),
+        "the settled trailing edge must remain pending while the leading refresh is in flight"
+    );
     client.send_response(id, json!(null));
 
     let (trailing_id, _) = client

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -904,10 +904,15 @@ fn e2e_downstream_refresh_burst_is_coalesced() {
         .expect("the leading refresh must reach the editor immediately");
     client.send_response(id, json!(null));
 
-    let leading_pull = client.send_request(
+    let leading_pull_id = client.send_request_async(
         "textDocument/diagnostic",
         json!({ "textDocument": { "uri": MD_URI } }),
     );
+    let (leading_pull, refreshes_during_leading_pull) = client
+        .receive_response_for_id_watching_server_requests(
+            leading_pull_id,
+            "workspace/diagnostic/refresh",
+        );
     assert!(
         leading_pull["result"]["items"]
             .as_array()
@@ -917,14 +922,27 @@ fn e2e_downstream_refresh_burst_is_coalesced() {
         "the leading refresh must expose the first downstream generation: {leading_pull}"
     );
 
-    let (trailing_id, _) = client
-        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(1200))
-        .expect("activity after the leading edge must produce one trailing refresh");
+    let (trailing_id, _) = match refreshes_during_leading_pull.as_slice() {
+        [] => client
+            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(1200))
+            .expect("activity after the leading edge must produce one trailing refresh"),
+        [(id, params)] => (id.clone(), params.clone()),
+        refreshes => panic!("the leading pull observed duplicate refreshes: {refreshes:?}"),
+    };
     client.send_response(trailing_id, json!(null));
 
-    let trailing_pull = client.send_request(
+    let trailing_pull_id = client.send_request_async(
         "textDocument/diagnostic",
         json!({ "textDocument": { "uri": MD_URI } }),
+    );
+    let (trailing_pull, refreshes_during_trailing_pull) = client
+        .receive_response_for_id_watching_server_requests(
+            trailing_pull_id,
+            "workspace/diagnostic/refresh",
+        );
+    assert!(
+        refreshes_during_trailing_pull.is_empty(),
+        "the trailing pull must not conceal duplicate refreshes: {refreshes_during_trailing_pull:?}"
     );
     let items = trailing_pull["result"]["items"]
         .as_array()

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -454,7 +454,10 @@ fn e2e_downstream_crash_evicts_its_pushed_diagnostics() {
 /// will send `workspace/diagnostic/refresh` (it's gated on this; an editor that
 /// doesn't advertise it is never sent the request).
 fn refresh_capable_caps() -> Value {
-    json!({ "workspace": { "diagnostics": { "refreshSupport": true } } })
+    json!({
+        "workspace": { "diagnostics": { "refreshSupport": true } },
+        "window": { "workDoneProgress": true }
+    })
 }
 
 #[test]
@@ -910,11 +913,11 @@ fn e2e_downstream_refresh_burst_is_coalesced() {
         "textDocument/diagnostic",
         json!({ "textDocument": { "uri": MD_URI } }),
     );
-    let (leading_pull, mut refreshes_before_barrier, mut barrier_pushes) = client
-        .receive_response_for_id_watching_server_requests_and_notification(
+    let (leading_pull, mut refreshes_before_barrier, mut barriers) = client
+        .receive_response_for_id_watching_two_server_requests(
             leading_pull_id,
             "workspace/diagnostic/refresh",
-            "textDocument/publishDiagnostics",
+            "window/workDoneProgress/create",
         );
     assert!(
         leading_pull["result"]["items"]
@@ -929,33 +932,27 @@ fn e2e_downstream_refresh_burst_is_coalesced() {
         "single-flight must suppress refreshes during the leading pull: {refreshes_before_barrier:?}"
     );
 
-    if barrier_pushes.is_empty() {
-        let (barrier, refreshes) = client
-            .wait_for_notification_watching_server_requests(
-                "textDocument/publishDiagnostics",
+    if barriers.is_empty() {
+        let (barrier_id, refreshes) = client
+            .wait_for_server_request_watching_server_requests(
+                "window/workDoneProgress/create",
                 "workspace/diagnostic/refresh",
                 Duration::from_secs(5),
             )
-            .expect("the upstream FIFO must publish the post-burst barrier");
-        barrier_pushes.push(barrier);
+            .expect("the upstream FIFO must expose the refresh-neutral progress barrier");
+        barriers.push((barrier_id, Value::Null));
         refreshes_before_barrier.extend(refreshes);
     }
-    assert!(
-        barrier_pushes
-            .iter()
-            .any(|params| params["diagnostics"]
-                .as_array()
-                .is_some_and(|diagnostics| diagnostics.iter().any(|diagnostic| {
-                    diagnostic["message"].as_str().is_some_and(|message| {
-                        message.ends_with("diagnostic-refresh-burst-admitted")
-                    })
-                }))),
-        "the upstream FIFO must expose the post-burst push barrier: {barrier_pushes:?}"
-    );
     assert!(
         refreshes_before_barrier.is_empty(),
         "single-flight must hold through complete burst admission: {refreshes_before_barrier:?}"
     );
+    assert_eq!(
+        barriers.len(),
+        1,
+        "expected one progress barrier: {barriers:?}"
+    );
+    client.send_response(barriers.remove(0).0, json!(null));
     client.send_response(id, json!(null));
 
     let (trailing_id, _) = client

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -61,6 +61,30 @@ fn init_client_with_mode_caps(mode: &str, capabilities: Value) -> (LspClient, te
         .arg("--config-file")
         .arg(config_path.to_str().expect("utf8 path"))
         .build();
+    let initialization_options = if mode == "diagnostics-refresh-burst" {
+        json!({
+            "languageServers": {
+                "mock-push": { "cmd": [mock_bin(), mode], "languages": ["lua"] }
+            },
+            "languages": {
+                "markdown": {
+                    "bridge": {
+                        "lua": {
+                            "aggregation": {
+                                "textDocument/publishDiagnostics": { "pullFallback": false }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    } else {
+        json!({
+            "languageServers": {
+                "mock-push": { "cmd": [mock_bin(), mode], "languages": ["lua"] }
+            }
+        })
+    };
 
     client.send_request(
         "initialize",
@@ -69,11 +93,7 @@ fn init_client_with_mode_caps(mode: &str, capabilities: Value) -> (LspClient, te
             "rootUri": null,
             "capabilities": capabilities,
             "workspaceFolders": null,
-            "initializationOptions": {
-                "languageServers": {
-                    "mock-push": { "cmd": [mock_bin(), mode], "languages": ["lua"] }
-                }
-            }
+            "initializationOptions": initialization_options
         }),
     );
     client.send_notification("initialized", json!({}));
@@ -884,22 +904,35 @@ fn e2e_downstream_refresh_burst_is_coalesced() {
         .expect("the leading refresh must reach the editor immediately");
     client.send_response(id, json!(null));
 
+    let leading_pull = client.send_request(
+        "textDocument/diagnostic",
+        json!({ "textDocument": { "uri": MD_URI } }),
+    );
+    assert!(
+        leading_pull["result"]["items"]
+            .as_array()
+            .is_some_and(|items| items.iter().any(|diagnostic| {
+                diagnostic["message"] == json!("mock-diagnostic-generation:1")
+            })),
+        "the leading refresh must expose the first downstream generation: {leading_pull}"
+    );
+
     let (trailing_id, _) = client
         .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(1200))
         .expect("activity after the leading edge must produce one trailing refresh");
     client.send_response(trailing_id, json!(null));
 
-    let response = client.send_request(
+    let trailing_pull = client.send_request(
         "textDocument/diagnostic",
         json!({ "textDocument": { "uri": MD_URI } }),
     );
-    let items = response["result"]["items"]
+    let items = trailing_pull["result"]["items"]
         .as_array()
         .expect("the pull after a coalesced refresh returns a full report");
     assert!(
-        items.iter().any(|diagnostic| diagnostic["message"]
-            .as_str()
-            .is_some_and(|message| message.starts_with("mock-diagnostic:"))),
+        items
+            .iter()
+            .any(|diagnostic| { diagnostic["message"] == json!("mock-diagnostic-generation:10") }),
         "the re-pull must include the refreshing downstream's latest diagnostics"
     );
 

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -923,15 +923,40 @@ fn e2e_downstream_refresh_burst_is_coalesced() {
             })),
         "the leading refresh must expose the first downstream generation: {leading_pull}"
     );
+    assert!(
+        refreshes_during_leading_pull.is_empty(),
+        "single-flight must suppress refreshes during the leading pull: {refreshes_during_leading_pull:?}"
+    );
+
+    // A second pull is an ordered post-burst barrier: the mock reads it only
+    // after writing refresh generations 2–10, and its response follows those
+    // refresh frames on the same downstream connection.
+    let barrier_pull_id = client.send_request_async(
+        "textDocument/diagnostic",
+        json!({ "textDocument": { "uri": MD_URI } }),
+    );
+    let (barrier_pull, refreshes_before_barrier) = client
+        .receive_response_for_id_watching_server_requests(
+            barrier_pull_id,
+            "workspace/diagnostic/refresh",
+        );
+    assert!(
+        barrier_pull["result"]["items"]
+            .as_array()
+            .is_some_and(|items| items.iter().any(|diagnostic| {
+                diagnostic["message"] == json!("mock-diagnostic-generation:10")
+            })),
+        "the ordered barrier must observe the complete downstream burst: {barrier_pull}"
+    );
+    assert!(
+        refreshes_before_barrier.is_empty(),
+        "single-flight must hold through complete burst admission: {refreshes_before_barrier:?}"
+    );
     client.send_response(id, json!(null));
 
-    let (trailing_id, _) = match refreshes_during_leading_pull.as_slice() {
-        [] => client
-            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(1200))
-            .expect("activity after the leading edge must produce one trailing refresh"),
-        [(id, params)] => (id.clone(), params.clone()),
-        refreshes => panic!("the leading pull observed duplicate refreshes: {refreshes:?}"),
-    };
+    let (trailing_id, _) = client
+        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(1200))
+        .expect("activity after the leading edge must produce one trailing refresh");
     client.send_response(trailing_id, json!(null));
 
     let trailing_pull_id = client.send_request_async(

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -874,6 +874,27 @@ fn e2e_downstream_refresh_forwarded_to_refresh_capable_client() {
 }
 
 #[test]
+fn e2e_downstream_refresh_burst_is_coalesced() {
+    let (mut client, _config_dir) =
+        init_client_with_mode_caps("diagnostics-refresh-burst", refresh_capable_caps());
+    open_host(&mut client);
+
+    let (id, _) = client
+        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(15))
+        .expect("a downstream refresh burst must eventually reach the editor");
+    client.send_response(id, json!(null));
+    assert!(
+        client
+            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(500))
+            .is_none(),
+        "one burst must produce at most one editor-visible refresh"
+    );
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
 fn e2e_downstream_refresh_gated_off_for_refresh_incapable_client() {
     // #521: the same downstream refresh must NOT be forwarded when the client did
     // not advertise `workspace.diagnostics.refreshSupport` — forwarding it would

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -885,7 +885,7 @@ fn e2e_downstream_refresh_burst_is_coalesced() {
     client.send_response(id, json!(null));
     assert!(
         client
-            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(500))
+            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(1200))
             .is_none(),
         "one burst must produce at most one editor-visible refresh"
     );

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -881,13 +881,33 @@ fn e2e_downstream_refresh_burst_is_coalesced() {
 
     let (id, _) = client
         .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(15))
-        .expect("a downstream refresh burst must eventually reach the editor");
+        .expect("the leading refresh must reach the editor immediately");
     client.send_response(id, json!(null));
+
+    let (trailing_id, _) = client
+        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(1200))
+        .expect("activity after the leading edge must produce one trailing refresh");
+    client.send_response(trailing_id, json!(null));
+
+    let response = client.send_request(
+        "textDocument/diagnostic",
+        json!({ "textDocument": { "uri": MD_URI } }),
+    );
+    let items = response["result"]["items"]
+        .as_array()
+        .expect("the pull after a coalesced refresh returns a full report");
+    assert!(
+        items.iter().any(|diagnostic| diagnostic["message"]
+            .as_str()
+            .is_some_and(|message| message.starts_with("mock-diagnostic:"))),
+        "the re-pull must include the refreshing downstream's latest diagnostics"
+    );
+
     assert!(
         client
             .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(2000))
             .is_none(),
-        "one burst must produce at most one editor-visible refresh"
+        "one burst must produce only its leading and trailing refreshes"
     );
 
     client.send_request("shutdown", json!(null));

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -902,8 +902,10 @@ fn e2e_downstream_refresh_burst_is_coalesced() {
     let (id, _) = client
         .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(15))
         .expect("the leading refresh must reach the editor immediately");
-    client.send_response(id, json!(null));
 
+    // Keep the leading refresh unacknowledged while pulling generation 1. The
+    // mock emits generations 2–10 after answering this pull, so every later
+    // downstream refresh arrives during the leading request's single-flight.
     let leading_pull_id = client.send_request_async(
         "textDocument/diagnostic",
         json!({ "textDocument": { "uri": MD_URI } }),
@@ -921,6 +923,7 @@ fn e2e_downstream_refresh_burst_is_coalesced() {
             })),
         "the leading refresh must expose the first downstream generation: {leading_pull}"
     );
+    client.send_response(id, json!(null));
 
     let (trailing_id, _) = match refreshes_during_leading_pull.as_slice() {
         [] => client

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -885,7 +885,7 @@ fn e2e_downstream_refresh_burst_is_coalesced() {
     client.send_response(id, json!(null));
     assert!(
         client
-            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(1200))
+            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(2000))
             .is_none(),
         "one burst must produce at most one editor-visible refresh"
     );

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -349,6 +349,7 @@ fn read_framed_message<R: BufRead>(reader: &mut R) -> ReadOutcome {
 /// (method, params) collected while waiting for it — the result of
 /// [`LspClient::wait_for_server_request_watching`].
 pub(crate) type WatchedServerRequest = (Value, Value, Vec<(String, Value)>);
+type TwoWatchedServerRequestResponse = (Value, Vec<(Value, Value)>, Vec<(Value, Value)>);
 
 impl LspClient {
     /// Spawn the kakehashi binary and create a new LSP client.
@@ -481,15 +482,15 @@ impl LspClient {
         &mut self,
         expected_id: i64,
         watched_method: Option<&str>,
-        watched_notification: Option<&str>,
-    ) -> (Value, Vec<(Value, Value)>, Vec<Value>) {
+        second_watched_method: Option<&str>,
+    ) -> TwoWatchedServerRequestResponse {
         const MAX_MESSAGES: u32 = 1000;
         const TIMEOUT: Duration = Duration::from_secs(30);
 
         let start_time = Instant::now();
         let mut message_count = 0u32;
         let mut watched = Vec::new();
-        let mut watched_notifications = Vec::new();
+        let mut second_watched = Vec::new();
 
         loop {
             // Check message count threshold
@@ -534,20 +535,20 @@ impl LspClient {
                             id.clone(),
                             message.get("params").cloned().unwrap_or(Value::Null),
                         ));
+                    } else if Some(method) == second_watched_method {
+                        second_watched.push((
+                            id.clone(),
+                            message.get("params").cloned().unwrap_or(Value::Null),
+                        ));
                     }
                     continue;
                 }
                 // Response should match our request id
                 if id.as_i64() == Some(expected_id) {
-                    return (message, watched, watched_notifications);
+                    return (message, watched, second_watched);
                 }
             }
-            if message.get("id").is_none()
-                && message.get("method").and_then(Value::as_str) == watched_notification
-            {
-                watched_notifications.push(message.get("params").cloned().unwrap_or(Value::Null));
-            }
-            // Otherwise it's an unrelated notification like window/logMessage, skip it
+            // Otherwise it's a notification like window/logMessage, skip it
         }
     }
 
@@ -615,26 +616,26 @@ impl LspClient {
         expected_id: i64,
         watched_method: &str,
     ) -> (Value, Vec<(Value, Value)>) {
-        let (response, requests, _) = self.receive_response_for_id_watching_server_requests_inner(
+        let (response, watched, _) = self.receive_response_for_id_watching_server_requests_inner(
             expected_id,
             Some(watched_method),
             None,
         );
-        (response, requests)
+        (response, watched)
     }
 
-    /// Receive a response while preserving both concurrent server requests and
-    /// notifications used as an ordered forwarding barrier.
-    pub(crate) fn receive_response_for_id_watching_server_requests_and_notification(
+    /// Receive a response while preserving two independently significant
+    /// server-request methods that race with it.
+    pub(crate) fn receive_response_for_id_watching_two_server_requests(
         &mut self,
         expected_id: i64,
         watched_method: &str,
-        watched_notification: &str,
-    ) -> (Value, Vec<(Value, Value)>, Vec<Value>) {
+        second_watched_method: &str,
+    ) -> TwoWatchedServerRequestResponse {
         self.receive_response_for_id_watching_server_requests_inner(
             expected_id,
             Some(watched_method),
-            Some(watched_notification),
+            Some(second_watched_method),
         )
     }
 
@@ -673,9 +674,9 @@ impl LspClient {
         }
     }
 
-    /// Wait for a notification while preserving server requests of
-    /// `watched_method` that precede it on the editor-facing connection.
-    pub(crate) fn wait_for_notification_watching_server_requests(
+    /// Wait for one server request while preserving requests of another method
+    /// that precede it on the editor-facing connection.
+    pub(crate) fn wait_for_server_request_watching_server_requests(
         &mut self,
         expected_method: &str,
         watched_method: &str,
@@ -692,18 +693,14 @@ impl LspClient {
 
             let message = self.try_receive_message(remaining)?;
             let method = message.get("method").and_then(Value::as_str);
-            if message.get("id").is_some() && method == Some(watched_method) {
-                watched.push((
-                    message.get("id").cloned().expect("checked above"),
-                    message.get("params").cloned().unwrap_or(Value::Null),
-                ));
-                continue;
-            }
-            if message.get("id").is_none() && method == Some(expected_method) {
-                return Some((
-                    message.get("params").cloned().unwrap_or(Value::Null),
-                    watched,
-                ));
+            if let Some(id) = message.get("id").cloned() {
+                if method == Some(watched_method) {
+                    watched.push((id, message.get("params").cloned().unwrap_or(Value::Null)));
+                    continue;
+                }
+                if method == Some(expected_method) {
+                    return Some((id, watched));
+                }
             }
         }
     }

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -473,11 +473,21 @@ impl LspClient {
     /// Skips server-initiated notifications and requests until finding matching response.
     /// Times out after 30 seconds or 1000 messages to prevent indefinite hangs.
     fn receive_response_for_id(&mut self, expected_id: i64) -> Value {
+        self.receive_response_for_id_watching_server_requests_inner(expected_id, None)
+            .0
+    }
+
+    fn receive_response_for_id_watching_server_requests_inner(
+        &mut self,
+        expected_id: i64,
+        watched_method: Option<&str>,
+    ) -> (Value, Vec<(Value, Value)>) {
         const MAX_MESSAGES: u32 = 1000;
         const TIMEOUT: Duration = Duration::from_secs(30);
 
         let start_time = Instant::now();
         let mut message_count = 0u32;
+        let mut watched = Vec::new();
 
         loop {
             // Check message count threshold
@@ -514,13 +524,20 @@ impl LspClient {
 
             // Check if this is a response to our request
             if let Some(id) = message.get("id") {
-                // Server-to-client requests have "method" field, skip them
-                if message.get("method").is_some() {
+                // Preserve watched server-to-client requests instead of silently
+                // discarding them while a synchronous client request is in flight.
+                if let Some(method) = message.get("method").and_then(Value::as_str) {
+                    if Some(method) == watched_method {
+                        watched.push((
+                            id.clone(),
+                            message.get("params").cloned().unwrap_or(Value::Null),
+                        ));
+                    }
                     continue;
                 }
                 // Response should match our request id
                 if id.as_i64() == Some(expected_id) {
-                    return message;
+                    return (message, watched);
                 }
             }
             // Otherwise it's a notification like window/logMessage, skip it
@@ -580,6 +597,21 @@ impl LspClient {
     /// Receive response for a specific request ID (public version).
     pub(crate) fn receive_response_for_id_public(&mut self, expected_id: i64) -> Value {
         self.receive_response_for_id(expected_id)
+    }
+
+    /// Receive one client-request response while preserving server requests of
+    /// `watched_method` that arrived before it. This prevents exact-sequence E2E
+    /// assertions from losing concurrent server requests in the ordinary
+    /// synchronous response loop.
+    pub(crate) fn receive_response_for_id_watching_server_requests(
+        &mut self,
+        expected_id: i64,
+        watched_method: &str,
+    ) -> (Value, Vec<(Value, Value)>) {
+        self.receive_response_for_id_watching_server_requests_inner(
+            expected_id,
+            Some(watched_method),
+        )
     }
 
     /// Wait for a notification with a specific method name.

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -473,7 +473,7 @@ impl LspClient {
     /// Skips server-initiated notifications and requests until finding matching response.
     /// Times out after 30 seconds or 1000 messages to prevent indefinite hangs.
     fn receive_response_for_id(&mut self, expected_id: i64) -> Value {
-        self.receive_response_for_id_watching_server_requests_inner(expected_id, None)
+        self.receive_response_for_id_watching_server_requests_inner(expected_id, None, None)
             .0
     }
 
@@ -481,13 +481,15 @@ impl LspClient {
         &mut self,
         expected_id: i64,
         watched_method: Option<&str>,
-    ) -> (Value, Vec<(Value, Value)>) {
+        watched_notification: Option<&str>,
+    ) -> (Value, Vec<(Value, Value)>, Vec<Value>) {
         const MAX_MESSAGES: u32 = 1000;
         const TIMEOUT: Duration = Duration::from_secs(30);
 
         let start_time = Instant::now();
         let mut message_count = 0u32;
         let mut watched = Vec::new();
+        let mut watched_notifications = Vec::new();
 
         loop {
             // Check message count threshold
@@ -537,10 +539,15 @@ impl LspClient {
                 }
                 // Response should match our request id
                 if id.as_i64() == Some(expected_id) {
-                    return (message, watched);
+                    return (message, watched, watched_notifications);
                 }
             }
-            // Otherwise it's a notification like window/logMessage, skip it
+            if message.get("id").is_none()
+                && message.get("method").and_then(Value::as_str) == watched_notification
+            {
+                watched_notifications.push(message.get("params").cloned().unwrap_or(Value::Null));
+            }
+            // Otherwise it's an unrelated notification like window/logMessage, skip it
         }
     }
 
@@ -608,9 +615,26 @@ impl LspClient {
         expected_id: i64,
         watched_method: &str,
     ) -> (Value, Vec<(Value, Value)>) {
+        let (response, requests, _) = self.receive_response_for_id_watching_server_requests_inner(
+            expected_id,
+            Some(watched_method),
+            None,
+        );
+        (response, requests)
+    }
+
+    /// Receive a response while preserving both concurrent server requests and
+    /// notifications used as an ordered forwarding barrier.
+    pub(crate) fn receive_response_for_id_watching_server_requests_and_notification(
+        &mut self,
+        expected_id: i64,
+        watched_method: &str,
+        watched_notification: &str,
+    ) -> (Value, Vec<(Value, Value)>, Vec<Value>) {
         self.receive_response_for_id_watching_server_requests_inner(
             expected_id,
             Some(watched_method),
+            Some(watched_notification),
         )
     }
 
@@ -646,6 +670,41 @@ impl LspClient {
             }
             // Otherwise it's a response or server-to-client request; skip it
             // and keep waiting within the deadline.
+        }
+    }
+
+    /// Wait for a notification while preserving server requests of
+    /// `watched_method` that precede it on the editor-facing connection.
+    pub(crate) fn wait_for_notification_watching_server_requests(
+        &mut self,
+        expected_method: &str,
+        watched_method: &str,
+        timeout: Duration,
+    ) -> Option<(Value, Vec<(Value, Value)>)> {
+        let start_time = Instant::now();
+        let mut watched = Vec::new();
+
+        loop {
+            let remaining = timeout.saturating_sub(start_time.elapsed());
+            if remaining.is_zero() {
+                return None;
+            }
+
+            let message = self.try_receive_message(remaining)?;
+            let method = message.get("method").and_then(Value::as_str);
+            if message.get("id").is_some() && method == Some(watched_method) {
+                watched.push((
+                    message.get("id").cloned().expect("checked above"),
+                    message.get("params").cloned().unwrap_or(Value::Null),
+                ));
+                continue;
+            }
+            if message.get("id").is_none() && method == Some(expected_method) {
+                return Some((
+                    message.get("params").cloned().unwrap_or(Value::Null),
+                    watched,
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- forward the first downstream `workspace/diagnostic/refresh` immediately
- debounce later activity globally per upstream workspace connection
- emit one trailing refresh after 100 ms quiet, with a 1 s max-wait cadence for continuous streams
- suppress a trailing send when another refresh already covered the latest downstream activity
- retain debounce ownership through refresh admission and single-flight handoff
- cancel/release debounce and single-flight state safely during shutdown
- verify the leading pull sees generation 1 and the trailing pull sees the latest generation 10

Closes #789

Follow-ups: #849 makes timing configurable; #850 prefetches `pullFallback` contexts before forwarding.

## Validation

- `cargo test --lib -q forwarded_refresh_`
- `cargo test --lib -q refresh_single_flight_`
- `cargo test --test e2e_push_diagnostics --features e2e -q e2e_downstream_refresh_`
- `cargo clippy --lib -- -D warnings`
- `cargo clippy --test e2e_push_diagnostics --features e2e -- -D warnings`
- `cargo fmt --check`
- burst E2E repeated three consecutive times after the final ordering changes

## Review

- revise Stage 1: multi-perspective review converged after concurrency, protocol/E2E, and ADR findings were fixed
- revise Stage 2: original Codex review thread converged to `no comments to provide`
- revise Stage 2: fresh Codex review session returned `no comments to provide` on its first response
- existing GitHub review findings were answered and resolved against the current head
- Copilot and Gemini were re-requested; both are unavailable because their account-level daily quotas are exhausted
- GitHub CI passed: Check, Test, Format, Clippy, and Audit

> Full `cargo test --lib -q` also exercises external/real-server tests in this repository; the current run hit unrelated semantic-cancellation and live language-server failures and was stopped after the focused changed paths passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Diagnostic refresh requests are now coalesced during bursts with clear leading-and-trailing behavior.
  * Forwarded refresh handling now uses a bounded debounce (quiet period) capped by a maximum wait, preventing duplicate trailing forwards.
  * Refresh activity is shutdown-aware to avoid lingering or mis-sequenced refreshes during shutdown.
* **Metrics**
  * Refresh metrics more accurately reflect “requested” vs “sent” when coalescing, gating, or shutdown suppresses sends.
* **Documentation**
  * Updated architecture documentation for the implemented downstream diagnostic refresh forwarding rules.
* **Tests**
  * Added/expanded unit and end-to-end coverage for burst coalescing, bounded max-wait, and shutdown suppression behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->