### PR TITLE
fix(cli): ignore parser-shaped directories

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -651,10 +651,10 @@ fn run_language_uninstall(
         if let Ok(entries) = fs::read_dir(&parser_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                let is_parser = path
-                    .extension()
-                    .map(|ext| ext == std::env::consts::DLL_EXTENSION)
-                    .unwrap_or(false);
+                let is_parser = path.is_file()
+                    && path
+                        .extension()
+                        .is_some_and(|ext| ext == std::env::consts::DLL_EXTENSION);
                 if is_parser && let Some(stem) = path.file_stem() {
                     languages.insert(stem.to_string_lossy().to_string());
                 }
@@ -772,7 +772,7 @@ fn run_language_uninstall(
 /// Find the parser file for a language.
 fn find_parser_file(parser_dir: &std::path::Path, lang: &str) -> Option<PathBuf> {
     let path = parser_dir.join(format!("{}.{}", lang, std::env::consts::DLL_EXTENSION));
-    if path.exists() { Some(path) } else { None }
+    if path.is_file() { Some(path) } else { None }
 }
 
 /// What to tell someone whose `--output` path is already taken. A regular

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -844,6 +844,84 @@ fn test_language_status_shows_installed() {
     );
 }
 
+/// Parser-shaped directories are not loadable shared libraries and must not
+/// be reported as installed parsers.
+#[test]
+fn test_language_status_ignores_parser_shaped_directories() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    fs::create_dir_all(test_dir.path().join(format!("parser/fakeparser.{ext}")))
+        .expect("Failed to create parser-shaped directory");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !combined.contains("fakeparser"),
+        "a directory named like a parser must not be reported as installed. Got: {combined}"
+    );
+}
+
+/// The other half of the same bug: when QUERIES make status list a language,
+/// `find_parser_file` decides whether it prints a parser as present — and a
+/// directory named like one is not a parser.
+#[test]
+fn test_language_status_marks_a_parser_shaped_directory_as_missing() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    fs::create_dir_all(test_dir.path().join(format!("parser/fakeparser.{ext}")))
+        .expect("Failed to create parser-shaped directory");
+    // Queries are what put the language in the listing at all, so the row exists
+    // and its parser column is the thing under test.
+    fs::create_dir_all(test_dir.path().join("queries/fakeparser"))
+        .expect("Failed to create queries directory");
+    fs::write(
+        test_dir.path().join("queries/fakeparser/highlights.scm"),
+        "; test\n",
+    )
+    .expect("Failed to write query file");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("fakeparser"),
+        "the queries should still list the language. Got: {combined}"
+    );
+    assert!(
+        combined.contains("✗ parser"),
+        "a parser-shaped DIRECTORY must not count as an installed parser. Got: {combined}"
+    );
+}
+
 /// Status must not report an install as empty when it could not inspect it.
 #[test]
 fn test_language_status_fails_when_install_directory_is_not_a_directory() {
@@ -1585,6 +1663,84 @@ fn test_language_uninstall_all() {
         })
         .unwrap_or_default();
     assert!(queries.is_empty(), "All queries should be removed");
+}
+
+/// Bulk uninstall discovery must ignore parser-shaped directories instead of
+/// treating them as installed languages that subsequently cannot be removed.
+#[test]
+fn test_language_uninstall_all_ignores_parser_shaped_directories() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    let parser_dir = test_dir.path().join(format!("parser/fakeparser.{ext}"));
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser-shaped directory");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success(), "uninstall failed: {combined}");
+    assert!(
+        combined.contains("No languages installed to uninstall"),
+        "parser-shaped directories must not enter uninstall discovery: {combined}"
+    );
+    assert!(
+        parser_dir.is_dir(),
+        "unrelated directory must remain intact"
+    );
+}
+
+/// Explicit uninstall must use the same regular-file check as discovery, so a
+/// parser-shaped directory is reported as absent and never passed to removal.
+#[test]
+fn test_language_uninstall_ignores_parser_shaped_directory() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    let parser_dir = test_dir.path().join(format!("parser/fakeparser.{ext}"));
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser-shaped directory");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "fakeparser",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success(), "uninstall failed: {combined}");
+    assert!(
+        combined.contains("Language 'fakeparser' is not installed"),
+        "parser-shaped directory must not count as an installed parser: {combined}"
+    );
+    assert!(
+        parser_dir.is_dir(),
+        "unrelated directory must remain intact"
+    );
 }
 
 /// Test that language uninstall --all ignores internal query staging directories


### PR DESCRIPTION
## Summary

`language status` and `language uninstall` discover installed parsers by scanning
`parser/` for entries with the platform DLL extension. A stale or unrelated
**directory** named `parser/lua.so` matched, so status reported a healthy row for
something that cannot be loaded, and `uninstall --all` offered it as a target that
`remove_file` then refused.

Fixes #828.

## Rebased onto current main (634 commits)

`status`'s own scan was rewritten upstream while this branch waited — it now uses a
checked `visit_install_directory` traversal that already performs the object-type
check. So **that half of the original fix is subsumed**, and what remains is the two
places it did not reach:

- **`uninstall --all` discovery** filters by object type before collecting a stem.
- **`find_parser_file`** asks `is_file` rather than `exists`. This is also the half of
  `status` the rewrite did *not* cover: when QUERIES are what put a language in the
  listing, this is what decides whether its parser column says present.

The rebase kept a review finding whose commit was otherwise absorbed: the fixture stem
is `fakeparser`, not `not-a-parser`, so it exercises directory-versus-file
classification rather than unsafe-name handling.

## What review changed — including a scope revert

Review first suggested moving bulk discovery onto the checked traversal, because it
swallows `read_dir` and per-entry failures. I did that, and a second reviewer showed the
widening was both **unpinned and regressive**:

- reverting the ~40 lines left **all 60 `test_cli` tests green** — nothing distinguished
  fail-closed from fail-open discovery
- and failing closed introduced a worse bug: one dangling `parser/dangling.dylib`
  aborted `uninstall --all` entirely, so a real `lua` beside it became unremovable —
  with a message naming the *directory* and saying "No such file or directory" while the
  directory plainly exists, and **no CLI path left to clear the dangling entry**

So it is reverted. This PR is back to exactly #828's scope: object type, not I/O errors.
The I/O-error question — including the `find_parser_file` case where `Path::is_file()`
conflates "not a file" with "could not tell" one function away from `fs::remove_file` —
is filed as #953, with the reproductions and the design decision it needs.

Review also showed the status regression **passed unchanged on `main`** — with no
matching query directory, main's scanner never reaches `find_parser_file`. It is kept
(neither of main's tests covers an entry *inside* `parser/` being a directory) but it is
not what pins this fix. A second test supplies `queries/fakeparser/` and asserts
`✗ parser`, which is.

Bulk discovery also moves onto the checked traversal, and that is not tidying. It
swallowed `read_dir` and per-entry failures, so an unreadable `parser/` beside a
readable `queries/` removed the queries, left the parser, and **still told the user it
had uninstalled everything** — a destructive command lying about what it did.

The object-type check is deliberately not `Path::is_file` either: that reports false
for "not a file" and for "could not tell" alike, and here "could not tell" must not
read as "nothing to uninstall". An entry that is simply absent stays normal; anything
else stops the command.

Review also showed the status regression **passed unchanged on `main`** — with no
matching query directory, main's scanner never reaches `find_parser_file`. A second
test now supplies `queries/fakeparser/` and asserts `✗ parser`, which is what pins that
half of the change.

## Validation

- `cargo test --test test_cli` — **60 passed, 0 failed**
- `cargo test --lib` — **3292 passed, 0 failed**
- `cargo clippy --lib --bins -- -D warnings` clean; `cargo fmt --check` clean

Mutation-verified:

| mutation | caught by |
|---|---|
| `find_parser_file` back to `exists()` | `..._marks_a_parser_shaped_directory_as_missing`, `..._uninstall_ignores_parser_shaped_directory` |
| bulk discovery drops the object-type check | `..._uninstall_all_ignores_parser_shaped_directories` |

CI also caught a gap in my local gate: removing a helper left callers in the **bin's own
unit tests**, which `cargo test --lib` and `--test test_cli` do not build. Re-gated with
CI's exact invocation (`cargo test`, no target filter) — lib 3292/0, bins 7/0.
