### PR TITLE
fix(config): warn when force targets stdout

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -640,12 +640,12 @@ fn write_content_to_output(
     force: bool,
     label: &str,
 ) -> Result<(), ExitCode> {
-    // Check for --force without --output (warn but continue)
-    if force && output.is_none() {
-        eprintln!("Warning: --force has no effect without --output");
+    let writes_stdout = output.as_ref().is_none_or(|path| path.as_os_str() == "-");
+    if force && writes_stdout {
+        eprintln!("Warning: --force has no effect when output is stdout");
     }
 
-    if let Some(path) = output.as_ref().filter(|p| p.as_os_str() != "-") {
+    if let Some(path) = output.as_ref().filter(|_| !writes_stdout) {
         let write_result = if force {
             write_forced_output(path, content)
         } else {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -450,6 +450,22 @@ fn test_config_init_output_dash_outputs_to_stdout() {
     );
 }
 
+#[test]
+fn test_config_init_force_output_dash_warns_force_is_ignored() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args(["config", "init", "--force", "--output", "-"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("autoInstall"));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Warning") && stderr.contains("--force"),
+        "Should warn that --force has no effect for stdout. Got: {stderr}"
+    );
+}
+
 /// Test that config schema outputs valid JSON to stdout
 #[test]
 fn test_config_schema_outputs_valid_json_to_stdout() {


### PR DESCRIPTION
## Summary

- treat omitted output and explicit `--output -` as the same effective stdout destination
- warn that `--force` has no effect for either stdout spelling
- preserve successful stdout content

Closes #808

## Stack

Depends on #807; merge #807 first, then rebase this branch onto current `main`.

## Validation

- focused new CLI regression test
- all config-init CLI tests
- `cargo clippy --bin kakehashi --test test_cli -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `--force` when output is directed to stdout, including explicit `--output -`.
  * Added a warning clarifying that `--force` has no effect when writing to stdout.
  * Ensured configuration templates continue to print successfully in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->