### PR TITLE
fix(bridge): preserve valid initialize capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,6 +975,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "serial_test",
  "shellexpand",
  "similar 3.1.1",
@@ -1778,6 +1779,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ path-clean = "1"
 regex = "1"
 schemars = { version = "1", features = ["preserve_order"] }
 serde = { version = "1", features = ["derive"] }
+serde_path_to_error = "0.1"
 # regex-fancy (pure Rust) over regex-onig (C oniguruma): we only compile
 # first-line-match regexes for language detection, never highlighting, so
 # fancy-regex's rare Sublime-syntax incompatibilities don't apply (covered by

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -181,11 +181,12 @@ Multiple downstream servers initialize in parallel since each is independent:
 
 **Malformed Initialize Capability Recovery:**
 
-An object-shaped `result.capabilities` is decoded with field-level recovery. If
-one top-level capability cannot be deserialized, the bridge logs the capability
-name and serde error, drops that capability, and retries. Independently valid
-capabilities remain available for routing, and the bridge completes the
-downstream handshake.
+An object-shaped `result.capabilities` is decoded with field-level recovery.
+Each top-level capability is validated once in isolation; invalid fields are
+logged with their serde errors, while the valid raw fields are assembled and
+decoded together into `ServerCapabilities`. Independently valid capabilities
+remain available for routing, and the bridge completes the downstream
+handshake without repeatedly traversing valid fields for every malformed one.
 
 The recovery boundary follows the scope of the damaged state:
 

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -179,6 +179,31 @@ Multiple downstream servers initialize in parallel since each is independent:
 
 **Future Extension (Phase 2)**: Rate-limited respawn to prevent respawn storms.
 
+**Malformed Initialize Capability Recovery:**
+
+An object-shaped `result.capabilities` is decoded with field-level recovery. If
+one top-level capability cannot be deserialized, the bridge logs the capability
+name and serde error, drops that capability, and retries. Independently valid
+capabilities remain available for routing, and the bridge completes the
+downstream handshake.
+
+The recovery boundary follows the scope of the damaged state:
+
+| Failure | Behavior |
+|----------|----------|
+| Malformed feature capability, such as `hoverProvider` | Drop that top-level capability, warn, continue |
+| Several malformed feature capabilities | Drop and warn for each one, preserve the rest |
+| Missing or null `capabilities` | Continue with empty capabilities for compatibility |
+| Non-object `result` or non-object `capabilities` | Fail initialization; no reliable capability boundary exists |
+| Invalid `positionEncoding` or legacy `offsetEncoding` | Fail initialization; position translation affects every bridged feature |
+
+Rejecting the whole server for one independent feature maximizes protocol
+strictness but sacrifices all otherwise usable functionality. Silently falling
+back to empty capabilities preserves the process but hides the defect and loses
+the same functionality. Field-level recovery accepts extra parsing complexity
+to keep the decision stateless and the failure scope aligned with the malformed
+advertisement.
+
 **Per-Downstream Document Lifecycle:**
 
 Maintain the latest host-document snapshot per downstream. When a slower server reaches `didOpen`, send the full text as of "now", not as of when the first downstream opened.
@@ -485,6 +510,10 @@ languageServers:
 
 ## Amendment History
 
+- **2026-07-18**: Added field-level recovery for malformed downstream
+  initialize capabilities (#860). Structurally unusable envelopes and global
+  position-encoding violations still fail initialization; independent malformed
+  feature fields are warned and dropped so valid routing capabilities survive.
 - **2026-07-13**: Added one workspace-wide `window/logMessage` severity policy
   for downstream-forwarded and kakehashi-originated messages (#852). The
   default is `info`; `window/showMessage` remains unaffected.

--- a/src/lsp/bridge/pool/handshake.rs
+++ b/src/lsp/bridge/pool/handshake.rs
@@ -155,7 +155,7 @@ mod tests {
         assert!(capabilities.hover_provider.is_none());
         assert!(capabilities.completion_provider.is_some());
         let mut messages = String::new();
-        for _ in 0..40 {
+        for _ in 0..200 {
             messages = std::fs::read_to_string(&output).unwrap_or_default();
             if messages.contains("\"method\":\"initialized\"") {
                 break;

--- a/src/lsp/bridge/pool/handshake.rs
+++ b/src/lsp/bridge/pool/handshake.rs
@@ -20,7 +20,7 @@ use super::ConnectionHandle;
 use super::connection_handle::NotificationSendResult;
 use crate::lsp::bridge::protocol::{
     RequestId, build_initialize_request, build_initialized_notification,
-    validate_initialize_response,
+    parse_initialize_response_capabilities,
 };
 
 /// Send `initialize`, await the response, send `initialized`, return the typed
@@ -62,13 +62,17 @@ pub(super) async fn perform_lsp_handshake(
         .map_err(|_| io::Error::other("bridge: initialize response channel closed"))?;
 
     // 3. Validate response and extract typed capabilities
-    validate_initialize_response(&response)?;
-    let caps_value = response
-        .get("result")
-        .and_then(|r| r.get("capabilities"))
-        .cloned()
-        .unwrap_or_default();
-    let capabilities = serde_json::from_value::<ServerCapabilities>(caps_value).unwrap_or_default();
+    let parsed = parse_initialize_response_capabilities(&response)?;
+    for dropped in parsed.dropped {
+        log::warn!(
+            target: "kakehashi::bridge",
+            "Downstream {} advertised malformed capability {:?}; ignoring it: {}",
+            handle.key(),
+            dropped.field,
+            dropped.error,
+        );
+    }
+    let capabilities = parsed.capabilities;
 
     // 4. Send initialized notification via the single-writer loop
     let initialized = build_initialized_notification();

--- a/src/lsp/bridge/pool/handshake.rs
+++ b/src/lsp/bridge/pool/handshake.rs
@@ -100,3 +100,71 @@ pub(super) async fn perform_lsp_handshake(
 
     Ok(capabilities)
 }
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::lsp::bridge::actor::{ResponseRouter, spawn_reader_task};
+    use crate::lsp::bridge::connection::AsyncBridgeConnection;
+
+    #[tokio::test]
+    async fn recovered_capabilities_complete_the_handshake() {
+        let temp = tempfile::tempdir().unwrap();
+        let output = temp.path().join("messages");
+        let mut connection = AsyncBridgeConnection::spawn(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "cat > \"$1\"".to_string(),
+            "sh".to_string(),
+            output.display().to_string(),
+        ])
+        .await
+        .unwrap();
+        let (writer, reader) = connection.split();
+        let router = Arc::new(ResponseRouter::new());
+        let reader_handle = spawn_reader_task(reader, Arc::clone(&router));
+        let handle = ConnectionHandle::new(writer, router, reader_handle);
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+        response_tx
+            .send(serde_json::json!({
+                "result": {
+                    "capabilities": {
+                        "hoverProvider": 42,
+                        "completionProvider": {"triggerCharacters": ["."]}
+                    }
+                }
+            }))
+            .unwrap();
+
+        let capabilities = perform_lsp_handshake(
+            &handle,
+            RequestId::new(1),
+            response_rx,
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .await
+        .expect("recoverable capability errors must not stop the handshake");
+
+        assert!(capabilities.hover_provider.is_none());
+        assert!(capabilities.completion_provider.is_some());
+        let mut messages = String::new();
+        for _ in 0..40 {
+            messages = std::fs::read_to_string(&output).unwrap_or_default();
+            if messages.contains("\"method\":\"initialized\"") {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        assert!(
+            messages.contains("\"method\":\"initialized\""),
+            "initialized notification was not written: {messages:?}"
+        );
+    }
+}

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -591,6 +591,58 @@ mod tests {
         );
     }
 
+    #[test]
+    fn multiple_malformed_capabilities_are_dropped_independently() {
+        let response = serde_json::json!({
+            "result": {
+                "capabilities": {
+                    "textDocumentSync": 1,
+                    "hoverProvider": 42,
+                    "completionProvider": true
+                }
+            }
+        });
+
+        let parsed = parse_initialize_response_capabilities(&response)
+            .expect("malformed feature capabilities must degrade independently");
+
+        assert!(parsed.capabilities.text_document_sync.is_some());
+        assert!(parsed.capabilities.hover_provider.is_none());
+        assert!(parsed.capabilities.completion_provider.is_none());
+        let mut dropped = parsed
+            .dropped
+            .iter()
+            .map(|dropped| dropped.field.as_str())
+            .collect::<Vec<_>>();
+        dropped.sort_unstable();
+        assert_eq!(dropped, ["completionProvider", "hoverProvider"]);
+    }
+
+    #[rstest]
+    #[case::omitted(serde_json::json!({"result": {}}))]
+    #[case::null(serde_json::json!({"result": {"capabilities": null}}))]
+    fn omitted_or_null_capabilities_remain_compatible(#[case] response: serde_json::Value) {
+        let parsed = parse_initialize_response_capabilities(&response)
+            .expect("omitted or null capabilities remain compatible");
+
+        assert_eq!(parsed.capabilities, ServerCapabilities::default());
+        assert!(parsed.dropped.is_empty());
+    }
+
+    #[rstest]
+    #[case::scalar_result(serde_json::json!({"result": 42}))]
+    #[case::array_result(serde_json::json!({"result": []}))]
+    #[case::scalar_capabilities(
+        serde_json::json!({"result": {"capabilities": "not-an-object"}})
+    )]
+    #[case::array_capabilities(serde_json::json!({"result": {"capabilities": []}}))]
+    fn structurally_invalid_initialize_payload_fails(#[case] response: serde_json::Value) {
+        let error = parse_initialize_response_capabilities(&response)
+            .expect_err("structural corruption must fail the handshake");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+    }
+
     #[rstest]
     #[case::null_result(
         serde_json::json!({"result": null}),
@@ -650,6 +702,7 @@ mod tests {
     ) {
         let error = parse_initialize_response_capabilities(&response)
             .expect_err("non-UTF-16 downstream encoding must fail initialization");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
         let message = error.to_string();
         assert!(message.contains(field), "unexpected error: {message}");
         assert!(message.contains(announced), "unexpected error: {message}");

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -5,7 +5,6 @@
 
 use std::str::FromStr;
 
-use serde::de::IntoDeserializer;
 use tower_lsp_server::ls_types::{
     ClientCapabilities, DidChangeConfigurationParams, DidChangeWorkspaceFoldersParams,
     DidCloseTextDocumentParams, InitializeParams, InitializedParams, ServerCapabilities,
@@ -213,7 +212,7 @@ fn recover_server_capabilities(
     let mut candidate = serde_json::Value::Object(capabilities.clone());
     let mut dropped = Vec::new();
     loop {
-        match serde_path_to_error::deserialize(candidate.clone().into_deserializer()) {
+        match serde_path_to_error::deserialize(&candidate) {
             Ok(capabilities) => {
                 return Ok(ParsedInitializeCapabilities {
                     capabilities,

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -584,12 +584,11 @@ mod tests {
         );
         assert_eq!(parsed.dropped.len(), 1);
         assert_eq!(parsed.dropped[0].field, "hoverProvider");
-        assert!(
-            parsed.dropped[0].error.contains("hoverProvider")
-                && parsed.dropped[0].error.contains("HoverProviderCapability"),
-            "unexpected serde error: {}",
-            parsed.dropped[0].error
-        );
+        let detail = parsed.dropped[0]
+            .error
+            .strip_prefix("hoverProvider: ")
+            .expect("serde error must include the JSON field path");
+        assert!(!detail.is_empty(), "serde error must retain its cause");
     }
 
     #[test]

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -5,10 +5,11 @@
 
 use std::str::FromStr;
 
+use serde::de::IntoDeserializer;
 use tower_lsp_server::ls_types::{
     ClientCapabilities, DidChangeConfigurationParams, DidChangeWorkspaceFoldersParams,
-    DidCloseTextDocumentParams, InitializeParams, InitializedParams, TextDocumentIdentifier, Uri,
-    WorkspaceFolder, WorkspaceFoldersChangeEvent,
+    DidCloseTextDocumentParams, InitializeParams, InitializedParams, ServerCapabilities,
+    TextDocumentIdentifier, Uri, WorkspaceFolder, WorkspaceFoldersChangeEvent,
 };
 
 use super::client_capabilities::build_bridge_client_capabilities;
@@ -130,12 +131,28 @@ pub(crate) fn build_did_change_configuration_notification(
     )
 }
 
-/// Validates a JSON-RPC initialize response.
+#[derive(Debug)]
+pub(crate) struct DroppedCapability {
+    pub(crate) field: String,
+    pub(crate) error: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct ParsedInitializeCapabilities {
+    pub(crate) capabilities: ServerCapabilities,
+    pub(crate) dropped: Vec<DroppedCapability>,
+}
+
+/// Validates a JSON-RPC initialize response and extracts usable capabilities.
 ///
 /// Uses lenient interpretation to maximize compatibility with non-conformant
 /// servers: a non-null `error` field is prioritized, a null `error` alongside a
-/// result is accepted, and a null/missing result is rejected.
-pub(crate) fn validate_initialize_response(response: &serde_json::Value) -> std::io::Result<()> {
+/// result is accepted, and a null/missing result is rejected. Malformed fields
+/// within an object-shaped capabilities payload are dropped independently so
+/// they do not erase unrelated valid features.
+pub(crate) fn parse_initialize_response_capabilities(
+    response: &serde_json::Value,
+) -> std::io::Result<ParsedInitializeCapabilities> {
     // 1. Check for error response (prioritize error if present)
     if let Some(error) = response.get("error").filter(|e| !e.is_null()) {
         // Error field is non-null: treat as error regardless of result
@@ -152,8 +169,13 @@ pub(crate) fn validate_initialize_response(response: &serde_json::Value) -> std:
     }
 
     // 2. Reject if result is absent or null
-    let Some(result) = response.get("result").filter(|r| !r.is_null()) else {
-        return Err(std::io::Error::other(
+    let Some(result) = response
+        .get("result")
+        .filter(|result| !result.is_null())
+        .and_then(serde_json::Value::as_object)
+    else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
             "bridge: initialize response missing valid result",
         ));
     };
@@ -166,7 +188,56 @@ pub(crate) fn validate_initialize_response(response: &serde_json::Value) -> std:
     )?;
     validate_utf16_encoding(result.get("offsetEncoding"), "offsetEncoding")?;
 
-    Ok(())
+    let Some(capabilities) = result
+        .get("capabilities")
+        .filter(|capabilities| !capabilities.is_null())
+    else {
+        return Ok(ParsedInitializeCapabilities {
+            capabilities: ServerCapabilities::default(),
+            dropped: Vec::new(),
+        });
+    };
+    let Some(capabilities) = capabilities.as_object() else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "bridge: invalid initialize capabilities: expected an object",
+        ));
+    };
+
+    let mut candidate = serde_json::Value::Object(capabilities.clone());
+    let mut dropped = Vec::new();
+    loop {
+        match serde_path_to_error::deserialize(candidate.clone().into_deserializer()) {
+            Ok(capabilities) => {
+                return Ok(ParsedInitializeCapabilities {
+                    capabilities,
+                    dropped,
+                });
+            }
+            Err(error) => {
+                let Some(serde_path_to_error::Segment::Map { key: field }) =
+                    error.path().iter().next()
+                else {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("bridge: invalid initialize capabilities: {error}"),
+                    ));
+                };
+                let field = field.clone();
+                let error = error.to_string();
+                let removed = candidate
+                    .as_object_mut()
+                    .and_then(|capabilities| capabilities.remove(&field));
+                if removed.is_none() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("bridge: invalid initialize capabilities: {error}"),
+                    ));
+                }
+                dropped.push(DroppedCapability { field, error });
+            }
+        }
+    }
 }
 
 fn validate_utf16_encoding(
@@ -182,14 +253,18 @@ fn validate_utf16_encoding(
         return Ok(());
     }
     let Some(encoding) = announced.as_str() else {
-        return Err(std::io::Error::other(format!(
-            "bridge: downstream initialize {field} is non-string; UTF-16 is required"
-        )));
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("bridge: downstream initialize {field} is non-string; UTF-16 is required"),
+        ));
     };
     if encoding != "utf-16" {
-        return Err(std::io::Error::other(format!(
-            "bridge: downstream initialize {field} announced {encoding:?}; UTF-16 is required"
-        )));
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "bridge: downstream initialize {field} announced {encoding:?}; UTF-16 is required"
+            ),
+        ));
     }
     Ok(())
 }
@@ -469,10 +544,40 @@ mod tests {
     #[trace]
     fn validate_accepts_valid_response(#[case] response: serde_json::Value) {
         assert!(
-            validate_initialize_response(&response).is_ok(),
+            parse_initialize_response_capabilities(&response).is_ok(),
             "Expected valid response to be accepted: {:?}",
             response
         );
+    }
+
+    #[test]
+    fn malformed_capability_does_not_discard_valid_capabilities() {
+        let response = serde_json::json!({
+            "result": {
+                "capabilities": {
+                    "hoverProvider": 42,
+                    "completionProvider": {
+                        "triggerCharacters": ["."]
+                    }
+                }
+            }
+        });
+
+        let parsed = parse_initialize_response_capabilities(&response)
+            .expect("one malformed capability must not fail the handshake");
+
+        assert!(parsed.capabilities.hover_provider.is_none());
+        assert_eq!(
+            parsed
+                .capabilities
+                .completion_provider
+                .expect("valid completion capability must survive")
+                .trigger_characters,
+            Some(vec![".".to_string()])
+        );
+        assert_eq!(parsed.dropped.len(), 1);
+        assert_eq!(parsed.dropped[0].field, "hoverProvider");
+        assert!(parsed.dropped[0].error.contains("invalid type"));
     }
 
     #[rstest]
@@ -493,7 +598,7 @@ mod tests {
         #[case] response: serde_json::Value,
         #[case] expected_error: &str,
     ) {
-        let result = validate_initialize_response(&response);
+        let result = parse_initialize_response_capabilities(&response);
         assert!(result.is_err(), "Expected rejection for: {:?}", response);
         let err_msg = result.unwrap_err().to_string();
         assert!(
@@ -532,7 +637,7 @@ mod tests {
         #[case] field: &str,
         #[case] announced: &str,
     ) {
-        let error = validate_initialize_response(&response)
+        let error = parse_initialize_response_capabilities(&response)
             .expect_err("non-UTF-16 downstream encoding must fail initialization");
         let message = error.to_string();
         assert!(message.contains(field), "unexpected error: {message}");
@@ -600,7 +705,7 @@ mod tests {
         #[case] expected_code: &str,
         #[case] expected_message: &str,
     ) {
-        let result = validate_initialize_response(&response);
+        let result = parse_initialize_response_capabilities(&response);
         assert!(result.is_err(), "Expected rejection for: {:?}", response);
         let err_msg = result.unwrap_err().to_string();
         assert!(

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -168,14 +168,16 @@ pub(crate) fn parse_initialize_response_capabilities(
     }
 
     // 2. Reject if result is absent or null
-    let Some(result) = response
-        .get("result")
-        .filter(|result| !result.is_null())
-        .and_then(serde_json::Value::as_object)
-    else {
+    let Some(result) = response.get("result").filter(|result| !result.is_null()) else {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             "bridge: initialize response missing valid result",
+        ));
+    };
+    let Some(result) = result.as_object() else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "bridge: invalid initialize result: expected an object",
         ));
     };
 
@@ -629,17 +631,34 @@ mod tests {
     }
 
     #[rstest]
-    #[case::scalar_result(serde_json::json!({"result": 42}))]
-    #[case::array_result(serde_json::json!({"result": []}))]
-    #[case::scalar_capabilities(
-        serde_json::json!({"result": {"capabilities": "not-an-object"}})
+    #[case::scalar_result(
+        serde_json::json!({"result": 42}),
+        "initialize result: expected an object"
     )]
-    #[case::array_capabilities(serde_json::json!({"result": {"capabilities": []}}))]
-    fn structurally_invalid_initialize_payload_fails(#[case] response: serde_json::Value) {
+    #[case::array_result(
+        serde_json::json!({"result": []}),
+        "initialize result: expected an object"
+    )]
+    #[case::scalar_capabilities(
+        serde_json::json!({"result": {"capabilities": "not-an-object"}}),
+        "initialize capabilities: expected an object"
+    )]
+    #[case::array_capabilities(
+        serde_json::json!({"result": {"capabilities": []}}),
+        "initialize capabilities: expected an object"
+    )]
+    fn structurally_invalid_initialize_payload_fails(
+        #[case] response: serde_json::Value,
+        #[case] expected: &str,
+    ) {
         let error = parse_initialize_response_capabilities(&response)
             .expect_err("structural corruption must fail the handshake");
 
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(
+            error.to_string().contains(expected),
+            "unexpected error: {error}"
+        );
     }
 
     #[rstest]

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -211,40 +211,44 @@ pub(crate) fn parse_initialize_response_capabilities(
 fn recover_server_capabilities(
     capabilities: &serde_json::Map<String, serde_json::Value>,
 ) -> std::io::Result<ParsedInitializeCapabilities> {
-    let mut candidate = serde_json::Value::Object(capabilities.clone());
+    let mut recovered = serde_json::Map::new();
     let mut dropped = Vec::new();
-    loop {
-        match serde_path_to_error::deserialize(&candidate) {
-            Ok(capabilities) => {
-                return Ok(ParsedInitializeCapabilities {
-                    capabilities,
-                    dropped,
-                });
+    for (field, value) in capabilities {
+        let mut probe = serde_json::Map::new();
+        probe.insert(field.clone(), value.clone());
+        let probe = serde_json::Value::Object(probe);
+        match serde_path_to_error::deserialize::<_, ServerCapabilities>(&probe) {
+            Ok(_) => {
+                let serde_json::Value::Object(mut probe) = probe else {
+                    unreachable!("capability probe is always an object");
+                };
+                recovered.insert(
+                    field.clone(),
+                    probe
+                        .remove(field)
+                        .expect("capability probe retains its only field"),
+                );
             }
             Err(error) => {
-                let Some(serde_path_to_error::Segment::Map { key: field }) =
-                    error.path().iter().next()
-                else {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("bridge: invalid initialize capabilities: {error}"),
-                    ));
-                };
-                let field = field.clone();
-                let error = error.to_string();
-                let removed = candidate
-                    .as_object_mut()
-                    .and_then(|capabilities| capabilities.remove(&field));
-                if removed.is_none() {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("bridge: invalid initialize capabilities: {error}"),
-                    ));
-                }
-                dropped.push(DroppedCapability { field, error });
+                dropped.push(DroppedCapability {
+                    field: field.clone(),
+                    error: error.to_string(),
+                });
             }
         }
     }
+
+    let capabilities =
+        serde_json::from_value(serde_json::Value::Object(recovered)).map_err(|error| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("bridge: invalid recovered initialize capabilities: {error}"),
+            )
+        })?;
+    Ok(ParsedInitializeCapabilities {
+        capabilities,
+        dropped,
+    })
 }
 
 fn validate_utf16_encoding(

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -204,6 +204,12 @@ pub(crate) fn parse_initialize_response_capabilities(
         ));
     };
 
+    recover_server_capabilities(capabilities)
+}
+
+fn recover_server_capabilities(
+    capabilities: &serde_json::Map<String, serde_json::Value>,
+) -> std::io::Result<ParsedInitializeCapabilities> {
     let mut candidate = serde_json::Value::Object(capabilities.clone());
     let mut dropped = Vec::new();
     loop {
@@ -577,7 +583,12 @@ mod tests {
         );
         assert_eq!(parsed.dropped.len(), 1);
         assert_eq!(parsed.dropped[0].field, "hoverProvider");
-        assert!(parsed.dropped[0].error.contains("invalid type"));
+        assert!(
+            parsed.dropped[0].error.contains("hoverProvider")
+                && parsed.dropped[0].error.contains("HoverProviderCapability"),
+            "unexpected serde error: {}",
+            parsed.dropped[0].error
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

- preserve independently valid downstream ServerCapabilities when another top-level capability has an invalid shape
- locate each serde failure, drop only its top-level capability, and log the connection, field, and deserialization context
- keep structurally invalid result/capabilities envelopes and unsupported position encodings as InvalidData handshake failures
- preserve the existing omitted/null capabilities compatibility boundary
- document the graceful-degradation decision in the server-pool ADR

## Behavior

Given a valid completionProvider and malformed hoverProvider, Kakehashi now keeps completion routing available, ignores hover support, warns about hoverProvider, and completes the downstream initialized handshake.

Several malformed feature capabilities are removed independently. A non-object result, non-object capabilities payload, or invalid positionEncoding still aborts initialization because no safe field-local recovery boundary exists.

## Validation

- make test (3,039 passed, 2 ignored)
- make check
- focused parser boundary tests
- full handshake regression proving initialized is sent after recovery
- staged revise review: multi-perspective local review and converged fresh Codex review

## Risk

Recovery validates each top-level capability once in isolation, moves valid raw values into one recovered object, and performs one final typed decode. The work is linear in the advertised capability payload and occurs only during downstream initialization. If the final recovered object still cannot deserialize, initialization fails instead of silently defaulting every capability.

Closes #860

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when downstream servers return malformed `initialize` capabilities.
  * Malformed individual capability fields are now dropped, while unrelated valid capabilities remain usable so the handshake can still complete.
  * Stricter handling for structurally invalid `initialize` responses and invalid UTF-16 encoding requirements.
* **Tests**
  * Added a Unix-only test covering capability recovery, verifying `completionProvider` is preserved and `initialized` is eventually sent.
* **Documentation**
  * Documented the new field-level recovery behavior and its bounded failure scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->