### PR TITLE
fix(config): publish forced output atomically

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -697,77 +697,50 @@ impl WriteDisposition {
 }
 
 fn write_forced_output(path: &std::path::Path, content: &str) -> std::io::Result<WriteDisposition> {
+    write_forced_output_with(path, content, |file, content| {
+        use std::io::Write as _;
+        file.write_all(content.as_bytes())
+    })
+}
+
+fn write_forced_output_with(
+    path: &std::path::Path,
+    content: &str,
+    write: impl FnOnce(&mut std::fs::File, &str) -> std::io::Result<()>,
+) -> std::io::Result<WriteDisposition> {
     if std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             format!("refusing to follow output symlink '{}'", path.display()),
         ));
     }
-    #[cfg(unix)]
-    {
-        use std::io::Write as _;
-        use std::os::unix::fs::OpenOptionsExt as _;
-        let create = || {
-            std::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .custom_flags(nix::libc::O_NOFOLLOW)
-                .open(path)
-        };
-        let (mut file, disposition) = match create() {
-            Ok(file) => (file, WriteDisposition::Created),
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => (
-                std::fs::OpenOptions::new()
-                    .write(true)
-                    .truncate(true)
-                    .custom_flags(nix::libc::O_NOFOLLOW)
-                    .open(path)?,
-                WriteDisposition::Overwrote,
-            ),
-            Err(error) => return Err(error),
-        };
-        file.write_all(content.as_bytes())?;
-        Ok(disposition)
-    }
-    #[cfg(not(unix))]
-    {
-        #[cfg(windows)]
-        {
-            use std::io::Write as _;
-            use std::os::windows::fs::OpenOptionsExt as _;
-            const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-            let create = || {
-                std::fs::OpenOptions::new()
-                    .write(true)
-                    .create_new(true)
-                    .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
-                    .open(path)
-            };
-            let (mut file, disposition) = match create() {
-                Ok(file) => (file, WriteDisposition::Created),
-                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => (
-                    std::fs::OpenOptions::new()
-                        .write(true)
-                        .truncate(true)
-                        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
-                        .open(path)?,
-                    WriteDisposition::Overwrote,
-                ),
-                Err(error) => return Err(error),
-            };
-            file.write_all(content.as_bytes())?;
-            Ok(disposition)
+
+    let directory = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty());
+    let mut temporary =
+        tempfile::NamedTempFile::new_in(directory.unwrap_or(std::path::Path::new(".")))?;
+    write(temporary.as_file_mut(), content)?;
+    temporary.as_file().sync_all()?;
+
+    match temporary.persist_noclobber(path) {
+        Ok(_) => Ok(WriteDisposition::Created),
+        Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let temporary = error.file;
+            let metadata = std::fs::symlink_metadata(path)?;
+            if metadata.file_type().is_symlink() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("refusing to follow output symlink '{}'", path.display()),
+                ));
+            }
+            temporary
+                .as_file()
+                .set_permissions(metadata.permissions())?;
+            temporary.persist(path).map_err(|error| error.error)?;
+            Ok(WriteDisposition::Overwrote)
         }
-        #[cfg(not(windows))]
-        {
-            let disposition = if path.exists() {
-                WriteDisposition::Overwrote
-            } else {
-                WriteDisposition::Created
-            };
-            std::fs::write(path, content)?;
-            Ok(disposition)
-        }
+        Err(error) => Err(error.error),
     }
 }
 
@@ -1243,6 +1216,23 @@ mod tests {
             WriteDisposition::Overwrote
         );
         assert_eq!(std::fs::read_to_string(output).unwrap(), "second");
+    }
+
+    #[test]
+    fn failed_force_output_preserves_existing_file() {
+        use std::io::Write as _;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let output = temp.path().join("config.toml");
+        std::fs::write(&output, "existing").unwrap();
+
+        let result = write_forced_output_with(&output, "generated", |file, content| {
+            file.write_all(&content.as_bytes()[..3])?;
+            Err(std::io::Error::other("injected write failure"))
+        });
+
+        assert!(result.is_err());
+        assert_eq!(std::fs::read_to_string(output).unwrap(), "existing");
     }
 
     #[cfg(unix)]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -718,25 +718,15 @@ fn write_forced_output_with(
     let directory = path
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty());
+    let mut builder = tempfile::Builder::new();
     #[cfg(unix)]
-    let created_permissions = {
-        let directory = directory.unwrap_or(std::path::Path::new("."));
-        let probe = directory.join(format!(".kakehashi-mode-{}", ulid::Ulid::new()));
-        let file = std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&probe)?;
-        let permissions = file.metadata()?.permissions();
-        drop(file);
-        std::fs::remove_file(probe)?;
-        permissions
-    };
-    let mut temporary =
-        tempfile::NamedTempFile::new_in(directory.unwrap_or(std::path::Path::new(".")))?;
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        builder.permissions(std::fs::Permissions::from_mode(0o666));
+    }
+    let mut temporary = builder.tempfile_in(directory.unwrap_or(std::path::Path::new(".")))?;
     write(temporary.as_file_mut(), content)?;
     temporary.as_file().sync_all()?;
-    #[cfg(unix)]
-    temporary.as_file().set_permissions(created_permissions)?;
 
     match temporary.persist_noclobber(path) {
         Ok(_) => Ok(WriteDisposition::Created),

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -718,10 +718,25 @@ fn write_forced_output_with(
     let directory = path
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty());
+    #[cfg(unix)]
+    let created_permissions = {
+        let directory = directory.unwrap_or(std::path::Path::new("."));
+        let probe = directory.join(format!(".kakehashi-mode-{}", ulid::Ulid::new()));
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&probe)?;
+        let permissions = file.metadata()?.permissions();
+        drop(file);
+        std::fs::remove_file(probe)?;
+        permissions
+    };
     let mut temporary =
         tempfile::NamedTempFile::new_in(directory.unwrap_or(std::path::Path::new(".")))?;
     write(temporary.as_file_mut(), content)?;
     temporary.as_file().sync_all()?;
+    #[cfg(unix)]
+    temporary.as_file().set_permissions(created_permissions)?;
 
     match temporary.persist_noclobber(path) {
         Ok(_) => Ok(WriteDisposition::Created),
@@ -1233,6 +1248,24 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(std::fs::read_to_string(output).unwrap(), "existing");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn new_force_output_uses_normal_creation_permissions() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let ordinary = temp.path().join("ordinary.toml");
+        let output = temp.path().join("config.toml");
+        std::fs::write(&ordinary, "ordinary").unwrap();
+
+        write_forced_output(&output, "generated").unwrap();
+
+        assert_eq!(
+            std::fs::metadata(output).unwrap().permissions().mode(),
+            std::fs::metadata(ordinary).unwrap().permissions().mode()
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- write forced config/schema output completely to a sibling temporary file
- atomically publish with no-clobber first to retain exact Created/Overwrote reporting
- preserve an existing destination and its permissions when a write fails
- retain force-mode symlink refusal

Closes #806

## Stack

Depends on #805; merge #805 first, then rebase this branch onto current `main`.

## Validation

- `cargo test --bin kakehashi`
- `cargo clippy --bin kakehashi -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forced-output writing to avoid partial/corrupted results when a write fails.
  * Prevented forced output from following symbolic links during replacement for safer updates.
  * Ensured forced-output files on Unix keep the expected creation permissions, matching normal file creation behavior.
* **Tests**
  * Added coverage to verify failed writes don’t modify existing output.
  * Added Unix-only checks to confirm permission consistency for forced-output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->