### PR TITLE
perf(semantic): overlap host and injection work

### DIFF
--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -94,6 +94,7 @@ pub(crate) async fn handle_semantic_tokens_full(
 ) -> Option<SemanticTokensResult> {
     pool.run(cancel.clone(), move || {
         let is_cancelled = || crate::cancel::is_cancelled(cancel.as_ref());
+        let compute_started = std::time::Instant::now();
         let mut host_tokens: Vec<RawToken> = Vec::with_capacity(1000);
         let lines: Vec<&str> = text.lines().collect();
         let line_starts = build_line_start_bytes(&text);
@@ -195,18 +196,21 @@ pub(crate) async fn handle_semantic_tokens_full(
             cancel.as_ref(),
         );
         let finalize_elapsed = finalize_start.elapsed();
+        let compute_elapsed = compute_started.elapsed();
         if is_cancelled() {
             return None;
         }
 
-        // One developer-only event per completed compute keeps the phases
-        // comparable without adding hot-loop logging or operator noise.
+        // Host/injection durations overlap when `parallel=true`, so `compute`
+        // is the authoritative wall time; branch durations must not be summed.
         log::debug!(
             target: "kakehashi::semantic",
-            "[SEMANTIC_TOKENS] compute phases: host={}ms injections={}ms finalize={}ms regions_reused={}",
+            "[SEMANTIC_TOKENS] compute phases: compute={}ms host={}ms injections={}ms finalize={}ms parallel={} regions_reused={}",
+            compute_elapsed.as_millis(),
             host_elapsed.as_millis(),
             injections_elapsed.as_millis(),
             finalize_elapsed.as_millis(),
+            should_parallelize,
             injection_cache
                 .as_ref()
                 // The same generation gate the reuse path applies: a

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -64,6 +64,10 @@ pub(crate) use token_collector::TokenKind;
 #[cfg(test)]
 use {delta::calculate_semantic_tokens_delta, tower_lsp_server::ls_types::SemanticTokens};
 
+/// Below this, scheduling a second Rayon branch costs more than the injection
+/// work it can overlap. Matches the injection-cache engagement threshold.
+const PARALLEL_HOST_INJECTION_MIN_REGIONS: usize = 8;
+
 /// Compute full-document semantic tokens (host + injections) as one work-unit
 /// on the bounded compute pool; the injection fan-out's `par_iter` runs on the
 /// same pool (a Rayon parallel iterator invoked from a pool thread stays on
@@ -94,40 +98,9 @@ pub(crate) async fn handle_semantic_tokens_full(
 ) -> Option<SemanticTokensResult> {
     pool.run(cancel.clone(), move || {
         let is_cancelled = || crate::cancel::is_cancelled(cancel.as_ref());
-        let t_start = std::time::Instant::now();
-
-        let mut all_tokens: Vec<RawToken> = Vec::with_capacity(1000);
+        let mut host_tokens: Vec<RawToken> = Vec::with_capacity(1000);
         let lines: Vec<&str> = text.lines().collect();
         let line_starts = build_line_start_bytes(&text);
-
-        // Collect host document tokens first (no exclusion — finalize handles it).
-        if !collect_host_tokens(
-            &text,
-            &tree,
-            &query,
-            filetype.as_deref(),
-            capture_mappings.as_deref(),
-            &text,
-            &lines,
-            &line_starts,
-            0,
-            0,
-            supports_multiline,
-            &[],
-            &[],
-            cancel.as_ref(),
-            &mut all_tokens,
-        ) {
-            return None;
-        }
-
-        let host_elapsed = t_start.elapsed();
-
-        // The host collector polls mid-query; this boundary also catches a
-        // supersede that lands after its last poll and before injection work.
-        if is_cancelled() {
-            return None;
-        }
 
         // Borrow the owned cache handle into a request-scoped context for the
         // injection pass (#529); `None` keeps the uncached behavior.
@@ -148,22 +121,66 @@ pub(crate) async fn handle_semantic_tokens_full(
             discovery: p.discovery.as_deref(),
         });
 
-        // Collect injection tokens in parallel using Rayon.
-        // Also returns active injection regions for finalize-time exclusion.
-        // `cancel` is polled inside discovery and the per-region fan-out so a
-        // supersede lands mid-pass, not just at these outer boundaries.
-        let (injection_tokens, active_injection_regions) = collect_injection_tokens_parallel(
-            &text,
-            &lines,
-            &line_starts,
-            &tree,
-            filetype.as_deref(),
-            &coordinator,
-            capture_mappings.as_deref(),
-            supports_multiline,
-            cache_ctx.as_ref(),
-            cancel.as_ref(),
-        );
+        let should_parallelize = cache_ctx
+            .as_ref()
+            .and_then(|ctx| ctx.discovery)
+            .is_some_and(|discovery| {
+                discovery.complete
+                    && discovery.regions.len() >= PARALLEL_HOST_INJECTION_MIN_REGIONS
+            });
+        let mut host_work = || {
+                    let started = std::time::Instant::now();
+                    let complete = collect_host_tokens(
+                        &text,
+                        &tree,
+                        &query,
+                        filetype.as_deref(),
+                        capture_mappings.as_deref(),
+                        &text,
+                        &lines,
+                        &line_starts,
+                        0,
+                        0,
+                        supports_multiline,
+                        &[],
+                        &[],
+                        cancel.as_ref(),
+                        &mut host_tokens,
+                    );
+                    (complete, started.elapsed())
+                };
+        let injection_work = || {
+                    let started = std::time::Instant::now();
+                    let result = collect_injection_tokens_parallel(
+                        &text,
+                        &lines,
+                        &line_starts,
+                        &tree,
+                        filetype.as_deref(),
+                        &coordinator,
+                        capture_mappings.as_deref(),
+                        supports_multiline,
+                        cache_ctx.as_ref(),
+                        cancel.as_ref(),
+                    );
+                    (result, started.elapsed())
+                };
+
+        // Host highlighting and a substantial injection pass read the same
+        // immutable snapshot and only meet during finalization. Overlap them
+        // when discovery proves enough injection work exists to amortize the
+        // second Rayon branch; otherwise retain the sequential fast path.
+        let ((host_complete, host_elapsed), (injection_result, injections_elapsed)) =
+            if should_parallelize {
+                rayon::join(host_work, injection_work)
+            } else {
+                (host_work(), injection_work())
+            };
+
+        if !host_complete {
+            return None;
+        }
+        let (injection_tokens, active_injection_regions) = injection_result;
 
         // A supersede observed during the injection pass leaves a partial token
         // set; drop it so the handler never stores partial results.
@@ -171,14 +188,12 @@ pub(crate) async fn handle_semantic_tokens_full(
             return None;
         }
 
-        let injections_elapsed = t_start.elapsed().saturating_sub(host_elapsed);
-
         // Merge injection tokens with host tokens
-        all_tokens.extend(injection_tokens);
+        host_tokens.extend(injection_tokens);
 
         let finalize_start = std::time::Instant::now();
         let result = finalize_tokens_cancellable(
-            all_tokens,
+            host_tokens,
             &active_injection_regions,
             &lines,
             cancel.as_ref(),

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -197,6 +197,11 @@ pub(crate) async fn handle_semantic_tokens_full(
         // second Rayon branch; otherwise retain the sequential fast path.
         let ((host_complete, host_elapsed), (injection_result, injections_elapsed)) =
             if should_parallelize {
+                // Match the sequential injection boundary: do not dispatch
+                // either Rayon branch when supersession has already landed.
+                if is_cancelled() {
+                    return None;
+                }
                 rayon::join(host_work, injection_work)
             } else {
                 let host_result = host_work();

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -64,6 +64,19 @@ pub(crate) use token_collector::TokenKind;
 #[cfg(test)]
 use {delta::calculate_semantic_tokens_delta, tower_lsp_server::ls_types::SemanticTokens};
 
+fn should_parallelize_host_and_injections(
+    compute_threads: usize,
+    current_generation: u64,
+    discovery: Option<(u64, bool, usize)>,
+) -> bool {
+    compute_threads >= 3
+        && discovery.is_some_and(|(generation, complete, region_count)| {
+            generation == current_generation
+                && complete
+                && region_count >= INJECTION_CACHE_MIN_REGIONS
+        })
+}
+
 /// Compute full-document semantic tokens (host + injections) as one work-unit
 /// on the bounded compute pool; the injection fan-out's `par_iter` runs on the
 /// same pool (a Rayon parallel iterator invoked from a pool thread stays on
@@ -92,6 +105,7 @@ pub(crate) async fn handle_semantic_tokens_full(
     injection_cache: Option<InjectionCacheParams>,
     cancel: Option<crate::cancel::CancelToken>,
 ) -> Option<SemanticTokensResult> {
+    let compute_threads = pool.thread_count();
     pool.run(cancel.clone(), move || {
         let is_cancelled = || crate::cancel::is_cancelled(cancel.as_ref());
         let compute_started = std::time::Instant::now();
@@ -119,11 +133,17 @@ pub(crate) async fn handle_semantic_tokens_full(
         });
 
         let should_parallelize = cache_ctx.as_ref().is_some_and(|ctx| {
-            ctx.discovery.is_some_and(|discovery| {
-                discovery.generation == ctx.generation
-                    && discovery.complete
-                    && discovery.regions.len() >= INJECTION_CACHE_MIN_REGIONS
-            })
+            should_parallelize_host_and_injections(
+                compute_threads,
+                ctx.generation,
+                ctx.discovery.map(|discovery| {
+                    (
+                        discovery.generation,
+                        discovery.complete,
+                        discovery.regions.len(),
+                    )
+                }),
+            )
         });
         let mut host_work = || {
                     let started = std::time::Instant::now();
@@ -234,6 +254,39 @@ pub(crate) async fn handle_semantic_tokens_full(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parallel_host_injection_gate_checks_pool_and_discovery_contract() {
+        let threshold = INJECTION_CACHE_MIN_REGIONS;
+        let cases = [
+            (1, 7, None, false, "single-thread pool"),
+            (2, 7, Some((7, true, threshold)), false, "two-thread pool"),
+            (3, 7, None, false, "absent discovery"),
+            (3, 7, Some((6, true, threshold)), false, "stale discovery"),
+            (
+                3,
+                7,
+                Some((7, false, threshold)),
+                false,
+                "partial discovery",
+            ),
+            (
+                3,
+                7,
+                Some((7, true, threshold - 1)),
+                false,
+                "below threshold",
+            ),
+            (3, 7, Some((7, true, threshold)), true, "eligible"),
+        ];
+        for (threads, generation, discovery, expected, label) in cases {
+            assert_eq!(
+                should_parallelize_host_and_injections(threads, generation, discovery),
+                expected,
+                "{label}"
+            );
+        }
+    }
     use tower_lsp_server::ls_types::{Range, SemanticToken};
 
     /// Returns the search path for tree-sitter grammars.

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -236,11 +236,11 @@ pub(crate) async fn handle_semantic_tokens_full(
         // is the authoritative wall time; branch durations must not be summed.
         log::debug!(
             target: "kakehashi::semantic",
-            "[SEMANTIC_TOKENS] compute phases: compute={}ms host={}ms injections={}ms finalize={}ms parallel={} regions_reused={}",
-            compute_elapsed.as_millis(),
-            host_elapsed.as_millis(),
-            injections_elapsed.as_millis(),
-            finalize_elapsed.as_millis(),
+            "[SEMANTIC_TOKENS] compute phases: compute={}us host={}us injections={}us finalize={}us parallel={} regions_reused={}",
+            compute_elapsed.as_micros(),
+            host_elapsed.as_micros(),
+            injections_elapsed.as_micros(),
+            finalize_elapsed.as_micros(),
             should_parallelize,
             injection_cache
                 .as_ref()

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -20,7 +20,7 @@ pub(crate) use parallel::build_document_discovery;
 pub(crate) use range::filter_semantic_tokens_by_range;
 
 // Re-export for parallel processing
-use parallel::{InjectionCacheCtx, collect_injection_tokens_parallel};
+use parallel::{INJECTION_CACHE_MIN_REGIONS, InjectionCacheCtx, collect_injection_tokens_parallel};
 
 /// Owned handle the LSP layer passes into [`handle_semantic_tokens_full`] to
 /// enable per-region injection-token caching (#529). `None` disables caching
@@ -63,10 +63,6 @@ pub(crate) use token_collector::TokenKind;
 // Test-only imports
 #[cfg(test)]
 use {delta::calculate_semantic_tokens_delta, tower_lsp_server::ls_types::SemanticTokens};
-
-/// Below this, scheduling a second Rayon branch costs more than the injection
-/// work it can overlap. Matches the injection-cache engagement threshold.
-const PARALLEL_HOST_INJECTION_MIN_REGIONS: usize = 8;
 
 /// Compute full-document semantic tokens (host + injections) as one work-unit
 /// on the bounded compute pool; the injection fan-out's `par_iter` runs on the
@@ -121,13 +117,13 @@ pub(crate) async fn handle_semantic_tokens_full(
             discovery: p.discovery.as_deref(),
         });
 
-        let should_parallelize = cache_ctx
-            .as_ref()
-            .and_then(|ctx| ctx.discovery)
-            .is_some_and(|discovery| {
-                discovery.complete
-                    && discovery.regions.len() >= PARALLEL_HOST_INJECTION_MIN_REGIONS
-            });
+        let should_parallelize = cache_ctx.as_ref().is_some_and(|ctx| {
+            ctx.discovery.is_some_and(|discovery| {
+                discovery.generation == ctx.generation
+                    && discovery.complete
+                    && discovery.regions.len() >= INJECTION_CACHE_MIN_REGIONS
+            })
+        });
         let mut host_work = || {
                     let started = std::time::Instant::now();
                     let complete = collect_host_tokens(

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -154,42 +154,42 @@ pub(crate) async fn handle_semantic_tokens_full(
             )
         });
         let mut host_work = || {
-                    let started = std::time::Instant::now();
-                    let complete = collect_host_tokens(
-                        &text,
-                        &tree,
-                        &query,
-                        filetype.as_deref(),
-                        capture_mappings.as_deref(),
-                        &text,
-                        &lines,
-                        &line_starts,
-                        0,
-                        0,
-                        supports_multiline,
-                        &[],
-                        &[],
-                        cancel.as_ref(),
-                        &mut host_tokens,
-                    );
-                    (complete, started.elapsed())
-                };
+            let started = std::time::Instant::now();
+            let complete = collect_host_tokens(
+                &text,
+                &tree,
+                &query,
+                filetype.as_deref(),
+                capture_mappings.as_deref(),
+                &text,
+                &lines,
+                &line_starts,
+                0,
+                0,
+                supports_multiline,
+                &[],
+                &[],
+                cancel.as_ref(),
+                &mut host_tokens,
+            );
+            (complete, started.elapsed())
+        };
         let injection_work = || {
-                    let started = std::time::Instant::now();
-                    let result = collect_injection_tokens_parallel(
-                        &text,
-                        &lines,
-                        &line_starts,
-                        &tree,
-                        filetype.as_deref(),
-                        &coordinator,
-                        capture_mappings.as_deref(),
-                        supports_multiline,
-                        cache_ctx.as_ref(),
-                        cancel.as_ref(),
-                    );
-                    (result, started.elapsed())
-                };
+            let started = std::time::Instant::now();
+            let result = collect_injection_tokens_parallel(
+                &text,
+                &lines,
+                &line_starts,
+                &tree,
+                filetype.as_deref(),
+                &coordinator,
+                capture_mappings.as_deref(),
+                supports_multiline,
+                cache_ctx.as_ref(),
+                cancel.as_ref(),
+            );
+            (result, started.elapsed())
+        };
 
         // Host highlighting and a substantial injection pass read the same
         // immutable snapshot and only meet during finalization. Overlap them

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -191,7 +191,11 @@ pub(crate) async fn handle_semantic_tokens_full(
             if should_parallelize {
                 rayon::join(host_work, injection_work)
             } else {
-                (host_work(), injection_work())
+                let host_result = host_work();
+                if !host_result.0 || is_cancelled() {
+                    return None;
+                }
+                (host_result, injection_work())
             };
 
         if !host_complete {

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -77,6 +77,14 @@ fn should_parallelize_host_and_injections(
         })
 }
 
+fn run_sequential_injection<T>(
+    host_complete: bool,
+    cancelled: bool,
+    injection_work: impl FnOnce() -> T,
+) -> Option<T> {
+    (!cancelled && host_complete).then(injection_work)
+}
+
 /// Compute full-document semantic tokens (host + injections) as one work-unit
 /// on the bounded compute pool; the injection fan-out's `par_iter` runs on the
 /// same pool (a Rayon parallel iterator invoked from a pool thread stays on
@@ -192,10 +200,9 @@ pub(crate) async fn handle_semantic_tokens_full(
                 rayon::join(host_work, injection_work)
             } else {
                 let host_result = host_work();
-                if !host_result.0 || is_cancelled() {
-                    return None;
-                }
-                (host_result, injection_work())
+                let injection_result =
+                    run_sequential_injection(host_result.0, is_cancelled(), injection_work)?;
+                (host_result, injection_result)
             };
 
         if !host_complete {
@@ -290,6 +297,24 @@ mod tests {
                 "{label}"
             );
         }
+    }
+
+    #[test]
+    fn sequential_injection_does_not_start_after_host_cancel() {
+        let starts = std::cell::Cell::new(0);
+        let mut work = || {
+            starts.set(starts.get() + 1);
+            "ran"
+        };
+
+        assert_eq!(run_sequential_injection(false, false, &mut work), None);
+        assert_eq!(run_sequential_injection(true, true, &mut work), None);
+        assert_eq!(starts.get(), 0);
+        assert_eq!(
+            run_sequential_injection(true, false, &mut work),
+            Some("ran")
+        );
+        assert_eq!(starts.get(), 1);
     }
     use tower_lsp_server::ls_types::{Range, SemanticToken};
 

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -35,7 +35,7 @@ use crate::text::position::byte_to_utf16_col;
 /// so small documents (the overwhelming majority) pay zero overhead and are
 /// byte-identical to the uncached path. The cache only helps once enough regions
 /// exist that reusing the untouched ones outweighs the per-region bookkeeping.
-const INJECTION_CACHE_MIN_REGIONS: usize = 8;
+pub(super) const INJECTION_CACHE_MIN_REGIONS: usize = 8;
 
 /// Test-only counter of how many times the discovery-reuse branch fired (skipped
 /// the injection query by reusing owned discovery). Lets an in-process server

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -1267,10 +1267,7 @@ pub(crate) fn collect_injection_tokens_parallel(
         DISCOVERY_REUSE_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let mut contexts = Vec::with_capacity(discovery.regions.len());
         let mut exclusion_byte_ranges = Vec::with_capacity(discovery.regions.len());
-        for region in &discovery.regions {
-            if is_cancelled(cancel) {
-                return (Vec::new(), Vec::new());
-            }
+        let completed = visit_until_cancelled(&discovery.regions, cancel, |region| {
             // A region whose highlight query isn't loaded is dropped (rebuild
             // returns None) — same as the inline path's query-missing branch. The
             // generation match makes this near-impossible, but the drop is safe.
@@ -1285,6 +1282,9 @@ pub(crate) fn collect_injection_tokens_parallel(
             ) {
                 contexts.push(ctx);
             }
+        });
+        if !completed {
+            return (Vec::new(), Vec::new());
         }
         (contexts, exclusion_byte_ranges)
     } else {
@@ -1447,6 +1447,20 @@ pub(crate) fn collect_injection_tokens_parallel(
     (all_tokens, active_regions)
 }
 
+fn visit_until_cancelled<T>(
+    items: &[T],
+    cancel: Option<&crate::cancel::CancelToken>,
+    mut visit: impl FnMut(&T),
+) -> bool {
+    for item in items {
+        if crate::cancel::is_cancelled(cancel) {
+            return false;
+        }
+        visit(item);
+    }
+    true
+}
+
 /// Translate an eligible region's host-absolute tokens into region-local
 /// coordinates for caching: subtract the region's first host line so a stored
 /// entry re-anchors with a single `line += line_start` on reuse. The column is
@@ -1577,6 +1591,20 @@ mod tests {
 
     use super::super::token_collector::build_line_start_bytes;
     use super::*;
+
+    #[test]
+    fn reusable_region_visit_stops_on_mid_loop_cancel() {
+        let cancel = crate::cancel::CancelToken::default();
+        cancel.cancel_after_polls(4);
+        let mut visited = Vec::new();
+
+        assert!(!visit_until_cancelled(
+            &[0, 1, 2, 3, 4],
+            Some(&cancel),
+            |item| visited.push(*item)
+        ));
+        assert_eq!(visited, vec![0, 1, 2]);
+    }
     use crate::language::registry::LanguageRegistry;
 
     fn create_test_registry() -> LanguageRegistry {

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -1268,6 +1268,9 @@ pub(crate) fn collect_injection_tokens_parallel(
         let mut contexts = Vec::with_capacity(discovery.regions.len());
         let mut exclusion_byte_ranges = Vec::with_capacity(discovery.regions.len());
         for region in &discovery.regions {
+            if is_cancelled(cancel) {
+                return (Vec::new(), Vec::new());
+            }
             // A region whose highlight query isn't loaded is dropped (rebuild
             // returns None) — same as the inline path's query-missing branch. The
             // generation match makes this near-impossible, but the drop is safe.

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -1447,6 +1447,10 @@ pub(crate) fn collect_injection_tokens_parallel(
     (all_tokens, active_regions)
 }
 
+/// Visit items until cancellation is observed between items.
+///
+/// A cancellation that arrives during `visit` is observed before the next
+/// item; the current opaque callback is allowed to finish.
 fn visit_until_cancelled<T>(
     items: &[T],
     cancel: Option<&crate::cancel::CancelToken>,

--- a/src/compute_pool.rs
+++ b/src/compute_pool.rs
@@ -20,6 +20,10 @@ pub(crate) struct ComputePool {
 }
 
 impl ComputePool {
+    pub(crate) fn thread_count(&self) -> usize {
+        self.pool.current_num_threads()
+    }
+
     /// Build the pool at the ADR-specified size:
     /// `available_parallelism - 2`, at least 1.
     pub(crate) fn new() -> Self {


### PR DESCRIPTION
## Summary

- overlap host highlighting and injection collection when generation-current completed discovery contains at least eight regions
- retain the sequential fast path for small/injection-free documents and compute pools with fewer than three workers
- preserve cancellation boundaries in both sequential and reused-discovery paths
- report authoritative microsecond wall time plus branch timings and parallel mode

Closes #790

## Measurement

50 samples, 12 warmups, `markdown_injections_large/full`:

- baseline-first: 2.108 ms → 1.519 ms (**-27.9%**)
- reversed order: HEAD 0.593 ms vs baseline 0.696 ms (**~14.8% faster**)
- reversed-order no-injection Rust control: 1.034 ms vs 1.034 ms (no drift)

The edit→reparse→delta end-to-end scenario was within +4.0%; this change targets the full semantic compute identified by the issue, not parse scheduling.

`samply`/`inferno` were unavailable locally. A 5-second macOS `sample(1)` profile of a generated 1,200-block Markdown edit workload captured `collect_host_tokens`, tree-sitter `QueryMatches`, Rayon jobs, and `finalize_tokens_cancellable`; the raw profile is `/tmp/kakehashi-790.sample.txt`. This confirms the host/query, injection/Rayon, and finalize attribution before applying the overlap lever.

## Validation

- `cargo test --lib -q analysis::semantic` (199 passed)
- `cargo test --lib -q semantic_tokens_full_returns_request_cancelled`
- `cargo test --lib -q reusable_region_visit_stops_on_mid_loop_cancel`
- `cargo test --lib -q sequential_injection_does_not_start_after_host_cancel`
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --check`

## Review

- revise Stage 1 converged
- revise Stage 2 converged in-thread, then a fresh independent Codex review returned no comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved semantic-token generation by running independent host and injection analysis concurrently when eligible.
  * Preserved a sequential “fast path” for smaller or less suitable requests to keep overhead low.
* **Reliability**
  * Strengthened cancellation behavior so token generation stops promptly and avoids returning partial injection results when host processing doesn’t complete.
  * Updated phase timing reporting to prevent misleading overlapping durations.
* **Testing**
  * Added unit coverage for the parallel eligibility gating and for cancellation stopping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->