### PR TITLE
fix(install): persist query uninstall intent

### DIFF
--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -757,13 +757,14 @@ fn write_uninstall_tombstone(
     queries_parent: &Path,
     language: &str,
 ) -> Result<(), QueryInstallError> {
-    write_uninstall_tombstone_with_before_publish(queries_parent, language, |_, _| {})
+    write_uninstall_tombstone_with_before_publish(queries_parent, language, |_, _| {}, |_| Ok(()))
 }
 
 fn write_uninstall_tombstone_with_before_publish(
     queries_parent: &Path,
     language: &str,
     before_publish: impl FnOnce(&Path, &Path),
+    _sync_parent: impl FnOnce(&Path) -> std::io::Result<()>,
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
@@ -1646,9 +1647,14 @@ mod tests {
         fs::write(&tombstone, "old tombstone\n").unwrap();
         let outside_alias = temp.path().join("outside-alias");
 
-        write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path, _| {
-            fs::hard_link(path, &outside_alias).unwrap();
-        })
+        write_uninstall_tombstone_with_before_publish(
+            &queries_parent,
+            "rust",
+            |path, _| {
+                fs::hard_link(path, &outside_alias).unwrap();
+            },
+            |_| Ok(()),
+        )
         .unwrap();
 
         assert_eq!(
@@ -1677,6 +1683,7 @@ mod tests {
                 fs::remove_file(staged_path).unwrap();
                 symlink(&victim, staged_path).unwrap();
             },
+            |_| Ok(()),
         );
 
         assert!(
@@ -1694,11 +1701,15 @@ mod tests {
         let tombstone = uninstall_tombstone_path(&queries_parent, "rust");
         fs::write(&tombstone, "old tombstone\n").unwrap();
 
-        let result =
-            write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path, _| {
+        let result = write_uninstall_tombstone_with_before_publish(
+            &queries_parent,
+            "rust",
+            |path, _| {
                 fs::remove_file(path).unwrap();
                 fs::create_dir(path).unwrap();
-            });
+            },
+            |_| Ok(()),
+        );
 
         assert!(result.is_err(), "a directory cannot be replaced by a file");
         let names: Vec<_> = fs::read_dir(&queries_parent)
@@ -1788,10 +1799,15 @@ mod tests {
         let victim = temp.path().join("victim");
         fs::write(&victim, "keep me\n").unwrap();
 
-        write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path, _| {
-            fs::remove_file(path).unwrap();
-            symlink_file(&victim, path).unwrap();
-        })
+        write_uninstall_tombstone_with_before_publish(
+            &queries_parent,
+            "rust",
+            |path, _| {
+                fs::remove_file(path).unwrap();
+                symlink_file(&victim, path).unwrap();
+            },
+            |_| Ok(()),
+        )
         .unwrap();
 
         assert_eq!(fs::read_to_string(victim).unwrap(), "keep me\n");

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -1670,6 +1670,37 @@ mod tests {
     }
 
     #[test]
+    fn uninstall_sync_failure_preserves_queries_and_backups() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let queries_dir = queries_parent.join("rust");
+        fs::create_dir_all(&queries_dir).unwrap();
+        fs::write(queries_dir.join("highlights.scm"), "old queries\n").unwrap();
+        let backup = queries_parent.join(".rust.123.0.backup");
+        fs::create_dir(&backup).unwrap();
+        fs::write(backup.join("highlights.scm"), "backup\n").unwrap();
+        write_backup_ownership_marker(&backup).unwrap();
+
+        let result = remove_query_install_and_backups_with_tombstone_writer(
+            &queries_parent,
+            "rust",
+            |_, _| {
+                Err(QueryInstallError::IoError(std::io::Error::other(
+                    "injected durability failure",
+                )))
+            },
+        );
+
+        assert!(matches!(result, Err(QueryInstallError::IoError(_))));
+        assert!(queries_dir.exists(), "canonical queries are not removed");
+        assert!(backup.exists(), "owned backup is not removed");
+        assert!(
+            backup_ownership_sidecar(&backup).exists(),
+            "backup ownership evidence is not removed"
+        );
+    }
+
+    #[test]
     fn tombstone_publish_does_not_truncate_raced_hard_link_alias() {
         let temp = TempDir::new().unwrap();
         let queries_parent = temp.path().join("queries");

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -519,10 +519,22 @@ pub fn remove_query_install_and_backups(
     queries_parent: &Path,
     language: &str,
 ) -> Result<QueryRemoval, QueryInstallError> {
+    remove_query_install_and_backups_with_tombstone_writer(
+        queries_parent,
+        language,
+        write_uninstall_tombstone,
+    )
+}
+
+fn remove_query_install_and_backups_with_tombstone_writer(
+    queries_parent: &Path,
+    language: &str,
+    write_tombstone: impl FnOnce(&Path, &str) -> Result<(), QueryInstallError>,
+) -> Result<QueryRemoval, QueryInstallError> {
     validate_safe_language_name(language)?;
     fs::create_dir_all(queries_parent)?;
     let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
-    write_uninstall_tombstone(queries_parent, language)?;
+    write_tombstone(queries_parent, language)?;
     let queries_dir = queries_parent.join(language);
     let mut removal = QueryRemoval {
         removed_queries: false,

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -757,14 +757,19 @@ fn write_uninstall_tombstone(
     queries_parent: &Path,
     language: &str,
 ) -> Result<(), QueryInstallError> {
-    write_uninstall_tombstone_with_before_publish(queries_parent, language, |_, _| {}, |_| Ok(()))
+    write_uninstall_tombstone_with_before_publish(
+        queries_parent,
+        language,
+        |_, _| {},
+        sync_tombstone_parent,
+    )
 }
 
 fn write_uninstall_tombstone_with_before_publish(
     queries_parent: &Path,
     language: &str,
     before_publish: impl FnOnce(&Path, &Path),
-    _sync_parent: impl FnOnce(&Path) -> std::io::Result<()>,
+    sync_parent: impl FnOnce(&Path) -> std::io::Result<()>,
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
@@ -805,6 +810,20 @@ fn write_uninstall_tombstone_with_before_publish(
     #[cfg(windows)]
     let published = publish_staged_tombstone(staged, &path, windows_publish)?;
     verify_published_tombstone(published, &path)?;
+    sync_parent(queries_parent)?;
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn sync_tombstone_parent(queries_parent: &Path) -> std::io::Result<()> {
+    fs::File::open(queries_parent)?.sync_all()
+}
+
+#[cfg(windows)]
+fn sync_tombstone_parent(_queries_parent: &Path) -> std::io::Result<()> {
+    // The stage handle carries FILE_FLAG_WRITE_THROUGH before FileRenameInfo
+    // publication. Microsoft documents that metadata changes, including a
+    // rename, issued through such a handle are flushed before return.
     Ok(())
 }
 
@@ -832,8 +851,8 @@ fn prepare_windows_tombstone_publish(
     use std::os::windows::io::{AsRawHandle as _, FromRawHandle as _};
     use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
     use windows_sys::Win32::Storage::FileSystem::{
-        DELETE, FILE_FLAG_BACKUP_SEMANTICS, FILE_GENERIC_READ, FILE_GENERIC_WRITE,
-        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, ReOpenFile,
+        DELETE, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_WRITE_THROUGH, FILE_GENERIC_READ,
+        FILE_GENERIC_WRITE, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, ReOpenFile,
     };
 
     let directory = fs::OpenOptions::new()
@@ -849,7 +868,7 @@ fn prepare_windows_tombstone_publish(
             staged.as_raw_handle(),
             FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE,
             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-            0,
+            FILE_FLAG_WRITE_THROUGH,
         )
     };
     if handle == INVALID_HANDLE_VALUE {
@@ -1720,6 +1739,30 @@ mod tests {
             names,
             vec![tombstone.file_name().unwrap().to_os_string()],
             "the private stage must be removed on every persist failure"
+        );
+    }
+
+    #[test]
+    fn tombstone_publish_propagates_parent_sync_failure() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let sync_called = std::cell::Cell::new(false);
+
+        let result = write_uninstall_tombstone_with_before_publish(
+            &queries_parent,
+            "rust",
+            |_, _| {},
+            |_| {
+                sync_called.set(true);
+                Err(std::io::Error::other("injected parent sync failure"))
+            },
+        );
+
+        assert!(sync_called.get(), "publication must cross the sync gate");
+        assert!(
+            matches!(result, Err(QueryInstallError::IoError(_))),
+            "sync failure must prevent uninstall from reaching removal"
         );
     }
 


### PR DESCRIPTION
## Summary

- flush the published tombstone parent directory before query removal on Unix-like platforms
- issue Windows `FileRenameInfo` through the same `FILE_FLAG_WRITE_THROUGH` stage handle so rename metadata is flushed before return
- propagate durability failures before removing canonical queries, owned backups, or backup ownership evidence
- add deterministic sync-failure and destructive-ordering regressions

Closes #829

## Stack

Depends on #837. This PR is intentionally based on `fix/issue-822-query-tombstone` at exact parent head `c029c61d4`; after #837 merges, rebase this branch onto current `main` and rerun revise/CI.

## Validation

- strict RED: injected parent-sync callback was not called
- `cargo test --lib -q tombstone_` (9/9)
- `cargo test --lib -q remove_query_install_` (5/5)
- `cargo test --lib -q uninstall_sync_failure_preserves_queries_and_backups`
- `make check`
- Stage-1 durability review: clean at `fe1a45b14`
- Codex continued review: `No comments`
- Codex fresh review: first-response `No comments`

## Durability contract

Unix ordering is staged-file sync → atomic publish → published identity verification → parent-directory `sync_all` → destructive removal. Unsupported directory sync errors fail the uninstall safely.

Windows reopens the already-created stage handle with `FILE_FLAG_WRITE_THROUGH`; Microsoft documents that metadata changes, including renames, issued through a write-through file handle are flushed rather than lazily persisted. The same handle performs `SetFileInformationByHandle(FileRenameInfo)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when uninstalling queries and their backups.
  * Added safeguards to ensure uninstall records are durably saved before removal completes.
  * If storage synchronization fails, the system now reports the failure and preserves managed queries and backups.
  * Improved consistency of uninstall behavior across supported platforms, including Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->