### PR TITLE
feat(diagnostics): prefetch downstream refresh cycles

### DIFF
--- a/docs/architecture-decisions/downstream-diagnostic-refresh-handling.md
+++ b/docs/architecture-decisions/downstream-diagnostic-refresh-handling.md
@@ -99,11 +99,15 @@ pull-driven downstream; whether the editor actually re-pulls is its own
 on it. This gate is orthogonal to rule 2's *pull*.
 
 Forwarding is scheduled once per upstream workspace connection, not once per
-downstream server. The first downstream refresh after idle is the leading edge
-and is forwarded immediately. Further downstream refreshes join one trailing
+downstream server. The first downstream refresh after idle starts a leading
+cycle immediately. Each cycle first completes the workspace-wide Path A prefetch
+and only then forwards the editor refresh, so a client pull cannot race ahead of
+kakehashi's proactive cache. Further downstream refreshes join one trailing
 debounce cycle: 100 ms of quiet releases the latest activity, while an anchored
 1 s maximum wait prevents a continuously chatty server from postponing it
-forever. If another editor refresh is sent after the latest downstream activity,
+forever. Prefetch cycles never overlap; if the maximum wait expires during a
+prefetch, the dirty trailing cycle starts immediately after the current prefetch
+finishes. If another editor refresh is sent after the latest downstream activity,
 that send already provides the required re-pull nudge and the trailing forward is
 suppressed. This keeps independent downstream servers on the same workspace-wide
 cadence without coupling separate kakehashi workspace connections.
@@ -200,17 +204,18 @@ keeps the default `true`. kakehashi never guesses the editor's behavior.
 
 ## Decision–Implementation Gap
 
-**Implemented**: rules 1 and 3. For rule 1 (accept always), kakehashi advertises
+**Implemented**: rules 1, 2, and 3. For rule 1 (accept always), kakehashi advertises
 `workspace.diagnostics.refreshSupport = true` to downstream
 (`src/lsp/bridge/protocol/client_capabilities.rs`), and the downstream
 `workspace/diagnostic/refresh` request handler
 (`src/lsp/bridge/workspace/diagnostic_refresh.rs`) acks it with a `null` result
-while emitting `UpstreamNotification::DiagnosticRefresh`. For rule 3, the
-lifecycle arm routes that notification through the workspace-wide leading +
-trailing scheduler, which checks `workspace.diagnostics.refreshSupport` before
-admission and sends through the existing detached single-flight path.
+while emitting `UpstreamNotification::DiagnosticRefresh`. For rule 2, the
+workspace-wide scheduler snapshots every open URI with the same
+`DiagnosticSnapshotPreparer` as didOpen/didSave/didChange, runs
+`collect_push_diagnostics`, and updates the shared pull layer before continuing.
+For rule 3, each completed prefetch cycle checks
+`workspace.diagnostics.refreshSupport` and sends through the existing detached
+single-flight path. A client without refresh support still runs rule 2 but skips
+only the editor-facing request.
 
-**Planned** (this decision):
-
-- Rule 2 — add the downstream-refresh → Path A pull trigger (today a downstream
-  refresh never re-pulls).
+There is no current implementation gap for this decision.

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -114,6 +114,15 @@ impl DocumentStore {
         Self::default()
     }
 
+    /// Snapshot the URIs of all currently open documents without retaining any
+    /// DashMap shard guards across async work.
+    pub(crate) fn open_uris(&self) -> Vec<Url> {
+        self.documents
+            .iter()
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
     pub(crate) fn invalidate_all_parses(&self) -> Vec<Url> {
         let mut uris = Vec::with_capacity(self.documents.len());
         for mut entry in self.documents.iter_mut() {

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -117,10 +117,11 @@ impl DocumentStore {
     /// Snapshot the URIs of all currently open documents without retaining any
     /// DashMap shard guards across async work.
     pub(crate) fn open_uris(&self) -> Vec<Url> {
-        self.documents
-            .iter()
-            .map(|entry| entry.key().clone())
-            .collect()
+        let mut uris = Vec::with_capacity(self.documents.len());
+        for entry in self.documents.iter() {
+            uris.push(entry.key().clone());
+        }
+        uris
     }
 
     pub(crate) fn invalidate_all_parses(&self) -> Vec<Url> {

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -1030,6 +1030,14 @@ async fn handle_server_request(
         Err(error) => jsonrpc::Response::from_error(id, error),
     };
     send_server_response(&deps.response_tx, response, server_prefix, method).await;
+    // A downstream server may wait for this response before answering the
+    // diagnostic pull triggered by the refresh. Queue the acknowledgement
+    // first so prefetch can never deadlock behind its own server request.
+    if method == "workspace/diagnostic/refresh" {
+        let _ = deps
+            .upstream_tx
+            .send(UpstreamNotification::DiagnosticRefresh);
+    }
 }
 
 /// Frame a server-request response and send it to the downstream server via the
@@ -2601,8 +2609,8 @@ mod tests {
     /// Test that workspace/diagnostic/refresh is forwarded upstream and acknowledged.
     ///
     /// When a downstream server sends workspace/diagnostic/refresh:
-    /// 1. An UpstreamNotification::DiagnosticRefresh is sent on the upstream channel
-    /// 2. A success response (not MethodNotFound) is sent back to the server
+    /// 1. A success response (not MethodNotFound) is queued back to the server
+    /// 2. Only then is UpstreamNotification::DiagnosticRefresh queued upstream
     #[tokio::test]
     async fn handle_message_diagnostic_refresh_forwards_upstream() {
         let router = ResponseRouter::new();
@@ -2635,13 +2643,7 @@ mod tests {
 
         handle_message(message, &router, "", &deps).await;
 
-        // Should have sent DiagnosticRefresh on the upstream channel
-        let notification = upstream_rx
-            .try_recv()
-            .expect("should have upstream notification");
-        assert_eq!(notification, UpstreamNotification::DiagnosticRefresh);
-
-        // Should have sent a success response (not MethodNotFound)
+        // The response is queued before prefetch can be triggered upstream.
         let response = response_rx.try_recv().expect("should have response");
         match response {
             OutboundMessage::Untracked(val) => {
@@ -2651,6 +2653,11 @@ mod tests {
             }
             _ => panic!("Expected Untracked variant"),
         }
+
+        let notification = upstream_rx
+            .try_recv()
+            .expect("should have upstream notification after response");
+        assert_eq!(notification, UpstreamNotification::DiagnosticRefresh);
     }
 
     /// workspace/workspaceFolders must be answered with the folders the

--- a/src/lsp/bridge/workspace/diagnostic_refresh.rs
+++ b/src/lsp/bridge/workspace/diagnostic_refresh.rs
@@ -8,7 +8,7 @@
 use log::debug;
 use tower_lsp_server::jsonrpc;
 
-use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamNotification};
+use crate::lsp::bridge::actor::ServerRequestDeps;
 
 /// Handle a `workspace/diagnostic/refresh` request, returning the JSON-RPC body
 /// the dispatcher wraps in a response.
@@ -18,11 +18,9 @@ pub(in crate::lsp::bridge) fn handle(
 ) -> jsonrpc::Result<serde_json::Value> {
     debug!(
         target: "kakehashi::bridge::reader",
-        "{}Forwarding workspace/diagnostic/refresh upstream",
+        "{}Acknowledging workspace/diagnostic/refresh",
         server_prefix
     );
-    let _ = deps
-        .upstream_tx
-        .send(UpstreamNotification::DiagnosticRefresh);
+    let _ = deps;
     Ok(serde_json::Value::Null)
 }

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -486,6 +486,13 @@ struct ForwardedRefreshDebounce {
     refresh_epoch: u64,
     refresh_epoch_at_last_activity: u64,
     covered_generation: Option<u64>,
+    prefetched_generation: Option<u64>,
+}
+
+fn forwarded_refresh_cycle_pending(debounce: &ForwardedRefreshDebounce) -> bool {
+    debounce.prefetched_generation != Some(debounce.generation)
+        || (debounce.covered_generation != Some(debounce.generation)
+            && debounce.refresh_epoch == debounce.refresh_epoch_at_last_activity)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -682,8 +689,7 @@ impl DiagnosticAggregator {
                         .last_activity_at
                         .expect("activity generation has a timestamp"),
                 },
-                send_trailing: debounce.covered_generation != Some(debounce.generation)
-                    && debounce.refresh_epoch == debounce.refresh_epoch_at_last_activity,
+                send_trailing: forwarded_refresh_cycle_pending(&debounce),
             };
         }
         if debounce.generation != observed {
@@ -693,9 +699,7 @@ impl DiagnosticAggregator {
                     .last_activity_at
                     .expect("activity generation has a timestamp"),
             })
-        } else if debounce.covered_generation != Some(debounce.generation)
-            && debounce.refresh_epoch == debounce.refresh_epoch_at_last_activity
-        {
+        } else if forwarded_refresh_cycle_pending(&debounce) {
             ForwardedRefreshWait::SendTrailing(ForwardedRefreshWaitSnapshot {
                 generation: debounce.generation,
                 last_activity_at: debounce
@@ -751,6 +755,32 @@ impl DiagnosticAggregator {
         if debounce.generation == generation {
             debounce.covered_generation = Some(generation);
         }
+    }
+
+    /// Record that the proactive pullFallback cache was refreshed for this
+    /// downstream activity generation. An older prefetch never covers activity
+    /// that arrived while it was running.
+    pub(crate) fn mark_forwarded_refresh_prefetched(&self, generation: u64) {
+        let mut debounce = self
+            .forwarded_refresh_debounce
+            .lock()
+            .recover_poison("DiagnosticAggregator::forwarded_refresh_debounce");
+        if debounce.generation == generation {
+            debounce.prefetched_generation = Some(generation);
+        }
+    }
+
+    /// Whether a completed prefetch for `generation` should still nudge the
+    /// editor. Newer activity must first receive its own prefetch, while another
+    /// refresh sent after this activity already supplies the nudge.
+    pub(crate) fn forwarded_refresh_needs_editor_send(&self, generation: u64) -> bool {
+        let debounce = self
+            .forwarded_refresh_debounce
+            .lock()
+            .recover_poison("DiagnosticAggregator::forwarded_refresh_debounce");
+        debounce.generation == generation
+            && debounce.covered_generation != Some(generation)
+            && debounce.refresh_epoch == debounce.refresh_epoch_at_last_activity
     }
 
     pub(crate) fn new() -> Self {
@@ -2463,6 +2493,7 @@ mod tests {
         let first = agg
             .begin_forwarded_refresh_debounce()
             .expect("the first refresh schedules the trailing task");
+        agg.mark_forwarded_refresh_prefetched(first.generation);
         agg.record_refresh_sent();
         assert!(
             agg.begin_forwarded_refresh_debounce().is_none(),
@@ -2478,6 +2509,7 @@ mod tests {
         else {
             panic!("activity after the leading send releases one trailing refresh");
         };
+        agg.mark_forwarded_refresh_prefetched(admitted.generation);
         agg.mark_forwarded_refresh_covered(admitted.generation);
         assert!(
             agg.finish_forwarded_refresh_admission(admitted.generation)
@@ -2496,6 +2528,7 @@ mod tests {
             .begin_forwarded_refresh_debounce()
             .expect("the first refresh schedules the settle task");
 
+        agg.mark_forwarded_refresh_prefetched(first.generation);
         agg.record_refresh_sent();
 
         assert_eq!(
@@ -2506,28 +2539,56 @@ mod tests {
     }
 
     #[test]
-    fn another_refresh_after_the_latest_activity_satisfies_the_trailing_edge() {
+    fn another_refresh_after_latest_activity_does_not_skip_its_prefetch() {
         let agg = DiagnosticAggregator::new();
         let first = agg
             .begin_forwarded_refresh_debounce()
             .expect("the first refresh schedules the settle task");
-        agg.record_refresh_sent();
+        agg.mark_forwarded_refresh_prefetched(first.generation);
         assert!(
             agg.begin_forwarded_refresh_debounce().is_none(),
-            "later downstream activity remains in the same debounce cycle"
+            "activity arriving during the first prefetch remains in the same task"
         );
+        // The old cycle's editor refresh is admitted only after the newer
+        // activity. It covers the editor nudge, but cannot retroactively prefetch
+        // the newer downstream state.
+        agg.record_refresh_sent();
         let ForwardedRefreshWait::Restart(latest) =
             agg.finish_forwarded_refresh_wait(first.generation, false)
         else {
             panic!("the waiter must observe the later activity");
         };
 
-        agg.record_refresh_sent();
+        let ForwardedRefreshWait::SendTrailing(admitted) =
+            agg.finish_forwarded_refresh_wait(latest.generation, false)
+        else {
+            panic!("an editor refresh cannot cover a pullFallback prefetch that never ran");
+        };
+        agg.mark_forwarded_refresh_prefetched(admitted.generation);
+        assert!(
+            !agg.forwarded_refresh_needs_editor_send(admitted.generation),
+            "the late editor refresh still covers the nudge after the newer prefetch"
+        );
+    }
 
+    #[test]
+    fn another_refresh_during_prefetch_skips_only_the_duplicate_editor_send() {
+        let agg = DiagnosticAggregator::new();
+        let generation = agg
+            .begin_forwarded_refresh_debounce()
+            .expect("the refresh starts one prefetch cycle");
+
+        agg.record_refresh_sent();
+        agg.mark_forwarded_refresh_prefetched(generation.generation);
+
+        assert!(
+            !agg.forwarded_refresh_needs_editor_send(generation.generation),
+            "an intervening editor refresh already supplies the post-prefetch nudge"
+        );
         assert_eq!(
-            agg.finish_forwarded_refresh_wait(latest.generation, false),
+            agg.finish_forwarded_refresh_wait(generation.generation, false),
             ForwardedRefreshWait::Settled,
-            "a refresh sent after the latest activity makes a forced trailing send redundant"
+            "the completed prefetch and intervening nudge cover the cycle"
         );
     }
 
@@ -2537,6 +2598,7 @@ mod tests {
         let first = agg
             .begin_forwarded_refresh_debounce()
             .expect("the first refresh schedules the settle task");
+        agg.mark_forwarded_refresh_prefetched(first.generation);
         agg.mark_forwarded_refresh_covered(first.generation);
         assert!(agg.begin_forwarded_refresh_debounce().is_none());
 
@@ -2547,6 +2609,7 @@ mod tests {
         else {
             panic!("activity after the leading edge needs a max-wait send");
         };
+        agg.mark_forwarded_refresh_prefetched(latest.generation);
         agg.mark_forwarded_refresh_covered(latest.generation);
 
         assert_eq!(
@@ -2562,6 +2625,7 @@ mod tests {
         let first = agg
             .begin_forwarded_refresh_debounce()
             .expect("the first refresh schedules the settle task");
+        agg.mark_forwarded_refresh_prefetched(first.generation);
         agg.mark_forwarded_refresh_covered(first.generation);
         assert!(agg.begin_forwarded_refresh_debounce().is_none());
         let ForwardedRefreshWait::MaxWait {
@@ -2599,6 +2663,7 @@ mod tests {
         let first = agg
             .begin_forwarded_refresh_debounce()
             .expect("the first refresh schedules the settle task");
+        agg.mark_forwarded_refresh_prefetched(first.generation);
         agg.mark_forwarded_refresh_covered(first.generation);
         assert!(agg.begin_forwarded_refresh_debounce().is_none());
         let ForwardedRefreshWait::Restart(latest) =

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -43,14 +43,34 @@ fn dispatches_to_any_server(
     !truncate_entries(expand_priorities(priorities, configs), max_fan_out).is_empty()
 }
 
-pub(crate) struct DiagnosticScheduler {
+#[derive(Clone)]
+pub(crate) struct DiagnosticSnapshotPreparer {
     language: std::sync::Arc<LanguageCoordinator>,
     documents: std::sync::Arc<DocumentStore>,
     bridge: std::sync::Arc<BridgeCoordinator>,
     settings_manager: std::sync::Arc<SettingsManager>,
     cache: std::sync::Arc<crate::lsp::cache::CacheCoordinator>,
+}
+
+impl DiagnosticSnapshotPreparer {
+    pub(crate) fn new(server: &Kakehashi) -> Self {
+        Self {
+            language: std::sync::Arc::clone(&server.language),
+            documents: std::sync::Arc::clone(&server.documents),
+            bridge: std::sync::Arc::clone(&server.bridge),
+            settings_manager: std::sync::Arc::clone(&server.settings_manager),
+            cache: std::sync::Arc::clone(&server.cache),
+        }
+    }
+}
+
+pub(crate) struct DiagnosticScheduler {
+    documents: std::sync::Arc<DocumentStore>,
+    bridge: std::sync::Arc<BridgeCoordinator>,
+    settings_manager: std::sync::Arc<SettingsManager>,
     debounced_diagnostics: std::sync::Arc<DebouncedDiagnosticsManager>,
     synthetic_diagnostics: std::sync::Arc<SyntheticDiagnosticsManager>,
+    snapshot_preparer: DiagnosticSnapshotPreparer,
     /// The single proactive publisher: the host-event pull below feeds its
     /// result into the cache and republishes (push-propagation-diagnostic-forwarding),
     /// rather than calling `client.publish_diagnostics` directly, so it can never
@@ -61,13 +81,12 @@ pub(crate) struct DiagnosticScheduler {
 impl DiagnosticScheduler {
     pub(crate) fn new(server: &Kakehashi) -> Self {
         Self {
-            language: std::sync::Arc::clone(&server.language),
             documents: std::sync::Arc::clone(&server.documents),
             bridge: std::sync::Arc::clone(&server.bridge),
             settings_manager: std::sync::Arc::clone(&server.settings_manager),
-            cache: std::sync::Arc::clone(&server.cache),
             debounced_diagnostics: std::sync::Arc::clone(&server.debounced_diagnostics),
             synthetic_diagnostics: std::sync::Arc::clone(&server.synthetic_diagnostics),
+            snapshot_preparer: DiagnosticSnapshotPreparer::new(server),
             publisher: std::sync::Arc::new(super::DiagnosticPublisher::new(server)),
         }
     }
@@ -148,6 +167,12 @@ impl DiagnosticScheduler {
     /// collection returns `Clear`, evicting any stale `PullLayer`; a
     /// configured-but-pull-gated host still lands here so its re-sync runs), and
     /// `Some(snapshot)` with virt regions and/or a pullable host context.
+    pub(crate) fn prepare_diagnostic_snapshot(&self, uri: &Url) -> Option<DiagnosticSnapshot> {
+        self.snapshot_preparer.prepare_diagnostic_snapshot(uri)
+    }
+}
+
+impl DiagnosticSnapshotPreparer {
     pub(crate) fn prepare_diagnostic_snapshot(&self, uri: &Url) -> Option<DiagnosticSnapshot> {
         let (snapshot, language_name) = {
             let doc = self.documents.get(uri)?;

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 use crate::lsp::lsp_impl::Kakehashi;
 use crate::lsp::lsp_impl::text_document::publish_diagnostic::{
-    DiagnosticSnapshot, PullLayerOutcome, collect_push_diagnostics,
+    DiagnosticSnapshot, DiagnosticSnapshotLineage, PullLayerOutcome, collect_push_diagnostics,
 };
 use crate::lsp::settings_manager::SettingsManager;
 use crate::lsp::synthetic_diagnostics::SyntheticDiagnosticsManager;
@@ -174,7 +174,7 @@ impl DiagnosticScheduler {
 
 impl DiagnosticSnapshotPreparer {
     pub(crate) fn prepare_diagnostic_snapshot(&self, uri: &Url) -> Option<DiagnosticSnapshot> {
-        let (snapshot, language_name) = {
+        let (snapshot, language_name, content_version) = {
             let doc = self.documents.get(uri)?;
             let snapshot = doc.snapshot()?;
             let language_name = self.language.detect_language(
@@ -183,7 +183,8 @@ impl DiagnosticSnapshotPreparer {
                 None,
                 doc.language_id(),
             )?;
-            (snapshot, language_name)
+            let content_version = doc.content_version();
+            (snapshot, language_name, content_version)
         };
 
         // Cross-layer gating, keyed by the same method name as the
@@ -367,6 +368,10 @@ impl DiagnosticSnapshotPreparer {
         };
 
         Some(DiagnosticSnapshot {
+            lineage: DiagnosticSnapshotLineage {
+                incarnation: snapshot.incarnation(),
+                content_version,
+            },
             virt_contexts,
             host_pull_enabled,
             host,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -273,15 +273,17 @@ impl DiagnosticPublisher {
     async fn prefetch_open_pull_fallback_diagnostics(&self) -> bool {
         let mut tasks = tokio::task::JoinSet::new();
         for uri in self.documents.open_uris() {
-            let snapshot = self.snapshot_preparer.prepare_diagnostic_snapshot(&uri);
-            let lineage = snapshot.as_ref().map(|snapshot| snapshot.lineage);
+            let Some(snapshot) = self.snapshot_preparer.prepare_diagnostic_snapshot(&uri) else {
+                continue;
+            };
+            let lineage = Some(snapshot.lineage);
             let pool = self.bridge.pool_arc();
             let publisher = self.clone();
             tasks.spawn(async move {
                 let errors = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
                 let error_sink = Some(std::sync::Arc::clone(&errors));
                 let outcome = collect_push_diagnostics_with_error_sink(
-                    snapshot,
+                    Some(snapshot),
                     &pool,
                     &uri,
                     LOG_TARGET,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -276,7 +276,7 @@ impl DiagnosticPublisher {
             let Some(snapshot) = self.snapshot_preparer.prepare_diagnostic_snapshot(&uri) else {
                 continue;
             };
-            let lineage = Some(snapshot.lineage);
+            let lineage = snapshot.lineage;
             let pool = self.bridge.pool_arc();
             let publisher = self.clone();
             tasks.spawn(async move {
@@ -326,12 +326,9 @@ impl DiagnosticPublisher {
     async fn commit_refresh_prefetch(
         &self,
         uri: &Url,
-        lineage: Option<DiagnosticSnapshotLineage>,
+        lineage: DiagnosticSnapshotLineage,
         outcome: PullLayerOutcome,
     ) {
-        let Some(lineage) = lineage else {
-            return;
-        };
         let edit_lock = self.documents.edit_lock(uri);
         let edit_guard = edit_lock.lock().await;
         let Some(document) = self.documents.get(uri) else {

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -677,7 +677,7 @@ impl DiagnosticPublisher {
         Some(host)
     }
 
-    /// Feed the host-event pull's combined result into the cache and republish.
+    /// Feed a proactive pull's combined result into the cache and republish.
     ///
     /// The pull blob is already host-local; it replaces the
     /// [`DiagnosticSource::PullLayer`] slot, then the merge folds in region push

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -26,6 +26,10 @@ use crate::lsp::diagnostic_cache::{
     DiagnosticAggregator, DiagnosticSource, merge_cached_diagnostics,
 };
 use crate::lsp::lsp_impl::Kakehashi;
+use crate::lsp::lsp_impl::coordinator::diagnostic::DiagnosticSnapshotPreparer;
+use crate::lsp::lsp_impl::text_document::publish_diagnostic::{
+    PullLayerOutcome, collect_push_diagnostics,
+};
 use crate::lsp::settings_manager::SettingsManager;
 use tower_lsp_server::Client;
 use tower_lsp_server::ls_types::Diagnostic;
@@ -129,6 +133,7 @@ pub(crate) struct DiagnosticPublisher {
     bridge: Arc<BridgeCoordinator>,
     settings_manager: Arc<SettingsManager>,
     cache: Arc<crate::lsp::cache::CacheCoordinator>,
+    snapshot_preparer: DiagnosticSnapshotPreparer,
     aggregator: Arc<DiagnosticAggregator>,
     shutdown: tokio_util::sync::CancellationToken,
 }
@@ -142,6 +147,7 @@ impl DiagnosticPublisher {
             bridge: Arc::clone(&server.bridge),
             settings_manager: Arc::clone(&server.settings_manager),
             cache: Arc::clone(&server.cache),
+            snapshot_preparer: DiagnosticSnapshotPreparer::new(server),
             aggregator: Arc::clone(&server.diagnostics),
             shutdown: server.shutdown_token.clone(),
         }
@@ -154,23 +160,26 @@ impl DiagnosticPublisher {
         if self.shutdown.is_cancelled() {
             return;
         }
-        if !self.diagnostic_refresh_supported() {
-            return;
+        // Preserve the metrics contract for editor-facing asks. Prefetch still
+        // runs without refreshSupport because pullFallback is a kakehashi cache
+        // policy, not a promise that the editor will pull.
+        if self.diagnostic_refresh_supported() {
+            self.aggregator.record_refresh_requested();
         }
-        // Preserve the metrics contract: each capability-eligible downstream
-        // ask is counted before this debounce decides how many wire sends survive.
-        self.aggregator.record_refresh_requested();
         let Some(snapshot) = self.aggregator.begin_forwarded_refresh_debounce() else {
             return;
         };
-        if self.request_pull_diagnostic_refresh_inner(true, false) {
-            self.aggregator
-                .mark_forwarded_refresh_covered(snapshot.generation);
-        }
         let publisher = self.clone();
         tokio::spawn(async move {
             let mut snapshot = snapshot;
             let mut deadline = snapshot.last_activity_at + FORWARDED_REFRESH_MAX_WAIT;
+            if !publisher
+                .complete_forwarded_refresh_cycle(snapshot.generation)
+                .await
+            {
+                publisher.aggregator.cancel_forwarded_refresh_debounce();
+                return;
+            }
             loop {
                 tokio::select! {
                     biased;
@@ -193,10 +202,10 @@ impl DiagnosticPublisher {
                             crate::lsp::diagnostic_cache::ForwardedRefreshWait::SendTrailing(
                                 admitted,
                             ) => {
-                                if publisher.request_pull_diagnostic_refresh_inner(true, false) {
-                                    publisher
-                                        .aggregator
-                                        .mark_forwarded_refresh_covered(admitted.generation);
+                                if publisher
+                                    .complete_forwarded_refresh_cycle(admitted.generation)
+                                    .await
+                                {
                                     if let Some(latest) = publisher
                                         .aggregator
                                         .finish_forwarded_refresh_admission(admitted.generation)
@@ -216,17 +225,13 @@ impl DiagnosticPublisher {
                                 snapshot: latest,
                                 send_trailing,
                             } => {
-                                if send_trailing {
-                                    if publisher
-                                        .request_pull_diagnostic_refresh_inner(true, false)
-                                    {
-                                        publisher
-                                            .aggregator
-                                            .mark_forwarded_refresh_covered(latest.generation);
-                                    } else {
-                                        publisher.aggregator.cancel_forwarded_refresh_debounce();
-                                        break;
-                                    }
+                                if send_trailing
+                                    && !publisher
+                                        .complete_forwarded_refresh_cycle(latest.generation)
+                                        .await
+                                {
+                                    publisher.aggregator.cancel_forwarded_refresh_debounce();
+                                    break;
                                 }
                                 snapshot = latest;
                                 deadline = tokio::time::Instant::now()
@@ -240,6 +245,62 @@ impl DiagnosticPublisher {
                 }
             }
         });
+    }
+
+    /// Complete one scheduled downstream-refresh cycle: refresh every proactive
+    /// pullFallback cache entry first, then (when supported) notify the editor.
+    async fn complete_forwarded_refresh_cycle(&self, generation: u64) -> bool {
+        if !self.prefetch_open_pull_fallback_diagnostics().await || self.shutdown.is_cancelled() {
+            return false;
+        }
+
+        if self.diagnostic_refresh_supported()
+            && !self.request_pull_diagnostic_refresh_inner(true, false)
+        {
+            return false;
+        }
+        // A client without refreshSupport is still covered by the completed
+        // prefetch. New downstream activity advances the generation and causes a
+        // trailing cycle; this activity must not prefetch twice merely because no
+        // editor-facing request can be sent.
+        self.aggregator.mark_forwarded_refresh_covered(generation);
+        true
+    }
+
+    async fn prefetch_open_pull_fallback_diagnostics(&self) -> bool {
+        let mut tasks = tokio::task::JoinSet::new();
+        for uri in self.documents.open_uris() {
+            let snapshot = self.snapshot_preparer.prepare_diagnostic_snapshot(&uri);
+            let pool = self.bridge.pool_arc();
+            let publisher = self.clone();
+            tasks.spawn(async move {
+                let outcome = collect_push_diagnostics(snapshot, &pool, &uri, LOG_TARGET).await;
+                match outcome {
+                    PullLayerOutcome::Skip => {}
+                    PullLayerOutcome::Clear => publisher.clear_pull_layer(&uri).await,
+                    PullLayerOutcome::Publish(diagnostics) => {
+                        publisher.publish_pull_layer(&uri, diagnostics).await;
+                    }
+                }
+            });
+        }
+
+        while !tasks.is_empty() {
+            tokio::select! {
+                biased;
+                _ = self.shutdown.cancelled() => {
+                    tasks.abort_all();
+                    while tasks.join_next().await.is_some() {}
+                    return false;
+                }
+                result = tasks.join_next() => {
+                    if let Some(Err(error)) = result {
+                        log::warn!(target: LOG_TARGET, "Diagnostic refresh prefetch task failed: {error}");
+                    }
+                }
+            }
+        }
+        true
     }
 
     fn diagnostic_refresh_supported(&self) -> bool {

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -28,7 +28,7 @@ use crate::lsp::diagnostic_cache::{
 use crate::lsp::lsp_impl::Kakehashi;
 use crate::lsp::lsp_impl::coordinator::diagnostic::DiagnosticSnapshotPreparer;
 use crate::lsp::lsp_impl::text_document::publish_diagnostic::{
-    PullLayerOutcome, collect_push_diagnostics,
+    PullLayerOutcome, collect_push_diagnostics_with_error_sink,
 };
 use crate::lsp::settings_manager::SettingsManager;
 use tower_lsp_server::Client;
@@ -253,17 +253,20 @@ impl DiagnosticPublisher {
         if !self.prefetch_open_pull_fallback_diagnostics().await || self.shutdown.is_cancelled() {
             return false;
         }
+        self.aggregator
+            .mark_forwarded_refresh_prefetched(generation);
 
-        if self.diagnostic_refresh_supported()
-            && !self.request_pull_diagnostic_refresh_inner(true, false)
+        if !self.diagnostic_refresh_supported() {
+            self.aggregator.mark_forwarded_refresh_covered(generation);
+        } else if self
+            .aggregator
+            .forwarded_refresh_needs_editor_send(generation)
         {
-            return false;
+            if !self.request_pull_diagnostic_refresh_inner(true, false) {
+                return false;
+            }
+            self.aggregator.mark_forwarded_refresh_covered(generation);
         }
-        // A client without refreshSupport is still covered by the completed
-        // prefetch. New downstream activity advances the generation and causes a
-        // trailing cycle; this activity must not prefetch twice merely because no
-        // editor-facing request can be sent.
-        self.aggregator.mark_forwarded_refresh_covered(generation);
         true
     }
 
@@ -271,10 +274,33 @@ impl DiagnosticPublisher {
         let mut tasks = tokio::task::JoinSet::new();
         for uri in self.documents.open_uris() {
             let snapshot = self.snapshot_preparer.prepare_diagnostic_snapshot(&uri);
+            let lineage = snapshot.as_ref().map(|snapshot| snapshot.lineage);
             let pool = self.bridge.pool_arc();
             let publisher = self.clone();
             tasks.spawn(async move {
-                let outcome = collect_push_diagnostics(snapshot, &pool, &uri, LOG_TARGET).await;
+                let errors = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+                let error_sink = Some(std::sync::Arc::clone(&errors));
+                let outcome = collect_push_diagnostics_with_error_sink(
+                    snapshot,
+                    &pool,
+                    &uri,
+                    LOG_TARGET,
+                    &error_sink,
+                )
+                .await;
+                if errors.load(std::sync::atomic::Ordering::Relaxed) != 0 {
+                    log::warn!(target: LOG_TARGET, "Keeping the previous pull layer after refresh prefetch failed for {uri}");
+                    return;
+                }
+                if lineage.is_some_and(|lineage| {
+                    publisher.documents.get(&uri).is_none_or(|document| {
+                        document.incarnation() != lineage.incarnation
+                            || document.content_version() != lineage.content_version
+                    })
+                }) {
+                    log::debug!(target: LOG_TARGET, "Discarding stale refresh prefetch for {uri}");
+                    return;
+                }
                 match outcome {
                     PullLayerOutcome::Skip => {}
                     PullLayerOutcome::Clear => publisher.clear_pull_layer(&uri).await,
@@ -647,12 +673,12 @@ impl DiagnosticPublisher {
     /// returned clean keeps its empty `PullLayer` (via [`Self::publish_pull_layer`]),
     /// so that path still suppresses a stale push — the two empties differ.
     ///
-    /// Deliberately does **not** emit `workspace/diagnostic/refresh` (#499). This is
-    /// the empty-contributors branch of the same host-event pull task as
-    /// [`Self::publish_pull_layer`], which #496 left no-refresh: both are always
-    /// downstream of a host event (didOpen/didChange/didSave) the editor originated
-    /// and re-pulls for on its own. There is no spontaneous `clear_pull_layer`, so a
-    /// refresh here would be redundant (the editor's own re-pull already covers it).
+    /// Deliberately does **not** emit `workspace/diagnostic/refresh` (#499). Host
+    /// events (didOpen/didChange/didSave) are editor-originated, while a downstream
+    /// refresh prefetch is enclosed by a workspace refresh cycle that forwards its
+    /// one capability-gated editor request only after every host finishes. Emitting
+    /// here would therefore duplicate that cycle's nudge; an incapable editor still
+    /// receives the clearing `publishDiagnostics` notification from `republish`.
     pub(crate) async fn clear_pull_layer(&self, host: &Url) {
         self.aggregator
             .evict_source(host, &DiagnosticSource::PullLayer);

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -28,7 +28,7 @@ use crate::lsp::diagnostic_cache::{
 use crate::lsp::lsp_impl::Kakehashi;
 use crate::lsp::lsp_impl::coordinator::diagnostic::DiagnosticSnapshotPreparer;
 use crate::lsp::lsp_impl::text_document::publish_diagnostic::{
-    PullLayerOutcome, collect_push_diagnostics_with_error_sink,
+    DiagnosticSnapshotLineage, PullLayerOutcome, collect_push_diagnostics_with_error_sink,
 };
 use crate::lsp::settings_manager::SettingsManager;
 use tower_lsp_server::Client;
@@ -292,22 +292,9 @@ impl DiagnosticPublisher {
                     log::warn!(target: LOG_TARGET, "Keeping the previous pull layer after refresh prefetch failed for {uri}");
                     return;
                 }
-                if lineage.is_some_and(|lineage| {
-                    publisher.documents.get(&uri).is_none_or(|document| {
-                        document.incarnation() != lineage.incarnation
-                            || document.content_version() != lineage.content_version
-                    })
-                }) {
-                    log::debug!(target: LOG_TARGET, "Discarding stale refresh prefetch for {uri}");
-                    return;
-                }
-                match outcome {
-                    PullLayerOutcome::Skip => {}
-                    PullLayerOutcome::Clear => publisher.clear_pull_layer(&uri).await,
-                    PullLayerOutcome::Publish(diagnostics) => {
-                        publisher.publish_pull_layer(&uri, diagnostics).await;
-                    }
-                }
+                publisher
+                    .commit_refresh_prefetch(&uri, lineage, outcome)
+                    .await;
             });
         }
 
@@ -327,6 +314,52 @@ impl DiagnosticPublisher {
             }
         }
         true
+    }
+
+    /// Commit a refresh prefetch only while its document inputs are current.
+    ///
+    /// The lineage check and synchronous cache mutation share the document's
+    /// edit lock with didChange/didClose/didOpen. This closes the check→commit
+    /// race without holding the lock across the editor-facing republish await.
+    async fn commit_refresh_prefetch(
+        &self,
+        uri: &Url,
+        lineage: Option<DiagnosticSnapshotLineage>,
+        outcome: PullLayerOutcome,
+    ) {
+        let Some(lineage) = lineage else {
+            return;
+        };
+        let edit_lock = self.documents.edit_lock(uri);
+        let edit_guard = edit_lock.lock().await;
+        let Some(document) = self.documents.get(uri) else {
+            drop(edit_guard);
+            self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
+            log::debug!(target: LOG_TARGET, "Discarding refresh prefetch for closed {uri}");
+            return;
+        };
+        let current = {
+            document.incarnation() == lineage.incarnation
+                && document.content_version() == lineage.content_version
+        };
+        drop(document);
+        if !current {
+            log::debug!(target: LOG_TARGET, "Discarding stale refresh prefetch for {uri}");
+            return;
+        }
+
+        match outcome {
+            PullLayerOutcome::Skip => return,
+            PullLayerOutcome::Clear => {
+                self.aggregator
+                    .evict_source(uri, &DiagnosticSource::PullLayer);
+            }
+            PullLayerOutcome::Publish(diagnostics) => {
+                self.aggregator.set_pull_layer(uri, diagnostics);
+            }
+        }
+        drop(edit_guard);
+        self.republish(uri).await;
     }
 
     fn diagnostic_refresh_supported(&self) -> bool {

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -756,6 +756,11 @@ print("hello")
 
         // Snapshot text is CONSTANT across both fires; only the store text changes.
         let snapshot = || DiagnosticSnapshot {
+            lineage:
+                crate::lsp::lsp_impl::text_document::publish_diagnostic::DiagnosticSnapshotLineage {
+                    incarnation: 0,
+                    content_version: 0,
+                },
             virt_contexts: vec![],
             host_pull_enabled: true,
             host: Some(HostRequestContext {
@@ -865,6 +870,11 @@ print("hello")
             .bridge
             .get_host_configs_for_language(&server.settings_manager.load_settings(), "rust");
         let snapshot = DiagnosticSnapshot {
+            lineage:
+                crate::lsp::lsp_impl::text_document::publish_diagnostic::DiagnosticSnapshotLineage {
+                    incarnation: 0,
+                    content_version: 0,
+                },
             virt_contexts: vec![],
             host_pull_enabled: true,
             host: Some(HostRequestContext {

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -15,15 +15,26 @@ use crate::config::settings::ResolvedLayerConfig;
 use crate::lsp::bridge::LanguageServerPool;
 use crate::lsp::lsp_impl::bridge_context::{DocumentRequestContext, HostRequestContext};
 
+use super::RequestErrorSink;
 use super::diagnostic::{
     collect_host_diagnostics, collect_region_diagnostics, combine_layer_diagnostics,
 };
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct DiagnosticSnapshotLineage {
+    pub(crate) incarnation: u64,
+    pub(crate) content_version: u64,
+}
 
 /// Everything a push-diagnostics task needs, captured at schedule time
 /// (cross-layer-aggregation): the virt layer's per-region contexts, the host
 /// layer's context when host bridging participates, and the resolved
 /// cross-layer config that combines them.
 pub(crate) struct DiagnosticSnapshot {
+    /// Document inputs from which this snapshot was prepared. Refresh prefetch
+    /// checks them again before committing so an edit or close/reopen cannot be
+    /// overwritten by an older in-flight pull.
+    pub(crate) lineage: DiagnosticSnapshotLineage,
     /// Per-region virt contexts; empty when the virt layer is gated off or
     /// the document has no bridgeable injection regions.
     pub(crate) virt_contexts: Vec<DocumentRequestContext>,
@@ -84,6 +95,16 @@ pub(crate) async fn collect_push_diagnostics(
     uri: &Url,
     log_target: &'static str,
 ) -> PullLayerOutcome {
+    collect_push_diagnostics_with_error_sink(snapshot_data, pool, uri, log_target, &None).await
+}
+
+pub(crate) async fn collect_push_diagnostics_with_error_sink(
+    snapshot_data: Option<DiagnosticSnapshot>,
+    pool: &Arc<LanguageServerPool>,
+    uri: &Url,
+    log_target: &'static str,
+    request_error_sink: &RequestErrorSink,
+) -> PullLayerOutcome {
     let Some(snapshot) = snapshot_data else {
         return PullLayerOutcome::Skip;
     };
@@ -105,6 +126,7 @@ pub(crate) async fn collect_push_diagnostics(
     // async blocks would otherwise rely on disjoint-field captures of
     // `snapshot`, which compiles but reads ambiguously).
     let DiagnosticSnapshot {
+        lineage: _,
         mut virt_contexts,
         host,
         host_pull_enabled,
@@ -145,10 +167,12 @@ pub(crate) async fn collect_push_diagnostics(
         let mut join_set = JoinSet::new();
         for region_ctx in virt_contexts {
             let pool = Arc::clone(pool);
+            let request_error_sink = request_error_sink.clone();
             // Push diagnostics run in LSP mode only — failures are log-only
             // (the editor re-pulls), so no request-error sink is threaded.
-            join_set
-                .spawn(async move { collect_region_diagnostics(&region_ctx, pool, &None).await });
+            join_set.spawn(async move {
+                collect_region_diagnostics(&region_ctx, pool, &request_error_sink).await
+            });
         }
 
         let mut all_diagnostics = Vec::new();
@@ -173,7 +197,7 @@ pub(crate) async fn collect_push_diagnostics(
             // for the re-sync (above), not the pull. Push diagnostics are
             // LSP-mode-only, so failures are log-only (`&None` error sink).
             Some(ctx) if host_pull_enabled => {
-                collect_host_diagnostics(ctx, Arc::clone(pool), &None).await
+                collect_host_diagnostics(ctx, Arc::clone(pool), request_error_sink).await
             }
             _ => Vec::new(),
         }
@@ -249,6 +273,10 @@ mod tests {
         pool.insert_connection(handle).await;
 
         let snapshot = DiagnosticSnapshot {
+            lineage: DiagnosticSnapshotLineage {
+                incarnation: 0,
+                content_version: 0,
+            },
             virt_contexts: vec![virt_ctx_for_server("test")],
             host: None,
             host_pull_enabled: false,

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -1,10 +1,9 @@
-//! Shared fan-out/aggregation for the host-event diagnostic pull
-//! (push-propagation-diagnostic-forwarding): on `didOpen`/`didSave`/`didChange`,
-//! `DiagnosticScheduler` pulls every layer's diagnostics from a prepared snapshot
-//! and the result is fed into the cache as the `PullLayer` blob, then republished.
-//! `DiagnosticScheduler` handles superseding (via `SyntheticDiagnosticsManager` /
-//! `DebouncedDiagnosticsManager`); this module just collects the per-layer
-//! diagnostics.
+//! Shared fan-out/aggregation for proactive diagnostic pulls. Host events
+//! (`didOpen`/`didSave`/`didChange`) and downstream refresh prefetch both pull
+//! every eligible layer from a prepared snapshot and feed the result into the
+//! cached `PullLayer`. Host-event callers treat request failures as log-only;
+//! refresh prefetch supplies an error sink so it can preserve the last good
+//! layer. Scheduling, supersession, and cache commit policy stay with callers.
 
 use std::sync::Arc;
 
@@ -63,7 +62,7 @@ impl DiagnosticSnapshot {
     }
 }
 
-/// What the host-event pull collection wants done to the host's `PullLayer`
+/// What a proactive pull collection wants done to the host's `PullLayer`
 /// slot (push-propagation-diagnostic-forwarding). The three states are
 /// distinct: `Skip` ≠ `Clear` (do nothing vs evict).
 pub(crate) enum PullLayerOutcome {

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -168,8 +168,9 @@ pub(crate) async fn collect_push_diagnostics_with_error_sink(
         for region_ctx in virt_contexts {
             let pool = Arc::clone(pool);
             let request_error_sink = request_error_sink.clone();
-            // Push diagnostics run in LSP mode only — failures are log-only
-            // (the editor re-pulls), so no request-error sink is threaded.
+            // Ordinary push diagnostics use no sink (failures are log-only);
+            // refresh prefetch installs one so it can preserve the last good
+            // PullLayer when any participating request fails.
             join_set.spawn(async move {
                 collect_region_diagnostics(&region_ctx, pool, &request_error_sink).await
             });
@@ -194,8 +195,8 @@ pub(crate) async fn collect_push_diagnostics_with_error_sink(
     let host_fut = async {
         match &host {
             // Pull only when enabled; a configured-but-gated host context exists
-            // for the re-sync (above), not the pull. Push diagnostics are
-            // LSP-mode-only, so failures are log-only (`&None` error sink).
+            // for the re-sync (above), not the pull. The caller chooses whether
+            // failures are log-only or counted for refresh-prefetch preservation.
             Some(ctx) if host_pull_enabled => {
                 collect_host_diagnostics(ctx, Arc::clone(pool), request_error_sink).await
             }

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -14,10 +14,10 @@ use crate::config::settings::ResolvedLayerConfig;
 use crate::lsp::bridge::LanguageServerPool;
 use crate::lsp::lsp_impl::bridge_context::{DocumentRequestContext, HostRequestContext};
 
-use super::RequestErrorSink;
 use super::diagnostic::{
     collect_host_diagnostics, collect_region_diagnostics, combine_layer_diagnostics,
 };
+use super::{RequestErrorSink, count_request_errors};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct DiagnosticSnapshotLineage {
@@ -175,20 +175,7 @@ pub(crate) async fn collect_push_diagnostics_with_error_sink(
             });
         }
 
-        let mut all_diagnostics = Vec::new();
-        while let Some(result) = join_set.join_next().await {
-            match result {
-                Ok(diags) => all_diagnostics.extend(diags),
-                Err(join_err) => {
-                    log::warn!(
-                        target: log_target,
-                        "Diagnostic region task panicked: {}",
-                        join_err
-                    );
-                }
-            }
-        }
-        all_diagnostics
+        collect_joined_region_diagnostics(join_set, request_error_sink, log_target).await
     };
 
     let host_fut = async {
@@ -210,6 +197,28 @@ pub(crate) async fn collect_push_diagnostics_with_error_sink(
     ))
 }
 
+async fn collect_joined_region_diagnostics(
+    mut join_set: JoinSet<Vec<tower_lsp_server::ls_types::Diagnostic>>,
+    request_error_sink: &RequestErrorSink,
+    log_target: &str,
+) -> Vec<tower_lsp_server::ls_types::Diagnostic> {
+    let mut all_diagnostics = Vec::new();
+    while let Some(result) = join_set.join_next().await {
+        match result {
+            Ok(diags) => all_diagnostics.extend(diags),
+            Err(join_err) => {
+                count_request_errors(request_error_sink, 1);
+                log::warn!(
+                    target: log_target,
+                    "Diagnostic region task panicked: {}",
+                    join_err
+                );
+            }
+        }
+    }
+    all_diagnostics
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -218,6 +227,7 @@ mod tests {
     use crate::lsp::bridge::ConnectionState;
     use crate::lsp::bridge::ResolvedServerConfig;
     use crate::lsp::bridge::test_helpers::create_handle_with_state;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn virt_ctx_for_server(server: &str) -> DocumentRequestContext {
         DocumentRequestContext {
@@ -255,6 +265,18 @@ mod tests {
             max_fan_out: None,
             client_progress_token: None,
         }
+    }
+
+    #[tokio::test]
+    async fn panicked_region_task_is_counted_as_prefetch_failure() {
+        let sink = Some(Arc::new(AtomicUsize::new(0)));
+        let mut join_set = JoinSet::new();
+        join_set.spawn(async { panic!("region task failed") });
+
+        let diagnostics = collect_joined_region_diagnostics(join_set, &sink, "test").await;
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(sink.unwrap().load(Ordering::Relaxed), 1);
     }
 
     /// An all-incapable virt snapshot must still publish an (empty) pull layer,

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -217,6 +217,8 @@ fn main() {
                     "diagnostics"
                     | "diagnostics-fail"
                     | "diagnostics-malformed"
+                    | "diagnostics-refresh-prefetch"
+                    | "diagnostics-refresh-prefetch-disabled"
                     | "diagnostics-refresh-burst"
                     | "diagnostics-push-pullcap" => json!({
                         "diagnosticProvider": {
@@ -330,7 +332,13 @@ fn main() {
                     // editor (#521). Fire-and-forget: the bridge's `null` ack comes
                     // back as a response with no `method`, which the read loop
                     // ignores. A fixed id is fine since nothing awaits the ack.
-                    if mode == "diagnostics-refresh" {
+                    if mode == "diagnostics-refresh"
+                        || matches!(
+                            mode.as_str(),
+                            "diagnostics-refresh-prefetch"
+                                | "diagnostics-refresh-prefetch-disabled"
+                        )
+                    {
                         request(&mut writer, json!(1000), "workspace/diagnostic/refresh");
                     } else if mode == "diagnostics-refresh-burst" {
                         diagnostic_generation = 1;
@@ -816,6 +824,13 @@ fn main() {
                 respond(&mut writer, id, json!({ "executed": command }));
             }
             "textDocument/diagnostic" => {
+                if matches!(
+                    mode.as_str(),
+                    "diagnostics-refresh-prefetch" | "diagnostics-refresh-prefetch-disabled"
+                ) {
+                    diagnostic_generation += 1;
+                    std::thread::sleep(std::time::Duration::from_millis(300));
+                }
                 if mode == "diagnostics-fail" {
                     // Healthy handshake (advertises diagnosticProvider), broken
                     // request: exercises the request-time diagnostic failure
@@ -839,6 +854,11 @@ fn main() {
                 // synced before the pull.
                 let diagnostic_message = if mode == "diagnostics-refresh-burst" {
                     format!("mock-diagnostic-generation:{diagnostic_generation}")
+                } else if matches!(
+                    mode.as_str(),
+                    "diagnostics-refresh-prefetch" | "diagnostics-refresh-prefetch-disabled"
+                ) {
+                    format!("mock-diagnostic-refresh-prefetched:{diagnostic_generation}")
                 } else {
                     message
                         .pointer("/params/textDocument/uri")

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -218,7 +218,11 @@ fn main() {
                     | "diagnostics-fail"
                     | "diagnostics-malformed"
                     | "diagnostics-refresh-prefetch"
+                    | "diagnostics-refresh-prefetch-ack-order"
                     | "diagnostics-refresh-prefetch-disabled"
+                    | "diagnostics-refresh-prefetch-fail"
+                    | "diagnostics-refresh-prefetch-stale"
+                    | "diagnostics-refresh-prefetch-unchanged"
                     | "diagnostics-refresh-burst"
                     | "diagnostics-push-pullcap" => json!({
                         "diagnosticProvider": {
@@ -336,10 +340,20 @@ fn main() {
                         || matches!(
                             mode.as_str(),
                             "diagnostics-refresh-prefetch"
+                                | "diagnostics-refresh-prefetch-ack-order"
                                 | "diagnostics-refresh-prefetch-disabled"
+                                | "diagnostics-refresh-prefetch-unchanged"
                         )
                     {
                         request(&mut writer, json!(1000), "workspace/diagnostic/refresh");
+                        if mode == "diagnostics-refresh-prefetch-ack-order" {
+                            match read_message(&mut reader) {
+                                Some(reply) if reply.get("id") == Some(&json!(1000)) => {}
+                                other => panic!(
+                                    "refresh prefetch started before its downstream ACK: {other:?}"
+                                ),
+                            }
+                        }
                     } else if mode == "diagnostics-refresh-burst" {
                         diagnostic_generation = 1;
                         request(&mut writer, json!(1000), "workspace/diagnostic/refresh");
@@ -826,7 +840,9 @@ fn main() {
             "textDocument/diagnostic" => {
                 if matches!(
                     mode.as_str(),
-                    "diagnostics-refresh-prefetch" | "diagnostics-refresh-prefetch-disabled"
+                    "diagnostics-refresh-prefetch"
+                        | "diagnostics-refresh-prefetch-ack-order"
+                        | "diagnostics-refresh-prefetch-disabled"
                 ) {
                     diagnostic_generation += 1;
                     std::thread::sleep(std::time::Duration::from_millis(1000));
@@ -837,6 +853,110 @@ fn main() {
                     // path (vs. a server that never starts), which CLI mode
                     // must not read as "no diagnostics".
                     respond_error(&mut writer, id, -32603, "mock diagnostic request failure");
+                    continue;
+                }
+                if mode == "diagnostics-refresh-prefetch-fail" {
+                    diagnostic_generation += 1;
+                    if diagnostic_generation == 1 {
+                        respond(
+                            &mut writer,
+                            id,
+                            json!({
+                                "kind": "full",
+                                "resultId": "refresh-prefetch-before-failure",
+                                "items": [{
+                                    "range": {
+                                        "start": { "line": 0, "character": 0 },
+                                        "end": { "line": 0, "character": 1 }
+                                    },
+                                    "severity": 2,
+                                    "message": "mock-diagnostic-before-refresh-failure"
+                                }]
+                            }),
+                        );
+                        request(&mut writer, json!(1000), "workspace/diagnostic/refresh");
+                    } else if diagnostic_generation == 2 {
+                        respond_error(&mut writer, id, -32603, "mock refresh prefetch failure");
+                    } else if message
+                        .pointer("/params/previousResultId")
+                        .and_then(Value::as_str)
+                        == Some("refresh-prefetch-before-failure")
+                    {
+                        respond(
+                            &mut writer,
+                            id,
+                            json!({
+                                "kind": "unchanged",
+                                "resultId": "refresh-prefetch-before-failure"
+                            }),
+                        );
+                    } else {
+                        respond(&mut writer, id, json!({ "kind": "full", "items": [] }));
+                    }
+                    continue;
+                }
+                if mode == "diagnostics-refresh-prefetch-stale" {
+                    diagnostic_generation += 1;
+                    if diagnostic_generation == 2 {
+                        std::thread::sleep(std::time::Duration::from_millis(1000));
+                    }
+                    let marker = match diagnostic_generation {
+                        1 => "mock-diagnostic-before-stale-prefetch",
+                        2 => "mock-diagnostic-from-stale-prefetch",
+                        _ => "mock-diagnostic-after-stale-prefetch",
+                    };
+                    respond(
+                        &mut writer,
+                        id,
+                        json!({
+                            "kind": "full",
+                            "items": [{
+                                "range": {
+                                    "start": { "line": 0, "character": 0 },
+                                    "end": { "line": 0, "character": 1 }
+                                },
+                                "severity": 2,
+                                "message": marker
+                            }]
+                        }),
+                    );
+                    if diagnostic_generation == 1 {
+                        // Let the initial publish reach the editor before the
+                        // refresh cycle emits its in-flight synchronization log.
+                        std::thread::sleep(std::time::Duration::from_millis(200));
+                        request(&mut writer, json!(1000), "workspace/diagnostic/refresh");
+                    }
+                    continue;
+                }
+                if mode == "diagnostics-refresh-prefetch-unchanged" {
+                    if message
+                        .pointer("/params/previousResultId")
+                        .and_then(Value::as_str)
+                        == Some("refresh-prefetch-stable")
+                    {
+                        respond(
+                            &mut writer,
+                            id,
+                            json!({ "kind": "unchanged", "resultId": "refresh-prefetch-stable" }),
+                        );
+                    } else {
+                        respond(
+                            &mut writer,
+                            id,
+                            json!({
+                                "kind": "full",
+                                "resultId": "refresh-prefetch-stable",
+                                "items": [{
+                                    "range": {
+                                        "start": { "line": 0, "character": 0 },
+                                        "end": { "line": 0, "character": 1 }
+                                    },
+                                    "severity": 2,
+                                    "message": "mock-diagnostic-refresh-unchanged"
+                                }]
+                            }),
+                        );
+                    }
                     continue;
                 }
                 if mode == "diagnostics-malformed" {
@@ -856,7 +976,9 @@ fn main() {
                     format!("mock-diagnostic-generation:{diagnostic_generation}")
                 } else if matches!(
                     mode.as_str(),
-                    "diagnostics-refresh-prefetch" | "diagnostics-refresh-prefetch-disabled"
+                    "diagnostics-refresh-prefetch"
+                        | "diagnostics-refresh-prefetch-ack-order"
+                        | "diagnostics-refresh-prefetch-disabled"
                 ) {
                     format!("mock-diagnostic-refresh-prefetched:{diagnostic_generation}")
                 } else {

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -829,7 +829,7 @@ fn main() {
                     "diagnostics-refresh-prefetch" | "diagnostics-refresh-prefetch-disabled"
                 ) {
                     diagnostic_generation += 1;
-                    std::thread::sleep(std::time::Duration::from_millis(300));
+                    std::thread::sleep(std::time::Duration::from_millis(1000));
                 }
                 if mode == "diagnostics-fail" {
                     // Healthy handshake (advertises diagnosticProvider), broken

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -218,6 +218,7 @@ fn main() {
                     | "diagnostics-fail"
                     | "diagnostics-malformed"
                     | "diagnostics-refresh-prefetch"
+                    | "diagnostics-refresh-prefetch-mixed"
                     | "diagnostics-refresh-prefetch-ack-order"
                     | "diagnostics-refresh-prefetch-disabled"
                     | "diagnostics-refresh-prefetch-fail"
@@ -340,6 +341,7 @@ fn main() {
                         || matches!(
                             mode.as_str(),
                             "diagnostics-refresh-prefetch"
+                                | "diagnostics-refresh-prefetch-mixed"
                                 | "diagnostics-refresh-prefetch-disabled"
                                 | "diagnostics-refresh-prefetch-unchanged"
                         )
@@ -831,7 +833,9 @@ fn main() {
             "textDocument/diagnostic" => {
                 if matches!(
                     mode.as_str(),
-                    "diagnostics-refresh-prefetch" | "diagnostics-refresh-prefetch-disabled"
+                    "diagnostics-refresh-prefetch"
+                        | "diagnostics-refresh-prefetch-mixed"
+                        | "diagnostics-refresh-prefetch-disabled"
                 ) {
                     diagnostic_generation += 1;
                     std::thread::sleep(std::time::Duration::from_millis(1000));
@@ -979,7 +983,9 @@ fn main() {
                     format!("mock-diagnostic-generation:{diagnostic_generation}")
                 } else if matches!(
                     mode.as_str(),
-                    "diagnostics-refresh-prefetch" | "diagnostics-refresh-prefetch-disabled"
+                    "diagnostics-refresh-prefetch"
+                        | "diagnostics-refresh-prefetch-mixed"
+                        | "diagnostics-refresh-prefetch-disabled"
                 ) {
                     format!("mock-diagnostic-refresh-prefetched:{diagnostic_generation}")
                 } else {

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -340,20 +340,11 @@ fn main() {
                         || matches!(
                             mode.as_str(),
                             "diagnostics-refresh-prefetch"
-                                | "diagnostics-refresh-prefetch-ack-order"
                                 | "diagnostics-refresh-prefetch-disabled"
                                 | "diagnostics-refresh-prefetch-unchanged"
                         )
                     {
                         request(&mut writer, json!(1000), "workspace/diagnostic/refresh");
-                        if mode == "diagnostics-refresh-prefetch-ack-order" {
-                            match read_message(&mut reader) {
-                                Some(reply) if reply.get("id") == Some(&json!(1000)) => {}
-                                other => panic!(
-                                    "refresh prefetch started before its downstream ACK: {other:?}"
-                                ),
-                            }
-                        }
                     } else if mode == "diagnostics-refresh-burst" {
                         diagnostic_generation = 1;
                         request(&mut writer, json!(1000), "workspace/diagnostic/refresh");
@@ -840,9 +831,7 @@ fn main() {
             "textDocument/diagnostic" => {
                 if matches!(
                     mode.as_str(),
-                    "diagnostics-refresh-prefetch"
-                        | "diagnostics-refresh-prefetch-ack-order"
-                        | "diagnostics-refresh-prefetch-disabled"
+                    "diagnostics-refresh-prefetch" | "diagnostics-refresh-prefetch-disabled"
                 ) {
                     diagnostic_generation += 1;
                     std::thread::sleep(std::time::Duration::from_millis(1000));
@@ -892,6 +881,20 @@ fn main() {
                         );
                     } else {
                         respond(&mut writer, id, json!({ "kind": "full", "items": [] }));
+                    }
+                    continue;
+                }
+                if mode == "diagnostics-refresh-prefetch-ack-order" {
+                    diagnostic_generation += 1;
+                    respond(&mut writer, id, json!({ "kind": "full", "items": [] }));
+                    if diagnostic_generation == 1 {
+                        request(&mut writer, json!(1000), "workspace/diagnostic/refresh");
+                        match read_message(&mut reader) {
+                            Some(reply) if reply.get("id") == Some(&json!(1000)) => {}
+                            other => panic!(
+                                "refresh prefetch started before its downstream ACK: {other:?}"
+                            ),
+                        }
                     }
                     continue;
                 }
@@ -976,9 +979,7 @@ fn main() {
                     format!("mock-diagnostic-generation:{diagnostic_generation}")
                 } else if matches!(
                     mode.as_str(),
-                    "diagnostics-refresh-prefetch"
-                        | "diagnostics-refresh-prefetch-ack-order"
-                        | "diagnostics-refresh-prefetch-disabled"
+                    "diagnostics-refresh-prefetch" | "diagnostics-refresh-prefetch-disabled"
                 ) {
                     format!("mock-diagnostic-refresh-prefetched:{diagnostic_generation}")
                 } else {

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -230,6 +230,7 @@ fn main() {
                             "interFileDependencies": false,
                             "workspaceDiagnostics": false
                         },
+                        "hoverProvider": mode == "diagnostics-refresh-prefetch-mixed",
                         "textDocumentSync": 1
                     }),
                     "on-type" => json!({
@@ -341,7 +342,6 @@ fn main() {
                         || matches!(
                             mode.as_str(),
                             "diagnostics-refresh-prefetch"
-                                | "diagnostics-refresh-prefetch-mixed"
                                 | "diagnostics-refresh-prefetch-disabled"
                                 | "diagnostics-refresh-prefetch-unchanged"
                         )
@@ -512,6 +512,9 @@ fn main() {
                         .unwrap_or(Value::Null)
                 };
                 respond(&mut writer, id, result);
+                if mode == "diagnostics-refresh-prefetch-mixed" {
+                    request(&mut writer, json!(1000), "workspace/diagnostic/refresh");
+                }
             }
             "textDocument/codeLens" => {
                 // One UNRESOLVED lens (data only, no command) on the first

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -1023,7 +1023,7 @@ fn e2e_downstream_refresh_prefetches_only_eligible_mixed_contexts() {
         init_client_with_mode_caps("diagnostics-refresh-prefetch-mixed", refresh_capable_caps());
     open_host_with_text(&mut client, MD_MIXED_TEXT);
 
-    let (_, published) = client
+    client
         .wait_for_notification_where(
             &["textDocument/publishDiagnostics"],
             Duration::from_secs(15),
@@ -1031,13 +1031,37 @@ fn e2e_downstream_refresh_prefetches_only_eligible_mixed_contexts() {
                 params["diagnostics"].as_array().is_some_and(|diagnostics| {
                     diagnostics.iter().any(|diagnostic| {
                         diagnostic["message"].as_str().is_some_and(|message| {
-                            message.starts_with("mock-diagnostic-refresh-prefetched:")
+                            message == "mock-diagnostic-refresh-prefetched:1"
                         })
                     })
                 })
             },
         )
-        .expect("the eligible lua context must contribute a prefetched diagnostic");
+        .expect("precondition: consume the initial didOpen diagnostic publish");
+
+    // The mixed mock requests refresh only after this hover round-trip.
+    // Its subsequent refresh prefetch is therefore generation 2 and cannot be
+    // confused with the generation-1 didOpen publish above.
+    client.send_request(
+        "textDocument/hover",
+        json!({
+            "textDocument": { "uri": MD_URI },
+            "position": { "line": 3, "character": 0 }
+        }),
+    );
+    let (_, published) = client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(15),
+            |params| {
+                params["diagnostics"].as_array().is_some_and(|diagnostics| {
+                    diagnostics.iter().any(|diagnostic| {
+                        diagnostic["message"] == json!("mock-diagnostic-refresh-prefetched:2")
+                    })
+                })
+            },
+        )
+        .expect("the refresh-specific prefetch must publish generation 2");
     let diagnostics = published["diagnostics"].as_array().unwrap();
     assert!(
         diagnostics

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -977,7 +977,7 @@ fn e2e_downstream_refresh_skips_pull_fallback_disabled_contexts() {
     open_host(&mut client);
 
     let (refresh_id, _) = client
-        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(250))
+        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(600))
         .expect("pullFallback=false must not delay the editor refresh with a downstream pull");
     client.send_response(refresh_id, json!(null));
     assert!(

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -995,6 +995,173 @@ fn e2e_downstream_refresh_skips_pull_fallback_disabled_contexts() {
 }
 
 #[test]
+fn e2e_downstream_refresh_forwards_after_prefetch_failure() {
+    let (mut client, _config_dir) =
+        init_client_with_mode_caps("diagnostics-refresh-prefetch-fail", refresh_capable_caps());
+    open_host(&mut client);
+
+    client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(5),
+            |params| {
+                params["diagnostics"].as_array().is_some_and(|diagnostics| {
+                    diagnostics.iter().any(|diagnostic| {
+                        diagnostic["message"] == json!("mock-diagnostic-before-refresh-failure")
+                    })
+                })
+            },
+        )
+        .expect("precondition: a successful pull layer is published before refresh");
+
+    let (refresh_id, _) = client
+        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(5))
+        .expect("a failed prefetch must not strand the downstream refresh cycle");
+    client.send_response(refresh_id, json!(null));
+
+    let pulled = client.send_request(
+        "textDocument/diagnostic",
+        json!({ "textDocument": { "uri": MD_URI } }),
+    );
+    assert!(
+        pulled["result"]["items"]
+            .as_array()
+            .is_some_and(|diagnostics| diagnostics.iter().any(|diagnostic| {
+                diagnostic["message"] == json!("mock-diagnostic-before-refresh-failure")
+            })),
+        "a failed refresh prefetch must preserve the previous pull layer: {pulled}"
+    );
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn e2e_downstream_refresh_preserves_unchanged_prefetch_results() {
+    let (mut client, _config_dir) = init_client_with_mode_caps(
+        "diagnostics-refresh-prefetch-unchanged",
+        refresh_capable_caps(),
+    );
+    open_host(&mut client);
+
+    let (refresh_id, _) = client
+        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(5))
+        .expect("the unchanged prefetch must complete before forwarding");
+    client.send_response(refresh_id, json!(null));
+
+    let pulled = client.send_request(
+        "textDocument/diagnostic",
+        json!({ "textDocument": { "uri": MD_URI } }),
+    );
+    assert!(
+        pulled["result"]["items"]
+            .as_array()
+            .is_some_and(|diagnostics| {
+                diagnostics.iter().any(|diagnostic| {
+                    diagnostic["message"] == json!("mock-diagnostic-refresh-unchanged")
+                })
+            }),
+        "an unchanged downstream report must retain its prior diagnostics: {pulled}"
+    );
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn e2e_downstream_refresh_ack_precedes_prefetch_request() {
+    let (mut client, _config_dir) = init_client_with_mode_caps(
+        "diagnostics-refresh-prefetch-ack-order",
+        refresh_capable_caps(),
+    );
+    open_host(&mut client);
+
+    let (refresh_id, _) = client
+        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(5))
+        .expect("prefetch must proceed after the downstream ACK");
+    client.send_response(refresh_id, json!(null));
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn e2e_downstream_refresh_discards_prefetch_after_document_change() {
+    let (mut client, _config_dir) =
+        init_client_with_mode_caps("diagnostics-refresh-prefetch-stale", refresh_capable_caps());
+    open_host(&mut client);
+
+    client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(5),
+            |params| {
+                params["diagnostics"].as_array().is_some_and(|diagnostics| {
+                    diagnostics.iter().any(|diagnostic| {
+                        diagnostic["message"] == json!("mock-diagnostic-before-stale-prefetch")
+                    })
+                })
+            },
+        )
+        .expect("precondition: the initial pull layer is published");
+    // The mock waits 200 ms before requesting refresh, then holds the second
+    // diagnostic pull for 1 s. This lands the edit inside that in-flight pull.
+    std::thread::sleep(Duration::from_millis(400));
+
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": MD_URI, "version": 2 },
+            "contentChanges": [{ "text": format!("{MD_TEXT}\n") }]
+        }),
+    );
+
+    let (refresh_id, _, publishes) = client
+        .wait_for_server_request_watching(
+            "workspace/diagnostic/refresh",
+            Duration::from_secs(5),
+            &["textDocument/publishDiagnostics"],
+        )
+        .expect("the refresh must still be forwarded after discarding stale prefetch data");
+    assert!(
+        publishes.iter().all(|(_, params)| {
+            params["diagnostics"].as_array().is_none_or(|diagnostics| {
+                diagnostics.iter().all(|diagnostic| {
+                    diagnostic["message"] != json!("mock-diagnostic-from-stale-prefetch")
+                })
+            })
+        }),
+        "an in-flight prefetch from the old document version must never publish: {publishes:?}"
+    );
+    client.send_response(refresh_id, json!(null));
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn e2e_shutdown_cancels_a_live_refresh_prefetch() {
+    let (mut client, _config_dir) =
+        init_client_with_mode_caps("diagnostics-refresh-prefetch", refresh_capable_caps());
+    open_host(&mut client);
+    assert!(
+        client
+            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(100),)
+            .is_none(),
+        "precondition: the delayed prefetch is still running"
+    );
+
+    client.send_request("shutdown", json!(null));
+    assert!(
+        client
+            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(400),)
+            .is_none(),
+        "shutdown must cancel the live prefetch without forwarding a refresh"
+    );
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
 fn e2e_downstream_refresh_burst_is_coalesced() {
     let (mut client, _config_dir) =
         init_client_with_mode_caps("diagnostics-refresh-burst", refresh_capable_caps());

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -61,7 +61,10 @@ fn init_client_with_mode_caps(mode: &str, capabilities: Value) -> (LspClient, te
         .arg("--config-file")
         .arg(config_path.to_str().expect("utf8 path"))
         .build();
-    let initialization_options = if mode == "diagnostics-refresh-burst" {
+    let initialization_options = if matches!(
+        mode,
+        "diagnostics-refresh-burst" | "diagnostics-refresh-prefetch-disabled"
+    ) {
         json!({
             "languageServers": {
                 "mock-push": { "cmd": [mock_bin(), mode], "languages": ["lua"] }
@@ -890,6 +893,101 @@ fn e2e_downstream_refresh_forwarded_to_refresh_capable_client() {
             .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(15))
             .is_some(),
         "a downstream's workspace/diagnostic/refresh must reach a refresh-capable editor (#521)"
+    );
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn e2e_downstream_refresh_prefetches_before_forwarding() {
+    let (mut client, _config_dir) =
+        init_client_with_mode_caps("diagnostics-refresh-prefetch", refresh_capable_caps());
+    open_host(&mut client);
+
+    assert!(
+        client
+            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(100),)
+            .is_none(),
+        "the editor refresh must wait for the delayed pullFallback prefetch"
+    );
+
+    let (_, published) = client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(15),
+            |params| {
+                params["diagnostics"].as_array().is_some_and(|diagnostics| {
+                    diagnostics.iter().any(|diagnostic| {
+                        diagnostic["message"].as_str().is_some_and(|message| {
+                            message.starts_with("mock-diagnostic-refresh-prefetched:")
+                        })
+                    })
+                })
+            },
+        )
+        .expect("the refresh cycle must publish its completed pullFallback prefetch");
+    assert_eq!(published["uri"], json!(MD_URI));
+
+    let (refresh_id, _) = client
+        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(2))
+        .expect("the editor refresh must follow the completed prefetch");
+    client.send_response(refresh_id, json!(null));
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn e2e_downstream_refresh_prefetch_is_client_capability_independent() {
+    let (mut client, _config_dir) =
+        init_client_with_mode_caps("diagnostics-refresh-prefetch", json!({}));
+    open_host(&mut client);
+
+    client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(15),
+            |params| {
+                params["diagnostics"].as_array().is_some_and(|diagnostics| {
+                    diagnostics.iter().any(|diagnostic| {
+                        diagnostic["message"] == json!("mock-diagnostic-refresh-prefetched:2")
+                    })
+                })
+            },
+        )
+        .expect("refresh prefetch must run even when the editor lacks refreshSupport");
+    assert!(
+        client
+            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(400),)
+            .is_none(),
+        "an editor without refreshSupport must not receive a refresh request"
+    );
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn e2e_downstream_refresh_skips_pull_fallback_disabled_contexts() {
+    let (mut client, _config_dir) = init_client_with_mode_caps(
+        "diagnostics-refresh-prefetch-disabled",
+        refresh_capable_caps(),
+    );
+    open_host(&mut client);
+
+    let (refresh_id, _) = client
+        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(250))
+        .expect("pullFallback=false must not delay the editor refresh with a downstream pull");
+    client.send_response(refresh_id, json!(null));
+    assert!(
+        client
+            .wait_for_notification(
+                "textDocument/publishDiagnostics",
+                Duration::from_millis(400),
+            )
+            .is_none(),
+        "pullFallback=false must not publish a prefetched diagnostic set"
     );
 
     client.send_request("shutdown", json!(null));

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -42,6 +42,7 @@ const MD_TEXT: &str = "# Test\n\n```lua\nlocal x = 1\n```\n";
 /// so a `didChange` carrying it is NOT skipped by the content-fingerprint guard
 /// (#422) and reaches the downstream mock.
 const MD_TEXT_EDITED: &str = "# Test\n\n```lua\nlocal x = 2\n```\n";
+const MD_MIXED_TEXT: &str = "# Test\n\n```lua\nlocal x = 1\n```\n\n```python\nprint('x')\n```\n";
 const HOST_LINE: i64 = 3;
 
 fn init_client() -> (LspClient, tempfile::TempDir) {
@@ -61,7 +62,25 @@ fn init_client_with_mode_caps(mode: &str, capabilities: Value) -> (LspClient, te
         .arg("--config-file")
         .arg(config_path.to_str().expect("utf8 path"))
         .build();
-    let initialization_options = if matches!(
+    let initialization_options = if mode == "diagnostics-refresh-prefetch-mixed" {
+        json!({
+            "languageServers": {
+                "mock-push": { "cmd": [mock_bin(), mode], "languages": ["lua", "python"] }
+            },
+            "languages": {
+                "markdown": {
+                    "bridge": {
+                        "lua": {},
+                        "python": {
+                            "aggregation": {
+                                "textDocument/publishDiagnostics": { "pullFallback": false }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    } else if matches!(
         mode,
         "diagnostics-refresh-burst" | "diagnostics-refresh-prefetch-disabled"
     ) {
@@ -866,6 +885,10 @@ fn e2e_publish_seal_delivers_via_refresh_and_pull_only() {
 /// Send a `didOpen` for the markdown host (with its lua region) so the bridge
 /// spawns the downstream mock for that region and forwards the region's events.
 fn open_host(client: &mut LspClient) {
+    open_host_with_text(client, MD_TEXT);
+}
+
+fn open_host_with_text(client: &mut LspClient, text: &str) {
     client.send_notification(
         "textDocument/didOpen",
         json!({
@@ -873,7 +896,7 @@ fn open_host(client: &mut LspClient) {
                 "uri": MD_URI,
                 "languageId": "markdown",
                 "version": 1,
-                "text": MD_TEXT
+                "text": text
             }
         }),
     );
@@ -990,6 +1013,49 @@ fn e2e_downstream_refresh_skips_pull_fallback_disabled_contexts() {
         "pullFallback=false must not publish a prefetched diagnostic set"
     );
 
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn e2e_downstream_refresh_prefetches_only_eligible_mixed_contexts() {
+    let (mut client, _config_dir) =
+        init_client_with_mode_caps("diagnostics-refresh-prefetch-mixed", refresh_capable_caps());
+    open_host_with_text(&mut client, MD_MIXED_TEXT);
+
+    let (_, published) = client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(15),
+            |params| {
+                params["diagnostics"].as_array().is_some_and(|diagnostics| {
+                    diagnostics.iter().any(|diagnostic| {
+                        diagnostic["message"].as_str().is_some_and(|message| {
+                            message.starts_with("mock-diagnostic-refresh-prefetched:")
+                        })
+                    })
+                })
+            },
+        )
+        .expect("the eligible lua context must contribute a prefetched diagnostic");
+    let diagnostics = published["diagnostics"].as_array().unwrap();
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic["range"]["start"]["line"] == json!(3)),
+        "the pullFallback=true lua context must be prefetched: {diagnostics:?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic["range"]["start"]["line"] != json!(7)),
+        "the pullFallback=false python context must not be prefetched: {diagnostics:?}"
+    );
+
+    let (refresh_id, _) = client
+        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(5))
+        .expect("the mixed-context prefetch must complete before editor refresh");
+    client.send_response(refresh_id, json!(null));
     client.send_request("shutdown", json!(null));
     client.send_notification("exit", json!(null));
 }


### PR DESCRIPTION
## Summary

- reuse the host-event diagnostic snapshot builder for downstream refresh prefetches
- prefetch every open document's effective `pullFallback` virt and `_self` contexts
- update the shared pull layer before forwarding `workspace/diagnostic/refresh`
- keep prefetch cycles serialized across leading, trailing, max-wait, and shutdown paths
- run prefetch even when the editor lacks refresh support; gate only the editor request
- acknowledge downstream refresh requests before queuing prefetch work
- discard results from superseded document revisions and keep the last good pull layer on failure
- verify ordering, client-capability independence, `pullFallback = false`, unchanged reports, failure recovery, document-change races, and shutdown cancellation

Closes #850

Stacked on #798 because it extends that PR's workspace refresh scheduler.

## Validation

- `cargo test --lib -q forwarded_refresh_`
- `cargo test --lib -q refresh_single_flight_`
- `cargo test --features e2e --test e2e_push_diagnostics -q e2e_downstream_refresh_`
- `cargo test --features e2e --test e2e_push_diagnostics -q e2e_shutdown_cancels_a_live_refresh_prefetch`
- `cargo clippy --lib -- -D warnings`
- `cargo clippy --test e2e_push_diagnostics --features e2e -- -D warnings`
- `cargo fmt --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved workspace diagnostic refresh handling with proactive prefetching for open documents.
  * Diagnostic results now remain consistent when documents change during refresh operations.
  * Refresh requests are coalesced to reduce redundant updates while preserving timely editor notifications.
  * Improved handling of refresh failures, stale results, unchanged results, and shutdown cancellation.

* **Bug Fixes**
  * Corrected diagnostic refresh acknowledgment and forwarding order.
  * Clients without editor refresh support can still receive refreshed diagnostic data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->