### PR TITLE
fix(config): reject hard-linked output targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,7 @@ dependencies = [
  "ulid",
  "ureq",
  "url",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,9 @@ futures = "0.3.31"
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process", "fs"] }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
+
 [features]
 e2e = []
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -739,10 +739,10 @@ fn write_forced_output_with(
                     format!("refusing to follow output symlink '{}'", path.display()),
                 ));
             }
-            reject_multiple_hard_links(path, &metadata)?;
             temporary
                 .as_file()
                 .set_permissions(metadata.permissions())?;
+            reject_multiple_hard_links(path)?;
             temporary.persist(path).map_err(|error| error.error)?;
             Ok(WriteDisposition::Overwrote)
         }
@@ -751,20 +751,14 @@ fn write_forced_output_with(
 }
 
 #[cfg(unix)]
-fn reject_multiple_hard_links(
-    _path: &std::path::Path,
-    metadata: &std::fs::Metadata,
-) -> std::io::Result<()> {
+fn reject_multiple_hard_links(path: &std::path::Path) -> std::io::Result<()> {
     use std::os::unix::fs::MetadataExt as _;
 
-    reject_hard_link_count(metadata.nlink())
+    reject_hard_link_count(std::fs::metadata(path)?.nlink())
 }
 
 #[cfg(windows)]
-fn reject_multiple_hard_links(
-    path: &std::path::Path,
-    _metadata: &std::fs::Metadata,
-) -> std::io::Result<()> {
+fn reject_multiple_hard_links(path: &std::path::Path) -> std::io::Result<()> {
     use std::os::windows::io::AsRawHandle as _;
     use windows_sys::Win32::Storage::FileSystem::{
         BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
@@ -785,10 +779,7 @@ fn reject_multiple_hard_links(
 }
 
 #[cfg(not(any(unix, windows)))]
-fn reject_multiple_hard_links(
-    _path: &std::path::Path,
-    _metadata: &std::fs::Metadata,
-) -> std::io::Result<()> {
+fn reject_multiple_hard_links(_path: &std::path::Path) -> std::io::Result<()> {
     Ok(())
 }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -739,6 +739,7 @@ fn write_forced_output_with(
                     format!("refusing to follow output symlink '{}'", path.display()),
                 ));
             }
+            reject_multiple_hard_links(path, &metadata)?;
             temporary
                 .as_file()
                 .set_permissions(metadata.permissions())?;
@@ -747,6 +748,60 @@ fn write_forced_output_with(
         }
         Err(error) => Err(error.error),
     }
+}
+
+#[cfg(unix)]
+fn reject_multiple_hard_links(
+    _path: &std::path::Path,
+    metadata: &std::fs::Metadata,
+) -> std::io::Result<()> {
+    use std::os::unix::fs::MetadataExt as _;
+
+    reject_hard_link_count(metadata.nlink())
+}
+
+#[cfg(windows)]
+fn reject_multiple_hard_links(
+    path: &std::path::Path,
+    _metadata: &std::fs::Metadata,
+) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
+    };
+
+    let file = std::fs::File::open(path)?;
+    let mut information = std::mem::MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
+    // SAFETY: the handle remains valid for the call and Windows initializes the
+    // complete output structure on success.
+    let succeeded =
+        unsafe { GetFileInformationByHandle(file.as_raw_handle(), information.as_mut_ptr()) };
+    if succeeded == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: GetFileInformationByHandle succeeded above.
+    let information = unsafe { information.assume_init() };
+    reject_hard_link_count(u64::from(information.nNumberOfLinks))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn reject_multiple_hard_links(
+    _path: &std::path::Path,
+    _metadata: &std::fs::Metadata,
+) -> std::io::Result<()> {
+    Ok(())
+}
+
+fn reject_hard_link_count(links: u64) -> std::io::Result<()> {
+    if links > 1 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "refusing atomic replacement of a file with {links} hard links; remove the aliases first"
+            ),
+        ));
+    }
+    Ok(())
 }
 
 /// Run the config init command
@@ -1238,6 +1293,53 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(std::fs::read_to_string(output).unwrap(), "existing");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn force_output_rejects_multiply_linked_file_without_changes() {
+        use std::os::unix::fs::MetadataExt as _;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let output = temp.path().join("config.toml");
+        let alias = temp.path().join("alias.toml");
+        std::fs::write(&output, "existing").unwrap();
+        std::fs::hard_link(&output, &alias).unwrap();
+        let inode = std::fs::metadata(&output).unwrap().ino();
+
+        let error = write_forced_output(&output, "generated").unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("hard links"));
+        assert_eq!(std::fs::read_to_string(&output).unwrap(), "existing");
+        assert_eq!(std::fs::read_to_string(&alias).unwrap(), "existing");
+        assert_eq!(std::fs::metadata(output).unwrap().ino(), inode);
+        assert_eq!(std::fs::metadata(alias).unwrap().ino(), inode);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn force_output_rejects_windows_hard_links_without_changes() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let output = temp.path().join("config.toml");
+        let alias = temp.path().join("alias.toml");
+        std::fs::write(&output, "existing").unwrap();
+        if let Err(error) = std::fs::hard_link(&output, &alias) {
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::Unsupported | std::io::ErrorKind::PermissionDenied
+            ) {
+                return;
+            }
+            panic!("create hard link: {error}");
+        }
+
+        let error = write_forced_output(&output, "generated").unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("hard links"));
+        assert_eq!(std::fs::read_to_string(output).unwrap(), "existing");
+        assert_eq!(std::fs::read_to_string(alias).unwrap(), "existing");
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- reject atomic force replacement when an existing output has multiple hard links
- preserve every alias and the original inode/content on refusal
- enforce the final pre-persist check on Unix and Windows
- query Windows link count through `GetFileInformationByHandle` using a target-specific direct `windows-sys 0.61` dependency

Closes #810

## Stack

Depends on #809; merge #809 first, then rebase this branch onto current `main`.

## Validation

- `cargo test --bin kakehashi` (8/8)
- `cargo clippy --bin kakehashi -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- attempted `cargo check --target x86_64-pc-windows-gnu --bin kakehashi`; unavailable because this Nix toolchain has no Windows core target and no `rustup` command. The cfg-windows FFI path therefore requires exact review/CI validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented forced file replacement when the destination has multiple hard links, preserving the original file and its linked copies.
  * Added platform-specific safeguards for Windows and Unix systems.
  * Improved error reporting for unsafe overwrite attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->