### PR TITLE
fix(install): reject managed parser symlinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,7 @@ dependencies = [
  "ulid",
  "ureq",
  "url",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,9 @@ percent-encoding = "2"
 rayon = "1"
 futures = "0.3.31"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+
 # Unix-only dependencies (signal handling; "fs" for FD_CLOEXEC in tests)
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process", "fs"] }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -408,7 +408,7 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
     if let Ok(entries) = fs::read_dir(&parser_dir) {
         for entry in entries.flatten() {
             let path = entry.path();
-            let is_parser = parser_entry_is_regular(&path)
+            let is_parser = parser::parser_file_is_regular(&path)
                 && path
                     .extension()
                     .is_some_and(|ext| ext == std::env::consts::DLL_EXTENSION);
@@ -509,7 +509,7 @@ fn run_language_uninstall(
         if let Ok(entries) = fs::read_dir(&parser_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                let is_parser = parser_entry_is_regular(&path)
+                let is_parser = parser::parser_file_is_regular(&path)
                     && path
                         .extension()
                         .is_some_and(|ext| ext == std::env::consts::DLL_EXTENSION);
@@ -630,30 +630,11 @@ fn run_language_uninstall(
 /// Find the parser file for a language.
 fn find_parser_file(parser_dir: &std::path::Path, lang: &str) -> Option<PathBuf> {
     let path = parser_dir.join(format!("{}.{}", lang, std::env::consts::DLL_EXTENSION));
-    if parser_entry_is_regular(&path) {
+    if parser::parser_file_is_regular(&path) {
         Some(path)
     } else {
         None
     }
-}
-
-fn parser_entry_is_regular(path: &Path) -> bool {
-    let Ok(metadata) = std::fs::symlink_metadata(path) else {
-        return false;
-    };
-    if !metadata.file_type().is_file() {
-        return false;
-    }
-    #[cfg(windows)]
-    {
-        use std::os::windows::fs::MetadataExt as _;
-        use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
-
-        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
-            return false;
-        }
-    }
-    true
 }
 
 /// Write content to stdout or a file, with --force / --output semantics.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -408,7 +408,7 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
     if let Ok(entries) = fs::read_dir(&parser_dir) {
         for entry in entries.flatten() {
             let path = entry.path();
-            let is_parser = path.is_file()
+            let is_parser = parser_entry_is_regular(&path)
                 && path
                     .extension()
                     .is_some_and(|ext| ext == std::env::consts::DLL_EXTENSION);
@@ -509,7 +509,7 @@ fn run_language_uninstall(
         if let Ok(entries) = fs::read_dir(&parser_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                let is_parser = path.is_file()
+                let is_parser = parser_entry_is_regular(&path)
                     && path
                         .extension()
                         .is_some_and(|ext| ext == std::env::consts::DLL_EXTENSION);
@@ -630,7 +630,30 @@ fn run_language_uninstall(
 /// Find the parser file for a language.
 fn find_parser_file(parser_dir: &std::path::Path, lang: &str) -> Option<PathBuf> {
     let path = parser_dir.join(format!("{}.{}", lang, std::env::consts::DLL_EXTENSION));
-    if path.is_file() { Some(path) } else { None }
+    if parser_entry_is_regular(&path) {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+fn parser_entry_is_regular(path: &Path) -> bool {
+    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+        return false;
+    };
+    if !metadata.file_type().is_file() {
+        return false;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt as _;
+        use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+
+        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return false;
+        }
+    }
+    true
 }
 
 /// Write content to stdout or a file, with --force / --output semantics.

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -148,6 +148,33 @@ pub fn parser_file_is_regular(path: &Path) -> bool {
     true
 }
 
+fn parser_leaf_is_link(metadata: &fs::Metadata) -> bool {
+    #[cfg(unix)]
+    {
+        metadata.file_type().is_symlink()
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt as _;
+        use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+
+        metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = metadata;
+        false
+    }
+}
+
+fn parser_leaf_requires_force(path: &Path) -> std::io::Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(!parser_leaf_is_link(&metadata)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
 #[cfg(windows)]
 fn remove_existing_parser_leaf(path: &Path) -> std::io::Result<()> {
     use std::os::windows::fs::MetadataExt as _;
@@ -330,7 +357,7 @@ pub fn install_parser(
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
 
     // Check if parser already exists
-    if parser_file_is_regular(&parser_file) && !options.force {
+    if !options.force && parser_leaf_requires_force(&parser_file)? {
         return Err(ParserInstallError::AlreadyExists(parser_file));
     }
 
@@ -1015,6 +1042,23 @@ mod tests {
             None,
             "managed parser links must not suppress repair"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_force_install_preserves_a_managed_parser_socket() {
+        use std::os::unix::net::UnixListener;
+
+        let temp = tempdir().unwrap();
+        let managed = temp
+            .path()
+            .join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        let listener = UnixListener::bind(&managed).unwrap();
+
+        assert!(parser_leaf_requires_force(&managed).unwrap());
+        assert!(managed.exists());
+
+        drop(listener);
     }
 
     #[cfg(windows)]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -120,11 +120,30 @@ pub fn parser_file_exists(language: &str, data_dir: &Path) -> Option<PathBuf> {
         data_dir
             .join("parser")
             .join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
-    if parser_file.exists() {
+    if parser_file_is_regular(&parser_file) {
         Some(parser_file)
     } else {
         None
     }
+}
+
+fn parser_file_is_regular(path: &Path) -> bool {
+    let Ok(metadata) = fs::symlink_metadata(path) else {
+        return false;
+    };
+    if !metadata.file_type().is_file() {
+        return false;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt as _;
+        use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+
+        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return false;
+        }
+    }
+    true
 }
 
 /// Upper bound for a single parser compile.
@@ -282,7 +301,7 @@ pub fn install_parser(
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
 
     // Check if parser already exists
-    if parser_file.exists() && !options.force {
+    if parser_file_is_regular(&parser_file) && !options.force {
         return Err(ParserInstallError::AlreadyExists(parser_file));
     }
 
@@ -937,6 +956,34 @@ fn invalid_metadata(message: String) -> ParserInstallError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn parser_file_exists_rejects_a_managed_symlink() {
+        let temp = tempdir().unwrap();
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).unwrap();
+        let external = temp
+            .path()
+            .join(format!("external.{}", std::env::consts::DLL_EXTENSION));
+        fs::write(&external, "external parser").unwrap();
+        let managed = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&external, &managed).unwrap();
+        #[cfg(windows)]
+        if let Err(e) = std::os::windows::fs::symlink_file(&external, &managed) {
+            if e.kind() == std::io::ErrorKind::PermissionDenied || e.raw_os_error() == Some(1314) {
+                return;
+            }
+            panic!("failed to create parser symlink: {e}");
+        }
+
+        assert_eq!(
+            parser_file_exists("lua", temp.path()),
+            None,
+            "managed parser links must not suppress repair"
+        );
+    }
     use tempfile::tempdir;
 
     const TREE_SITTER_JSON_URL: &str =

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -127,7 +127,9 @@ pub fn parser_file_exists(language: &str, data_dir: &Path) -> Option<PathBuf> {
     }
 }
 
-fn parser_file_is_regular(path: &Path) -> bool {
+/// Whether `path` is a regular managed parser leaf rather than a link/reparse
+/// entry whose target merely looks like a parser file.
+pub fn parser_file_is_regular(path: &Path) -> bool {
     let Ok(metadata) = fs::symlink_metadata(path) else {
         return false;
     };

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -151,14 +151,24 @@ pub fn parser_file_is_regular(path: &Path) -> bool {
 #[cfg(windows)]
 fn remove_existing_parser_leaf(path: &Path) -> std::io::Result<()> {
     use std::os::windows::fs::MetadataExt as _;
-    use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_DIRECTORY;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
+    };
 
     let metadata = match fs::symlink_metadata(path) {
         Ok(metadata) => metadata,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(err) => return Err(err),
     };
-    if metadata.file_attributes() & FILE_ATTRIBUTE_DIRECTORY != 0 {
+    let attributes = metadata.file_attributes();
+    if attributes & FILE_ATTRIBUTE_DIRECTORY != 0 && attributes & FILE_ATTRIBUTE_REPARSE_POINT == 0
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::IsADirectory,
+            "managed parser leaf is an ordinary directory",
+        ));
+    }
+    if attributes & FILE_ATTRIBUTE_DIRECTORY != 0 {
         fs::remove_dir(path)
     } else {
         fs::remove_file(path)
@@ -391,7 +401,10 @@ pub fn install_parser(
             // first there (a small non-atomic window, acceptable on the
             // non-primary platform).
             #[cfg(windows)]
-            remove_existing_parser_leaf(&parser_file)?;
+            if let Err(e) = remove_existing_parser_leaf(&parser_file) {
+                let _ = fs::remove_file(&tmp_file);
+                return Err(ParserInstallError::IoError(e));
+            }
             if let Err(e) = fs::rename(&tmp_file, &parser_file) {
                 let _ = fs::remove_file(&tmp_file);
                 return Err(ParserInstallError::IoError(e));
@@ -1027,6 +1040,21 @@ mod tests {
             external.is_dir(),
             "removing the link must preserve its target"
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn replacement_preserves_an_ordinary_parser_directory() {
+        let temp = tempdir().unwrap();
+        let managed = temp
+            .path()
+            .join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        fs::create_dir(&managed).unwrap();
+
+        let err = remove_existing_parser_leaf(&managed).unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::IsADirectory);
+        assert!(managed.is_dir());
     }
     use tempfile::tempdir;
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -148,6 +148,23 @@ pub fn parser_file_is_regular(path: &Path) -> bool {
     true
 }
 
+#[cfg(windows)]
+fn remove_existing_parser_leaf(path: &Path) -> std::io::Result<()> {
+    use std::os::windows::fs::MetadataExt as _;
+    use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_DIRECTORY;
+
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err),
+    };
+    if metadata.file_attributes() & FILE_ATTRIBUTE_DIRECTORY != 0 {
+        fs::remove_dir(path)
+    } else {
+        fs::remove_file(path)
+    }
+}
+
 /// Upper bound for a single parser compile.
 ///
 /// The loader shells out to `cc` with no timeout of its own; a pathological
@@ -374,7 +391,7 @@ pub fn install_parser(
             // first there (a small non-atomic window, acceptable on the
             // non-primary platform).
             #[cfg(windows)]
-            let _ = fs::remove_file(&parser_file);
+            remove_existing_parser_leaf(&parser_file)?;
             if let Err(e) = fs::rename(&tmp_file, &parser_file) {
                 let _ = fs::remove_file(&tmp_file);
                 return Err(ParserInstallError::IoError(e));
@@ -984,6 +1001,31 @@ mod tests {
             parser_file_exists("lua", temp.path()),
             None,
             "managed parser links must not suppress repair"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn replacement_removes_a_managed_parser_directory_link() {
+        let temp = tempdir().unwrap();
+        let external = temp.path().join("external");
+        fs::create_dir(&external).unwrap();
+        let managed = temp
+            .path()
+            .join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        if let Err(e) = std::os::windows::fs::symlink_dir(&external, &managed) {
+            if e.kind() == std::io::ErrorKind::PermissionDenied || e.raw_os_error() == Some(1314) {
+                return;
+            }
+            panic!("failed to create parser directory link: {e}");
+        }
+
+        remove_existing_parser_leaf(&managed).unwrap();
+
+        assert!(!managed.exists());
+        assert!(
+            external.is_dir(),
+            "removing the link must preserve its target"
         );
     }
     use tempfile::tempdir;

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -400,7 +400,7 @@ impl QueryLoader {
         for path in search_paths {
             for ext in PARSER_EXTENSIONS {
                 let parser_path = Self::parser_library_path(path.as_ref(), language, ext);
-                if parser_path.exists() {
+                if crate::install::parser::parser_file_is_regular(&parser_path) {
                     return Some(parser_path);
                 }
             }
@@ -536,6 +536,36 @@ mod tests {
                 .unwrap()
                 .to_string_lossy()
                 .ends_with("parser/rust.so")
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn implicit_library_resolution_rejects_managed_parser_symlinks() {
+        let dir = tempdir().unwrap();
+        let parser_dir = dir.path().join("parser");
+        fs::create_dir_all(&parser_dir).unwrap();
+        let external = dir.path().join("external.so");
+        fs::write(&external, "external parser").unwrap();
+        let managed = parser_dir.join("rust.so");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&external, &managed).unwrap();
+        #[cfg(windows)]
+        if let Err(e) = std::os::windows::fs::symlink_file(&external, &managed) {
+            if e.kind() == std::io::ErrorKind::PermissionDenied || e.raw_os_error() == Some(1314) {
+                return;
+            }
+            panic!("failed to create parser symlink: {e}");
+        }
+
+        assert!(
+            QueryLoader::resolve_library_path(None, "rust", &[dir.path()]).is_none(),
+            "implicit managed parser lookup must not follow links"
+        );
+        assert_eq!(
+            QueryLoader::resolve_library_path(managed.to_str(), "rust", NO_SEARCH_PATHS),
+            Some(managed),
+            "explicit parser configuration remains an intentional path override"
         );
     }
 

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1331,6 +1331,94 @@ fn test_language_uninstall_all_ignores_parser_shaped_directories() {
     );
 }
 
+#[cfg(any(unix, windows))]
+#[test]
+fn test_language_uninstall_all_ignores_symlinked_parser_files() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
+    let external = test_dir.path().join(format!("external.{ext}"));
+    fs::write(&external, "external parser").expect("Failed to create external parser");
+    let managed = test_dir.path().join(format!("parser/lua.{ext}"));
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&external, &managed).expect("Failed to symlink parser");
+    #[cfg(windows)]
+    if let Err(e) = std::os::windows::fs::symlink_file(&external, &managed) {
+        if e.kind() == std::io::ErrorKind::PermissionDenied || e.raw_os_error() == Some(1314) {
+            return;
+        }
+        panic!("failed to create parser symlink: {e}");
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success(), "uninstall failed: {combined}");
+    assert!(combined.contains("No languages installed to uninstall"));
+    assert!(managed.is_symlink(), "managed symlink must remain intact");
+    assert!(external.is_file(), "external parser must remain intact");
+}
+
+#[cfg(any(unix, windows))]
+#[test]
+fn test_language_uninstall_explicit_ignores_symlinked_parser_files() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
+    let external = test_dir.path().join(format!("external.{ext}"));
+    fs::write(&external, "external parser").expect("Failed to create external parser");
+    let managed = test_dir.path().join(format!("parser/lua.{ext}"));
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&external, &managed).expect("Failed to symlink parser");
+    #[cfg(windows)]
+    if let Err(e) = std::os::windows::fs::symlink_file(&external, &managed) {
+        if e.kind() == std::io::ErrorKind::PermissionDenied || e.raw_os_error() == Some(1314) {
+            return;
+        }
+        panic!("failed to create parser symlink: {e}");
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "lua",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success(), "uninstall failed: {combined}");
+    assert!(combined.contains("Language 'lua' is not installed"));
+    assert!(managed.is_symlink(), "managed symlink must remain intact");
+    assert!(external.is_file(), "external parser must remain intact");
+}
+
 /// Explicit uninstall must use the same regular-file check as discovery, so a
 /// parser-shaped directory is reported as absent and never passed to removal.
 #[test]

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -762,6 +762,52 @@ fn test_language_status_ignores_parser_shaped_directories() {
     );
 }
 
+/// A managed parser symlink must not be reported as an installed parser even
+/// when its external target is a regular file.
+#[cfg(any(unix, windows))]
+#[test]
+fn test_language_status_ignores_symlinked_parser_files() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
+    let external = test_dir.path().join(format!("external.{ext}"));
+    fs::write(&external, "external parser").expect("Failed to create external parser");
+    let managed = test_dir.path().join(format!("parser/lua.{ext}"));
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&external, &managed).expect("Failed to symlink parser");
+    #[cfg(windows)]
+    if let Err(e) = std::os::windows::fs::symlink_file(&external, &managed) {
+        if e.kind() == std::io::ErrorKind::PermissionDenied || e.raw_os_error() == Some(1314) {
+            return;
+        }
+        panic!("failed to create parser symlink: {e}");
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success(), "status failed: {combined}");
+    assert!(
+        combined.contains("No languages installed"),
+        "managed parser symlinks must be ignored: {combined}"
+    );
+    assert!(external.is_file(), "external parser must remain intact");
+}
+
 /// Test that language status shows missing queries
 #[test]
 fn test_language_status_missing_queries() {


### PR DESCRIPTION
Fixes #842

## Summary
- reject symlink/reparse-point parser leaves in install and CLI discovery
- repair managed links safely while preserving ordinary directories and special files
- reject managed links during implicit runtime parser resolution while preserving explicit parser overrides
- cover status, explicit/bulk uninstall, runtime lookup, and platform-specific replacement behavior

## Validation
- `cargo test --lib parser_file_exists`
- `cargo test --lib implicit_library_resolution_rejects_managed_parser_symlinks`
- `cargo test --lib test_resolve_library_path`
- focused CLI status/uninstall tests
- `make check`
- fresh exact-parent Codex review: no remaining actionable correctness findings

## Stack
Depends on #831.