### PR TITLE
fix(install): reject query language directory symlinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +151,36 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.4",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "cc"
@@ -511,6 +547,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs4"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +902,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,10 +1022,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "junction"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "kakehashi"
 version = "0.8.0"
 dependencies = [
  "arc-swap",
+ "cap-primitives",
+ "cap-std",
  "clap",
  "dashmap",
  "dirs",
@@ -962,6 +1049,7 @@ dependencies = [
  "ignore",
  "indexmap",
  "insta",
+ "junction",
  "libloading",
  "line-index",
  "log",
@@ -972,7 +1060,6 @@ dependencies = [
  "rayon",
  "regex",
  "rstest",
- "same-file",
  "schemars",
  "serde",
  "serde_json",
@@ -1104,6 +1191,12 @@ checksum = "ab84ba33842e323474cc2e32179407782b6dd272eeb433c47e5cd11912163cf0"
 dependencies = [
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -1563,6 +1656,16 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -2791,6 +2894,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.13.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,18 +171,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cap-std"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
-dependencies = [
- "cap-primitives",
- "io-extras",
- "io-lifetimes 3.0.1",
- "rustix 1.1.4",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,7 +1025,6 @@ version = "0.8.0"
 dependencies = [
  "arc-swap",
  "cap-primitives",
- "cap-std",
  "clap",
  "dashmap",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,6 +972,7 @@ dependencies = [
  "rayon",
  "regex",
  "rstest",
+ "same-file",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,7 @@ dependencies = [
  "ulid",
  "ureq",
  "url",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ percent-encoding = "2"
 rayon = "1"
 futures = "0.3.31"
 
-[target.'cfg(not(any(target_os = "aix", target_os = "openbsd", target_os = "dragonfly")))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos", target_os = "freebsd", target_os = "netbsd", target_os = "solaris", target_os = "illumos", windows))'.dependencies]
 cap-primitives = "4"
 
 [target.'cfg(windows)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ log = "0.4"
 lua-pattern = { version = "0.1", features = ["to-regex"] }
 path-clean = "1"
 regex = "1"
+same-file = "1"
 schemars = { version = "1", features = ["preserve_order"] }
 serde = { version = "1", features = ["derive"] }
 # regex-fancy (pure Rust) over regex-onig (C oniguruma): we only compile

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ opt-level = 3
 [dependencies]
 arc-swap = "1"
 cap-primitives = "4"
-cap-std = "4"
 clap = { version = "4", features = ["derive"] }
 dashmap = "6"
 dirs = "6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ opt-level = 3
 
 [dependencies]
 arc-swap = "1"
-cap-primitives = "4"
 clap = { version = "4", features = ["derive"] }
 dashmap = "6"
 dirs = "6"
@@ -100,6 +99,9 @@ url = "2"
 percent-encoding = "2"
 rayon = "1"
 futures = "0.3.31"
+
+[target.'cfg(not(any(target_os = "aix", target_os = "openbsd", target_os = "dragonfly")))'.dependencies]
+cap-primitives = "4"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,9 @@ percent-encoding = "2"
 rayon = "1"
 futures = "0.3.31"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+
 # Unix-only dependencies (signal handling; "fs" for FD_CLOEXEC in tests)
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process", "fs"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ opt-level = 3
 
 [dependencies]
 arc-swap = "1"
+cap-primitives = "4"
+cap-std = "4"
 clap = { version = "4", features = ["derive"] }
 dashmap = "6"
 dirs = "6"
@@ -60,7 +62,6 @@ log = "0.4"
 lua-pattern = { version = "0.1", features = ["to-regex"] }
 path-clean = "1"
 regex = "1"
-same-file = "1"
 schemars = { version = "1", features = ["preserve_order"] }
 serde = { version = "1", features = ["derive"] }
 # regex-fancy (pure Rust) over regex-onig (C oniguruma): we only compile
@@ -115,6 +116,9 @@ e2e = []
 # Signal::SIGPIPE for asserting the termination signal.
 [target.'cfg(unix)'.dev-dependencies]
 nix = { version = "0.31", features = ["fs", "signal"] }
+
+[target.'cfg(windows)'.dev-dependencies]
+junction = { version = "2", default-features = false }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -467,8 +467,18 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
 }
 
 fn installed_query_language_name(path: &Path) -> Option<String> {
-    if !std::fs::symlink_metadata(path).ok()?.is_dir() {
+    let metadata = std::fs::symlink_metadata(path).ok()?;
+    if !metadata.is_dir() {
         return None;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt as _;
+        use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+
+        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return None;
+        }
     }
     let name = path.file_name()?.to_string_lossy();
     if name.starts_with('.') {
@@ -1095,5 +1105,18 @@ mod tests {
         );
         assert_eq!(installed_query_language_name(&unsafe_name), None);
         assert_eq!(installed_query_language_name(&hidden), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn installed_query_language_name_rejects_directory_junctions() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let external = temp.path().join("external");
+        let managed = temp.path().join("queries/lua");
+        std::fs::create_dir_all(&external).unwrap();
+        std::fs::create_dir_all(managed.parent().unwrap()).unwrap();
+        junction::create(&external, &managed).unwrap();
+
+        assert_eq!(installed_query_language_name(&managed), None);
     }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -467,7 +467,7 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
 }
 
 fn installed_query_language_name(path: &Path) -> Option<String> {
-    if !path.is_dir() {
+    if !std::fs::symlink_metadata(path).ok()?.is_dir() {
         return None;
     }
     let name = path.file_name()?.to_string_lossy();

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -458,13 +458,6 @@ fn query_directory_open_options() -> cap_primitives::fs::OpenOptions {
     options
 }
 
-#[cfg(not(any(unix, windows)))]
-fn query_directory_open_options() -> cap_primitives::fs::OpenOptions {
-    let mut options = cap_primitives::fs::OpenOptions::new();
-    options.read(true);
-    options
-}
-
 #[cfg(any(
     target_os = "linux",
     target_os = "android",
@@ -477,8 +470,7 @@ fn query_directory_open_options() -> cap_primitives::fs::OpenOptions {
     target_os = "netbsd",
     target_os = "solaris",
     target_os = "illumos",
-    windows,
-    not(any(unix, windows))
+    windows
 ))]
 fn open_query_language_dir_nofollow(queries_dir: &Path) -> std::io::Result<fs::File> {
     use cap_primitives::fs::FollowSymlinks;
@@ -535,8 +527,7 @@ fn open_query_language_dir_nofollow(queries_dir: &Path) -> std::io::Result<fs::F
     target_os = "netbsd",
     target_os = "solaris",
     target_os = "illumos",
-    windows,
-    not(any(unix, windows))
+    windows
 ))]
 pub fn query_install_is_complete(queries_dir: &Path) -> bool {
     use cap_primitives::fs::FollowSymlinks;
@@ -557,28 +548,26 @@ pub fn query_install_is_complete(queries_dir: &Path) -> bool {
         && (cap_primitives::fs::stat(
             &directory,
             Path::new(QUERY_INSTALL_COMPLETE_MARKER),
-            FollowSymlinks::Yes,
+            FollowSymlinks::No,
         )
         .is_ok_and(|marker| marker.is_file())
             || metadata.len() > 0)
 }
 
-#[cfg(all(
-    unix,
-    not(any(
-        target_os = "linux",
-        target_os = "android",
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "tvos",
-        target_os = "watchos",
-        target_os = "visionos",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "solaris",
-        target_os = "illumos"
-    ))
-))]
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos",
+    target_os = "visionos",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "solaris",
+    target_os = "illumos",
+    windows
+)))]
 pub fn query_install_is_complete(queries_dir: &Path) -> bool {
     let Ok(directory_metadata) = fs::symlink_metadata(queries_dir) else {
         return false;
@@ -589,8 +578,9 @@ pub fn query_install_is_complete(queries_dir: &Path) -> bool {
     let Ok(metadata) = fs::symlink_metadata(queries_dir.join("highlights.scm")) else {
         return false;
     };
-    metadata.file_type().is_file()
-        && (queries_dir.join(QUERY_INSTALL_COMPLETE_MARKER).is_file() || metadata.len() > 0)
+    let marker_is_file = fs::symlink_metadata(queries_dir.join(QUERY_INSTALL_COMPLETE_MARKER))
+        .is_ok_and(|marker| marker.file_type().is_file());
+    metadata.file_type().is_file() && (marker_is_file || metadata.len() > 0)
 }
 
 /// Whether a kakehashi-owned crash backup is safe to restore as the exact
@@ -1191,6 +1181,26 @@ mod tests {
     }
 
     #[cfg(unix)]
+    fn create_file_symlink_or_skip(target: &Path, link: &Path) -> bool {
+        std::os::unix::fs::symlink(target, link).unwrap();
+        true
+    }
+
+    #[cfg(windows)]
+    fn create_file_symlink_or_skip(target: &Path, link: &Path) -> bool {
+        match std::os::windows::fs::symlink_file(target, link) {
+            Ok(()) => true,
+            Err(e)
+                if e.kind() == std::io::ErrorKind::PermissionDenied
+                    || e.raw_os_error() == Some(1314) =>
+            {
+                false
+            }
+            Err(e) => panic!("failed to create file symlink: {e}"),
+        }
+    }
+
+    #[cfg(unix)]
     #[test]
     fn symlinked_highlights_file_is_not_a_complete_install() {
         use std::os::unix::fs::symlink;
@@ -1247,6 +1257,28 @@ mod tests {
         assert!(
             !query_install_is_complete(&managed),
             "managed language-directory symlinks must not redirect completeness checks"
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn query_install_is_incomplete_when_completion_marker_is_a_symlink() {
+        let temp = TempDir::new().unwrap();
+        let queries_dir = temp.path().join("queries/lua");
+        fs::create_dir_all(&queries_dir).unwrap();
+        fs::write(queries_dir.join("highlights.scm"), "").unwrap();
+        let external_marker = queries_dir.join("external-marker-target");
+        fs::write(&external_marker, "owned elsewhere").unwrap();
+        if !create_file_symlink_or_skip(
+            &external_marker,
+            &queries_dir.join(QUERY_INSTALL_COMPLETE_MARKER),
+        ) {
+            return;
+        }
+
+        assert!(
+            !query_install_is_complete(&queries_dir),
+            "an external marker target must not make empty highlights complete"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -414,7 +414,44 @@ fn install_queries_recursive(
     })
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn open_directory_nofollow(path: &Path) -> std::io::Result<fs::File> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(nix::libc::O_PATH | nix::libc::O_DIRECTORY | nix::libc::O_NOFOLLOW)
+        .open(path)
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos",
+    target_os = "visionos"
+))]
+fn open_directory_nofollow(path: &Path) -> std::io::Result<fs::File> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(nix::libc::O_SEARCH | nix::libc::O_NOFOLLOW)
+        .open(path)
+}
+
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos"
+    ))
+))]
 fn open_directory_nofollow(path: &Path) -> std::io::Result<fs::File> {
     use std::os::unix::fs::OpenOptionsExt as _;
 
@@ -1138,6 +1175,26 @@ mod tests {
         assert!(
             !query_install_is_complete(&managed),
             "managed language-directory symlinks must not redirect completeness checks"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn query_install_completeness_does_not_require_directory_read_permission() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = TempDir::new().unwrap();
+        let queries_dir = temp.path().join("queries/lua");
+        fs::create_dir_all(&queries_dir).unwrap();
+        fs::write(queries_dir.join("highlights.scm"), "(comment) @comment").unwrap();
+        fs::set_permissions(&queries_dir, fs::Permissions::from_mode(0o111)).unwrap();
+
+        let complete = query_install_is_complete(&queries_dir);
+
+        fs::set_permissions(&queries_dir, fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(
+            complete,
+            "known query files in a searchable directory remain inspectable"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -415,13 +415,14 @@ fn install_queries_recursive(
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
-fn open_directory_nofollow(path: &Path) -> std::io::Result<fs::File> {
-    use std::os::unix::fs::OpenOptionsExt as _;
+fn query_directory_open_options() -> cap_primitives::fs::OpenOptions {
+    use cap_primitives::fs::OpenOptionsExt as _;
 
-    fs::OpenOptions::new()
+    let mut options = cap_primitives::fs::OpenOptions::new();
+    options
         .read(true)
-        .custom_flags(nix::libc::O_PATH | nix::libc::O_DIRECTORY | nix::libc::O_NOFOLLOW)
-        .open(path)
+        .custom_flags(nix::libc::O_PATH | nix::libc::O_DIRECTORY);
+    options
 }
 
 #[cfg(any(
@@ -429,15 +430,19 @@ fn open_directory_nofollow(path: &Path) -> std::io::Result<fs::File> {
     target_os = "ios",
     target_os = "tvos",
     target_os = "watchos",
-    target_os = "visionos"
+    target_os = "visionos",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "solaris",
+    target_os = "illumos",
+    target_os = "aix"
 ))]
-fn open_directory_nofollow(path: &Path) -> std::io::Result<fs::File> {
-    use std::os::unix::fs::OpenOptionsExt as _;
+fn query_directory_open_options() -> cap_primitives::fs::OpenOptions {
+    use cap_primitives::fs::OpenOptionsExt as _;
 
-    fs::OpenOptions::new()
-        .read(true)
-        .custom_flags(nix::libc::O_SEARCH | nix::libc::O_NOFOLLOW)
-        .open(path)
+    let mut options = cap_primitives::fs::OpenOptions::new();
+    options.read(true).custom_flags(nix::libc::O_SEARCH);
+    options
 }
 
 #[cfg(all(
@@ -449,79 +454,99 @@ fn open_directory_nofollow(path: &Path) -> std::io::Result<fs::File> {
         target_os = "ios",
         target_os = "tvos",
         target_os = "watchos",
-        target_os = "visionos"
+        target_os = "visionos",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "solaris",
+        target_os = "illumos",
+        target_os = "aix"
     ))
 ))]
-fn open_directory_nofollow(path: &Path) -> std::io::Result<fs::File> {
-    use std::os::unix::fs::OpenOptionsExt as _;
-
-    fs::OpenOptions::new()
-        .read(true)
-        .custom_flags(nix::libc::O_DIRECTORY | nix::libc::O_NOFOLLOW)
-        .open(path)
+fn query_directory_open_options() -> cap_primitives::fs::OpenOptions {
+    let mut options = cap_primitives::fs::OpenOptions::new();
+    options.read(true);
+    options
 }
 
 #[cfg(windows)]
-fn open_directory_nofollow(path: &Path) -> std::io::Result<fs::File> {
-    use std::os::windows::fs::OpenOptionsExt as _;
+fn query_directory_open_options() -> cap_primitives::fs::OpenOptions {
+    use cap_primitives::fs::OpenOptionsExt as _;
     use windows_sys::Win32::Storage::FileSystem::{
-        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES,
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_READ_ATTRIBUTES,
     };
 
-    fs::OpenOptions::new()
-        // Metadata identity needs attributes, not directory enumeration.
-        // Keeping this narrower than GENERIC_READ preserves traversable-but-
-        // non-listable directory ACLs, matching the child pathname checks.
+    let mut options = cap_primitives::fs::OpenOptions::new();
+    options
         .access_mode(FILE_READ_ATTRIBUTES)
-        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
-        .open(path)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
+    options
 }
 
 #[cfg(not(any(unix, windows)))]
-fn open_directory_nofollow(_path: &Path) -> std::io::Result<fs::File> {
-    Err(std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
-        "no-follow directory handles are unavailable on this platform",
-    ))
+fn query_directory_open_options() -> cap_primitives::fs::OpenOptions {
+    let mut options = cap_primitives::fs::OpenOptions::new();
+    options.read(true);
+    options
 }
 
-fn directory_identity_nofollow(path: &Path) -> std::io::Result<same_file::Handle> {
-    let directory = open_directory_nofollow(path)?;
-    let metadata = directory.metadata()?;
-    if !metadata.is_dir() || metadata.file_type().is_symlink() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "query language entry is not a real directory",
+fn open_query_language_dir_nofollow(queries_dir: &Path) -> std::io::Result<fs::File> {
+    use cap_primitives::fs::FollowSymlinks;
+
+    let parent = queries_dir
+        .parent()
+        .ok_or_else(|| std::io::Error::other("query language directory has no parent"))?;
+    let name = queries_dir
+        .file_name()
+        .ok_or_else(|| std::io::Error::other("query language directory has no name"))?;
+    let parent = cap_std::fs::Dir::open_ambient_dir(parent, cap_std::ambient_authority())?;
+    let parent = parent.into_std_file();
+    let mut options = query_directory_open_options();
+    options
+        ._cap_fs_ext_follow(FollowSymlinks::No)
+        ._cap_fs_ext_maybe_dir(true);
+    let directory = cap_primitives::fs::open(&parent, Path::new(name), &options)?;
+    if !directory.metadata()?.is_dir() {
+        return Err(std::io::Error::other(
+            "query language entry is not a directory",
         ));
     }
-    same_file::Handle::from_file(directory)
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt as _;
+        use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+
+        if directory.metadata()?.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return Err(std::io::Error::other(
+                "query language entry is a reparse point",
+            ));
+        }
+    }
+    Ok(directory)
 }
 
 pub fn query_install_is_complete(queries_dir: &Path) -> bool {
-    let Ok(directory_before) = directory_identity_nofollow(queries_dir) else {
+    use cap_primitives::fs::FollowSymlinks;
+
+    let Ok(directory) = open_query_language_dir_nofollow(queries_dir) else {
         return false;
     };
-    let highlights_path = queries_dir.join("highlights.scm");
-    let Ok(metadata) = fs::symlink_metadata(&highlights_path) else {
+    let Ok(metadata) =
+        cap_primitives::fs::stat(&directory, Path::new("highlights.scm"), FollowSymlinks::No)
+    else {
         return false;
     };
     // The marker is written only after a staged install has written all
     // required files. Legacy direct-write directories did not have it, so a
     // non-empty highlights.scm still counts as installed to avoid clobbering
     // valid user-managed or pre-marker query directories.
-    let complete = metadata.file_type().is_file()
-        && (queries_dir.join(QUERY_INSTALL_COMPLETE_MARKER).is_file() || metadata.len() > 0);
-    if !complete {
-        return false;
-    }
-
-    // Child checks above necessarily resolve a pathname. Re-open the managed
-    // entry without following links and compare directory identity afterward,
-    // so a replacement symlink cannot satisfy the completeness predicate.
-    let Ok(directory_after) = directory_identity_nofollow(queries_dir) else {
-        return false;
-    };
-    directory_before == directory_after
+    metadata.is_file()
+        && (cap_primitives::fs::stat(
+            &directory,
+            Path::new(QUERY_INSTALL_COMPLETE_MARKER),
+            FollowSymlinks::Yes,
+        )
+        .is_ok_and(|marker| marker.is_file())
+            || metadata.len() > 0)
 }
 
 /// Whether a kakehashi-owned crash backup is safe to restore as the exact
@@ -1181,7 +1206,37 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
+    #[cfg(windows)]
+    #[test]
+    fn query_install_is_incomplete_when_language_directory_is_a_junction() {
+        let temp = TempDir::new().unwrap();
+        let external = temp.path().join("external");
+        fs::create_dir_all(&external).unwrap();
+        fs::write(external.join("highlights.scm"), "(comment) @comment").unwrap();
+        let managed = temp.path().join("queries/lua");
+        fs::create_dir_all(managed.parent().unwrap()).unwrap();
+        junction::create(&external, &managed).unwrap();
+
+        assert!(
+            !query_install_is_complete(&managed),
+            "managed directory junctions must not redirect completeness checks"
+        );
+    }
+
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "solaris",
+        target_os = "illumos",
+        target_os = "aix"
+    ))]
     #[test]
     fn query_install_completeness_does_not_require_directory_read_permission() {
         use std::os::unix::fs::PermissionsExt as _;

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -913,16 +913,20 @@ fn replace_query_dir(
         return Ok(ReplaceQueryDirResult::Uninstalled);
     }
 
-    if !queries_dir.exists() {
-        fs::rename(tmp_queries_dir, queries_dir)?;
-        return Ok(ReplaceQueryDirResult::Replaced);
+    match fs::symlink_metadata(queries_dir) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            fs::rename(tmp_queries_dir, queries_dir)?;
+            return Ok(ReplaceQueryDirResult::Replaced);
+        }
+        Err(e) => return Err(QueryInstallError::IoError(e)),
+        Ok(_) => {}
     }
 
     let backup_dir = unique_backup_query_dir(queries_dir, language);
     write_backup_ownership_marker(&backup_dir)?;
     if let Err(e) = fs::rename(queries_dir, &backup_dir) {
         let _ = fs::remove_file(backup_ownership_sidecar(&backup_dir));
-        // The target vanished between the exists() check above and this
+        // The target vanished between the metadata check above and this
         // rename (external cleanup — the lock only serializes kakehashi's own
         // installers): nothing to back up, so publish the staged dir instead
         // of aborting the install.
@@ -1560,6 +1564,38 @@ mod tests {
         assert!(
             !queries_parent.join("raced_lang").exists(),
             "uninstall tombstone must prevent restoring canonical queries"
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn replace_query_dir_repairs_a_dangling_language_directory_symlink() {
+        let temp_dir = TempDir::new().unwrap();
+        let queries_parent = temp_dir.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let queries_dir = queries_parent.join("lua");
+        let missing_target = temp_dir.path().join("missing");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&missing_target, &queries_dir).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(&missing_target, &queries_dir).unwrap();
+        let staged = create_unique_temp_query_dir(&queries_parent, "lua").unwrap();
+        fs::write(staged.join("highlights.scm"), "managed").unwrap();
+        write_install_marker_for_tests(&staged).unwrap();
+
+        let result = replace_query_dir(&staged, &queries_dir, "lua", false);
+
+        assert!(matches!(result, Ok(ReplaceQueryDirResult::Replaced)));
+        assert!(
+            fs::symlink_metadata(&queries_dir)
+                .unwrap()
+                .file_type()
+                .is_dir(),
+            "the dangling symlink must be replaced by the staged directory"
+        );
+        assert_eq!(
+            fs::read_to_string(queries_dir.join("highlights.scm")).unwrap(),
+            "managed"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -421,6 +421,9 @@ pub fn query_install_is_complete(queries_dir: &Path) -> bool {
     if !directory_metadata.is_dir() {
         return false;
     }
+    let Ok(directory_before) = same_file::Handle::from_path(queries_dir) else {
+        return false;
+    };
     let highlights_path = queries_dir.join("highlights.scm");
     let Ok(metadata) = fs::symlink_metadata(&highlights_path) else {
         return false;
@@ -429,8 +432,26 @@ pub fn query_install_is_complete(queries_dir: &Path) -> bool {
     // required files. Legacy direct-write directories did not have it, so a
     // non-empty highlights.scm still counts as installed to avoid clobbering
     // valid user-managed or pre-marker query directories.
-    metadata.file_type().is_file()
-        && (queries_dir.join(QUERY_INSTALL_COMPLETE_MARKER).is_file() || metadata.len() > 0)
+    let complete = metadata.file_type().is_file()
+        && (queries_dir.join(QUERY_INSTALL_COMPLETE_MARKER).is_file() || metadata.len() > 0);
+    if !complete {
+        return false;
+    }
+
+    // Child checks above necessarily resolve a pathname. Revalidate both the
+    // managed entry type and directory identity afterward so replacing the
+    // directory with a symlink during those checks cannot make an external
+    // query tree satisfy the completeness predicate.
+    let Ok(directory_metadata) = fs::symlink_metadata(queries_dir) else {
+        return false;
+    };
+    if !directory_metadata.is_dir() {
+        return false;
+    }
+    let Ok(directory_after) = same_file::Handle::from_path(queries_dir) else {
+        return false;
+    };
+    directory_before == directory_after
 }
 
 /// Whether a kakehashi-owned crash backup is safe to restore as the exact

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -498,8 +498,16 @@ fn open_query_language_dir_nofollow(queries_dir: &Path) -> std::io::Result<fs::F
     let name = queries_dir
         .file_name()
         .ok_or_else(|| std::io::Error::other("query language directory has no name"))?;
-    let parent = cap_std::fs::Dir::open_ambient_dir(parent, cap_std::ambient_authority())?;
-    let parent = parent.into_std_file();
+    let mut parent_options = query_directory_open_options();
+    parent_options._cap_fs_ext_maybe_dir(true);
+    let parent = cap_primitives::fs::open_ambient(
+        parent,
+        &parent_options,
+        cap_primitives::ambient_authority(),
+    )?;
+    if !parent.metadata()?.is_dir() {
+        return Err(std::io::Error::other("queries parent is not a directory"));
+    }
     let mut options = query_directory_open_options();
     options
         ._cap_fs_ext_follow(FollowSymlinks::No)
@@ -1246,13 +1254,23 @@ mod tests {
         fs::create_dir_all(&queries_dir).unwrap();
         fs::write(queries_dir.join("highlights.scm"), "(comment) @comment").unwrap();
         fs::set_permissions(&queries_dir, fs::Permissions::from_mode(0o111)).unwrap();
+        fs::set_permissions(
+            queries_dir.parent().unwrap(),
+            fs::Permissions::from_mode(0o111),
+        )
+        .unwrap();
 
         let complete = query_install_is_complete(&queries_dir);
 
+        fs::set_permissions(
+            queries_dir.parent().unwrap(),
+            fs::Permissions::from_mode(0o700),
+        )
+        .unwrap();
         fs::set_permissions(&queries_dir, fs::Permissions::from_mode(0o700)).unwrap();
         assert!(
             complete,
-            "known query files in a searchable directory remain inspectable"
+            "known query files under searchable directories remain inspectable"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -415,6 +415,12 @@ fn install_queries_recursive(
 }
 
 pub fn query_install_is_complete(queries_dir: &Path) -> bool {
+    let Ok(directory_metadata) = fs::symlink_metadata(queries_dir) else {
+        return false;
+    };
+    if !directory_metadata.is_dir() {
+        return false;
+    }
     let highlights_path = queries_dir.join("highlights.scm");
     let Ok(metadata) = fs::symlink_metadata(&highlights_path) else {
         return false;
@@ -1035,6 +1041,26 @@ mod tests {
             "crash recovery must restore the exact pre-replacement directory"
         );
         assert!(!backup.exists());
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn query_install_is_incomplete_when_language_directory_is_a_symlink() {
+        let temp = TempDir::new().unwrap();
+        let external = temp.path().join("external");
+        std::fs::create_dir_all(&external).unwrap();
+        std::fs::write(external.join("highlights.scm"), "(comment) @comment").unwrap();
+        let managed = temp.path().join("queries/lua");
+        std::fs::create_dir_all(managed.parent().unwrap()).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&external, &managed).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(&external, &managed).unwrap();
+
+        assert!(
+            !query_install_is_complete(&managed),
+            "managed language-directory symlinks must not redirect completeness checks"
+        );
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -465,11 +465,14 @@ fn open_directory_nofollow(path: &Path) -> std::io::Result<fs::File> {
 fn open_directory_nofollow(path: &Path) -> std::io::Result<fs::File> {
     use std::os::windows::fs::OpenOptionsExt as _;
     use windows_sys::Win32::Storage::FileSystem::{
-        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES,
     };
 
     fs::OpenOptions::new()
-        .read(true)
+        // Metadata identity needs attributes, not directory enumeration.
+        // Keeping this narrower than GENERIC_READ preserves traversable-but-
+        // non-listable directory ACLs, matching the child pathname checks.
+        .access_mode(FILE_READ_ATTRIBUTES)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
         .open(path)
 }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -434,37 +434,13 @@ fn query_directory_open_options() -> cap_primitives::fs::OpenOptions {
     target_os = "freebsd",
     target_os = "netbsd",
     target_os = "solaris",
-    target_os = "illumos",
-    target_os = "aix"
+    target_os = "illumos"
 ))]
 fn query_directory_open_options() -> cap_primitives::fs::OpenOptions {
     use cap_primitives::fs::OpenOptionsExt as _;
 
     let mut options = cap_primitives::fs::OpenOptions::new();
     options.read(true).custom_flags(nix::libc::O_SEARCH);
-    options
-}
-
-#[cfg(all(
-    unix,
-    not(any(
-        target_os = "linux",
-        target_os = "android",
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "tvos",
-        target_os = "watchos",
-        target_os = "visionos",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "solaris",
-        target_os = "illumos",
-        target_os = "aix"
-    ))
-))]
-fn query_directory_open_options() -> cap_primitives::fs::OpenOptions {
-    let mut options = cap_primitives::fs::OpenOptions::new();
-    options.read(true);
     options
 }
 
@@ -489,6 +465,21 @@ fn query_directory_open_options() -> cap_primitives::fs::OpenOptions {
     options
 }
 
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos",
+    target_os = "visionos",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "solaris",
+    target_os = "illumos",
+    windows,
+    not(any(unix, windows))
+))]
 fn open_query_language_dir_nofollow(queries_dir: &Path) -> std::io::Result<fs::File> {
     use cap_primitives::fs::FollowSymlinks;
 
@@ -532,6 +523,21 @@ fn open_query_language_dir_nofollow(queries_dir: &Path) -> std::io::Result<fs::F
     Ok(directory)
 }
 
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos",
+    target_os = "visionos",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "solaris",
+    target_os = "illumos",
+    windows,
+    not(any(unix, windows))
+))]
 pub fn query_install_is_complete(queries_dir: &Path) -> bool {
     use cap_primitives::fs::FollowSymlinks;
 
@@ -555,6 +561,36 @@ pub fn query_install_is_complete(queries_dir: &Path) -> bool {
         )
         .is_ok_and(|marker| marker.is_file())
             || metadata.len() > 0)
+}
+
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "solaris",
+        target_os = "illumos"
+    ))
+))]
+pub fn query_install_is_complete(queries_dir: &Path) -> bool {
+    let Ok(directory_metadata) = fs::symlink_metadata(queries_dir) else {
+        return false;
+    };
+    if !directory_metadata.is_dir() {
+        return false;
+    }
+    let Ok(metadata) = fs::symlink_metadata(queries_dir.join("highlights.scm")) else {
+        return false;
+    };
+    metadata.file_type().is_file()
+        && (queries_dir.join(QUERY_INSTALL_COMPLETE_MARKER).is_file() || metadata.len() > 0)
 }
 
 /// Whether a kakehashi-owned crash backup is safe to restore as the exact
@@ -1242,8 +1278,7 @@ mod tests {
         target_os = "freebsd",
         target_os = "netbsd",
         target_os = "solaris",
-        target_os = "illumos",
-        target_os = "aix"
+        target_os = "illumos"
     ))]
     #[test]
     fn query_install_completeness_does_not_require_directory_read_permission() {

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -731,7 +731,7 @@ fn recover_interrupted_query_install(
         return Ok(());
     }
     let queries_dir = queries_parent.join(language);
-    if queries_dir.exists() {
+    if path_entry_exists(&queries_dir)? {
         return Ok(());
     }
 
@@ -739,7 +739,7 @@ fn recover_interrupted_query_install(
     if uninstall_tombstone_path(queries_parent, language).is_file() {
         return Ok(());
     }
-    if queries_dir.exists() {
+    if path_entry_exists(&queries_dir)? {
         return Ok(());
     }
 
@@ -765,6 +765,14 @@ fn recover_interrupted_query_install(
     }
     let _ = fs::remove_file(ownership);
     Ok(())
+}
+
+fn path_entry_exists(path: &Path) -> Result<bool, QueryInstallError> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(QueryInstallError::IoError(e)),
+    }
 }
 
 fn uninstall_tombstone_path(queries_parent: &Path, language: &str) -> PathBuf {
@@ -913,13 +921,9 @@ fn replace_query_dir(
         return Ok(ReplaceQueryDirResult::Uninstalled);
     }
 
-    match fs::symlink_metadata(queries_dir) {
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            fs::rename(tmp_queries_dir, queries_dir)?;
-            return Ok(ReplaceQueryDirResult::Replaced);
-        }
-        Err(e) => return Err(QueryInstallError::IoError(e)),
-        Ok(_) => {}
+    if !path_entry_exists(queries_dir)? {
+        fs::rename(tmp_queries_dir, queries_dir)?;
+        return Ok(ReplaceQueryDirResult::Replaced);
     }
 
     let backup_dir = unique_backup_query_dir(queries_dir, language);
@@ -1310,6 +1314,35 @@ mod tests {
             !tmp.exists(),
             "generated staging dirs from crashed installs should be collected"
         );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn recovery_does_not_restore_a_backup_over_a_dangling_managed_symlink() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let queries_dir = queries_parent.join("lua");
+        if !create_dir_symlink_or_skip(&temp.path().join("missing"), &queries_dir) {
+            return;
+        }
+        let backup = queries_parent.join(".lua.1.1.backup");
+        fs::create_dir_all(&backup).unwrap();
+        fs::write(backup.join("highlights.scm"), "backup").unwrap();
+        write_install_marker_for_tests(&backup).unwrap();
+        write_backup_ownership_marker(&backup).unwrap();
+
+        let result = recover_interrupted_query_install(&queries_parent, "lua");
+
+        assert!(result.is_ok(), "recovery failed: {result:?}");
+        assert!(
+            fs::symlink_metadata(&queries_dir)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "recovery must leave the occupied managed entry for normal repair"
+        );
+        assert!(backup.is_dir(), "backup must remain available for recovery");
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -1007,6 +1007,26 @@ mod tests {
     use tempfile::TempDir;
 
     #[cfg(unix)]
+    fn create_dir_symlink_or_skip(target: &Path, link: &Path) -> bool {
+        std::os::unix::fs::symlink(target, link).unwrap();
+        true
+    }
+
+    #[cfg(windows)]
+    fn create_dir_symlink_or_skip(target: &Path, link: &Path) -> bool {
+        match std::os::windows::fs::symlink_dir(target, link) {
+            Ok(()) => true,
+            Err(e)
+                if e.kind() == std::io::ErrorKind::PermissionDenied
+                    || e.raw_os_error() == Some(1314) =>
+            {
+                false
+            }
+            Err(e) => panic!("failed to create directory symlink: {e}"),
+        }
+    }
+
+    #[cfg(unix)]
     #[test]
     fn symlinked_highlights_file_is_not_a_complete_install() {
         use std::os::unix::fs::symlink;
@@ -1056,10 +1076,9 @@ mod tests {
         std::fs::write(external.join("highlights.scm"), "(comment) @comment").unwrap();
         let managed = temp.path().join("queries/lua");
         std::fs::create_dir_all(managed.parent().unwrap()).unwrap();
-        #[cfg(unix)]
-        std::os::unix::fs::symlink(&external, &managed).unwrap();
-        #[cfg(windows)]
-        std::os::windows::fs::symlink_dir(&external, &managed).unwrap();
+        if !create_dir_symlink_or_skip(&external, &managed) {
+            return;
+        }
 
         assert!(
             !query_install_is_complete(&managed),
@@ -1575,10 +1594,9 @@ mod tests {
         fs::create_dir_all(&queries_parent).unwrap();
         let queries_dir = queries_parent.join("lua");
         let missing_target = temp_dir.path().join("missing");
-        #[cfg(unix)]
-        std::os::unix::fs::symlink(&missing_target, &queries_dir).unwrap();
-        #[cfg(windows)]
-        std::os::windows::fs::symlink_dir(&missing_target, &queries_dir).unwrap();
+        if !create_dir_symlink_or_skip(&missing_target, &queries_dir) {
+            return;
+        }
         let staged = create_unique_temp_query_dir(&queries_parent, "lua").unwrap();
         fs::write(staged.join("highlights.scm"), "managed").unwrap();
         write_install_marker_for_tests(&staged).unwrap();
@@ -1596,6 +1614,44 @@ mod tests {
         assert_eq!(
             fs::read_to_string(queries_dir.join("highlights.scm")).unwrap(),
             "managed"
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn replace_query_dir_repairs_a_live_language_directory_symlink() {
+        let temp_dir = TempDir::new().unwrap();
+        let queries_parent = temp_dir.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let external = temp_dir.path().join("external");
+        fs::create_dir_all(&external).unwrap();
+        fs::write(external.join("highlights.scm"), "external").unwrap();
+        let queries_dir = queries_parent.join("lua");
+        if !create_dir_symlink_or_skip(&external, &queries_dir) {
+            return;
+        }
+        let staged = create_unique_temp_query_dir(&queries_parent, "lua").unwrap();
+        fs::write(staged.join("highlights.scm"), "managed").unwrap();
+        write_install_marker_for_tests(&staged).unwrap();
+
+        let result = replace_query_dir(&staged, &queries_dir, "lua", false);
+
+        assert!(matches!(result, Ok(ReplaceQueryDirResult::Replaced)));
+        assert!(
+            fs::symlink_metadata(&queries_dir)
+                .unwrap()
+                .file_type()
+                .is_dir(),
+            "the live symlink must be replaced by the staged directory"
+        );
+        assert_eq!(
+            fs::read_to_string(queries_dir.join("highlights.scm")).unwrap(),
+            "managed"
+        );
+        assert_eq!(
+            fs::read_to_string(external.join("highlights.scm")).unwrap(),
+            "external",
+            "repair must not modify the symlink target"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -414,14 +414,51 @@ fn install_queries_recursive(
     })
 }
 
-pub fn query_install_is_complete(queries_dir: &Path) -> bool {
-    let Ok(directory_metadata) = fs::symlink_metadata(queries_dir) else {
-        return false;
+#[cfg(unix)]
+fn open_directory_nofollow(path: &Path) -> std::io::Result<fs::File> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(nix::libc::O_DIRECTORY | nix::libc::O_NOFOLLOW)
+        .open(path)
+}
+
+#[cfg(windows)]
+fn open_directory_nofollow(path: &Path) -> std::io::Result<fs::File> {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
     };
-    if !directory_metadata.is_dir() {
-        return false;
+
+    fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_directory_nofollow(_path: &Path) -> std::io::Result<fs::File> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "no-follow directory handles are unavailable on this platform",
+    ))
+}
+
+fn directory_identity_nofollow(path: &Path) -> std::io::Result<same_file::Handle> {
+    let directory = open_directory_nofollow(path)?;
+    let metadata = directory.metadata()?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "query language entry is not a real directory",
+        ));
     }
-    let Ok(directory_before) = same_file::Handle::from_path(queries_dir) else {
+    same_file::Handle::from_file(directory)
+}
+
+pub fn query_install_is_complete(queries_dir: &Path) -> bool {
+    let Ok(directory_before) = directory_identity_nofollow(queries_dir) else {
         return false;
     };
     let highlights_path = queries_dir.join("highlights.scm");
@@ -438,17 +475,10 @@ pub fn query_install_is_complete(queries_dir: &Path) -> bool {
         return false;
     }
 
-    // Child checks above necessarily resolve a pathname. Revalidate both the
-    // managed entry type and directory identity afterward so replacing the
-    // directory with a symlink during those checks cannot make an external
-    // query tree satisfy the completeness predicate.
-    let Ok(directory_metadata) = fs::symlink_metadata(queries_dir) else {
-        return false;
-    };
-    if !directory_metadata.is_dir() {
-        return false;
-    }
-    let Ok(directory_after) = same_file::Handle::from_path(queries_dir) else {
+    // Child checks above necessarily resolve a pathname. Re-open the managed
+    // entry without following links and compare directory identity afterward,
+    // so a replacement symlink cannot satisfy the completeness predicate.
+    let Ok(directory_after) = directory_identity_nofollow(queries_dir) else {
         return false;
     };
     directory_before == directory_after

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -725,6 +725,48 @@ fn test_language_status_shows_installed() {
     );
 }
 
+/// A symlink at the managed query-language entry is not an installed query
+/// directory, even when its external target contains complete-looking files.
+#[cfg(any(unix, windows))]
+#[test]
+fn test_language_status_ignores_symlinked_query_language_directories() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let external = test_dir.path().join("external/lua");
+    fs::create_dir_all(&external).expect("Failed to create external query dir");
+    fs::write(external.join("highlights.scm"), "(comment) @comment")
+        .expect("Failed to write external query");
+    let managed = test_dir.path().join("data/queries/lua");
+    fs::create_dir_all(managed.parent().unwrap()).expect("Failed to create queries parent");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&external, &managed).expect("Failed to symlink query dir");
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(&external, &managed).expect("Failed to symlink query dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            test_dir.path().join("data").to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success(), "status failed: {combined}");
+    assert!(
+        combined.contains("No languages installed"),
+        "query-directory symlinks must not enter discovery: {combined}"
+    );
+    assert!(external.join("highlights.scm").is_file());
+}
+
 /// Test that language status shows missing queries
 #[test]
 fn test_language_status_missing_queries() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -3,6 +3,26 @@
 
 use std::process::Command;
 
+#[cfg(unix)]
+fn create_dir_symlink_or_skip(target: &std::path::Path, link: &std::path::Path) -> bool {
+    std::os::unix::fs::symlink(target, link).expect("Failed to symlink query dir");
+    true
+}
+
+#[cfg(windows)]
+fn create_dir_symlink_or_skip(target: &std::path::Path, link: &std::path::Path) -> bool {
+    match std::os::windows::fs::symlink_dir(target, link) {
+        Ok(()) => true,
+        Err(e)
+            if e.kind() == std::io::ErrorKind::PermissionDenied
+                || e.raw_os_error() == Some(1314) =>
+        {
+            false
+        }
+        Err(e) => panic!("failed to create directory symlink: {e}"),
+    }
+}
+
 /// Test that --help flag shows help message with program description
 #[test]
 fn test_help_flag_shows_help_message() {
@@ -739,10 +759,9 @@ fn test_language_status_ignores_symlinked_query_language_directories() {
         .expect("Failed to write external query");
     let managed = test_dir.path().join("data/queries/lua");
     fs::create_dir_all(managed.parent().unwrap()).expect("Failed to create queries parent");
-    #[cfg(unix)]
-    std::os::unix::fs::symlink(&external, &managed).expect("Failed to symlink query dir");
-    #[cfg(windows)]
-    std::os::windows::fs::symlink_dir(&external, &managed).expect("Failed to symlink query dir");
+    if !create_dir_symlink_or_skip(&external, &managed) {
+        return;
+    }
 
     let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
         .args([
@@ -1265,10 +1284,9 @@ fn test_language_uninstall_all_ignores_symlinked_query_language_directories() {
     fs::write(&external_query, "(comment) @comment").expect("Failed to write external query");
     let managed = test_dir.path().join("data/queries/lua");
     fs::create_dir_all(managed.parent().unwrap()).expect("Failed to create queries parent");
-    #[cfg(unix)]
-    std::os::unix::fs::symlink(&external, &managed).expect("Failed to symlink query dir");
-    #[cfg(windows)]
-    std::os::windows::fs::symlink_dir(&external, &managed).expect("Failed to symlink query dir");
+    if !create_dir_symlink_or_skip(&external, &managed) {
+        return;
+    }
 
     let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
         .args([

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1251,6 +1251,57 @@ fn test_language_uninstall_all() {
     assert!(queries.is_empty(), "All queries should be removed");
 }
 
+/// Bulk uninstall discovery must not follow a managed query-language symlink
+/// or claim that removing external query content is in scope.
+#[cfg(any(unix, windows))]
+#[test]
+fn test_language_uninstall_all_ignores_symlinked_query_language_directories() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let external = test_dir.path().join("external/lua");
+    fs::create_dir_all(&external).expect("Failed to create external query dir");
+    let external_query = external.join("highlights.scm");
+    fs::write(&external_query, "(comment) @comment").expect("Failed to write external query");
+    let managed = test_dir.path().join("data/queries/lua");
+    fs::create_dir_all(managed.parent().unwrap()).expect("Failed to create queries parent");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&external, &managed).expect("Failed to symlink query dir");
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(&external, &managed).expect("Failed to symlink query dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--force",
+            "--data-dir",
+            test_dir.path().join("data").to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success(), "uninstall failed: {combined}");
+    assert!(
+        combined.contains("No languages installed to uninstall"),
+        "query-directory symlinks must not enter uninstall discovery: {combined}"
+    );
+    assert!(
+        managed.is_symlink(),
+        "managed symlink must remain untouched"
+    );
+    assert!(
+        external_query.is_file(),
+        "external query must remain intact"
+    );
+}
+
 /// Test that language uninstall --all ignores internal query staging directories
 #[test]
 fn test_language_uninstall_all_ignores_internal_query_dirs() {


### PR DESCRIPTION
## Summary

- reject a symlink or Windows reparse point at the managed `queries/<language>` directory entry
- pin the resolved queries parent and inspect the language root and active completeness files through handle-relative no-follow operations on supported platforms
- keep #825's owned crash-backup recovery semantics intact while repairing live and dangling managed-root symlinks during normal install
- exclude symlinked/junction-backed language entries from CLI status and bulk-uninstall discovery

## User impact

An external query tree can no longer satisfy active install completeness through a managed language-directory link. Status no longer reports it as installed, bulk uninstall does not claim to remove it, and normal install safely replaces live or dangling managed links without touching their targets.

Fixes #835.

## Stack

- Base: #825, exact parent `81fb524f6b07b5fcb8748d49f12cea7d4777a1d8`
- This PR preserves #825's deliberate active-vs-owned-backup distinction.

## Validation

- active completeness/query-install tests: 6 passed
- owned-backup recovery test: 1 passed
- replace-query-dir tests: 3 passed
- interrupted-recovery tests: 3 passed
- `cargo test --test test_cli language_status`: 9 passed
- `cargo test --test test_cli language_uninstall`: 8 passed
- `make check`
- fresh Stage-1 exact-stack review: clean
- Codex review: multiple filesystem/permission/platform findings fixed; continued clean
- fresh Codex exact-stack review: final parent-symlink finding refuted against #830/configured-parent contract; clean
