### PR TITLE
feat: globally gate window log messages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -140,8 +140,10 @@ the timing snapshot it started with. `maxWaitMs` must be at least `debounceMs`.
 `features."window/logMessage".logLevel` is one workspace-wide threshold for
 both messages forwarded from downstream servers and messages emitted by
 kakehashi itself. Values are `error`, `warning`, `info`, `log`, and `off`; the
-default `info` suppresses only LSP `Log` messages. Live updates affect subsequent
-messages. `window/showMessage` is never filtered by this policy.
+default `info` forwards Error, Warning, and Info while suppressing LSP `Log` and
+`Debug`. The `log` threshold passes through Log, LSP 3.18 Debug, and future
+`MessageType` values. Live updates affect subsequent messages.
+`window/showMessage` is never filtered by this policy.
 
 ```json
 {

--- a/docs/README.md
+++ b/docs/README.md
@@ -122,6 +122,9 @@ servers in the workspace:
 debounceMs = 100
 maxWaitMs = 1000
 
+[features."window/logMessage"]
+logLevel = "info"
+
 [features."workspace/diagnostic/refresh"]
 debounceMs = 100
 maxWaitMs = 1000
@@ -133,6 +136,12 @@ Publish diagnostics keep only the latest merged set per URI, and different URIs
 never delay one another. Pull diagnostics are unaffected. The values
 apply to cycles admitted after a live configuration update; an active cycle keeps
 the timing snapshot it started with. `maxWaitMs` must be at least `debounceMs`.
+
+`features."window/logMessage".logLevel` is one workspace-wide threshold for
+both messages forwarded from downstream servers and messages emitted by
+kakehashi itself. Values are `error`, `warning`, `info`, `log`, and `off`; the
+default `info` suppresses only LSP `Log` messages. Live updates affect subsequent
+messages. `window/showMessage` is never filtered by this policy.
 
 ```json
 {

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -226,11 +226,13 @@ downstream ──notification──►  bridge  ──notification──►  ups
                                └─ ...
 ```
 
-**Implemented: `window/*` forwarding (#378, #852).** The reader task parses and
-enqueues both `window/logMessage` and `window/showMessage`. At the common
-client-facing delivery boundary, `window/logMessage` uses the global
-`features."window/logMessage".logLevel` threshold shared with kakehashi's own
-logs (`info` by default); `window/showMessage` remains unfiltered. Both are
+**Implemented: `window/*` forwarding (#378, #852).** The reader task parses both
+methods and applies the live global `features."window/logMessage".logLevel`
+threshold before enqueue, so suppressed logs cannot consume the bounded queue
+needed by allowed logs and unfiltered `window/showMessage`. The common
+client-facing delivery boundary checks the same workspace policy again to close
+live-update races and also shares it with kakehashi's own logs (`info` by
+default). Both forwarded methods are
 prefixed with `[kakehashi:<server>]` for
 distinguishability and need
 no coordinate translation. They reuse the `UpstreamNotification` decoupling

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -226,10 +226,12 @@ downstream ──notification──►  bridge  ──notification──►  ups
                                └─ ...
 ```
 
-**Implemented: `window/*` forwarding (#378).** The reader task forwards both
-`window/logMessage` and `window/showMessage` unconditionally — the bridge
-stays transparent, so messages a direct connection would surface are not
-silently swallowed. Both are prefixed with `[kakehashi:<server>]` for
+**Implemented: `window/*` forwarding (#378, #852).** The reader task parses and
+enqueues both `window/logMessage` and `window/showMessage`. At the common
+client-facing delivery boundary, `window/logMessage` uses the global
+`features."window/logMessage".logLevel` threshold shared with kakehashi's own
+logs (`info` by default); `window/showMessage` remains unfiltered. Both are
+prefixed with `[kakehashi:<server>]` for
 distinguishability and need
 no coordinate translation. They reuse the `UpstreamNotification` decoupling
 (reader task -> forwarding loop -> tower-lsp `Client`) but travel on a
@@ -481,6 +483,9 @@ languageServers:
 
 ## Amendment History
 
+- **2026-07-13**: Added one workspace-wide `window/logMessage` severity policy
+  for downstream-forwarded and kakehashi-originated messages (#852). The
+  default is `info`; `window/showMessage` remains unaffected.
 - **2026-07-01**: Renamed the `languageServers.*.rootMarkers` config key to
   `workspaceMarkers` (aligning with the LSP spec's `workspaceFolders`); the old
   `rootMarkers` is accepted as a deprecated serde alias for backward

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -690,6 +690,10 @@ fn run_config_init(output: Option<PathBuf>, force: bool) -> Result<(), ExitCode>
         "[features.textDocument/publishDiagnostics]",
         "[features.\"textDocument/publishDiagnostics\"]",
     );
+    let config_toml = config_toml.replace(
+        "[features.window/logMessage]",
+        "[features.\"window/logMessage\"]",
+    );
 
     // Prepend documentation link
     let content = format!("{}\n{}", DOC_LINK, config_toml);

--- a/src/config.rs
+++ b/src/config.rs
@@ -414,6 +414,9 @@ impl From<&WorkspaceSettings> for RawWorkspaceSettings {
                             .max_wait_ms,
                     ),
                 }),
+                window_log_message: Some(settings::LogMessageFeatureSettings {
+                    log_level: Some(settings.features.window_log_message),
+                }),
                 workspace_diagnostic_refresh: Some(settings::DebounceFeatureSettings {
                     debounce_ms: Some(settings.features.workspace_diagnostic_refresh.debounce_ms),
                     max_wait_ms: Some(settings.features.workspace_diagnostic_refresh.max_wait_ms),
@@ -823,6 +826,7 @@ mod tests {
             let raw = RawWorkspaceSettings {
                 features: Some(settings::FeatureSettings {
                     text_document_publish_diagnostics: None,
+                    window_log_message: None,
                     workspace_diagnostic_refresh: Some(settings::DebounceFeatureSettings {
                         debounce_ms: Some(0),
                         max_wait_ms: Some(max_wait_ms),

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -9,8 +9,8 @@ use super::settings::{
     CaptureMapping, CaptureMappings, DEFAULT_DEBOUNCE_MS, DEFAULT_PUBLISH_DIAGNOSTICS_DEBOUNCE_MS,
     DEFAULT_PUBLISH_DIAGNOSTICS_MAX_WAIT_MS, DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_DEBOUNCE_MS,
     DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_MAX_WAIT_MS, DebounceFeatureSettings, FeatureSettings,
-    LanguageSettings, LayerAggregationConfig, LayerSource, LayersConfig, QueryTypeMappings,
-    RawWorkspaceSettings, RootMarker,
+    LanguageSettings, LayerAggregationConfig, LayerSource, LayersConfig, LogMessageFeatureSettings,
+    LogMessageLevel, QueryTypeMappings, RawWorkspaceSettings, RootMarker,
 };
 use std::collections::HashMap;
 
@@ -28,6 +28,9 @@ pub fn default_settings() -> RawWorkspaceSettings {
             text_document_publish_diagnostics: Some(DebounceFeatureSettings {
                 debounce_ms: Some(DEFAULT_PUBLISH_DIAGNOSTICS_DEBOUNCE_MS),
                 max_wait_ms: Some(DEFAULT_PUBLISH_DIAGNOSTICS_MAX_WAIT_MS),
+            }),
+            window_log_message: Some(LogMessageFeatureSettings {
+                log_level: Some(LogMessageLevel::Info),
             }),
             workspace_diagnostic_refresh: Some(DebounceFeatureSettings {
                 debounce_ms: Some(DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_DEBOUNCE_MS),
@@ -541,6 +544,12 @@ mod tests {
         assert!(toml.contains(
             "[features.textDocument/publishDiagnostics]\ndebounceMs = 100\nmaxWaitMs = 1000"
         ));
+    }
+
+    #[test]
+    fn default_settings_emit_log_message_feature_policy() {
+        let toml = toml::to_string_pretty(&default_settings()).unwrap();
+        assert!(toml.contains("[features.window/logMessage]\nlogLevel = \"info\""));
     }
 
     #[test]

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -1,6 +1,7 @@
 use super::settings::{
     AggregationConfig, BridgeLanguageConfig, BridgeServerConfig, DebounceFeatureSettings,
     FeatureSettings, LanguageSettings, LayerAggregationConfig, LayersConfig,
+    LogMessageFeatureSettings,
 };
 use super::{CaptureMappings, RawWorkspaceSettings, WILDCARD_KEY};
 use std::collections::{HashMap, HashSet};
@@ -433,6 +434,12 @@ fn merge_features(
                 }),
                 (base, overlay) => overlay.or(base),
             },
+            window_log_message: match (base.window_log_message, overlay.window_log_message) {
+                (Some(base), Some(overlay)) => Some(LogMessageFeatureSettings {
+                    log_level: overlay.log_level.or(base.log_level),
+                }),
+                (base, overlay) => overlay.or(base),
+            },
             workspace_diagnostic_refresh: match (
                 base.workspace_diagnostic_refresh,
                 overlay.workspace_diagnostic_refresh,
@@ -553,6 +560,34 @@ mod tests {
             .unwrap();
         assert_eq!(publish.debounce_ms, Some(80));
         assert_eq!(publish.max_wait_ms, Some(400));
+    }
+
+    #[test]
+    fn log_message_feature_merge_preserves_unspecified_level() {
+        let base: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [features."window/logMessage"]
+            logLevel = "warning"
+            "#,
+        )
+        .unwrap();
+        let overlay: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [features."textDocument/publishDiagnostics"]
+            debounceMs = 80
+            "#,
+        )
+        .unwrap();
+        let merged = merge_workspace_settings(Some(base), Some(overlay)).unwrap();
+        assert_eq!(
+            merged
+                .features
+                .unwrap()
+                .window_log_message
+                .unwrap()
+                .log_level,
+            Some(crate::config::settings::LogMessageLevel::Warning)
+        );
     }
     use crate::config::QueryTypeMappings;
     use crate::config::settings;

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -675,12 +675,17 @@ impl LogMessageLevel {
     }
 
     pub(crate) fn from_u8(value: u8) -> Self {
+        const ERROR: u8 = LogMessageLevel::Error as u8;
+        const WARNING: u8 = LogMessageLevel::Warning as u8;
+        const INFO: u8 = LogMessageLevel::Info as u8;
+        const LOG: u8 = LogMessageLevel::Log as u8;
+        const OFF: u8 = LogMessageLevel::Off as u8;
         match value {
-            value if value == Self::Error as u8 => Self::Error,
-            value if value == Self::Warning as u8 => Self::Warning,
-            value if value == Self::Info as u8 => Self::Info,
-            value if value == Self::Log as u8 => Self::Log,
-            value if value == Self::Off as u8 => Self::Off,
+            ERROR => Self::Error,
+            WARNING => Self::Warning,
+            INFO => Self::Info,
+            LOG => Self::Log,
+            OFF => Self::Off,
             _ => Self::Off,
         }
     }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -659,6 +659,7 @@ pub struct DebounceFeatureSettings {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
+#[repr(u8)]
 pub enum LogMessageLevel {
     Error,
     Warning,
@@ -669,6 +670,20 @@ pub enum LogMessageLevel {
 }
 
 impl LogMessageLevel {
+    pub(crate) const fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    pub(crate) fn from_u8(value: u8) -> Self {
+        match value {
+            value if value == Self::Error as u8 => Self::Error,
+            value if value == Self::Warning as u8 => Self::Warning,
+            value if value == Self::Log as u8 => Self::Log,
+            value if value == Self::Off as u8 => Self::Off,
+            _ => Self::Info,
+        }
+    }
+
     pub(crate) fn allows(self, message_type: tower_lsp_server::ls_types::MessageType) -> bool {
         use tower_lsp_server::ls_types::MessageType;
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -976,22 +976,26 @@ mod tests {
     fn log_message_level_filters_lsp_severity_order() {
         use tower_lsp_server::ls_types::MessageType;
 
-        assert!(LogMessageLevel::Error.allows(MessageType::ERROR));
-        assert!(!LogMessageLevel::Error.allows(MessageType::WARNING));
-        assert!(LogMessageLevel::Warning.allows(MessageType::WARNING));
-        assert!(!LogMessageLevel::Warning.allows(MessageType::INFO));
-        assert!(LogMessageLevel::Info.allows(MessageType::INFO));
-        assert!(!LogMessageLevel::Info.allows(MessageType::LOG));
-        assert!(LogMessageLevel::Log.allows(MessageType::LOG));
         let debug: MessageType = serde_json::from_str("5").unwrap();
-        assert!(LogMessageLevel::Log.allows(debug));
-        assert!(!LogMessageLevel::Info.allows(debug));
-        assert!(!LogMessageLevel::Off.allows(MessageType::ERROR));
-
-        assert_eq!(
-            LogMessageLevel::from_u8(LogMessageLevel::Info.as_u8()),
-            LogMessageLevel::Info
-        );
+        let message_types = [
+            MessageType::ERROR,
+            MessageType::WARNING,
+            MessageType::INFO,
+            MessageType::LOG,
+            debug,
+        ];
+        for (level, expected) in [
+            (LogMessageLevel::Error, [true, false, false, false, false]),
+            (LogMessageLevel::Warning, [true, true, false, false, false]),
+            (LogMessageLevel::Info, [true, true, true, false, false]),
+            (LogMessageLevel::Log, [true, true, true, true, true]),
+            (LogMessageLevel::Off, [false, false, false, false, false]),
+        ] {
+            for (message_type, expected) in message_types.into_iter().zip(expected) {
+                assert_eq!(level.allows(message_type), expected, "level={level:?}");
+            }
+            assert_eq!(LogMessageLevel::from_u8(level.as_u8()), level);
+        }
         assert_eq!(LogMessageLevel::from_u8(u8::MAX), LogMessageLevel::Off);
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -678,9 +678,10 @@ impl LogMessageLevel {
         match value {
             value if value == Self::Error as u8 => Self::Error,
             value if value == Self::Warning as u8 => Self::Warning,
+            value if value == Self::Info as u8 => Self::Info,
             value if value == Self::Log as u8 => Self::Log,
             value if value == Self::Off as u8 => Self::Off,
-            _ => Self::Info,
+            _ => Self::Off,
         }
     }
 
@@ -694,10 +695,10 @@ impl LogMessageLevel {
                 message_type,
                 MessageType::ERROR | MessageType::WARNING | MessageType::INFO
             ),
-            Self::Log => matches!(
-                message_type,
-                MessageType::ERROR | MessageType::WARNING | MessageType::INFO | MessageType::LOG
-            ),
+            // `MessageType` is an open integer enum. Treat `log` as the
+            // pass-through threshold so LSP 3.18 `Debug = 5` and future
+            // severities are not silently dropped by an older ls-types crate.
+            Self::Log => true,
             Self::Off => false,
         }
     }
@@ -982,7 +983,16 @@ mod tests {
         assert!(LogMessageLevel::Info.allows(MessageType::INFO));
         assert!(!LogMessageLevel::Info.allows(MessageType::LOG));
         assert!(LogMessageLevel::Log.allows(MessageType::LOG));
+        let debug: MessageType = serde_json::from_str("5").unwrap();
+        assert!(LogMessageLevel::Log.allows(debug));
+        assert!(!LogMessageLevel::Info.allows(debug));
         assert!(!LogMessageLevel::Off.allows(MessageType::ERROR));
+
+        assert_eq!(
+            LogMessageLevel::from_u8(LogMessageLevel::Info.as_u8()),
+            LogMessageLevel::Info
+        );
+        assert_eq!(LogMessageLevel::from_u8(u8::MAX), LogMessageLevel::Off);
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -657,11 +657,50 @@ pub struct DebounceFeatureSettings {
     pub max_wait_ms: Option<u64>,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum LogMessageLevel {
+    Error,
+    Warning,
+    #[default]
+    Info,
+    Log,
+    Off,
+}
+
+impl LogMessageLevel {
+    pub(crate) fn allows(self, message_type: tower_lsp_server::ls_types::MessageType) -> bool {
+        use tower_lsp_server::ls_types::MessageType;
+
+        match self {
+            Self::Error => message_type == MessageType::ERROR,
+            Self::Warning => matches!(message_type, MessageType::ERROR | MessageType::WARNING),
+            Self::Info => matches!(
+                message_type,
+                MessageType::ERROR | MessageType::WARNING | MessageType::INFO
+            ),
+            Self::Log => matches!(
+                message_type,
+                MessageType::ERROR | MessageType::WARNING | MessageType::INFO | MessageType::LOG
+            ),
+            Self::Off => false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LogMessageFeatureSettings {
+    pub log_level: Option<LogMessageLevel>,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct FeatureSettings {
     #[serde(rename = "textDocument/publishDiagnostics")]
     pub text_document_publish_diagnostics: Option<DebounceFeatureSettings>,
+    #[serde(rename = "window/logMessage")]
+    pub window_log_message: Option<LogMessageFeatureSettings>,
     #[serde(rename = "workspace/diagnostic/refresh")]
     pub workspace_diagnostic_refresh: Option<DebounceFeatureSettings>,
 }
@@ -684,6 +723,7 @@ impl Default for ResolvedDebounceFeatureSettings {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ResolvedFeatureSettings {
     pub text_document_publish_diagnostics: ResolvedDebounceFeatureSettings,
+    pub window_log_message: LogMessageLevel,
     pub workspace_diagnostic_refresh: ResolvedDebounceFeatureSettings,
 }
 
@@ -700,6 +740,11 @@ impl FeatureSettings {
                     .and_then(|settings| settings.max_wait_ms)
                     .unwrap_or(DEFAULT_PUBLISH_DIAGNOSTICS_MAX_WAIT_MS),
             },
+            window_log_message: self
+                .window_log_message
+                .as_ref()
+                .and_then(|settings| settings.log_level)
+                .unwrap_or_default(),
             workspace_diagnostic_refresh: ResolvedDebounceFeatureSettings {
                 debounce_ms: refresh
                     .and_then(|settings| settings.debounce_ms)
@@ -876,6 +921,54 @@ mod tests {
     use super::*;
     use crate::config::WILDCARD_KEY;
     use rstest::rstest;
+
+    #[rstest]
+    #[case("error", LogMessageLevel::Error)]
+    #[case("warning", LogMessageLevel::Warning)]
+    #[case("info", LogMessageLevel::Info)]
+    #[case("log", LogMessageLevel::Log)]
+    #[case("off", LogMessageLevel::Off)]
+    fn log_message_level_parses_all_supported_values(
+        #[case] value: &str,
+        #[case] expected: LogMessageLevel,
+    ) {
+        let input = format!("[features.\"window/logMessage\"]\nlogLevel = \"{value}\"");
+        let raw: RawWorkspaceSettings = toml::from_str(&input).unwrap();
+        assert_eq!(
+            raw.features.unwrap().window_log_message.unwrap().log_level,
+            Some(expected)
+        );
+    }
+
+    #[test]
+    fn log_message_level_rejects_unknown_values_and_fields() {
+        assert!(
+            toml::from_str::<RawWorkspaceSettings>(
+                "[features.\"window/logMessage\"]\nlogLevel = \"debug\""
+            )
+            .is_err()
+        );
+        assert!(
+            toml::from_str::<RawWorkspaceSettings>(
+                "[features.\"window/logMessage\"]\nlevel = \"info\""
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn log_message_level_filters_lsp_severity_order() {
+        use tower_lsp_server::ls_types::MessageType;
+
+        assert!(LogMessageLevel::Error.allows(MessageType::ERROR));
+        assert!(!LogMessageLevel::Error.allows(MessageType::WARNING));
+        assert!(LogMessageLevel::Warning.allows(MessageType::WARNING));
+        assert!(!LogMessageLevel::Warning.allows(MessageType::INFO));
+        assert!(LogMessageLevel::Info.allows(MessageType::INFO));
+        assert!(!LogMessageLevel::Info.allows(MessageType::LOG));
+        assert!(LogMessageLevel::Log.allows(MessageType::LOG));
+        assert!(!LogMessageLevel::Off.allows(MessageType::ERROR));
+    }
 
     #[test]
     fn test_json_schema_generation() {

--- a/src/lsp/aggregation/server/fan_in/result.rs
+++ b/src/lsp/aggregation/server/fan_in/result.rs
@@ -32,7 +32,7 @@ impl<T> FanInResult<T> {
     /// - `Cancelled`: returns `Err(Error::request_cancelled())`.
     pub(crate) async fn handle<R>(
         self,
-        client: &tower_lsp_server::Client,
+        notifier: &crate::lsp::client::ClientNotifier<'_>,
         method_name: &str,
         no_result: R,
         on_done: impl FnOnce(T) -> tower_lsp_server::jsonrpc::Result<R>,
@@ -45,8 +45,8 @@ impl<T> FanInResult<T> {
                 } else {
                     tower_lsp_server::ls_types::MessageType::LOG
                 };
-                client
-                    .log_message(
+                notifier
+                    .log(
                         level,
                         format!("No {method_name} response from any bridge server"),
                     )

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -938,8 +938,8 @@ fn handle_cancel_request(message: &serde_json::Value, deps: &ServerRequestDeps) 
 ///
 /// Routes `window/logMessage`, `window/showMessage`, and `telemetry/event` to
 /// their per-method modules ([`window::log_message`], [`window::show_message`],
-/// [`telemetry::event`]); all are forwarded unconditionally so the bridge stays
-/// transparent.
+/// [`telemetry::event`]). Valid notifications are enqueued here; the upstream
+/// delivery boundary applies the global `window/logMessage` severity policy.
 ///
 /// `$/progress`, `$/cancelRequest`, and non-scratch `textDocument/publishDiagnostics`
 /// (routed to the diagnostics cache — push-propagation-diagnostic-forwarding) are

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -938,8 +938,9 @@ fn handle_cancel_request(message: &serde_json::Value, deps: &ServerRequestDeps) 
 ///
 /// Routes `window/logMessage`, `window/showMessage`, and `telemetry/event` to
 /// their per-method modules ([`window::log_message`], [`window::show_message`],
-/// [`telemetry::event`]). Valid notifications are enqueued here; the upstream
-/// delivery boundary applies the global `window/logMessage` severity policy.
+/// [`telemetry::event`]). Suppressed log messages are rejected before they can
+/// occupy the bounded queue; the upstream delivery boundary rechecks the live
+/// policy to close a concurrent configuration-update race.
 ///
 /// `$/progress`, `$/cancelRequest`, and non-scratch `textDocument/publishDiagnostics`
 /// (routed to the diagnostics cache — push-propagation-diagnostic-forwarding) are

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -1235,10 +1235,21 @@ mod tests {
         mpsc::Receiver<UpstreamNotification>,
         impl std::any::Any,
     ) {
+        server_request_deps_with_window_capacity(server_name, 16)
+    }
+
+    fn server_request_deps_with_window_capacity(
+        server_name: Option<&str>,
+        capacity: usize,
+    ) -> (
+        ServerRequestDeps,
+        mpsc::Receiver<UpstreamNotification>,
+        impl std::any::Any,
+    ) {
         let (tx, rx) = mpsc::channel(16);
         let caps = Arc::new(DynamicCapabilityRegistry::new());
         let (upstream_tx, upstream_rx) = mpsc::unbounded_channel();
-        let (window_tx, window_rx) = mpsc::channel(16);
+        let (window_tx, window_rx) = mpsc::channel(capacity);
         let progress_registry = Arc::new(crate::lsp::bridge::ProgressRegistry::new());
         let progress_connection_id = progress_registry.new_connection_id();
         let deps = ServerRequestDeps {
@@ -1257,6 +1268,44 @@ mod tests {
             progress_connection_id,
         };
         (deps, window_rx, (rx, upstream_rx))
+    }
+
+    #[tokio::test]
+    async fn suppressed_log_does_not_consume_window_queue_capacity() {
+        let router = ResponseRouter::new();
+        let (deps, mut window_rx, _keep) =
+            server_request_deps_with_window_capacity(Some("mock-ls"), 1);
+        deps.dynamic_capabilities
+            .store_log_message_level(crate::config::settings::LogMessageLevel::Off);
+
+        handle_message(
+            json!({
+                "jsonrpc": "2.0",
+                "method": "window/logMessage",
+                "params": { "type": 4, "message": "suppressed" }
+            }),
+            &router,
+            "",
+            &deps,
+        )
+        .await;
+        handle_message(
+            json!({
+                "jsonrpc": "2.0",
+                "method": "window/showMessage",
+                "params": { "type": 1, "message": "visible" }
+            }),
+            &router,
+            "",
+            &deps,
+        )
+        .await;
+
+        assert!(matches!(
+            window_rx.try_recv(),
+            Ok(UpstreamNotification::ShowMessage { message, .. })
+                if message == "[kakehashi:mock-ls] visible"
+        ));
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -122,7 +122,7 @@ fn shutdown_invalidated_connection(key: ConnectionKey, handle: Arc<ConnectionHan
 
 use std::collections::HashMap;
 use std::io;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
@@ -415,6 +415,9 @@ pub struct LanguageServerPool {
     /// Merged into bridge defaults during downstream LSP handshake so servers
     /// can provide richer responses (e.g., markdown docs, resolve support).
     client_capabilities: OnceLock<tower_lsp_server::ls_types::ClientCapabilities>,
+    /// Workspace-wide downstream log threshold. Existing connection registries
+    /// receive live updates; newly spawned readers copy the current value.
+    log_message_level: AtomicU8,
     /// Sender for forwarding downstream server notifications to the upstream editor.
     ///
     /// Cloned into each reader task so they can signal events like
@@ -505,6 +508,9 @@ impl LanguageServerPool {
             root_uri: OnceLock::new(),
             workspace_folders: OnceLock::new(),
             client_capabilities: OnceLock::new(),
+            log_message_level: AtomicU8::new(
+                crate::config::settings::LogMessageLevel::Info.as_u8(),
+            ),
             upstream_tx,
             upstream_rx: std::sync::Mutex::new(Some(upstream_rx)),
             window_tx,
@@ -543,6 +549,18 @@ impl LanguageServerPool {
     /// (#404).
     pub(crate) fn inbound_request_registry(&self) -> super::InboundRequestRegistry {
         self.inbound_request_registry.clone()
+    }
+
+    pub(crate) async fn set_log_message_level(
+        &self,
+        level: crate::config::settings::LogMessageLevel,
+    ) {
+        self.log_message_level
+            .store(level.as_u8(), Ordering::Release);
+        let connections = self.connections.lock().await;
+        for handle in connections.values() {
+            handle.dynamic_capabilities().store_log_message_level(level);
+        }
     }
 
     /// Shared work-done progress token registry (for seam tests that need to
@@ -2187,6 +2205,11 @@ impl LanguageServerPool {
 
         // Create dynamic capability registry (shared between reader and connection handle)
         let dynamic_capabilities = Arc::new(DynamicCapabilityRegistry::new());
+        dynamic_capabilities.store_log_message_level(
+            crate::config::settings::LogMessageLevel::from_u8(
+                self.log_message_level.load(Ordering::Acquire),
+            ),
+        );
 
         // workspaceMarkers workspace-root detection (root_markers module): the same
         // marker workspace resolved for the pool key above (entry-priority

--- a/src/lsp/bridge/pool/dynamic_capability_registry.rs
+++ b/src/lsp/bridge/pool/dynamic_capability_registry.rs
@@ -82,7 +82,7 @@ mod tests {
     use std::sync::Arc;
     use std::thread;
 
-    use tower_lsp_server::ls_types::{Registration, Unregistration};
+    use tower_lsp_server::ls_types::{MessageType, Registration, Unregistration};
 
     use super::DynamicCapabilityRegistry;
 
@@ -160,6 +160,37 @@ mod tests {
 
         // "diag-2" should still be registered
         assert!(registry.has_registration("textDocument/diagnostic"));
+    }
+
+    #[test]
+    fn downstream_log_gate_matches_every_global_level() {
+        use crate::config::settings::LogMessageLevel;
+
+        let registry = DynamicCapabilityRegistry::new();
+        let debug: MessageType = serde_json::from_str("5").unwrap();
+        let message_types = [
+            MessageType::ERROR,
+            MessageType::WARNING,
+            MessageType::INFO,
+            MessageType::LOG,
+            debug,
+        ];
+        for level in [
+            LogMessageLevel::Error,
+            LogMessageLevel::Warning,
+            LogMessageLevel::Info,
+            LogMessageLevel::Log,
+            LogMessageLevel::Off,
+        ] {
+            registry.store_log_message_level(level);
+            for message_type in message_types {
+                assert_eq!(
+                    registry.allows_log_message(message_type),
+                    level.allows(message_type),
+                    "downstream atomic gate diverged at {level:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/lsp/bridge/pool/dynamic_capability_registry.rs
+++ b/src/lsp/bridge/pool/dynamic_capability_registry.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::RwLock;
+use std::sync::atomic::{AtomicU8, Ordering};
 
 use tower_lsp_server::ls_types::{Registration, Unregistration};
 
@@ -17,12 +18,18 @@ use crate::error::LockResultExt;
 /// with different document selectors).
 pub(crate) struct DynamicCapabilityRegistry {
     registrations: RwLock<HashMap<String, Registration>>,
+    /// Live workspace policy copied into every connection. The reader checks
+    /// it before a suppressed log can consume bounded window-queue capacity.
+    log_message_level: AtomicU8,
 }
 
 impl DynamicCapabilityRegistry {
     pub(crate) fn new() -> Self {
         Self {
             registrations: RwLock::new(HashMap::new()),
+            log_message_level: AtomicU8::new(
+                crate::config::settings::LogMessageLevel::Info.as_u8(),
+            ),
         }
     }
 
@@ -52,6 +59,21 @@ impl DynamicCapabilityRegistry {
             .recover_poison("DynamicCapabilityRegistry::has_registration")
             .values()
             .any(|r| r.method == method)
+    }
+
+    pub(crate) fn store_log_message_level(&self, level: crate::config::settings::LogMessageLevel) {
+        self.log_message_level
+            .store(level.as_u8(), Ordering::Release);
+    }
+
+    pub(crate) fn allows_log_message(
+        &self,
+        message_type: tower_lsp_server::ls_types::MessageType,
+    ) -> bool {
+        crate::config::settings::LogMessageLevel::from_u8(
+            self.log_message_level.load(Ordering::Acquire),
+        )
+        .allows(message_type)
     }
 }
 

--- a/src/lsp/bridge/window/log_message.rs
+++ b/src/lsp/bridge/window/log_message.rs
@@ -12,15 +12,15 @@
 
 use log::debug;
 use serde::Deserialize;
-use tower_lsp_server::ls_types::LogMessageParams;
 
 use super::{prefixed_message, send_window_notification};
 use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamNotification};
 
 #[derive(Deserialize)]
-struct LogMessageType {
+struct BorrowedLogMessageParams<'a> {
     #[serde(rename = "type")]
     typ: tower_lsp_server::ls_types::MessageType,
+    message: &'a str,
 }
 
 /// Forward a `window/logMessage` notification to the editor.
@@ -29,7 +29,7 @@ pub(in crate::lsp::bridge) fn forward(
     server_prefix: &str,
     deps: &ServerRequestDeps,
 ) {
-    let Ok(log_type) = LogMessageType::deserialize(&message["params"]) else {
+    let Ok(params) = BorrowedLogMessageParams::deserialize(&message["params"]) else {
         debug!(
             target: "kakehashi::bridge::reader",
             "{}Dropping window/logMessage with invalid params",
@@ -37,27 +37,17 @@ pub(in crate::lsp::bridge) fn forward(
         );
         return;
     };
-    if !deps.dynamic_capabilities.allows_log_message(log_type.typ) {
+    if !deps.dynamic_capabilities.allows_log_message(params.typ) {
         return;
     }
 
-    // Deserialize the message text only after the cheap severity gate, so a
-    // suppressed downstream flood does not allocate one String per message.
-    match LogMessageParams::deserialize(&message["params"]) {
-        Ok(params) => send_window_notification(
-            deps,
-            server_prefix,
-            "window/logMessage",
-            UpstreamNotification::LogMessage {
-                typ: params.typ,
-                message: prefixed_message(deps.server_name.as_deref(), &params.message),
-            },
-        ),
-        Err(e) => debug!(
-            target: "kakehashi::bridge::reader",
-            "{}Dropping window/logMessage with invalid params: {}",
-            server_prefix,
-            e
-        ),
-    }
+    send_window_notification(
+        deps,
+        server_prefix,
+        "window/logMessage",
+        UpstreamNotification::LogMessage {
+            typ: params.typ,
+            message: prefixed_message(deps.server_name.as_deref(), params.message),
+        },
+    );
 }

--- a/src/lsp/bridge/window/log_message.rs
+++ b/src/lsp/bridge/window/log_message.rs
@@ -24,6 +24,7 @@ pub(in crate::lsp::bridge) fn forward(
 ) {
     // Deserialize from a reference to avoid cloning the params value.
     match LogMessageParams::deserialize(&message["params"]) {
+        Ok(params) if !deps.dynamic_capabilities.allows_log_message(params.typ) => {}
         Ok(params) => send_window_notification(
             deps,
             server_prefix,

--- a/src/lsp/bridge/window/log_message.rs
+++ b/src/lsp/bridge/window/log_message.rs
@@ -1,9 +1,10 @@
 //! `window/logMessage` notification forwarder.
 //!
-//! Inbound (downstream → editor). Valid messages are enqueued here; the shared
-//! client-facing delivery boundary applies the workspace-wide severity policy
-//! used by kakehashi's own log messages too. A downstream flood cannot harm the bridge because the window
-//! channel is bounded and drop-on-full (see [`UpstreamNotification`]). The text
+//! Inbound (downstream → editor). The live workspace threshold is checked before
+//! enqueue so suppressed logs cannot consume bounded queue capacity; the shared
+//! client-facing delivery boundary rechecks it for configuration races and uses
+//! the same policy for kakehashi's own messages. A downstream flood cannot harm
+//! the bridge because the window channel is bounded and drop-on-full (see [`UpstreamNotification`]). The text
 //! is prefixed with the originating server name so output from multiple bridged
 //! servers stays distinguishable.
 //!

--- a/src/lsp/bridge/window/log_message.rs
+++ b/src/lsp/bridge/window/log_message.rs
@@ -1,8 +1,8 @@
 //! `window/logMessage` notification forwarder.
 //!
-//! Inbound (downstream → editor). Forwarded unconditionally so the bridge stays
-//! transparent: messages a direct connection would surface are not silently
-//! swallowed. A downstream flood cannot harm the bridge because the window
+//! Inbound (downstream → editor). Valid messages are enqueued here; the shared
+//! client-facing delivery boundary applies the workspace-wide severity policy
+//! used by kakehashi's own log messages too. A downstream flood cannot harm the bridge because the window
 //! channel is bounded and drop-on-full (see [`UpstreamNotification`]). The text
 //! is prefixed with the originating server name so output from multiple bridged
 //! servers stays distinguishable.

--- a/src/lsp/bridge/window/log_message.rs
+++ b/src/lsp/bridge/window/log_message.rs
@@ -17,15 +17,33 @@ use tower_lsp_server::ls_types::LogMessageParams;
 use super::{prefixed_message, send_window_notification};
 use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamNotification};
 
+#[derive(Deserialize)]
+struct LogMessageType {
+    #[serde(rename = "type")]
+    typ: tower_lsp_server::ls_types::MessageType,
+}
+
 /// Forward a `window/logMessage` notification to the editor.
 pub(in crate::lsp::bridge) fn forward(
     message: &serde_json::Value,
     server_prefix: &str,
     deps: &ServerRequestDeps,
 ) {
-    // Deserialize from a reference to avoid cloning the params value.
+    let Ok(log_type) = LogMessageType::deserialize(&message["params"]) else {
+        debug!(
+            target: "kakehashi::bridge::reader",
+            "{}Dropping window/logMessage with invalid params",
+            server_prefix
+        );
+        return;
+    };
+    if !deps.dynamic_capabilities.allows_log_message(log_type.typ) {
+        return;
+    }
+
+    // Deserialize the message text only after the cheap severity gate, so a
+    // suppressed downstream flood does not allocate one String per message.
     match LogMessageParams::deserialize(&message["params"]) {
-        Ok(params) if !deps.dynamic_capabilities.allows_log_message(params.typ) => {}
         Ok(params) => send_window_notification(
             deps,
             server_prefix,

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -266,7 +266,7 @@ impl<'a> ClientNotifier<'a> {
                         LanguageLogLevel::Warning => MessageType::WARNING,
                         LanguageLogLevel::Info => MessageType::INFO,
                     };
-                    self.log(message_type, message.clone()).await;
+                    self.log(message_type, message).await;
                 }
                 LanguageEvent::ShowMessage { level, message } => {
                     let message_type = match level {
@@ -274,9 +274,7 @@ impl<'a> ClientNotifier<'a> {
                         LanguageLogLevel::Warning => MessageType::WARNING,
                         LanguageLogLevel::Info => MessageType::INFO,
                     };
-                    self.client
-                        .show_message(message_type, message.clone())
-                        .await;
+                    self.client.show_message(message_type, message).await;
                 }
                 // Refresh requests are handled once, before the loop — see above.
                 LanguageEvent::SemanticTokensRefresh { .. } => {}
@@ -299,10 +297,10 @@ impl<'a> ClientNotifier<'a> {
                         .await;
                 }
                 SettingsEventKind::Warning => {
-                    self.log(MessageType::WARNING, event.message.clone()).await;
+                    self.log(MessageType::WARNING, event.message.as_str()).await;
                 }
                 SettingsEventKind::Info => {
-                    self.log(MessageType::INFO, event.message.clone()).await;
+                    self.log(MessageType::INFO, event.message.as_str()).await;
                 }
             }
         }

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -12,6 +12,7 @@ use tower_lsp_server::ls_types::notification::Progress;
 use tower_lsp_server::ls_types::{ClientCapabilities, MessageType};
 
 use crate::language::{LanguageEvent, LanguageLogLevel};
+use crate::lsp::settings_manager::SettingsManager;
 use crate::lsp::{SettingsEvent, SettingsEventKind};
 
 use super::progress::{create_progress_begin, create_progress_end};
@@ -99,6 +100,7 @@ fn batch_requests_semantic_tokens_refresh(events: &[LanguageEvent]) -> bool {
 #[derive(Clone)]
 pub(crate) struct ClientNotifier<'a> {
     client: Client,
+    settings_manager: &'a SettingsManager,
     /// Reference to capabilities stored in Kakehashi.
     /// Uses OnceLock to handle pre/post initialization states.
     client_capabilities: &'a OnceLock<ClientCapabilities>,
@@ -108,6 +110,7 @@ impl std::fmt::Debug for ClientNotifier<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ClientNotifier")
             .field("client", &self.client)
+            .field("settings_manager", &"&SettingsManager")
             .field("client_capabilities", &"&OnceLock<ClientCapabilities>")
             .finish()
     }
@@ -117,17 +120,27 @@ impl<'a> ClientNotifier<'a> {
     /// Create a new `ClientNotifier` wrapping the given LSP client.
     pub(crate) fn new(
         client: Client,
+        settings_manager: &'a SettingsManager,
         client_capabilities: &'a OnceLock<ClientCapabilities>,
     ) -> Self {
         Self {
             client,
+            settings_manager,
             client_capabilities,
         }
     }
 
     /// Log a message to the client at the specified severity level.
     pub(crate) async fn log(&self, level: MessageType, message: impl Into<String>) {
-        self.client.log_message(level, message.into()).await;
+        if self
+            .settings_manager
+            .load_settings()
+            .features
+            .window_log_message
+            .allows(level)
+        {
+            self.client.log_message(level, message.into()).await;
+        }
     }
 
     /// Log an informational message.
@@ -253,7 +266,7 @@ impl<'a> ClientNotifier<'a> {
                         LanguageLogLevel::Warning => MessageType::WARNING,
                         LanguageLogLevel::Info => MessageType::INFO,
                     };
-                    self.client.log_message(message_type, message.clone()).await;
+                    self.log(message_type, message.clone()).await;
                 }
                 LanguageEvent::ShowMessage { level, message } => {
                     let message_type = match level {
@@ -286,14 +299,10 @@ impl<'a> ClientNotifier<'a> {
                         .await;
                 }
                 SettingsEventKind::Warning => {
-                    self.client
-                        .log_message(MessageType::WARNING, event.message.clone())
-                        .await;
+                    self.log(MessageType::WARNING, event.message.clone()).await;
                 }
                 SettingsEventKind::Info => {
-                    self.client
-                        .log_message(MessageType::INFO, event.message.clone())
-                        .await;
+                    self.log(MessageType::INFO, event.message.clone()).await;
                 }
             }
         }

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -183,6 +183,13 @@ pub(super) async fn apply_shared_settings(
         None => settings_manager.apply_settings(settings),
     }
     let settings = settings_manager.load_settings();
+    // Update the reader-side copy before propagating downstream settings so a
+    // newly suppressed log cannot occupy the bounded window queue after this
+    // configuration application completes.
+    bridge
+        .pool()
+        .set_log_message_level(settings.features.window_log_message)
+        .await;
     // Path c: apply downstream config at this single reload choke point
     // (initialize, didChangeConfiguration, auto-install reload): push runtime
     // settings in place and recycle connections whose launch config changed.

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -63,7 +63,11 @@ pub(super) fn build_notifier<'a>(
     client: &'a Client,
     settings_manager: &'a SettingsManager,
 ) -> ClientNotifier<'a> {
-    ClientNotifier::new(client.clone(), settings_manager.client_capabilities_lock())
+    ClientNotifier::new(
+        client.clone(),
+        settings_manager,
+        settings_manager.client_capabilities_lock(),
+    )
 }
 
 /// Detect the canonical language for a document using the full language-detection-fallback-chain.

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1048,8 +1048,8 @@ impl Kakehashi {
             crate::lsp::aggregation::server::FanInResult::Done(value) => Ok(value),
             crate::lsp::aggregation::server::FanInResult::NoResult { errors } => {
                 if errors > 0 {
-                    self.client
-                        .log_message(
+                    self.notifier()
+                        .log(
                             tower_lsp_server::ls_types::MessageType::WARNING,
                             format!("No {request_method} response from any host bridge server"),
                         )

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -189,7 +189,7 @@ impl Kakehashi {
             self.home_dir.as_deref(),
             |var| std::env::var(var).ok(),
         );
-        let settings_events = settings_outcome.events.clone();
+        let settings_events = settings_outcome.events;
         let mut default_settings_warning = None;
 
         // Nudge users off the deprecated `rootMarkers` config key. The claim

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -258,14 +258,15 @@ impl Kakehashi {
         let will_save_advertised = host_bridging_enabled || settings.any_bridge_server_runnable();
         self.apply_initial_settings(raw_settings, settings).await;
 
+        let notifier = self.notifier();
         for (level, message) in startup_logs {
-            self.notifier().log(level, message).await;
+            notifier.log(level, message).await;
         }
-        self.notifier().log_settings_events(&settings_events).await;
+        notifier.log_settings_events(&settings_events).await;
         if let Some(message) = default_settings_warning {
-            self.notifier().log_warning(message).await;
+            notifier.log_warning(message).await;
         }
-        self.notifier().log_info("server initialized!").await;
+        notifier.log_info("server initialized!").await;
         Ok(InitializeResult {
             server_info: Some(ServerInfo {
                 name: "kakehashi".to_string(),

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -79,10 +79,13 @@ impl Kakehashi {
             check_semantic_tokens_refresh_support(&params.capabilities)
         );
 
-        // Debug: Log initialization
-        self.notifier()
-            .log_info("Received initialization request")
-            .await;
+        // Client-facing startup logs are held until settings are resolved and
+        // applied, so initializationOptions can suppress them with the same
+        // global policy as every subsequent internal message.
+        let mut startup_logs = vec![(
+            tower_lsp_server::ls_types::MessageType::INFO,
+            "Received initialization request".to_string(),
+        )];
 
         // Extract first workspace folder for reuse
         let first_folder = params.workspace_folders.as_ref().and_then(|f| f.first());
@@ -165,18 +168,16 @@ impl Kakehashi {
                 "current working directory (fallback)"
             };
 
-            self.notifier()
-                .log_info(format!(
-                    "Using workspace root from {}: {}",
-                    source,
-                    path.display()
-                ))
-                .await;
+            startup_logs.push((
+                tower_lsp_server::ls_types::MessageType::INFO,
+                format!("Using workspace root from {}: {}", source, path.display()),
+            ));
             self.settings_manager.set_root_path(Some(path.clone()));
         } else {
-            self.notifier()
-                .log_warning("Failed to determine workspace root - config file will not be loaded")
-                .await;
+            startup_logs.push((
+                tower_lsp_server::ls_types::MessageType::WARNING,
+                "Failed to determine workspace root - config file will not be loaded".to_string(),
+            ));
         }
 
         let root_path = self.settings_manager.root_path().as_ref().clone();
@@ -188,9 +189,8 @@ impl Kakehashi {
             self.home_dir.as_deref(),
             |var| std::env::var(var).ok(),
         );
-        self.notifier()
-            .log_settings_events(&settings_outcome.events)
-            .await;
+        let settings_events = settings_outcome.events.clone();
+        let mut default_settings_warning = None;
 
         // Nudge users off the deprecated `rootMarkers` config key. The claim
         // guard latches session-wide so a later didChangeConfiguration carrying
@@ -229,11 +229,9 @@ impl Kakehashi {
                     log::error!(
                         "Failed to expand default settings: {e}. Falling back to empty defaults."
                     );
-                    self.notifier()
-                        .log_warning(format!(
-                            "Failed to expand default settings: {e}. Some features (e.g., semantic highlighting, parser detection) may be degraded."
-                        ))
-                        .await;
+                    default_settings_warning = Some(format!(
+                        "Failed to expand default settings: {e}. Some features (e.g., semantic highlighting, parser detection) may be degraded."
+                    ));
                     WorkspaceSettings::default()
                 }
             };
@@ -260,6 +258,13 @@ impl Kakehashi {
         let will_save_advertised = host_bridging_enabled || settings.any_bridge_server_runnable();
         self.apply_initial_settings(raw_settings, settings).await;
 
+        for (level, message) in startup_logs {
+            self.notifier().log(level, message).await;
+        }
+        self.notifier().log_settings_events(&settings_events).await;
+        if let Some(message) = default_settings_warning {
+            self.notifier().log_warning(message).await;
+        }
         self.notifier().log_info("server initialized!").await;
         Ok(InitializeResult {
             server_info: Some(ServerInfo {
@@ -723,8 +728,8 @@ async fn forward_upstream_request(
 ///   editor's response relayed back; loss-intolerant (a dropped request hangs
 ///   the downstream). Serviced via [`spawn_upstream_request`] so a slow/human
 ///   editor never stalls the loop.
-/// - `window_rx` (bounded, reader drops on full): `LogMessage`/`ShowMessage` and
-///   `telemetry/event` — best-effort notifications, forwarded unconditionally.
+/// - `window_rx` (bounded, reader drops on full): threshold-admitted `LogMessage`,
+///   unfiltered `ShowMessage`, and `telemetry/event` — best-effort notifications.
 ///
 /// Notification dispatch awaits tower-lsp's internal bounded channel, so a slow
 /// editor stalls the loop — but the `biased` select drains the two loss-intolerant

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -504,9 +504,12 @@ impl Kakehashi {
             // The single proactive diagnostics publisher: region pushes routed up
             // by the reader resolve to a host + region and republish the merged
             // host set (push-propagation-diagnostic-forwarding).
-            let diagnostic_publisher = Some(Arc::new(
-                crate::lsp::lsp_impl::coordinator::DiagnosticPublisher::new(self),
-            ));
+            let delivery_context = Some(Arc::new(UpstreamDeliveryContext {
+                diagnostic_publisher: Arc::new(
+                    crate::lsp::lsp_impl::coordinator::DiagnosticPublisher::new(self),
+                ),
+                settings_manager: Arc::clone(&self.settings_manager),
+            }));
             // LSP conditions workspace/applyEdit on the client capability;
             // resolved once here — client capabilities are fixed after
             // initialize.
@@ -524,7 +527,7 @@ impl Kakehashi {
                 translators,
                 inbound_request_registry,
                 client,
-                diagnostic_publisher,
+                delivery_context,
                 token,
                 editor_supports_apply_edit,
             ));
@@ -740,6 +743,11 @@ async fn forward_upstream_request(
 /// - The `cancel_token` is cancelled (deterministic shutdown)
 // Heterogeneous channels + collaborators threaded into one long-lived loop task;
 // bundling them into a struct would just move the list, not shorten it.
+struct UpstreamDeliveryContext {
+    diagnostic_publisher: Arc<crate::lsp::lsp_impl::coordinator::DiagnosticPublisher>,
+    settings_manager: Arc<crate::lsp::settings_manager::SettingsManager>,
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn upstream_forwarding_loop(
     mut upstream_rx: tokio::sync::mpsc::UnboundedReceiver<crate::lsp::bridge::UpstreamNotification>,
@@ -750,7 +758,7 @@ async fn upstream_forwarding_loop(
     translators: Option<Arc<UpstreamRequestTranslators>>,
     inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry,
     client: Client,
-    diagnostic_publisher: Option<Arc<crate::lsp::lsp_impl::coordinator::DiagnosticPublisher>>,
+    delivery_context: Option<Arc<UpstreamDeliveryContext>>,
     cancel_token: tokio_util::sync::CancellationToken,
     editor_supports_apply_edit: bool,
 ) {
@@ -802,7 +810,7 @@ async fn upstream_forwarding_loop(
                             coalesce_upstream_batch(batch),
                             &mut created_tokens,
                             &mut begun_tokens,
-                            diagnostic_publisher.as_deref(),
+                            delivery_context.as_deref(),
                             &cancel_token,
                         )
                         .await;
@@ -844,7 +852,7 @@ async fn upstream_forwarding_loop(
                             notification,
                             &mut created_tokens,
                             &mut begun_tokens,
-                            diagnostic_publisher.as_deref(),
+                            delivery_context.as_deref(),
                         )
                         .await
                     }
@@ -865,7 +873,7 @@ async fn deliver_upstream_batch(
     batch: Vec<crate::lsp::bridge::UpstreamNotification>,
     created_tokens: &mut std::collections::HashSet<tower_lsp_server::ls_types::NumberOrString>,
     begun_tokens: &mut std::collections::HashSet<tower_lsp_server::ls_types::NumberOrString>,
-    diagnostic_publisher: Option<&crate::lsp::lsp_impl::coordinator::DiagnosticPublisher>,
+    delivery_context: Option<&UpstreamDeliveryContext>,
     cancel_token: &tokio_util::sync::CancellationToken,
 ) {
     use crate::lsp::bridge::UpstreamNotification;
@@ -890,7 +898,9 @@ async fn deliver_upstream_batch(
             }),
             barrier => {
                 if !pushes.is_empty() {
-                    if let Some(publisher) = diagnostic_publisher {
+                    if let Some(publisher) =
+                        delivery_context.map(|context| context.diagnostic_publisher.as_ref())
+                    {
                         tokio::select! {
                             biased;
                             _ = cancel_token.cancelled() => return,
@@ -908,14 +918,15 @@ async fn deliver_upstream_batch(
                     barrier,
                     created_tokens,
                     begun_tokens,
-                    diagnostic_publisher,
+                    delivery_context,
                 )
                 .await;
             }
         }
     }
     if !pushes.is_empty()
-        && let Some(publisher) = diagnostic_publisher
+        && let Some(publisher) =
+            delivery_context.map(|context| context.diagnostic_publisher.as_ref())
     {
         tokio::select! {
             biased;
@@ -1420,7 +1431,7 @@ async fn deliver_upstream_notification(
     notification: crate::lsp::bridge::UpstreamNotification,
     created_tokens: &mut std::collections::HashSet<tower_lsp_server::ls_types::NumberOrString>,
     begun_tokens: &mut std::collections::HashSet<tower_lsp_server::ls_types::NumberOrString>,
-    diagnostic_publisher: Option<&crate::lsp::lsp_impl::coordinator::DiagnosticPublisher>,
+    delivery_context: Option<&UpstreamDeliveryContext>,
 ) {
     use crate::lsp::bridge::UpstreamNotification;
     use tower_lsp_server::ls_types::{ProgressParamsValue, WorkDoneProgress};
@@ -1433,7 +1444,9 @@ async fn deliver_upstream_notification(
             // avoids blocking this delivery loop on the editor round-trip
             // (head-of-line). A `None` publisher (test loop) has no settings to gate
             // on, so the forward is dropped; production always has one (#521, #789).
-            if let Some(publisher) = diagnostic_publisher {
+            if let Some(publisher) =
+                delivery_context.map(|context| context.diagnostic_publisher.as_ref())
+            {
                 publisher.request_forwarded_diagnostic_refresh();
             }
         }
@@ -1449,14 +1462,25 @@ async fn deliver_upstream_notification(
             // (test loop) drops it. (Pushes without a server name were already
             // dropped at the reader, so `server` is always set here.) The
             // `connection_id` tags the cached slot so a later crash can evict it (#469).
-            if let Some(publisher) = diagnostic_publisher {
+            if let Some(publisher) =
+                delivery_context.map(|context| context.diagnostic_publisher.as_ref())
+            {
                 publisher
                     .publish_push(uri, server, connection_id, diagnostics)
                     .await;
             }
         }
         UpstreamNotification::LogMessage { typ, message } => {
-            client.log_message(typ, message).await;
+            if delivery_context.is_none_or(|context| {
+                context
+                    .settings_manager
+                    .load_settings()
+                    .features
+                    .window_log_message
+                    .allows(typ)
+            }) {
+                client.log_message(typ, message).await;
+            }
         }
         UpstreamNotification::ShowMessage { typ, message } => {
             client.show_message(typ, message).await;
@@ -1561,7 +1585,9 @@ async fn deliver_upstream_notification(
             // diagnostic slots it produced and republish the affected hosts so a
             // dead server's diagnostics don't linger until didClose (#469). A
             // `None` publisher (test loop) has no cache to evict.
-            if let Some(publisher) = diagnostic_publisher {
+            if let Some(publisher) =
+                delivery_context.map(|context| context.diagnostic_publisher.as_ref())
+            {
                 publisher.evict_connection_diagnostics(connection_id).await;
             }
         }

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -453,13 +453,13 @@ impl Kakehashi {
                     None,
                 )
                 .await
-                .handle(&self.client, "code action", None, Ok)
+                .handle(&self.notifier(), "code action", None, Ok)
                 .await
             }
             AggregationStrategy::Concatenated => {
                 dispatch_concatenated(&ctx.document, pool.clone(), f, None, None, None)
                     .await
-                    .handle(&self.client, "code action", None, |vecs| {
+                    .handle(&self.notifier(), "code action", None, |vecs| {
                         Ok(concat_merge(vecs))
                     })
                     .await
@@ -591,8 +591,8 @@ impl Kakehashi {
             FanInResult::Done(value) => Ok(on_done(value)),
             FanInResult::NoResult { errors } => {
                 if errors > 0 {
-                    self.client
-                        .log_message(
+                    self.notifier()
+                        .log(
                             MessageType::WARNING,
                             format!("No {METHOD} response from any host bridge server"),
                         )

--- a/src/lsp/lsp_impl/text_document/color_presentation.rs
+++ b/src/lsp/lsp_impl/text_document/color_presentation.rs
@@ -66,7 +66,7 @@ impl Kakehashi {
         .await;
 
         result
-            .handle(&self.client, "color presentation", Vec::new(), Ok)
+            .handle(&self.notifier(), "color presentation", Vec::new(), Ok)
             .await
     }
 }

--- a/src/lsp/lsp_impl/text_document/completion.rs
+++ b/src/lsp/lsp_impl/text_document/completion.rs
@@ -84,7 +84,7 @@ impl Kakehashi {
         .await;
 
         result
-            .handle(&self.client, "completion", None, |v| {
+            .handle(&self.notifier(), "completion", None, |v| {
                 Ok(v.map(CompletionResponse::List))
             })
             .await

--- a/src/lsp/lsp_impl/text_document/declaration.rs
+++ b/src/lsp/lsp_impl/text_document/declaration.rs
@@ -88,7 +88,9 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        result.handle(&self.client, "declaration", None, Ok).await
+        result
+            .handle(&self.notifier(), "declaration", None, Ok)
+            .await
     }
 
     /// Shape the winning links per the client's `LocationLink` support.

--- a/src/lsp/lsp_impl/text_document/definition.rs
+++ b/src/lsp/lsp_impl/text_document/definition.rs
@@ -92,7 +92,9 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        result.handle(&self.client, "definition", None, Ok).await
+        result
+            .handle(&self.notifier(), "definition", None, Ok)
+            .await
     }
 
     /// Shape the winning links per the client's `LocationLink` support.

--- a/src/lsp/lsp_impl/text_document/document_highlight.rs
+++ b/src/lsp/lsp_impl/text_document/document_highlight.rs
@@ -84,7 +84,7 @@ impl Kakehashi {
         .await;
 
         result
-            .handle(&self.client, "document highlight", None, Ok)
+            .handle(&self.notifier(), "document highlight", None, Ok)
             .await
     }
 }

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -558,8 +558,8 @@ impl Kakehashi {
                 // `errors` was just recorded into the sink above; this arm only
                 // chooses log severity.
                 if errors > 0 {
-                    self.client
-                        .log_message(
+                    self.notifier()
+                        .log(
                             tower_lsp_server::ls_types::MessageType::WARNING,
                             "No textDocument/formatting response from any host bridge server",
                         )

--- a/src/lsp/lsp_impl/text_document/hover.rs
+++ b/src/lsp/lsp_impl/text_document/hover.rs
@@ -70,6 +70,6 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        result.handle(&self.client, "hover", None, Ok).await
+        result.handle(&self.notifier(), "hover", None, Ok).await
     }
 }

--- a/src/lsp/lsp_impl/text_document/implementation.rs
+++ b/src/lsp/lsp_impl/text_document/implementation.rs
@@ -89,7 +89,7 @@ impl Kakehashi {
         )
         .await;
         result
-            .handle(&self.client, "implementation", None, Ok)
+            .handle(&self.notifier(), "implementation", None, Ok)
             .await
     }
 

--- a/src/lsp/lsp_impl/text_document/inlay_hint.rs
+++ b/src/lsp/lsp_impl/text_document/inlay_hint.rs
@@ -84,6 +84,8 @@ impl Kakehashi {
         )
         .await;
 
-        result.handle(&self.client, "inlay hint", None, Ok).await
+        result
+            .handle(&self.notifier(), "inlay hint", None, Ok)
+            .await
     }
 }

--- a/src/lsp/lsp_impl/text_document/linked_editing_range.rs
+++ b/src/lsp/lsp_impl/text_document/linked_editing_range.rs
@@ -79,7 +79,7 @@ impl Kakehashi {
         )
         .await;
         result
-            .handle(&self.client, "linkedEditingRange", None, Ok)
+            .handle(&self.notifier(), "linkedEditingRange", None, Ok)
             .await
     }
 }

--- a/src/lsp/lsp_impl/text_document/moniker.rs
+++ b/src/lsp/lsp_impl/text_document/moniker.rs
@@ -76,6 +76,6 @@ impl Kakehashi {
         )
         .await;
 
-        result.handle(&self.client, "moniker", None, Ok).await
+        result.handle(&self.notifier(), "moniker", None, Ok).await
     }
 }

--- a/src/lsp/lsp_impl/text_document/on_type_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/on_type_formatting.rs
@@ -92,7 +92,7 @@ impl Kakehashi {
         )
         .await;
         result
-            .handle(&self.client, "onTypeFormatting", None, Ok)
+            .handle(&self.notifier(), "onTypeFormatting", None, Ok)
             .await
     }
 }

--- a/src/lsp/lsp_impl/text_document/prepare_rename.rs
+++ b/src/lsp/lsp_impl/text_document/prepare_rename.rs
@@ -84,6 +84,8 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        result.handle(&self.client, "prepareRename", None, Ok).await
+        result
+            .handle(&self.notifier(), "prepareRename", None, Ok)
+            .await
     }
 }

--- a/src/lsp/lsp_impl/text_document/references.rs
+++ b/src/lsp/lsp_impl/text_document/references.rs
@@ -93,6 +93,8 @@ impl Kakehashi {
         )
         .await;
 
-        result.handle(&self.client, "references", None, Ok).await
+        result
+            .handle(&self.notifier(), "references", None, Ok)
+            .await
     }
 }

--- a/src/lsp/lsp_impl/text_document/rename.rs
+++ b/src/lsp/lsp_impl/text_document/rename.rs
@@ -99,7 +99,7 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        result.handle(&self.client, "rename", None, Ok).await
+        result.handle(&self.notifier(), "rename", None, Ok).await
     }
 }
 

--- a/src/lsp/lsp_impl/text_document/signature_help.rs
+++ b/src/lsp/lsp_impl/text_document/signature_help.rs
@@ -83,7 +83,7 @@ impl Kakehashi {
         )
         .await;
         result
-            .handle(&self.client, "signature help", None, Ok)
+            .handle(&self.notifier(), "signature help", None, Ok)
             .await
     }
 }

--- a/src/lsp/lsp_impl/text_document/type_definition.rs
+++ b/src/lsp/lsp_impl/text_document/type_definition.rs
@@ -89,7 +89,7 @@ impl Kakehashi {
         )
         .await;
         result
-            .handle(&self.client, "type definition", None, Ok)
+            .handle(&self.notifier(), "type definition", None, Ok)
             .await
     }
 

--- a/tests/e2e_window_notifications.rs
+++ b/tests/e2e_window_notifications.rs
@@ -77,6 +77,40 @@ fn shutdown(client: &mut LspClient) {
     client.send_notification("exit", json!(null));
 }
 
+#[test]
+fn e2e_log_off_suppresses_internal_messages_during_initialize() {
+    let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
+    let config_path = config_dir.path().join("window_notifications_off.toml");
+    std::fs::write(&config_path, "").expect("Failed to write config");
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("temp path should be UTF-8"))
+        .build();
+
+    let initialize_id = client.send_request_async(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "features": {
+                    "window/logMessage": { "logLevel": "off" }
+                }
+            }
+        }),
+    );
+    let (_, logs) = client
+        .receive_response_for_id_watching_notifications(initialize_id, &["window/logMessage"]);
+    assert!(
+        logs.is_empty(),
+        "the resolved off policy must suppress kakehashi startup logs: {logs:?}"
+    );
+    client.send_notification("initialized", json!({}));
+    shutdown(&mut client);
+}
+
 /// Matches only notifications forwarded from the mock downstream server,
 /// ignoring kakehashi's own window/logMessage output.
 ///

--- a/tests/e2e_window_notifications.rs
+++ b/tests/e2e_window_notifications.rs
@@ -3,7 +3,8 @@
 //! the `mock-lsp-formatter` test binary in `notify` mode (which emits a
 //! showMessage followed by a logMessage right after `initialize`).
 //!
-//! Both window/* notifications are forwarded unconditionally. The mock sends
+//! `window/logMessage` obeys one live workspace policy for both downstream and
+//! kakehashi-originated messages. `window/showMessage` remains unaffected. The mock sends
 //! showMessage BEFORE logMessage and the bridge preserves notification order
 //! end-to-end (single reader task -> single forwarding loop), so the test can
 //! assert showMessage arrives first, then logMessage — no flaky
@@ -26,7 +27,7 @@ fn mock_formatter_bin() -> &'static str {
 
 /// Spawn kakehashi with the given `languageServers` map and complete the
 /// initialize handshake.
-fn init_client(language_servers: Value) -> (LspClient, tempfile::TempDir) {
+fn init_client(initialization_options: Value) -> (LspClient, tempfile::TempDir) {
     let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
     let config_path = config_dir.path().join("window_notifications.toml");
     std::fs::write(&config_path, "").expect("Failed to write config");
@@ -43,7 +44,7 @@ fn init_client(language_servers: Value) -> (LspClient, tempfile::TempDir) {
             "rootUri": null,
             "capabilities": {},
             "workspaceFolders": null,
-            "initializationOptions": { "languageServers": language_servers }
+            "initializationOptions": initialization_options
         }),
     );
     client.send_notification("initialized", json!({}));
@@ -54,14 +55,18 @@ fn init_client(language_servers: Value) -> (LspClient, tempfile::TempDir) {
 /// bridged server configured for lua, whose `initialize` reply triggers the
 /// mock's notifications.
 fn open_markdown(client: &mut LspClient) {
+    open_markdown_with(client, "file:///test_window_notifications.md", "lua");
+}
+
+fn open_markdown_with(client: &mut LspClient, uri: &str, fence_language: &str) {
     client.send_notification(
         "textDocument/didOpen",
         json!({
             "textDocument": {
-                "uri": "file:///test_window_notifications.md",
+                "uri": uri,
                 "languageId": "markdown",
                 "version": 1,
-                "text": "# Test\n\n```lua\nlocal x = 1\n```\n"
+                "text": format!("# Test\n\n```{fence_language}\nvalue = 1\n```\n")
             }
         }),
     );
@@ -88,7 +93,9 @@ fn from_mock(params: &Value) -> bool {
 fn e2e_forwards_window_show_and_log_messages() {
     let bin = mock_formatter_bin();
     let (mut client, _config_dir) = init_client(json!({
-        "mock-notify": { "cmd": [bin, "notify"], "languages": ["lua"] }
+        "languageServers": {
+            "mock-notify": { "cmd": [bin, "notify"], "languages": ["lua"] }
+        }
     }));
 
     open_markdown(&mut client);
@@ -139,6 +146,87 @@ fn e2e_forwards_window_show_and_log_messages() {
         Some(3),
         "MessageType::INFO should pass through unchanged"
     );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_global_log_policy_gates_both_origins_and_updates_live() {
+    let bin = mock_formatter_bin();
+    let (mut client, _config_dir) = init_client(json!({
+        "features": {
+            "window/logMessage": { "logLevel": "off" }
+        },
+        "languageServers": {
+            "mock-muted": { "cmd": [bin, "notify"], "languages": ["lua"] },
+            "mock-live": { "cmd": [bin, "notify"], "languages": ["python"] }
+        }
+    }));
+
+    open_markdown_with(
+        &mut client,
+        "file:///test_window_notifications_muted.md",
+        "lua",
+    );
+    let (method, _) = client
+        .wait_for_notification_where(
+            &["window/showMessage", "window/logMessage"],
+            Duration::from_secs(15),
+            |params| {
+                params["message"]
+                    .as_str()
+                    .is_some_and(|message| message.contains("[kakehashi:mock-muted]"))
+            },
+        )
+        .expect("showMessage must remain visible while logMessage is off");
+    assert_eq!(method, "window/showMessage");
+    assert!(
+        client
+            .wait_for_notification_where(
+                &["window/logMessage"],
+                Duration::from_millis(300),
+                |params| params["message"]
+                    .as_str()
+                    .is_some_and(|message| message.contains("[kakehashi:mock-muted]")),
+            )
+            .is_none(),
+        "downstream info log should be suppressed by the global off policy"
+    );
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "kakehashi": {
+                    "features": {
+                        "window/logMessage": { "logLevel": "info" }
+                    }
+                }
+            }
+        }),
+    );
+    client
+        .wait_for_notification_where(&["window/logMessage"], Duration::from_secs(5), |params| {
+            params["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("Configuration updated"))
+        })
+        .expect("kakehashi's own info log should use the newly applied policy");
+
+    open_markdown_with(
+        &mut client,
+        "file:///test_window_notifications_live.md",
+        "python",
+    );
+    let (method, params) = client
+        .wait_for_notification_where(&["window/logMessage"], Duration::from_secs(15), |params| {
+            params["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("[kakehashi:mock-live]"))
+        })
+        .expect("subsequent downstream info log should use the live policy");
+    assert_eq!(method, "window/logMessage");
+    assert_eq!(params["type"].as_i64(), Some(3));
 
     shutdown(&mut client);
 }

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -607,6 +607,42 @@ impl LspClient {
         self.receive_response_for_id(expected_id)
     }
 
+    /// Receive a client-request response while retaining selected notifications
+    /// that arrived before it. Useful for initialization tests, where the normal
+    /// synchronous response helper intentionally discards notifications.
+    pub(crate) fn receive_response_for_id_watching_notifications(
+        &mut self,
+        expected_id: i64,
+        watched_methods: &[&str],
+    ) -> (Value, Vec<(String, Value)>) {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let mut watched = Vec::new();
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "timed out waiting for response {expected_id}"
+            );
+            let message = self
+                .try_receive_message(remaining)
+                .expect("server closed before the expected response");
+            if message.get("id").and_then(Value::as_i64) == Some(expected_id)
+                && message.get("method").is_none()
+            {
+                return (message, watched);
+            }
+            if message.get("id").is_none()
+                && let Some(method) = message.get("method").and_then(Value::as_str)
+                && watched_methods.contains(&method)
+            {
+                watched.push((
+                    method.to_string(),
+                    message.get("params").cloned().unwrap_or(Value::Null),
+                ));
+            }
+        }
+    }
+
     /// Receive one client-request response while preserving server requests of
     /// `watched_method` that arrived before it. This prevents exact-sequence E2E
     /// assertions from losing concurrent server requests in the ordinary

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -631,6 +631,21 @@ impl LspClient {
             {
                 return (message, watched);
             }
+            if let (Some(id), Some(method)) = (
+                message.get("id").cloned(),
+                message.get("method").and_then(Value::as_str),
+            ) {
+                if method == "window/showMessageRequest" {
+                    // This request is explicitly permitted during initialize;
+                    // null means the user dismissed it. Reply immediately so
+                    // a server awaiting the choice can finish initialization.
+                    self.send_response(id, Value::Null);
+                    continue;
+                }
+                panic!(
+                    "unexpected server request {method} while waiting for response {expected_id}"
+                );
+            }
             if message.get("id").is_none()
                 && let Some(method) = message.get("method").and_then(Value::as_str)
                 && watched_methods.contains(&method)

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -292,6 +292,17 @@ fn test_config_init_emits_publish_diagnostics_feature_defaults() {
     ));
 }
 
+#[test]
+fn test_config_init_emits_log_message_feature_default() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args(["config", "init"])
+        .output()
+        .expect("run config init");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("[features.\"window/logMessage\"]\nlogLevel = \"info\""));
+}
+
 /// Test that config init documents the per-root-instance default by emitting
 /// `preferSharedInstance = false` under the `languageServers._` wildcard, so
 /// the opt-in (#391) is discoverable in the generated template.

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -303,6 +303,24 @@ fn test_config_init_emits_log_message_feature_default() {
     assert!(stdout.contains("[features.\"window/logMessage\"]\nlogLevel = \"info\""));
 }
 
+#[test]
+fn test_config_init_orders_global_feature_blocks() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args(["config", "init"])
+        .output()
+        .expect("run config init");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let publish = stdout
+        .find("[features.\"textDocument/publishDiagnostics\"]")
+        .unwrap();
+    let log = stdout.find("[features.\"window/logMessage\"]").unwrap();
+    let refresh = stdout
+        .find("[features.\"workspace/diagnostic/refresh\"]")
+        .unwrap();
+    assert!(publish < log && log < refresh);
+}
+
 /// Test that config init documents the per-root-instance default by emitting
 /// `preferSharedInstance = false` under the `languageServers._` wildcard, so
 /// the opt-in (#391) is discoverable in the generated template.


### PR DESCRIPTION
Closes #852

## Summary
- add the global `features."window/logMessage".logLevel` policy with an `info` default
- apply one live severity threshold to downstream-forwarded and kakehashi-originated log messages
- preserve all `window/showMessage` notifications
- emit publish, log, and refresh feature defaults in the requested `config init` order
- document the common client-facing delivery boundary

## Validation
- `cargo test --lib -q log_message`
- `cargo test --lib -q upstream_forwarding`
- `cargo test --test test_cli -q config_init`
- `cargo test --features e2e --test e2e_window_notifications -q`
- `cargo clippy --lib -- -D warnings`
- `cargo clippy --features e2e --test e2e_window_notifications -- -D warnings`
- `cargo fmt --all -- --check`