### PR TITLE
fix(lsp): recover concurrent auto-install waiters

### DIFF
--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -879,18 +879,21 @@ impl DocumentStore {
     /// Release parked first-parse waiters when a parse pass gives up without
     /// producing anything to publish — auto-install failed, the parser is
     /// still missing after an install, or the edit path detected no
-    /// language. Publishes a resolved-but-tree-less snapshot at the CURRENT
-    /// (text, version), which advances the lifetime out of bootstrap so the
+    /// language. Publishes a resolved-but-tree-less snapshot at the EXPECTED
+    /// lifetime's current (text, version), which advances it out of bootstrap so the
     /// generous first-parse backstop is bounded by the give-up instead of
     /// burning in full on every request. Gated on the lifetime still being
     /// at bootstrap: once any snapshot exists no first-parse waiter is
     /// parked, and a tree-less publish would only downgrade serve-stale
     /// answers. A later successful parse of the SAME version is re-admitted
     /// by the cell's tree-upgrade clause (see [`SnapshotSlot::admits`]).
-    pub(crate) fn publish_giveup_snapshot(&self, uri: &Url) {
+    pub(crate) fn publish_giveup_snapshot(&self, uri: &Url, expected_incarnation: u64) {
         let Some(doc) = self.documents.get(uri) else {
             return;
         };
+        if doc.incarnation() != expected_incarnation {
+            return;
+        }
         if doc.latest_snapshot_slot().snapshot.is_some() {
             return;
         }
@@ -1033,9 +1036,9 @@ mod tests {
         fn giveup_publish_fills_bootstrap_only() {
             let store = DocumentStore::new();
             let uri = Url::parse("file:///giveup.rs").unwrap();
-            store.insert(uri.clone(), "a".into(), Some("rust".into()), None);
+            let incarnation = store.insert(uri.clone(), "a".into(), Some("rust".into()), None);
 
-            store.publish_giveup_snapshot(&uri);
+            store.publish_giveup_snapshot(&uri, incarnation);
             let view = store.latest_snapshot(&uri).unwrap();
             let snapshot = view.slot.snapshot.expect("give-up publishes at bootstrap");
             assert!(snapshot.tree.is_none());
@@ -1044,12 +1047,33 @@ mod tests {
             // A newer input version does NOT re-open the give-up: a snapshot
             // exists, so no first-parse waiter is parked.
             store.update_document(uri.clone(), "ab".into(), None);
-            store.publish_giveup_snapshot(&uri);
+            store.publish_giveup_snapshot(&uri, incarnation);
             let view = store.latest_snapshot(&uri).unwrap();
             assert_eq!(
                 view.slot.snapshot.unwrap().parsed_version,
                 0,
                 "give-up is a no-op once any snapshot exists"
+            );
+        }
+
+        #[test]
+        fn stale_giveup_does_not_publish_into_reopened_lifetime() {
+            let store = DocumentStore::new();
+            let uri = Url::parse("file:///stale-giveup.rs").unwrap();
+            let old_incarnation =
+                store.insert(uri.clone(), "old".into(), Some("rust".into()), None);
+            store.remove(&uri);
+            let new_incarnation =
+                store.insert(uri.clone(), "new".into(), Some("rust".into()), None);
+            assert_ne!(new_incarnation, old_incarnation);
+
+            store.publish_giveup_snapshot(&uri, old_incarnation);
+
+            let view = store.latest_snapshot(&uri).unwrap();
+            assert_eq!(view.slot.current_incarnation, new_incarnation);
+            assert!(
+                view.slot.snapshot.is_none(),
+                "an old task must not release the reopened lifetime's bootstrap waiters"
             );
         }
 

--- a/src/lsp/auto_install.rs
+++ b/src/lsp/auto_install.rs
@@ -11,7 +11,7 @@
 
 mod manager;
 
-pub(crate) use manager::{AutoInstallManager, InstallEvent};
+pub(crate) use manager::{AutoInstallManager, InstallEvent, InstallOutcome};
 
 use crate::lsp::in_progress_set::InProgressSet;
 

--- a/src/lsp/auto_install.rs
+++ b/src/lsp/auto_install.rs
@@ -11,7 +11,7 @@
 
 mod manager;
 
-pub(crate) use manager::{AutoInstallManager, InstallEvent, InstallOutcome};
+pub(crate) use manager::{AutoInstallManager, InstallEvent, InstallOutcome, InstallResult};
 
 use crate::lsp::in_progress_set::InProgressSet;
 

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -11,6 +11,7 @@
 use std::{
     collections::HashMap,
     future::Future,
+    io::Write,
     path::PathBuf,
     sync::{Arc, Mutex},
 };
@@ -439,7 +440,30 @@ impl AutoInstallManager {
                     completion: completion.clone(),
                 },
             );
-            assert!(self.installing_languages.try_start_install(language));
+            if !self.installing_languages.try_start_install(language) {
+                let _ = writeln!(
+                    std::io::stderr(),
+                    "Auto-install state mismatch for '{}': repairing a stale installing marker",
+                    language
+                );
+                events.push(InstallEvent::Log {
+                    level: MessageType::WARNING,
+                    message: format!(
+                        "Auto-install state for '{}' was inconsistent; retrying with repaired state",
+                        language
+                    ),
+                });
+                self.installing_languages.finish_install(language);
+                if !self.installing_languages.try_start_install(language) {
+                    claims.remove(language);
+                    return InstallResult {
+                        outcome: InstallOutcome::Failed,
+                        events,
+                        completion: None,
+                        claim: None,
+                    };
+                }
+            }
             InstallMarkerGuard {
                 installing: self.installing_languages.clone(),
                 claims: Arc::clone(&self.claims),
@@ -921,6 +945,26 @@ mod tests {
                 .try_start_install("unsupported"),
             "unsupported and metadata-error exits share this skip path and must release the claim"
         );
+    }
+
+    #[tokio::test]
+    async fn stale_installing_marker_is_repaired_without_panicking() {
+        let temp = tempdir().unwrap();
+        let installing = InstallingLanguages::new();
+        assert!(installing.try_start_install("stale-marker"));
+        let failed = FailedParserRegistry::new(temp.path());
+        failed.init().unwrap();
+        let manager = AutoInstallManager::new(installing.clone(), failed);
+
+        let result = manager
+            .try_install_with_support_check("stale-marker", |_, _| async {
+                TrackedSupportCheck::completed(true, None)
+            })
+            .await;
+
+        assert_eq!(result.outcome, InstallOutcome::Unsupported);
+        drop(result);
+        assert!(installing.try_start_install("stale-marker"));
     }
 
     #[tokio::test]

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -44,6 +44,21 @@ struct ClaimState {
     completion: tokio::sync::watch::Sender<Option<InstallOutcome>>,
 }
 
+#[cfg(test)]
+pub(crate) struct TestInstallClaim {
+    guard: Option<InstallMarkerGuard>,
+}
+
+#[cfg(test)]
+impl TestInstallClaim {
+    pub(crate) fn complete(mut self, outcome: InstallOutcome) {
+        self.guard
+            .take()
+            .expect("test claim is present")
+            .complete(outcome);
+    }
+}
+
 impl Drop for InstallResult {
     fn drop(&mut self) {
         // An uncompleted claim fails closed through InstallMarkerGuard::drop.
@@ -52,6 +67,20 @@ impl Drop for InstallResult {
 }
 
 impl InstallResult {
+    fn with_claim(
+        outcome: InstallOutcome,
+        events: Vec<InstallEvent>,
+        mut claim: InstallMarkerGuard,
+    ) -> Self {
+        claim.preserve_terminal(outcome.clone());
+        Self {
+            outcome,
+            events,
+            completion: None,
+            claim: Some(claim),
+        }
+    }
+
     pub(crate) fn complete_claim(&mut self) {
         if let Some(claim) = self.claim.take() {
             claim.complete(self.outcome.clone());
@@ -79,6 +108,8 @@ pub(crate) enum InstallOutcome {
     },
     /// Installation already in progress for this language
     AlreadyInstalling,
+    /// The owner disappeared before producing a terminal install result
+    Abandoned,
     /// Parser previously crashed, skipping to protect system
     ParserFailed,
     /// Language not supported by nvim-treesitter
@@ -153,6 +184,10 @@ struct InstallMarkerGuard {
 }
 
 impl InstallMarkerGuard {
+    fn preserve_terminal(&mut self, outcome: InstallOutcome) {
+        self.terminal = Some(outcome);
+    }
+
     fn complete(mut self, outcome: InstallOutcome) {
         self.terminal = Some(outcome);
     }
@@ -160,7 +195,7 @@ impl InstallMarkerGuard {
 
 impl Drop for InstallMarkerGuard {
     fn drop(&mut self) {
-        let terminal = self.terminal.take().unwrap_or(InstallOutcome::Failed);
+        let terminal = self.terminal.take().unwrap_or(InstallOutcome::Abandoned);
         self.installing.finish_install(&self.language);
         self.claims
             .lock()
@@ -180,6 +215,32 @@ impl AutoInstallManager {
             installing_languages,
             failed_parsers,
             claims: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn begin_test_claim(&self, language: &str) -> TestInstallClaim {
+        let mut claims = self
+            .claims
+            .lock()
+            .recover_poison("AutoInstallManager::begin_test_claim");
+        assert!(!claims.contains_key(language));
+        let (completion, _) = tokio::sync::watch::channel(None);
+        claims.insert(
+            language.to_string(),
+            ClaimState {
+                completion: completion.clone(),
+            },
+        );
+        assert!(self.installing_languages.try_start_install(language));
+        TestInstallClaim {
+            guard: Some(InstallMarkerGuard {
+                installing: self.installing_languages.clone(),
+                claims: Arc::clone(&self.claims),
+                completion,
+                language: language.to_string(),
+                terminal: None,
+            }),
         }
     }
 
@@ -282,6 +343,34 @@ impl AutoInstallManager {
     where
         F: FnOnce(String, Option<PathBuf>) -> Fut + Send + 'static,
         Fut: Future<Output = TrackedSupportCheck> + Send + 'static,
+    {
+        self.try_install_with_support_check_and_executor(
+            language,
+            support_check,
+            |language, data_dir| async move {
+                crate::install::install_language_async(
+                    language,
+                    data_dir,
+                    false,
+                    crate::install::parser::ParserCompile::KillableSubprocess,
+                )
+                .await
+            },
+        )
+        .await
+    }
+
+    async fn try_install_with_support_check_and_executor<F, Fut, I, IFut>(
+        &self,
+        language: &str,
+        support_check: F,
+        install_executor: I,
+    ) -> InstallResult
+    where
+        F: FnOnce(String, Option<PathBuf>) -> Fut + Send + 'static,
+        Fut: Future<Output = TrackedSupportCheck> + Send + 'static,
+        I: FnOnce(String, PathBuf) -> IFut + Send + 'static,
+        IFut: Future<Output = crate::install::InstallResult> + Send + 'static,
     {
         let mut events = Vec::new();
 
@@ -414,11 +503,16 @@ impl AutoInstallManager {
         }
 
         if should_skip {
-            return InstallResult {
-                outcome: InstallOutcome::Unsupported,
-                events,
-                completion: None,
-                claim: install_marker,
+            return match install_marker {
+                Some(claim) => {
+                    InstallResult::with_claim(InstallOutcome::Unsupported, events, claim)
+                }
+                None => InstallResult {
+                    outcome: InstallOutcome::Unsupported,
+                    events,
+                    completion: None,
+                    claim: None,
+                },
             };
         }
         let Some(install_marker) = install_marker else {
@@ -449,12 +543,11 @@ impl AutoInstallManager {
                     message: "Could not determine data directory for auto-install".to_string(),
                 });
                 events.push(InstallEvent::ProgressEnd { success: false });
-                return InstallResult {
-                    outcome: InstallOutcome::NoDataDir,
+                return InstallResult::with_claim(
+                    InstallOutcome::NoDataDir,
                     events,
-                    completion: None,
-                    claim: Some(install_marker),
-                };
+                    install_marker,
+                );
             }
         };
 
@@ -471,12 +564,7 @@ impl AutoInstallManager {
             let outcome = InstallOutcome::AlreadyExists {
                 data_dir: data_dir.clone(),
             };
-            return InstallResult {
-                outcome,
-                events,
-                completion: None,
-                claim: Some(install_marker),
-            };
+            return InstallResult::with_claim(outcome, events, install_marker);
         }
 
         // Log installation start
@@ -498,16 +586,28 @@ impl AutoInstallManager {
             // Auto-install runs inside the LSP server, whose `current_exe()` is the
             // kakehashi binary — so the killable subprocess (re-exec
             // `__compile-parser`) is valid and bounds a hung `cc`.
-            let result = crate::install::install_language_async(
-                task_lang,
-                task_data_dir,
-                false,
-                crate::install::parser::ParserCompile::KillableSubprocess,
-            )
-            .await;
-            (result, install_marker)
+            let result = install_executor(task_lang.clone(), task_data_dir.clone()).await;
+            let parser_exists =
+                crate::install::parser_file_exists(&task_lang, &task_data_dir).is_some();
+            let terminal = if result.is_success() {
+                InstallOutcome::Success {
+                    data_dir: task_data_dir.clone(),
+                }
+            } else if parser_exists {
+                InstallOutcome::SuccessWithWarnings {
+                    data_dir: task_data_dir.clone(),
+                }
+            } else {
+                InstallOutcome::Failed
+            };
+            let mut install_marker = install_marker;
+            // If the caller awaiting this task is cancelled, the task output is
+            // dropped. Keep the real install result on the guard so waiters see
+            // success rather than the guard's fail-closed fallback.
+            install_marker.preserve_terminal(terminal);
+            (result, parser_exists, install_marker)
         });
-        let (result, install_marker) = match install_task.await {
+        let (result, parser_exists, install_marker) = match install_task.await {
             Ok(result) => result,
             Err(join_error) => {
                 events.push(InstallEvent::ProgressEnd { success: false });
@@ -524,9 +624,6 @@ impl AutoInstallManager {
             }
         };
 
-        // Check if parser file exists after install attempt (even if queries failed)
-        let parser_exists = crate::install::parser_file_exists(&lang, &data_dir).is_some();
-
         if result.is_success() {
             events.push(InstallEvent::ProgressEnd { success: true });
             events.push(InstallEvent::Log {
@@ -536,12 +633,7 @@ impl AutoInstallManager {
             let outcome = InstallOutcome::Success {
                 data_dir: data_dir.clone(),
             };
-            InstallResult {
-                outcome,
-                events,
-                completion: None,
-                claim: Some(install_marker),
-            }
+            InstallResult::with_claim(outcome, events, install_marker)
         } else if parser_exists {
             // Parser compiled but queries had issues - still usable
             events.push(InstallEvent::ProgressEnd { success: true });
@@ -562,12 +654,7 @@ impl AutoInstallManager {
             let outcome = InstallOutcome::SuccessWithWarnings {
                 data_dir: data_dir.clone(),
             };
-            InstallResult {
-                outcome,
-                events,
-                completion: None,
-                claim: Some(install_marker),
-            }
+            InstallResult::with_claim(outcome, events, install_marker)
         } else {
             // Installation failed
             events.push(InstallEvent::ProgressEnd { success: false });
@@ -589,12 +676,7 @@ impl AutoInstallManager {
             });
 
             let outcome = InstallOutcome::Failed;
-            InstallResult {
-                outcome,
-                events,
-                completion: None,
-                claim: Some(install_marker),
-            }
+            InstallResult::with_claim(outcome, events, install_marker)
         }
     }
 }
@@ -659,6 +741,61 @@ mod tests {
             "marker must be released when the guard drops, even if try_install \
              is cancelled at its install await"
         );
+    }
+
+    #[tokio::test]
+    async fn cancelled_owner_preserves_detached_install_success_for_exact_waiter() {
+        let (manager, _temp) = create_test_manager();
+        let owner_manager = manager.clone();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let owner = tokio::spawn(async move {
+            owner_manager
+                .try_install_with_support_check_and_executor(
+                    "controlled-detached-success",
+                    |_, _| async { TrackedSupportCheck::completed(false, None) },
+                    |_, _| async move {
+                        let _ = started_tx.send(());
+                        let _ = release_rx.await;
+                        crate::install::InstallResult {
+                            parser_path: Some(PathBuf::from("/installed/parser")),
+                            queries_path: Some(PathBuf::from("/installed/queries")),
+                            parser_error: None,
+                            queries_error: None,
+                        }
+                    },
+                )
+                .await
+        });
+        started_rx.await.expect("install executor must start");
+
+        let duplicate = manager
+            .try_install_with_support_check("controlled-detached-success", |_, _| async {
+                panic!("the exact waiter must not start another support check")
+            })
+            .await;
+        assert_eq!(duplicate.outcome, InstallOutcome::AlreadyInstalling);
+        let mut completion = duplicate
+            .completion
+            .clone()
+            .expect("waiter observes the owner's exact claim")
+            .receiver;
+
+        owner.abort();
+        let _ = owner.await;
+        let _ = release_tx.send(());
+        let terminal = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if let Some(outcome) = completion.borrow().clone() {
+                    break outcome;
+                }
+                completion.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("detached install must publish its actual result");
+
+        assert!(matches!(terminal, InstallOutcome::Success { .. }));
     }
 
     #[tokio::test]
@@ -880,8 +1017,24 @@ mod tests {
             .await;
         assert_eq!(duplicate.outcome, InstallOutcome::AlreadyInstalling);
         assert_eq!(duplicate_lookups.load(Ordering::SeqCst), 0);
+        let mut completion = duplicate
+            .completion
+            .clone()
+            .expect("waiter observes the abandoned owner's exact claim")
+            .receiver;
 
         let _ = release_tx.send(());
+        let terminal = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if let Some(outcome) = completion.borrow().clone() {
+                    break outcome;
+                }
+                completion.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("abandoned support owner must publish a retryable outcome");
+        assert_eq!(terminal, InstallOutcome::Abandoned);
         tokio::time::timeout(std::time::Duration::from_secs(1), async {
             while !manager.installing_languages.try_start_install("lua") {
                 tokio::task::yield_now().await;

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -8,9 +8,15 @@
 //! calls `try_install()`, dispatches the events, and then handles
 //! post-install coordination (settings update, language reload).
 
-use std::{future::Future, path::PathBuf};
+use std::{
+    collections::HashMap,
+    future::Future,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
 use tower_lsp_server::ls_types::MessageType;
 
+use crate::error::LockResultExt;
 use crate::install::support_check::{
     TrackedSupportCheck, should_skip_unsupported_language_tracked,
 };
@@ -19,12 +25,38 @@ use crate::language::FailedParserRegistry;
 use super::{InstallingLanguages, InstallingLanguagesExt};
 
 /// Result of an installation attempt with all events for Kakehashi to dispatch.
-#[derive(Debug)]
 pub(crate) struct InstallResult {
     /// What happened during the installation attempt
     pub outcome: InstallOutcome,
     /// Events to be dispatched to ClientNotifier by Kakehashi
     pub events: Vec<InstallEvent>,
+    /// Exact in-flight claim observed by an `AlreadyInstalling` caller.
+    pub completion: Option<InstallCompletion>,
+    claim: Option<InstallMarkerGuard>,
+}
+
+#[derive(Clone)]
+pub(crate) struct InstallCompletion {
+    pub(crate) receiver: tokio::sync::watch::Receiver<Option<InstallOutcome>>,
+}
+
+struct ClaimState {
+    completion: tokio::sync::watch::Sender<Option<InstallOutcome>>,
+}
+
+impl Drop for InstallResult {
+    fn drop(&mut self) {
+        // An uncompleted claim fails closed through InstallMarkerGuard::drop.
+        let _ = self.claim.take();
+    }
+}
+
+impl InstallResult {
+    pub(crate) fn complete_claim(&mut self) {
+        if let Some(claim) = self.claim.take() {
+            claim.complete(self.outcome.clone());
+        }
+    }
 }
 
 /// Outcome of an installation attempt.
@@ -58,22 +90,6 @@ pub(crate) enum InstallOutcome {
 }
 
 impl InstallOutcome {
-    /// Check if the caller should skip parsing after this outcome.
-    ///
-    /// True when a reload will handle parsing (`Success`, `SuccessWithWarnings`,
-    /// `AlreadyExists`) or another task is mid-install (`AlreadyInstalling`);
-    /// false when no install happened or will (`ParserFailed`, `Unsupported`,
-    /// `Failed`, `NoDataDir`).
-    pub(crate) fn should_skip_parse(&self) -> bool {
-        matches!(
-            self,
-            InstallOutcome::Success { .. }
-                | InstallOutcome::SuccessWithWarnings { .. }
-                | InstallOutcome::AlreadyExists { .. }
-                | InstallOutcome::AlreadyInstalling
-        )
-    }
-
     /// Get the data directory if installation was successful.
     pub(crate) fn data_dir(&self) -> Option<&PathBuf> {
         match self {
@@ -109,6 +125,7 @@ pub(crate) struct AutoInstallManager {
     installing_languages: InstallingLanguages,
     /// Tracks parsers that have crashed to prevent repeated failures
     failed_parsers: FailedParserRegistry,
+    claims: Arc<Mutex<HashMap<String, ClaimState>>>,
 }
 
 impl std::fmt::Debug for AutoInstallManager {
@@ -123,18 +140,33 @@ impl std::fmt::Debug for AutoInstallManager {
 /// RAII marker for an in-flight install: clears the `InstallingLanguages`
 /// entry on drop. Manual `finish_install` calls would leak the marker if the
 /// calling future were dropped at an await, leaving the language stuck
-/// `AlreadyInstalling` (and, via `should_skip_parse`, never parsed) for the
+/// `AlreadyInstalling` (and therefore never parsed) for the
 /// server's lifetime. The guard first moves into the support-check task, then
 /// into the install task on success, so it tracks detached work's true
 /// lifetime rather than the caller's.
 struct InstallMarkerGuard {
     installing: InstallingLanguages,
+    claims: Arc<Mutex<HashMap<String, ClaimState>>>,
+    completion: tokio::sync::watch::Sender<Option<InstallOutcome>>,
     language: String,
+    terminal: Option<InstallOutcome>,
+}
+
+impl InstallMarkerGuard {
+    fn complete(mut self, outcome: InstallOutcome) {
+        self.terminal = Some(outcome);
+    }
 }
 
 impl Drop for InstallMarkerGuard {
     fn drop(&mut self) {
+        let terminal = self.terminal.take().unwrap_or(InstallOutcome::Failed);
         self.installing.finish_install(&self.language);
+        self.claims
+            .lock()
+            .recover_poison("AutoInstallManager::finish_claim")
+            .remove(&self.language);
+        self.completion.send_replace(Some(terminal));
     }
 }
 
@@ -147,6 +179,7 @@ impl AutoInstallManager {
         Self {
             installing_languages,
             failed_parsers,
+            claims: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -265,6 +298,8 @@ impl AutoInstallManager {
             return InstallResult {
                 outcome: InstallOutcome::ParserFailed,
                 events,
+                completion: None,
+                claim: None,
             };
         }
 
@@ -272,22 +307,43 @@ impl AutoInstallManager {
         // for the same language do not all fetch metadata. Ordinary early
         // returns release the RAII claim; a timeout transfers it to a detached
         // keeper until the still-running blocking lookup exits.
-        if !self.installing_languages.try_start_install(language) {
-            events.push(InstallEvent::Log {
-                level: MessageType::INFO,
-                message: format!(
-                    "Language '{}' support is already being checked or installed",
-                    language
-                ),
-            });
-            return InstallResult {
-                outcome: InstallOutcome::AlreadyInstalling,
-                events,
-            };
-        }
-        let install_marker = InstallMarkerGuard {
-            installing: self.installing_languages.clone(),
-            language: language.to_string(),
+        let install_marker = {
+            let mut claims = self
+                .claims
+                .lock()
+                .recover_poison("AutoInstallManager::claim_install");
+            if let Some(claim) = claims.get(language) {
+                events.push(InstallEvent::Log {
+                    level: MessageType::INFO,
+                    message: format!(
+                        "Language '{}' support is already being checked or installed",
+                        language
+                    ),
+                });
+                return InstallResult {
+                    outcome: InstallOutcome::AlreadyInstalling,
+                    events,
+                    completion: Some(InstallCompletion {
+                        receiver: claim.completion.subscribe(),
+                    }),
+                    claim: None,
+                };
+            }
+            let (completion, _) = tokio::sync::watch::channel(None);
+            claims.insert(
+                language.to_string(),
+                ClaimState {
+                    completion: completion.clone(),
+                },
+            );
+            assert!(self.installing_languages.try_start_install(language));
+            InstallMarkerGuard {
+                installing: self.installing_languages.clone(),
+                claims: Arc::clone(&self.claims),
+                completion,
+                language: language.to_string(),
+                terminal: None,
+            }
         };
 
         // Check if language is supported by nvim-treesitter
@@ -301,18 +357,24 @@ impl AutoInstallManager {
         let support_task = tokio::spawn(async move {
             let mut result = support_check(lookup_language, lookup_data_dir).await;
             if let Some(completion) = result.completion.take() {
+                let terminal = if result.should_skip {
+                    InstallOutcome::Unsupported
+                } else {
+                    InstallOutcome::Failed
+                };
                 // Start the keeper inside this detached task. If the caller
                 // dropped our JoinHandle while the check was running, task
                 // output would be discarded and could not safely carry the
                 // marker/completion pair back to it.
                 tokio::spawn(async move {
-                    let _marker = install_marker;
                     if let Err(join_error) = completion.await {
                         log::error!(
                             target: "kakehashi::auto_install",
                             "Metadata support-check completion task failed: {}",
                             join_error
                         );
+                    } else {
+                        install_marker.complete(terminal);
                     }
                 });
                 (result, None)
@@ -333,6 +395,8 @@ impl AutoInstallManager {
                 return InstallResult {
                     outcome: InstallOutcome::Failed,
                     events,
+                    completion: None,
+                    claim: None,
                 };
             }
         };
@@ -353,6 +417,8 @@ impl AutoInstallManager {
             return InstallResult {
                 outcome: InstallOutcome::Unsupported,
                 events,
+                completion: None,
+                claim: install_marker,
             };
         }
         let Some(install_marker) = install_marker else {
@@ -366,6 +432,8 @@ impl AutoInstallManager {
             return InstallResult {
                 outcome: InstallOutcome::Failed,
                 events,
+                completion: None,
+                claim: None,
             };
         };
 
@@ -384,6 +452,8 @@ impl AutoInstallManager {
                 return InstallResult {
                     outcome: InstallOutcome::NoDataDir,
                     events,
+                    completion: None,
+                    claim: Some(install_marker),
                 };
             }
         };
@@ -398,11 +468,14 @@ impl AutoInstallManager {
                 ),
             });
             events.push(InstallEvent::ProgressEnd { success: true });
+            let outcome = InstallOutcome::AlreadyExists {
+                data_dir: data_dir.clone(),
+            };
             return InstallResult {
-                outcome: InstallOutcome::AlreadyExists {
-                    data_dir: data_dir.clone(),
-                },
+                outcome,
                 events,
+                completion: None,
+                claim: Some(install_marker),
             };
         }
 
@@ -422,19 +495,19 @@ impl AutoInstallManager {
         let task_lang = lang.clone();
         let task_data_dir = data_dir.clone();
         let install_task = tokio::spawn(async move {
-            let _marker = install_marker;
             // Auto-install runs inside the LSP server, whose `current_exe()` is the
             // kakehashi binary — so the killable subprocess (re-exec
             // `__compile-parser`) is valid and bounds a hung `cc`.
-            crate::install::install_language_async(
+            let result = crate::install::install_language_async(
                 task_lang,
                 task_data_dir,
                 false,
                 crate::install::parser::ParserCompile::KillableSubprocess,
             )
-            .await
+            .await;
+            (result, install_marker)
         });
-        let result = match install_task.await {
+        let (result, install_marker) = match install_task.await {
             Ok(result) => result,
             Err(join_error) => {
                 events.push(InstallEvent::ProgressEnd { success: false });
@@ -445,6 +518,8 @@ impl AutoInstallManager {
                 return InstallResult {
                     outcome: InstallOutcome::Failed,
                     events,
+                    completion: None,
+                    claim: None,
                 };
             }
         };
@@ -458,11 +533,14 @@ impl AutoInstallManager {
                 level: MessageType::INFO,
                 message: format!("Successfully installed language '{}'. Reloading...", lang),
             });
+            let outcome = InstallOutcome::Success {
+                data_dir: data_dir.clone(),
+            };
             InstallResult {
-                outcome: InstallOutcome::Success {
-                    data_dir: data_dir.clone(),
-                },
+                outcome,
                 events,
+                completion: None,
+                claim: Some(install_marker),
             }
         } else if parser_exists {
             // Parser compiled but queries had issues - still usable
@@ -481,11 +559,14 @@ impl AutoInstallManager {
                 ),
             });
 
+            let outcome = InstallOutcome::SuccessWithWarnings {
+                data_dir: data_dir.clone(),
+            };
             InstallResult {
-                outcome: InstallOutcome::SuccessWithWarnings {
-                    data_dir: data_dir.clone(),
-                },
+                outcome,
                 events,
+                completion: None,
+                claim: Some(install_marker),
             }
         } else {
             // Installation failed
@@ -507,9 +588,12 @@ impl AutoInstallManager {
                 ),
             });
 
+            let outcome = InstallOutcome::Failed;
             InstallResult {
-                outcome: InstallOutcome::Failed,
+                outcome,
                 events,
+                completion: None,
+                claim: Some(install_marker),
             }
         }
     }
@@ -552,10 +636,21 @@ mod tests {
     fn install_marker_guard_releases_on_drop() {
         let installing = InstallingLanguages::new();
         assert!(installing.try_start_install("lua"));
+        let claims = Arc::new(Mutex::new(HashMap::new()));
+        let (completion, _) = tokio::sync::watch::channel(None);
+        claims.lock().unwrap().insert(
+            "lua".to_string(),
+            ClaimState {
+                completion: completion.clone(),
+            },
+        );
 
         let guard = InstallMarkerGuard {
             installing: installing.clone(),
+            claims,
+            completion,
             language: "lua".to_string(),
+            terminal: None,
         };
         drop(guard);
 
@@ -608,9 +703,51 @@ mod tests {
                 if message.contains("already being checked or installed")
         )));
 
+        let mut completion = result
+            .completion
+            .clone()
+            .expect("duplicate receives exact claim")
+            .receiver;
+        let waiter = tokio::spawn(async move {
+            loop {
+                if let Some(outcome) = completion.borrow().clone() {
+                    return outcome;
+                }
+                completion.changed().await.unwrap();
+            }
+        });
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+
         let _ = release_tx.send(());
+        let mut first_result = first.await.expect("first install task must finish");
+        assert_eq!(first_result.outcome, InstallOutcome::Unsupported);
+        first_result.complete_claim();
+        drop(first_result);
+
+        let second_manager = manager.clone();
+        let (second_started_tx, second_started_rx) = tokio::sync::oneshot::channel();
+        let (second_release_tx, second_release_rx) = tokio::sync::oneshot::channel();
+        let second = tokio::spawn(async move {
+            second_manager
+                .try_install_with_support_check("lua", |_, _| async move {
+                    let _ = second_started_tx.send(());
+                    let _ = second_release_rx.await;
+                    TrackedSupportCheck::completed(true, None)
+                })
+                .await
+        });
+        second_started_rx.await.expect("second claim must start");
+
         assert_eq!(
-            first.await.expect("first install task must finish").outcome,
+            waiter
+                .await
+                .expect("a failed winner must still release install waiters"),
+            InstallOutcome::Unsupported
+        );
+        let _ = second_release_tx.send(());
+        assert_eq!(
+            second.await.expect("second claim must finish").outcome,
             InstallOutcome::Unsupported
         );
     }
@@ -626,6 +763,7 @@ mod tests {
             .await;
 
         assert_eq!(result.outcome, InstallOutcome::Unsupported);
+        drop(result);
         assert!(
             manager
                 .installing_languages
@@ -658,8 +796,24 @@ mod tests {
             })
             .await;
         assert_eq!(duplicate.outcome, InstallOutcome::AlreadyInstalling);
+        let mut completion = duplicate
+            .completion
+            .clone()
+            .expect("duplicate observes timed-out claim")
+            .receiver;
 
         let _ = release_tx.send(());
+        let terminal = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if let Some(outcome) = completion.borrow().clone() {
+                    return outcome;
+                }
+                completion.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("timed-out claim must publish its terminal outcome");
+        assert_eq!(terminal, InstallOutcome::Unsupported);
         tokio::time::timeout(std::time::Duration::from_secs(1), async {
             while !manager.installing_languages.try_start_install("lua") {
                 tokio::task::yield_now().await;
@@ -805,37 +959,6 @@ mod tests {
             e,
             InstallEvent::Log { level: MessageType::WARNING, message } if message.contains("previously crashed")
         )));
-    }
-
-    #[test]
-    fn test_install_outcome_should_skip_parse() {
-        // Outcomes that should skip parse (installation handled or in progress)
-        assert!(
-            InstallOutcome::Success {
-                data_dir: PathBuf::from("/tmp")
-            }
-            .should_skip_parse()
-        );
-        assert!(
-            InstallOutcome::SuccessWithWarnings {
-                data_dir: PathBuf::from("/tmp")
-            }
-            .should_skip_parse()
-        );
-        assert!(
-            InstallOutcome::AlreadyExists {
-                data_dir: PathBuf::from("/tmp")
-            }
-            .should_skip_parse()
-        );
-        // AlreadyInstalling: another task is installing, caller should wait
-        assert!(InstallOutcome::AlreadyInstalling.should_skip_parse());
-
-        // Outcomes that should NOT skip parse (no installation will happen)
-        assert!(!InstallOutcome::ParserFailed.should_skip_parse());
-        assert!(!InstallOutcome::Unsupported.should_skip_parse());
-        assert!(!InstallOutcome::Failed.should_skip_parse());
-        assert!(!InstallOutcome::NoDataDir.should_skip_parse());
     }
 
     #[test]

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -732,6 +732,21 @@ mod tests {
         (AutoInstallManager::new(installing, failed), temp)
     }
 
+    async fn wait_for_terminal(
+        receiver: &mut tokio::sync::watch::Receiver<Option<InstallOutcome>>,
+    ) -> InstallOutcome {
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if let Some(outcome) = receiver.borrow().clone() {
+                    break outcome;
+                }
+                receiver.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("install claim must publish a terminal outcome")
+    }
+
     #[test]
     fn test_is_parser_failed_returns_false_for_new_parser() {
         let (manager, _temp) = create_test_manager();
@@ -834,6 +849,84 @@ mod tests {
         .expect("detached install must publish its actual result");
 
         assert!(matches!(terminal, InstallOutcome::Success { .. }));
+    }
+
+    #[tokio::test]
+    async fn panicked_support_task_abandons_exact_claim_and_allows_retry() {
+        let (manager, _temp) = create_test_manager();
+        let owner_manager = manager.clone();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let owner = tokio::spawn(async move {
+            owner_manager
+                .try_install_with_support_check("panic-support", |_, _| async move {
+                    let _ = started_tx.send(());
+                    let _ = release_rx.await;
+                    panic!("controlled support panic");
+                })
+                .await
+        });
+        started_rx.await.unwrap();
+        let duplicate = manager
+            .try_install_with_support_check("panic-support", |_, _| async {
+                panic!("exact waiter must not run support check")
+            })
+            .await;
+        let mut completion = duplicate.completion.clone().unwrap().receiver;
+
+        let _ = release_tx.send(());
+        assert_eq!(owner.await.unwrap().outcome, InstallOutcome::Failed);
+        assert_eq!(
+            wait_for_terminal(&mut completion).await,
+            InstallOutcome::Abandoned
+        );
+        let retry = manager
+            .try_install_with_support_check("panic-support", |_, _| async {
+                TrackedSupportCheck::completed(true, None)
+            })
+            .await;
+        assert_eq!(retry.outcome, InstallOutcome::Unsupported);
+    }
+
+    #[tokio::test]
+    async fn panicked_install_task_abandons_exact_claim_and_allows_retry() {
+        let (manager, _temp) = create_test_manager();
+        let owner_manager = manager.clone();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let owner = tokio::spawn(async move {
+            owner_manager
+                .try_install_with_support_check_and_executor(
+                    "panic-install",
+                    |_, _| async { TrackedSupportCheck::completed(false, None) },
+                    |_, _| async move {
+                        let _ = started_tx.send(());
+                        let _ = release_rx.await;
+                        panic!("controlled install panic");
+                    },
+                )
+                .await
+        });
+        started_rx.await.unwrap();
+        let duplicate = manager
+            .try_install_with_support_check("panic-install", |_, _| async {
+                panic!("exact waiter must not run support check")
+            })
+            .await;
+        let mut completion = duplicate.completion.clone().unwrap().receiver;
+
+        let _ = release_tx.send(());
+        assert_eq!(owner.await.unwrap().outcome, InstallOutcome::Failed);
+        assert_eq!(
+            wait_for_terminal(&mut completion).await,
+            InstallOutcome::Abandoned
+        );
+        let retry = manager
+            .try_install_with_support_check("panic-install", |_, _| async {
+                TrackedSupportCheck::completed(true, None)
+            })
+            .await;
+        assert_eq!(retry.outcome, InstallOutcome::Unsupported);
     }
 
     #[tokio::test]

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -244,6 +244,20 @@ impl AutoInstallManager {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn begin_test_result(
+        &self,
+        language: &str,
+        outcome: InstallOutcome,
+    ) -> InstallResult {
+        let TestInstallClaim { guard } = self.begin_test_claim(language);
+        InstallResult::with_claim(
+            outcome,
+            Vec::new(),
+            guard.expect("test result claim is present"),
+        )
+    }
+
     /// Initialize the failed parser registry with crash detection.
     ///
     /// State storage location: `KAKEHASHI_STATE_DIR` if set, else the default

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1196,6 +1196,11 @@ impl BridgeCoordinator {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn begin_test_eager_open_batch(&self, uri: &Url) -> CancellationToken {
+        self.supersede_eager_open_tasks(uri).1
+    }
+
     /// Whether every eager-open task registered for `uri` has finished
     /// (no batch counts as finished).
     ///

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -106,6 +106,11 @@ pub(super) struct ReloadLanguageState<'a> {
     request_semantic_refresh: bool,
 }
 
+pub(super) struct SettingsReloadInput {
+    raw_settings: Option<RawWorkspaceSettings>,
+    settings: WorkspaceSettings,
+}
+
 /// One server process owns one effective workspace settings snapshot. Keep the
 /// complete async reload transaction ordered across didChangeConfiguration and
 /// post-install reloads, including downstream propagation and SettingsManager
@@ -148,7 +153,35 @@ pub(super) async fn apply_shared_settings(
     raw_settings: Option<RawWorkspaceSettings>,
     settings: WorkspaceSettings,
 ) -> Vec<Url> {
-    let _reload = SETTINGS_RELOAD_LOCK.lock().await;
+    let reload = lock_settings_reload().await;
+    apply_shared_settings_locked(
+        &reload,
+        client,
+        language_state,
+        settings_manager,
+        cache,
+        bridge,
+        SettingsReloadInput {
+            raw_settings,
+            settings,
+        },
+    )
+    .await
+}
+
+pub(super) async fn apply_shared_settings_locked(
+    _reload: &tokio::sync::MutexGuard<'static, ()>,
+    client: &Client,
+    language_state: ReloadLanguageState<'_>,
+    settings_manager: &SettingsManager,
+    cache: &CacheCoordinator,
+    bridge: &BridgeCoordinator,
+    input: SettingsReloadInput,
+) -> Vec<Url> {
+    let SettingsReloadInput {
+        raw_settings,
+        settings,
+    } = input;
     // TRANSITIONAL generation bump BEFORE any query/config mutation: from
     // this instant, every generation-stamped product built from the OLD
     // queries (snapshot-riding discovery/bridge/resolved regions, layer

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -112,6 +112,10 @@ pub(super) struct ReloadLanguageState<'a> {
 /// publication after the synchronous language/query swap.
 static SETTINGS_RELOAD_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
+pub(super) async fn lock_settings_reload() -> tokio::sync::MutexGuard<'static, ()> {
+    SETTINGS_RELOAD_LOCK.lock().await
+}
+
 struct ParserReloadGuard<'a> {
     parser_pool: &'a std::sync::Mutex<DocumentParserPool>,
 }

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -215,9 +215,12 @@ impl InjectionCoordinator {
         let edit_lock = self.documents.edit_lock(uri);
         let _lifecycle_guard = edit_lock.lock().await;
         after_lifecycle_lock.await;
-        if self.documents.get(uri).is_none() {
+        let Some(incarnation) = self.documents.get(uri).map(|doc| doc.incarnation()) else {
             self.bridge.cancel_eager_open(uri);
             self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
+            return false;
+        };
+        if required_incarnation.is_some_and(|required| incarnation != required) {
             return false;
         }
 
@@ -225,13 +228,6 @@ impl InjectionCoordinator {
             self.bridge.cancel_eager_open(uri);
             return false;
         };
-        let Some(incarnation) = self.documents.get(uri).map(|doc| doc.incarnation()) else {
-            self.bridge.cancel_eager_open(uri);
-            return false;
-        };
-        if required_incarnation.is_some_and(|required| incarnation != required) {
-            return false;
-        }
         let injections = self.resolve_injection_data(uri, &host_language);
         if injections.is_empty() {
             self.bridge.cancel_eager_open(uri);
@@ -569,6 +565,41 @@ mod tests {
         assert!(
             !reached_side_effects.load(std::sync::atomic::Ordering::SeqCst),
             "a stale detached task must stop before parser load or notification side effects"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_injection_pass_does_not_cancel_reopened_eager_batch() {
+        let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///stale-injection-pass.unknown").unwrap();
+        let old_incarnation = server.documents.insert(
+            uri.clone(),
+            "# old".to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        let (token_tx, token_rx) = tokio::sync::oneshot::channel();
+
+        let processed = server
+            .injection_coordinator()
+            .process_injections_after_lifecycle_lock(&uri, false, Some(old_incarnation), async {
+                server.documents.remove_preserving_edit_lock(&uri);
+                let new_incarnation =
+                    server
+                        .documents
+                        .insert(uri.clone(), "new".to_string(), None, None);
+                assert_ne!(new_incarnation, old_incarnation);
+                let token = server.bridge.begin_test_eager_open_batch(&uri);
+                let _ = token_tx.send(token);
+            })
+            .await;
+        let token = token_rx.await.unwrap();
+
+        assert!(!processed);
+        assert!(
+            !token.is_cancelled(),
+            "a stale pass must not cancel the reopened lifetime's eager batch"
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -273,14 +273,14 @@ impl InjectionCoordinator {
         //   promptly without waiting on the compile.
         // - `maybe_auto_install_language`'s `InstallingLanguages` tracker dedupes
         //   concurrent attempts, and the injected install (`is_injection=true`) never
-        //   reparses or resurrects the host document, so a `didClose` racing this
-        //   spawn is benign (it just finishes installing a global parser).
+        //   reparses or resurrects the host document. The detached task retains this
+        //   pass's incarnation so a close/reopen cannot apply its stale language set.
         let install_task = {
             let coordinator = self.clone();
             let uri = uri.clone();
             async move {
                 coordinator
-                    .check_injected_languages_auto_install(&uri, &languages)
+                    .check_injected_languages_auto_install(&uri, &languages, incarnation)
                     .await;
             }
         };
@@ -300,7 +300,30 @@ impl InjectionCoordinator {
         &self,
         uri: &Url,
         languages: &HashSet<String>,
+        expected_incarnation: u64,
     ) {
+        self.check_injected_languages_auto_install_after_incarnation_check(
+            uri,
+            languages,
+            expected_incarnation,
+            std::future::ready(()),
+        )
+        .await;
+    }
+
+    async fn check_injected_languages_auto_install_after_incarnation_check<F>(
+        &self,
+        uri: &Url,
+        languages: &HashSet<String>,
+        expected_incarnation: u64,
+        after_incarnation_check: F,
+    ) where
+        F: std::future::Future<Output = ()>,
+    {
+        if !self.same_document_incarnation(uri, expected_incarnation) {
+            return;
+        }
+        after_incarnation_check.await;
         let install = self.install_coordinator();
         let auto_install_enabled = self.settings_manager.is_auto_install_enabled();
 
@@ -338,6 +361,9 @@ impl InjectionCoordinator {
             .iter()
             .filter(|lang| parser_enabled_injection_language(lang))
         {
+            if !self.same_document_incarnation(uri, expected_incarnation) {
+                return;
+            }
             let resolved_lang = if self.language.has_parser_available(lang) {
                 lang.clone()
             } else if let Some(normalized) = crate::language::heuristic::detect_from_token(lang) {
@@ -350,6 +376,9 @@ impl InjectionCoordinator {
                 .language
                 .ensure_language_loaded_async(&resolved_lang)
                 .await;
+            if !self.same_document_incarnation(uri, expected_incarnation) {
+                return;
+            }
             if load_result.success {
                 load_events.extend(load_result.events);
                 continue;
@@ -363,24 +392,28 @@ impl InjectionCoordinator {
             // Only attempt the (injected-language) install while the host document
             // is still open. The injected-language install does not reparse the
             // host document (is_injection=true), so no host text is needed here.
-            if self.documents.get(uri).is_some() {
-                let _ = install
-                    .maybe_auto_install_language(
-                        &resolved_lang,
-                        uri.clone(),
-                        true,
-                        self.documents.get(uri).map(|doc| doc.incarnation()),
-                        true,
-                    )
-                    .await;
-            }
+            let _ = install
+                .maybe_auto_install_language(
+                    &resolved_lang,
+                    uri.clone(),
+                    true,
+                    Some(expected_incarnation),
+                    true,
+                )
+                .await;
         }
 
         // Forward the collected load events (deduped to ≤1 refresh by #531) so the
         // editor re-pulls tokens for any injected language loaded just now.
-        if !load_events.is_empty() {
+        if !load_events.is_empty() && self.same_document_incarnation(uri, expected_incarnation) {
             self.notifier().log_language_events(&load_events).await;
         }
+    }
+
+    fn same_document_incarnation(&self, uri: &Url, expected: u64) -> bool {
+        self.documents
+            .get(uri)
+            .is_some_and(|document| document.incarnation() == expected)
     }
 
     fn notifier(&self) -> ClientNotifier<'_> {
@@ -449,7 +482,7 @@ mod tests {
         assert!(!parser_enabled_injection_language("plaintext"));
         assert!(parser_enabled_injection_language("python"));
     }
-    use std::sync::Arc;
+    use std::{collections::HashSet, sync::Arc};
     use tokio::sync::Notify;
     use tower_lsp_server::LspService;
     use url::Url;
@@ -497,6 +530,46 @@ mod tests {
                 .insert(uri, "# new".to_string(), Some("markdown".to_string()), None);
 
         assert_ne!(new_incarnation, old_incarnation);
+    }
+
+    #[tokio::test]
+    async fn stale_injection_install_task_stops_before_side_effects() {
+        let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///stale-injection-install.md").unwrap();
+        let old_incarnation = server.documents.insert(
+            uri.clone(),
+            "# old".to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        server.documents.remove(&uri);
+        let new_incarnation = server.documents.insert(
+            uri.clone(),
+            "# new".to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        assert_ne!(new_incarnation, old_incarnation);
+
+        let reached_side_effects = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let observed = std::sync::Arc::clone(&reached_side_effects);
+        server
+            .injection_coordinator()
+            .check_injected_languages_auto_install_after_incarnation_check(
+                &uri,
+                &HashSet::new(),
+                old_incarnation,
+                async move {
+                    observed.store(true, std::sync::atomic::Ordering::SeqCst);
+                },
+            )
+            .await;
+
+        assert!(
+            !reached_side_effects.load(std::sync::atomic::Ordering::SeqCst),
+            "a stale detached task must stop before parser load or notification side effects"
+        );
     }
 
     /// The snapshot fast path of `resolve_injection_data` must produce

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -172,20 +172,39 @@ impl InjectionCoordinator {
     /// Resolves injection data once and reuses it across all three steps. Must be
     /// called AFTER parse_document so the AST is available.
     pub(crate) async fn process_injections(&self, uri: &Url, forward_did_change: bool) {
+        let _ = self
+            .process_injections_after_lifecycle_lock(
+                uri,
+                forward_did_change,
+                None,
+                std::future::ready(()),
+            )
+            .await;
+    }
+
+    pub(crate) async fn process_injections_for_incarnation(
+        &self,
+        uri: &Url,
+        forward_did_change: bool,
+        incarnation: u64,
+    ) -> bool {
         self.process_injections_after_lifecycle_lock(
             uri,
             forward_did_change,
+            Some(incarnation),
             std::future::ready(()),
         )
-        .await;
+        .await
     }
 
     async fn process_injections_after_lifecycle_lock<F>(
         &self,
         uri: &Url,
         forward_did_change: bool,
+        required_incarnation: Option<u64>,
         after_lifecycle_lock: F,
-    ) where
+    ) -> bool
+    where
         F: std::future::Future<Output = ()>,
     {
         // Serialize the complete tree-derived downstream pass with didClose and
@@ -199,21 +218,24 @@ impl InjectionCoordinator {
         if self.documents.get(uri).is_none() {
             self.bridge.cancel_eager_open(uri);
             self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
-            return;
+            return false;
         }
 
         let Some(host_language) = self.get_language_for_document(uri) else {
             self.bridge.cancel_eager_open(uri);
-            return;
+            return false;
         };
         let Some(incarnation) = self.documents.get(uri).map(|doc| doc.incarnation()) else {
             self.bridge.cancel_eager_open(uri);
-            return;
+            return false;
         };
+        if required_incarnation.is_some_and(|required| incarnation != required) {
+            return false;
+        }
         let injections = self.resolve_injection_data(uri, &host_language);
         if injections.is_empty() {
             self.bridge.cancel_eager_open(uri);
-            return;
+            return true;
         }
 
         // Stop the previous pass before closing a replaced language-bearing URI;
@@ -266,6 +288,7 @@ impl InjectionCoordinator {
 
         self.eager_spawn_bridge_servers(uri, incarnation, &host_language, injections)
             .await;
+        true
     }
 
     /// Check injected languages and handle missing parsers: auto-install when enabled,
@@ -342,7 +365,13 @@ impl InjectionCoordinator {
             // host document (is_injection=true), so no host text is needed here.
             if self.documents.get(uri).is_some() {
                 let _ = install
-                    .maybe_auto_install_language(&resolved_lang, uri.clone(), true)
+                    .maybe_auto_install_language(
+                        &resolved_lang,
+                        uri.clone(),
+                        true,
+                        self.documents.get(uri).map(|doc| doc.incarnation()),
+                        true,
+                    )
                     .await;
             }
         }
@@ -445,7 +474,7 @@ mod tests {
         let process_release = Arc::clone(&release);
         let process = tokio::spawn(async move {
             injection
-                .process_injections_after_lifecycle_lock(&process_uri, false, async move {
+                .process_injections_after_lifecycle_lock(&process_uri, false, None, async move {
                     process_entered.notify_one();
                     process_release.notified().await;
                 })

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -4,12 +4,13 @@ use crate::lsp::auto_install::AutoInstallManager;
 use url::Url;
 
 use crate::config::WorkspaceSettings;
-use crate::lsp::auto_install::InstallEvent;
+use crate::lsp::auto_install::{InstallEvent, InstallResult};
 use crate::lsp::bridge::BridgeCoordinator;
 use crate::lsp::cache::CacheCoordinator;
 use crate::lsp::client::ClientNotifier;
 use crate::lsp::lsp_impl::{
-    Kakehashi, ReloadLanguageState, apply_shared_settings, build_notifier, lock_settings_reload,
+    Kakehashi, ReloadLanguageState, SettingsReloadInput, apply_shared_settings_locked,
+    build_notifier, lock_settings_reload,
 };
 use crate::lsp::settings_manager::SettingsManager;
 use tower_lsp_server::Client;
@@ -180,35 +181,18 @@ impl InstallCoordinator {
 
         self.dispatch_install_events(language, &result.events).await;
 
-        if let Some(data_dir) = result.outcome.data_dir() {
+        if let Some(data_dir) = result.outcome.data_dir().cloned() {
             self.reload_language_after_install(
                 language,
-                data_dir,
+                &data_dir,
                 uri.clone(),
                 is_injection,
                 expected_incarnation,
+                Some(&mut result),
             )
             .await;
-            let _reload = lock_settings_reload().await;
-            let load_result = self.language.ensure_language_loaded_async(language).await;
-            self.notifier()
-                .log_language_events(&load_result.events)
-                .await;
-            let global_loaded = self.language.has_parser_available(language);
-            if global_loaded {
-                result.complete_claim();
-            }
-            if global_loaded
-                && !is_injection
-                && self.same_document_incarnation(&uri, expected_incarnation)
-            {
-                self.parse_coordinator()
-                    .reparse_installed_document(uri.clone(), language, expected_incarnation)
-                    .await;
-            }
             let recovered =
                 self.install_reparse_recovered(language, &uri, is_injection, expected_incarnation);
-            drop(_reload);
             if recovered {
                 return true;
             }
@@ -287,7 +271,9 @@ impl InstallCoordinator {
         uri: Url,
         is_injection: bool,
         expected_incarnation: Option<u64>,
+        claim: Option<&mut InstallResult>,
     ) {
+        let reload = lock_settings_reload().await;
         let settings_snapshot = self.settings_manager.load_settings_pair();
         let (updated_raw_settings, updated_settings) = updated_settings_after_install(
             &settings_snapshot.raw_settings,
@@ -295,15 +281,21 @@ impl InstallCoordinator {
             data_dir,
         );
 
-        self.apply_raw_settings(updated_raw_settings, updated_settings)
+        self.apply_raw_settings_locked(&reload, updated_raw_settings, updated_settings)
             .await;
 
         let load_result = self.language.ensure_language_loaded_async(language).await;
+        let global_loaded = self.language.has_parser_available(language);
+        if global_loaded && let Some(claim) = claim {
+            claim.complete_claim();
+        }
+        drop(reload);
+
         self.notifier()
             .log_language_events(&load_result.events)
             .await;
 
-        if !is_injection {
+        if global_loaded && !is_injection {
             // Resurrection-safe, off-ingress reparse: re-detects the language from
             // the current document lifetime and persists through a non-inserting
             // CAS, so a didClose/reopen during the install can't receive a tree for
@@ -315,12 +307,14 @@ impl InstallCoordinator {
         }
     }
 
-    async fn apply_raw_settings(
+    async fn apply_raw_settings_locked(
         &self,
+        reload: &tokio::sync::MutexGuard<'static, ()>,
         raw_settings: crate::config::RawWorkspaceSettings,
         settings: WorkspaceSettings,
     ) {
-        let _reparse_uris = apply_shared_settings(
+        let _reparse_uris = apply_shared_settings_locked(
+            reload,
             &self.client,
             ReloadLanguageState {
                 language: &self.language,
@@ -332,8 +326,10 @@ impl InstallCoordinator {
             &self.settings_manager,
             &self.cache,
             &self.bridge,
-            Some(raw_settings),
-            settings,
+            SettingsReloadInput {
+                raw_settings: Some(raw_settings),
+                settings,
+            },
         )
         .await;
     }
@@ -382,7 +378,9 @@ mod tests {
     use super::*;
     use crate::config::{LanguageSettings, RawWorkspaceSettings, WILDCARD_KEY, WorkspaceSettings};
     use std::collections::HashMap;
+    use std::future::Future;
     use std::path::Path;
+    use std::task::Poll;
     use tower_lsp_server::LspService;
 
     #[test]
@@ -521,12 +519,70 @@ mod tests {
                 first.clone(),
                 false,
                 server.documents.get(&first).map(|doc| doc.incarnation()),
+                None,
             )
             .await;
 
         assert!(
             server.documents.get(&first).unwrap().tree().is_some(),
             "the document that won the install should be reparsed"
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_after_install_merges_into_settings_published_while_waiting() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let initial_raw = RawWorkspaceSettings {
+            search_paths: Some(vec!["/initial".to_string()]),
+            ..Default::default()
+        };
+        let initial = WorkspaceSettings {
+            search_paths: vec!["/initial".to_string()],
+            ..Default::default()
+        };
+        server
+            .settings_manager
+            .apply_settings_with_raw(initial_raw, initial);
+
+        let reload_guard = lock_settings_reload().await;
+        let install = server.install_coordinator();
+        let mut reload = Box::pin(install.reload_language_after_install(
+            "test-language",
+            Path::new("/installed"),
+            Url::parse("file:///workspace/test.txt").unwrap(),
+            true,
+            None,
+            None,
+        ));
+        std::future::poll_fn(|cx| {
+            assert!(reload.as_mut().poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+
+        let newer_raw = RawWorkspaceSettings {
+            search_paths: Some(vec!["/newer".to_string()]),
+            ..Default::default()
+        };
+        let newer = WorkspaceSettings {
+            search_paths: vec!["/newer".to_string()],
+            ..Default::default()
+        };
+        server
+            .settings_manager
+            .apply_settings_with_raw(newer_raw, newer);
+        drop(reload_guard);
+        reload.await;
+
+        let snapshot = server.settings_manager.load_settings_pair();
+        assert_eq!(
+            snapshot.raw_settings.search_paths,
+            Some(vec!["/newer".to_string(), "/installed".to_string()])
+        );
+        assert_eq!(
+            snapshot.settings.search_paths,
+            vec!["/newer".to_string(), "/installed".to_string()]
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -162,6 +162,10 @@ impl InstallCoordinator {
         expected_incarnation: Option<u64>,
         allow_recovery: bool,
     ) -> bool {
+        if !self.same_document_incarnation(&uri, expected_incarnation) {
+            return false;
+        }
+
         if self.language.has_parser_available(language) {
             if !is_injection && self.same_document_incarnation(&uri, expected_incarnation) {
                 self.parse_coordinator()
@@ -379,6 +383,7 @@ impl InstallCoordinator {
 mod tests {
     use super::*;
     use crate::config::{LanguageSettings, RawWorkspaceSettings, WILDCARD_KEY, WorkspaceSettings};
+    use futures::StreamExt;
     use std::collections::HashMap;
     use std::future::Future;
     use std::path::Path;
@@ -645,5 +650,45 @@ mod tests {
             .await;
 
         assert!(server.documents.get(&uri).unwrap().tree().is_none());
+    }
+
+    #[tokio::test]
+    async fn stale_install_task_stops_before_install_events() {
+        let (service, mut socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let language = "stale-install-language";
+        server
+            .auto_install
+            .failed_parsers_handle()
+            .mark_failed(language)
+            .unwrap();
+        let uri = Url::parse("file:///workspace/stale-install.txt").unwrap();
+        let old_incarnation = server.documents.insert(
+            uri.clone(),
+            "old".to_string(),
+            Some(language.to_string()),
+            None,
+        );
+        server.documents.remove(&uri);
+        let new_incarnation = server.documents.insert(
+            uri.clone(),
+            "new".to_string(),
+            Some(language.to_string()),
+            None,
+        );
+        assert_ne!(new_incarnation, old_incarnation);
+
+        assert!(
+            !server
+                .install_coordinator()
+                .maybe_auto_install_language(language, uri, false, Some(old_incarnation), true,)
+                .await
+        );
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(10), socket.next())
+                .await
+                .is_err(),
+            "a stale task must not emit parser failure or install progress events"
+        );
     }
 }

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -224,10 +224,9 @@ impl InstallCoordinator {
                     break crate::lsp::auto_install::InstallOutcome::Failed;
                 }
             };
-            if let Some(data_dir) = terminal.data_dir()
+            if terminal.data_dir().is_some()
                 && self.same_document_incarnation(&uri, expected_incarnation)
             {
-                let _ = data_dir;
                 if !is_injection {
                     self.parse_coordinator()
                         .reparse_installed_document(uri.clone(), language, expected_incarnation)

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -164,7 +164,7 @@ impl InstallCoordinator {
         self.dispatch_install_events(language, &result.events).await;
 
         if let Some(data_dir) = result.outcome.data_dir() {
-            self.reload_language_after_install(language, data_dir, uri, is_injection)
+            self.reload_language_after_install(language, data_dir, is_injection)
                 .await;
             return true;
         }
@@ -191,7 +191,6 @@ impl InstallCoordinator {
         &self,
         language: &str,
         data_dir: &std::path::Path,
-        uri: Url,
         is_injection: bool,
     ) {
         let settings_snapshot = self.settings_manager.load_settings_pair();
@@ -210,15 +209,28 @@ impl InstallCoordinator {
             .await;
 
         if !is_injection {
-            let host_language = self.get_language_for_document(&uri);
-            // Resurrection-safe, off-ingress reparse: re-reads the latest store
-            // text and persists through a non-inserting CAS, so a didClose during
-            // the install can't be resurrected. (The original didOpen's ticket
-            // already advanced the watermark on its skip-parse path, so this
-            // carries no ticket.)
-            self.parse_coordinator()
-                .reparse_installed_document(uri.clone(), host_language)
-                .await;
+            let uris = self
+                .documents
+                .open_uris()
+                .into_iter()
+                .filter(|candidate| {
+                    self.documents
+                        .get(candidate)
+                        .is_some_and(|document| document.tree().is_none())
+                        && self.get_language_for_document(candidate).as_deref() == Some(language)
+                })
+                .collect::<Vec<_>>();
+            let parse = self.parse_coordinator();
+            for uri in uris {
+                // Resurrection-safe, off-ingress reparse: re-reads the latest store
+                // text and persists through a non-inserting CAS, so a didClose during
+                // the install can't be resurrected. (The original didOpen's ticket
+                // already advanced the watermark on its skip-parse path, so this
+                // carries no ticket.)
+                parse
+                    .reparse_installed_document(uri, Some(language.to_string()))
+                    .await;
+            }
         }
     }
 
@@ -274,6 +286,7 @@ mod tests {
     use crate::config::{LanguageSettings, RawWorkspaceSettings, WILDCARD_KEY, WorkspaceSettings};
     use std::collections::HashMap;
     use std::path::Path;
+    use tower_lsp_server::LspService;
 
     #[test]
     fn reload_after_install_preserves_explicit_matching_override_in_raw_settings() {
@@ -384,6 +397,40 @@ mod tests {
                 "/custom".to_string(),
                 "/installed".to_string(),
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn reload_after_install_reparses_every_open_document_for_the_language() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
+        let first = Url::parse("file:///workspace/first.rs").unwrap();
+        let waiting = Url::parse("file:///workspace/waiting.rs").unwrap();
+        for uri in [&first, &waiting] {
+            server.documents.insert(
+                uri.clone(),
+                "fn main() {}".to_string(),
+                Some("rust".to_string()),
+                None,
+            );
+        }
+
+        server
+            .install_coordinator()
+            .reload_language_after_install("rust", Path::new("/installed"), false)
+            .await;
+
+        assert!(
+            server.documents.get(&first).unwrap().tree().is_some(),
+            "the document that won the install should be reparsed"
+        );
+        assert!(
+            server.documents.get(&waiting).unwrap().tree().is_some(),
+            "a same-language document that lost the install claim must also be reparsed"
         );
     }
 }

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -191,7 +191,7 @@ impl InstallCoordinator {
         &self,
         language: &str,
         data_dir: &std::path::Path,
-        is_injection: bool,
+        _is_injection: bool,
     ) {
         let settings_snapshot = self.settings_manager.load_settings_pair();
         let (updated_raw_settings, updated_settings) = updated_settings_after_install(
@@ -208,29 +208,25 @@ impl InstallCoordinator {
             .log_language_events(&load_result.events)
             .await;
 
-        if !is_injection {
-            let uris = self
-                .documents
-                .open_uris()
-                .into_iter()
-                .filter(|candidate| {
-                    self.documents
-                        .get(candidate)
-                        .is_some_and(|document| document.tree().is_none())
-                        && self.get_language_for_document(candidate).as_deref() == Some(language)
-                })
-                .collect::<Vec<_>>();
-            let parse = self.parse_coordinator();
-            for uri in uris {
-                // Resurrection-safe, off-ingress reparse: re-reads the latest store
-                // text and persists through a non-inserting CAS, so a didClose during
-                // the install can't be resurrected. (The original didOpen's ticket
-                // already advanced the watermark on its skip-parse path, so this
-                // carries no ticket.)
-                parse
-                    .reparse_installed_document(uri, Some(language.to_string()))
-                    .await;
-            }
+        let uris = self
+            .documents
+            .open_uris()
+            .into_iter()
+            .filter(|candidate| {
+                self.documents
+                    .get(candidate)
+                    .is_some_and(|document| document.tree().is_none())
+                    && self.get_language_for_document(candidate).as_deref() == Some(language)
+            })
+            .collect::<Vec<_>>();
+        let parse = self.parse_coordinator();
+        for uri in uris {
+            // Resurrection-safe, off-ingress reparse: re-detects the language from
+            // the current document lifetime and persists through a non-inserting
+            // CAS, so a didClose/reopen during the install can't receive a tree for
+            // the old language. This runs even when an injection discovered the
+            // parser first: the global install claim may have host-language waiters.
+            parse.reparse_installed_document(uri, language).await;
         }
     }
 
@@ -432,5 +428,57 @@ mod tests {
             server.documents.get(&waiting).unwrap().tree().is_some(),
             "a same-language document that lost the install claim must also be reparsed"
         );
+    }
+
+    #[tokio::test]
+    async fn injection_install_reparses_waiting_host_documents_for_the_same_language() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
+        let waiting = Url::parse("file:///workspace/waiting.rs").unwrap();
+        server.documents.insert(
+            waiting.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+
+        server
+            .install_coordinator()
+            .reload_language_after_install("rust", Path::new("/installed"), true)
+            .await;
+
+        assert!(server.documents.get(&waiting).unwrap().tree().is_some());
+    }
+
+    #[tokio::test]
+    async fn reload_does_not_attach_installed_language_tree_to_relabelled_document() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("go".to_string(), tree_sitter_go::LANGUAGE.into());
+        let uri = Url::parse("file:///workspace/reopened.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "package main".to_string(),
+            Some("go".to_string()),
+            None,
+        );
+
+        server
+            .parse_coordinator()
+            .reparse_installed_document(uri.clone(), "rust")
+            .await;
+
+        assert!(server.documents.get(&uri).unwrap().tree().is_none());
     }
 }

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -305,7 +305,14 @@ impl InstallCoordinator {
 
         let load_result = self.language.ensure_language_loaded_async(language).await;
         let global_loaded = self.language.has_parser_available(language);
-        if global_loaded && let Some(claim) = claim {
+        if !global_loaded && let Some(expected_incarnation) = expected_incarnation {
+            self.documents
+                .publish_giveup_snapshot(&uri, expected_incarnation);
+        }
+        if let Some(claim) = claim {
+            if !global_loaded {
+                claim.outcome = crate::lsp::auto_install::InstallOutcome::Failed;
+            }
             claim.complete_claim();
         }
         drop(reload);
@@ -547,6 +554,64 @@ mod tests {
             server.documents.get(&first).unwrap().tree().is_some(),
             "the document that won the install should be reparsed"
         );
+    }
+
+    #[tokio::test]
+    async fn reload_failure_completes_claim_as_failed() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let language = "missing-after-install";
+        let uri = Url::parse("file:///workspace/missing.txt").unwrap();
+        let incarnation = server.documents.insert(
+            uri.clone(),
+            "missing parser".to_string(),
+            Some(language.to_string()),
+            None,
+        );
+        let mut claim = server.auto_install.begin_test_result(
+            language,
+            crate::lsp::auto_install::InstallOutcome::Success {
+                data_dir: std::path::PathBuf::from("/installed"),
+            },
+        );
+        let duplicate = server.auto_install.try_install(language).await;
+        assert_eq!(
+            duplicate.outcome,
+            crate::lsp::auto_install::InstallOutcome::AlreadyInstalling
+        );
+        let mut completion = duplicate
+            .completion
+            .clone()
+            .expect("exact waiter observes the reload claim")
+            .receiver;
+
+        server
+            .install_coordinator()
+            .reload_language_after_install(
+                language,
+                Path::new("/installed"),
+                uri.clone(),
+                true,
+                Some(incarnation),
+                Some(&mut claim),
+            )
+            .await;
+
+        assert_eq!(
+            claim.outcome,
+            crate::lsp::auto_install::InstallOutcome::Failed
+        );
+        assert_eq!(
+            completion.borrow_and_update().clone(),
+            Some(crate::lsp::auto_install::InstallOutcome::Failed),
+            "the exact waiter must observe the failed reload"
+        );
+        let snapshot = server
+            .documents
+            .latest_snapshot(&uri)
+            .and_then(|view| view.slot.snapshot)
+            .expect("failed reload must release the owner's first-parse waiters");
+        assert!(snapshot.tree.is_none());
     }
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -259,6 +259,19 @@ impl InstallCoordinator {
                 }
                 return false;
             }
+            if terminal == crate::lsp::auto_install::InstallOutcome::Abandoned
+                && self.same_document_incarnation(&uri, expected_incarnation)
+                && allow_recovery
+            {
+                return Box::pin(self.maybe_auto_install_language(
+                    language,
+                    uri,
+                    is_injection,
+                    expected_incarnation,
+                    false,
+                ))
+                .await;
+            }
         } else {
             result.complete_claim();
         }
@@ -534,6 +547,99 @@ mod tests {
             server.documents.get(&first).unwrap().tree().is_some(),
             "the document that won the install should be reparsed"
         );
+    }
+
+    #[tokio::test]
+    async fn successful_claim_reparses_owner_and_waiter_documents() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let first = Url::parse("file:///workspace/first.rs").unwrap();
+        let second = Url::parse("file:///workspace/second.rs").unwrap();
+        let first_incarnation = server.documents.insert(
+            first.clone(),
+            "fn first() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let second_incarnation = server.documents.insert(
+            second.clone(),
+            "fn second() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let claim = server.auto_install.begin_test_claim("rust");
+        let install = server.install_coordinator();
+        let mut waiter = Box::pin(install.maybe_auto_install_language(
+            "rust",
+            second.clone(),
+            false,
+            Some(second_incarnation),
+            true,
+        ));
+        std::future::poll_fn(|cx| {
+            assert!(waiter.as_mut().poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
+        server
+            .install_coordinator()
+            .reload_language_after_install(
+                "rust",
+                Path::new("/installed"),
+                first.clone(),
+                false,
+                Some(first_incarnation),
+                None,
+            )
+            .await;
+        claim.complete(crate::lsp::auto_install::InstallOutcome::Success {
+            data_dir: std::path::PathBuf::from("/installed"),
+        });
+
+        assert!(waiter.await);
+        assert!(server.documents.get(&first).unwrap().tree().is_some());
+        assert!(server.documents.get(&second).unwrap().tree().is_some());
+    }
+
+    #[tokio::test]
+    async fn abandoned_claim_waiter_takes_over_reparse() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///workspace/waiter.rs").unwrap();
+        let incarnation = server.documents.insert(
+            uri.clone(),
+            "fn waiter() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let claim = server.auto_install.begin_test_claim("rust");
+        let install = server.install_coordinator();
+        let mut waiter = Box::pin(install.maybe_auto_install_language(
+            "rust",
+            uri.clone(),
+            false,
+            Some(incarnation),
+            true,
+        ));
+        std::future::poll_fn(|cx| {
+            assert!(waiter.as_mut().poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
+        drop(claim);
+
+        assert!(waiter.await);
+        assert!(server.documents.get(&uri).unwrap().tree().is_some());
     }
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -209,7 +209,10 @@ impl InstallCoordinator {
         // burn the full first-parse backstop. Harmless for AlreadyInstalling:
         // its eventual reload-reparse lands the same-version tree through the
         // snapshot cell's tree-upgrade clause.
-        self.documents.publish_giveup_snapshot(&uri);
+        if let Some(expected_incarnation) = expected_incarnation {
+            self.documents
+                .publish_giveup_snapshot(&uri, expected_incarnation);
+        }
         if result.outcome == crate::lsp::auto_install::InstallOutcome::AlreadyInstalling {
             let completion_token = result
                 .completion

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -9,7 +9,7 @@ use crate::lsp::bridge::BridgeCoordinator;
 use crate::lsp::cache::CacheCoordinator;
 use crate::lsp::client::ClientNotifier;
 use crate::lsp::lsp_impl::{
-    Kakehashi, ReloadLanguageState, apply_shared_settings, build_notifier, detect_document_language,
+    Kakehashi, ReloadLanguageState, apply_shared_settings, build_notifier, lock_settings_reload,
 };
 use crate::lsp::settings_manager::SettingsManager;
 use tower_lsp_server::Client;
@@ -151,35 +151,128 @@ impl InstallCoordinator {
     /// Try to auto-install a language if not already being installed.
     ///
     /// Delegates to `AutoInstallManager::try_install()`, dispatches its events, and
-    /// reloads on success. Returns `true` when installation was triggered, signaling
-    /// the caller to skip `parse_document` (a re-parse happens after reload).
+    /// reloads on success. An `AlreadyInstalling` caller waits for the shared
+    /// install claim, then reloads its own document when the parser artifact exists.
     pub(crate) async fn maybe_auto_install_language(
         &self,
         language: &str,
         uri: Url,
         is_injection: bool,
+        expected_incarnation: Option<u64>,
+        allow_recovery: bool,
     ) -> bool {
-        let result = self.auto_install.try_install(language).await;
+        if self.language.has_parser_available(language) {
+            if !is_injection && self.same_document_incarnation(&uri, expected_incarnation) {
+                self.parse_coordinator()
+                    .reparse_installed_document(uri.clone(), language, expected_incarnation)
+                    .await;
+            }
+            if !self.same_document_incarnation(&uri, expected_incarnation) {
+                return false;
+            }
+            let recovered =
+                self.install_reparse_recovered(language, &uri, is_injection, expected_incarnation);
+            if recovered {
+                return true;
+            }
+        }
+        let mut result = self.auto_install.try_install(language).await;
 
         self.dispatch_install_events(language, &result.events).await;
 
         if let Some(data_dir) = result.outcome.data_dir() {
-            self.reload_language_after_install(language, data_dir, is_injection)
+            self.reload_language_after_install(
+                language,
+                data_dir,
+                uri.clone(),
+                is_injection,
+                expected_incarnation,
+            )
+            .await;
+            let _reload = lock_settings_reload().await;
+            let load_result = self.language.ensure_language_loaded_async(language).await;
+            self.notifier()
+                .log_language_events(&load_result.events)
                 .await;
-            return true;
+            let global_loaded = self.language.has_parser_available(language);
+            if global_loaded {
+                result.complete_claim();
+            }
+            if global_loaded
+                && !is_injection
+                && self.same_document_incarnation(&uri, expected_incarnation)
+            {
+                self.parse_coordinator()
+                    .reparse_installed_document(uri.clone(), language, expected_incarnation)
+                    .await;
+            }
+            let recovered =
+                self.install_reparse_recovered(language, &uri, is_injection, expected_incarnation);
+            drop(_reload);
+            if recovered {
+                return true;
+            }
+            drop(result);
+            return false;
         }
 
         // Every no-reparse outcome lands here — Failed/Unsupported/NoDataDir/
-        // ParserFailed (should_skip_parse() == false, but did_open's
-        // auto-install branch never runs parse_document regardless) as well
-        // as AlreadyInstalling. None of them publishes a snapshot anywhere
+        // ParserFailed (the did_open auto-install branch never runs
+        // parse_document regardless) as well as AlreadyInstalling. None of
+        // them publishes a snapshot anywhere
         // below, so release a parked first-parse waiter with a tree-less
         // snapshot (bootstrap-gated inside) instead of letting every request
         // burn the full first-parse backstop. Harmless for AlreadyInstalling:
         // its eventual reload-reparse lands the same-version tree through the
         // snapshot cell's tree-upgrade clause.
         self.documents.publish_giveup_snapshot(&uri);
-        result.outcome.should_skip_parse()
+        if result.outcome == crate::lsp::auto_install::InstallOutcome::AlreadyInstalling {
+            let completion_token = result
+                .completion
+                .clone()
+                .expect("duplicate install has claim token");
+            let mut completion = completion_token.receiver.clone();
+            let terminal = loop {
+                if let Some(outcome) = completion.borrow().clone() {
+                    break outcome;
+                }
+                if completion.changed().await.is_err() {
+                    break crate::lsp::auto_install::InstallOutcome::Failed;
+                }
+            };
+            if let Some(data_dir) = terminal.data_dir()
+                && self.same_document_incarnation(&uri, expected_incarnation)
+            {
+                let _ = data_dir;
+                if !is_injection {
+                    self.parse_coordinator()
+                        .reparse_installed_document(uri.clone(), language, expected_incarnation)
+                        .await;
+                }
+                if self.install_reparse_recovered(
+                    language,
+                    &uri,
+                    is_injection,
+                    expected_incarnation,
+                ) {
+                    return true;
+                }
+                if allow_recovery {
+                    return Box::pin(self.maybe_auto_install_language(
+                        language,
+                        uri,
+                        is_injection,
+                        expected_incarnation,
+                        false,
+                    ))
+                    .await;
+                }
+                return false;
+            }
+        } else {
+            result.complete_claim();
+        }
+        self.same_document_incarnation(&uri, expected_incarnation)
     }
 
     /// Reload a language after installation and optionally re-parse the document.
@@ -191,7 +284,9 @@ impl InstallCoordinator {
         &self,
         language: &str,
         data_dir: &std::path::Path,
-        _is_injection: bool,
+        uri: Url,
+        is_injection: bool,
+        expected_incarnation: Option<u64>,
     ) {
         let settings_snapshot = self.settings_manager.load_settings_pair();
         let (updated_raw_settings, updated_settings) = updated_settings_after_install(
@@ -208,25 +303,15 @@ impl InstallCoordinator {
             .log_language_events(&load_result.events)
             .await;
 
-        let uris = self
-            .documents
-            .open_uris()
-            .into_iter()
-            .filter(|candidate| {
-                self.documents
-                    .get(candidate)
-                    .is_some_and(|document| document.tree().is_none())
-                    && self.get_language_for_document(candidate).as_deref() == Some(language)
-            })
-            .collect::<Vec<_>>();
-        let parse = self.parse_coordinator();
-        for uri in uris {
+        if !is_injection {
             // Resurrection-safe, off-ingress reparse: re-detects the language from
             // the current document lifetime and persists through a non-inserting
             // CAS, so a didClose/reopen during the install can't receive a tree for
-            // the old language. This runs even when an injection discovered the
-            // parser first: the global install claim may have host-language waiters.
-            parse.reparse_installed_document(uri, language).await;
+            // the old language. A host waiter whose install claim was won by an
+            // injection reaches this same per-URI path after the claim completes.
+            self.parse_coordinator()
+                .reparse_installed_document(uri, language, expected_incarnation)
+                .await;
         }
     }
 
@@ -257,8 +342,24 @@ impl InstallCoordinator {
         build_notifier(&self.client, &self.settings_manager)
     }
 
-    fn get_language_for_document(&self, uri: &Url) -> Option<String> {
-        detect_document_language(&self.language, &self.documents, uri)
+    fn same_document_incarnation(&self, uri: &Url, expected: Option<u64>) -> bool {
+        expected.is_some() && self.documents.get(uri).map(|doc| doc.incarnation()) == expected
+    }
+
+    fn install_reparse_recovered(
+        &self,
+        language: &str,
+        uri: &Url,
+        is_injection: bool,
+        expected_incarnation: Option<u64>,
+    ) -> bool {
+        self.same_document_incarnation(uri, expected_incarnation)
+            && self.language.has_parser_available(language)
+            && (is_injection
+                || self
+                    .documents
+                    .get(uri)
+                    .is_some_and(|document| document.tree().is_some()))
     }
 
     fn parse_coordinator(&self) -> ParseCoordinator {
@@ -397,7 +498,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reload_after_install_reparses_every_open_document_for_the_language() {
+    async fn reload_after_install_reparses_the_requesting_document() {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
         server
@@ -405,42 +506,8 @@ mod tests {
             .language_registry_for_parallel()
             .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
         let first = Url::parse("file:///workspace/first.rs").unwrap();
-        let waiting = Url::parse("file:///workspace/waiting.rs").unwrap();
-        for uri in [&first, &waiting] {
-            server.documents.insert(
-                uri.clone(),
-                "fn main() {}".to_string(),
-                Some("rust".to_string()),
-                None,
-            );
-        }
-
-        server
-            .install_coordinator()
-            .reload_language_after_install("rust", Path::new("/installed"), false)
-            .await;
-
-        assert!(
-            server.documents.get(&first).unwrap().tree().is_some(),
-            "the document that won the install should be reparsed"
-        );
-        assert!(
-            server.documents.get(&waiting).unwrap().tree().is_some(),
-            "a same-language document that lost the install claim must also be reparsed"
-        );
-    }
-
-    #[tokio::test]
-    async fn injection_install_reparses_waiting_host_documents_for_the_same_language() {
-        let (service, _socket) = LspService::new(Kakehashi::new);
-        let server = service.inner();
-        server
-            .language
-            .language_registry_for_parallel()
-            .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
-        let waiting = Url::parse("file:///workspace/waiting.rs").unwrap();
         server.documents.insert(
-            waiting.clone(),
+            first.clone(),
             "fn main() {}".to_string(),
             Some("rust".to_string()),
             None,
@@ -448,10 +515,19 @@ mod tests {
 
         server
             .install_coordinator()
-            .reload_language_after_install("rust", Path::new("/installed"), true)
+            .reload_language_after_install(
+                "rust",
+                Path::new("/installed"),
+                first.clone(),
+                false,
+                server.documents.get(&first).map(|doc| doc.incarnation()),
+            )
             .await;
 
-        assert!(server.documents.get(&waiting).unwrap().tree().is_some());
+        assert!(
+            server.documents.get(&first).unwrap().tree().is_some(),
+            "the document that won the install should be reparsed"
+        );
     }
 
     #[tokio::test]
@@ -476,7 +552,38 @@ mod tests {
 
         server
             .parse_coordinator()
-            .reparse_installed_document(uri.clone(), "rust")
+            .reparse_installed_document(uri.clone(), "rust", None)
+            .await;
+
+        assert!(server.documents.get(&uri).unwrap().tree().is_none());
+    }
+
+    #[tokio::test]
+    async fn old_install_task_rejects_close_reopen_with_the_same_language() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
+        let uri = Url::parse("file:///workspace/reopened.rs").unwrap();
+        let original = server.documents.insert(
+            uri.clone(),
+            "fn old() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        server.documents.remove(&uri);
+        server.documents.insert(
+            uri.clone(),
+            "fn new() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+
+        server
+            .parse_coordinator()
+            .reparse_installed_document(uri.clone(), "rust", Some(original))
             .await;
 
         assert!(server.documents.get(&uri).unwrap().tree().is_none());

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -783,7 +783,7 @@ impl ParseCoordinator {
             let language_name =
                 self.language
                     .detect_language(uri.path(), doc.text(), None, doc.language_id());
-            if language_name.as_deref() != Some(installed_language) {
+            if language_name.is_some() && language_name.as_deref() != Some(installed_language) {
                 return;
             }
             (
@@ -1179,6 +1179,31 @@ impl ParseCoordinator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tower_lsp_server::LspService;
+
+    #[tokio::test]
+    async fn reparse_without_detectable_language_publishes_giveup_snapshot() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///workspace/no-language.unknown").unwrap();
+        let incarnation =
+            server
+                .documents
+                .insert(uri.clone(), "plain text".to_string(), None, None);
+
+        server
+            .parse_coordinator()
+            .reparse_installed_document(uri.clone(), "rust", Some(incarnation))
+            .await;
+
+        let snapshot = server
+            .documents
+            .latest_snapshot(&uri)
+            .and_then(|view| view.slot.snapshot)
+            .expect("undetectable language must release first-parse waiters");
+        assert!(snapshot.tree.is_none());
+        assert_eq!(snapshot.incarnation, incarnation);
+    }
 
     /// The four documented invariants of the settle-refresh gate.
     #[test]

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -794,11 +794,13 @@ impl ParseCoordinator {
         };
         let Some(language_name) = language_name else {
             // Give-up: release a parked first-parse waiter (bootstrap-gated).
-            self.documents.publish_giveup_snapshot(&uri);
+            self.documents
+                .publish_giveup_snapshot(&uri, expected_incarnation);
             return;
         };
         if self.auto_install.is_parser_failed(&language_name) {
-            self.documents.publish_giveup_snapshot(&uri);
+            self.documents
+                .publish_giveup_snapshot(&uri, expected_incarnation);
             return;
         }
         let load_result = self
@@ -807,7 +809,8 @@ impl ParseCoordinator {
             .await;
         let mut events = load_result.events;
         if !load_result.success {
-            self.documents.publish_giveup_snapshot(&uri);
+            self.documents
+                .publish_giveup_snapshot(&uri, expected_incarnation);
             self.notifier().log_language_events(&events).await;
             return;
         }
@@ -930,7 +933,8 @@ impl ParseCoordinator {
         // unavailable after the install, exhausted attempts): a no-op after
         // a successful publish (bootstrap gate), otherwise it releases a
         // parked first-parse waiter.
-        self.documents.publish_giveup_snapshot(&uri);
+        self.documents
+            .publish_giveup_snapshot(&uri, expected_incarnation);
         self.notifier().log_language_events(&events).await;
     }
 
@@ -1011,12 +1015,12 @@ impl ParseCoordinator {
             // Give-up: release a parked first-parse waiter with a tree-less
             // snapshot (bootstrap-gated inside) rather than letting every
             // request burn the full first-parse backstop.
-            self.documents.publish_giveup_snapshot(uri);
+            self.documents.publish_giveup_snapshot(uri, incarnation);
             advance_watermark();
             return;
         };
         if self.auto_install.is_parser_failed(&language_name) {
-            self.documents.publish_giveup_snapshot(uri);
+            self.documents.publish_giveup_snapshot(uri, incarnation);
             advance_watermark();
             return;
         }
@@ -1025,7 +1029,7 @@ impl ParseCoordinator {
             .ensure_language_loaded_async(&language_name)
             .await;
         if !load_result.success {
-            self.documents.publish_giveup_snapshot(uri);
+            self.documents.publish_giveup_snapshot(uri, incarnation);
             advance_watermark();
             self.notifier()
                 .log_language_events(&load_result.events)
@@ -1162,7 +1166,7 @@ impl ParseCoordinator {
         // Covers the parse-produced-no-tree path (timeout / parser
         // unavailable): a no-op after a successful publish (bootstrap gate),
         // otherwise it releases a parked first-parse waiter.
-        self.documents.publish_giveup_snapshot(uri);
+        self.documents.publish_giveup_snapshot(uri, incarnation);
         advance_watermark();
         self.notifier().log_language_events(&events).await;
     }

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -746,7 +746,12 @@ impl ParseCoordinator {
     /// tree lands (or another parse wins). Sustained editing falls back to the
     /// reader's on-demand parse; the parse actor replaces this with a proper
     /// coalescing loop.
-    pub(crate) async fn reparse_installed_document(&self, uri: Url, installed_language: &str) {
+    pub(crate) async fn reparse_installed_document(
+        &self,
+        uri: Url,
+        installed_language: &str,
+        required_incarnation: Option<u64>,
+    ) {
         /// Bound on the convergence retries (a burst of edits landing exactly as
         /// the install completes); past this the reader on-demand parse covers it.
         const MAX_REPARSE_ATTEMPTS: usize = 8;
@@ -770,6 +775,9 @@ impl ParseCoordinator {
                 return;
             };
             if doc.tree().is_some() {
+                return;
+            }
+            if required_incarnation.is_some_and(|required| doc.incarnation() != required) {
                 return;
             }
             let language_name =

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -746,7 +746,7 @@ impl ParseCoordinator {
     /// tree lands (or another parse wins). Sustained editing falls back to the
     /// reader's on-demand parse; the parse actor replaces this with a proper
     /// coalescing loop.
-    pub(crate) async fn reparse_installed_document(&self, uri: Url, language_id: Option<String>) {
+    pub(crate) async fn reparse_installed_document(&self, uri: Url, installed_language: &str) {
         /// Bound on the convergence retries (a burst of edits landing exactly as
         /// the install completes); past this the reader on-demand parse covers it.
         const MAX_REPARSE_ATTEMPTS: usize = 8;
@@ -774,7 +774,10 @@ impl ParseCoordinator {
             }
             let language_name =
                 self.language
-                    .detect_language(uri.path(), doc.text(), None, language_id.as_deref());
+                    .detect_language(uri.path(), doc.text(), None, doc.language_id());
+            if language_name.as_deref() != Some(installed_language) {
+                return;
+            }
             (
                 language_name,
                 doc.language_id().map(|s| s.to_string()),

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -224,7 +224,7 @@ impl Kakehashi {
         // mint a ULID: a `didChange` processed while grammars install would
         // adjust the tracker, leaving our stale byte ranges un-adjusted and
         // minting an id for bytes the edit moved.
-        self.ensure_injection_languages_loaded(&uri, &host_language, text, tree, byte)
+        self.ensure_injection_languages_loaded(&uri, &host_language, text, tree, byte, incarnation)
             .await;
 
         // Re-resolve a CURRENT snapshot after the await and recompute the
@@ -368,6 +368,7 @@ impl Kakehashi {
         text: &str,
         host_tree: &tree_sitter::Tree,
         byte: usize,
+        incarnation: u64,
     ) {
         use std::collections::HashSet;
 
@@ -408,7 +409,7 @@ impl Kakehashi {
                 break;
             }
             coordinator
-                .check_injected_languages_auto_install(uri, &fresh)
+                .check_injected_languages_auto_install(uri, &fresh, incarnation)
                 .await;
             seen.extend(fresh);
         }

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -142,6 +142,18 @@ fn resolve_index(n: i64, stack_len: usize) -> Option<usize> {
 impl Kakehashi {
     /// Handler for `kakehashi/node`.
     pub async fn kakehashi_node(&self, params: NodeParams) -> Result<Value> {
+        self.kakehashi_node_after_injection_load(params, std::future::ready(()))
+            .await
+    }
+
+    async fn kakehashi_node_after_injection_load<F>(
+        &self,
+        params: NodeParams,
+        after_injection_load: F,
+    ) -> Result<Value>
+    where
+        F: std::future::Future<Output = ()>,
+    {
         let lsp_uri = params.text_document.uri;
         let position = params.position;
         let injection = params.injection;
@@ -226,6 +238,7 @@ impl Kakehashi {
         // minting an id for bytes the edit moved.
         self.ensure_injection_languages_loaded(&uri, &host_language, text, tree, byte, incarnation)
             .await;
+        after_injection_load.await;
 
         // Re-resolve a CURRENT snapshot after the await and recompute the
         // position mapping: a `didChange` processed during the (awaited)
@@ -234,6 +247,12 @@ impl Kakehashi {
         // post-await snapshot.
         let Some(snapshot) = self.current_snapshot(&uri).await else {
             log::debug!(target: "kakehashi::node", "no current parse snapshot for {} after load", uri);
+            return Ok(Value::Null);
+        };
+        if snapshot.incarnation != incarnation {
+            return Ok(Value::Null);
+        }
+        let Some(host_language) = snapshot.language.clone() else {
             return Ok(Value::Null);
         };
         let incarnation = snapshot.incarnation;
@@ -427,6 +446,68 @@ impl Kakehashi {
         let _ = self
             .wait_for_current_snapshot(uri, std::time::Duration::from_millis(200))
             .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp_server::LspService;
+
+    #[tokio::test]
+    async fn injection_node_rejects_close_reopen_during_language_load() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("go".to_string(), tree_sitter_go::LANGUAGE.into());
+        let uri = Url::parse("file:///workspace/reopened.rs").unwrap();
+        let old_incarnation = server.documents.insert(
+            uri.clone(),
+            "fn old() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        assert!(
+            server
+                .parse_coordinator()
+                .parse_document(uri.clone(), Some("rust"), None)
+                .await
+        );
+        let params = NodeParams {
+            text_document: TextDocumentIdentifier {
+                uri: uri.as_str().parse().unwrap(),
+            },
+            position: Position::new(0, 0),
+            injection: Some(Value::Bool(true)),
+        };
+
+        let result = server
+            .kakehashi_node_after_injection_load(params, async {
+                server.documents.remove(&uri);
+                let new_incarnation = server.documents.insert(
+                    uri.clone(),
+                    "package main".to_string(),
+                    Some("go".to_string()),
+                    None,
+                );
+                assert_ne!(new_incarnation, old_incarnation);
+                assert!(
+                    server
+                        .parse_coordinator()
+                        .parse_document(uri.clone(), Some("go"), None)
+                        .await
+                );
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result, Value::Null);
     }
 }
 

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -119,9 +119,18 @@ impl Kakehashi {
                     // spawn is pure wasted work and races the bridge-state sweep.
                     let is_cli_mode = self.is_cli_mode();
                     tokio::spawn(async move {
-                        install
-                            .maybe_auto_install_language(&lang, install_uri.clone(), false)
+                        let same_lifetime = install
+                            .maybe_auto_install_language(
+                                &lang,
+                                install_uri.clone(),
+                                false,
+                                Some(incarnation),
+                                true,
+                            )
                             .await;
+                        if !same_lifetime {
+                            return;
+                        }
                         // The skipped inline parse meant the handler's
                         // process_injections (below) ran with no tree. Now that the
                         // off-ingress reparse may have produced one, run the normal
@@ -133,11 +142,20 @@ impl Kakehashi {
                         // fail or be deduped (AlreadyInstalling) with no reparse, and
                         // process_injections would otherwise cancel the eager-open
                         // for a still-tree-less document.
-                        let has_tree = documents
-                            .get(&install_uri)
-                            .is_some_and(|doc| doc.tree().is_some());
+                        let has_tree = documents.get(&install_uri).is_some_and(|doc| {
+                            doc.incarnation() == incarnation && doc.tree().is_some()
+                        });
                         if has_tree {
-                            injection.process_injections(&install_uri, false).await;
+                            let same_lifetime = injection
+                                .process_injections_for_incarnation(
+                                    &install_uri,
+                                    false,
+                                    incarnation,
+                                )
+                                .await;
+                            if !same_lifetime {
+                                return;
+                            }
                             // Re-fire the proactive synthetic diagnostic now that a
                             // tree exists: the handler's spawn (below) ran in the
                             // skip-parse path with no tree, so its snapshot was None
@@ -145,7 +163,14 @@ impl Kakehashi {
                             // first open of a just-installed parser. Skipped in CLI
                             // mode (#489), matching the handler's own gate.
                             if !is_cli_mode {
-                                diagnostic_scheduler.spawn_synthetic_diagnostic_task(install_uri);
+                                let edit_lock = documents.edit_lock(&install_uri);
+                                let _lifecycle = edit_lock.lock().await;
+                                if documents.get(&install_uri).is_some_and(|doc| {
+                                    doc.incarnation() == incarnation && doc.tree().is_some()
+                                }) {
+                                    diagnostic_scheduler
+                                        .spawn_synthetic_diagnostic_task(install_uri);
+                                }
                             }
                         }
                     });
@@ -1143,7 +1168,7 @@ print("hello")
         // The document was closed during the install: nothing is in the store.
         server
             .parse_coordinator()
-            .reparse_installed_document(uri.clone(), "rust")
+            .reparse_installed_document(uri.clone(), "rust", None)
             .await;
 
         assert!(
@@ -1173,7 +1198,7 @@ print("hello")
 
         server
             .parse_coordinator()
-            .reparse_installed_document(uri.clone(), "rust")
+            .reparse_installed_document(uri.clone(), "rust", None)
             .await;
 
         assert!(
@@ -1263,7 +1288,7 @@ print("hello")
 
         server
             .parse_coordinator()
-            .reparse_installed_document(uri.clone(), "rust")
+            .reparse_installed_document(uri.clone(), "rust", None)
             .await;
 
         let doc = server.documents.get(&uri).unwrap();

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -6,6 +6,7 @@ use super::super::{Kakehashi, build_notifier, uri_to_url};
 use crate::document::DocumentStore;
 use crate::language::LanguageEvent;
 
+#[cfg(test)]
 async fn has_tree_for_incarnation(
     documents: &DocumentStore,
     uri: &url::Url,
@@ -18,6 +19,27 @@ async fn has_tree_for_incarnation(
         return false;
     };
     document.incarnation() == incarnation && document.tree().is_some()
+}
+
+async fn spawn_synthetic_diagnostic_for_incarnation<F>(
+    documents: &DocumentStore,
+    diagnostic_scheduler: &crate::lsp::lsp_impl::coordinator::DiagnosticScheduler,
+    uri: url::Url,
+    incarnation: u64,
+    after_lifecycle_lock: F,
+) where
+    F: std::future::Future<Output = ()>,
+{
+    let edit_lock = documents.edit_lock(&uri);
+    let _lifecycle = edit_lock.lock().await;
+    after_lifecycle_lock.await;
+    let Some(document) = documents.get(&uri) else {
+        documents.remove_edit_lock_if_unshared(&uri, &edit_lock);
+        return;
+    };
+    if document.incarnation() == incarnation && document.tree().is_some() {
+        diagnostic_scheduler.spawn_synthetic_diagnostic_task(uri);
+    }
 }
 
 impl Kakehashi {
@@ -177,11 +199,15 @@ impl Kakehashi {
                             // and the pull-layer diagnostics were skipped on this
                             // first open of a just-installed parser. Skipped in CLI
                             // mode (#489), matching the handler's own gate.
-                            if !is_cli_mode
-                                && has_tree_for_incarnation(&documents, &install_uri, incarnation)
-                                    .await
-                            {
-                                diagnostic_scheduler.spawn_synthetic_diagnostic_task(install_uri);
+                            if !is_cli_mode {
+                                spawn_synthetic_diagnostic_for_incarnation(
+                                    &documents,
+                                    &diagnostic_scheduler,
+                                    install_uri,
+                                    incarnation,
+                                    std::future::ready(()),
+                                )
+                                .await;
                             }
                         }
                     });
@@ -349,6 +375,79 @@ mod tests {
         assert!(
             weak_lock.upgrade().is_none(),
             "the missing-document path must remove its inserted edit lock"
+        );
+    }
+
+    #[tokio::test]
+    async fn install_recovery_diagnostic_registration_is_ordered_before_close() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
+        let uri = Url::parse("file:///test/close-at-install-diagnostic.rs").unwrap();
+        let incarnation = server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        server
+            .parse_coordinator()
+            .parse_document(uri.clone(), Some("rust"), None)
+            .await;
+
+        let (locked_tx, locked_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let documents = std::sync::Arc::clone(&server.documents);
+        let scheduler = server.diagnostic_scheduler();
+        let recovery_uri = uri.clone();
+        let recovery = tokio::spawn(async move {
+            spawn_synthetic_diagnostic_for_incarnation(
+                &documents,
+                &scheduler,
+                recovery_uri,
+                incarnation,
+                async move {
+                    let _ = locked_tx.send(());
+                    let _ = release_rx.await;
+                },
+            )
+            .await;
+        });
+        locked_rx.await.unwrap();
+
+        let close_documents = std::sync::Arc::clone(&server.documents);
+        let close_diagnostics = std::sync::Arc::clone(&server.synthetic_diagnostics);
+        let close_uri = uri.clone();
+        let (close_started_tx, close_started_rx) = tokio::sync::oneshot::channel();
+        let mut close = tokio::spawn(async move {
+            let edit_lock = close_documents.edit_lock(&close_uri);
+            let _ = close_started_tx.send(());
+            let _lifecycle = edit_lock.lock().await;
+            close_documents.remove_preserving_edit_lock(&close_uri);
+            close_diagnostics.remove_document(&close_uri);
+        });
+        close_started_rx.await.unwrap();
+        tokio::task::yield_now().await;
+        let close_finished_before_release = tokio::select! {
+            result = &mut close => {
+                result.unwrap();
+                true
+            }
+            () = tokio::time::sleep(std::time::Duration::from_millis(100)) => false,
+        };
+
+        let _ = release_tx.send(());
+        recovery.await.unwrap();
+        if !close_finished_before_release {
+            close.await.unwrap();
+        }
+
+        assert!(
+            !server.synthetic_diagnostics.has_active_task(&uri),
+            "didClose must remove the install recovery diagnostic registration"
         );
     }
 

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -3,7 +3,22 @@
 use tower_lsp_server::ls_types::DidOpenTextDocumentParams;
 
 use super::super::{Kakehashi, build_notifier, uri_to_url};
+use crate::document::DocumentStore;
 use crate::language::LanguageEvent;
+
+async fn has_tree_for_incarnation(
+    documents: &DocumentStore,
+    uri: &url::Url,
+    incarnation: u64,
+) -> bool {
+    let edit_lock = documents.edit_lock(uri);
+    let _lifecycle = edit_lock.lock().await;
+    let Some(document) = documents.get(uri) else {
+        documents.remove_edit_lock_if_unshared(uri, &edit_lock);
+        return false;
+    };
+    document.incarnation() == incarnation && document.tree().is_some()
+}
 
 impl Kakehashi {
     pub(crate) async fn did_open_impl(&self, params: DidOpenTextDocumentParams) {
@@ -162,15 +177,11 @@ impl Kakehashi {
                             // and the pull-layer diagnostics were skipped on this
                             // first open of a just-installed parser. Skipped in CLI
                             // mode (#489), matching the handler's own gate.
-                            if !is_cli_mode {
-                                let edit_lock = documents.edit_lock(&install_uri);
-                                let _lifecycle = edit_lock.lock().await;
-                                if documents.get(&install_uri).is_some_and(|doc| {
-                                    doc.incarnation() == incarnation && doc.tree().is_some()
-                                }) {
-                                    diagnostic_scheduler
-                                        .spawn_synthetic_diagnostic_task(install_uri);
-                                }
+                            if !is_cli_mode
+                                && has_tree_for_incarnation(&documents, &install_uri, incarnation)
+                                    .await
+                            {
+                                diagnostic_scheduler.spawn_synthetic_diagnostic_task(install_uri);
                             }
                         }
                     });
@@ -324,6 +335,21 @@ mod tests {
         })
         .await
         .expect("condition should become true");
+    }
+
+    #[tokio::test]
+    async fn missing_install_recovery_document_reclaims_inserted_edit_lock() {
+        let documents = DocumentStore::new();
+        let uri = Url::parse("file:///test/closed-during-install.rs").unwrap();
+        let edit_lock = documents.edit_lock(&uri);
+        let weak_lock = std::sync::Arc::downgrade(&edit_lock);
+        drop(edit_lock);
+
+        assert!(!has_tree_for_incarnation(&documents, &uri, 1).await);
+        assert!(
+            weak_lock.upgrade().is_none(),
+            "the missing-document path must remove its inserted edit lock"
+        );
     }
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -6,21 +6,6 @@ use super::super::{Kakehashi, build_notifier, uri_to_url};
 use crate::document::DocumentStore;
 use crate::language::LanguageEvent;
 
-#[cfg(test)]
-async fn has_tree_for_incarnation(
-    documents: &DocumentStore,
-    uri: &url::Url,
-    incarnation: u64,
-) -> bool {
-    let edit_lock = documents.edit_lock(uri);
-    let _lifecycle = edit_lock.lock().await;
-    let Some(document) = documents.get(uri) else {
-        documents.remove_edit_lock_if_unshared(uri, &edit_lock);
-        return false;
-    };
-    document.incarnation() == incarnation && document.tree().is_some()
-}
-
 async fn spawn_synthetic_diagnostic_for_incarnation<F>(
     documents: &DocumentStore,
     diagnostic_scheduler: &crate::lsp::lsp_impl::coordinator::DiagnosticScheduler,
@@ -367,13 +352,21 @@ mod tests {
 
     #[tokio::test]
     async fn missing_install_recovery_document_reclaims_inserted_edit_lock() {
-        let documents = DocumentStore::new();
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
         let uri = Url::parse("file:///test/closed-during-install.rs").unwrap();
-        let edit_lock = documents.edit_lock(&uri);
+        let edit_lock = server.documents.edit_lock(&uri);
         let weak_lock = std::sync::Arc::downgrade(&edit_lock);
         drop(edit_lock);
 
-        assert!(!has_tree_for_incarnation(&documents, &uri, 1).await);
+        spawn_synthetic_diagnostic_for_incarnation(
+            &server.documents,
+            &server.diagnostic_scheduler(),
+            uri,
+            1,
+            std::future::ready(()),
+        )
+        .await;
         assert!(
             weak_lock.upgrade().is_none(),
             "the missing-document path must remove its inserted edit lock"

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -426,19 +426,16 @@ mod tests {
         });
         close_started_rx.await.unwrap();
         tokio::task::yield_now().await;
-        let close_finished_before_release = tokio::select! {
-            result = &mut close => {
-                result.unwrap();
-                true
-            }
-            () = tokio::time::sleep(std::time::Duration::from_millis(100)) => false,
-        };
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), &mut close)
+                .await
+                .is_err(),
+            "didClose must wait until install recovery registers diagnostics"
+        );
 
         let _ = release_tx.send(());
         recovery.await.unwrap();
-        if !close_finished_before_release {
-            close.await.unwrap();
-        }
+        close.await.unwrap();
 
         assert!(
             !server.synthetic_diagnostics.has_active_task(&uri),

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -37,7 +37,9 @@ async fn spawn_synthetic_diagnostic_for_incarnation<F>(
         documents.remove_edit_lock_if_unshared(&uri, &edit_lock);
         return;
     };
-    if document.incarnation() == incarnation && document.tree().is_some() {
+    let eligible = document.incarnation() == incarnation && document.tree().is_some();
+    drop(document);
+    if eligible {
         diagnostic_scheduler.spawn_synthetic_diagnostic_task(uri);
     }
 }

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -1143,7 +1143,7 @@ print("hello")
         // The document was closed during the install: nothing is in the store.
         server
             .parse_coordinator()
-            .reparse_installed_document(uri.clone(), Some("rust".to_string()))
+            .reparse_installed_document(uri.clone(), "rust")
             .await;
 
         assert!(
@@ -1173,7 +1173,7 @@ print("hello")
 
         server
             .parse_coordinator()
-            .reparse_installed_document(uri.clone(), Some("rust".to_string()))
+            .reparse_installed_document(uri.clone(), "rust")
             .await;
 
         assert!(
@@ -1263,7 +1263,7 @@ print("hello")
 
         server
             .parse_coordinator()
-            .reparse_installed_document(uri.clone(), Some("rust".to_string()))
+            .reparse_installed_document(uri.clone(), "rust")
             .await;
 
         let doc = server.documents.get(&uri).unwrap();


### PR DESCRIPTION
## Summary

- bind concurrent parser-install waiters to the exact in-flight claim and terminal outcome
- reparse each waiting host document after the winner completes its single serialized global reload
- preserve document incarnation and lifecycle ordering through post-parse injection and diagnostic work
- serialize post-install settings merge, parser load, and claim publication without holding the global lock during document parsing
- handle ABA claims, timed-out support checks, owner cancellation, abandoned-claim takeover, and cross-language settings-generation races

## User impact

Concurrent `didOpen` requests for the same missing language no longer leave the requests that observed `AlreadyInstalling` permanently tree-less. Their parser-backed LSP features recover as soon as the shared installation and reload completes.

## Validation

- `make check`
- `cargo test --lib` (2999 passed, 2 ignored)
- `cargo test --lib lsp::auto_install::manager::tests`
- `cargo test --lib lsp::lsp_impl::coordinator::install::tests`
- `cargo test --lib lsp::lsp_impl::text_document::did_open::tests::reparse_installed_document`
- `cargo test --lib missing_install_recovery_document_reclaims_inserted_edit_lock`
- continued Codex review: no comments to provide
- fresh Codex review: no comments to provide

Closes #844
Closes #847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic language installation for concurrent requests with correct waiter completion, proper cancellation/abandon handling, and clearer terminal outcomes.
  * Made post-install recovery/reparse and “give-up” snapshot publishing incarnation-aware to avoid stale results after close/reopen or relabel.
  * Updated injected-language processing (including eager-open, installs, and synthetic diagnostics) to be incarnation-safe; stale kakehashi node requests now reliably return `null`.
  * Refreshed shared settings reload flow to prevent redundant locking and ensure consistent application.

* **Tests**
  * Updated and added coverage for duplicate installers, timeouts/cancellation, incarnation-gated injection/reparse, stale-snapshot early exits, and diagnostic ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->