### PR TITLE
feat(worker): prototype supervised tree worker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
         with:
           persist-credentials: false
       - run: cargo check
+      - run: cargo check --bench tree_worker_stage1
 
   test:
     name: Test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,12 @@ jobs:
       - run: rustup component add rust-analyzer
       - run: make deps/tree-sitter
       - run: cargo test
+      - name: Smoke-test tree worker benchmark CLI
+        run: >-
+          cargo bench --locked --bench tree_worker_stage1 --
+          --bin target/release/kakehashi
+          --parser deps/tree-sitter/parser/rust.so
+          --requests 8 --threads 2 --lines 20
 
   benchmark-tools:
     name: Benchmark tools (${{ matrix.os }})

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
       - run: rustup component add rust-analyzer
       - run: make deps/tree-sitter
       - run: cargo test
+      - run: cargo build --release --locked --bin kakehashi
       - name: Smoke-test tree worker benchmark CLI
         run: >-
           cargo bench --locked --bench tree_worker_stage1 --

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +267,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +308,16 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "dashmap"
@@ -341,6 +369,16 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -612,6 +650,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -977,6 +1025,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serial_test",
+ "sha2",
  "shellexpand",
  "similar 3.1.1",
  "streaming-iterator",
@@ -1827,6 +1876,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shellexpand"
 version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,6 +2497,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2523,6 +2589,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,3 +138,7 @@ rstest = "0.26"
 [[bench]]
 name = "semantic_tokens"
 harness = false
+
+[[bench]]
+name = "tree_worker_stage1"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,16 @@ opt-level = 3
 [profile.dev.package.regex]
 opt-level = 3
 
+[profile.dev.package.sha2]
+opt-level = 3
+
 [profile.test.package.tree-sitter]
 opt-level = 3
 
 [profile.test.package.regex]
+opt-level = 3
+
+[profile.test.package.sha2]
 opt-level = 3
 
 [dependencies]
@@ -75,6 +81,7 @@ two-face = { version = "0.5", default-features = false, features = ["syntect-def
 # OS-trust-store TLS posture reqwest(rustls) had (src/install/http.rs).
 ureq = { version = "3", features = ["platform-verifier"] }
 serde_json = "1"
+sha2 = "0.10"
 shellexpand = "3"
 similar = "3"
 flate2 = "1"

--- a/benches/profile/results/single_worker_stage1_2026-07-19.json
+++ b/benches/profile/results/single_worker_stage1_2026-07-19.json
@@ -1,10 +1,14 @@
 {
-  "schema": 1,
+  "schema": 2,
   "experiment": "single-tree-worker-stage1-host-parse-prototype",
-  "source_commit": "a5d0524efc989b946ab32b6869f16f8f9009e311",
-  "binary_sha256": "6ff9d15f7d574beaec45c554af60a040134b9255ed301fa836de5ca6623fd6d2",
-  "benchmark_sha256": "d6cf22b0bd58f839d482719ed92de8285c77bc7d33e9eb604f4eab18bf5c2254",
-  "parser_sha256": "e75df6b549c18158dd0e506d9cd78224cea0e2a01e9a3e79a11cdfff9fb4b1fe",
+  "source_commit": "87cbb0db42a0872d05bfa85e5549baa72285902d",
+  "binary_sha256": "77e835820aa65d836510821b08d1695043d3c1028a89086b44d1d9af93dc22cc",
+  "benchmark_sha256": "ff80bd942cd8f83d61de288dd7223c651af6d8d2919493beace296d982c5f04d",
+  "parser_sha256": "dc4dfaabbd5f93cd8923474b8467ab7119773a66a01a9bac7d1f4311fc23062e",
+  "parser_source": {
+    "url": "https://github.com/tree-sitter/tree-sitter-rust",
+    "revision": "77a3747266f4d621d0757825e6b11edcbf991ca5"
+  },
   "environment": {
     "machine": "Apple M4",
     "os": "macOS 26.5.1 (25F80)",
@@ -16,43 +20,119 @@
     "threads": 4,
     "source_lines": 200,
     "request_frame_bytes": 8133,
-    "direct_parser_cache_hits": 996,
-    "worker_parser_cache_hits": 997,
-    "note": "Two consecutive page-cache-warm summary batches; no confidence interval."
+    "raw_batches": [
+      "single_worker_stage1_2026-07-19_batch_a.json",
+      "single_worker_stage1_2026-07-19_batch_b.json"
+    ],
+    "note": "Two consecutive page-cache-warm batches; no confidence interval."
   },
   "batches": [
     {
-      "cold_start_us": 3730.25,
+      "schema": 1,
+      "requests": 1000,
+      "threads": 4,
+      "source_lines": 200,
+      "request_frame_bytes": 8069,
+      "cold_start_us": 1108750.75,
       "sequential": {
-        "direct": {"p50_us": 808.834, "p95_us": 823.375, "p99_us": 830.459, "mean_us": 768.519267},
-        "worker_parent_observed": {"p50_us": 1138.875, "p95_us": 1372.084, "p99_us": 1391.958, "mean_us": 1090.447202},
-        "worker_compute": {"p50_us": 1010.666, "p95_us": 1219.375, "p99_us": 1229.542, "mean_us": 966.111412},
-        "worker_queue": {"p50_us": 5.0, "p95_us": 8.333, "p99_us": 18.875, "mean_us": 5.461271}
+        "direct": {
+          "p50_us": 960.917,
+          "p95_us": 1100.708,
+          "p99_us": 1183.75,
+          "mean_us": 1006.508422
+        },
+        "worker_parent_observed": {
+          "p50_us": 1129.709,
+          "p95_us": 1172.0,
+          "p99_us": 1217.791,
+          "mean_us": 1084.497511
+        },
+        "worker_compute": {
+          "p50_us": 1008.5,
+          "p95_us": 1033.583,
+          "p99_us": 1072.791,
+          "mean_us": 961.191374
+        },
+        "worker_queue": {
+          "p50_us": 4.542,
+          "p95_us": 7.75,
+          "p99_us": 10.792,
+          "mean_us": 4.97864
+        }
       },
       "parallel": {
-        "direct_request_latency": {"p50_us": 1606.959, "p95_us": 2038.709, "p99_us": 2953.041, "mean_us": 1663.009363},
-        "worker_request_latency": {"p50_us": 1782.083, "p95_us": 2783.416, "p99_us": 3766.125, "mean_us": 1958.225098},
-        "direct_wall_ms": 416.695583,
-        "worker_wall_ms": 493.3005,
-        "direct_requests_per_second": 2399.8334534781957,
-        "worker_requests_per_second": 2027.1619428725494
+        "direct_request_latency": {
+          "p50_us": 1277.875,
+          "p95_us": 1557.334,
+          "p99_us": 1618.792,
+          "mean_us": 1276.203831
+        },
+        "worker_request_latency": {
+          "p50_us": 1730.041,
+          "p95_us": 2162.667,
+          "p99_us": 2306.416,
+          "mean_us": 1786.093039
+        },
+        "direct_wall_ms": 320.506417,
+        "worker_wall_ms": 447.09700000000004,
+        "direct_parser_cache_hits": 996,
+        "worker_parser_cache_hits": 997,
+        "direct_requests_per_second": 3120.0623356006004,
+        "worker_requests_per_second": 2236.6511070304655
       }
     },
     {
-      "cold_start_us": 3399.5,
+      "schema": 1,
+      "requests": 1000,
+      "threads": 4,
+      "source_lines": 200,
+      "request_frame_bytes": 8069,
+      "cold_start_us": 1095208.542,
       "sequential": {
-        "direct": {"p50_us": 730.375, "p95_us": 825.709, "p99_us": 838.083, "mean_us": 735.612035},
-        "worker_parent_observed": {"p50_us": 978.916, "p95_us": 1163.375, "p99_us": 1188.417, "mean_us": 969.662396},
-        "worker_compute": {"p50_us": 871.875, "p95_us": 1032.167, "p99_us": 1045.542, "mean_us": 861.171694},
-        "worker_queue": {"p50_us": 4.042, "p95_us": 7.625, "p99_us": 11.917, "mean_us": 4.58003}
+        "direct": {
+          "p50_us": 1093.667,
+          "p95_us": 1108.0,
+          "p99_us": 1123.459,
+          "mean_us": 1058.767824
+        },
+        "worker_parent_observed": {
+          "p50_us": 1000.167,
+          "p95_us": 1161.5,
+          "p99_us": 1177.083,
+          "mean_us": 1042.1313129999999
+        },
+        "worker_compute": {
+          "p50_us": 879.791,
+          "p95_us": 1022.5,
+          "p99_us": 1038.25,
+          "mean_us": 922.289995
+        },
+        "worker_queue": {
+          "p50_us": 4.334,
+          "p95_us": 7.042,
+          "p99_us": 9.292,
+          "mean_us": 4.690554
+        }
       },
       "parallel": {
-        "direct_request_latency": {"p50_us": 1331.792, "p95_us": 2010.167, "p99_us": 2182.958, "mean_us": 1410.930249},
-        "worker_request_latency": {"p50_us": 1708.292, "p95_us": 2172.459, "p99_us": 2336.875, "mean_us": 1771.911374},
-        "direct_wall_ms": 353.357166,
-        "worker_wall_ms": 447.580583,
-        "direct_requests_per_second": 2829.997793224321,
-        "worker_requests_per_second": 2234.234544531169
+        "direct_request_latency": {
+          "p50_us": 1384.917,
+          "p95_us": 2153.375,
+          "p99_us": 2320.75,
+          "mean_us": 1471.164802
+        },
+        "worker_request_latency": {
+          "p50_us": 1749.0,
+          "p95_us": 2211.334,
+          "p99_us": 2346.833,
+          "mean_us": 1791.140396
+        },
+        "direct_wall_ms": 372.279584,
+        "worker_wall_ms": 448.392792,
+        "direct_parser_cache_hits": 996,
+        "worker_parser_cache_hits": 997,
+        "direct_requests_per_second": 2686.153211130697,
+        "worker_requests_per_second": 2230.187500427081
       }
     }
   ]

--- a/benches/profile/results/single_worker_stage1_2026-07-19.json
+++ b/benches/profile/results/single_worker_stage1_2026-07-19.json
@@ -1,0 +1,59 @@
+{
+  "schema": 1,
+  "experiment": "single-tree-worker-stage1-host-parse-prototype",
+  "source_commit": "a5d0524efc989b946ab32b6869f16f8f9009e311",
+  "binary_sha256": "6ff9d15f7d574beaec45c554af60a040134b9255ed301fa836de5ca6623fd6d2",
+  "benchmark_sha256": "d6cf22b0bd58f839d482719ed92de8285c77bc7d33e9eb604f4eab18bf5c2254",
+  "parser_sha256": "e75df6b549c18158dd0e506d9cd78224cea0e2a01e9a3e79a11cdfff9fb4b1fe",
+  "environment": {
+    "machine": "Apple M4",
+    "os": "macOS 26.5.1 (25F80)",
+    "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)",
+    "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)"
+  },
+  "method": {
+    "requests": 1000,
+    "threads": 4,
+    "source_lines": 200,
+    "request_frame_bytes": 8133,
+    "direct_parser_cache_hits": 996,
+    "worker_parser_cache_hits": 997,
+    "note": "Two consecutive page-cache-warm summary batches; no confidence interval."
+  },
+  "batches": [
+    {
+      "cold_start_us": 3730.25,
+      "sequential": {
+        "direct": {"p50_us": 808.834, "p95_us": 823.375, "p99_us": 830.459, "mean_us": 768.519267},
+        "worker_parent_observed": {"p50_us": 1138.875, "p95_us": 1372.084, "p99_us": 1391.958, "mean_us": 1090.447202},
+        "worker_compute": {"p50_us": 1010.666, "p95_us": 1219.375, "p99_us": 1229.542, "mean_us": 966.111412},
+        "worker_queue": {"p50_us": 5.0, "p95_us": 8.333, "p99_us": 18.875, "mean_us": 5.461271}
+      },
+      "parallel": {
+        "direct_request_latency": {"p50_us": 1606.959, "p95_us": 2038.709, "p99_us": 2953.041, "mean_us": 1663.009363},
+        "worker_request_latency": {"p50_us": 1782.083, "p95_us": 2783.416, "p99_us": 3766.125, "mean_us": 1958.225098},
+        "direct_wall_ms": 416.695583,
+        "worker_wall_ms": 493.3005,
+        "direct_requests_per_second": 2399.8334534781957,
+        "worker_requests_per_second": 2027.1619428725494
+      }
+    },
+    {
+      "cold_start_us": 3399.5,
+      "sequential": {
+        "direct": {"p50_us": 730.375, "p95_us": 825.709, "p99_us": 838.083, "mean_us": 735.612035},
+        "worker_parent_observed": {"p50_us": 978.916, "p95_us": 1163.375, "p99_us": 1188.417, "mean_us": 969.662396},
+        "worker_compute": {"p50_us": 871.875, "p95_us": 1032.167, "p99_us": 1045.542, "mean_us": 861.171694},
+        "worker_queue": {"p50_us": 4.042, "p95_us": 7.625, "p99_us": 11.917, "mean_us": 4.58003}
+      },
+      "parallel": {
+        "direct_request_latency": {"p50_us": 1331.792, "p95_us": 2010.167, "p99_us": 2182.958, "mean_us": 1410.930249},
+        "worker_request_latency": {"p50_us": 1708.292, "p95_us": 2172.459, "p99_us": 2336.875, "mean_us": 1771.911374},
+        "direct_wall_ms": 353.357166,
+        "worker_wall_ms": 447.580583,
+        "direct_requests_per_second": 2829.997793224321,
+        "worker_requests_per_second": 2234.234544531169
+      }
+    }
+  ]
+}

--- a/benches/profile/results/single_worker_stage1_2026-07-19.json
+++ b/benches/profile/results/single_worker_stage1_2026-07-19.json
@@ -1,9 +1,9 @@
 {
   "schema": 2,
   "experiment": "single-tree-worker-stage1-host-parse-prototype",
-  "source_commit": "87cbb0db42a0872d05bfa85e5549baa72285902d",
-  "binary_sha256": "77e835820aa65d836510821b08d1695043d3c1028a89086b44d1d9af93dc22cc",
-  "benchmark_sha256": "ff80bd942cd8f83d61de288dd7223c651af6d8d2919493beace296d982c5f04d",
+  "source_commit": "419b00d36f7eca00f9ca206fb9b6b2cb3f8180c7",
+  "binary_sha256": "54ca1bda67dd637f0f308b66ad0304333f1375e36410cbe3510708ce7051f8f9",
+  "benchmark_sha256": "53b3d83efb1f4810f0d4635f26110017dbec28a11d088f80e7fa9e5e2e5d6fc5",
   "parser_sha256": "dc4dfaabbd5f93cd8923474b8467ab7119773a66a01a9bac7d1f4311fc23062e",
   "parser_source": {
     "url": "https://github.com/tree-sitter/tree-sitter-rust",
@@ -19,12 +19,12 @@
     "requests": 1000,
     "threads": 4,
     "source_lines": 200,
-    "request_frame_bytes": 8133,
+    "request_frame_bytes": 8069,
     "raw_batches": [
       "single_worker_stage1_2026-07-19_batch_a.json",
       "single_worker_stage1_2026-07-19_batch_b.json"
     ],
-    "note": "Two consecutive page-cache-warm batches; no confidence interval."
+    "note": "Two consecutive page-cache-warm batches in fixed direct-then-worker order; no confidence interval."
   },
   "batches": [
     {
@@ -33,52 +33,52 @@
       "threads": 4,
       "source_lines": 200,
       "request_frame_bytes": 8069,
-      "cold_start_us": 1108750.75,
+      "cold_start_us": 1089344.708,
       "sequential": {
         "direct": {
-          "p50_us": 960.917,
-          "p95_us": 1100.708,
-          "p99_us": 1183.75,
-          "mean_us": 1006.508422
+          "p50_us": 957.25,
+          "p95_us": 1084.542,
+          "p99_us": 1092.458,
+          "mean_us": 999.708486
         },
         "worker_parent_observed": {
-          "p50_us": 1129.709,
-          "p95_us": 1172.0,
-          "p99_us": 1217.791,
-          "mean_us": 1084.497511
+          "p50_us": 1147.458,
+          "p95_us": 1170.333,
+          "p99_us": 1189.5,
+          "mean_us": 1105.101109
         },
         "worker_compute": {
-          "p50_us": 1008.5,
-          "p95_us": 1033.583,
-          "p99_us": 1072.791,
-          "mean_us": 961.191374
+          "p50_us": 1011.292,
+          "p95_us": 1029.25,
+          "p99_us": 1040.084,
+          "mean_us": 973.3149549999999
         },
         "worker_queue": {
-          "p50_us": 4.542,
-          "p95_us": 7.75,
-          "p99_us": 10.792,
-          "mean_us": 4.97864
+          "p50_us": 4.708,
+          "p95_us": 7.292,
+          "p99_us": 9.333,
+          "mean_us": 4.9741040000000005
         }
       },
       "parallel": {
         "direct_request_latency": {
-          "p50_us": 1277.875,
-          "p95_us": 1557.334,
-          "p99_us": 1618.792,
-          "mean_us": 1276.203831
+          "p50_us": 1591.042,
+          "p95_us": 2294.667,
+          "p99_us": 2495.833,
+          "mean_us": 1634.142335
         },
         "worker_request_latency": {
-          "p50_us": 1730.041,
-          "p95_us": 2162.667,
-          "p99_us": 2306.416,
-          "mean_us": 1786.093039
+          "p50_us": 1632.833,
+          "p95_us": 2036.167,
+          "p99_us": 2191.375,
+          "mean_us": 1676.624515
         },
-        "direct_wall_ms": 320.506417,
-        "worker_wall_ms": 447.09700000000004,
+        "direct_wall_ms": 409.796667,
+        "worker_wall_ms": 419.98037500000004,
         "direct_parser_cache_hits": 996,
         "worker_parser_cache_hits": 997,
-        "direct_requests_per_second": 3120.0623356006004,
-        "worker_requests_per_second": 2236.6511070304655
+        "direct_requests_per_second": 2440.234585900134,
+        "worker_requests_per_second": 2381.063638985512
       }
     },
     {
@@ -87,52 +87,52 @@
       "threads": 4,
       "source_lines": 200,
       "request_frame_bytes": 8069,
-      "cold_start_us": 1095208.542,
+      "cold_start_us": 1141117.792,
       "sequential": {
         "direct": {
-          "p50_us": 1093.667,
-          "p95_us": 1108.0,
-          "p99_us": 1123.459,
-          "mean_us": 1058.767824
+          "p50_us": 1274.458,
+          "p95_us": 1304.042,
+          "p99_us": 1328.041,
+          "mean_us": 1274.578951
         },
         "worker_parent_observed": {
-          "p50_us": 1000.167,
-          "p95_us": 1161.5,
-          "p99_us": 1177.083,
-          "mean_us": 1042.1313129999999
+          "p50_us": 1175.417,
+          "p95_us": 1396.167,
+          "p99_us": 1419.583,
+          "mean_us": 1254.386044
         },
         "worker_compute": {
-          "p50_us": 879.791,
-          "p95_us": 1022.5,
-          "p99_us": 1038.25,
-          "mean_us": 922.289995
+          "p50_us": 1035.709,
+          "p95_us": 1230.084,
+          "p99_us": 1255.584,
+          "mean_us": 1112.2578259999998
         },
         "worker_queue": {
-          "p50_us": 4.334,
-          "p95_us": 7.042,
-          "p99_us": 9.292,
-          "mean_us": 4.690554
+          "p50_us": 5.208,
+          "p95_us": 8.625,
+          "p99_us": 13.584,
+          "mean_us": 5.902079
         }
       },
       "parallel": {
         "direct_request_latency": {
-          "p50_us": 1384.917,
-          "p95_us": 2153.375,
-          "p99_us": 2320.75,
-          "mean_us": 1471.164802
+          "p50_us": 1759.75,
+          "p95_us": 2483.416,
+          "p99_us": 2836.25,
+          "mean_us": 1781.824118
         },
         "worker_request_latency": {
-          "p50_us": 1749.0,
-          "p95_us": 2211.334,
-          "p99_us": 2346.833,
-          "mean_us": 1791.140396
+          "p50_us": 1586.792,
+          "p95_us": 1684.958,
+          "p99_us": 1783.166,
+          "mean_us": 1571.1603
         },
-        "direct_wall_ms": 372.279584,
-        "worker_wall_ms": 448.392792,
+        "direct_wall_ms": 468.649792,
+        "worker_wall_ms": 395.665083,
         "direct_parser_cache_hits": 996,
         "worker_parser_cache_hits": 997,
-        "direct_requests_per_second": 2686.153211130697,
-        "worker_requests_per_second": 2230.187500427081
+        "direct_requests_per_second": 2133.7894885910887,
+        "worker_requests_per_second": 2527.390065400338
       }
     }
   ]

--- a/benches/profile/results/single_worker_stage1_2026-07-19_batch_a.json
+++ b/benches/profile/results/single_worker_stage1_2026-07-19_batch_a.json
@@ -1,0 +1,54 @@
+{
+  "schema": 1,
+  "requests": 1000,
+  "threads": 4,
+  "source_lines": 200,
+  "request_frame_bytes": 8069,
+  "cold_start_us": 1108750.75,
+  "sequential": {
+    "direct": {
+      "p50_us": 960.917,
+      "p95_us": 1100.708,
+      "p99_us": 1183.75,
+      "mean_us": 1006.508422
+    },
+    "worker_parent_observed": {
+      "p50_us": 1129.709,
+      "p95_us": 1172.0,
+      "p99_us": 1217.791,
+      "mean_us": 1084.497511
+    },
+    "worker_compute": {
+      "p50_us": 1008.5,
+      "p95_us": 1033.583,
+      "p99_us": 1072.791,
+      "mean_us": 961.191374
+    },
+    "worker_queue": {
+      "p50_us": 4.542,
+      "p95_us": 7.75,
+      "p99_us": 10.792,
+      "mean_us": 4.97864
+    }
+  },
+  "parallel": {
+    "direct_request_latency": {
+      "p50_us": 1277.875,
+      "p95_us": 1557.334,
+      "p99_us": 1618.792,
+      "mean_us": 1276.203831
+    },
+    "worker_request_latency": {
+      "p50_us": 1730.041,
+      "p95_us": 2162.667,
+      "p99_us": 2306.416,
+      "mean_us": 1786.093039
+    },
+    "direct_wall_ms": 320.506417,
+    "worker_wall_ms": 447.09700000000004,
+    "direct_parser_cache_hits": 996,
+    "worker_parser_cache_hits": 997,
+    "direct_requests_per_second": 3120.0623356006004,
+    "worker_requests_per_second": 2236.6511070304655
+  }
+}

--- a/benches/profile/results/single_worker_stage1_2026-07-19_batch_a.json
+++ b/benches/profile/results/single_worker_stage1_2026-07-19_batch_a.json
@@ -4,51 +4,51 @@
   "threads": 4,
   "source_lines": 200,
   "request_frame_bytes": 8069,
-  "cold_start_us": 1108750.75,
+  "cold_start_us": 1089344.708,
   "sequential": {
     "direct": {
-      "p50_us": 960.917,
-      "p95_us": 1100.708,
-      "p99_us": 1183.75,
-      "mean_us": 1006.508422
+      "p50_us": 957.25,
+      "p95_us": 1084.542,
+      "p99_us": 1092.458,
+      "mean_us": 999.708486
     },
     "worker_parent_observed": {
-      "p50_us": 1129.709,
-      "p95_us": 1172.0,
-      "p99_us": 1217.791,
-      "mean_us": 1084.497511
+      "p50_us": 1147.458,
+      "p95_us": 1170.333,
+      "p99_us": 1189.5,
+      "mean_us": 1105.101109
     },
     "worker_compute": {
-      "p50_us": 1008.5,
-      "p95_us": 1033.583,
-      "p99_us": 1072.791,
-      "mean_us": 961.191374
+      "p50_us": 1011.292,
+      "p95_us": 1029.25,
+      "p99_us": 1040.084,
+      "mean_us": 973.3149549999999
     },
     "worker_queue": {
-      "p50_us": 4.542,
-      "p95_us": 7.75,
-      "p99_us": 10.792,
-      "mean_us": 4.97864
+      "p50_us": 4.708,
+      "p95_us": 7.292,
+      "p99_us": 9.333,
+      "mean_us": 4.9741040000000005
     }
   },
   "parallel": {
     "direct_request_latency": {
-      "p50_us": 1277.875,
-      "p95_us": 1557.334,
-      "p99_us": 1618.792,
-      "mean_us": 1276.203831
+      "p50_us": 1591.042,
+      "p95_us": 2294.667,
+      "p99_us": 2495.833,
+      "mean_us": 1634.142335
     },
     "worker_request_latency": {
-      "p50_us": 1730.041,
-      "p95_us": 2162.667,
-      "p99_us": 2306.416,
-      "mean_us": 1786.093039
+      "p50_us": 1632.833,
+      "p95_us": 2036.167,
+      "p99_us": 2191.375,
+      "mean_us": 1676.624515
     },
-    "direct_wall_ms": 320.506417,
-    "worker_wall_ms": 447.09700000000004,
+    "direct_wall_ms": 409.796667,
+    "worker_wall_ms": 419.98037500000004,
     "direct_parser_cache_hits": 996,
     "worker_parser_cache_hits": 997,
-    "direct_requests_per_second": 3120.0623356006004,
-    "worker_requests_per_second": 2236.6511070304655
+    "direct_requests_per_second": 2440.234585900134,
+    "worker_requests_per_second": 2381.063638985512
   }
 }

--- a/benches/profile/results/single_worker_stage1_2026-07-19_batch_b.json
+++ b/benches/profile/results/single_worker_stage1_2026-07-19_batch_b.json
@@ -1,0 +1,54 @@
+{
+  "schema": 1,
+  "requests": 1000,
+  "threads": 4,
+  "source_lines": 200,
+  "request_frame_bytes": 8069,
+  "cold_start_us": 1095208.542,
+  "sequential": {
+    "direct": {
+      "p50_us": 1093.667,
+      "p95_us": 1108.0,
+      "p99_us": 1123.459,
+      "mean_us": 1058.767824
+    },
+    "worker_parent_observed": {
+      "p50_us": 1000.167,
+      "p95_us": 1161.5,
+      "p99_us": 1177.083,
+      "mean_us": 1042.1313129999999
+    },
+    "worker_compute": {
+      "p50_us": 879.791,
+      "p95_us": 1022.5,
+      "p99_us": 1038.25,
+      "mean_us": 922.289995
+    },
+    "worker_queue": {
+      "p50_us": 4.334,
+      "p95_us": 7.042,
+      "p99_us": 9.292,
+      "mean_us": 4.690554
+    }
+  },
+  "parallel": {
+    "direct_request_latency": {
+      "p50_us": 1384.917,
+      "p95_us": 2153.375,
+      "p99_us": 2320.75,
+      "mean_us": 1471.164802
+    },
+    "worker_request_latency": {
+      "p50_us": 1749.0,
+      "p95_us": 2211.334,
+      "p99_us": 2346.833,
+      "mean_us": 1791.140396
+    },
+    "direct_wall_ms": 372.279584,
+    "worker_wall_ms": 448.392792,
+    "direct_parser_cache_hits": 996,
+    "worker_parser_cache_hits": 997,
+    "direct_requests_per_second": 2686.153211130697,
+    "worker_requests_per_second": 2230.187500427081
+  }
+}

--- a/benches/profile/results/single_worker_stage1_2026-07-19_batch_b.json
+++ b/benches/profile/results/single_worker_stage1_2026-07-19_batch_b.json
@@ -4,51 +4,51 @@
   "threads": 4,
   "source_lines": 200,
   "request_frame_bytes": 8069,
-  "cold_start_us": 1095208.542,
+  "cold_start_us": 1141117.792,
   "sequential": {
     "direct": {
-      "p50_us": 1093.667,
-      "p95_us": 1108.0,
-      "p99_us": 1123.459,
-      "mean_us": 1058.767824
+      "p50_us": 1274.458,
+      "p95_us": 1304.042,
+      "p99_us": 1328.041,
+      "mean_us": 1274.578951
     },
     "worker_parent_observed": {
-      "p50_us": 1000.167,
-      "p95_us": 1161.5,
-      "p99_us": 1177.083,
-      "mean_us": 1042.1313129999999
+      "p50_us": 1175.417,
+      "p95_us": 1396.167,
+      "p99_us": 1419.583,
+      "mean_us": 1254.386044
     },
     "worker_compute": {
-      "p50_us": 879.791,
-      "p95_us": 1022.5,
-      "p99_us": 1038.25,
-      "mean_us": 922.289995
+      "p50_us": 1035.709,
+      "p95_us": 1230.084,
+      "p99_us": 1255.584,
+      "mean_us": 1112.2578259999998
     },
     "worker_queue": {
-      "p50_us": 4.334,
-      "p95_us": 7.042,
-      "p99_us": 9.292,
-      "mean_us": 4.690554
+      "p50_us": 5.208,
+      "p95_us": 8.625,
+      "p99_us": 13.584,
+      "mean_us": 5.902079
     }
   },
   "parallel": {
     "direct_request_latency": {
-      "p50_us": 1384.917,
-      "p95_us": 2153.375,
-      "p99_us": 2320.75,
-      "mean_us": 1471.164802
+      "p50_us": 1759.75,
+      "p95_us": 2483.416,
+      "p99_us": 2836.25,
+      "mean_us": 1781.824118
     },
     "worker_request_latency": {
-      "p50_us": 1749.0,
-      "p95_us": 2211.334,
-      "p99_us": 2346.833,
-      "mean_us": 1791.140396
+      "p50_us": 1586.792,
+      "p95_us": 1684.958,
+      "p99_us": 1783.166,
+      "mean_us": 1571.1603
     },
-    "direct_wall_ms": 372.279584,
-    "worker_wall_ms": 448.392792,
+    "direct_wall_ms": 468.649792,
+    "worker_wall_ms": 395.665083,
     "direct_parser_cache_hits": 996,
     "worker_parser_cache_hits": 997,
-    "direct_requests_per_second": 2686.153211130697,
-    "worker_requests_per_second": 2230.187500427081
+    "direct_requests_per_second": 2133.7894885910887,
+    "worker_requests_per_second": 2527.390065400338
   }
 }

--- a/benches/tree_worker_stage1.rs
+++ b/benches/tree_worker_stage1.rs
@@ -1,0 +1,201 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+
+use clap::Parser;
+use kakehashi::tree_worker::{
+    Client, DeriveSnapshot, DerivedSnapshot, LocalDeriver, RequestContext, Response,
+};
+use rayon::prelude::*;
+use serde_json::json;
+
+#[derive(Parser)]
+struct Args {
+    #[arg(long)]
+    bin: PathBuf,
+    #[arg(long)]
+    parser: PathBuf,
+    #[arg(long, default_value_t = 1_000)]
+    requests: usize,
+    #[arg(long, default_value_t = 4)]
+    threads: usize,
+    #[arg(long, default_value_t = 200)]
+    lines: usize,
+}
+
+fn request(id: u64, generation: u64, parser: &std::path::Path, text: &str) -> DeriveSnapshot {
+    DeriveSnapshot {
+        context: RequestContext {
+            request_id: id,
+            worker_generation: generation,
+            uri: format!("file:///benchmark-{}.rs", id % 16),
+            incarnation: 1,
+            content_version: id,
+            configuration_generation: 0,
+        },
+        language: "rust".into(),
+        grammar_symbol: "rust".into(),
+        parser_path: parser.to_path_buf(),
+        text: text.into(),
+    }
+}
+
+fn snapshot(response: Response) -> DerivedSnapshot {
+    match response {
+        Response::Snapshot(snapshot) => snapshot,
+        response => panic!("benchmark derive failed: {response:?}"),
+    }
+}
+
+fn percentile(values: &[u64], percentile: usize) -> u64 {
+    let mut values = values.to_vec();
+    values.sort_unstable();
+    values[(values.len() * percentile).div_ceil(100).saturating_sub(1)]
+}
+
+fn summary(samples: &[u64]) -> serde_json::Value {
+    json!({
+        "p50_us": percentile(samples, 50) as f64 / 1_000.0,
+        "p95_us": percentile(samples, 95) as f64 / 1_000.0,
+        "p99_us": percentile(samples, 99) as f64 / 1_000.0,
+        "mean_us": samples.iter().sum::<u64>() as f64 / samples.len() as f64 / 1_000.0,
+    })
+}
+
+fn main() {
+    let args = Args::parse();
+    assert!(args.requests > 0, "--requests must be positive");
+    assert!(args.threads > 0, "--threads must be positive");
+    let text = (0..args.lines)
+        .map(|index| format!("fn function_{index}() {{ let value = {index}; }}\n"))
+        .collect::<String>();
+    let generation = 1;
+
+    let cold_started = Instant::now();
+    let worker = Client::spawn(&args.bin, args.threads, generation).unwrap();
+    let cold_start_us = cold_started.elapsed().as_secs_f64() * 1_000_000.0;
+    snapshot(
+        worker
+            .derive(request(1, generation, &args.parser, &text))
+            .unwrap(),
+    );
+
+    let mut local = LocalDeriver::new();
+    snapshot(local.derive(request(2, generation, &args.parser, &text)));
+
+    let mut direct_sequential = Vec::with_capacity(args.requests);
+    for index in 0..args.requests {
+        let started = Instant::now();
+        snapshot(local.derive(request(
+            10_000 + index as u64,
+            generation,
+            &args.parser,
+            &text,
+        )));
+        direct_sequential.push(started.elapsed().as_nanos() as u64);
+    }
+
+    let mut worker_sequential = Vec::with_capacity(args.requests);
+    let mut worker_compute = Vec::with_capacity(args.requests);
+    let mut worker_queue = Vec::with_capacity(args.requests);
+    for index in 0..args.requests {
+        let started = Instant::now();
+        let result = snapshot(
+            worker
+                .derive(request(
+                    20_000 + index as u64,
+                    generation,
+                    &args.parser,
+                    &text,
+                ))
+                .unwrap(),
+        );
+        worker_sequential.push(started.elapsed().as_nanos() as u64);
+        worker_compute.push(result.compute_ns);
+        worker_queue.push(result.queue_wait_ns);
+    }
+
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(args.threads)
+        .build()
+        .unwrap();
+    let direct_parallel_started = Instant::now();
+    let direct_parallel = pool.install(|| {
+        (0..args.requests)
+            .into_par_iter()
+            .map_init(LocalDeriver::new, |local, index| {
+                let started = Instant::now();
+                snapshot(local.derive(request(
+                    30_000 + index as u64,
+                    generation,
+                    &args.parser,
+                    &text,
+                )));
+                started.elapsed().as_nanos() as u64
+            })
+            .collect::<Vec<_>>()
+    });
+    let direct_parallel_wall_ms = direct_parallel_started.elapsed().as_secs_f64() * 1_000.0;
+
+    let worker = Arc::new(worker);
+    let worker_parallel_started = Instant::now();
+    let worker_parallel = pool.install(|| {
+        (0..args.requests)
+            .into_par_iter()
+            .map(|index| {
+                let started = Instant::now();
+                snapshot(
+                    worker
+                        .derive(request(
+                            40_000 + index as u64,
+                            generation,
+                            &args.parser,
+                            &text,
+                        ))
+                        .unwrap(),
+                );
+                started.elapsed().as_nanos() as u64
+            })
+            .collect::<Vec<_>>()
+    });
+    let worker_parallel_wall_ms = worker_parallel_started.elapsed().as_secs_f64() * 1_000.0;
+    Arc::try_unwrap(worker)
+        .ok()
+        .expect("parallel benchmark released worker")
+        .shutdown()
+        .unwrap();
+
+    let request_bytes = serde_json::to_vec(&kakehashi::tree_worker::Request::DeriveSnapshot(
+        request(50_000, generation, &args.parser, &text),
+    ))
+    .unwrap()
+    .len()
+        + 4;
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({
+            "schema": 1,
+            "requests": args.requests,
+            "threads": args.threads,
+            "source_lines": args.lines,
+            "request_frame_bytes": request_bytes,
+            "cold_start_us": cold_start_us,
+            "sequential": {
+                "direct": summary(&direct_sequential),
+                "worker_parent_observed": summary(&worker_sequential),
+                "worker_compute": summary(&worker_compute),
+                "worker_queue": summary(&worker_queue),
+            },
+            "parallel": {
+                "direct_request_latency": summary(&direct_parallel),
+                "worker_request_latency": summary(&worker_parallel),
+                "direct_wall_ms": direct_parallel_wall_ms,
+                "worker_wall_ms": worker_parallel_wall_ms,
+                "direct_requests_per_second": args.requests as f64 / (direct_parallel_wall_ms / 1_000.0),
+                "worker_requests_per_second": args.requests as f64 / (worker_parallel_wall_ms / 1_000.0),
+            },
+        }))
+        .unwrap()
+    );
+}

--- a/benches/tree_worker_stage1.rs
+++ b/benches/tree_worker_stage1.rs
@@ -9,6 +9,11 @@ use kakehashi::tree_worker::{
 use rayon::prelude::*;
 use serde_json::json;
 
+thread_local! {
+    static PARALLEL_LOCAL_DERIVER: std::cell::RefCell<LocalDeriver> =
+        std::cell::RefCell::new(LocalDeriver::new());
+}
+
 #[derive(Parser)]
 struct Args {
     #[arg(long)]
@@ -123,19 +128,26 @@ fn main() {
     let direct_parallel = pool.install(|| {
         (0..args.requests)
             .into_par_iter()
-            .map_init(LocalDeriver::new, |local, index| {
+            .map(|index| {
                 let started = Instant::now();
-                snapshot(local.derive(request(
-                    30_000 + index as u64,
-                    generation,
-                    &args.parser,
-                    &text,
-                )));
-                started.elapsed().as_nanos() as u64
+                let snapshot = PARALLEL_LOCAL_DERIVER.with(|local| {
+                    snapshot(local.borrow_mut().derive(request(
+                        30_000 + index as u64,
+                        generation,
+                        &args.parser,
+                        &text,
+                    )))
+                });
+                (
+                    started.elapsed().as_nanos() as u64,
+                    snapshot.parser_cache_hit,
+                )
             })
             .collect::<Vec<_>>()
     });
     let direct_parallel_wall_ms = direct_parallel_started.elapsed().as_secs_f64() * 1_000.0;
+    let (direct_parallel, direct_cache_hits): (Vec<_>, Vec<_>) =
+        direct_parallel.into_iter().unzip();
 
     let worker = Arc::new(worker);
     let worker_parallel_started = Instant::now();
@@ -144,7 +156,7 @@ fn main() {
             .into_par_iter()
             .map(|index| {
                 let started = Instant::now();
-                snapshot(
+                let snapshot = snapshot(
                     worker
                         .derive(request(
                             40_000 + index as u64,
@@ -154,11 +166,16 @@ fn main() {
                         ))
                         .unwrap(),
                 );
-                started.elapsed().as_nanos() as u64
+                (
+                    started.elapsed().as_nanos() as u64,
+                    snapshot.parser_cache_hit,
+                )
             })
             .collect::<Vec<_>>()
     });
     let worker_parallel_wall_ms = worker_parallel_started.elapsed().as_secs_f64() * 1_000.0;
+    let (worker_parallel, worker_cache_hits): (Vec<_>, Vec<_>) =
+        worker_parallel.into_iter().unzip();
     Arc::try_unwrap(worker)
         .ok()
         .expect("parallel benchmark released worker")
@@ -192,6 +209,8 @@ fn main() {
                 "worker_request_latency": summary(&worker_parallel),
                 "direct_wall_ms": direct_parallel_wall_ms,
                 "worker_wall_ms": worker_parallel_wall_ms,
+                "direct_parser_cache_hits": direct_cache_hits.into_iter().filter(|hit| *hit).count(),
+                "worker_parser_cache_hits": worker_cache_hits.into_iter().filter(|hit| *hit).count(),
                 "direct_requests_per_second": args.requests as f64 / (direct_parallel_wall_ms / 1_000.0),
                 "worker_requests_per_second": args.requests as f64 / (worker_parallel_wall_ms / 1_000.0),
             },

--- a/benches/tree_worker_stage1.rs
+++ b/benches/tree_worker_stage1.rs
@@ -16,6 +16,9 @@ thread_local! {
 
 #[derive(Parser)]
 struct Args {
+    // Cargo appends this flag when launching a harness-free benchmark.
+    #[arg(long = "bench", hide = true)]
+    _bench: bool,
     #[arg(long)]
     bin: PathBuf,
     #[arg(long)]

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage1-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage1-measurement.md
@@ -29,14 +29,18 @@ non-regression gate.
 
 The committed result is
 `benches/profile/results/single_worker_stage1_2026-07-19.json`.
-It records source, binary, benchmark, and parser SHA-256 digests. The measured
-release build ran on an Apple M4 with macOS 26.5.1 and Rust 1.95.0.
+It records source, binary, benchmark, and parser SHA-256 digests, and retains
+the two raw collector outputs beside the aggregate. The measured release build
+ran on an Apple M4 with macOS 26.5.1 and Rust 1.95.0. The Rust grammar came
+from `tree-sitter/tree-sitter-rust` revision
+`77a3747266f4d621d0757825e6b11edcbf991ca5`; its recorded digest is the final
+identity check.
 
 Each of two consecutive page-cache-warm batches parsed a generated 200-line
 Rust document 1,000 times. The sequential path measured one request at a time.
 The parallel path used four caller threads and a four-thread worker budget.
 Both paths retained one parser cache per compute thread; the final runs recorded
-996 direct and 997 worker cache hits, avoiding the earlier unfair benchmark
+996 direct and 997 worker cache hits in each batch, avoiding the earlier unfair benchmark
 variant that recreated direct parsers at Rayon split boundaries.
 
 The request frame was 8,133 bytes, dominated by repeated full text. The worker
@@ -49,27 +53,60 @@ also includes JSON encoding/decoding, pipe I/O, wakeup, and response routing.
 
 | Batch | Direct p50 / p95 / p99 | Worker p50 / p95 / p99 | Worker queue p50 |
 |---|---:|---:|---:|
-| A | 808.8 / 823.4 / 830.5 µs | 1138.9 / 1372.1 / 1392.0 µs | 5.0 µs |
-| B | 730.4 / 825.7 / 838.1 µs | 978.9 / 1163.4 / 1188.4 µs | 4.0 µs |
+| A | 960.9 / 1100.7 / 1183.8 µs | 1129.7 / 1172.0 / 1217.8 µs | 4.5 µs |
+| B | 1093.7 / 1108.0 / 1123.5 µs | 1000.2 / 1161.5 / 1177.1 µs | 4.3 µs |
 
-The parent-observed worker p50 was 41% slower in batch A and 34% slower in
-batch B. Queue wait was small. Worker-reported compute was also slower than the
-earlier direct interval, so the remainder cannot be labeled pure transport
+The parent-observed worker p50 was 18% slower in batch A and 9% faster in batch
+B. This reversal under a fixed direct-then-worker order is evidence that the
+sequential difference is smaller than run-order noise, not evidence of a worker
+win. Queue wait remained small. The remainder cannot be labeled pure transport
 overhead without an alternating paired collector.
 
 ### Four-thread throughput
 
 | Batch | Direct | Worker | Worker delta |
 |---|---:|---:|---:|
-| A | 2399.8 req/s | 2027.2 req/s | -15.5% |
-| B | 2830.0 req/s | 2234.2 req/s | -21.1% |
+| A | 3120.1 req/s | 2236.7 req/s | -28.3% |
+| B | 2686.2 req/s | 2230.2 req/s | -17.0% |
 
 The worker did use multiple compute threads and preserved almost identical
 parser-cache hit rates, but did not improve throughput in this full-text
-protocol shape. Warm worker spawn plus handshake was 3.4--3.7 ms. A first run
-after relinking observed a 698-ms cold value and is intentionally excluded from
-the two warm batches; cold-start acceptance needs a dedicated alternating
-collector rather than this microbenchmark.
+protocol shape. Exact executable SHA-256 authentication added after review made
+spawn plus handshake 1.10--1.11 s in these runs, dominated by hashing the 34 MiB
+parent and child images with the current implementation. The final retained
+executable snapshot should hash once and reuse its identity across worker
+generations; cold-start acceptance needs a dedicated alternating collector.
+
+An intermediate measurement exposed a sender-mutex guard accidentally retained
+across response wait: throughput fell to 693--818 req/s and p99 reached
+117--140 ms. Releasing the guard immediately after bounded queue admission
+restored 2230--2237 req/s. Those defective runs are not part of the committed
+results.
+
+## Reproduction
+
+The measured artifacts were prepared and collected with:
+
+```sh
+cargo build --release --locked --bin kakehashi
+target/release/kakehashi language install rust \
+  --data-dir deps/test/kakehashi --force
+shasum -a 256 target/release/kakehashi \
+  deps/test/kakehashi/parser/rust.dylib
+
+cargo bench --locked --bench tree_worker_stage1 -- \
+  --bin target/release/kakehashi \
+  --parser deps/test/kakehashi/parser/rust.dylib \
+  --requests 1000 --threads 4 --lines 200 \
+  > benches/profile/results/single_worker_stage1_2026-07-19_batch_a.json
+
+# Repeat the preceding cargo bench command with batch_b.json as the output.
+```
+
+Before comparing results, the parser revision and all three recorded SHA-256
+values must match the aggregate JSON. The raw files are the collector output;
+the aggregate embeds them unchanged under `batches` plus environment and
+artifact provenance.
 
 ## Decision and next stage
 

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage1-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage1-measurement.md
@@ -19,6 +19,12 @@ incarnation, content version, and configuration generation. No `Tree`, `Node`,
 The worker accepts concurrent requests and routes out-of-order responses by
 request ID.
 
+The prototype authenticates the exact bytes at the caller-supplied spawn path
+against the image observed by the child. It does not yet bind that path to the
+parent's running image or retain the immutable session-private executable
+snapshot required by the final ADR. That parent-image binding remains a
+cutover prerequisite, not a security property claimed by Stage 1.
+
 This prototype does not yet maintain a worker-side document replica or
 incremental `Tree`. Every `DeriveSnapshot` request carries the complete source
 text and performs a full parse. It does not run injection discovery, queries,
@@ -43,7 +49,7 @@ Both paths retained one parser cache per compute thread; the final runs recorded
 996 direct and 997 worker cache hits in each batch, avoiding the earlier unfair benchmark
 variant that recreated direct parsers at Rayon split boundaries.
 
-The request frame was 8,133 bytes, dominated by repeated full text. The worker
+The request frame was 8,069 bytes, dominated by repeated full text. The worker
 reported queue wait and parse/summary compute separately; parent-observed time
 also includes JSON encoding/decoding, pipe I/O, wakeup, and response routing.
 
@@ -53,10 +59,10 @@ also includes JSON encoding/decoding, pipe I/O, wakeup, and response routing.
 
 | Batch | Direct p50 / p95 / p99 | Worker p50 / p95 / p99 | Worker queue p50 |
 |---|---:|---:|---:|
-| A | 960.9 / 1100.7 / 1183.8 µs | 1129.7 / 1172.0 / 1217.8 µs | 4.5 µs |
-| B | 1093.7 / 1108.0 / 1123.5 µs | 1000.2 / 1161.5 / 1177.1 µs | 4.3 µs |
+| A | 957.3 / 1084.5 / 1092.5 µs | 1147.5 / 1170.3 / 1189.5 µs | 4.7 µs |
+| B | 1274.5 / 1304.0 / 1328.0 µs | 1175.4 / 1396.2 / 1419.6 µs | 5.2 µs |
 
-The parent-observed worker p50 was 18% slower in batch A and 9% faster in batch
+The parent-observed worker p50 was 20% slower in batch A and 8% faster in batch
 B. This reversal under a fixed direct-then-worker order is evidence that the
 sequential difference is smaller than run-order noise, not evidence of a worker
 win. Queue wait remained small. The remainder cannot be labeled pure transport
@@ -66,14 +72,15 @@ overhead without an alternating paired collector.
 
 | Batch | Direct | Worker | Worker delta |
 |---|---:|---:|---:|
-| A | 3120.1 req/s | 2236.7 req/s | -28.3% |
-| B | 2686.2 req/s | 2230.2 req/s | -17.0% |
+| A | 2440.2 req/s | 2381.1 req/s | -2.4% |
+| B | 2133.8 req/s | 2527.4 req/s | +18.4% |
 
-The worker did use multiple compute threads and preserved almost identical
-parser-cache hit rates, but did not improve throughput in this full-text
-protocol shape. Exact executable SHA-256 authentication added after review made
-spawn plus handshake 1.10--1.11 s in these runs, dominated by hashing the 34 MiB
-parent and child images with the current implementation. The final retained
+The worker did use all four compute threads and preserved the expected cache
+hit rates. The two batches disagree on the throughput direction, so this
+fixed-order collector cannot establish either a win or a regression. Exact
+executable SHA-256 authentication added after review made spawn plus handshake
+1.09--1.14 s in these runs, dominated by hashing the 34 MiB parent and child
+images with the current implementation. The final retained
 executable snapshot should hash once and reuse its identity across worker
 generations; cold-start acceptance needs a dedicated alternating collector.
 
@@ -82,6 +89,13 @@ across response wait: throughput fell to 693--818 req/s and p99 reached
 117--140 ms. Releasing the guard immediately after bounded queue admission
 restored 2230--2237 req/s. Those defective runs are not part of the committed
 results.
+
+A second intermediate implementation used `Rayon::scope` to remove lifetime
+completion messages. The control scope consumed one compute slot, shifted the
+worker cache-hit count from 997 to 998, and reduced throughput to 1597--1815
+req/s. Waiting for all bounded admission permits at EOF instead preserved four
+compute threads without retaining per-request completion history. Those runs
+are also excluded.
 
 ## Reproduction
 
@@ -92,6 +106,7 @@ cargo build --release --locked --bin kakehashi
 target/release/kakehashi language install rust \
   --data-dir deps/test/kakehashi --force
 shasum -a 256 target/release/kakehashi \
+  target/release/deps/tree_worker_stage1-8d08bf9882b4bf01 \
   deps/test/kakehashi/parser/rust.dylib
 
 cargo bench --locked --bench tree_worker_stage1 -- \
@@ -107,6 +122,17 @@ Before comparing results, the parser revision and all three recorded SHA-256
 values must match the aggregate JSON. The raw files are the collector output;
 the aggregate embeds them unchanged under `batches` plus environment and
 artifact provenance.
+
+The embedding can be checked without trusting the prose:
+
+```sh
+jq -e --slurpfile a \
+  benches/profile/results/single_worker_stage1_2026-07-19_batch_a.json \
+  --slurpfile b \
+  benches/profile/results/single_worker_stage1_2026-07-19_batch_b.json \
+  '.batches == [$a[0], $b[0]]' \
+  benches/profile/results/single_worker_stage1_2026-07-19.json
+```
 
 ## Decision and next stage
 

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage1-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage1-measurement.md
@@ -1,0 +1,94 @@
+# Single Tree Worker Stage 1 Measurement
+
+## Scope
+
+This is the first real Rust worker-protocol probe for the
+[single resident multithreaded tree worker](single-resident-multithreaded-tree-worker.md).
+It compares the same dynamic Rust grammar and the same owned host-parse summary
+through two paths:
+
+```text
+direct: benchmark -> process-local grammar/parser cache -> host parse summary
+worker: benchmark -> framed JSON -> one resident Rust worker ->
+        four-thread grammar/parser caches -> host parse summary -> framed JSON
+```
+
+The response is guarded by request ID, worker generation, URI, document
+incarnation, content version, and configuration generation. No `Tree`, `Node`,
+`Language`, parser, or other pointer-bearing value crosses the process boundary.
+The worker accepts concurrent requests and routes out-of-order responses by
+request ID.
+
+This prototype does not yet maintain a worker-side document replica or
+incremental `Tree`. Every `DeriveSnapshot` request carries the complete source
+text and performs a full parse. It does not run injection discovery, queries,
+semantic tokens, captures, or node tracking, so it is not a production
+non-regression gate.
+
+## Environment and method
+
+The committed result is
+`benches/profile/results/single_worker_stage1_2026-07-19.json`.
+It records source, binary, benchmark, and parser SHA-256 digests. The measured
+release build ran on an Apple M4 with macOS 26.5.1 and Rust 1.95.0.
+
+Each of two consecutive page-cache-warm batches parsed a generated 200-line
+Rust document 1,000 times. The sequential path measured one request at a time.
+The parallel path used four caller threads and a four-thread worker budget.
+Both paths retained one parser cache per compute thread; the final runs recorded
+996 direct and 997 worker cache hits, avoiding the earlier unfair benchmark
+variant that recreated direct parsers at Rayon split boundaries.
+
+The request frame was 8,133 bytes, dominated by repeated full text. The worker
+reported queue wait and parse/summary compute separately; parent-observed time
+also includes JSON encoding/decoding, pipe I/O, wakeup, and response routing.
+
+## Results
+
+### Sequential request latency
+
+| Batch | Direct p50 / p95 / p99 | Worker p50 / p95 / p99 | Worker queue p50 |
+|---|---:|---:|---:|
+| A | 808.8 / 823.4 / 830.5 µs | 1138.9 / 1372.1 / 1392.0 µs | 5.0 µs |
+| B | 730.4 / 825.7 / 838.1 µs | 978.9 / 1163.4 / 1188.4 µs | 4.0 µs |
+
+The parent-observed worker p50 was 41% slower in batch A and 34% slower in
+batch B. Queue wait was small. Worker-reported compute was also slower than the
+earlier direct interval, so the remainder cannot be labeled pure transport
+overhead without an alternating paired collector.
+
+### Four-thread throughput
+
+| Batch | Direct | Worker | Worker delta |
+|---|---:|---:|---:|
+| A | 2399.8 req/s | 2027.2 req/s | -15.5% |
+| B | 2830.0 req/s | 2234.2 req/s | -21.1% |
+
+The worker did use multiple compute threads and preserved almost identical
+parser-cache hit rates, but did not improve throughput in this full-text
+protocol shape. Warm worker spawn plus handshake was 3.4--3.7 ms. A first run
+after relinking observed a 698-ms cold value and is intentionally excluded from
+the two warm batches; cold-start acceptance needs a dedicated alternating
+collector rather than this microbenchmark.
+
+## Decision and next stage
+
+Stage 1 validates the process, framing, build/protocol handshake, generation
+guards, concurrent request router, bounded request deadline, worker-local
+grammar/parser caches, and a real high-level host-parse response. It does not
+pass a performance gate and makes no performance-win claim.
+
+The result narrows Stage 2. Repeating full document text in every derive request
+is the wrong steady-state boundary. Stage 2 must add versioned `SyncDocument`
+and `ApplyEdits` messages, keep the latest text and incremental `Tree` in the
+worker, and make `DeriveSnapshot` refer only to guarded worker-owned state. Its
+measurement must:
+
+* alternate direct and worker order across independent process pairs;
+* separate edit application, queue wait, incremental parse, derivation,
+  serialization, and parent resume;
+* compare stable parser- and tree-cache hit rates;
+* include injected Markdown and concurrent documents; and
+* reject any apparent throughput win caused by asymmetric cache warmup.
+
+The ADR remains `proposed`.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage1-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage1-measurement.md
@@ -105,8 +105,11 @@ The measured artifacts were prepared and collected with:
 cargo build --release --locked --bin kakehashi
 target/release/kakehashi language install rust \
   --data-dir deps/test/kakehashi --force
-shasum -a 256 target/release/kakehashi \
-  target/release/deps/tree_worker_stage1-8d08bf9882b4bf01 \
+stage1_bench_bin="$(cargo bench --locked --bench tree_worker_stage1 \
+  --no-run --message-format=json \
+  | jq -sr 'map(select(.reason == "compiler-artifact" and \
+      .target.name == "tree_worker_stage1")) | last | .executable')"
+shasum -a 256 target/release/kakehashi "$stage1_bench_bin" \
   deps/test/kakehashi/parser/rust.dylib
 
 cargo bench --locked --bench tree_worker_stage1 -- \

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage1-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage1-measurement.md
@@ -107,7 +107,7 @@ target/release/kakehashi language install rust \
   --data-dir deps/test/kakehashi --force
 stage1_bench_bin="$(cargo bench --locked --bench tree_worker_stage1 \
   --no-run --message-format=json \
-  | jq -sr 'map(select(.reason == "compiler-artifact" and \
+  | jq -sr 'map(select(.reason == "compiler-artifact" and
       .target.name == "tree_worker_stage1")) | last | .executable')"
 shasum -a 256 target/release/kakehashi "$stage1_bench_bin" \
   deps/test/kakehashi/parser/rust.dylib

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -81,6 +81,13 @@ enum Commands {
         /// Output path for the compiled shared library
         output_path: PathBuf,
     },
+    /// Internal: run the development tree-worker protocol on stdin/stdout.
+    #[command(name = "__tree-worker", hide = true)]
+    TreeWorker {
+        /// Fixed compute budget selected by the parent process.
+        #[arg(long)]
+        threads: usize,
+    },
     /// Report diagnostics for files via the configured downstream language servers
     ///
     /// Only pull diagnostics (textDocument/diagnostic) are collected. Push
@@ -338,6 +345,11 @@ fn main() -> ExitCode {
             grammar_dir,
             output_path,
         }) => run_compile_parser(&grammar_dir, &output_path),
+        Some(Commands::TreeWorker { threads }) => kakehashi::tree_worker::run_stdio(threads)
+            .map_err(|error| {
+                eprintln!("tree worker failed: {error}");
+                ExitCode::FAILURE
+            }),
         None => {
             // Start LSP server (backward compatible default behavior)
             // Only LSP mode needs a tokio runtime; CLI subcommands are synchronous

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,4 @@ pub mod install;
 pub(crate) mod language;
 pub mod lsp;
 pub(crate) mod text;
+pub mod tree_worker;

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -863,7 +863,8 @@ fn terminate(child: &mut Child, timeout: Duration) {
 mod tests {
     use std::collections::HashMap;
     use std::io::{Cursor, Write};
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Condvar, Mutex};
+    use std::time::Duration;
 
     use super::{
         BUILD_ID, DeriveSnapshot, Handshake, HandshakeReady, PROTOCOL_VERSION, Request,
@@ -881,6 +882,56 @@ mod tests {
 
         fn flush(&mut self) -> std::io::Result<()> {
             Ok(())
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct GatedWriter(Arc<(Mutex<GateState>, Condvar)>);
+
+    #[derive(Default)]
+    struct GateState {
+        bytes: Vec<u8>,
+        flushes: usize,
+        blocked: bool,
+        released: bool,
+    }
+
+    impl Write for GatedWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            let (state, _) = &*self.0;
+            state.lock().unwrap().bytes.write(bytes)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            let (state, changed) = &*self.0;
+            let mut state = state.lock().unwrap();
+            state.flushes += 1;
+            if state.flushes >= 2 && !state.released {
+                state.blocked = true;
+                changed.notify_all();
+                state = changed.wait_while(state, |state| !state.released).unwrap();
+            }
+            state.bytes.flush()
+        }
+    }
+
+    impl GatedWriter {
+        fn wait_until_blocked(&self) {
+            let (state, changed) = &*self.0;
+            let state = state.lock().unwrap();
+            let (state, timeout) = changed
+                .wait_timeout_while(state, Duration::from_secs(5), |state| !state.blocked)
+                .unwrap();
+            assert!(
+                !timeout.timed_out() && state.blocked,
+                "writer never blocked"
+            );
+        }
+
+        fn release(&self) {
+            let (state, changed) = &*self.0;
+            state.lock().unwrap().released = true;
+            changed.notify_all();
         }
     }
 
@@ -1073,5 +1124,37 @@ mod tests {
             error.context.as_ref().map(|context| context.request_id),
             Some(7)
         );
+    }
+
+    #[test]
+    fn worker_backpressures_until_the_response_writer_resumes() {
+        let writer = GatedWriter::default();
+        let gate = writer.clone();
+        let mut requests = vec![handshake(PROTOCOL_VERSION)];
+        for request_id in 1..=12 {
+            let Request::DeriveSnapshot(mut request) = request() else {
+                unreachable!()
+            };
+            request.context.request_id = request_id;
+            requests.push(Request::DeriveSnapshot(request));
+        }
+        let (completed, completed_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = completed.send(run(Cursor::new(framed(&requests)), writer, 1));
+        });
+
+        gate.wait_until_blocked();
+        assert!(
+            completed_rx
+                .recv_timeout(Duration::from_millis(50))
+                .is_err(),
+            "worker must not consume an unbounded request stream while stdout is stalled"
+        );
+
+        gate.release();
+        completed_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("worker did not resume after stdout was released")
+            .unwrap();
     }
 }

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -1,0 +1,414 @@
+//! Development-only process boundary for the tree-worker prototype.
+//!
+//! The protocol deliberately returns owned, serializable tree-derived data.
+//! Tree-sitter pointer-bearing values never cross this module's transport.
+
+use std::io::{self, Read, Write};
+use std::path::PathBuf;
+use std::sync::mpsc;
+
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+
+pub const PROTOCOL_VERSION: u32 = 1;
+pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
+pub const BUILD_ID: &str = concat!(env!("CARGO_PKG_NAME"), "-", env!("CARGO_PKG_VERSION"));
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct RequestContext {
+    pub request_id: u64,
+    pub worker_generation: u64,
+    pub uri: String,
+    pub incarnation: u64,
+    pub content_version: u64,
+    pub configuration_generation: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Handshake {
+    pub protocol_version: u32,
+    pub build_id: String,
+    pub worker_generation: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DeriveSnapshot {
+    pub context: RequestContext,
+    pub language: String,
+    pub grammar_symbol: String,
+    pub parser_path: PathBuf,
+    pub text: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Request {
+    Handshake(Handshake),
+    DeriveSnapshot(DeriveSnapshot),
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct HandshakeReady {
+    pub protocol_version: u32,
+    pub build_id: String,
+    pub worker_generation: u64,
+    pub compute_threads: usize,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DerivedSnapshot {
+    pub context: RequestContext,
+    pub language: String,
+    pub root_kind: String,
+    pub root_start_byte: usize,
+    pub root_end_byte: usize,
+    pub has_error: bool,
+    pub named_node_count: usize,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct WorkerError {
+    pub request_id: Option<u64>,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Response {
+    HandshakeReady(HandshakeReady),
+    Snapshot(DerivedSnapshot),
+    Error(WorkerError),
+}
+
+pub fn encode_frame<W: Write, T: Serialize>(writer: &mut W, value: &T) -> io::Result<()> {
+    let payload = serde_json::to_vec(value)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    if payload.len() > MAX_FRAME_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("frame exceeds {MAX_FRAME_BYTES} bytes"),
+        ));
+    }
+    let length = u32::try_from(payload.len())
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    writer.write_all(&length.to_be_bytes())?;
+    writer.write_all(&payload)?;
+    writer.flush()
+}
+
+pub fn decode_frame<R: Read, T: DeserializeOwned>(reader: &mut R) -> io::Result<Option<T>> {
+    let mut length = [0_u8; 4];
+    match reader.read(&mut length[..1])? {
+        0 => return Ok(None),
+        1 => reader.read_exact(&mut length[1..])?,
+        _ => unreachable!("one-byte read returned more than one byte"),
+    }
+    let length = u32::from_be_bytes(length) as usize;
+    if length > MAX_FRAME_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("frame exceeds {MAX_FRAME_BYTES} bytes"),
+        ));
+    }
+    let mut payload = vec![0_u8; length];
+    reader.read_exact(&mut payload)?;
+    serde_json::from_slice(&payload)
+        .map(Some)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+}
+
+fn named_node_count(root: tree_sitter::Node<'_>) -> usize {
+    let mut count = 0;
+    let mut pending = vec![root];
+    while let Some(node) = pending.pop() {
+        count += usize::from(node.is_named());
+        pending.extend((0..node.child_count() as u32).filter_map(|index| node.child(index)));
+    }
+    count
+}
+
+pub fn derive_snapshot_with_language(
+    request: DeriveSnapshot,
+    language: tree_sitter::Language,
+) -> Response {
+    let mut parser = tree_sitter::Parser::new();
+    if let Err(error) = parser.set_language(&language) {
+        return Response::Error(WorkerError {
+            request_id: Some(request.context.request_id),
+            message: format!("incompatible grammar: {error}"),
+        });
+    }
+    let Some(tree) = parser.parse(request.text.as_bytes(), None) else {
+        return Response::Error(WorkerError {
+            request_id: Some(request.context.request_id),
+            message: "parser returned no tree".into(),
+        });
+    };
+    let root = tree.root_node();
+    Response::Snapshot(DerivedSnapshot {
+        context: request.context,
+        language: request.language,
+        root_kind: root.kind().into(),
+        root_start_byte: root.start_byte(),
+        root_end_byte: root.end_byte(),
+        has_error: root.has_error(),
+        named_node_count: named_node_count(root),
+    })
+}
+
+fn derive_snapshot(request: DeriveSnapshot) -> Response {
+    let request_id = request.context.request_id;
+    let mut loader = crate::language::loader::ParserLoader::new();
+    match loader.load_language(&request.parser_path, &request.grammar_symbol) {
+        Ok(language) => derive_snapshot_with_language(request, language),
+        Err(error) => Response::Error(WorkerError {
+            request_id: Some(request_id),
+            message: error.to_string(),
+        }),
+    }
+}
+
+pub fn run<R, W>(mut reader: R, writer: W, compute_threads: usize) -> io::Result<()>
+where
+    R: Read,
+    W: Write + Send + 'static,
+{
+    if compute_threads == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "worker compute thread count must be positive",
+        ));
+    }
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(compute_threads)
+        .thread_name(|index| format!("kakehashi-tree-worker-{index}"))
+        .build()
+        .map_err(io::Error::other)?;
+    let (responses, response_rx) = mpsc::channel::<Response>();
+    let writer_thread = std::thread::spawn(move || -> io::Result<()> {
+        let mut writer = writer;
+        for response in response_rx {
+            encode_frame(&mut writer, &response)?;
+        }
+        Ok(())
+    });
+
+    let Some(Request::Handshake(handshake)) = decode_frame::<_, Request>(&mut reader)? else {
+        drop(responses);
+        return join_writer(writer_thread);
+    };
+    if handshake.protocol_version != PROTOCOL_VERSION || handshake.build_id != BUILD_ID {
+        responses
+            .send(Response::Error(WorkerError {
+                request_id: None,
+                message: "worker protocol/build identity mismatch".into(),
+            }))
+            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
+        drop(responses);
+        join_writer(writer_thread)?;
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "worker protocol/build identity mismatch",
+        ));
+    }
+    let worker_generation = handshake.worker_generation;
+    responses
+        .send(Response::HandshakeReady(HandshakeReady {
+            protocol_version: PROTOCOL_VERSION,
+            build_id: BUILD_ID.into(),
+            worker_generation,
+            compute_threads,
+        }))
+        .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
+
+    let (completed, completed_rx) = mpsc::channel();
+    let mut pending = 0_usize;
+    while let Some(request) = decode_frame::<_, Request>(&mut reader)? {
+        let Request::DeriveSnapshot(request) = request else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "handshake may only be sent once",
+            ));
+        };
+        if request.context.worker_generation != worker_generation {
+            responses
+                .send(Response::Error(WorkerError {
+                    request_id: Some(request.context.request_id),
+                    message: "stale worker generation".into(),
+                }))
+                .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
+            continue;
+        }
+        pending += 1;
+        let responses = responses.clone();
+        let completed = completed.clone();
+        pool.spawn(move || {
+            let _ = responses.send(derive_snapshot(request));
+            let _ = completed.send(());
+        });
+    }
+    drop(completed);
+    for _ in 0..pending {
+        completed_rx.recv().map_err(|_| {
+            io::Error::new(io::ErrorKind::BrokenPipe, "worker compute task stopped")
+        })?;
+    }
+    drop(responses);
+    join_writer(writer_thread)
+}
+
+fn join_writer(thread: std::thread::JoinHandle<io::Result<()>>) -> io::Result<()> {
+    thread
+        .join()
+        .map_err(|_| io::Error::other("worker writer panicked"))?
+}
+
+pub fn run_stdio(compute_threads: usize) -> io::Result<()> {
+    run(std::io::stdin(), std::io::stdout(), compute_threads)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, Write};
+    use std::sync::{Arc, Mutex};
+
+    use super::{
+        BUILD_ID, DeriveSnapshot, Handshake, HandshakeReady, PROTOCOL_VERSION, Request,
+        RequestContext, Response, decode_frame, derive_snapshot_with_language, encode_frame, run,
+    };
+
+    #[derive(Clone, Default)]
+    struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().write(bytes)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn framed(requests: &[Request]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for request in requests {
+            encode_frame(&mut bytes, request).unwrap();
+        }
+        bytes
+    }
+
+    fn handshake(version: u32) -> Request {
+        Request::Handshake(Handshake {
+            protocol_version: version,
+            build_id: BUILD_ID.into(),
+            worker_generation: 3,
+        })
+    }
+
+    fn request() -> Request {
+        Request::DeriveSnapshot(DeriveSnapshot {
+            context: RequestContext {
+                request_id: 7,
+                worker_generation: 3,
+                uri: "file:///example.rs".into(),
+                incarnation: 11,
+                content_version: 5,
+                configuration_generation: 2,
+            },
+            language: "rust".into(),
+            grammar_symbol: "rust".into(),
+            parser_path: "/unused/in/unit-test".into(),
+            text: "fn main() {}".into(),
+        })
+    }
+
+    #[test]
+    fn frame_round_trip_preserves_request() {
+        let request = request();
+        let mut bytes = Vec::new();
+        encode_frame(&mut bytes, &request).unwrap();
+
+        assert_eq!(
+            decode_frame(&mut Cursor::new(bytes)).unwrap(),
+            Some(request)
+        );
+    }
+
+    #[test]
+    fn oversized_frame_is_rejected_before_payload_read() {
+        let bytes = (64_u32 * 1024 * 1024 + 1).to_be_bytes();
+        let error = decode_frame::<_, Request>(&mut Cursor::new(bytes)).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("frame exceeds"));
+    }
+
+    #[test]
+    fn derive_snapshot_returns_only_guarded_serializable_data() {
+        let Request::DeriveSnapshot(request) = request() else {
+            unreachable!()
+        };
+
+        let response = derive_snapshot_with_language(request, tree_sitter_rust::LANGUAGE.into());
+
+        let Response::Snapshot(snapshot) = response else {
+            panic!("expected snapshot response");
+        };
+        assert_eq!(snapshot.context.request_id, 7);
+        assert_eq!(snapshot.context.content_version, 5);
+        assert_eq!(snapshot.language, "rust");
+        assert_eq!(snapshot.root_kind, "source_file");
+        assert!(!snapshot.has_error);
+        assert!(snapshot.named_node_count >= 2);
+    }
+
+    #[test]
+    fn worker_requires_matching_handshake_before_work() {
+        let output = SharedWriter::default();
+        let captured = output.clone();
+
+        let error = run(
+            Cursor::new(framed(&[handshake(PROTOCOL_VERSION + 1)])),
+            output,
+            2,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        let bytes = captured.0.lock().unwrap().clone();
+        let response = decode_frame::<_, Response>(&mut Cursor::new(bytes))
+            .unwrap()
+            .unwrap();
+        assert!(matches!(response, Response::Error(_)));
+    }
+
+    #[test]
+    fn worker_reports_budget_and_routes_guarded_request_errors() {
+        let output = SharedWriter::default();
+        let captured = output.clone();
+
+        run(
+            Cursor::new(framed(&[handshake(PROTOCOL_VERSION), request()])),
+            output,
+            2,
+        )
+        .unwrap();
+
+        let bytes = captured.0.lock().unwrap().clone();
+        let mut bytes = Cursor::new(bytes);
+        assert_eq!(
+            decode_frame::<_, Response>(&mut bytes).unwrap(),
+            Some(Response::HandshakeReady(HandshakeReady {
+                protocol_version: PROTOCOL_VERSION,
+                build_id: BUILD_ID.into(),
+                worker_generation: 3,
+                compute_threads: 2,
+            }))
+        );
+        let response = decode_frame::<_, Response>(&mut bytes).unwrap().unwrap();
+        let Response::Error(error) = response else {
+            panic!("missing parser path must return a routed request error");
+        };
+        assert_eq!(error.request_id, Some(7));
+    }
+}

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -10,11 +10,12 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant};
 use std::{
     cell::RefCell,
-    collections::{HashMap, hash_map::Entry},
+    collections::HashMap,
     sync::{Arc, Mutex},
 };
 
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use sha2::{Digest, Sha256};
 
 pub const PROTOCOL_VERSION: u32 = 1;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
@@ -77,7 +78,7 @@ pub struct DerivedSnapshot {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct WorkerError {
-    pub request_id: Option<u64>,
+    pub context: Option<RequestContext>,
     pub message: String,
 }
 
@@ -143,7 +144,7 @@ pub fn derive_snapshot_with_language(
     let mut parser = tree_sitter::Parser::new();
     if let Err(error) = parser.set_language(&language) {
         return Response::Error(WorkerError {
-            request_id: Some(request.context.request_id),
+            context: Some(request.context),
             message: format!("incompatible grammar: {error}"),
         });
     }
@@ -163,7 +164,7 @@ fn derive_snapshot_with_parser(
     let started = Instant::now();
     let Some(tree) = parser.parse(request.text.as_bytes(), None) else {
         return Response::Error(WorkerError {
-            request_id: Some(request.context.request_id),
+            context: Some(request.context),
             message: "parser returned no tree".into(),
         });
     };
@@ -226,7 +227,7 @@ impl WorkerThreadState {
     }
 
     fn derive(&mut self, request: DeriveSnapshot, queue_wait: Duration) -> Response {
-        let request_id = request.context.request_id;
+        let request_context = request.context.clone();
         let key = GrammarKey {
             parser_path: request.parser_path.clone(),
             grammar_symbol: request.grammar_symbol.clone(),
@@ -243,7 +244,7 @@ impl WorkerThreadState {
                 }
                 Err(error) => {
                     return Response::Error(WorkerError {
-                        request_id: Some(request_id),
+                        context: Some(request_context),
                         message: error.to_string(),
                     });
                 }
@@ -256,7 +257,7 @@ impl WorkerThreadState {
             let mut parser = tree_sitter::Parser::new();
             if let Err(error) = parser.set_language(&language) {
                 return Response::Error(WorkerError {
-                    request_id: Some(request_id),
+                    context: Some(request_context),
                     message: format!("incompatible grammar: {error}"),
                 });
             }
@@ -278,7 +279,20 @@ fn derive_snapshot(request: DeriveSnapshot, queue_wait: Duration) -> Response {
     WORKER_THREAD_STATE.with(|state| state.borrow_mut().derive(request, queue_wait))
 }
 
-pub fn run<R, W>(mut reader: R, writer: W, compute_threads: usize) -> io::Result<()>
+pub fn run<R, W>(reader: R, writer: W, compute_threads: usize) -> io::Result<()>
+where
+    R: Read,
+    W: Write + Send + 'static,
+{
+    run_with_build_id(reader, writer, compute_threads, BUILD_ID)
+}
+
+fn run_with_build_id<R, W>(
+    mut reader: R,
+    writer: W,
+    compute_threads: usize,
+    build_id: &str,
+) -> io::Result<()>
 where
     R: Read,
     W: Write + Send + 'static,
@@ -303,14 +317,25 @@ where
         Ok(())
     });
 
-    let Some(Request::Handshake(handshake)) = decode_frame::<_, Request>(&mut reader)? else {
-        drop(responses);
-        return join_writer(writer_thread);
+    let handshake = match decode_frame::<_, Request>(&mut reader)? {
+        Some(Request::Handshake(handshake)) => handshake,
+        None => {
+            drop(responses);
+            return join_writer(writer_thread);
+        }
+        Some(Request::DeriveSnapshot(_)) => {
+            drop(responses);
+            join_writer(writer_thread)?;
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "tree worker requires handshake as its first message",
+            ));
+        }
     };
-    if handshake.protocol_version != PROTOCOL_VERSION || handshake.build_id != BUILD_ID {
+    if handshake.protocol_version != PROTOCOL_VERSION || handshake.build_id != build_id {
         responses
             .send(Response::Error(WorkerError {
-                request_id: None,
+                context: None,
                 message: "worker protocol/build identity mismatch".into(),
             }))
             .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
@@ -325,13 +350,20 @@ where
     responses
         .send(Response::HandshakeReady(HandshakeReady {
             protocol_version: PROTOCOL_VERSION,
-            build_id: BUILD_ID.into(),
+            build_id: build_id.into(),
             worker_generation,
             compute_threads,
         }))
         .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
 
     let (completed, completed_rx) = mpsc::channel();
+    let max_inflight = compute_threads.saturating_mul(2).max(1);
+    let (permits, permit_rx) = mpsc::sync_channel(max_inflight);
+    for _ in 0..max_inflight {
+        permits
+            .send(())
+            .map_err(|_| io::Error::other("worker admission queue stopped"))?;
+    }
     let mut pending = 0_usize;
     while let Some(request) = decode_frame::<_, Request>(&mut reader)? {
         let Request::DeriveSnapshot(request) = request else {
@@ -343,19 +375,24 @@ where
         if request.context.worker_generation != worker_generation {
             responses
                 .send(Response::Error(WorkerError {
-                    request_id: Some(request.context.request_id),
+                    context: Some(request.context),
                     message: "stale worker generation".into(),
                 }))
                 .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
             continue;
         }
+        permit_rx
+            .recv()
+            .map_err(|_| io::Error::other("worker admission queue stopped"))?;
         pending += 1;
         let responses = responses.clone();
         let completed = completed.clone();
+        let permits = permits.clone();
         let enqueued = Instant::now();
         pool.spawn(move || {
             let _ = responses.send(derive_snapshot(request, enqueued.elapsed()));
             let _ = completed.send(());
+            let _ = permits.send(());
         });
     }
     drop(completed);
@@ -375,15 +412,42 @@ fn join_writer(thread: std::thread::JoinHandle<io::Result<()>>) -> io::Result<()
 }
 
 pub fn run_stdio(compute_threads: usize) -> io::Result<()> {
-    run(std::io::stdin(), std::io::stdout(), compute_threads)
+    let build_id = executable_digest(&std::env::current_exe()?)?;
+    run_with_build_id(
+        std::io::stdin(),
+        std::io::stdout(),
+        compute_threads,
+        &build_id,
+    )
+}
+
+fn executable_digest(path: &std::path::Path) -> io::Result<String> {
+    let mut file = std::fs::File::open(path)?;
+    let mut digest = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    Ok(format!("sha256:{:x}", digest.finalize()))
 }
 
 pub struct Client {
-    child: Mutex<Child>,
-    stdin: Mutex<Option<ChildStdin>>,
-    routes: Arc<Mutex<HashMap<u64, mpsc::Sender<io::Result<Response>>>>>,
+    child: Arc<Mutex<Child>>,
+    outbound: Mutex<Option<mpsc::SyncSender<Request>>>,
+    routes: Arc<Mutex<HashMap<u64, Route>>>,
     reader: Option<std::thread::JoinHandle<()>>,
+    writer: Option<std::thread::JoinHandle<()>>,
     ready: HandshakeReady,
+    max_inflight: usize,
+}
+
+struct Route {
+    expected: RequestContext,
+    sender: mpsc::Sender<io::Result<Response>>,
 }
 
 impl Client {
@@ -398,6 +462,7 @@ impl Client {
                 "worker compute thread count must be positive",
             ));
         }
+        let build_id = executable_digest(executable)?;
         let mut child = Command::new(executable)
             .args(["__tree-worker", "--threads", &compute_threads.to_string()])
             .stdin(Stdio::piped())
@@ -412,10 +477,10 @@ impl Client {
             .stdout
             .take()
             .ok_or_else(|| io::Error::other("worker stdout was not piped"))?;
-        let routes = Arc::new(Mutex::new(
-            HashMap::<u64, mpsc::Sender<io::Result<Response>>>::new(),
-        ));
+        let child = Arc::new(Mutex::new(child));
+        let routes = Arc::new(Mutex::new(HashMap::<u64, Route>::new()));
         let reader_routes = Arc::clone(&routes);
+        let reader_child = Arc::clone(&child);
         let (handshake_tx, handshake_rx) = mpsc::channel();
         let reader = std::thread::spawn(move || {
             let mut handshake_tx = Some(handshake_tx);
@@ -426,7 +491,12 @@ impl Client {
                             let _ = handshake.send(Ok(response));
                             continue;
                         }
-                        route_response(&reader_routes, response);
+                        if let Err(error) = route_response(&reader_routes, response) {
+                            let kind = error.kind();
+                            let message = error.to_string();
+                            fail_routes(None, &reader_routes, kind, &message);
+                            break;
+                        }
                     }
                     Ok(None) => {
                         fail_routes(
@@ -445,56 +515,88 @@ impl Client {
                     }
                 }
             }
+            if let Ok(mut child) = reader_child.lock() {
+                terminate(&mut child, Duration::from_secs(1));
+            }
         });
-        encode_frame(
+        if let Err(error) = encode_frame(
             &mut stdin,
             &Request::Handshake(Handshake {
                 protocol_version: PROTOCOL_VERSION,
-                build_id: BUILD_ID.into(),
+                build_id: build_id.clone(),
                 worker_generation,
             }),
-        )?;
+        ) {
+            return failed_spawn(child, stdin, reader, error);
+        }
         let ready = match handshake_rx.recv_timeout(Duration::from_secs(5)) {
             Ok(Ok(Response::HandshakeReady(ready)))
                 if ready.protocol_version == PROTOCOL_VERSION
-                    && ready.build_id == BUILD_ID
+                    && ready.build_id == build_id
                     && ready.worker_generation == worker_generation
                     && ready.compute_threads == compute_threads =>
             {
                 ready
             }
             Ok(Ok(response)) => {
-                terminate(&mut child, Duration::from_secs(1));
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("invalid worker handshake response: {response:?}"),
-                ));
+                return failed_spawn(
+                    child,
+                    stdin,
+                    reader,
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("invalid worker handshake response: {response:?}"),
+                    ),
+                );
             }
             Ok(Err(error)) => {
-                terminate(&mut child, Duration::from_secs(1));
-                return Err(error);
+                return failed_spawn(child, stdin, reader, error);
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                terminate(&mut child, Duration::from_secs(1));
-                return Err(io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    "tree worker handshake timed out",
-                ));
+                return failed_spawn(
+                    child,
+                    stdin,
+                    reader,
+                    io::Error::new(io::ErrorKind::TimedOut, "tree worker handshake timed out"),
+                );
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
-                terminate(&mut child, Duration::from_secs(1));
-                return Err(io::Error::new(
-                    io::ErrorKind::BrokenPipe,
-                    "tree worker handshake channel closed",
-                ));
+                return failed_spawn(
+                    child,
+                    stdin,
+                    reader,
+                    io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        "tree worker handshake channel closed",
+                    ),
+                );
             }
         };
+        let max_inflight = compute_threads.saturating_mul(4).max(1);
+        let (outbound, outbound_rx) = mpsc::sync_channel::<Request>(max_inflight);
+        let writer_routes = Arc::clone(&routes);
+        let writer_child = Arc::clone(&child);
+        let writer = std::thread::spawn(move || {
+            for request in outbound_rx {
+                if let Err(error) = encode_frame(&mut stdin, &request) {
+                    let kind = error.kind();
+                    let message = error.to_string();
+                    fail_routes(None, &writer_routes, kind, &message);
+                    if let Ok(mut child) = writer_child.lock() {
+                        terminate(&mut child, Duration::from_secs(1));
+                    }
+                    break;
+                }
+            }
+        });
         Ok(Self {
-            child: Mutex::new(child),
-            stdin: Mutex::new(Some(stdin)),
+            child,
+            outbound: Mutex::new(Some(outbound)),
             routes,
             reader: Some(reader),
+            writer: Some(writer),
             ready,
+            max_inflight,
         })
     }
 
@@ -511,6 +613,7 @@ impl Client {
         request: DeriveSnapshot,
         timeout: Duration,
     ) -> io::Result<Response> {
+        let started = Instant::now();
         if request.context.worker_generation != self.ready.worker_generation {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -518,38 +621,54 @@ impl Client {
             ));
         }
         let request_id = request.context.request_id;
+        let expected = request.context.clone();
         let (response_tx, response_rx) = mpsc::channel();
         {
             let mut routes = self
                 .routes
                 .lock()
                 .map_err(|_| io::Error::other("worker response router is poisoned"))?;
-            match routes.entry(request_id) {
-                Entry::Vacant(route) => {
-                    route.insert(response_tx);
-                }
-                Entry::Occupied(_) => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::AlreadyExists,
-                        format!("tree worker request {request_id} is already active"),
-                    ));
-                }
+            if routes.contains_key(&request_id) {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    format!("tree worker request {request_id} is already active"),
+                ));
             }
-        }
-        {
-            let mut stdin = self
-                .stdin
-                .lock()
-                .map_err(|_| io::Error::other("worker stdin lock is poisoned"))?;
-            let stdin = stdin
-                .as_mut()
-                .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker is shut down"))?;
-            if let Err(error) = encode_frame(stdin, &Request::DeriveSnapshot(request)) {
-                self.remove_route(request_id);
-                return Err(error);
+            if routes.len() >= self.max_inflight {
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "tree worker in-flight limit reached",
+                ));
             }
+            routes.insert(
+                request_id,
+                Route {
+                    expected,
+                    sender: response_tx,
+                },
+            );
         }
-        let response = match response_rx.recv_timeout(timeout) {
+        let outbound = self
+            .outbound
+            .lock()
+            .map_err(|_| io::Error::other("worker outbound lock is poisoned"))?;
+        let outbound = outbound
+            .as_ref()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker is shut down"))?;
+        if let Err(error) = outbound.try_send(Request::DeriveSnapshot(request)) {
+            self.remove_route(request_id);
+            return Err(match error {
+                mpsc::TrySendError::Full(_) => io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "tree worker outbound queue is full",
+                ),
+                mpsc::TrySendError::Disconnected(_) => {
+                    io::Error::new(io::ErrorKind::BrokenPipe, "tree worker writer stopped")
+                }
+            });
+        }
+        let remaining = timeout.saturating_sub(started.elapsed());
+        let response = match response_rx.recv_timeout(remaining) {
             Ok(response) => response?,
             Err(mpsc::RecvTimeoutError::Timeout) => {
                 self.remove_route(request_id);
@@ -568,17 +687,6 @@ impl Client {
                 ));
             }
         };
-        let response_id = match &response {
-            Response::Snapshot(snapshot) => Some(snapshot.context.request_id),
-            Response::Error(error) => error.request_id,
-            Response::HandshakeReady(_) => None,
-        };
-        if response_id != Some(request_id) {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("unexpected response for request {response_id:?}"),
-            ));
-        }
         Ok(response)
     }
 
@@ -589,16 +697,20 @@ impl Client {
     }
 
     pub fn shutdown(mut self) -> io::Result<()> {
-        self.stdin
+        self.outbound
             .get_mut()
-            .map_err(|_| io::Error::other("worker stdin lock is poisoned"))?
+            .map_err(|_| io::Error::other("worker outbound lock is poisoned"))?
             .take();
-        let status = wait_until(
-            self.child
-                .get_mut()
-                .map_err(|_| io::Error::other("worker child lock is poisoned"))?,
-            Duration::from_secs(2),
-        )?;
+        let status = {
+            let mut child = self
+                .child
+                .lock()
+                .map_err(|_| io::Error::other("worker child lock is poisoned"))?;
+            wait_until(&mut child, Duration::from_secs(2))?
+        };
+        if let Some(writer) = self.writer.take() {
+            let _ = writer.join();
+        }
         if let Some(reader) = self.reader.take() {
             let _ = reader.join();
         }
@@ -612,13 +724,30 @@ impl Client {
     }
 }
 
+fn failed_spawn(
+    child: Arc<Mutex<Child>>,
+    stdin: ChildStdin,
+    reader: std::thread::JoinHandle<()>,
+    error: io::Error,
+) -> io::Result<Client> {
+    drop(stdin);
+    if let Ok(mut child) = child.lock() {
+        terminate(&mut child, Duration::from_secs(1));
+    }
+    let _ = reader.join();
+    Err(error)
+}
+
 impl Drop for Client {
     fn drop(&mut self) {
-        if let Ok(stdin) = self.stdin.get_mut() {
-            stdin.take();
+        if let Ok(outbound) = self.outbound.get_mut() {
+            outbound.take();
         }
-        if let Ok(child) = self.child.get_mut() {
-            terminate(child, Duration::from_secs(1));
+        if let Ok(mut child) = self.child.lock() {
+            terminate(&mut child, Duration::from_secs(1));
+        }
+        if let Some(writer) = self.writer.take() {
+            let _ = writer.join();
         }
         if let Some(reader) = self.reader.take() {
             let _ = reader.join();
@@ -629,36 +758,53 @@ impl Drop for Client {
 fn response_request_id(response: &Response) -> Option<u64> {
     match response {
         Response::Snapshot(snapshot) => Some(snapshot.context.request_id),
-        Response::Error(error) => error.request_id,
+        Response::Error(error) => error.context.as_ref().map(|context| context.request_id),
         Response::HandshakeReady(_) => None,
     }
 }
 
-fn route_response(
-    routes: &Mutex<HashMap<u64, mpsc::Sender<io::Result<Response>>>>,
-    response: Response,
-) {
+fn response_context(response: &Response) -> Option<&RequestContext> {
+    match response {
+        Response::Snapshot(snapshot) => Some(&snapshot.context),
+        Response::Error(error) => error.context.as_ref(),
+        Response::HandshakeReady(_) => None,
+    }
+}
+
+fn route_response(routes: &Mutex<HashMap<u64, Route>>, response: Response) -> io::Result<()> {
     let Some(request_id) = response_request_id(&response) else {
-        fail_routes(
-            None,
-            routes,
+        return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "unexpected response without request id",
-        );
-        return;
+        ));
     };
     let route = routes
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .remove(&request_id);
-    if let Some(route) = route {
-        let _ = route.send(Ok(response));
+        .remove(&request_id)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("response has unknown request id {request_id}"),
+            )
+        })?;
+    if response_context(&response) != Some(&route.expected) {
+        let error = io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("response context mismatch for request {request_id}"),
+        );
+        let _ = route
+            .sender
+            .send(Err(io::Error::new(error.kind(), error.to_string())));
+        return Err(error);
     }
+    let _ = route.sender.send(Ok(response));
+    Ok(())
 }
 
 fn fail_routes(
     handshake: Option<mpsc::Sender<io::Result<Response>>>,
-    routes: &Mutex<HashMap<u64, mpsc::Sender<io::Result<Response>>>>,
+    routes: &Mutex<HashMap<u64, Route>>,
     kind: io::ErrorKind,
     message: &str,
 ) {
@@ -671,7 +817,9 @@ fn fail_routes(
             .unwrap_or_else(std::sync::PoisonError::into_inner),
     );
     for route in routes.into_values() {
-        let _ = route.send(Err(io::Error::new(kind, message.to_string())));
+        let _ = route
+            .sender
+            .send(Err(io::Error::new(kind, message.to_string())));
     }
 }
 
@@ -699,12 +847,14 @@ fn terminate(child: &mut Child, timeout: Duration) {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::io::{Cursor, Write};
     use std::sync::{Arc, Mutex};
 
     use super::{
         BUILD_ID, DeriveSnapshot, Handshake, HandshakeReady, PROTOCOL_VERSION, Request,
-        RequestContext, Response, decode_frame, derive_snapshot_with_language, encode_frame, run,
+        RequestContext, Response, Route, WorkerError, decode_frame, derive_snapshot_with_language,
+        encode_frame, route_response, run,
     };
 
     #[derive(Clone, Default)]
@@ -814,6 +964,71 @@ mod tests {
     }
 
     #[test]
+    fn worker_rejects_work_before_handshake() {
+        let output = SharedWriter::default();
+
+        let error = run(Cursor::new(framed(&[request()])), output, 2).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("handshake"));
+    }
+
+    #[test]
+    fn response_router_rejects_unknown_request_id() {
+        let routes = Mutex::new(HashMap::new());
+        let response = Response::Error(WorkerError {
+            context: Some(RequestContext {
+                request_id: 99,
+                worker_generation: 3,
+                uri: "file:///unknown.rs".into(),
+                incarnation: 1,
+                content_version: 1,
+                configuration_generation: 1,
+            }),
+            message: "unexpected".into(),
+        });
+
+        let error = route_response(&routes, response).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("unknown request id 99"));
+    }
+
+    #[test]
+    fn response_router_rejects_stale_context() {
+        let expected = RequestContext {
+            request_id: 7,
+            worker_generation: 3,
+            uri: "file:///example.rs".into(),
+            incarnation: 11,
+            content_version: 5,
+            configuration_generation: 2,
+        };
+        let (sender, _receiver) = std::sync::mpsc::channel();
+        let routes = Mutex::new(HashMap::from([(
+            7,
+            Route {
+                expected: expected.clone(),
+                sender,
+            },
+        )]));
+        let mut stale = expected;
+        stale.content_version += 1;
+
+        let error = route_response(
+            &routes,
+            Response::Error(WorkerError {
+                context: Some(stale),
+                message: "stale".into(),
+            }),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("context mismatch"));
+    }
+
+    #[test]
     fn worker_reports_budget_and_routes_guarded_request_errors() {
         let output = SharedWriter::default();
         let captured = output.clone();
@@ -840,6 +1055,9 @@ mod tests {
         let Response::Error(error) = response else {
             panic!("missing parser path must return a routed request error");
         };
-        assert_eq!(error.request_id, Some(7));
+        assert_eq!(
+            error.context.as_ref().map(|context| context.request_id),
+            Some(7)
+        );
     }
 }

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -194,6 +194,28 @@ struct WorkerThreadState {
     parsers: HashMap<GrammarKey, tree_sitter::Parser>,
 }
 
+pub struct LocalDeriver {
+    state: WorkerThreadState,
+}
+
+impl Default for LocalDeriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LocalDeriver {
+    pub fn new() -> Self {
+        Self {
+            state: WorkerThreadState::new(),
+        }
+    }
+
+    pub fn derive(&mut self, request: DeriveSnapshot) -> Response {
+        self.state.derive(request, Duration::ZERO)
+    }
+}
+
 impl WorkerThreadState {
     fn new() -> Self {
         Self {

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -8,6 +8,11 @@ use std::path::PathBuf;
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
+use std::{
+    cell::RefCell,
+    collections::{HashMap, hash_map::Entry},
+    sync::{Arc, Mutex},
+};
 
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
@@ -65,6 +70,9 @@ pub struct DerivedSnapshot {
     pub root_end_byte: usize,
     pub has_error: bool,
     pub named_node_count: usize,
+    pub parser_cache_hit: bool,
+    pub queue_wait_ns: u64,
+    pub compute_ns: u64,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -139,6 +147,20 @@ pub fn derive_snapshot_with_language(
             message: format!("incompatible grammar: {error}"),
         });
     }
+    derive_snapshot_with_parser(request, &mut parser, false, Duration::ZERO)
+}
+
+fn duration_ns(duration: Duration) -> u64 {
+    duration.as_nanos().min(u128::from(u64::MAX)) as u64
+}
+
+fn derive_snapshot_with_parser(
+    request: DeriveSnapshot,
+    parser: &mut tree_sitter::Parser,
+    parser_cache_hit: bool,
+    queue_wait: Duration,
+) -> Response {
+    let started = Instant::now();
     let Some(tree) = parser.parse(request.text.as_bytes(), None) else {
         return Response::Error(WorkerError {
             request_id: Some(request.context.request_id),
@@ -154,19 +176,84 @@ pub fn derive_snapshot_with_language(
         root_end_byte: root.end_byte(),
         has_error: root.has_error(),
         named_node_count: named_node_count(root),
+        parser_cache_hit,
+        queue_wait_ns: duration_ns(queue_wait),
+        compute_ns: duration_ns(started.elapsed()),
     })
 }
 
-fn derive_snapshot(request: DeriveSnapshot) -> Response {
-    let request_id = request.context.request_id;
-    let mut loader = crate::language::loader::ParserLoader::new();
-    match loader.load_language(&request.parser_path, &request.grammar_symbol) {
-        Ok(language) => derive_snapshot_with_language(request, language),
-        Err(error) => Response::Error(WorkerError {
-            request_id: Some(request_id),
-            message: error.to_string(),
-        }),
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct GrammarKey {
+    parser_path: PathBuf,
+    grammar_symbol: String,
+}
+
+struct WorkerThreadState {
+    loader: crate::language::loader::ParserLoader,
+    languages: HashMap<GrammarKey, tree_sitter::Language>,
+    parsers: HashMap<GrammarKey, tree_sitter::Parser>,
+}
+
+impl WorkerThreadState {
+    fn new() -> Self {
+        Self {
+            loader: crate::language::loader::ParserLoader::new(),
+            languages: HashMap::new(),
+            parsers: HashMap::new(),
+        }
     }
+
+    fn derive(&mut self, request: DeriveSnapshot, queue_wait: Duration) -> Response {
+        let request_id = request.context.request_id;
+        let key = GrammarKey {
+            parser_path: request.parser_path.clone(),
+            grammar_symbol: request.grammar_symbol.clone(),
+        };
+        let language = match self.languages.get(&key).cloned() {
+            Some(language) => language,
+            None => match self
+                .loader
+                .load_language(&request.parser_path, &request.grammar_symbol)
+            {
+                Ok(language) => {
+                    self.languages.insert(key.clone(), language.clone());
+                    language
+                }
+                Err(error) => {
+                    return Response::Error(WorkerError {
+                        request_id: Some(request_id),
+                        message: error.to_string(),
+                    });
+                }
+            },
+        };
+        let parser_cache_hit = self.parsers.contains_key(&key);
+        let mut parser = if let Some(parser) = self.parsers.remove(&key) {
+            parser
+        } else {
+            let mut parser = tree_sitter::Parser::new();
+            if let Err(error) = parser.set_language(&language) {
+                return Response::Error(WorkerError {
+                    request_id: Some(request_id),
+                    message: format!("incompatible grammar: {error}"),
+                });
+            }
+            parser
+        };
+        let response =
+            derive_snapshot_with_parser(request, &mut parser, parser_cache_hit, queue_wait);
+        self.parsers.insert(key, parser);
+        response
+    }
+}
+
+thread_local! {
+    static WORKER_THREAD_STATE: RefCell<WorkerThreadState> =
+        RefCell::new(WorkerThreadState::new());
+}
+
+fn derive_snapshot(request: DeriveSnapshot, queue_wait: Duration) -> Response {
+    WORKER_THREAD_STATE.with(|state| state.borrow_mut().derive(request, queue_wait))
 }
 
 pub fn run<R, W>(mut reader: R, writer: W, compute_threads: usize) -> io::Result<()>
@@ -243,8 +330,9 @@ where
         pending += 1;
         let responses = responses.clone();
         let completed = completed.clone();
+        let enqueued = Instant::now();
         pool.spawn(move || {
-            let _ = responses.send(derive_snapshot(request));
+            let _ = responses.send(derive_snapshot(request, enqueued.elapsed()));
             let _ = completed.send(());
         });
     }
@@ -269,9 +357,9 @@ pub fn run_stdio(compute_threads: usize) -> io::Result<()> {
 }
 
 pub struct Client {
-    child: Child,
-    stdin: Option<ChildStdin>,
-    responses: mpsc::Receiver<io::Result<Response>>,
+    child: Mutex<Child>,
+    stdin: Mutex<Option<ChildStdin>>,
+    routes: Arc<Mutex<HashMap<u64, mpsc::Sender<io::Result<Response>>>>>,
     reader: Option<std::thread::JoinHandle<()>>,
     ready: HandshakeReady,
 }
@@ -302,24 +390,35 @@ impl Client {
             .stdout
             .take()
             .ok_or_else(|| io::Error::other("worker stdout was not piped"))?;
-        let (responses_tx, responses) = mpsc::channel();
+        let routes = Arc::new(Mutex::new(
+            HashMap::<u64, mpsc::Sender<io::Result<Response>>>::new(),
+        ));
+        let reader_routes = Arc::clone(&routes);
+        let (handshake_tx, handshake_rx) = mpsc::channel();
         let reader = std::thread::spawn(move || {
+            let mut handshake_tx = Some(handshake_tx);
             loop {
                 match decode_frame::<_, Response>(&mut stdout) {
                     Ok(Some(response)) => {
-                        if responses_tx.send(Ok(response)).is_err() {
-                            break;
+                        if let Some(handshake) = handshake_tx.take() {
+                            let _ = handshake.send(Ok(response));
+                            continue;
                         }
+                        route_response(&reader_routes, response);
                     }
                     Ok(None) => {
-                        let _ = responses_tx.send(Err(io::Error::new(
+                        fail_routes(
+                            handshake_tx.take(),
+                            &reader_routes,
                             io::ErrorKind::UnexpectedEof,
                             "tree worker closed its response stream",
-                        )));
+                        );
                         break;
                     }
                     Err(error) => {
-                        let _ = responses_tx.send(Err(error));
+                        let kind = error.kind();
+                        let message = error.to_string();
+                        fail_routes(handshake_tx.take(), &reader_routes, kind, &message);
                         break;
                     }
                 }
@@ -333,7 +432,7 @@ impl Client {
                 worker_generation,
             }),
         )?;
-        let ready = match responses.recv_timeout(Duration::from_secs(5)) {
+        let ready = match handshake_rx.recv_timeout(Duration::from_secs(5)) {
             Ok(Ok(Response::HandshakeReady(ready)))
                 if ready.protocol_version == PROTOCOL_VERSION
                     && ready.build_id == BUILD_ID
@@ -369,9 +468,9 @@ impl Client {
             }
         };
         Ok(Self {
-            child,
-            stdin: Some(stdin),
-            responses,
+            child: Mutex::new(child),
+            stdin: Mutex::new(Some(stdin)),
+            routes,
             reader: Some(reader),
             ready,
         })
@@ -381,12 +480,12 @@ impl Client {
         self.ready.compute_threads
     }
 
-    pub fn derive(&mut self, request: DeriveSnapshot) -> io::Result<Response> {
+    pub fn derive(&self, request: DeriveSnapshot) -> io::Result<Response> {
         self.derive_with_timeout(request, Duration::from_secs(60))
     }
 
     pub fn derive_with_timeout(
-        &mut self,
+        &self,
         request: DeriveSnapshot,
         timeout: Duration,
     ) -> io::Result<Response> {
@@ -397,15 +496,44 @@ impl Client {
             ));
         }
         let request_id = request.context.request_id;
-        let stdin = self
-            .stdin
-            .as_mut()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker is shut down"))?;
-        encode_frame(stdin, &Request::DeriveSnapshot(request))?;
-        let response = match self.responses.recv_timeout(timeout) {
+        let (response_tx, response_rx) = mpsc::channel();
+        {
+            let mut routes = self
+                .routes
+                .lock()
+                .map_err(|_| io::Error::other("worker response router is poisoned"))?;
+            match routes.entry(request_id) {
+                Entry::Vacant(route) => {
+                    route.insert(response_tx);
+                }
+                Entry::Occupied(_) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::AlreadyExists,
+                        format!("tree worker request {request_id} is already active"),
+                    ));
+                }
+            }
+        }
+        {
+            let mut stdin = self
+                .stdin
+                .lock()
+                .map_err(|_| io::Error::other("worker stdin lock is poisoned"))?;
+            let stdin = stdin
+                .as_mut()
+                .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker is shut down"))?;
+            if let Err(error) = encode_frame(stdin, &Request::DeriveSnapshot(request)) {
+                self.remove_route(request_id);
+                return Err(error);
+            }
+        }
+        let response = match response_rx.recv_timeout(timeout) {
             Ok(response) => response?,
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                terminate(&mut self.child, Duration::from_secs(1));
+                self.remove_route(request_id);
+                if let Ok(mut child) = self.child.lock() {
+                    terminate(&mut child, Duration::from_secs(1));
+                }
                 return Err(io::Error::new(
                     io::ErrorKind::TimedOut,
                     format!("tree worker request {request_id} timed out"),
@@ -432,9 +560,23 @@ impl Client {
         Ok(response)
     }
 
+    fn remove_route(&self, request_id: u64) {
+        if let Ok(mut routes) = self.routes.lock() {
+            routes.remove(&request_id);
+        }
+    }
+
     pub fn shutdown(mut self) -> io::Result<()> {
-        self.stdin.take();
-        let status = wait_until(&mut self.child, Duration::from_secs(2))?;
+        self.stdin
+            .get_mut()
+            .map_err(|_| io::Error::other("worker stdin lock is poisoned"))?
+            .take();
+        let status = wait_until(
+            self.child
+                .get_mut()
+                .map_err(|_| io::Error::other("worker child lock is poisoned"))?,
+            Duration::from_secs(2),
+        )?;
         if let Some(reader) = self.reader.take() {
             let _ = reader.join();
         }
@@ -450,11 +592,64 @@ impl Client {
 
 impl Drop for Client {
     fn drop(&mut self) {
-        self.stdin.take();
-        terminate(&mut self.child, Duration::from_secs(1));
+        if let Ok(stdin) = self.stdin.get_mut() {
+            stdin.take();
+        }
+        if let Ok(child) = self.child.get_mut() {
+            terminate(child, Duration::from_secs(1));
+        }
         if let Some(reader) = self.reader.take() {
             let _ = reader.join();
         }
+    }
+}
+
+fn response_request_id(response: &Response) -> Option<u64> {
+    match response {
+        Response::Snapshot(snapshot) => Some(snapshot.context.request_id),
+        Response::Error(error) => error.request_id,
+        Response::HandshakeReady(_) => None,
+    }
+}
+
+fn route_response(
+    routes: &Mutex<HashMap<u64, mpsc::Sender<io::Result<Response>>>>,
+    response: Response,
+) {
+    let Some(request_id) = response_request_id(&response) else {
+        fail_routes(
+            None,
+            routes,
+            io::ErrorKind::InvalidData,
+            "unexpected response without request id",
+        );
+        return;
+    };
+    let route = routes
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(&request_id);
+    if let Some(route) = route {
+        let _ = route.send(Ok(response));
+    }
+}
+
+fn fail_routes(
+    handshake: Option<mpsc::Sender<io::Result<Response>>>,
+    routes: &Mutex<HashMap<u64, mpsc::Sender<io::Result<Response>>>>,
+    kind: io::ErrorKind,
+    message: &str,
+) {
+    if let Some(handshake) = handshake {
+        let _ = handshake.send(Err(io::Error::new(kind, message.to_string())));
+    }
+    let routes = std::mem::take(
+        &mut *routes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner),
+    );
+    for route in routes.into_values() {
+        let _ = route.send(Err(io::Error::new(kind, message.to_string())));
     }
 }
 

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -862,7 +862,8 @@ fn terminate(child: &mut Child, timeout: Duration) {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::io::{Cursor, Write};
+    use std::io::{Cursor, Read, Write};
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Condvar, Mutex};
     use std::time::Duration;
 
@@ -932,6 +933,19 @@ mod tests {
             let (state, changed) = &*self.0;
             state.lock().unwrap().released = true;
             changed.notify_all();
+        }
+    }
+
+    struct CountingReader {
+        cursor: Cursor<Vec<u8>>,
+        bytes_read: Arc<AtomicUsize>,
+    }
+
+    impl Read for CountingReader {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            let read = self.cursor.read(buffer)?;
+            self.bytes_read.fetch_add(read, Ordering::Relaxed);
+            Ok(read)
         }
     }
 
@@ -1138,17 +1152,33 @@ mod tests {
             request.context.request_id = request_id;
             requests.push(Request::DeriveSnapshot(request));
         }
+        let admitted_prefix_bytes = framed(&requests[..4]).len();
+        let framed_requests = framed(&requests);
+        let bytes_read = Arc::new(AtomicUsize::new(0));
+        let reader = CountingReader {
+            cursor: Cursor::new(framed_requests.clone()),
+            bytes_read: Arc::clone(&bytes_read),
+        };
         let (completed, completed_rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
-            let _ = completed.send(run(Cursor::new(framed(&requests)), writer, 1));
+            let _ = completed.send(run(reader, writer, 1));
         });
 
         gate.wait_until_blocked();
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(
+            bytes_read.load(Ordering::Relaxed) <= admitted_prefix_bytes,
+            "worker read past two admitted requests plus one bounded lookahead"
+        );
+        assert!(
+            bytes_read.load(Ordering::Relaxed) < framed_requests.len(),
+            "worker consumed the complete request stream while stdout was stalled"
+        );
         assert!(
             completed_rx
                 .recv_timeout(Duration::from_millis(50))
                 .is_err(),
-            "worker must not consume an unbounded request stream while stdout is stalled"
+            "worker unexpectedly completed while stdout was stalled"
         );
 
         gate.release();

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -281,7 +281,7 @@ fn derive_snapshot(request: DeriveSnapshot, queue_wait: Duration) -> Response {
 
 pub fn run<R, W>(reader: R, writer: W, compute_threads: usize) -> io::Result<()>
 where
-    R: Read,
+    R: Read + Send,
     W: Write + Send + 'static,
 {
     run_with_build_id(reader, writer, compute_threads, BUILD_ID)
@@ -294,7 +294,7 @@ fn run_with_build_id<R, W>(
     build_id: &str,
 ) -> io::Result<()>
 where
-    R: Read,
+    R: Read + Send,
     W: Write + Send + 'static,
 {
     if compute_threads == 0 {
@@ -308,11 +308,23 @@ where
         .thread_name(|index| format!("kakehashi-tree-worker-{index}"))
         .build()
         .map_err(io::Error::other)?;
-    let (responses, response_rx) = mpsc::channel::<Response>();
+    let max_inflight = compute_threads.saturating_mul(2).max(1);
+    let (permits, permit_rx) = mpsc::sync_channel(max_inflight);
+    for _ in 0..max_inflight {
+        permits
+            .send(())
+            .map_err(|_| io::Error::other("worker admission queue stopped"))?;
+    }
+    let (responses, response_rx) = mpsc::sync_channel::<(Response, bool)>(max_inflight);
+    let writer_permits = permits.clone();
     let writer_thread = std::thread::spawn(move || -> io::Result<()> {
         let mut writer = writer;
-        for response in response_rx {
-            encode_frame(&mut writer, &response)?;
+        for (response, releases_permit) in response_rx {
+            let result = encode_frame(&mut writer, &response);
+            if releases_permit {
+                let _ = writer_permits.send(());
+            }
+            result?;
         }
         Ok(())
     });
@@ -334,10 +346,13 @@ where
     };
     if handshake.protocol_version != PROTOCOL_VERSION || handshake.build_id != build_id {
         responses
-            .send(Response::Error(WorkerError {
-                context: None,
-                message: "worker protocol/build identity mismatch".into(),
-            }))
+            .send((
+                Response::Error(WorkerError {
+                    context: None,
+                    message: "worker protocol/build identity mismatch".into(),
+                }),
+                false,
+            ))
             .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
         drop(responses);
         join_writer(writer_thread)?;
@@ -348,61 +363,62 @@ where
     }
     let worker_generation = handshake.worker_generation;
     responses
-        .send(Response::HandshakeReady(HandshakeReady {
-            protocol_version: PROTOCOL_VERSION,
-            build_id: build_id.into(),
-            worker_generation,
-            compute_threads,
-        }))
+        .send((
+            Response::HandshakeReady(HandshakeReady {
+                protocol_version: PROTOCOL_VERSION,
+                build_id: build_id.into(),
+                worker_generation,
+                compute_threads,
+            }),
+            false,
+        ))
         .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
 
-    let (completed, completed_rx) = mpsc::channel();
-    let max_inflight = compute_threads.saturating_mul(2).max(1);
-    let (permits, permit_rx) = mpsc::sync_channel(max_inflight);
-    for _ in 0..max_inflight {
-        permits
-            .send(())
-            .map_err(|_| io::Error::other("worker admission queue stopped"))?;
-    }
-    let mut pending = 0_usize;
-    while let Some(request) = decode_frame::<_, Request>(&mut reader)? {
-        let Request::DeriveSnapshot(request) = request else {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "handshake may only be sent once",
-            ));
-        };
-        if request.context.worker_generation != worker_generation {
-            responses
-                .send(Response::Error(WorkerError {
-                    context: Some(request.context),
-                    message: "stale worker generation".into(),
-                }))
-                .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
-            continue;
+    let service_responses = responses.clone();
+    let service_permits = permits.clone();
+    let service_result = pool.scope(move |scope| -> io::Result<()> {
+        while let Some(request) = decode_frame::<_, Request>(&mut reader)? {
+            let Request::DeriveSnapshot(request) = request else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "handshake may only be sent once",
+                ));
+            };
+            if request.context.worker_generation != worker_generation {
+                service_responses
+                    .send((
+                        Response::Error(WorkerError {
+                            context: Some(request.context),
+                            message: "stale worker generation".into(),
+                        }),
+                        false,
+                    ))
+                    .map_err(|_| {
+                        io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped")
+                    })?;
+                continue;
+            }
+            let enqueued = Instant::now();
+            permit_rx
+                .recv()
+                .map_err(|_| io::Error::other("worker admission queue stopped"))?;
+            let responses = service_responses.clone();
+            let permits = service_permits.clone();
+            scope.spawn(move |_| {
+                if responses
+                    .send((derive_snapshot(request, enqueued.elapsed()), true))
+                    .is_err()
+                {
+                    let _ = permits.send(());
+                }
+            });
         }
-        permit_rx
-            .recv()
-            .map_err(|_| io::Error::other("worker admission queue stopped"))?;
-        pending += 1;
-        let responses = responses.clone();
-        let completed = completed.clone();
-        let permits = permits.clone();
-        let enqueued = Instant::now();
-        pool.spawn(move || {
-            let _ = responses.send(derive_snapshot(request, enqueued.elapsed()));
-            let _ = completed.send(());
-            let _ = permits.send(());
-        });
-    }
-    drop(completed);
-    for _ in 0..pending {
-        completed_rx.recv().map_err(|_| {
-            io::Error::new(io::ErrorKind::BrokenPipe, "worker compute task stopped")
-        })?;
-    }
+        Ok(())
+    });
     drop(responses);
-    join_writer(writer_thread)
+    let writer_result = join_writer(writer_thread);
+    service_result?;
+    writer_result
 }
 
 fn join_writer(thread: std::thread::JoinHandle<io::Result<()>>) -> io::Result<()> {

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -281,7 +281,7 @@ fn derive_snapshot(request: DeriveSnapshot, queue_wait: Duration) -> Response {
 
 pub fn run<R, W>(reader: R, writer: W, compute_threads: usize) -> io::Result<()>
 where
-    R: Read + Send,
+    R: Read,
     W: Write + Send + 'static,
 {
     run_with_build_id(reader, writer, compute_threads, BUILD_ID)
@@ -294,7 +294,7 @@ fn run_with_build_id<R, W>(
     build_id: &str,
 ) -> io::Result<()>
 where
-    R: Read + Send,
+    R: Read,
     W: Write + Send + 'static,
 {
     if compute_threads == 0 {
@@ -374,51 +374,47 @@ where
         ))
         .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
 
-    let service_responses = responses.clone();
-    let service_permits = permits.clone();
-    let service_result = pool.scope(move |scope| -> io::Result<()> {
-        while let Some(request) = decode_frame::<_, Request>(&mut reader)? {
-            let Request::DeriveSnapshot(request) = request else {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "handshake may only be sent once",
-                ));
-            };
-            if request.context.worker_generation != worker_generation {
-                service_responses
-                    .send((
-                        Response::Error(WorkerError {
-                            context: Some(request.context),
-                            message: "stale worker generation".into(),
-                        }),
-                        false,
-                    ))
-                    .map_err(|_| {
-                        io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped")
-                    })?;
-                continue;
-            }
-            let enqueued = Instant::now();
-            permit_rx
-                .recv()
-                .map_err(|_| io::Error::other("worker admission queue stopped"))?;
-            let responses = service_responses.clone();
-            let permits = service_permits.clone();
-            scope.spawn(move |_| {
-                if responses
-                    .send((derive_snapshot(request, enqueued.elapsed()), true))
-                    .is_err()
-                {
-                    let _ = permits.send(());
-                }
-            });
+    while let Some(request) = decode_frame::<_, Request>(&mut reader)? {
+        let Request::DeriveSnapshot(request) = request else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "handshake may only be sent once",
+            ));
+        };
+        if request.context.worker_generation != worker_generation {
+            responses
+                .send((
+                    Response::Error(WorkerError {
+                        context: Some(request.context),
+                        message: "stale worker generation".into(),
+                    }),
+                    false,
+                ))
+                .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
+            continue;
         }
-        Ok(())
-    });
+        let enqueued = Instant::now();
+        permit_rx
+            .recv()
+            .map_err(|_| io::Error::other("worker admission queue stopped"))?;
+        let responses = responses.clone();
+        let permits = permits.clone();
+        pool.spawn(move || {
+            if responses
+                .send((derive_snapshot(request, enqueued.elapsed()), true))
+                .is_err()
+            {
+                let _ = permits.send(());
+            }
+        });
+    }
+    for _ in 0..max_inflight {
+        permit_rx
+            .recv()
+            .map_err(|_| io::Error::other("worker admission queue stopped"))?;
+    }
     drop(responses);
-    let writer_result = join_writer(writer_thread);
-    service_result?;
-    writer_result
+    join_writer(writer_thread)
 }
 
 fn join_writer(thread: std::thread::JoinHandle<io::Result<()>>) -> io::Result<()> {

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -229,7 +229,10 @@ impl WorkerThreadState {
     fn derive(&mut self, request: DeriveSnapshot, queue_wait: Duration) -> Response {
         let request_context = request.context.clone();
         let key = GrammarKey {
-            parser_path: request.parser_path.clone(),
+            parser_path: request
+                .parser_path
+                .canonicalize()
+                .unwrap_or_else(|_| request.parser_path.clone()),
             grammar_symbol: request.grammar_symbol.clone(),
         };
         let language = match self.languages.get(&key).cloned() {
@@ -315,16 +318,12 @@ where
             .send(())
             .map_err(|_| io::Error::other("worker admission queue stopped"))?;
     }
-    let (responses, response_rx) = mpsc::sync_channel::<(Response, bool)>(max_inflight);
-    let writer_permits = permits.clone();
+    let (responses, response_rx) =
+        mpsc::sync_channel::<(Response, Option<AdmissionPermit>)>(max_inflight);
     let writer_thread = std::thread::spawn(move || -> io::Result<()> {
         let mut writer = writer;
-        for (response, releases_permit) in response_rx {
-            let result = encode_frame(&mut writer, &response);
-            if releases_permit {
-                let _ = writer_permits.send(());
-            }
-            result?;
+        for (response, _permit) in response_rx {
+            encode_frame(&mut writer, &response)?;
         }
         Ok(())
     });
@@ -351,7 +350,7 @@ where
                     context: None,
                     message: "worker protocol/build identity mismatch".into(),
                 }),
-                false,
+                None,
             ))
             .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
         drop(responses);
@@ -370,7 +369,7 @@ where
                 worker_generation,
                 compute_threads,
             }),
-            false,
+            None,
         ))
         .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
 
@@ -388,7 +387,7 @@ where
                         context: Some(request.context),
                         message: "stale worker generation".into(),
                     }),
-                    false,
+                    None,
                 ))
                 .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
             continue;
@@ -398,14 +397,9 @@ where
             .recv()
             .map_err(|_| io::Error::other("worker admission queue stopped"))?;
         let responses = responses.clone();
-        let permits = permits.clone();
+        let permit = AdmissionPermit(permits.clone());
         pool.spawn(move || {
-            if responses
-                .send((derive_snapshot(request, enqueued.elapsed()), true))
-                .is_err()
-            {
-                let _ = permits.send(());
-            }
+            let _ = responses.send((derive_snapshot(request, enqueued.elapsed()), Some(permit)));
         });
     }
     for _ in 0..max_inflight {
@@ -421,6 +415,14 @@ fn join_writer(thread: std::thread::JoinHandle<io::Result<()>>) -> io::Result<()
     thread
         .join()
         .map_err(|_| io::Error::other("worker writer panicked"))?
+}
+
+struct AdmissionPermit(mpsc::SyncSender<()>);
+
+impl Drop for AdmissionPermit {
+    fn drop(&mut self) {
+        let _ = self.0.send(());
+    }
 }
 
 pub fn run_stdio(compute_threads: usize) -> io::Result<()> {
@@ -620,6 +622,11 @@ impl Client {
         self.derive_with_timeout(request, Duration::from_secs(60))
     }
 
+    /// Sends one request with a process-level recovery deadline.
+    ///
+    /// A timeout terminates the shared worker because native parser code may be
+    /// non-cooperative. All concurrent requests consequently fail, and this
+    /// client cannot be reused; the supervisor must create a new generation.
     pub fn derive_with_timeout(
         &self,
         request: DeriveSnapshot,
@@ -844,8 +851,22 @@ fn wait_until(child: &mut Child, timeout: Duration) -> io::Result<std::process::
             return Ok(status);
         }
         if Instant::now() >= deadline {
-            child.kill()?;
-            return child.wait();
+            let kill_error = child.kill().err();
+            let reap_deadline = Instant::now() + timeout;
+            loop {
+                if let Some(status) = child.try_wait()? {
+                    return Ok(status);
+                }
+                if Instant::now() >= reap_deadline {
+                    return Err(kill_error.unwrap_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            "tree worker did not exit after kill",
+                        )
+                    }));
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
         }
         std::thread::sleep(Duration::from_millis(5));
     }
@@ -938,14 +959,53 @@ mod tests {
 
     struct CountingReader {
         cursor: Cursor<Vec<u8>>,
-        bytes_read: Arc<AtomicUsize>,
+        progress: Arc<(AtomicUsize, Condvar, Mutex<()>)>,
     }
 
     impl Read for CountingReader {
         fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
             let read = self.cursor.read(buffer)?;
-            self.bytes_read.fetch_add(read, Ordering::Relaxed);
+            self.progress.0.fetch_add(read, Ordering::Relaxed);
+            self.progress.1.notify_all();
             Ok(read)
+        }
+    }
+
+    fn wait_for_read_progress(progress: &Arc<(AtomicUsize, Condvar, Mutex<()>)>, minimum: usize) {
+        let guard = progress.2.lock().unwrap();
+        let (_guard, timeout) = progress
+            .1
+            .wait_timeout_while(guard, Duration::from_secs(5), |_| {
+                progress.0.load(Ordering::Relaxed) < minimum
+            })
+            .unwrap();
+        assert!(
+            !timeout.timed_out(),
+            "reader did not reach bounded lookahead"
+        );
+    }
+
+    #[derive(Default)]
+    struct FailAfterFirstFlush {
+        bytes: Vec<u8>,
+        flushes: usize,
+    }
+
+    impl Write for FailAfterFirstFlush {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.bytes.write(bytes)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.flushes += 1;
+            if self.flushes > 1 {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "injected writer failure",
+                ))
+            } else {
+                Ok(())
+            }
         }
     }
 
@@ -1154,10 +1214,10 @@ mod tests {
         }
         let admitted_prefix_bytes = framed(&requests[..4]).len();
         let framed_requests = framed(&requests);
-        let bytes_read = Arc::new(AtomicUsize::new(0));
+        let progress = Arc::new((AtomicUsize::new(0), Condvar::new(), Mutex::new(())));
         let reader = CountingReader {
             cursor: Cursor::new(framed_requests.clone()),
-            bytes_read: Arc::clone(&bytes_read),
+            progress: Arc::clone(&progress),
         };
         let (completed, completed_rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
@@ -1165,13 +1225,13 @@ mod tests {
         });
 
         gate.wait_until_blocked();
-        std::thread::sleep(Duration::from_millis(50));
+        wait_for_read_progress(&progress, admitted_prefix_bytes);
         assert!(
-            bytes_read.load(Ordering::Relaxed) <= admitted_prefix_bytes,
+            progress.0.load(Ordering::Relaxed) <= admitted_prefix_bytes,
             "worker read past two admitted requests plus one bounded lookahead"
         );
         assert!(
-            bytes_read.load(Ordering::Relaxed) < framed_requests.len(),
+            progress.0.load(Ordering::Relaxed) < framed_requests.len(),
             "worker consumed the complete request stream while stdout was stalled"
         );
         assert!(
@@ -1186,5 +1246,31 @@ mod tests {
             .recv_timeout(Duration::from_secs(5))
             .expect("worker did not resume after stdout was released")
             .unwrap();
+    }
+
+    #[test]
+    fn writer_failure_releases_all_admission_permits() {
+        let mut requests = vec![handshake(PROTOCOL_VERSION)];
+        for request_id in 1..=8 {
+            let Request::DeriveSnapshot(mut request) = request() else {
+                unreachable!()
+            };
+            request.context.request_id = request_id;
+            requests.push(Request::DeriveSnapshot(request));
+        }
+        let (completed, completed_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = completed.send(run(
+                Cursor::new(framed(&requests)),
+                FailAfterFirstFlush::default(),
+                1,
+            ));
+        });
+
+        let error = completed_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("worker deadlocked after response writer failure")
+            .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
     }
 }

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -5,7 +5,9 @@
 
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
+use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::mpsc;
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
@@ -264,6 +266,218 @@ fn join_writer(thread: std::thread::JoinHandle<io::Result<()>>) -> io::Result<()
 
 pub fn run_stdio(compute_threads: usize) -> io::Result<()> {
     run(std::io::stdin(), std::io::stdout(), compute_threads)
+}
+
+pub struct Client {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    responses: mpsc::Receiver<io::Result<Response>>,
+    reader: Option<std::thread::JoinHandle<()>>,
+    ready: HandshakeReady,
+}
+
+impl Client {
+    pub fn spawn(
+        executable: &std::path::Path,
+        compute_threads: usize,
+        worker_generation: u64,
+    ) -> io::Result<Self> {
+        if compute_threads == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "worker compute thread count must be positive",
+            ));
+        }
+        let mut child = Command::new(executable)
+            .args(["__tree-worker", "--threads", &compute_threads.to_string()])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()?;
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| io::Error::other("worker stdin was not piped"))?;
+        let mut stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| io::Error::other("worker stdout was not piped"))?;
+        let (responses_tx, responses) = mpsc::channel();
+        let reader = std::thread::spawn(move || {
+            loop {
+                match decode_frame::<_, Response>(&mut stdout) {
+                    Ok(Some(response)) => {
+                        if responses_tx.send(Ok(response)).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(None) => {
+                        let _ = responses_tx.send(Err(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "tree worker closed its response stream",
+                        )));
+                        break;
+                    }
+                    Err(error) => {
+                        let _ = responses_tx.send(Err(error));
+                        break;
+                    }
+                }
+            }
+        });
+        encode_frame(
+            &mut stdin,
+            &Request::Handshake(Handshake {
+                protocol_version: PROTOCOL_VERSION,
+                build_id: BUILD_ID.into(),
+                worker_generation,
+            }),
+        )?;
+        let ready = match responses.recv_timeout(Duration::from_secs(5)) {
+            Ok(Ok(Response::HandshakeReady(ready)))
+                if ready.protocol_version == PROTOCOL_VERSION
+                    && ready.build_id == BUILD_ID
+                    && ready.worker_generation == worker_generation
+                    && ready.compute_threads == compute_threads =>
+            {
+                ready
+            }
+            Ok(Ok(response)) => {
+                terminate(&mut child, Duration::from_secs(1));
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid worker handshake response: {response:?}"),
+                ));
+            }
+            Ok(Err(error)) => {
+                terminate(&mut child, Duration::from_secs(1));
+                return Err(error);
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                terminate(&mut child, Duration::from_secs(1));
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "tree worker handshake timed out",
+                ));
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                terminate(&mut child, Duration::from_secs(1));
+                return Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "tree worker handshake channel closed",
+                ));
+            }
+        };
+        Ok(Self {
+            child,
+            stdin: Some(stdin),
+            responses,
+            reader: Some(reader),
+            ready,
+        })
+    }
+
+    pub fn compute_threads(&self) -> usize {
+        self.ready.compute_threads
+    }
+
+    pub fn derive(&mut self, request: DeriveSnapshot) -> io::Result<Response> {
+        self.derive_with_timeout(request, Duration::from_secs(60))
+    }
+
+    pub fn derive_with_timeout(
+        &mut self,
+        request: DeriveSnapshot,
+        timeout: Duration,
+    ) -> io::Result<Response> {
+        if request.context.worker_generation != self.ready.worker_generation {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "request targets a stale worker generation",
+            ));
+        }
+        let request_id = request.context.request_id;
+        let stdin = self
+            .stdin
+            .as_mut()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker is shut down"))?;
+        encode_frame(stdin, &Request::DeriveSnapshot(request))?;
+        let response = match self.responses.recv_timeout(timeout) {
+            Ok(response) => response?,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                terminate(&mut self.child, Duration::from_secs(1));
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!("tree worker request {request_id} timed out"),
+                ));
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "tree worker response channel closed",
+                ));
+            }
+        };
+        let response_id = match &response {
+            Response::Snapshot(snapshot) => Some(snapshot.context.request_id),
+            Response::Error(error) => error.request_id,
+            Response::HandshakeReady(_) => None,
+        };
+        if response_id != Some(request_id) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unexpected response for request {response_id:?}"),
+            ));
+        }
+        Ok(response)
+    }
+
+    pub fn shutdown(mut self) -> io::Result<()> {
+        self.stdin.take();
+        let status = wait_until(&mut self.child, Duration::from_secs(2))?;
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+        if status.success() {
+            Ok(())
+        } else {
+            Err(io::Error::other(format!(
+                "tree worker exited with {status}"
+            )))
+        }
+    }
+}
+
+impl Drop for Client {
+    fn drop(&mut self) {
+        self.stdin.take();
+        terminate(&mut self.child, Duration::from_secs(1));
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+    }
+}
+
+fn wait_until(child: &mut Child, timeout: Duration) -> io::Result<std::process::ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(status);
+        }
+        if Instant::now() >= deadline {
+            child.kill()?;
+            return child.wait();
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+fn terminate(child: &mut Child, timeout: Duration) {
+    if child.try_wait().ok().flatten().is_some() {
+        return;
+    }
+    let _ = child.kill();
+    let _ = wait_until(child, timeout);
 }
 
 #[cfg(test)]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -648,24 +648,26 @@ impl Client {
                 },
             );
         }
-        let outbound = self
-            .outbound
-            .lock()
-            .map_err(|_| io::Error::other("worker outbound lock is poisoned"))?;
-        let outbound = outbound
-            .as_ref()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker is shut down"))?;
-        if let Err(error) = outbound.try_send(Request::DeriveSnapshot(request)) {
-            self.remove_route(request_id);
-            return Err(match error {
-                mpsc::TrySendError::Full(_) => io::Error::new(
-                    io::ErrorKind::WouldBlock,
-                    "tree worker outbound queue is full",
-                ),
-                mpsc::TrySendError::Disconnected(_) => {
-                    io::Error::new(io::ErrorKind::BrokenPipe, "tree worker writer stopped")
-                }
-            });
+        {
+            let outbound = self
+                .outbound
+                .lock()
+                .map_err(|_| io::Error::other("worker outbound lock is poisoned"))?;
+            let outbound = outbound
+                .as_ref()
+                .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker is shut down"))?;
+            if let Err(error) = outbound.try_send(Request::DeriveSnapshot(request)) {
+                self.remove_route(request_id);
+                return Err(match error {
+                    mpsc::TrySendError::Full(_) => io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        "tree worker outbound queue is full",
+                    ),
+                    mpsc::TrySendError::Disconnected(_) => {
+                        io::Error::new(io::ErrorKind::BrokenPipe, "tree worker writer stopped")
+                    }
+                });
+            }
         }
         let remaining = timeout.saturating_sub(started.elapsed());
         let response = match response_rx.recv_timeout(remaining) {

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -1,0 +1,33 @@
+use std::path::PathBuf;
+
+use kakehashi::tree_worker::{Client, DeriveSnapshot, RequestContext, Response};
+
+#[test]
+fn real_worker_handshakes_and_contains_request_errors() {
+    let executable = PathBuf::from(env!("CARGO_BIN_EXE_kakehashi"));
+    let mut worker = Client::spawn(&executable, 2, 41).unwrap();
+
+    assert_eq!(worker.compute_threads(), 2);
+    let response = worker
+        .derive(DeriveSnapshot {
+            context: RequestContext {
+                request_id: 9,
+                worker_generation: 41,
+                uri: "file:///missing.rs".into(),
+                incarnation: 1,
+                content_version: 0,
+                configuration_generation: 0,
+            },
+            language: "rust".into(),
+            grammar_symbol: "rust".into(),
+            parser_path: PathBuf::from("/missing/tree-sitter-rust"),
+            text: "fn main() {}".into(),
+        })
+        .unwrap();
+
+    let Response::Error(error) = response else {
+        panic!("missing grammar must be a contained request error");
+    };
+    assert_eq!(error.request_id, Some(9));
+    worker.shutdown().unwrap();
+}

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -1,11 +1,12 @@
 use std::path::PathBuf;
+use std::sync::{Arc, Barrier};
 
 use kakehashi::tree_worker::{Client, DeriveSnapshot, RequestContext, Response};
 
 #[test]
 fn real_worker_handshakes_and_contains_request_errors() {
     let executable = PathBuf::from(env!("CARGO_BIN_EXE_kakehashi"));
-    let mut worker = Client::spawn(&executable, 2, 41).unwrap();
+    let worker = Client::spawn(&executable, 2, 41).unwrap();
 
     assert_eq!(worker.compute_threads(), 2);
     let response = worker
@@ -29,5 +30,114 @@ fn real_worker_handshakes_and_contains_request_errors() {
         panic!("missing grammar must be a contained request error");
     };
     assert_eq!(error.request_id, Some(9));
+    worker.shutdown().unwrap();
+}
+
+#[test]
+fn concurrent_requests_are_routed_by_request_id() {
+    let executable = PathBuf::from(env!("CARGO_BIN_EXE_kakehashi"));
+    let worker = Arc::new(Client::spawn(&executable, 2, 43).unwrap());
+    let barrier = Arc::new(Barrier::new(3));
+    let handles: Vec<_> = [20_u64, 21]
+        .into_iter()
+        .map(|request_id| {
+            let worker = Arc::clone(&worker);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                worker
+                    .derive(DeriveSnapshot {
+                        context: RequestContext {
+                            request_id,
+                            worker_generation: 43,
+                            uri: format!("file:///{request_id}.rs"),
+                            incarnation: 1,
+                            content_version: 0,
+                            configuration_generation: 0,
+                        },
+                        language: "rust".into(),
+                        grammar_symbol: "rust".into(),
+                        parser_path: PathBuf::from(format!("/missing/{request_id}")),
+                        text: "fn main() {}".into(),
+                    })
+                    .unwrap()
+            })
+        })
+        .collect();
+    barrier.wait();
+
+    let mut ids = handles
+        .into_iter()
+        .map(|handle| match handle.join().unwrap() {
+            Response::Error(error) => error.request_id.unwrap(),
+            response => panic!("missing grammars must fail independently: {response:?}"),
+        })
+        .collect::<Vec<_>>();
+    ids.sort_unstable();
+    assert_eq!(ids, [20, 21]);
+    Arc::try_unwrap(worker)
+        .ok()
+        .expect("request threads released the worker")
+        .shutdown()
+        .unwrap();
+}
+
+#[cfg(feature = "e2e")]
+#[test]
+fn real_worker_derives_a_snapshot_from_an_installed_grammar() {
+    let data_dir = kakehashi::install::test_support::test_data_dir_path();
+    std::fs::create_dir_all(&data_dir).unwrap();
+    kakehashi::install::test_support::ensure_test_languages_installed(&data_dir).unwrap();
+    let parser = data_dir
+        .join("parser")
+        .join(format!("rust.{}", std::env::consts::DLL_EXTENSION));
+    let executable = PathBuf::from(env!("CARGO_BIN_EXE_kakehashi"));
+    let worker = Client::spawn(&executable, 1, 42).unwrap();
+
+    let response = worker
+        .derive(DeriveSnapshot {
+            context: RequestContext {
+                request_id: 10,
+                worker_generation: 42,
+                uri: "file:///example.rs".into(),
+                incarnation: 1,
+                content_version: 0,
+                configuration_generation: 0,
+            },
+            language: "rust".into(),
+            grammar_symbol: "rust".into(),
+            parser_path: parser.clone(),
+            text: "fn main() {}".into(),
+        })
+        .unwrap();
+
+    let Response::Snapshot(snapshot) = response else {
+        panic!("installed grammar must produce a snapshot: {response:?}");
+    };
+    assert_eq!(snapshot.root_kind, "source_file");
+    assert_eq!(snapshot.context.worker_generation, 42);
+    assert!(!snapshot.parser_cache_hit);
+
+    let response = worker
+        .derive(DeriveSnapshot {
+            context: RequestContext {
+                request_id: 11,
+                worker_generation: 42,
+                uri: "file:///example.rs".into(),
+                incarnation: 1,
+                content_version: 1,
+                configuration_generation: 0,
+            },
+            language: "rust".into(),
+            grammar_symbol: "rust".into(),
+            parser_path: parser,
+            text: "fn main() { let x = 1; }".into(),
+        })
+        .unwrap();
+    let Response::Snapshot(snapshot) = response else {
+        panic!("second derive must produce a snapshot: {response:?}");
+    };
+    assert!(snapshot.parser_cache_hit);
+    assert!(snapshot.compute_ns > 0);
     worker.shutdown().unwrap();
 }

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -29,7 +29,10 @@ fn real_worker_handshakes_and_contains_request_errors() {
     let Response::Error(error) = response else {
         panic!("missing grammar must be a contained request error");
     };
-    assert_eq!(error.request_id, Some(9));
+    assert_eq!(
+        error.context.as_ref().map(|context| context.request_id),
+        Some(9)
+    );
     worker.shutdown().unwrap();
 }
 
@@ -69,7 +72,7 @@ fn concurrent_requests_are_routed_by_request_id() {
     let mut ids = handles
         .into_iter()
         .map(|handle| match handle.join().unwrap() {
-            Response::Error(error) => error.request_id.unwrap(),
+            Response::Error(error) => error.context.unwrap().request_id,
             response => panic!("missing grammars must fail independently: {response:?}"),
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
## 概要

ADR の Stage 1 として、development-only の常駐 1 process / 内部複数 thread tree worker prototype を追加します。PR #863 の Phase 0 計測を土台にした stacked PR です。

## 実装

- 4-byte length-prefixed JSON frame、protocol version、request ID、worker generation
- caller-supplied spawn image と child image の SHA-256 handshake
- request ID だけでなく URI / incarnation / content version / configuration generation を含む全 context の応答検証
- hidden `__tree-worker` mode と bounded Rayon compute pool
- parent outbound / active route / worker admission / response queue の全境界を bounded 化
- response が実際に write されるまで admission permit を保持し、stdout stall 時の先読みを `2 permits + 1 framed lookahead` に制限
- timeout / protocol corruption / EOF / startup failure で child を terminate + reap
- dynamic grammar/parser の worker-thread-local cache
- real process concurrency / installed grammar / slow writer backpressure tests

## 実測

Apple M4、Rust 1.95、8,069-byte full-text request、1,000 requests、4 threads、page-cache-warm 2 batch:

| Batch | direct | worker | delta |
|---|---:|---:|---:|
| A | 2440.2 req/s | 2381.1 req/s | -2.4% |
| B | 2133.8 req/s | 2527.4 req/s | +18.4% |

固定の direct→worker 順で方向が反転したため、Stage 1 は性能向上を証明しません。一方で実測から次を発見・修正しました。

- sender mutex guard の応答待ち保持で 693–818 req/s まで直列化
- Rayon control scope が compute slot を1本消費し 1597–1815 req/s まで低下
- cache warmup 非対称で見かけの worker 勝ちが発生

exact executable hashing を毎回行う現在の spawn + handshake は 1.09–1.14 s です。最終設計では session-private executable snapshot を一度 hash し、generation 間で identity を再利用する必要があります。

## Stage 1 の意図的な制限

- 毎 request で全文送信・full parse
- worker-side document replica / incremental Tree なし
- injection / query / semantic token / node identity なし
- parent running image への immutable snapshot binding は未実装

Stage 2 では versioned `SyncDocument` / `ApplyEdits`、worker-owned text + incremental Tree、state-reference-only derive、alternating paired collector を実装します。

## 検証

- `cargo test --locked --quiet`
- `make check`
- `cargo check --locked --bench tree_worker_stage1`
- `cargo test --locked --features e2e --test tree_worker_process`
- multi-perspective review: protocol / lifecycle / performance = No findings
- independent Codex review = No findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tree-worker process for deriving syntax-tree snapshots through a framed request/response interface.
  * Added worker startup, handshake validation, request routing, timeouts, backpressure, caching, and concurrent processing.
  * Added a hidden CLI command for launching the tree worker.

* **Testing & Benchmarking**
  * Added integration tests for worker communication, concurrent requests, errors, and parser caching.
  * Added a benchmark command and recorded sequential and parallel performance results.

* **Documentation**
  * Added an architecture decision record describing the worker measurement approach and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->