### PR TITLE
feat(config): configure workspace diagnostic refresh debounce

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -112,6 +112,21 @@ This section is a practical reference. For the exhaustive field list and types, 
 
 ### Configuration Options
 
+Workspace-wide client-facing policies live under top-level `features`, keyed by
+the LSP method they govern. Diagnostic refresh bursts use one scheduler shared by
+all downstream servers in the workspace:
+
+```toml
+[features."workspace/diagnostic/refresh"]
+debounceMs = 100
+maxWaitMs = 1000
+```
+
+The first refresh after idle is immediate. Later activity is released after
+`debounceMs` of quiet, with `maxWaitMs` bounding a continuous burst. The values
+apply to cycles admitted after a live configuration update; an active cycle keeps
+the timing snapshot it started with. `maxWaitMs` must be at least `debounceMs`.
+
 ```json
 {
   "searchPaths": ["$HOME/.local/share/kakehashi", "/another/path"],

--- a/docs/architecture-decisions/downstream-diagnostic-refresh-handling.md
+++ b/docs/architecture-decisions/downstream-diagnostic-refresh-handling.md
@@ -103,11 +103,23 @@ downstream server. The first downstream refresh after idle starts a leading
 cycle immediately. Each cycle first completes the workspace-wide Path A prefetch
 and only then forwards the editor refresh, so a client pull cannot race ahead of
 kakehashi's proactive cache. Further downstream refreshes join one trailing
-debounce cycle: 100 ms of quiet releases the latest activity, while an anchored
-1 s maximum wait prevents a continuously chatty server from postponing it
-forever. Prefetch cycles never overlap; if the maximum wait expires during a
-prefetch, the dirty trailing cycle starts immediately after the current prefetch
-finishes. If another editor refresh is sent after the latest downstream activity,
+debounce cycle. Its workspace-wide timing policy is configured independently of
+languages and downstream servers:
+
+```toml
+[features."workspace/diagnostic/refresh"]
+debounceMs = 100
+maxWaitMs = 1000
+```
+
+The shown values are programmed defaults. `debounceMs` of quiet releases the
+latest activity, while the anchored `maxWaitMs` prevents a continuously chatty
+server from postponing it forever. `maxWaitMs` must be at least `debounceMs`;
+invalid updates are rejected as a whole. A cycle snapshots both values when its
+leading edge is admitted, so live updates affect the next cycle without moving
+an in-flight deadline. Prefetch cycles never overlap; if the maximum wait expires
+during a prefetch, the dirty trailing cycle starts immediately after the current
+prefetch finishes. If another editor refresh is sent after the latest downstream activity,
 that send already provides the required re-pull nudge and the trailing forward is
 suppressed. This keeps independent downstream servers on the same workspace-wide
 cadence without coupling separate kakehashi workspace connections.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -679,13 +679,6 @@ fn run_config_init(output: Option<PathBuf>, force: bool) -> Result<(), ExitCode>
         eprintln!("Failed to serialize configuration: {}", e);
         ExitCode::FAILURE
     })?;
-    // The serializer leaves `/` unquoted in this table path even though TOML
-    // bare keys cannot contain it. Quote the LSP method key so the generated
-    // template is standards-compliant and matches the documented form.
-    let config_toml = config_toml.replace(
-        "[features.workspace/diagnostic/refresh]",
-        "[features.\"workspace/diagnostic/refresh\"]",
-    );
 
     // Prepend documentation link
     let content = format!("{}\n{}", DOC_LINK, config_toml);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -679,9 +679,9 @@ fn run_config_init(output: Option<PathBuf>, force: bool) -> Result<(), ExitCode>
         eprintln!("Failed to serialize configuration: {}", e);
         ExitCode::FAILURE
     })?;
-    // TOML 1.1 permits `/` in bare keys, but quote LSP method names in the
-    // generated template so their method-keyed nature is immediately visible
-    // and matches the documented configuration form.
+    // The serializer leaves `/` unquoted in this table path even though TOML
+    // bare keys cannot contain it. Quote the LSP method key so the generated
+    // template is standards-compliant and matches the documented form.
     let config_toml = config_toml.replace(
         "[features.workspace/diagnostic/refresh]",
         "[features.\"workspace/diagnostic/refresh\"]",

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -679,6 +679,13 @@ fn run_config_init(output: Option<PathBuf>, force: bool) -> Result<(), ExitCode>
         eprintln!("Failed to serialize configuration: {}", e);
         ExitCode::FAILURE
     })?;
+    // TOML 1.1 permits `/` in bare keys, but quote LSP method names in the
+    // generated template so their method-keyed nature is immediately visible
+    // and matches the documented configuration form.
+    let config_toml = config_toml.replace(
+        "[features.workspace/diagnostic/refresh]",
+        "[features.\"workspace/diagnostic/refresh\"]",
+    );
 
     // Prepend documentation link
     let content = format!("{}\n{}", DOC_LINK, config_toml);

--- a/src/config.rs
+++ b/src/config.rs
@@ -260,11 +260,15 @@ impl WorkspaceSettings {
         let mut errors = Vec::new();
 
         let refresh = ws.features.workspace_diagnostic_refresh;
-        if refresh.max_wait_ms < refresh.debounce_ms {
+        if refresh.max_wait_ms == 0
+            || refresh.debounce_ms > settings::MAX_FEATURE_TIMING_MS
+            || refresh.max_wait_ms > settings::MAX_FEATURE_TIMING_MS
+            || refresh.max_wait_ms < refresh.debounce_ms
+        {
             errors.push(expand::ExpandError::InvalidSetting {
                 message: format!(
-                    "features.\"workspace/diagnostic/refresh\".maxWaitMs ({}) must be greater than or equal to debounceMs ({})",
-                    refresh.max_wait_ms, refresh.debounce_ms
+                    "features.\"workspace/diagnostic/refresh\" requires 0 <= debounceMs <= maxWaitMs <= {} and maxWaitMs > 0 (got debounceMs={}, maxWaitMs={})",
+                    settings::MAX_FEATURE_TIMING_MS, refresh.debounce_ms, refresh.max_wait_ms
                 ),
             });
         }
@@ -727,7 +731,35 @@ mod tests {
         )
         .unwrap();
         let error = WorkspaceSettings::try_from_settings(&raw, None, |_| None).unwrap_err();
-        assert!(error.to_string().contains("maxWaitMs (100)"));
+        assert!(error.to_string().contains("debounceMs=101, maxWaitMs=100"));
+    }
+
+    #[test]
+    fn workspace_diagnostic_refresh_rejects_zero_and_unbounded_max_wait() {
+        for max_wait_ms in [0, settings::MAX_FEATURE_TIMING_MS + 1] {
+            let raw = RawWorkspaceSettings {
+                features: Some(settings::FeatureSettings {
+                    workspace_diagnostic_refresh: Some(settings::DebounceFeatureSettings {
+                        debounce_ms: Some(0),
+                        max_wait_ms: Some(max_wait_ms),
+                    }),
+                }),
+                ..Default::default()
+            };
+            assert!(WorkspaceSettings::try_from_settings(&raw, None, |_| None).is_err());
+        }
+    }
+
+    #[test]
+    fn feature_policy_rejects_unknown_methods_and_fields() {
+        for invalid in [
+            r#"[features."workspace/diagnostic/refresh"]
+               debouncMs = 100"#,
+            r#"[features."workspace/diagnostics/refresh"]
+               debounceMs = 100"#,
+        ] {
+            assert!(toml::from_str::<RawWorkspaceSettings>(invalid).is_err());
+        }
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,6 +71,10 @@ fn base_convert(settings: &RawWorkspaceSettings) -> WorkspaceSettings {
         diagnostics_debounce_ms: settings
             .diagnostics_debounce_ms
             .unwrap_or(DEFAULT_DEBOUNCE_MS),
+        features: settings.features.as_ref().map_or_else(
+            settings::ResolvedFeatureSettings::default,
+            settings::FeatureSettings::resolve,
+        ),
         language_servers: settings.language_servers.clone().unwrap_or_default(),
     }
 }
@@ -255,6 +259,16 @@ impl WorkspaceSettings {
         let mut ws = base_convert(settings);
         let mut errors = Vec::new();
 
+        let refresh = ws.features.workspace_diagnostic_refresh;
+        if refresh.max_wait_ms < refresh.debounce_ms {
+            errors.push(expand::ExpandError::InvalidSetting {
+                message: format!(
+                    "features.\"workspace/diagnostic/refresh\".maxWaitMs ({}) must be greater than or equal to debounceMs ({})",
+                    refresh.max_wait_ms, refresh.debounce_ms
+                ),
+            });
+        }
+
         // Resolve base configs first so expansion only sees effective parser/query paths.
         ws.languages = merge::resolve_base_configs(&ws.languages);
 
@@ -367,6 +381,12 @@ impl From<&WorkspaceSettings> for RawWorkspaceSettings {
             capture_mappings,
             auto_install: Some(settings.auto_install),
             diagnostics_debounce_ms: Some(settings.diagnostics_debounce_ms),
+            features: Some(settings::FeatureSettings {
+                workspace_diagnostic_refresh: Some(settings::DebounceFeatureSettings {
+                    debounce_ms: Some(settings.features.workspace_diagnostic_refresh.debounce_ms),
+                    max_wait_ms: Some(settings.features.workspace_diagnostic_refresh.max_wait_ms),
+                }),
+            }),
             language_servers: Some(settings.language_servers.clone()),
         }
     }
@@ -564,6 +584,7 @@ mod tests {
             capture_mappings: HashMap::new(),
             auto_install: None,
             diagnostics_debounce_ms: None,
+            features: None,
             language_servers: None,
         };
 
@@ -593,6 +614,7 @@ mod tests {
             capture_mappings: HashMap::new(),
             auto_install: None,
             diagnostics_debounce_ms: None,
+            features: None,
             language_servers: None,
         };
 
@@ -615,6 +637,7 @@ mod tests {
             capture_mappings: HashMap::new(),
             auto_install: None,
             diagnostics_debounce_ms: None,
+            features: None,
             language_servers: None,
         };
 
@@ -641,6 +664,7 @@ mod tests {
             capture_mappings: HashMap::new(),
             auto_install,
             diagnostics_debounce_ms: None,
+            features: None,
             language_servers: None,
         };
 
@@ -660,11 +684,50 @@ mod tests {
             capture_mappings: HashMap::new(),
             auto_install: None,
             diagnostics_debounce_ms: raw,
+            features: None,
             language_servers: None,
         };
 
         let workspace: WorkspaceSettings = base_convert(&settings);
         assert_eq!(workspace.diagnostics_debounce_ms, expected);
+    }
+
+    #[test]
+    fn workspace_diagnostic_refresh_feature_resolves_defaults_and_custom_values() {
+        let defaults = base_convert(&RawWorkspaceSettings::default());
+        assert_eq!(
+            defaults.features.workspace_diagnostic_refresh,
+            settings::ResolvedDebounceFeatureSettings::default()
+        );
+
+        let raw: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [features."workspace/diagnostic/refresh"]
+            debounceMs = 25
+            maxWaitMs = 250
+            "#,
+        )
+        .unwrap();
+        let custom = WorkspaceSettings::try_from_settings(&raw, None, |_| None).unwrap();
+        assert_eq!(custom.features.workspace_diagnostic_refresh.debounce_ms, 25);
+        assert_eq!(
+            custom.features.workspace_diagnostic_refresh.max_wait_ms,
+            250
+        );
+    }
+
+    #[test]
+    fn workspace_diagnostic_refresh_rejects_invalid_timing() {
+        let raw: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [features."workspace/diagnostic/refresh"]
+            debounceMs = 101
+            maxWaitMs = 100
+            "#,
+        )
+        .unwrap();
+        let error = WorkspaceSettings::try_from_settings(&raw, None, |_| None).unwrap_err();
+        assert!(error.to_string().contains("maxWaitMs (100)"));
     }
 
     #[test]
@@ -948,6 +1011,7 @@ mod try_from_settings_tests {
             capture_mappings: HashMap::new(),
             auto_install: None,
             diagnostics_debounce_ms: None,
+            features: None,
             language_servers: None,
         };
         let env = make_env(&[("TEST_VAR", "/home/user")]);
@@ -971,6 +1035,7 @@ mod try_from_settings_tests {
             capture_mappings: HashMap::new(),
             auto_install: None,
             diagnostics_debounce_ms: None,
+            features: None,
             language_servers: None,
         };
         let env = make_env(&[("TEST_VAR", "/opt/parsers")]);
@@ -1000,6 +1065,7 @@ mod try_from_settings_tests {
             capture_mappings: HashMap::new(),
             auto_install: None,
             diagnostics_debounce_ms: None,
+            features: None,
             language_servers: None,
         };
         let env = make_env(&[("TEST_VAR", "/queries")]);
@@ -1035,6 +1101,7 @@ mod try_from_settings_tests {
             capture_mappings: HashMap::new(),
             auto_install: None,
             diagnostics_debounce_ms: None,
+            features: None,
             language_servers: None,
         };
 
@@ -1056,6 +1123,7 @@ mod try_from_settings_tests {
             capture_mappings: HashMap::new(),
             auto_install: None,
             diagnostics_debounce_ms: None,
+            features: None,
             language_servers: None,
         };
         let env = make_env(&[]);
@@ -1085,6 +1153,7 @@ mod try_from_settings_tests {
             capture_mappings: HashMap::new(),
             auto_install: None,
             diagnostics_debounce_ms: None,
+            features: None,
             language_servers: None,
         };
         let env = make_env(&[]);
@@ -1104,6 +1173,7 @@ mod try_from_settings_tests {
             capture_mappings: HashMap::new(),
             auto_install: None,
             diagnostics_debounce_ms: None,
+            features: None,
             language_servers: None,
         };
         let env = make_env(&[]);

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -526,9 +526,18 @@ mod tests {
     #[test]
     fn default_settings_emit_workspace_refresh_feature_policy() {
         let toml = toml::to_string_pretty(&default_settings()).unwrap();
-        assert!(toml.contains("[features.workspace/diagnostic/refresh]"));
+        let parsed: RawWorkspaceSettings =
+            toml::from_str(&toml).expect("serialized defaults must be valid TOML");
+        assert!(toml.contains("[features.\"workspace/diagnostic/refresh\"]"));
         assert!(toml.contains("debounceMs = 100"));
         assert!(toml.contains("maxWaitMs = 1000"));
+        assert_eq!(
+            parsed
+                .features
+                .and_then(|features| features.workspace_diagnostic_refresh)
+                .and_then(|refresh| refresh.max_wait_ms),
+            Some(1000)
+        );
     }
 
     #[test]

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -6,8 +6,11 @@
 use super::WILDCARD_KEY;
 use super::settings::{
     AggregationConfig, AggregationStrategy, BridgeLanguageConfig, BridgeServerConfig,
-    CaptureMapping, CaptureMappings, DEFAULT_DEBOUNCE_MS, LanguageSettings, LayerAggregationConfig,
-    LayerSource, LayersConfig, QueryTypeMappings, RawWorkspaceSettings, RootMarker,
+    CaptureMapping, CaptureMappings, DEFAULT_DEBOUNCE_MS,
+    DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_DEBOUNCE_MS,
+    DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_MAX_WAIT_MS, DebounceFeatureSettings, FeatureSettings,
+    LanguageSettings, LayerAggregationConfig, LayerSource, LayersConfig, QueryTypeMappings,
+    RawWorkspaceSettings, RootMarker,
 };
 use std::collections::HashMap;
 
@@ -21,6 +24,12 @@ pub fn default_settings() -> RawWorkspaceSettings {
         capture_mappings: default_capture_mappings(),
         auto_install: Some(true),
         diagnostics_debounce_ms: Some(DEFAULT_DEBOUNCE_MS),
+        features: Some(FeatureSettings {
+            workspace_diagnostic_refresh: Some(DebounceFeatureSettings {
+                debounce_ms: Some(DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_DEBOUNCE_MS),
+                max_wait_ms: Some(DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_MAX_WAIT_MS),
+            }),
+        }),
         language_servers: Some(default_language_servers()),
     }
 }
@@ -512,6 +521,14 @@ mod tests {
             Some(DEFAULT_DEBOUNCE_MS),
             "template diagnosticsDebounceMs must mirror the runtime default"
         );
+    }
+
+    #[test]
+    fn default_settings_emit_workspace_refresh_feature_policy() {
+        let toml = toml::to_string_pretty(&default_settings()).unwrap();
+        assert!(toml.contains("[features.workspace/diagnostic/refresh]"));
+        assert!(toml.contains("debounceMs = 100"));
+        assert!(toml.contains("maxWaitMs = 1000"));
     }
 
     #[test]

--- a/src/config/expand.rs
+++ b/src/config/expand.rs
@@ -45,6 +45,8 @@ pub(crate) enum ExpandError {
     UndefinedVar { var_name: String, input: String },
     /// The path uses `~` but no home directory is available.
     NoHomeDir { input: String },
+    /// A setting violates a cross-field invariant.
+    InvalidSetting { message: String },
 }
 
 impl fmt::Display for ExpandError {
@@ -62,6 +64,7 @@ impl fmt::Display for ExpandError {
                     "path uses ~ but home directory is not available (in \"{input}\")"
                 )
             }
+            ExpandError::InvalidSetting { message } => write!(f, "{message}"),
         }
     }
 }

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -1,6 +1,6 @@
 use super::settings::{
-    AggregationConfig, BridgeLanguageConfig, BridgeServerConfig, LanguageSettings,
-    LayerAggregationConfig, LayersConfig,
+    AggregationConfig, BridgeLanguageConfig, BridgeServerConfig, DebounceFeatureSettings,
+    FeatureSettings, LanguageSettings, LayerAggregationConfig, LayersConfig,
 };
 use super::{CaptureMappings, RawWorkspaceSettings, WILDCARD_KEY};
 use std::collections::{HashMap, HashSet};
@@ -405,6 +405,7 @@ pub(crate) fn merge_workspace_settings(
                 diagnostics_debounce_ms: overlay
                     .diagnostics_debounce_ms
                     .or(base.diagnostics_debounce_ms),
+                features: merge_features(base.features, overlay.features),
                 language_servers: merge_language_servers(
                     base.language_servers,
                     overlay.language_servers,
@@ -413,6 +414,27 @@ pub(crate) fn merge_workspace_settings(
             Some(merged)
         }
         (base, overlay) => base.or(overlay),
+    }
+}
+
+fn merge_features(
+    base: Option<FeatureSettings>,
+    overlay: Option<FeatureSettings>,
+) -> Option<FeatureSettings> {
+    match (base, overlay) {
+        (Some(base), Some(overlay)) => Some(FeatureSettings {
+            workspace_diagnostic_refresh: match (
+                base.workspace_diagnostic_refresh,
+                overlay.workspace_diagnostic_refresh,
+            ) {
+                (Some(base), Some(overlay)) => Some(DebounceFeatureSettings {
+                    debounce_ms: overlay.debounce_ms.or(base.debounce_ms),
+                    max_wait_ms: overlay.max_wait_ms.or(base.max_wait_ms),
+                }),
+                (base, overlay) => overlay.or(base),
+            },
+        }),
+        (base, overlay) => overlay.or(base),
     }
 }
 
@@ -468,6 +490,33 @@ fn merge_capture_mappings(mut base: CaptureMappings, overlay: CaptureMappings) -
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn feature_timing_merge_preserves_unspecified_fields() {
+        let base: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [features."workspace/diagnostic/refresh"]
+            debounceMs = 40
+            maxWaitMs = 400
+            "#,
+        )
+        .unwrap();
+        let overlay: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [features."workspace/diagnostic/refresh"]
+            debounceMs = 80
+            "#,
+        )
+        .unwrap();
+        let merged = merge_workspace_settings(Some(base), Some(overlay)).unwrap();
+        let refresh = merged
+            .features
+            .unwrap()
+            .workspace_diagnostic_refresh
+            .unwrap();
+        assert_eq!(refresh.debounce_ms, Some(80));
+        assert_eq!(refresh.max_wait_ms, Some(400));
+    }
     use crate::config::QueryTypeMappings;
     use crate::config::settings;
     use std::collections::HashMap;
@@ -519,6 +568,7 @@ mod tests {
             search_paths: Some(vec!["/base/path".to_string()]),
             auto_install: Some(true),
             diagnostics_debounce_ms: None,
+            features: None,
             languages: HashMap::from([
                 (
                     "python".to_string(),
@@ -607,6 +657,7 @@ mod tests {
             search_paths: Some(vec!["/overlay/path".to_string()]),
             auto_install: Some(false),
             diagnostics_debounce_ms: None,
+            features: None,
             languages: HashMap::from([
                 (
                     // shared key: python — overlay overrides queries, inherits parser/bridge/aliases

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -633,9 +633,63 @@ pub struct RawWorkspaceSettings {
     /// pull it triggers. Higher values cut refresh/pull volume during rapid typing
     /// at the cost of latency. Defaults to [`DEFAULT_DEBOUNCE_MS`] when unset.
     pub diagnostics_debounce_ms: Option<u64>,
+    /// Workspace-wide, client-facing feature policies keyed by LSP method.
+    pub features: Option<FeatureSettings>,
     /// Language servers for bridging LSP requests to injection regions.
     /// Map of server name to server configuration.
     pub language_servers: Option<HashMap<String, BridgeServerConfig>>,
+}
+
+pub const DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_DEBOUNCE_MS: u64 = 100;
+pub const DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_MAX_WAIT_MS: u64 = 1000;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DebounceFeatureSettings {
+    pub debounce_ms: Option<u64>,
+    pub max_wait_ms: Option<u64>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+pub struct FeatureSettings {
+    #[serde(rename = "workspace/diagnostic/refresh")]
+    pub workspace_diagnostic_refresh: Option<DebounceFeatureSettings>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ResolvedDebounceFeatureSettings {
+    pub debounce_ms: u64,
+    pub max_wait_ms: u64,
+}
+
+impl Default for ResolvedDebounceFeatureSettings {
+    fn default() -> Self {
+        Self {
+            debounce_ms: DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_DEBOUNCE_MS,
+            max_wait_ms: DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_MAX_WAIT_MS,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ResolvedFeatureSettings {
+    pub workspace_diagnostic_refresh: ResolvedDebounceFeatureSettings,
+}
+
+impl FeatureSettings {
+    pub(crate) fn resolve(&self) -> ResolvedFeatureSettings {
+        let refresh = self.workspace_diagnostic_refresh.as_ref();
+        ResolvedFeatureSettings {
+            workspace_diagnostic_refresh: ResolvedDebounceFeatureSettings {
+                debounce_ms: refresh
+                    .and_then(|settings| settings.debounce_ms)
+                    .unwrap_or(DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_DEBOUNCE_MS),
+                max_wait_ms: refresh
+                    .and_then(|settings| settings.max_wait_ms)
+                    .unwrap_or(DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_MAX_WAIT_MS),
+            },
+        }
+    }
 }
 
 /// Generate JSON Schema for the workspace configuration.
@@ -774,6 +828,7 @@ pub struct WorkspaceSettings {
     pub capture_mappings: CaptureMappings,
     pub auto_install: bool,
     pub diagnostics_debounce_ms: u64,
+    pub features: ResolvedFeatureSettings,
     pub language_servers: HashMap<String, BridgeServerConfig>,
 }
 
@@ -785,6 +840,7 @@ impl Default for WorkspaceSettings {
             capture_mappings: CaptureMappings::default(),
             auto_install: true, // Default to true for zero-config experience
             diagnostics_debounce_ms: DEFAULT_DEBOUNCE_MS,
+            features: ResolvedFeatureSettings::default(),
             language_servers: HashMap::new(),
         }
     }
@@ -1158,6 +1214,7 @@ mod tests {
             capture_mappings: HashMap::new(),
             auto_install: None,
             diagnostics_debounce_ms: None,
+            features: None,
             language_servers: None,
         };
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -655,11 +655,27 @@ pub struct DebounceFeatureSettings {
     pub max_wait_ms: Option<u64>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct FeatureSettings {
     #[serde(rename = "workspace/diagnostic/refresh")]
     pub workspace_diagnostic_refresh: Option<DebounceFeatureSettings>,
+}
+
+impl Serialize for FeatureSettings {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+
+        let mut map = serializer.serialize_map(Some(1))?;
+        map.serialize_entry(
+            "workspace/diagnostic/refresh",
+            &self.workspace_diagnostic_refresh,
+        )?;
+        map.end()
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -642,15 +642,21 @@ pub struct RawWorkspaceSettings {
 
 pub const DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_DEBOUNCE_MS: u64 = 100;
 pub const DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_MAX_WAIT_MS: u64 = 1000;
+/// Largest accepted debounce/max-wait duration (24 hours). This keeps timer
+/// arithmetic within a practical, platform-independent Instant range.
+pub const MAX_FEATURE_TIMING_MS: u64 = 86_400_000;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DebounceFeatureSettings {
+    #[schemars(range(max = 86_400_000))]
     pub debounce_ms: Option<u64>,
+    #[schemars(range(min = 1, max = 86_400_000))]
     pub max_wait_ms: Option<u64>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct FeatureSettings {
     #[serde(rename = "workspace/diagnostic/refresh")]
     pub workspace_diagnostic_refresh: Option<DebounceFeatureSettings>,

--- a/src/config/snapshots/kakehashi__config__merge__tests__merge_workspace_settings_all_fields.snap
+++ b/src/config/snapshots/kakehashi__config__merge__tests__merge_workspace_settings_all_fields.snap
@@ -71,6 +71,7 @@ expression: result
   },
   "autoInstall": false,
   "diagnosticsDebounceMs": null,
+  "features": null,
   "languageServers": {
     "lua-language-server": {
       "cmd": [

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1605,6 +1605,7 @@ mod tests {
             capture_mappings: Default::default(),
             auto_install: false,
             diagnostics_debounce_ms: crate::config::settings::DEFAULT_DEBOUNCE_MS,
+            features: Default::default(),
             language_servers: HashMap::new(),
         }
     }

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -168,12 +168,24 @@ impl DiagnosticPublisher {
         std::time::Duration,
     )> {
         let snapshot = self.aggregator.begin_forwarded_refresh_debounce()?;
-        // This ArcSwap load is the admission linearization point. The preceding
-        // claim is internal bookkeeping only: no task starts and no timing is
-        // consumed before this snapshot, so an earlier settings store affects
-        // this cycle and a later one affects the next cycle.
+        Some(self.snapshot_forwarded_refresh_cycle(snapshot))
+    }
+
+    fn snapshot_forwarded_refresh_cycle(
+        &self,
+        snapshot: crate::lsp::diagnostic_cache::ForwardedRefreshWaitSnapshot,
+    ) -> (
+        crate::lsp::diagnostic_cache::ForwardedRefreshWaitSnapshot,
+        std::time::Duration,
+        std::time::Duration,
+    ) {
+        // This ArcSwap load is the cycle-admission linearization point. The
+        // initial scheduler claim is internal bookkeeping, and continued-stream
+        // callers arrive only after the previous cycle completes. No timing for
+        // this cycle is consumed before the snapshot, so an earlier settings
+        // store affects this cycle and a later one affects the next cycle.
         let (settle_window, max_wait) = self.forwarded_refresh_timing();
-        Some((snapshot, settle_window, max_wait))
+        (snapshot, settle_window, max_wait)
     }
 
     /// Forward the first downstream `workspace/diagnostic/refresh` immediately,
@@ -197,6 +209,8 @@ impl DiagnosticPublisher {
         let publisher = self.clone();
         tokio::spawn(async move {
             let mut snapshot = snapshot;
+            let mut settle_window = settle_window;
+            let mut max_wait = max_wait;
             let mut deadline = snapshot.last_activity_at + max_wait;
             if !publisher
                 .complete_forwarded_refresh_cycle(snapshot.generation)
@@ -236,7 +250,8 @@ impl DiagnosticPublisher {
                                         .aggregator
                                         .finish_forwarded_refresh_admission(admitted.generation)
                                     {
-                                        snapshot = latest;
+                                        (snapshot, settle_window, max_wait) = publisher
+                                            .snapshot_forwarded_refresh_cycle(latest);
                                         deadline = tokio::time::Instant::now() + max_wait;
                                         continue;
                                     }
@@ -258,7 +273,8 @@ impl DiagnosticPublisher {
                                     publisher.aggregator.cancel_forwarded_refresh_debounce();
                                     break;
                                 }
-                                snapshot = latest;
+                                (snapshot, settle_window, max_wait) = publisher
+                                    .snapshot_forwarded_refresh_cycle(latest);
                                 deadline = tokio::time::Instant::now() + max_wait;
                             }
                             crate::lsp::diagnostic_cache::ForwardedRefreshWait::Restart(_) => {
@@ -1429,7 +1445,7 @@ mod tests {
         server.settings_manager.apply_settings(settings);
         let publisher = DiagnosticPublisher::new(server);
 
-        let (_, admitted_settle, admitted_max_wait) = publisher
+        let (snapshot, admitted_settle, admitted_max_wait) = publisher
             .admit_forwarded_refresh()
             .expect("idle scheduler admits the old timing snapshot");
 
@@ -1445,18 +1461,16 @@ mod tests {
             ),
             "an update after admission must not change the active cycle"
         );
-        server.diagnostics.cancel_forwarded_refresh_debounce();
-        let (_, next_settle, next_max_wait) = publisher
-            .admit_forwarded_refresh()
-            .expect("the next idle cycle reads the live settings");
+        let (_, next_settle, next_max_wait) = publisher.snapshot_forwarded_refresh_cycle(snapshot);
         assert_eq!(
             (next_settle, next_max_wait),
             (
                 std::time::Duration::from_millis(20),
                 std::time::Duration::from_millis(40)
             ),
-            "the next cycle must use the live update"
+            "the next continuous-stream cycle must use the live update"
         );
+        server.diagnostics.cancel_forwarded_refresh_debounce();
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -167,13 +167,13 @@ impl DiagnosticPublisher {
         std::time::Duration,
         std::time::Duration,
     )> {
-        // Read timing before the idle→active state transition. Once begin()
-        // admits this cycle, its timing is already an owned snapshot; a live
-        // settings swap can only affect a later admission.
+        let snapshot = self.aggregator.begin_forwarded_refresh_debounce()?;
+        // This ArcSwap load is the admission linearization point. The preceding
+        // claim is internal bookkeeping only: no task starts and no timing is
+        // consumed before this snapshot, so an earlier settings store affects
+        // this cycle and a later one affects the next cycle.
         let (settle_window, max_wait) = self.forwarded_refresh_timing();
-        self.aggregator
-            .begin_forwarded_refresh_debounce()
-            .map(|snapshot| (snapshot, settle_window, max_wait))
+        Some((snapshot, settle_window, max_wait))
     }
 
     /// Forward the first downstream `workspace/diagnostic/refresh` immediately,
@@ -192,9 +192,8 @@ impl DiagnosticPublisher {
         let Some((snapshot, settle_window, max_wait)) = self.admit_forwarded_refresh() else {
             return;
         };
-        // Snapshot timing once per admitted cycle. Live configuration updates
-        // affect the next idle→active admission without moving this cycle's
-        // already-established quiet/max-wait boundaries.
+        // Timing was snapshotted at admission; later live updates cannot move
+        // this cycle's already-established quiet/max-wait boundaries.
         let publisher = self.clone();
         tokio::spawn(async move {
             let mut snapshot = snapshot;

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -92,24 +92,19 @@ impl RepublishOutcome {
 /// chose existing config surfaces over new ones — revisit if a real setup
 /// needs a different cadence.
 const WIRE_PUBLISH_QUIET_WINDOW: std::time::Duration = std::time::Duration::from_secs(1);
-/// Short enough that a downstream re-analysis still prompts a timely editor
-/// pull, but longer than the 1 ms-scale refresh bursts observed in #789.
+#[cfg(test)]
 const FORWARDED_REFRESH_SETTLE_WINDOW: std::time::Duration = std::time::Duration::from_millis(100);
-/// Bound staleness when a server emits refreshes continuously. This matches the
-/// existing diagnostics publish cadence and still reduces a sustained stream
-/// from an unbounded rate to at most one refresh per second.
+#[cfg(test)]
 const FORWARDED_REFRESH_MAX_WAIT: std::time::Duration = std::time::Duration::from_secs(1);
 
 async fn wait_for_forwarded_refresh_settle(
     aggregator: &DiagnosticAggregator,
     mut snapshot: crate::lsp::diagnostic_cache::ForwardedRefreshWaitSnapshot,
     deadline: tokio::time::Instant,
+    settle_window: std::time::Duration,
 ) -> crate::lsp::diagnostic_cache::ForwardedRefreshWait {
     loop {
-        tokio::time::sleep_until(
-            (snapshot.last_activity_at + FORWARDED_REFRESH_SETTLE_WINDOW).min(deadline),
-        )
-        .await;
+        tokio::time::sleep_until((snapshot.last_activity_at + settle_window).min(deadline)).await;
         let force = tokio::time::Instant::now() >= deadline;
         match aggregator.finish_forwarded_refresh_wait(snapshot.generation, force) {
             crate::lsp::diagnostic_cache::ForwardedRefreshWait::Restart(latest) => {
@@ -153,6 +148,18 @@ impl DiagnosticPublisher {
         }
     }
 
+    fn forwarded_refresh_timing(&self) -> (std::time::Duration, std::time::Duration) {
+        let timing = self
+            .settings_manager
+            .load_settings()
+            .features
+            .workspace_diagnostic_refresh;
+        (
+            std::time::Duration::from_millis(timing.debounce_ms),
+            std::time::Duration::from_millis(timing.max_wait_ms),
+        )
+    }
+
     /// Forward the first downstream `workspace/diagnostic/refresh` immediately,
     /// then coalesce later burst activity into at most one trailing refresh
     /// after quiet or the max-wait deadline (#789).
@@ -169,10 +176,14 @@ impl DiagnosticPublisher {
         let Some(snapshot) = self.aggregator.begin_forwarded_refresh_debounce() else {
             return;
         };
+        // Snapshot timing once per admitted cycle. Live configuration updates
+        // affect the next idle→active admission without moving this cycle's
+        // already-established quiet/max-wait boundaries.
+        let (settle_window, max_wait) = self.forwarded_refresh_timing();
         let publisher = self.clone();
         tokio::spawn(async move {
             let mut snapshot = snapshot;
-            let mut deadline = snapshot.last_activity_at + FORWARDED_REFRESH_MAX_WAIT;
+            let mut deadline = snapshot.last_activity_at + max_wait;
             if !publisher
                 .complete_forwarded_refresh_cycle(snapshot.generation)
                 .await
@@ -191,6 +202,7 @@ impl DiagnosticPublisher {
                         &publisher.aggregator,
                         snapshot,
                         deadline,
+                        settle_window,
                     ) => {
                         // Cancellation can race immediately after `select!` chose the
                         // timer branch, so re-check at the refresh admission boundary.
@@ -211,8 +223,7 @@ impl DiagnosticPublisher {
                                         .finish_forwarded_refresh_admission(admitted.generation)
                                     {
                                         snapshot = latest;
-                                        deadline = tokio::time::Instant::now()
-                                            + FORWARDED_REFRESH_MAX_WAIT;
+                                        deadline = tokio::time::Instant::now() + max_wait;
                                         continue;
                                     }
                                 } else {
@@ -234,8 +245,7 @@ impl DiagnosticPublisher {
                                     break;
                                 }
                                 snapshot = latest;
-                                deadline = tokio::time::Instant::now()
-                                    + FORWARDED_REFRESH_MAX_WAIT;
+                                deadline = tokio::time::Instant::now() + max_wait;
                             }
                             crate::lsp::diagnostic_cache::ForwardedRefreshWait::Restart(_) => {
                                 unreachable!("the settle waiter consumes restart decisions")
@@ -1385,6 +1395,48 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn forwarded_refresh_timing_reads_live_settings_for_next_cycle() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .settings_manager
+            .set_capabilities(ClientCapabilities {
+                workspace: Some(WorkspaceClientCapabilities {
+                    diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
+                        refresh_support: Some(true),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        let mut settings = (*server.settings_manager.load_settings()).clone();
+        settings.features.workspace_diagnostic_refresh.debounce_ms = 250;
+        settings.features.workspace_diagnostic_refresh.max_wait_ms = 800;
+        server.settings_manager.apply_settings(settings);
+        let publisher = DiagnosticPublisher::new(server);
+
+        assert_eq!(
+            publisher.forwarded_refresh_timing(),
+            (
+                std::time::Duration::from_millis(250),
+                std::time::Duration::from_millis(800)
+            )
+        );
+
+        let mut settings = (*server.settings_manager.load_settings()).clone();
+        settings.features.workspace_diagnostic_refresh.debounce_ms = 20;
+        settings.features.workspace_diagnostic_refresh.max_wait_ms = 40;
+        server.settings_manager.apply_settings(settings);
+        assert_eq!(
+            publisher.forwarded_refresh_timing(),
+            (
+                std::time::Duration::from_millis(20),
+                std::time::Duration::from_millis(40)
+            )
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn shutdown_cancels_pending_forwarded_refresh() {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
@@ -1867,7 +1919,13 @@ mod tests {
         let deadline = snapshot.last_activity_at + FORWARDED_REFRESH_MAX_WAIT;
         let waiter_aggregator = Arc::clone(&aggregator);
         let waiter = tokio::spawn(async move {
-            super::wait_for_forwarded_refresh_settle(&waiter_aggregator, snapshot, deadline).await
+            super::wait_for_forwarded_refresh_settle(
+                &waiter_aggregator,
+                snapshot,
+                deadline,
+                FORWARDED_REFRESH_SETTLE_WINDOW,
+            )
+            .await
         });
         tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 
@@ -1893,6 +1951,35 @@ mod tests {
             aggregator.begin_forwarded_refresh_debounce().is_none(),
             "a max-wait fire must keep the cycle active until activity becomes quiet"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn forwarded_refresh_waiter_uses_custom_quiet_window() {
+        let aggregator = Arc::new(DiagnosticAggregator::new());
+        let snapshot = aggregator
+            .begin_forwarded_refresh_debounce()
+            .expect("first refresh claims the debounce task");
+        aggregator.mark_forwarded_refresh_covered(snapshot.generation);
+        assert!(aggregator.begin_forwarded_refresh_debounce().is_none());
+        let deadline = snapshot.last_activity_at + std::time::Duration::from_millis(800);
+        let waiter_aggregator = Arc::clone(&aggregator);
+        let waiter = tokio::spawn(async move {
+            super::wait_for_forwarded_refresh_settle(
+                &waiter_aggregator,
+                snapshot,
+                deadline,
+                std::time::Duration::from_millis(250),
+            )
+            .await
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        tokio::time::advance(std::time::Duration::from_millis(248)).await;
+        assert!(!waiter.is_finished());
+        tokio::time::advance(std::time::Duration::from_millis(1)).await;
+        assert!(matches!(
+            waiter.await.unwrap(),
+            crate::lsp::diagnostic_cache::ForwardedRefreshWait::SendTrailing(_)
+        ));
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -160,6 +160,22 @@ impl DiagnosticPublisher {
         )
     }
 
+    fn admit_forwarded_refresh(
+        &self,
+    ) -> Option<(
+        crate::lsp::diagnostic_cache::ForwardedRefreshWaitSnapshot,
+        std::time::Duration,
+        std::time::Duration,
+    )> {
+        // Read timing before the idle→active state transition. Once begin()
+        // admits this cycle, its timing is already an owned snapshot; a live
+        // settings swap can only affect a later admission.
+        let (settle_window, max_wait) = self.forwarded_refresh_timing();
+        self.aggregator
+            .begin_forwarded_refresh_debounce()
+            .map(|snapshot| (snapshot, settle_window, max_wait))
+    }
+
     /// Forward the first downstream `workspace/diagnostic/refresh` immediately,
     /// then coalesce later burst activity into at most one trailing refresh
     /// after quiet or the max-wait deadline (#789).
@@ -173,13 +189,12 @@ impl DiagnosticPublisher {
         if self.diagnostic_refresh_supported() {
             self.aggregator.record_refresh_requested();
         }
-        let Some(snapshot) = self.aggregator.begin_forwarded_refresh_debounce() else {
+        let Some((snapshot, settle_window, max_wait)) = self.admit_forwarded_refresh() else {
             return;
         };
         // Snapshot timing once per admitted cycle. Live configuration updates
         // affect the next idle→active admission without moving this cycle's
         // already-established quiet/max-wait boundaries.
-        let (settle_window, max_wait) = self.forwarded_refresh_timing();
         let publisher = self.clone();
         tokio::spawn(async move {
             let mut snapshot = snapshot;
@@ -1415,24 +1430,33 @@ mod tests {
         server.settings_manager.apply_settings(settings);
         let publisher = DiagnosticPublisher::new(server);
 
-        assert_eq!(
-            publisher.forwarded_refresh_timing(),
-            (
-                std::time::Duration::from_millis(250),
-                std::time::Duration::from_millis(800)
-            )
-        );
+        let (_, admitted_settle, admitted_max_wait) = publisher
+            .admit_forwarded_refresh()
+            .expect("idle scheduler admits the old timing snapshot");
 
         let mut settings = (*server.settings_manager.load_settings()).clone();
         settings.features.workspace_diagnostic_refresh.debounce_ms = 20;
         settings.features.workspace_diagnostic_refresh.max_wait_ms = 40;
         server.settings_manager.apply_settings(settings);
         assert_eq!(
-            publisher.forwarded_refresh_timing(),
+            (admitted_settle, admitted_max_wait),
+            (
+                std::time::Duration::from_millis(250),
+                std::time::Duration::from_millis(800)
+            ),
+            "an update after admission must not change the active cycle"
+        );
+        server.diagnostics.cancel_forwarded_refresh_debounce();
+        let (_, next_settle, next_max_wait) = publisher
+            .admit_forwarded_refresh()
+            .expect("the next idle cycle reads the live settings");
+        assert_eq!(
+            (next_settle, next_max_wait),
             (
                 std::time::Duration::from_millis(20),
                 std::time::Duration::from_millis(40)
-            )
+            ),
+            "the next cycle must use the live update"
         );
     }
 

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -416,7 +416,7 @@ impl Kakehashi {
                 let event = crate::lsp::SettingsEvent::error(format!(
                     "Invalid configuration: {errs}. \
                      This configuration has been discarded; previous settings remain in effect. \
-                     Please correct the affected paths and environment variables or remove them from your config.",
+                     Please correct the invalid settings or remove them from your config.",
                 ));
                 self.notifier().log_settings_events(&[event]).await;
             }

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -65,7 +65,7 @@ fn settings_payload(settings: Value) -> (Value, Vec<String>) {
 
         let mut unknown_keys = object
             .into_iter()
-            .filter_map(|(key, value)| is_kakehashi_section_sibling(&key, &value).then_some(key))
+            .filter_map(|(key, value)| is_kakehashi_workspace_entry(&key, &value).then_some(key))
             .collect::<Vec<_>>();
         unknown_keys.extend(unknown_workspace_setting_keys(&kakehashi));
         sort_and_dedup_unknown_keys(&mut unknown_keys);
@@ -99,7 +99,7 @@ fn uses_deprecated_unwrapped_didchange_shape(settings: &Value) -> bool {
 fn kakehashi_targeted_payload(object: serde_json::Map<String, Value>) -> serde_json::Value {
     let object = object
         .into_iter()
-        .filter(|(key, _)| is_workspace_setting_key_or_typo(key))
+        .filter(|(key, value)| is_kakehashi_workspace_entry(key, value))
         .collect();
     Value::Object(object)
 }
@@ -130,7 +130,7 @@ fn is_workspace_setting_key_or_typo(key: &str) -> bool {
             .any(|known_key| is_one_edit_apart(key, known_key))
 }
 
-fn is_kakehashi_section_sibling(key: &str, value: &Value) -> bool {
+fn is_kakehashi_workspace_entry(key: &str, value: &Value) -> bool {
     if key == "features" {
         return value
             .as_object()
@@ -507,6 +507,19 @@ mod tests {
         }));
 
         assert_eq!(unknown_keys, ["features"]);
+    }
+
+    #[test]
+    fn settings_payload_ignores_unrelated_unwrapped_features() {
+        let (payload, unknown_keys) = settings_payload(serde_json::json!({
+            "autoInstall": true,
+            "features": {
+                "someOtherClientFeature": true
+            }
+        }));
+
+        assert_eq!(payload, serde_json::json!({ "autoInstall": true }));
+        assert!(unknown_keys.is_empty());
     }
 
     #[test]

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -65,8 +65,7 @@ fn settings_payload(settings: Value) -> (Value, Vec<String>) {
 
         let mut unknown_keys = object
             .into_iter()
-            .map(|(key, _)| key)
-            .filter(|key| is_workspace_setting_key_or_typo(key))
+            .filter_map(|(key, value)| is_kakehashi_section_sibling(&key, &value).then_some(key))
             .collect::<Vec<_>>();
         unknown_keys.extend(unknown_workspace_setting_keys(&kakehashi));
         sort_and_dedup_unknown_keys(&mut unknown_keys);
@@ -129,6 +128,15 @@ fn is_workspace_setting_key_or_typo(key: &str) -> bool {
         || KNOWN_WORKSPACE_SETTING_KEYS
             .iter()
             .any(|known_key| is_one_edit_apart(key, known_key))
+}
+
+fn is_kakehashi_section_sibling(key: &str, value: &Value) -> bool {
+    if key == "features" {
+        return value
+            .as_object()
+            .is_some_and(|features| features.contains_key("workspace/diagnostic/refresh"));
+    }
+    is_workspace_setting_key_or_typo(key)
 }
 
 fn is_one_edit_apart(candidate: &str, known: &str) -> bool {
@@ -468,6 +476,37 @@ mod tests {
         assert!(!is_workspace_setting_key_or_typo("editor"));
         assert!(!is_workspace_setting_key_or_typo("files"));
         assert!(!is_workspace_setting_key_or_typo("workbench"));
+    }
+
+    #[test]
+    fn settings_payload_ignores_unrelated_features_section_sibling() {
+        let (payload, unknown_keys) = settings_payload(serde_json::json!({
+            "kakehashi": {
+                "autoInstall": true
+            },
+            "features": {
+                "someOtherClientFeature": true
+            }
+        }));
+
+        assert_eq!(payload, serde_json::json!({ "autoInstall": true }));
+        assert!(unknown_keys.is_empty());
+    }
+
+    #[test]
+    fn settings_payload_rejects_kakehashi_features_section_sibling() {
+        let (_payload, unknown_keys) = settings_payload(serde_json::json!({
+            "kakehashi": {
+                "autoInstall": true
+            },
+            "features": {
+                "workspace/diagnostic/refresh": {
+                    "debounceMs": 20
+                }
+            }
+        }));
+
+        assert_eq!(unknown_keys, ["features"]);
     }
 
     #[test]

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -13,6 +13,7 @@ const KNOWN_WORKSPACE_SETTING_KEYS: &[&str] = &[
     "captureMappings",
     "autoInstall",
     "diagnosticsDebounceMs",
+    "features",
     "languageServers",
 ];
 
@@ -413,7 +414,7 @@ impl Kakehashi {
             }
             Err(errs) => {
                 let event = crate::lsp::SettingsEvent::error(format!(
-                    "Path expansion failed: {errs}. \
+                    "Invalid configuration: {errs}. \
                      This configuration has been discarded; previous settings remain in effect. \
                      Please correct the affected paths and environment variables or remove them from your config.",
                 ));

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -129,7 +129,7 @@ pub fn load_settings(
                 Ok(ws) => Some(ws),
                 Err(errs) => {
                     events.push(SettingsEvent::error(format!(
-                        "Path expansion failed: {errs}. \
+                        "Invalid configuration: {errs}. \
                      This configuration has been discarded; previous settings remain in effect. \
                      Please correct the affected paths and environment variables or remove them from your config.",
                     )));

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -131,7 +131,7 @@ pub fn load_settings(
                     events.push(SettingsEvent::error(format!(
                         "Invalid configuration: {errs}. \
                      This configuration has been discarded; previous settings remain in effect. \
-                     Please correct the affected paths and environment variables or remove them from your config.",
+                     Please correct the invalid settings or remove them from your config.",
                     )));
                     None
                 }
@@ -553,10 +553,11 @@ mod tests {
             "Settings should be None when expansion fails"
         );
 
-        let has_error_event = outcome
-            .events
-            .iter()
-            .any(|e| e.kind == SettingsEventKind::Error && e.message.contains("expansion failed"));
+        let has_error_event = outcome.events.iter().any(|e| {
+            e.kind == SettingsEventKind::Error
+                && e.message.contains("Invalid configuration")
+                && e.message.contains("UNDEFINED_VAR")
+        });
 
         assert!(
             has_error_event,

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -267,6 +267,18 @@ fn test_config_init_includes_capture_mappings() {
     );
 }
 
+#[test]
+fn test_config_init_emits_workspace_refresh_feature_defaults() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args(["config", "init"])
+        .output()
+        .expect("run config init");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("[features.\"workspace/diagnostic/refresh\"]\n"));
+    assert!(stdout.contains("debounceMs = 100\nmaxWaitMs = 1000"));
+}
+
 /// Test that config init documents the per-root-instance default by emitting
 /// `preferSharedInstance = false` under the `languageServers._` wildcard, so
 /// the opt-in (#391) is discoverable in the generated template.


### PR DESCRIPTION
## Summary

- add top-level `features."workspace/diagnostic/refresh"` timing policy
- default `debounceMs` to 100 and `maxWaitMs` to 1000 in runtime and `config init`
- preserve partial feature overrides across layered and live configuration updates
- reject `maxWaitMs < debounceMs` transactionally
- snapshot timing when a workspace refresh cycle is admitted
- document the workspace-wide scheduler policy and live-update semantics

Closes #849

Stacked on #798 because it configures that PR's refresh scheduler.

## Validation

- `cargo test --lib -q workspace_diagnostic_refresh`
- `cargo test --lib -q feature_timing_merge`
- `cargo test --lib -q forwarded_refresh_`
- `cargo test --test test_cli -q config_init`
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --all -- --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable workspace-wide diagnostic refresh policies.
  - Supports debounce and maximum-wait timings, with sensible defaults of 100 ms and 1,000 ms.
  - Configuration changes apply to the next refresh cycle and prevent overlapping refreshes.

- **Bug Fixes**
  - Invalid timing combinations and unsupported feature settings are now rejected with clearer errors.
  - Configuration merging preserves unspecified timing values.

- **Documentation**
  - Added configuration examples and detailed scheduling behavior to the README and architecture documentation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->