### PR TITLE
feat(diagnostics): reuse downstream pull reports

### DIFF
--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -180,6 +180,24 @@ kakehashi keeps answering `textDocument/diagnostic` from the client:
 Path A writes the cache; Path B reads it for push-driven servers — one cache,
 two readers.
 
+Path B also keeps a downstream pull baseline per exact `(connection key,
+downstream document URI)`. A full report with a `resultId` stores that id and
+the server-local diagnostics; the next pull sends it as `previousResultId`.
+An `unchanged` response reuses those items instead of treating the region as
+empty. Region items stay in **virtual-local coordinates** and are transformed
+with the request's current `RegionOffset` on every full or unchanged response,
+so an edit above an otherwise unchanged region re-anchors the cached findings
+without invalidating its downstream content lineage. Host items are already in
+host coordinates and use the same cache without transformation.
+
+The baseline is discarded on downstream `null`/full-without-resultId, virtual
+or host `didClose`, region identity/language replacement, connection respawn,
+and settings replacement. A mere geometry shift of the same stable region id
+does not discard it: virtual-local storage plus lazy re-anchor is precisely what
+makes that reuse correct. Concurrent pulls update a lineage only when the cache
+still matches the `previousResultId` that request sent, so a late response based
+on an older id cannot overwrite a newer baseline.
+
 ### Per-server source and fallback
 
 Each downstream server has exactly one *native* diagnostic source, decided by

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -184,7 +184,8 @@ Path B also keeps a downstream pull baseline per exact `(connection key,
 downstream document URI)`. A full report with a `resultId` stores that id and
 the server-local diagnostics; the next pull sends it as `previousResultId`.
 An `unchanged` response reuses those items instead of treating the region as
-empty. Region items stay in **virtual-local coordinates** and are transformed
+empty, while advancing the baseline to the response's returned `resultId` for
+the next pull. Region items stay in **virtual-local coordinates** and are transformed
 with the request's current `RegionOffset` on every full or unchanged response,
 so an edit above an otherwise unchanged region re-anchors the cached findings
 without invalidating its downstream content lineage. Host items are already in
@@ -192,11 +193,13 @@ host coordinates and use the same cache without transformation.
 
 The baseline is discarded on downstream `null`/full-without-resultId, virtual
 or host `didClose`, region identity/language replacement, connection respawn,
-and settings replacement. A mere geometry shift of the same stable region id
+and a settings replacement affecting that exact connection. A mere geometry shift of the same stable region id
 does not discard it: virtual-local storage plus lazy re-anchor is precisely what
-makes that reuse correct. Concurrent pulls update a lineage only when the cache
-still matches the `previousResultId` that request sent, so a late response based
-on an older id cannot overwrite a newer baseline.
+makes that reuse correct. Concurrent pulls carry a bridge-local monotonically
+increasing request sequence: the later-started request owns the final lineage
+regardless of response completion order, so a late older response cannot
+overwrite or clear its baseline even when an opaque downstream `resultId`
+repeats.
 
 ### Per-server source and fallback
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -43,7 +43,7 @@ pub(crate) use shutdown_timeout::GlobalShutdownTimeout;
 pub(crate) struct DiagnosticPullBaseline {
     pub(crate) result_id: String,
     pub(crate) diagnostics: Arc<Vec<tower_lsp_server::ls_types::Diagnostic>>,
-    pub(crate) revision: u64,
+    pub(crate) request_sequence: u64,
 }
 
 pub(crate) struct DiagnosticPullSnapshot {
@@ -51,6 +51,7 @@ pub(crate) struct DiagnosticPullSnapshot {
     pub(crate) settings_generation: u64,
     pub(crate) document_generation: u64,
     pub(crate) connection_generation: u64,
+    pub(crate) request_sequence: u64,
 }
 
 fn same_launch_config(
@@ -372,7 +373,8 @@ pub struct LanguageServerPool {
     pub(crate) diagnostic_pull_generation: AtomicU64,
     /// Serializes baseline snapshots/mutations with every invalidation fence.
     pub(crate) diagnostic_pull_lock: std::sync::Mutex<()>,
-    pub(crate) diagnostic_pull_revision: AtomicU64,
+    pub(crate) diagnostic_pull_request_sequence: AtomicU64,
+    pub(crate) diagnostic_pull_applied_sequences: DashMap<(ConnectionKey, String), u64>,
     /// Upstream request ID → set of downstream connections, for fan-out cancel
     /// forwarding (ls-bridge-message-ordering). Multiple connections can share an ID when a single
     /// upstream request (e.g. diagnostic) targets several injected languages.
@@ -486,7 +488,8 @@ impl LanguageServerPool {
             diagnostic_document_generations: DashMap::new(),
             diagnostic_pull_generation: AtomicU64::new(0),
             diagnostic_pull_lock: std::sync::Mutex::new(()),
-            diagnostic_pull_revision: AtomicU64::new(1),
+            diagnostic_pull_request_sequence: AtomicU64::new(1),
+            diagnostic_pull_applied_sequences: DashMap::new(),
             upstream_request_registry: std::sync::Mutex::new(HashMap::new()),
             cancel_metrics: CancelForwardingMetrics::default(),
             consecutive_panic_counts: std::sync::Mutex::new(HashMap::new()),
@@ -681,16 +684,6 @@ impl LanguageServerPool {
         // A downstream may change diagnostic semantics without changing its
         // document contents, so no previousResultId lineage survives a settings
         // replacement safely.
-        {
-            let _guard = self
-                .diagnostic_pull_lock
-                .lock()
-                .recover_poison("LanguageServerPool::diagnostic_pull_lock");
-            self.diagnostic_pull_generation
-                .fetch_add(1, Ordering::AcqRel);
-            self.diagnostic_pull_baselines.clear();
-            self.diagnostic_document_generations.clear();
-        }
         let mut connections = self.connections.lock().await;
         let mut invalidated = Vec::new();
         let mut resolved = HashMap::new();
@@ -710,6 +703,13 @@ impl LanguageServerPool {
             }
         }
 
+        let mut affected_connections = invalidated.clone();
+        affected_connections.extend(connections.iter().filter_map(|(key, handle)| {
+            let settings = resolved.get(key).and_then(|settings| settings.as_ref());
+            (settings != handle.current_settings().as_deref()).then(|| key.clone())
+        }));
+        self.invalidate_diagnostic_connections(&affected_connections);
+
         let mut stale_handles = Vec::new();
         for key in invalidated {
             if let Some(handle) = connections.get(&key) {
@@ -720,16 +720,6 @@ impl LanguageServerPool {
                 .await
                 .retain(|(_, connection_key), _| connection_key != &key);
             self.document_tracker.purge_connection(&key).await;
-            {
-                let _guard = self
-                    .diagnostic_pull_lock
-                    .lock()
-                    .recover_poison("LanguageServerPool::diagnostic_pull_lock");
-                self.diagnostic_pull_baselines
-                    .retain(|(connection_key, _), _| connection_key != &key);
-                self.diagnostic_document_generations
-                    .retain(|(connection_key, _), _| connection_key != &key);
-            }
             self.purge_open_transition_locks(&key).await;
             if let Some(handle) = connections.remove(&key) {
                 stale_handles.push((key, handle));
@@ -1691,6 +1681,9 @@ impl LanguageServerPool {
             settings_generation: self.diagnostic_pull_generation.load(Ordering::Acquire),
             document_generation,
             connection_generation: self.document_connection_generation(&key.0),
+            request_sequence: self
+                .diagnostic_pull_request_sequence
+                .fetch_add(1, Ordering::Relaxed),
         }
     }
 
@@ -1700,10 +1693,30 @@ impl LanguageServerPool {
             .lock()
             .recover_poison("LanguageServerPool::diagnostic_pull_lock");
         self.diagnostic_pull_baselines.remove(key);
+        self.diagnostic_pull_applied_sequences.remove(key);
         self.diagnostic_document_generations
             .entry(key.clone())
             .and_modify(|generation| *generation = generation.wrapping_add(1))
             .or_insert(1);
+    }
+
+    pub(super) fn invalidate_diagnostic_connections(&self, keys: &[ConnectionKey]) {
+        if keys.is_empty() {
+            return;
+        }
+        let _guard = self
+            .diagnostic_pull_lock
+            .lock()
+            .recover_poison("LanguageServerPool::diagnostic_pull_lock");
+        self.diagnostic_pull_generation
+            .fetch_add(1, Ordering::AcqRel);
+        let affected = |key: &ConnectionKey| keys.iter().any(|candidate| candidate == key);
+        self.diagnostic_pull_baselines
+            .retain(|(key, _), _| !affected(key));
+        self.diagnostic_document_generations
+            .retain(|(key, _), _| !affected(key));
+        self.diagnostic_pull_applied_sequences
+            .retain(|(key, _), _| !affected(key));
     }
 
     /// Resolve the marker workspace AND the pool key `(server_name, root)` for a
@@ -2096,16 +2109,7 @@ impl LanguageServerPool {
                     self.document_tracker
                         .purge_connection(&connection_key)
                         .await;
-                    {
-                        let _guard = self
-                            .diagnostic_pull_lock
-                            .lock()
-                            .recover_poison("LanguageServerPool::diagnostic_pull_lock");
-                        self.diagnostic_pull_baselines
-                            .retain(|(key, _), _| key != &connection_key);
-                        self.diagnostic_document_generations
-                            .retain(|(key, _), _| key != &connection_key);
-                    }
+                    self.invalidate_diagnostic_connections(std::slice::from_ref(&connection_key));
                     self.purge_open_transition_locks(&connection_key).await;
                     // Remove only after every async purge completes. If this
                     // acquire future is aborted at a cleanup await, the stale
@@ -6764,7 +6768,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn settings_reload_clears_diagnostic_pull_baselines() {
+    async fn no_op_settings_reload_preserves_diagnostic_pull_baselines() {
         let pool = LanguageServerPool::new();
         pool.diagnostic_pull_baselines.insert(
             (
@@ -6774,13 +6778,42 @@ mod tests {
             DiagnosticPullBaseline {
                 result_id: "r1".to_string(),
                 diagnostics: Arc::new(Vec::new()),
-                revision: 1,
+                request_sequence: 1,
             },
         );
 
         pool.propagate_settings(|_| None).await;
 
-        assert!(pool.diagnostic_pull_baselines.is_empty());
+        assert_eq!(pool.diagnostic_pull_baselines.len(), 1);
+    }
+
+    #[test]
+    fn diagnostic_invalidation_is_scoped_to_connection_key() {
+        let pool = LanguageServerPool::new();
+        let affected = ConnectionKey::for_server("rust-analyzer-a");
+        let unrelated = ConnectionKey::for_server("rust-analyzer-b");
+        for key in [&affected, &unrelated] {
+            pool.diagnostic_pull_baselines.insert(
+                (key.clone(), "file:///test.rs".to_string()),
+                DiagnosticPullBaseline {
+                    result_id: "r1".to_string(),
+                    diagnostics: Arc::new(Vec::new()),
+                    request_sequence: 1,
+                },
+            );
+        }
+
+        pool.invalidate_diagnostic_connections(std::slice::from_ref(&affected));
+
+        assert!(
+            !pool
+                .diagnostic_pull_baselines
+                .contains_key(&(affected, "file:///test.rs".to_string()))
+        );
+        assert!(
+            pool.diagnostic_pull_baselines
+                .contains_key(&(unrelated, "file:///test.rs".to_string()))
+        );
     }
 
     #[test]

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -52,6 +52,8 @@ pub(crate) struct DiagnosticPullSnapshot {
     pub(crate) document_generation: u64,
     pub(crate) connection_generation: u64,
     pub(crate) request_sequence: u64,
+    pub(crate) host_uri: String,
+    pub(crate) host_generation: u64,
 }
 
 fn same_launch_config(
@@ -375,6 +377,7 @@ pub struct LanguageServerPool {
     pub(crate) diagnostic_pull_lock: std::sync::Mutex<()>,
     pub(crate) diagnostic_pull_request_sequence: AtomicU64,
     pub(crate) diagnostic_pull_applied_sequences: DashMap<(ConnectionKey, String), u64>,
+    pub(crate) diagnostic_host_generations: DashMap<String, u64>,
     /// Upstream request ID → set of downstream connections, for fan-out cancel
     /// forwarding (ls-bridge-message-ordering). Multiple connections can share an ID when a single
     /// upstream request (e.g. diagnostic) targets several injected languages.
@@ -490,6 +493,7 @@ impl LanguageServerPool {
             diagnostic_pull_lock: std::sync::Mutex::new(()),
             diagnostic_pull_request_sequence: AtomicU64::new(1),
             diagnostic_pull_applied_sequences: DashMap::new(),
+            diagnostic_host_generations: DashMap::new(),
             upstream_request_registry: std::sync::Mutex::new(HashMap::new()),
             cancel_metrics: CancelForwardingMetrics::default(),
             consecutive_panic_counts: std::sync::Mutex::new(HashMap::new()),
@@ -1662,6 +1666,7 @@ impl LanguageServerPool {
     pub(crate) fn diagnostic_pull_snapshot(
         &self,
         key: &(ConnectionKey, String),
+        host_uri: &str,
     ) -> DiagnosticPullSnapshot {
         let _guard = self
             .diagnostic_pull_lock
@@ -1688,6 +1693,12 @@ impl LanguageServerPool {
             request_sequence: self
                 .diagnostic_pull_request_sequence
                 .fetch_add(1, Ordering::Relaxed),
+            host_uri: host_uri.to_string(),
+            host_generation: self
+                .diagnostic_host_generations
+                .get(host_uri)
+                .map(|entry| *entry)
+                .unwrap_or(0),
         }
     }
 
@@ -1700,6 +1711,17 @@ impl LanguageServerPool {
         self.diagnostic_pull_applied_sequences.remove(key);
         self.diagnostic_document_generations
             .entry(key.clone())
+            .and_modify(|generation| *generation = generation.wrapping_add(1))
+            .or_insert(1);
+    }
+
+    pub(crate) fn invalidate_diagnostic_host(&self, host_uri: &Url) {
+        let _guard = self
+            .diagnostic_pull_lock
+            .lock()
+            .recover_poison("LanguageServerPool::diagnostic_pull_lock");
+        self.diagnostic_host_generations
+            .entry(host_uri.as_str().to_string())
             .and_modify(|generation| *generation = generation.wrapping_add(1))
             .or_insert(1);
     }

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -43,6 +43,14 @@ pub(crate) use shutdown_timeout::GlobalShutdownTimeout;
 pub(crate) struct DiagnosticPullBaseline {
     pub(crate) result_id: String,
     pub(crate) diagnostics: Arc<Vec<tower_lsp_server::ls_types::Diagnostic>>,
+    pub(crate) revision: u64,
+}
+
+pub(crate) struct DiagnosticPullSnapshot {
+    pub(crate) baseline: Option<DiagnosticPullBaseline>,
+    pub(crate) settings_generation: u64,
+    pub(crate) document_generation: u64,
+    pub(crate) connection_generation: u64,
 }
 
 fn same_launch_config(
@@ -362,6 +370,9 @@ pub struct LanguageServerPool {
     pub(crate) diagnostic_document_generations: DashMap<(ConnectionKey, String), u64>,
     /// Invalidates in-flight baseline reads across a settings replacement.
     pub(crate) diagnostic_pull_generation: AtomicU64,
+    /// Serializes baseline snapshots/mutations with every invalidation fence.
+    pub(crate) diagnostic_pull_lock: std::sync::Mutex<()>,
+    pub(crate) diagnostic_pull_revision: AtomicU64,
     /// Upstream request ID → set of downstream connections, for fan-out cancel
     /// forwarding (ls-bridge-message-ordering). Multiple connections can share an ID when a single
     /// upstream request (e.g. diagnostic) targets several injected languages.
@@ -474,6 +485,8 @@ impl LanguageServerPool {
             diagnostic_pull_baselines: DashMap::new(),
             diagnostic_document_generations: DashMap::new(),
             diagnostic_pull_generation: AtomicU64::new(0),
+            diagnostic_pull_lock: std::sync::Mutex::new(()),
+            diagnostic_pull_revision: AtomicU64::new(1),
             upstream_request_registry: std::sync::Mutex::new(HashMap::new()),
             cancel_metrics: CancelForwardingMetrics::default(),
             consecutive_panic_counts: std::sync::Mutex::new(HashMap::new()),
@@ -668,10 +681,16 @@ impl LanguageServerPool {
         // A downstream may change diagnostic semantics without changing its
         // document contents, so no previousResultId lineage survives a settings
         // replacement safely.
-        self.diagnostic_pull_generation
-            .fetch_add(1, Ordering::AcqRel);
-        self.diagnostic_pull_baselines.clear();
-        self.diagnostic_document_generations.clear();
+        {
+            let _guard = self
+                .diagnostic_pull_lock
+                .lock()
+                .recover_poison("LanguageServerPool::diagnostic_pull_lock");
+            self.diagnostic_pull_generation
+                .fetch_add(1, Ordering::AcqRel);
+            self.diagnostic_pull_baselines.clear();
+            self.diagnostic_document_generations.clear();
+        }
         let mut connections = self.connections.lock().await;
         let mut invalidated = Vec::new();
         let mut resolved = HashMap::new();
@@ -701,10 +720,16 @@ impl LanguageServerPool {
                 .await
                 .retain(|(_, connection_key), _| connection_key != &key);
             self.document_tracker.purge_connection(&key).await;
-            self.diagnostic_pull_baselines
-                .retain(|(connection_key, _), _| connection_key != &key);
-            self.diagnostic_document_generations
-                .retain(|(connection_key, _), _| connection_key != &key);
+            {
+                let _guard = self
+                    .diagnostic_pull_lock
+                    .lock()
+                    .recover_poison("LanguageServerPool::diagnostic_pull_lock");
+                self.diagnostic_pull_baselines
+                    .retain(|(connection_key, _), _| connection_key != &key);
+                self.diagnostic_document_generations
+                    .retain(|(connection_key, _), _| connection_key != &key);
+            }
             self.purge_open_transition_locks(&key).await;
             if let Some(handle) = connections.remove(&key) {
                 stale_handles.push((key, handle));
@@ -1644,14 +1669,36 @@ impl LanguageServerPool {
 }
 
 impl LanguageServerPool {
-    pub(crate) fn diagnostic_document_generation(&self, key: &(ConnectionKey, String)) -> u64 {
-        self.diagnostic_document_generations
+    pub(crate) fn diagnostic_pull_snapshot(
+        &self,
+        key: &(ConnectionKey, String),
+    ) -> DiagnosticPullSnapshot {
+        let _guard = self
+            .diagnostic_pull_lock
+            .lock()
+            .recover_poison("LanguageServerPool::diagnostic_pull_lock");
+        let baseline = self
+            .diagnostic_pull_baselines
+            .get(key)
+            .map(|entry| entry.value().clone());
+        let document_generation = self
+            .diagnostic_document_generations
             .get(key)
             .map(|entry| *entry)
-            .unwrap_or(0)
+            .unwrap_or(0);
+        DiagnosticPullSnapshot {
+            baseline,
+            settings_generation: self.diagnostic_pull_generation.load(Ordering::Acquire),
+            document_generation,
+            connection_generation: self.document_connection_generation(&key.0),
+        }
     }
 
     pub(crate) fn invalidate_diagnostic_document(&self, key: &(ConnectionKey, String)) {
+        let _guard = self
+            .diagnostic_pull_lock
+            .lock()
+            .recover_poison("LanguageServerPool::diagnostic_pull_lock");
         self.diagnostic_pull_baselines.remove(key);
         self.diagnostic_document_generations
             .entry(key.clone())
@@ -2049,10 +2096,16 @@ impl LanguageServerPool {
                     self.document_tracker
                         .purge_connection(&connection_key)
                         .await;
-                    self.diagnostic_pull_baselines
-                        .retain(|(key, _), _| key != &connection_key);
-                    self.diagnostic_document_generations
-                        .retain(|(key, _), _| key != &connection_key);
+                    {
+                        let _guard = self
+                            .diagnostic_pull_lock
+                            .lock()
+                            .recover_poison("LanguageServerPool::diagnostic_pull_lock");
+                        self.diagnostic_pull_baselines
+                            .retain(|(key, _), _| key != &connection_key);
+                        self.diagnostic_document_generations
+                            .retain(|(key, _), _| key != &connection_key);
+                    }
                     self.purge_open_transition_locks(&connection_key).await;
                     // Remove only after every async purge completes. If this
                     // acquire future is aborted at a cleanup await, the stale
@@ -6721,6 +6774,7 @@ mod tests {
             DiagnosticPullBaseline {
                 result_id: "r1".to_string(),
                 diagnostics: Arc::new(Vec::new()),
+                revision: 1,
             },
         );
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -377,6 +377,10 @@ pub struct LanguageServerPool {
     pub(crate) diagnostic_pull_lock: std::sync::Mutex<()>,
     pub(crate) diagnostic_pull_request_sequence: AtomicU64,
     pub(crate) diagnostic_pull_applied_sequences: DashMap<(ConnectionKey, String), u64>,
+    /// Assigns a process-unique incarnation to hosts when their first pull
+    /// begins. Closed hosts can then be removed from the generation map
+    /// without a later reopen reusing an old generation.
+    pub(crate) diagnostic_host_epoch: AtomicU64,
     pub(crate) diagnostic_host_generations: DashMap<String, u64>,
     /// Upstream request ID → set of downstream connections, for fan-out cancel
     /// forwarding (ls-bridge-message-ordering). Multiple connections can share an ID when a single
@@ -493,6 +497,7 @@ impl LanguageServerPool {
             diagnostic_pull_lock: std::sync::Mutex::new(()),
             diagnostic_pull_request_sequence: AtomicU64::new(1),
             diagnostic_pull_applied_sequences: DashMap::new(),
+            diagnostic_host_epoch: AtomicU64::new(1),
             diagnostic_host_generations: DashMap::new(),
             upstream_request_registry: std::sync::Mutex::new(HashMap::new()),
             cancel_metrics: CancelForwardingMetrics::default(),
@@ -1668,11 +1673,10 @@ impl LanguageServerPool {
             .diagnostic_pull_lock
             .lock()
             .recover_poison("LanguageServerPool::diagnostic_pull_lock");
-        let host_generation = self
+        let host_generation = *self
             .diagnostic_host_generations
-            .get(host_uri.as_str())
-            .map(|entry| *entry)
-            .unwrap_or(0);
+            .entry(host_uri.as_str().to_string())
+            .or_insert_with(|| self.diagnostic_host_epoch.fetch_add(1, Ordering::Relaxed));
         let request_sequence = self
             .diagnostic_pull_request_sequence
             .fetch_add(1, Ordering::Relaxed);
@@ -1732,10 +1736,7 @@ impl LanguageServerPool {
             .diagnostic_pull_lock
             .lock()
             .recover_poison("LanguageServerPool::diagnostic_pull_lock");
-        self.diagnostic_host_generations
-            .entry(host_uri.as_str().to_string())
-            .and_modify(|generation| *generation = generation.wrapping_add(1))
-            .or_insert(1);
+        self.diagnostic_host_generations.remove(host_uri.as_str());
     }
 
     pub(super) fn invalidate_diagnostic_connections(&self, keys: &[ConnectionKey]) {

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -39,6 +39,12 @@ pub(crate) use dynamic_capability_registry::DynamicCapabilityRegistry;
 pub(crate) use message_sender::{ConnectionHandleSender, MessageSender};
 pub(crate) use shutdown_timeout::GlobalShutdownTimeout;
 
+#[derive(Clone)]
+pub(crate) struct DiagnosticPullBaseline {
+    pub(crate) result_id: String,
+    pub(crate) diagnostics: Arc<Vec<tower_lsp_server::ls_types::Diagnostic>>,
+}
+
 fn same_launch_config(
     old: &crate::config::settings::BridgeServerConfig,
     new: &crate::config::settings::BridgeServerConfig,
@@ -346,6 +352,12 @@ pub struct LanguageServerPool {
     /// servers via `bridge._self`, with their version and content
     /// fingerprint for lazy full-text re-sync.
     host_documents: Mutex<HashMap<(String, ConnectionKey), HostDocSyncState>>,
+    /// Last full downstream pull report per exact connection/document. Region
+    /// diagnostics stay virtual-local and are re-anchored with the request's
+    /// current offset when a server answers `unchanged`.
+    pub(crate) diagnostic_pull_baselines: DashMap<(ConnectionKey, String), DiagnosticPullBaseline>,
+    /// Invalidates in-flight baseline reads across a settings replacement.
+    pub(crate) diagnostic_pull_generation: AtomicU64,
     /// Upstream request ID → set of downstream connections, for fan-out cancel
     /// forwarding (ls-bridge-message-ordering). Multiple connections can share an ID when a single
     /// upstream request (e.g. diagnostic) targets several injected languages.
@@ -455,6 +467,8 @@ impl LanguageServerPool {
             host_lifecycle_locks: DashMap::new(),
             latest_virtual_contents: DashMap::new(),
             host_documents: Mutex::new(HashMap::new()),
+            diagnostic_pull_baselines: DashMap::new(),
+            diagnostic_pull_generation: AtomicU64::new(0),
             upstream_request_registry: std::sync::Mutex::new(HashMap::new()),
             cancel_metrics: CancelForwardingMetrics::default(),
             consecutive_panic_counts: std::sync::Mutex::new(HashMap::new()),
@@ -646,6 +660,12 @@ impl LanguageServerPool {
         &self,
         resolve: impl Fn(&str) -> Option<crate::config::settings::BridgeServerConfig>,
     ) -> usize {
+        // A downstream may change diagnostic semantics without changing its
+        // document contents, so no previousResultId lineage survives a settings
+        // replacement safely.
+        self.diagnostic_pull_generation
+            .fetch_add(1, Ordering::AcqRel);
+        self.diagnostic_pull_baselines.clear();
         let mut connections = self.connections.lock().await;
         let mut invalidated = Vec::new();
         let mut resolved = HashMap::new();
@@ -675,6 +695,8 @@ impl LanguageServerPool {
                 .await
                 .retain(|(_, connection_key), _| connection_key != &key);
             self.document_tracker.purge_connection(&key).await;
+            self.diagnostic_pull_baselines
+                .retain(|(connection_key, _), _| connection_key != &key);
             self.purge_open_transition_locks(&key).await;
             if let Some(handle) = connections.remove(&key) {
                 stale_handles.push((key, handle));
@@ -2004,6 +2026,8 @@ impl LanguageServerPool {
                     self.document_tracker
                         .purge_connection(&connection_key)
                         .await;
+                    self.diagnostic_pull_baselines
+                        .retain(|(key, _), _| key != &connection_key);
                     self.purge_open_transition_locks(&connection_key).await;
                     // Remove only after every async purge completes. If this
                     // acquire future is aborted at a cleanup await, the stale
@@ -6659,6 +6683,25 @@ mod tests {
             })
             .await;
         assert_eq!(pushed, 0, "no live connections → nothing pushed");
+    }
+
+    #[tokio::test]
+    async fn settings_reload_clears_diagnostic_pull_baselines() {
+        let pool = LanguageServerPool::new();
+        pool.diagnostic_pull_baselines.insert(
+            (
+                ConnectionKey::for_server("rust-analyzer"),
+                "file:///test.rs".to_string(),
+            ),
+            DiagnosticPullBaseline {
+                result_id: "r1".to_string(),
+                diagnostics: Arc::new(Vec::new()),
+            },
+        );
+
+        pool.propagate_settings(|_| None).await;
+
+        assert!(pool.diagnostic_pull_baselines.is_empty());
     }
 
     #[test]

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1663,10 +1663,28 @@ impl LanguageServerPool {
 }
 
 impl LanguageServerPool {
+    pub(crate) fn begin_diagnostic_pull(&self, host_uri: &Url) -> (u64, u64) {
+        let _guard = self
+            .diagnostic_pull_lock
+            .lock()
+            .recover_poison("LanguageServerPool::diagnostic_pull_lock");
+        let host_generation = self
+            .diagnostic_host_generations
+            .get(host_uri.as_str())
+            .map(|entry| *entry)
+            .unwrap_or(0);
+        let request_sequence = self
+            .diagnostic_pull_request_sequence
+            .fetch_add(1, Ordering::Relaxed);
+        (host_generation, request_sequence)
+    }
+
     pub(crate) fn diagnostic_pull_snapshot(
         &self,
         key: &(ConnectionKey, String),
         host_uri: &str,
+        host_generation: u64,
+        request_sequence: u64,
     ) -> DiagnosticPullSnapshot {
         let _guard = self
             .diagnostic_pull_lock
@@ -1690,15 +1708,9 @@ impl LanguageServerPool {
                 .unwrap_or(0),
             document_generation,
             connection_generation: self.document_connection_generation(&key.0),
-            request_sequence: self
-                .diagnostic_pull_request_sequence
-                .fetch_add(1, Ordering::Relaxed),
+            request_sequence,
             host_uri: host_uri.to_string(),
-            host_generation: self
-                .diagnostic_host_generations
-                .get(host_uri)
-                .map(|entry| *entry)
-                .unwrap_or(0),
+            host_generation,
         }
     }
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -356,6 +356,10 @@ pub struct LanguageServerPool {
     /// diagnostics stay virtual-local and are re-anchored with the request's
     /// current offset when a server answers `unchanged`.
     pub(crate) diagnostic_pull_baselines: DashMap<(ConnectionKey, String), DiagnosticPullBaseline>,
+    /// Per downstream document incarnation fence. Unlike connection generation,
+    /// this advances on close so an old response cannot attach to a reopen of
+    /// the same URI on the same process.
+    pub(crate) diagnostic_document_generations: DashMap<(ConnectionKey, String), u64>,
     /// Invalidates in-flight baseline reads across a settings replacement.
     pub(crate) diagnostic_pull_generation: AtomicU64,
     /// Upstream request ID → set of downstream connections, for fan-out cancel
@@ -468,6 +472,7 @@ impl LanguageServerPool {
             latest_virtual_contents: DashMap::new(),
             host_documents: Mutex::new(HashMap::new()),
             diagnostic_pull_baselines: DashMap::new(),
+            diagnostic_document_generations: DashMap::new(),
             diagnostic_pull_generation: AtomicU64::new(0),
             upstream_request_registry: std::sync::Mutex::new(HashMap::new()),
             cancel_metrics: CancelForwardingMetrics::default(),
@@ -666,6 +671,7 @@ impl LanguageServerPool {
         self.diagnostic_pull_generation
             .fetch_add(1, Ordering::AcqRel);
         self.diagnostic_pull_baselines.clear();
+        self.diagnostic_document_generations.clear();
         let mut connections = self.connections.lock().await;
         let mut invalidated = Vec::new();
         let mut resolved = HashMap::new();
@@ -696,6 +702,8 @@ impl LanguageServerPool {
                 .retain(|(_, connection_key), _| connection_key != &key);
             self.document_tracker.purge_connection(&key).await;
             self.diagnostic_pull_baselines
+                .retain(|(connection_key, _), _| connection_key != &key);
+            self.diagnostic_document_generations
                 .retain(|(connection_key, _), _| connection_key != &key);
             self.purge_open_transition_locks(&key).await;
             if let Some(handle) = connections.remove(&key) {
@@ -1636,6 +1644,21 @@ impl LanguageServerPool {
 }
 
 impl LanguageServerPool {
+    pub(crate) fn diagnostic_document_generation(&self, key: &(ConnectionKey, String)) -> u64 {
+        self.diagnostic_document_generations
+            .get(key)
+            .map(|entry| *entry)
+            .unwrap_or(0)
+    }
+
+    pub(crate) fn invalidate_diagnostic_document(&self, key: &(ConnectionKey, String)) {
+        self.diagnostic_pull_baselines.remove(key);
+        self.diagnostic_document_generations
+            .entry(key.clone())
+            .and_modify(|generation| *generation = generation.wrapping_add(1))
+            .or_insert(1);
+    }
+
     /// Resolve the marker workspace AND the pool key `(server_name, root)` for a
     /// request on `document_uri` in a SINGLE filesystem walk — the one point of
     /// root resolution. The spawn handshake (`marker`) and every map lookup
@@ -2027,6 +2050,8 @@ impl LanguageServerPool {
                         .purge_connection(&connection_key)
                         .await;
                     self.diagnostic_pull_baselines
+                        .retain(|(key, _), _| key != &connection_key);
+                    self.diagnostic_document_generations
                         .retain(|(key, _), _| key != &connection_key);
                     self.purge_open_transition_locks(&connection_key).await;
                     // Remove only after every async purge completes. If this

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -369,8 +369,8 @@ pub struct LanguageServerPool {
     /// this advances on close so an old response cannot attach to a reopen of
     /// the same URI on the same process.
     pub(crate) diagnostic_document_generations: DashMap<(ConnectionKey, String), u64>,
-    /// Invalidates in-flight baseline reads across a settings replacement.
-    pub(crate) diagnostic_pull_generation: AtomicU64,
+    /// Per-connection settings/respawn fence for in-flight baseline reads.
+    pub(crate) diagnostic_pull_generations: DashMap<ConnectionKey, u64>,
     /// Serializes baseline snapshots/mutations with every invalidation fence.
     pub(crate) diagnostic_pull_lock: std::sync::Mutex<()>,
     pub(crate) diagnostic_pull_request_sequence: AtomicU64,
@@ -486,7 +486,7 @@ impl LanguageServerPool {
             host_documents: Mutex::new(HashMap::new()),
             diagnostic_pull_baselines: DashMap::new(),
             diagnostic_document_generations: DashMap::new(),
-            diagnostic_pull_generation: AtomicU64::new(0),
+            diagnostic_pull_generations: DashMap::new(),
             diagnostic_pull_lock: std::sync::Mutex::new(()),
             diagnostic_pull_request_sequence: AtomicU64::new(1),
             diagnostic_pull_applied_sequences: DashMap::new(),
@@ -1678,7 +1678,11 @@ impl LanguageServerPool {
             .unwrap_or(0);
         DiagnosticPullSnapshot {
             baseline,
-            settings_generation: self.diagnostic_pull_generation.load(Ordering::Acquire),
+            settings_generation: self
+                .diagnostic_pull_generations
+                .get(&key.0)
+                .map(|entry| *entry)
+                .unwrap_or(0),
             document_generation,
             connection_generation: self.document_connection_generation(&key.0),
             request_sequence: self
@@ -1708,8 +1712,12 @@ impl LanguageServerPool {
             .diagnostic_pull_lock
             .lock()
             .recover_poison("LanguageServerPool::diagnostic_pull_lock");
-        self.diagnostic_pull_generation
-            .fetch_add(1, Ordering::AcqRel);
+        for key in keys {
+            self.diagnostic_pull_generations
+                .entry(key.clone())
+                .and_modify(|generation| *generation = generation.wrapping_add(1))
+                .or_insert(1);
+        }
         let affected = |key: &ConnectionKey| keys.iter().any(|candidate| candidate == key);
         self.diagnostic_pull_baselines
             .retain(|(key, _), _| !affected(key));

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -200,6 +200,11 @@ impl LanguageServerPool {
                 diagnostics
             }
             DownstreamDiagnosticReport::Unchanged { result_id } => {
+                // A compliant server returns Unchanged only after we supplied a
+                // previousResultId. Without a baseline, the empty result below
+                // is deliberately non-cacheable; advancing the sequence merely
+                // prevents this malformed older response from outranking a
+                // concurrent newer pull. A later Full report can still apply.
                 if may_apply && let Some(baseline) = &snapshot.baseline {
                     self.store_diagnostic_baseline_if_current(
                         cache_key,

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -154,7 +154,7 @@ impl LanguageServerPool {
         if !lineage_is_current {
             return match report {
                 DownstreamDiagnosticReport::Full { diagnostics, .. } => diagnostics,
-                DownstreamDiagnosticReport::Unchanged | DownstreamDiagnosticReport::Null => {
+                DownstreamDiagnosticReport::Unchanged { .. } | DownstreamDiagnosticReport::Null => {
                     Vec::new()
                 }
             };
@@ -180,12 +180,22 @@ impl LanguageServerPool {
                 }
                 diagnostics
             }
-            DownstreamDiagnosticReport::Unchanged => diagnostics_for_unchanged_baseline(
-                snapshot
-                    .baseline
-                    .as_ref()
-                    .map(|entry| entry.diagnostics.as_slice()),
-            ),
+            DownstreamDiagnosticReport::Unchanged { result_id } => {
+                if let Some(baseline) = &snapshot.baseline {
+                    self.store_diagnostic_baseline_if_current(
+                        cache_key,
+                        previous_revision,
+                        result_id,
+                        baseline.diagnostics.as_ref().clone(),
+                    );
+                }
+                diagnostics_for_unchanged_baseline(
+                    snapshot
+                        .baseline
+                        .as_ref()
+                        .map(|entry| entry.diagnostics.as_slice()),
+                )
+            }
             DownstreamDiagnosticReport::Null => {
                 self.diagnostic_pull_baselines
                     .remove_if(cache_key, |_, entry| {
@@ -292,7 +302,9 @@ fn transform_diagnostic_response_to_host(
     let report = parse_downstream_diagnostic_report(response)?;
     let mut diagnostics = match report {
         DownstreamDiagnosticReport::Full { diagnostics, .. } => diagnostics,
-        DownstreamDiagnosticReport::Unchanged | DownstreamDiagnosticReport::Null => Vec::new(),
+        DownstreamDiagnosticReport::Unchanged { .. } | DownstreamDiagnosticReport::Null => {
+            Vec::new()
+        }
     };
     for diag in &mut diagnostics {
         transform_diagnostic(diag, offset, host_uri);
@@ -305,7 +317,9 @@ pub(super) enum DownstreamDiagnosticReport {
         result_id: Option<String>,
         diagnostics: Vec<Diagnostic>,
     },
-    Unchanged,
+    Unchanged {
+        result_id: String,
+    },
     Null,
 }
 
@@ -336,7 +350,11 @@ pub(super) fn parse_downstream_diagnostic_report(
             result_id: report.full_document_diagnostic_report.result_id,
             diagnostics: report.full_document_diagnostic_report.items,
         }),
-        Ok(DocumentDiagnosticReport::Unchanged(_)) => Ok(DownstreamDiagnosticReport::Unchanged),
+        Ok(DocumentDiagnosticReport::Unchanged(report)) => {
+            Ok(DownstreamDiagnosticReport::Unchanged {
+                result_id: report.unchanged_document_diagnostic_report.result_id,
+            })
+        }
         Err(err) => {
             log::warn!(
                 target: "kakehashi::bridge",
@@ -455,8 +473,20 @@ mod tests {
             Some("r1")
         );
         assert_eq!(
-            resolve_current(&pool, &key, baseline, DownstreamDiagnosticReport::Unchanged,),
+            resolve_current(
+                &pool,
+                &key,
+                baseline,
+                DownstreamDiagnosticReport::Unchanged {
+                    result_id: "r2".to_string(),
+                },
+            ),
             diagnostics
+        );
+        assert_eq!(
+            pool.diagnostic_pull_baselines.get(&key).unwrap().result_id,
+            "r2",
+            "unchanged advances to the resultId returned for the next pull"
         );
     }
 
@@ -623,7 +653,9 @@ mod tests {
         let diagnostics = pool.resolve_diagnostic_pull_report(
             &key,
             snapshot,
-            DownstreamDiagnosticReport::Unchanged,
+            DownstreamDiagnosticReport::Unchanged {
+                result_id: "r2".to_string(),
+            },
             true,
         );
 

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -360,9 +360,10 @@ pub(super) fn parse_downstream_diagnostic_report(
     // two paths reject the same shapes): an absent/unknown `kind`, a `full`
     // report missing `items`, a malformed `unchanged` report or
     // `relatedDocuments`, or `items` that don't deserialize as `Diagnostic[]`
-    // is a malformed payload (request failure). A valid `unchanged` report is
-    // the authoritative empty. `relatedDocuments` (diagnostics for OTHER
-    // documents) are dropped — they have no place in this region's report.
+    // is a malformed payload (request failure). A valid `unchanged` report and
+    // its result ID are returned for the caller to resolve against the request's
+    // baseline. `relatedDocuments` (diagnostics for OTHER documents) are
+    // dropped — they have no place in this region's report.
     match serde_json::from_value::<DocumentDiagnosticReport>(result) {
         Ok(DocumentDiagnosticReport::Full(report)) => Ok(DownstreamDiagnosticReport::Full {
             result_id: report.full_document_diagnostic_report.result_id,
@@ -674,6 +675,10 @@ mod tests {
         // Close lands while the first pull awaits connection readiness, before
         // it can create a downstream cache key/snapshot.
         pool.invalidate_diagnostic_host(&host);
+        assert!(
+            !pool.diagnostic_host_generations.contains_key(host.as_str()),
+            "closed hosts must not remain retained"
+        );
         let snapshot =
             pool.diagnostic_pull_snapshot(&key, host.as_str(), host_generation, request_sequence);
 
@@ -689,6 +694,12 @@ mod tests {
         );
 
         assert!(!pool.diagnostic_pull_baselines.contains_key(&key));
+
+        let (reopened_generation, _) = pool.begin_diagnostic_pull(&host);
+        assert_ne!(
+            reopened_generation, host_generation,
+            "a reopen must receive a fresh incarnation after pruning"
+        );
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -50,6 +50,7 @@ impl LanguageServerPool {
         virtual_content: &str,
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Vec<Diagnostic>> {
+        let (host_generation, request_sequence) = self.begin_diagnostic_pull(host_uri);
         // Pre-work: wait for server to become Ready (unlike other handlers that fail fast).
         let handle = self
             .get_or_create_connection_wait_ready(
@@ -78,7 +79,12 @@ impl LanguageServerPool {
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
         let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, injection_language, region_id);
         let cache_key = (handle.key().clone(), virtual_uri.to_uri_string());
-        let snapshot = self.diagnostic_pull_snapshot(&cache_key, host_uri.as_str());
+        let snapshot = self.diagnostic_pull_snapshot(
+            &cache_key,
+            host_uri.as_str(),
+            host_generation,
+            request_sequence,
+        );
         let previous_result_id = snapshot
             .baseline
             .as_ref()
@@ -417,13 +423,22 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    fn test_snapshot(
+        pool: &LanguageServerPool,
+        key: &(super::super::super::pool::ConnectionKey, String),
+    ) -> super::super::super::pool::DiagnosticPullSnapshot {
+        let host = Url::parse("file:///host.md").unwrap();
+        let (host_generation, request_sequence) = pool.begin_diagnostic_pull(&host);
+        pool.diagnostic_pull_snapshot(key, host.as_str(), host_generation, request_sequence)
+    }
+
     fn resolve_current(
         pool: &LanguageServerPool,
         key: &(super::super::super::pool::ConnectionKey, String),
         baseline: Option<super::super::super::pool::DiagnosticPullBaseline>,
         report: DownstreamDiagnosticReport,
     ) -> Vec<Diagnostic> {
-        let mut snapshot = pool.diagnostic_pull_snapshot(key, "file:///host.md");
+        let mut snapshot = test_snapshot(pool, key);
         snapshot.baseline = baseline;
         pool.resolve_diagnostic_pull_report(key, snapshot, report, true)
     }
@@ -562,8 +577,8 @@ mod tests {
             );
             pool.diagnostic_pull_applied_sequences
                 .insert(key.clone(), 0);
-            let older = pool.diagnostic_pull_snapshot(&key, "file:///host.md");
-            let newer = pool.diagnostic_pull_snapshot(&key, "file:///host.md");
+            let older = test_snapshot(&pool, &key);
+            let newer = test_snapshot(&pool, &key);
             let resolve = |snapshot, result_id: &str| {
                 pool.resolve_diagnostic_pull_report(
                     &key,
@@ -631,7 +646,7 @@ mod tests {
             super::super::super::pool::ConnectionKey::for_server("lua_ls"),
             "kakehashi-virtual://region-1".to_string(),
         );
-        let snapshot = pool.diagnostic_pull_snapshot(&key, "file:///host.md");
+        let snapshot = test_snapshot(&pool, &key);
         pool.invalidate_diagnostic_document(&key);
 
         pool.resolve_diagnostic_pull_report(
@@ -655,11 +670,14 @@ mod tests {
             super::super::super::pool::ConnectionKey::for_server("lua_ls"),
             "kakehashi-virtual://region-1".to_string(),
         );
-        let snapshot = pool.diagnostic_pull_snapshot(&key, host.as_str());
-
-        // No downstream document/baseline exists yet: this models close
-        // landing between the first pull's snapshot and its didOpen.
+        let (host_generation, request_sequence) = pool.begin_diagnostic_pull(&host);
+        // Close lands while the first pull awaits connection readiness, before
+        // it can create a downstream cache key/snapshot.
         pool.invalidate_diagnostic_host(&host);
+        let snapshot =
+            pool.diagnostic_pull_snapshot(&key, host.as_str(), host_generation, request_sequence);
+
+        // No downstream document/baseline existed when close ran.
         pool.resolve_diagnostic_pull_report(
             &key,
             snapshot,
@@ -691,7 +709,7 @@ mod tests {
                 request_sequence: 1,
             },
         );
-        let snapshot = pool.diagnostic_pull_snapshot(&key, "file:///host.md");
+        let snapshot = test_snapshot(&pool, &key);
 
         pool.invalidate_diagnostic_connections(std::slice::from_ref(&key.0));
         let diagnostics = pool.resolve_diagnostic_pull_report(
@@ -728,7 +746,7 @@ mod tests {
         );
         pool.diagnostic_pull_applied_sequences
             .insert(key.clone(), 0);
-        let snapshot = pool.diagnostic_pull_snapshot(&key, "file:///host.md");
+        let snapshot = test_snapshot(&pool, &key);
 
         pool.invalidate_diagnostic_connections(std::slice::from_ref(&affected));
         let diagnostics = pool.resolve_diagnostic_pull_report(

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -78,7 +78,7 @@ impl LanguageServerPool {
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
         let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, injection_language, region_id);
         let cache_key = (handle.key().clone(), virtual_uri.to_uri_string());
-        let snapshot = self.diagnostic_pull_snapshot(&cache_key);
+        let snapshot = self.diagnostic_pull_snapshot(&cache_key, host_uri.as_str());
         let previous_result_id = snapshot
             .baseline
             .as_ref()
@@ -153,6 +153,13 @@ impl LanguageServerPool {
                     .unwrap_or(0)
             && snapshot.document_generation == current_document_generation
             && snapshot.connection_generation == self.document_connection_generation(&cache_key.0);
+        let lineage_is_current = lineage_is_current
+            && snapshot.host_generation
+                == self
+                    .diagnostic_host_generations
+                    .get(&snapshot.host_uri)
+                    .map(|entry| *entry)
+                    .unwrap_or(0);
         if !lineage_is_current {
             return match report {
                 DownstreamDiagnosticReport::Full { diagnostics, .. } => diagnostics,
@@ -416,7 +423,7 @@ mod tests {
         baseline: Option<super::super::super::pool::DiagnosticPullBaseline>,
         report: DownstreamDiagnosticReport,
     ) -> Vec<Diagnostic> {
-        let mut snapshot = pool.diagnostic_pull_snapshot(key);
+        let mut snapshot = pool.diagnostic_pull_snapshot(key, "file:///host.md");
         snapshot.baseline = baseline;
         pool.resolve_diagnostic_pull_report(key, snapshot, report, true)
     }
@@ -555,8 +562,8 @@ mod tests {
             );
             pool.diagnostic_pull_applied_sequences
                 .insert(key.clone(), 0);
-            let older = pool.diagnostic_pull_snapshot(&key);
-            let newer = pool.diagnostic_pull_snapshot(&key);
+            let older = pool.diagnostic_pull_snapshot(&key, "file:///host.md");
+            let newer = pool.diagnostic_pull_snapshot(&key, "file:///host.md");
             let resolve = |snapshot, result_id: &str| {
                 pool.resolve_diagnostic_pull_report(
                     &key,
@@ -624,7 +631,7 @@ mod tests {
             super::super::super::pool::ConnectionKey::for_server("lua_ls"),
             "kakehashi-virtual://region-1".to_string(),
         );
-        let snapshot = pool.diagnostic_pull_snapshot(&key);
+        let snapshot = pool.diagnostic_pull_snapshot(&key, "file:///host.md");
         pool.invalidate_diagnostic_document(&key);
 
         pool.resolve_diagnostic_pull_report(
@@ -632,6 +639,32 @@ mod tests {
             snapshot,
             DownstreamDiagnosticReport::Full {
                 result_id: Some("old".to_string()),
+                diagnostics: Vec::new(),
+            },
+            true,
+        );
+
+        assert!(!pool.diagnostic_pull_baselines.contains_key(&key));
+    }
+
+    #[test]
+    fn host_close_fences_a_first_pull_not_yet_tracked_downstream() {
+        let pool = LanguageServerPool::new();
+        let host = Url::parse("file:///host.md").unwrap();
+        let key = (
+            super::super::super::pool::ConnectionKey::for_server("lua_ls"),
+            "kakehashi-virtual://region-1".to_string(),
+        );
+        let snapshot = pool.diagnostic_pull_snapshot(&key, host.as_str());
+
+        // No downstream document/baseline exists yet: this models close
+        // landing between the first pull's snapshot and its didOpen.
+        pool.invalidate_diagnostic_host(&host);
+        pool.resolve_diagnostic_pull_report(
+            &key,
+            snapshot,
+            DownstreamDiagnosticReport::Full {
+                result_id: Some("old-incarnation".to_string()),
                 diagnostics: Vec::new(),
             },
             true,
@@ -658,7 +691,7 @@ mod tests {
                 request_sequence: 1,
             },
         );
-        let snapshot = pool.diagnostic_pull_snapshot(&key);
+        let snapshot = pool.diagnostic_pull_snapshot(&key, "file:///host.md");
 
         pool.invalidate_diagnostic_connections(std::slice::from_ref(&key.0));
         let diagnostics = pool.resolve_diagnostic_pull_report(
@@ -695,7 +728,7 @@ mod tests {
         );
         pool.diagnostic_pull_applied_sequences
             .insert(key.clone(), 0);
-        let snapshot = pool.diagnostic_pull_snapshot(&key);
+        let snapshot = pool.diagnostic_pull_snapshot(&key, "file:///host.md");
 
         pool.invalidate_diagnostic_connections(std::slice::from_ref(&affected));
         let diagnostics = pool.resolve_diagnostic_pull_report(

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -159,35 +159,43 @@ impl LanguageServerPool {
                 }
             };
         }
-        let previous_revision = snapshot.baseline.as_ref().map(|entry| entry.revision);
+        let may_apply = self
+            .diagnostic_pull_applied_sequences
+            .get(cache_key)
+            .is_none_or(|sequence| *sequence < snapshot.request_sequence);
         match report {
             DownstreamDiagnosticReport::Full {
                 result_id,
                 diagnostics,
             } => {
-                if let Some(result_id) = result_id {
+                if may_apply && let Some(result_id) = result_id {
                     self.store_diagnostic_baseline_if_current(
                         cache_key,
-                        previous_revision,
+                        snapshot.request_sequence,
                         result_id,
                         diagnostics.clone(),
                     );
-                } else {
-                    self.diagnostic_pull_baselines
-                        .remove_if(cache_key, |_, entry| {
-                            Some(entry.revision) == previous_revision
-                        });
+                } else if may_apply {
+                    self.diagnostic_pull_baselines.remove(cache_key);
+                }
+                if may_apply {
+                    self.diagnostic_pull_applied_sequences
+                        .insert(cache_key.clone(), snapshot.request_sequence);
                 }
                 diagnostics
             }
             DownstreamDiagnosticReport::Unchanged { result_id } => {
-                if let Some(baseline) = &snapshot.baseline {
+                if may_apply && let Some(baseline) = &snapshot.baseline {
                     self.store_diagnostic_baseline_if_current(
                         cache_key,
-                        previous_revision,
+                        snapshot.request_sequence,
                         result_id,
                         baseline.diagnostics.as_ref().clone(),
                     );
+                }
+                if may_apply {
+                    self.diagnostic_pull_applied_sequences
+                        .insert(cache_key.clone(), snapshot.request_sequence);
                 }
                 diagnostics_for_unchanged_baseline(
                     snapshot
@@ -197,10 +205,11 @@ impl LanguageServerPool {
                 )
             }
             DownstreamDiagnosticReport::Null => {
-                self.diagnostic_pull_baselines
-                    .remove_if(cache_key, |_, entry| {
-                        Some(entry.revision) == previous_revision
-                    });
+                if may_apply {
+                    self.diagnostic_pull_baselines.remove(cache_key);
+                    self.diagnostic_pull_applied_sequences
+                        .insert(cache_key.clone(), snapshot.request_sequence);
+                }
                 Vec::new()
             }
         }
@@ -209,35 +218,29 @@ impl LanguageServerPool {
     fn store_diagnostic_baseline_if_current(
         &self,
         cache_key: &(super::super::pool::ConnectionKey, String),
-        expected_revision: Option<u64>,
+        request_sequence: u64,
         result_id: String,
         diagnostics: Vec<Diagnostic>,
     ) -> bool {
         use dashmap::mapref::entry::Entry;
         match self.diagnostic_pull_baselines.entry(cache_key.clone()) {
-            Entry::Occupied(mut entry) if Some(entry.get().revision) == expected_revision => {
+            Entry::Occupied(mut entry) if entry.get().request_sequence < request_sequence => {
                 entry.insert(super::super::pool::DiagnosticPullBaseline {
                     result_id,
                     diagnostics: std::sync::Arc::new(diagnostics),
-                    revision: self
-                        .diagnostic_pull_revision
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                        .wrapping_add(1),
+                    request_sequence,
                 });
                 true
             }
-            Entry::Vacant(entry) if expected_revision.is_none() => {
+            Entry::Vacant(entry) => {
                 entry.insert(super::super::pool::DiagnosticPullBaseline {
                     result_id,
                     diagnostics: std::sync::Arc::new(diagnostics),
-                    revision: self
-                        .diagnostic_pull_revision
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                        .wrapping_add(1),
+                    request_sequence,
                 });
                 true
             }
-            Entry::Occupied(_) | Entry::Vacant(_) => false,
+            Entry::Occupied(_) => false,
         }
     }
 }
@@ -500,7 +503,7 @@ mod tests {
         let old = super::super::super::pool::DiagnosticPullBaseline {
             result_id: "r1".to_string(),
             diagnostics: std::sync::Arc::new(vec![Diagnostic::default()]),
-            revision: 1,
+            request_sequence: 1,
         };
         pool.diagnostic_pull_baselines.insert(
             key.clone(),
@@ -510,7 +513,7 @@ mod tests {
                     message: "new".to_string(),
                     ..Default::default()
                 }]),
-                revision: 2,
+                request_sequence: 2,
             },
         );
 
@@ -533,44 +536,52 @@ mod tests {
     }
 
     #[test]
-    fn concurrent_responses_can_advance_a_baseline_only_once() {
-        let pool = std::sync::Arc::new(LanguageServerPool::new());
-        let key = (
-            super::super::super::pool::ConnectionKey::for_server("lua_ls"),
-            "kakehashi-virtual://region-1".to_string(),
-        );
-        pool.diagnostic_pull_baselines.insert(
-            key.clone(),
-            super::super::super::pool::DiagnosticPullBaseline {
-                result_id: "r1".to_string(),
-                diagnostics: std::sync::Arc::new(Vec::new()),
-                revision: 1,
-            },
-        );
-        let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
-        let mut threads = Vec::new();
-        for result_id in ["r2", "r3"] {
-            let pool = std::sync::Arc::clone(&pool);
-            let key = key.clone();
-            let barrier = std::sync::Arc::clone(&barrier);
-            threads.push(std::thread::spawn(move || {
-                barrier.wait();
-                pool.store_diagnostic_baseline_if_current(
+    fn newer_request_wins_in_both_response_completion_orders() {
+        fn final_result_id(newer_completes_first: bool) -> String {
+            let pool = LanguageServerPool::new();
+            let key = (
+                super::super::super::pool::ConnectionKey::for_server("lua_ls"),
+                "kakehashi-virtual://region-1".to_string(),
+            );
+            pool.diagnostic_pull_baselines.insert(
+                key.clone(),
+                super::super::super::pool::DiagnosticPullBaseline {
+                    result_id: "r1".to_string(),
+                    diagnostics: std::sync::Arc::new(Vec::new()),
+                    request_sequence: 0,
+                },
+            );
+            pool.diagnostic_pull_applied_sequences
+                .insert(key.clone(), 0);
+            let older = pool.diagnostic_pull_snapshot(&key);
+            let newer = pool.diagnostic_pull_snapshot(&key);
+            let resolve = |snapshot, result_id: &str| {
+                pool.resolve_diagnostic_pull_report(
                     &key,
-                    Some(1),
-                    result_id.to_string(),
-                    Vec::new(),
-                )
-            }));
+                    snapshot,
+                    DownstreamDiagnosticReport::Full {
+                        result_id: Some(result_id.to_string()),
+                        diagnostics: Vec::new(),
+                    },
+                    true,
+                );
+            };
+            if newer_completes_first {
+                resolve(newer, "r3");
+                resolve(older, "r2");
+            } else {
+                resolve(older, "r2");
+                resolve(newer, "r3");
+            }
+            pool.diagnostic_pull_baselines
+                .get(&key)
+                .unwrap()
+                .result_id
+                .clone()
         }
-        barrier.wait();
 
-        let updates = threads
-            .into_iter()
-            .map(|thread| thread.join().unwrap())
-            .filter(|updated| *updated)
-            .count();
-        assert_eq!(updates, 1, "the r1 lineage may advance exactly once");
+        assert_eq!(final_result_id(false), "r3");
+        assert_eq!(final_result_id(true), "r3");
     }
 
     #[test]
@@ -585,13 +596,15 @@ mod tests {
             super::super::super::pool::DiagnosticPullBaseline {
                 result_id: "r1".to_string(),
                 diagnostics: std::sync::Arc::new(Vec::new()),
-                revision: 3,
+                request_sequence: 3,
             },
         );
+        pool.diagnostic_pull_applied_sequences
+            .insert(key.clone(), 3);
         let old = super::super::super::pool::DiagnosticPullBaseline {
             result_id: "r1".to_string(),
             diagnostics: std::sync::Arc::new(Vec::new()),
-            revision: 1,
+            request_sequence: 1,
         };
 
         resolve_current(&pool, &key, Some(old), DownstreamDiagnosticReport::Null);
@@ -599,10 +612,6 @@ mod tests {
         assert_eq!(
             pool.diagnostic_pull_baselines.get(&key).unwrap().result_id,
             "r1"
-        );
-        assert_eq!(
-            pool.diagnostic_pull_baselines.get(&key).unwrap().revision,
-            3
         );
     }
 
@@ -629,8 +638,8 @@ mod tests {
         assert!(!pool.diagnostic_pull_baselines.contains_key(&key));
     }
 
-    #[tokio::test]
-    async fn settings_invalidation_is_atomic_with_baseline_snapshot_and_resolution() {
+    #[test]
+    fn settings_invalidation_is_atomic_with_baseline_snapshot_and_resolution() {
         let pool = LanguageServerPool::new();
         let key = (
             super::super::super::pool::ConnectionKey::for_server("lua_ls"),
@@ -644,12 +653,12 @@ mod tests {
                     message: "old settings".to_string(),
                     ..Default::default()
                 }]),
-                revision: 1,
+                request_sequence: 1,
             },
         );
         let snapshot = pool.diagnostic_pull_snapshot(&key);
 
-        pool.propagate_settings(|_| None).await;
+        pool.invalidate_diagnostic_connections(std::slice::from_ref(&key.0));
         let diagnostics = pool.resolve_diagnostic_pull_report(
             &key,
             snapshot,

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -48,7 +48,6 @@ impl LanguageServerPool {
         offset: RegionOffset,
         virtual_content: &str,
         upstream_request_id: Option<UpstreamId>,
-        previous_result_id: Option<&str>,
     ) -> io::Result<Vec<Diagnostic>> {
         // Pre-work: wait for server to become Ready (unlike other handlers that fail fast).
         let handle = self
@@ -74,36 +73,116 @@ impl LanguageServerPool {
         // Server is Ready and supports diagnostics — proceed with standard lifecycle.
         // Use execute_bridge_request_with_handle to reuse the pre-fetched handle,
         // avoiding a redundant HashMap lookup.
-        self.execute_bridge_request_with_handle(
-            handle,
-            host_uri,
-            injection_language,
-            region_id,
-            &offset,
-            virtual_content,
-            upstream_request_id,
-            |virtual_uri, request_id| {
-                build_diagnostic_request(virtual_uri, request_id, previous_result_id)
-            },
-            |response, ctx| {
-                // A downstream JSON-RPC error response is a request failure, not
-                // "no diagnostics" — propagate it as `Err` so CLI mode's
-                // request-error sink can surface it (mirrors the formatting
-                // path; LSP mode just logs and the layer stays empty).
-                if response_has_jsonrpc_error(&response, "textDocument/diagnostic") {
-                    return Err(io::Error::other(format!(
-                        "downstream server '{server_name}' answered textDocument/diagnostic \
+        let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(host_uri)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+        let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, injection_language, region_id);
+        let cache_key = (handle.key().clone(), virtual_uri.to_uri_string());
+        let connection_generation = self.document_connection_generation(handle.key());
+        let settings_generation = self
+            .diagnostic_pull_generation
+            .load(std::sync::atomic::Ordering::Acquire);
+        let baseline = self
+            .diagnostic_pull_baselines
+            .get(&cache_key)
+            .map(|entry| entry.value().clone());
+        let previous_result_id = baseline.as_ref().map(|entry| entry.result_id.clone());
+
+        let report = self
+            .execute_bridge_request_with_handle(
+                handle,
+                host_uri,
+                injection_language,
+                region_id,
+                &offset,
+                virtual_content,
+                upstream_request_id,
+                |virtual_uri, request_id| {
+                    build_diagnostic_request(virtual_uri, request_id, previous_result_id.as_deref())
+                },
+                |response, _ctx| {
+                    // A downstream JSON-RPC error response is a request failure, not
+                    // "no diagnostics" — propagate it as `Err` so CLI mode's
+                    // request-error sink can surface it (mirrors the formatting
+                    // path; LSP mode just logs and the layer stays empty).
+                    if response_has_jsonrpc_error(&response, "textDocument/diagnostic") {
+                        return Err(io::Error::other(format!(
+                            "downstream server '{server_name}' answered textDocument/diagnostic \
                          with an error response: {}",
-                        jsonrpc_error_summary(&response)
-                    )));
+                            jsonrpc_error_summary(&response)
+                        )));
+                    }
+                    // A present-but-malformed payload (absent `result`, unknown
+                    // report kind, missing/garbled `items`) is likewise a request
+                    // failure; `null` clears the baseline and `unchanged` reuses it.
+                    parse_downstream_diagnostic_report(response)
+                },
+            )
+            .await??;
+
+        let lineage_is_current = connection_generation
+            == self.document_connection_generation(&cache_key.0)
+            && settings_generation
+                == self
+                    .diagnostic_pull_generation
+                    .load(std::sync::atomic::Ordering::Acquire)
+            && self.is_virtual_doc_open_on_connection(&cache_key.1, &cache_key.0);
+        let mut diagnostics =
+            self.resolve_diagnostic_pull_report(&cache_key, baseline, report, lineage_is_current);
+        for diagnostic in &mut diagnostics {
+            transform_diagnostic(diagnostic, &offset, host_uri.as_str());
+        }
+        Ok(diagnostics)
+    }
+
+    pub(super) fn resolve_diagnostic_pull_report(
+        &self,
+        cache_key: &(super::super::pool::ConnectionKey, String),
+        baseline: Option<super::super::pool::DiagnosticPullBaseline>,
+        report: DownstreamDiagnosticReport,
+        lineage_is_current: bool,
+    ) -> Vec<Diagnostic> {
+        if !lineage_is_current {
+            return match report {
+                DownstreamDiagnosticReport::Full { diagnostics, .. } => diagnostics,
+                DownstreamDiagnosticReport::Unchanged | DownstreamDiagnosticReport::Null => {
+                    Vec::new()
                 }
-                // A present-but-malformed payload (absent `result`, unknown
-                // report kind, missing/garbled `items`) is likewise a request
-                // failure; only `null`/`unchanged` stays an empty layer.
-                transform_diagnostic_response_to_host(response, ctx.offset, host_uri.as_str())
-            },
-        )
-        .await?
+            };
+        }
+        let previous_result_id = baseline.as_ref().map(|entry| entry.result_id.as_str());
+        match report {
+            DownstreamDiagnosticReport::Full {
+                result_id,
+                diagnostics,
+            } => {
+                if let Some(result_id) = result_id {
+                    let current_matches_request = self
+                        .diagnostic_pull_baselines
+                        .get(cache_key)
+                        .map(|entry| Some(entry.result_id.as_str()) == previous_result_id)
+                        .unwrap_or(previous_result_id.is_none());
+                    if current_matches_request {
+                        self.diagnostic_pull_baselines.insert(
+                            cache_key.clone(),
+                            super::super::pool::DiagnosticPullBaseline {
+                                result_id,
+                                diagnostics: std::sync::Arc::new(diagnostics.clone()),
+                            },
+                        );
+                    }
+                } else {
+                    self.diagnostic_pull_baselines.remove(cache_key);
+                }
+                diagnostics
+            }
+            DownstreamDiagnosticReport::Unchanged => diagnostics_for_unchanged_baseline(
+                baseline.as_ref().map(|entry| entry.diagnostics.as_slice()),
+            ),
+            DownstreamDiagnosticReport::Null => {
+                self.diagnostic_pull_baselines.remove(cache_key);
+                Vec::new()
+            }
+        }
     }
 }
 
@@ -151,18 +230,42 @@ fn build_diagnostic_request(
 /// deserialize as a `DocumentDiagnosticReport` (no/unknown `kind`, a `full`
 /// report missing `items`, a malformed `unchanged` report, or `items` that
 /// aren't `Diagnostic[]`) — validated by the same typed deserialize the host
-/// parser uses. A `null` result or a valid `unchanged` report is the
-/// authoritative "no diagnostics" answer and stays an empty `Vec` (`Ok`).
+/// parser uses. A `null` result is authoritative empty; a valid `unchanged`
+/// report is resolved against the request's cached baseline by the caller.
 /// Collapsing a malformed payload into the same empty value as "no
 /// capability" would let a broken downstream server pass as "nothing wrong" —
 /// the fan-in counts `Err`s, which CLI mode maps onto its `2` exit code and
 /// the editor path logs at WARNING. Only related info matching `host_uri` is
 /// transformed.
+#[cfg(test)]
 fn transform_diagnostic_response_to_host(
-    mut response: serde_json::Value,
+    response: serde_json::Value,
     offset: &RegionOffset,
     host_uri: &str,
 ) -> io::Result<Vec<Diagnostic>> {
+    let report = parse_downstream_diagnostic_report(response)?;
+    let mut diagnostics = match report {
+        DownstreamDiagnosticReport::Full { diagnostics, .. } => diagnostics,
+        DownstreamDiagnosticReport::Unchanged | DownstreamDiagnosticReport::Null => Vec::new(),
+    };
+    for diag in &mut diagnostics {
+        transform_diagnostic(diag, offset, host_uri);
+    }
+    Ok(diagnostics)
+}
+
+pub(super) enum DownstreamDiagnosticReport {
+    Full {
+        result_id: Option<String>,
+        diagnostics: Vec<Diagnostic>,
+    },
+    Unchanged,
+    Null,
+}
+
+pub(super) fn parse_downstream_diagnostic_report(
+    mut response: serde_json::Value,
+) -> io::Result<DownstreamDiagnosticReport> {
     // Absent `result` with no error (the caller already promoted an error
     // response to `Err`) is a protocol violation — a request failure.
     let Some(result) = response.get_mut("result").map(serde_json::Value::take) else {
@@ -171,8 +274,7 @@ fn transform_diagnostic_response_to_host(
         ));
     };
     if result.is_null() {
-        // Authoritative "no diagnostics" — a handled response, not a failure.
-        return Ok(Vec::new());
+        return Ok(DownstreamDiagnosticReport::Null);
     }
 
     // Validate the whole report via the typed `DocumentDiagnosticReport`
@@ -183,26 +285,22 @@ fn transform_diagnostic_response_to_host(
     // is a malformed payload (request failure). A valid `unchanged` report is
     // the authoritative empty. `relatedDocuments` (diagnostics for OTHER
     // documents) are dropped — they have no place in this region's report.
-    let mut diagnostics = match serde_json::from_value::<DocumentDiagnosticReport>(result) {
-        Ok(DocumentDiagnosticReport::Full(report)) => report.full_document_diagnostic_report.items,
-        Ok(DocumentDiagnosticReport::Unchanged(_)) => return Ok(Vec::new()),
+    match serde_json::from_value::<DocumentDiagnosticReport>(result) {
+        Ok(DocumentDiagnosticReport::Full(report)) => Ok(DownstreamDiagnosticReport::Full {
+            result_id: report.full_document_diagnostic_report.result_id,
+            diagnostics: report.full_document_diagnostic_report.items,
+        }),
+        Ok(DocumentDiagnosticReport::Unchanged(_)) => Ok(DownstreamDiagnosticReport::Unchanged),
         Err(err) => {
             log::warn!(
                 target: "kakehashi::bridge",
                 "Failed to deserialize diagnostic report: {err}"
             );
-            return Err(io::Error::other(format!(
+            Err(io::Error::other(format!(
                 "malformed diagnostic result from downstream server: {err}"
-            )));
+            )))
         }
-    };
-
-    // Transform coordinates on typed structs
-    for diag in &mut diagnostics {
-        transform_diagnostic(diag, offset, host_uri);
     }
-
-    Ok(diagnostics)
 }
 
 fn diagnostics_for_unchanged_baseline(baseline: Option<&[Diagnostic]>) -> Vec<Diagnostic> {
@@ -265,6 +363,89 @@ mod tests {
             baseline[0].range.start.line, 1,
             "cache remains virtual-local"
         );
+    }
+
+    #[test]
+    fn full_report_establishes_baseline_and_unchanged_reuses_it() {
+        let pool = LanguageServerPool::new();
+        let key = (
+            super::super::super::pool::ConnectionKey::for_server("lua_ls"),
+            "kakehashi-virtual://region-1".to_string(),
+        );
+        let diagnostics = vec![Diagnostic {
+            message: "cached".to_string(),
+            ..Default::default()
+        }];
+
+        assert_eq!(
+            pool.resolve_diagnostic_pull_report(
+                &key,
+                None,
+                DownstreamDiagnosticReport::Full {
+                    result_id: Some("r1".to_string()),
+                    diagnostics: diagnostics.clone(),
+                },
+                true,
+            ),
+            diagnostics
+        );
+        let baseline = pool
+            .diagnostic_pull_baselines
+            .get(&key)
+            .map(|entry| entry.value().clone());
+        assert_eq!(
+            baseline.as_ref().map(|entry| entry.result_id.as_str()),
+            Some("r1")
+        );
+        assert_eq!(
+            pool.resolve_diagnostic_pull_report(
+                &key,
+                baseline,
+                DownstreamDiagnosticReport::Unchanged,
+                true,
+            ),
+            diagnostics
+        );
+    }
+
+    #[test]
+    fn late_full_report_cannot_replace_a_newer_baseline() {
+        let pool = LanguageServerPool::new();
+        let key = (
+            super::super::super::pool::ConnectionKey::for_server("lua_ls"),
+            "kakehashi-virtual://region-1".to_string(),
+        );
+        let old = super::super::super::pool::DiagnosticPullBaseline {
+            result_id: "r1".to_string(),
+            diagnostics: std::sync::Arc::new(vec![Diagnostic::default()]),
+        };
+        pool.diagnostic_pull_baselines.insert(
+            key.clone(),
+            super::super::super::pool::DiagnosticPullBaseline {
+                result_id: "r2".to_string(),
+                diagnostics: std::sync::Arc::new(vec![Diagnostic {
+                    message: "new".to_string(),
+                    ..Default::default()
+                }]),
+            },
+        );
+
+        pool.resolve_diagnostic_pull_report(
+            &key,
+            Some(old),
+            DownstreamDiagnosticReport::Full {
+                result_id: Some("late".to_string()),
+                diagnostics: vec![Diagnostic {
+                    message: "late".to_string(),
+                    ..Default::default()
+                }],
+            },
+            true,
+        );
+
+        let current = pool.diagnostic_pull_baselines.get(&key).unwrap();
+        assert_eq!(current.result_id, "r2");
+        assert_eq!(current.diagnostics[0].message, "new");
     }
 
     #[test]
@@ -414,7 +595,7 @@ mod tests {
     }
 
     #[test]
-    fn diagnostic_response_unchanged_kind_returns_empty() {
+    fn spurious_diagnostic_unchanged_without_baseline_returns_empty() {
         let response = json!({
             "jsonrpc": "2.0",
             "id": 42,
@@ -426,7 +607,7 @@ mod tests {
 
         let diagnostics =
             transform_diagnostic_response_to_host(response, &RegionOffset::new(5, 0), "unused")
-                .expect("unchanged is an authoritative empty result, not a failure");
+                .expect("spurious unchanged without a baseline stays empty, not a failure");
         assert!(diagnostics.is_empty());
     }
 

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -147,8 +147,10 @@ impl LanguageServerPool {
         let lineage_is_current = document_is_open
             && snapshot.settings_generation
                 == self
-                    .diagnostic_pull_generation
-                    .load(std::sync::atomic::Ordering::Acquire)
+                    .diagnostic_pull_generations
+                    .get(&cache_key.0)
+                    .map(|entry| *entry)
+                    .unwrap_or(0)
             && snapshot.document_generation == current_document_generation
             && snapshot.connection_generation == self.document_connection_generation(&cache_key.0);
         if !lineage_is_current {
@@ -670,6 +672,46 @@ mod tests {
 
         assert!(diagnostics.is_empty());
         assert!(!pool.diagnostic_pull_baselines.contains_key(&key));
+    }
+
+    #[test]
+    fn unrelated_connection_invalidation_preserves_in_flight_unchanged() {
+        let pool = LanguageServerPool::new();
+        let affected = super::super::super::pool::ConnectionKey::for_server("lua_ls_a");
+        let key = (
+            super::super::super::pool::ConnectionKey::for_server("lua_ls_b"),
+            "kakehashi-virtual://region-1".to_string(),
+        );
+        pool.diagnostic_pull_baselines.insert(
+            key.clone(),
+            super::super::super::pool::DiagnosticPullBaseline {
+                result_id: "r1".to_string(),
+                diagnostics: std::sync::Arc::new(vec![Diagnostic {
+                    message: "unrelated".to_string(),
+                    ..Default::default()
+                }]),
+                request_sequence: 0,
+            },
+        );
+        pool.diagnostic_pull_applied_sequences
+            .insert(key.clone(), 0);
+        let snapshot = pool.diagnostic_pull_snapshot(&key);
+
+        pool.invalidate_diagnostic_connections(std::slice::from_ref(&affected));
+        let diagnostics = pool.resolve_diagnostic_pull_report(
+            &key,
+            snapshot,
+            DownstreamDiagnosticReport::Unchanged {
+                result_id: "r2".to_string(),
+            },
+            true,
+        );
+
+        assert_eq!(diagnostics[0].message, "unrelated");
+        assert_eq!(
+            pool.diagnostic_pull_baselines.get(&key).unwrap().result_id,
+            "r2"
+        );
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -17,6 +17,7 @@ use std::io;
 use std::time::Duration;
 
 use crate::config::settings::BridgeServerConfig;
+use crate::error::LockResultExt;
 use tower_lsp_server::ls_types::{Diagnostic, DocumentDiagnosticReport};
 use url::Url;
 
@@ -77,16 +78,11 @@ impl LanguageServerPool {
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
         let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, injection_language, region_id);
         let cache_key = (handle.key().clone(), virtual_uri.to_uri_string());
-        let connection_generation = self.document_connection_generation(handle.key());
-        let document_generation = self.diagnostic_document_generation(&cache_key);
-        let settings_generation = self
-            .diagnostic_pull_generation
-            .load(std::sync::atomic::Ordering::Acquire);
-        let baseline = self
-            .diagnostic_pull_baselines
-            .get(&cache_key)
-            .map(|entry| entry.value().clone());
-        let previous_result_id = baseline.as_ref().map(|entry| entry.result_id.clone());
+        let snapshot = self.diagnostic_pull_snapshot(&cache_key);
+        let previous_result_id = snapshot
+            .baseline
+            .as_ref()
+            .map(|entry| entry.result_id.clone());
 
         let report = self
             .execute_bridge_request_with_handle(
@@ -120,16 +116,12 @@ impl LanguageServerPool {
             )
             .await??;
 
-        let lineage_is_current = connection_generation
-            == self.document_connection_generation(&cache_key.0)
-            && settings_generation
-                == self
-                    .diagnostic_pull_generation
-                    .load(std::sync::atomic::Ordering::Acquire)
-            && document_generation == self.diagnostic_document_generation(&cache_key)
-            && self.is_virtual_doc_open_on_connection(&cache_key.1, &cache_key.0);
-        let mut diagnostics =
-            self.resolve_diagnostic_pull_report(&cache_key, baseline, report, lineage_is_current);
+        let mut diagnostics = self.resolve_diagnostic_pull_report(
+            &cache_key,
+            snapshot,
+            report,
+            self.is_virtual_doc_open_on_connection(&cache_key.1, &cache_key.0),
+        );
         for diagnostic in &mut diagnostics {
             transform_diagnostic(diagnostic, &offset, host_uri.as_str());
         }
@@ -139,10 +131,26 @@ impl LanguageServerPool {
     pub(super) fn resolve_diagnostic_pull_report(
         &self,
         cache_key: &(super::super::pool::ConnectionKey, String),
-        baseline: Option<super::super::pool::DiagnosticPullBaseline>,
+        snapshot: super::super::pool::DiagnosticPullSnapshot,
         report: DownstreamDiagnosticReport,
-        lineage_is_current: bool,
+        document_is_open: bool,
     ) -> Vec<Diagnostic> {
+        let _guard = self
+            .diagnostic_pull_lock
+            .lock()
+            .recover_poison("LanguageServerPool::diagnostic_pull_lock");
+        let current_document_generation = self
+            .diagnostic_document_generations
+            .get(cache_key)
+            .map(|entry| *entry)
+            .unwrap_or(0);
+        let lineage_is_current = document_is_open
+            && snapshot.settings_generation
+                == self
+                    .diagnostic_pull_generation
+                    .load(std::sync::atomic::Ordering::Acquire)
+            && snapshot.document_generation == current_document_generation
+            && snapshot.connection_generation == self.document_connection_generation(&cache_key.0);
         if !lineage_is_current {
             return match report {
                 DownstreamDiagnosticReport::Full { diagnostics, .. } => diagnostics,
@@ -151,7 +159,7 @@ impl LanguageServerPool {
                 }
             };
         }
-        let previous_result_id = baseline.as_ref().map(|entry| entry.result_id.as_str());
+        let previous_revision = snapshot.baseline.as_ref().map(|entry| entry.revision);
         match report {
             DownstreamDiagnosticReport::Full {
                 result_id,
@@ -160,25 +168,28 @@ impl LanguageServerPool {
                 if let Some(result_id) = result_id {
                     self.store_diagnostic_baseline_if_current(
                         cache_key,
-                        previous_result_id,
+                        previous_revision,
                         result_id,
                         diagnostics.clone(),
                     );
                 } else {
                     self.diagnostic_pull_baselines
                         .remove_if(cache_key, |_, entry| {
-                            Some(entry.result_id.as_str()) == previous_result_id
+                            Some(entry.revision) == previous_revision
                         });
                 }
                 diagnostics
             }
             DownstreamDiagnosticReport::Unchanged => diagnostics_for_unchanged_baseline(
-                baseline.as_ref().map(|entry| entry.diagnostics.as_slice()),
+                snapshot
+                    .baseline
+                    .as_ref()
+                    .map(|entry| entry.diagnostics.as_slice()),
             ),
             DownstreamDiagnosticReport::Null => {
                 self.diagnostic_pull_baselines
                     .remove_if(cache_key, |_, entry| {
-                        Some(entry.result_id.as_str()) == previous_result_id
+                        Some(entry.revision) == previous_revision
                     });
                 Vec::new()
             }
@@ -188,25 +199,31 @@ impl LanguageServerPool {
     fn store_diagnostic_baseline_if_current(
         &self,
         cache_key: &(super::super::pool::ConnectionKey, String),
-        expected_result_id: Option<&str>,
+        expected_revision: Option<u64>,
         result_id: String,
         diagnostics: Vec<Diagnostic>,
     ) -> bool {
         use dashmap::mapref::entry::Entry;
         match self.diagnostic_pull_baselines.entry(cache_key.clone()) {
-            Entry::Occupied(mut entry)
-                if Some(entry.get().result_id.as_str()) == expected_result_id =>
-            {
+            Entry::Occupied(mut entry) if Some(entry.get().revision) == expected_revision => {
                 entry.insert(super::super::pool::DiagnosticPullBaseline {
                     result_id,
                     diagnostics: std::sync::Arc::new(diagnostics),
+                    revision: self
+                        .diagnostic_pull_revision
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                        .wrapping_add(1),
                 });
                 true
             }
-            Entry::Vacant(entry) if expected_result_id.is_none() => {
+            Entry::Vacant(entry) if expected_revision.is_none() => {
                 entry.insert(super::super::pool::DiagnosticPullBaseline {
                     result_id,
                     diagnostics: std::sync::Arc::new(diagnostics),
+                    revision: self
+                        .diagnostic_pull_revision
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                        .wrapping_add(1),
                 });
                 true
             }
@@ -370,6 +387,17 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    fn resolve_current(
+        pool: &LanguageServerPool,
+        key: &(super::super::super::pool::ConnectionKey, String),
+        baseline: Option<super::super::super::pool::DiagnosticPullBaseline>,
+        report: DownstreamDiagnosticReport,
+    ) -> Vec<Diagnostic> {
+        let mut snapshot = pool.diagnostic_pull_snapshot(key);
+        snapshot.baseline = baseline;
+        pool.resolve_diagnostic_pull_report(key, snapshot, report, true)
+    }
+
     #[test]
     fn unchanged_baseline_is_reanchored_with_the_current_offset() {
         let baseline = vec![Diagnostic {
@@ -407,14 +435,14 @@ mod tests {
         }];
 
         assert_eq!(
-            pool.resolve_diagnostic_pull_report(
+            resolve_current(
+                &pool,
                 &key,
                 None,
                 DownstreamDiagnosticReport::Full {
                     result_id: Some("r1".to_string()),
                     diagnostics: diagnostics.clone(),
                 },
-                true,
             ),
             diagnostics
         );
@@ -427,12 +455,7 @@ mod tests {
             Some("r1")
         );
         assert_eq!(
-            pool.resolve_diagnostic_pull_report(
-                &key,
-                baseline,
-                DownstreamDiagnosticReport::Unchanged,
-                true,
-            ),
+            resolve_current(&pool, &key, baseline, DownstreamDiagnosticReport::Unchanged,),
             diagnostics
         );
     }
@@ -447,6 +470,7 @@ mod tests {
         let old = super::super::super::pool::DiagnosticPullBaseline {
             result_id: "r1".to_string(),
             diagnostics: std::sync::Arc::new(vec![Diagnostic::default()]),
+            revision: 1,
         };
         pool.diagnostic_pull_baselines.insert(
             key.clone(),
@@ -456,10 +480,12 @@ mod tests {
                     message: "new".to_string(),
                     ..Default::default()
                 }]),
+                revision: 2,
             },
         );
 
-        pool.resolve_diagnostic_pull_report(
+        resolve_current(
+            &pool,
             &key,
             Some(old),
             DownstreamDiagnosticReport::Full {
@@ -469,7 +495,6 @@ mod tests {
                     ..Default::default()
                 }],
             },
-            true,
         );
 
         let current = pool.diagnostic_pull_baselines.get(&key).unwrap();
@@ -489,6 +514,7 @@ mod tests {
             super::super::super::pool::DiagnosticPullBaseline {
                 result_id: "r1".to_string(),
                 diagnostics: std::sync::Arc::new(Vec::new()),
+                revision: 1,
             },
         );
         let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
@@ -501,7 +527,7 @@ mod tests {
                 barrier.wait();
                 pool.store_diagnostic_baseline_if_current(
                     &key,
-                    Some("r1"),
+                    Some(1),
                     result_id.to_string(),
                     Vec::new(),
                 )
@@ -527,25 +553,26 @@ mod tests {
         pool.diagnostic_pull_baselines.insert(
             key.clone(),
             super::super::super::pool::DiagnosticPullBaseline {
-                result_id: "r2".to_string(),
+                result_id: "r1".to_string(),
                 diagnostics: std::sync::Arc::new(Vec::new()),
+                revision: 3,
             },
         );
         let old = super::super::super::pool::DiagnosticPullBaseline {
             result_id: "r1".to_string(),
             diagnostics: std::sync::Arc::new(Vec::new()),
+            revision: 1,
         };
 
-        pool.resolve_diagnostic_pull_report(
-            &key,
-            Some(old),
-            DownstreamDiagnosticReport::Null,
-            true,
-        );
+        resolve_current(&pool, &key, Some(old), DownstreamDiagnosticReport::Null);
 
         assert_eq!(
             pool.diagnostic_pull_baselines.get(&key).unwrap().result_id,
-            "r2"
+            "r1"
+        );
+        assert_eq!(
+            pool.diagnostic_pull_baselines.get(&key).unwrap().revision,
+            3
         );
     }
 
@@ -556,21 +583,51 @@ mod tests {
             super::super::super::pool::ConnectionKey::for_server("lua_ls"),
             "kakehashi-virtual://region-1".to_string(),
         );
-        let captured_generation = pool.diagnostic_document_generation(&key);
+        let snapshot = pool.diagnostic_pull_snapshot(&key);
         pool.invalidate_diagnostic_document(&key);
 
-        let lineage_is_current = captured_generation == pool.diagnostic_document_generation(&key);
         pool.resolve_diagnostic_pull_report(
             &key,
-            None,
+            snapshot,
             DownstreamDiagnosticReport::Full {
                 result_id: Some("old".to_string()),
                 diagnostics: Vec::new(),
             },
-            lineage_is_current,
+            true,
         );
 
-        assert!(!lineage_is_current);
+        assert!(!pool.diagnostic_pull_baselines.contains_key(&key));
+    }
+
+    #[tokio::test]
+    async fn settings_invalidation_is_atomic_with_baseline_snapshot_and_resolution() {
+        let pool = LanguageServerPool::new();
+        let key = (
+            super::super::super::pool::ConnectionKey::for_server("lua_ls"),
+            "kakehashi-virtual://region-1".to_string(),
+        );
+        pool.diagnostic_pull_baselines.insert(
+            key.clone(),
+            super::super::super::pool::DiagnosticPullBaseline {
+                result_id: "r1".to_string(),
+                diagnostics: std::sync::Arc::new(vec![Diagnostic {
+                    message: "old settings".to_string(),
+                    ..Default::default()
+                }]),
+                revision: 1,
+            },
+        );
+        let snapshot = pool.diagnostic_pull_snapshot(&key);
+
+        pool.propagate_settings(|_| None).await;
+        let diagnostics = pool.resolve_diagnostic_pull_report(
+            &key,
+            snapshot,
+            DownstreamDiagnosticReport::Unchanged,
+            true,
+        );
+
+        assert!(diagnostics.is_empty());
         assert!(!pool.diagnostic_pull_baselines.contains_key(&key));
     }
 

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -78,6 +78,7 @@ impl LanguageServerPool {
         let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, injection_language, region_id);
         let cache_key = (handle.key().clone(), virtual_uri.to_uri_string());
         let connection_generation = self.document_connection_generation(handle.key());
+        let document_generation = self.diagnostic_document_generation(&cache_key);
         let settings_generation = self
             .diagnostic_pull_generation
             .load(std::sync::atomic::Ordering::Acquire);
@@ -125,6 +126,7 @@ impl LanguageServerPool {
                 == self
                     .diagnostic_pull_generation
                     .load(std::sync::atomic::Ordering::Acquire)
+            && document_generation == self.diagnostic_document_generation(&cache_key)
             && self.is_virtual_doc_open_on_connection(&cache_key.1, &cache_key.0);
         let mut diagnostics =
             self.resolve_diagnostic_pull_report(&cache_key, baseline, report, lineage_is_current);
@@ -156,22 +158,17 @@ impl LanguageServerPool {
                 diagnostics,
             } => {
                 if let Some(result_id) = result_id {
-                    let current_matches_request = self
-                        .diagnostic_pull_baselines
-                        .get(cache_key)
-                        .map(|entry| Some(entry.result_id.as_str()) == previous_result_id)
-                        .unwrap_or(previous_result_id.is_none());
-                    if current_matches_request {
-                        self.diagnostic_pull_baselines.insert(
-                            cache_key.clone(),
-                            super::super::pool::DiagnosticPullBaseline {
-                                result_id,
-                                diagnostics: std::sync::Arc::new(diagnostics.clone()),
-                            },
-                        );
-                    }
+                    self.store_diagnostic_baseline_if_current(
+                        cache_key,
+                        previous_result_id,
+                        result_id,
+                        diagnostics.clone(),
+                    );
                 } else {
-                    self.diagnostic_pull_baselines.remove(cache_key);
+                    self.diagnostic_pull_baselines
+                        .remove_if(cache_key, |_, entry| {
+                            Some(entry.result_id.as_str()) == previous_result_id
+                        });
                 }
                 diagnostics
             }
@@ -179,9 +176,41 @@ impl LanguageServerPool {
                 baseline.as_ref().map(|entry| entry.diagnostics.as_slice()),
             ),
             DownstreamDiagnosticReport::Null => {
-                self.diagnostic_pull_baselines.remove(cache_key);
+                self.diagnostic_pull_baselines
+                    .remove_if(cache_key, |_, entry| {
+                        Some(entry.result_id.as_str()) == previous_result_id
+                    });
                 Vec::new()
             }
+        }
+    }
+
+    fn store_diagnostic_baseline_if_current(
+        &self,
+        cache_key: &(super::super::pool::ConnectionKey, String),
+        expected_result_id: Option<&str>,
+        result_id: String,
+        diagnostics: Vec<Diagnostic>,
+    ) -> bool {
+        use dashmap::mapref::entry::Entry;
+        match self.diagnostic_pull_baselines.entry(cache_key.clone()) {
+            Entry::Occupied(mut entry)
+                if Some(entry.get().result_id.as_str()) == expected_result_id =>
+            {
+                entry.insert(super::super::pool::DiagnosticPullBaseline {
+                    result_id,
+                    diagnostics: std::sync::Arc::new(diagnostics),
+                });
+                true
+            }
+            Entry::Vacant(entry) if expected_result_id.is_none() => {
+                entry.insert(super::super::pool::DiagnosticPullBaseline {
+                    result_id,
+                    diagnostics: std::sync::Arc::new(diagnostics),
+                });
+                true
+            }
+            Entry::Occupied(_) | Entry::Vacant(_) => false,
         }
     }
 }
@@ -446,6 +475,103 @@ mod tests {
         let current = pool.diagnostic_pull_baselines.get(&key).unwrap();
         assert_eq!(current.result_id, "r2");
         assert_eq!(current.diagnostics[0].message, "new");
+    }
+
+    #[test]
+    fn concurrent_responses_can_advance_a_baseline_only_once() {
+        let pool = std::sync::Arc::new(LanguageServerPool::new());
+        let key = (
+            super::super::super::pool::ConnectionKey::for_server("lua_ls"),
+            "kakehashi-virtual://region-1".to_string(),
+        );
+        pool.diagnostic_pull_baselines.insert(
+            key.clone(),
+            super::super::super::pool::DiagnosticPullBaseline {
+                result_id: "r1".to_string(),
+                diagnostics: std::sync::Arc::new(Vec::new()),
+            },
+        );
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+        let mut threads = Vec::new();
+        for result_id in ["r2", "r3"] {
+            let pool = std::sync::Arc::clone(&pool);
+            let key = key.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            threads.push(std::thread::spawn(move || {
+                barrier.wait();
+                pool.store_diagnostic_baseline_if_current(
+                    &key,
+                    Some("r1"),
+                    result_id.to_string(),
+                    Vec::new(),
+                )
+            }));
+        }
+        barrier.wait();
+
+        let updates = threads
+            .into_iter()
+            .map(|thread| thread.join().unwrap())
+            .filter(|updated| *updated)
+            .count();
+        assert_eq!(updates, 1, "the r1 lineage may advance exactly once");
+    }
+
+    #[test]
+    fn stale_lineage_cannot_remove_a_newer_baseline() {
+        let pool = LanguageServerPool::new();
+        let key = (
+            super::super::super::pool::ConnectionKey::for_server("lua_ls"),
+            "kakehashi-virtual://region-1".to_string(),
+        );
+        pool.diagnostic_pull_baselines.insert(
+            key.clone(),
+            super::super::super::pool::DiagnosticPullBaseline {
+                result_id: "r2".to_string(),
+                diagnostics: std::sync::Arc::new(Vec::new()),
+            },
+        );
+        let old = super::super::super::pool::DiagnosticPullBaseline {
+            result_id: "r1".to_string(),
+            diagnostics: std::sync::Arc::new(Vec::new()),
+        };
+
+        pool.resolve_diagnostic_pull_report(
+            &key,
+            Some(old),
+            DownstreamDiagnosticReport::Null,
+            true,
+        );
+
+        assert_eq!(
+            pool.diagnostic_pull_baselines.get(&key).unwrap().result_id,
+            "r2"
+        );
+    }
+
+    #[test]
+    fn document_close_fences_a_response_from_the_previous_incarnation() {
+        let pool = LanguageServerPool::new();
+        let key = (
+            super::super::super::pool::ConnectionKey::for_server("lua_ls"),
+            "kakehashi-virtual://region-1".to_string(),
+        );
+        let captured_generation = pool.diagnostic_document_generation(&key);
+        pool.invalidate_diagnostic_document(&key);
+
+        let lineage_is_current = captured_generation == pool.diagnostic_document_generation(&key);
+        pool.resolve_diagnostic_pull_report(
+            &key,
+            None,
+            DownstreamDiagnosticReport::Full {
+                result_id: Some("old".to_string()),
+                diagnostics: Vec::new(),
+            },
+            lineage_is_current,
+        );
+
+        assert!(!lineage_is_current);
+        assert!(!pool.diagnostic_pull_baselines.contains_key(&key));
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -205,6 +205,10 @@ fn transform_diagnostic_response_to_host(
     Ok(diagnostics)
 }
 
+fn diagnostics_for_unchanged_baseline(baseline: Option<&[Diagnostic]>) -> Vec<Diagnostic> {
+    baseline.unwrap_or_default().to_vec()
+}
+
 /// Transform a single typed Diagnostic by applying the region offset to its range.
 ///
 /// Also transforms relatedInformation locations if present, filtering out entries
@@ -238,6 +242,30 @@ mod tests {
     use super::super::test_helpers::*;
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn unchanged_baseline_is_reanchored_with_the_current_offset() {
+        let baseline = vec![Diagnostic {
+            range: tower_lsp_server::ls_types::Range::new(
+                tower_lsp_server::ls_types::Position::new(1, 2),
+                tower_lsp_server::ls_types::Position::new(1, 5),
+            ),
+            message: "cached".to_string(),
+            ..Default::default()
+        }];
+
+        let mut diagnostics = diagnostics_for_unchanged_baseline(Some(&baseline));
+        for diagnostic in &mut diagnostics {
+            transform_diagnostic(diagnostic, &RegionOffset::new(20, 0), "file:///host.md");
+        }
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].range.start.line, 21);
+        assert_eq!(
+            baseline[0].range.start.line, 1,
+            "cache remains virtual-local"
+        );
+    }
 
     #[test]
     fn diagnostic_response_transforms_range_to_host_coordinates() {

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -120,7 +120,19 @@ impl LanguageServerPool {
                     parse_downstream_diagnostic_report(response)
                 },
             )
-            .await??;
+            .await?;
+
+        let report = match report {
+            Ok(report) => report,
+            Err(error) => {
+                self.record_failed_diagnostic_pull(
+                    &cache_key,
+                    snapshot,
+                    self.is_virtual_doc_open_on_connection(&cache_key.1, &cache_key.0),
+                );
+                return Err(error);
+            }
+        };
 
         let mut diagnostics = self.resolve_diagnostic_pull_report(
             &cache_key,
@@ -145,27 +157,8 @@ impl LanguageServerPool {
             .diagnostic_pull_lock
             .lock()
             .recover_poison("LanguageServerPool::diagnostic_pull_lock");
-        let current_document_generation = self
-            .diagnostic_document_generations
-            .get(cache_key)
-            .map(|entry| *entry)
-            .unwrap_or(0);
-        let lineage_is_current = document_is_open
-            && snapshot.settings_generation
-                == self
-                    .diagnostic_pull_generations
-                    .get(&cache_key.0)
-                    .map(|entry| *entry)
-                    .unwrap_or(0)
-            && snapshot.document_generation == current_document_generation
-            && snapshot.connection_generation == self.document_connection_generation(&cache_key.0);
-        let lineage_is_current = lineage_is_current
-            && snapshot.host_generation
-                == self
-                    .diagnostic_host_generations
-                    .get(&snapshot.host_uri)
-                    .map(|entry| *entry)
-                    .unwrap_or(0);
+        let lineage_is_current =
+            self.diagnostic_pull_lineage_is_current(cache_key, &snapshot, document_is_open);
         if !lineage_is_current {
             return match report {
                 DownstreamDiagnosticReport::Full { diagnostics, .. } => diagnostics,
@@ -233,6 +226,55 @@ impl LanguageServerPool {
                 Vec::new()
             }
         }
+    }
+
+    pub(super) fn record_failed_diagnostic_pull(
+        &self,
+        cache_key: &(super::super::pool::ConnectionKey, String),
+        snapshot: super::super::pool::DiagnosticPullSnapshot,
+        document_is_open: bool,
+    ) {
+        let _guard = self
+            .diagnostic_pull_lock
+            .lock()
+            .recover_poison("LanguageServerPool::diagnostic_pull_lock");
+        if self.diagnostic_pull_lineage_is_current(cache_key, &snapshot, document_is_open)
+            && self
+                .diagnostic_pull_applied_sequences
+                .get(cache_key)
+                .is_none_or(|sequence| *sequence < snapshot.request_sequence)
+        {
+            self.diagnostic_pull_applied_sequences
+                .insert(cache_key.clone(), snapshot.request_sequence);
+        }
+    }
+
+    fn diagnostic_pull_lineage_is_current(
+        &self,
+        cache_key: &(super::super::pool::ConnectionKey, String),
+        snapshot: &super::super::pool::DiagnosticPullSnapshot,
+        document_is_open: bool,
+    ) -> bool {
+        let current_document_generation = self
+            .diagnostic_document_generations
+            .get(cache_key)
+            .map(|entry| *entry)
+            .unwrap_or(0);
+        document_is_open
+            && snapshot.settings_generation
+                == self
+                    .diagnostic_pull_generations
+                    .get(&cache_key.0)
+                    .map(|entry| *entry)
+                    .unwrap_or(0)
+            && snapshot.document_generation == current_document_generation
+            && snapshot.connection_generation == self.document_connection_generation(&cache_key.0)
+            && snapshot.host_generation
+                == self
+                    .diagnostic_host_generations
+                    .get(&snapshot.host_uri)
+                    .map(|entry| *entry)
+                    .unwrap_or(0)
     }
 
     fn store_diagnostic_baseline_if_current(
@@ -612,6 +654,42 @@ mod tests {
 
         assert_eq!(final_result_id(false), "r3");
         assert_eq!(final_result_id(true), "r3");
+    }
+
+    #[test]
+    fn newer_malformed_report_fences_an_older_full_report() {
+        let pool = LanguageServerPool::new();
+        let key = (
+            super::super::super::pool::ConnectionKey::for_server("lua_ls"),
+            "kakehashi-virtual://region-1".to_string(),
+        );
+        pool.diagnostic_pull_baselines.insert(
+            key.clone(),
+            super::super::super::pool::DiagnosticPullBaseline {
+                result_id: "r1".to_string(),
+                diagnostics: std::sync::Arc::new(Vec::new()),
+                request_sequence: 0,
+            },
+        );
+        let older = test_snapshot(&pool, &key);
+        let newer = test_snapshot(&pool, &key);
+
+        pool.record_failed_diagnostic_pull(&key, newer, true);
+        pool.resolve_diagnostic_pull_report(
+            &key,
+            older,
+            DownstreamDiagnosticReport::Full {
+                result_id: Some("late".to_string()),
+                diagnostics: Vec::new(),
+            },
+            true,
+        );
+
+        assert_eq!(
+            pool.diagnostic_pull_baselines.get(&key).unwrap().result_id,
+            "r1",
+            "the older successful response must not supersede a newer malformed response"
+        );
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -176,8 +176,10 @@ impl LanguageServerPool {
         // Use the connection key from OpenedVirtualDoc for per-connection tracking
         self.untrack_document(&doc.virtual_uri, &doc.connection_key)
             .await;
-        self.diagnostic_pull_baselines
-            .remove(&(doc.connection_key.clone(), doc.virtual_uri.to_uri_string()));
+        self.invalidate_diagnostic_document(&(
+            doc.connection_key.clone(),
+            doc.virtual_uri.to_uri_string(),
+        ));
         drop(transition_guard);
         self.remove_open_transition_lock_if_unshared(
             &doc.virtual_uri,

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -193,6 +193,9 @@ impl LanguageServerPool {
     /// The connection to downstream language servers remains open — only the
     /// virtual documents are closed.
     pub(crate) async fn close_host_document(&self, host_uri: &Url) -> Vec<OpenedVirtualDoc> {
+        // Fence even a first pull that snapshotted before its downstream
+        // didOpen became visible in the tracker.
+        self.invalidate_diagnostic_host(host_uri);
         // 1. Remove and get all virtual docs for this host
         let virtual_docs = self.remove_host_virtual_docs(host_uri).await;
 

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -176,6 +176,8 @@ impl LanguageServerPool {
         // Use the connection key from OpenedVirtualDoc for per-connection tracking
         self.untrack_document(&doc.virtual_uri, &doc.connection_key)
             .await;
+        self.diagnostic_pull_baselines
+            .remove(&(doc.connection_key.clone(), doc.virtual_uri.to_uri_string()));
         drop(transition_guard);
         self.remove_open_transition_lock_if_unshared(
             &doc.virtual_uri,

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -441,11 +441,18 @@ impl LanguageServerPool {
                     super::diagnostic::parse_downstream_diagnostic_report(response)
                 },
             )
-            .await??;
+            .await?;
         let document_is_open = self
             .host_documents()
             .await
             .contains_key(&(cache_key.1.clone(), cache_key.0.clone()));
+        let report = match report {
+            Ok(report) => report,
+            Err(error) => {
+                self.record_failed_diagnostic_pull(&cache_key, snapshot, document_is_open);
+                return Err(error);
+            }
+        };
         Ok(self.resolve_diagnostic_pull_report(&cache_key, snapshot, report, document_is_open))
     }
 

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -420,6 +420,10 @@ impl LanguageServerPool {
             .map(|entry| entry.result_id.clone());
         if let Some(result_id) = &previous_result_id {
             params["previousResultId"] = serde_json::Value::String(result_id.clone());
+        } else if let Some(params) = params.as_object_mut() {
+            // Keep absence distinct from JSON null even if a future caller
+            // reuses a params object instead of constructing a fresh one.
+            params.remove("previousResultId");
         }
         let report = self
             .execute_host_request(

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -406,16 +406,11 @@ impl LanguageServerPool {
             return Ok(Vec::new());
         }
         let cache_key = (handle.key().clone(), doc.uri.as_str().to_string());
-        let connection_generation = self.document_connection_generation(handle.key());
-        let document_generation = self.diagnostic_document_generation(&cache_key);
-        let settings_generation = self
-            .diagnostic_pull_generation
-            .load(std::sync::atomic::Ordering::Acquire);
-        let baseline = self
-            .diagnostic_pull_baselines
-            .get(&cache_key)
-            .map(|entry| entry.value().clone());
-        let previous_result_id = baseline.as_ref().map(|entry| entry.result_id.clone());
+        let snapshot = self.diagnostic_pull_snapshot(&cache_key);
+        let previous_result_id = snapshot
+            .baseline
+            .as_ref()
+            .map(|entry| entry.result_id.clone());
         if let Some(result_id) = &previous_result_id {
             params["previousResultId"] = serde_json::Value::String(result_id.clone());
         }
@@ -440,14 +435,7 @@ impl LanguageServerPool {
             .host_documents()
             .await
             .contains_key(&(cache_key.1.clone(), cache_key.0.clone()));
-        let lineage_is_current = document_is_open
-            && connection_generation == self.document_connection_generation(&cache_key.0)
-            && settings_generation
-                == self
-                    .diagnostic_pull_generation
-                    .load(std::sync::atomic::Ordering::Acquire)
-            && document_generation == self.diagnostic_document_generation(&cache_key);
-        Ok(self.resolve_diagnostic_pull_report(&cache_key, baseline, report, lineage_is_current))
+        Ok(self.resolve_diagnostic_pull_report(&cache_key, snapshot, report, document_is_open))
     }
 
     /// Drive a host bridge request end-to-end: register for cancel

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -23,9 +23,9 @@ use std::io;
 use std::sync::Arc;
 
 use tower_lsp_server::ls_types::{
-    Diagnostic, DidChangeTextDocumentParams, DidOpenTextDocumentParams, DocumentDiagnosticReport,
-    Location, LocationLink, TextDocumentContentChangeEvent, TextDocumentIdentifier,
-    TextDocumentItem, TextEdit, Uri, VersionedTextDocumentIdentifier,
+    Diagnostic, DidChangeTextDocumentParams, DidOpenTextDocumentParams, Location, LocationLink,
+    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem, TextEdit, Uri,
+    VersionedTextDocumentIdentifier,
 };
 use url::Url;
 
@@ -197,6 +197,8 @@ impl LanguageServerPool {
             handle.send_notification(notification);
         }
         docs.retain(|(doc_uri, _), _| *doc_uri != uri_string);
+        self.diagnostic_pull_baselines
+            .retain(|(_, doc_uri), _| doc_uri != &uri_string);
     }
 
     /// Forward a `textDocument/willSave` notification (#357) to every host
@@ -359,9 +361,10 @@ impl LanguageServerPool {
     /// (error response, absent `result` member, unknown `kind`, a `full` report
     /// missing `items`, or items that fail to deserialize) is a counted request
     /// failure (`Err`), mirroring [`Self::send_host_formatting_request`]; a
-    /// `null`/`unchanged` result is the authoritative empty `Ok(vec![])`; and a
-    /// server that does not advertise the capability stays the lenient empty
-    /// `Ok(vec![])`. The dedicated method keeps that strictness out of the
+    /// `null` is authoritative empty, while `unchanged` reuses the baseline
+    /// established by the preceding full report. A server that does not
+    /// advertise the capability stays the lenient empty `Ok(vec![])`. The
+    /// dedicated method keeps that strictness out of the
     /// shared raw path that other host methods rely on.
     ///
     /// Waits through server initialization (the caller's request timeout bounds
@@ -377,7 +380,7 @@ impl LanguageServerPool {
         server_name: &str,
         server_config: &BridgeServerConfig,
         doc: &HostDocument<'_>,
-        params: serde_json::Value,
+        mut params: serde_json::Value,
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Vec<Diagnostic>> {
         let method = "textDocument/diagnostic";
@@ -395,14 +398,47 @@ impl LanguageServerPool {
             // nothing without looking like a failure.
             return Ok(Vec::new());
         }
-        self.execute_host_request(
-            handle,
-            doc,
-            upstream_request_id,
-            |request_id| JsonRpcRequest::new(request_id.as_i64(), method, params),
-            move |response| parse_host_diagnostic_response(response, method),
-        )
-        .await?
+        let cache_key = (handle.key().clone(), doc.uri.as_str().to_string());
+        let connection_generation = self.document_connection_generation(handle.key());
+        let settings_generation = self
+            .diagnostic_pull_generation
+            .load(std::sync::atomic::Ordering::Acquire);
+        let baseline = self
+            .diagnostic_pull_baselines
+            .get(&cache_key)
+            .map(|entry| entry.value().clone());
+        let previous_result_id = baseline.as_ref().map(|entry| entry.result_id.clone());
+        if let Some(result_id) = &previous_result_id {
+            params["previousResultId"] = serde_json::Value::String(result_id.clone());
+        }
+        let report = self
+            .execute_host_request(
+                handle,
+                doc,
+                upstream_request_id,
+                |request_id| JsonRpcRequest::new(request_id.as_i64(), method, params),
+                move |response| {
+                    if response_has_jsonrpc_error(&response, method) {
+                        return Err(io::Error::other(format!(
+                            "downstream server answered {method} with an error response: {}",
+                            jsonrpc_error_summary(&response)
+                        )));
+                    }
+                    super::diagnostic::parse_downstream_diagnostic_report(response)
+                },
+            )
+            .await??;
+        let document_is_open = self
+            .host_documents()
+            .await
+            .contains_key(&(cache_key.1.clone(), cache_key.0.clone()));
+        let lineage_is_current = document_is_open
+            && connection_generation == self.document_connection_generation(&cache_key.0)
+            && settings_generation
+                == self
+                    .diagnostic_pull_generation
+                    .load(std::sync::atomic::Ordering::Acquire);
+        Ok(self.resolve_diagnostic_pull_report(&cache_key, baseline, report, lineage_is_current))
     }
 
     /// Drive a host bridge request end-to-end: register for cancel
@@ -603,12 +639,12 @@ fn parse_host_formatting_response(
 /// malformed report (an unknown `kind`, a `full` report missing `items`, or
 /// `items` that fail to deserialize) is a request failure (`Err`) — collapsing
 /// it into the empty layer would let a broken host server pass as "nothing
-/// wrong". A `null` result or an `unchanged` report (a server should not send
-/// `unchanged` — we never supply `previousResultId` — but honor it) is the
-/// authoritative empty `Ok(vec![])`. `relatedDocuments` entries are dropped:
-/// diagnostics for OTHER documents have no place in this document's report.
+/// wrong". A `null` result or a spurious `unchanged` report without a cached
+/// baseline is the authoritative empty `Ok(vec![])`. `relatedDocuments`
+/// entries are dropped: diagnostics for OTHER documents have no place here.
+#[cfg(test)]
 fn parse_host_diagnostic_response(
-    mut response: serde_json::Value,
+    response: serde_json::Value,
     method: &'static str,
 ) -> io::Result<Vec<Diagnostic>> {
     if response_has_jsonrpc_error(&response, method) {
@@ -617,28 +653,10 @@ fn parse_host_diagnostic_response(
             jsonrpc_error_summary(&response)
         )));
     }
-    let Some(result) = response.get_mut("result").map(serde_json::Value::take) else {
-        return Err(io::Error::other(format!(
-            "{method} response carries neither result nor error (protocol violation)"
-        )));
-    };
-    if result.is_null() {
-        return Ok(Vec::new());
-    }
-    match serde_json::from_value::<DocumentDiagnosticReport>(result) {
-        Ok(DocumentDiagnosticReport::Full(report)) => {
-            Ok(report.full_document_diagnostic_report.items)
-        }
-        Ok(DocumentDiagnosticReport::Unchanged(_)) => Ok(Vec::new()),
-        Err(e) => {
-            log::warn!(
-                target: "kakehashi::bridge",
-                "host diagnostic report failed to deserialize: {e}"
-            );
-            Err(io::Error::other(format!(
-                "malformed {method} result from downstream server: {e}"
-            )))
-        }
+    match super::diagnostic::parse_downstream_diagnostic_report(response)? {
+        super::diagnostic::DownstreamDiagnosticReport::Full { diagnostics, .. } => Ok(diagnostics),
+        super::diagnostic::DownstreamDiagnosticReport::Unchanged
+        | super::diagnostic::DownstreamDiagnosticReport::Null => Ok(Vec::new()),
     }
 }
 
@@ -842,10 +860,10 @@ mod tests {
     }
 
     #[test]
-    fn host_diagnostic_null_and_unchanged_are_authoritative_empty() {
-        // `null` and an `unchanged` report are handled responses meaning "no
-        // diagnostics" — `Ok(vec![])`, not a failure. (We never send a
-        // `previousResultId`, but honor `unchanged` if a server volunteers it.)
+    fn host_diagnostic_null_and_spurious_unchanged_are_empty() {
+        // This parser seam has no baseline. `null` and a volunteered
+        // `unchanged` therefore stay empty; the live send path resolves a
+        // legitimate unchanged response from its per-document cache.
         let null = serde_json::json!({ "jsonrpc": "2.0", "id": 1, "result": null });
         assert!(
             parse_host_diagnostic_response(null, "textDocument/diagnostic")
@@ -859,7 +877,7 @@ mod tests {
         });
         assert!(
             parse_host_diagnostic_response(unchanged, "textDocument/diagnostic")
-                .expect("unchanged is authoritative empty")
+                .expect("spurious unchanged without a baseline stays empty")
                 .is_empty()
         );
     }

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -392,6 +392,7 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Vec<Diagnostic>> {
         let method = "textDocument/diagnostic";
+        let (host_generation, request_sequence) = self.begin_diagnostic_pull(doc.uri);
         let handle = self
             .get_or_create_connection_wait_ready(
                 server_name,
@@ -407,7 +408,12 @@ impl LanguageServerPool {
             return Ok(Vec::new());
         }
         let cache_key = (handle.key().clone(), doc.uri.as_str().to_string());
-        let snapshot = self.diagnostic_pull_snapshot(&cache_key, doc.uri.as_str());
+        let snapshot = self.diagnostic_pull_snapshot(
+            &cache_key,
+            doc.uri.as_str(),
+            host_generation,
+            request_sequence,
+        );
         let previous_result_id = snapshot
             .baseline
             .as_ref()

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -652,7 +652,7 @@ fn parse_host_diagnostic_response(
     }
     match super::diagnostic::parse_downstream_diagnostic_report(response)? {
         super::diagnostic::DownstreamDiagnosticReport::Full { diagnostics, .. } => Ok(diagnostics),
-        super::diagnostic::DownstreamDiagnosticReport::Unchanged
+        super::diagnostic::DownstreamDiagnosticReport::Unchanged { .. }
         | super::diagnostic::DownstreamDiagnosticReport::Null => Ok(Vec::new()),
     }
 }

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -196,9 +196,16 @@ impl LanguageServerPool {
             );
             handle.send_notification(notification);
         }
+        let closed_keys = docs
+            .keys()
+            .filter(|(doc_uri, _)| doc_uri == &uri_string)
+            .cloned()
+            .map(|(doc_uri, connection_key)| (connection_key, doc_uri))
+            .collect::<Vec<_>>();
         docs.retain(|(doc_uri, _), _| *doc_uri != uri_string);
-        self.diagnostic_pull_baselines
-            .retain(|(_, doc_uri), _| doc_uri != &uri_string);
+        for key in closed_keys {
+            self.invalidate_diagnostic_document(&key);
+        }
     }
 
     /// Forward a `textDocument/willSave` notification (#357) to every host
@@ -400,6 +407,7 @@ impl LanguageServerPool {
         }
         let cache_key = (handle.key().clone(), doc.uri.as_str().to_string());
         let connection_generation = self.document_connection_generation(handle.key());
+        let document_generation = self.diagnostic_document_generation(&cache_key);
         let settings_generation = self
             .diagnostic_pull_generation
             .load(std::sync::atomic::Ordering::Acquire);
@@ -437,7 +445,8 @@ impl LanguageServerPool {
             && settings_generation
                 == self
                     .diagnostic_pull_generation
-                    .load(std::sync::atomic::Ordering::Acquire);
+                    .load(std::sync::atomic::Ordering::Acquire)
+            && document_generation == self.diagnostic_document_generation(&cache_key);
         Ok(self.resolve_diagnostic_pull_report(&cache_key, baseline, report, lineage_is_current))
     }
 

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -168,6 +168,7 @@ impl LanguageServerPool {
     /// Mirrors the virt path's `close_host_document`; called from the
     /// upstream `didClose` handler.
     pub(crate) async fn close_host_bridge_document(&self, uri: &Url) {
+        self.invalidate_diagnostic_host(uri);
         let Ok(uri_lsp) = host_url_to_lsp_uri(uri) else {
             return;
         };
@@ -406,7 +407,7 @@ impl LanguageServerPool {
             return Ok(Vec::new());
         }
         let cache_key = (handle.key().clone(), doc.uri.as_str().to_string());
-        let snapshot = self.diagnostic_pull_snapshot(&cache_key);
+        let snapshot = self.diagnostic_pull_snapshot(&cache_key, doc.uri.as_str());
         let previous_result_id = snapshot
             .baseline
             .as_ref()

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -659,7 +659,6 @@ async fn send_diagnostic_fan_out_request(t: FanOutTask) -> std::io::Result<Vec<D
             t.offset,
             &t.virtual_content,
             t.upstream_id,
-            None, // No previous_result_id
         ),
     )
     .await


### PR DESCRIPTION
Closes #796

## Summary

- cache downstream diagnostic result IDs and server-local items per connection/document
- send previousResultId on subsequent virtual and host pulls
- preserve diagnostics on unchanged responses and adopt their returned next result ID
- keep region diagnostics virtual-local and re-anchor with the current host offset
- fence concurrent pulls by request order and invalidate safely across close/reopen, settings, respawn, and host incarnations
- scope settings invalidation to the affected ConnectionKey and document the coordinate/lifecycle decision

## Validation

- 27 focused downstream diagnostic parser/cache tests
- host diagnostic parser tests
- cargo fmt --check
- cargo clippy --lib -- -D warnings
- git diff --check
- full cargo test --lib: 2905 passed, 2 ignored, 5 pre-existing environment/fixture failures (one tree-sitter clone checkout; four bridge tests lacking an open host lifecycle)

## Review

- multi-perspective lifecycle/protocol review: converged
- iterative Codex review: converged
- fresh Codex review: no actionable findings

This PR intentionally remains Draft until the full revise pipeline finishes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added baseline-aware diagnostic pulls that reuse downstream unchanged results to reduce diagnostic flicker and speed up incremental diagnostic updates.
* **Bug Fixes**
  * Prevented late/outdated diagnostic responses from overwriting newer results using improved request sequencing and lineage validation.
  * Correctly reanchored cached diagnostics when document regions/offsets change, including unchanged responses.
  * More reliably clears diagnostic caches on document close, host close, connection respawn/replacement, and settings or identity changes.
  * Improved robustness for `null`, malformed, and baseline-missing diagnostic responses to avoid incorrect or empty reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->