### PR TITLE
feat: debounce publish diagnostics per URI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -132,7 +132,9 @@ released after `debounceMs` of quiet, with `maxWaitMs` bounding a continuous bur
 Publish diagnostics keep only the latest merged set per URI, and different URIs
 never delay one another. Pull diagnostics are unaffected. The values
 apply to cycles admitted after a live configuration update; an active cycle keeps
-the timing snapshot it started with. `maxWaitMs` must be at least `debounceMs`.
+the timing snapshot it started with. `debounceMs` may be zero; `maxWaitMs` must be
+positive and at least `debounceMs`. Both values are limited to 86,400,000 ms
+(24 hours).
 
 ```json
 {

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,17 +113,24 @@ This section is a practical reference. For the exhaustive field list and types, 
 ### Configuration Options
 
 Workspace-wide client-facing policies live under top-level `features`, keyed by
-the LSP method they govern. Diagnostic refresh bursts use one scheduler shared by
-all downstream servers in the workspace:
+the LSP method they govern. Publish scheduling is global policy with independent
+state per host URI; diagnostic refresh uses one scheduler shared by all downstream
+servers in the workspace:
 
 ```toml
+[features."textDocument/publishDiagnostics"]
+debounceMs = 100
+maxWaitMs = 1000
+
 [features."workspace/diagnostic/refresh"]
 debounceMs = 100
 maxWaitMs = 1000
 ```
 
-The first refresh after idle is immediate. Later activity is released after
-`debounceMs` of quiet, with `maxWaitMs` bounding a continuous burst. The values
+Both schedulers send the first activity after idle immediately. Later activity is
+released after `debounceMs` of quiet, with `maxWaitMs` bounding a continuous burst.
+Publish diagnostics keep only the latest merged set per URI, and different URIs
+never delay one another. Pull diagnostics are unaffected. The values
 apply to cycles admitted after a live configuration update; an active cycle keeps
 the timing snapshot it started with. `maxWaitMs` must be at least `debounceMs`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,7 +128,11 @@ maxWaitMs = 1000
 ```
 
 Both schedulers send the first activity after idle immediately. Later activity is
-released after `debounceMs` of quiet, with `maxWaitMs` bounding a continuous burst.
+released after `debounceMs` of quiet, with `maxWaitMs` bounding when a continuous
+burst must attempt a flush. If the cache changes while a publish set is being
+assembled, Kakehashi discards that stale attempt and retries at a bounded rate so
+it never sends an internally superseded set; therefore `maxWaitMs` bounds the
+attempt, not completion under uninterrupted concurrent mutation.
 Publish diagnostics keep only the latest merged set per URI, and different URIs
 never delay one another. Pull diagnostics are unaffected. The values
 apply to cycles admitted after a live configuration update; an active cycle keeps

--- a/docs/architecture-decisions/cross-layer-aggregation.md
+++ b/docs/architecture-decisions/cross-layer-aggregation.md
@@ -81,7 +81,11 @@ Phased roadmap:
    the editor-facing wire sends (the pull-first opt-out; delivery continues
    via `workspace/diagnostic/refresh` → re-pull, and `didClose`'s clearing
    publish still fails open) — prerequisites and caveats in
-   push-propagation-diagnostic-forwarding "Config wire seal".
+   push-propagation-diagnostic-forwarding "Config wire seal". Non-empty
+   publishes then pass through the independent global
+   `features."textDocument/publishDiagnostics"` scheduler; aggregation decides
+   *what* may publish, while that per-URI scheduler decides *when* it reaches
+   the wire.
 5. **Layer-level `concatenated` for `textDocument/codeAction`** — ✅
    implemented (and the DEFAULT for the method): the virt layer's actions
    (merged across every injection region the request range overlaps) and the

--- a/docs/architecture-decisions/cross-layer-aggregation.md
+++ b/docs/architecture-decisions/cross-layer-aggregation.md
@@ -81,8 +81,8 @@ Phased roadmap:
    the editor-facing wire sends (the pull-first opt-out; delivery continues
    via `workspace/diagnostic/refresh` → re-pull, and `didClose`'s clearing
    publish still fails open) — prerequisites and caveats in
-   push-propagation-diagnostic-forwarding "Config wire seal". Non-empty
-   publishes then pass through the independent global
+   push-propagation-diagnostic-forwarding "Config wire seal". With non-empty
+   priorities, publishes (including open-document clearing payloads) pass through the independent global
    `features."textDocument/publishDiagnostics"` scheduler; aggregation decides
    *what* may publish, while that per-URI scheduler decides *when* it reaches
    the wire.

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -290,8 +290,9 @@ Re-merging on every push republishes the cumulative host set: when region A
 publishes, then the host layer, then region C, each event re-runs the merge and
 records `{A}`, `{A, host}`, `{A, host, C}` — a slot is *replaced* by its
 source's latest push, never accumulated. (The wire sends are subject to the
-quiet window below, so the editor may see `{A}` and then `{A, host, C}`
-directly, the intermediate state coalesced into the trailing flush.)
+leading + trailing debounce below, so the editor may see `{A}` and then
+`{A, host, C}` directly, the intermediate state coalesced until the next
+debounce/max-wait deadline.)
 
 ### Versioning and staleness (the crux)
 
@@ -586,9 +587,9 @@ because the #380 benefit now outweighs it:
 - Re-publish is unthrottled at the merge level (the `didChange` debounce is
   gone): a no-op push is suppressed (winner content unchanged), and a chatty
   linter emitting distinct results across separate loop wakes re-merges and
-  re-records each time — but the WIRE sends are coalesced by the per-host quiet
-  window (see "Wire quiet window"), so the editor sees at most one publish per
-  window. To bound the
+  re-records each time — but the WIRE sends are coalesced by the per-host
+  debounce/max-wait scheduler (see "Wire leading + trailing debounce"), so the
+  editor sees the latest set at the next admitted deadline. To bound the
   cost of a push-happy/misbehaving downstream, the forwarding loop first coalesces a
   drained burst of `publishDiagnostics` by `(connection, uri)` to the latest
   (`coalesce_upstream_batch`, #426), then records each surviving push in a

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -98,19 +98,23 @@ source. Push-driven servers feed this path natively; pull-driven servers feed it
 via the `pullFallback` toggle and, opportunistically, via any push they emit (see
 Per-server source and fallback).
 
-**Wire quiet window.** The wire sends are additionally coalesced per host: a
-changed merge inside a 1 s quiet window after the last send is withheld
-(wire-dirty) and one trailing republish at the window's end re-merges the
-*latest* cache, so a burst of feeds (spontaneous pushes, the pull-layer
-completion, the post-parse geometry re-merge — measured ~2.2 × ~1 MB
-publishes/s during sustained typing) collapses into at most one full-set
-publish per second per host. The first publish after quiet passes through
-immediately, so a change arriving after >= 1 s of wire quiet gains no latency
-(a second isolated change inside the window still waits for it). Only the wire
-waits: change detection, the coverage bump, and the refresh nudge fire at
-the same points as before, and `didClose`'s clearing publish bypasses the
-window (a deferred clear would be dropped by the trailing task's
-closed-document guard).
+**Wire leading + trailing debounce.** Wire sends are coalesced per host URI
+under a workspace-wide method policy:
+
+```toml
+[features."textDocument/publishDiagnostics"]
+debounceMs = 100
+maxWaitMs = 1000
+```
+
+The first changed merge after idle passes immediately. Later changes update the
+cached latest set and one trailing republish re-merges it after `debounceMs` of
+quiet; continuous activity is forced no later than `maxWaitMs` after the previous
+send. State is per URI, so a noisy document cannot delay another. Only the wire
+waits: change detection, the coverage bump, and the refresh nudge fire at the same
+points as before. `didClose` forgets pending state and sends its clearing publish
+outside the debounce; shutdown cancels pending tasks. Pull diagnostics are outside
+this scheduler.
 
 **Config wire seal.** The cross-layer gate for
 `textDocument/publishDiagnostics` doubles as a seal on the editor-facing wire

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -109,8 +109,11 @@ maxWaitMs = 1000
 
 The first changed merge after idle passes immediately. Later changes update the
 cached latest set and one trailing republish re-merges it after `debounceMs` of
-quiet; continuous activity is forced no later than `maxWaitMs` after the previous
-send. State is per URI, so a noisy document cannot delay another. Only the wire
+quiet; continuous activity starts a flush attempt no later than `maxWaitMs` after
+the cycle begins. If the cache changes during that merge, the stale attempt is
+discarded and retried at a bounded rate rather than sending an already-superseded
+set, so max-wait bounds the attempt rather than completion under uninterrupted
+concurrent mutation. State is per URI, so a noisy document cannot delay another. Only the wire
 waits: change detection, the coverage bump, and the refresh nudge fire at the same
 points as before. `didClose` forgets pending state and sends its clearing publish
 outside the debounce; shutdown cancels pending tasks. Pull diagnostics are outside

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -679,7 +679,6 @@ fn run_config_init(output: Option<PathBuf>, force: bool) -> Result<(), ExitCode>
         eprintln!("Failed to serialize configuration: {}", e);
         ExitCode::FAILURE
     })?;
-
     // Prepend documentation link
     let content = format!("{}\n{}", DOC_LINK, config_toml);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -259,6 +259,20 @@ impl WorkspaceSettings {
         let mut ws = base_convert(settings);
         let mut errors = Vec::new();
 
+        let publish = ws.features.text_document_publish_diagnostics;
+        if publish.max_wait_ms == 0
+            || publish.debounce_ms > settings::MAX_FEATURE_TIMING_MS
+            || publish.max_wait_ms > settings::MAX_FEATURE_TIMING_MS
+            || publish.max_wait_ms < publish.debounce_ms
+        {
+            errors.push(expand::ExpandError::InvalidSetting {
+                message: format!(
+                    "features.\"textDocument/publishDiagnostics\" requires 0 <= debounceMs <= maxWaitMs <= {} and maxWaitMs > 0 (got debounceMs={}, maxWaitMs={})",
+                    settings::MAX_FEATURE_TIMING_MS, publish.debounce_ms, publish.max_wait_ms
+                ),
+            });
+        }
+
         let refresh = ws.features.workspace_diagnostic_refresh;
         if refresh.max_wait_ms == 0
             || refresh.debounce_ms > settings::MAX_FEATURE_TIMING_MS
@@ -386,6 +400,20 @@ impl From<&WorkspaceSettings> for RawWorkspaceSettings {
             auto_install: Some(settings.auto_install),
             diagnostics_debounce_ms: Some(settings.diagnostics_debounce_ms),
             features: Some(settings::FeatureSettings {
+                text_document_publish_diagnostics: Some(settings::DebounceFeatureSettings {
+                    debounce_ms: Some(
+                        settings
+                            .features
+                            .text_document_publish_diagnostics
+                            .debounce_ms,
+                    ),
+                    max_wait_ms: Some(
+                        settings
+                            .features
+                            .text_document_publish_diagnostics
+                            .max_wait_ms,
+                    ),
+                }),
                 workspace_diagnostic_refresh: Some(settings::DebounceFeatureSettings {
                     debounce_ms: Some(settings.features.workspace_diagnostic_refresh.debounce_ms),
                     max_wait_ms: Some(settings.features.workspace_diagnostic_refresh.max_wait_ms),
@@ -721,6 +749,61 @@ mod tests {
     }
 
     #[test]
+    fn publish_diagnostics_feature_resolves_defaults_and_custom_values() {
+        let defaults = base_convert(&RawWorkspaceSettings::default());
+        assert_eq!(
+            defaults
+                .features
+                .text_document_publish_diagnostics
+                .debounce_ms,
+            settings::DEFAULT_PUBLISH_DIAGNOSTICS_DEBOUNCE_MS
+        );
+        assert_eq!(
+            defaults
+                .features
+                .text_document_publish_diagnostics
+                .max_wait_ms,
+            settings::DEFAULT_PUBLISH_DIAGNOSTICS_MAX_WAIT_MS
+        );
+        let raw: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [features."textDocument/publishDiagnostics"]
+            debounceMs = 30
+            maxWaitMs = 300
+            "#,
+        )
+        .unwrap();
+        let custom = WorkspaceSettings::try_from_settings(&raw, None, |_| None).unwrap();
+        assert_eq!(
+            custom
+                .features
+                .text_document_publish_diagnostics
+                .debounce_ms,
+            30
+        );
+        assert_eq!(
+            custom
+                .features
+                .text_document_publish_diagnostics
+                .max_wait_ms,
+            300
+        );
+    }
+
+    #[test]
+    fn publish_diagnostics_rejects_invalid_timing() {
+        let raw: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [features."textDocument/publishDiagnostics"]
+            debounceMs = 101
+            maxWaitMs = 100
+            "#,
+        )
+        .unwrap();
+        assert!(WorkspaceSettings::try_from_settings(&raw, None, |_| None).is_err());
+    }
+
+    #[test]
     fn workspace_diagnostic_refresh_rejects_invalid_timing() {
         let raw: RawWorkspaceSettings = toml::from_str(
             r#"
@@ -739,6 +822,7 @@ mod tests {
         for max_wait_ms in [0, settings::MAX_FEATURE_TIMING_MS + 1] {
             let raw = RawWorkspaceSettings {
                 features: Some(settings::FeatureSettings {
+                    text_document_publish_diagnostics: None,
                     workspace_diagnostic_refresh: Some(settings::DebounceFeatureSettings {
                         debounce_ms: Some(0),
                         max_wait_ms: Some(max_wait_ms),

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -6,8 +6,8 @@
 use super::WILDCARD_KEY;
 use super::settings::{
     AggregationConfig, AggregationStrategy, BridgeLanguageConfig, BridgeServerConfig,
-    CaptureMapping, CaptureMappings, DEFAULT_DEBOUNCE_MS,
-    DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_DEBOUNCE_MS,
+    CaptureMapping, CaptureMappings, DEFAULT_DEBOUNCE_MS, DEFAULT_PUBLISH_DIAGNOSTICS_DEBOUNCE_MS,
+    DEFAULT_PUBLISH_DIAGNOSTICS_MAX_WAIT_MS, DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_DEBOUNCE_MS,
     DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_MAX_WAIT_MS, DebounceFeatureSettings, FeatureSettings,
     LanguageSettings, LayerAggregationConfig, LayerSource, LayersConfig, QueryTypeMappings,
     RawWorkspaceSettings, RootMarker,
@@ -25,6 +25,10 @@ pub fn default_settings() -> RawWorkspaceSettings {
         auto_install: Some(true),
         diagnostics_debounce_ms: Some(DEFAULT_DEBOUNCE_MS),
         features: Some(FeatureSettings {
+            text_document_publish_diagnostics: Some(DebounceFeatureSettings {
+                debounce_ms: Some(DEFAULT_PUBLISH_DIAGNOSTICS_DEBOUNCE_MS),
+                max_wait_ms: Some(DEFAULT_PUBLISH_DIAGNOSTICS_MAX_WAIT_MS),
+            }),
             workspace_diagnostic_refresh: Some(DebounceFeatureSettings {
                 debounce_ms: Some(DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_DEBOUNCE_MS),
                 max_wait_ms: Some(DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_MAX_WAIT_MS),
@@ -536,6 +540,23 @@ mod tests {
                 .features
                 .and_then(|features| features.workspace_diagnostic_refresh)
                 .and_then(|refresh| refresh.max_wait_ms),
+            Some(1000)
+        );
+    }
+
+    #[test]
+    fn default_settings_emit_publish_diagnostics_feature_policy() {
+        let toml = toml::to_string_pretty(&default_settings()).unwrap();
+        let parsed: RawWorkspaceSettings =
+            toml::from_str(&toml).expect("serialized defaults must be valid TOML");
+        assert!(toml.contains("[features.\"textDocument/publishDiagnostics\"]"));
+        assert!(toml.contains("debounceMs = 100"));
+        assert!(toml.contains("maxWaitMs = 1000"));
+        assert_eq!(
+            parsed
+                .features
+                .and_then(|features| features.text_document_publish_diagnostics)
+                .and_then(|publish| publish.max_wait_ms),
             Some(1000)
         );
     }

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -423,6 +423,16 @@ fn merge_features(
 ) -> Option<FeatureSettings> {
     match (base, overlay) {
         (Some(base), Some(overlay)) => Some(FeatureSettings {
+            text_document_publish_diagnostics: match (
+                base.text_document_publish_diagnostics,
+                overlay.text_document_publish_diagnostics,
+            ) {
+                (Some(base), Some(overlay)) => Some(DebounceFeatureSettings {
+                    debounce_ms: overlay.debounce_ms.or(base.debounce_ms),
+                    max_wait_ms: overlay.max_wait_ms.or(base.max_wait_ms),
+                }),
+                (base, overlay) => overlay.or(base),
+            },
             workspace_diagnostic_refresh: match (
                 base.workspace_diagnostic_refresh,
                 overlay.workspace_diagnostic_refresh,
@@ -516,6 +526,33 @@ mod tests {
             .unwrap();
         assert_eq!(refresh.debounce_ms, Some(80));
         assert_eq!(refresh.max_wait_ms, Some(400));
+    }
+
+    #[test]
+    fn publish_feature_merge_preserves_unspecified_max_wait() {
+        let base: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [features."textDocument/publishDiagnostics"]
+            debounceMs = 40
+            maxWaitMs = 400
+            "#,
+        )
+        .unwrap();
+        let overlay: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [features."textDocument/publishDiagnostics"]
+            debounceMs = 80
+            "#,
+        )
+        .unwrap();
+        let merged = merge_workspace_settings(Some(base), Some(overlay)).unwrap();
+        let publish = merged
+            .features
+            .unwrap()
+            .text_document_publish_diagnostics
+            .unwrap();
+        assert_eq!(publish.debounce_ms, Some(80));
+        assert_eq!(publish.max_wait_ms, Some(400));
     }
     use crate::config::QueryTypeMappings;
     use crate::config::settings;

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -642,6 +642,8 @@ pub struct RawWorkspaceSettings {
 
 pub const DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_DEBOUNCE_MS: u64 = 100;
 pub const DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_MAX_WAIT_MS: u64 = 1000;
+pub const DEFAULT_PUBLISH_DIAGNOSTICS_DEBOUNCE_MS: u64 = 100;
+pub const DEFAULT_PUBLISH_DIAGNOSTICS_MAX_WAIT_MS: u64 = 1000;
 /// Largest accepted debounce/max-wait duration (24 hours). This keeps timer
 /// arithmetic within a practical, platform-independent Instant range.
 pub const MAX_FEATURE_TIMING_MS: u64 = 86_400_000;
@@ -658,6 +660,8 @@ pub struct DebounceFeatureSettings {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct FeatureSettings {
+    #[serde(rename = "textDocument/publishDiagnostics")]
+    pub text_document_publish_diagnostics: Option<DebounceFeatureSettings>,
     #[serde(rename = "workspace/diagnostic/refresh")]
     pub workspace_diagnostic_refresh: Option<DebounceFeatureSettings>,
 }
@@ -669,7 +673,11 @@ impl Serialize for FeatureSettings {
     {
         use serde::ser::SerializeMap;
 
-        let mut map = serializer.serialize_map(Some(1))?;
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry(
+            "textDocument/publishDiagnostics",
+            &self.text_document_publish_diagnostics,
+        )?;
         map.serialize_entry(
             "workspace/diagnostic/refresh",
             &self.workspace_diagnostic_refresh,
@@ -695,13 +703,23 @@ impl Default for ResolvedDebounceFeatureSettings {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ResolvedFeatureSettings {
+    pub text_document_publish_diagnostics: ResolvedDebounceFeatureSettings,
     pub workspace_diagnostic_refresh: ResolvedDebounceFeatureSettings,
 }
 
 impl FeatureSettings {
     pub(crate) fn resolve(&self) -> ResolvedFeatureSettings {
+        let publish = self.text_document_publish_diagnostics.as_ref();
         let refresh = self.workspace_diagnostic_refresh.as_ref();
         ResolvedFeatureSettings {
+            text_document_publish_diagnostics: ResolvedDebounceFeatureSettings {
+                debounce_ms: publish
+                    .and_then(|settings| settings.debounce_ms)
+                    .unwrap_or(DEFAULT_PUBLISH_DIAGNOSTICS_DEBOUNCE_MS),
+                max_wait_ms: publish
+                    .and_then(|settings| settings.max_wait_ms)
+                    .unwrap_or(DEFAULT_PUBLISH_DIAGNOSTICS_MAX_WAIT_MS),
+            },
             workspace_diagnostic_refresh: ResolvedDebounceFeatureSettings {
                 debounce_ms: refresh
                     .and_then(|settings| settings.debounce_ms)

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1002,14 +1002,15 @@ impl DiagnosticAggregator {
     /// what the editor already received. The parked task may still wake, but
     /// `dirty = false` makes its unchanged republish a no-op.
     pub(crate) fn settle_wire_reversion(&self, host: &Url, diagnostics: &[Diagnostic]) -> bool {
-        let matches_wire = self
+        let wire = self
             .last_wire_published
             .lock()
             .recover_poison("DiagnosticAggregator::last_wire_published")
             .get(host)
-            .is_some_and(|wire| {
-                wire.as_slice() == diagnostics || same_diagnostic_multiset(wire, diagnostics)
-            });
+            .cloned();
+        let matches_wire = wire.is_some_and(|wire| {
+            wire.as_slice() == diagnostics || same_diagnostic_multiset(&wire, diagnostics)
+        });
         if !matches_wire {
             return false;
         }
@@ -1335,13 +1336,13 @@ impl DiagnosticAggregator {
 
         // Called under the per-host republish lock after the send await, so the
         // last-recorded set is exactly the set that just reached the wire.
-        if let Some(sent) = self
+        let sent = self
             .last_published
             .lock()
             .recover_poison("DiagnosticAggregator::last_published")
             .get(host)
-            .cloned()
-        {
+            .cloned();
+        if let Some(sent) = sent {
             self.last_wire_published
                 .lock()
                 .recover_poison("DiagnosticAggregator::last_wire_published")

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -999,7 +999,9 @@ impl DiagnosticAggregator {
     }
 
     /// Settle a withheld wire debt when the latest merged set has reverted to
-    /// what the editor already received. The parked task may still wake, but
+    /// what the editor already received. The reversion is still set-changing
+    /// activity for the quiet-window cadence, so advance its activity clock
+    /// without recreating wire debt. The parked task may still wake, but
     /// `dirty = false` makes its unchanged republish a no-op.
     pub(crate) fn settle_wire_reversion(&self, host: &Url, diagnostics: &[Diagnostic]) -> bool {
         let wire = self
@@ -1020,6 +1022,7 @@ impl DiagnosticAggregator {
             .recover_poison("DiagnosticAggregator::wire_gate")
             .get_mut(host)
         {
+            gate.last_activity_at = Some(tokio::time::Instant::now());
             gate.dirty = false;
         }
         true
@@ -1596,6 +1599,40 @@ mod tests {
             agg.wire_debounce_admit(&host(), debounce, max_wait, false),
             WireAdmit::SendNow
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wire_reversion_advances_the_quiet_activity_clock() {
+        let agg = DiagnosticAggregator::new();
+        let host = host();
+        let debounce = std::time::Duration::from_millis(100);
+        let max_wait = std::time::Duration::from_secs(1);
+
+        assert!(agg.published_set_changed(&host, &[diag("A")]));
+        assert_eq!(
+            agg.wire_debounce_admit(&host, debounce, max_wait, true),
+            WireAdmit::SendNow
+        );
+        agg.wire_gate_commit_send(&host);
+
+        tokio::time::advance(std::time::Duration::from_millis(10)).await;
+        assert!(agg.published_set_changed(&host, &[diag("B")]));
+        assert!(matches!(
+            agg.wire_debounce_admit(&host, debounce, max_wait, true),
+            WireAdmit::Defer { .. }
+        ));
+
+        tokio::time::advance(std::time::Duration::from_millis(40)).await;
+        assert!(agg.published_set_changed(&host, &[diag("A")]));
+        assert!(agg.settle_wire_reversion(&host, &[diag("A")]));
+
+        tokio::time::advance(std::time::Duration::from_millis(65)).await;
+        assert!(agg.published_set_changed(&host, &[diag("C")]));
+        assert!(matches!(
+            agg.wire_debounce_admit(&host, debounce, max_wait, true),
+            WireAdmit::Defer { remaining, .. }
+                if remaining == debounce
+        ));
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1157,12 +1157,6 @@ impl DiagnosticAggregator {
         {
             gate.last_activity_at = Some(tokio::time::Instant::now());
             gate.stale_retry_started = false;
-            gate.pending = false;
-            let obsolete = std::mem::replace(
-                &mut gate.cancellation,
-                tokio_util::sync::CancellationToken::new(),
-            );
-            obsolete.cancel();
             gate.dirty = false;
         }
         true
@@ -1202,12 +1196,6 @@ impl DiagnosticAggregator {
         {
             gate.last_activity_at = Some(tokio::time::Instant::now());
             gate.stale_retry_started = false;
-            gate.pending = false;
-            let obsolete = std::mem::replace(
-                &mut gate.cancellation,
-                tokio_util::sync::CancellationToken::new(),
-            );
-            obsolete.cancel();
             gate.dirty = false;
         }
         Some(true)
@@ -2223,26 +2211,22 @@ mod tests {
             WireAdmit::Defer { .. }
         ));
         assert!(agg.wire_gate_take_pending(&host));
-        let (_, obsolete_retry) = agg
-            .wire_gate_schedule_latest(&host, debounce, max_wait)
-            .expect("the stale reversion attempt owns a retry");
+        assert!(
+            agg.wire_gate_schedule_latest(&host, debounce, max_wait)
+                .is_some()
+        );
 
         tokio::time::advance(std::time::Duration::from_millis(40)).await;
         assert!(agg.published_set_changed(&host, &[diag("A")]));
         assert!(agg.settle_wire_reversion(&host, &[diag("A")]));
-        assert!(obsolete_retry.is_cancelled());
         assert!(
-            {
-                let gates = agg.wire_gate.lock().unwrap();
-                let gate = gates.get(&host).unwrap();
-                !gate.stale_retry_started && !gate.pending
-            },
+            !agg.wire_gate
+                .lock()
+                .unwrap()
+                .get(&host)
+                .unwrap()
+                .stale_retry_started,
             "settling all wire debt must reset stale retry backoff for the next cycle"
-        );
-        assert!(
-            agg.wire_gate_schedule_latest(&host, debounce, max_wait)
-                .is_some(),
-            "a new stale cycle must not be absorbed by the obsolete retry task"
         );
 
         tokio::time::advance(std::time::Duration::from_millis(65)).await;

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1072,6 +1072,21 @@ impl DiagnosticAggregator {
         diagnostics: &[Diagnostic],
         cache_revision: u64,
     ) -> Option<bool> {
+        // Same-host callers hold the republish lock, so compare against an Arc
+        // snapshot off the global map locks. Large multiset comparison and the
+        // replacement allocation must not block cache activity for other URIs.
+        let previous = self
+            .last_published
+            .lock()
+            .recover_poison("DiagnosticAggregator::last_published")
+            .get(host)
+            .cloned();
+        let changed = previous.as_ref().is_none_or(|previous| {
+            previous.as_ref() != diagnostics
+                && !same_diagnostic_multiset(previous.as_ref(), diagnostics)
+        });
+        let replacement = changed.then(|| Arc::from(diagnostics));
+
         let revisions = self
             .cache_revisions
             .lock()
@@ -1079,7 +1094,13 @@ impl DiagnosticAggregator {
         if revisions.get(host).copied().unwrap_or(0) != cache_revision {
             return None;
         }
-        Some(self.published_set_changed(host, diagnostics))
+        if let Some(replacement) = replacement {
+            self.last_published
+                .lock()
+                .recover_poison("DiagnosticAggregator::last_published")
+                .insert(host.clone(), replacement);
+        }
+        Some(changed)
     }
 
     /// Forget the last-recorded set for `host` (host `didClose`), so its entry
@@ -1135,6 +1156,13 @@ impl DiagnosticAggregator {
         diagnostics: &[Diagnostic],
         cache_revision: u64,
     ) -> Option<bool> {
+        let matches_wire = self
+            .last_wire_published
+            .lock()
+            .recover_poison("DiagnosticAggregator::last_wire_published")
+            .get(host)
+            .cloned()
+            .is_some_and(|wire| wire.as_ref() == diagnostics);
         let revisions = self
             .cache_revisions
             .lock()
@@ -1142,7 +1170,19 @@ impl DiagnosticAggregator {
         if revisions.get(host).copied().unwrap_or(0) != cache_revision {
             return None;
         }
-        Some(self.settle_wire_reversion(host, diagnostics))
+        if !matches_wire {
+            return Some(false);
+        }
+        if let Some(gate) = self
+            .wire_gate
+            .lock()
+            .recover_poison("DiagnosticAggregator::wire_gate")
+            .get_mut(host)
+        {
+            gate.last_activity_at = Some(tokio::time::Instant::now());
+            gate.dirty = false;
+        }
+        Some(true)
     }
 
     /// Begin a workspace-wide refresh under the single-flight + coverage guard

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -543,6 +543,9 @@ struct WireGate {
     /// A trailing republish task is scheduled; bounds the tasks to one per
     /// host per window.
     pending: bool,
+    /// Wakes a parked trailing task when didClose or a publish seal forgets
+    /// this gate, so long configured windows do not retain the publisher.
+    cancellation: tokio_util::sync::CancellationToken,
     /// The recorded last-published set may not have reached the editor's
     /// push namespace: either a changed merge was withheld by the quiet
     /// window, or a send was admitted but its commit never happened (aborted
@@ -555,7 +558,7 @@ struct WireGate {
 /// The wire-gate decision for one republish attempt: send now, or withhold
 /// until the quiet window elapses (scheduling the trailing republish iff no
 /// task is already parked).
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub(crate) enum WireAdmit {
     /// Window clear: write to the wire now.
     SendNow,
@@ -566,8 +569,32 @@ pub(crate) enum WireAdmit {
     Defer {
         schedule_trailing: bool,
         remaining: std::time::Duration,
+        cancellation: tokio_util::sync::CancellationToken,
     },
 }
+
+impl PartialEq for WireAdmit {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::SendNow, Self::SendNow) => true,
+            (
+                Self::Defer {
+                    schedule_trailing: left_schedule,
+                    remaining: left_remaining,
+                    ..
+                },
+                Self::Defer {
+                    schedule_trailing: right_schedule,
+                    remaining: right_remaining,
+                    ..
+                },
+            ) => left_schedule == right_schedule && left_remaining == right_remaining,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for WireAdmit {}
 
 /// Per-host coverage versions for the refresh gate (#497, commit 2).
 #[derive(Default, Clone, Copy)]
@@ -1266,6 +1293,7 @@ impl DiagnosticAggregator {
                     last_sent_at: None,
                     last_activity_at: Some(now),
                     pending: false,
+                    cancellation: tokio_util::sync::CancellationToken::new(),
                     dirty: true,
                 },
             );
@@ -1302,6 +1330,7 @@ impl DiagnosticAggregator {
             WireAdmit::Defer {
                 schedule_trailing,
                 remaining: deadline.saturating_duration_since(now),
+                cancellation: gate.cancellation.clone(),
             }
         }
     }
@@ -1331,6 +1360,7 @@ impl DiagnosticAggregator {
                     last_sent_at: Some(now),
                     last_activity_at: Some(now),
                     pending: false,
+                    cancellation: tokio_util::sync::CancellationToken::new(),
                     dirty: false,
                 },
             );
@@ -1396,10 +1426,14 @@ impl DiagnosticAggregator {
     /// bypasses the gate for closed hosts) and when the publish seal renders
     /// the gate state moot.
     pub(crate) fn forget_wire_gate(&self, host: &Url) {
-        self.wire_gate
+        let gate = self
+            .wire_gate
             .lock()
             .recover_poison("DiagnosticAggregator::wire_gate")
             .remove(host);
+        if let Some(gate) = gate {
+            gate.cancellation.cancel();
+        }
     }
 
     /// Drop one `source`'s slots (every server) under `host` — e.g. a region

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1676,6 +1676,17 @@ impl DiagnosticAggregator {
             cancellation: tokio_util::sync::CancellationToken::new(),
             dirty: true,
         });
+        let starts_idle_cycle = !gate.pending
+            && !gate.dirty
+            && gate
+                .last_activity_at
+                .is_none_or(|at| now.saturating_duration_since(at) >= gate.debounce);
+        if starts_idle_cycle {
+            gate.debounce = debounce;
+            gate.max_wait = max_wait;
+            gate.cycle_started_at = now;
+            gate.stale_retry_started = false;
+        }
         gate.last_activity_at = Some(now);
         gate.last_cache_revision = cache_revision;
         gate.dirty = true;
@@ -2009,6 +2020,27 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn stale_handoff_snapshots_live_timing_at_an_idle_cycle_boundary() {
+        let agg = DiagnosticAggregator::new();
+        let host = host();
+        let old_debounce = std::time::Duration::from_millis(100);
+        let old_max_wait = std::time::Duration::from_secs(1);
+        assert_eq!(
+            agg.wire_debounce_admit(&host, old_debounce, old_max_wait, true),
+            WireAdmit::SendNow
+        );
+        agg.wire_gate_commit_send(&host);
+        tokio::time::advance(old_debounce).await;
+
+        let new_debounce = std::time::Duration::from_millis(250);
+        let new_max_wait = std::time::Duration::from_secs(2);
+        let (remaining, _) = agg
+            .wire_gate_schedule_latest(&host, new_debounce, new_max_wait)
+            .expect("an idle stale handoff starts a fresh cycle");
+        assert_eq!(remaining, new_debounce);
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn stale_handoff_mints_a_first_gate_and_backs_off_after_max_wait() {
         let agg = DiagnosticAggregator::new();
         let host = host();
@@ -2068,7 +2100,11 @@ mod tests {
                 std::time::Duration::from_millis(1),
             )
             .unwrap();
-        assert_eq!(remaining, std::time::Duration::from_millis(50));
+        assert_eq!(
+            remaining,
+            std::time::Duration::ZERO,
+            "a settled idle gate starts a fresh cycle instead of inheriting max-wait debt"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1156,6 +1156,7 @@ impl DiagnosticAggregator {
             .get_mut(host)
         {
             gate.last_activity_at = Some(tokio::time::Instant::now());
+            gate.stale_retry_started = false;
             gate.dirty = false;
         }
         true
@@ -1194,6 +1195,7 @@ impl DiagnosticAggregator {
             .get_mut(host)
         {
             gate.last_activity_at = Some(tokio::time::Instant::now());
+            gate.stale_retry_started = false;
             gate.dirty = false;
         }
         Some(true)
@@ -2208,10 +2210,24 @@ mod tests {
             agg.wire_debounce_admit(&host, debounce, max_wait, true),
             WireAdmit::Defer { .. }
         ));
+        assert!(agg.wire_gate_take_pending(&host));
+        assert!(
+            agg.wire_gate_schedule_latest(&host, debounce, max_wait)
+                .is_some()
+        );
 
         tokio::time::advance(std::time::Duration::from_millis(40)).await;
         assert!(agg.published_set_changed(&host, &[diag("A")]));
         assert!(agg.settle_wire_reversion(&host, &[diag("A")]));
+        assert!(
+            !agg.wire_gate
+                .lock()
+                .unwrap()
+                .get(&host)
+                .unwrap()
+                .stale_retry_started,
+            "settling all wire debt must reset stale retry backoff for the next cycle"
+        );
 
         tokio::time::advance(std::time::Duration::from_millis(65)).await;
         assert!(agg.published_set_changed(&host, &[diag("C")]));

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -520,6 +520,11 @@ pub(crate) enum ForwardedRefreshWait {
 /// change (window already elapsed, or first publish) passes through
 /// immediately — the gate adds no latency outside bursts.
 struct WireGate {
+    /// Timing snapshot for the active burst. Live configuration updates are
+    /// admitted only when a new leading edge starts or a max-wait send rolls a
+    /// continuous burst into its next cycle.
+    debounce: std::time::Duration,
+    max_wait: std::time::Duration,
     /// When the last `publishDiagnostics` was actually **committed** (written
     /// to the wire and stamped by [`DiagnosticAggregator::wire_gate_commit_send`]).
     /// `None` means the entry was minted by an admit whose send has not
@@ -1217,6 +1222,8 @@ impl DiagnosticAggregator {
             gates.insert(
                 host.clone(),
                 WireGate {
+                    debounce,
+                    max_wait,
                     last_sent_at: None,
                     last_activity_at: Some(now),
                     pending: false,
@@ -1227,17 +1234,25 @@ impl DiagnosticAggregator {
         };
         let was_quiet = gate
             .last_activity_at
-            .is_some_and(|at| now.duration_since(at) >= debounce);
+            .is_some_and(|at| now.duration_since(at) >= gate.debounce);
         if record_activity {
             gate.last_activity_at = Some(now);
         }
-        let quiet_deadline = gate.last_activity_at.unwrap_or(now) + debounce;
-        let max_deadline = gate.last_sent_at.map(|at| at + max_wait);
+        let quiet_deadline = gate.last_activity_at.unwrap_or(now) + gate.debounce;
+        let max_deadline = gate.last_sent_at.map(|at| at + gate.max_wait);
+        let reached_max_wait = max_deadline.is_some_and(|deadline| now >= deadline);
         let send_now = gate.last_sent_at.is_none()
             || (record_activity && was_quiet)
-            || max_deadline.is_some_and(|deadline| now >= deadline)
+            || reached_max_wait
             || (!record_activity && now >= quiet_deadline);
         if send_now {
+            // The send ends the admitted cycle. A real activity that starts a
+            // quiet leading edge, recovers an uncommitted first send, or rolls
+            // a continuous burst at maxWait owns the next cycle's snapshot.
+            if record_activity && (gate.last_sent_at.is_none() || was_quiet || reached_max_wait) {
+                gate.debounce = debounce;
+                gate.max_wait = max_wait;
+            }
             gate.dirty = true;
             WireAdmit::SendNow
         } else {
@@ -1272,6 +1287,8 @@ impl DiagnosticAggregator {
             gates.insert(
                 host.clone(),
                 WireGate {
+                    debounce: std::time::Duration::ZERO,
+                    max_wait: std::time::Duration::ZERO,
                     last_sent_at: Some(now),
                     last_activity_at: Some(now),
                     pending: false,
@@ -1527,6 +1544,43 @@ mod tests {
             agg.wire_debounce_admit(&host(), debounce, max_wait, false),
             WireAdmit::SendNow
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wire_debounce_keeps_admitted_timing_until_cycle_boundary() {
+        let agg = DiagnosticAggregator::new();
+        let admitted_debounce = std::time::Duration::from_millis(100);
+        let admitted_max_wait = std::time::Duration::from_millis(1000);
+        let updated_debounce = std::time::Duration::from_millis(500);
+        let updated_max_wait = std::time::Duration::from_millis(5000);
+        assert_eq!(
+            agg.wire_debounce_admit(&host(), admitted_debounce, admitted_max_wait, true),
+            WireAdmit::SendNow
+        );
+        agg.wire_gate_commit_send(&host());
+
+        tokio::time::advance(std::time::Duration::from_millis(10)).await;
+        assert!(matches!(
+            agg.wire_debounce_admit(
+                &host(),
+                updated_debounce,
+                updated_max_wait,
+                true
+            ),
+            WireAdmit::Defer { remaining, .. }
+                if remaining == admitted_debounce
+        ));
+        tokio::time::advance(std::time::Duration::from_millis(50)).await;
+        assert!(matches!(
+            agg.wire_debounce_admit(
+                &host(),
+                updated_debounce,
+                updated_max_wait,
+                true
+            ),
+            WireAdmit::Defer { remaining, .. }
+                if remaining == admitted_debounce
+        ));
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1029,17 +1029,18 @@ impl DiagnosticAggregator {
     /// what the editor already received. The reversion is still set-changing
     /// activity for the quiet-window cadence, so advance its activity clock
     /// without recreating wire debt. The parked task may still wake, but
-    /// `dirty = false` makes its unchanged republish a no-op.
+    /// `dirty = false` makes its unchanged republish a no-op. Both stored and
+    /// current sets come from [`merge_cached_diagnostics`], whose total sort
+    /// makes direct slice equality sufficient here; avoiding a clone and the
+    /// multiset fallback keeps large diagnostic bursts off the allocation and
+    /// JSON-serialization path.
     pub(crate) fn settle_wire_reversion(&self, host: &Url, diagnostics: &[Diagnostic]) -> bool {
-        let wire = self
+        let matches_wire = self
             .last_wire_published
             .lock()
             .recover_poison("DiagnosticAggregator::last_wire_published")
             .get(host)
-            .cloned();
-        let matches_wire = wire.is_some_and(|wire| {
-            wire.as_slice() == diagnostics || same_diagnostic_multiset(&wire, diagnostics)
-        });
+            .is_some_and(|wire| wire.as_slice() == diagnostics);
         if !matches_wire {
             return false;
         }
@@ -1667,6 +1668,29 @@ mod tests {
             WireAdmit::Defer { remaining, .. }
                 if remaining == debounce
         ));
+    }
+
+    #[test]
+    fn wire_reversion_requires_canonical_diagnostic_order() {
+        let agg = DiagnosticAggregator::new();
+        let host = host();
+
+        assert!(agg.published_set_changed(&host, &[diag("A"), diag("B")]));
+        assert_eq!(
+            agg.wire_debounce_admit(
+                &host,
+                std::time::Duration::ZERO,
+                std::time::Duration::from_secs(1),
+                true,
+            ),
+            WireAdmit::SendNow
+        );
+        agg.wire_gate_commit_send(&host);
+
+        assert!(
+            !agg.settle_wire_reversion(&host, &[diag("B"), diag("A")]),
+            "the wire fast path compares canonical slices directly"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1029,7 +1029,12 @@ impl DiagnosticAggregator {
             .recover_poison("DiagnosticAggregator::cache_revisions");
         let mut cache = self.lock();
         let removed = cache.remove(host).is_some();
-        revisions.remove(host);
+        // Keep advancing the host's incarnation even after its slots disappear.
+        // Otherwise a pre-close snapshot can validate after reopen when the new
+        // document happens to reach the same small revision again.
+        if let Some(revision) = revisions.get_mut(host) {
+            *revision = revision.wrapping_add(1);
+        }
         removed
     }
 
@@ -3014,9 +3019,16 @@ mod tests {
     fn evict_host_drops_all() {
         let agg = DiagnosticAggregator::new();
         agg.set_pull_layer(&host(), vec![diag("h")]);
+        let before_close = agg.snapshot_with_revision(&host()).1;
         assert!(agg.evict_host(&host()));
         assert!(agg.snapshot(&host()).is_empty());
         assert!(!agg.evict_host(&host()), "second evict is a no-op");
+        agg.set_pull_layer(&host(), vec![diag("reopened")]);
+        assert_ne!(
+            agg.snapshot_with_revision(&host()).1,
+            before_close,
+            "a reopened host must not reuse a pre-close snapshot revision"
+        );
     }
 
     #[test]
@@ -3069,10 +3081,9 @@ mod tests {
             !agg.evict_host(&host()),
             "the source eviction already removed the cache entry"
         );
-        assert_eq!(
-            agg.snapshot_with_revision(&host()).1,
-            0,
-            "didClose-style host eviction forgets a revision even when slots were already empty"
+        assert!(
+            agg.snapshot_with_revision(&host()).1 > 0,
+            "didClose-style host eviction preserves an incarnation even when slots were already empty"
         );
     }
 

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1047,6 +1047,7 @@ impl DiagnosticAggregator {
     /// the merge order shuffled — while a genuine change in any field is still
     /// detected. The per-host diagnostic count is small, so the O(n²) match is cheap
     /// and avoids serializing every diagnostic.
+    #[cfg(test)]
     pub(crate) fn published_set_changed(&self, host: &Url, diagnostics: &[Diagnostic]) -> bool {
         let mut last = self
             .last_published
@@ -1133,6 +1134,7 @@ impl DiagnosticAggregator {
     /// makes direct slice equality sufficient here; avoiding a clone and the
     /// multiset fallback keeps large diagnostic bursts off the allocation and
     /// JSON-serialization path.
+    #[cfg(test)]
     pub(crate) fn settle_wire_reversion(&self, host: &Url, diagnostics: &[Diagnostic]) -> bool {
         let matches_wire = self
             .last_wire_published
@@ -1404,6 +1406,7 @@ impl DiagnosticAggregator {
         self.wire_debounce_admit(host, window, window, true)
     }
 
+    #[cfg(test)]
     pub(crate) fn wire_debounce_admit(
         &self,
         host: &Url,
@@ -1593,6 +1596,7 @@ impl DiagnosticAggregator {
     /// fresh entry gets `true` and clears its `pending`, which at worst
     /// schedules one extra trailing task — the defer-reschedule design, not
     /// this bail, is what keeps that safe.)
+    #[cfg(test)]
     pub(crate) fn wire_gate_take_pending(&self, host: &Url) -> bool {
         if let Some(gate) = self
             .wire_gate

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1702,12 +1702,16 @@ impl DiagnosticAggregator {
             cancellation: tokio_util::sync::CancellationToken::new(),
             dirty: true,
         });
-        let starts_idle_cycle = !gate.pending
-            && !gate.dirty
+        let starts_idle_cycle = !gate.dirty
             && gate
                 .last_activity_at
                 .is_none_or(|at| now.saturating_duration_since(at) >= gate.debounce);
         if starts_idle_cycle {
+            if gate.pending {
+                gate.cancellation.cancel();
+                gate.cancellation = tokio_util::sync::CancellationToken::new();
+                gate.pending = false;
+            }
             gate.debounce = debounce;
             gate.max_wait = max_wait;
             gate.cycle_started_at = now;
@@ -2211,23 +2215,22 @@ mod tests {
             WireAdmit::Defer { .. }
         ));
         assert!(agg.wire_gate_take_pending(&host));
-        assert!(
-            agg.wire_gate_schedule_latest(&host, debounce, max_wait)
-                .is_some()
-        );
+        let (_, fallback) = agg
+            .wire_gate_schedule_latest(&host, debounce, max_wait)
+            .expect("the stale attempt owns a fallback");
 
         tokio::time::advance(std::time::Duration::from_millis(40)).await;
         assert!(agg.published_set_changed(&host, &[diag("A")]));
         assert!(agg.settle_wire_reversion(&host, &[diag("A")]));
         assert!(
-            !agg.wire_gate
-                .lock()
-                .unwrap()
-                .get(&host)
-                .unwrap()
-                .stale_retry_started,
-            "settling all wire debt must reset stale retry backoff for the next cycle"
+            {
+                let gates = agg.wire_gate.lock().unwrap();
+                let gate = gates.get(&host).unwrap();
+                !gate.stale_retry_started && gate.pending
+            },
+            "settlement resets backoff but retains the parked abort fallback"
         );
+        assert!(!fallback.is_cancelled());
 
         tokio::time::advance(std::time::Duration::from_millis(65)).await;
         assert!(agg.published_set_changed(&host, &[diag("C")]));
@@ -2236,6 +2239,34 @@ mod tests {
             WireAdmit::Defer { remaining, .. }
                 if remaining == debounce
         ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_stale_handoff_transfers_settled_fallback_to_live_timing() {
+        let agg = DiagnosticAggregator::new();
+        let host = host();
+        let old_debounce = std::time::Duration::from_millis(100);
+        let old_max_wait = std::time::Duration::from_secs(1);
+        assert!(agg.published_set_changed(&host, &[diag("A")]));
+        assert_eq!(
+            agg.wire_debounce_admit(&host, old_debounce, old_max_wait, true),
+            WireAdmit::SendNow
+        );
+        agg.wire_gate_commit_send(&host);
+        let (_, old_fallback) = agg
+            .wire_gate_schedule_latest(&host, old_debounce, old_max_wait)
+            .expect("stale work parks a fallback");
+        assert!(agg.settle_wire_reversion(&host, &[diag("A")]));
+        assert!(!old_fallback.is_cancelled());
+
+        tokio::time::advance(old_debounce).await;
+        let new_debounce = std::time::Duration::from_millis(250);
+        let (remaining, replacement) = agg
+            .wire_gate_schedule_latest(&host, new_debounce, std::time::Duration::from_secs(2))
+            .expect("the new handoff atomically replaces the settled fallback");
+        assert!(old_fallback.is_cancelled());
+        assert!(!replacement.is_cancelled());
+        assert_eq!(remaining, new_debounce);
     }
 
     #[test]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -568,6 +568,9 @@ struct WireGate {
 /// republish iff no task is already parked).
 #[derive(Debug)]
 pub(crate) enum WireAdmit {
+    /// The cache changed after the caller's snapshot; rebuild before making a
+    /// wire decision so stale diagnostics never reach the editor.
+    RetryLatest,
     /// Window clear: write to the wire now.
     SendNow,
     /// Before the active deadline: withhold. `schedule_trailing` is `true` for
@@ -591,6 +594,7 @@ pub(crate) enum WireTrailingWake {
 impl PartialEq for WireAdmit {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
+            (Self::RetryLatest, Self::RetryLatest) => true,
             (Self::SendNow, Self::SendNow) => true,
             (
                 Self::Defer {
@@ -1391,6 +1395,34 @@ impl DiagnosticAggregator {
         }
     }
 
+    /// Admit only if `cache_revision` still names the latest cache snapshot.
+    /// Holding the revision lock through the gate mutation closes the
+    /// snapshot→admission gap without taking the heavier cache lock.
+    pub(crate) fn wire_debounce_admit_current_revision(
+        &self,
+        host: &Url,
+        debounce: std::time::Duration,
+        max_wait: std::time::Duration,
+        record_activity: bool,
+        cache_revision: u64,
+    ) -> WireAdmit {
+        let revisions = self
+            .cache_revisions
+            .lock()
+            .recover_poison("DiagnosticAggregator::cache_revisions");
+        let current = revisions.get(host).copied().unwrap_or(0);
+        if current != cache_revision {
+            return WireAdmit::RetryLatest;
+        }
+        self.wire_debounce_admit_for_revision(
+            host,
+            debounce,
+            max_wait,
+            record_activity,
+            cache_revision,
+        )
+    }
+
     /// Record that a wire `publishDiagnostics` for `host` was actually sent:
     /// stamp the send time (anchoring max-wait for the active cycle) and settle
     /// the `dirty` debt. Called right after the send await, under the same
@@ -1792,6 +1824,26 @@ mod tests {
             agg.wire_debounce_admit_for_revision(&host, debounce, max_wait, false, 3),
             WireAdmit::Defer { remaining, .. } if remaining == debounce
         ));
+    }
+
+    #[test]
+    fn wire_admission_rejects_a_stale_cache_snapshot() {
+        let agg = DiagnosticAggregator::new();
+        let host = host();
+        agg.set_pull_layer(&host, vec![diag("A")]);
+        let (_, stale_revision) = agg.snapshot_with_revision(&host);
+        agg.set_pull_layer(&host, vec![diag("B")]);
+
+        assert_eq!(
+            agg.wire_debounce_admit_current_revision(
+                &host,
+                std::time::Duration::from_millis(100),
+                std::time::Duration::from_secs(1),
+                false,
+                stale_revision,
+            ),
+            WireAdmit::RetryLatest
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1561,7 +1561,9 @@ impl DiagnosticAggregator {
         if let Some(gate) = gates.get_mut(host) {
             gate.last_sent_at = Some(now);
             gate.cycle_started_at = now;
-            gate.stale_retry_started = false;
+            if !preserve_debt {
+                gate.stale_retry_started = false;
+            }
             gate.dirty = preserve_debt;
         } else {
             // The admit minted an entry, but a `forget_wire_gate` (seal) can
@@ -2298,14 +2300,40 @@ mod tests {
             "a send admitted before the cache mutation must not settle newer debt"
         );
         assert!(agg.wire_gate_is_dirty(&host));
-        assert!(
-            agg.wire_gate_schedule_latest(
+        let (first_retry, _) = agg
+            .wire_gate_schedule_latest(
                 &host,
                 std::time::Duration::ZERO,
                 std::time::Duration::from_secs(1),
             )
-            .is_some(),
-            "the preserved debt must be eligible for a latest-snapshot retry"
+            .expect("the preserved debt must be eligible for a latest-snapshot retry");
+        assert_eq!(first_retry, std::time::Duration::ZERO);
+        assert_eq!(agg.wire_gate_trailing_wake(&host), WireTrailingWake::Ready);
+
+        let next_revision = agg.snapshot_with_revision(&host).1;
+        assert_eq!(
+            agg.wire_debounce_admit_current_revision(
+                &host,
+                std::time::Duration::ZERO,
+                std::time::Duration::from_secs(1),
+                false,
+                next_revision,
+            ),
+            WireAdmit::SendNow
+        );
+        agg.set_pull_layer(&host, vec![diag("C")]);
+        assert!(!agg.wire_gate_commit_send_current_revision(&host, next_revision));
+        let (repeated_retry, _) = agg
+            .wire_gate_schedule_latest(
+                &host,
+                std::time::Duration::ZERO,
+                std::time::Duration::from_secs(1),
+            )
+            .expect("repeated stale sends retain their retry duty");
+        assert_eq!(
+            repeated_retry,
+            std::time::Duration::from_millis(50),
+            "continuous zero-debounce stale sends must remain rate-limited"
         );
     }
 

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1666,18 +1666,19 @@ impl DiagnosticAggregator {
             return None;
         }
         let quiet_deadline = now + gate.debounce;
-        let deadline = gate
+        let max_deadline = gate
             .cycle_started_at
             .checked_add(gate.max_wait)
-            .map_or(quiet_deadline, |max| quiet_deadline.min(max));
+            .unwrap_or(quiet_deadline);
+        let deadline = quiet_deadline.min(max_deadline);
         // A max-wait attempt that itself became stale must not self-spawn an
         // unbounded zero-delay full-merge chain. Back off by the active
         // debounce (at least one millisecond); once churn settles, that retry
         // sends the latest set.
-        let remaining = if deadline <= now {
+        let remaining = if max_deadline <= now {
             gate.debounce.max(std::time::Duration::from_millis(50))
         } else {
-            deadline - now
+            deadline.saturating_duration_since(now)
         };
         gate.pending = true;
         Some((remaining, gate.cancellation.clone()))
@@ -2022,12 +2023,14 @@ mod tests {
 
         let zero = DiagnosticAggregator::new();
         let zero_host = Url::parse("file:///zero-debounce.rs").unwrap();
-        zero.wire_gate_schedule_latest(
-            &zero_host,
-            std::time::Duration::ZERO,
-            std::time::Duration::from_millis(1),
-        )
-        .unwrap();
+        let (initial_remaining, _) = zero
+            .wire_gate_schedule_latest(
+                &zero_host,
+                std::time::Duration::ZERO,
+                std::time::Duration::from_millis(1),
+            )
+            .unwrap();
+        assert_eq!(initial_remaining, std::time::Duration::ZERO);
         assert!(zero.wire_gate_take_pending(&zero_host));
         zero.wire_gate_commit_send(&zero_host);
         tokio::time::advance(std::time::Duration::from_millis(1)).await;

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1621,6 +1621,37 @@ impl DiagnosticAggregator {
         WireTrailingWake::Ready
     }
 
+    /// Preserve wire debt when a republish discovers that its merged snapshot
+    /// became stale. The newer cache writer owns the content handoff, while
+    /// this bounded trailing task guarantees quiet/max-wait progress even if
+    /// that writer's abortable republish never reaches admission.
+    pub(crate) fn wire_gate_schedule_latest(
+        &self,
+        host: &Url,
+    ) -> Option<(std::time::Duration, tokio_util::sync::CancellationToken)> {
+        let now = tokio::time::Instant::now();
+        let mut gates = self
+            .wire_gate
+            .lock()
+            .recover_poison("DiagnosticAggregator::wire_gate");
+        let gate = gates.get_mut(host)?;
+        gate.last_activity_at = Some(now);
+        gate.dirty = true;
+        if gate.pending {
+            return None;
+        }
+        let quiet_deadline = now + gate.debounce;
+        let deadline = gate
+            .last_sent_at
+            .map(|sent| quiet_deadline.min(sent + gate.max_wait))
+            .unwrap_or(quiet_deadline);
+        gate.pending = true;
+        Some((
+            deadline.saturating_duration_since(now),
+            gate.cancellation.clone(),
+        ))
+    }
+
     /// Forget the wire-gate state for `host` so the entry doesn't linger and a
     /// parked trailing task bails ([`Self::wire_gate_take_pending`] returns
     /// `false`). Called on `didClose` (`clear_host`, next to
@@ -1883,6 +1914,29 @@ mod tests {
         );
         tokio::time::advance(std::time::Duration::from_millis(70)).await;
         assert_eq!(agg.wire_gate_trailing_wake(&host), WireTrailingWake::Ready);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stale_handoff_schedules_one_latest_wire_retry() {
+        let agg = DiagnosticAggregator::new();
+        let host = host();
+        let debounce = std::time::Duration::from_millis(100);
+        let max_wait = std::time::Duration::from_secs(1);
+        assert_eq!(
+            agg.wire_debounce_admit(&host, debounce, max_wait, true),
+            WireAdmit::SendNow
+        );
+        agg.wire_gate_commit_send(&host);
+
+        let (remaining, _) = agg
+            .wire_gate_schedule_latest(&host)
+            .expect("the stale handoff owns one retry");
+        assert_eq!(remaining, debounce);
+        assert!(
+            agg.wire_gate_schedule_latest(&host).is_none(),
+            "a second stale handoff shares the pending retry"
+        );
+        assert!(agg.wire_gate_is_dirty(&host));
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1157,6 +1157,12 @@ impl DiagnosticAggregator {
         {
             gate.last_activity_at = Some(tokio::time::Instant::now());
             gate.stale_retry_started = false;
+            gate.pending = false;
+            let obsolete = std::mem::replace(
+                &mut gate.cancellation,
+                tokio_util::sync::CancellationToken::new(),
+            );
+            obsolete.cancel();
             gate.dirty = false;
         }
         true
@@ -1196,6 +1202,12 @@ impl DiagnosticAggregator {
         {
             gate.last_activity_at = Some(tokio::time::Instant::now());
             gate.stale_retry_started = false;
+            gate.pending = false;
+            let obsolete = std::mem::replace(
+                &mut gate.cancellation,
+                tokio_util::sync::CancellationToken::new(),
+            );
+            obsolete.cancel();
             gate.dirty = false;
         }
         Some(true)
@@ -2211,22 +2223,26 @@ mod tests {
             WireAdmit::Defer { .. }
         ));
         assert!(agg.wire_gate_take_pending(&host));
-        assert!(
-            agg.wire_gate_schedule_latest(&host, debounce, max_wait)
-                .is_some()
-        );
+        let (_, obsolete_retry) = agg
+            .wire_gate_schedule_latest(&host, debounce, max_wait)
+            .expect("the stale reversion attempt owns a retry");
 
         tokio::time::advance(std::time::Duration::from_millis(40)).await;
         assert!(agg.published_set_changed(&host, &[diag("A")]));
         assert!(agg.settle_wire_reversion(&host, &[diag("A")]));
+        assert!(obsolete_retry.is_cancelled());
         assert!(
-            !agg.wire_gate
-                .lock()
-                .unwrap()
-                .get(&host)
-                .unwrap()
-                .stale_retry_started,
+            {
+                let gates = agg.wire_gate.lock().unwrap();
+                let gate = gates.get(&host).unwrap();
+                !gate.stale_retry_started && !gate.pending
+            },
             "settling all wire debt must reset stale retry backoff for the next cycle"
+        );
+        assert!(
+            agg.wire_gate_schedule_latest(&host, debounce, max_wait)
+                .is_some(),
+            "a new stale cycle must not be absorbed by the obsolete retry task"
         );
 
         tokio::time::advance(std::time::Duration::from_millis(65)).await;

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -412,12 +412,12 @@ pub(crate) struct DiagnosticAggregator {
     /// set via re-pull instead). Updated under the host's republish lock
     /// (same-host republishes are serialized), and forgotten on `didClose`
     /// ([`Self::forget_published`]).
-    last_published: Mutex<HashMap<Url, Vec<Diagnostic>>>,
+    last_published: Mutex<HashMap<Url, Arc<[Diagnostic]>>>,
     /// The last set that actually completed a client-facing wire send. This is
     /// distinct from `last_published`, which advances when a set is recorded
     /// even if debounce withholds it. Keeping both lets an A -> pending B -> A
     /// reversion cancel the wire debt instead of sending duplicate A.
-    last_wire_published: Mutex<HashMap<Url, Vec<Diagnostic>>>,
+    last_wire_published: Mutex<HashMap<Url, Arc<[Diagnostic]>>>,
     /// Single-flight guard for the **workspace-wide** `workspace/diagnostic/refresh`
     /// nudge (#497). `workspace/diagnostic/refresh` is param-less and workspace-wide,
     /// so concurrent refreshes are redundant; without this, a burst of set-changing
@@ -1047,13 +1047,14 @@ impl DiagnosticAggregator {
             // arrive slice-equal — the O(n²) multiset walk below is only the
             // fallback for order variation a future unsorted caller could
             // introduce.
-            if prev.as_slice() == diagnostics || same_diagnostic_multiset(prev, diagnostics) {
+            if prev.as_ref() == diagnostics || same_diagnostic_multiset(prev.as_ref(), diagnostics)
+            {
                 return false;
             }
-            *prev = diagnostics.to_vec();
+            *prev = Arc::from(diagnostics);
             return true;
         }
-        last.insert(host.clone(), diagnostics.to_vec());
+        last.insert(host.clone(), Arc::from(diagnostics));
         true
     }
 
@@ -1085,7 +1086,7 @@ impl DiagnosticAggregator {
             .lock()
             .recover_poison("DiagnosticAggregator::last_wire_published")
             .get(host)
-            .is_some_and(|wire| wire.as_slice() == diagnostics);
+            .is_some_and(|wire| wire.as_ref() == diagnostics);
         if !matches_wire {
             return false;
         }
@@ -1902,6 +1903,34 @@ mod tests {
             !agg.settle_wire_reversion(&host, &[diag("B"), diag("A")]),
             "the wire fast path compares canonical slices directly"
         );
+    }
+
+    #[test]
+    fn wire_commit_shares_the_recorded_diagnostic_snapshot() {
+        let agg = DiagnosticAggregator::new();
+        let host = host();
+        assert!(agg.published_set_changed(&host, &[diag("A")]));
+        assert_eq!(
+            agg.wire_gate_admit(&host, std::time::Duration::ZERO),
+            WireAdmit::SendNow
+        );
+        agg.wire_gate_commit_send(&host);
+
+        let recorded = agg
+            .last_published
+            .lock()
+            .unwrap()
+            .get(&host)
+            .cloned()
+            .unwrap();
+        let wire = agg
+            .last_wire_published
+            .lock()
+            .unwrap()
+            .get(&host)
+            .cloned()
+            .unwrap();
+        assert!(Arc::ptr_eq(&recorded, &wire));
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -573,6 +573,13 @@ pub(crate) enum WireAdmit {
     },
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WireTrailingWake {
+    Gone,
+    Wait(std::time::Duration),
+    Ready,
+}
+
 impl PartialEq for WireAdmit {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -1420,6 +1427,34 @@ impl DiagnosticAggregator {
         }
     }
 
+    /// Revalidate a parked trailing task's deadline before it performs the
+    /// expensive snapshot/merge path. Later activity may have moved the quiet
+    /// deadline since the task was spawned; in that case keep ownership of the
+    /// pending slot and sleep again. Max-wait still caps the reschedule.
+    pub(crate) fn wire_gate_trailing_wake(&self, host: &Url) -> WireTrailingWake {
+        let now = tokio::time::Instant::now();
+        let mut gates = self
+            .wire_gate
+            .lock()
+            .recover_poison("DiagnosticAggregator::wire_gate");
+        let Some(gate) = gates.get_mut(host) else {
+            return WireTrailingWake::Gone;
+        };
+        if !gate.pending {
+            return WireTrailingWake::Gone;
+        }
+        let quiet_deadline = gate.last_activity_at.unwrap_or(now) + gate.debounce;
+        let deadline = gate
+            .last_sent_at
+            .map(|sent| quiet_deadline.min(sent + gate.max_wait))
+            .unwrap_or(quiet_deadline);
+        if now < deadline {
+            return WireTrailingWake::Wait(deadline - now);
+        }
+        gate.pending = false;
+        WireTrailingWake::Ready
+    }
+
     /// Forget the wire-gate state for `host` so the entry doesn't linger and a
     /// parked trailing task bails ([`Self::wire_gate_take_pending`] returns
     /// `false`). Called on `didClose` (`clear_host`, next to
@@ -1634,6 +1669,38 @@ mod tests {
             agg.wire_debounce_admit(&host(), debounce, max_wait, false),
             WireAdmit::SendNow
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stale_wire_timer_resleeps_without_consuming_pending() {
+        let agg = DiagnosticAggregator::new();
+        let host = host();
+        let debounce = std::time::Duration::from_millis(100);
+        let max_wait = std::time::Duration::from_secs(1);
+
+        assert_eq!(
+            agg.wire_debounce_admit(&host, debounce, max_wait, true),
+            WireAdmit::SendNow
+        );
+        agg.wire_gate_commit_send(&host);
+        tokio::time::advance(std::time::Duration::from_millis(10)).await;
+        assert!(matches!(
+            agg.wire_debounce_admit(&host, debounce, max_wait, true),
+            WireAdmit::Defer { .. }
+        ));
+        tokio::time::advance(std::time::Duration::from_millis(70)).await;
+        assert!(matches!(
+            agg.wire_debounce_admit(&host, debounce, max_wait, true),
+            WireAdmit::Defer { .. }
+        ));
+
+        tokio::time::advance(std::time::Duration::from_millis(30)).await;
+        assert_eq!(
+            agg.wire_gate_trailing_wake(&host),
+            WireTrailingWake::Wait(std::time::Duration::from_millis(70))
+        );
+        tokio::time::advance(std::time::Duration::from_millis(70)).await;
+        assert_eq!(agg.wire_gate_trailing_wake(&host), WireTrailingWake::Ready);
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -379,6 +379,10 @@ fn transform_region_diagnostic(diag: &mut Diagnostic, offset: &RegionOffset, hos
 #[derive(Default)]
 pub(crate) struct DiagnosticAggregator {
     cache: Mutex<HashMap<Url, SourceSlots>>,
+    /// Allocates process-unique cache incarnations so a reopened URI never
+    /// reuses a pre-close snapshot revision while closed-URI map entries can
+    /// still be reclaimed.
+    next_cache_revision: AtomicU64,
     /// Per-host cache mutation revision. Writers and snapshots lock this map
     /// before `cache`, making a revision and its slots one atomic state. A
     /// trailing wire task uses it to notice activity whose foreground
@@ -969,8 +973,7 @@ impl DiagnosticAggregator {
             },
         );
         if changed {
-            let revision = revisions.entry(host.clone()).or_default();
-            *revision = revision.wrapping_add(1);
+            revisions.insert(host.clone(), self.allocate_cache_revision());
         }
     }
 
@@ -1029,12 +1032,7 @@ impl DiagnosticAggregator {
             .recover_poison("DiagnosticAggregator::cache_revisions");
         let mut cache = self.lock();
         let removed = cache.remove(host).is_some();
-        // Keep advancing the host's incarnation even after its slots disappear.
-        // Otherwise a pre-close snapshot can validate after reopen when the new
-        // document happens to reach the same small revision again.
-        if let Some(revision) = revisions.get_mut(host) {
-            *revision = revision.wrapping_add(1);
-        }
+        revisions.remove(host);
         removed
     }
 
@@ -1750,8 +1748,7 @@ impl DiagnosticAggregator {
             cache.remove(host);
         }
         if removed {
-            let revision = revisions.entry(host.clone()).or_default();
-            *revision = revision.wrapping_add(1);
+            revisions.insert(host.clone(), self.allocate_cache_revision());
         }
         removed
     }
@@ -1811,10 +1808,23 @@ impl DiagnosticAggregator {
             !sources.is_empty()
         });
         for host in &affected {
-            let revision = revisions.entry(host.clone()).or_default();
-            *revision = revision.wrapping_add(1);
+            revisions.insert(host.clone(), self.allocate_cache_revision());
         }
         affected
+    }
+
+    fn allocate_cache_revision(&self) -> u64 {
+        self.next_cache_revision
+            .fetch_add(1, Ordering::Relaxed)
+            .wrapping_add(1)
+    }
+
+    #[cfg(test)]
+    fn cache_revision_count(&self) -> usize {
+        self.cache_revisions
+            .lock()
+            .recover_poison("DiagnosticAggregator::cache_revisions")
+            .len()
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<Url, SourceSlots>> {
@@ -3067,6 +3077,21 @@ mod tests {
     }
 
     #[test]
+    fn evict_host_reclaims_distinct_uri_revisions() {
+        let agg = DiagnosticAggregator::new();
+        for index in 0..100 {
+            let uri = Url::parse(&format!("file:///closed-{index}.rs")).unwrap();
+            agg.set_pull_layer(&uri, vec![diag("diagnostic")]);
+            assert!(agg.evict_host(&uri));
+        }
+        assert_eq!(
+            agg.cache_revision_count(),
+            0,
+            "closed URI generations must not accumulate tombstones"
+        );
+    }
+
+    #[test]
     fn evict_source_drops_only_that_source() {
         let agg = DiagnosticAggregator::new();
         let region = DiagnosticSource::Region("R1".to_string());
@@ -3116,9 +3141,10 @@ mod tests {
             !agg.evict_host(&host()),
             "the source eviction already removed the cache entry"
         );
-        assert!(
-            agg.snapshot_with_revision(&host()).1 > 0,
-            "didClose-style host eviction preserves an incarnation even when slots were already empty"
+        assert_eq!(
+            agg.snapshot_with_revision(&host()).1,
+            0,
+            "didClose-style host eviction reclaims the closed host's revision tombstone"
         );
     }
 

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1139,12 +1139,13 @@ impl DiagnosticAggregator {
     /// JSON-serialization path.
     #[cfg(test)]
     pub(crate) fn settle_wire_reversion(&self, host: &Url, diagnostics: &[Diagnostic]) -> bool {
-        let matches_wire = self
+        let wire = self
             .last_wire_published
             .lock()
             .recover_poison("DiagnosticAggregator::last_wire_published")
             .get(host)
-            .is_some_and(|wire| wire.as_ref() == diagnostics);
+            .cloned();
+        let matches_wire = wire.is_some_and(|wire| wire.as_ref() == diagnostics);
         if !matches_wire {
             return false;
         }
@@ -1169,12 +1170,13 @@ impl DiagnosticAggregator {
         diagnostics: &[Diagnostic],
         cache_revision: u64,
     ) -> Option<bool> {
-        let matches_wire = self
+        let wire = self
             .last_wire_published
             .lock()
             .recover_poison("DiagnosticAggregator::last_wire_published")
             .get(host)
-            .is_some_and(|wire| wire.as_ref() == diagnostics);
+            .cloned();
+        let matches_wire = wire.is_some_and(|wire| wire.as_ref() == diagnostics);
         let revisions = self
             .cache_revisions
             .lock()

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -409,6 +409,11 @@ pub(crate) struct DiagnosticAggregator {
     /// (same-host republishes are serialized), and forgotten on `didClose`
     /// ([`Self::forget_published`]).
     last_published: Mutex<HashMap<Url, Vec<Diagnostic>>>,
+    /// The last set that actually completed a client-facing wire send. This is
+    /// distinct from `last_published`, which advances when a set is recorded
+    /// even if debounce withholds it. Keeping both lets an A -> pending B -> A
+    /// reversion cancel the wire debt instead of sending duplicate A.
+    last_wire_published: Mutex<HashMap<Url, Vec<Diagnostic>>>,
     /// Single-flight guard for the **workspace-wide** `workspace/diagnostic/refresh`
     /// nudge (#497). `workspace/diagnostic/refresh` is param-less and workspace-wide,
     /// so concurrent refreshes are redundant; without this, a burst of set-changing
@@ -987,6 +992,36 @@ impl DiagnosticAggregator {
             .lock()
             .recover_poison("DiagnosticAggregator::last_published")
             .remove(host);
+        self.last_wire_published
+            .lock()
+            .recover_poison("DiagnosticAggregator::last_wire_published")
+            .remove(host);
+    }
+
+    /// Settle a withheld wire debt when the latest merged set has reverted to
+    /// what the editor already received. The parked task may still wake, but
+    /// `dirty = false` makes its unchanged republish a no-op.
+    pub(crate) fn settle_wire_reversion(&self, host: &Url, diagnostics: &[Diagnostic]) -> bool {
+        let matches_wire = self
+            .last_wire_published
+            .lock()
+            .recover_poison("DiagnosticAggregator::last_wire_published")
+            .get(host)
+            .is_some_and(|wire| {
+                wire.as_slice() == diagnostics || same_diagnostic_multiset(wire, diagnostics)
+            });
+        if !matches_wire {
+            return false;
+        }
+        if let Some(gate) = self
+            .wire_gate
+            .lock()
+            .recover_poison("DiagnosticAggregator::wire_gate")
+            .get_mut(host)
+        {
+            gate.dirty = false;
+        }
+        true
     }
 
     /// Begin a workspace-wide refresh under the single-flight + coverage guard
@@ -1295,6 +1330,22 @@ impl DiagnosticAggregator {
                     dirty: false,
                 },
             );
+        }
+        drop(gates);
+
+        // Called under the per-host republish lock after the send await, so the
+        // last-recorded set is exactly the set that just reached the wire.
+        if let Some(sent) = self
+            .last_published
+            .lock()
+            .recover_poison("DiagnosticAggregator::last_published")
+            .get(host)
+            .cloned()
+        {
+            self.last_wire_published
+                .lock()
+                .recover_poison("DiagnosticAggregator::last_wire_published")
+                .insert(host.clone(), sent);
         }
     }
 

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1269,7 +1269,7 @@ impl DiagnosticAggregator {
         };
         let was_quiet = gate
             .last_activity_at
-            .is_some_and(|at| now.duration_since(at) >= gate.debounce);
+            .is_some_and(|at| now.saturating_duration_since(at) >= gate.debounce);
         if record_activity {
             gate.last_activity_at = Some(now);
         }

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1394,8 +1394,8 @@ impl DiagnosticAggregator {
     }
 
     /// Record that a wire `publishDiagnostics` for `host` was actually sent:
-    /// stamp the send time (opening a fresh quiet window) and settle the
-    /// `dirty` debt. Called right after the send await, under the same
+    /// stamp the send time (anchoring max-wait for the active cycle) and settle
+    /// the `dirty` debt. Called right after the send await, under the same
     /// republish-lock hold as the [`Self::wire_gate_admit`] that admitted it.
     /// Clones the key only on first insert.
     pub(crate) fn wire_gate_commit_send(&self, host: &Url) {

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1628,14 +1628,31 @@ impl DiagnosticAggregator {
     pub(crate) fn wire_gate_schedule_latest(
         &self,
         host: &Url,
+        debounce: std::time::Duration,
+        max_wait: std::time::Duration,
     ) -> Option<(std::time::Duration, tokio_util::sync::CancellationToken)> {
         let now = tokio::time::Instant::now();
+        let revisions = self
+            .cache_revisions
+            .lock()
+            .recover_poison("DiagnosticAggregator::cache_revisions");
+        let cache_revision = revisions.get(host).copied().unwrap_or(0);
         let mut gates = self
             .wire_gate
             .lock()
             .recover_poison("DiagnosticAggregator::wire_gate");
-        let gate = gates.get_mut(host)?;
+        let gate = gates.entry(host.clone()).or_insert_with(|| WireGate {
+            debounce,
+            max_wait,
+            last_sent_at: None,
+            last_activity_at: Some(now),
+            last_cache_revision: cache_revision,
+            pending: false,
+            cancellation: tokio_util::sync::CancellationToken::new(),
+            dirty: true,
+        });
         gate.last_activity_at = Some(now);
+        gate.last_cache_revision = cache_revision;
         gate.dirty = true;
         if gate.pending {
             return None;
@@ -1645,11 +1662,17 @@ impl DiagnosticAggregator {
             .last_sent_at
             .map(|sent| quiet_deadline.min(sent + gate.max_wait))
             .unwrap_or(quiet_deadline);
+        // A max-wait attempt that itself became stale must not self-spawn an
+        // unbounded zero-delay full-merge chain. Back off by the active
+        // debounce (at least one millisecond); once churn settles, that retry
+        // sends the latest set.
+        let remaining = if deadline <= now {
+            gate.debounce.max(std::time::Duration::from_millis(1))
+        } else {
+            deadline - now
+        };
         gate.pending = true;
-        Some((
-            deadline.saturating_duration_since(now),
-            gate.cancellation.clone(),
-        ))
+        Some((remaining, gate.cancellation.clone()))
     }
 
     /// Forget the wire-gate state for `host` so the entry doesn't linger and a
@@ -1922,21 +1945,62 @@ mod tests {
         let host = host();
         let debounce = std::time::Duration::from_millis(100);
         let max_wait = std::time::Duration::from_secs(1);
+        agg.set_pull_layer(&host, vec![diag("A")]);
+        let revision = agg.snapshot_with_revision(&host).1;
         assert_eq!(
-            agg.wire_debounce_admit(&host, debounce, max_wait, true),
+            agg.wire_debounce_admit_for_revision(&host, debounce, max_wait, true, revision),
             WireAdmit::SendNow
         );
         agg.wire_gate_commit_send(&host);
 
+        agg.set_pull_layer(&host, vec![diag("B")]);
         let (remaining, _) = agg
-            .wire_gate_schedule_latest(&host)
+            .wire_gate_schedule_latest(&host, debounce, max_wait)
             .expect("the stale handoff owns one retry");
         assert_eq!(remaining, debounce);
         assert!(
-            agg.wire_gate_schedule_latest(&host).is_none(),
+            agg.wire_gate_schedule_latest(&host, debounce, max_wait)
+                .is_none(),
             "a second stale handoff shares the pending retry"
         );
         assert!(agg.wire_gate_is_dirty(&host));
+
+        tokio::time::advance(debounce).await;
+        assert_eq!(agg.wire_gate_trailing_wake(&host), WireTrailingWake::Ready);
+        let latest_revision = agg.snapshot_with_revision(&host).1;
+        assert_eq!(
+            agg.wire_debounce_admit_for_revision(
+                &host,
+                debounce,
+                max_wait,
+                false,
+                latest_revision,
+            ),
+            WireAdmit::SendNow,
+            "the scheduled revision is not debounced a second time"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stale_handoff_mints_a_first_gate_and_backs_off_after_max_wait() {
+        let agg = DiagnosticAggregator::new();
+        let host = host();
+        let debounce = std::time::Duration::from_millis(100);
+        let max_wait = std::time::Duration::from_millis(500);
+
+        let (remaining, _) = agg
+            .wire_gate_schedule_latest(&host, debounce, max_wait)
+            .expect("a stale first publish mints retry debt");
+        assert_eq!(remaining, debounce);
+        assert!(agg.wire_gate_is_dirty(&host));
+
+        assert!(agg.wire_gate_take_pending(&host));
+        agg.wire_gate_commit_send(&host);
+        tokio::time::advance(max_wait).await;
+        let (remaining, _) = agg
+            .wire_gate_schedule_latest(&host, debounce, max_wait)
+            .expect("a stale max-wait attempt schedules one successor");
+        assert_eq!(remaining, debounce, "past max-wait retries back off");
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -546,6 +546,10 @@ struct WireGate {
     /// exists before the first send commits, so an aborted/stale first publish
     /// cannot postpone delivery forever under continuous activity.
     cycle_started_at: tokio::time::Instant,
+    /// Whether this cycle has already scheduled one stale-snapshot retry. The
+    /// first zero-debounce retry may run immediately; later stale retries are
+    /// rate-limited even before max-wait.
+    stale_retry_started: bool,
     /// Latest set-changing feed admitted for this host. Trailing retries do
     /// not advance it, so `debounce` measures quiet since real activity.
     last_activity_at: Option<tokio::time::Instant>,
@@ -1437,6 +1441,7 @@ impl DiagnosticAggregator {
                     max_wait,
                     last_sent_at: None,
                     cycle_started_at: now,
+                    stale_retry_started: false,
                     last_activity_at: Some(now),
                     last_cache_revision: cache_revision,
                     pending: false,
@@ -1527,6 +1532,7 @@ impl DiagnosticAggregator {
         if let Some(gate) = gates.get_mut(host) {
             gate.last_sent_at = Some(now);
             gate.cycle_started_at = now;
+            gate.stale_retry_started = false;
             gate.dirty = false;
         } else {
             // The admit minted an entry, but a `forget_wire_gate` (seal) can
@@ -1538,6 +1544,7 @@ impl DiagnosticAggregator {
                     max_wait: std::time::Duration::ZERO,
                     last_sent_at: Some(now),
                     cycle_started_at: now,
+                    stale_retry_started: false,
                     last_activity_at: Some(now),
                     last_cache_revision: 0,
                     pending: false,
@@ -1653,6 +1660,7 @@ impl DiagnosticAggregator {
             max_wait,
             last_sent_at: None,
             cycle_started_at: now,
+            stale_retry_started: false,
             last_activity_at: Some(now),
             last_cache_revision: cache_revision,
             pending: false,
@@ -1673,13 +1681,14 @@ impl DiagnosticAggregator {
         let deadline = quiet_deadline.min(max_deadline);
         // A max-wait attempt that itself became stale must not self-spawn an
         // unbounded zero-delay full-merge chain. Back off by the active
-        // debounce (at least one millisecond); once churn settles, that retry
+        // debounce (at least 50 milliseconds); once churn settles, that retry
         // sends the latest set.
-        let remaining = if max_deadline <= now {
+        let remaining = if max_deadline <= now || (gate.stale_retry_started && deadline <= now) {
             gate.debounce.max(std::time::Duration::from_millis(50))
         } else {
             deadline.saturating_duration_since(now)
         };
+        gate.stale_retry_started = true;
         gate.pending = true;
         Some((remaining, gate.cancellation.clone()))
     }
@@ -2031,6 +2040,15 @@ mod tests {
             )
             .unwrap();
         assert_eq!(initial_remaining, std::time::Duration::ZERO);
+        assert!(zero.wire_gate_take_pending(&zero_host));
+        let (second_remaining, _) = zero
+            .wire_gate_schedule_latest(
+                &zero_host,
+                std::time::Duration::ZERO,
+                std::time::Duration::from_millis(1),
+            )
+            .unwrap();
+        assert_eq!(second_remaining, std::time::Duration::from_millis(50));
         assert!(zero.wire_gate_take_pending(&zero_host));
         zero.wire_gate_commit_send(&zero_host);
         tokio::time::advance(std::time::Duration::from_millis(1)).await;

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -379,9 +379,10 @@ fn transform_region_diagnostic(diag: &mut Diagnostic, offset: &RegionOffset, hos
 #[derive(Default)]
 pub(crate) struct DiagnosticAggregator {
     cache: Mutex<HashMap<Url, SourceSlots>>,
-    /// Per-host cache mutation revision, updated while `cache` is locked and
-    /// snapshotted under the same lock. A trailing wire task uses it to notice
-    /// activity whose foreground republish is still queued on the host lock.
+    /// Per-host cache mutation revision. Writers and snapshots lock this map
+    /// before `cache`, making a revision and its slots one atomic state. A
+    /// trailing wire task uses it to notice activity whose foreground
+    /// republish is still queued on the host lock.
     cache_revisions: Mutex<HashMap<Url, u64>>,
     /// Per-host republish locks. The publisher holds a host's lock across its
     /// snapshot→merge→publish so two concurrent republishes for the **same** host
@@ -936,6 +937,10 @@ impl DiagnosticAggregator {
         connection_id: Option<ProgressConnectionId>,
         diagnostics: Vec<Diagnostic>,
     ) {
+        let mut revisions = self
+            .cache_revisions
+            .lock()
+            .recover_poison("DiagnosticAggregator::cache_revisions");
         let mut cache = self.lock();
         // Look up by `&Url` first and clone the host key only when inserting a new
         // host entry, rather than `entry(host.clone())` cloning on every call.
@@ -956,7 +961,8 @@ impl DiagnosticAggregator {
             },
         );
         if changed {
-            self.bump_cache_revision(host);
+            let revision = revisions.entry(host.clone()).or_default();
+            *revision = revision.wrapping_add(1);
         }
     }
 
@@ -984,15 +990,13 @@ impl DiagnosticAggregator {
     /// Snapshot slots and their mutation revision atomically with respect to
     /// cache writers.
     pub(crate) fn snapshot_with_revision(&self, host: &Url) -> (SourceSlots, u64) {
-        let cache = self.lock();
-        let snapshot = cache.get(host).cloned().unwrap_or_default();
-        let revision = self
+        let revisions = self
             .cache_revisions
             .lock()
-            .recover_poison("DiagnosticAggregator::cache_revisions")
-            .get(host)
-            .copied()
-            .unwrap_or(0);
+            .recover_poison("DiagnosticAggregator::cache_revisions");
+        let cache = self.lock();
+        let snapshot = cache.get(host).cloned().unwrap_or_default();
+        let revision = revisions.get(host).copied().unwrap_or(0);
         (snapshot, revision)
     }
 
@@ -1011,12 +1015,13 @@ impl DiagnosticAggregator {
 
     /// Drop everything for a host (host `didClose`). Returns whether it existed.
     pub(crate) fn evict_host(&self, host: &Url) -> bool {
+        let mut revisions = self
+            .cache_revisions
+            .lock()
+            .recover_poison("DiagnosticAggregator::cache_revisions");
         let mut cache = self.lock();
         let removed = cache.remove(host).is_some();
-        self.cache_revisions
-            .lock()
-            .recover_poison("DiagnosticAggregator::cache_revisions")
-            .remove(host);
+        revisions.remove(host);
         removed
     }
 
@@ -1056,6 +1061,25 @@ impl DiagnosticAggregator {
         }
         last.insert(host.clone(), Arc::from(diagnostics));
         true
+    }
+
+    /// Compare-and-record only while `cache_revision` is still current. Cache
+    /// writers take the revision lock before changing slots, so `None` means
+    /// the caller must hand off to the republish paired with the newer write.
+    pub(crate) fn published_set_changed_current_revision(
+        &self,
+        host: &Url,
+        diagnostics: &[Diagnostic],
+        cache_revision: u64,
+    ) -> Option<bool> {
+        let revisions = self
+            .cache_revisions
+            .lock()
+            .recover_poison("DiagnosticAggregator::cache_revisions");
+        if revisions.get(host).copied().unwrap_or(0) != cache_revision {
+            return None;
+        }
+        Some(self.published_set_changed(host, diagnostics))
     }
 
     /// Forget the last-recorded set for `host` (host `didClose`), so its entry
@@ -1100,6 +1124,25 @@ impl DiagnosticAggregator {
             gate.dirty = false;
         }
         true
+    }
+
+    /// Revision-validated form of [`Self::settle_wire_reversion`]. The
+    /// revision lock remains held while clearing wire debt, so a newer cache
+    /// mutation cannot be hidden by a stale reversion snapshot.
+    pub(crate) fn settle_wire_reversion_current_revision(
+        &self,
+        host: &Url,
+        diagnostics: &[Diagnostic],
+        cache_revision: u64,
+    ) -> Option<bool> {
+        let revisions = self
+            .cache_revisions
+            .lock()
+            .recover_poison("DiagnosticAggregator::cache_revisions");
+        if revisions.get(host).copied().unwrap_or(0) != cache_revision {
+            return None;
+        }
+        Some(self.settle_wire_reversion(host, diagnostics))
     }
 
     /// Begin a workspace-wide refresh under the single-flight + coverage guard
@@ -1560,6 +1603,10 @@ impl DiagnosticAggregator {
     /// until the whole host is closed (#424). Returns whether the source existed.
     /// The host entry is removed if it becomes empty.
     pub(crate) fn evict_source(&self, host: &Url, source: &DiagnosticSource) -> bool {
+        let mut revisions = self
+            .cache_revisions
+            .lock()
+            .recover_poison("DiagnosticAggregator::cache_revisions");
         let mut cache = self.lock();
         // Borrow by `&Url` (no key clone) — the common case (host present, other
         // sources remain) is a single lookup. The host entry is removed only when
@@ -1572,7 +1619,8 @@ impl DiagnosticAggregator {
             cache.remove(host);
         }
         if removed {
-            self.bump_cache_revision(host);
+            let revision = revisions.entry(host.clone()).or_default();
+            *revision = revision.wrapping_add(1);
         }
         removed
     }
@@ -1612,6 +1660,10 @@ impl DiagnosticAggregator {
     /// host-event pull recomputes it — an intentional asymmetry (#469 targets the
     /// push path; the pull layer self-refreshes on the next pull).
     pub(crate) fn evict_connection(&self, connection_id: ProgressConnectionId) -> Vec<Url> {
+        let mut revisions = self
+            .cache_revisions
+            .lock()
+            .recover_poison("DiagnosticAggregator::cache_revisions");
         let mut cache = self.lock();
         let mut affected = Vec::new();
         cache.retain(|host, sources| {
@@ -1628,7 +1680,8 @@ impl DiagnosticAggregator {
             !sources.is_empty()
         });
         for host in &affected {
-            self.bump_cache_revision(host);
+            let revision = revisions.entry(host.clone()).or_default();
+            *revision = revision.wrapping_add(1);
         }
         affected
     }
@@ -1640,17 +1693,6 @@ impl DiagnosticAggregator {
         self.cache
             .lock()
             .recover_poison("DiagnosticAggregator::cache")
-    }
-
-    /// Advance a host revision while the caller still holds `cache`, keeping
-    /// [`Self::snapshot_with_revision`] atomic with the corresponding mutation.
-    fn bump_cache_revision(&self, host: &Url) {
-        let mut revisions = self
-            .cache_revisions
-            .lock()
-            .recover_poison("DiagnosticAggregator::cache_revisions");
-        let revision = revisions.entry(host.clone()).or_default();
-        *revision = revision.wrapping_add(1);
     }
 }
 

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -518,11 +518,11 @@ pub(crate) enum ForwardedRefreshWait {
 }
 
 /// Per-host coalescing state for the editor-facing `publishDiagnostics` wire
-/// sends. A changed merge inside the quiet window after the last send is
+/// sends. A changed merge before the active debounce/max-wait deadline is
 /// **withheld** from the wire (`dirty`) and a single trailing republish is
 /// scheduled (`pending`); the trailing run re-merges the *latest* cache, so
-/// every state change inside the window collapses into one send. An isolated
-/// change (window already elapsed, or first publish) passes through
+/// every state change before that deadline collapses into one send. An
+/// isolated change (no active burst, or first publish) passes through
 /// immediately — the gate adds no latency outside bursts.
 struct WireGate {
     /// Timing snapshot for the active burst. Live configuration updates are
@@ -541,7 +541,7 @@ struct WireGate {
     /// not advance it, so `debounce` measures quiet since real activity.
     last_activity_at: Option<tokio::time::Instant>,
     /// A trailing republish task is scheduled; bounds the tasks to one per
-    /// host per window.
+    /// host per active deadline.
     pending: bool,
     /// Wakes a parked trailing task when didClose or a publish seal forgets
     /// this gate, so long configured windows do not retain the publisher.
@@ -556,13 +556,13 @@ struct WireGate {
 }
 
 /// The wire-gate decision for one republish attempt: send now, or withhold
-/// until the quiet window elapses (scheduling the trailing republish iff no
-/// task is already parked).
+/// until the earlier debounce/max-wait deadline (scheduling the trailing
+/// republish iff no task is already parked).
 #[derive(Debug)]
 pub(crate) enum WireAdmit {
     /// Window clear: write to the wire now.
     SendNow,
-    /// Inside the quiet window: withhold. `schedule_trailing` is `true` for
+    /// Before the active deadline: withhold. `schedule_trailing` is `true` for
     /// at most one caller at a time — the first defer while no trailing task
     /// is parked (it must spawn the trailing republish after `remaining`);
     /// attempts while one is parked get `false`.

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1009,12 +1009,10 @@ impl DiagnosticAggregator {
     pub(crate) fn evict_host(&self, host: &Url) -> bool {
         let mut cache = self.lock();
         let removed = cache.remove(host).is_some();
-        if removed {
-            self.cache_revisions
-                .lock()
-                .recover_poison("DiagnosticAggregator::cache_revisions")
-                .remove(host);
-        }
+        self.cache_revisions
+            .lock()
+            .recover_poison("DiagnosticAggregator::cache_revisions")
+            .remove(host);
         removed
     }
 
@@ -2721,6 +2719,15 @@ mod tests {
         assert!(
             !agg.evict_source(&host(), &region),
             "evicting a source from an absent host is a no-op"
+        );
+        assert!(
+            !agg.evict_host(&host()),
+            "the source eviction already removed the cache entry"
+        );
+        assert_eq!(
+            agg.snapshot_with_revision(&host()).1,
+            0,
+            "didClose-style host eviction forgets a revision even when slots were already empty"
         );
     }
 

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1357,11 +1357,12 @@ impl DiagnosticAggregator {
             );
             return WireAdmit::SendNow;
         };
-        let record_activity = record_activity || gate.last_cache_revision != cache_revision;
+        let discovered_cache_activity = gate.last_cache_revision != cache_revision;
+        let any_activity = record_activity || discovered_cache_activity;
         let was_quiet = gate
             .last_activity_at
             .is_some_and(|at| now.saturating_duration_since(at) >= gate.debounce);
-        if record_activity {
+        if any_activity {
             gate.last_activity_at = Some(now);
             gate.last_cache_revision = cache_revision;
         }
@@ -1371,7 +1372,7 @@ impl DiagnosticAggregator {
         let send_now = gate.last_sent_at.is_none()
             || (record_activity && was_quiet)
             || reached_max_wait
-            || (!record_activity && now >= quiet_deadline);
+            || (!any_activity && now >= quiet_deadline);
         if send_now {
             // The send ends the admitted cycle. A real activity that starts a
             // quiet leading edge, recovers an uncommitted first send, or rolls
@@ -1819,7 +1820,7 @@ mod tests {
             WireAdmit::Defer { .. }
         ));
 
-        tokio::time::advance(std::time::Duration::from_millis(90)).await;
+        tokio::time::advance(std::time::Duration::from_millis(100)).await;
         assert!(matches!(
             agg.wire_debounce_admit_for_revision(&host, debounce, max_wait, false, 3),
             WireAdmit::Defer { remaining, .. } if remaining == debounce

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -527,6 +527,9 @@ struct WireGate {
     /// passes immediately, and the `dirty` debt below records that the
     /// last-recorded set may never have reached the wire.
     last_sent_at: Option<tokio::time::Instant>,
+    /// Latest set-changing feed admitted for this host. Trailing retries do
+    /// not advance it, so `debounce` measures quiet since real activity.
+    last_activity_at: Option<tokio::time::Instant>,
     /// A trailing republish task is scheduled; bounds the tasks to one per
     /// host per window.
     pending: bool,
@@ -1187,7 +1190,18 @@ impl DiagnosticAggregator {
     /// defer while no trailing task is parked). Called under the host's
     /// republish lock, so same-host decisions are serialized — including the
     /// decide→commit pair.
+    #[cfg(test)]
     pub(crate) fn wire_gate_admit(&self, host: &Url, window: std::time::Duration) -> WireAdmit {
+        self.wire_debounce_admit(host, window, window, true)
+    }
+
+    pub(crate) fn wire_debounce_admit(
+        &self,
+        host: &Url,
+        debounce: std::time::Duration,
+        max_wait: std::time::Duration,
+        record_activity: bool,
+    ) -> WireAdmit {
         let now = tokio::time::Instant::now();
         let mut gates = self
             .wire_gate
@@ -1204,26 +1218,36 @@ impl DiagnosticAggregator {
                 host.clone(),
                 WireGate {
                     last_sent_at: None,
+                    last_activity_at: Some(now),
                     pending: false,
                     dirty: true,
                 },
             );
             return WireAdmit::SendNow;
         };
-        let elapsed = gate.last_sent_at.map(|at| now.duration_since(at));
-        match elapsed {
-            Some(elapsed) if elapsed < window => {
-                gate.dirty = true;
-                let schedule_trailing = !gate.pending;
-                gate.pending = true;
-                WireAdmit::Defer {
-                    schedule_trailing,
-                    remaining: window - elapsed,
-                }
-            }
-            _ => {
-                gate.dirty = true;
-                WireAdmit::SendNow
+        let was_quiet = gate
+            .last_activity_at
+            .is_some_and(|at| now.duration_since(at) >= debounce);
+        if record_activity {
+            gate.last_activity_at = Some(now);
+        }
+        let quiet_deadline = gate.last_activity_at.unwrap_or(now) + debounce;
+        let max_deadline = gate.last_sent_at.map(|at| at + max_wait);
+        let send_now = gate.last_sent_at.is_none()
+            || (record_activity && was_quiet)
+            || max_deadline.is_some_and(|deadline| now >= deadline)
+            || (!record_activity && now >= quiet_deadline);
+        if send_now {
+            gate.dirty = true;
+            WireAdmit::SendNow
+        } else {
+            let deadline = max_deadline.map_or(quiet_deadline, |max| quiet_deadline.min(max));
+            gate.dirty = true;
+            let schedule_trailing = !gate.pending;
+            gate.pending = true;
+            WireAdmit::Defer {
+                schedule_trailing,
+                remaining: deadline.saturating_duration_since(now),
             }
         }
     }
@@ -1249,6 +1273,7 @@ impl DiagnosticAggregator {
                 host.clone(),
                 WireGate {
                     last_sent_at: Some(now),
+                    last_activity_at: Some(now),
                     pending: false,
                     dirty: false,
                 },
@@ -1465,6 +1490,89 @@ mod tests {
         assert!(
             !agg.wire_gate_is_dirty(&host()),
             "the post-send commit clears the dirty marker"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wire_debounce_tracks_quiet_from_latest_activity() {
+        let agg = DiagnosticAggregator::new();
+        let debounce = std::time::Duration::from_millis(100);
+        let max_wait = std::time::Duration::from_secs(1);
+        assert_eq!(
+            agg.wire_debounce_admit(&host(), debounce, max_wait, true),
+            WireAdmit::SendNow
+        );
+        agg.wire_gate_commit_send(&host());
+
+        tokio::time::advance(std::time::Duration::from_millis(10)).await;
+        assert!(matches!(
+            agg.wire_debounce_admit(&host(), debounce, max_wait, true),
+            WireAdmit::Defer { .. }
+        ));
+        tokio::time::advance(std::time::Duration::from_millis(80)).await;
+        assert!(matches!(
+            agg.wire_debounce_admit(&host(), debounce, max_wait, true),
+            WireAdmit::Defer { .. }
+        ));
+        tokio::time::advance(std::time::Duration::from_millis(20)).await;
+        assert!(agg.wire_gate_take_pending(&host()));
+        assert!(matches!(
+            agg.wire_debounce_admit(&host(), debounce, max_wait, false),
+            WireAdmit::Defer { remaining, .. }
+                if remaining == std::time::Duration::from_millis(80)
+        ));
+        tokio::time::advance(std::time::Duration::from_millis(80)).await;
+        assert!(agg.wire_gate_take_pending(&host()));
+        assert_eq!(
+            agg.wire_debounce_admit(&host(), debounce, max_wait, false),
+            WireAdmit::SendNow
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wire_debounce_forces_continuous_activity_at_max_wait() {
+        let agg = DiagnosticAggregator::new();
+        let debounce = std::time::Duration::from_millis(100);
+        let max_wait = std::time::Duration::from_millis(1000);
+        assert_eq!(
+            agg.wire_debounce_admit(&host(), debounce, max_wait, true),
+            WireAdmit::SendNow
+        );
+        agg.wire_gate_commit_send(&host());
+        for _ in 0..10 {
+            tokio::time::advance(std::time::Duration::from_millis(90)).await;
+            assert!(matches!(
+                agg.wire_debounce_admit(&host(), debounce, max_wait, true),
+                WireAdmit::Defer { .. }
+            ));
+        }
+        tokio::time::advance(std::time::Duration::from_millis(100)).await;
+        assert_eq!(
+            agg.wire_debounce_admit(&host(), debounce, max_wait, true),
+            WireAdmit::SendNow
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wire_debounce_is_independent_per_uri() {
+        let agg = DiagnosticAggregator::new();
+        let first = host();
+        let second = Url::parse("file:///other.md").unwrap();
+        let debounce = std::time::Duration::from_millis(100);
+        let max_wait = std::time::Duration::from_secs(1);
+        assert_eq!(
+            agg.wire_debounce_admit(&first, debounce, max_wait, true),
+            WireAdmit::SendNow
+        );
+        agg.wire_gate_commit_send(&first);
+        assert!(matches!(
+            agg.wire_debounce_admit(&first, debounce, max_wait, true),
+            WireAdmit::Defer { .. }
+        ));
+        assert_eq!(
+            agg.wire_debounce_admit(&second, debounce, max_wait, true),
+            WireAdmit::SendNow,
+            "one URI's pending burst must not delay another URI"
         );
     }
 

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -542,6 +542,10 @@ struct WireGate {
     /// passes immediately, and the `dirty` debt below records that the
     /// last-recorded set may never have reached the wire.
     last_sent_at: Option<tokio::time::Instant>,
+    /// Start of the current max-wait cycle. Unlike `last_sent_at`, this also
+    /// exists before the first send commits, so an aborted/stale first publish
+    /// cannot postpone delivery forever under continuous activity.
+    cycle_started_at: tokio::time::Instant,
     /// Latest set-changing feed admitted for this host. Trailing retries do
     /// not advance it, so `debounce` measures quiet since real activity.
     last_activity_at: Option<tokio::time::Instant>,
@@ -1432,6 +1436,7 @@ impl DiagnosticAggregator {
                     debounce,
                     max_wait,
                     last_sent_at: None,
+                    cycle_started_at: now,
                     last_activity_at: Some(now),
                     last_cache_revision: cache_revision,
                     pending: false,
@@ -1451,8 +1456,8 @@ impl DiagnosticAggregator {
             gate.last_cache_revision = cache_revision;
         }
         let quiet_deadline = gate.last_activity_at.unwrap_or(now) + gate.debounce;
-        let max_deadline = gate.last_sent_at.map(|at| at + gate.max_wait);
-        let reached_max_wait = max_deadline.is_some_and(|deadline| now >= deadline);
+        let max_deadline = gate.cycle_started_at + gate.max_wait;
+        let reached_max_wait = now >= max_deadline;
         let send_now = gate.last_sent_at.is_none()
             || (record_activity && was_quiet)
             || reached_max_wait
@@ -1468,7 +1473,7 @@ impl DiagnosticAggregator {
             gate.dirty = true;
             WireAdmit::SendNow
         } else {
-            let deadline = max_deadline.map_or(quiet_deadline, |max| quiet_deadline.min(max));
+            let deadline = quiet_deadline.min(max_deadline);
             gate.dirty = true;
             let schedule_trailing = !gate.pending;
             gate.pending = true;
@@ -1521,6 +1526,7 @@ impl DiagnosticAggregator {
             .recover_poison("DiagnosticAggregator::wire_gate");
         if let Some(gate) = gates.get_mut(host) {
             gate.last_sent_at = Some(now);
+            gate.cycle_started_at = now;
             gate.dirty = false;
         } else {
             // The admit minted an entry, but a `forget_wire_gate` (seal) can
@@ -1531,6 +1537,7 @@ impl DiagnosticAggregator {
                     debounce: std::time::Duration::ZERO,
                     max_wait: std::time::Duration::ZERO,
                     last_sent_at: Some(now),
+                    cycle_started_at: now,
                     last_activity_at: Some(now),
                     last_cache_revision: 0,
                     pending: false,
@@ -1611,9 +1618,9 @@ impl DiagnosticAggregator {
         }
         let quiet_deadline = gate.last_activity_at.unwrap_or(now) + gate.debounce;
         let deadline = gate
-            .last_sent_at
-            .map(|sent| quiet_deadline.min(sent + gate.max_wait))
-            .unwrap_or(quiet_deadline);
+            .cycle_started_at
+            .checked_add(gate.max_wait)
+            .map_or(quiet_deadline, |max| quiet_deadline.min(max));
         if now < deadline {
             return WireTrailingWake::Wait(deadline - now);
         }
@@ -1645,6 +1652,7 @@ impl DiagnosticAggregator {
             debounce,
             max_wait,
             last_sent_at: None,
+            cycle_started_at: now,
             last_activity_at: Some(now),
             last_cache_revision: cache_revision,
             pending: false,
@@ -1659,15 +1667,15 @@ impl DiagnosticAggregator {
         }
         let quiet_deadline = now + gate.debounce;
         let deadline = gate
-            .last_sent_at
-            .map(|sent| quiet_deadline.min(sent + gate.max_wait))
-            .unwrap_or(quiet_deadline);
+            .cycle_started_at
+            .checked_add(gate.max_wait)
+            .map_or(quiet_deadline, |max| quiet_deadline.min(max));
         // A max-wait attempt that itself became stale must not self-spawn an
         // unbounded zero-delay full-merge chain. Back off by the active
         // debounce (at least one millisecond); once churn settles, that retry
         // sends the latest set.
         let remaining = if deadline <= now {
-            gate.debounce.max(std::time::Duration::from_millis(1))
+            gate.debounce.max(std::time::Duration::from_millis(50))
         } else {
             deadline - now
         };
@@ -1994,13 +2002,43 @@ mod tests {
         assert_eq!(remaining, debounce);
         assert!(agg.wire_gate_is_dirty(&host));
 
-        assert!(agg.wire_gate_take_pending(&host));
+        tokio::time::advance(std::time::Duration::from_millis(400)).await;
+        assert!(
+            agg.wire_gate_schedule_latest(&host, debounce, max_wait)
+                .is_none()
+        );
+        tokio::time::advance(std::time::Duration::from_millis(100)).await;
+        assert_eq!(
+            agg.wire_gate_trailing_wake(&host),
+            WireTrailingWake::Ready,
+            "continuous first-send churn is capped by max-wait"
+        );
         agg.wire_gate_commit_send(&host);
         tokio::time::advance(max_wait).await;
         let (remaining, _) = agg
             .wire_gate_schedule_latest(&host, debounce, max_wait)
             .expect("a stale max-wait attempt schedules one successor");
         assert_eq!(remaining, debounce, "past max-wait retries back off");
+
+        let zero = DiagnosticAggregator::new();
+        let zero_host = Url::parse("file:///zero-debounce.rs").unwrap();
+        zero.wire_gate_schedule_latest(
+            &zero_host,
+            std::time::Duration::ZERO,
+            std::time::Duration::from_millis(1),
+        )
+        .unwrap();
+        assert!(zero.wire_gate_take_pending(&zero_host));
+        zero.wire_gate_commit_send(&zero_host);
+        tokio::time::advance(std::time::Duration::from_millis(1)).await;
+        let (remaining, _) = zero
+            .wire_gate_schedule_latest(
+                &zero_host,
+                std::time::Duration::ZERO,
+                std::time::Duration::from_millis(1),
+            )
+            .unwrap();
+        assert_eq!(remaining, std::time::Duration::from_millis(50));
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1176,7 +1176,6 @@ impl DiagnosticAggregator {
             .lock()
             .recover_poison("DiagnosticAggregator::last_wire_published")
             .get(host)
-            .cloned()
             .is_some_and(|wire| wire.as_ref() == diagnostics);
         let revisions = self
             .cache_revisions

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1525,12 +1525,34 @@ impl DiagnosticAggregator {
         )
     }
 
-    /// Record that a wire `publishDiagnostics` for `host` was actually sent:
-    /// stamp the send time (anchoring max-wait for the active cycle) and settle
-    /// the `dirty` debt. Called right after the send await, under the same
-    /// republish-lock hold as the [`Self::wire_gate_admit`] that admitted it.
-    /// Clones the key only on first insert.
-    pub(crate) fn wire_gate_commit_send(&self, host: &Url) {
+    /// Record that a wire `publishDiagnostics` for `host` was actually sent,
+    /// settling debt only while the admitted cache revision is still current.
+    /// Returns `false` when cache activity landed during the send await, so the
+    /// caller must schedule a latest-snapshot retry. The revision lock remains
+    /// held through the gate mutation, closing the admission-to-commit gap.
+    pub(crate) fn wire_gate_commit_send_current_revision(
+        &self,
+        host: &Url,
+        cache_revision: u64,
+    ) -> bool {
+        let revisions = self
+            .cache_revisions
+            .lock()
+            .recover_poison("DiagnosticAggregator::cache_revisions");
+        let revision_is_current = revisions.get(host).copied().unwrap_or(0) == cache_revision;
+        self.commit_wire_gate_state(host, !revision_is_current);
+        drop(revisions);
+        self.record_committed_wire_snapshot(host);
+        revision_is_current
+    }
+
+    #[cfg(test)]
+    fn wire_gate_commit_send(&self, host: &Url) {
+        self.commit_wire_gate_state(host, false);
+        self.record_committed_wire_snapshot(host);
+    }
+
+    fn commit_wire_gate_state(&self, host: &Url, preserve_debt: bool) {
         let now = tokio::time::Instant::now();
         let mut gates = self
             .wire_gate
@@ -1540,7 +1562,7 @@ impl DiagnosticAggregator {
             gate.last_sent_at = Some(now);
             gate.cycle_started_at = now;
             gate.stale_retry_started = false;
-            gate.dirty = false;
+            gate.dirty = preserve_debt;
         } else {
             // The admit minted an entry, but a `forget_wire_gate` (seal) can
             // race in off the happy path; re-minting settled is fine.
@@ -1556,12 +1578,13 @@ impl DiagnosticAggregator {
                     last_cache_revision: 0,
                     pending: false,
                     cancellation: tokio_util::sync::CancellationToken::new(),
-                    dirty: false,
+                    dirty: preserve_debt,
                 },
             );
         }
-        drop(gates);
+    }
 
+    fn record_committed_wire_snapshot(&self, host: &Url) {
         // Called under the per-host republish lock after the send await, so the
         // last-recorded set is exactly the set that just reached the wire.
         let sent = self
@@ -2246,6 +2269,44 @@ mod tests {
             .cloned()
             .unwrap();
         assert!(Arc::ptr_eq(&recorded, &wire));
+    }
+
+    #[test]
+    fn wire_commit_preserves_debt_when_cache_advances_during_send() {
+        let agg = DiagnosticAggregator::new();
+        let host = host();
+        agg.set_pull_layer(&host, vec![diag("A")]);
+        let admitted_revision = agg.snapshot_with_revision(&host).1;
+        assert_eq!(
+            agg.published_set_changed_current_revision(&host, &[diag("A")], admitted_revision),
+            Some(true)
+        );
+        assert_eq!(
+            agg.wire_debounce_admit_current_revision(
+                &host,
+                std::time::Duration::ZERO,
+                std::time::Duration::from_secs(1),
+                true,
+                admitted_revision,
+            ),
+            WireAdmit::SendNow
+        );
+
+        agg.set_pull_layer(&host, vec![diag("B")]);
+        assert!(
+            !agg.wire_gate_commit_send_current_revision(&host, admitted_revision),
+            "a send admitted before the cache mutation must not settle newer debt"
+        );
+        assert!(agg.wire_gate_is_dirty(&host));
+        assert!(
+            agg.wire_gate_schedule_latest(
+                &host,
+                std::time::Duration::ZERO,
+                std::time::Duration::from_secs(1),
+            )
+            .is_some(),
+            "the preserved debt must be eligible for a latest-snapshot retry"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -379,6 +379,10 @@ fn transform_region_diagnostic(diag: &mut Diagnostic, offset: &RegionOffset, hos
 #[derive(Default)]
 pub(crate) struct DiagnosticAggregator {
     cache: Mutex<HashMap<Url, SourceSlots>>,
+    /// Per-host cache mutation revision, updated while `cache` is locked and
+    /// snapshotted under the same lock. A trailing wire task uses it to notice
+    /// activity whose foreground republish is still queued on the host lock.
+    cache_revisions: Mutex<HashMap<Url, u64>>,
     /// Per-host republish locks. The publisher holds a host's lock across its
     /// snapshot→merge→publish so two concurrent republishes for the **same** host
     /// (a region push vs a host-event pull, on different tasks) cannot interleave
@@ -540,6 +544,10 @@ struct WireGate {
     /// Latest set-changing feed admitted for this host. Trailing retries do
     /// not advance it, so `debounce` measures quiet since real activity.
     last_activity_at: Option<tokio::time::Instant>,
+    /// Cache revision whose activity was last admitted. This prevents a
+    /// trailing task from mistaking newly snapshotted cache data for its own
+    /// timer-only retry.
+    last_cache_revision: u64,
     /// A trailing republish task is scheduled; bounds the tasks to one per
     /// host per active deadline.
     pending: bool,
@@ -932,6 +940,10 @@ impl DiagnosticAggregator {
         } else {
             cache.entry(host.clone()).or_default()
         };
+        let changed = source_slots
+            .get(&source)
+            .and_then(|servers| servers.get(&server))
+            .is_none_or(|slot| slot.diagnostics != diagnostics);
         source_slots.entry(source).or_default().insert(
             server,
             SlotEntry {
@@ -939,6 +951,9 @@ impl DiagnosticAggregator {
                 connection_id,
             },
         );
+        if changed {
+            self.bump_cache_revision(host);
+        }
     }
 
     /// Replace the cached host-event pull blob for a host
@@ -959,8 +974,22 @@ impl DiagnosticAggregator {
     /// Snapshot every source/server slot for a host, cloned for merging off-lock.
     /// Empty when the host has no slots.
     pub(crate) fn snapshot(&self, host: &Url) -> SourceSlots {
+        self.snapshot_with_revision(host).0
+    }
+
+    /// Snapshot slots and their mutation revision atomically with respect to
+    /// cache writers.
+    pub(crate) fn snapshot_with_revision(&self, host: &Url) -> (SourceSlots, u64) {
         let cache = self.lock();
-        cache.get(host).cloned().unwrap_or_default()
+        let snapshot = cache.get(host).cloned().unwrap_or_default();
+        let revision = self
+            .cache_revisions
+            .lock()
+            .recover_poison("DiagnosticAggregator::cache_revisions")
+            .get(host)
+            .copied()
+            .unwrap_or(0);
+        (snapshot, revision)
     }
 
     /// Whether `host` has a cached `Region` push slot with **non-empty** diagnostics
@@ -979,7 +1008,14 @@ impl DiagnosticAggregator {
     /// Drop everything for a host (host `didClose`). Returns whether it existed.
     pub(crate) fn evict_host(&self, host: &Url) -> bool {
         let mut cache = self.lock();
-        cache.remove(host).is_some()
+        let removed = cache.remove(host).is_some();
+        if removed {
+            self.cache_revisions
+                .lock()
+                .recover_poison("DiagnosticAggregator::cache_revisions")
+                .remove(host);
+        }
+        removed
     }
 
     /// Whether `diagnostics` differs from the last merged-and-recorded set for
@@ -1281,6 +1317,17 @@ impl DiagnosticAggregator {
         max_wait: std::time::Duration,
         record_activity: bool,
     ) -> WireAdmit {
+        self.wire_debounce_admit_for_revision(host, debounce, max_wait, record_activity, 0)
+    }
+
+    pub(crate) fn wire_debounce_admit_for_revision(
+        &self,
+        host: &Url,
+        debounce: std::time::Duration,
+        max_wait: std::time::Duration,
+        record_activity: bool,
+        cache_revision: u64,
+    ) -> WireAdmit {
         let now = tokio::time::Instant::now();
         let mut gates = self
             .wire_gate
@@ -1300,6 +1347,7 @@ impl DiagnosticAggregator {
                     max_wait,
                     last_sent_at: None,
                     last_activity_at: Some(now),
+                    last_cache_revision: cache_revision,
                     pending: false,
                     cancellation: tokio_util::sync::CancellationToken::new(),
                     dirty: true,
@@ -1307,11 +1355,13 @@ impl DiagnosticAggregator {
             );
             return WireAdmit::SendNow;
         };
+        let record_activity = record_activity || gate.last_cache_revision != cache_revision;
         let was_quiet = gate
             .last_activity_at
             .is_some_and(|at| now.saturating_duration_since(at) >= gate.debounce);
         if record_activity {
             gate.last_activity_at = Some(now);
+            gate.last_cache_revision = cache_revision;
         }
         let quiet_deadline = gate.last_activity_at.unwrap_or(now) + gate.debounce;
         let max_deadline = gate.last_sent_at.map(|at| at + gate.max_wait);
@@ -1367,6 +1417,7 @@ impl DiagnosticAggregator {
                     max_wait: std::time::Duration::ZERO,
                     last_sent_at: Some(now),
                     last_activity_at: Some(now),
+                    last_cache_revision: 0,
                     pending: false,
                     cancellation: tokio_util::sync::CancellationToken::new(),
                     dirty: false,
@@ -1488,6 +1539,9 @@ impl DiagnosticAggregator {
         if slots.is_empty() {
             cache.remove(host);
         }
+        if removed {
+            self.bump_cache_revision(host);
+        }
         removed
     }
 
@@ -1541,6 +1595,9 @@ impl DiagnosticAggregator {
             }
             !sources.is_empty()
         });
+        for host in &affected {
+            self.bump_cache_revision(host);
+        }
         affected
     }
 
@@ -1551,6 +1608,17 @@ impl DiagnosticAggregator {
         self.cache
             .lock()
             .recover_poison("DiagnosticAggregator::cache")
+    }
+
+    /// Advance a host revision while the caller still holds `cache`, keeping
+    /// [`Self::snapshot_with_revision`] atomic with the corresponding mutation.
+    fn bump_cache_revision(&self, host: &Url) {
+        let mut revisions = self
+            .cache_revisions
+            .lock()
+            .recover_poison("DiagnosticAggregator::cache_revisions");
+        let revision = revisions.entry(host.clone()).or_default();
+        *revision = revision.wrapping_add(1);
     }
 }
 
@@ -1701,6 +1769,31 @@ mod tests {
         );
         tokio::time::advance(std::time::Duration::from_millis(70)).await;
         assert_eq!(agg.wire_gate_trailing_wake(&host), WireTrailingWake::Ready);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn trailing_observation_of_new_cache_revision_counts_as_activity() {
+        let agg = DiagnosticAggregator::new();
+        let host = host();
+        let debounce = std::time::Duration::from_millis(100);
+        let max_wait = std::time::Duration::from_secs(1);
+
+        assert_eq!(
+            agg.wire_debounce_admit_for_revision(&host, debounce, max_wait, true, 1),
+            WireAdmit::SendNow
+        );
+        agg.wire_gate_commit_send(&host);
+        tokio::time::advance(std::time::Duration::from_millis(10)).await;
+        assert!(matches!(
+            agg.wire_debounce_admit_for_revision(&host, debounce, max_wait, true, 2),
+            WireAdmit::Defer { .. }
+        ));
+
+        tokio::time::advance(std::time::Duration::from_millis(90)).await;
+        assert!(matches!(
+            agg.wire_debounce_admit_for_revision(&host, debounce, max_wait, false, 3),
+            WireAdmit::Defer { remaining, .. } if remaining == debounce
+        ));
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1249,7 +1249,7 @@ impl DiagnosticAggregator {
             // The send ends the admitted cycle. A real activity that starts a
             // quiet leading edge, recovers an uncommitted first send, or rolls
             // a continuous burst at maxWait owns the next cycle's snapshot.
-            if record_activity && (gate.last_sent_at.is_none() || was_quiet || reached_max_wait) {
+            if reached_max_wait || (record_activity && (gate.last_sent_at.is_none() || was_quiet)) {
                 gate.debounce = debounce;
                 gate.max_wait = max_wait;
             }
@@ -1580,6 +1580,47 @@ mod tests {
             ),
             WireAdmit::Defer { remaining, .. }
                 if remaining == admitted_debounce
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wire_debounce_adopts_live_timing_after_trailing_max_wait() {
+        let agg = DiagnosticAggregator::new();
+        let admitted_debounce = std::time::Duration::from_millis(200);
+        let admitted_max_wait = std::time::Duration::from_millis(1000);
+        let updated_debounce = std::time::Duration::from_millis(500);
+        let updated_max_wait = std::time::Duration::from_millis(5000);
+        assert_eq!(
+            agg.wire_debounce_admit(&host(), admitted_debounce, admitted_max_wait, true),
+            WireAdmit::SendNow
+        );
+        agg.wire_gate_commit_send(&host());
+
+        for _ in 0..9 {
+            tokio::time::advance(std::time::Duration::from_millis(100)).await;
+            assert!(matches!(
+                agg.wire_debounce_admit(&host(), updated_debounce, updated_max_wait, true),
+                WireAdmit::Defer { .. }
+            ));
+        }
+        tokio::time::advance(std::time::Duration::from_millis(100)).await;
+        assert!(agg.wire_gate_take_pending(&host()));
+        assert_eq!(
+            agg.wire_debounce_admit(&host(), updated_debounce, updated_max_wait, false),
+            WireAdmit::SendNow
+        );
+        agg.wire_gate_commit_send(&host());
+
+        tokio::time::advance(std::time::Duration::from_millis(100)).await;
+        assert!(matches!(
+            agg.wire_debounce_admit(
+                &host(),
+                updated_debounce,
+                updated_max_wait,
+                true
+            ),
+            WireAdmit::Defer { remaining, .. }
+                if remaining == updated_debounce
         ));
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1090,7 +1090,16 @@ impl DiagnosticPublisher {
     }
 
     fn schedule_stale_wire_retry(&self, host: &Url) {
-        if let Some((remaining, cancellation)) = self.aggregator.wire_gate_schedule_latest(host) {
+        let timing = self
+            .settings_manager
+            .load_settings()
+            .features
+            .text_document_publish_diagnostics;
+        if let Some((remaining, cancellation)) = self.aggregator.wire_gate_schedule_latest(
+            host,
+            std::time::Duration::from_millis(timing.debounce_ms),
+            std::time::Duration::from_millis(timing.max_wait_ms),
+        ) {
             self.spawn_trailing_wire_publish(host.clone(), remaining, cancellation);
         }
     }

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1067,7 +1067,12 @@ impl DiagnosticPublisher {
                 // would both defer the next change and consume a withheld
                 // `dirty` debt. Same lock hold as the admit, so the pair is
                 // atomic per host.
-                self.aggregator.wire_gate_commit_send(host);
+                if !self
+                    .aggregator
+                    .wire_gate_commit_send_current_revision(host, cache_revision)
+                {
+                    self.schedule_stale_wire_retry(host);
+                }
             }
             crate::lsp::diagnostic_cache::WireAdmit::Defer {
                 schedule_trailing,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1086,22 +1086,29 @@ impl DiagnosticPublisher {
         cancellation: tokio_util::sync::CancellationToken,
     ) {
         let publisher = self.clone();
-        // Anchor the deadline NOW (at defer time), not at the task's first poll
-        // — under load the first poll can lag, which would silently stretch the
-        // quiet window.
-        let deadline = tokio::time::Instant::now() + remaining;
+        // Anchor before spawning: under load the task's first poll may lag,
+        // which must not stretch the admitted deadline.
+        let mut deadline = tokio::time::Instant::now() + remaining;
         tokio::spawn(async move {
-            tokio::select! {
-                biased;
-                _ = publisher.shutdown.cancelled() => {
-                    publisher.aggregator.forget_wire_gate(&host);
-                    return;
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = publisher.shutdown.cancelled() => {
+                        publisher.aggregator.forget_wire_gate(&host);
+                        return;
+                    }
+                    _ = cancellation.cancelled() => return,
+                    _ = tokio::time::sleep_until(deadline) => {}
                 }
-                _ = cancellation.cancelled() => return,
-                _ = tokio::time::sleep_until(deadline) => {}
-            }
-            if !publisher.aggregator.wire_gate_take_pending(&host) {
-                return; // gate forgotten while parked: debt cancelled
+                match publisher.aggregator.wire_gate_trailing_wake(&host) {
+                    crate::lsp::diagnostic_cache::WireTrailingWake::Gone => return,
+                    crate::lsp::diagnostic_cache::WireTrailingWake::Wait(next) => {
+                        // Later activity moved the quiet deadline. Resleep
+                        // without rebuilding the diagnostic set.
+                        deadline = tokio::time::Instant::now() + next;
+                    }
+                    crate::lsp::diagnostic_cache::WireTrailingWake::Ready => break,
+                }
             }
             // Belt to the bail above: a host closed while this task was parked
             // (but not yet forgotten) is `clear_host`'s to finish — its

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -943,7 +943,10 @@ impl DiagnosticPublisher {
             // editor-originated pull-layer update whose caller deliberately
             // does not nudge pull clients. Preserve this caller's
             // push-origin refresh responsibility conservatively.
-            None => return RepublishOutcome::Deferred,
+            None => {
+                self.schedule_stale_wire_retry(host);
+                return RepublishOutcome::Deferred;
+            }
             Some(true) => RepublishOutcome::Changed,
             Some(false) => RepublishOutcome::Unchanged,
         };
@@ -1015,7 +1018,10 @@ impl DiagnosticPublisher {
             &diagnostics,
             cache_revision,
         ) {
-            None => return changed,
+            None => {
+                self.schedule_stale_wire_retry(host);
+                return changed;
+            }
             Some(true) => return changed,
             Some(false) => {}
         }
@@ -1040,7 +1046,10 @@ impl DiagnosticPublisher {
             wire_activity && changed == RepublishOutcome::Changed,
             cache_revision,
         ) {
-            crate::lsp::diagnostic_cache::WireAdmit::RetryLatest => return changed,
+            crate::lsp::diagnostic_cache::WireAdmit::RetryLatest => {
+                self.schedule_stale_wire_retry(host);
+                return changed;
+            }
             crate::lsp::diagnostic_cache::WireAdmit::SendNow => {
                 log::debug!(
                     target: LOG_TARGET,
@@ -1078,6 +1087,12 @@ impl DiagnosticPublisher {
             }
         }
         changed
+    }
+
+    fn schedule_stale_wire_retry(&self, host: &Url) {
+        if let Some((remaining, cancellation)) = self.aggregator.wire_gate_schedule_latest(host) {
+            self.spawn_trailing_wire_publish(host.clone(), remaining, cancellation);
+        }
     }
 
     /// Re-run [`Self::republish`] for `host` at the next debounce/max-wait deadline,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -76,22 +76,10 @@ impl RepublishOutcome {
     }
 }
 
-/// Quiet window for the editor-facing `publishDiagnostics` wire sends, per
-/// host. A changed merge inside the window after the last send is withheld and
-/// re-merged by one trailing republish at the window's end, so a burst of
-/// feeds (spontaneous pushes, the pull-layer completion, the post-parse
-/// geometry re-merge) collapses into at most one full-set publish per window
-/// per host — on a diagnostics-heavy host each publish is ~1 MB (measured:
-/// ~2,235 merged diagnostics), so the gate bounds sustained-typing wire cost
-/// at ~1 MB/s/host where it was ~2.2. An isolated change (window already
-/// elapsed) passes through immediately: the gate adds no latency outside
-/// bursts (more precisely: to a change arriving after >= 1 s of wire quiet).
-/// Deliberately a fixed constant, not a config knob: the window trades only
-/// push-namespace refresh cadence against pipe bytes, the failure mode of a
-/// wrong value is mild in both directions, and this branch's review explicitly
-/// chose existing config surfaces over new ones — revisit if a real setup
-/// needs a different cadence.
-const WIRE_PUBLISH_QUIET_WINDOW: std::time::Duration = std::time::Duration::from_secs(1);
+/// Programmed quiet-window default used by paused-time tests. Runtime scheduling
+/// reads the top-level feature policy on each set-changing admission.
+#[cfg(test)]
+const WIRE_PUBLISH_QUIET_WINDOW: std::time::Duration = std::time::Duration::from_millis(100);
 #[cfg(test)]
 const FORWARDED_REFRESH_SETTLE_WINDOW: std::time::Duration = std::time::Duration::from_millis(100);
 #[cfg(test)]
@@ -851,6 +839,14 @@ impl DiagnosticPublisher {
     /// [`Self::request_pull_diagnostic_refresh`] on `Changed` OR `Deferred` —
     /// see [`RepublishOutcome::Deferred`] for why the deferral still nudges.
     pub(crate) async fn republish(&self, host: &Url) -> RepublishOutcome {
+        self.republish_with_wire_activity(host, true).await
+    }
+
+    async fn republish_with_wire_activity(
+        &self,
+        host: &Url,
+        wire_activity: bool,
+    ) -> RepublishOutcome {
         // Serialize the whole snapshot→merge→publish so concurrent republishes
         // (region push vs host-event pull) emit in order and a stale snapshot can
         // never publish after a fresh one (push-propagation-diagnostic-forwarding).
@@ -1010,10 +1006,17 @@ impl DiagnosticPublisher {
         // immediately. Deferral withholds only the wire: the set was already
         // recorded above, so the return value (and with it the push-origin
         // coverage bump + refresh nudge) is unaffected.
-        match self
-            .aggregator
-            .wire_gate_admit(host, WIRE_PUBLISH_QUIET_WINDOW)
-        {
+        let timing = self
+            .settings_manager
+            .load_settings()
+            .features
+            .text_document_publish_diagnostics;
+        match self.aggregator.wire_debounce_admit(
+            host,
+            std::time::Duration::from_millis(timing.debounce_ms),
+            std::time::Duration::from_millis(timing.max_wait_ms),
+            wire_activity,
+        ) {
             crate::lsp::diagnostic_cache::WireAdmit::SendNow => {
                 log::debug!(
                     target: LOG_TARGET,
@@ -1063,11 +1066,8 @@ impl DiagnosticPublisher {
     /// reopened incarnation's fresh entry is instead kept safe by the
     /// defer-reschedule design — see `wire_gate_take_pending`.)
     ///
-    /// Shutdown: a task parked at teardown fires up to one window later and
-    /// sends a fire-and-forget notification into a closing client — tower-lsp
-    /// suppresses or error-logs it; nothing panics and no fresh downstream
-    /// state is created (unlike the reparse loop, which checks the shutdown
-    /// token because its work spawns bridge connections).
+    /// Shutdown races the timer against the shared cancellation token, forgets
+    /// this host's gate state, and exits without a wire send.
     ///
     /// [`WireAdmit::Defer`]: crate::lsp::diagnostic_cache::WireAdmit::Defer
     fn spawn_trailing_wire_publish(&self, host: Url, remaining: std::time::Duration) {
@@ -1077,7 +1077,14 @@ impl DiagnosticPublisher {
         // quiet window.
         let deadline = tokio::time::Instant::now() + remaining;
         tokio::spawn(async move {
-            tokio::time::sleep_until(deadline).await;
+            tokio::select! {
+                biased;
+                _ = publisher.shutdown.cancelled() => {
+                    publisher.aggregator.forget_wire_gate(&host);
+                    return;
+                }
+                _ = tokio::time::sleep_until(deadline) => {}
+            }
             if !publisher.aggregator.wire_gate_take_pending(&host) {
                 return; // gate forgotten while parked: debt cancelled
             }
@@ -1088,7 +1095,7 @@ impl DiagnosticPublisher {
             if publisher.documents.get(&host).is_none() {
                 return;
             }
-            publisher.republish(&host).await;
+            publisher.republish_with_wire_activity(&host, false).await;
         });
     }
 
@@ -2083,6 +2090,45 @@ mod tests {
             RepublishOutcome::Unchanged,
             "after the flush an identical re-merge is a plain unchanged skip"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_cancels_pending_trailing_publish() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        register_rust(server);
+        server.settings_manager.apply_settings(rust_settings(true));
+        let uri = Url::parse("file:///test/host_trailing_shutdown.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let publisher = DiagnosticPublisher::new(server);
+        server.diagnostics.record(
+            &uri,
+            DiagnosticSource::Host,
+            "rust_ls".to_string(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("first")],
+        );
+        publisher.republish(&uri).await;
+        server.diagnostics.record(
+            &uri,
+            DiagnosticSource::Host,
+            "rust_ls".to_string(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("withheld")],
+        );
+        publisher.republish(&uri).await;
+        assert!(server.diagnostics.wire_gate_is_dirty(&uri));
+
+        server.shutdown_token.cancel();
+        tokio::time::advance(WIRE_PUBLISH_QUIET_WINDOW).await;
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        assert!(!server.diagnostics.wire_gate_is_dirty(&uri));
+        assert!(!server.diagnostics.wire_gate_take_pending(&uri));
     }
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1015,7 +1015,7 @@ impl DiagnosticPublisher {
             host,
             std::time::Duration::from_millis(timing.debounce_ms),
             std::time::Duration::from_millis(timing.max_wait_ms),
-            wire_activity,
+            wire_activity && changed == RepublishOutcome::Changed,
         ) {
             crate::lsp::diagnostic_cache::WireAdmit::SendNow => {
                 log::debug!(
@@ -2076,8 +2076,14 @@ mod tests {
             "the change was withheld from the wire"
         );
 
+        // An identical feed while the changed set is already dirty must not
+        // count as new burst activity and move the quiet deadline.
+        tokio::time::advance(super::WIRE_PUBLISH_QUIET_WINDOW / 2).await;
+        assert_eq!(publisher.republish(&uri).await, RepublishOutcome::Unchanged);
+        assert!(server.diagnostics.wire_gate_is_dirty(&uri));
+
         // The window elapses; the parked trailing task re-runs republish.
-        tokio::time::advance(super::WIRE_PUBLISH_QUIET_WINDOW).await;
+        tokio::time::advance(super::WIRE_PUBLISH_QUIET_WINDOW / 2).await;
         // Advance virtual time once more so Tokio drains the woken trailing
         // task through its nested awaits without relying on a poll count.
         tokio::time::sleep(std::time::Duration::from_millis(1)).await;

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -939,7 +939,11 @@ impl DiagnosticPublisher {
             &diagnostics,
             cache_revision,
         ) {
-            None => return RepublishOutcome::Unchanged,
+            // A newer cache writer owns the wire handoff, but it may be an
+            // editor-originated pull-layer update whose caller deliberately
+            // does not nudge pull clients. Preserve this caller's
+            // push-origin refresh responsibility conservatively.
+            None => return RepublishOutcome::Deferred,
             Some(true) => RepublishOutcome::Changed,
             Some(false) => RepublishOutcome::Unchanged,
         };

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -860,7 +860,7 @@ impl DiagnosticPublisher {
         // is the client's outbound-channel send, not a round-trip.
         let _guard = self.aggregator.lock_republish(host).await;
 
-        let mut snapshot = self.aggregator.snapshot(host);
+        let (mut snapshot, cache_revision) = self.aggregator.snapshot_with_revision(host);
         // Drop Host push slots whose server is no longer a configured `_self` host
         // server for the document's current language — so a host server's pushed
         // diagnostics don't linger in the editor after the user disables `_self`
@@ -1019,11 +1019,12 @@ impl DiagnosticPublisher {
             .load_settings()
             .features
             .text_document_publish_diagnostics;
-        match self.aggregator.wire_debounce_admit(
+        match self.aggregator.wire_debounce_admit_for_revision(
             host,
             std::time::Duration::from_millis(timing.debounce_ms),
             std::time::Duration::from_millis(timing.max_wait_ms),
             wire_activity && changed == RepublishOutcome::Changed,
+            cache_revision,
         ) {
             crate::lsp::diagnostic_cache::WireAdmit::SendNow => {
                 log::debug!(

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -2285,14 +2285,14 @@ mod tests {
             vec![diag("B")],
         );
         publisher.republish(&uri).await;
-        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
         assert!(
             Arc::strong_count(&server.diagnostics) > baseline,
             "the parked task holds a publisher clone"
         );
 
         server.diagnostics.forget_wire_gate(&uri);
-        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
         assert_eq!(
             Arc::strong_count(&server.diagnostics),
             baseline,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1006,10 +1006,10 @@ impl DiagnosticPublisher {
             return changed;
         }
 
-        // Coalesce the wire sends per host (the quiet window): a burst of
+        // Coalesce the wire sends per host (debounce plus max-wait): a burst of
         // set-changing feeds — spontaneous pushes, the pull-layer completion,
         // the post-parse geometry re-merge, each ~1 MB on a diagnostics-heavy
-        // host — collapses into at most one publish per window, re-merged from
+        // host — collapses until the next deadline, re-merged from
         // the LATEST cache by the trailing republish. An isolated change sends
         // immediately. Deferral withholds only the wire: the set was already
         // recorded above, so the return value (and with it the push-origin
@@ -1051,7 +1051,7 @@ impl DiagnosticPublisher {
             } => {
                 log::debug!(
                     target: LOG_TARGET,
-                    "withholding publish of {} merged diagnostics for {} ({}ms of quiet window left)",
+                    "withholding publish of {} merged diagnostics for {} ({}ms until debounce/max-wait deadline)",
                     diagnostics.len(),
                     host,
                     remaining.as_millis()
@@ -1064,7 +1064,7 @@ impl DiagnosticPublisher {
         changed
     }
 
-    /// Re-run [`Self::republish`] for `host` once the quiet window elapses,
+    /// Re-run [`Self::republish`] for `host` at the next debounce/max-wait deadline,
     /// sending the (re-merged, latest) withheld set to the wire. At most one
     /// task is parked per host at a time ([`WireAdmit::Defer`]'s
     /// `schedule_trailing`). Clears the gate's `pending` marker *before*

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -860,209 +860,212 @@ impl DiagnosticPublisher {
         // is the client's outbound-channel send, not a round-trip.
         let _guard = self.aggregator.lock_republish(host).await;
 
-        let (mut snapshot, cache_revision) = self.aggregator.snapshot_with_revision(host);
-        // Drop Host push slots whose server is no longer a configured `_self` host
-        // server for the document's current language — so a host server's pushed
-        // diagnostics don't linger in the editor after the user disables `_self`
-        // (or unconfigures the server) via `workspace/didChangeConfiguration`. The
-        // slots stay cached (cleared on `didClose`); they're just filtered out of
-        // this publish. (The analogous Region/config-change re-merge is deferred.)
-        self.filter_stale_host_slots(host, &mut snapshot);
-        // Drop a pull-driven server's push slots when the host-event pull blob
-        // (`PullLayer`) is present: that server already contributes via the
-        // pull, so keeping its spontaneous push too would double-count it
-        // (#425). The cache keeps the slot; only this publish snapshot is
-        // filtered.
-        self.filter_pull_driven_push_slots(&mut snapshot).await;
-        // Recompute injection offsets only when there are region push slots to
-        // transform. A PullLayer-only snapshot (the common pull-driven case) needs
-        // none, so skip the whole-document injection resolution — and shorten the
-        // time this host's republish lock is held. The predicate IS
-        // `DiagnosticAggregator::has_region_slots`'s (the shared
-        // `has_live_region_slots`): the geometry-unknown deferral below relies
-        // on the reparse loop's post-parse republish, which is gated on
-        // exactly that check.
-        let needs_geometry = crate::lsp::diagnostic_cache::has_live_region_slots(&snapshot);
-        let region_offsets = if needs_geometry {
-            match self.current_region_offsets(host) {
-                Some(offsets) => offsets,
-                // The document is open but has no parse snapshot: `did_change`
-                // cleared the tree and the off-ingress reparse hasn't landed yet,
-                // so the regions' current offsets are UNKNOWN — not gone. Merging
-                // now would silently drop every region push slot and publish a
-                // set missing whole servers, which the post-parse republish then
-                // reverts: on a diagnostics-heavy host that flapped the editor
-                // between the full and the region-less set on every edit cycle
-                // (~2 × ~1 MB publishes per keystroke settle, plus visible
-                // flicker for push-mode clients). Defer instead: publish nothing,
-                // record nothing. The reparse loop re-runs `republish` after the
-                // parse lands whenever non-empty region slots remain
-                // (`has_region_slots` — the same predicate as `needs_geometry`),
-                // and the pass's debounced pull re-feeds and republishes too.
-                // Caveats, accepted: a parse give-up (timeout / parser gone)
-                // leaves the tree absent, so both retries stay deferred until
-                // the next edit (main published a region-LESS set there — worse);
-                // and an edit that evicts the very slots that forced this defer
-                // hands coverage to the debounced pull alone. Push-origin
-                // delivery does not depend on the retry: `Deferred` nudges
-                // pull-mode clients at defer time (see `RepublishOutcome`).
-                None => {
-                    log::debug!(
-                        target: LOG_TARGET,
-                        "defer republish for {host}: tree pending, region geometry unknown"
-                    );
-                    return RepublishOutcome::Deferred;
+        'latest: loop {
+            let (mut snapshot, cache_revision) = self.aggregator.snapshot_with_revision(host);
+            // Drop Host push slots whose server is no longer a configured `_self` host
+            // server for the document's current language — so a host server's pushed
+            // diagnostics don't linger in the editor after the user disables `_self`
+            // (or unconfigures the server) via `workspace/didChangeConfiguration`. The
+            // slots stay cached (cleared on `didClose`); they're just filtered out of
+            // this publish. (The analogous Region/config-change re-merge is deferred.)
+            self.filter_stale_host_slots(host, &mut snapshot);
+            // Drop a pull-driven server's push slots when the host-event pull blob
+            // (`PullLayer`) is present: that server already contributes via the
+            // pull, so keeping its spontaneous push too would double-count it
+            // (#425). The cache keeps the slot; only this publish snapshot is
+            // filtered.
+            self.filter_pull_driven_push_slots(&mut snapshot).await;
+            // Recompute injection offsets only when there are region push slots to
+            // transform. A PullLayer-only snapshot (the common pull-driven case) needs
+            // none, so skip the whole-document injection resolution — and shorten the
+            // time this host's republish lock is held. The predicate IS
+            // `DiagnosticAggregator::has_region_slots`'s (the shared
+            // `has_live_region_slots`): the geometry-unknown deferral below relies
+            // on the reparse loop's post-parse republish, which is gated on
+            // exactly that check.
+            let needs_geometry = crate::lsp::diagnostic_cache::has_live_region_slots(&snapshot);
+            let region_offsets = if needs_geometry {
+                match self.current_region_offsets(host) {
+                    Some(offsets) => offsets,
+                    // The document is open but has no parse snapshot: `did_change`
+                    // cleared the tree and the off-ingress reparse hasn't landed yet,
+                    // so the regions' current offsets are UNKNOWN — not gone. Merging
+                    // now would silently drop every region push slot and publish a
+                    // set missing whole servers, which the post-parse republish then
+                    // reverts: on a diagnostics-heavy host that flapped the editor
+                    // between the full and the region-less set on every edit cycle
+                    // (~2 × ~1 MB publishes per keystroke settle, plus visible
+                    // flicker for push-mode clients). Defer instead: publish nothing,
+                    // record nothing. The reparse loop re-runs `republish` after the
+                    // parse lands whenever non-empty region slots remain
+                    // (`has_region_slots` — the same predicate as `needs_geometry`),
+                    // and the pass's debounced pull re-feeds and republishes too.
+                    // Caveats, accepted: a parse give-up (timeout / parser gone)
+                    // leaves the tree absent, so both retries stay deferred until
+                    // the next edit (main published a region-LESS set there — worse);
+                    // and an edit that evicts the very slots that forced this defer
+                    // hands coverage to the debounced pull alone. Push-origin
+                    // delivery does not depend on the retry: `Deferred` nudges
+                    // pull-mode clients at defer time (see `RepublishOutcome`).
+                    None => {
+                        log::debug!(
+                            target: LOG_TARGET,
+                            "defer republish for {host}: tree pending, region geometry unknown"
+                        );
+                        return RepublishOutcome::Deferred;
+                    }
                 }
-            }
-        } else {
-            HashMap::new()
-        };
-        let diagnostics = merge_cached_diagnostics(host, snapshot, &region_offsets);
+            } else {
+                HashMap::new()
+            };
+            let diagnostics = merge_cached_diagnostics(host, snapshot, &region_offsets);
 
-        let lsp_uri = match crate::lsp::lsp_impl::url_to_uri(host) {
-            Ok(uri) => uri,
-            Err(e) => {
-                log::warn!(target: LOG_TARGET, "skip publish, bad host URI {host}: {e}");
-                return RepublishOutcome::Unchanged;
-            }
-        };
+            let lsp_uri = match crate::lsp::lsp_impl::url_to_uri(host) {
+                Ok(uri) => uri,
+                Err(e) => {
+                    log::warn!(target: LOG_TARGET, "skip publish, bad host URI {host}: {e}");
+                    return RepublishOutcome::Unchanged;
+                }
+            };
 
-        // Suppress a republish that would re-send the exact set the editor already
-        // has — a redundant publishDiagnostics is needless flicker/noise (#422).
-        // Done under the per-host republish lock (held above), so the compare-and-set
-        // is serialized with other republishes for this host. A withheld wire
-        // send (`wire_gate_is_dirty`) still proceeds: the recorded set is ahead
-        // of what actually reached the editor, so the trailing republish must
-        // send even though its own merge compares unchanged.
-        let changed = if self.aggregator.published_set_changed(host, &diagnostics) {
-            RepublishOutcome::Changed
-        } else {
-            RepublishOutcome::Unchanged
-        };
-        if changed == RepublishOutcome::Unchanged && !self.aggregator.wire_gate_is_dirty(host) {
-            log::debug!(
-                target: LOG_TARGET,
-                "skip republish for {host}: merged set unchanged ({} diagnostics)",
-                diagnostics.len()
-            );
-            return RepublishOutcome::Unchanged;
-        }
-
-        // The cross-layer gate for `textDocument/publishDiagnostics` doubles as a
-        // WIRE SEAL when it resolves to no layers at all: a pull-first editor
-        // setup can stop the proactive publishes entirely via existing config.
-        // On a diagnostics-heavy host they dominated the editor pipe (measured:
-        // 51 publishes × ~1 MB in a 44 s typing burst, 68% of all server→client
-        // bytes — head-of-line blocking every other response) while a pulling
-        // editor ignores them or renders them as a duplicate namespace. The
-        // merge above still ran and recorded the set: change detection keeps
-        // driving the push-origin coverage bump and
-        // `workspace/diagnostic/refresh`, which IS the sealed setup's delivery
-        // signal (refresh → client re-pull). The wire-gate state is dropped —
-        // there is no wire under the seal, so nothing can be owed to it (a
-        // stale `dirty` from before a mid-session seal would otherwise linger).
-        if self.publish_sealed(host) {
-            self.aggregator.forget_wire_gate(host);
-            log::debug!(
-                target: LOG_TARGET,
-                "seal: skipping publish of {} merged diagnostics for {} \
-                 (layers.aggregation publishDiagnostics resolves to no layers)",
-                diagnostics.len(),
-                host
-            );
-            return changed;
-        }
-
-        // A republish for a CLOSED host bypasses the quiet window and never
-        // touches gate state. This is (or races) `didClose`'s clearing publish,
-        // and both halves matter: a *deferred* clearing publish would be
-        // dropped by the trailing task's closed-document guard, pinning the
-        // closed buffer's last diagnostics in the editor forever; and a racing
-        // in-flight republish that *stamped* fresh gate state here (after
-        // `clear_host`'s forget, which does not hold the republish lock) would
-        // be exactly what defers that clearing publish. Both republishes are
-        // serialized on the per-host lock, so the clearing (empty) publish
-        // always lands last. (This ungated send shares the pre-existing
-        // record-before-send hazard: an abort landing exactly at the send
-        // below loses it — same class as main, bounded to closed-host races.)
-        if self.documents.get(host).is_none() {
-            log::debug!(
-                target: LOG_TARGET,
-                "publishing {} merged diagnostics for closed host {} (quiet window bypassed)",
-                diagnostics.len(),
-                host
-            );
-            self.client
-                .publish_diagnostics(lsp_uri, diagnostics, None)
-                .await;
-            return changed;
-        }
-
-        // The logical recorded set may change inside a burst and then revert
-        // to the set already on the wire (A -> pending B -> A). In that case
-        // there is no wire work left: settle the dirty debt so the parked
-        // trailing task does not emit duplicate A.
-        if self.aggregator.settle_wire_reversion(host, &diagnostics) {
-            return changed;
-        }
-
-        // Coalesce the wire sends per host (debounce plus max-wait): a burst of
-        // set-changing feeds — spontaneous pushes, the pull-layer completion,
-        // the post-parse geometry re-merge, each ~1 MB on a diagnostics-heavy
-        // host — collapses until the next deadline, re-merged from
-        // the LATEST cache by the trailing republish. An isolated change sends
-        // immediately. Deferral withholds only the wire: the set was already
-        // recorded above, so the return value (and with it the push-origin
-        // coverage bump + refresh nudge) is unaffected.
-        let timing = self
-            .settings_manager
-            .load_settings()
-            .features
-            .text_document_publish_diagnostics;
-        match self.aggregator.wire_debounce_admit_for_revision(
-            host,
-            std::time::Duration::from_millis(timing.debounce_ms),
-            std::time::Duration::from_millis(timing.max_wait_ms),
-            wire_activity && changed == RepublishOutcome::Changed,
-            cache_revision,
-        ) {
-            crate::lsp::diagnostic_cache::WireAdmit::SendNow => {
+            // Suppress a republish that would re-send the exact set the editor already
+            // has — a redundant publishDiagnostics is needless flicker/noise (#422).
+            // Done under the per-host republish lock (held above), so the compare-and-set
+            // is serialized with other republishes for this host. A withheld wire
+            // send (`wire_gate_is_dirty`) still proceeds: the recorded set is ahead
+            // of what actually reached the editor, so the trailing republish must
+            // send even though its own merge compares unchanged.
+            let changed = if self.aggregator.published_set_changed(host, &diagnostics) {
+                RepublishOutcome::Changed
+            } else {
+                RepublishOutcome::Unchanged
+            };
+            if changed == RepublishOutcome::Unchanged && !self.aggregator.wire_gate_is_dirty(host) {
                 log::debug!(
                     target: LOG_TARGET,
-                    "publishing {} merged diagnostics for {}",
+                    "skip republish for {host}: merged set unchanged ({} diagnostics)",
+                    diagnostics.len()
+                );
+                return RepublishOutcome::Unchanged;
+            }
+
+            // The cross-layer gate for `textDocument/publishDiagnostics` doubles as a
+            // WIRE SEAL when it resolves to no layers at all: a pull-first editor
+            // setup can stop the proactive publishes entirely via existing config.
+            // On a diagnostics-heavy host they dominated the editor pipe (measured:
+            // 51 publishes × ~1 MB in a 44 s typing burst, 68% of all server→client
+            // bytes — head-of-line blocking every other response) while a pulling
+            // editor ignores them or renders them as a duplicate namespace. The
+            // merge above still ran and recorded the set: change detection keeps
+            // driving the push-origin coverage bump and
+            // `workspace/diagnostic/refresh`, which IS the sealed setup's delivery
+            // signal (refresh → client re-pull). The wire-gate state is dropped —
+            // there is no wire under the seal, so nothing can be owed to it (a
+            // stale `dirty` from before a mid-session seal would otherwise linger).
+            if self.publish_sealed(host) {
+                self.aggregator.forget_wire_gate(host);
+                log::debug!(
+                    target: LOG_TARGET,
+                    "seal: skipping publish of {} merged diagnostics for {} \
+                     (layers.aggregation publishDiagnostics resolves to no layers)",
+                    diagnostics.len(),
+                    host
+                );
+                return changed;
+            }
+
+            // A republish for a CLOSED host bypasses the quiet window and never
+            // touches gate state. This is (or races) `didClose`'s clearing publish,
+            // and both halves matter: a *deferred* clearing publish would be
+            // dropped by the trailing task's closed-document guard, pinning the
+            // closed buffer's last diagnostics in the editor forever; and a racing
+            // in-flight republish that *stamped* fresh gate state here (after
+            // `clear_host`'s forget, which does not hold the republish lock) would
+            // be exactly what defers that clearing publish. Both republishes are
+            // serialized on the per-host lock, so the clearing (empty) publish
+            // always lands last. (This ungated send shares the pre-existing
+            // record-before-send hazard: an abort landing exactly at the send
+            // below loses it — same class as main, bounded to closed-host races.)
+            if self.documents.get(host).is_none() {
+                log::debug!(
+                    target: LOG_TARGET,
+                    "publishing {} merged diagnostics for closed host {} (quiet window bypassed)",
                     diagnostics.len(),
                     host
                 );
                 self.client
                     .publish_diagnostics(lsp_uri, diagnostics, None)
                     .await;
-                // Stamp the send only AFTER it completed: this republish can run
-                // inside an abortable task (the synthetic pull is aborted on
-                // supersession), and an abort landing at the send await must not
-                // leave gate state claiming a send that never happened — that
-                // would both defer the next change and consume a withheld
-                // `dirty` debt. Same lock hold as the admit, so the pair is
-                // atomic per host.
-                self.aggregator.wire_gate_commit_send(host);
+                return changed;
             }
-            crate::lsp::diagnostic_cache::WireAdmit::Defer {
-                schedule_trailing,
-                remaining,
-                cancellation,
-            } => {
-                log::debug!(
-                    target: LOG_TARGET,
-                    "withholding publish of {} merged diagnostics for {} ({}ms until debounce/max-wait deadline)",
-                    diagnostics.len(),
-                    host,
-                    remaining.as_millis()
-                );
-                if schedule_trailing {
-                    self.spawn_trailing_wire_publish(host.clone(), remaining, cancellation);
+
+            // The logical recorded set may change inside a burst and then revert
+            // to the set already on the wire (A -> pending B -> A). In that case
+            // there is no wire work left: settle the dirty debt so the parked
+            // trailing task does not emit duplicate A.
+            if self.aggregator.settle_wire_reversion(host, &diagnostics) {
+                return changed;
+            }
+
+            // Coalesce the wire sends per host (debounce plus max-wait): a burst of
+            // set-changing feeds — spontaneous pushes, the pull-layer completion,
+            // the post-parse geometry re-merge, each ~1 MB on a diagnostics-heavy
+            // host — collapses until the next deadline, re-merged from
+            // the LATEST cache by the trailing republish. An isolated change sends
+            // immediately. Deferral withholds only the wire: the set was already
+            // recorded above, so the return value (and with it the push-origin
+            // coverage bump + refresh nudge) is unaffected.
+            let timing = self
+                .settings_manager
+                .load_settings()
+                .features
+                .text_document_publish_diagnostics;
+            match self.aggregator.wire_debounce_admit_current_revision(
+                host,
+                std::time::Duration::from_millis(timing.debounce_ms),
+                std::time::Duration::from_millis(timing.max_wait_ms),
+                wire_activity && changed == RepublishOutcome::Changed,
+                cache_revision,
+            ) {
+                crate::lsp::diagnostic_cache::WireAdmit::RetryLatest => continue 'latest,
+                crate::lsp::diagnostic_cache::WireAdmit::SendNow => {
+                    log::debug!(
+                        target: LOG_TARGET,
+                        "publishing {} merged diagnostics for {}",
+                        diagnostics.len(),
+                        host
+                    );
+                    self.client
+                        .publish_diagnostics(lsp_uri, diagnostics, None)
+                        .await;
+                    // Stamp the send only AFTER it completed: this republish can run
+                    // inside an abortable task (the synthetic pull is aborted on
+                    // supersession), and an abort landing at the send await must not
+                    // leave gate state claiming a send that never happened — that
+                    // would both defer the next change and consume a withheld
+                    // `dirty` debt. Same lock hold as the admit, so the pair is
+                    // atomic per host.
+                    self.aggregator.wire_gate_commit_send(host);
+                }
+                crate::lsp::diagnostic_cache::WireAdmit::Defer {
+                    schedule_trailing,
+                    remaining,
+                    cancellation,
+                } => {
+                    log::debug!(
+                        target: LOG_TARGET,
+                        "withholding publish of {} merged diagnostics for {} ({}ms until debounce/max-wait deadline)",
+                        diagnostics.len(),
+                        host,
+                        remaining.as_millis()
+                    );
+                    if schedule_trailing {
+                        self.spawn_trailing_wire_publish(host.clone(), remaining, cancellation);
+                    }
                 }
             }
+            return changed;
         }
-        changed
     }
 
     /// Re-run [`Self::republish`] for `host` at the next debounce/max-wait deadline,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -998,6 +998,14 @@ impl DiagnosticPublisher {
             return changed;
         }
 
+        // The logical recorded set may change inside a burst and then revert
+        // to the set already on the wire (A -> pending B -> A). In that case
+        // there is no wire work left: settle the dirty debt so the parked
+        // trailing task does not emit duplicate A.
+        if self.aggregator.settle_wire_reversion(host, &diagnostics) {
+            return changed;
+        }
+
         // Coalesce the wire sends per host (the quiet window): a burst of
         // set-changing feeds — spontaneous pushes, the pull-layer completion,
         // the post-parse geometry re-merge, each ~1 MB on a diagnostics-heavy
@@ -2135,6 +2143,59 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(1)).await;
         assert!(!server.diagnostics.wire_gate_is_dirty(&uri));
         assert!(!server.diagnostics.wire_gate_take_pending(&uri));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pending_publish_reversion_does_not_duplicate_the_wire_set() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        register_rust(server);
+        server.settings_manager.apply_settings(rust_settings(true));
+        let uri = Url::parse("file:///test/host_reversion.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let publisher = DiagnosticPublisher::new(server);
+
+        server.diagnostics.record(
+            &uri,
+            DiagnosticSource::Host,
+            "rust_ls".to_string(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("A")],
+        );
+        assert_eq!(publisher.republish(&uri).await, RepublishOutcome::Changed);
+
+        server.diagnostics.record(
+            &uri,
+            DiagnosticSource::Host,
+            "rust_ls".to_string(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("B")],
+        );
+        assert_eq!(publisher.republish(&uri).await, RepublishOutcome::Changed);
+        assert!(server.diagnostics.wire_gate_is_dirty(&uri));
+
+        server.diagnostics.record(
+            &uri,
+            DiagnosticSource::Host,
+            "rust_ls".to_string(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("A")],
+        );
+        assert_eq!(publisher.republish(&uri).await, RepublishOutcome::Changed);
+        assert!(
+            !server.diagnostics.wire_gate_is_dirty(&uri),
+            "reverting to the wire set cancels the withheld debt"
+        );
+
+        tokio::time::advance(super::WIRE_PUBLISH_QUIET_WINDOW).await;
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        assert!(!server.diagnostics.wire_gate_is_dirty(&uri));
+        assert_eq!(publisher.republish(&uri).await, RepublishOutcome::Unchanged);
     }
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -860,212 +860,220 @@ impl DiagnosticPublisher {
         // is the client's outbound-channel send, not a round-trip.
         let _guard = self.aggregator.lock_republish(host).await;
 
-        'latest: loop {
-            let (mut snapshot, cache_revision) = self.aggregator.snapshot_with_revision(host);
-            // Drop Host push slots whose server is no longer a configured `_self` host
-            // server for the document's current language — so a host server's pushed
-            // diagnostics don't linger in the editor after the user disables `_self`
-            // (or unconfigures the server) via `workspace/didChangeConfiguration`. The
-            // slots stay cached (cleared on `didClose`); they're just filtered out of
-            // this publish. (The analogous Region/config-change re-merge is deferred.)
-            self.filter_stale_host_slots(host, &mut snapshot);
-            // Drop a pull-driven server's push slots when the host-event pull blob
-            // (`PullLayer`) is present: that server already contributes via the
-            // pull, so keeping its spontaneous push too would double-count it
-            // (#425). The cache keeps the slot; only this publish snapshot is
-            // filtered.
-            self.filter_pull_driven_push_slots(&mut snapshot).await;
-            // Recompute injection offsets only when there are region push slots to
-            // transform. A PullLayer-only snapshot (the common pull-driven case) needs
-            // none, so skip the whole-document injection resolution — and shorten the
-            // time this host's republish lock is held. The predicate IS
-            // `DiagnosticAggregator::has_region_slots`'s (the shared
-            // `has_live_region_slots`): the geometry-unknown deferral below relies
-            // on the reparse loop's post-parse republish, which is gated on
-            // exactly that check.
-            let needs_geometry = crate::lsp::diagnostic_cache::has_live_region_slots(&snapshot);
-            let region_offsets = if needs_geometry {
-                match self.current_region_offsets(host) {
-                    Some(offsets) => offsets,
-                    // The document is open but has no parse snapshot: `did_change`
-                    // cleared the tree and the off-ingress reparse hasn't landed yet,
-                    // so the regions' current offsets are UNKNOWN — not gone. Merging
-                    // now would silently drop every region push slot and publish a
-                    // set missing whole servers, which the post-parse republish then
-                    // reverts: on a diagnostics-heavy host that flapped the editor
-                    // between the full and the region-less set on every edit cycle
-                    // (~2 × ~1 MB publishes per keystroke settle, plus visible
-                    // flicker for push-mode clients). Defer instead: publish nothing,
-                    // record nothing. The reparse loop re-runs `republish` after the
-                    // parse lands whenever non-empty region slots remain
-                    // (`has_region_slots` — the same predicate as `needs_geometry`),
-                    // and the pass's debounced pull re-feeds and republishes too.
-                    // Caveats, accepted: a parse give-up (timeout / parser gone)
-                    // leaves the tree absent, so both retries stay deferred until
-                    // the next edit (main published a region-LESS set there — worse);
-                    // and an edit that evicts the very slots that forced this defer
-                    // hands coverage to the debounced pull alone. Push-origin
-                    // delivery does not depend on the retry: `Deferred` nudges
-                    // pull-mode clients at defer time (see `RepublishOutcome`).
-                    None => {
-                        log::debug!(
-                            target: LOG_TARGET,
-                            "defer republish for {host}: tree pending, region geometry unknown"
-                        );
-                        return RepublishOutcome::Deferred;
-                    }
+        let (mut snapshot, cache_revision) = self.aggregator.snapshot_with_revision(host);
+        // Drop Host push slots whose server is no longer a configured `_self` host
+        // server for the document's current language — so a host server's pushed
+        // diagnostics don't linger in the editor after the user disables `_self`
+        // (or unconfigures the server) via `workspace/didChangeConfiguration`. The
+        // slots stay cached (cleared on `didClose`); they're just filtered out of
+        // this publish. (The analogous Region/config-change re-merge is deferred.)
+        self.filter_stale_host_slots(host, &mut snapshot);
+        // Drop a pull-driven server's push slots when the host-event pull blob
+        // (`PullLayer`) is present: that server already contributes via the
+        // pull, so keeping its spontaneous push too would double-count it
+        // (#425). The cache keeps the slot; only this publish snapshot is
+        // filtered.
+        self.filter_pull_driven_push_slots(&mut snapshot).await;
+        // Recompute injection offsets only when there are region push slots to
+        // transform. A PullLayer-only snapshot (the common pull-driven case) needs
+        // none, so skip the whole-document injection resolution — and shorten the
+        // time this host's republish lock is held. The predicate IS
+        // `DiagnosticAggregator::has_region_slots`'s (the shared
+        // `has_live_region_slots`): the geometry-unknown deferral below relies
+        // on the reparse loop's post-parse republish, which is gated on
+        // exactly that check.
+        let needs_geometry = crate::lsp::diagnostic_cache::has_live_region_slots(&snapshot);
+        let region_offsets = if needs_geometry {
+            match self.current_region_offsets(host) {
+                Some(offsets) => offsets,
+                // The document is open but has no parse snapshot: `did_change`
+                // cleared the tree and the off-ingress reparse hasn't landed yet,
+                // so the regions' current offsets are UNKNOWN — not gone. Merging
+                // now would silently drop every region push slot and publish a
+                // set missing whole servers, which the post-parse republish then
+                // reverts: on a diagnostics-heavy host that flapped the editor
+                // between the full and the region-less set on every edit cycle
+                // (~2 × ~1 MB publishes per keystroke settle, plus visible
+                // flicker for push-mode clients). Defer instead: publish nothing,
+                // record nothing. The reparse loop re-runs `republish` after the
+                // parse lands whenever non-empty region slots remain
+                // (`has_region_slots` — the same predicate as `needs_geometry`),
+                // and the pass's debounced pull re-feeds and republishes too.
+                // Caveats, accepted: a parse give-up (timeout / parser gone)
+                // leaves the tree absent, so both retries stay deferred until
+                // the next edit (main published a region-LESS set there — worse);
+                // and an edit that evicts the very slots that forced this defer
+                // hands coverage to the debounced pull alone. Push-origin
+                // delivery does not depend on the retry: `Deferred` nudges
+                // pull-mode clients at defer time (see `RepublishOutcome`).
+                None => {
+                    log::debug!(
+                        target: LOG_TARGET,
+                        "defer republish for {host}: tree pending, region geometry unknown"
+                    );
+                    return RepublishOutcome::Deferred;
                 }
-            } else {
-                HashMap::new()
-            };
-            let diagnostics = merge_cached_diagnostics(host, snapshot, &region_offsets);
+            }
+        } else {
+            HashMap::new()
+        };
+        let diagnostics = merge_cached_diagnostics(host, snapshot, &region_offsets);
 
-            let lsp_uri = match crate::lsp::lsp_impl::url_to_uri(host) {
-                Ok(uri) => uri,
-                Err(e) => {
-                    log::warn!(target: LOG_TARGET, "skip publish, bad host URI {host}: {e}");
-                    return RepublishOutcome::Unchanged;
-                }
-            };
-
-            // Suppress a republish that would re-send the exact set the editor already
-            // has — a redundant publishDiagnostics is needless flicker/noise (#422).
-            // Done under the per-host republish lock (held above), so the compare-and-set
-            // is serialized with other republishes for this host. A withheld wire
-            // send (`wire_gate_is_dirty`) still proceeds: the recorded set is ahead
-            // of what actually reached the editor, so the trailing republish must
-            // send even though its own merge compares unchanged.
-            let changed = if self.aggregator.published_set_changed(host, &diagnostics) {
-                RepublishOutcome::Changed
-            } else {
-                RepublishOutcome::Unchanged
-            };
-            if changed == RepublishOutcome::Unchanged && !self.aggregator.wire_gate_is_dirty(host) {
-                log::debug!(
-                    target: LOG_TARGET,
-                    "skip republish for {host}: merged set unchanged ({} diagnostics)",
-                    diagnostics.len()
-                );
+        let lsp_uri = match crate::lsp::lsp_impl::url_to_uri(host) {
+            Ok(uri) => uri,
+            Err(e) => {
+                log::warn!(target: LOG_TARGET, "skip publish, bad host URI {host}: {e}");
                 return RepublishOutcome::Unchanged;
             }
+        };
 
-            // The cross-layer gate for `textDocument/publishDiagnostics` doubles as a
-            // WIRE SEAL when it resolves to no layers at all: a pull-first editor
-            // setup can stop the proactive publishes entirely via existing config.
-            // On a diagnostics-heavy host they dominated the editor pipe (measured:
-            // 51 publishes × ~1 MB in a 44 s typing burst, 68% of all server→client
-            // bytes — head-of-line blocking every other response) while a pulling
-            // editor ignores them or renders them as a duplicate namespace. The
-            // merge above still ran and recorded the set: change detection keeps
-            // driving the push-origin coverage bump and
-            // `workspace/diagnostic/refresh`, which IS the sealed setup's delivery
-            // signal (refresh → client re-pull). The wire-gate state is dropped —
-            // there is no wire under the seal, so nothing can be owed to it (a
-            // stale `dirty` from before a mid-session seal would otherwise linger).
-            if self.publish_sealed(host) {
-                self.aggregator.forget_wire_gate(host);
+        // Suppress a republish that would re-send the exact set the editor already
+        // has — a redundant publishDiagnostics is needless flicker/noise (#422).
+        // Done under the per-host republish lock (held above), so the compare-and-set
+        // is serialized with other republishes for this host. A withheld wire
+        // send (`wire_gate_is_dirty`) still proceeds: the recorded set is ahead
+        // of what actually reached the editor, so the trailing republish must
+        // send even though its own merge compares unchanged.
+        let changed = match self.aggregator.published_set_changed_current_revision(
+            host,
+            &diagnostics,
+            cache_revision,
+        ) {
+            None => return RepublishOutcome::Unchanged,
+            Some(true) => RepublishOutcome::Changed,
+            Some(false) => RepublishOutcome::Unchanged,
+        };
+        if changed == RepublishOutcome::Unchanged && !self.aggregator.wire_gate_is_dirty(host) {
+            log::debug!(
+                target: LOG_TARGET,
+                "skip republish for {host}: merged set unchanged ({} diagnostics)",
+                diagnostics.len()
+            );
+            return RepublishOutcome::Unchanged;
+        }
+
+        // The cross-layer gate for `textDocument/publishDiagnostics` doubles as a
+        // WIRE SEAL when it resolves to no layers at all: a pull-first editor
+        // setup can stop the proactive publishes entirely via existing config.
+        // On a diagnostics-heavy host they dominated the editor pipe (measured:
+        // 51 publishes × ~1 MB in a 44 s typing burst, 68% of all server→client
+        // bytes — head-of-line blocking every other response) while a pulling
+        // editor ignores them or renders them as a duplicate namespace. The
+        // merge above still ran and recorded the set: change detection keeps
+        // driving the push-origin coverage bump and
+        // `workspace/diagnostic/refresh`, which IS the sealed setup's delivery
+        // signal (refresh → client re-pull). The wire-gate state is dropped —
+        // there is no wire under the seal, so nothing can be owed to it (a
+        // stale `dirty` from before a mid-session seal would otherwise linger).
+        if self.publish_sealed(host) {
+            self.aggregator.forget_wire_gate(host);
+            log::debug!(
+                target: LOG_TARGET,
+                "seal: skipping publish of {} merged diagnostics for {} \
+                 (layers.aggregation publishDiagnostics resolves to no layers)",
+                diagnostics.len(),
+                host
+            );
+            return changed;
+        }
+
+        // A republish for a CLOSED host bypasses the quiet window and never
+        // touches gate state. This is (or races) `didClose`'s clearing publish,
+        // and both halves matter: a *deferred* clearing publish would be
+        // dropped by the trailing task's closed-document guard, pinning the
+        // closed buffer's last diagnostics in the editor forever; and a racing
+        // in-flight republish that *stamped* fresh gate state here (after
+        // `clear_host`'s forget, which does not hold the republish lock) would
+        // be exactly what defers that clearing publish. Both republishes are
+        // serialized on the per-host lock, so the clearing (empty) publish
+        // always lands last. (This ungated send shares the pre-existing
+        // record-before-send hazard: an abort landing exactly at the send
+        // below loses it — same class as main, bounded to closed-host races.)
+        if self.documents.get(host).is_none() {
+            log::debug!(
+                target: LOG_TARGET,
+                "publishing {} merged diagnostics for closed host {} (quiet window bypassed)",
+                diagnostics.len(),
+                host
+            );
+            self.client
+                .publish_diagnostics(lsp_uri, diagnostics, None)
+                .await;
+            return changed;
+        }
+
+        // The logical recorded set may change inside a burst and then revert
+        // to the set already on the wire (A -> pending B -> A). In that case
+        // there is no wire work left: settle the dirty debt so the parked
+        // trailing task does not emit duplicate A.
+        match self.aggregator.settle_wire_reversion_current_revision(
+            host,
+            &diagnostics,
+            cache_revision,
+        ) {
+            None => return changed,
+            Some(true) => return changed,
+            Some(false) => {}
+        }
+
+        // Coalesce the wire sends per host (debounce plus max-wait): a burst of
+        // set-changing feeds — spontaneous pushes, the pull-layer completion,
+        // the post-parse geometry re-merge, each ~1 MB on a diagnostics-heavy
+        // host — collapses until the next deadline, re-merged from
+        // the LATEST cache by the trailing republish. An isolated change sends
+        // immediately. Deferral withholds only the wire: the set was already
+        // recorded above, so the return value (and with it the push-origin
+        // coverage bump + refresh nudge) is unaffected.
+        let timing = self
+            .settings_manager
+            .load_settings()
+            .features
+            .text_document_publish_diagnostics;
+        match self.aggregator.wire_debounce_admit_current_revision(
+            host,
+            std::time::Duration::from_millis(timing.debounce_ms),
+            std::time::Duration::from_millis(timing.max_wait_ms),
+            wire_activity && changed == RepublishOutcome::Changed,
+            cache_revision,
+        ) {
+            crate::lsp::diagnostic_cache::WireAdmit::RetryLatest => return changed,
+            crate::lsp::diagnostic_cache::WireAdmit::SendNow => {
                 log::debug!(
                     target: LOG_TARGET,
-                    "seal: skipping publish of {} merged diagnostics for {} \
-                     (layers.aggregation publishDiagnostics resolves to no layers)",
-                    diagnostics.len(),
-                    host
-                );
-                return changed;
-            }
-
-            // A republish for a CLOSED host bypasses the quiet window and never
-            // touches gate state. This is (or races) `didClose`'s clearing publish,
-            // and both halves matter: a *deferred* clearing publish would be
-            // dropped by the trailing task's closed-document guard, pinning the
-            // closed buffer's last diagnostics in the editor forever; and a racing
-            // in-flight republish that *stamped* fresh gate state here (after
-            // `clear_host`'s forget, which does not hold the republish lock) would
-            // be exactly what defers that clearing publish. Both republishes are
-            // serialized on the per-host lock, so the clearing (empty) publish
-            // always lands last. (This ungated send shares the pre-existing
-            // record-before-send hazard: an abort landing exactly at the send
-            // below loses it — same class as main, bounded to closed-host races.)
-            if self.documents.get(host).is_none() {
-                log::debug!(
-                    target: LOG_TARGET,
-                    "publishing {} merged diagnostics for closed host {} (quiet window bypassed)",
+                    "publishing {} merged diagnostics for {}",
                     diagnostics.len(),
                     host
                 );
                 self.client
                     .publish_diagnostics(lsp_uri, diagnostics, None)
                     .await;
-                return changed;
+                // Stamp the send only AFTER it completed: this republish can run
+                // inside an abortable task (the synthetic pull is aborted on
+                // supersession), and an abort landing at the send await must not
+                // leave gate state claiming a send that never happened — that
+                // would both defer the next change and consume a withheld
+                // `dirty` debt. Same lock hold as the admit, so the pair is
+                // atomic per host.
+                self.aggregator.wire_gate_commit_send(host);
             }
-
-            // The logical recorded set may change inside a burst and then revert
-            // to the set already on the wire (A -> pending B -> A). In that case
-            // there is no wire work left: settle the dirty debt so the parked
-            // trailing task does not emit duplicate A.
-            if self.aggregator.settle_wire_reversion(host, &diagnostics) {
-                return changed;
-            }
-
-            // Coalesce the wire sends per host (debounce plus max-wait): a burst of
-            // set-changing feeds — spontaneous pushes, the pull-layer completion,
-            // the post-parse geometry re-merge, each ~1 MB on a diagnostics-heavy
-            // host — collapses until the next deadline, re-merged from
-            // the LATEST cache by the trailing republish. An isolated change sends
-            // immediately. Deferral withholds only the wire: the set was already
-            // recorded above, so the return value (and with it the push-origin
-            // coverage bump + refresh nudge) is unaffected.
-            let timing = self
-                .settings_manager
-                .load_settings()
-                .features
-                .text_document_publish_diagnostics;
-            match self.aggregator.wire_debounce_admit_current_revision(
-                host,
-                std::time::Duration::from_millis(timing.debounce_ms),
-                std::time::Duration::from_millis(timing.max_wait_ms),
-                wire_activity && changed == RepublishOutcome::Changed,
-                cache_revision,
-            ) {
-                crate::lsp::diagnostic_cache::WireAdmit::RetryLatest => continue 'latest,
-                crate::lsp::diagnostic_cache::WireAdmit::SendNow => {
-                    log::debug!(
-                        target: LOG_TARGET,
-                        "publishing {} merged diagnostics for {}",
-                        diagnostics.len(),
-                        host
-                    );
-                    self.client
-                        .publish_diagnostics(lsp_uri, diagnostics, None)
-                        .await;
-                    // Stamp the send only AFTER it completed: this republish can run
-                    // inside an abortable task (the synthetic pull is aborted on
-                    // supersession), and an abort landing at the send await must not
-                    // leave gate state claiming a send that never happened — that
-                    // would both defer the next change and consume a withheld
-                    // `dirty` debt. Same lock hold as the admit, so the pair is
-                    // atomic per host.
-                    self.aggregator.wire_gate_commit_send(host);
-                }
-                crate::lsp::diagnostic_cache::WireAdmit::Defer {
-                    schedule_trailing,
-                    remaining,
-                    cancellation,
-                } => {
-                    log::debug!(
-                        target: LOG_TARGET,
-                        "withholding publish of {} merged diagnostics for {} ({}ms until debounce/max-wait deadline)",
-                        diagnostics.len(),
-                        host,
-                        remaining.as_millis()
-                    );
-                    if schedule_trailing {
-                        self.spawn_trailing_wire_publish(host.clone(), remaining, cancellation);
-                    }
+            crate::lsp::diagnostic_cache::WireAdmit::Defer {
+                schedule_trailing,
+                remaining,
+                cancellation,
+            } => {
+                log::debug!(
+                    target: LOG_TARGET,
+                    "withholding publish of {} merged diagnostics for {} ({}ms until debounce/max-wait deadline)",
+                    diagnostics.len(),
+                    host,
+                    remaining.as_millis()
+                );
+                if schedule_trailing {
+                    self.spawn_trailing_wire_publish(host.clone(), remaining, cancellation);
                 }
             }
-            return changed;
         }
+        changed
     }
 
     /// Re-run [`Self::republish`] for `host` at the next debounce/max-wait deadline,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1047,6 +1047,7 @@ impl DiagnosticPublisher {
             crate::lsp::diagnostic_cache::WireAdmit::Defer {
                 schedule_trailing,
                 remaining,
+                cancellation,
             } => {
                 log::debug!(
                     target: LOG_TARGET,
@@ -1056,7 +1057,7 @@ impl DiagnosticPublisher {
                     remaining.as_millis()
                 );
                 if schedule_trailing {
-                    self.spawn_trailing_wire_publish(host.clone(), remaining);
+                    self.spawn_trailing_wire_publish(host.clone(), remaining, cancellation);
                 }
             }
         }
@@ -1078,7 +1079,12 @@ impl DiagnosticPublisher {
     /// this host's gate state, and exits without a wire send.
     ///
     /// [`WireAdmit::Defer`]: crate::lsp::diagnostic_cache::WireAdmit::Defer
-    fn spawn_trailing_wire_publish(&self, host: Url, remaining: std::time::Duration) {
+    fn spawn_trailing_wire_publish(
+        &self,
+        host: Url,
+        remaining: std::time::Duration,
+        cancellation: tokio_util::sync::CancellationToken,
+    ) {
         let publisher = self.clone();
         // Anchor the deadline NOW (at defer time), not at the task's first poll
         // — under load the first poll can lag, which would silently stretch the
@@ -1091,6 +1097,7 @@ impl DiagnosticPublisher {
                     publisher.aggregator.forget_wire_gate(&host);
                     return;
                 }
+                _ = cancellation.cancelled() => return,
                 _ = tokio::time::sleep_until(deadline) => {}
             }
             if !publisher.aggregator.wire_gate_take_pending(&host) {
@@ -2196,6 +2203,54 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(1)).await;
         assert!(!server.diagnostics.wire_gate_is_dirty(&uri));
         assert_eq!(publisher.republish(&uri).await, RepublishOutcome::Unchanged);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn forgetting_wire_gate_wakes_the_trailing_task() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        register_rust(server);
+        server.settings_manager.apply_settings(rust_settings(true));
+        let uri = Url::parse("file:///test/host_forget_wire_gate.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let publisher = DiagnosticPublisher::new(server);
+
+        server.diagnostics.record(
+            &uri,
+            DiagnosticSource::Host,
+            "rust_ls".to_string(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("A")],
+        );
+        publisher.republish(&uri).await;
+        let baseline = Arc::strong_count(&server.diagnostics);
+
+        server.diagnostics.record(
+            &uri,
+            DiagnosticSource::Host,
+            "rust_ls".to_string(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("B")],
+        );
+        publisher.republish(&uri).await;
+        tokio::task::yield_now().await;
+        assert!(
+            Arc::strong_count(&server.diagnostics) > baseline,
+            "the parked task holds a publisher clone"
+        );
+
+        server.diagnostics.forget_wire_gate(&uri);
+        tokio::task::yield_now().await;
+        assert_eq!(
+            Arc::strong_count(&server.diagnostics),
+            baseline,
+            "forgetting the gate must wake and release its parked task"
+        );
     }
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -104,7 +104,18 @@ fn uses_deprecated_unwrapped_didchange_shape(settings: &Value) -> bool {
 fn kakehashi_targeted_payload(object: serde_json::Map<String, Value>) -> serde_json::Value {
     let object = object
         .into_iter()
-        .filter(|(key, value)| is_kakehashi_workspace_entry(key, value))
+        .filter_map(|(key, mut value)| {
+            if !is_kakehashi_workspace_entry(&key, &value) {
+                return None;
+            }
+            if key == "features"
+                && let Some(features) = value.as_object_mut()
+            {
+                features
+                    .retain(|feature, _| KNOWN_FEATURE_SETTING_KEYS.contains(&feature.as_str()));
+            }
+            Some((key, value))
+        })
         .collect();
     Value::Object(object)
 }
@@ -547,6 +558,32 @@ mod tests {
         }));
 
         assert_eq!(payload, serde_json::json!({ "features": features }));
+        assert!(unknown_keys.is_empty());
+    }
+
+    #[test]
+    fn settings_payload_projects_mixed_unwrapped_features() {
+        let (payload, unknown_keys) = settings_payload(serde_json::json!({
+            "features": {
+                "textDocument/publishDiagnostics": {
+                    "debounceMs": 30,
+                    "maxWaitMs": 300
+                },
+                "someOtherClientFeature": true
+            }
+        }));
+
+        assert_eq!(
+            payload,
+            serde_json::json!({
+                "features": {
+                    "textDocument/publishDiagnostics": {
+                        "debounceMs": 30,
+                        "maxWaitMs": 300
+                    }
+                }
+            })
+        );
         assert!(unknown_keys.is_empty());
     }
 

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -17,6 +17,11 @@ const KNOWN_WORKSPACE_SETTING_KEYS: &[&str] = &[
     "languageServers",
 ];
 
+const KNOWN_FEATURE_SETTING_KEYS: &[&str] = &[
+    "textDocument/publishDiagnostics",
+    "workspace/diagnostic/refresh",
+];
+
 const KNOWN_AGGREGATION_SETTING_KEYS: &[&str] = &[
     "maxFanOut",
     "priorities",
@@ -132,9 +137,11 @@ fn is_workspace_setting_key_or_typo(key: &str) -> bool {
 
 fn is_kakehashi_workspace_entry(key: &str, value: &Value) -> bool {
     if key == "features" {
-        return value
-            .as_object()
-            .is_some_and(|features| features.contains_key("workspace/diagnostic/refresh"));
+        return value.as_object().is_some_and(|features| {
+            KNOWN_FEATURE_SETTING_KEYS
+                .iter()
+                .any(|key| features.contains_key(*key))
+        });
     }
     is_workspace_setting_key_or_typo(key)
 }
@@ -436,8 +443,8 @@ impl Kakehashi {
 mod tests {
     use super::*;
     use crate::config::settings::{
-        AggregationConfig, BridgeLanguageConfig, BridgeServerConfig, LanguageSettings,
-        LayerAggregationConfig, LayersConfig, QueryItem, QueryTypeMappings,
+        AggregationConfig, BridgeLanguageConfig, BridgeServerConfig, FeatureSettings,
+        LanguageSettings, LayerAggregationConfig, LayersConfig, QueryItem, QueryTypeMappings,
     };
     use std::collections::BTreeSet;
 
@@ -464,6 +471,11 @@ mod tests {
     #[test]
     fn known_workspace_setting_keys_match_schema_properties() {
         assert_known_keys_match_schema::<RawWorkspaceSettings>(KNOWN_WORKSPACE_SETTING_KEYS, &[]);
+    }
+
+    #[test]
+    fn known_feature_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<FeatureSettings>(KNOWN_FEATURE_SETTING_KEYS, &[]);
     }
 
     #[test]
@@ -519,6 +531,22 @@ mod tests {
         }));
 
         assert_eq!(payload, serde_json::json!({ "autoInstall": true }));
+        assert!(unknown_keys.is_empty());
+    }
+
+    #[test]
+    fn settings_payload_keeps_unwrapped_publish_diagnostics_features() {
+        let features = serde_json::json!({
+            "textDocument/publishDiagnostics": {
+                "debounceMs": 30,
+                "maxWaitMs": 300
+            }
+        });
+        let (payload, unknown_keys) = settings_payload(serde_json::json!({
+            "features": features
+        }));
+
+        assert_eq!(payload, serde_json::json!({ "features": features }));
         assert!(unknown_keys.is_empty());
     }
 

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -332,6 +332,19 @@ fn main() {
                             "textDocument/publishDiagnostics",
                             push_diagnostics(uri, true),
                         );
+                    } else if mode == "diagnostics-push-burst" {
+                        for generation in 1..=4 {
+                            notify(
+                                &mut writer,
+                                "textDocument/publishDiagnostics",
+                                push_diagnostics_with_message(
+                                    uri,
+                                    format!("mock-push-burst:{generation}"),
+                                ),
+                            );
+                            let delay = if generation == 1 { 300 } else { 30 };
+                            std::thread::sleep(std::time::Duration::from_millis(delay));
+                        }
                     }
                     // `diagnostics-refresh`: ask the client (via the bridge) to
                     // re-pull diagnostics. The bridge forwards this upstream to the
@@ -1237,6 +1250,21 @@ fn push_diagnostics(uri: &str, present: bool) -> Value {
         json!([])
     };
     json!({ "uri": uri, "diagnostics": diagnostics })
+}
+
+fn push_diagnostics_with_message(uri: &str, message: String) -> Value {
+    json!({
+        "uri": uri,
+        "diagnostics": [{
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 7 }
+            },
+            "severity": 1,
+            "source": "mock-push",
+            "message": message
+        }]
+    })
 }
 
 /// Send a server→client **request** (a message carrying both `id` and `method`,

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -147,6 +147,69 @@ fn is_mock_push(d: &Value) -> bool {
 }
 
 #[test]
+fn e2e_publish_diagnostics_burst_keeps_latest_trailing_value() {
+    let (mut client, _config_dir) = init_client_with_mode("diagnostics-push-burst");
+    open_host(&mut client);
+
+    client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(15),
+            |params| {
+                params["diagnostics"].as_array().is_some_and(|diagnostics| {
+                    diagnostics
+                        .iter()
+                        .any(|diagnostic| diagnostic["message"] == json!("mock-push-burst:1"))
+                })
+            },
+        )
+        .expect("the isolated leading diagnostic must publish immediately");
+
+    client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(5),
+            |params| {
+                params["diagnostics"].as_array().is_some_and(|diagnostics| {
+                    diagnostics
+                        .iter()
+                        .any(|diagnostic| diagnostic["message"] == json!("mock-push-burst:2"))
+                })
+            },
+        )
+        .expect("the first change after idle starts the next burst immediately");
+
+    let (_, trailing) = client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(5),
+            |params| {
+                params["diagnostics"].as_array().is_some_and(|diagnostics| {
+                    diagnostics.iter().any(|diagnostic| {
+                        diagnostic["message"].as_str().is_some_and(|message| {
+                            message == "mock-push-burst:3" || message == "mock-push-burst:4"
+                        })
+                    })
+                })
+            },
+        )
+        .expect("the burst must produce one trailing publish");
+    assert!(
+        trailing["diagnostics"]
+            .as_array()
+            .is_some_and(|diagnostics| {
+                diagnostics
+                    .iter()
+                    .any(|diagnostic| diagnostic["message"] == json!("mock-push-burst:4"))
+            }),
+        "the trailing publish must contain only the latest burst value: {trailing}"
+    );
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
 fn e2e_push_diagnostic_reaches_editor_in_host_coords_then_clears() {
     let (mut client, _config_dir) = init_client();
 

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -279,6 +279,18 @@ fn test_config_init_emits_workspace_refresh_feature_defaults() {
     assert!(stdout.contains("debounceMs = 100\nmaxWaitMs = 1000"));
 }
 
+#[test]
+fn test_config_init_emits_publish_diagnostics_feature_defaults() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args(["config", "init"])
+        .output()
+        .expect("run config init");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("[features.\"textDocument/publishDiagnostics\"]\n"));
+    assert!(stdout.contains("debounceMs = 100\nmaxWaitMs = 1000"));
+}
+
 /// Test that config init documents the per-root-instance default by emitting
 /// `preferSharedInstance = false` under the `languageServers._` wildcard, so
 /// the opt-in (#391) is discoverable in the generated template.

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -287,8 +287,9 @@ fn test_config_init_emits_publish_diagnostics_feature_defaults() {
         .expect("run config init");
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("[features.\"textDocument/publishDiagnostics\"]\n"));
-    assert!(stdout.contains("debounceMs = 100\nmaxWaitMs = 1000"));
+    assert!(stdout.contains(
+        "[features.\"textDocument/publishDiagnostics\"]\ndebounceMs = 100\nmaxWaitMs = 1000"
+    ));
 }
 
 /// Test that config init documents the per-root-instance default by emitting


### PR DESCRIPTION
Closes #851

## Summary
- add global `features."textDocument/publishDiagnostics"` timing settings with 100 ms debounce and 1000 ms max-wait defaults
- schedule leading and trailing diagnostic publishes independently per URI
- coalesce burst updates to the latest coherent merged diagnostics; `maxWaitMs` bounds flush attempts, while stale concurrent snapshots retry at a bounded rate
- snapshot timing at each cycle boundary so live updates do not reshape active bursts
- preserve wire debt across stale and aborted handoffs, cancel forgotten tasks, and share immutable wire snapshots
- accept mixed client feature payloads while projecting only Kakehashi settings
- document the cross-layer timing boundary and generated config

## Validation
- `make check`
- `cargo test --lib diagnostic_cache::tests` (72 passed)
- `cargo test --features e2e --test e2e_push_diagnostics` (48 passed)
- `cargo test --test test_cli config_init` (10 passed)
- multi-perspective revise review plus Codex follow-up and fresh independent review: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable `textDocument/publishDiagnostics` debounce/max-wait settings (with defaults) alongside existing workspace diagnostic refresh.
  * Extended feature configuration handling to accept only supported `features` keys.
* **Bug Fixes**
  * Reworked publishDiagnostics scheduling to use a global per-URI debounce policy with revision-aware retrying and correct “latest trailing” behavior; pull diagnostics remain unchanged.
  * Improved user-facing error output when configuration serialization fails.
* **Documentation**
  * Updated scheduling policy docs/architecture notes with expanded examples and clearer debounce/max-wait validation rules.
* **Tests**
  * Added CLI and end-to-end coverage for burst publishing and trailing latest correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->