### PR TITLE
fix(install): confine metadata cache directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +151,36 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.4",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "cc"
@@ -511,6 +547,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs4"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +902,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +1026,8 @@ name = "kakehashi"
 version = "0.8.0"
 dependencies = [
  "arc-swap",
+ "cap-primitives",
+ "cap-std",
  "clap",
  "dashmap",
  "dirs",
@@ -1102,6 +1179,12 @@ checksum = "ab84ba33842e323474cc2e32179407782b6dd272eeb433c47e5cd11912163cf0"
 dependencies = [
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -1561,6 +1644,16 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -2789,6 +2882,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.13.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,6 +1082,7 @@ dependencies = [
  "ulid",
  "ureq",
  "url",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,9 @@ futures = "0.3.31"
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process", "fs"] }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
+
 [features]
 e2e = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ opt-level = 3
 
 [dependencies]
 arc-swap = "1"
+cap-primitives = "4.0.2"
+cap-std = "4.0.2"
 clap = { version = "4", features = ["derive"] }
 dashmap = "6"
 dirs = "6"

--- a/src/install/cache.rs
+++ b/src/install/cache.rs
@@ -150,8 +150,9 @@ fn publish_cache_temp(
     let filename: Vec<u16> = "parsers.lua".encode_utf16().collect();
     let header = std::mem::offset_of!(FILE_RENAME_INFO, FileName);
     let size = header + filename.len() * std::mem::size_of::<u16>();
-    let mut buffer = vec![0_u8; size];
-    let information = buffer.as_mut_ptr().cast::<FILE_RENAME_INFO>();
+    let units = size.div_ceil(std::mem::size_of::<FILE_RENAME_INFO>());
+    let mut buffer = vec![FILE_RENAME_INFO::default(); units];
+    let information = buffer.as_mut_ptr();
     // SAFETY: `buffer` is sized for the fixed header plus the UTF-16 filename;
     // both file handles remain alive for the call, and the relative filename is
     // resolved by Windows against the validated cache-directory handle.

--- a/src/install/cache.rs
+++ b/src/install/cache.rs
@@ -83,13 +83,15 @@ impl MetadataCache {
             .map(|metadata| metadata.permissions());
         let temporary_name = format!(".parsers.lua.{}.tmp", ulid::Ulid::new());
         let mut temporary = create_cache_temp(&cache_dir, &temporary_name)?;
-        write(&mut temporary, content)?;
-        if let Some(permissions) = existing_permissions {
-            temporary.set_permissions(permissions)?;
-        }
-        temporary.sync_all()?;
-        drop(temporary);
-        if let Err(error) = cache_dir.rename(&temporary_name, &cache_dir, "parsers.lua") {
+        let publish = (|| {
+            write(&mut temporary, content)?;
+            if let Some(permissions) = existing_permissions {
+                temporary.set_permissions(permissions)?;
+            }
+            temporary.sync_all()?;
+            publish_cache_temp(&cache_dir, temporary, &temporary_name)
+        })();
+        if let Err(error) = publish {
             let _ = cache_dir.remove_file(&temporary_name);
             return Err(error);
         }
@@ -119,6 +121,60 @@ impl MetadataCache {
         let cache =
             cap_primitives::fs::open_dir_nofollow(&root.into_std_file(), Path::new("cache"))?;
         Ok(cap_std::fs::Dir::from_std_file(cache))
+    }
+}
+
+#[cfg(not(windows))]
+fn publish_cache_temp(
+    cache_dir: &cap_std::fs::Dir,
+    temporary: cap_std::fs::File,
+    temporary_name: &str,
+) -> io::Result<()> {
+    drop(temporary);
+    cache_dir.rename(temporary_name, cache_dir, "parsers.lua")
+}
+
+#[cfg(windows)]
+fn publish_cache_temp(
+    cache_dir: &cap_std::fs::Dir,
+    temporary: cap_std::fs::File,
+    _temporary_name: &str,
+) -> io::Result<()> {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_RENAME_INFO, FileRenameInfo, SetFileInformationByHandle,
+    };
+
+    let directory = cache_dir.try_clone()?.into_std_file();
+    let temporary = temporary.into_std();
+    let filename: Vec<u16> = "parsers.lua".encode_utf16().collect();
+    let header = std::mem::offset_of!(FILE_RENAME_INFO, FileName);
+    let size = header + filename.len() * std::mem::size_of::<u16>();
+    let mut buffer = vec![0_u8; size];
+    let information = buffer.as_mut_ptr().cast::<FILE_RENAME_INFO>();
+    // SAFETY: `buffer` is sized for the fixed header plus the UTF-16 filename;
+    // both file handles remain alive for the call, and the relative filename is
+    // resolved by Windows against the validated cache-directory handle.
+    let succeeded = unsafe {
+        (*information).Anonymous.ReplaceIfExists = true;
+        (*information).RootDirectory = directory.as_raw_handle();
+        (*information).FileNameLength = u32::try_from(filename.len() * 2).unwrap();
+        std::ptr::copy_nonoverlapping(
+            filename.as_ptr(),
+            (*information).FileName.as_mut_ptr(),
+            filename.len(),
+        );
+        SetFileInformationByHandle(
+            temporary.as_raw_handle(),
+            FileRenameInfo,
+            information.cast(),
+            u32::try_from(size).unwrap(),
+        )
+    };
+    if succeeded == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
     }
 }
 
@@ -212,6 +268,19 @@ mod tests {
         // Read from cache
         let cached = cache.read().expect("Cache should be readable");
         assert_eq!(cached, content);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_cache_write_atomically_replaces_existing_entry() {
+        let temp = tempdir().unwrap();
+        let cache = MetadataCache::with_default_ttl(temp.path());
+        cache.write("first").unwrap();
+
+        cache.write("second").unwrap();
+
+        assert_eq!(cache.read().as_deref(), Some("second"));
+        assert_eq!(fs::read_dir(&cache.cache_dir).unwrap().count(), 1);
     }
 
     #[cfg(unix)]
@@ -382,6 +451,7 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(fs::read_to_string(cache.cache_path()).unwrap(), "previous");
+        assert_eq!(fs::read_dir(&cache.cache_dir).unwrap().count(), 1);
     }
 
     #[cfg(unix)]

--- a/src/install/cache.rs
+++ b/src/install/cache.rs
@@ -34,6 +34,7 @@ impl MetadataCache {
     }
 
     /// Path to the cached parsers.lua file.
+    #[cfg(test)]
     fn cache_path(&self) -> PathBuf {
         self.cache_dir.join("parsers.lua")
     }
@@ -42,14 +43,14 @@ impl MetadataCache {
     ///
     /// Returns `None` if cache doesn't exist or is stale.
     pub fn read(&self) -> Option<String> {
-        let cache_path = self.cache_path();
-        let mut file = open_cache_file(&cache_path).ok()?;
+        let cache_dir = self.open_cache_dir(false).ok()?;
+        let mut file = open_cache_file(&cache_dir).ok()?;
         let metadata = file.metadata().ok()?;
         if !cache_metadata_is_regular(&metadata) {
             return None;
         }
         let modified = metadata.modified().ok()?;
-        let age = SystemTime::now().duration_since(modified).ok()?;
+        let age = SystemTime::now().duration_since(modified.into_std()).ok()?;
 
         if age > self.ttl {
             // Cache is stale
@@ -72,77 +73,125 @@ impl MetadataCache {
     fn write_with(
         &self,
         content: &str,
-        write: impl FnOnce(&mut fs::File, &str) -> io::Result<()>,
+        write: impl FnOnce(&mut cap_std::fs::File, &str) -> io::Result<()>,
     ) -> io::Result<()> {
-        // Ensure cache directory exists
-        fs::create_dir_all(&self.cache_dir)?;
-
-        let cache_path = self.cache_path();
-        let existing_permissions = fs::symlink_metadata(&cache_path)
+        let cache_dir = self.open_cache_dir(true)?;
+        let existing_permissions = cache_dir
+            .symlink_metadata("parsers.lua")
             .ok()
             .filter(|metadata| metadata.file_type().is_file())
             .map(|metadata| metadata.permissions());
-        let mut builder = tempfile::Builder::new();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt as _;
-            builder.permissions(fs::Permissions::from_mode(0o666));
-        }
-        let mut temporary = builder.tempfile_in(&self.cache_dir)?;
-        write(temporary.as_file_mut(), content)?;
+        let temporary_name = format!(".parsers.lua.{}.tmp", ulid::Ulid::new());
+        let mut temporary = create_cache_temp(&cache_dir, &temporary_name)?;
+        write(&mut temporary, content)?;
         if let Some(permissions) = existing_permissions {
-            temporary.as_file().set_permissions(permissions)?;
+            temporary.set_permissions(permissions)?;
         }
-        temporary.as_file().sync_all()?;
-        temporary.persist(cache_path).map_err(|error| error.error)?;
+        temporary.sync_all()?;
+        drop(temporary);
+        if let Err(error) = cache_dir.rename(&temporary_name, &cache_dir, "parsers.lua") {
+            let _ = cache_dir.remove_file(&temporary_name);
+            return Err(error);
+        }
 
-        // The file data is durable above. Best-effort directory sync also
-        // persists the replaced directory entry on filesystems that support it.
-        if let Ok(directory) = fs::File::open(&self.cache_dir) {
-            let _ = directory.sync_all();
+        if let Ok(directory) = cache_dir.try_clone() {
+            let _ = directory.into_std_file().sync_all();
         }
 
         Ok(())
     }
+
+    fn open_cache_dir(&self, create: bool) -> io::Result<cap_std::fs::Dir> {
+        use cap_std::ambient_authority;
+
+        let data_dir = self.cache_dir.parent().unwrap_or_else(|| Path::new("."));
+        if create {
+            fs::create_dir_all(data_dir)?;
+        }
+        let root = cap_std::fs::Dir::open_ambient_dir(data_dir, ambient_authority())?;
+        if create {
+            match root.create_dir("cache") {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error),
+            }
+        }
+        let cache =
+            cap_primitives::fs::open_dir_nofollow(&root.into_std_file(), Path::new("cache"))?;
+        Ok(cap_std::fs::Dir::from_std_file(cache))
+    }
 }
 
 #[cfg(unix)]
-fn open_cache_file(path: &Path) -> io::Result<fs::File> {
-    use std::os::unix::fs::OpenOptionsExt as _;
+fn open_cache_file(cache_dir: &cap_std::fs::Dir) -> io::Result<cap_std::fs::File> {
+    use cap_std::fs::OpenOptionsExt as _;
 
-    fs::OpenOptions::new()
-        .read(true)
-        .custom_flags(nix::libc::O_NOFOLLOW)
-        .open(path)
+    let mut options = cap_std::fs::OpenOptions::new();
+    options.read(true).custom_flags(nix::libc::O_NOFOLLOW);
+    cache_dir.open_with("parsers.lua", &options)
 }
 
 #[cfg(windows)]
-fn cache_metadata_is_regular(metadata: &fs::Metadata) -> bool {
-    use std::os::windows::fs::MetadataExt as _;
+fn cache_metadata_is_regular(metadata: &cap_std::fs::Metadata) -> bool {
+    use cap_std::fs::MetadataExt as _;
 
     const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
     metadata.file_type().is_file() && metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT == 0
 }
 
 #[cfg(not(windows))]
-fn cache_metadata_is_regular(metadata: &fs::Metadata) -> bool {
+fn cache_metadata_is_regular(metadata: &cap_std::fs::Metadata) -> bool {
     metadata.file_type().is_file()
 }
 
 #[cfg(windows)]
-fn open_cache_file(path: &Path) -> io::Result<fs::File> {
-    use std::os::windows::fs::OpenOptionsExt as _;
+fn open_cache_file(cache_dir: &cap_std::fs::Dir) -> io::Result<cap_std::fs::File> {
+    use cap_std::fs::OpenOptionsExt as _;
 
     const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-    fs::OpenOptions::new()
+    let mut options = cap_std::fs::OpenOptions::new();
+    options
         .read(true)
-        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
-        .open(path)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    cache_dir.open_with("parsers.lua", &options)
+}
+
+#[cfg(unix)]
+fn create_cache_temp(cache_dir: &cap_std::fs::Dir, name: &str) -> io::Result<cap_std::fs::File> {
+    use cap_std::fs::OpenOptionsExt as _;
+
+    let mut options = cap_std::fs::OpenOptions::new();
+    options
+        .write(true)
+        .create_new(true)
+        .mode(0o666)
+        .custom_flags(nix::libc::O_NOFOLLOW);
+    cache_dir.open_with(name, &options)
+}
+
+#[cfg(windows)]
+fn create_cache_temp(cache_dir: &cap_std::fs::Dir, name: &str) -> io::Result<cap_std::fs::File> {
+    use cap_std::fs::OpenOptionsExt as _;
+
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    let mut options = cap_std::fs::OpenOptions::new();
+    options
+        .write(true)
+        .create_new(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    cache_dir.open_with(name, &options)
 }
 
 #[cfg(not(any(unix, windows)))]
-fn open_cache_file(path: &Path) -> io::Result<fs::File> {
-    fs::File::open(path)
+fn create_cache_temp(cache_dir: &cap_std::fs::Dir, name: &str) -> io::Result<cap_std::fs::File> {
+    let mut options = cap_std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    cache_dir.open_with(name, &options)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_cache_file(cache_dir: &cap_std::fs::Dir) -> io::Result<cap_std::fs::File> {
+    cache_dir.open("parsers.lua")
 }
 
 #[cfg(test)]
@@ -210,6 +259,88 @@ mod tests {
 
         assert_eq!(cache.read(), None);
         assert_eq!(fs::read_to_string(target).unwrap(), "outside metadata");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cache_directory_symlink_redirects_neither_reads_nor_writes() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().unwrap();
+        let outside = temp.path().join("outside");
+        let cache_dir = temp.path().join("cache");
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join("parsers.lua"), "outside metadata").unwrap();
+        symlink(&outside, &cache_dir).unwrap();
+        let cache = MetadataCache::with_default_ttl(temp.path());
+
+        assert_eq!(cache.read(), None);
+        assert!(cache.write("replacement").is_err());
+        assert_eq!(
+            fs::read_to_string(outside.join("parsers.lua")).unwrap(),
+            "outside metadata"
+        );
+        assert!(
+            cache_dir
+                .symlink_metadata()
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_data_directory_remains_supported() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().unwrap();
+        let actual = temp.path().join("actual-data");
+        let linked = temp.path().join("linked-data");
+        fs::create_dir_all(&actual).unwrap();
+        symlink(&actual, &linked).unwrap();
+        let cache = MetadataCache::with_default_ttl(&linked);
+
+        cache.write("metadata").unwrap();
+
+        assert_eq!(cache.read().as_deref(), Some("metadata"));
+        assert_eq!(
+            fs::read_to_string(actual.join("cache/parsers.lua")).unwrap(),
+            "metadata"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_cache_directory_symlink_redirects_neither_reads_nor_writes() {
+        use std::os::windows::fs::symlink_dir;
+
+        let temp = tempdir().unwrap();
+        let outside = temp.path().join("outside");
+        let cache_dir = temp.path().join("cache");
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join("parsers.lua"), "outside metadata").unwrap();
+        if let Err(error) = symlink_dir(&outside, &cache_dir) {
+            if error.kind() == io::ErrorKind::PermissionDenied {
+                return;
+            }
+            panic!("create cache directory symlink: {error}");
+        }
+        let cache = MetadataCache::with_default_ttl(temp.path());
+
+        assert_eq!(cache.read(), None);
+        assert!(cache.write("replacement").is_err());
+        assert_eq!(
+            fs::read_to_string(outside.join("parsers.lua")).unwrap(),
+            "outside metadata"
+        );
+        assert!(
+            cache_dir
+                .symlink_metadata()
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
## Summary

- open the configured data directory as the ambient root while preserving intentionally symlinked data roots
- open the managed `cache` leaf with no-follow semantics
- perform cache reads, temporary creation, and atomic rename relative to the validated directory handle
- reject Unix and Windows cache-directory symlink redirection without touching targets

Closes #816

## Stack

Depends on #815; merge #815 first, then rebase this branch onto current `main`.

## Validation

- RED: leaf directory symlink read external metadata and redirected writes
- `cargo test --lib install::cache::tests` (10/10)
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened cache read/write behavior to block unsafe symlink and special-file cache entries.
  * Cache updates are now published atomically to reduce the chance of incomplete or corrupted cache data.
  * Improved failure handling and cleanup to avoid leaving partial cache state.
  * Preserved cache permissions where applicable, with more reliable cache replacement on Windows.
* **Tests**
  * Added coverage for atomic replacement and single-entry cache behavior across repeated writes.
  * Added additional symlink-related tests to validate correct handling on Unix and Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->