### PR TITLE
fix(install): confine query uninstall tombstones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,7 @@ dependencies = [
  "ulid",
  "ureq",
  "url",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ futures = "0.3.31"
 nix = { version = "0.31", features = ["signal", "process", "fs"] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
 
 [features]
 e2e = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,9 @@ futures = "0.3.31"
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process", "fs"] }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+
 [features]
 e2e = []
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -769,9 +769,14 @@ fn write_uninstall_tombstone_with_before_publish(
     remove_stale_uninstall_stages(queries_parent, language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
     validate_existing_tombstone(&path)?;
-    let stage_prefix = format!(".{language}.uninstalled.");
+    let stage_counter = QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stage_prefix = format!(
+        ".{language}.uninstalled.{}.{}.",
+        std::process::id(),
+        stage_counter
+    );
     let mut builder = tempfile::Builder::new();
-    builder.prefix(&stage_prefix).suffix(".tmp");
+    builder.prefix(&stage_prefix).suffix(".tmp").rand_bytes(12);
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt as _;
@@ -798,14 +803,13 @@ fn remove_stale_uninstall_stages(
     queries_parent: &Path,
     language: &str,
 ) -> Result<(), QueryInstallError> {
-    let prefix = format!(".{language}.uninstalled.");
     for entry in fs::read_dir(queries_parent)? {
         let entry = entry?;
         let name = entry.file_name();
         let Some(name) = name.to_str() else {
             continue;
         };
-        if !name.starts_with(&prefix) || !name.ends_with(".tmp") {
+        if !generated_uninstall_stage_matches_language(name, language) {
             continue;
         }
         let file_type = entry.file_type()?;
@@ -819,6 +823,28 @@ fn remove_stale_uninstall_stages(
         }
     }
     Ok(())
+}
+
+fn generated_uninstall_stage_matches_language(name: &str, language: &str) -> bool {
+    let prefix = format!(".{language}.uninstalled.");
+    let Some(rest) = name
+        .strip_prefix(&prefix)
+        .and_then(|rest| rest.strip_suffix(".tmp"))
+    else {
+        return false;
+    };
+    let mut parts = rest.split('.');
+    let (Some(pid), Some(counter), Some(random), None) =
+        (parts.next(), parts.next(), parts.next(), parts.next())
+    else {
+        return false;
+    };
+    !pid.is_empty()
+        && pid.bytes().all(|byte| byte.is_ascii_digit())
+        && !counter.is_empty()
+        && counter.bytes().all(|byte| byte.is_ascii_digit())
+        && random.len() == 12
+        && random.bytes().all(|byte| byte.is_ascii_alphanumeric())
 }
 
 /// Open or create the managed tombstone leaf without following a link there.
@@ -1581,14 +1607,20 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let queries_parent = temp.path().join("queries");
         fs::create_dir_all(&queries_parent).unwrap();
-        let stale = queries_parent.join(".rust.uninstalled.crashed.tmp");
+        let stale = queries_parent.join(".rust.uninstalled.123.7.ABCDEFGHIJKL.tmp");
         fs::write(&stale, "partial\n").unwrap();
-        let unrelated = queries_parent.join(".lua.uninstalled.crashed.tmp");
+        let same_language_unrelated = queries_parent.join(".rust.uninstalled.notes.tmp");
+        fs::write(&same_language_unrelated, "keep notes\n").unwrap();
+        let unrelated = queries_parent.join(".lua.uninstalled.123.7.ABCDEFGHIJKL.tmp");
         fs::write(&unrelated, "keep\n").unwrap();
 
         write_uninstall_tombstone(&queries_parent, "rust").unwrap();
 
         assert!(!stale.exists(), "same-language stale stage is managed");
+        assert!(
+            same_language_unrelated.exists(),
+            "a wildcard-like name is not proof of kakehashi ownership"
+        );
         assert!(unrelated.exists(), "other languages have separate locks");
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -766,11 +766,12 @@ fn write_uninstall_tombstone_with_before_publish(
     before_publish: impl FnOnce(&Path, &Path),
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
+    remove_stale_uninstall_stages(queries_parent, language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
     validate_existing_tombstone(&path)?;
     let stage_prefix = format!(".{language}.uninstalled.");
     let mut builder = tempfile::Builder::new();
-    builder.prefix(&stage_prefix);
+    builder.prefix(&stage_prefix).suffix(".tmp");
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt as _;
@@ -784,6 +785,39 @@ fn write_uninstall_tombstone_with_before_publish(
     before_publish(&path, staged.path());
     let published = staged.persist(&path).map_err(|error| error.error)?;
     verify_published_tombstone(published, &path)?;
+    Ok(())
+}
+
+/// Remove crash-stranded private stages for `language`.
+///
+/// Production callers hold that language's [`QueryReplaceLockGuard`], so no
+/// live kakehashi publisher can own a matching stage while this sweep runs.
+/// File symlinks are removed as directory entries; matching directories are
+/// not managed by this file-stage namespace and are left untouched.
+fn remove_stale_uninstall_stages(
+    queries_parent: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    let prefix = format!(".{language}.uninstalled.");
+    for entry in fs::read_dir(queries_parent)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if !name.starts_with(&prefix) || !name.ends_with(".tmp") {
+            continue;
+        }
+        let file_type = entry.file_type()?;
+        if !file_type.is_file() && !file_type.is_symlink() {
+            continue;
+        }
+        match fs::remove_file(entry.path()) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(QueryInstallError::IoError(error)),
+        }
+    }
     Ok(())
 }
 
@@ -1540,6 +1574,22 @@ mod tests {
             vec![tombstone.file_name().unwrap().to_os_string()],
             "the private stage must be removed on every persist failure"
         );
+    }
+
+    #[test]
+    fn tombstone_publish_reclaims_crash_stranded_stage() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let stale = queries_parent.join(".rust.uninstalled.crashed.tmp");
+        fs::write(&stale, "partial\n").unwrap();
+        let unrelated = queries_parent.join(".lua.uninstalled.crashed.tmp");
+        fs::write(&unrelated, "keep\n").unwrap();
+
+        write_uninstall_tombstone(&queries_parent, "rust").unwrap();
+
+        assert!(!stale.exists(), "same-language stale stage is managed");
+        assert!(unrelated.exists(), "other languages have separate locks");
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -787,6 +787,11 @@ fn write_uninstall_tombstone_with_before_publish(
     }
     let mut staged = builder.tempfile_in(queries_parent)?;
     if let Some(permissions) = existing_permissions {
+        // On Windows this can only carry `readonly = false`: validation
+        // already write-opened the destination, so a readonly leaf fails
+        // before staging exactly as origin/main's File::create did. Keeping
+        // that order avoids making a readonly stage impossible to reopen with
+        // the DELETE-capable handle required for confined publication.
         staged.as_file().set_permissions(permissions)?;
     }
     staged.write_all(b"ok\n")?;

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -766,7 +766,6 @@ fn write_uninstall_tombstone_with_before_publish(
     before_publish: impl FnOnce(&Path, &Path),
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
-    remove_stale_uninstall_stages(queries_parent, language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
     validate_existing_tombstone(&path)?;
     let stage_counter = QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -793,60 +792,6 @@ fn write_uninstall_tombstone_with_before_publish(
     Ok(())
 }
 
-/// Remove crash-stranded private stages for `language`.
-///
-/// Production callers hold that language's [`QueryReplaceLockGuard`], so no
-/// live kakehashi publisher can own a matching stage while this sweep runs.
-/// File symlinks are removed as directory entries; matching directories are
-/// not managed by this file-stage namespace and are left untouched.
-fn remove_stale_uninstall_stages(
-    queries_parent: &Path,
-    language: &str,
-) -> Result<(), QueryInstallError> {
-    for entry in fs::read_dir(queries_parent)? {
-        let entry = entry?;
-        let name = entry.file_name();
-        let Some(name) = name.to_str() else {
-            continue;
-        };
-        if !generated_uninstall_stage_matches_language(name, language) {
-            continue;
-        }
-        let file_type = entry.file_type()?;
-        if !file_type.is_file() && !file_type.is_symlink() {
-            continue;
-        }
-        match fs::remove_file(entry.path()) {
-            Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => return Err(QueryInstallError::IoError(error)),
-        }
-    }
-    Ok(())
-}
-
-fn generated_uninstall_stage_matches_language(name: &str, language: &str) -> bool {
-    let prefix = format!(".{language}.uninstalled.");
-    let Some(rest) = name
-        .strip_prefix(&prefix)
-        .and_then(|rest| rest.strip_suffix(".tmp"))
-    else {
-        return false;
-    };
-    let mut parts = rest.split('.');
-    let (Some(pid), Some(counter), Some(random), None) =
-        (parts.next(), parts.next(), parts.next(), parts.next())
-    else {
-        return false;
-    };
-    !pid.is_empty()
-        && pid.bytes().all(|byte| byte.is_ascii_digit())
-        && !counter.is_empty()
-        && counter.bytes().all(|byte| byte.is_ascii_digit())
-        && random.len() == 12
-        && random.bytes().all(|byte| byte.is_ascii_alphanumeric())
-}
-
 /// Open or create the managed tombstone leaf without following a link there.
 ///
 /// Parent components deliberately retain ordinary path resolution: users may
@@ -870,13 +815,14 @@ fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(error),
     };
-    if !file.metadata()?.file_type().is_file() {
+    let metadata = file.metadata()?;
+    if !metadata.file_type().is_file() {
         return Err(std::io::Error::other(
             "query uninstall tombstone is not a regular file",
         ));
     }
     use std::os::unix::fs::MetadataExt as _;
-    require_single_link(file.metadata()?.nlink())?;
+    require_single_link(metadata.nlink())?;
     Ok(())
 }
 
@@ -1600,28 +1546,6 @@ mod tests {
             vec![tombstone.file_name().unwrap().to_os_string()],
             "the private stage must be removed on every persist failure"
         );
-    }
-
-    #[test]
-    fn tombstone_publish_reclaims_crash_stranded_stage() {
-        let temp = TempDir::new().unwrap();
-        let queries_parent = temp.path().join("queries");
-        fs::create_dir_all(&queries_parent).unwrap();
-        let stale = queries_parent.join(".rust.uninstalled.123.7.ABCDEFGHIJKL.tmp");
-        fs::write(&stale, "partial\n").unwrap();
-        let same_language_unrelated = queries_parent.join(".rust.uninstalled.notes.tmp");
-        fs::write(&same_language_unrelated, "keep notes\n").unwrap();
-        let unrelated = queries_parent.join(".lua.uninstalled.123.7.ABCDEFGHIJKL.tmp");
-        fs::write(&unrelated, "keep\n").unwrap();
-
-        write_uninstall_tombstone(&queries_parent, "rust").unwrap();
-
-        assert!(!stale.exists(), "same-language stale stage is managed");
-        assert!(
-            same_language_unrelated.exists(),
-            "a wildcard-like name is not proof of kakehashi ownership"
-        );
-        assert!(unrelated.exists(), "other languages have separate locks");
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -789,7 +789,7 @@ fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
         ));
     }
     use std::os::unix::fs::MetadataExt as _;
-    reject_multiple_links(file.metadata()?.nlink())?;
+    require_single_link(file.metadata()?.nlink())?;
     Ok(file)
 }
 
@@ -830,15 +830,15 @@ fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
     }
     // SAFETY: GetFileInformationByHandle succeeded above.
     let information = unsafe { information.assume_init() };
-    reject_multiple_links(u64::from(information.nNumberOfLinks))?;
+    require_single_link(u64::from(information.nNumberOfLinks))?;
     Ok(file)
 }
 
 #[cfg(any(unix, windows))]
-fn reject_multiple_links(links: u64) -> std::io::Result<()> {
-    if links > 1 {
+fn require_single_link(links: u64) -> std::io::Result<()> {
+    if links != 1 {
         Err(std::io::Error::other(
-            "query uninstall tombstone has multiple hard links",
+            "query uninstall tombstone must have exactly one hard link",
         ))
     } else {
         Ok(())
@@ -1361,6 +1361,14 @@ mod tests {
             matches!(result, Err(QueryInstallError::IoError(_))),
             "a multiply linked managed tombstone must fail the uninstall"
         );
+    }
+
+    #[test]
+    #[cfg(any(unix, windows))]
+    fn tombstone_link_count_requires_one_live_name() {
+        assert!(require_single_link(0).is_err());
+        assert!(require_single_link(1).is_ok());
+        assert!(require_single_link(2).is_err());
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -851,10 +851,53 @@ fn prepare_windows_tombstone_publish(
     }
     // SAFETY: successful ReOpenFile returned a newly owned handle.
     let rename_handle = unsafe { fs::File::from_raw_handle(handle) };
+    normalize_windows_stage_attributes(&rename_handle)?;
     Ok(WindowsTombstonePublish {
         directory,
         rename_handle,
     })
+}
+
+#[cfg(windows)]
+fn normalize_windows_stage_attributes(file: &fs::File) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_NORMAL, FILE_ATTRIBUTE_TEMPORARY, FILE_BASIC_INFO, FileBasicInfo,
+        GetFileInformationByHandleEx, SetFileInformationByHandle,
+    };
+
+    let mut information = FILE_BASIC_INFO::default();
+    // SAFETY: `information` is the exact buffer for FileBasicInfo and `file`
+    // keeps the handle valid throughout both calls.
+    let read = unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle(),
+            FileBasicInfo,
+            (&mut information as *mut FILE_BASIC_INFO).cast(),
+            u32::try_from(std::mem::size_of::<FILE_BASIC_INFO>()).unwrap(),
+        )
+    };
+    if read == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    information.FileAttributes &= !FILE_ATTRIBUTE_TEMPORARY;
+    if information.FileAttributes == 0 {
+        information.FileAttributes = FILE_ATTRIBUTE_NORMAL;
+    }
+    // SAFETY: same valid handle and correctly sized initialized structure.
+    let written = unsafe {
+        SetFileInformationByHandle(
+            file.as_raw_handle(),
+            FileBasicInfo,
+            (&information as *const FILE_BASIC_INFO).cast(),
+            u32::try_from(std::mem::size_of::<FILE_BASIC_INFO>()).unwrap(),
+        )
+    };
+    if written == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(windows)]
@@ -1728,7 +1771,9 @@ mod tests {
     #[test]
     #[cfg(windows)]
     fn windows_tombstone_publish_replaces_raced_symlink_entry() {
+        use std::os::windows::fs::MetadataExt as _;
         use std::os::windows::fs::symlink_file;
+        use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_TEMPORARY;
 
         let temp = TempDir::new().unwrap();
         let queries_parent = temp.path().join("queries");
@@ -1753,6 +1798,14 @@ mod tests {
             "handle-relative replace must replace the symlink entry itself"
         );
         assert_eq!(fs::read_to_string(tombstone).unwrap(), "ok\n");
+        assert_eq!(
+            fs::metadata(uninstall_tombstone_path(&queries_parent, "rust"))
+                .unwrap()
+                .file_attributes()
+                & FILE_ATTRIBUTE_TEMPORARY,
+            0,
+            "published tombstone must not retain tempfile cache semantics"
+        );
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -768,6 +768,7 @@ fn write_uninstall_tombstone_with_before_publish(
     validate_safe_language_name(language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
     let existing_permissions = validate_existing_tombstone(&path)?;
+    let had_existing_tombstone = existing_permissions.is_some();
     let stage_counter = QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let stage_prefix = format!(
         ".{language}.uninstalled.{}.{}.",
@@ -790,9 +791,74 @@ fn write_uninstall_tombstone_with_before_publish(
     staged.write_all(b"ok\n")?;
     staged.as_file().sync_all()?;
     before_publish(&path, staged.path());
-    let published = staged.persist(&path).map_err(|error| error.error)?;
+    let published = publish_staged_tombstone(staged, &path, had_existing_tombstone)?;
     verify_published_tombstone(published, &path)?;
     Ok(())
+}
+
+#[cfg(not(windows))]
+fn publish_staged_tombstone(
+    staged: tempfile::NamedTempFile,
+    path: &Path,
+    _had_existing_tombstone: bool,
+) -> std::io::Result<fs::File> {
+    staged.persist(path).map_err(|error| error.error)
+}
+
+#[cfg(windows)]
+fn publish_staged_tombstone(
+    staged: tempfile::NamedTempFile,
+    path: &Path,
+    had_existing_tombstone: bool,
+) -> std::io::Result<fs::File> {
+    if !had_existing_tombstone {
+        return staged.persist(path).map_err(|error| error.error);
+    }
+
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_NORMAL, REPLACEFILE_WRITE_THROUGH, ReplaceFileW, SetFileAttributesW,
+    };
+
+    let (file, temporary_path) = staged.into_parts();
+    let temporary_wide: Vec<u16> = temporary_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let destination_wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    // NamedTempFile marks the stage temporary. Normalize it before
+    // publication, matching tempfile::persist's Windows implementation.
+    // SAFETY: both UTF-16 buffers are NUL-terminated and live through calls.
+    if unsafe { SetFileAttributesW(temporary_wide.as_ptr(), FILE_ATTRIBUTE_NORMAL) } == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // ReplaceFileW preserves the replaced file's security descriptor and
+    // other metadata that std::fs::Permissions cannot represent on Windows.
+    // WRITE_THROUGH also waits for the replacement to reach disk.
+    // SAFETY: paths are valid NUL-terminated buffers; optional pointers are
+    // null; `file` keeps the staged inode open for later identity checking.
+    let succeeded = unsafe {
+        ReplaceFileW(
+            destination_wide.as_ptr(),
+            temporary_wide.as_ptr(),
+            std::ptr::null(),
+            REPLACEFILE_WRITE_THROUGH,
+            std::ptr::null(),
+            std::ptr::null(),
+        )
+    };
+    if succeeded == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // The temporary pathname moved away. Dropping TempPath attempts to unlink
+    // that now-missing old name and must not touch the published destination.
+    drop(temporary_path);
+    Ok(file)
 }
 
 /// Open or create the managed tombstone leaf without following a link there.

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -767,10 +767,22 @@ fn write_uninstall_tombstone_with_before_publish(
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
-    let mut file = open_regular_tombstone(&path)?;
+    validate_existing_tombstone(&path)?;
+    let stage_prefix = format!(".{language}.uninstalled.");
+    let mut builder = tempfile::Builder::new();
+    builder.prefix(&stage_prefix);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        // Match File::create's 0o666 & !umask contract rather than inheriting
+        // tempfile's private 0o600 default when the inode is published.
+        builder.permissions(fs::Permissions::from_mode(0o666));
+    }
+    let mut staged = builder.tempfile_in(queries_parent)?;
+    staged.write_all(b"ok\n")?;
+    staged.as_file().sync_all()?;
     before_publish(&path);
-    file.set_len(0)?;
-    file.write_all(b"ok\n")?;
+    staged.persist(path).map_err(|error| error.error)?;
     Ok(())
 }
 
@@ -778,21 +790,25 @@ fn write_uninstall_tombstone_with_before_publish(
 ///
 /// Parent components deliberately retain ordinary path resolution: users may
 /// symlink their data directory or `queries` directory. Only the final,
-/// kakehashi-owned leaf is constrained, and truncation happens after the
-/// opened handle has been confirmed to name a regular file.
+/// kakehashi-owned leaf is constrained. An observed existing leaf is validated,
+/// then a private same-directory inode atomically replaces its directory entry;
+/// no pre-existing inode is ever truncated.
 #[cfg(unix)]
-fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
+fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
     use std::os::unix::fs::OpenOptionsExt;
 
-    let file = fs::OpenOptions::new()
-        .create(true)
+    let file = match fs::OpenOptions::new()
         .write(true)
-        .truncate(false)
         // O_NOFOLLOW binds the validation to the opened leaf rather than a
         // racy metadata pre-check. O_NONBLOCK prevents a substituted FIFO
         // from blocking the uninstall before fstat can reject it.
         .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK)
-        .open(path)?;
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
     if !file.metadata()?.file_type().is_file() {
         return Err(std::io::Error::other(
             "query uninstall tombstone is not a regular file",
@@ -800,24 +816,28 @@ fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
     }
     use std::os::unix::fs::MetadataExt as _;
     require_single_link(file.metadata()?.nlink())?;
-    Ok(file)
+    Ok(())
 }
 
 #[cfg(windows)]
-fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
+fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
     use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
     use windows_sys::Win32::Storage::FileSystem::{
         FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT,
     };
 
-    let file = fs::OpenOptions::new()
-        .create(true)
+    let file = match fs::OpenOptions::new()
         .write(true)
-        .truncate(false)
         // Open the reparse point itself, if present, so validation cannot be
-        // raced into following its target. Truncation happens only afterward.
+        // raced into following its target. Publication later replaces the
+        // directory entry rather than writing through this handle.
         .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
-        .open(path)?;
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
     let metadata = file.metadata()?;
     if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
         || !metadata.file_type().is_file()
@@ -841,7 +861,7 @@ fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
     // SAFETY: GetFileInformationByHandle succeeded above.
     let information = unsafe { information.assume_init() };
     require_single_link(u64::from(information.nNumberOfLinks))?;
-    Ok(file)
+    Ok(())
 }
 
 #[cfg(any(unix, windows))]
@@ -856,13 +876,15 @@ fn require_single_link(links: u64) -> std::io::Result<()> {
 }
 
 #[cfg(not(any(unix, windows)))]
-fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
-    // No portable no-follow open exists. Creating a fresh leaf is atomic and
-    // safe; conservatively reject an existing leaf on these platforms.
-    fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(path)
+fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => Ok(()),
+        Ok(_) => Err(std::io::Error::other(
+            "query uninstall tombstone is not a regular file",
+        )),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
 }
 
 fn clear_uninstall_tombstone(
@@ -1370,6 +1392,95 @@ mod tests {
         assert!(
             matches!(result, Err(QueryInstallError::IoError(_))),
             "an already multiply linked managed tombstone must fail the uninstall"
+        );
+    }
+
+    #[test]
+    fn tombstone_publish_does_not_truncate_raced_hard_link_alias() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let tombstone = uninstall_tombstone_path(&queries_parent, "rust");
+        fs::write(&tombstone, "old tombstone\n").unwrap();
+        let outside_alias = temp.path().join("outside-alias");
+
+        write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path| {
+            fs::hard_link(path, &outside_alias).unwrap();
+        })
+        .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&outside_alias).unwrap(),
+            "old tombstone\n",
+            "a link raced after validation must retain the old inode contents"
+        );
+        assert_eq!(fs::read_to_string(tombstone).unwrap(), "ok\n");
+    }
+
+    #[test]
+    fn failed_tombstone_publish_cleans_private_stage() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let tombstone = uninstall_tombstone_path(&queries_parent, "rust");
+        fs::write(&tombstone, "old tombstone\n").unwrap();
+
+        let result =
+            write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path| {
+                fs::remove_file(path).unwrap();
+                fs::create_dir(path).unwrap();
+            });
+
+        assert!(result.is_err(), "a directory cannot be replaced by a file");
+        let names: Vec<_> = fs::read_dir(&queries_parent)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        assert_eq!(
+            names,
+            vec![tombstone.file_name().unwrap().to_os_string()],
+            "the private stage must be removed on every persist failure"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn tombstone_atomic_publish_preserves_file_create_umask_mode() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let control = queries_parent.join("control");
+        fs::File::create(&control).unwrap();
+
+        write_uninstall_tombstone(&queries_parent, "rust").unwrap();
+
+        let expected = fs::metadata(control).unwrap().permissions().mode() & 0o777;
+        let actual = fs::metadata(uninstall_tombstone_path(&queries_parent, "rust"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn remove_query_install_supports_windows_symlinked_queries_parent() {
+        use std::os::windows::fs::symlink_dir;
+
+        let temp = TempDir::new().unwrap();
+        let real_queries = temp.path().join("real-queries");
+        fs::create_dir_all(&real_queries).unwrap();
+        let linked_queries = temp.path().join("queries");
+        symlink_dir(&real_queries, &linked_queries).unwrap();
+
+        remove_query_install_and_backups(&linked_queries, "rust").unwrap();
+
+        assert_eq!(
+            fs::read_to_string(uninstall_tombstone_path(&real_queries, "rust")).unwrap(),
+            "ok\n"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -768,6 +768,7 @@ fn write_uninstall_tombstone_with_before_publish(
     validate_safe_language_name(language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
     let existing_permissions = validate_existing_tombstone(&path)?;
+    #[cfg(not(windows))]
     let had_existing_tombstone = existing_permissions.is_some();
     let stage_counter = QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let stage_prefix = format!(
@@ -790,8 +791,13 @@ fn write_uninstall_tombstone_with_before_publish(
     }
     staged.write_all(b"ok\n")?;
     staged.as_file().sync_all()?;
+    #[cfg(windows)]
+    let windows_publish = prepare_windows_tombstone_publish(queries_parent, staged.as_file())?;
     before_publish(&path, staged.path());
+    #[cfg(not(windows))]
     let published = publish_staged_tombstone(staged, &path, had_existing_tombstone)?;
+    #[cfg(windows)]
+    let published = publish_staged_tombstone(staged, &path, windows_publish)?;
     verify_published_tombstone(published, &path)?;
     Ok(())
 }
@@ -806,59 +812,100 @@ fn publish_staged_tombstone(
 }
 
 #[cfg(windows)]
+struct WindowsTombstonePublish {
+    directory: fs::File,
+    rename_handle: fs::File,
+}
+
+#[cfg(windows)]
+fn prepare_windows_tombstone_publish(
+    queries_parent: &Path,
+    staged: &fs::File,
+) -> std::io::Result<WindowsTombstonePublish> {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    use std::os::windows::io::{AsRawHandle as _, FromRawHandle as _};
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        DELETE, FILE_FLAG_BACKUP_SEMANTICS, FILE_GENERIC_READ, FILE_GENERIC_WRITE,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, ReOpenFile,
+    };
+
+    let directory = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+        .open(queries_parent)?;
+    // Reopen the already-created stage BY HANDLE with DELETE access. This
+    // cannot be redirected by replacing its temporary pathname later.
+    // SAFETY: `staged` remains valid for the call; a successful returned
+    // handle is newly owned and converted exactly once into `File`.
+    let handle = unsafe {
+        ReOpenFile(
+            staged.as_raw_handle(),
+            FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            0,
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: successful ReOpenFile returned a newly owned handle.
+    let rename_handle = unsafe { fs::File::from_raw_handle(handle) };
+    Ok(WindowsTombstonePublish {
+        directory,
+        rename_handle,
+    })
+}
+
+#[cfg(windows)]
 fn publish_staged_tombstone(
     staged: tempfile::NamedTempFile,
     path: &Path,
-    had_existing_tombstone: bool,
+    publish: WindowsTombstonePublish,
 ) -> std::io::Result<fs::File> {
-    if !had_existing_tombstone {
-        return staged.persist(path).map_err(|error| error.error);
-    }
-
     use std::os::windows::ffi::OsStrExt as _;
+    use std::os::windows::io::AsRawHandle as _;
     use windows_sys::Win32::Storage::FileSystem::{
-        FILE_ATTRIBUTE_NORMAL, REPLACEFILE_WRITE_THROUGH, ReplaceFileW, SetFileAttributesW,
+        FILE_RENAME_INFO, FileRenameInfo, SetFileInformationByHandle,
     };
 
-    let (file, temporary_path) = staged.into_parts();
-    let temporary_wide: Vec<u16> = temporary_path
-        .as_os_str()
+    let filename: Vec<u16> = path
+        .file_name()
+        .ok_or_else(|| std::io::Error::other("tombstone path has no file name"))?
         .encode_wide()
-        .chain(std::iter::once(0))
         .collect();
-    let destination_wide: Vec<u16> = path
-        .as_os_str()
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect();
-    // NamedTempFile marks the stage temporary. Normalize it before
-    // publication, matching tempfile::persist's Windows implementation.
-    // SAFETY: both UTF-16 buffers are NUL-terminated and live through calls.
-    if unsafe { SetFileAttributesW(temporary_wide.as_ptr(), FILE_ATTRIBUTE_NORMAL) } == 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    // ReplaceFileW preserves the replaced file's security descriptor and
-    // other metadata that std::fs::Permissions cannot represent on Windows.
-    // WRITE_THROUGH also waits for the replacement to reach disk.
-    // SAFETY: paths are valid NUL-terminated buffers; optional pointers are
-    // null; `file` keeps the staged inode open for later identity checking.
+    let header = std::mem::offset_of!(FILE_RENAME_INFO, FileName);
+    let size = header + filename.len() * std::mem::size_of::<u16>();
+    let units = size.div_ceil(std::mem::size_of::<FILE_RENAME_INFO>());
+    let mut buffer = vec![FILE_RENAME_INFO::default(); units];
+    let information = buffer.as_mut_ptr();
+    // Rename the already-opened stage relative to the parent handle pinned
+    // before the race hook. ReplaceIfExists replaces a reparse-point directory
+    // entry; it never opens/follows that entry's target.
+    // SAFETY: `buffer` covers the header and UTF-16 filename; both file handles
+    // remain alive; the relative name has no separators.
     let succeeded = unsafe {
-        ReplaceFileW(
-            destination_wide.as_ptr(),
-            temporary_wide.as_ptr(),
-            std::ptr::null(),
-            REPLACEFILE_WRITE_THROUGH,
-            std::ptr::null(),
-            std::ptr::null(),
+        (*information).Anonymous.ReplaceIfExists = true;
+        (*information).RootDirectory = publish.directory.as_raw_handle();
+        (*information).FileNameLength = u32::try_from(filename.len() * 2).unwrap();
+        std::ptr::copy_nonoverlapping(
+            filename.as_ptr(),
+            (*information).FileName.as_mut_ptr(),
+            filename.len(),
+        );
+        SetFileInformationByHandle(
+            publish.rename_handle.as_raw_handle(),
+            FileRenameInfo,
+            information.cast(),
+            u32::try_from(size).unwrap(),
         )
     };
     if succeeded == 0 {
         return Err(std::io::Error::last_os_error());
     }
-    // The temporary pathname moved away. Dropping TempPath attempts to unlink
-    // that now-missing old name and must not touch the published destination.
+    let (_original_handle, temporary_path) = staged.into_parts();
     drop(temporary_path);
-    Ok(file)
+    Ok(publish.rename_handle)
 }
 
 /// Open or create the managed tombstone leaf without following a link there.
@@ -1676,6 +1723,36 @@ mod tests {
             fs::read_to_string(uninstall_tombstone_path(&real_queries, "rust")).unwrap(),
             "ok\n"
         );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn windows_tombstone_publish_replaces_raced_symlink_entry() {
+        use std::os::windows::fs::symlink_file;
+
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let tombstone = uninstall_tombstone_path(&queries_parent, "rust");
+        fs::write(&tombstone, "old\n").unwrap();
+        let victim = temp.path().join("victim");
+        fs::write(&victim, "keep me\n").unwrap();
+
+        write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path, _| {
+            fs::remove_file(path).unwrap();
+            symlink_file(&victim, path).unwrap();
+        })
+        .unwrap();
+
+        assert_eq!(fs::read_to_string(victim).unwrap(), "keep me\n");
+        assert!(
+            fs::symlink_metadata(&tombstone)
+                .unwrap()
+                .file_type()
+                .is_file(),
+            "handle-relative replace must replace the symlink entry itself"
+        );
+        assert_eq!(fs::read_to_string(tombstone).unwrap(), "ok\n");
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -757,8 +757,18 @@ fn write_uninstall_tombstone(
     queries_parent: &Path,
     language: &str,
 ) -> Result<(), QueryInstallError> {
+    write_uninstall_tombstone_with_before_publish(queries_parent, language, |_| {})
+}
+
+fn write_uninstall_tombstone_with_before_publish(
+    queries_parent: &Path,
+    language: &str,
+    before_publish: impl FnOnce(&Path),
+) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
-    let mut file = open_regular_tombstone(&uninstall_tombstone_path(queries_parent, language))?;
+    let path = uninstall_tombstone_path(queries_parent, language);
+    let mut file = open_regular_tombstone(&path)?;
+    before_publish(&path);
     file.set_len(0)?;
     file.write_all(b"ok\n")?;
     Ok(())
@@ -1359,16 +1369,8 @@ mod tests {
         );
         assert!(
             matches!(result, Err(QueryInstallError::IoError(_))),
-            "a multiply linked managed tombstone must fail the uninstall"
+            "an already multiply linked managed tombstone must fail the uninstall"
         );
-    }
-
-    #[test]
-    #[cfg(any(unix, windows))]
-    fn tombstone_link_count_requires_one_live_name() {
-        assert!(require_single_link(0).is_err());
-        assert!(require_single_link(1).is_ok());
-        assert!(require_single_link(2).is_err());
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -767,7 +767,7 @@ fn write_uninstall_tombstone_with_before_publish(
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
-    validate_existing_tombstone(&path)?;
+    let existing_permissions = validate_existing_tombstone(&path)?;
     let stage_counter = QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let stage_prefix = format!(
         ".{language}.uninstalled.{}.{}.",
@@ -784,6 +784,9 @@ fn write_uninstall_tombstone_with_before_publish(
         builder.permissions(fs::Permissions::from_mode(0o666));
     }
     let mut staged = builder.tempfile_in(queries_parent)?;
+    if let Some(permissions) = existing_permissions {
+        staged.as_file().set_permissions(permissions)?;
+    }
     staged.write_all(b"ok\n")?;
     staged.as_file().sync_all()?;
     before_publish(&path, staged.path());
@@ -800,7 +803,7 @@ fn write_uninstall_tombstone_with_before_publish(
 /// then a private same-directory inode atomically replaces its directory entry;
 /// no pre-existing inode is ever truncated.
 #[cfg(unix)]
-fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
+fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
     use std::os::unix::fs::OpenOptionsExt;
 
     let file = match fs::OpenOptions::new()
@@ -812,7 +815,7 @@ fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
         .open(path)
     {
         Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(error),
     };
     let metadata = file.metadata()?;
@@ -823,11 +826,11 @@ fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
     }
     use std::os::unix::fs::MetadataExt as _;
     require_single_link(metadata.nlink())?;
-    Ok(())
+    Ok(Some(metadata.permissions()))
 }
 
 #[cfg(windows)]
-fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
+fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
     use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
     use windows_sys::Win32::Storage::FileSystem::{
         FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT,
@@ -842,7 +845,7 @@ fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
         .open(path)
     {
         Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(error),
     };
     let metadata = file.metadata()?;
@@ -855,7 +858,7 @@ fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
     }
     let information = windows_file_information(&file)?;
     require_single_link(u64::from(information.nNumberOfLinks))?;
-    Ok(())
+    Ok(Some(metadata.permissions()))
 }
 
 #[cfg(any(unix, windows))]
@@ -954,13 +957,13 @@ fn verify_published_tombstone(_published: fs::File, path: &Path) -> std::io::Res
 }
 
 #[cfg(not(any(unix, windows)))]
-fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
+fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
     match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_file() => Ok(()),
+        Ok(metadata) if metadata.file_type().is_file() => Ok(Some(metadata.permissions())),
         Ok(_) => Err(std::io::Error::other(
             "query uninstall tombstone is not a regular file",
         )),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(error) => Err(error),
     }
 }
@@ -1568,6 +1571,26 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn tombstone_atomic_publish_preserves_existing_mode() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let tombstone = uninstall_tombstone_path(&queries_parent, "rust");
+        fs::write(&tombstone, "old\n").unwrap();
+        fs::set_permissions(&tombstone, fs::Permissions::from_mode(0o600)).unwrap();
+
+        write_uninstall_tombstone(&queries_parent, "rust").unwrap();
+
+        assert_eq!(
+            fs::metadata(tombstone).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -757,13 +757,13 @@ fn write_uninstall_tombstone(
     queries_parent: &Path,
     language: &str,
 ) -> Result<(), QueryInstallError> {
-    write_uninstall_tombstone_with_before_publish(queries_parent, language, |_| {})
+    write_uninstall_tombstone_with_before_publish(queries_parent, language, |_, _| {})
 }
 
 fn write_uninstall_tombstone_with_before_publish(
     queries_parent: &Path,
     language: &str,
-    before_publish: impl FnOnce(&Path),
+    before_publish: impl FnOnce(&Path, &Path),
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
@@ -781,7 +781,7 @@ fn write_uninstall_tombstone_with_before_publish(
     let mut staged = builder.tempfile_in(queries_parent)?;
     staged.write_all(b"ok\n")?;
     staged.as_file().sync_all()?;
-    before_publish(&path);
+    before_publish(&path, staged.path());
     staged.persist(path).map_err(|error| error.error)?;
     Ok(())
 }
@@ -1404,7 +1404,7 @@ mod tests {
         fs::write(&tombstone, "old tombstone\n").unwrap();
         let outside_alias = temp.path().join("outside-alias");
 
-        write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path| {
+        write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path, _| {
             fs::hard_link(path, &outside_alias).unwrap();
         })
         .unwrap();
@@ -1426,7 +1426,7 @@ mod tests {
         fs::write(&tombstone, "old tombstone\n").unwrap();
 
         let result =
-            write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path| {
+            write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path, _| {
                 fs::remove_file(path).unwrap();
                 fs::create_dir(path).unwrap();
             });

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -788,6 +788,8 @@ fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
             "query uninstall tombstone is not a regular file",
         ));
     }
+    use std::os::unix::fs::MetadataExt as _;
+    reject_multiple_links(file.metadata()?.nlink())?;
     Ok(file)
 }
 
@@ -814,7 +816,33 @@ fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
             "query uninstall tombstone is not a regular file",
         ));
     }
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
+    };
+    let mut information = std::mem::MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
+    // SAFETY: `file` keeps this handle valid for the call, and Windows
+    // initializes the complete output structure whenever it reports success.
+    let succeeded =
+        unsafe { GetFileInformationByHandle(file.as_raw_handle(), information.as_mut_ptr()) };
+    if succeeded == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: GetFileInformationByHandle succeeded above.
+    let information = unsafe { information.assume_init() };
+    reject_multiple_links(u64::from(information.nNumberOfLinks))?;
     Ok(file)
+}
+
+#[cfg(any(unix, windows))]
+fn reject_multiple_links(links: u64) -> std::io::Result<()> {
+    if links > 1 {
+        Err(std::io::Error::other(
+            "query uninstall tombstone has multiple hard links",
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(not(any(unix, windows)))]
@@ -1310,6 +1338,28 @@ mod tests {
         assert_eq!(
             fs::read_to_string(uninstall_tombstone_path(&real_queries, "rust")).unwrap(),
             "ok\n"
+        );
+    }
+
+    #[test]
+    fn remove_query_install_rejects_hard_linked_uninstall_tombstone() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let victim = temp.path().join("victim");
+        fs::write(&victim, "keep me\n").unwrap();
+        fs::hard_link(&victim, uninstall_tombstone_path(&queries_parent, "rust")).unwrap();
+
+        let result = remove_query_install_and_backups(&queries_parent, "rust");
+
+        assert_eq!(
+            fs::read_to_string(&victim).unwrap(),
+            "keep me\n",
+            "opening the tombstone must not overwrite another hard-link name"
+        );
+        assert!(
+            matches!(result, Err(QueryInstallError::IoError(_))),
+            "a multiply linked managed tombstone must fail the uninstall"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -782,7 +782,8 @@ fn write_uninstall_tombstone_with_before_publish(
     staged.write_all(b"ok\n")?;
     staged.as_file().sync_all()?;
     before_publish(&path, staged.path());
-    staged.persist(path).map_err(|error| error.error)?;
+    let published = staged.persist(&path).map_err(|error| error.error)?;
+    verify_published_tombstone(published, &path)?;
     Ok(())
 }
 
@@ -846,20 +847,7 @@ fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
             "query uninstall tombstone is not a regular file",
         ));
     }
-    use std::os::windows::io::AsRawHandle as _;
-    use windows_sys::Win32::Storage::FileSystem::{
-        BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
-    };
-    let mut information = std::mem::MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
-    // SAFETY: `file` keeps this handle valid for the call, and Windows
-    // initializes the complete output structure whenever it reports success.
-    let succeeded =
-        unsafe { GetFileInformationByHandle(file.as_raw_handle(), information.as_mut_ptr()) };
-    if succeeded == 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    // SAFETY: GetFileInformationByHandle succeeded above.
-    let information = unsafe { information.assume_init() };
+    let information = windows_file_information(&file)?;
     require_single_link(u64::from(information.nNumberOfLinks))?;
     Ok(())
 }
@@ -872,6 +860,90 @@ fn require_single_link(links: u64) -> std::io::Result<()> {
         ))
     } else {
         Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn verify_published_tombstone(published: fs::File, path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _};
+
+    let expected = published.metadata()?;
+    drop(published);
+    let final_file = fs::OpenOptions::new()
+        .write(true)
+        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK)
+        .open(path)?;
+    let actual = final_file.metadata()?;
+    if !actual.file_type().is_file()
+        || actual.nlink() != 1
+        || expected.dev() != actual.dev()
+        || expected.ino() != actual.ino()
+    {
+        return Err(std::io::Error::other(
+            "published query uninstall tombstone changed identity",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn verify_published_tombstone(published: fs::File, path: &Path) -> std::io::Result<()> {
+    use std::os::windows::fs::{MetadataExt as _, OpenOptionsExt as _};
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT,
+    };
+
+    let expected = windows_file_information(&published)?;
+    drop(published);
+    let final_file = fs::OpenOptions::new()
+        .write(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)?;
+    let metadata = final_file.metadata()?;
+    let actual = windows_file_information(&final_file)?;
+    if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+        || !metadata.file_type().is_file()
+        || actual.nNumberOfLinks != 1
+        || expected.dwVolumeSerialNumber != actual.dwVolumeSerialNumber
+        || expected.nFileIndexHigh != actual.nFileIndexHigh
+        || expected.nFileIndexLow != actual.nFileIndexLow
+    {
+        return Err(std::io::Error::other(
+            "published query uninstall tombstone changed identity",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn windows_file_information(
+    file: &fs::File,
+) -> std::io::Result<windows_sys::Win32::Storage::FileSystem::BY_HANDLE_FILE_INFORMATION> {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
+    };
+
+    let mut information = std::mem::MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
+    // SAFETY: `file` keeps this handle valid for the call, and Windows
+    // initializes the complete output structure whenever it reports success.
+    let succeeded =
+        unsafe { GetFileInformationByHandle(file.as_raw_handle(), information.as_mut_ptr()) };
+    if succeeded == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: GetFileInformationByHandle succeeded above.
+    Ok(unsafe { information.assume_init() })
+}
+
+#[cfg(not(any(unix, windows)))]
+fn verify_published_tombstone(_published: fs::File, path: &Path) -> std::io::Result<()> {
+    if fs::symlink_metadata(path)?.file_type().is_file() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(
+            "published query uninstall tombstone is not a regular file",
+        ))
     }
 }
 
@@ -1415,6 +1487,33 @@ mod tests {
             "a link raced after validation must retain the old inode contents"
         );
         assert_eq!(fs::read_to_string(tombstone).unwrap(), "ok\n");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn tombstone_publish_rejects_substituted_private_stage() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let victim = temp.path().join("victim");
+        fs::write(&victim, "keep me\n").unwrap();
+
+        let result = write_uninstall_tombstone_with_before_publish(
+            &queries_parent,
+            "rust",
+            |_, staged_path| {
+                fs::remove_file(staged_path).unwrap();
+                symlink(&victim, staged_path).unwrap();
+            },
+        );
+
+        assert!(
+            result.is_err(),
+            "publication must reject a stage path detached from its opened handle"
+        );
+        assert_eq!(fs::read_to_string(victim).unwrap(), "keep me\n");
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -758,9 +758,73 @@ fn write_uninstall_tombstone(
     language: &str,
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
-    let mut file = fs::File::create(uninstall_tombstone_path(queries_parent, language))?;
+    let mut file = open_regular_tombstone(&uninstall_tombstone_path(queries_parent, language))?;
+    file.set_len(0)?;
     file.write_all(b"ok\n")?;
     Ok(())
+}
+
+/// Open or create the managed tombstone leaf without following a link there.
+///
+/// Parent components deliberately retain ordinary path resolution: users may
+/// symlink their data directory or `queries` directory. Only the final,
+/// kakehashi-owned leaf is constrained, and truncation happens after the
+/// opened handle has been confirmed to name a regular file.
+#[cfg(unix)]
+fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        // O_NOFOLLOW binds the validation to the opened leaf rather than a
+        // racy metadata pre-check. O_NONBLOCK prevents a substituted FIFO
+        // from blocking the uninstall before fstat can reject it.
+        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK)
+        .open(path)?;
+    if !file.metadata()?.file_type().is_file() {
+        return Err(std::io::Error::other(
+            "query uninstall tombstone is not a regular file",
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(windows)]
+fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
+    use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT,
+    };
+
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        // Open the reparse point itself, if present, so validation cannot be
+        // raced into following its target. Truncation happens only afterward.
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)?;
+    let metadata = file.metadata()?;
+    if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+        || !metadata.file_type().is_file()
+    {
+        return Err(std::io::Error::other(
+            "query uninstall tombstone is not a regular file",
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
+    // No portable no-follow open exists. Creating a fresh leaf is atomic and
+    // safe; conservatively reject an existing leaf on these platforms.
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
 }
 
 fn clear_uninstall_tombstone(
@@ -1189,6 +1253,63 @@ mod tests {
         assert!(
             !queries_parent.exists(),
             "unsafe cleanup must not even create the queries directory"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn remove_query_install_rejects_symlinked_uninstall_tombstone() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let victim = temp.path().join("victim");
+        fs::write(&victim, "keep me\n").unwrap();
+        symlink(&victim, uninstall_tombstone_path(&queries_parent, "rust")).unwrap();
+
+        let result = remove_query_install_and_backups(&queries_parent, "rust");
+
+        assert_eq!(
+            fs::read_to_string(&victim).unwrap(),
+            "keep me\n",
+            "opening the tombstone must not follow and overwrite its target"
+        );
+        assert!(
+            matches!(result, Err(QueryInstallError::IoError(_))),
+            "a managed tombstone symlink must fail the uninstall"
+        );
+    }
+
+    #[test]
+    fn remove_query_install_reuses_regular_uninstall_tombstone() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let tombstone = uninstall_tombstone_path(&queries_parent, "rust");
+        fs::write(&tombstone, "stale tombstone contents\n").unwrap();
+
+        remove_query_install_and_backups(&queries_parent, "rust").unwrap();
+
+        assert_eq!(fs::read_to_string(tombstone).unwrap(), "ok\n");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn remove_query_install_supports_symlinked_queries_parent() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let real_queries = temp.path().join("real-queries");
+        fs::create_dir_all(&real_queries).unwrap();
+        let linked_queries = temp.path().join("queries");
+        symlink(&real_queries, &linked_queries).unwrap();
+
+        remove_query_install_and_backups(&linked_queries, "rust").unwrap();
+
+        assert_eq!(
+            fs::read_to_string(uninstall_tombstone_path(&real_queries, "rust")).unwrap(),
+            "ok\n"
         );
     }
 


### PR DESCRIPTION
## Summary

- reject pre-existing tombstone symlinks, reparse points, special files, and multiply linked regular leaves before uninstall
- publish `ok` through a private same-parent inode so no pre-existing inode is truncated, including a hard-link alias raced after validation
- preserve symlinked `data_dir` / `queries` parents while constraining only the managed tombstone leaf
- verify the published inode against a no-follow final reopen; on Windows, pin parent/stage handles and replace the basename with `FileRenameInfo`
- preserve Unix existing modes/new-file umask behavior and normalize Windows tempfile attributes

Closes #822

## Security boundary

This PR prevents this call from opening, following, truncating, or writing an outside victim through the managed tombstone leaf. Whole-transaction confinement against a concurrently retargeted writable parent is separately tracked by #830.

## Follow-ups found during review

- #829: make uninstall-intent directory publication power-loss durable before destructive removal
- #830: bind the full query transaction to one parent-directory identity
- #832: recover crash-stranded named stages only with verifiable ownership
- #836: preserve full Windows owner/DACL metadata through handle-bound replacement

## Validation

- strict RED: symlink leaf overwrote victim (`keep me` became `ok`)
- strict RED: hard-link alias raced after validation was truncated
- strict RED: substituted private stage was accepted
- strict RED: existing Unix `0600` mode became `0644`
- `cargo test --lib -q tombstone_` (8/8)
- `cargo test --lib -q remove_query_install_` (5/5)
- `make check`
- full library suite: 2903 passed, 2 ignored; 5 unrelated current-main failures (missing rust fixture and four closed-host bridge lifecycle tests)
- Stage 1 multi-perspective review: clean at `c029c61d4`
- Codex continued review: clean after findings fixed/refuted
- Codex fresh review: first-response `No comments`

## Platform note

The Windows release target is not installed locally. Windows code was fact-checked against the `windows-sys` API and reviewed independently; cfg-gated regressions cover parent symlinks, destination reparse replacement, and clearing `FILE_ATTRIBUTE_TEMPORARY` when run on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved uninstall reliability by making tombstone updates atomic, reducing the risk of incomplete or corrupted uninstall state.
  * Added safeguards against symlinks, hard links, file replacement races, and other filesystem manipulation scenarios.
  * Preserved appropriate file permissions and cleaned up temporary files when updates fail.

* **Platform Support**
  * Improved compatibility and safety for uninstall operations on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->