### PR TITLE
fix(install): bind query uninstall to parent identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +151,36 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.4",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "cc"
@@ -511,6 +547,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs4"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +902,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +1026,7 @@ name = "kakehashi"
 version = "0.8.0"
 dependencies = [
  "arc-swap",
+ "cap-std",
  "clap",
  "dashmap",
  "dirs",
@@ -1103,6 +1179,12 @@ checksum = "ab84ba33842e323474cc2e32179407782b6dd272eeb433c47e5cd11912163cf0"
 dependencies = [
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -1562,6 +1644,16 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -2790,6 +2882,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.13.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
+name = "cap-fs-ext"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "cap-primitives"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,6 +1038,7 @@ name = "kakehashi"
 version = "0.8.0"
 dependencies = [
  "arc-swap",
+ "cap-fs-ext",
  "cap-std",
  "clap",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ opt-level = 3
 
 [dependencies]
 arc-swap = "1"
+cap-std = "4.0.2"
 clap = { version = "4", features = ["derive"] }
 dashmap = "6"
 dirs = "6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ opt-level = 3
 [dependencies]
 arc-swap = "1"
 cap-std = "4.0.2"
+cap-fs-ext = "4.0.2"
 clap = { version = "4", features = ["derive"] }
 dashmap = "6"
 dirs = "6"

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -801,19 +801,32 @@ fn write_uninstall_tombstone(
     queries_parent: &Path,
     language: &str,
 ) -> Result<(), QueryInstallError> {
-    write_uninstall_tombstone_with_before_publish(
-        queries_parent,
-        language,
-        |_, _| {},
-        sync_tombstone_parent,
-    )
+    let pinned = cap_std::fs::Dir::open_ambient_dir(queries_parent, cap_std::ambient_authority())?;
+    write_uninstall_tombstone_at(&pinned, queries_parent, language)
 }
 
 #[cfg(unix)]
 fn write_uninstall_tombstone_at(
     queries_parent: &cap_std::fs::Dir,
+    ambient_path: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    write_uninstall_tombstone_at_with_hooks(
+        queries_parent,
+        ambient_path,
+        language,
+        |_, _, _| {},
+        |parent| parent.try_clone()?.into_std_file().sync_all(),
+    )
+}
+
+#[cfg(unix)]
+fn write_uninstall_tombstone_at_with_hooks(
+    queries_parent: &cap_std::fs::Dir,
     _ambient_path: &Path,
     language: &str,
+    before_publish: impl FnOnce(&cap_std::fs::Dir, &str, &str),
+    sync_parent: impl FnOnce(&cap_std::fs::Dir) -> std::io::Result<()>,
 ) -> Result<(), QueryInstallError> {
     use cap_fs_ext::{
         FollowSymlinks, MetadataExt as CapMetadataExt, OpenOptionsFollowExt, OpenOptionsSyncExt,
@@ -864,6 +877,7 @@ fn write_uninstall_tombstone_at(
         staged.write_all(b"ok\n")?;
         staged.sync_all()?;
         let staged_metadata = staged.metadata()?;
+        before_publish(queries_parent, &tombstone_name, &stage_name);
         queries_parent.rename(&stage_name, queries_parent, &tombstone_name)?;
 
         let mut published_options = cap_std::fs::OpenOptions::new();
@@ -886,7 +900,7 @@ fn write_uninstall_tombstone_at(
             )));
         }
         require_single_link(std::os::unix::fs::MetadataExt::nlink(&published_metadata))?;
-        queries_parent.try_clone()?.into_std_file().sync_all()?;
+        sync_parent(queries_parent)?;
         Ok(())
     })();
     if result.is_err() {
@@ -898,8 +912,25 @@ fn write_uninstall_tombstone_at(
 #[cfg(windows)]
 fn write_uninstall_tombstone_at(
     queries_parent: &cap_std::fs::Dir,
+    ambient_path: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    write_uninstall_tombstone_at_with_hooks(
+        queries_parent,
+        ambient_path,
+        language,
+        |_, _, _| {},
+        |_| Ok(()),
+    )
+}
+
+#[cfg(windows)]
+fn write_uninstall_tombstone_at_with_hooks(
+    queries_parent: &cap_std::fs::Dir,
     _ambient_path: &Path,
     language: &str,
+    before_publish: impl FnOnce(&cap_std::fs::Dir, &str, &str),
+    sync_parent: impl FnOnce(&cap_std::fs::Dir) -> std::io::Result<()>,
 ) -> Result<(), QueryInstallError> {
     use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
     use std::os::windows::ffi::OsStrExt as _;
@@ -968,6 +999,7 @@ fn write_uninstall_tombstone_at(
         // SAFETY: successful ReOpenFile returned a newly owned handle.
         let rename_handle = unsafe { fs::File::from_raw_handle(handle) };
         normalize_windows_stage_attributes(&rename_handle)?;
+        before_publish(queries_parent, &tombstone_name, &stage_name);
         let filename: Vec<u16> = std::ffi::OsStr::new(&tombstone_name)
             .encode_wide()
             .collect();
@@ -1012,6 +1044,7 @@ fn write_uninstall_tombstone_at(
             )));
         }
         require_single_link(u64::from(actual.nNumberOfLinks))?;
+        sync_parent(queries_parent)?;
         Ok(())
     })();
     if result.is_err() {
@@ -1027,116 +1060,19 @@ fn write_uninstall_tombstone_with_before_publish(
     before_publish: impl FnOnce(&Path, &Path),
     sync_parent: impl FnOnce(&Path) -> std::io::Result<()>,
 ) -> Result<(), QueryInstallError> {
-    validate_safe_language_name(language)?;
-    let path = uninstall_tombstone_path(queries_parent, language);
-    let existing_permissions = validate_existing_tombstone(&path)?;
-    #[cfg(not(windows))]
-    let had_existing_tombstone = existing_permissions.is_some();
-    let stage_counter = QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let stage_prefix = format!(
-        ".{language}.uninstalled.{}.{}.",
-        std::process::id(),
-        stage_counter
-    );
-    let mut builder = tempfile::Builder::new();
-    builder.prefix(&stage_prefix).suffix(".tmp").rand_bytes(12);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        // Match File::create's 0o666 & !umask contract rather than inheriting
-        // tempfile's private 0o600 default when the inode is published.
-        builder.permissions(fs::Permissions::from_mode(0o666));
-    }
-    let mut staged = builder.tempfile_in(queries_parent)?;
-    if let Some(permissions) = existing_permissions {
-        // On Windows this can only carry `readonly = false`: validation
-        // already write-opened the destination, so a readonly leaf fails
-        // before staging exactly as origin/main's File::create did. Keeping
-        // that order avoids making a readonly stage impossible to reopen with
-        // the DELETE-capable handle required for confined publication.
-        staged.as_file().set_permissions(permissions)?;
-    }
-    staged.write_all(b"ok\n")?;
-    staged.as_file().sync_all()?;
-    #[cfg(windows)]
-    let windows_publish = prepare_windows_tombstone_publish(queries_parent, staged.as_file())?;
-    before_publish(&path, staged.path());
-    #[cfg(not(windows))]
-    let published = publish_staged_tombstone(staged, &path, had_existing_tombstone)?;
-    #[cfg(windows)]
-    let published = publish_staged_tombstone(staged, &path, windows_publish)?;
-    verify_published_tombstone(published, &path)?;
-    sync_parent(queries_parent)?;
-    Ok(())
-}
-
-#[cfg(all(test, not(windows)))]
-fn sync_tombstone_parent(queries_parent: &Path) -> std::io::Result<()> {
-    fs::File::open(queries_parent)?.sync_all()
-}
-
-#[cfg(all(test, windows))]
-fn sync_tombstone_parent(_queries_parent: &Path) -> std::io::Result<()> {
-    // The stage handle carries FILE_FLAG_WRITE_THROUGH before FileRenameInfo
-    // publication. Microsoft documents that metadata changes, including a
-    // rename, issued through such a handle are flushed before return.
-    Ok(())
-}
-
-#[cfg(all(test, not(windows)))]
-fn publish_staged_tombstone(
-    staged: tempfile::NamedTempFile,
-    path: &Path,
-    _had_existing_tombstone: bool,
-) -> std::io::Result<fs::File> {
-    staged.persist(path).map_err(|error| error.error)
-}
-
-#[cfg(all(test, windows))]
-struct WindowsTombstonePublish {
-    directory: fs::File,
-    rename_handle: fs::File,
-}
-
-#[cfg(all(test, windows))]
-fn prepare_windows_tombstone_publish(
-    queries_parent: &Path,
-    staged: &fs::File,
-) -> std::io::Result<WindowsTombstonePublish> {
-    use std::os::windows::fs::OpenOptionsExt as _;
-    use std::os::windows::io::{AsRawHandle as _, FromRawHandle as _};
-    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
-    use windows_sys::Win32::Storage::FileSystem::{
-        DELETE, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_WRITE_THROUGH, FILE_GENERIC_READ,
-        FILE_GENERIC_WRITE, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, ReOpenFile,
-    };
-
-    let directory = fs::OpenOptions::new()
-        .read(true)
-        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
-        .open(queries_parent)?;
-    // Reopen the already-created stage BY HANDLE with DELETE access. This
-    // cannot be redirected by replacing its temporary pathname later.
-    // SAFETY: `staged` remains valid for the call; a successful returned
-    // handle is newly owned and converted exactly once into `File`.
-    let handle = unsafe {
-        ReOpenFile(
-            staged.as_raw_handle(),
-            FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE,
-            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-            FILE_FLAG_WRITE_THROUGH,
-        )
-    };
-    if handle == INVALID_HANDLE_VALUE {
-        return Err(std::io::Error::last_os_error());
-    }
-    // SAFETY: successful ReOpenFile returned a newly owned handle.
-    let rename_handle = unsafe { fs::File::from_raw_handle(handle) };
-    normalize_windows_stage_attributes(&rename_handle)?;
-    Ok(WindowsTombstonePublish {
-        directory,
-        rename_handle,
-    })
+    let pinned = cap_std::fs::Dir::open_ambient_dir(queries_parent, cap_std::ambient_authority())?;
+    write_uninstall_tombstone_at_with_hooks(
+        &pinned,
+        queries_parent,
+        language,
+        |_, tombstone_name, stage_name| {
+            before_publish(
+                &queries_parent.join(tombstone_name),
+                &queries_parent.join(stage_name),
+            );
+        },
+        |_| sync_parent(queries_parent),
+    )
 }
 
 #[cfg(windows)]
@@ -1181,123 +1117,6 @@ fn normalize_windows_stage_attributes(file: &fs::File) -> std::io::Result<()> {
     }
 }
 
-#[cfg(all(test, windows))]
-fn publish_staged_tombstone(
-    staged: tempfile::NamedTempFile,
-    path: &Path,
-    publish: WindowsTombstonePublish,
-) -> std::io::Result<fs::File> {
-    use std::os::windows::ffi::OsStrExt as _;
-    use std::os::windows::io::AsRawHandle as _;
-    use windows_sys::Win32::Storage::FileSystem::{
-        FILE_RENAME_INFO, FileRenameInfo, SetFileInformationByHandle,
-    };
-
-    let filename: Vec<u16> = path
-        .file_name()
-        .ok_or_else(|| std::io::Error::other("tombstone path has no file name"))?
-        .encode_wide()
-        .collect();
-    let header = std::mem::offset_of!(FILE_RENAME_INFO, FileName);
-    let size = header + filename.len() * std::mem::size_of::<u16>();
-    let units = size.div_ceil(std::mem::size_of::<FILE_RENAME_INFO>());
-    let mut buffer = vec![FILE_RENAME_INFO::default(); units];
-    let information = buffer.as_mut_ptr();
-    // Rename the already-opened stage relative to the parent handle pinned
-    // before the race hook. ReplaceIfExists replaces a reparse-point directory
-    // entry; it never opens/follows that entry's target.
-    // SAFETY: `buffer` covers the header and UTF-16 filename; both file handles
-    // remain alive; the relative name has no separators.
-    let succeeded = unsafe {
-        (*information).Anonymous.ReplaceIfExists = true;
-        (*information).RootDirectory = publish.directory.as_raw_handle();
-        (*information).FileNameLength = u32::try_from(filename.len() * 2).unwrap();
-        std::ptr::copy_nonoverlapping(
-            filename.as_ptr(),
-            (*information).FileName.as_mut_ptr(),
-            filename.len(),
-        );
-        SetFileInformationByHandle(
-            publish.rename_handle.as_raw_handle(),
-            FileRenameInfo,
-            information.cast(),
-            u32::try_from(size).unwrap(),
-        )
-    };
-    if succeeded == 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    let (_original_handle, temporary_path) = staged.into_parts();
-    drop(temporary_path);
-    Ok(publish.rename_handle)
-}
-
-/// Open or create the managed tombstone leaf without following a link there.
-///
-/// Parent components deliberately retain ordinary path resolution: users may
-/// symlink their data directory or `queries` directory. Only the final,
-/// kakehashi-owned leaf is constrained. An observed existing leaf is validated,
-/// then a private same-directory inode atomically replaces its directory entry;
-/// no pre-existing inode is ever truncated.
-#[cfg(all(test, unix))]
-fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
-    use std::os::unix::fs::OpenOptionsExt;
-
-    let file = match fs::OpenOptions::new()
-        .write(true)
-        // O_NOFOLLOW binds the validation to the opened leaf rather than a
-        // racy metadata pre-check. O_NONBLOCK prevents a substituted FIFO
-        // from blocking the uninstall before fstat can reject it.
-        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK)
-        .open(path)
-    {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => return Err(error),
-    };
-    let metadata = file.metadata()?;
-    if !metadata.file_type().is_file() {
-        return Err(std::io::Error::other(
-            "query uninstall tombstone is not a regular file",
-        ));
-    }
-    use std::os::unix::fs::MetadataExt as _;
-    require_single_link(metadata.nlink())?;
-    Ok(Some(metadata.permissions()))
-}
-
-#[cfg(all(test, windows))]
-fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
-    use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
-    use windows_sys::Win32::Storage::FileSystem::{
-        FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT,
-    };
-
-    let file = match fs::OpenOptions::new()
-        .write(true)
-        // Open the reparse point itself, if present, so validation cannot be
-        // raced into following its target. Publication later replaces the
-        // directory entry rather than writing through this handle.
-        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
-        .open(path)
-    {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => return Err(error),
-    };
-    let metadata = file.metadata()?;
-    if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
-        || !metadata.file_type().is_file()
-    {
-        return Err(std::io::Error::other(
-            "query uninstall tombstone is not a regular file",
-        ));
-    }
-    let information = windows_file_information(&file)?;
-    require_single_link(u64::from(information.nNumberOfLinks))?;
-    Ok(Some(metadata.permissions()))
-}
-
 #[cfg(any(unix, windows))]
 fn require_single_link(links: u64) -> std::io::Result<()> {
     if links != 1 {
@@ -1307,58 +1126,6 @@ fn require_single_link(links: u64) -> std::io::Result<()> {
     } else {
         Ok(())
     }
-}
-
-#[cfg(all(test, unix))]
-fn verify_published_tombstone(published: fs::File, path: &Path) -> std::io::Result<()> {
-    use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _};
-
-    let expected = published.metadata()?;
-    drop(published);
-    let final_file = fs::OpenOptions::new()
-        .write(true)
-        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK)
-        .open(path)?;
-    let actual = final_file.metadata()?;
-    if !actual.file_type().is_file()
-        || actual.nlink() != 1
-        || expected.dev() != actual.dev()
-        || expected.ino() != actual.ino()
-    {
-        return Err(std::io::Error::other(
-            "published query uninstall tombstone changed identity",
-        ));
-    }
-    Ok(())
-}
-
-#[cfg(all(test, windows))]
-fn verify_published_tombstone(published: fs::File, path: &Path) -> std::io::Result<()> {
-    use std::os::windows::fs::{MetadataExt as _, OpenOptionsExt as _};
-    use windows_sys::Win32::Storage::FileSystem::{
-        FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT,
-    };
-
-    let expected = windows_file_information(&published)?;
-    drop(published);
-    let final_file = fs::OpenOptions::new()
-        .write(true)
-        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
-        .open(path)?;
-    let metadata = final_file.metadata()?;
-    let actual = windows_file_information(&final_file)?;
-    if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
-        || !metadata.file_type().is_file()
-        || actual.nNumberOfLinks != 1
-        || expected.dwVolumeSerialNumber != actual.dwVolumeSerialNumber
-        || expected.nFileIndexHigh != actual.nFileIndexHigh
-        || expected.nFileIndexLow != actual.nFileIndexLow
-    {
-        return Err(std::io::Error::other(
-            "published query uninstall tombstone changed identity",
-        ));
-    }
-    Ok(())
 }
 
 #[cfg(windows)]
@@ -1380,29 +1147,6 @@ fn windows_file_information(
     }
     // SAFETY: GetFileInformationByHandle succeeded above.
     Ok(unsafe { information.assume_init() })
-}
-
-#[cfg(all(test, not(any(unix, windows))))]
-fn verify_published_tombstone(_published: fs::File, path: &Path) -> std::io::Result<()> {
-    if fs::symlink_metadata(path)?.file_type().is_file() {
-        Ok(())
-    } else {
-        Err(std::io::Error::other(
-            "published query uninstall tombstone is not a regular file",
-        ))
-    }
-}
-
-#[cfg(all(test, not(any(unix, windows))))]
-fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
-    match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_file() => Ok(Some(metadata.permissions())),
-        Ok(_) => Err(std::io::Error::other(
-            "query uninstall tombstone is not a regular file",
-        )),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(error),
-    }
 }
 
 fn clear_uninstall_tombstone(

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -531,10 +531,20 @@ fn remove_query_install_and_backups_with_tombstone_writer(
     language: &str,
     write_tombstone: impl FnOnce(&Path, &str) -> Result<(), QueryInstallError>,
 ) -> Result<QueryRemoval, QueryInstallError> {
+    remove_query_install_and_backups_with_hooks(queries_parent, language, write_tombstone, |_| {})
+}
+
+fn remove_query_install_and_backups_with_hooks(
+    queries_parent: &Path,
+    language: &str,
+    write_tombstone: impl FnOnce(&Path, &str) -> Result<(), QueryInstallError>,
+    before_remove: impl FnOnce(&Path),
+) -> Result<QueryRemoval, QueryInstallError> {
     validate_safe_language_name(language)?;
     fs::create_dir_all(queries_parent)?;
     let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
     write_tombstone(queries_parent, language)?;
+    before_remove(queries_parent);
     let queries_dir = queries_parent.join(language);
     let mut removal = QueryRemoval {
         removed_queries: false,

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -544,7 +544,7 @@ fn remove_query_install_and_backups_with_hooks(
     fs::create_dir_all(queries_parent)?;
     let pinned_parent =
         cap_std::fs::Dir::open_ambient_dir(queries_parent, cap_std::ambient_authority())?;
-    let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
+    let _replace_lock = QueryReplaceLockGuard::acquire_at(&pinned_parent, language)?;
     write_tombstone(queries_parent, language)?;
     before_remove(queries_parent);
     let mut removal = QueryRemoval {
@@ -1380,6 +1380,20 @@ impl QueryReplaceLockGuard {
             .write(true)
             .truncate(false)
             .open(path)?;
+        file.lock_exclusive()?;
+        Ok(Self { _file: file })
+    }
+
+    fn acquire_at(
+        queries_parent: &cap_std::fs::Dir,
+        language: &str,
+    ) -> Result<Self, QueryInstallError> {
+        validate_safe_language_name(language)?;
+        let mut options = cap_std::fs::OpenOptions::new();
+        options.create(true).write(true).truncate(false);
+        let file = queries_parent
+            .open_with(format!(".{language}.replace.lock"), &options)?
+            .into_std();
         file.lock_exclusive()?;
         Ok(Self { _file: file })
     }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -522,7 +522,7 @@ pub fn remove_query_install_and_backups(
     remove_query_install_and_backups_with_tombstone_writer(
         queries_parent,
         language,
-        |pinned, parent, lang| write_uninstall_tombstone_at(pinned, parent, lang),
+        write_uninstall_tombstone_at,
     )
 }
 
@@ -626,6 +626,7 @@ fn remove_dir_all_at_tolerating_vanished(
 /// deleted, and (b) `Path::exists()` returns false on ANY metadata error
 /// (e.g. PermissionDenied), which must propagate the original error instead
 /// of being mistaken for absence.
+#[cfg(test)]
 fn remove_dir_all_tolerating_vanished(dir: &Path) -> Result<bool, QueryInstallError> {
     match fs::remove_dir_all(dir) {
         Ok(()) => Ok(true),
@@ -795,6 +796,7 @@ fn uninstall_tombstone_path(queries_parent: &Path, language: &str) -> PathBuf {
     queries_parent.join(format!(".{language}{QUERY_UNINSTALL_TOMBSTONE_SUFFIX}"))
 }
 
+#[cfg(test)]
 fn write_uninstall_tombstone(
     queries_parent: &Path,
     language: &str,
@@ -1018,6 +1020,7 @@ fn write_uninstall_tombstone_at(
     result
 }
 
+#[cfg(test)]
 fn write_uninstall_tombstone_with_before_publish(
     queries_parent: &Path,
     language: &str,
@@ -1067,12 +1070,12 @@ fn write_uninstall_tombstone_with_before_publish(
     Ok(())
 }
 
-#[cfg(not(windows))]
+#[cfg(all(test, not(windows)))]
 fn sync_tombstone_parent(queries_parent: &Path) -> std::io::Result<()> {
     fs::File::open(queries_parent)?.sync_all()
 }
 
-#[cfg(windows)]
+#[cfg(all(test, windows))]
 fn sync_tombstone_parent(_queries_parent: &Path) -> std::io::Result<()> {
     // The stage handle carries FILE_FLAG_WRITE_THROUGH before FileRenameInfo
     // publication. Microsoft documents that metadata changes, including a
@@ -1080,7 +1083,7 @@ fn sync_tombstone_parent(_queries_parent: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-#[cfg(not(windows))]
+#[cfg(all(test, not(windows)))]
 fn publish_staged_tombstone(
     staged: tempfile::NamedTempFile,
     path: &Path,
@@ -1089,13 +1092,13 @@ fn publish_staged_tombstone(
     staged.persist(path).map_err(|error| error.error)
 }
 
-#[cfg(windows)]
+#[cfg(all(test, windows))]
 struct WindowsTombstonePublish {
     directory: fs::File,
     rename_handle: fs::File,
 }
 
-#[cfg(windows)]
+#[cfg(all(test, windows))]
 fn prepare_windows_tombstone_publish(
     queries_parent: &Path,
     staged: &fs::File,
@@ -1178,7 +1181,7 @@ fn normalize_windows_stage_attributes(file: &fs::File) -> std::io::Result<()> {
     }
 }
 
-#[cfg(windows)]
+#[cfg(all(test, windows))]
 fn publish_staged_tombstone(
     staged: tempfile::NamedTempFile,
     path: &Path,
@@ -1236,7 +1239,7 @@ fn publish_staged_tombstone(
 /// kakehashi-owned leaf is constrained. An observed existing leaf is validated,
 /// then a private same-directory inode atomically replaces its directory entry;
 /// no pre-existing inode is ever truncated.
-#[cfg(unix)]
+#[cfg(all(test, unix))]
 fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
     use std::os::unix::fs::OpenOptionsExt;
 
@@ -1263,7 +1266,7 @@ fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permis
     Ok(Some(metadata.permissions()))
 }
 
-#[cfg(windows)]
+#[cfg(all(test, windows))]
 fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
     use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
     use windows_sys::Win32::Storage::FileSystem::{
@@ -1306,7 +1309,7 @@ fn require_single_link(links: u64) -> std::io::Result<()> {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(test, unix))]
 fn verify_published_tombstone(published: fs::File, path: &Path) -> std::io::Result<()> {
     use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _};
 
@@ -1329,7 +1332,7 @@ fn verify_published_tombstone(published: fs::File, path: &Path) -> std::io::Resu
     Ok(())
 }
 
-#[cfg(windows)]
+#[cfg(all(test, windows))]
 fn verify_published_tombstone(published: fs::File, path: &Path) -> std::io::Result<()> {
     use std::os::windows::fs::{MetadataExt as _, OpenOptionsExt as _};
     use windows_sys::Win32::Storage::FileSystem::{
@@ -1379,7 +1382,7 @@ fn windows_file_information(
     Ok(unsafe { information.assume_init() })
 }
 
-#[cfg(not(any(unix, windows)))]
+#[cfg(all(test, not(any(unix, windows))))]
 fn verify_published_tombstone(_published: fs::File, path: &Path) -> std::io::Result<()> {
     if fs::symlink_metadata(path)?.file_type().is_file() {
         Ok(())
@@ -1390,7 +1393,7 @@ fn verify_published_tombstone(_published: fs::File, path: &Path) -> std::io::Res
     }
 }
 
-#[cfg(not(any(unix, windows)))]
+#[cfg(all(test, not(any(unix, windows))))]
 fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
     match fs::symlink_metadata(path) {
         Ok(metadata) if metadata.file_type().is_file() => Ok(Some(metadata.permissions())),

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -542,10 +542,11 @@ fn remove_query_install_and_backups_with_hooks(
 ) -> Result<QueryRemoval, QueryInstallError> {
     validate_safe_language_name(language)?;
     fs::create_dir_all(queries_parent)?;
+    let pinned_parent =
+        cap_std::fs::Dir::open_ambient_dir(queries_parent, cap_std::ambient_authority())?;
     let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
     write_tombstone(queries_parent, language)?;
     before_remove(queries_parent);
-    let queries_dir = queries_parent.join(language);
     let mut removal = QueryRemoval {
         removed_queries: false,
         removed_backups: false,
@@ -555,14 +556,14 @@ fn remove_query_install_and_backups_with_hooks(
     // (e.g. PermissionDenied), which would skip removal and report "not
     // installed" over a still-present unreadable dir. The tolerant removal
     // reports whether anything was actually removed.
-    removal.removed_queries = remove_dir_all_tolerating_vanished(&queries_dir)?;
+    removal.removed_queries = remove_dir_all_at_tolerating_vanished(&pinned_parent, language)?;
 
     // Propagate per-entry read_dir errors: uninstall must not report success
     // while backups it could not even enumerate stay behind.
-    for entry in fs::read_dir(queries_parent)? {
+    for entry in pinned_parent.entries()? {
         let entry = entry?;
-        let path = entry.path();
-        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
             continue;
         };
         // file_type() over path.is_dir(): is_dir() swallows metadata errors
@@ -570,18 +571,20 @@ fn remove_query_install_and_backups_with_hooks(
         // while uninstall reports success.
         if entry.file_type()?.is_dir()
             && generated_backup_matches_language(name, language)
-            && backup_is_owned(&path)
+            && pinned_parent
+                .metadata(backup_ownership_sidecar_name(name))
+                .is_ok_and(|metadata| metadata.is_file())
         {
-            let ownership = backup_ownership_sidecar(&path);
+            let ownership = backup_ownership_sidecar_name(name);
             // Same NotFound tolerance as the canonical dir above: a backup
             // deleted externally after enumeration is already the end state.
-            let removed_dir = remove_dir_all_tolerating_vanished(&path)?;
+            let removed_dir = remove_dir_all_at_tolerating_vanished(&pinned_parent, &file_name)?;
             // The sidecar is a kakehashi-owned artifact too: deleting it
             // counts as removal even when the dir itself vanished first —
             // and, like every other I/O in this loop, only NotFound is
             // tolerated (an unremovable marker must fail the uninstall, not
             // linger behind a success report).
-            let removed_sidecar = match fs::remove_file(ownership) {
+            let removed_sidecar = match pinned_parent.remove_file(ownership) {
                 Ok(()) => true,
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
                 Err(e) => return Err(QueryInstallError::IoError(e)),
@@ -592,6 +595,23 @@ fn remove_query_install_and_backups_with_hooks(
         }
     }
     Ok(removal)
+}
+
+fn remove_dir_all_at_tolerating_vanished(
+    parent: &cap_std::fs::Dir,
+    name: impl AsRef<Path>,
+) -> Result<bool, QueryInstallError> {
+    let name = name.as_ref();
+    match parent.remove_dir_all(name) {
+        Ok(()) => Ok(true),
+        Err(e)
+            if e.kind() == std::io::ErrorKind::NotFound
+                && matches!(parent.try_exists(name), Ok(false)) =>
+        {
+            Ok(false)
+        }
+        Err(e) => Err(QueryInstallError::IoError(e)),
+    }
 }
 
 /// `fs::remove_dir_all` that treats a CONFIRMED-vanished directory as the
@@ -1259,6 +1279,10 @@ fn backup_ownership_sidecar(backup_dir: &Path) -> PathBuf {
     ))
 }
 
+fn backup_ownership_sidecar_name(backup_name: &str) -> String {
+    format!("{backup_name}{QUERY_BACKUP_OWNERSHIP_MARKER}")
+}
+
 fn write_backup_ownership_marker(backup_dir: &Path) -> Result<(), QueryInstallError> {
     let mut file = fs::File::create(backup_ownership_sidecar(backup_dir))?;
     file.write_all(b"ok\n")?;
@@ -1654,6 +1678,51 @@ mod tests {
         assert_eq!(
             fs::read_to_string(uninstall_tombstone_path(&real_queries, "rust")).unwrap(),
             "ok\n"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn remove_query_install_stays_bound_when_symlinked_parent_is_retargeted() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let original = temp.path().join("original-queries");
+        let replacement = temp.path().join("replacement-queries");
+        fs::create_dir_all(original.join("rust")).unwrap();
+        fs::create_dir_all(replacement.join("rust")).unwrap();
+        fs::write(original.join("rust/highlights.scm"), "original\n").unwrap();
+        fs::write(replacement.join("rust/highlights.scm"), "outside\n").unwrap();
+        let linked = temp.path().join("queries");
+        symlink(&original, &linked).unwrap();
+
+        remove_query_install_and_backups_with_hooks(
+            &linked,
+            "rust",
+            write_uninstall_tombstone,
+            |queries_parent| {
+                fs::remove_file(queries_parent).unwrap();
+                symlink(&replacement, queries_parent).unwrap();
+            },
+        )
+        .unwrap();
+
+        assert!(
+            !original.join("rust").exists(),
+            "cleanup must stay in the directory that received durable intent"
+        );
+        assert_eq!(
+            fs::read_to_string(replacement.join("rust/highlights.scm")).unwrap(),
+            "outside\n",
+            "retargeting must not redirect destructive cleanup"
+        );
+        assert!(
+            uninstall_tombstone_path(&original, "rust").exists(),
+            "the pinned directory retains its uninstall intent"
+        );
+        assert!(
+            !uninstall_tombstone_path(&replacement, "rust").exists(),
+            "the replacement directory must remain untouched"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -522,14 +522,14 @@ pub fn remove_query_install_and_backups(
     remove_query_install_and_backups_with_tombstone_writer(
         queries_parent,
         language,
-        write_uninstall_tombstone,
+        |pinned, parent, lang| write_uninstall_tombstone_at(pinned, parent, lang),
     )
 }
 
 fn remove_query_install_and_backups_with_tombstone_writer(
     queries_parent: &Path,
     language: &str,
-    write_tombstone: impl FnOnce(&Path, &str) -> Result<(), QueryInstallError>,
+    write_tombstone: impl FnOnce(&cap_std::fs::Dir, &Path, &str) -> Result<(), QueryInstallError>,
 ) -> Result<QueryRemoval, QueryInstallError> {
     remove_query_install_and_backups_with_hooks(queries_parent, language, write_tombstone, |_| {})
 }
@@ -537,7 +537,7 @@ fn remove_query_install_and_backups_with_tombstone_writer(
 fn remove_query_install_and_backups_with_hooks(
     queries_parent: &Path,
     language: &str,
-    write_tombstone: impl FnOnce(&Path, &str) -> Result<(), QueryInstallError>,
+    write_tombstone: impl FnOnce(&cap_std::fs::Dir, &Path, &str) -> Result<(), QueryInstallError>,
     before_remove: impl FnOnce(&Path),
 ) -> Result<QueryRemoval, QueryInstallError> {
     validate_safe_language_name(language)?;
@@ -545,7 +545,7 @@ fn remove_query_install_and_backups_with_hooks(
     let pinned_parent =
         cap_std::fs::Dir::open_ambient_dir(queries_parent, cap_std::ambient_authority())?;
     let _replace_lock = QueryReplaceLockGuard::acquire_at(&pinned_parent, language)?;
-    write_tombstone(queries_parent, language)?;
+    write_tombstone(&pinned_parent, queries_parent, language)?;
     before_remove(queries_parent);
     let mut removal = QueryRemoval {
         removed_queries: false,
@@ -805,6 +805,217 @@ fn write_uninstall_tombstone(
         |_, _| {},
         sync_tombstone_parent,
     )
+}
+
+#[cfg(unix)]
+fn write_uninstall_tombstone_at(
+    queries_parent: &cap_std::fs::Dir,
+    _ambient_path: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    use cap_fs_ext::{
+        FollowSymlinks, MetadataExt as CapMetadataExt, OpenOptionsFollowExt, OpenOptionsSyncExt,
+    };
+
+    validate_safe_language_name(language)?;
+    let tombstone_name = format!(".{language}{QUERY_UNINSTALL_TOMBSTONE_SUFFIX}");
+    let mut existing_options = cap_std::fs::OpenOptions::new();
+    existing_options
+        .write(true)
+        .follow(FollowSymlinks::No)
+        .nonblock(true);
+    let existing_permissions = match queries_parent.open_with(&tombstone_name, &existing_options) {
+        Ok(file) => {
+            let metadata = file.metadata()?;
+            if !metadata.is_file() {
+                return Err(QueryInstallError::IoError(std::io::Error::other(
+                    "query uninstall tombstone is not a regular file",
+                )));
+            }
+            require_single_link(CapMetadataExt::nlink(&metadata))?;
+            Some(file.into_std().metadata()?.permissions())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(QueryInstallError::IoError(error)),
+    };
+
+    let stage_name = loop {
+        let counter = QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let candidate = format!(
+            ".{language}.uninstalled.{}.{}.tmp",
+            std::process::id(),
+            counter
+        );
+        let mut options = cap_std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        match queries_parent.open_with(&candidate, &options) {
+            Ok(file) => break (candidate, file.into_std()),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(QueryInstallError::IoError(error)),
+        }
+    };
+    let (stage_name, mut staged) = stage_name;
+    let result = (|| -> Result<(), QueryInstallError> {
+        if let Some(permissions) = existing_permissions {
+            staged.set_permissions(permissions)?;
+        }
+        staged.write_all(b"ok\n")?;
+        staged.sync_all()?;
+        let staged_metadata = staged.metadata()?;
+        queries_parent.rename(&stage_name, queries_parent, &tombstone_name)?;
+
+        let mut published_options = cap_std::fs::OpenOptions::new();
+        published_options
+            .read(true)
+            .follow(FollowSymlinks::No)
+            .nonblock(true);
+        let published = queries_parent
+            .open_with(&tombstone_name, &published_options)?
+            .into_std();
+        let published_metadata = published.metadata()?;
+        if !published_metadata.is_file()
+            || std::os::unix::fs::MetadataExt::dev(&published_metadata)
+                != std::os::unix::fs::MetadataExt::dev(&staged_metadata)
+            || std::os::unix::fs::MetadataExt::ino(&published_metadata)
+                != std::os::unix::fs::MetadataExt::ino(&staged_metadata)
+        {
+            return Err(QueryInstallError::IoError(std::io::Error::other(
+                "published query uninstall tombstone changed identity",
+            )));
+        }
+        require_single_link(std::os::unix::fs::MetadataExt::nlink(&published_metadata))?;
+        queries_parent.try_clone()?.into_std_file().sync_all()?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = queries_parent.remove_file(&stage_name);
+    }
+    result
+}
+
+#[cfg(windows)]
+fn write_uninstall_tombstone_at(
+    queries_parent: &cap_std::fs::Dir,
+    _ambient_path: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+    use std::os::windows::ffi::OsStrExt as _;
+    use std::os::windows::io::{AsRawHandle as _, FromRawHandle as _};
+    use windows_sys::Win32::Foundation::{DELETE, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_FLAG_WRITE_THROUGH, FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_RENAME_INFO,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FileRenameInfo, ReOpenFile,
+        SetFileInformationByHandle,
+    };
+
+    validate_safe_language_name(language)?;
+    let tombstone_name = format!(".{language}{QUERY_UNINSTALL_TOMBSTONE_SUFFIX}");
+    let mut existing_options = cap_std::fs::OpenOptions::new();
+    existing_options.write(true).follow(FollowSymlinks::No);
+    let existing_permissions = match queries_parent.open_with(&tombstone_name, &existing_options) {
+        Ok(file) => {
+            let file = file.into_std();
+            let metadata = file.metadata()?;
+            if !metadata.is_file() {
+                return Err(QueryInstallError::IoError(std::io::Error::other(
+                    "query uninstall tombstone is not a regular file",
+                )));
+            }
+            require_single_link(u64::from(windows_file_information(&file)?.nNumberOfLinks))?;
+            Some(metadata.permissions())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(QueryInstallError::IoError(error)),
+    };
+
+    let (stage_name, mut staged) = loop {
+        let counter = QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let candidate = format!(
+            ".{language}.uninstalled.{}.{}.tmp",
+            std::process::id(),
+            counter
+        );
+        let mut options = cap_std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        match queries_parent.open_with(&candidate, &options) {
+            Ok(file) => break (candidate, file.into_std()),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(QueryInstallError::IoError(error)),
+        }
+    };
+    let result = (|| -> Result<(), QueryInstallError> {
+        if let Some(permissions) = existing_permissions {
+            staged.set_permissions(permissions)?;
+        }
+        staged.write_all(b"ok\n")?;
+        staged.sync_all()?;
+        let directory = queries_parent.try_clone()?.into_std_file();
+        // SAFETY: `staged` owns a valid handle; success returns a new owned handle.
+        let handle = unsafe {
+            ReOpenFile(
+                staged.as_raw_handle(),
+                FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                FILE_FLAG_WRITE_THROUGH,
+            )
+        };
+        if handle == INVALID_HANDLE_VALUE {
+            return Err(QueryInstallError::IoError(std::io::Error::last_os_error()));
+        }
+        // SAFETY: successful ReOpenFile returned a newly owned handle.
+        let rename_handle = unsafe { fs::File::from_raw_handle(handle) };
+        normalize_windows_stage_attributes(&rename_handle)?;
+        let filename: Vec<u16> = std::ffi::OsStr::new(&tombstone_name)
+            .encode_wide()
+            .collect();
+        let header = std::mem::offset_of!(FILE_RENAME_INFO, FileName);
+        let size = header + filename.len() * std::mem::size_of::<u16>();
+        let units = size.div_ceil(std::mem::size_of::<FILE_RENAME_INFO>());
+        let mut buffer = vec![FILE_RENAME_INFO::default(); units];
+        let information = buffer.as_mut_ptr();
+        // SAFETY: the buffer covers the header/name and both handles stay valid.
+        let succeeded = unsafe {
+            (*information).Anonymous.ReplaceIfExists = true;
+            (*information).RootDirectory = directory.as_raw_handle();
+            (*information).FileNameLength = u32::try_from(filename.len() * 2).unwrap();
+            std::ptr::copy_nonoverlapping(
+                filename.as_ptr(),
+                (*information).FileName.as_mut_ptr(),
+                filename.len(),
+            );
+            SetFileInformationByHandle(
+                rename_handle.as_raw_handle(),
+                FileRenameInfo,
+                information.cast(),
+                u32::try_from(size).unwrap(),
+            )
+        };
+        if succeeded == 0 {
+            return Err(QueryInstallError::IoError(std::io::Error::last_os_error()));
+        }
+        let mut published_options = cap_std::fs::OpenOptions::new();
+        published_options.read(true).follow(FollowSymlinks::No);
+        let published = queries_parent
+            .open_with(&tombstone_name, &published_options)?
+            .into_std();
+        let expected = windows_file_information(&rename_handle)?;
+        let actual = windows_file_information(&published)?;
+        if expected.dwVolumeSerialNumber != actual.dwVolumeSerialNumber
+            || expected.nFileIndexHigh != actual.nFileIndexHigh
+            || expected.nFileIndexLow != actual.nFileIndexLow
+        {
+            return Err(QueryInstallError::IoError(std::io::Error::other(
+                "published query uninstall tombstone changed identity",
+            )));
+        }
+        require_single_link(u64::from(actual.nNumberOfLinks))?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = queries_parent.remove_file(&stage_name);
+    }
+    result
 }
 
 fn write_uninstall_tombstone_with_before_publish(
@@ -1713,11 +1924,12 @@ mod tests {
         remove_query_install_and_backups_with_hooks(
             &linked,
             "rust",
-            write_uninstall_tombstone,
-            |queries_parent| {
-                fs::remove_file(queries_parent).unwrap();
-                symlink(&replacement, queries_parent).unwrap();
+            |pinned, ambient_parent, language| {
+                fs::remove_file(ambient_parent).unwrap();
+                symlink(&replacement, ambient_parent).unwrap();
+                write_uninstall_tombstone_at(pinned, ambient_parent, language)
             },
+            |_| {},
         )
         .unwrap();
 
@@ -1777,7 +1989,7 @@ mod tests {
         let result = remove_query_install_and_backups_with_tombstone_writer(
             &queries_parent,
             "rust",
-            |_, _| {
+            |_, _, _| {
                 Err(QueryInstallError::IoError(std::io::Error::other(
                     "injected durability failure",
                 )))


### PR DESCRIPTION
## Summary

- open the resolved `queries` directory once and bind the per-language lock, tombstone transaction, enumeration, and destructive removal to that capability
- publish and verify uninstall intent handle-relatively on Unix and Windows while preserving #822 leaf no-follow/link checks and #829 durability ordering
- add a deterministic parent-retarget race proving the original directory is completed and the replacement remains untouched
- migrate leaf-race, cleanup, permission, identity, and durability tests onto the production pinned writer

## Stacked dependency

This draft is stacked on #840 (`fix/issue-829-query-tombstone-durability`) at exact base `fe1a45b1478d2e69299301b2a036b5444164a8b3`. The stack contains latest `origin/main` (`75a09c99ba628be59c8833eed571924e4b576a54`). Rebase onto `main` and run full CI after the parent lands.

## Validation

- `cargo test --lib -q remove_query_install_` (6 passed)
- `cargo test --lib -q tombstone_` (9 passed)
- `make check`
- full `cargo test --lib -q`: only the five known current-main environment failures (missing Rust cancellation fixture and four closed-host bridge tests)
- Stage-1 exact-head re-review: CLEAN
- Codex continued exact-head: CLEAN
- Codex fresh exact-head: CLEAN

Closes #830

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability and race resistance of query installation cleanup.
  * Ensured uninstall operations remain bound to the original installation location if paths change during cleanup.
  * Strengthened tombstone creation and removal behavior, including safer handling of permissions, identity, and interrupted operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->