### PR TITLE
fix(install): preserve Windows tombstone security

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,14 @@ jobs:
       - run: make deps/tree-sitter
       - run: cargo test
 
+  test-windows-query-tombstone:
+    name: Test Windows query tombstone
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: cargo test --lib windows_tombstone -- --nocapture
+      - run: cargo test --lib windows_security_copy_failure -- --nocapture
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@v7
       - run: cargo test --lib windows_tombstone -- --nocapture
       - run: cargo test --lib windows_security_copy_failure -- --nocapture
+      - run: cargo test --lib windows_differing_owner -- --nocapture
 
   fmt:
     name: Format

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +151,36 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.4",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "cc"
@@ -511,6 +547,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs4"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +902,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +1026,7 @@ name = "kakehashi"
 version = "0.8.0"
 dependencies = [
  "arc-swap",
+ "cap-std",
  "clap",
  "dashmap",
  "dirs",
@@ -1103,6 +1179,12 @@ checksum = "ab84ba33842e323474cc2e32179407782b6dd272eeb433c47e5cd11912163cf0"
 dependencies = [
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -1562,6 +1644,16 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -2790,6 +2882,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.13.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
+name = "cap-fs-ext"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "cap-primitives"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,6 +1038,7 @@ name = "kakehashi"
 version = "0.8.0"
 dependencies = [
  "arc-swap",
+ "cap-fs-ext",
  "cap-std",
  "clap",
  "dashmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,7 @@ dependencies = [
  "ulid",
  "ureq",
  "url",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ futures = "0.3.31"
 nix = { version = "0.31", features = ["signal", "process", "fs"] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
 
 [features]
 e2e = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ opt-level = 3
 
 [dependencies]
 arc-swap = "1"
+cap-std = "4.0.2"
 clap = { version = "4", features = ["derive"] }
 dashmap = "6"
 dirs = "6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ opt-level = 3
 [dependencies]
 arc-swap = "1"
 cap-std = "4.0.2"
+cap-fs-ext = "4.0.2"
 clap = { version = "4", features = ["derive"] }
 dashmap = "6"
 dirs = "6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,9 @@ futures = "0.3.31"
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process", "fs"] }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+
 [features]
 e2e = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ futures = "0.3.31"
 nix = { version = "0.31", features = ["signal", "process", "fs"] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem"] }
 
 [features]
 e2e = []

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -1194,7 +1194,10 @@ fn copy_windows_tombstone_security(source: &fs::File, target: &fs::File) -> std:
             )
         };
         if status != ERROR_SUCCESS {
-            return Err(std::io::Error::from_raw_os_error(status as i32));
+            return Err(std::io::Error::other(format!(
+                "GetSecurityInfo failed: {}",
+                std::io::Error::from_raw_os_error(status as i32)
+            )));
         }
         Ok((SecurityDescriptor(descriptor), owner, group, dacl))
     }
@@ -1210,7 +1213,10 @@ fn copy_windows_tombstone_security(source: &fs::File, target: &fs::File) -> std:
     if unsafe { GetSecurityDescriptorControl(source_descriptor.0, &mut control, &mut revision) }
         == 0
     {
-        return Err(std::io::Error::last_os_error());
+        return Err(std::io::Error::other(format!(
+            "GetSecurityDescriptorControl failed: {}",
+            std::io::Error::last_os_error()
+        )));
     }
     let dacl_mode = if control & SE_DACL_PROTECTED != 0 {
         PROTECTED_DACL_SECURITY_INFORMATION
@@ -1230,7 +1236,10 @@ fn copy_windows_tombstone_security(source: &fs::File, target: &fs::File) -> std:
         )
     };
     if dacl_status != ERROR_SUCCESS {
-        return Err(std::io::Error::from_raw_os_error(dacl_status as i32));
+        return Err(std::io::Error::other(format!(
+            "SetSecurityInfo DACL failed: {}",
+            std::io::Error::from_raw_os_error(dacl_status as i32)
+        )));
     }
 
     // New stages normally inherit the same owner/group. Only request the
@@ -1257,7 +1266,10 @@ fn copy_windows_tombstone_security(source: &fs::File, target: &fs::File) -> std:
             )
         };
         if handle.is_null() || handle == windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE {
-            return Err(std::io::Error::last_os_error());
+            return Err(std::io::Error::other(format!(
+                "ReOpenFile WRITE_OWNER failed: {}",
+                std::io::Error::last_os_error()
+            )));
         }
         // SAFETY: successful ReOpenFile returned a newly owned handle.
         let owner_handle = unsafe { fs::File::from_raw_handle(handle) };
@@ -1281,7 +1293,10 @@ fn copy_windows_tombstone_security(source: &fs::File, target: &fs::File) -> std:
             )
         };
         if status != ERROR_SUCCESS {
-            return Err(std::io::Error::from_raw_os_error(status as i32));
+            return Err(std::io::Error::other(format!(
+                "SetSecurityInfo owner/group failed: {}",
+                std::io::Error::from_raw_os_error(status as i32)
+            )));
         }
     }
     Ok(())
@@ -2180,14 +2195,18 @@ mod tests {
     #[test]
     #[cfg(windows)]
     fn windows_tombstone_preserves_null_protected_dacl() {
-        use std::os::windows::io::AsRawHandle as _;
-        use windows_sys::Win32::Foundation::{ERROR_SUCCESS, LocalFree};
+        use std::os::windows::io::{AsRawHandle as _, FromRawHandle as _};
+        use windows_sys::Win32::Foundation::{ERROR_SUCCESS, INVALID_HANDLE_VALUE, LocalFree};
         use windows_sys::Win32::Security::Authorization::{
             GetSecurityInfo, SE_FILE_OBJECT, SetSecurityInfo,
         };
         use windows_sys::Win32::Security::{
             DACL_SECURITY_INFORMATION, GetSecurityDescriptorControl,
             PROTECTED_DACL_SECURITY_INFORMATION, SE_DACL_PROTECTED,
+        };
+        use windows_sys::Win32::Storage::FileSystem::{
+            FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, READ_CONTROL, ReOpenFile,
+            WRITE_DAC,
         };
 
         let temp = TempDir::new().unwrap();
@@ -2200,11 +2219,23 @@ mod tests {
             .write(true)
             .open(&tombstone)
             .unwrap();
+        // SAFETY: success returns a distinct owned handle with WRITE_DAC.
+        let security_handle = unsafe {
+            ReOpenFile(
+                existing.as_raw_handle(),
+                READ_CONTROL | WRITE_DAC,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                0,
+            )
+        };
+        assert_ne!(security_handle, INVALID_HANDLE_VALUE);
+        // SAFETY: successful ReOpenFile returned a newly owned handle.
+        let security_file = unsafe { fs::File::from_raw_handle(security_handle) };
         // SAFETY: the handle is valid; a null DACL is intentional and grants
         // full access while remaining observably distinct from an inherited ACL.
         let status = unsafe {
             SetSecurityInfo(
-                existing.as_raw_handle(),
+                security_file.as_raw_handle(),
                 SE_FILE_OBJECT,
                 DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
                 std::ptr::null_mut(),

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -769,9 +769,14 @@ fn write_uninstall_tombstone_with_before_publish(
     remove_stale_uninstall_stages(queries_parent, language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
     validate_existing_tombstone(&path)?;
-    let stage_prefix = format!(".{language}.uninstalled.");
+    let stage_counter = QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stage_prefix = format!(
+        ".{language}.uninstalled.{}.{}.",
+        std::process::id(),
+        stage_counter
+    );
     let mut builder = tempfile::Builder::new();
-    builder.prefix(&stage_prefix).suffix(".tmp");
+    builder.prefix(&stage_prefix).suffix(".tmp").rand_bytes(12);
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt as _;
@@ -798,14 +803,13 @@ fn remove_stale_uninstall_stages(
     queries_parent: &Path,
     language: &str,
 ) -> Result<(), QueryInstallError> {
-    let prefix = format!(".{language}.uninstalled.");
     for entry in fs::read_dir(queries_parent)? {
         let entry = entry?;
         let name = entry.file_name();
         let Some(name) = name.to_str() else {
             continue;
         };
-        if !name.starts_with(&prefix) || !name.ends_with(".tmp") {
+        if !generated_uninstall_stage_matches_language(name, language) {
             continue;
         }
         let file_type = entry.file_type()?;
@@ -819,6 +823,28 @@ fn remove_stale_uninstall_stages(
         }
     }
     Ok(())
+}
+
+fn generated_uninstall_stage_matches_language(name: &str, language: &str) -> bool {
+    let prefix = format!(".{language}.uninstalled.");
+    let Some(rest) = name
+        .strip_prefix(&prefix)
+        .and_then(|rest| rest.strip_suffix(".tmp"))
+    else {
+        return false;
+    };
+    let mut parts = rest.split('.');
+    let (Some(pid), Some(counter), Some(random), None) =
+        (parts.next(), parts.next(), parts.next(), parts.next())
+    else {
+        return false;
+    };
+    !pid.is_empty()
+        && pid.bytes().all(|byte| byte.is_ascii_digit())
+        && !counter.is_empty()
+        && counter.bytes().all(|byte| byte.is_ascii_digit())
+        && random.len() == 12
+        && random.bytes().all(|byte| byte.is_ascii_alphanumeric())
 }
 
 /// Open or create the managed tombstone leaf without following a link there.
@@ -1581,14 +1607,20 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let queries_parent = temp.path().join("queries");
         fs::create_dir_all(&queries_parent).unwrap();
-        let stale = queries_parent.join(".rust.uninstalled.crashed.tmp");
+        let stale = queries_parent.join(".rust.uninstalled.123.7.ABCDEFGHIJKL.tmp");
         fs::write(&stale, "partial\n").unwrap();
-        let unrelated = queries_parent.join(".lua.uninstalled.crashed.tmp");
+        let same_language_unrelated = queries_parent.join(".rust.uninstalled.notes.tmp");
+        fs::write(&same_language_unrelated, "keep notes\n").unwrap();
+        let unrelated = queries_parent.join(".lua.uninstalled.123.7.ABCDEFGHIJKL.tmp");
         fs::write(&unrelated, "keep\n").unwrap();
 
         write_uninstall_tombstone(&queries_parent, "rust").unwrap();
 
         assert!(!stale.exists(), "same-language stale stage is managed");
+        assert!(
+            same_language_unrelated.exists(),
+            "a wildcard-like name is not proof of kakehashi ownership"
+        );
         assert!(unrelated.exists(), "other languages have separate locks");
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -766,11 +766,12 @@ fn write_uninstall_tombstone_with_before_publish(
     before_publish: impl FnOnce(&Path, &Path),
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
+    remove_stale_uninstall_stages(queries_parent, language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
     validate_existing_tombstone(&path)?;
     let stage_prefix = format!(".{language}.uninstalled.");
     let mut builder = tempfile::Builder::new();
-    builder.prefix(&stage_prefix);
+    builder.prefix(&stage_prefix).suffix(".tmp");
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt as _;
@@ -784,6 +785,39 @@ fn write_uninstall_tombstone_with_before_publish(
     before_publish(&path, staged.path());
     let published = staged.persist(&path).map_err(|error| error.error)?;
     verify_published_tombstone(published, &path)?;
+    Ok(())
+}
+
+/// Remove crash-stranded private stages for `language`.
+///
+/// Production callers hold that language's [`QueryReplaceLockGuard`], so no
+/// live kakehashi publisher can own a matching stage while this sweep runs.
+/// File symlinks are removed as directory entries; matching directories are
+/// not managed by this file-stage namespace and are left untouched.
+fn remove_stale_uninstall_stages(
+    queries_parent: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    let prefix = format!(".{language}.uninstalled.");
+    for entry in fs::read_dir(queries_parent)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if !name.starts_with(&prefix) || !name.ends_with(".tmp") {
+            continue;
+        }
+        let file_type = entry.file_type()?;
+        if !file_type.is_file() && !file_type.is_symlink() {
+            continue;
+        }
+        match fs::remove_file(entry.path()) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(QueryInstallError::IoError(error)),
+        }
+    }
     Ok(())
 }
 
@@ -1540,6 +1574,22 @@ mod tests {
             vec![tombstone.file_name().unwrap().to_os_string()],
             "the private stage must be removed on every persist failure"
         );
+    }
+
+    #[test]
+    fn tombstone_publish_reclaims_crash_stranded_stage() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let stale = queries_parent.join(".rust.uninstalled.crashed.tmp");
+        fs::write(&stale, "partial\n").unwrap();
+        let unrelated = queries_parent.join(".lua.uninstalled.crashed.tmp");
+        fs::write(&unrelated, "keep\n").unwrap();
+
+        write_uninstall_tombstone(&queries_parent, "rust").unwrap();
+
+        assert!(!stale.exists(), "same-language stale stage is managed");
+        assert!(unrelated.exists(), "other languages have separate locks");
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -932,6 +932,25 @@ fn write_uninstall_tombstone_at_with_hooks(
     before_publish: impl FnOnce(&cap_std::fs::Dir, &str, &str),
     sync_parent: impl FnOnce(&cap_std::fs::Dir) -> std::io::Result<()>,
 ) -> Result<(), QueryInstallError> {
+    write_uninstall_tombstone_at_with_security_copy(
+        queries_parent,
+        _ambient_path,
+        language,
+        before_publish,
+        sync_parent,
+        copy_windows_tombstone_security,
+    )
+}
+
+#[cfg(windows)]
+fn write_uninstall_tombstone_at_with_security_copy(
+    queries_parent: &cap_std::fs::Dir,
+    _ambient_path: &Path,
+    language: &str,
+    before_publish: impl FnOnce(&cap_std::fs::Dir, &str, &str),
+    sync_parent: impl FnOnce(&cap_std::fs::Dir) -> std::io::Result<()>,
+    copy_security: impl FnOnce(&fs::File, &fs::File) -> std::io::Result<()>,
+) -> Result<(), QueryInstallError> {
     use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
     use std::os::windows::ffi::OsStrExt as _;
     use std::os::windows::io::{AsRawHandle as _, FromRawHandle as _};
@@ -939,28 +958,29 @@ fn write_uninstall_tombstone_at_with_hooks(
     use windows_sys::Win32::Storage::FileSystem::{
         FILE_FLAG_WRITE_THROUGH, FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_RENAME_INFO,
         FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FileRenameInfo, ReOpenFile,
-        SetFileInformationByHandle,
+        SetFileInformationByHandle, WRITE_DAC,
     };
 
     validate_safe_language_name(language)?;
     let tombstone_name = format!(".{language}{QUERY_UNINSTALL_TOMBSTONE_SUFFIX}");
     let mut existing_options = cap_std::fs::OpenOptions::new();
     existing_options.write(true).follow(FollowSymlinks::No);
-    let existing_permissions = match queries_parent.open_with(&tombstone_name, &existing_options) {
-        Ok(file) => {
-            let file = file.into_std();
-            let metadata = file.metadata()?;
-            if !metadata.is_file() {
-                return Err(QueryInstallError::IoError(std::io::Error::other(
-                    "query uninstall tombstone is not a regular file",
-                )));
+    let (existing_permissions, existing_file) =
+        match queries_parent.open_with(&tombstone_name, &existing_options) {
+            Ok(file) => {
+                let file = file.into_std();
+                let metadata = file.metadata()?;
+                if !metadata.is_file() {
+                    return Err(QueryInstallError::IoError(std::io::Error::other(
+                        "query uninstall tombstone is not a regular file",
+                    )));
+                }
+                require_single_link(u64::from(windows_file_information(&file)?.nNumberOfLinks))?;
+                (Some(metadata.permissions()), Some(file))
             }
-            require_single_link(u64::from(windows_file_information(&file)?.nNumberOfLinks))?;
-            Some(metadata.permissions())
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
-        Err(error) => return Err(QueryInstallError::IoError(error)),
-    };
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => (None, None),
+            Err(error) => return Err(QueryInstallError::IoError(error)),
+        };
 
     let (stage_name, mut staged) = loop {
         let counter = QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -988,7 +1008,7 @@ fn write_uninstall_tombstone_at_with_hooks(
         let handle = unsafe {
             ReOpenFile(
                 staged.as_raw_handle(),
-                FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE,
+                FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE | WRITE_DAC,
                 FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                 FILE_FLAG_WRITE_THROUGH,
             )
@@ -999,6 +1019,9 @@ fn write_uninstall_tombstone_at_with_hooks(
         // SAFETY: successful ReOpenFile returned a newly owned handle.
         let rename_handle = unsafe { fs::File::from_raw_handle(handle) };
         normalize_windows_stage_attributes(&rename_handle)?;
+        if let Some(existing_file) = &existing_file {
+            copy_security(existing_file, &rename_handle)?;
+        }
         before_publish(queries_parent, &tombstone_name, &stage_name);
         let filename: Vec<u16> = std::ffi::OsStr::new(&tombstone_name)
             .encode_wide()
@@ -1115,6 +1138,152 @@ fn normalize_windows_stage_attributes(file: &fs::File) -> std::io::Result<()> {
     } else {
         Ok(())
     }
+}
+
+#[cfg(windows)]
+fn copy_windows_tombstone_security(source: &fs::File, target: &fs::File) -> std::io::Result<()> {
+    use std::os::windows::io::{AsRawHandle as _, FromRawHandle as _};
+    use windows_sys::Win32::Foundation::{ERROR_SUCCESS, LocalFree};
+    use windows_sys::Win32::Security::Authorization::{
+        GetSecurityInfo, SE_FILE_OBJECT, SetSecurityInfo,
+    };
+    use windows_sys::Win32::Security::{
+        DACL_SECURITY_INFORMATION, EqualSid, GROUP_SECURITY_INFORMATION,
+        GetSecurityDescriptorControl, OWNER_SECURITY_INFORMATION,
+        PROTECTED_DACL_SECURITY_INFORMATION, SE_DACL_PROTECTED,
+        UNPROTECTED_DACL_SECURITY_INFORMATION,
+    };
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, READ_CONTROL, ReOpenFile, WRITE_DAC,
+        WRITE_OWNER,
+    };
+
+    struct SecurityDescriptor(windows_sys::Win32::Security::PSECURITY_DESCRIPTOR);
+    impl Drop for SecurityDescriptor {
+        fn drop(&mut self) {
+            // SAFETY: GetSecurityInfo allocates this descriptor with LocalAlloc.
+            unsafe { LocalFree(self.0.cast()) };
+        }
+    }
+
+    unsafe fn read_security(
+        file: &fs::File,
+    ) -> std::io::Result<(
+        SecurityDescriptor,
+        windows_sys::Win32::Security::PSID,
+        windows_sys::Win32::Security::PSID,
+        *mut windows_sys::Win32::Security::ACL,
+    )> {
+        use std::os::windows::io::AsRawHandle as _;
+
+        let mut owner = std::ptr::null_mut();
+        let mut group = std::ptr::null_mut();
+        let mut dacl = std::ptr::null_mut();
+        let mut descriptor = std::ptr::null_mut();
+        // SAFETY: output pointers remain valid until the returned descriptor is dropped.
+        let status = unsafe {
+            GetSecurityInfo(
+                file.as_raw_handle(),
+                SE_FILE_OBJECT,
+                OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+                &mut owner,
+                &mut group,
+                &mut dacl,
+                std::ptr::null_mut(),
+                &mut descriptor,
+            )
+        };
+        if status != ERROR_SUCCESS {
+            return Err(std::io::Error::from_raw_os_error(status as i32));
+        }
+        Ok((SecurityDescriptor(descriptor), owner, group, dacl))
+    }
+
+    // SAFETY: both handles remain open and descriptor-owned pointers stay valid.
+    let (source_descriptor, source_owner, source_group, source_dacl) =
+        unsafe { read_security(source)? };
+    // SAFETY: same contract for the already-opened private stage.
+    let (_target_descriptor, target_owner, target_group, _) = unsafe { read_security(target)? };
+    let mut control = 0;
+    let mut revision = 0;
+    // SAFETY: descriptor is valid and outputs are initialized by the API.
+    if unsafe { GetSecurityDescriptorControl(source_descriptor.0, &mut control, &mut revision) }
+        == 0
+    {
+        return Err(std::io::Error::last_os_error());
+    }
+    let dacl_mode = if control & SE_DACL_PROTECTED != 0 {
+        PROTECTED_DACL_SECURITY_INFORMATION
+    } else {
+        UNPROTECTED_DACL_SECURITY_INFORMATION
+    };
+    // SAFETY: target has WRITE_DAC and the source DACL remains descriptor-owned.
+    let dacl_status = unsafe {
+        SetSecurityInfo(
+            target.as_raw_handle(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION | dacl_mode,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            source_dacl,
+            std::ptr::null_mut(),
+        )
+    };
+    if dacl_status != ERROR_SUCCESS {
+        return Err(std::io::Error::from_raw_os_error(dacl_status as i32));
+    }
+
+    // New stages normally inherit the same owner/group. Only request the
+    // privileged WRITE_OWNER path when either SID actually differs.
+    let sids_differ = |source, target| {
+        if source.is_null() || target.is_null() {
+            source != target
+        } else {
+            // SAFETY: both non-null pointers refer to descriptor-owned SIDs.
+            (unsafe { EqualSid(source, target) }) == 0
+        }
+    };
+    let owner_differs = sids_differ(source_owner, target_owner);
+    let group_differs = sids_differ(source_group, target_group);
+    if owner_differs || group_differs {
+        // SAFETY: successful ReOpenFile returns a distinct owned handle.
+        let handle = unsafe {
+            ReOpenFile(
+                target.as_raw_handle(),
+                READ_CONTROL | WRITE_DAC | WRITE_OWNER,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                0,
+            )
+        };
+        if handle.is_null() || handle == windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE {
+            return Err(std::io::Error::last_os_error());
+        }
+        // SAFETY: successful ReOpenFile returned a newly owned handle.
+        let owner_handle = unsafe { fs::File::from_raw_handle(handle) };
+        let mut information = 0;
+        if owner_differs {
+            information |= OWNER_SECURITY_INFORMATION;
+        }
+        if group_differs {
+            information |= GROUP_SECURITY_INFORMATION;
+        }
+        // SAFETY: selected SID pointers remain owned by source_descriptor.
+        let status = unsafe {
+            SetSecurityInfo(
+                owner_handle.as_raw_handle(),
+                SE_FILE_OBJECT,
+                information,
+                source_owner,
+                source_group,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        if status != ERROR_SUCCESS {
+            return Err(std::io::Error::from_raw_os_error(status as i32));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(any(unix, windows))]
@@ -1965,6 +2134,117 @@ mod tests {
             0,
             "published tombstone must not retain tempfile cache semantics"
         );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn windows_security_copy_failure_aborts_before_tombstone_publication() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(queries_parent.join("rust")).unwrap();
+        let tombstone = uninstall_tombstone_path(&queries_parent, "rust");
+        fs::write(&tombstone, "old\n").unwrap();
+        let pinned =
+            cap_std::fs::Dir::open_ambient_dir(&queries_parent, cap_std::ambient_authority())
+                .unwrap();
+
+        let result = write_uninstall_tombstone_at_with_security_copy(
+            &pinned,
+            &queries_parent,
+            "rust",
+            |_, _, _| {},
+            |_| Ok(()),
+            |_, _| {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "denied",
+                ))
+            },
+        );
+
+        assert!(matches!(result, Err(QueryInstallError::IoError(_))));
+        assert_eq!(fs::read_to_string(&tombstone).unwrap(), "old\n");
+        assert!(queries_parent.join("rust").exists());
+        assert_eq!(
+            fs::read_dir(&queries_parent)
+                .unwrap()
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_name().to_string_lossy().ends_with(".tmp"))
+                .count(),
+            0,
+            "a denied security copy must clean the private stage"
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn windows_tombstone_preserves_null_protected_dacl() {
+        use std::os::windows::io::AsRawHandle as _;
+        use windows_sys::Win32::Foundation::{ERROR_SUCCESS, LocalFree};
+        use windows_sys::Win32::Security::Authorization::{
+            GetSecurityInfo, SE_FILE_OBJECT, SetSecurityInfo,
+        };
+        use windows_sys::Win32::Security::{
+            DACL_SECURITY_INFORMATION, GetSecurityDescriptorControl,
+            PROTECTED_DACL_SECURITY_INFORMATION, SE_DACL_PROTECTED,
+        };
+
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let tombstone = uninstall_tombstone_path(&queries_parent, "rust");
+        fs::write(&tombstone, "old\n").unwrap();
+        let existing = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&tombstone)
+            .unwrap();
+        // SAFETY: the handle is valid; a null DACL is intentional and grants
+        // full access while remaining observably distinct from an inherited ACL.
+        let status = unsafe {
+            SetSecurityInfo(
+                existing.as_raw_handle(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(status, ERROR_SUCCESS);
+        drop(existing);
+
+        write_uninstall_tombstone(&queries_parent, "rust").unwrap();
+
+        let published = fs::File::open(&tombstone).unwrap();
+        let mut dacl = std::ptr::null_mut();
+        let mut descriptor = std::ptr::null_mut();
+        // SAFETY: outputs live until descriptor is released below.
+        let status = unsafe {
+            GetSecurityInfo(
+                published.as_raw_handle(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut dacl,
+                std::ptr::null_mut(),
+                &mut descriptor,
+            )
+        };
+        assert_eq!(status, ERROR_SUCCESS);
+        let mut control = 0;
+        let mut revision = 0;
+        // SAFETY: descriptor was returned successfully by GetSecurityInfo.
+        assert_ne!(
+            unsafe { GetSecurityDescriptorControl(descriptor, &mut control, &mut revision) },
+            0
+        );
+        assert!(dacl.is_null(), "the explicit null DACL must be preserved");
+        assert_ne!(control & SE_DACL_PROTECTED, 0);
+        // SAFETY: GetSecurityInfo allocates the descriptor with LocalAlloc.
+        unsafe { LocalFree(descriptor.cast()) };
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -787,6 +787,11 @@ fn write_uninstall_tombstone_with_before_publish(
     }
     let mut staged = builder.tempfile_in(queries_parent)?;
     if let Some(permissions) = existing_permissions {
+        // On Windows this can only carry `readonly = false`: validation
+        // already write-opened the destination, so a readonly leaf fails
+        // before staging exactly as origin/main's File::create did. Keeping
+        // that order avoids making a readonly stage impossible to reopen with
+        // the DELETE-capable handle required for confined publication.
         staged.as_file().set_permissions(permissions)?;
     }
     staged.write_all(b"ok\n")?;

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -801,19 +801,32 @@ fn write_uninstall_tombstone(
     queries_parent: &Path,
     language: &str,
 ) -> Result<(), QueryInstallError> {
-    write_uninstall_tombstone_with_before_publish(
-        queries_parent,
-        language,
-        |_, _| {},
-        sync_tombstone_parent,
-    )
+    let pinned = cap_std::fs::Dir::open_ambient_dir(queries_parent, cap_std::ambient_authority())?;
+    write_uninstall_tombstone_at(&pinned, queries_parent, language)
 }
 
 #[cfg(unix)]
 fn write_uninstall_tombstone_at(
     queries_parent: &cap_std::fs::Dir,
+    ambient_path: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    write_uninstall_tombstone_at_with_hooks(
+        queries_parent,
+        ambient_path,
+        language,
+        |_, _, _| {},
+        |parent| parent.try_clone()?.into_std_file().sync_all(),
+    )
+}
+
+#[cfg(unix)]
+fn write_uninstall_tombstone_at_with_hooks(
+    queries_parent: &cap_std::fs::Dir,
     _ambient_path: &Path,
     language: &str,
+    before_publish: impl FnOnce(&cap_std::fs::Dir, &str, &str),
+    sync_parent: impl FnOnce(&cap_std::fs::Dir) -> std::io::Result<()>,
 ) -> Result<(), QueryInstallError> {
     use cap_fs_ext::{
         FollowSymlinks, MetadataExt as CapMetadataExt, OpenOptionsFollowExt, OpenOptionsSyncExt,
@@ -864,6 +877,7 @@ fn write_uninstall_tombstone_at(
         staged.write_all(b"ok\n")?;
         staged.sync_all()?;
         let staged_metadata = staged.metadata()?;
+        before_publish(queries_parent, &tombstone_name, &stage_name);
         queries_parent.rename(&stage_name, queries_parent, &tombstone_name)?;
 
         let mut published_options = cap_std::fs::OpenOptions::new();
@@ -886,7 +900,7 @@ fn write_uninstall_tombstone_at(
             )));
         }
         require_single_link(std::os::unix::fs::MetadataExt::nlink(&published_metadata))?;
-        queries_parent.try_clone()?.into_std_file().sync_all()?;
+        sync_parent(queries_parent)?;
         Ok(())
     })();
     if result.is_err() {
@@ -898,8 +912,25 @@ fn write_uninstall_tombstone_at(
 #[cfg(windows)]
 fn write_uninstall_tombstone_at(
     queries_parent: &cap_std::fs::Dir,
+    ambient_path: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    write_uninstall_tombstone_at_with_hooks(
+        queries_parent,
+        ambient_path,
+        language,
+        |_, _, _| {},
+        |_| Ok(()),
+    )
+}
+
+#[cfg(windows)]
+fn write_uninstall_tombstone_at_with_hooks(
+    queries_parent: &cap_std::fs::Dir,
     _ambient_path: &Path,
     language: &str,
+    before_publish: impl FnOnce(&cap_std::fs::Dir, &str, &str),
+    sync_parent: impl FnOnce(&cap_std::fs::Dir) -> std::io::Result<()>,
 ) -> Result<(), QueryInstallError> {
     use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
     use std::os::windows::ffi::OsStrExt as _;
@@ -968,6 +999,7 @@ fn write_uninstall_tombstone_at(
         // SAFETY: successful ReOpenFile returned a newly owned handle.
         let rename_handle = unsafe { fs::File::from_raw_handle(handle) };
         normalize_windows_stage_attributes(&rename_handle)?;
+        before_publish(queries_parent, &tombstone_name, &stage_name);
         let filename: Vec<u16> = std::ffi::OsStr::new(&tombstone_name)
             .encode_wide()
             .collect();
@@ -1012,6 +1044,7 @@ fn write_uninstall_tombstone_at(
             )));
         }
         require_single_link(u64::from(actual.nNumberOfLinks))?;
+        sync_parent(queries_parent)?;
         Ok(())
     })();
     if result.is_err() {
@@ -1027,116 +1060,19 @@ fn write_uninstall_tombstone_with_before_publish(
     before_publish: impl FnOnce(&Path, &Path),
     sync_parent: impl FnOnce(&Path) -> std::io::Result<()>,
 ) -> Result<(), QueryInstallError> {
-    validate_safe_language_name(language)?;
-    let path = uninstall_tombstone_path(queries_parent, language);
-    let existing_permissions = validate_existing_tombstone(&path)?;
-    #[cfg(not(windows))]
-    let had_existing_tombstone = existing_permissions.is_some();
-    let stage_counter = QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let stage_prefix = format!(
-        ".{language}.uninstalled.{}.{}.",
-        std::process::id(),
-        stage_counter
-    );
-    let mut builder = tempfile::Builder::new();
-    builder.prefix(&stage_prefix).suffix(".tmp").rand_bytes(12);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        // Match File::create's 0o666 & !umask contract rather than inheriting
-        // tempfile's private 0o600 default when the inode is published.
-        builder.permissions(fs::Permissions::from_mode(0o666));
-    }
-    let mut staged = builder.tempfile_in(queries_parent)?;
-    if let Some(permissions) = existing_permissions {
-        // On Windows this can only carry `readonly = false`: validation
-        // already write-opened the destination, so a readonly leaf fails
-        // before staging exactly as origin/main's File::create did. Keeping
-        // that order avoids making a readonly stage impossible to reopen with
-        // the DELETE-capable handle required for confined publication.
-        staged.as_file().set_permissions(permissions)?;
-    }
-    staged.write_all(b"ok\n")?;
-    staged.as_file().sync_all()?;
-    #[cfg(windows)]
-    let windows_publish = prepare_windows_tombstone_publish(queries_parent, staged.as_file())?;
-    before_publish(&path, staged.path());
-    #[cfg(not(windows))]
-    let published = publish_staged_tombstone(staged, &path, had_existing_tombstone)?;
-    #[cfg(windows)]
-    let published = publish_staged_tombstone(staged, &path, windows_publish)?;
-    verify_published_tombstone(published, &path)?;
-    sync_parent(queries_parent)?;
-    Ok(())
-}
-
-#[cfg(all(test, not(windows)))]
-fn sync_tombstone_parent(queries_parent: &Path) -> std::io::Result<()> {
-    fs::File::open(queries_parent)?.sync_all()
-}
-
-#[cfg(all(test, windows))]
-fn sync_tombstone_parent(_queries_parent: &Path) -> std::io::Result<()> {
-    // The stage handle carries FILE_FLAG_WRITE_THROUGH before FileRenameInfo
-    // publication. Microsoft documents that metadata changes, including a
-    // rename, issued through such a handle are flushed before return.
-    Ok(())
-}
-
-#[cfg(all(test, not(windows)))]
-fn publish_staged_tombstone(
-    staged: tempfile::NamedTempFile,
-    path: &Path,
-    _had_existing_tombstone: bool,
-) -> std::io::Result<fs::File> {
-    staged.persist(path).map_err(|error| error.error)
-}
-
-#[cfg(all(test, windows))]
-struct WindowsTombstonePublish {
-    directory: fs::File,
-    rename_handle: fs::File,
-}
-
-#[cfg(all(test, windows))]
-fn prepare_windows_tombstone_publish(
-    queries_parent: &Path,
-    staged: &fs::File,
-) -> std::io::Result<WindowsTombstonePublish> {
-    use std::os::windows::fs::OpenOptionsExt as _;
-    use std::os::windows::io::{AsRawHandle as _, FromRawHandle as _};
-    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
-    use windows_sys::Win32::Storage::FileSystem::{
-        DELETE, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_WRITE_THROUGH, FILE_GENERIC_READ,
-        FILE_GENERIC_WRITE, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, ReOpenFile,
-    };
-
-    let directory = fs::OpenOptions::new()
-        .read(true)
-        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
-        .open(queries_parent)?;
-    // Reopen the already-created stage BY HANDLE with DELETE access. This
-    // cannot be redirected by replacing its temporary pathname later.
-    // SAFETY: `staged` remains valid for the call; a successful returned
-    // handle is newly owned and converted exactly once into `File`.
-    let handle = unsafe {
-        ReOpenFile(
-            staged.as_raw_handle(),
-            FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE,
-            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-            FILE_FLAG_WRITE_THROUGH,
-        )
-    };
-    if handle == INVALID_HANDLE_VALUE {
-        return Err(std::io::Error::last_os_error());
-    }
-    // SAFETY: successful ReOpenFile returned a newly owned handle.
-    let rename_handle = unsafe { fs::File::from_raw_handle(handle) };
-    normalize_windows_stage_attributes(&rename_handle)?;
-    Ok(WindowsTombstonePublish {
-        directory,
-        rename_handle,
-    })
+    let pinned = cap_std::fs::Dir::open_ambient_dir(queries_parent, cap_std::ambient_authority())?;
+    write_uninstall_tombstone_at_with_hooks(
+        &pinned,
+        queries_parent,
+        language,
+        |_, tombstone_name, stage_name| {
+            before_publish(
+                &queries_parent.join(tombstone_name),
+                &queries_parent.join(stage_name),
+            );
+        },
+        |_| sync_parent(queries_parent),
+    )
 }
 
 #[cfg(windows)]
@@ -1181,123 +1117,6 @@ fn normalize_windows_stage_attributes(file: &fs::File) -> std::io::Result<()> {
     }
 }
 
-#[cfg(all(test, windows))]
-fn publish_staged_tombstone(
-    staged: tempfile::NamedTempFile,
-    path: &Path,
-    publish: WindowsTombstonePublish,
-) -> std::io::Result<fs::File> {
-    use std::os::windows::ffi::OsStrExt as _;
-    use std::os::windows::io::AsRawHandle as _;
-    use windows_sys::Win32::Storage::FileSystem::{
-        FILE_RENAME_INFO, FileRenameInfo, SetFileInformationByHandle,
-    };
-
-    let filename: Vec<u16> = path
-        .file_name()
-        .ok_or_else(|| std::io::Error::other("tombstone path has no file name"))?
-        .encode_wide()
-        .collect();
-    let header = std::mem::offset_of!(FILE_RENAME_INFO, FileName);
-    let size = header + filename.len() * std::mem::size_of::<u16>();
-    let units = size.div_ceil(std::mem::size_of::<FILE_RENAME_INFO>());
-    let mut buffer = vec![FILE_RENAME_INFO::default(); units];
-    let information = buffer.as_mut_ptr();
-    // Rename the already-opened stage relative to the parent handle pinned
-    // before the race hook. ReplaceIfExists replaces a reparse-point directory
-    // entry; it never opens/follows that entry's target.
-    // SAFETY: `buffer` covers the header and UTF-16 filename; both file handles
-    // remain alive; the relative name has no separators.
-    let succeeded = unsafe {
-        (*information).Anonymous.ReplaceIfExists = true;
-        (*information).RootDirectory = publish.directory.as_raw_handle();
-        (*information).FileNameLength = u32::try_from(filename.len() * 2).unwrap();
-        std::ptr::copy_nonoverlapping(
-            filename.as_ptr(),
-            (*information).FileName.as_mut_ptr(),
-            filename.len(),
-        );
-        SetFileInformationByHandle(
-            publish.rename_handle.as_raw_handle(),
-            FileRenameInfo,
-            information.cast(),
-            u32::try_from(size).unwrap(),
-        )
-    };
-    if succeeded == 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    let (_original_handle, temporary_path) = staged.into_parts();
-    drop(temporary_path);
-    Ok(publish.rename_handle)
-}
-
-/// Open or create the managed tombstone leaf without following a link there.
-///
-/// Parent components deliberately retain ordinary path resolution: users may
-/// symlink their data directory or `queries` directory. Only the final,
-/// kakehashi-owned leaf is constrained. An observed existing leaf is validated,
-/// then a private same-directory inode atomically replaces its directory entry;
-/// no pre-existing inode is ever truncated.
-#[cfg(all(test, unix))]
-fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
-    use std::os::unix::fs::OpenOptionsExt;
-
-    let file = match fs::OpenOptions::new()
-        .write(true)
-        // O_NOFOLLOW binds the validation to the opened leaf rather than a
-        // racy metadata pre-check. O_NONBLOCK prevents a substituted FIFO
-        // from blocking the uninstall before fstat can reject it.
-        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK)
-        .open(path)
-    {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => return Err(error),
-    };
-    let metadata = file.metadata()?;
-    if !metadata.file_type().is_file() {
-        return Err(std::io::Error::other(
-            "query uninstall tombstone is not a regular file",
-        ));
-    }
-    use std::os::unix::fs::MetadataExt as _;
-    require_single_link(metadata.nlink())?;
-    Ok(Some(metadata.permissions()))
-}
-
-#[cfg(all(test, windows))]
-fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
-    use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
-    use windows_sys::Win32::Storage::FileSystem::{
-        FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT,
-    };
-
-    let file = match fs::OpenOptions::new()
-        .write(true)
-        // Open the reparse point itself, if present, so validation cannot be
-        // raced into following its target. Publication later replaces the
-        // directory entry rather than writing through this handle.
-        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
-        .open(path)
-    {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => return Err(error),
-    };
-    let metadata = file.metadata()?;
-    if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
-        || !metadata.file_type().is_file()
-    {
-        return Err(std::io::Error::other(
-            "query uninstall tombstone is not a regular file",
-        ));
-    }
-    let information = windows_file_information(&file)?;
-    require_single_link(u64::from(information.nNumberOfLinks))?;
-    Ok(Some(metadata.permissions()))
-}
-
 #[cfg(any(unix, windows))]
 fn require_single_link(links: u64) -> std::io::Result<()> {
     if links != 1 {
@@ -1307,58 +1126,6 @@ fn require_single_link(links: u64) -> std::io::Result<()> {
     } else {
         Ok(())
     }
-}
-
-#[cfg(all(test, unix))]
-fn verify_published_tombstone(published: fs::File, path: &Path) -> std::io::Result<()> {
-    use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _};
-
-    let expected = published.metadata()?;
-    drop(published);
-    let final_file = fs::OpenOptions::new()
-        .write(true)
-        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK)
-        .open(path)?;
-    let actual = final_file.metadata()?;
-    if !actual.file_type().is_file()
-        || actual.nlink() != 1
-        || expected.dev() != actual.dev()
-        || expected.ino() != actual.ino()
-    {
-        return Err(std::io::Error::other(
-            "published query uninstall tombstone changed identity",
-        ));
-    }
-    Ok(())
-}
-
-#[cfg(all(test, windows))]
-fn verify_published_tombstone(published: fs::File, path: &Path) -> std::io::Result<()> {
-    use std::os::windows::fs::{MetadataExt as _, OpenOptionsExt as _};
-    use windows_sys::Win32::Storage::FileSystem::{
-        FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT,
-    };
-
-    let expected = windows_file_information(&published)?;
-    drop(published);
-    let final_file = fs::OpenOptions::new()
-        .write(true)
-        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
-        .open(path)?;
-    let metadata = final_file.metadata()?;
-    let actual = windows_file_information(&final_file)?;
-    if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
-        || !metadata.file_type().is_file()
-        || actual.nNumberOfLinks != 1
-        || expected.dwVolumeSerialNumber != actual.dwVolumeSerialNumber
-        || expected.nFileIndexHigh != actual.nFileIndexHigh
-        || expected.nFileIndexLow != actual.nFileIndexLow
-    {
-        return Err(std::io::Error::other(
-            "published query uninstall tombstone changed identity",
-        ));
-    }
-    Ok(())
 }
 
 #[cfg(windows)]
@@ -1380,29 +1147,6 @@ fn windows_file_information(
     }
     // SAFETY: GetFileInformationByHandle succeeded above.
     Ok(unsafe { information.assume_init() })
-}
-
-#[cfg(all(test, not(any(unix, windows))))]
-fn verify_published_tombstone(_published: fs::File, path: &Path) -> std::io::Result<()> {
-    if fs::symlink_metadata(path)?.file_type().is_file() {
-        Ok(())
-    } else {
-        Err(std::io::Error::other(
-            "published query uninstall tombstone is not a regular file",
-        ))
-    }
-}
-
-#[cfg(all(test, not(any(unix, windows))))]
-fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
-    match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_file() => Ok(Some(metadata.permissions())),
-        Ok(_) => Err(std::io::Error::other(
-            "query uninstall tombstone is not a regular file",
-        )),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(error),
-    }
 }
 
 fn clear_uninstall_tombstone(

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -766,7 +766,6 @@ fn write_uninstall_tombstone_with_before_publish(
     before_publish: impl FnOnce(&Path, &Path),
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
-    remove_stale_uninstall_stages(queries_parent, language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
     validate_existing_tombstone(&path)?;
     let stage_counter = QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -793,60 +792,6 @@ fn write_uninstall_tombstone_with_before_publish(
     Ok(())
 }
 
-/// Remove crash-stranded private stages for `language`.
-///
-/// Production callers hold that language's [`QueryReplaceLockGuard`], so no
-/// live kakehashi publisher can own a matching stage while this sweep runs.
-/// File symlinks are removed as directory entries; matching directories are
-/// not managed by this file-stage namespace and are left untouched.
-fn remove_stale_uninstall_stages(
-    queries_parent: &Path,
-    language: &str,
-) -> Result<(), QueryInstallError> {
-    for entry in fs::read_dir(queries_parent)? {
-        let entry = entry?;
-        let name = entry.file_name();
-        let Some(name) = name.to_str() else {
-            continue;
-        };
-        if !generated_uninstall_stage_matches_language(name, language) {
-            continue;
-        }
-        let file_type = entry.file_type()?;
-        if !file_type.is_file() && !file_type.is_symlink() {
-            continue;
-        }
-        match fs::remove_file(entry.path()) {
-            Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => return Err(QueryInstallError::IoError(error)),
-        }
-    }
-    Ok(())
-}
-
-fn generated_uninstall_stage_matches_language(name: &str, language: &str) -> bool {
-    let prefix = format!(".{language}.uninstalled.");
-    let Some(rest) = name
-        .strip_prefix(&prefix)
-        .and_then(|rest| rest.strip_suffix(".tmp"))
-    else {
-        return false;
-    };
-    let mut parts = rest.split('.');
-    let (Some(pid), Some(counter), Some(random), None) =
-        (parts.next(), parts.next(), parts.next(), parts.next())
-    else {
-        return false;
-    };
-    !pid.is_empty()
-        && pid.bytes().all(|byte| byte.is_ascii_digit())
-        && !counter.is_empty()
-        && counter.bytes().all(|byte| byte.is_ascii_digit())
-        && random.len() == 12
-        && random.bytes().all(|byte| byte.is_ascii_alphanumeric())
-}
-
 /// Open or create the managed tombstone leaf without following a link there.
 ///
 /// Parent components deliberately retain ordinary path resolution: users may
@@ -870,13 +815,14 @@ fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(error),
     };
-    if !file.metadata()?.file_type().is_file() {
+    let metadata = file.metadata()?;
+    if !metadata.file_type().is_file() {
         return Err(std::io::Error::other(
             "query uninstall tombstone is not a regular file",
         ));
     }
     use std::os::unix::fs::MetadataExt as _;
-    require_single_link(file.metadata()?.nlink())?;
+    require_single_link(metadata.nlink())?;
     Ok(())
 }
 
@@ -1600,28 +1546,6 @@ mod tests {
             vec![tombstone.file_name().unwrap().to_os_string()],
             "the private stage must be removed on every persist failure"
         );
-    }
-
-    #[test]
-    fn tombstone_publish_reclaims_crash_stranded_stage() {
-        let temp = TempDir::new().unwrap();
-        let queries_parent = temp.path().join("queries");
-        fs::create_dir_all(&queries_parent).unwrap();
-        let stale = queries_parent.join(".rust.uninstalled.123.7.ABCDEFGHIJKL.tmp");
-        fs::write(&stale, "partial\n").unwrap();
-        let same_language_unrelated = queries_parent.join(".rust.uninstalled.notes.tmp");
-        fs::write(&same_language_unrelated, "keep notes\n").unwrap();
-        let unrelated = queries_parent.join(".lua.uninstalled.123.7.ABCDEFGHIJKL.tmp");
-        fs::write(&unrelated, "keep\n").unwrap();
-
-        write_uninstall_tombstone(&queries_parent, "rust").unwrap();
-
-        assert!(!stale.exists(), "same-language stale stage is managed");
-        assert!(
-            same_language_unrelated.exists(),
-            "a wildcard-like name is not proof of kakehashi ownership"
-        );
-        assert!(unrelated.exists(), "other languages have separate locks");
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -531,10 +531,20 @@ fn remove_query_install_and_backups_with_tombstone_writer(
     language: &str,
     write_tombstone: impl FnOnce(&Path, &str) -> Result<(), QueryInstallError>,
 ) -> Result<QueryRemoval, QueryInstallError> {
+    remove_query_install_and_backups_with_hooks(queries_parent, language, write_tombstone, |_| {})
+}
+
+fn remove_query_install_and_backups_with_hooks(
+    queries_parent: &Path,
+    language: &str,
+    write_tombstone: impl FnOnce(&Path, &str) -> Result<(), QueryInstallError>,
+    before_remove: impl FnOnce(&Path),
+) -> Result<QueryRemoval, QueryInstallError> {
     validate_safe_language_name(language)?;
     fs::create_dir_all(queries_parent)?;
     let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
     write_tombstone(queries_parent, language)?;
+    before_remove(queries_parent);
     let queries_dir = queries_parent.join(language);
     let mut removal = QueryRemoval {
         removed_queries: false,

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -789,7 +789,7 @@ fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
         ));
     }
     use std::os::unix::fs::MetadataExt as _;
-    reject_multiple_links(file.metadata()?.nlink())?;
+    require_single_link(file.metadata()?.nlink())?;
     Ok(file)
 }
 
@@ -830,15 +830,15 @@ fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
     }
     // SAFETY: GetFileInformationByHandle succeeded above.
     let information = unsafe { information.assume_init() };
-    reject_multiple_links(u64::from(information.nNumberOfLinks))?;
+    require_single_link(u64::from(information.nNumberOfLinks))?;
     Ok(file)
 }
 
 #[cfg(any(unix, windows))]
-fn reject_multiple_links(links: u64) -> std::io::Result<()> {
-    if links > 1 {
+fn require_single_link(links: u64) -> std::io::Result<()> {
+    if links != 1 {
         Err(std::io::Error::other(
-            "query uninstall tombstone has multiple hard links",
+            "query uninstall tombstone must have exactly one hard link",
         ))
     } else {
         Ok(())
@@ -1361,6 +1361,14 @@ mod tests {
             matches!(result, Err(QueryInstallError::IoError(_))),
             "a multiply linked managed tombstone must fail the uninstall"
         );
+    }
+
+    #[test]
+    #[cfg(any(unix, windows))]
+    fn tombstone_link_count_requires_one_live_name() {
+        assert!(require_single_link(0).is_err());
+        assert!(require_single_link(1).is_ok());
+        assert!(require_single_link(2).is_err());
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -544,7 +544,7 @@ fn remove_query_install_and_backups_with_hooks(
     fs::create_dir_all(queries_parent)?;
     let pinned_parent =
         cap_std::fs::Dir::open_ambient_dir(queries_parent, cap_std::ambient_authority())?;
-    let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
+    let _replace_lock = QueryReplaceLockGuard::acquire_at(&pinned_parent, language)?;
     write_tombstone(queries_parent, language)?;
     before_remove(queries_parent);
     let mut removal = QueryRemoval {
@@ -1380,6 +1380,20 @@ impl QueryReplaceLockGuard {
             .write(true)
             .truncate(false)
             .open(path)?;
+        file.lock_exclusive()?;
+        Ok(Self { _file: file })
+    }
+
+    fn acquire_at(
+        queries_parent: &cap_std::fs::Dir,
+        language: &str,
+    ) -> Result<Self, QueryInstallError> {
+        validate_safe_language_name(language)?;
+        let mut options = cap_std::fs::OpenOptions::new();
+        options.create(true).write(true).truncate(false);
+        let file = queries_parent
+            .open_with(format!(".{language}.replace.lock"), &options)?
+            .into_std();
         file.lock_exclusive()?;
         Ok(Self { _file: file })
     }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -851,10 +851,53 @@ fn prepare_windows_tombstone_publish(
     }
     // SAFETY: successful ReOpenFile returned a newly owned handle.
     let rename_handle = unsafe { fs::File::from_raw_handle(handle) };
+    normalize_windows_stage_attributes(&rename_handle)?;
     Ok(WindowsTombstonePublish {
         directory,
         rename_handle,
     })
+}
+
+#[cfg(windows)]
+fn normalize_windows_stage_attributes(file: &fs::File) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_NORMAL, FILE_ATTRIBUTE_TEMPORARY, FILE_BASIC_INFO, FileBasicInfo,
+        GetFileInformationByHandleEx, SetFileInformationByHandle,
+    };
+
+    let mut information = FILE_BASIC_INFO::default();
+    // SAFETY: `information` is the exact buffer for FileBasicInfo and `file`
+    // keeps the handle valid throughout both calls.
+    let read = unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle(),
+            FileBasicInfo,
+            (&mut information as *mut FILE_BASIC_INFO).cast(),
+            u32::try_from(std::mem::size_of::<FILE_BASIC_INFO>()).unwrap(),
+        )
+    };
+    if read == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    information.FileAttributes &= !FILE_ATTRIBUTE_TEMPORARY;
+    if information.FileAttributes == 0 {
+        information.FileAttributes = FILE_ATTRIBUTE_NORMAL;
+    }
+    // SAFETY: same valid handle and correctly sized initialized structure.
+    let written = unsafe {
+        SetFileInformationByHandle(
+            file.as_raw_handle(),
+            FileBasicInfo,
+            (&information as *const FILE_BASIC_INFO).cast(),
+            u32::try_from(std::mem::size_of::<FILE_BASIC_INFO>()).unwrap(),
+        )
+    };
+    if written == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(windows)]
@@ -1728,7 +1771,9 @@ mod tests {
     #[test]
     #[cfg(windows)]
     fn windows_tombstone_publish_replaces_raced_symlink_entry() {
+        use std::os::windows::fs::MetadataExt as _;
         use std::os::windows::fs::symlink_file;
+        use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_TEMPORARY;
 
         let temp = TempDir::new().unwrap();
         let queries_parent = temp.path().join("queries");
@@ -1753,6 +1798,14 @@ mod tests {
             "handle-relative replace must replace the symlink entry itself"
         );
         assert_eq!(fs::read_to_string(tombstone).unwrap(), "ok\n");
+        assert_eq!(
+            fs::metadata(uninstall_tombstone_path(&queries_parent, "rust"))
+                .unwrap()
+                .file_attributes()
+                & FILE_ATTRIBUTE_TEMPORARY,
+            0,
+            "published tombstone must not retain tempfile cache semantics"
+        );
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -768,6 +768,7 @@ fn write_uninstall_tombstone_with_before_publish(
     validate_safe_language_name(language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
     let existing_permissions = validate_existing_tombstone(&path)?;
+    let had_existing_tombstone = existing_permissions.is_some();
     let stage_counter = QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let stage_prefix = format!(
         ".{language}.uninstalled.{}.{}.",
@@ -790,9 +791,74 @@ fn write_uninstall_tombstone_with_before_publish(
     staged.write_all(b"ok\n")?;
     staged.as_file().sync_all()?;
     before_publish(&path, staged.path());
-    let published = staged.persist(&path).map_err(|error| error.error)?;
+    let published = publish_staged_tombstone(staged, &path, had_existing_tombstone)?;
     verify_published_tombstone(published, &path)?;
     Ok(())
+}
+
+#[cfg(not(windows))]
+fn publish_staged_tombstone(
+    staged: tempfile::NamedTempFile,
+    path: &Path,
+    _had_existing_tombstone: bool,
+) -> std::io::Result<fs::File> {
+    staged.persist(path).map_err(|error| error.error)
+}
+
+#[cfg(windows)]
+fn publish_staged_tombstone(
+    staged: tempfile::NamedTempFile,
+    path: &Path,
+    had_existing_tombstone: bool,
+) -> std::io::Result<fs::File> {
+    if !had_existing_tombstone {
+        return staged.persist(path).map_err(|error| error.error);
+    }
+
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_NORMAL, REPLACEFILE_WRITE_THROUGH, ReplaceFileW, SetFileAttributesW,
+    };
+
+    let (file, temporary_path) = staged.into_parts();
+    let temporary_wide: Vec<u16> = temporary_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let destination_wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    // NamedTempFile marks the stage temporary. Normalize it before
+    // publication, matching tempfile::persist's Windows implementation.
+    // SAFETY: both UTF-16 buffers are NUL-terminated and live through calls.
+    if unsafe { SetFileAttributesW(temporary_wide.as_ptr(), FILE_ATTRIBUTE_NORMAL) } == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // ReplaceFileW preserves the replaced file's security descriptor and
+    // other metadata that std::fs::Permissions cannot represent on Windows.
+    // WRITE_THROUGH also waits for the replacement to reach disk.
+    // SAFETY: paths are valid NUL-terminated buffers; optional pointers are
+    // null; `file` keeps the staged inode open for later identity checking.
+    let succeeded = unsafe {
+        ReplaceFileW(
+            destination_wide.as_ptr(),
+            temporary_wide.as_ptr(),
+            std::ptr::null(),
+            REPLACEFILE_WRITE_THROUGH,
+            std::ptr::null(),
+            std::ptr::null(),
+        )
+    };
+    if succeeded == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // The temporary pathname moved away. Dropping TempPath attempts to unlink
+    // that now-missing old name and must not touch the published destination.
+    drop(temporary_path);
+    Ok(file)
 }
 
 /// Open or create the managed tombstone leaf without following a link there.

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -767,10 +767,22 @@ fn write_uninstall_tombstone_with_before_publish(
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
-    let mut file = open_regular_tombstone(&path)?;
+    validate_existing_tombstone(&path)?;
+    let stage_prefix = format!(".{language}.uninstalled.");
+    let mut builder = tempfile::Builder::new();
+    builder.prefix(&stage_prefix);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        // Match File::create's 0o666 & !umask contract rather than inheriting
+        // tempfile's private 0o600 default when the inode is published.
+        builder.permissions(fs::Permissions::from_mode(0o666));
+    }
+    let mut staged = builder.tempfile_in(queries_parent)?;
+    staged.write_all(b"ok\n")?;
+    staged.as_file().sync_all()?;
     before_publish(&path);
-    file.set_len(0)?;
-    file.write_all(b"ok\n")?;
+    staged.persist(path).map_err(|error| error.error)?;
     Ok(())
 }
 
@@ -778,21 +790,25 @@ fn write_uninstall_tombstone_with_before_publish(
 ///
 /// Parent components deliberately retain ordinary path resolution: users may
 /// symlink their data directory or `queries` directory. Only the final,
-/// kakehashi-owned leaf is constrained, and truncation happens after the
-/// opened handle has been confirmed to name a regular file.
+/// kakehashi-owned leaf is constrained. An observed existing leaf is validated,
+/// then a private same-directory inode atomically replaces its directory entry;
+/// no pre-existing inode is ever truncated.
 #[cfg(unix)]
-fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
+fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
     use std::os::unix::fs::OpenOptionsExt;
 
-    let file = fs::OpenOptions::new()
-        .create(true)
+    let file = match fs::OpenOptions::new()
         .write(true)
-        .truncate(false)
         // O_NOFOLLOW binds the validation to the opened leaf rather than a
         // racy metadata pre-check. O_NONBLOCK prevents a substituted FIFO
         // from blocking the uninstall before fstat can reject it.
         .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK)
-        .open(path)?;
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
     if !file.metadata()?.file_type().is_file() {
         return Err(std::io::Error::other(
             "query uninstall tombstone is not a regular file",
@@ -800,24 +816,28 @@ fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
     }
     use std::os::unix::fs::MetadataExt as _;
     require_single_link(file.metadata()?.nlink())?;
-    Ok(file)
+    Ok(())
 }
 
 #[cfg(windows)]
-fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
+fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
     use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
     use windows_sys::Win32::Storage::FileSystem::{
         FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT,
     };
 
-    let file = fs::OpenOptions::new()
-        .create(true)
+    let file = match fs::OpenOptions::new()
         .write(true)
-        .truncate(false)
         // Open the reparse point itself, if present, so validation cannot be
-        // raced into following its target. Truncation happens only afterward.
+        // raced into following its target. Publication later replaces the
+        // directory entry rather than writing through this handle.
         .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
-        .open(path)?;
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
     let metadata = file.metadata()?;
     if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
         || !metadata.file_type().is_file()
@@ -841,7 +861,7 @@ fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
     // SAFETY: GetFileInformationByHandle succeeded above.
     let information = unsafe { information.assume_init() };
     require_single_link(u64::from(information.nNumberOfLinks))?;
-    Ok(file)
+    Ok(())
 }
 
 #[cfg(any(unix, windows))]
@@ -856,13 +876,15 @@ fn require_single_link(links: u64) -> std::io::Result<()> {
 }
 
 #[cfg(not(any(unix, windows)))]
-fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
-    // No portable no-follow open exists. Creating a fresh leaf is atomic and
-    // safe; conservatively reject an existing leaf on these platforms.
-    fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(path)
+fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => Ok(()),
+        Ok(_) => Err(std::io::Error::other(
+            "query uninstall tombstone is not a regular file",
+        )),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
 }
 
 fn clear_uninstall_tombstone(
@@ -1370,6 +1392,95 @@ mod tests {
         assert!(
             matches!(result, Err(QueryInstallError::IoError(_))),
             "an already multiply linked managed tombstone must fail the uninstall"
+        );
+    }
+
+    #[test]
+    fn tombstone_publish_does_not_truncate_raced_hard_link_alias() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let tombstone = uninstall_tombstone_path(&queries_parent, "rust");
+        fs::write(&tombstone, "old tombstone\n").unwrap();
+        let outside_alias = temp.path().join("outside-alias");
+
+        write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path| {
+            fs::hard_link(path, &outside_alias).unwrap();
+        })
+        .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&outside_alias).unwrap(),
+            "old tombstone\n",
+            "a link raced after validation must retain the old inode contents"
+        );
+        assert_eq!(fs::read_to_string(tombstone).unwrap(), "ok\n");
+    }
+
+    #[test]
+    fn failed_tombstone_publish_cleans_private_stage() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let tombstone = uninstall_tombstone_path(&queries_parent, "rust");
+        fs::write(&tombstone, "old tombstone\n").unwrap();
+
+        let result =
+            write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path| {
+                fs::remove_file(path).unwrap();
+                fs::create_dir(path).unwrap();
+            });
+
+        assert!(result.is_err(), "a directory cannot be replaced by a file");
+        let names: Vec<_> = fs::read_dir(&queries_parent)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        assert_eq!(
+            names,
+            vec![tombstone.file_name().unwrap().to_os_string()],
+            "the private stage must be removed on every persist failure"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn tombstone_atomic_publish_preserves_file_create_umask_mode() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let control = queries_parent.join("control");
+        fs::File::create(&control).unwrap();
+
+        write_uninstall_tombstone(&queries_parent, "rust").unwrap();
+
+        let expected = fs::metadata(control).unwrap().permissions().mode() & 0o777;
+        let actual = fs::metadata(uninstall_tombstone_path(&queries_parent, "rust"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn remove_query_install_supports_windows_symlinked_queries_parent() {
+        use std::os::windows::fs::symlink_dir;
+
+        let temp = TempDir::new().unwrap();
+        let real_queries = temp.path().join("real-queries");
+        fs::create_dir_all(&real_queries).unwrap();
+        let linked_queries = temp.path().join("queries");
+        symlink_dir(&real_queries, &linked_queries).unwrap();
+
+        remove_query_install_and_backups(&linked_queries, "rust").unwrap();
+
+        assert_eq!(
+            fs::read_to_string(uninstall_tombstone_path(&real_queries, "rust")).unwrap(),
+            "ok\n"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -757,13 +757,14 @@ fn write_uninstall_tombstone(
     queries_parent: &Path,
     language: &str,
 ) -> Result<(), QueryInstallError> {
-    write_uninstall_tombstone_with_before_publish(queries_parent, language, |_, _| {})
+    write_uninstall_tombstone_with_before_publish(queries_parent, language, |_, _| {}, |_| Ok(()))
 }
 
 fn write_uninstall_tombstone_with_before_publish(
     queries_parent: &Path,
     language: &str,
     before_publish: impl FnOnce(&Path, &Path),
+    _sync_parent: impl FnOnce(&Path) -> std::io::Result<()>,
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
@@ -1646,9 +1647,14 @@ mod tests {
         fs::write(&tombstone, "old tombstone\n").unwrap();
         let outside_alias = temp.path().join("outside-alias");
 
-        write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path, _| {
-            fs::hard_link(path, &outside_alias).unwrap();
-        })
+        write_uninstall_tombstone_with_before_publish(
+            &queries_parent,
+            "rust",
+            |path, _| {
+                fs::hard_link(path, &outside_alias).unwrap();
+            },
+            |_| Ok(()),
+        )
         .unwrap();
 
         assert_eq!(
@@ -1677,6 +1683,7 @@ mod tests {
                 fs::remove_file(staged_path).unwrap();
                 symlink(&victim, staged_path).unwrap();
             },
+            |_| Ok(()),
         );
 
         assert!(
@@ -1694,11 +1701,15 @@ mod tests {
         let tombstone = uninstall_tombstone_path(&queries_parent, "rust");
         fs::write(&tombstone, "old tombstone\n").unwrap();
 
-        let result =
-            write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path, _| {
+        let result = write_uninstall_tombstone_with_before_publish(
+            &queries_parent,
+            "rust",
+            |path, _| {
                 fs::remove_file(path).unwrap();
                 fs::create_dir(path).unwrap();
-            });
+            },
+            |_| Ok(()),
+        );
 
         assert!(result.is_err(), "a directory cannot be replaced by a file");
         let names: Vec<_> = fs::read_dir(&queries_parent)
@@ -1788,10 +1799,15 @@ mod tests {
         let victim = temp.path().join("victim");
         fs::write(&victim, "keep me\n").unwrap();
 
-        write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path, _| {
-            fs::remove_file(path).unwrap();
-            symlink_file(&victim, path).unwrap();
-        })
+        write_uninstall_tombstone_with_before_publish(
+            &queries_parent,
+            "rust",
+            |path, _| {
+                fs::remove_file(path).unwrap();
+                symlink_file(&victim, path).unwrap();
+            },
+            |_| Ok(()),
+        )
         .unwrap();
 
         assert_eq!(fs::read_to_string(victim).unwrap(), "keep me\n");

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -958,7 +958,7 @@ fn write_uninstall_tombstone_at_with_security_copy(
     use windows_sys::Win32::Storage::FileSystem::{
         DELETE, FILE_FLAG_WRITE_THROUGH, FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_RENAME_INFO,
         FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FileRenameInfo, ReOpenFile,
-        SetFileInformationByHandle, WRITE_DAC,
+        SetFileInformationByHandle,
     };
 
     validate_safe_language_name(language)?;
@@ -1008,7 +1008,7 @@ fn write_uninstall_tombstone_at_with_security_copy(
         let handle = unsafe {
             ReOpenFile(
                 staged.as_raw_handle(),
-                FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE | WRITE_DAC,
+                FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE,
                 FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                 FILE_FLAG_WRITE_THROUGH,
             )
@@ -1150,7 +1150,7 @@ fn copy_windows_tombstone_security(source: &fs::File, target: &fs::File) -> std:
     use windows_sys::Win32::Security::{
         DACL_SECURITY_INFORMATION, EqualSid, GROUP_SECURITY_INFORMATION,
         GetSecurityDescriptorControl, OWNER_SECURITY_INFORMATION,
-        PROTECTED_DACL_SECURITY_INFORMATION, SE_DACL_PROTECTED,
+        PROTECTED_DACL_SECURITY_INFORMATION, SE_DACL_PRESENT, SE_DACL_PROTECTED,
         UNPROTECTED_DACL_SECURITY_INFORMATION,
     };
     use windows_sys::Win32::Storage::FileSystem::{
@@ -1218,30 +1218,16 @@ fn copy_windows_tombstone_security(source: &fs::File, target: &fs::File) -> std:
             std::io::Error::last_os_error()
         )));
     }
+    if control & SE_DACL_PRESENT == 0 {
+        return Err(std::io::Error::other(
+            "validated tombstone security descriptor has no DACL presence bit",
+        ));
+    }
     let dacl_mode = if control & SE_DACL_PROTECTED != 0 {
         PROTECTED_DACL_SECURITY_INFORMATION
     } else {
         UNPROTECTED_DACL_SECURITY_INFORMATION
     };
-    // SAFETY: target has WRITE_DAC and the source DACL remains descriptor-owned.
-    let dacl_status = unsafe {
-        SetSecurityInfo(
-            target.as_raw_handle(),
-            SE_FILE_OBJECT,
-            DACL_SECURITY_INFORMATION | dacl_mode,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            source_dacl,
-            std::ptr::null_mut(),
-        )
-    };
-    if dacl_status != ERROR_SUCCESS {
-        return Err(std::io::Error::other(format!(
-            "SetSecurityInfo DACL failed: {}",
-            std::io::Error::from_raw_os_error(dacl_status as i32)
-        )));
-    }
-
     // New stages normally inherit the same owner/group. Only request the
     // privileged WRITE_OWNER path when either SID actually differs.
     let sids_differ = |source: windows_sys::Win32::Security::PSID,
@@ -1255,51 +1241,97 @@ fn copy_windows_tombstone_security(source: &fs::File, target: &fs::File) -> std:
     };
     let owner_differs = sids_differ(source_owner, target_owner);
     let group_differs = sids_differ(source_group, target_group);
-    if owner_differs || group_differs {
-        // SAFETY: successful ReOpenFile returns a distinct owned handle.
-        let handle = unsafe {
-            ReOpenFile(
-                target.as_raw_handle(),
-                READ_CONTROL | WRITE_DAC | WRITE_OWNER,
-                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                0,
-            )
-        };
-        if handle.is_null() || handle == windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE {
-            return Err(std::io::Error::other(format!(
-                "ReOpenFile WRITE_OWNER failed: {}",
-                std::io::Error::last_os_error()
-            )));
-        }
-        // SAFETY: successful ReOpenFile returned a newly owned handle.
-        let owner_handle = unsafe { fs::File::from_raw_handle(handle) };
-        let mut information = 0;
-        if owner_differs {
-            information |= OWNER_SECURITY_INFORMATION;
-        }
-        if group_differs {
-            information |= GROUP_SECURITY_INFORMATION;
-        }
-        // SAFETY: selected SID pointers remain owned by source_descriptor.
-        let status = unsafe {
-            SetSecurityInfo(
-                owner_handle.as_raw_handle(),
-                SE_FILE_OBJECT,
-                information,
-                source_owner,
-                source_group,
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
-            )
-        };
-        if status != ERROR_SUCCESS {
-            return Err(std::io::Error::other(format!(
-                "SetSecurityInfo owner/group failed: {}",
-                std::io::Error::from_raw_os_error(status as i32)
-            )));
-        }
+    let mut owner_information = 0;
+    if owner_differs {
+        owner_information |= OWNER_SECURITY_INFORMATION;
     }
-    Ok(())
+    if group_differs {
+        owner_information |= GROUP_SECURITY_INFORMATION;
+    }
+    let mut security_access = READ_CONTROL | WRITE_DAC;
+    if owner_information != 0 {
+        security_access |= WRITE_OWNER;
+    }
+    // Keep security mutation on a distinct handle so the proven
+    // DELETE-capable/write-through rename handle retains its original access
+    // contract. Success returns a new owned handle for the same stage inode.
+    let security_handle = unsafe {
+        ReOpenFile(
+            target.as_raw_handle(),
+            security_access,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            0,
+        )
+    };
+    if security_handle.is_null()
+        || security_handle == windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE
+    {
+        return Err(std::io::Error::other(format!(
+            "ReOpenFile security access failed: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    // SAFETY: successful ReOpenFile returned a newly owned handle.
+    let security_file = unsafe { fs::File::from_raw_handle(security_handle) };
+    apply_windows_security_parts(
+        owner_information,
+        || {
+            // SAFETY: selected SID pointers remain owned by source_descriptor.
+            let status = unsafe {
+                SetSecurityInfo(
+                    security_file.as_raw_handle(),
+                    SE_FILE_OBJECT,
+                    owner_information,
+                    source_owner,
+                    source_group,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                )
+            };
+            if status != ERROR_SUCCESS {
+                return Err(std::io::Error::other(format!(
+                    "SetSecurityInfo owner/group failed: {}",
+                    std::io::Error::from_raw_os_error(status as i32)
+                )));
+            }
+            Ok(())
+        },
+        || {
+            // SAFETY: target has WRITE_DAC and the source DACL remains descriptor-owned.
+            let status = unsafe {
+                SetSecurityInfo(
+                    security_file.as_raw_handle(),
+                    SE_FILE_OBJECT,
+                    DACL_SECURITY_INFORMATION | dacl_mode,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    source_dacl,
+                    std::ptr::null_mut(),
+                )
+            };
+            if status != ERROR_SUCCESS {
+                return Err(std::io::Error::other(format!(
+                    "SetSecurityInfo DACL failed: {}",
+                    std::io::Error::from_raw_os_error(status as i32)
+                )));
+            }
+            Ok(())
+        },
+    )
+}
+
+#[cfg(windows)]
+fn apply_windows_security_parts(
+    owner_information: u32,
+    apply_owner_group: impl FnOnce() -> std::io::Result<()>,
+    apply_dacl: impl FnOnce() -> std::io::Result<()>,
+) -> std::io::Result<()> {
+    // A restrictive source DACL may deny reopening with WRITE_OWNER, so owner
+    // and group must be complete before the DACL is installed.
+    if owner_information != 0 {
+        apply_owner_group()?;
+    }
+    apply_dacl()
 }
 
 #[cfg(any(unix, windows))]
@@ -2190,6 +2222,35 @@ mod tests {
             0,
             "a denied security copy must clean the private stage"
         );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn windows_differing_owner_is_applied_before_restrictive_dacl() {
+        use std::cell::RefCell;
+        use windows_sys::Win32::Security::OWNER_SECURITY_INFORMATION;
+
+        let operations = RefCell::new(Vec::new());
+        apply_windows_security_parts(
+            OWNER_SECURITY_INFORMATION,
+            || {
+                if operations.borrow().contains(&"dacl") {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "restrictive DACL already installed",
+                    ));
+                }
+                operations.borrow_mut().push("owner");
+                Ok(())
+            },
+            || {
+                operations.borrow_mut().push("dacl");
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(operations.into_inner(), ["owner", "dacl"]);
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -954,11 +954,10 @@ fn write_uninstall_tombstone_at_with_security_copy(
     use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
     use std::os::windows::ffi::OsStrExt as _;
     use std::os::windows::io::{AsRawHandle as _, FromRawHandle as _};
-    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE, INVALID_HANDLE_VALUE};
     use windows_sys::Win32::Storage::FileSystem::{
-        DELETE, FILE_FLAG_WRITE_THROUGH, FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_RENAME_INFO,
-        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FileRenameInfo, ReOpenFile,
-        SetFileInformationByHandle,
+        DELETE, FILE_FLAG_WRITE_THROUGH, FILE_RENAME_INFO, FILE_SHARE_DELETE, FILE_SHARE_READ,
+        FILE_SHARE_WRITE, FileRenameInfo, ReOpenFile, SetFileInformationByHandle,
     };
 
     validate_safe_language_name(language)?;
@@ -1008,7 +1007,7 @@ fn write_uninstall_tombstone_at_with_security_copy(
         let handle = unsafe {
             ReOpenFile(
                 staged.as_raw_handle(),
-                FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE,
+                GENERIC_READ | GENERIC_WRITE | DELETE,
                 FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                 FILE_FLAG_WRITE_THROUGH,
             )

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -768,6 +768,7 @@ fn write_uninstall_tombstone_with_before_publish(
     validate_safe_language_name(language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
     let existing_permissions = validate_existing_tombstone(&path)?;
+    #[cfg(not(windows))]
     let had_existing_tombstone = existing_permissions.is_some();
     let stage_counter = QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let stage_prefix = format!(
@@ -790,8 +791,13 @@ fn write_uninstall_tombstone_with_before_publish(
     }
     staged.write_all(b"ok\n")?;
     staged.as_file().sync_all()?;
+    #[cfg(windows)]
+    let windows_publish = prepare_windows_tombstone_publish(queries_parent, staged.as_file())?;
     before_publish(&path, staged.path());
+    #[cfg(not(windows))]
     let published = publish_staged_tombstone(staged, &path, had_existing_tombstone)?;
+    #[cfg(windows)]
+    let published = publish_staged_tombstone(staged, &path, windows_publish)?;
     verify_published_tombstone(published, &path)?;
     Ok(())
 }
@@ -806,59 +812,100 @@ fn publish_staged_tombstone(
 }
 
 #[cfg(windows)]
+struct WindowsTombstonePublish {
+    directory: fs::File,
+    rename_handle: fs::File,
+}
+
+#[cfg(windows)]
+fn prepare_windows_tombstone_publish(
+    queries_parent: &Path,
+    staged: &fs::File,
+) -> std::io::Result<WindowsTombstonePublish> {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    use std::os::windows::io::{AsRawHandle as _, FromRawHandle as _};
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        DELETE, FILE_FLAG_BACKUP_SEMANTICS, FILE_GENERIC_READ, FILE_GENERIC_WRITE,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, ReOpenFile,
+    };
+
+    let directory = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+        .open(queries_parent)?;
+    // Reopen the already-created stage BY HANDLE with DELETE access. This
+    // cannot be redirected by replacing its temporary pathname later.
+    // SAFETY: `staged` remains valid for the call; a successful returned
+    // handle is newly owned and converted exactly once into `File`.
+    let handle = unsafe {
+        ReOpenFile(
+            staged.as_raw_handle(),
+            FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            0,
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: successful ReOpenFile returned a newly owned handle.
+    let rename_handle = unsafe { fs::File::from_raw_handle(handle) };
+    Ok(WindowsTombstonePublish {
+        directory,
+        rename_handle,
+    })
+}
+
+#[cfg(windows)]
 fn publish_staged_tombstone(
     staged: tempfile::NamedTempFile,
     path: &Path,
-    had_existing_tombstone: bool,
+    publish: WindowsTombstonePublish,
 ) -> std::io::Result<fs::File> {
-    if !had_existing_tombstone {
-        return staged.persist(path).map_err(|error| error.error);
-    }
-
     use std::os::windows::ffi::OsStrExt as _;
+    use std::os::windows::io::AsRawHandle as _;
     use windows_sys::Win32::Storage::FileSystem::{
-        FILE_ATTRIBUTE_NORMAL, REPLACEFILE_WRITE_THROUGH, ReplaceFileW, SetFileAttributesW,
+        FILE_RENAME_INFO, FileRenameInfo, SetFileInformationByHandle,
     };
 
-    let (file, temporary_path) = staged.into_parts();
-    let temporary_wide: Vec<u16> = temporary_path
-        .as_os_str()
+    let filename: Vec<u16> = path
+        .file_name()
+        .ok_or_else(|| std::io::Error::other("tombstone path has no file name"))?
         .encode_wide()
-        .chain(std::iter::once(0))
         .collect();
-    let destination_wide: Vec<u16> = path
-        .as_os_str()
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect();
-    // NamedTempFile marks the stage temporary. Normalize it before
-    // publication, matching tempfile::persist's Windows implementation.
-    // SAFETY: both UTF-16 buffers are NUL-terminated and live through calls.
-    if unsafe { SetFileAttributesW(temporary_wide.as_ptr(), FILE_ATTRIBUTE_NORMAL) } == 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    // ReplaceFileW preserves the replaced file's security descriptor and
-    // other metadata that std::fs::Permissions cannot represent on Windows.
-    // WRITE_THROUGH also waits for the replacement to reach disk.
-    // SAFETY: paths are valid NUL-terminated buffers; optional pointers are
-    // null; `file` keeps the staged inode open for later identity checking.
+    let header = std::mem::offset_of!(FILE_RENAME_INFO, FileName);
+    let size = header + filename.len() * std::mem::size_of::<u16>();
+    let units = size.div_ceil(std::mem::size_of::<FILE_RENAME_INFO>());
+    let mut buffer = vec![FILE_RENAME_INFO::default(); units];
+    let information = buffer.as_mut_ptr();
+    // Rename the already-opened stage relative to the parent handle pinned
+    // before the race hook. ReplaceIfExists replaces a reparse-point directory
+    // entry; it never opens/follows that entry's target.
+    // SAFETY: `buffer` covers the header and UTF-16 filename; both file handles
+    // remain alive; the relative name has no separators.
     let succeeded = unsafe {
-        ReplaceFileW(
-            destination_wide.as_ptr(),
-            temporary_wide.as_ptr(),
-            std::ptr::null(),
-            REPLACEFILE_WRITE_THROUGH,
-            std::ptr::null(),
-            std::ptr::null(),
+        (*information).Anonymous.ReplaceIfExists = true;
+        (*information).RootDirectory = publish.directory.as_raw_handle();
+        (*information).FileNameLength = u32::try_from(filename.len() * 2).unwrap();
+        std::ptr::copy_nonoverlapping(
+            filename.as_ptr(),
+            (*information).FileName.as_mut_ptr(),
+            filename.len(),
+        );
+        SetFileInformationByHandle(
+            publish.rename_handle.as_raw_handle(),
+            FileRenameInfo,
+            information.cast(),
+            u32::try_from(size).unwrap(),
         )
     };
     if succeeded == 0 {
         return Err(std::io::Error::last_os_error());
     }
-    // The temporary pathname moved away. Dropping TempPath attempts to unlink
-    // that now-missing old name and must not touch the published destination.
+    let (_original_handle, temporary_path) = staged.into_parts();
     drop(temporary_path);
-    Ok(file)
+    Ok(publish.rename_handle)
 }
 
 /// Open or create the managed tombstone leaf without following a link there.
@@ -1676,6 +1723,36 @@ mod tests {
             fs::read_to_string(uninstall_tombstone_path(&real_queries, "rust")).unwrap(),
             "ok\n"
         );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn windows_tombstone_publish_replaces_raced_symlink_entry() {
+        use std::os::windows::fs::symlink_file;
+
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let tombstone = uninstall_tombstone_path(&queries_parent, "rust");
+        fs::write(&tombstone, "old\n").unwrap();
+        let victim = temp.path().join("victim");
+        fs::write(&victim, "keep me\n").unwrap();
+
+        write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path, _| {
+            fs::remove_file(path).unwrap();
+            symlink_file(&victim, path).unwrap();
+        })
+        .unwrap();
+
+        assert_eq!(fs::read_to_string(victim).unwrap(), "keep me\n");
+        assert!(
+            fs::symlink_metadata(&tombstone)
+                .unwrap()
+                .file_type()
+                .is_file(),
+            "handle-relative replace must replace the symlink entry itself"
+        );
+        assert_eq!(fs::read_to_string(tombstone).unwrap(), "ok\n");
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -757,8 +757,18 @@ fn write_uninstall_tombstone(
     queries_parent: &Path,
     language: &str,
 ) -> Result<(), QueryInstallError> {
+    write_uninstall_tombstone_with_before_publish(queries_parent, language, |_| {})
+}
+
+fn write_uninstall_tombstone_with_before_publish(
+    queries_parent: &Path,
+    language: &str,
+    before_publish: impl FnOnce(&Path),
+) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
-    let mut file = open_regular_tombstone(&uninstall_tombstone_path(queries_parent, language))?;
+    let path = uninstall_tombstone_path(queries_parent, language);
+    let mut file = open_regular_tombstone(&path)?;
+    before_publish(&path);
     file.set_len(0)?;
     file.write_all(b"ok\n")?;
     Ok(())
@@ -1359,16 +1369,8 @@ mod tests {
         );
         assert!(
             matches!(result, Err(QueryInstallError::IoError(_))),
-            "a multiply linked managed tombstone must fail the uninstall"
+            "an already multiply linked managed tombstone must fail the uninstall"
         );
-    }
-
-    #[test]
-    #[cfg(any(unix, windows))]
-    fn tombstone_link_count_requires_one_live_name() {
-        assert!(require_single_link(0).is_err());
-        assert!(require_single_link(1).is_ok());
-        assert!(require_single_link(2).is_err());
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -767,7 +767,7 @@ fn write_uninstall_tombstone_with_before_publish(
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
-    validate_existing_tombstone(&path)?;
+    let existing_permissions = validate_existing_tombstone(&path)?;
     let stage_counter = QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let stage_prefix = format!(
         ".{language}.uninstalled.{}.{}.",
@@ -784,6 +784,9 @@ fn write_uninstall_tombstone_with_before_publish(
         builder.permissions(fs::Permissions::from_mode(0o666));
     }
     let mut staged = builder.tempfile_in(queries_parent)?;
+    if let Some(permissions) = existing_permissions {
+        staged.as_file().set_permissions(permissions)?;
+    }
     staged.write_all(b"ok\n")?;
     staged.as_file().sync_all()?;
     before_publish(&path, staged.path());
@@ -800,7 +803,7 @@ fn write_uninstall_tombstone_with_before_publish(
 /// then a private same-directory inode atomically replaces its directory entry;
 /// no pre-existing inode is ever truncated.
 #[cfg(unix)]
-fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
+fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
     use std::os::unix::fs::OpenOptionsExt;
 
     let file = match fs::OpenOptions::new()
@@ -812,7 +815,7 @@ fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
         .open(path)
     {
         Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(error),
     };
     let metadata = file.metadata()?;
@@ -823,11 +826,11 @@ fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
     }
     use std::os::unix::fs::MetadataExt as _;
     require_single_link(metadata.nlink())?;
-    Ok(())
+    Ok(Some(metadata.permissions()))
 }
 
 #[cfg(windows)]
-fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
+fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
     use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
     use windows_sys::Win32::Storage::FileSystem::{
         FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT,
@@ -842,7 +845,7 @@ fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
         .open(path)
     {
         Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(error),
     };
     let metadata = file.metadata()?;
@@ -855,7 +858,7 @@ fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
     }
     let information = windows_file_information(&file)?;
     require_single_link(u64::from(information.nNumberOfLinks))?;
-    Ok(())
+    Ok(Some(metadata.permissions()))
 }
 
 #[cfg(any(unix, windows))]
@@ -954,13 +957,13 @@ fn verify_published_tombstone(_published: fs::File, path: &Path) -> std::io::Res
 }
 
 #[cfg(not(any(unix, windows)))]
-fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
+fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
     match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_file() => Ok(()),
+        Ok(metadata) if metadata.file_type().is_file() => Ok(Some(metadata.permissions())),
         Ok(_) => Err(std::io::Error::other(
             "query uninstall tombstone is not a regular file",
         )),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(error) => Err(error),
     }
 }
@@ -1568,6 +1571,26 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn tombstone_atomic_publish_preserves_existing_mode() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let tombstone = uninstall_tombstone_path(&queries_parent, "rust");
+        fs::write(&tombstone, "old\n").unwrap();
+        fs::set_permissions(&tombstone, fs::Permissions::from_mode(0o600)).unwrap();
+
+        write_uninstall_tombstone(&queries_parent, "rust").unwrap();
+
+        assert_eq!(
+            fs::metadata(tombstone).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -954,9 +954,9 @@ fn write_uninstall_tombstone_at_with_security_copy(
     use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
     use std::os::windows::ffi::OsStrExt as _;
     use std::os::windows::io::{AsRawHandle as _, FromRawHandle as _};
-    use windows_sys::Win32::Foundation::{DELETE, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
     use windows_sys::Win32::Storage::FileSystem::{
-        FILE_FLAG_WRITE_THROUGH, FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_RENAME_INFO,
+        DELETE, FILE_FLAG_WRITE_THROUGH, FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_RENAME_INFO,
         FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FileRenameInfo, ReOpenFile,
         SetFileInformationByHandle, WRITE_DAC,
     };
@@ -1235,7 +1235,8 @@ fn copy_windows_tombstone_security(source: &fs::File, target: &fs::File) -> std:
 
     // New stages normally inherit the same owner/group. Only request the
     // privileged WRITE_OWNER path when either SID actually differs.
-    let sids_differ = |source, target| {
+    let sids_differ = |source: windows_sys::Win32::Security::PSID,
+                       target: windows_sys::Win32::Security::PSID| {
         if source.is_null() || target.is_null() {
             source != target
         } else {

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -757,13 +757,13 @@ fn write_uninstall_tombstone(
     queries_parent: &Path,
     language: &str,
 ) -> Result<(), QueryInstallError> {
-    write_uninstall_tombstone_with_before_publish(queries_parent, language, |_| {})
+    write_uninstall_tombstone_with_before_publish(queries_parent, language, |_, _| {})
 }
 
 fn write_uninstall_tombstone_with_before_publish(
     queries_parent: &Path,
     language: &str,
-    before_publish: impl FnOnce(&Path),
+    before_publish: impl FnOnce(&Path, &Path),
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
@@ -781,7 +781,7 @@ fn write_uninstall_tombstone_with_before_publish(
     let mut staged = builder.tempfile_in(queries_parent)?;
     staged.write_all(b"ok\n")?;
     staged.as_file().sync_all()?;
-    before_publish(&path);
+    before_publish(&path, staged.path());
     staged.persist(path).map_err(|error| error.error)?;
     Ok(())
 }
@@ -1404,7 +1404,7 @@ mod tests {
         fs::write(&tombstone, "old tombstone\n").unwrap();
         let outside_alias = temp.path().join("outside-alias");
 
-        write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path| {
+        write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path, _| {
             fs::hard_link(path, &outside_alias).unwrap();
         })
         .unwrap();
@@ -1426,7 +1426,7 @@ mod tests {
         fs::write(&tombstone, "old tombstone\n").unwrap();
 
         let result =
-            write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path| {
+            write_uninstall_tombstone_with_before_publish(&queries_parent, "rust", |path, _| {
                 fs::remove_file(path).unwrap();
                 fs::create_dir(path).unwrap();
             });

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -788,6 +788,8 @@ fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
             "query uninstall tombstone is not a regular file",
         ));
     }
+    use std::os::unix::fs::MetadataExt as _;
+    reject_multiple_links(file.metadata()?.nlink())?;
     Ok(file)
 }
 
@@ -814,7 +816,33 @@ fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
             "query uninstall tombstone is not a regular file",
         ));
     }
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
+    };
+    let mut information = std::mem::MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
+    // SAFETY: `file` keeps this handle valid for the call, and Windows
+    // initializes the complete output structure whenever it reports success.
+    let succeeded =
+        unsafe { GetFileInformationByHandle(file.as_raw_handle(), information.as_mut_ptr()) };
+    if succeeded == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: GetFileInformationByHandle succeeded above.
+    let information = unsafe { information.assume_init() };
+    reject_multiple_links(u64::from(information.nNumberOfLinks))?;
     Ok(file)
+}
+
+#[cfg(any(unix, windows))]
+fn reject_multiple_links(links: u64) -> std::io::Result<()> {
+    if links > 1 {
+        Err(std::io::Error::other(
+            "query uninstall tombstone has multiple hard links",
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(not(any(unix, windows)))]
@@ -1310,6 +1338,28 @@ mod tests {
         assert_eq!(
             fs::read_to_string(uninstall_tombstone_path(&real_queries, "rust")).unwrap(),
             "ok\n"
+        );
+    }
+
+    #[test]
+    fn remove_query_install_rejects_hard_linked_uninstall_tombstone() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let victim = temp.path().join("victim");
+        fs::write(&victim, "keep me\n").unwrap();
+        fs::hard_link(&victim, uninstall_tombstone_path(&queries_parent, "rust")).unwrap();
+
+        let result = remove_query_install_and_backups(&queries_parent, "rust");
+
+        assert_eq!(
+            fs::read_to_string(&victim).unwrap(),
+            "keep me\n",
+            "opening the tombstone must not overwrite another hard-link name"
+        );
+        assert!(
+            matches!(result, Err(QueryInstallError::IoError(_))),
+            "a multiply linked managed tombstone must fail the uninstall"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -522,7 +522,7 @@ pub fn remove_query_install_and_backups(
     remove_query_install_and_backups_with_tombstone_writer(
         queries_parent,
         language,
-        |pinned, parent, lang| write_uninstall_tombstone_at(pinned, parent, lang),
+        write_uninstall_tombstone_at,
     )
 }
 
@@ -626,6 +626,7 @@ fn remove_dir_all_at_tolerating_vanished(
 /// deleted, and (b) `Path::exists()` returns false on ANY metadata error
 /// (e.g. PermissionDenied), which must propagate the original error instead
 /// of being mistaken for absence.
+#[cfg(test)]
 fn remove_dir_all_tolerating_vanished(dir: &Path) -> Result<bool, QueryInstallError> {
     match fs::remove_dir_all(dir) {
         Ok(()) => Ok(true),
@@ -795,6 +796,7 @@ fn uninstall_tombstone_path(queries_parent: &Path, language: &str) -> PathBuf {
     queries_parent.join(format!(".{language}{QUERY_UNINSTALL_TOMBSTONE_SUFFIX}"))
 }
 
+#[cfg(test)]
 fn write_uninstall_tombstone(
     queries_parent: &Path,
     language: &str,
@@ -1018,6 +1020,7 @@ fn write_uninstall_tombstone_at(
     result
 }
 
+#[cfg(test)]
 fn write_uninstall_tombstone_with_before_publish(
     queries_parent: &Path,
     language: &str,
@@ -1067,12 +1070,12 @@ fn write_uninstall_tombstone_with_before_publish(
     Ok(())
 }
 
-#[cfg(not(windows))]
+#[cfg(all(test, not(windows)))]
 fn sync_tombstone_parent(queries_parent: &Path) -> std::io::Result<()> {
     fs::File::open(queries_parent)?.sync_all()
 }
 
-#[cfg(windows)]
+#[cfg(all(test, windows))]
 fn sync_tombstone_parent(_queries_parent: &Path) -> std::io::Result<()> {
     // The stage handle carries FILE_FLAG_WRITE_THROUGH before FileRenameInfo
     // publication. Microsoft documents that metadata changes, including a
@@ -1080,7 +1083,7 @@ fn sync_tombstone_parent(_queries_parent: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-#[cfg(not(windows))]
+#[cfg(all(test, not(windows)))]
 fn publish_staged_tombstone(
     staged: tempfile::NamedTempFile,
     path: &Path,
@@ -1089,13 +1092,13 @@ fn publish_staged_tombstone(
     staged.persist(path).map_err(|error| error.error)
 }
 
-#[cfg(windows)]
+#[cfg(all(test, windows))]
 struct WindowsTombstonePublish {
     directory: fs::File,
     rename_handle: fs::File,
 }
 
-#[cfg(windows)]
+#[cfg(all(test, windows))]
 fn prepare_windows_tombstone_publish(
     queries_parent: &Path,
     staged: &fs::File,
@@ -1178,7 +1181,7 @@ fn normalize_windows_stage_attributes(file: &fs::File) -> std::io::Result<()> {
     }
 }
 
-#[cfg(windows)]
+#[cfg(all(test, windows))]
 fn publish_staged_tombstone(
     staged: tempfile::NamedTempFile,
     path: &Path,
@@ -1236,7 +1239,7 @@ fn publish_staged_tombstone(
 /// kakehashi-owned leaf is constrained. An observed existing leaf is validated,
 /// then a private same-directory inode atomically replaces its directory entry;
 /// no pre-existing inode is ever truncated.
-#[cfg(unix)]
+#[cfg(all(test, unix))]
 fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
     use std::os::unix::fs::OpenOptionsExt;
 
@@ -1263,7 +1266,7 @@ fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permis
     Ok(Some(metadata.permissions()))
 }
 
-#[cfg(windows)]
+#[cfg(all(test, windows))]
 fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
     use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
     use windows_sys::Win32::Storage::FileSystem::{
@@ -1306,7 +1309,7 @@ fn require_single_link(links: u64) -> std::io::Result<()> {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(test, unix))]
 fn verify_published_tombstone(published: fs::File, path: &Path) -> std::io::Result<()> {
     use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _};
 
@@ -1329,7 +1332,7 @@ fn verify_published_tombstone(published: fs::File, path: &Path) -> std::io::Resu
     Ok(())
 }
 
-#[cfg(windows)]
+#[cfg(all(test, windows))]
 fn verify_published_tombstone(published: fs::File, path: &Path) -> std::io::Result<()> {
     use std::os::windows::fs::{MetadataExt as _, OpenOptionsExt as _};
     use windows_sys::Win32::Storage::FileSystem::{
@@ -1379,7 +1382,7 @@ fn windows_file_information(
     Ok(unsafe { information.assume_init() })
 }
 
-#[cfg(not(any(unix, windows)))]
+#[cfg(all(test, not(any(unix, windows))))]
 fn verify_published_tombstone(_published: fs::File, path: &Path) -> std::io::Result<()> {
     if fs::symlink_metadata(path)?.file_type().is_file() {
         Ok(())
@@ -1390,7 +1393,7 @@ fn verify_published_tombstone(_published: fs::File, path: &Path) -> std::io::Res
     }
 }
 
-#[cfg(not(any(unix, windows)))]
+#[cfg(all(test, not(any(unix, windows))))]
 fn validate_existing_tombstone(path: &Path) -> std::io::Result<Option<fs::Permissions>> {
     match fs::symlink_metadata(path) {
         Ok(metadata) if metadata.file_type().is_file() => Ok(Some(metadata.permissions())),

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -542,10 +542,11 @@ fn remove_query_install_and_backups_with_hooks(
 ) -> Result<QueryRemoval, QueryInstallError> {
     validate_safe_language_name(language)?;
     fs::create_dir_all(queries_parent)?;
+    let pinned_parent =
+        cap_std::fs::Dir::open_ambient_dir(queries_parent, cap_std::ambient_authority())?;
     let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
     write_tombstone(queries_parent, language)?;
     before_remove(queries_parent);
-    let queries_dir = queries_parent.join(language);
     let mut removal = QueryRemoval {
         removed_queries: false,
         removed_backups: false,
@@ -555,14 +556,14 @@ fn remove_query_install_and_backups_with_hooks(
     // (e.g. PermissionDenied), which would skip removal and report "not
     // installed" over a still-present unreadable dir. The tolerant removal
     // reports whether anything was actually removed.
-    removal.removed_queries = remove_dir_all_tolerating_vanished(&queries_dir)?;
+    removal.removed_queries = remove_dir_all_at_tolerating_vanished(&pinned_parent, language)?;
 
     // Propagate per-entry read_dir errors: uninstall must not report success
     // while backups it could not even enumerate stay behind.
-    for entry in fs::read_dir(queries_parent)? {
+    for entry in pinned_parent.entries()? {
         let entry = entry?;
-        let path = entry.path();
-        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
             continue;
         };
         // file_type() over path.is_dir(): is_dir() swallows metadata errors
@@ -570,18 +571,20 @@ fn remove_query_install_and_backups_with_hooks(
         // while uninstall reports success.
         if entry.file_type()?.is_dir()
             && generated_backup_matches_language(name, language)
-            && backup_is_owned(&path)
+            && pinned_parent
+                .metadata(backup_ownership_sidecar_name(name))
+                .is_ok_and(|metadata| metadata.is_file())
         {
-            let ownership = backup_ownership_sidecar(&path);
+            let ownership = backup_ownership_sidecar_name(name);
             // Same NotFound tolerance as the canonical dir above: a backup
             // deleted externally after enumeration is already the end state.
-            let removed_dir = remove_dir_all_tolerating_vanished(&path)?;
+            let removed_dir = remove_dir_all_at_tolerating_vanished(&pinned_parent, &file_name)?;
             // The sidecar is a kakehashi-owned artifact too: deleting it
             // counts as removal even when the dir itself vanished first —
             // and, like every other I/O in this loop, only NotFound is
             // tolerated (an unremovable marker must fail the uninstall, not
             // linger behind a success report).
-            let removed_sidecar = match fs::remove_file(ownership) {
+            let removed_sidecar = match pinned_parent.remove_file(ownership) {
                 Ok(()) => true,
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
                 Err(e) => return Err(QueryInstallError::IoError(e)),
@@ -592,6 +595,23 @@ fn remove_query_install_and_backups_with_hooks(
         }
     }
     Ok(removal)
+}
+
+fn remove_dir_all_at_tolerating_vanished(
+    parent: &cap_std::fs::Dir,
+    name: impl AsRef<Path>,
+) -> Result<bool, QueryInstallError> {
+    let name = name.as_ref();
+    match parent.remove_dir_all(name) {
+        Ok(()) => Ok(true),
+        Err(e)
+            if e.kind() == std::io::ErrorKind::NotFound
+                && matches!(parent.try_exists(name), Ok(false)) =>
+        {
+            Ok(false)
+        }
+        Err(e) => Err(QueryInstallError::IoError(e)),
+    }
 }
 
 /// `fs::remove_dir_all` that treats a CONFIRMED-vanished directory as the
@@ -1259,6 +1279,10 @@ fn backup_ownership_sidecar(backup_dir: &Path) -> PathBuf {
     ))
 }
 
+fn backup_ownership_sidecar_name(backup_name: &str) -> String {
+    format!("{backup_name}{QUERY_BACKUP_OWNERSHIP_MARKER}")
+}
+
 fn write_backup_ownership_marker(backup_dir: &Path) -> Result<(), QueryInstallError> {
     let mut file = fs::File::create(backup_ownership_sidecar(backup_dir))?;
     file.write_all(b"ok\n")?;
@@ -1654,6 +1678,51 @@ mod tests {
         assert_eq!(
             fs::read_to_string(uninstall_tombstone_path(&real_queries, "rust")).unwrap(),
             "ok\n"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn remove_query_install_stays_bound_when_symlinked_parent_is_retargeted() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let original = temp.path().join("original-queries");
+        let replacement = temp.path().join("replacement-queries");
+        fs::create_dir_all(original.join("rust")).unwrap();
+        fs::create_dir_all(replacement.join("rust")).unwrap();
+        fs::write(original.join("rust/highlights.scm"), "original\n").unwrap();
+        fs::write(replacement.join("rust/highlights.scm"), "outside\n").unwrap();
+        let linked = temp.path().join("queries");
+        symlink(&original, &linked).unwrap();
+
+        remove_query_install_and_backups_with_hooks(
+            &linked,
+            "rust",
+            write_uninstall_tombstone,
+            |queries_parent| {
+                fs::remove_file(queries_parent).unwrap();
+                symlink(&replacement, queries_parent).unwrap();
+            },
+        )
+        .unwrap();
+
+        assert!(
+            !original.join("rust").exists(),
+            "cleanup must stay in the directory that received durable intent"
+        );
+        assert_eq!(
+            fs::read_to_string(replacement.join("rust/highlights.scm")).unwrap(),
+            "outside\n",
+            "retargeting must not redirect destructive cleanup"
+        );
+        assert!(
+            uninstall_tombstone_path(&original, "rust").exists(),
+            "the pinned directory retains its uninstall intent"
+        );
+        assert!(
+            !uninstall_tombstone_path(&replacement, "rust").exists(),
+            "the replacement directory must remain untouched"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -1670,6 +1670,37 @@ mod tests {
     }
 
     #[test]
+    fn uninstall_sync_failure_preserves_queries_and_backups() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let queries_dir = queries_parent.join("rust");
+        fs::create_dir_all(&queries_dir).unwrap();
+        fs::write(queries_dir.join("highlights.scm"), "old queries\n").unwrap();
+        let backup = queries_parent.join(".rust.123.0.backup");
+        fs::create_dir(&backup).unwrap();
+        fs::write(backup.join("highlights.scm"), "backup\n").unwrap();
+        write_backup_ownership_marker(&backup).unwrap();
+
+        let result = remove_query_install_and_backups_with_tombstone_writer(
+            &queries_parent,
+            "rust",
+            |_, _| {
+                Err(QueryInstallError::IoError(std::io::Error::other(
+                    "injected durability failure",
+                )))
+            },
+        );
+
+        assert!(matches!(result, Err(QueryInstallError::IoError(_))));
+        assert!(queries_dir.exists(), "canonical queries are not removed");
+        assert!(backup.exists(), "owned backup is not removed");
+        assert!(
+            backup_ownership_sidecar(&backup).exists(),
+            "backup ownership evidence is not removed"
+        );
+    }
+
+    #[test]
     fn tombstone_publish_does_not_truncate_raced_hard_link_alias() {
         let temp = TempDir::new().unwrap();
         let queries_parent = temp.path().join("queries");

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -782,7 +782,8 @@ fn write_uninstall_tombstone_with_before_publish(
     staged.write_all(b"ok\n")?;
     staged.as_file().sync_all()?;
     before_publish(&path, staged.path());
-    staged.persist(path).map_err(|error| error.error)?;
+    let published = staged.persist(&path).map_err(|error| error.error)?;
+    verify_published_tombstone(published, &path)?;
     Ok(())
 }
 
@@ -846,20 +847,7 @@ fn validate_existing_tombstone(path: &Path) -> std::io::Result<()> {
             "query uninstall tombstone is not a regular file",
         ));
     }
-    use std::os::windows::io::AsRawHandle as _;
-    use windows_sys::Win32::Storage::FileSystem::{
-        BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
-    };
-    let mut information = std::mem::MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
-    // SAFETY: `file` keeps this handle valid for the call, and Windows
-    // initializes the complete output structure whenever it reports success.
-    let succeeded =
-        unsafe { GetFileInformationByHandle(file.as_raw_handle(), information.as_mut_ptr()) };
-    if succeeded == 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    // SAFETY: GetFileInformationByHandle succeeded above.
-    let information = unsafe { information.assume_init() };
+    let information = windows_file_information(&file)?;
     require_single_link(u64::from(information.nNumberOfLinks))?;
     Ok(())
 }
@@ -872,6 +860,90 @@ fn require_single_link(links: u64) -> std::io::Result<()> {
         ))
     } else {
         Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn verify_published_tombstone(published: fs::File, path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _};
+
+    let expected = published.metadata()?;
+    drop(published);
+    let final_file = fs::OpenOptions::new()
+        .write(true)
+        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK)
+        .open(path)?;
+    let actual = final_file.metadata()?;
+    if !actual.file_type().is_file()
+        || actual.nlink() != 1
+        || expected.dev() != actual.dev()
+        || expected.ino() != actual.ino()
+    {
+        return Err(std::io::Error::other(
+            "published query uninstall tombstone changed identity",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn verify_published_tombstone(published: fs::File, path: &Path) -> std::io::Result<()> {
+    use std::os::windows::fs::{MetadataExt as _, OpenOptionsExt as _};
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT,
+    };
+
+    let expected = windows_file_information(&published)?;
+    drop(published);
+    let final_file = fs::OpenOptions::new()
+        .write(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)?;
+    let metadata = final_file.metadata()?;
+    let actual = windows_file_information(&final_file)?;
+    if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+        || !metadata.file_type().is_file()
+        || actual.nNumberOfLinks != 1
+        || expected.dwVolumeSerialNumber != actual.dwVolumeSerialNumber
+        || expected.nFileIndexHigh != actual.nFileIndexHigh
+        || expected.nFileIndexLow != actual.nFileIndexLow
+    {
+        return Err(std::io::Error::other(
+            "published query uninstall tombstone changed identity",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn windows_file_information(
+    file: &fs::File,
+) -> std::io::Result<windows_sys::Win32::Storage::FileSystem::BY_HANDLE_FILE_INFORMATION> {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
+    };
+
+    let mut information = std::mem::MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
+    // SAFETY: `file` keeps this handle valid for the call, and Windows
+    // initializes the complete output structure whenever it reports success.
+    let succeeded =
+        unsafe { GetFileInformationByHandle(file.as_raw_handle(), information.as_mut_ptr()) };
+    if succeeded == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: GetFileInformationByHandle succeeded above.
+    Ok(unsafe { information.assume_init() })
+}
+
+#[cfg(not(any(unix, windows)))]
+fn verify_published_tombstone(_published: fs::File, path: &Path) -> std::io::Result<()> {
+    if fs::symlink_metadata(path)?.file_type().is_file() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(
+            "published query uninstall tombstone is not a regular file",
+        ))
     }
 }
 
@@ -1415,6 +1487,33 @@ mod tests {
             "a link raced after validation must retain the old inode contents"
         );
         assert_eq!(fs::read_to_string(tombstone).unwrap(), "ok\n");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn tombstone_publish_rejects_substituted_private_stage() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let victim = temp.path().join("victim");
+        fs::write(&victim, "keep me\n").unwrap();
+
+        let result = write_uninstall_tombstone_with_before_publish(
+            &queries_parent,
+            "rust",
+            |_, staged_path| {
+                fs::remove_file(staged_path).unwrap();
+                symlink(&victim, staged_path).unwrap();
+            },
+        );
+
+        assert!(
+            result.is_err(),
+            "publication must reject a stage path detached from its opened handle"
+        );
+        assert_eq!(fs::read_to_string(victim).unwrap(), "keep me\n");
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -519,10 +519,22 @@ pub fn remove_query_install_and_backups(
     queries_parent: &Path,
     language: &str,
 ) -> Result<QueryRemoval, QueryInstallError> {
+    remove_query_install_and_backups_with_tombstone_writer(
+        queries_parent,
+        language,
+        write_uninstall_tombstone,
+    )
+}
+
+fn remove_query_install_and_backups_with_tombstone_writer(
+    queries_parent: &Path,
+    language: &str,
+    write_tombstone: impl FnOnce(&Path, &str) -> Result<(), QueryInstallError>,
+) -> Result<QueryRemoval, QueryInstallError> {
     validate_safe_language_name(language)?;
     fs::create_dir_all(queries_parent)?;
     let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
-    write_uninstall_tombstone(queries_parent, language)?;
+    write_tombstone(queries_parent, language)?;
     let queries_dir = queries_parent.join(language);
     let mut removal = QueryRemoval {
         removed_queries: false,

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -757,14 +757,19 @@ fn write_uninstall_tombstone(
     queries_parent: &Path,
     language: &str,
 ) -> Result<(), QueryInstallError> {
-    write_uninstall_tombstone_with_before_publish(queries_parent, language, |_, _| {}, |_| Ok(()))
+    write_uninstall_tombstone_with_before_publish(
+        queries_parent,
+        language,
+        |_, _| {},
+        sync_tombstone_parent,
+    )
 }
 
 fn write_uninstall_tombstone_with_before_publish(
     queries_parent: &Path,
     language: &str,
     before_publish: impl FnOnce(&Path, &Path),
-    _sync_parent: impl FnOnce(&Path) -> std::io::Result<()>,
+    sync_parent: impl FnOnce(&Path) -> std::io::Result<()>,
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
     let path = uninstall_tombstone_path(queries_parent, language);
@@ -805,6 +810,20 @@ fn write_uninstall_tombstone_with_before_publish(
     #[cfg(windows)]
     let published = publish_staged_tombstone(staged, &path, windows_publish)?;
     verify_published_tombstone(published, &path)?;
+    sync_parent(queries_parent)?;
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn sync_tombstone_parent(queries_parent: &Path) -> std::io::Result<()> {
+    fs::File::open(queries_parent)?.sync_all()
+}
+
+#[cfg(windows)]
+fn sync_tombstone_parent(_queries_parent: &Path) -> std::io::Result<()> {
+    // The stage handle carries FILE_FLAG_WRITE_THROUGH before FileRenameInfo
+    // publication. Microsoft documents that metadata changes, including a
+    // rename, issued through such a handle are flushed before return.
     Ok(())
 }
 
@@ -832,8 +851,8 @@ fn prepare_windows_tombstone_publish(
     use std::os::windows::io::{AsRawHandle as _, FromRawHandle as _};
     use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
     use windows_sys::Win32::Storage::FileSystem::{
-        DELETE, FILE_FLAG_BACKUP_SEMANTICS, FILE_GENERIC_READ, FILE_GENERIC_WRITE,
-        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, ReOpenFile,
+        DELETE, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_WRITE_THROUGH, FILE_GENERIC_READ,
+        FILE_GENERIC_WRITE, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, ReOpenFile,
     };
 
     let directory = fs::OpenOptions::new()
@@ -849,7 +868,7 @@ fn prepare_windows_tombstone_publish(
             staged.as_raw_handle(),
             FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE,
             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-            0,
+            FILE_FLAG_WRITE_THROUGH,
         )
     };
     if handle == INVALID_HANDLE_VALUE {
@@ -1720,6 +1739,30 @@ mod tests {
             names,
             vec![tombstone.file_name().unwrap().to_os_string()],
             "the private stage must be removed on every persist failure"
+        );
+    }
+
+    #[test]
+    fn tombstone_publish_propagates_parent_sync_failure() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let sync_called = std::cell::Cell::new(false);
+
+        let result = write_uninstall_tombstone_with_before_publish(
+            &queries_parent,
+            "rust",
+            |_, _| {},
+            |_| {
+                sync_called.set(true);
+                Err(std::io::Error::other("injected parent sync failure"))
+            },
+        );
+
+        assert!(sync_called.get(), "publication must cross the sync gate");
+        assert!(
+            matches!(result, Err(QueryInstallError::IoError(_))),
+            "sync failure must prevent uninstall from reaching removal"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -522,14 +522,14 @@ pub fn remove_query_install_and_backups(
     remove_query_install_and_backups_with_tombstone_writer(
         queries_parent,
         language,
-        write_uninstall_tombstone,
+        |pinned, parent, lang| write_uninstall_tombstone_at(pinned, parent, lang),
     )
 }
 
 fn remove_query_install_and_backups_with_tombstone_writer(
     queries_parent: &Path,
     language: &str,
-    write_tombstone: impl FnOnce(&Path, &str) -> Result<(), QueryInstallError>,
+    write_tombstone: impl FnOnce(&cap_std::fs::Dir, &Path, &str) -> Result<(), QueryInstallError>,
 ) -> Result<QueryRemoval, QueryInstallError> {
     remove_query_install_and_backups_with_hooks(queries_parent, language, write_tombstone, |_| {})
 }
@@ -537,7 +537,7 @@ fn remove_query_install_and_backups_with_tombstone_writer(
 fn remove_query_install_and_backups_with_hooks(
     queries_parent: &Path,
     language: &str,
-    write_tombstone: impl FnOnce(&Path, &str) -> Result<(), QueryInstallError>,
+    write_tombstone: impl FnOnce(&cap_std::fs::Dir, &Path, &str) -> Result<(), QueryInstallError>,
     before_remove: impl FnOnce(&Path),
 ) -> Result<QueryRemoval, QueryInstallError> {
     validate_safe_language_name(language)?;
@@ -545,7 +545,7 @@ fn remove_query_install_and_backups_with_hooks(
     let pinned_parent =
         cap_std::fs::Dir::open_ambient_dir(queries_parent, cap_std::ambient_authority())?;
     let _replace_lock = QueryReplaceLockGuard::acquire_at(&pinned_parent, language)?;
-    write_tombstone(queries_parent, language)?;
+    write_tombstone(&pinned_parent, queries_parent, language)?;
     before_remove(queries_parent);
     let mut removal = QueryRemoval {
         removed_queries: false,
@@ -805,6 +805,217 @@ fn write_uninstall_tombstone(
         |_, _| {},
         sync_tombstone_parent,
     )
+}
+
+#[cfg(unix)]
+fn write_uninstall_tombstone_at(
+    queries_parent: &cap_std::fs::Dir,
+    _ambient_path: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    use cap_fs_ext::{
+        FollowSymlinks, MetadataExt as CapMetadataExt, OpenOptionsFollowExt, OpenOptionsSyncExt,
+    };
+
+    validate_safe_language_name(language)?;
+    let tombstone_name = format!(".{language}{QUERY_UNINSTALL_TOMBSTONE_SUFFIX}");
+    let mut existing_options = cap_std::fs::OpenOptions::new();
+    existing_options
+        .write(true)
+        .follow(FollowSymlinks::No)
+        .nonblock(true);
+    let existing_permissions = match queries_parent.open_with(&tombstone_name, &existing_options) {
+        Ok(file) => {
+            let metadata = file.metadata()?;
+            if !metadata.is_file() {
+                return Err(QueryInstallError::IoError(std::io::Error::other(
+                    "query uninstall tombstone is not a regular file",
+                )));
+            }
+            require_single_link(CapMetadataExt::nlink(&metadata))?;
+            Some(file.into_std().metadata()?.permissions())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(QueryInstallError::IoError(error)),
+    };
+
+    let stage_name = loop {
+        let counter = QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let candidate = format!(
+            ".{language}.uninstalled.{}.{}.tmp",
+            std::process::id(),
+            counter
+        );
+        let mut options = cap_std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        match queries_parent.open_with(&candidate, &options) {
+            Ok(file) => break (candidate, file.into_std()),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(QueryInstallError::IoError(error)),
+        }
+    };
+    let (stage_name, mut staged) = stage_name;
+    let result = (|| -> Result<(), QueryInstallError> {
+        if let Some(permissions) = existing_permissions {
+            staged.set_permissions(permissions)?;
+        }
+        staged.write_all(b"ok\n")?;
+        staged.sync_all()?;
+        let staged_metadata = staged.metadata()?;
+        queries_parent.rename(&stage_name, queries_parent, &tombstone_name)?;
+
+        let mut published_options = cap_std::fs::OpenOptions::new();
+        published_options
+            .read(true)
+            .follow(FollowSymlinks::No)
+            .nonblock(true);
+        let published = queries_parent
+            .open_with(&tombstone_name, &published_options)?
+            .into_std();
+        let published_metadata = published.metadata()?;
+        if !published_metadata.is_file()
+            || std::os::unix::fs::MetadataExt::dev(&published_metadata)
+                != std::os::unix::fs::MetadataExt::dev(&staged_metadata)
+            || std::os::unix::fs::MetadataExt::ino(&published_metadata)
+                != std::os::unix::fs::MetadataExt::ino(&staged_metadata)
+        {
+            return Err(QueryInstallError::IoError(std::io::Error::other(
+                "published query uninstall tombstone changed identity",
+            )));
+        }
+        require_single_link(std::os::unix::fs::MetadataExt::nlink(&published_metadata))?;
+        queries_parent.try_clone()?.into_std_file().sync_all()?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = queries_parent.remove_file(&stage_name);
+    }
+    result
+}
+
+#[cfg(windows)]
+fn write_uninstall_tombstone_at(
+    queries_parent: &cap_std::fs::Dir,
+    _ambient_path: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+    use std::os::windows::ffi::OsStrExt as _;
+    use std::os::windows::io::{AsRawHandle as _, FromRawHandle as _};
+    use windows_sys::Win32::Foundation::{DELETE, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_FLAG_WRITE_THROUGH, FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_RENAME_INFO,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FileRenameInfo, ReOpenFile,
+        SetFileInformationByHandle,
+    };
+
+    validate_safe_language_name(language)?;
+    let tombstone_name = format!(".{language}{QUERY_UNINSTALL_TOMBSTONE_SUFFIX}");
+    let mut existing_options = cap_std::fs::OpenOptions::new();
+    existing_options.write(true).follow(FollowSymlinks::No);
+    let existing_permissions = match queries_parent.open_with(&tombstone_name, &existing_options) {
+        Ok(file) => {
+            let file = file.into_std();
+            let metadata = file.metadata()?;
+            if !metadata.is_file() {
+                return Err(QueryInstallError::IoError(std::io::Error::other(
+                    "query uninstall tombstone is not a regular file",
+                )));
+            }
+            require_single_link(u64::from(windows_file_information(&file)?.nNumberOfLinks))?;
+            Some(metadata.permissions())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(QueryInstallError::IoError(error)),
+    };
+
+    let (stage_name, mut staged) = loop {
+        let counter = QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let candidate = format!(
+            ".{language}.uninstalled.{}.{}.tmp",
+            std::process::id(),
+            counter
+        );
+        let mut options = cap_std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        match queries_parent.open_with(&candidate, &options) {
+            Ok(file) => break (candidate, file.into_std()),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(QueryInstallError::IoError(error)),
+        }
+    };
+    let result = (|| -> Result<(), QueryInstallError> {
+        if let Some(permissions) = existing_permissions {
+            staged.set_permissions(permissions)?;
+        }
+        staged.write_all(b"ok\n")?;
+        staged.sync_all()?;
+        let directory = queries_parent.try_clone()?.into_std_file();
+        // SAFETY: `staged` owns a valid handle; success returns a new owned handle.
+        let handle = unsafe {
+            ReOpenFile(
+                staged.as_raw_handle(),
+                FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                FILE_FLAG_WRITE_THROUGH,
+            )
+        };
+        if handle == INVALID_HANDLE_VALUE {
+            return Err(QueryInstallError::IoError(std::io::Error::last_os_error()));
+        }
+        // SAFETY: successful ReOpenFile returned a newly owned handle.
+        let rename_handle = unsafe { fs::File::from_raw_handle(handle) };
+        normalize_windows_stage_attributes(&rename_handle)?;
+        let filename: Vec<u16> = std::ffi::OsStr::new(&tombstone_name)
+            .encode_wide()
+            .collect();
+        let header = std::mem::offset_of!(FILE_RENAME_INFO, FileName);
+        let size = header + filename.len() * std::mem::size_of::<u16>();
+        let units = size.div_ceil(std::mem::size_of::<FILE_RENAME_INFO>());
+        let mut buffer = vec![FILE_RENAME_INFO::default(); units];
+        let information = buffer.as_mut_ptr();
+        // SAFETY: the buffer covers the header/name and both handles stay valid.
+        let succeeded = unsafe {
+            (*information).Anonymous.ReplaceIfExists = true;
+            (*information).RootDirectory = directory.as_raw_handle();
+            (*information).FileNameLength = u32::try_from(filename.len() * 2).unwrap();
+            std::ptr::copy_nonoverlapping(
+                filename.as_ptr(),
+                (*information).FileName.as_mut_ptr(),
+                filename.len(),
+            );
+            SetFileInformationByHandle(
+                rename_handle.as_raw_handle(),
+                FileRenameInfo,
+                information.cast(),
+                u32::try_from(size).unwrap(),
+            )
+        };
+        if succeeded == 0 {
+            return Err(QueryInstallError::IoError(std::io::Error::last_os_error()));
+        }
+        let mut published_options = cap_std::fs::OpenOptions::new();
+        published_options.read(true).follow(FollowSymlinks::No);
+        let published = queries_parent
+            .open_with(&tombstone_name, &published_options)?
+            .into_std();
+        let expected = windows_file_information(&rename_handle)?;
+        let actual = windows_file_information(&published)?;
+        if expected.dwVolumeSerialNumber != actual.dwVolumeSerialNumber
+            || expected.nFileIndexHigh != actual.nFileIndexHigh
+            || expected.nFileIndexLow != actual.nFileIndexLow
+        {
+            return Err(QueryInstallError::IoError(std::io::Error::other(
+                "published query uninstall tombstone changed identity",
+            )));
+        }
+        require_single_link(u64::from(actual.nNumberOfLinks))?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = queries_parent.remove_file(&stage_name);
+    }
+    result
 }
 
 fn write_uninstall_tombstone_with_before_publish(
@@ -1713,11 +1924,12 @@ mod tests {
         remove_query_install_and_backups_with_hooks(
             &linked,
             "rust",
-            write_uninstall_tombstone,
-            |queries_parent| {
-                fs::remove_file(queries_parent).unwrap();
-                symlink(&replacement, queries_parent).unwrap();
+            |pinned, ambient_parent, language| {
+                fs::remove_file(ambient_parent).unwrap();
+                symlink(&replacement, ambient_parent).unwrap();
+                write_uninstall_tombstone_at(pinned, ambient_parent, language)
             },
+            |_| {},
         )
         .unwrap();
 
@@ -1777,7 +1989,7 @@ mod tests {
         let result = remove_query_install_and_backups_with_tombstone_writer(
             &queries_parent,
             "rust",
-            |_, _| {
+            |_, _, _| {
                 Err(QueryInstallError::IoError(std::io::Error::other(
                     "injected durability failure",
                 )))

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -758,9 +758,73 @@ fn write_uninstall_tombstone(
     language: &str,
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
-    let mut file = fs::File::create(uninstall_tombstone_path(queries_parent, language))?;
+    let mut file = open_regular_tombstone(&uninstall_tombstone_path(queries_parent, language))?;
+    file.set_len(0)?;
     file.write_all(b"ok\n")?;
     Ok(())
+}
+
+/// Open or create the managed tombstone leaf without following a link there.
+///
+/// Parent components deliberately retain ordinary path resolution: users may
+/// symlink their data directory or `queries` directory. Only the final,
+/// kakehashi-owned leaf is constrained, and truncation happens after the
+/// opened handle has been confirmed to name a regular file.
+#[cfg(unix)]
+fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        // O_NOFOLLOW binds the validation to the opened leaf rather than a
+        // racy metadata pre-check. O_NONBLOCK prevents a substituted FIFO
+        // from blocking the uninstall before fstat can reject it.
+        .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK)
+        .open(path)?;
+    if !file.metadata()?.file_type().is_file() {
+        return Err(std::io::Error::other(
+            "query uninstall tombstone is not a regular file",
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(windows)]
+fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
+    use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT,
+    };
+
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        // Open the reparse point itself, if present, so validation cannot be
+        // raced into following its target. Truncation happens only afterward.
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)?;
+    let metadata = file.metadata()?;
+    if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+        || !metadata.file_type().is_file()
+    {
+        return Err(std::io::Error::other(
+            "query uninstall tombstone is not a regular file",
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_regular_tombstone(path: &Path) -> std::io::Result<fs::File> {
+    // No portable no-follow open exists. Creating a fresh leaf is atomic and
+    // safe; conservatively reject an existing leaf on these platforms.
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
 }
 
 fn clear_uninstall_tombstone(
@@ -1189,6 +1253,63 @@ mod tests {
         assert!(
             !queries_parent.exists(),
             "unsafe cleanup must not even create the queries directory"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn remove_query_install_rejects_symlinked_uninstall_tombstone() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let victim = temp.path().join("victim");
+        fs::write(&victim, "keep me\n").unwrap();
+        symlink(&victim, uninstall_tombstone_path(&queries_parent, "rust")).unwrap();
+
+        let result = remove_query_install_and_backups(&queries_parent, "rust");
+
+        assert_eq!(
+            fs::read_to_string(&victim).unwrap(),
+            "keep me\n",
+            "opening the tombstone must not follow and overwrite its target"
+        );
+        assert!(
+            matches!(result, Err(QueryInstallError::IoError(_))),
+            "a managed tombstone symlink must fail the uninstall"
+        );
+    }
+
+    #[test]
+    fn remove_query_install_reuses_regular_uninstall_tombstone() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let tombstone = uninstall_tombstone_path(&queries_parent, "rust");
+        fs::write(&tombstone, "stale tombstone contents\n").unwrap();
+
+        remove_query_install_and_backups(&queries_parent, "rust").unwrap();
+
+        assert_eq!(fs::read_to_string(tombstone).unwrap(), "ok\n");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn remove_query_install_supports_symlinked_queries_parent() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let real_queries = temp.path().join("real-queries");
+        fs::create_dir_all(&real_queries).unwrap();
+        let linked_queries = temp.path().join("queries");
+        symlink(&real_queries, &linked_queries).unwrap();
+
+        remove_query_install_and_backups(&linked_queries, "rust").unwrap();
+
+        assert_eq!(
+            fs::read_to_string(uninstall_tombstone_path(&real_queries, "rust")).unwrap(),
+            "ok\n"
         );
     }
 


### PR DESCRIPTION
## Summary

- read owner, group, and DACL from the validated existing tombstone handle and apply them to the already-opened private stage before publication
- preserve protected versus inheritable DACL control state and request WRITE_OWNER only when owner/group SIDs differ
- fail before FileRenameInfo publication if descriptor access is denied; never fall back to a pathname replacement
- retain #822 leaf confinement, #829 durability ordering, and #830 pinned-parent publication

## Stacked dependency

Stacked on draft #843 at exact base `24e81eff03d087b4a8637723c9f6280d4d424739`, which contains latest `origin/main` (`75a09c99ba628be59c8833eed571924e4b576a54`).

## Tests

- Windows: explicit null protected DACL survives replacement
- Windows: injected security-copy denial aborts before publication and cleans the private stage
- local `make check`
- local tombstone-focused suite

Windows validation is expected from remote CI because this host is macOS.

Closes #836