### PR TITLE
test: make sandboxed checks hermetic

### DIFF
--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -1943,22 +1943,14 @@ mod tests {
 
     #[test]
     fn process_injection_sync_returns_incomplete_on_mid_region_cancel() {
-        use crate::config::WorkspaceSettings;
-
         let coordinator = LanguageCoordinator::new();
-        let settings = WorkspaceSettings {
-            search_paths: vec![test_search_path()],
-            ..Default::default()
-        };
-        let _summary = coordinator.load_settings(&settings);
-        assert!(
-            coordinator.ensure_language_loaded("rust").success,
-            "rust fixture must be installed for cancellation coverage"
+        let registry = create_test_registry();
+        let language = registry.get("rust").expect("rust must be registered");
+        let highlight_query = Arc::new(
+            Query::new(&language, "(identifier) @variable")
+                .expect("inline rust highlight query must compile"),
         );
-        let highlight_query = coordinator
-            .highlight_query("rust")
-            .expect("rust highlight query must be installed for cancellation coverage");
-        let factory = ThreadLocalParserFactory::new(coordinator.language_registry_for_parallel());
+        let factory = ThreadLocalParserFactory::new(registry);
         let declarations = (0..256)
             .map(|index| format!("let value_{index} = {index};"))
             .collect::<Vec<_>>()

--- a/src/install.rs
+++ b/src/install.rs
@@ -711,7 +711,7 @@ mod tests {
         );
         assert!(
             result.parser_path.is_some(),
-            "query tombstone cleanup failures must not prevent parser installation"
+            "query tombstone cleanup failures must preserve the available parser result"
         );
         assert!(result.queries_error.is_some());
     }

--- a/src/install.rs
+++ b/src/install.rs
@@ -696,13 +696,31 @@ mod tests {
         )
         .unwrap();
         std::fs::write(data_dir.join("queries"), "not a directory").unwrap();
+        let expected_queries_error =
+            queries::clear_uninstall_tombstone_for_install(data_dir, "lua")
+                .unwrap_err()
+                .to_string();
 
-        let result = install_language_blocking(
+        fn successful_query_install(
+            _base_url: &str,
+            language: &str,
+            data_dir: &std::path::Path,
+            _force: bool,
+        ) -> Result<queries::QueryInstallResult, queries::QueryInstallError> {
+            Ok(queries::QueryInstallResult {
+                language: language.to_string(),
+                install_path: data_dir.join("queries").join(language),
+                files_downloaded: Vec::new(),
+            })
+        }
+
+        let result = install_language_blocking_with_query_installer(
             "lua",
             data_dir,
             false,
-            "http://127.0.0.1:1",
+            "https://example.invalid",
             parser::ParserCompile::InProcess,
+            successful_query_install,
         );
 
         assert!(
@@ -713,6 +731,9 @@ mod tests {
             result.parser_path.is_some(),
             "query tombstone cleanup failures must preserve the available parser result"
         );
-        assert!(result.queries_error.is_some());
+        assert_eq!(
+            result.queries_error.as_deref(),
+            Some(expected_queries_error.as_str())
+        );
     }
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -685,6 +685,16 @@ mod tests {
     fn install_language_reports_tombstone_cleanup_as_query_error_only() {
         let temp = tempfile::TempDir::new().unwrap();
         let data_dir = temp.path();
+
+        // Keep the parser side successful without fetching metadata or source:
+        // this test isolates how a query tombstone failure is classified.
+        let parser_dir = data_dir.join("parser");
+        std::fs::create_dir_all(&parser_dir).unwrap();
+        std::fs::write(
+            parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION)),
+            "",
+        )
+        .unwrap();
         std::fs::write(data_dir.join("queries"), "not a directory").unwrap();
 
         let result = install_language_blocking(


### PR DESCRIPTION
## Summary

- use the statically linked Rust test grammar and an inline highlight query for cancellation coverage
- seed the parser result and inject a successful query installer so tombstone classification is tested without network access
- assert that the tombstone cleanup error itself is preserved

## Validation

- `make check`
- `cargo test --lib install::tests`
- cancellation test with an empty `TREE_SITTER_GRAMMARS`
- tombstone test with outbound proxies pointed at a closed local port
- `nix build .#packages.aarch64-darwin.default -L --no-link`

Closes #857


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for cancellation during semantic processing.
  * Added more precise validation that uninstall cleanup failures are reported as query errors, without incorrectly reporting parser errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->