### PR TITLE
fix(cli): ignore invalid parser filename stems

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -446,8 +446,11 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
             }
             Err(error) => return Err(error),
         };
-        if is_file && let Some(stem) = path.file_stem() {
-            languages.insert(stem.to_string_lossy().to_string());
+        if is_file
+            && let Some(stem) = path.file_stem()
+            && let Some(language) = safe_parser_language_name(&stem.to_string_lossy())
+        {
+            languages.insert(language);
         }
         Ok(())
     })
@@ -589,6 +592,21 @@ fn visit_install_directory(
     Ok(())
 }
 
+/// The language a parser FILENAME stem names, or `None` when the stem is not one
+/// this CLI can safely manage.
+///
+/// Parser discovery is where a name enters from the FILESYSTEM rather than from
+/// config, so it is where the safe-name contract has to be applied; the queries
+/// side already applies it in `installed_query_language_name_checked`.
+///
+/// Shared by `status` and `uninstall --all` so they agree on which NAMES count —
+/// a name one lists and the other refuses to touch is what made `uninstall --all`
+/// fail partway. They still differ on I/O errors (status propagates, uninstall
+/// swallows); that divergence predates this and is tracked separately.
+fn safe_parser_language_name(stem: &str) -> Option<String> {
+    queries::is_safe_language_name(stem).then(|| stem.to_string())
+}
+
 fn installed_query_language_name(path: &Path) -> Option<String> {
     installed_query_language_name_checked(path).ok().flatten()
 }
@@ -643,6 +661,11 @@ fn run_language_uninstall(
         eprintln!("Warning: failed to recover interrupted query installs: {e}");
     }
 
+    // Parser files discovery walked past because their names are not ones this
+    // CLI manages. Kept so the summary cannot claim it removed everything while
+    // one of them is still on disk.
+    let mut unmanaged: Vec<PathBuf> = Vec::new();
+
     // Determine which languages to uninstall
     let languages_to_uninstall: Vec<String> = if all {
         // Collect all installed languages
@@ -656,7 +679,16 @@ fn run_language_uninstall(
                         .extension()
                         .is_some_and(|ext| ext == std::env::consts::DLL_EXTENSION);
                 if is_parser && let Some(stem) = path.file_stem() {
-                    languages.insert(stem.to_string_lossy().to_string());
+                    let stem = stem.to_string_lossy();
+                    match safe_parser_language_name(&stem) {
+                        Some(language) => {
+                            languages.insert(language);
+                        }
+                        // Remembered, not just skipped: this command goes on to
+                        // say it uninstalled everything, and a parser file left
+                        // on disk makes that false.
+                        None => unmanaged.push(path.clone()),
+                    }
                 }
             }
         }
@@ -758,9 +790,26 @@ fn run_language_uninstall(
         return Err(ExitCode::FAILURE);
     }
 
+    if !unmanaged.is_empty() {
+        eprintln!();
+        for path in &unmanaged {
+            eprintln!(
+                "Note: left '{}' in place — its name is not one this CLI manages.",
+                path.display()
+            );
+        }
+    }
+
     if any_removed {
         if all {
-            eprintln!("\nUninstalled all languages.");
+            // Not "all" when discovery deliberately walked past something that
+            // is still on disk; saying so would be the command reporting a
+            // completeness it knows it does not have.
+            if unmanaged.is_empty() {
+                eprintln!("\nUninstalled all languages.");
+            } else {
+                eprintln!("\nUninstalled all managed languages.");
+            }
         } else {
             eprintln!("\nUninstalled '{}'.", languages_to_uninstall[0]);
         }

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -922,6 +922,49 @@ fn test_language_status_marks_a_parser_shaped_directory_as_missing() {
     );
 }
 
+/// A parser artifact whose STEM is outside the installer's language-name
+/// contract is an unmanaged file, not an install. Distinct from the
+/// directory cases above: this one is a real file with a real extension, and
+/// only its name disqualifies it.
+#[test]
+fn test_language_status_ignores_invalid_parser_language_names() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
+    fs::write(
+        test_dir.path().join(format!("parser/not-a-language.{ext}")),
+        "unmanaged",
+    )
+    .expect("Failed to create invalid parser artifact");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success(), "status failed: {combined}");
+    assert!(
+        combined.contains("No languages installed"),
+        "invalid parser stems must be ignored: {combined}"
+    );
+    assert!(
+        !combined.contains("not-a-language"),
+        "invalid parser stem became a status row: {combined}"
+    );
+}
+
 /// Status must not report an install as empty when it could not inspect it.
 #[test]
 fn test_language_status_fails_when_install_directory_is_not_a_directory() {
@@ -1701,6 +1744,94 @@ fn test_language_uninstall_all_ignores_parser_shaped_directories() {
     assert!(
         parser_dir.is_dir(),
         "unrelated directory must remain intact"
+    );
+}
+
+/// Bulk uninstall must ignore an unmanaged parser artifact whose filename stem
+/// is outside the safe language-name contract. Distinct from the directory case
+/// above: this is a real file, and only its name disqualifies it.
+#[test]
+fn test_language_uninstall_all_ignores_invalid_parser_language_names() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
+    let artifact = test_dir.path().join(format!("parser/not-a-language.{ext}"));
+    fs::write(&artifact, "unmanaged").expect("Failed to create invalid parser artifact");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success(), "uninstall failed: {combined}");
+    assert!(
+        combined.contains("No languages installed to uninstall"),
+        "invalid parser stems must not enter uninstall discovery: {combined}"
+    );
+    assert!(artifact.is_file(), "unmanaged artifact must remain intact");
+}
+
+/// Issue #833's actual shape: an unmanaged artifact BESIDE a real install. Both
+/// of the single-artifact tests above stop at the "nothing installed" guard and
+/// never reach removal, so this is the one that reaches it — and the one that
+/// catches the command calling the result "all" while a parser file it walked
+/// past is still on disk.
+#[test]
+fn test_language_uninstall_all_leaves_unmanaged_artifacts_and_says_so() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
+    let managed = test_dir.path().join(format!("parser/rust.{ext}"));
+    fs::write(&managed, "parser").expect("Failed to create managed parser");
+    let unmanaged = test_dir.path().join(format!("parser/not-a-language.{ext}"));
+    fs::write(&unmanaged, "unmanaged").expect("Failed to create unmanaged artifact");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success(), "uninstall failed: {combined}");
+    assert!(!managed.exists(), "the managed parser must be removed");
+    assert!(
+        unmanaged.is_file(),
+        "the unmanaged artifact must be left alone: {combined}"
+    );
+    assert!(
+        combined.contains("not-a-language"),
+        "the user must be told what was left behind: {combined}"
+    );
+    assert!(
+        !combined.contains("Uninstalled all languages."),
+        "'all' is false while a parser file it walked past is still there: {combined}"
     );
 }
 


### PR DESCRIPTION
## Summary

`language status` and `language uninstall --all` took the filename stem of anything in
`parser/` with the platform DLL extension as an installed language. A stale or unmanaged
artifact such as `parser/not-a-language.so` therefore became a status row, and
`uninstall --all` discovered a name it then refused to act on — **failing with "Invalid
language name" after the user asked to remove everything**.

Fixes #833.

## The fix

Discovery is the only place a language name enters from the **filesystem** rather than
from config, so it is the only place the installer's safe-name contract
(`queries::is_safe_language_name`) has to be enforced; every path downstream already
assumes it holds.

Both call sites go through one predicate, because a name that one of them lists and the
other refuses to touch is exactly the shape that made `uninstall --all` fail partway.

## Rebased onto current main (634 commits, over #831)

Two things changed under this branch while it waited:

- `status`'s scan was rewritten upstream into a checked `visit_install_directory`
  traversal, so the safe-name check now sits inside that instead of a bare `read_dir`.
- **#831** landed the object-type filter in both call sites.

The two fixes are **orthogonal and both needed**: #831 asks whether an entry is a FILE,
this asks whether its name is one we can manage. A parser-shaped *directory* and a real
file called `not-a-language.so` are different inputs, each needing its own answer. The
rebase composes them rather than choosing.

The branch's third commit was a refactor extracting a shared `path`-taking helper. On
the rebased base the two sites no longer share an object-type check (status uses the
traversal's `metadata` handling, uninstall its own), so the shared piece is the *name*
half only — `safe_parser_language_name(stem)`, which is what both now call. The
refactor's stated intent ("centralize parser-stem classification so both CLI paths stay
aligned") is met; its literal diff is not.

## What review changed

Both new tests set up a data dir containing **only** the bad artifact, so both stopped
at the "nothing installed" guard and never reached the removal path — issue #833's own
shape, an unmanaged artifact *beside* a real install, was unpinned. Reaching it showed
the filter alone is not enough:

```
✓ Removed parser: …/parser/rust.dylib

Uninstalled all languages.        exit=0
--- remaining ---
not-a-language.dylib
```

Failing loudly (the pre-fix behaviour) was at least honest; silently claiming
completeness is not. Discovery now remembers what it stepped over, the summary names
each one, and it says "all managed languages" rather than "all" when anything is left.
The mixed scenario is now a test.

## Surfaced, not decided here

`is_safe_language_name` is `[a-z0-9_]+`, but the runtime read side is deliberately
laxer — `is_single_path_component`, whose own doc says names like `typescript-react` are
legal to place by hand. So a hand-placed `parser/typescript-react.so` is a loadable,
documented install that `status` now omits. Not introduced in isolation (the queries
side has behaved this way all along), so it is a "managed inventory vs loadable
inventory" decision rather than a revert: filed as #956.

The I/O-error half of these same discovery paths is #953.

## Validation

- `cargo test` (CI's exact invocation, no target filter) — lib **3295/0**, bins **7/0**,
  `test_cli` **63/0**
- `cargo clippy --lib --bins -- -D warnings` clean; `cargo fmt --check` clean

Mutation-verified:

| mutation | caught by |
|---|---|
| safe-name predicate always accepts | the two `..._ignores_invalid_parser_language_names` tests + the mixed one |
| summary always says "all" | `..._leaves_unmanaged_artifacts_and_says_so` |
| skipped artifacts are not reported | `..._leaves_unmanaged_artifacts_and_says_so` |

An independent review also confirmed the two filters are **conjunctive at both sites**
with neither shadowing the other, across all four inputs (file/directory × valid/invalid
stem), and that #831's directory tests still exercise the object-type check rather than
passing on the new name filter (their stem `fakeparser` is a valid name).

Both of this branch's tests are kept alongside #831's rather than merged into them —
they set up different fixtures (a real file with a bad name vs a directory with a good
one) and would stop testing their own thing if combined.
