### PR TITLE
fix(semantic): respect end-exclusive token ranges

### DIFF
--- a/src/analysis/semantic/range.rs
+++ b/src/analysis/semantic/range.rs
@@ -27,7 +27,7 @@ pub(crate) fn filter_semantic_tokens_by_range(
     }
 }
 
-/// Filter semantic tokens to only those within the specified range.
+/// Filter semantic tokens to only those intersecting the specified range.
 ///
 /// This function:
 /// 1. Converts delta-encoded tokens to absolute positions
@@ -44,7 +44,7 @@ fn filter_tokens_by_range(tokens: &[SemanticToken], range: &Range) -> Vec<Semant
     let mut abs_line = 0usize;
     let mut abs_col = 0usize;
 
-    // Collect tokens that are within the range (with absolute positions)
+    // Collect tokens intersecting the range (with absolute positions)
     let mut filtered_tokens: Vec<(usize, usize, u32, u32, u32)> = Vec::new();
 
     for token in tokens {
@@ -56,11 +56,17 @@ fn filter_tokens_by_range(tokens: &[SemanticToken], range: &Range) -> Vec<Semant
             abs_col += token.delta_start as usize;
         }
 
-        // Check if token is within range
-        if abs_line >= start_line && abs_line <= end_line {
+        // Delta encoding orders tokens monotonically, so later tokens cannot
+        // re-enter the range after either end boundary has been reached.
+        if abs_line > end_line {
+            break;
+        }
+
+        // Check if token intersects the range
+        if abs_line >= start_line {
             // For boundary lines, check column positions
             if abs_line == end_line && abs_col >= range.end.character as usize {
-                continue;
+                break;
             }
             if abs_line == start_line
                 && abs_col + token.length as usize <= range.start.character as usize

--- a/src/analysis/semantic/range.rs
+++ b/src/analysis/semantic/range.rs
@@ -31,9 +31,13 @@ pub(crate) fn filter_semantic_tokens_by_range(
 ///
 /// This function:
 /// 1. Converts delta-encoded tokens to absolute positions
-/// 2. Filters to tokens within the range (inclusive)
+/// 2. Keeps tokens that intersect the end-exclusive range
 /// 3. Re-encodes as delta-encoded tokens
 fn filter_tokens_by_range(tokens: &[SemanticToken], range: &Range) -> Vec<SemanticToken> {
+    if (range.start.line, range.start.character) >= (range.end.line, range.end.character) {
+        return Vec::new();
+    }
+
     let start_line = range.start.line as usize;
     let end_line = range.end.line as usize;
 
@@ -235,6 +239,32 @@ mod tests {
         assert!(
             filter_tokens_by_range(&tokens, &range).is_empty(),
             "a token beginning at the end-exclusive boundary is outside the range"
+        );
+    }
+
+    #[test]
+    fn test_filter_tokens_returns_nothing_for_empty_range_inside_token() {
+        let tokens = vec![SemanticToken {
+            delta_line: 1,
+            delta_start: 5,
+            length: 3,
+            token_type: 0,
+            token_modifiers_bitset: 0,
+        }];
+        let range = Range {
+            start: Position {
+                line: 1,
+                character: 6,
+            },
+            end: Position {
+                line: 1,
+                character: 6,
+            },
+        };
+
+        assert!(
+            filter_tokens_by_range(&tokens, &range).is_empty(),
+            "an empty range intersects no semantic token"
         );
     }
 

--- a/src/analysis/semantic/range.rs
+++ b/src/analysis/semantic/range.rs
@@ -243,6 +243,32 @@ mod tests {
     }
 
     #[test]
+    fn test_filter_tokens_excludes_end_boundary_on_multiline_range() {
+        let tokens = vec![SemanticToken {
+            delta_line: 1,
+            delta_start: 5,
+            length: 3,
+            token_type: 0,
+            token_modifiers_bitset: 0,
+        }];
+        let range = Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 1,
+                character: 5,
+            },
+        };
+
+        assert!(
+            filter_tokens_by_range(&tokens, &range).is_empty(),
+            "the end line retains the range's exclusive character boundary"
+        );
+    }
+
+    #[test]
     fn test_filter_tokens_returns_nothing_for_empty_range_inside_token() {
         let tokens = vec![SemanticToken {
             delta_line: 1,

--- a/src/analysis/semantic/range.rs
+++ b/src/analysis/semantic/range.rs
@@ -55,7 +55,7 @@ fn filter_tokens_by_range(tokens: &[SemanticToken], range: &Range) -> Vec<Semant
         // Check if token is within range
         if abs_line >= start_line && abs_line <= end_line {
             // For boundary lines, check column positions
-            if abs_line == end_line && abs_col > range.end.character as usize {
+            if abs_line == end_line && abs_col >= range.end.character as usize {
                 continue;
             }
             if abs_line == start_line
@@ -209,6 +209,32 @@ mod tests {
         assert!(
             filtered.is_empty(),
             "Token starting after range.end should be excluded"
+        );
+    }
+
+    #[test]
+    fn test_filter_tokens_excludes_token_starting_at_exclusive_range_end() {
+        let tokens = vec![SemanticToken {
+            delta_line: 1,
+            delta_start: 5,
+            length: 3,
+            token_type: 0,
+            token_modifiers_bitset: 0,
+        }];
+        let range = Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 1,
+                character: 5,
+            },
+        };
+
+        assert!(
+            filter_tokens_by_range(&tokens, &range).is_empty(),
+            "a token beginning at the end-exclusive boundary is outside the range"
         );
     }
 

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -25,7 +25,7 @@ use url::Url;
 
 #[cfg(test)]
 use tower_lsp_server::ls_types::{
-    PartialResultParams, TextDocumentIdentifier, WorkDoneProgressParams,
+    PartialResultParams, Position, Range, TextDocumentIdentifier, WorkDoneProgressParams,
 };
 
 use crate::analysis::{
@@ -1063,6 +1063,14 @@ impl Kakehashi {
         };
 
         let domain_range = range;
+        if (domain_range.start.line, domain_range.start.character)
+            >= (domain_range.end.line, domain_range.end.character)
+        {
+            return Ok(Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
+                result_id: None,
+                data: vec![],
+            })));
+        }
 
         // Snapshot the settings generation at the top, before any await (#535): a
         // reload that bumps the generation after this leaves this request's stored
@@ -1341,6 +1349,55 @@ mod tests {
             work_done_progress_params: WorkDoneProgressParams::default(),
             partial_result_params: PartialResultParams::default(),
         }
+    }
+
+    fn range_params(uri: &Url, range: Range) -> SemanticTokensRangeParams {
+        SemanticTokensRangeParams {
+            text_document: TextDocumentIdentifier {
+                uri: crate::lsp::lsp_impl::url_to_uri(uri).expect("test URI should convert"),
+            },
+            range,
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn semantic_tokens_empty_range_does_not_wait_for_first_parse() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let uri = Url::parse("file:///empty_semantic_range.rs").expect("valid test uri");
+        service.inner().documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+
+        let result = timeout(
+            Duration::from_millis(1),
+            service.inner().semantic_tokens_range_impl(range_params(
+                &uri,
+                Range {
+                    start: Position {
+                        line: 0,
+                        character: 3,
+                    },
+                    end: Position {
+                        line: 0,
+                        character: 3,
+                    },
+                },
+            )),
+        )
+        .await
+        .expect("an empty range must not wait for the first parse")
+        .expect("empty range request should succeed")
+        .expect("empty range request should return a token result");
+
+        let SemanticTokensRangeResult::Tokens(tokens) = result else {
+            panic!("empty range must return a complete empty token result");
+        };
+        assert!(tokens.data.is_empty());
     }
 
     /// Serve-current (the Neovim client contract): a full request arriving


### PR DESCRIPTION
Closes #838.

## Summary

- exclude semantic tokens that begin exactly at an LSP range end-exclusive boundary
- return no tokens for empty or reversed ranges
- short-circuit empty or reversed range requests before first-parse waiting and full-document tokenization
- stop scanning the monotonic token stream after passing the requested range end
- preserve intersection behavior for tokens that genuinely overlap a non-empty range
- cover the end-exclusive boundary on both same-line and multi-line ranges

## Rebase adaptation

Rebased onto origin/main at 8b8571d75026d91aff24b39a2a2cf85edb86a2e8. Since the original base, semantic-token changes on main were limited to cancellation and parallel-discovery work; range projection, finalization, and both range-handler call paths remained compatible. The rebased original commits are patch-identical by range-diff. Post-rebase review added a handler-boundary fast path so empty or reversed viewports avoid the current first-parse/full-compute pipeline.

## TDD and review fixes

- RED: reproduced a token at 1:5..8 leaking into range 1:0..5
- GREEN: changed the end-line start comparison from > to >=
- RED: reproduced an empty range inside a token returning that token
- GREEN: reject empty/reversed ranges before projection
- RED: proved an empty range waited for first parse instead of returning immediately
- GREEN: return an empty result at the handler boundary before snapshot or token work
- mutation RED: proved the old strict comparison leaks the end-boundary token on a multi-line range
- GREEN: retained the end-exclusive comparison and added the multi-line sibling regression
- Gemini: stop decoding once monotonic token positions pass the requested end

## Incremental commits

- fix(semantic): respect range end boundary
- fix(semantic): reject empty token ranges
- perf(semantic): skip empty range compute
- test(semantic): pin multiline range end
- perf(semantic): stop range scan early

## Validation

- cargo test --lib -q analysis::semantic::range (8/8)
- cargo test --lib semantic_tokens_empty_range_does_not_wait_for_first_parse (1/1)
- make check
- git diff --check
- revise multi-perspective review: clean after fix rounds
- Codex MCP continued review: no comments to provide
- Codex MCP fresh independent reviews: no comments to provide, including final optimized head
- Gemini performance finding fixed in 0a2c8d615

Ready for merge after current-head remote review and CI converge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated semantic token range handling to treat the range end as end-exclusive.
  * Tokens that begin exactly at the exclusive end boundary are now excluded.
  * Empty or reversed semantic token range requests now return no tokens immediately.
  * Improves responsiveness for empty semantic token requests.

* **Tests**
  * Added regression coverage for end-exclusive boundary behavior and empty-range handling, including a completion-time check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->