### PR TITLE
feat(worker): validate document lifecycle in shadow

### DIFF
--- a/benches/profile/attest_worker_binary.py
+++ b/benches/profile/attest_worker_binary.py
@@ -157,7 +157,11 @@ def git(checkout, *arguments):
 
 
 def require_clean(checkout):
-    status = git(checkout, "status", "--porcelain")
+    status = "\n".join(
+        line
+        for line in git(checkout, "status", "--porcelain").splitlines()
+        if line != "?? .DS_Store"
+    )
     if status:
         raise ValueError(f"binary source checkout is dirty:\n{status}")
 

--- a/benches/profile/attest_worker_binary.py
+++ b/benches/profile/attest_worker_binary.py
@@ -8,9 +8,12 @@ import pathlib
 import platform
 import shutil
 import subprocess
+import sys
 import tarfile
 import tempfile
 import urllib.parse
+
+sys.dont_write_bytecode = True
 
 from collect_worker_proxy import (
     ATTESTED_BUILD_COMMAND,

--- a/benches/profile/collect_worker_proxy.py
+++ b/benches/profile/collect_worker_proxy.py
@@ -54,6 +54,7 @@ ATTESTED_BUILD_COMMAND = [
 ]
 HARNESS_SCRIPT_NAMES = (
     "collect_worker_proxy.py",
+    "collect_worker_shadow.py",
     "collect_worker_cold_start.py",
     "collect_worker_capture_pilot.py",
     "drive.py",

--- a/benches/profile/collect_worker_proxy.py
+++ b/benches/profile/collect_worker_proxy.py
@@ -484,7 +484,10 @@ def runtime_artifact_files(root):
             continue
         files.extend(
             item for item in artifact_root.rglob("*")
-            if item.is_file() and not item.is_symlink()
+            if item.is_file()
+            and not item.is_symlink()
+            and not item.name.endswith(".replace.lock")
+            and item.name != ".kakehashi-install-complete"
         )
     return sorted(
         files, key=lambda item: item.relative_to(root).as_posix()

--- a/benches/profile/collect_worker_shadow.py
+++ b/benches/profile/collect_worker_shadow.py
@@ -43,13 +43,20 @@ def order(batch_index):
     return ("disabled", "shadow") if batch_index % 2 == 0 else ("shadow", "disabled")
 
 
-def parse_comparisons(output):
+def parse_comparisons(output, expected=201):
     matches = COMPARISON_RE.findall(output)
     if len(matches) != 1:
         raise ValueError(f"expected one complete shadow summary, got {len(matches)}")
     values = map(int, matches[0])
-    result = dict(zip(("matched", "mismatched", "superseded", "pending"), values))
-    if result["matched"] <= 0 or result["mismatched"] or result["pending"]:
+    result = dict(
+        zip(("matched", "mismatched", "superseded", "pending"), values, strict=True)
+    )
+    if (
+        result["matched"] != expected
+        or result["mismatched"]
+        or result["superseded"]
+        or result["pending"]
+    ):
         raise ValueError(f"shadow validation did not converge: {result}")
     return result
 

--- a/benches/profile/collect_worker_shadow.py
+++ b/benches/profile/collect_worker_shadow.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Collect paired Stage 3 shadow/control runs with reproducible provenance."""
+
+import argparse
+import json
+import os
+import pathlib
+import platform
+import re
+import sys
+import tempfile
+
+from collect_worker_proxy import (
+    artifact_identity,
+    artifact_provenance,
+    bounded_run,
+    build_driver_command,
+    controlled_environment,
+    cpu_model,
+    harness_identity,
+    load_binary_attestation,
+    parse_driver_summary,
+    portable_environment,
+    require_benchmark_artifacts,
+    require_posix,
+    sha256_file,
+    stage_measurement_inputs,
+    tool_version,
+    verify_file_sha256,
+)
+
+SCENARIO = [
+    "--lang", "rust", "--size", "200", "--requests", "200",
+    "--edits", "1", "--warm-semantic-cache", "--settle", "0.5",
+]
+COMPARISON_RE = re.compile(
+    r"shadow comparisons matched=(\d+) mismatched=(\d+) "
+    r"superseded=(\d+) pending=(\d+)"
+)
+
+
+def order(batch_index):
+    return ("disabled", "shadow") if batch_index % 2 == 0 else ("shadow", "disabled")
+
+
+def parse_comparisons(output):
+    matches = COMPARISON_RE.findall(output)
+    if len(matches) != 1:
+        raise ValueError(f"expected one complete shadow summary, got {len(matches)}")
+    values = map(int, matches[0])
+    result = dict(zip(("matched", "mismatched", "superseded", "pending"), values))
+    if result["matched"] <= 0 or result["mismatched"] or result["pending"]:
+        raise ValueError(f"shadow validation did not converge: {result}")
+    return result
+
+
+def delta_percent(control, shadow, key):
+    return round((shadow[key] / control[key] - 1) * 100, 2)
+
+
+def run_variant(kind, binary, data_dir, script_dir, threads, timeout):
+    environment = controlled_environment(os.environ)
+    environment["KAKEHASHI_TREE_WORKER_SHADOW"] = "true" if kind == "shadow" else "false"
+    environment["KAKEHASHI_TREE_WORKER_THREADS"] = str(threads)
+    environment["RUST_LOG"] = (
+        "kakehashi::tree_worker_shadow=info,"
+        "kakehashi::tree_worker_shadow_metrics=info"
+    )
+    with tempfile.TemporaryDirectory(prefix="kakehashi-shadow-xdg-") as xdg:
+        environment["XDG_CONFIG_HOME"] = str(pathlib.Path(xdg) / "config")
+        environment["XDG_STATE_HOME"] = str(pathlib.Path(xdg) / "state")
+        completed = bounded_run(
+            build_driver_command("direct", binary, data_dir, SCENARIO, script_dir),
+            environment,
+            timeout_seconds=timeout,
+        )
+    result = parse_driver_summary(completed.stderr, 200)
+    if kind == "shadow":
+        result["comparisons"] = parse_comparisons(completed.stderr)
+    elif "shadow comparisons matched=" in completed.stderr:
+        raise ValueError("control run unexpectedly enabled shadow mode")
+    return result
+
+
+def collect(args):
+    source_script_dir = pathlib.Path(__file__).resolve().parent
+    binary_sha256 = sha256_file(args.bin)
+    attestation = load_binary_attestation(args.binary_attestation, args.bin)
+    source_harness = harness_identity(source_script_dir)
+    source_artifacts = artifact_identity(args.data_dir)
+    staging, binary, data_dir, script_dir = stage_measurement_inputs(
+        args.bin, args.data_dir, source_script_dir
+    )
+    try:
+        batches = []
+        for index in range(args.batches):
+            batch = {"batch": index + 1, "order": list(order(index))}
+            for kind in order(index):
+                batch[kind] = run_variant(
+                    kind, binary, data_dir, script_dir, args.worker_threads, args.run_timeout
+                )
+            batch["shadow_delta_percent"] = {
+                key: delta_percent(batch["disabled"], batch["shadow"], key)
+                for key in ("wall", "p50", "p90", "p95", "p99")
+            }
+            batches.append(batch)
+            print(f"batch {index + 1}/{args.batches}", file=sys.stderr)
+        if artifact_identity(data_dir) != source_artifacts:
+            raise RuntimeError("runtime artifacts changed during collection")
+        verify_file_sha256(binary, binary_sha256)
+        if harness_identity(source_script_dir) != source_harness:
+            raise RuntimeError("benchmark harness changed during collection")
+        result = {
+            "schema": 1,
+            "experiment": "single-tree-worker-stage3-shadow",
+            "environment": {
+                "platform": platform.platform(),
+                "python": platform.python_version(),
+                "rustc": tool_version(["rustc", "--version"]),
+                "cpu_model": cpu_model(),
+                "binary_sha256": binary_sha256,
+                "retained_environment": portable_environment(os.environ),
+            },
+            "artifacts": artifact_provenance(data_dir, args.nvim_treesitter_checkout),
+            "binary_attestation": attestation,
+            "harness": {
+                "execution": "private staged driver and collector helpers",
+                "source_files_sha256": source_harness,
+            },
+            "collector": {
+                "batches": args.batches,
+                "order": "disabled-shadow on odd batches; shadow-disabled on even batches",
+                "fresh_xdg_per_variant": True,
+                "shadow_compute_threads": args.worker_threads,
+            },
+            "steady_state": {"rust_edit_semantic_tokens": {
+                "arguments": SCENARIO,
+                "batches": batches,
+            }},
+        }
+        args.output.write_text(json.dumps(result, indent=2) + "\n")
+    finally:
+        staging.cleanup()
+
+
+def main():
+    require_posix()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bin", type=pathlib.Path, required=True)
+    parser.add_argument("--data-dir", type=pathlib.Path, required=True)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    parser.add_argument("--binary-attestation", type=pathlib.Path, required=True)
+    parser.add_argument("--nvim-treesitter-checkout", type=pathlib.Path, required=True)
+    parser.add_argument("--batches", type=int, default=2)
+    parser.add_argument("--worker-threads", type=int, default=4)
+    parser.add_argument("--run-timeout", type=float, default=120)
+    args = parser.parse_args()
+    if args.batches <= 0 or args.worker_threads <= 0 or args.run_timeout <= 0:
+        parser.error("batches, worker-threads, and run-timeout must be positive")
+    require_benchmark_artifacts(args.data_dir)
+    collect(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/benches/profile/collect_worker_shadow.py
+++ b/benches/profile/collect_worker_shadow.py
@@ -92,6 +92,7 @@ def collect(args):
         args.bin, args.data_dir, source_script_dir
     )
     try:
+        provenance = artifact_provenance(data_dir, args.nvim_treesitter_checkout)
         batches = []
         for index in range(args.batches):
             batch = {"batch": index + 1, "order": list(order(index))}
@@ -121,7 +122,7 @@ def collect(args):
                 "binary_sha256": binary_sha256,
                 "retained_environment": portable_environment(os.environ),
             },
-            "artifacts": artifact_provenance(data_dir, args.nvim_treesitter_checkout),
+            "artifacts": provenance,
             "binary_attestation": attestation,
             "harness": {
                 "execution": "private staged driver and collector helpers",

--- a/benches/profile/results/single_worker_stage3_binary_attestation_2026-07-19.json
+++ b/benches/profile/results/single_worker_stage3_binary_attestation_2026-07-19.json
@@ -1,0 +1,39 @@
+{
+  "schema": 1,
+  "source_repository": "https://github.com/atusy/kakehashi",
+  "source_commit": "9f6d7a50e44f30b445c7232604904dc68a7d2868",
+  "source_remote_refs_containing_commit": [
+    "refs/remotes/origin/feat/tree-worker-stage3-shadow"
+  ],
+  "source_checkout_clean": true,
+  "build_command": [
+    "cargo",
+    "build",
+    "--locked",
+    "--release",
+    "--bin",
+    "kakehashi"
+  ],
+  "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)",
+  "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)",
+  "native_toolchain": {
+    "rustc_verbose": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8",
+    "cc": "Apple clang version 21.0.0 (clang-2100.1.1.101)\nTarget: arm64-apple-darwin25.5.0\nThread model: posix\nInstalledDir: /Library/Developer/CommandLineTools/usr/bin",
+    "linker": "@(#)PROGRAM:ld PROJECT:ld-1267\nBUILD 18:30:29 Apr 22 2026\nconfigured to support archs: armv6 armv7 armv7s arm64 arm64e arm64_32 i386 x86_64 x86_64h armv6m armv7k armv7m armv7em armv8m.main armv8.1m.main\nwill use ld-classic for: armv6 armv7 armv7s i386 armv6m armv7k armv7m armv7em\nLTO support using: LLVM version 21.0.0 (static support for 30, runtime is 30)\nTAPI support using: Apple TAPI version 21.0.0 (tapi-2100.0.2.6)\nLibrary search paths:\n\t/usr/local/lib\n\t/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib\n\t/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/swift\nFramework search paths:\n\t/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks",
+    "sdk_path": "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
+    "sdk_version": "26.5"
+  },
+  "build_environment": {
+    "PATH": "<redacted-search-path>",
+    "TMPDIR": "<redacted-path>",
+    "LANG": "C.UTF-8",
+    "LC_ALL": "C.UTF-8",
+    "CARGO_TARGET_DIR": "${ATTESTED_BUILD_ROOT}/target",
+    "CARGO_HOME": "${ATTESTED_BUILD_ROOT}/target/cargo-home"
+  },
+  "built_in_fresh_target": true,
+  "source_isolated_archive": true,
+  "cargo_config_ancestry_clean": true,
+  "binary_relative": "target/release/kakehashi",
+  "binary_sha256": "a6ee0ac80a97c814259a4c8855dc195332b4cab1a5faf34077d025818c577657"
+}

--- a/benches/profile/results/single_worker_stage3_binary_attestation_2026-07-19.json
+++ b/benches/profile/results/single_worker_stage3_binary_attestation_2026-07-19.json
@@ -1,7 +1,7 @@
 {
   "schema": 1,
   "source_repository": "https://github.com/atusy/kakehashi",
-  "source_commit": "9f6d7a50e44f30b445c7232604904dc68a7d2868",
+  "source_commit": "00d99301c1751d3ca17ece6f7012de999ade5617",
   "source_remote_refs_containing_commit": [
     "refs/remotes/origin/feat/tree-worker-stage3-shadow"
   ],
@@ -35,5 +35,5 @@
   "source_isolated_archive": true,
   "cargo_config_ancestry_clean": true,
   "binary_relative": "target/release/kakehashi",
-  "binary_sha256": "a6ee0ac80a97c814259a4c8855dc195332b4cab1a5faf34077d025818c577657"
+  "binary_sha256": "90902453b256fcbab027fa84fbf87f2483aad1e077df3ae37ecdebc4590eb1ca"
 }

--- a/benches/profile/results/single_worker_stage3_shadow_2026-07-19.json
+++ b/benches/profile/results/single_worker_stage3_shadow_2026-07-19.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "source_commit": "900077461aa0d740baef65bca28560c4a1a18b8b",
-  "binary_sha256": "9469eb77490b348c579595dc08b009699556d4f1a0571176313a1207cd4b138b",
+  "source_commit": "fadac25333af6238903de043022f2a376c2c490d",
+  "binary_sha256": "29e0509e40c90337a157753bda6c8a165cfaeea1419b70bceffffb033e43dced",
   "environment": {
     "cpu": "Apple M4",
     "os": "macOS 26.5.1 (25F80)",
@@ -23,37 +23,37 @@
       "name": "A",
       "order": ["disabled", "shadow"],
       "disabled": {
-        "wall_ms": 14726.119,
-        "ms_per_cycle": 73.63,
-        "semantic_ms": {"p50": 52.9, "p90": 60.3, "p95": 63.3, "p99": 68.9, "max": 156.7},
+        "wall_ms": 14032.410750049166,
+        "ms_per_cycle": 70.16,
+        "semantic_ms": {"p50": 51.6, "p90": 55.7, "p95": 57.2, "p99": 61.2, "max": 63.2},
         "responses_ok": 200
       },
       "shadow": {
-        "wall_ms": 15825.299,
-        "ms_per_cycle": 79.13,
-        "semantic_ms": {"p50": 59.6, "p90": 65.7, "p95": 67.3, "p99": 73.5, "max": 178.9},
+        "wall_ms": 15124.330458929762,
+        "ms_per_cycle": 75.62,
+        "semantic_ms": {"p50": 57.1, "p90": 64.7, "p95": 67.7, "p99": 73.2, "max": 74.3},
         "responses_ok": 200,
         "comparisons": {"matched": 201, "mismatched": 0, "superseded": 0, "pending": 0}
       },
-      "shadow_delta_percent": {"wall": 7.46, "p50": 12.67, "p90": 8.96, "p95": 6.32, "p99": 6.68}
+      "shadow_delta_percent": {"wall": 7.78, "p50": 10.66, "p90": 16.16, "p95": 18.36, "p99": 19.61}
     },
     {
       "name": "B",
       "order": ["shadow", "disabled"],
       "disabled": {
-        "wall_ms": 16676.5592090087,
-        "ms_per_cycle": 83.38,
-        "semantic_ms": {"p50": 62.0, "p90": 70.8, "p95": 75.0, "p99": 79.0, "max": 81.0},
+        "wall_ms": 14165.658124955371,
+        "ms_per_cycle": 70.83,
+        "semantic_ms": {"p50": 52.6, "p90": 57.8, "p95": 59.5, "p99": 62.7, "max": 80.2},
         "responses_ok": 200
       },
       "shadow": {
-        "wall_ms": 18132.641332922503,
-        "ms_per_cycle": 90.66,
-        "semantic_ms": {"p50": 70.6, "p90": 77.3, "p95": 79.5, "p99": 85.1, "max": 87.8},
+        "wall_ms": 15217.304041958414,
+        "ms_per_cycle": 76.09,
+        "semantic_ms": {"p50": 57.2, "p90": 65.5, "p95": 68.0, "p99": 73.5, "max": 74.7},
         "responses_ok": 200,
         "comparisons": {"matched": 201, "mismatched": 0, "superseded": 0, "pending": 0}
       },
-      "shadow_delta_percent": {"wall": 8.73, "p50": 13.87, "p90": 9.18, "p95": 6.0, "p99": 7.72}
+      "shadow_delta_percent": {"wall": 7.42, "p50": 8.75, "p90": 13.32, "p95": 14.29, "p99": 17.22}
     }
   ]
 }

--- a/benches/profile/results/single_worker_stage3_shadow_2026-07-19.json
+++ b/benches/profile/results/single_worker_stage3_shadow_2026-07-19.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_commit": "7f0d8039c29209a9c67fc98f84fe0d9e96c62c2a",
+  "source_commit": "900077461aa0d740baef65bca28560c4a1a18b8b",
   "binary_sha256": "9469eb77490b348c579595dc08b009699556d4f1a0571176313a1207cd4b138b",
   "environment": {
     "cpu": "Apple M4",

--- a/benches/profile/results/single_worker_stage3_shadow_2026-07-19.json
+++ b/benches/profile/results/single_worker_stage3_shadow_2026-07-19.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": 1,
+  "source_commit": "7f0d8039c29209a9c67fc98f84fe0d9e96c62c2a",
+  "binary_sha256": "9469eb77490b348c579595dc08b009699556d4f1a0571176313a1207cd4b138b",
+  "environment": {
+    "cpu": "Apple M4",
+    "os": "macOS 26.5.1 (25F80)",
+    "rustc": "rustc 1.95.0 (59807616e 2026-04-14)"
+  },
+  "workload": {
+    "driver": "benches/profile/drive.py",
+    "language": "rust",
+    "generated_lines": 200,
+    "cycles": 200,
+    "edits_per_cycle": 1,
+    "request": "textDocument/semanticTokens/full",
+    "warm_semantic_cache": true,
+    "settle_seconds": 0.5,
+    "shadow_compute_threads": 4
+  },
+  "batches": [
+    {
+      "name": "A",
+      "order": ["disabled", "shadow"],
+      "disabled": {
+        "wall_ms": 14726.119,
+        "ms_per_cycle": 73.63,
+        "semantic_ms": {"p50": 52.9, "p90": 60.3, "p95": 63.3, "p99": 68.9, "max": 156.7},
+        "responses_ok": 200
+      },
+      "shadow": {
+        "wall_ms": 15825.299,
+        "ms_per_cycle": 79.13,
+        "semantic_ms": {"p50": 59.6, "p90": 65.7, "p95": 67.3, "p99": 73.5, "max": 178.9},
+        "responses_ok": 200,
+        "comparisons": {"matched": 201, "mismatched": 0, "superseded": 0, "pending": 0}
+      },
+      "shadow_delta_percent": {"wall": 7.46, "p50": 12.67, "p90": 8.96, "p95": 6.32, "p99": 6.68}
+    },
+    {
+      "name": "B",
+      "order": ["shadow", "disabled"],
+      "disabled": {
+        "wall_ms": 16676.5592090087,
+        "ms_per_cycle": 83.38,
+        "semantic_ms": {"p50": 62.0, "p90": 70.8, "p95": 75.0, "p99": 79.0, "max": 81.0},
+        "responses_ok": 200
+      },
+      "shadow": {
+        "wall_ms": 18132.641332922503,
+        "ms_per_cycle": 90.66,
+        "semantic_ms": {"p50": 70.6, "p90": 77.3, "p95": 79.5, "p99": 85.1, "max": 87.8},
+        "responses_ok": 200,
+        "comparisons": {"matched": 201, "mismatched": 0, "superseded": 0, "pending": 0}
+      },
+      "shadow_delta_percent": {"wall": 8.73, "p50": 13.87, "p90": 9.18, "p95": 6.0, "p99": 7.72}
+    }
+  ]
+}

--- a/benches/profile/results/single_worker_stage3_shadow_2026-07-19.json
+++ b/benches/profile/results/single_worker_stage3_shadow_2026-07-19.json
@@ -1,59 +1,199 @@
 {
-  "schema_version": 1,
-  "source_commit": "946de588c3928136138afb112200d6cf34af0da3",
-  "binary_sha256": "8584e64bfb38d8548221d5f5fc3c4d3a086530697a153b4a8b193fb51a885ac1",
+  "schema": 1,
+  "experiment": "single-tree-worker-stage3-shadow",
   "environment": {
-    "cpu": "Apple M4",
-    "os": "macOS 26.5.1 (25F80)",
-    "rustc": "rustc 1.95.0 (59807616e 2026-04-14)"
+    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "python": "3.12.13",
+    "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)",
+    "cpu_model": "Apple M4",
+    "binary_sha256": "a6ee0ac80a97c814259a4c8855dc195332b4cab1a5faf34077d025818c577657",
+    "retained_environment": {
+      "PATH": "<redacted-search-path>",
+      "TMPDIR": "<redacted-path>",
+      "LANG": "C.UTF-8",
+      "LC_ALL": "C.UTF-8"
+    }
   },
-  "workload": {
-    "driver": "benches/profile/drive.py",
-    "language": "rust",
-    "generated_lines": 200,
-    "cycles": 200,
-    "edits_per_cycle": 1,
-    "request": "textDocument/semanticTokens/full",
-    "warm_semantic_cache": true,
-    "settle_seconds": 0.5,
+  "artifacts": {
+    "nvim_treesitter_repository": "https://github.com/nvim-treesitter/nvim-treesitter",
+    "nvim_treesitter_revision": "4916d6592ede8c07973490d9322f187e07dfefac",
+    "nvim_treesitter_fetched_main": "24977147550d53589e53b874ec75e14e4fbc304e",
+    "verification": "parser metadata and every installed query byte-matched"
+  },
+  "binary_attestation": {
+    "schema": 1,
+    "source_repository": "https://github.com/atusy/kakehashi",
+    "source_commit": "9f6d7a50e44f30b445c7232604904dc68a7d2868",
+    "source_remote_refs_containing_commit": [
+      "refs/remotes/origin/feat/tree-worker-stage3-shadow"
+    ],
+    "source_checkout_clean": true,
+    "build_command": [
+      "cargo",
+      "build",
+      "--locked",
+      "--release",
+      "--bin",
+      "kakehashi"
+    ],
+    "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)",
+    "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)",
+    "native_toolchain": {
+      "rustc_verbose": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8",
+      "cc": "Apple clang version 21.0.0 (clang-2100.1.1.101)\nTarget: arm64-apple-darwin25.5.0\nThread model: posix\nInstalledDir: /Library/Developer/CommandLineTools/usr/bin",
+      "linker": "@(#)PROGRAM:ld PROJECT:ld-1267\nBUILD 18:30:29 Apr 22 2026\nconfigured to support archs: armv6 armv7 armv7s arm64 arm64e arm64_32 i386 x86_64 x86_64h armv6m armv7k armv7m armv7em armv8m.main armv8.1m.main\nwill use ld-classic for: armv6 armv7 armv7s i386 armv6m armv7k armv7m armv7em\nLTO support using: LLVM version 21.0.0 (static support for 30, runtime is 30)\nTAPI support using: Apple TAPI version 21.0.0 (tapi-2100.0.2.6)\nLibrary search paths:\n\t/usr/local/lib\n\t/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib\n\t/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/swift\nFramework search paths:\n\t/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks",
+      "sdk_path": "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
+      "sdk_version": "26.5"
+    },
+    "build_environment": {
+      "PATH": "<redacted-search-path>",
+      "TMPDIR": "<redacted-path>",
+      "LANG": "C.UTF-8",
+      "LC_ALL": "C.UTF-8",
+      "CARGO_TARGET_DIR": "${ATTESTED_BUILD_ROOT}/target",
+      "CARGO_HOME": "${ATTESTED_BUILD_ROOT}/target/cargo-home"
+    },
+    "built_in_fresh_target": true,
+    "source_isolated_archive": true,
+    "cargo_config_ancestry_clean": true,
+    "binary_relative": "target/release/kakehashi",
+    "binary_sha256": "a6ee0ac80a97c814259a4c8855dc195332b4cab1a5faf34077d025818c577657"
+  },
+  "harness": {
+    "execution": "private staged driver and collector helpers",
+    "source_files_sha256": {
+      "collect_worker_proxy.py": "00867d5ebd4f23b0d02ad94b7f49cb41c8d868da8c49620f809f4cb300ba7f56",
+      "collect_worker_shadow.py": "cac7e119837531da2821ed1ca4776d1319a9cd8e91547da7f6d805fdd3701a28",
+      "collect_worker_cold_start.py": "7648e2b0eba60b20b7f11a641c07c6ccdd5a1d3b75bc91492f32acfa90750109",
+      "collect_worker_capture_pilot.py": "3a709d50253dc23060ca99f885978e71a8b58f07a71af6c492d2fa73916a75f5",
+      "drive.py": "3e9e2d8d84b6a2c4704c41f2e4efbd3a54499b1a6882d4f648c0c6ef2e178c12",
+      "worker_proxy.py": "e3fe07d73168835e71fb976109e034b121b1112d6c7a746be1575ac07a6fd542",
+      "gen_session.py": "6f4f6b8388c607db1c70fe29579ce14fe00d57668cab17601432ff123cfb15a3"
+    }
+  },
+  "collector": {
+    "batches": 2,
+    "order": "disabled-shadow on odd batches; shadow-disabled on even batches",
+    "fresh_xdg_per_variant": true,
     "shadow_compute_threads": 4
   },
-  "batches": [
-    {
-      "name": "A",
-      "order": ["disabled", "shadow"],
-      "disabled": {
-        "wall_ms": 14208.375375019386,
-        "ms_per_cycle": 71.04,
-        "semantic_ms": {"p50": 52.0, "p90": 56.6, "p95": 57.6, "p99": 61.2, "max": 62.4},
-        "responses_ok": 200
-      },
-      "shadow": {
-        "wall_ms": 15401.541374973021,
-        "ms_per_cycle": 77.01,
-        "semantic_ms": {"p50": 59.1, "p90": 64.5, "p95": 67.0, "p99": 68.6, "max": 72.2},
-        "responses_ok": 200,
-        "comparisons": {"matched": 201, "mismatched": 0, "superseded": 0, "pending": 0}
-      },
-      "shadow_delta_percent": {"wall": 8.4, "p50": 13.65, "p90": 13.96, "p95": 16.32, "p99": 12.09}
-    },
-    {
-      "name": "B",
-      "order": ["shadow", "disabled"],
-      "disabled": {
-        "wall_ms": 13559.062582906336,
-        "ms_per_cycle": 67.80,
-        "semantic_ms": {"p50": 50.3, "p90": 53.0, "p95": 54.2, "p99": 57.0, "max": 59.3},
-        "responses_ok": 200
-      },
-      "shadow": {
-        "wall_ms": 15332.948083989322,
-        "ms_per_cycle": 76.66,
-        "semantic_ms": {"p50": 57.7, "p90": 65.4, "p95": 67.5, "p99": 73.6, "max": 76.7},
-        "responses_ok": 200,
-        "comparisons": {"matched": 201, "mismatched": 0, "superseded": 0, "pending": 0}
-      },
-      "shadow_delta_percent": {"wall": 13.08, "p50": 14.71, "p90": 23.4, "p95": 24.54, "p99": 29.12}
+  "steady_state": {
+    "rust_edit_semantic_tokens": {
+      "arguments": [
+        "--lang",
+        "rust",
+        "--size",
+        "200",
+        "--requests",
+        "200",
+        "--edits",
+        "1",
+        "--warm-semantic-cache",
+        "--settle",
+        "0.5"
+      ],
+      "batches": [
+        {
+          "batch": 1,
+          "order": [
+            "disabled",
+            "shadow"
+          ],
+          "disabled": {
+            "count": 200,
+            "ok": 200,
+            "canceled": 0,
+            "null": 0,
+            "errors": 0,
+            "tokens_per_request": 17807,
+            "p50": 57.5,
+            "p90": 62.0,
+            "p95": 63.5,
+            "p99": 67.8,
+            "max": 76.7,
+            "wall": 15282.706290949136,
+            "wire_kib": 37800.9
+          },
+          "shadow": {
+            "count": 200,
+            "ok": 200,
+            "canceled": 0,
+            "null": 0,
+            "errors": 0,
+            "tokens_per_request": 17807,
+            "p50": 62.9,
+            "p90": 68.3,
+            "p95": 71.3,
+            "p99": 74.6,
+            "max": 150.5,
+            "wall": 16335.963875055313,
+            "wire_kib": 37800.9,
+            "comparisons": {
+              "matched": 201,
+              "mismatched": 0,
+              "superseded": 0,
+              "pending": 0
+            }
+          },
+          "shadow_delta_percent": {
+            "wall": 6.89,
+            "p50": 9.39,
+            "p90": 10.16,
+            "p95": 12.28,
+            "p99": 10.03
+          }
+        },
+        {
+          "batch": 2,
+          "order": [
+            "shadow",
+            "disabled"
+          ],
+          "shadow": {
+            "count": 200,
+            "ok": 200,
+            "canceled": 0,
+            "null": 0,
+            "errors": 0,
+            "tokens_per_request": 17807,
+            "p50": 55.6,
+            "p90": 60.7,
+            "p95": 63.4,
+            "p99": 66.5,
+            "max": 67.8,
+            "wall": 14803.383833030239,
+            "wire_kib": 37800.9,
+            "comparisons": {
+              "matched": 201,
+              "mismatched": 0,
+              "superseded": 0,
+              "pending": 0
+            }
+          },
+          "disabled": {
+            "count": 200,
+            "ok": 200,
+            "canceled": 0,
+            "null": 0,
+            "errors": 0,
+            "tokens_per_request": 17807,
+            "p50": 49.2,
+            "p90": 51.8,
+            "p95": 54.0,
+            "p99": 57.7,
+            "max": 61.2,
+            "wall": 13742.651749984361,
+            "wire_kib": 37800.9
+          },
+          "shadow_delta_percent": {
+            "wall": 7.72,
+            "p50": 13.01,
+            "p90": 17.18,
+            "p95": 17.41,
+            "p99": 15.25
+          }
+        }
+      ]
     }
-  ]
+  }
 }

--- a/benches/profile/results/single_worker_stage3_shadow_2026-07-19.json
+++ b/benches/profile/results/single_worker_stage3_shadow_2026-07-19.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "source_commit": "fadac25333af6238903de043022f2a376c2c490d",
-  "binary_sha256": "29e0509e40c90337a157753bda6c8a165cfaeea1419b70bceffffb033e43dced",
+  "source_commit": "946de588c3928136138afb112200d6cf34af0da3",
+  "binary_sha256": "8584e64bfb38d8548221d5f5fc3c4d3a086530697a153b4a8b193fb51a885ac1",
   "environment": {
     "cpu": "Apple M4",
     "os": "macOS 26.5.1 (25F80)",
@@ -23,37 +23,37 @@
       "name": "A",
       "order": ["disabled", "shadow"],
       "disabled": {
-        "wall_ms": 14032.410750049166,
-        "ms_per_cycle": 70.16,
-        "semantic_ms": {"p50": 51.6, "p90": 55.7, "p95": 57.2, "p99": 61.2, "max": 63.2},
+        "wall_ms": 14208.375375019386,
+        "ms_per_cycle": 71.04,
+        "semantic_ms": {"p50": 52.0, "p90": 56.6, "p95": 57.6, "p99": 61.2, "max": 62.4},
         "responses_ok": 200
       },
       "shadow": {
-        "wall_ms": 15124.330458929762,
-        "ms_per_cycle": 75.62,
-        "semantic_ms": {"p50": 57.1, "p90": 64.7, "p95": 67.7, "p99": 73.2, "max": 74.3},
+        "wall_ms": 15401.541374973021,
+        "ms_per_cycle": 77.01,
+        "semantic_ms": {"p50": 59.1, "p90": 64.5, "p95": 67.0, "p99": 68.6, "max": 72.2},
         "responses_ok": 200,
         "comparisons": {"matched": 201, "mismatched": 0, "superseded": 0, "pending": 0}
       },
-      "shadow_delta_percent": {"wall": 7.78, "p50": 10.66, "p90": 16.16, "p95": 18.36, "p99": 19.61}
+      "shadow_delta_percent": {"wall": 8.4, "p50": 13.65, "p90": 13.96, "p95": 16.32, "p99": 12.09}
     },
     {
       "name": "B",
       "order": ["shadow", "disabled"],
       "disabled": {
-        "wall_ms": 14165.658124955371,
-        "ms_per_cycle": 70.83,
-        "semantic_ms": {"p50": 52.6, "p90": 57.8, "p95": 59.5, "p99": 62.7, "max": 80.2},
+        "wall_ms": 13559.062582906336,
+        "ms_per_cycle": 67.80,
+        "semantic_ms": {"p50": 50.3, "p90": 53.0, "p95": 54.2, "p99": 57.0, "max": 59.3},
         "responses_ok": 200
       },
       "shadow": {
-        "wall_ms": 15217.304041958414,
-        "ms_per_cycle": 76.09,
-        "semantic_ms": {"p50": 57.2, "p90": 65.5, "p95": 68.0, "p99": 73.5, "max": 74.7},
+        "wall_ms": 15332.948083989322,
+        "ms_per_cycle": 76.66,
+        "semantic_ms": {"p50": 57.7, "p90": 65.4, "p95": 67.5, "p99": 73.6, "max": 76.7},
         "responses_ok": 200,
         "comparisons": {"matched": 201, "mismatched": 0, "superseded": 0, "pending": 0}
       },
-      "shadow_delta_percent": {"wall": 7.42, "p50": 8.75, "p90": 13.32, "p95": 14.29, "p99": 17.22}
+      "shadow_delta_percent": {"wall": 13.08, "p50": 14.71, "p90": 23.4, "p95": 24.54, "p99": 29.12}
     }
   ]
 }

--- a/benches/profile/results/single_worker_stage3_shadow_2026-07-19.json
+++ b/benches/profile/results/single_worker_stage3_shadow_2026-07-19.json
@@ -6,7 +6,7 @@
     "python": "3.12.13",
     "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)",
     "cpu_model": "Apple M4",
-    "binary_sha256": "a6ee0ac80a97c814259a4c8855dc195332b4cab1a5faf34077d025818c577657",
+    "binary_sha256": "90902453b256fcbab027fa84fbf87f2483aad1e077df3ae37ecdebc4590eb1ca",
     "retained_environment": {
       "PATH": "<redacted-search-path>",
       "TMPDIR": "<redacted-path>",
@@ -23,7 +23,7 @@
   "binary_attestation": {
     "schema": 1,
     "source_repository": "https://github.com/atusy/kakehashi",
-    "source_commit": "9f6d7a50e44f30b445c7232604904dc68a7d2868",
+    "source_commit": "00d99301c1751d3ca17ece6f7012de999ade5617",
     "source_remote_refs_containing_commit": [
       "refs/remotes/origin/feat/tree-worker-stage3-shadow"
     ],
@@ -57,13 +57,13 @@
     "source_isolated_archive": true,
     "cargo_config_ancestry_clean": true,
     "binary_relative": "target/release/kakehashi",
-    "binary_sha256": "a6ee0ac80a97c814259a4c8855dc195332b4cab1a5faf34077d025818c577657"
+    "binary_sha256": "90902453b256fcbab027fa84fbf87f2483aad1e077df3ae37ecdebc4590eb1ca"
   },
   "harness": {
     "execution": "private staged driver and collector helpers",
     "source_files_sha256": {
       "collect_worker_proxy.py": "00867d5ebd4f23b0d02ad94b7f49cb41c8d868da8c49620f809f4cb300ba7f56",
-      "collect_worker_shadow.py": "cac7e119837531da2821ed1ca4776d1319a9cd8e91547da7f6d805fdd3701a28",
+      "collect_worker_shadow.py": "c4696420ae0b47920dfaea45ec636c68f07373bcbdc260fc733e091ae17a7e9e",
       "collect_worker_cold_start.py": "7648e2b0eba60b20b7f11a641c07c6ccdd5a1d3b75bc91492f32acfa90750109",
       "collect_worker_capture_pilot.py": "3a709d50253dc23060ca99f885978e71a8b58f07a71af6c492d2fa73916a75f5",
       "drive.py": "3e9e2d8d84b6a2c4704c41f2e4efbd3a54499b1a6882d4f648c0c6ef2e178c12",
@@ -106,12 +106,12 @@
             "null": 0,
             "errors": 0,
             "tokens_per_request": 17807,
-            "p50": 57.5,
-            "p90": 62.0,
-            "p95": 63.5,
-            "p99": 67.8,
-            "max": 76.7,
-            "wall": 15282.706290949136,
+            "p50": 50.8,
+            "p90": 53.1,
+            "p95": 54.3,
+            "p99": 57.2,
+            "max": 58.9,
+            "wall": 13776.48274996318,
             "wire_kib": 37800.9
           },
           "shadow": {
@@ -121,12 +121,12 @@
             "null": 0,
             "errors": 0,
             "tokens_per_request": 17807,
-            "p50": 62.9,
-            "p90": 68.3,
-            "p95": 71.3,
-            "p99": 74.6,
-            "max": 150.5,
-            "wall": 16335.963875055313,
+            "p50": 56.4,
+            "p90": 60.3,
+            "p95": 62.2,
+            "p99": 66.7,
+            "max": 67.8,
+            "wall": 14868.049292010255,
             "wire_kib": 37800.9,
             "comparisons": {
               "matched": 201,
@@ -136,11 +136,11 @@
             }
           },
           "shadow_delta_percent": {
-            "wall": 6.89,
-            "p50": 9.39,
-            "p90": 10.16,
-            "p95": 12.28,
-            "p99": 10.03
+            "wall": 7.92,
+            "p50": 11.02,
+            "p90": 13.56,
+            "p95": 14.55,
+            "p99": 16.61
           }
         },
         {
@@ -156,12 +156,12 @@
             "null": 0,
             "errors": 0,
             "tokens_per_request": 17807,
-            "p50": 55.6,
-            "p90": 60.7,
-            "p95": 63.4,
-            "p99": 66.5,
-            "max": 67.8,
-            "wall": 14803.383833030239,
+            "p50": 55.4,
+            "p90": 59.8,
+            "p95": 62.3,
+            "p99": 65.2,
+            "max": 74.6,
+            "wall": 14742.709832964465,
             "wire_kib": 37800.9,
             "comparisons": {
               "matched": 201,
@@ -177,20 +177,20 @@
             "null": 0,
             "errors": 0,
             "tokens_per_request": 17807,
-            "p50": 49.2,
-            "p90": 51.8,
-            "p95": 54.0,
-            "p99": 57.7,
-            "max": 61.2,
-            "wall": 13742.651749984361,
+            "p50": 50.1,
+            "p90": 56.6,
+            "p95": 59.3,
+            "p99": 64.8,
+            "max": 68.0,
+            "wall": 13873.362708021887,
             "wire_kib": 37800.9
           },
           "shadow_delta_percent": {
-            "wall": 7.72,
-            "p50": 13.01,
-            "p90": 17.18,
-            "p95": 17.41,
-            "p99": 15.25
+            "wall": 6.27,
+            "p50": 10.58,
+            "p90": 5.65,
+            "p95": 5.06,
+            "p99": 0.62
           }
         }
       ]

--- a/benches/profile/test_attest_worker_binary.py
+++ b/benches/profile/test_attest_worker_binary.py
@@ -18,6 +18,7 @@ from attest_worker_binary import (
     isolated_local_git_environment,
     native_toolchain_metadata,
     portable_build_environment,
+    require_clean,
     require_isolated_source,
     require_uncredentialed_repository_url,
     remote_verification_environment,
@@ -26,6 +27,15 @@ from attest_worker_binary import (
 
 
 class BinaryAttestationTest(unittest.TestCase):
+    @mock.patch("attest_worker_binary.git")
+    def test_clean_check_ignores_only_root_finder_metadata(self, git_status):
+        git_status.return_value = "?? .DS_Store"
+        require_clean(pathlib.Path("/checkout"))
+
+        git_status.return_value = "?? .DS_Store\n M src/main.rs"
+        with self.assertRaisesRegex(ValueError, "src/main.rs"):
+            require_clean(pathlib.Path("/checkout"))
+
     def test_recorded_build_environment_redacts_local_paths(self):
         recorded = portable_build_environment({
             "PATH": "/home/developer/bin:/usr/bin",

--- a/benches/profile/test_collect_worker_proxy.py
+++ b/benches/profile/test_collect_worker_proxy.py
@@ -47,6 +47,17 @@ from collect_worker_proxy import (
 
 
 class CollectionHelpersTest(unittest.TestCase):
+    def test_runtime_artifacts_exclude_internal_replace_locks(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            query = root / "queries/rust/highlights.scm"
+            query.parent.mkdir(parents=True)
+            query.write_text("(identifier) @variable\n")
+            (root / "queries/.rust.replace.lock").write_text("")
+            (query.parent / ".kakehashi-install-complete").write_text("")
+
+            self.assertEqual(collector.runtime_artifact_files(root), [query])
+
     def test_recorded_environment_redacts_local_paths(self):
         self.assertEqual(portable_environment({
             "PATH": "/home/developer/bin:/usr/bin",

--- a/benches/profile/test_collect_worker_shadow.py
+++ b/benches/profile/test_collect_worker_shadow.py
@@ -19,6 +19,10 @@ class ShadowCollectorTest(unittest.TestCase):
         self.assertEqual(parse_comparisons(output)["matched"], 201)
         with self.assertRaises(ValueError):
             parse_comparisons(output.replace("pending=0", "pending=1"))
+        with self.assertRaises(ValueError):
+            parse_comparisons(output.replace("superseded=0", "superseded=1"))
+        with self.assertRaises(ValueError):
+            parse_comparisons(output.replace("matched=201", "matched=200"))
 
     def test_delta_percent_uses_control_as_baseline(self):
         self.assertEqual(delta_percent({"wall": 100}, {"wall": 112.5}, "wall"), 12.5)

--- a/benches/profile/test_collect_worker_shadow.py
+++ b/benches/profile/test_collect_worker_shadow.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from collect_worker_shadow import delta_percent, order, parse_comparisons
+
+
+class ShadowCollectorTest(unittest.TestCase):
+    def test_order_reverses_each_batch(self):
+        self.assertEqual(order(0), ("disabled", "shadow"))
+        self.assertEqual(order(1), ("shadow", "disabled"))
+
+    def test_parse_comparisons_requires_a_complete_match(self):
+        output = "shadow comparisons matched=201 mismatched=0 superseded=0 pending=0"
+        self.assertEqual(parse_comparisons(output)["matched"], 201)
+        with self.assertRaises(ValueError):
+            parse_comparisons(output.replace("pending=0", "pending=1"))
+
+    def test_delta_percent_uses_control_as_baseline(self):
+        self.assertEqual(delta_percent({"wall": 100}, {"wall": 112.5}, "wall"), 12.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage3-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage3-measurement.md
@@ -25,8 +25,8 @@ captures, semantic tokens, or node identities.
 The committed result is
 `benches/profile/results/single_worker_stage3_shadow_2026-07-19.json`. The
 release binary was built from commit
-`9f6d7a50e44f30b445c7232604904dc68a7d2868` and has SHA-256
-`a6ee0ac80a97c814259a4c8855dc195332b4cab1a5faf34077d025818c577657`.
+`00d99301c1751d3ca17ece6f7012de999ade5617` and has SHA-256
+`90902453b256fcbab027fa84fbf87f2483aad1e077df3ae37ecdebc4590eb1ca`.
 The run used an Apple M4, macOS 26.5.1, Rust 1.95.0, and four worker compute
 threads.
 
@@ -52,24 +52,28 @@ comparisons at shutdown.
 
 | Batch and order | Disabled ms/cycle | Shadow ms/cycle | Shadow wall delta |
 |---|---:|---:|---:|
-| A, disabled first | 76.41 | 81.68 | +6.89% |
-| B, shadow first | 68.71 | 74.02 | +7.72% |
+| A, disabled first | 68.88 | 74.34 | +7.92% |
+| B, shadow first | 69.37 | 73.71 | +6.27% |
 
 | Batch | Disabled p50 / p90 / p95 / p99 | Shadow p50 / p90 / p95 / p99 | Shadow p50 delta |
 |---|---:|---:|---:|
-| A | 57.5 / 62.0 / 63.5 / 67.8 ms | 62.9 / 68.3 / 71.3 / 74.6 ms | +9.39% |
-| B | 49.2 / 51.8 / 54.0 / 57.7 ms | 55.6 / 60.7 / 63.4 / 66.5 ms | +13.01% |
+| A | 50.8 / 53.1 / 54.3 / 57.2 ms | 56.4 / 60.3 / 62.2 / 66.7 ms | +11.02% |
+| B | 50.1 / 56.6 / 59.3 / 64.8 ms | 55.4 / 59.8 / 62.3 / 65.2 ms | +10.58% |
 
 Reversing execution order did not reverse the result. Continuous shadow parsing
-cost 6.9--7.7% wall time and 9.4--13.0% at p50 in this single-document
-edit-and-token workload. The p90--p99 deltas ranged from 10.0% to 17.4%.
-Batch B's disabled baseline was faster than batch A's, so the range includes
-temporal/system variation rather than isolating one fixed shadow cost.
+cost 6.3--7.9% wall time and 10.6--11.0% at p50 in this single-document
+edit-and-token workload. The p90--p99 deltas ranged from 0.6% to 16.6%.
+The two disabled wall baselines differed by less than 1%, while percentile
+variation still shows why the reversed order is retained rather than treating
+one batch as a fixed shadow cost.
 
 This final run includes review-driven allocation removal, exact parser/query
 generation fencing, per-URI open-incarnation admission, atomic comparison
 lifecycle state, and bounded actor drain before the final summary. Those
 correctness checks are part of the measured hot path.
+The authoritative summary traversal also runs inside the existing compute-pool
+injection work-unit rather than blocking a Tokio worker or adding another pool
+submission.
 Earlier exploratory runs had lower overhead after allocation removal, but they
 predated the final lifecycle fences and are not retained as acceptance evidence.
 

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage3-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage3-measurement.md
@@ -25,8 +25,8 @@ captures, semantic tokens, or node identities.
 The committed result is
 `benches/profile/results/single_worker_stage3_shadow_2026-07-19.json`. The
 release binary was built from commit
-`fadac25333af6238903de043022f2a376c2c490d` and has SHA-256
-`29e0509e40c90337a157753bda6c8a165cfaeea1419b70bceffffb033e43dced`.
+`946de588c3928136138afb112200d6cf34af0da3` and has SHA-256
+`8584e64bfb38d8548221d5f5fc3c4d3a086530697a153b4a8b193fb51a885ac1`.
 The run used an Apple M4, macOS 26.5.1, Rust 1.95.0, and four worker compute
 threads.
 
@@ -52,21 +52,25 @@ comparisons at shutdown.
 
 | Batch and order | Disabled ms/cycle | Shadow ms/cycle | Shadow wall delta |
 |---|---:|---:|---:|
-| A, disabled first | 70.16 | 75.62 | +7.78% |
-| B, shadow first | 70.83 | 76.09 | +7.42% |
+| A, disabled first | 71.04 | 77.01 | +8.40% |
+| B, shadow first | 67.80 | 76.66 | +13.08% |
 
 | Batch | Disabled p50 / p90 / p95 / p99 | Shadow p50 / p90 / p95 / p99 | Shadow p50 delta |
 |---|---:|---:|---:|
-| A | 51.6 / 55.7 / 57.2 / 61.2 ms | 57.1 / 64.7 / 67.7 / 73.2 ms | +10.66% |
-| B | 52.6 / 57.8 / 59.5 / 62.7 ms | 57.2 / 65.5 / 68.0 / 73.5 ms | +8.75% |
+| A | 52.0 / 56.6 / 57.6 / 61.2 ms | 59.1 / 64.5 / 67.0 / 68.6 ms | +13.65% |
+| B | 50.3 / 53.0 / 54.2 / 57.0 ms | 57.7 / 65.4 / 67.5 / 73.6 ms | +14.71% |
 
 Reversing execution order did not reverse the result. Continuous shadow parsing
-cost about 7.4--7.8% wall time and 8.8--10.7% at p50 in this single-document
-edit-and-token workload. The p90--p99 deltas were 13.3--19.6% in both batches.
-This final run includes the review-driven replacement of per-node traversal
-allocation with one `TreeCursor` on both paths, plus borrowed-key lookup for
-existing comparison entries. Those changes reduced p50 overhead from the
-earlier exploratory 12.7--13.9%, but did not remove duplicate-parse contention.
+cost 8.4--13.1% wall time and 13.7--14.7% at p50 in this single-document
+edit-and-token workload. The p90--p99 deltas ranged from 12.1% to 29.1%.
+Batch B's disabled baseline was faster than batch A's, so the range includes
+temporal/system variation rather than isolating one fixed shadow cost.
+
+This final run includes review-driven allocation removal, exact parser/query
+generation fencing, per-URI open-incarnation admission, and atomic comparison
+lifecycle state. Those correctness checks are part of the measured hot path.
+Earlier exploratory runs had lower overhead after allocation removal, but they
+predated the final lifecycle fences and are not retained as acceptance evidence.
 
 This does not imply that the eventual worker-authoritative design is slower by
 the same amount. Shadow mode deliberately performs both the legacy parse and

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage3-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage3-measurement.md
@@ -1,0 +1,117 @@
+# Single Tree Worker Stage 3 Shadow Measurement
+
+## Scope
+
+Stage 3 connects the resident worker to the real LSP document lifecycle while
+the existing in-process path remains authoritative. With
+`KAKEHASHI_TREE_WORKER_SHADOW=true`, `didOpen`, ordered incremental
+`didChange`, and `didClose` events are mirrored through a bounded actor into one
+resident worker. The parent compares the worker's latest owned tree summary
+with the authoritative parse but never publishes the worker result.
+
+This measurement asks two separate questions:
+
+1. Does the worker reproduce the authoritative incremental tree over a real LSP
+   session?
+2. What is the foreground cost of continuously parsing every edit twice, even
+   though the worker transport itself is asynchronous?
+
+The summary comparison covers language, root kind and byte range,
+`has_error`, and named-node count. It does not yet compare injections, query
+captures, semantic tokens, or node identities.
+
+## Environment and method
+
+The committed result is
+`benches/profile/results/single_worker_stage3_shadow_2026-07-19.json`. The
+release binary was built from commit
+`7f0d8039c29209a9c67fc98f84fe0d9e96c62c2a` and has SHA-256
+`9469eb77490b348c579595dc08b009699556d4f1a0571176313a1207cd4b138b`.
+The run used an Apple M4, macOS 26.5.1, Rust 1.95.0, and four worker compute
+threads.
+
+`benches/profile/drive.py` generated a 200-line Rust document. After one warm
+semantic-token request, each of 200 measured cycles sent one ranged edit and
+synchronously requested `textDocument/semanticTokens/full`. A 500 ms settle
+followed `didOpen`. Both variants used the same release binary and installed
+grammar data. Batch A ran shadow disabled then enabled; batch B reversed that
+order to expose drift and thermal/order effects.
+
+The driver measures request-to-response latency, so the semantic-token values
+include waiting for the authoritative incremental parse. The shadow actor does
+not await worker IPC on the LSP ingress path. Any consistent foreground delta
+therefore measures shared CPU and scheduler contention from duplicate work,
+not a direct pipe round trip.
+
+## Results
+
+All 400 measured semantic-token requests in each variant completed
+successfully. Both shadow runs matched all 201 tree versions, including the
+open snapshot, with zero mismatches, superseded comparisons, or pending
+comparisons at shutdown.
+
+| Batch and order | Disabled ms/cycle | Shadow ms/cycle | Shadow wall delta |
+|---|---:|---:|---:|
+| A, disabled first | 73.63 | 79.13 | +7.46% |
+| B, shadow first | 83.38 | 90.66 | +8.73% |
+
+| Batch | Disabled p50 / p90 / p95 / p99 | Shadow p50 / p90 / p95 / p99 | Shadow p50 delta |
+|---|---:|---:|---:|
+| A | 52.9 / 60.3 / 63.3 / 68.9 ms | 59.6 / 65.7 / 67.3 / 73.5 ms | +12.67% |
+| B | 62.0 / 70.8 / 75.0 / 79.0 ms | 70.6 / 77.3 / 79.5 / 85.1 ms | +13.87% |
+
+Absolute latency shifted between batches, but reversing execution order did not
+reverse the result. Continuous shadow parsing cost about 7.5--8.7% wall time
+and 12.7--13.9% at p50 in this single-document edit-and-token workload. Tail
+deltas were smaller but remained positive at p90 through p99 in both batches.
+
+This does not imply that the eventual worker-authoritative design is slower by
+the same amount. Shadow mode deliberately performs both the legacy parse and
+the future parse. Cutover removes the legacy parse, while later fusion can move
+tree-derived work behind the same ownership boundary. The result instead shows
+that asynchronous shadow IPC alone does not isolate foreground performance:
+the duplicate native parse competes for the same CPU while the client waits for
+the authoritative result.
+
+## Reproduction
+
+```sh
+cargo build --release --locked --bin kakehashi
+shasum -a 256 target/release/kakehashi
+
+KAKEHASHI_TREE_WORKER_SHADOW=true \
+KAKEHASHI_TREE_WORKER_THREADS=4 \
+RUST_LOG=kakehashi::tree_worker_shadow=info,kakehashi::tree_worker_shadow_metrics=info \
+python3 benches/profile/drive.py \
+  --bin ./target/release/kakehashi \
+  --lang rust --size 200 --requests 200 --edits 1 \
+  --warm-semantic-cache --settle 0.5 \
+  --data-dir deps/test/kakehashi
+
+# Repeat without KAKEHASHI_TREE_WORKER_SHADOW, then repeat the pair in the
+# opposite order. Use isolated but identical XDG_CONFIG_HOME and XDG_STATE_HOME
+# directories for every run.
+```
+
+## Consequence for Stage 3
+
+The real-process lifecycle and latest-version comparison are viable: the
+bounded actor preserved ordered incremental coordinates, the worker matched
+every observed version, and worker failure remains isolated from public LSP
+results. The measurement also adds a performance gate for later stages.
+
+Full-rate shadowing should remain an explicit validation mode rather than the
+normal user path. Sampling or deferring shadow work could reduce validation
+overhead, but either weakens coverage or adds scheduling state and is not
+evidence about worker-authoritative performance. The more relevant next
+measurement is cutover mode, where the parent no longer performs the duplicate
+parse. That stage must compare one authoritative worker parse against one
+authoritative in-process parse under identical LSP workloads.
+
+Before cutover, supervision must also convert transport loss, worker-required
+restart, and process death into bounded restart plus full resynchronization of
+open documents. A failed or repeatedly crashing parser must disable only its
+session path and emit an actionable error; no restart-time parser blacklist is
+required.
+
+The ADR remains `proposed`.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage3-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage3-measurement.md
@@ -25,8 +25,8 @@ captures, semantic tokens, or node identities.
 The committed result is
 `benches/profile/results/single_worker_stage3_shadow_2026-07-19.json`. The
 release binary was built from commit
-`946de588c3928136138afb112200d6cf34af0da3` and has SHA-256
-`8584e64bfb38d8548221d5f5fc3c4d3a086530697a153b4a8b193fb51a885ac1`.
+`9f6d7a50e44f30b445c7232604904dc68a7d2868` and has SHA-256
+`a6ee0ac80a97c814259a4c8855dc195332b4cab1a5faf34077d025818c577657`.
 The run used an Apple M4, macOS 26.5.1, Rust 1.95.0, and four worker compute
 threads.
 
@@ -52,23 +52,24 @@ comparisons at shutdown.
 
 | Batch and order | Disabled ms/cycle | Shadow ms/cycle | Shadow wall delta |
 |---|---:|---:|---:|
-| A, disabled first | 71.04 | 77.01 | +8.40% |
-| B, shadow first | 67.80 | 76.66 | +13.08% |
+| A, disabled first | 76.41 | 81.68 | +6.89% |
+| B, shadow first | 68.71 | 74.02 | +7.72% |
 
 | Batch | Disabled p50 / p90 / p95 / p99 | Shadow p50 / p90 / p95 / p99 | Shadow p50 delta |
 |---|---:|---:|---:|
-| A | 52.0 / 56.6 / 57.6 / 61.2 ms | 59.1 / 64.5 / 67.0 / 68.6 ms | +13.65% |
-| B | 50.3 / 53.0 / 54.2 / 57.0 ms | 57.7 / 65.4 / 67.5 / 73.6 ms | +14.71% |
+| A | 57.5 / 62.0 / 63.5 / 67.8 ms | 62.9 / 68.3 / 71.3 / 74.6 ms | +9.39% |
+| B | 49.2 / 51.8 / 54.0 / 57.7 ms | 55.6 / 60.7 / 63.4 / 66.5 ms | +13.01% |
 
 Reversing execution order did not reverse the result. Continuous shadow parsing
-cost 8.4--13.1% wall time and 13.7--14.7% at p50 in this single-document
-edit-and-token workload. The p90--p99 deltas ranged from 12.1% to 29.1%.
+cost 6.9--7.7% wall time and 9.4--13.0% at p50 in this single-document
+edit-and-token workload. The p90--p99 deltas ranged from 10.0% to 17.4%.
 Batch B's disabled baseline was faster than batch A's, so the range includes
 temporal/system variation rather than isolating one fixed shadow cost.
 
 This final run includes review-driven allocation removal, exact parser/query
-generation fencing, per-URI open-incarnation admission, and atomic comparison
-lifecycle state. Those correctness checks are part of the measured hot path.
+generation fencing, per-URI open-incarnation admission, atomic comparison
+lifecycle state, and bounded actor drain before the final summary. Those
+correctness checks are part of the measured hot path.
 Earlier exploratory runs had lower overhead after allocation removal, but they
 predated the final lifecycle fences and are not retained as acceptance evidence.
 
@@ -83,22 +84,26 @@ the authoritative result.
 ## Reproduction
 
 ```sh
-cargo build --release --locked --bin kakehashi
-shasum -a 256 target/release/kakehashi
+python3 benches/profile/attest_worker_binary.py \
+  --checkout . \
+  --output benches/profile/results/single_worker_stage3_binary_attestation_2026-07-19.json
 
-KAKEHASHI_TREE_WORKER_SHADOW=true \
-KAKEHASHI_TREE_WORKER_THREADS=4 \
-RUST_LOG=kakehashi::tree_worker_shadow=info,kakehashi::tree_worker_shadow_metrics=info \
-python3 benches/profile/drive.py \
+# Prepare DATA_DIR from one fixed nvim-treesitter checkout as in the Phase 0
+# procedure, including byte-identical parsers.lua and runtime/queries files.
+python3 benches/profile/collect_worker_shadow.py \
   --bin ./target/release/kakehashi \
-  --lang rust --size 200 --requests 200 --edits 1 \
-  --warm-semantic-cache --settle 0.5 \
-  --data-dir deps/test/kakehashi
-
-# Repeat without KAKEHASHI_TREE_WORKER_SHADOW, then repeat the pair in the
-# opposite order. Use isolated but identical XDG_CONFIG_HOME and XDG_STATE_HOME
-# directories for every run.
+  --binary-attestation benches/profile/results/single_worker_stage3_binary_attestation_2026-07-19.json \
+  --data-dir "$DATA_DIR" \
+  --nvim-treesitter-checkout "$NVIM_TREESITTER_CHECKOUT" \
+  --batches 2 --worker-threads 4 \
+  --output benches/profile/results/single_worker_stage3_shadow_2026-07-19.json
 ```
+
+The collector alternates order, explicitly sets shadow to `false` for control,
+creates a fresh empty `XDG_CONFIG_HOME` and `XDG_STATE_HOME` for every variant,
+requires a complete drained comparison summary, and writes the batches,
+deltas, binary attestation, runtime provenance, and harness hashes directly to
+the committed JSON.
 
 ## Consequence for Stage 3
 

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage3-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage3-measurement.md
@@ -25,8 +25,8 @@ captures, semantic tokens, or node identities.
 The committed result is
 `benches/profile/results/single_worker_stage3_shadow_2026-07-19.json`. The
 release binary was built from commit
-`900077461aa0d740baef65bca28560c4a1a18b8b` and has SHA-256
-`9469eb77490b348c579595dc08b009699556d4f1a0571176313a1207cd4b138b`.
+`fadac25333af6238903de043022f2a376c2c490d` and has SHA-256
+`29e0509e40c90337a157753bda6c8a165cfaeea1419b70bceffffb033e43dced`.
 The run used an Apple M4, macOS 26.5.1, Rust 1.95.0, and four worker compute
 threads.
 
@@ -52,18 +52,21 @@ comparisons at shutdown.
 
 | Batch and order | Disabled ms/cycle | Shadow ms/cycle | Shadow wall delta |
 |---|---:|---:|---:|
-| A, disabled first | 73.63 | 79.13 | +7.46% |
-| B, shadow first | 83.38 | 90.66 | +8.73% |
+| A, disabled first | 70.16 | 75.62 | +7.78% |
+| B, shadow first | 70.83 | 76.09 | +7.42% |
 
 | Batch | Disabled p50 / p90 / p95 / p99 | Shadow p50 / p90 / p95 / p99 | Shadow p50 delta |
 |---|---:|---:|---:|
-| A | 52.9 / 60.3 / 63.3 / 68.9 ms | 59.6 / 65.7 / 67.3 / 73.5 ms | +12.67% |
-| B | 62.0 / 70.8 / 75.0 / 79.0 ms | 70.6 / 77.3 / 79.5 / 85.1 ms | +13.87% |
+| A | 51.6 / 55.7 / 57.2 / 61.2 ms | 57.1 / 64.7 / 67.7 / 73.2 ms | +10.66% |
+| B | 52.6 / 57.8 / 59.5 / 62.7 ms | 57.2 / 65.5 / 68.0 / 73.5 ms | +8.75% |
 
-Absolute latency shifted between batches, but reversing execution order did not
-reverse the result. Continuous shadow parsing cost about 7.5--8.7% wall time
-and 12.7--13.9% at p50 in this single-document edit-and-token workload. Tail
-deltas were smaller but remained positive at p90 through p99 in both batches.
+Reversing execution order did not reverse the result. Continuous shadow parsing
+cost about 7.4--7.8% wall time and 8.8--10.7% at p50 in this single-document
+edit-and-token workload. The p90--p99 deltas were 13.3--19.6% in both batches.
+This final run includes the review-driven replacement of per-node traversal
+allocation with one `TreeCursor` on both paths, plus borrowed-key lookup for
+existing comparison entries. Those changes reduced p50 overhead from the
+earlier exploratory 12.7--13.9%, but did not remove duplicate-parse contention.
 
 This does not imply that the eventual worker-authoritative design is slower by
 the same amount. Shadow mode deliberately performs both the legacy parse and

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage3-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage3-measurement.md
@@ -25,7 +25,7 @@ captures, semantic tokens, or node identities.
 The committed result is
 `benches/profile/results/single_worker_stage3_shadow_2026-07-19.json`. The
 release binary was built from commit
-`7f0d8039c29209a9c67fc98f84fe0d9e96c62c2a` and has SHA-256
+`900077461aa0d740baef65bca28560c4a1a18b8b` and has SHA-256
 `9469eb77490b348c579595dc08b009699556d4f1a0571176313a1207cd4b138b`.
 The run used an Apple M4, macOS 26.5.1, Rust 1.95.0, and four worker compute
 threads.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1117,6 +1117,11 @@ records a preliminary raw-relay estimate for an additional resident
 child-process transport hop. It is not a worker prototype result or a bound on
 the future protocol, and it does not change this decision's `proposed` status.
 
+The [Stage 3 shadow measurement](single-resident-multithreaded-tree-worker-stage3-measurement.md)
+records real LSP lifecycle comparison and the foreground cost of running both
+the authoritative and worker parse for every edit. It validates the comparison
+path, not the performance of a worker-authoritative cutover.
+
 The implementation should proceed in measured stages:
 
 1. Prototype the framed transport, supervision, and one high-level

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -112,6 +112,13 @@ pub(crate) struct LanguageCoordinator {
     load_inflight: dashmap::DashMap<String, Arc<tokio::sync::Notify>>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct WorkerGrammarDescriptor {
+    pub(crate) parser_path: PathBuf,
+    pub(crate) grammar_symbol: String,
+    pub(crate) configuration_generation: u64,
+}
+
 impl Default for LanguageCoordinator {
     fn default() -> Self {
         Self::new()
@@ -1741,6 +1748,42 @@ impl LanguageCoordinator {
     pub(crate) fn search_paths(&self) -> Vec<std::path::PathBuf> {
         self.config_store.search_paths()
     }
+
+    /// Resolve the dynamic grammar identity the isolated tree worker must load.
+    /// Derived languages that share a base parser use the base export symbol;
+    /// standalone derived parsers retain their own symbol.
+    pub(crate) fn worker_grammar_descriptor(
+        &self,
+        language_id: &str,
+        settings: &WorkspaceSettings,
+    ) -> Option<WorkerGrammarDescriptor> {
+        let grammar_symbol = self
+            .resolve_base(language_id)
+            .unwrap_or_else(|| language_id.to_string());
+        let parser_config = settings
+            .languages
+            .get(&grammar_symbol)
+            .and_then(|language| language.parser.as_deref());
+        let parser_path = QueryLoader::resolve_library_path(
+            parser_config,
+            &grammar_symbol,
+            &self.config_store.search_paths(),
+        )?;
+        Some(WorkerGrammarDescriptor {
+            parser_path: parser_path
+                .canonicalize()
+                .unwrap_or_else(|_| parser_path.clone()),
+            grammar_symbol,
+            configuration_generation: self
+                .load_generation
+                .load(std::sync::atomic::Ordering::Acquire),
+        })
+    }
+
+    pub(crate) fn configuration_generation(&self) -> u64 {
+        self.load_generation
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
 }
 
 /// Truncate a pattern string for display in log messages.
@@ -1773,6 +1816,39 @@ mod tests {
     use crate::config::settings::RawWorkspaceSettings;
     use std::fs;
     use tempfile::tempdir;
+
+    #[test]
+    fn worker_grammar_descriptor_uses_shared_base_parser_identity() {
+        let coordinator = LanguageCoordinator::new();
+        let parser_path = "/nonexistent/tree-sitter-markdown.so";
+        let settings = WorkspaceSettings {
+            languages: HashMap::from([
+                (
+                    "markdown".to_string(),
+                    LanguageSettings {
+                        parser: Some(parser_path.to_string()),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "rmd".to_string(),
+                    LanguageSettings {
+                        base: Some("markdown".to_string()),
+                        ..Default::default()
+                    },
+                ),
+            ]),
+            ..Default::default()
+        };
+        coordinator.build_base_map(&settings.languages);
+
+        let descriptor = coordinator
+            .worker_grammar_descriptor("rmd", &settings)
+            .unwrap();
+
+        assert_eq!(descriptor.grammar_symbol, "markdown");
+        assert_eq!(descriptor.parser_path, PathBuf::from(parser_path));
+    }
 
     /// Pins the #575 single-flight fix: a caller that arrives while another
     /// caller already claimed the in-flight marker for a language must PARK

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1533,6 +1533,23 @@ impl LanguageCoordinator {
         self.query_store().bindings_query(lang_name)
     }
 
+    pub(crate) fn bindings_query_versioned(
+        &self,
+        lang_name: &str,
+    ) -> (u64, Option<Arc<tree_sitter::Query>>) {
+        use crate::error::LockResultExt;
+
+        let _reload = self
+            .settings_reload_lock
+            .lock()
+            .recover_poison("LanguageCoordinator::bindings_query_versioned");
+        (
+            self.load_generation
+                .load(std::sync::atomic::Ordering::Acquire),
+            self.query_store().bindings_query(lang_name),
+        )
+    }
+
     /// Get capture mappings.
     ///
     /// Visibility: pub(crate) - called by LSP layer (semantic_tokens) and analysis

--- a/src/language/parser_pool.rs
+++ b/src/language/parser_pool.rs
@@ -32,11 +32,12 @@ pub struct DocumentParserPool {
     /// Factory for creating new parsers
     factory: ParserFactory,
     generation: u64,
+    configuration_generation: u64,
     reload_depth: usize,
 }
 
 pub(crate) enum ParserCheckout {
-    Acquired(Parser, u64),
+    Acquired(Parser, u64, u64),
     Reloading,
     Unavailable,
 }
@@ -48,6 +49,7 @@ impl DocumentParserPool {
             available: HashMap::new(),
             factory,
             generation: 0,
+            configuration_generation: 0,
             reload_depth: 0,
         }
     }
@@ -58,8 +60,9 @@ impl DocumentParserPool {
         self.reload_depth = self.reload_depth.saturating_add(1);
     }
 
-    pub(crate) fn finish_reload(&mut self) {
+    pub(crate) fn finish_reload_at(&mut self, configuration_generation: u64) {
         self.generation = self.generation.wrapping_add(1);
+        self.configuration_generation = configuration_generation;
         self.available.clear();
         self.reload_depth = self.reload_depth.saturating_sub(1);
     }
@@ -70,7 +73,9 @@ impl DocumentParserPool {
         }
         let generation = self.generation;
         match self.acquire(language_id) {
-            Some(parser) => ParserCheckout::Acquired(parser, generation),
+            Some(parser) => {
+                ParserCheckout::Acquired(parser, generation, self.configuration_generation)
+            }
             None => ParserCheckout::Unavailable,
         }
     }
@@ -168,5 +173,22 @@ mod tests {
         let parser2 = pool.acquire("rust");
         assert!(parser2.is_some());
         assert_eq!(pool.pool_size("rust"), 0);
+    }
+
+    #[test]
+    fn versioned_checkout_carries_the_reload_configuration_generation() {
+        let language_registry = create_test_language_registry();
+        let factory = ParserFactory::new(language_registry);
+        let mut pool = DocumentParserPool::new(factory);
+        pool.begin_reload();
+        pool.finish_reload_at(42);
+
+        let ParserCheckout::Acquired(_, _, configuration_generation) =
+            pool.acquire_versioned("rust")
+        else {
+            panic!("parser must be available after reload");
+        };
+
+        assert_eq!(configuration_generation, 42);
     }
 }

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -10,6 +10,7 @@ mod region_offset;
 mod show_document_translation;
 mod snapshot_read;
 pub(crate) mod text_document;
+mod tree_worker_shadow;
 mod whole_document;
 mod workspace;
 
@@ -404,6 +405,9 @@ pub struct Kakehashi {
     /// the ingress writer ticket, coalescing bursts to one reparse over the latest
     /// text. Shared (`Arc`) with the spawned parse loops.
     parse_scheduler: std::sync::Arc<parse_scheduler::ParseScheduler>,
+    /// Non-authoritative, opt-in mirror of document parser state in one
+    /// process-isolated worker. Queue failure disables only this shadow path.
+    tree_worker_shadow: tree_worker_shadow::TreeWorkerShadow,
 }
 
 impl std::fmt::Debug for Kakehashi {
@@ -482,6 +486,7 @@ impl Kakehashi {
             cli_mode: std::sync::atomic::AtomicBool::new(false),
             experimental: std::sync::atomic::AtomicBool::new(crate::experimental::enabled()),
             parse_scheduler: std::sync::Arc::new(parse_scheduler::ParseScheduler::default()),
+            tree_worker_shadow: tree_worker_shadow::TreeWorkerShadow::from_environment(),
         }
     }
 

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -1128,7 +1128,7 @@ mod tests {
         let parsed = service
             .inner()
             .parse_coordinator()
-            .parse_with_pool(
+            .parse_with_pool_versioned(
                 "test",
                 &url::Url::parse("file:///reload-race.test").unwrap(),
                 0,
@@ -1146,7 +1146,11 @@ mod tests {
             )
             .await;
 
-        assert_eq!(parsed, Some(2), "only the current-generation parse lands");
+        assert_eq!(
+            parsed,
+            Some((2, 1)),
+            "only the current-generation parse lands"
+        );
         assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 
@@ -1205,7 +1209,7 @@ mod tests {
         let parsed = service
             .inner()
             .parse_coordinator()
-            .parse_with_pool(
+            .parse_with_pool_versioned(
                 "test",
                 &url::Url::parse("file:///stuck-reload.test").unwrap(),
                 0,

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -124,15 +124,22 @@ pub(super) async fn lock_settings_reload() -> tokio::sync::MutexGuard<'static, (
 
 struct ParserReloadGuard<'a> {
     parser_pool: &'a std::sync::Mutex<DocumentParserPool>,
+    language: &'a LanguageCoordinator,
 }
 
 impl<'a> ParserReloadGuard<'a> {
-    fn begin(parser_pool: &'a std::sync::Mutex<DocumentParserPool>) -> Self {
+    fn begin(
+        parser_pool: &'a std::sync::Mutex<DocumentParserPool>,
+        language: &'a LanguageCoordinator,
+    ) -> Self {
         parser_pool
             .lock()
             .recover_poison("ParserReloadGuard::begin")
             .begin_reload();
-        Self { parser_pool }
+        Self {
+            parser_pool,
+            language,
+        }
     }
 }
 
@@ -141,7 +148,7 @@ impl Drop for ParserReloadGuard<'_> {
         self.parser_pool
             .lock()
             .recover_poison("ParserReloadGuard::drop")
-            .finish_reload();
+            .finish_reload_at(self.language.configuration_generation());
     }
 }
 
@@ -194,7 +201,8 @@ pub(super) async fn apply_shared_settings_locked(
     // built MID-swap against a half-updated query set.
     cache.bump_semantic_token_generation();
     crate::analysis::semantic::invalidate_thread_local_parser_caches();
-    let parser_reload = ParserReloadGuard::begin(language_state.parser_pool);
+    let parser_reload =
+        ParserReloadGuard::begin(language_state.parser_pool, language_state.language);
     let mut summary = language_state.language.load_settings(&settings);
     let reparse_uris = if language_state.invalidate_documents {
         language_state.documents.invalidate_all_parses()
@@ -1063,7 +1071,7 @@ mod tests {
             let mut pool = service.inner().parser_pool.lock().unwrap();
             pool.release("stale".to_string(), tree_sitter::Parser::new());
             match pool.acquire_versioned("stale") {
-                crate::language::parser_pool::ParserCheckout::Acquired(parser, generation) => {
+                crate::language::parser_pool::ParserCheckout::Acquired(parser, generation, _) => {
                     (parser, generation)
                 }
                 _ => panic!("precondition: stale parser is available"),
@@ -1130,7 +1138,7 @@ mod tests {
                     if call == 0 {
                         let mut pool = parser_pool.lock().unwrap();
                         pool.begin_reload();
-                        pool.finish_reload();
+                        pool.finish_reload_at(1);
                         pool.release("test".to_string(), tree_sitter::Parser::new());
                     }
                     (parser, Some(call + 1))
@@ -1157,7 +1165,7 @@ mod tests {
             ),
             "no parser checkout may start inside the reload window"
         );
-        pool.finish_reload();
+        pool.finish_reload_at(1);
         assert!(
             matches!(
                 pool.acquire_versioned("test"),
@@ -1165,11 +1173,11 @@ mod tests {
             ),
             "one reload finishing must not close an overlapping reload window"
         );
-        pool.finish_reload();
+        pool.finish_reload_at(1);
         pool.release("test".to_string(), tree_sitter::Parser::new());
         assert!(matches!(
             pool.acquire_versioned("test"),
-            crate::language::parser_pool::ParserCheckout::Acquired(_, _)
+            crate::language::parser_pool::ParserCheckout::Acquired(_, _, _)
         ));
     }
 
@@ -1177,10 +1185,10 @@ mod tests {
     fn parser_reload_guard_finishes_reload_during_unwind() {
         let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
         let parser_pool = &service.inner().parser_pool;
-        let unwind = std::panic::catch_unwind(|| {
-            let _reload = ParserReloadGuard::begin(parser_pool);
+        let unwind = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _reload = ParserReloadGuard::begin(parser_pool, &service.inner().language);
             panic!("simulate reload failure");
-        });
+        }));
 
         assert!(unwind.is_err());
         assert!(!matches!(
@@ -1205,7 +1213,12 @@ mod tests {
             )
             .await;
 
-        service.inner().parser_pool.lock().unwrap().finish_reload();
+        service
+            .inner()
+            .parser_pool
+            .lock()
+            .unwrap()
+            .finish_reload_at(1);
         assert_eq!(parsed, None);
     }
 

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -407,7 +407,7 @@ pub struct Kakehashi {
     parse_scheduler: std::sync::Arc<parse_scheduler::ParseScheduler>,
     /// Non-authoritative, opt-in mirror of document parser state in one
     /// process-isolated worker. Queue failure disables only this shadow path.
-    tree_worker_shadow: tree_worker_shadow::TreeWorkerShadow,
+    tree_worker_shadow: std::sync::Arc<tree_worker_shadow::TreeWorkerShadow>,
 }
 
 impl std::fmt::Debug for Kakehashi {
@@ -486,7 +486,9 @@ impl Kakehashi {
             cli_mode: std::sync::atomic::AtomicBool::new(false),
             experimental: std::sync::atomic::AtomicBool::new(crate::experimental::enabled()),
             parse_scheduler: std::sync::Arc::new(parse_scheduler::ParseScheduler::default()),
-            tree_worker_shadow: tree_worker_shadow::TreeWorkerShadow::from_environment(),
+            tree_worker_shadow: std::sync::Arc::new(
+                tree_worker_shadow::TreeWorkerShadow::from_environment(),
+            ),
         }
     }
 

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -35,6 +35,7 @@ pub(crate) struct InjectionCoordinator {
     auto_install: AutoInstallManager,
     bridge: std::sync::Arc<BridgeCoordinator>,
     diagnostics: std::sync::Arc<DiagnosticAggregator>,
+    tree_worker_shadow: std::sync::Arc<crate::lsp::lsp_impl::tree_worker_shadow::TreeWorkerShadow>,
 }
 
 impl InjectionCoordinator {
@@ -50,6 +51,7 @@ impl InjectionCoordinator {
             auto_install: server.auto_install.clone(),
             bridge: std::sync::Arc::clone(&server.bridge),
             diagnostics: std::sync::Arc::clone(&server.diagnostics),
+            tree_worker_shadow: std::sync::Arc::clone(&server.tree_worker_shadow),
         }
     }
 
@@ -459,6 +461,7 @@ impl InjectionCoordinator {
             settings_manager: std::sync::Arc::clone(&self.settings_manager),
             auto_install: self.auto_install.clone(),
             bridge: std::sync::Arc::clone(&self.bridge),
+            tree_worker_shadow: std::sync::Arc::clone(&self.tree_worker_shadow),
         })
     }
 }

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -50,6 +50,8 @@ pub(super) struct InstallCoordinatorDeps {
     pub(super) settings_manager: std::sync::Arc<SettingsManager>,
     pub(super) auto_install: AutoInstallManager,
     pub(super) bridge: std::sync::Arc<BridgeCoordinator>,
+    pub(super) tree_worker_shadow:
+        std::sync::Arc<crate::lsp::lsp_impl::tree_worker_shadow::TreeWorkerShadow>,
 }
 
 pub(crate) struct InstallCoordinator {
@@ -62,6 +64,7 @@ pub(crate) struct InstallCoordinator {
     settings_manager: std::sync::Arc<SettingsManager>,
     auto_install: AutoInstallManager,
     bridge: std::sync::Arc<BridgeCoordinator>,
+    tree_worker_shadow: std::sync::Arc<crate::lsp::lsp_impl::tree_worker_shadow::TreeWorkerShadow>,
 }
 
 impl InstallCoordinator {
@@ -76,6 +79,7 @@ impl InstallCoordinator {
             settings_manager: std::sync::Arc::clone(&server.settings_manager),
             auto_install: server.auto_install.clone(),
             bridge: std::sync::Arc::clone(&server.bridge),
+            tree_worker_shadow: std::sync::Arc::clone(&server.tree_worker_shadow),
         })
     }
 
@@ -90,6 +94,7 @@ impl InstallCoordinator {
             settings_manager: deps.settings_manager,
             auto_install: deps.auto_install,
             bridge: deps.bridge,
+            tree_worker_shadow: deps.tree_worker_shadow,
         }
     }
 
@@ -395,6 +400,7 @@ impl InstallCoordinator {
             settings_manager: std::sync::Arc::clone(&self.settings_manager),
             auto_install: self.auto_install.clone(),
             bridge: std::sync::Arc::clone(&self.bridge),
+            tree_worker_shadow: std::sync::Arc::clone(&self.tree_worker_shadow),
         })
     }
 }

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -48,7 +48,7 @@ const RELOAD_WAIT_BACKSTOP: std::time::Duration = PARSE_TIMEOUT;
 /// [`parse_with_deadline`](crate::language::injection::parse_with_deadline)
 /// primitive under the name the parse-loop call sites use.
 ///
-/// `parse_with_pool`'s `tokio::time::timeout` only abandons the *awaiter*;
+/// `parse_with_pool_versioned`'s `tokio::time::timeout` only abandons the *awaiter*;
 /// the in-parse abort is what actually reclaims the bounded-pool thread from
 /// a pathological parse (see the primitive's doc).
 fn parse_text_with_deadline(
@@ -168,25 +168,7 @@ impl ParseCoordinator {
     /// - Settings changed during both the initial parse and its one retry, so
     ///   neither result belongs to the current parser generation
     /// - The closure returned `None`
-    pub(crate) async fn parse_with_pool<T, F>(
-        &self,
-        language_name: &str,
-        uri: &Url,
-        text_len: usize,
-        parse_fn: F,
-    ) -> Option<T>
-    where
-        F: FnMut(tree_sitter::Parser, std::time::Instant, bool) -> (tree_sitter::Parser, Option<T>)
-            + Send
-            + 'static,
-        T: Send + 'static,
-    {
-        self.parse_with_pool_versioned(language_name, uri, text_len, parse_fn)
-            .await
-            .map(|(value, _generation)| value)
-    }
-
-    async fn parse_with_pool_versioned<T, F>(
+    pub(crate) async fn parse_with_pool_versioned<T, F>(
         &self,
         language_name: &str,
         uri: &Url,
@@ -213,7 +195,7 @@ impl ParseCoordinator {
                     let (parser, parser_generation, configuration_generation) = loop {
                         match parser_pool
                             .lock()
-                            .recover_poison("ParseCoordinator::parse_with_pool(acquire)")
+                            .recover_poison("ParseCoordinator::parse_with_pool_versioned(acquire)")
                             .acquire_versioned(&language_name_owned)
                         {
                             crate::language::parser_pool::ParserCheckout::Acquired(
@@ -248,7 +230,7 @@ impl ParseCoordinator {
                     let (parser, value) = parse_fn(parser, deadline, attempt != 0);
                     match parser_pool
                         .lock()
-                        .recover_poison("ParseCoordinator::parse_with_pool(release)")
+                        .recover_poison("ParseCoordinator::parse_with_pool_versioned(release)")
                         .release_versioned(language_name_owned, parser, parser_generation)
                     {
                         Ok(()) => {

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -210,7 +210,7 @@ impl ParseCoordinator {
                 let mut language_name_owned = language_name_owned;
                 for attempt in 0..2 {
                     let reload_wait_deadline = std::time::Instant::now() + RELOAD_WAIT_BACKSTOP;
-                    let (parser, parser_generation) = loop {
+                    let (parser, parser_generation, configuration_generation) = loop {
                         match parser_pool
                             .lock()
                             .recover_poison("ParseCoordinator::parse_with_pool(acquire)")
@@ -219,7 +219,8 @@ impl ParseCoordinator {
                             crate::language::parser_pool::ParserCheckout::Acquired(
                                 parser,
                                 generation,
-                            ) => break (parser, generation),
+                                configuration_generation,
+                            ) => break (parser, generation, configuration_generation),
                             crate::language::parser_pool::ParserCheckout::Reloading => {
                                 // A reload is synchronous and normally brief. Keep this
                                 // transient state inside the bounded work unit instead
@@ -251,7 +252,7 @@ impl ParseCoordinator {
                         .release_versioned(language_name_owned, parser, parser_generation)
                     {
                         Ok(()) => {
-                            return value.map(|value| (value, parser_generation));
+                            return value.map(|value| (value, configuration_generation));
                         }
                         Err(stale_language_name) => {
                             language_name_owned = stale_language_name;

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -181,6 +181,24 @@ impl ParseCoordinator {
             + 'static,
         T: Send + 'static,
     {
+        self.parse_with_pool_versioned(language_name, uri, text_len, parse_fn)
+            .await
+            .map(|(value, _generation)| value)
+    }
+
+    async fn parse_with_pool_versioned<T, F>(
+        &self,
+        language_name: &str,
+        uri: &Url,
+        text_len: usize,
+        parse_fn: F,
+    ) -> Option<(T, u64)>
+    where
+        F: FnMut(tree_sitter::Parser, std::time::Instant, bool) -> (tree_sitter::Parser, Option<T>)
+            + Send
+            + 'static,
+        T: Send + 'static,
+    {
         use crate::error::LockResultExt;
 
         let parser_pool = std::sync::Arc::clone(&self.parser_pool);
@@ -232,7 +250,9 @@ impl ParseCoordinator {
                         .recover_poison("ParseCoordinator::parse_with_pool(release)")
                         .release_versioned(language_name_owned, parser, parser_generation)
                     {
-                        Ok(()) => return value,
+                        Ok(()) => {
+                            return value.map(|value| (value, parser_generation));
+                        }
                         Err(stale_language_name) => {
                             language_name_owned = stale_language_name;
                         }
@@ -565,7 +585,7 @@ impl ParseCoordinator {
             let language_name_clone = language_name.clone();
 
             let parsed_tree = if load_result.success {
-                self.parse_with_pool(
+                self.parse_with_pool_versioned(
                     &language_name,
                     &uri,
                     text.len(),
@@ -582,7 +602,7 @@ impl ParseCoordinator {
                 None
             };
 
-            if let Some(tree) = parsed_tree {
+            if let Some((tree, configuration_generation)) = parsed_tree {
                 // Legacy tree CAS BEFORE the snapshot publish: a legacy-store
                 // reader woken by the publish (the explicit-action waiters
                 // read `doc.snapshot()` after `wait_for_current_snapshot`)
@@ -619,7 +639,7 @@ impl ParseCoordinator {
                         incarnation,
                         content_version,
                         &language_name,
-                        self.language.configuration_generation(),
+                        configuration_generation,
                         &tree,
                     );
                     self.populate_injections_on_pool(
@@ -859,7 +879,7 @@ impl ParseCoordinator {
             // document text is never copied.
             let text_for_parse = text.clone();
             let parsed = self
-                .parse_with_pool(
+                .parse_with_pool_versioned(
                     &language_name,
                     &uri,
                     text_len,
@@ -873,7 +893,9 @@ impl ParseCoordinator {
                 )
                 .await;
 
-            let Some(tree) = parsed else { break };
+            let Some((tree, configuration_generation)) = parsed else {
+                break;
+            };
 
             // Persist FIRST through the non-inserting, tree-absent CAS —
             // before the snapshot publish, so a legacy-store reader the
@@ -904,7 +926,7 @@ impl ParseCoordinator {
                     expected_incarnation,
                     content_version,
                     &language_name,
-                    self.language.configuration_generation(),
+                    configuration_generation,
                     &tree,
                 );
                 self.populate_injections_on_pool(
@@ -1070,7 +1092,7 @@ impl ParseCoordinator {
         // (`didChange` → `apply_edit_and_seed`), satisfying tree-sitter's contract.
         let text_for_parse = text.clone();
         let parsed = self
-            .parse_with_pool(
+            .parse_with_pool_versioned(
                 &language_name,
                 uri,
                 text_len,
@@ -1093,7 +1115,7 @@ impl ParseCoordinator {
             .await;
 
         let mut events = load_result.events;
-        if let Some(tree) = parsed {
+        if let Some((tree, configuration_generation)) = parsed {
             // Legacy tree CAS BEFORE the snapshot publish (see the
             // parse_document ordering note): a legacy-store reader woken by
             // the publish must find the tree already attached. Text +
@@ -1124,7 +1146,7 @@ impl ParseCoordinator {
                     incarnation,
                     content_version,
                     &language_name,
-                    self.language.configuration_generation(),
+                    configuration_generation,
                     &tree,
                 );
                 self.populate_injections_on_pool(

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -92,6 +92,8 @@ pub(super) struct ParseCoordinatorDeps {
     pub(super) settings_manager: std::sync::Arc<SettingsManager>,
     pub(super) auto_install: AutoInstallManager,
     pub(super) bridge: std::sync::Arc<BridgeCoordinator>,
+    pub(super) tree_worker_shadow:
+        std::sync::Arc<crate::lsp::lsp_impl::tree_worker_shadow::TreeWorkerShadow>,
 }
 
 pub(crate) struct ParseCoordinator {
@@ -104,6 +106,7 @@ pub(crate) struct ParseCoordinator {
     settings_manager: std::sync::Arc<SettingsManager>,
     auto_install: AutoInstallManager,
     bridge: std::sync::Arc<BridgeCoordinator>,
+    tree_worker_shadow: std::sync::Arc<crate::lsp::lsp_impl::tree_worker_shadow::TreeWorkerShadow>,
 }
 
 impl ParseCoordinator {
@@ -118,6 +121,7 @@ impl ParseCoordinator {
             settings_manager: std::sync::Arc::clone(&server.settings_manager),
             auto_install: server.auto_install.clone(),
             bridge: std::sync::Arc::clone(&server.bridge),
+            tree_worker_shadow: std::sync::Arc::clone(&server.tree_worker_shadow),
         })
     }
 
@@ -132,6 +136,7 @@ impl ParseCoordinator {
             settings_manager: deps.settings_manager,
             auto_install: deps.auto_install,
             bridge: deps.bridge,
+            tree_worker_shadow: deps.tree_worker_shadow,
         }
     }
 
@@ -609,6 +614,13 @@ impl ParseCoordinator {
                 // populate — the snapshot then publishes without discovery and
                 // readers discover inline for that (already-superseded) snapshot.
                 let regions = if stored {
+                    self.tree_worker_shadow.record_authoritative(
+                        &uri,
+                        incarnation,
+                        content_version,
+                        &language_name,
+                        &tree,
+                    );
                     self.populate_injections_on_pool(
                         uri.clone(),
                         text.clone(),
@@ -886,6 +898,13 @@ impl ParseCoordinator {
             // out-of-order version at publish. A rejected CAS skips populate —
             // the snapshot still publishes as stale-but-consistent.
             let regions = if stored {
+                self.tree_worker_shadow.record_authoritative(
+                    &uri,
+                    expected_incarnation,
+                    content_version,
+                    &language_name,
+                    &tree,
+                );
                 self.populate_injections_on_pool(
                     uri.clone(),
                     text.clone(),
@@ -1098,6 +1117,13 @@ impl ParseCoordinator {
             // publishes as stale-but-consistent (its readers discover inline;
             // the scheduler's dirty loop is already reparsing the newer text).
             let regions = if stored {
+                self.tree_worker_shadow.record_authoritative(
+                    uri,
+                    incarnation,
+                    content_version,
+                    &language_name,
+                    &tree,
+                );
                 self.populate_injections_on_pool(
                     uri.clone(),
                     text.clone(),

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -619,6 +619,7 @@ impl ParseCoordinator {
                         incarnation,
                         content_version,
                         &language_name,
+                        self.language.configuration_generation(),
                         &tree,
                     );
                     self.populate_injections_on_pool(
@@ -903,6 +904,7 @@ impl ParseCoordinator {
                     expected_incarnation,
                     content_version,
                     &language_name,
+                    self.language.configuration_generation(),
                     &tree,
                 );
                 self.populate_injections_on_pool(
@@ -1122,6 +1124,7 @@ impl ParseCoordinator {
                     incarnation,
                     content_version,
                     &language_name,
+                    self.language.configuration_generation(),
                     &tree,
                 );
                 self.populate_injections_on_pool(

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -404,7 +404,7 @@ impl ParseCoordinator {
             .is_enabled()
             .then_some(configuration_generation);
         let shadow_uri = uri.clone();
-        let populated = self
+        let mut populated = self
             .compute_pool
             .run(None, move || {
                 let shadow_summary = shadow_generation.map(|generation| {
@@ -450,7 +450,7 @@ impl ParseCoordinator {
             })
             .await
             .unwrap_or_default();
-        if let Some(summary) = populated.shadow_summary.clone() {
+        if let Some(summary) = populated.shadow_summary.take() {
             self.tree_worker_shadow.record_authoritative_summary(
                 &shadow_uri,
                 incarnation,

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -25,6 +25,14 @@ struct PopulatedSnapshotRegions {
         u64,
         std::sync::Arc<Vec<crate::language::injection::ResolvedInjection>>,
     )>,
+    shadow_summary: Option<super::super::tree_worker_shadow::TreeSummary>,
+}
+
+#[derive(Clone, Copy)]
+struct ShadowParseContext {
+    incarnation: u64,
+    content_version: u64,
+    configuration_generation: u64,
 }
 
 /// Timeout for compute-pool parse operations to prevent hangs on pathological inputs.
@@ -325,9 +333,13 @@ impl ParseCoordinator {
         text: std::sync::Arc<str>,
         tree: tree_sitter::Tree,
         language_name: String,
-        incarnation: u64,
-        content_version: u64,
+        shadow_context: ShadowParseContext,
     ) -> PopulatedSnapshotRegions {
+        let ShadowParseContext {
+            incarnation,
+            content_version,
+            configuration_generation,
+        } = shadow_context;
         let cache = std::sync::Arc::clone(&self.cache);
         let language = std::sync::Arc::clone(&self.language);
         let tracker = self.bridge.node_tracker_arc();
@@ -387,8 +399,21 @@ impl ParseCoordinator {
             .settings_manager
             .load_settings()
             .any_bridge_server_runnable();
-        self.compute_pool
+        let shadow_generation = self
+            .tree_worker_shadow
+            .is_enabled()
+            .then_some(configuration_generation);
+        let shadow_uri = uri.clone();
+        let populated = self
+            .compute_pool
             .run(None, move || {
+                let shadow_summary = shadow_generation.map(|generation| {
+                    super::super::tree_worker_shadow::TreeSummary::from_tree(
+                        &language_name,
+                        generation,
+                        &tree,
+                    )
+                });
                 // A refused pass (`None`) maps to all-`None` region fields —
                 // the snapshot then rides WITHOUT regions and readers fall
                 // back to inline resolution. Mapping it to the ran-and-empty
@@ -407,7 +432,10 @@ impl ParseCoordinator {
                     build_bridge_regions,
                     build_bridge_regions,
                 ) else {
-                    return PopulatedSnapshotRegions::default();
+                    return PopulatedSnapshotRegions {
+                        shadow_summary,
+                        ..Default::default()
+                    };
                 };
                 PopulatedSnapshotRegions {
                     discovery: populated.discovery.map(std::sync::Arc::new),
@@ -417,10 +445,20 @@ impl ParseCoordinator {
                     resolved_regions: populated
                         .resolved_regions
                         .map(|regions| (populated.generation, std::sync::Arc::new(regions))),
+                    shadow_summary,
                 }
             })
             .await
-            .unwrap_or_default()
+            .unwrap_or_default();
+        if let Some(summary) = populated.shadow_summary.clone() {
+            self.tree_worker_shadow.record_authoritative_summary(
+                &shadow_uri,
+                incarnation,
+                content_version,
+                summary,
+            );
+        }
+        populated
     }
 
     /// Parse the (already-registered) document at `uri` and publish the result.
@@ -617,21 +655,16 @@ impl ParseCoordinator {
                 // populate — the snapshot then publishes without discovery and
                 // readers discover inline for that (already-superseded) snapshot.
                 let regions = if stored {
-                    self.tree_worker_shadow.record_authoritative(
-                        &uri,
-                        incarnation,
-                        content_version,
-                        &language_name,
-                        configuration_generation,
-                        &tree,
-                    );
                     self.populate_injections_on_pool(
                         uri.clone(),
                         text.clone(),
                         tree.clone(),
                         language_name.clone(),
-                        incarnation,
-                        content_version,
+                        ShadowParseContext {
+                            incarnation,
+                            content_version,
+                            configuration_generation,
+                        },
                     )
                     .await
                 } else {
@@ -904,21 +937,16 @@ impl ParseCoordinator {
             // out-of-order version at publish. A rejected CAS skips populate —
             // the snapshot still publishes as stale-but-consistent.
             let regions = if stored {
-                self.tree_worker_shadow.record_authoritative(
-                    &uri,
-                    expected_incarnation,
-                    content_version,
-                    &language_name,
-                    configuration_generation,
-                    &tree,
-                );
                 self.populate_injections_on_pool(
                     uri.clone(),
                     text.clone(),
                     tree.clone(),
                     language_name.clone(),
-                    expected_incarnation,
-                    content_version,
+                    ShadowParseContext {
+                        incarnation: expected_incarnation,
+                        content_version,
+                        configuration_generation,
+                    },
                 )
                 .await
             } else {
@@ -1124,21 +1152,16 @@ impl ParseCoordinator {
             // publishes as stale-but-consistent (its readers discover inline;
             // the scheduler's dirty loop is already reparsing the newer text).
             let regions = if stored {
-                self.tree_worker_shadow.record_authoritative(
-                    uri,
-                    incarnation,
-                    content_version,
-                    &language_name,
-                    configuration_generation,
-                    &tree,
-                );
                 self.populate_injections_on_pool(
                     uri.clone(),
                     text.clone(),
                     tree.clone(),
                     language_name.clone(),
-                    incarnation,
-                    content_version,
+                    ShadowParseContext {
+                        incarnation,
+                        content_version,
+                        configuration_generation,
+                    },
                 )
                 .await
             } else {

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -647,7 +647,7 @@ impl Kakehashi {
         // Without this, the task only exits when all senders are dropped.
         self.shutdown_token.cancel();
 
-        self.tree_worker_shadow.shutdown();
+        self.tree_worker_shadow.shutdown().await;
 
         // Graceful shutdown of all downstream language server connections (ls-bridge-graceful-shutdown)
         // - Transitions to Closing state, sends LSP shutdown/exit handshake

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -647,6 +647,8 @@ impl Kakehashi {
         // Without this, the task only exits when all senders are dropped.
         self.shutdown_token.cancel();
 
+        self.tree_worker_shadow.shutdown();
+
         // Graceful shutdown of all downstream language server connections (ls-bridge-graceful-shutdown)
         // - Transitions to Closing state, sends LSP shutdown/exit handshake
         // - Escalates to SIGTERM/SIGKILL for unresponsive servers (Unix)

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -4,7 +4,7 @@ use tower_lsp_server::ls_types::DidChangeTextDocumentParams;
 
 use super::super::{Kakehashi, uri_to_url};
 use crate::language::node_tracker::EditInfo;
-use crate::lsp::text_sync::apply_content_changes_with_edits;
+use crate::lsp::text_sync::apply_content_changes_detailed;
 
 impl Kakehashi {
     pub(crate) async fn did_change_impl(&self, params: DidChangeTextDocumentParams) {
@@ -59,7 +59,9 @@ impl Kakehashi {
         };
 
         // Apply content changes and build tree-sitter edits
-        let (text, edits) = apply_content_changes_with_edits(&old_text, params.content_changes);
+        let changes = apply_content_changes_detailed(&old_text, params.content_changes);
+        let text = changes.text;
+        let edits = changes.input_edits;
 
         // lazy-node-identity-tracking: Apply START-priority invalidation to node tracker.
         // Use InputEdits directly for precise invalidation when available,

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -38,12 +38,17 @@ impl Kakehashi {
         // Retrieve the stored document's current text (the base for the diff). The
         // language is re-detected by the off-ingress reparse from the stored
         // `language_id`, so it is not needed here.
-        let old_text = {
+        let (old_text, base_version, incarnation, language_id) = {
             let doc = self.documents.get(&uri);
             match doc {
                 // `text_arc()` is a refcount bump, not a full copy of the pre-edit
                 // text — cheap on every keystroke (#498).
-                Some(d) => d.text_arc(),
+                Some(d) => (
+                    d.text_arc(),
+                    d.content_version(),
+                    d.incarnation(),
+                    d.language_id().map(str::to_string),
+                ),
                 None => {
                     self.notifier()
                         .log_warning("Document not found for change event")
@@ -62,6 +67,8 @@ impl Kakehashi {
         let changes = apply_content_changes_detailed(&old_text, params.content_changes);
         let text = changes.text;
         let edits = changes.input_edits;
+        let sequential_byte_edits = changes.sequential_byte_edits;
+        let shadow_text = self.tree_worker_shadow.is_enabled().then(|| text.clone());
 
         // lazy-node-identity-tracking: Apply START-priority invalidation to node tracker.
         // Use InputEdits directly for precise invalidation when available,
@@ -100,6 +107,32 @@ impl Kakehashi {
         // keeps no seed and parses from scratch (#348).
         let ticket = crate::lsp::current_writer_ticket();
         self.documents.apply_edit_clearing_tree(&uri, text, &edits);
+
+        if let Some(shadow_text) = shadow_text {
+            let language_name = self.language.detect_language(
+                uri.path(),
+                &shadow_text,
+                None,
+                language_id.as_deref(),
+            );
+            if let Some(language_name) = language_name
+                && let Some(grammar) = self.language.worker_grammar_descriptor(
+                    &language_name,
+                    &self.settings_manager.load_settings(),
+                )
+            {
+                self.tree_worker_shadow.mirror_change(
+                    &uri,
+                    incarnation,
+                    base_version,
+                    base_version.wrapping_add(1),
+                    language_name,
+                    grammar,
+                    shadow_text,
+                    sequential_byte_edits,
+                );
+            }
+        }
 
         // NOTE: We intentionally do NOT invalidate the semantic token cache here.
         // The cached tokens (with their result_id) are needed for delta calculations.

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -19,7 +19,19 @@ impl Kakehashi {
     }
 
     async fn clear_document_state_on_close_locked(&self, uri: &url::Url) -> Option<u64> {
-        let closing_incarnation = self.documents.get(uri).map(|doc| doc.incarnation());
+        let closing_document = self
+            .documents
+            .get(uri)
+            .map(|doc| (doc.incarnation(), doc.content_version()));
+        let closing_incarnation = closing_document.map(|(incarnation, _)| incarnation);
+        if let Some((incarnation, content_version)) = closing_document {
+            self.tree_worker_shadow.mirror_close(
+                uri,
+                incarnation,
+                content_version.wrapping_add(1),
+                self.language.configuration_generation(),
+            );
+        }
         if let Some(incarnation) = closing_incarnation {
             self.bridge.close_host_incarnation(uri, incarnation).await;
         }

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -76,6 +76,22 @@ impl Kakehashi {
         self.bridge.open_host_incarnation(&uri, incarnation).await;
         drop(edit_guard);
 
+        if self.tree_worker_shadow.is_enabled()
+            && let Some(language_name) = language_name.clone()
+            && let Some(grammar) = self
+                .language
+                .worker_grammar_descriptor(&language_name, &self.settings_manager.load_settings())
+        {
+            self.tree_worker_shadow.mirror_full(
+                &uri,
+                incarnation,
+                0,
+                language_name,
+                grammar,
+                text.clone(),
+            );
+        }
+
         // Host-tier hoist (parse-decoupled-document-lifecycle ADR): attach the real
         // host document to any `_self` host-bridge server *before* the parser load,
         // the parse, and auto-install — none of which the host tier depends on.

--- a/src/lsp/lsp_impl/text_document/native_bindings.rs
+++ b/src/lsp/lsp_impl/text_document/native_bindings.rs
@@ -260,7 +260,7 @@ impl Kakehashi {
         let content_text_for_parse = std::sync::Arc::clone(&content_text);
         let parsed = self
             .parse_coordinator()
-            .parse_with_pool(
+            .parse_with_pool_versioned(
                 &layer_language,
                 uri,
                 content_text.len(),
@@ -280,11 +280,16 @@ impl Kakehashi {
             .await;
 
         match parsed {
-            Some(layer_tree) => {
-                // Resolve after parse_with_pool: a reload can invalidate the
+            Some((layer_tree, configuration_generation)) => {
+                // Resolve after parse_with_pool_versioned: a reload can invalidate the
                 // first parser generation and make it retry with the new
                 // grammar, whose bindings query must accompany that tree.
-                let Some(query) = self.language.bindings_query(&layer_language) else {
+                let (query_generation, query) =
+                    self.language.bindings_query_versioned(&layer_language);
+                if query_generation != configuration_generation {
+                    return Some(None);
+                }
+                let Some(query) = query else {
                     return Some(None);
                 };
                 Some(Some((query, content_text, layer_tree, content_range.start)))

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -77,9 +77,14 @@ struct PendingComparison {
 }
 
 #[derive(Default)]
+struct ComparisonSlot {
+    closed_incarnation: Option<u64>,
+    pending: Option<PendingComparison>,
+}
+
+#[derive(Default)]
 struct ComparisonStore {
-    pending: dashmap::DashMap<String, PendingComparison>,
-    closed: dashmap::DashMap<String, u64>,
+    slots: dashmap::DashMap<String, ComparisonSlot>,
     closed_order: Mutex<VecDeque<(String, u64)>>,
     matched: AtomicU64,
     mismatched: AtomicU64,
@@ -215,7 +220,7 @@ impl TreeWorkerShadow {
             self.comparisons.matched.load(Ordering::Relaxed),
             self.comparisons.mismatched.load(Ordering::Relaxed),
             self.comparisons.superseded.load(Ordering::Relaxed),
-            self.comparisons.pending.len(),
+            self.comparisons.pending_count(),
         );
         self.disabled.store(true, Ordering::Release);
         if let Some(sender) = &self.sender {
@@ -438,25 +443,31 @@ enum ComparisonSide {
 
 impl ComparisonStore {
     fn record(&self, uri: &str, incarnation: u64, content_version: u64, side: ComparisonSide) {
-        if self
-            .closed
-            .get(uri)
-            .is_some_and(|closed| *closed >= incarnation)
-        {
-            self.superseded.fetch_add(1, Ordering::Relaxed);
-            return;
-        }
         let incoming_generation = match &side {
             ComparisonSide::Authoritative(summary) | ComparisonSide::Shadow(summary) => {
                 summary.configuration_generation
             }
         };
         let incoming = (incarnation, content_version, incoming_generation);
-        let mut pending = if let Some(pending) = self.pending.get_mut(uri) {
-            pending
+        let mut slot = if let Some(slot) = self.slots.get_mut(uri) {
+            slot
         } else {
-            self.pending.entry(uri.to_string()).or_default()
+            self.slots.entry(uri.to_string()).or_default()
         };
+        if slot
+            .closed_incarnation
+            .is_some_and(|closed| closed >= incarnation)
+        {
+            self.superseded.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+
+        let pending = slot.pending.get_or_insert_with(|| PendingComparison {
+            incarnation,
+            content_version,
+            configuration_generation: incoming_generation,
+            ..Default::default()
+        });
         let current = (
             pending.incarnation,
             pending.content_version,
@@ -481,27 +492,20 @@ impl ComparisonStore {
             ComparisonSide::Authoritative(summary) => pending.authoritative = Some(summary),
             ComparisonSide::Shadow(summary) => pending.shadow = Some(summary),
         }
-        let completed = pending.authoritative.is_some() && pending.shadow.is_some();
-        drop(pending);
-        if !completed {
+        if pending.authoritative.is_none() || pending.shadow.is_none() {
             return;
         }
-        let Some((_, completed)) = self.pending.remove_if(uri, |_, pending| {
-            pending.incarnation == incarnation
-                && pending.content_version == content_version
-                && pending.configuration_generation == incoming_generation
-                && pending.authoritative.is_some()
-                && pending.shadow.is_some()
-        }) else {
-            self.superseded.fetch_add(1, Ordering::Relaxed);
-            return;
-        };
+        let completed = slot
+            .pending
+            .take()
+            .expect("completed comparison remains in its URI slot");
         let authoritative = completed
             .authoritative
             .expect("completed comparison has an authoritative summary");
         let shadow = completed
             .shadow
             .expect("completed comparison has a shadow summary");
+        drop(slot);
         if authoritative == shadow {
             self.matched.fetch_add(1, Ordering::Relaxed);
         } else {
@@ -514,15 +518,20 @@ impl ComparisonStore {
     }
 
     fn mark_closed(&self, uri: &str, incarnation: u64) {
-        self.pending.remove(uri);
-        if self
-            .closed
-            .get(uri)
-            .is_some_and(|closed| *closed > incarnation)
+        let mut slot = if let Some(slot) = self.slots.get_mut(uri) {
+            slot
+        } else {
+            self.slots.entry(uri.to_string()).or_default()
+        };
+        slot.pending = None;
+        if slot
+            .closed_incarnation
+            .is_some_and(|closed| closed >= incarnation)
         {
             return;
         }
-        self.closed.insert(uri.to_string(), incarnation);
+        slot.closed_incarnation = Some(incarnation);
+        drop(slot);
 
         use crate::error::LockResultExt;
         let mut order = self
@@ -534,14 +543,36 @@ impl ComparisonStore {
             let Some((expired_uri, expired_incarnation)) = order.pop_front() else {
                 break;
             };
-            self.closed
-                .remove_if(&expired_uri, |_, closed| *closed == expired_incarnation);
+            self.slots.remove_if(&expired_uri, |_, slot| {
+                slot.closed_incarnation == Some(expired_incarnation) && slot.pending.is_none()
+            });
         }
     }
 
     fn reopen(&self, uri: &str, incarnation: u64) {
-        self.closed
-            .remove_if(uri, |_, closed| *closed < incarnation);
+        let Some(mut slot) = self.slots.get_mut(uri) else {
+            return;
+        };
+        if slot
+            .pending
+            .as_ref()
+            .is_some_and(|pending| pending.incarnation < incarnation)
+        {
+            slot.pending = None;
+        }
+        if slot
+            .closed_incarnation
+            .is_some_and(|closed| closed < incarnation)
+        {
+            slot.closed_incarnation = None;
+        }
+    }
+
+    fn pending_count(&self) -> usize {
+        self.slots
+            .iter()
+            .filter(|slot| slot.pending.is_some())
+            .count()
     }
 }
 
@@ -740,7 +771,7 @@ mod tests {
                 store.record("file:///a.rs", 1, 2, authoritative);
             }
             assert_eq!(store.matched.load(Ordering::Relaxed), 1);
-            assert!(store.pending.is_empty());
+            assert_eq!(store.pending_count(), 0);
         }
     }
 
@@ -770,7 +801,7 @@ mod tests {
         assert_eq!(store.matched.load(Ordering::Relaxed), 0);
         assert_eq!(store.mismatched.load(Ordering::Relaxed), 1);
         assert_eq!(store.superseded.load(Ordering::Relaxed), 2);
-        assert!(store.pending.is_empty());
+        assert_eq!(store.pending_count(), 0);
     }
 
     #[test]
@@ -792,7 +823,7 @@ mod tests {
         assert_eq!(store.matched.load(Ordering::Relaxed), 1);
         assert_eq!(store.mismatched.load(Ordering::Relaxed), 0);
         assert_eq!(store.superseded.load(Ordering::Relaxed), 1);
-        assert!(store.pending.is_empty());
+        assert_eq!(store.pending_count(), 0);
     }
 
     #[test]
@@ -802,7 +833,7 @@ mod tests {
         store.mark_closed(uri, 1);
 
         store.record(uri, 1, 2, ComparisonSide::Authoritative(summary("late")));
-        assert!(store.pending.is_empty());
+        assert_eq!(store.pending_count(), 0);
         assert_eq!(store.superseded.load(Ordering::Relaxed), 1);
 
         store.reopen(uri, 2);
@@ -814,7 +845,28 @@ mod tests {
         );
         store.record(uri, 2, 0, ComparisonSide::Shadow(summary("source_file")));
         assert_eq!(store.matched.load(Ordering::Relaxed), 1);
-        assert!(store.pending.is_empty());
+        assert_eq!(store.pending_count(), 0);
+    }
+
+    #[test]
+    fn duplicate_close_keeps_one_live_tombstone() {
+        use crate::error::LockResultExt;
+
+        let store = ComparisonStore::default();
+        let uri = "file:///a.rs";
+        store.mark_closed(uri, 1);
+        store.mark_closed(uri, 1);
+
+        assert_eq!(
+            store
+                .closed_order
+                .lock()
+                .recover_poison("duplicate close test")
+                .len(),
+            1
+        );
+        let slot = store.slots.get(uri).unwrap();
+        assert_eq!(slot.closed_incarnation, Some(1));
     }
 
     #[test]
@@ -824,6 +876,11 @@ mod tests {
             store.mark_closed(&format!("file:///{index}.rs"), 1);
         }
 
-        assert!(store.closed.len() <= CLOSED_COMPARISON_TOMBSTONES);
+        let retained = store
+            .slots
+            .iter()
+            .filter(|slot| slot.closed_incarnation.is_some())
+            .count();
+        assert!(retained <= CLOSED_COMPARISON_TOMBSTONES);
     }
 }

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -571,18 +571,15 @@ impl ComparisonStore {
     }
 
     fn mark_closed(&self, uri: &str, incarnation: u64) {
-        let Some(slot) = self.slots.get_mut(uri) else {
-            return;
-        };
-        if slot.open_incarnation > incarnation {
-            return;
-        }
-        if slot.pending.is_some() {
-            self.superseded.fetch_add(1, Ordering::Relaxed);
-        }
-        drop(slot);
-        self.slots
-            .remove_if(uri, |_, slot| slot.open_incarnation <= incarnation);
+        self.slots.remove_if(uri, |_, slot| {
+            if slot.open_incarnation > incarnation {
+                return false;
+            }
+            if slot.pending.is_some() {
+                self.superseded.fetch_add(1, Ordering::Relaxed);
+            }
+            true
+        });
     }
 
     fn open(&self, uri: &str, incarnation: u64) {

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -377,7 +377,11 @@ enum ComparisonSide {
 impl ComparisonStore {
     fn record(&self, uri: &str, incarnation: u64, content_version: u64, side: ComparisonSide) {
         let incoming = (incarnation, content_version);
-        let mut pending = self.pending.entry(uri.to_string()).or_default();
+        let mut pending = if let Some(pending) = self.pending.get_mut(uri) {
+            pending
+        } else {
+            self.pending.entry(uri.to_string()).or_default()
+        };
         let current = (pending.incarnation, pending.content_version);
         if incoming < current {
             self.superseded.fetch_add(1, Ordering::Relaxed);
@@ -455,13 +459,23 @@ impl TreeSummary {
 
 fn named_node_count(root: tree_sitter::Node<'_>) -> usize {
     let mut count = 0;
-    let mut pending = vec![root];
-    while let Some(node) = pending.pop() {
-        if node.is_named() {
-            count += 1;
+    let mut cursor = root.walk();
+    let mut ascending = false;
+    loop {
+        if !ascending {
+            count += usize::from(cursor.node().is_named());
+            if cursor.goto_first_child() {
+                continue;
+            }
         }
-        let mut cursor = node.walk();
-        pending.extend(node.children(&mut cursor));
+        if cursor.goto_next_sibling() {
+            ascending = false;
+            continue;
+        }
+        if !cursor.goto_parent() {
+            break;
+        }
+        ascending = true;
     }
     count
 }

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -2,18 +2,19 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, mpsc};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::language::coordinator::WorkerGrammarDescriptor;
 use crate::lsp::text_sync::SequentialByteEdit;
 use crate::tree_worker::{
     ApplyDocumentEditsAndDerive, ByteEdit, Client, CloseDocument, DeriveDocumentSnapshot,
-    RequestContext, Response, SyncDocument,
+    RequestContext, Response, SyncDocument, named_node_count,
 };
 
 const SHADOW_ENV: &str = "KAKEHASHI_TREE_WORKER_SHADOW";
 const SHADOW_THREADS_ENV: &str = "KAKEHASHI_TREE_WORKER_THREADS";
 const SHADOW_QUEUE_CAPACITY: usize = 256;
+const SHADOW_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 static NEXT_WORKER_GENERATION: AtomicU64 = AtomicU64::new(1);
 
 enum ShadowCommand {
@@ -23,7 +24,7 @@ enum ShadowCommand {
         fallback: SyncDocument,
     },
     Close(CloseDocument),
-    Shutdown,
+    Shutdown(mpsc::SyncSender<()>),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -49,6 +50,7 @@ impl ReplicaIdentity {
 
 pub(super) struct TreeWorkerShadow {
     sender: Option<mpsc::SyncSender<ShadowCommand>>,
+    accepting: Arc<AtomicBool>,
     disabled: Arc<AtomicBool>,
     next_request_id: AtomicU64,
     worker_generation: u64,
@@ -92,11 +94,13 @@ struct ComparisonStore {
 impl TreeWorkerShadow {
     pub(super) fn from_environment() -> Self {
         let disabled = Arc::new(AtomicBool::new(false));
+        let accepting = Arc::new(AtomicBool::new(false));
         let comparisons = Arc::new(ComparisonStore::default());
         let worker_generation = NEXT_WORKER_GENERATION.fetch_add(1, Ordering::Relaxed);
         if !shadow_enabled() {
             return Self {
                 sender: None,
+                accepting,
                 disabled,
                 next_request_id: AtomicU64::new(1),
                 worker_generation,
@@ -110,6 +114,7 @@ impl TreeWorkerShadow {
                 disabled.store(true, Ordering::Release);
                 return Self {
                     sender: None,
+                    accepting,
                     disabled,
                     next_request_id: AtomicU64::new(1),
                     worker_generation,
@@ -121,7 +126,7 @@ impl TreeWorkerShadow {
         let (sender, receiver) = mpsc::sync_channel(SHADOW_QUEUE_CAPACITY);
         let actor_disabled = Arc::clone(&disabled);
         let actor_comparisons = Arc::clone(&comparisons);
-        std::thread::Builder::new()
+        let spawn = std::thread::Builder::new()
             .name("kakehashi-tree-worker-shadow".into())
             .spawn(move || {
                 run_actor(
@@ -132,14 +137,30 @@ impl TreeWorkerShadow {
                     actor_disabled,
                     actor_comparisons,
                 );
-            })
-            .expect("tree worker shadow actor thread must spawn");
+            });
+        if let Err(error) = spawn {
+            disabled.store(true, Ordering::Release);
+            log::error!(
+                target: "kakehashi::tree_worker_shadow",
+                "disabled shadow worker because actor thread could not spawn: {error}"
+            );
+            return Self {
+                sender: None,
+                accepting,
+                disabled,
+                next_request_id: AtomicU64::new(1),
+                worker_generation,
+                comparisons,
+            };
+        }
+        accepting.store(true, Ordering::Release);
         log::info!(
             target: "kakehashi::tree_worker_shadow",
             "enabled one shadow worker with {compute_threads} compute threads"
         );
         Self {
             sender: Some(sender),
+            accepting,
             disabled,
             next_request_id: AtomicU64::new(1),
             worker_generation,
@@ -162,7 +183,9 @@ impl TreeWorkerShadow {
     }
 
     pub(super) fn is_enabled(&self) -> bool {
-        self.sender.is_some() && !self.disabled.load(Ordering::Acquire)
+        self.sender.is_some()
+            && self.accepting.load(Ordering::Acquire)
+            && !self.disabled.load(Ordering::Acquire)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -212,18 +235,7 @@ impl TreeWorkerShadow {
     }
 
     pub(super) fn shutdown(&self) {
-        log::info!(
-            target: "kakehashi::tree_worker_shadow_metrics",
-            "shadow comparisons matched={} mismatched={} superseded={} pending={}",
-            self.comparisons.matched.load(Ordering::Relaxed),
-            self.comparisons.mismatched.load(Ordering::Relaxed),
-            self.comparisons.superseded.load(Ordering::Relaxed),
-            self.comparisons.pending_count(),
-        );
-        self.disabled.store(true, Ordering::Release);
-        if let Some(sender) = &self.sender {
-            let _ = sender.try_send(ShadowCommand::Shutdown);
-        }
+        self.shutdown_with_timeout(SHADOW_SHUTDOWN_TIMEOUT);
     }
 
     pub(super) fn record_authoritative(
@@ -291,7 +303,7 @@ impl TreeWorkerShadow {
     }
 
     fn submit(&self, command: ShadowCommand) {
-        if self.disabled.load(Ordering::Acquire) {
+        if !self.accepting.load(Ordering::Acquire) || self.disabled.load(Ordering::Acquire) {
             return;
         }
         let Some(sender) = &self.sender else {
@@ -305,6 +317,51 @@ impl TreeWorkerShadow {
             );
         }
     }
+
+    fn shutdown_with_timeout(&self, timeout: Duration) {
+        if !self.accepting.swap(false, Ordering::AcqRel) {
+            return;
+        }
+        let deadline = Instant::now() + timeout;
+        let (ack_sender, ack_receiver) = mpsc::sync_channel(0);
+        let Some(sender) = &self.sender else {
+            return;
+        };
+        let mut command = ShadowCommand::Shutdown(ack_sender);
+        loop {
+            match sender.try_send(command) {
+                Ok(()) => break,
+                Err(mpsc::TrySendError::Full(returned)) if Instant::now() < deadline => {
+                    command = returned;
+                    std::thread::yield_now();
+                }
+                Err(error) => {
+                    log_incomplete_shutdown(&format!("could not enqueue drain request: {error}"));
+                    return;
+                }
+            }
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if ack_receiver.recv_timeout(remaining).is_err() {
+            log_incomplete_shutdown("timed out waiting for actor drain");
+            return;
+        }
+        log::info!(
+            target: "kakehashi::tree_worker_shadow_metrics",
+            "shadow comparisons matched={} mismatched={} superseded={} pending={}",
+            self.comparisons.matched.load(Ordering::Relaxed),
+            self.comparisons.mismatched.load(Ordering::Relaxed),
+            self.comparisons.superseded.load(Ordering::Relaxed),
+            self.comparisons.pending_count(),
+        );
+    }
+}
+
+fn log_incomplete_shutdown(reason: &str) {
+    log::error!(
+        target: "kakehashi::tree_worker_shadow_metrics",
+        "shadow validation incomplete: {reason}"
+    );
 }
 
 fn shadow_enabled() -> bool {
@@ -342,8 +399,13 @@ fn run_actor(
         }
     };
     let mut replicas = HashMap::<String, ReplicaIdentity>::new();
+    let mut shutdown_ack = None;
     while let Ok(command) = receiver.recv() {
-        if disabled.load(Ordering::Acquire) || matches!(command, ShadowCommand::Shutdown) {
+        if disabled.load(Ordering::Acquire) {
+            break;
+        }
+        if let ShadowCommand::Shutdown(ack) = command {
+            shutdown_ack = Some(ack);
             break;
         }
         let started = Instant::now();
@@ -376,7 +438,7 @@ fn run_actor(
                 comparisons.mark_closed(&request.context.uri, request.context.incarnation);
                 (client.close_document(request), None)
             }
-            ShadowCommand::Shutdown => unreachable!(),
+            ShadowCommand::Shutdown(_) => unreachable!(),
         };
         match response {
             Ok(Response::Snapshot(snapshot)) => {
@@ -423,6 +485,9 @@ fn run_actor(
     }
     if let Err(error) = client.shutdown() {
         log::warn!(target: "kakehashi::tree_worker_shadow", "worker shutdown failed: {error}");
+    }
+    if let Some(ack) = shutdown_ack {
+        let _ = ack.send(());
     }
 }
 
@@ -574,29 +639,6 @@ impl TreeSummary {
     }
 }
 
-fn named_node_count(root: tree_sitter::Node<'_>) -> usize {
-    let mut count = 0;
-    let mut cursor = root.walk();
-    let mut ascending = false;
-    loop {
-        if !ascending {
-            count += usize::from(cursor.node().is_named());
-            if cursor.goto_first_child() {
-                continue;
-            }
-        }
-        if cursor.goto_next_sibling() {
-            ascending = false;
-            continue;
-        }
-        if !cursor.goto_parent() {
-            break;
-        }
-        ascending = true;
-    }
-    count
-}
-
 fn sync_and_derive(client: &Client, request: SyncDocument) -> std::io::Result<Response> {
     let context = request.context.clone();
     match client.sync_document(request)? {
@@ -614,6 +656,7 @@ mod tests {
     fn shadow(sender: mpsc::SyncSender<ShadowCommand>) -> TreeWorkerShadow {
         TreeWorkerShadow {
             sender: Some(sender),
+            accepting: Arc::new(AtomicBool::new(true)),
             disabled: Arc::new(AtomicBool::new(false)),
             next_request_id: AtomicU64::new(1),
             worker_generation: 7,
@@ -683,8 +726,10 @@ mod tests {
     fn bounded_queue_failure_disables_the_shadow_session() {
         let (sender, _receiver) = mpsc::sync_channel(1);
         let shadow = shadow(sender);
-        shadow.submit(ShadowCommand::Shutdown);
-        shadow.submit(ShadowCommand::Shutdown);
+        let (ack, _receiver) = mpsc::sync_channel(0);
+        shadow.submit(ShadowCommand::Shutdown(ack));
+        let (ack, _receiver) = mpsc::sync_channel(0);
+        shadow.submit(ShadowCommand::Shutdown(ack));
 
         assert!(!shadow.is_enabled());
     }
@@ -693,9 +738,10 @@ mod tests {
     fn shutdown_disables_the_actor_even_when_its_queue_is_full() {
         let (sender, _receiver) = mpsc::sync_channel(1);
         let shadow = shadow(sender);
-        shadow.submit(ShadowCommand::Shutdown);
+        let (ack, _receiver) = mpsc::sync_channel(0);
+        shadow.submit(ShadowCommand::Shutdown(ack));
 
-        shadow.shutdown();
+        shadow.shutdown_with_timeout(Duration::from_millis(1));
 
         assert!(!shadow.is_enabled());
     }

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, mpsc};
@@ -23,6 +24,27 @@ enum ShadowCommand {
     },
     Close(CloseDocument),
     Shutdown,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ReplicaIdentity {
+    incarnation: u64,
+    language: String,
+    grammar_symbol: String,
+    parser_path: PathBuf,
+    configuration_generation: u64,
+}
+
+impl ReplicaIdentity {
+    fn from_sync(request: &SyncDocument) -> Self {
+        Self {
+            incarnation: request.context.incarnation,
+            language: request.language.clone(),
+            grammar_symbol: request.grammar_symbol.clone(),
+            parser_path: request.parser_path.clone(),
+            configuration_generation: request.context.configuration_generation,
+        }
+    }
 }
 
 pub(super) struct TreeWorkerShadow {
@@ -189,6 +211,7 @@ impl TreeWorkerShadow {
             self.comparisons.superseded.load(Ordering::Relaxed),
             self.comparisons.pending.len(),
         );
+        self.disabled.store(true, Ordering::Release);
         if let Some(sender) = &self.sender {
             let _ = sender.try_send(ShadowCommand::Shutdown);
         }
@@ -304,28 +327,46 @@ fn run_actor(
             return;
         }
     };
+    let mut replicas = HashMap::<String, ReplicaIdentity>::new();
     while let Ok(command) = receiver.recv() {
         if disabled.load(Ordering::Acquire) || matches!(command, ShadowCommand::Shutdown) {
             break;
         }
         let started = Instant::now();
-        let response = match command {
-            ShadowCommand::Sync(request) => sync_and_derive(&client, request),
+        let (response, synced_identity) = match command {
+            ShadowCommand::Sync(request) => {
+                let identity = ReplicaIdentity::from_sync(&request);
+                (sync_and_derive(&client, request), Some(identity))
+            }
             ShadowCommand::Apply { request, fallback } => {
-                match client.apply_document_edits_and_derive(request) {
-                    Ok(Response::Snapshot(snapshot)) => Ok(Response::Snapshot(snapshot)),
-                    Ok(Response::WorkerRestartRequired(required)) => {
-                        Ok(Response::WorkerRestartRequired(required))
+                let uri = fallback.context.uri.clone();
+                let identity = ReplicaIdentity::from_sync(&fallback);
+                if replica_requires_sync(&replicas, &uri, &identity) {
+                    (sync_and_derive(&client, fallback), Some(identity))
+                } else {
+                    match client.apply_document_edits_and_derive(request) {
+                        Ok(Response::Snapshot(snapshot)) => {
+                            (Ok(Response::Snapshot(snapshot)), None)
+                        }
+                        Ok(Response::WorkerRestartRequired(required)) => {
+                            (Ok(Response::WorkerRestartRequired(required)), None)
+                        }
+                        Ok(_) => (sync_and_derive(&client, fallback), Some(identity)),
+                        Err(error) => (Err(error), None),
                     }
-                    Ok(_) => sync_and_derive(&client, fallback),
-                    Err(error) => Err(error),
                 }
             }
-            ShadowCommand::Close(request) => client.close_document(request),
+            ShadowCommand::Close(request) => {
+                replicas.remove(&request.context.uri);
+                (client.close_document(request), None)
+            }
             ShadowCommand::Shutdown => unreachable!(),
         };
         match response {
             Ok(Response::Snapshot(snapshot)) => {
+                if let Some(identity) = synced_identity {
+                    replicas.insert(snapshot.context.uri.clone(), identity);
+                }
                 log::debug!(
                     target: "kakehashi::tree_worker_shadow_metrics",
                     "uri={} version={} parent_us={} queue_us={} compute_us={}",
@@ -367,6 +408,14 @@ fn run_actor(
     if let Err(error) = client.shutdown() {
         log::warn!(target: "kakehashi::tree_worker_shadow", "worker shutdown failed: {error}");
     }
+}
+
+fn replica_requires_sync(
+    replicas: &HashMap<String, ReplicaIdentity>,
+    uri: &str,
+    desired: &ReplicaIdentity,
+) -> bool {
+    replicas.get(uri) != Some(desired)
 }
 
 enum ComparisonSide {
@@ -569,6 +618,45 @@ mod tests {
         shadow.submit(ShadowCommand::Shutdown);
 
         assert!(!shadow.is_enabled());
+    }
+
+    #[test]
+    fn shutdown_disables_the_actor_even_when_its_queue_is_full() {
+        let (sender, _receiver) = mpsc::sync_channel(1);
+        let shadow = shadow(sender);
+        shadow.submit(ShadowCommand::Shutdown);
+
+        shadow.shutdown();
+
+        assert!(!shadow.is_enabled());
+    }
+
+    #[test]
+    fn replica_identity_change_requires_a_full_sync() {
+        let (sender, _receiver) = mpsc::sync_channel(1);
+        let shadow = shadow(sender);
+        let uri = url::Url::parse("file:///example").unwrap();
+        let request =
+            shadow.sync_request(&uri, 2, 4, "rust".into(), grammar(), "fn main() {}".into());
+        let identity = ReplicaIdentity::from_sync(&request);
+        let mut replicas = HashMap::from([(uri.as_str().to_string(), identity.clone())]);
+
+        assert!(!replica_requires_sync(&replicas, uri.as_str(), &identity));
+
+        let mut changed = identity.clone();
+        changed.language = "bash".into();
+        assert!(replica_requires_sync(&replicas, uri.as_str(), &changed));
+
+        changed = identity.clone();
+        changed.grammar_symbol = "rust_with_changes".into();
+        assert!(replica_requires_sync(&replicas, uri.as_str(), &changed));
+
+        changed = identity.clone();
+        changed.configuration_generation += 1;
+        assert!(replica_requires_sync(&replicas, uri.as_str(), &changed));
+
+        replicas.remove(uri.as_str());
+        assert!(replica_requires_sync(&replicas, uri.as_str(), &identity));
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -58,6 +58,7 @@ pub(super) struct TreeWorkerShadow {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct TreeSummary {
     language: String,
+    configuration_generation: u64,
     root_kind: String,
     root_start_byte: usize,
     root_end_byte: usize,
@@ -69,6 +70,7 @@ struct TreeSummary {
 struct PendingComparison {
     incarnation: u64,
     content_version: u64,
+    configuration_generation: u64,
     authoritative: Option<TreeSummary>,
     shadow: Option<TreeSummary>,
 }
@@ -223,6 +225,7 @@ impl TreeWorkerShadow {
         incarnation: u64,
         content_version: u64,
         language: &str,
+        configuration_generation: u64,
         tree: &tree_sitter::Tree,
     ) {
         if !self.is_enabled() {
@@ -232,7 +235,11 @@ impl TreeWorkerShadow {
             uri.as_str(),
             incarnation,
             content_version,
-            ComparisonSide::Authoritative(TreeSummary::from_tree(language, tree)),
+            ComparisonSide::Authoritative(TreeSummary::from_tree(
+                language,
+                configuration_generation,
+                tree,
+            )),
         );
     }
 
@@ -358,6 +365,7 @@ fn run_actor(
             }
             ShadowCommand::Close(request) => {
                 replicas.remove(&request.context.uri);
+                comparisons.pending.remove(&request.context.uri);
                 (client.close_document(request), None)
             }
             ShadowCommand::Shutdown => unreachable!(),
@@ -425,13 +433,22 @@ enum ComparisonSide {
 
 impl ComparisonStore {
     fn record(&self, uri: &str, incarnation: u64, content_version: u64, side: ComparisonSide) {
-        let incoming = (incarnation, content_version);
+        let incoming_generation = match &side {
+            ComparisonSide::Authoritative(summary) | ComparisonSide::Shadow(summary) => {
+                summary.configuration_generation
+            }
+        };
+        let incoming = (incarnation, content_version, incoming_generation);
         let mut pending = if let Some(pending) = self.pending.get_mut(uri) {
             pending
         } else {
             self.pending.entry(uri.to_string()).or_default()
         };
-        let current = (pending.incarnation, pending.content_version);
+        let current = (
+            pending.incarnation,
+            pending.content_version,
+            pending.configuration_generation,
+        );
         if incoming < current {
             self.superseded.fetch_add(1, Ordering::Relaxed);
             return;
@@ -443,6 +460,7 @@ impl ComparisonStore {
             *pending = PendingComparison {
                 incarnation,
                 content_version,
+                configuration_generation: incoming_generation,
                 ..Default::default()
             };
         }
@@ -450,21 +468,27 @@ impl ComparisonStore {
             ComparisonSide::Authoritative(summary) => pending.authoritative = Some(summary),
             ComparisonSide::Shadow(summary) => pending.shadow = Some(summary),
         }
-        let completed = pending
-            .authoritative
-            .as_ref()
-            .zip(pending.shadow.as_ref())
-            .map(|(authoritative, shadow)| (authoritative.clone(), shadow.clone()));
+        let completed = pending.authoritative.is_some() && pending.shadow.is_some();
         drop(pending);
-        let Some((authoritative, shadow)) = completed else {
+        if !completed {
             return;
-        };
-        self.pending.remove_if(uri, |_, pending| {
+        }
+        let Some((_, completed)) = self.pending.remove_if(uri, |_, pending| {
             pending.incarnation == incarnation
                 && pending.content_version == content_version
+                && pending.configuration_generation == incoming_generation
                 && pending.authoritative.is_some()
                 && pending.shadow.is_some()
-        });
+        }) else {
+            self.superseded.fetch_add(1, Ordering::Relaxed);
+            return;
+        };
+        let authoritative = completed
+            .authoritative
+            .expect("completed comparison has an authoritative summary");
+        let shadow = completed
+            .shadow
+            .expect("completed comparison has a shadow summary");
         if authoritative == shadow {
             self.matched.fetch_add(1, Ordering::Relaxed);
         } else {
@@ -482,10 +506,11 @@ impl ComparisonStore {
 }
 
 impl TreeSummary {
-    fn from_tree(language: &str, tree: &tree_sitter::Tree) -> Self {
+    fn from_tree(language: &str, configuration_generation: u64, tree: &tree_sitter::Tree) -> Self {
         let root = tree.root_node();
         Self {
             language: language.to_string(),
+            configuration_generation,
             root_kind: root.kind().to_string(),
             root_start_byte: root.start_byte(),
             root_end_byte: root.end_byte(),
@@ -497,6 +522,7 @@ impl TreeSummary {
     fn from_snapshot(snapshot: &crate::tree_worker::DerivedSnapshot) -> Self {
         Self {
             language: snapshot.language.clone(),
+            configuration_generation: snapshot.context.configuration_generation,
             root_kind: snapshot.root_kind.clone(),
             root_start_byte: snapshot.root_start_byte,
             root_end_byte: snapshot.root_end_byte,
@@ -564,6 +590,7 @@ mod tests {
     fn summary(root_kind: &str) -> TreeSummary {
         TreeSummary {
             language: "rust".into(),
+            configuration_generation: 3,
             root_kind: root_kind.into(),
             root_start_byte: 0,
             root_end_byte: 10,
@@ -703,6 +730,28 @@ mod tests {
         assert_eq!(store.matched.load(Ordering::Relaxed), 0);
         assert_eq!(store.mismatched.load(Ordering::Relaxed), 1);
         assert_eq!(store.superseded.load(Ordering::Relaxed), 2);
+        assert!(store.pending.is_empty());
+    }
+
+    #[test]
+    fn comparisons_do_not_pair_across_configuration_generations() {
+        let store = ComparisonStore::default();
+        let authoritative = summary("source_file");
+        let mut stale_shadow = authoritative.clone();
+        stale_shadow.configuration_generation -= 1;
+
+        store.record(
+            "file:///a.rs",
+            1,
+            2,
+            ComparisonSide::Authoritative(authoritative.clone()),
+        );
+        store.record("file:///a.rs", 1, 2, ComparisonSide::Shadow(stale_shadow));
+        store.record("file:///a.rs", 1, 2, ComparisonSide::Shadow(authoritative));
+
+        assert_eq!(store.matched.load(Ordering::Relaxed), 1);
+        assert_eq!(store.mismatched.load(Ordering::Relaxed), 0);
+        assert_eq!(store.superseded.load(Ordering::Relaxed), 1);
         assert!(store.pending.is_empty());
     }
 }

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -1,7 +1,7 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, mpsc};
+use std::sync::{Arc, mpsc};
 use std::time::Instant;
 
 use crate::language::coordinator::WorkerGrammarDescriptor;
@@ -14,7 +14,6 @@ use crate::tree_worker::{
 const SHADOW_ENV: &str = "KAKEHASHI_TREE_WORKER_SHADOW";
 const SHADOW_THREADS_ENV: &str = "KAKEHASHI_TREE_WORKER_THREADS";
 const SHADOW_QUEUE_CAPACITY: usize = 256;
-const CLOSED_COMPARISON_TOMBSTONES: usize = 4_096;
 static NEXT_WORKER_GENERATION: AtomicU64 = AtomicU64::new(1);
 
 enum ShadowCommand {
@@ -78,14 +77,13 @@ struct PendingComparison {
 
 #[derive(Default)]
 struct ComparisonSlot {
-    closed_incarnation: Option<u64>,
+    open_incarnation: u64,
     pending: Option<PendingComparison>,
 }
 
 #[derive(Default)]
 struct ComparisonStore {
     slots: dashmap::DashMap<String, ComparisonSlot>,
-    closed_order: Mutex<VecDeque<(String, u64)>>,
     matched: AtomicU64,
     mismatched: AtomicU64,
     superseded: AtomicU64,
@@ -159,7 +157,7 @@ impl TreeWorkerShadow {
         text: String,
     ) {
         let request = self.sync_request(uri, incarnation, content_version, language, grammar, text);
-        self.comparisons.reopen(uri.as_str(), incarnation);
+        self.comparisons.open(uri.as_str(), incarnation);
         self.submit(ShadowCommand::Sync(request));
     }
 
@@ -352,7 +350,7 @@ fn run_actor(
         let (response, synced_identity) = match command {
             ShadowCommand::Sync(request) => {
                 let identity = ReplicaIdentity::from_sync(&request);
-                comparisons.reopen(&request.context.uri, request.context.incarnation);
+                comparisons.open(&request.context.uri, request.context.incarnation);
                 (sync_and_derive(&client, request), Some(identity))
             }
             ShadowCommand::Apply { request, fallback } => {
@@ -449,15 +447,11 @@ impl ComparisonStore {
             }
         };
         let incoming = (incarnation, content_version, incoming_generation);
-        let mut slot = if let Some(slot) = self.slots.get_mut(uri) {
-            slot
-        } else {
-            self.slots.entry(uri.to_string()).or_default()
+        let Some(mut slot) = self.slots.get_mut(uri) else {
+            self.superseded.fetch_add(1, Ordering::Relaxed);
+            return;
         };
-        if slot
-            .closed_incarnation
-            .is_some_and(|closed| closed >= incarnation)
-        {
+        if slot.open_incarnation != incarnation {
             self.superseded.fetch_add(1, Ordering::Relaxed);
             return;
         }
@@ -518,54 +512,30 @@ impl ComparisonStore {
     }
 
     fn mark_closed(&self, uri: &str, incarnation: u64) {
-        let mut slot = if let Some(slot) = self.slots.get_mut(uri) {
-            slot
-        } else {
-            self.slots.entry(uri.to_string()).or_default()
+        let Some(slot) = self.slots.get_mut(uri) else {
+            return;
         };
-        if slot
-            .closed_incarnation
-            .is_some_and(|closed| closed >= incarnation)
-        {
+        if slot.open_incarnation > incarnation {
             return;
         }
-        if slot
-            .pending
-            .as_ref()
-            .is_some_and(|pending| pending.incarnation <= incarnation)
-        {
+        if slot.pending.is_some() {
             self.superseded.fetch_add(1, Ordering::Relaxed);
-            slot.pending = None;
         }
-        slot.closed_incarnation = Some(incarnation);
         drop(slot);
-
-        use crate::error::LockResultExt;
-        let mut order = self
-            .closed_order
-            .lock()
-            .recover_poison("TreeWorkerShadow::mark_closed");
-        order.push_back((uri.to_string(), incarnation));
-        while order.len() > CLOSED_COMPARISON_TOMBSTONES {
-            let Some((expired_uri, expired_incarnation)) = order.pop_front() else {
-                break;
-            };
-            self.slots.remove_if(&expired_uri, |_, slot| {
-                slot.closed_incarnation == Some(expired_incarnation) && slot.pending.is_none()
-            });
-        }
+        self.slots
+            .remove_if(uri, |_, slot| slot.open_incarnation <= incarnation);
     }
 
-    fn reopen(&self, uri: &str, incarnation: u64) {
-        let Some(mut slot) = self.slots.get_mut(uri) else {
-            return;
-        };
-        if slot
-            .pending
-            .as_ref()
-            .is_some_and(|pending| pending.incarnation < incarnation)
-        {
-            slot.pending = None;
+    fn open(&self, uri: &str, incarnation: u64) {
+        let mut slot = self.slots.entry(uri.to_string()).or_default();
+        if slot.open_incarnation < incarnation {
+            if slot.pending.is_some() {
+                self.superseded.fetch_add(1, Ordering::Relaxed);
+            }
+            *slot = ComparisonSlot {
+                open_incarnation: incarnation,
+                pending: None,
+            };
         }
     }
 
@@ -762,6 +732,7 @@ mod tests {
     fn comparisons_match_regardless_of_arrival_order() {
         for authoritative_first in [true, false] {
             let store = ComparisonStore::default();
+            store.open("file:///a.rs", 1);
             let authoritative = ComparisonSide::Authoritative(summary("source_file"));
             let shadow = ComparisonSide::Shadow(summary("source_file"));
             if authoritative_first {
@@ -779,6 +750,7 @@ mod tests {
     #[test]
     fn comparisons_keep_only_the_latest_document_version() {
         let store = ComparisonStore::default();
+        store.open("file:///a.rs", 1);
         store.record(
             "file:///a.rs",
             1,
@@ -808,6 +780,7 @@ mod tests {
     #[test]
     fn comparisons_do_not_pair_across_configuration_generations() {
         let store = ComparisonStore::default();
+        store.open("file:///a.rs", 1);
         let authoritative = summary("source_file");
         let mut stale_shadow = authoritative.clone();
         stale_shadow.configuration_generation -= 1;
@@ -831,13 +804,14 @@ mod tests {
     fn closed_incarnation_rejects_late_results_until_reopen() {
         let store = ComparisonStore::default();
         let uri = "file:///a.rs";
+        store.open(uri, 1);
         store.mark_closed(uri, 1);
 
         store.record(uri, 1, 2, ComparisonSide::Authoritative(summary("late")));
         assert_eq!(store.pending_count(), 0);
         assert_eq!(store.superseded.load(Ordering::Relaxed), 1);
 
-        store.reopen(uri, 2);
+        store.open(uri, 2);
         store.record(
             uri,
             2,
@@ -850,30 +824,21 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_close_keeps_one_live_tombstone() {
-        use crate::error::LockResultExt;
-
+    fn duplicate_close_keeps_the_uri_closed() {
         let store = ComparisonStore::default();
         let uri = "file:///a.rs";
+        store.open(uri, 1);
         store.mark_closed(uri, 1);
         store.mark_closed(uri, 1);
 
-        assert_eq!(
-            store
-                .closed_order
-                .lock()
-                .recover_poison("duplicate close test")
-                .len(),
-            1
-        );
-        let slot = store.slots.get(uri).unwrap();
-        assert_eq!(slot.closed_incarnation, Some(1));
+        assert!(!store.slots.contains_key(uri));
     }
 
     #[test]
     fn delayed_old_close_preserves_reopened_incarnation_comparison() {
         let store = ComparisonStore::default();
         let uri = "file:///a.rs";
+        store.open(uri, 2);
         store.record(
             uri,
             2,
@@ -892,17 +857,14 @@ mod tests {
     }
 
     #[test]
-    fn closed_comparison_tombstones_stay_bounded() {
+    fn closed_comparison_slots_are_removed() {
         let store = ComparisonStore::default();
-        for index in 0..=CLOSED_COMPARISON_TOMBSTONES {
-            store.mark_closed(&format!("file:///{index}.rs"), 1);
+        for index in 0..=4_096 {
+            let uri = format!("file:///{index}.rs");
+            store.open(&uri, 1);
+            store.mark_closed(&uri, 1);
         }
 
-        let retained = store
-            .slots
-            .iter()
-            .filter(|slot| slot.closed_incarnation.is_some())
-            .count();
-        assert!(retained <= CLOSED_COMPARISON_TOMBSTONES);
+        assert!(store.slots.is_empty());
     }
 }

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -1,0 +1,380 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, mpsc};
+use std::time::Instant;
+
+use crate::language::coordinator::WorkerGrammarDescriptor;
+use crate::lsp::text_sync::SequentialByteEdit;
+use crate::tree_worker::{
+    ApplyDocumentEditsAndDerive, ByteEdit, Client, CloseDocument, DeriveDocumentSnapshot,
+    RequestContext, Response, SyncDocument,
+};
+
+const SHADOW_ENV: &str = "KAKEHASHI_TREE_WORKER_SHADOW";
+const SHADOW_THREADS_ENV: &str = "KAKEHASHI_TREE_WORKER_THREADS";
+const SHADOW_QUEUE_CAPACITY: usize = 256;
+static NEXT_WORKER_GENERATION: AtomicU64 = AtomicU64::new(1);
+
+enum ShadowCommand {
+    Sync(SyncDocument),
+    Apply {
+        request: ApplyDocumentEditsAndDerive,
+        fallback: SyncDocument,
+    },
+    Close(CloseDocument),
+    Shutdown,
+}
+
+pub(super) struct TreeWorkerShadow {
+    sender: Option<mpsc::SyncSender<ShadowCommand>>,
+    disabled: Arc<AtomicBool>,
+    next_request_id: AtomicU64,
+    worker_generation: u64,
+}
+
+impl TreeWorkerShadow {
+    pub(super) fn from_environment() -> Self {
+        let disabled = Arc::new(AtomicBool::new(false));
+        let worker_generation = NEXT_WORKER_GENERATION.fetch_add(1, Ordering::Relaxed);
+        if !shadow_enabled() {
+            return Self {
+                sender: None,
+                disabled,
+                next_request_id: AtomicU64::new(1),
+                worker_generation,
+            };
+        }
+        let executable = match std::env::current_exe() {
+            Ok(executable) => executable,
+            Err(error) => {
+                log::error!(target: "kakehashi::tree_worker_shadow", "cannot resolve worker executable: {error}");
+                disabled.store(true, Ordering::Release);
+                return Self {
+                    sender: None,
+                    disabled,
+                    next_request_id: AtomicU64::new(1),
+                    worker_generation,
+                };
+            }
+        };
+        let compute_threads = configured_compute_threads();
+        let (sender, receiver) = mpsc::sync_channel(SHADOW_QUEUE_CAPACITY);
+        let actor_disabled = Arc::clone(&disabled);
+        std::thread::Builder::new()
+            .name("kakehashi-tree-worker-shadow".into())
+            .spawn(move || {
+                run_actor(
+                    receiver,
+                    executable,
+                    compute_threads,
+                    worker_generation,
+                    actor_disabled,
+                );
+            })
+            .expect("tree worker shadow actor thread must spawn");
+        log::info!(
+            target: "kakehashi::tree_worker_shadow",
+            "enabled one shadow worker with {compute_threads} compute threads"
+        );
+        Self {
+            sender: Some(sender),
+            disabled,
+            next_request_id: AtomicU64::new(1),
+            worker_generation,
+        }
+    }
+
+    pub(super) fn mirror_full(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        language: String,
+        grammar: WorkerGrammarDescriptor,
+        text: String,
+    ) {
+        let request = self.sync_request(uri, incarnation, content_version, language, grammar, text);
+        self.submit(ShadowCommand::Sync(request));
+    }
+
+    pub(super) fn is_enabled(&self) -> bool {
+        self.sender.is_some() && !self.disabled.load(Ordering::Acquire)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn mirror_change(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        base_version: u64,
+        content_version: u64,
+        language: String,
+        grammar: WorkerGrammarDescriptor,
+        text: String,
+        edits: Option<Vec<SequentialByteEdit>>,
+    ) {
+        let fallback =
+            self.sync_request(uri, incarnation, content_version, language, grammar, text);
+        let Some(edits) = edits else {
+            self.submit(ShadowCommand::Sync(fallback));
+            return;
+        };
+        let request = ApplyDocumentEditsAndDerive {
+            context: fallback.context.clone(),
+            base_version,
+            edits: edits
+                .into_iter()
+                .map(|edit| ByteEdit {
+                    start_byte: edit.start_byte,
+                    old_end_byte: edit.old_end_byte,
+                    new_text: edit.new_text,
+                })
+                .collect(),
+        };
+        self.submit(ShadowCommand::Apply { request, fallback });
+    }
+
+    pub(super) fn mirror_close(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        configuration_generation: u64,
+    ) {
+        self.submit(ShadowCommand::Close(CloseDocument {
+            context: self.context(uri, incarnation, content_version, configuration_generation),
+        }));
+    }
+
+    pub(super) fn shutdown(&self) {
+        if let Some(sender) = &self.sender {
+            let _ = sender.try_send(ShadowCommand::Shutdown);
+        }
+    }
+
+    fn sync_request(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        language: String,
+        grammar: WorkerGrammarDescriptor,
+        text: String,
+    ) -> SyncDocument {
+        SyncDocument {
+            context: self.context(
+                uri,
+                incarnation,
+                content_version,
+                grammar.configuration_generation,
+            ),
+            language,
+            grammar_symbol: grammar.grammar_symbol,
+            parser_path: grammar.parser_path,
+            text,
+        }
+    }
+
+    fn context(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        configuration_generation: u64,
+    ) -> RequestContext {
+        RequestContext {
+            request_id: self.next_request_id.fetch_add(1, Ordering::Relaxed),
+            worker_generation: self.worker_generation,
+            uri: uri.as_str().to_string(),
+            incarnation,
+            content_version,
+            configuration_generation,
+        }
+    }
+
+    fn submit(&self, command: ShadowCommand) {
+        if self.disabled.load(Ordering::Acquire) {
+            return;
+        }
+        let Some(sender) = &self.sender else {
+            return;
+        };
+        if let Err(error) = sender.try_send(command) {
+            self.disabled.store(true, Ordering::Release);
+            log::error!(
+                target: "kakehashi::tree_worker_shadow",
+                "disabled shadow worker after bounded queue failure: {error}"
+            );
+        }
+    }
+}
+
+fn shadow_enabled() -> bool {
+    std::env::var(SHADOW_ENV)
+        .ok()
+        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "TRUE"))
+}
+
+fn configured_compute_threads() -> usize {
+    std::env::var(SHADOW_THREADS_ENV)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|threads| *threads > 0)
+        .unwrap_or_else(|| {
+            std::thread::available_parallelism()
+                .map(|threads| threads.get().min(8))
+                .unwrap_or(1)
+        })
+}
+
+fn run_actor(
+    receiver: mpsc::Receiver<ShadowCommand>,
+    executable: PathBuf,
+    compute_threads: usize,
+    worker_generation: u64,
+    disabled: Arc<AtomicBool>,
+) {
+    let client = match Client::spawn(&executable, compute_threads, worker_generation) {
+        Ok(client) => client,
+        Err(error) => {
+            disabled.store(true, Ordering::Release);
+            log::error!(target: "kakehashi::tree_worker_shadow", "worker spawn failed: {error}");
+            return;
+        }
+    };
+    while let Ok(command) = receiver.recv() {
+        if disabled.load(Ordering::Acquire) || matches!(command, ShadowCommand::Shutdown) {
+            break;
+        }
+        let started = Instant::now();
+        let response = match command {
+            ShadowCommand::Sync(request) => sync_and_derive(&client, request),
+            ShadowCommand::Apply { request, fallback } => {
+                match client.apply_document_edits_and_derive(request) {
+                    Ok(Response::Snapshot(snapshot)) => Ok(Response::Snapshot(snapshot)),
+                    Ok(Response::WorkerRestartRequired(required)) => {
+                        Ok(Response::WorkerRestartRequired(required))
+                    }
+                    Ok(_) => sync_and_derive(&client, fallback),
+                    Err(error) => Err(error),
+                }
+            }
+            ShadowCommand::Close(request) => client.close_document(request),
+            ShadowCommand::Shutdown => unreachable!(),
+        };
+        match response {
+            Ok(Response::Snapshot(snapshot)) => log::debug!(
+                target: "kakehashi::tree_worker_shadow_metrics",
+                "uri={} version={} parent_us={} queue_us={} compute_us={}",
+                snapshot.context.uri,
+                snapshot.context.content_version,
+                started.elapsed().as_micros(),
+                snapshot.queue_wait_ns / 1_000,
+                snapshot.compute_ns / 1_000,
+            ),
+            Ok(Response::WorkerRestartRequired(required)) => {
+                disabled.store(true, Ordering::Release);
+                log::error!(
+                    target: "kakehashi::tree_worker_shadow",
+                    "disabled shadow worker pending restart: {}",
+                    required.reason
+                );
+                break;
+            }
+            Ok(Response::Error(error)) => log::warn!(
+                target: "kakehashi::tree_worker_shadow",
+                "shadow request rejected: {}",
+                error.message
+            ),
+            Ok(_) => {}
+            Err(error) => {
+                disabled.store(true, Ordering::Release);
+                log::error!(target: "kakehashi::tree_worker_shadow", "worker transport failed: {error}");
+                break;
+            }
+        }
+    }
+    if let Err(error) = client.shutdown() {
+        log::warn!(target: "kakehashi::tree_worker_shadow", "worker shutdown failed: {error}");
+    }
+}
+
+fn sync_and_derive(client: &Client, request: SyncDocument) -> std::io::Result<Response> {
+    let context = request.context.clone();
+    match client.sync_document(request)? {
+        Response::DocumentAck(_) => {
+            client.derive_document_snapshot(DeriveDocumentSnapshot { context })
+        }
+        response => Ok(response),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn shadow(sender: mpsc::SyncSender<ShadowCommand>) -> TreeWorkerShadow {
+        TreeWorkerShadow {
+            sender: Some(sender),
+            disabled: Arc::new(AtomicBool::new(false)),
+            next_request_id: AtomicU64::new(1),
+            worker_generation: 7,
+        }
+    }
+
+    fn grammar() -> WorkerGrammarDescriptor {
+        WorkerGrammarDescriptor {
+            parser_path: "/parser/rust.so".into(),
+            grammar_symbol: "rust".into(),
+            configuration_generation: 3,
+        }
+    }
+
+    #[test]
+    fn mirror_change_preserves_sequential_edits_and_full_sync_fallback() {
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let shadow = shadow(sender);
+        let uri = url::Url::parse("file:///example.rs").unwrap();
+
+        shadow.mirror_change(
+            &uri,
+            2,
+            4,
+            5,
+            "rust".into(),
+            grammar(),
+            "aXXbYde".into(),
+            Some(vec![
+                SequentialByteEdit {
+                    start_byte: 1,
+                    old_end_byte: 1,
+                    new_text: "XX".into(),
+                },
+                SequentialByteEdit {
+                    start_byte: 4,
+                    old_end_byte: 5,
+                    new_text: "Y".into(),
+                },
+            ]),
+        );
+
+        let ShadowCommand::Apply { request, fallback } = receiver.recv().unwrap() else {
+            panic!("incremental mirror must enqueue an apply command");
+        };
+        assert_eq!(request.base_version, 4);
+        assert_eq!(request.context.content_version, 5);
+        assert_eq!(request.edits[0].new_text, "XX");
+        assert_eq!(request.edits[1].start_byte, 4);
+        assert_eq!(fallback.text, "aXXbYde");
+    }
+
+    #[test]
+    fn bounded_queue_failure_disables_the_shadow_session() {
+        let (sender, _receiver) = mpsc::sync_channel(1);
+        let shadow = shadow(sender);
+        shadow.submit(ShadowCommand::Shutdown);
+        shadow.submit(ShadowCommand::Shutdown);
+
+        assert!(!shadow.is_enabled());
+    }
+}

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -523,12 +523,19 @@ impl ComparisonStore {
         } else {
             self.slots.entry(uri.to_string()).or_default()
         };
-        slot.pending = None;
         if slot
             .closed_incarnation
             .is_some_and(|closed| closed >= incarnation)
         {
             return;
+        }
+        if slot
+            .pending
+            .as_ref()
+            .is_some_and(|pending| pending.incarnation <= incarnation)
+        {
+            self.superseded.fetch_add(1, Ordering::Relaxed);
+            slot.pending = None;
         }
         slot.closed_incarnation = Some(incarnation);
         drop(slot);
@@ -559,12 +566,6 @@ impl ComparisonStore {
             .is_some_and(|pending| pending.incarnation < incarnation)
         {
             slot.pending = None;
-        }
-        if slot
-            .closed_incarnation
-            .is_some_and(|closed| closed < incarnation)
-        {
-            slot.closed_incarnation = None;
         }
     }
 
@@ -867,6 +868,27 @@ mod tests {
         );
         let slot = store.slots.get(uri).unwrap();
         assert_eq!(slot.closed_incarnation, Some(1));
+    }
+
+    #[test]
+    fn delayed_old_close_preserves_reopened_incarnation_comparison() {
+        let store = ComparisonStore::default();
+        let uri = "file:///a.rs";
+        store.record(
+            uri,
+            2,
+            0,
+            ComparisonSide::Authoritative(summary("source_file")),
+        );
+
+        store.mark_closed(uri, 1);
+        store.record(uri, 1, 9, ComparisonSide::Shadow(summary("stale")));
+        store.record(uri, 2, 0, ComparisonSide::Shadow(summary("source_file")));
+
+        assert_eq!(store.matched.load(Ordering::Relaxed), 1);
+        assert_eq!(store.mismatched.load(Ordering::Relaxed), 0);
+        assert_eq!(store.superseded.load(Ordering::Relaxed), 1);
+        assert_eq!(store.pending_count(), 0);
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, mpsc};
+use std::sync::{Arc, Mutex, mpsc};
 use std::time::Instant;
 
 use crate::language::coordinator::WorkerGrammarDescriptor;
@@ -14,6 +14,7 @@ use crate::tree_worker::{
 const SHADOW_ENV: &str = "KAKEHASHI_TREE_WORKER_SHADOW";
 const SHADOW_THREADS_ENV: &str = "KAKEHASHI_TREE_WORKER_THREADS";
 const SHADOW_QUEUE_CAPACITY: usize = 256;
+const CLOSED_COMPARISON_TOMBSTONES: usize = 4_096;
 static NEXT_WORKER_GENERATION: AtomicU64 = AtomicU64::new(1);
 
 enum ShadowCommand {
@@ -78,6 +79,8 @@ struct PendingComparison {
 #[derive(Default)]
 struct ComparisonStore {
     pending: dashmap::DashMap<String, PendingComparison>,
+    closed: dashmap::DashMap<String, u64>,
+    closed_order: Mutex<VecDeque<(String, u64)>>,
     matched: AtomicU64,
     mismatched: AtomicU64,
     superseded: AtomicU64,
@@ -151,6 +154,7 @@ impl TreeWorkerShadow {
         text: String,
     ) {
         let request = self.sync_request(uri, incarnation, content_version, language, grammar, text);
+        self.comparisons.reopen(uri.as_str(), incarnation);
         self.submit(ShadowCommand::Sync(request));
     }
 
@@ -198,7 +202,7 @@ impl TreeWorkerShadow {
         content_version: u64,
         configuration_generation: u64,
     ) {
-        self.comparisons.clear_uri(uri);
+        self.comparisons.mark_closed(uri.as_str(), incarnation);
         self.submit(ShadowCommand::Close(CloseDocument {
             context: self.context(uri, incarnation, content_version, configuration_generation),
         }));
@@ -343,6 +347,7 @@ fn run_actor(
         let (response, synced_identity) = match command {
             ShadowCommand::Sync(request) => {
                 let identity = ReplicaIdentity::from_sync(&request);
+                comparisons.reopen(&request.context.uri, request.context.incarnation);
                 (sync_and_derive(&client, request), Some(identity))
             }
             ShadowCommand::Apply { request, fallback } => {
@@ -365,7 +370,7 @@ fn run_actor(
             }
             ShadowCommand::Close(request) => {
                 replicas.remove(&request.context.uri);
-                comparisons.pending.remove(&request.context.uri);
+                comparisons.mark_closed(&request.context.uri, request.context.incarnation);
                 (client.close_document(request), None)
             }
             ShadowCommand::Shutdown => unreachable!(),
@@ -433,6 +438,14 @@ enum ComparisonSide {
 
 impl ComparisonStore {
     fn record(&self, uri: &str, incarnation: u64, content_version: u64, side: ComparisonSide) {
+        if self
+            .closed
+            .get(uri)
+            .is_some_and(|closed| *closed >= incarnation)
+        {
+            self.superseded.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
         let incoming_generation = match &side {
             ComparisonSide::Authoritative(summary) | ComparisonSide::Shadow(summary) => {
                 summary.configuration_generation
@@ -500,8 +513,35 @@ impl ComparisonStore {
         }
     }
 
-    fn clear_uri(&self, uri: &url::Url) {
-        self.pending.remove(uri.as_str());
+    fn mark_closed(&self, uri: &str, incarnation: u64) {
+        self.pending.remove(uri);
+        if self
+            .closed
+            .get(uri)
+            .is_some_and(|closed| *closed > incarnation)
+        {
+            return;
+        }
+        self.closed.insert(uri.to_string(), incarnation);
+
+        use crate::error::LockResultExt;
+        let mut order = self
+            .closed_order
+            .lock()
+            .recover_poison("TreeWorkerShadow::mark_closed");
+        order.push_back((uri.to_string(), incarnation));
+        while order.len() > CLOSED_COMPARISON_TOMBSTONES {
+            let Some((expired_uri, expired_incarnation)) = order.pop_front() else {
+                break;
+            };
+            self.closed
+                .remove_if(&expired_uri, |_, closed| *closed == expired_incarnation);
+        }
+    }
+
+    fn reopen(&self, uri: &str, incarnation: u64) {
+        self.closed
+            .remove_if(uri, |_, closed| *closed < incarnation);
     }
 }
 
@@ -753,5 +793,37 @@ mod tests {
         assert_eq!(store.mismatched.load(Ordering::Relaxed), 0);
         assert_eq!(store.superseded.load(Ordering::Relaxed), 1);
         assert!(store.pending.is_empty());
+    }
+
+    #[test]
+    fn closed_incarnation_rejects_late_results_until_reopen() {
+        let store = ComparisonStore::default();
+        let uri = "file:///a.rs";
+        store.mark_closed(uri, 1);
+
+        store.record(uri, 1, 2, ComparisonSide::Authoritative(summary("late")));
+        assert!(store.pending.is_empty());
+        assert_eq!(store.superseded.load(Ordering::Relaxed), 1);
+
+        store.reopen(uri, 2);
+        store.record(
+            uri,
+            2,
+            0,
+            ComparisonSide::Authoritative(summary("source_file")),
+        );
+        store.record(uri, 2, 0, ComparisonSide::Shadow(summary("source_file")));
+        assert_eq!(store.matched.load(Ordering::Relaxed), 1);
+        assert!(store.pending.is_empty());
+    }
+
+    #[test]
+    fn closed_comparison_tombstones_stay_bounded() {
+        let store = ComparisonStore::default();
+        for index in 0..=CLOSED_COMPARISON_TOMBSTONES {
+            store.mark_closed(&format!("file:///{index}.rs"), 1);
+        }
+
+        assert!(store.closed.len() <= CLOSED_COMPARISON_TOMBSTONES);
     }
 }

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -58,7 +58,7 @@ pub(super) struct TreeWorkerShadow {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct TreeSummary {
+pub(super) struct TreeSummary {
     language: String,
     configuration_generation: u64,
     root_kind: String,
@@ -238,14 +238,12 @@ impl TreeWorkerShadow {
         self.shutdown_with_timeout(SHADOW_SHUTDOWN_TIMEOUT);
     }
 
-    pub(super) fn record_authoritative(
+    pub(super) fn record_authoritative_summary(
         &self,
         uri: &url::Url,
         incarnation: u64,
         content_version: u64,
-        language: &str,
-        configuration_generation: u64,
-        tree: &tree_sitter::Tree,
+        summary: TreeSummary,
     ) {
         if !self.is_enabled() {
             return;
@@ -254,11 +252,7 @@ impl TreeWorkerShadow {
             uri.as_str(),
             incarnation,
             content_version,
-            ComparisonSide::Authoritative(TreeSummary::from_tree(
-                language,
-                configuration_generation,
-                tree,
-            )),
+            ComparisonSide::Authoritative(summary),
         );
     }
 
@@ -401,11 +395,11 @@ fn run_actor(
     let mut replicas = HashMap::<String, ReplicaIdentity>::new();
     let mut shutdown_ack = None;
     while let Ok(command) = receiver.recv() {
-        if disabled.load(Ordering::Acquire) {
-            break;
-        }
         if let ShadowCommand::Shutdown(ack) = command {
             shutdown_ack = Some(ack);
+            break;
+        }
+        if disabled.load(Ordering::Acquire) {
             break;
         }
         let started = Instant::now();
@@ -613,7 +607,11 @@ impl ComparisonStore {
 }
 
 impl TreeSummary {
-    fn from_tree(language: &str, configuration_generation: u64, tree: &tree_sitter::Tree) -> Self {
+    pub(super) fn from_tree(
+        language: &str,
+        configuration_generation: u64,
+        tree: &tree_sitter::Tree,
+    ) -> Self {
         let root = tree.root_node();
         Self {
             language: language.to_string(),

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -234,8 +234,22 @@ impl TreeWorkerShadow {
         }));
     }
 
-    pub(super) fn shutdown(&self) {
-        self.shutdown_with_timeout(SHADOW_SHUTDOWN_TIMEOUT);
+    pub(super) async fn shutdown(&self) {
+        let accepting = Arc::clone(&self.accepting);
+        let sender = self.sender.clone();
+        let comparisons = Arc::clone(&self.comparisons);
+        if let Err(error) = tokio::task::spawn_blocking(move || {
+            shutdown_with_timeout(
+                &accepting,
+                sender.as_ref(),
+                &comparisons,
+                SHADOW_SHUTDOWN_TIMEOUT,
+            );
+        })
+        .await
+        {
+            log_incomplete_shutdown(&format!("shutdown task failed: {error}"));
+        }
     }
 
     pub(super) fn record_authoritative_summary(
@@ -312,43 +326,58 @@ impl TreeWorkerShadow {
         }
     }
 
+    #[cfg(test)]
     fn shutdown_with_timeout(&self, timeout: Duration) {
-        if !self.accepting.swap(false, Ordering::AcqRel) {
-            return;
-        }
-        let deadline = Instant::now() + timeout;
-        let (ack_sender, ack_receiver) = mpsc::sync_channel(0);
-        let Some(sender) = &self.sender else {
-            return;
-        };
-        let mut command = ShadowCommand::Shutdown(ack_sender);
-        loop {
-            match sender.try_send(command) {
-                Ok(()) => break,
-                Err(mpsc::TrySendError::Full(returned)) if Instant::now() < deadline => {
-                    command = returned;
-                    std::thread::sleep(Duration::from_millis(1));
-                }
-                Err(error) => {
-                    log_incomplete_shutdown(&format!("could not enqueue drain request: {error}"));
-                    return;
-                }
-            }
-        }
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if ack_receiver.recv_timeout(remaining).is_err() {
-            log_incomplete_shutdown("timed out waiting for actor drain");
-            return;
-        }
-        log::info!(
-            target: "kakehashi::tree_worker_shadow_metrics",
-            "shadow comparisons matched={} mismatched={} superseded={} pending={}",
-            self.comparisons.matched.load(Ordering::Relaxed),
-            self.comparisons.mismatched.load(Ordering::Relaxed),
-            self.comparisons.superseded.load(Ordering::Relaxed),
-            self.comparisons.pending_count(),
+        shutdown_with_timeout(
+            &self.accepting,
+            self.sender.as_ref(),
+            &self.comparisons,
+            timeout,
         );
     }
+}
+
+fn shutdown_with_timeout(
+    accepting: &AtomicBool,
+    sender: Option<&mpsc::SyncSender<ShadowCommand>>,
+    comparisons: &ComparisonStore,
+    timeout: Duration,
+) {
+    if !accepting.swap(false, Ordering::AcqRel) {
+        return;
+    }
+    let deadline = Instant::now() + timeout;
+    let (ack_sender, ack_receiver) = mpsc::sync_channel(0);
+    let Some(sender) = sender else {
+        return;
+    };
+    let mut command = ShadowCommand::Shutdown(ack_sender);
+    loop {
+        match sender.try_send(command) {
+            Ok(()) => break,
+            Err(mpsc::TrySendError::Full(returned)) if Instant::now() < deadline => {
+                command = returned;
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            Err(error) => {
+                log_incomplete_shutdown(&format!("could not enqueue drain request: {error}"));
+                return;
+            }
+        }
+    }
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if ack_receiver.recv_timeout(remaining).is_err() {
+        log_incomplete_shutdown("timed out waiting for actor drain");
+        return;
+    }
+    log::info!(
+        target: "kakehashi::tree_worker_shadow_metrics",
+        "shadow comparisons matched={} mismatched={} superseded={} pending={}",
+        comparisons.matched.load(Ordering::Relaxed),
+        comparisons.mismatched.load(Ordering::Relaxed),
+        comparisons.superseded.load(Ordering::Relaxed),
+        comparisons.pending_count(),
+    );
 }
 
 fn log_incomplete_shutdown(reason: &str) {

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -327,7 +327,7 @@ impl TreeWorkerShadow {
                 Ok(()) => break,
                 Err(mpsc::TrySendError::Full(returned)) if Instant::now() < deadline => {
                     command = returned;
-                    std::thread::yield_now();
+                    std::thread::sleep(Duration::from_millis(1));
                 }
                 Err(error) => {
                     log_incomplete_shutdown(&format!("could not enqueue drain request: {error}"));

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -30,11 +30,39 @@ pub(super) struct TreeWorkerShadow {
     disabled: Arc<AtomicBool>,
     next_request_id: AtomicU64,
     worker_generation: u64,
+    comparisons: Arc<ComparisonStore>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TreeSummary {
+    language: String,
+    root_kind: String,
+    root_start_byte: usize,
+    root_end_byte: usize,
+    has_error: bool,
+    named_node_count: usize,
+}
+
+#[derive(Default)]
+struct PendingComparison {
+    incarnation: u64,
+    content_version: u64,
+    authoritative: Option<TreeSummary>,
+    shadow: Option<TreeSummary>,
+}
+
+#[derive(Default)]
+struct ComparisonStore {
+    pending: dashmap::DashMap<String, PendingComparison>,
+    matched: AtomicU64,
+    mismatched: AtomicU64,
+    superseded: AtomicU64,
 }
 
 impl TreeWorkerShadow {
     pub(super) fn from_environment() -> Self {
         let disabled = Arc::new(AtomicBool::new(false));
+        let comparisons = Arc::new(ComparisonStore::default());
         let worker_generation = NEXT_WORKER_GENERATION.fetch_add(1, Ordering::Relaxed);
         if !shadow_enabled() {
             return Self {
@@ -42,6 +70,7 @@ impl TreeWorkerShadow {
                 disabled,
                 next_request_id: AtomicU64::new(1),
                 worker_generation,
+                comparisons,
             };
         }
         let executable = match std::env::current_exe() {
@@ -54,12 +83,14 @@ impl TreeWorkerShadow {
                     disabled,
                     next_request_id: AtomicU64::new(1),
                     worker_generation,
+                    comparisons,
                 };
             }
         };
         let compute_threads = configured_compute_threads();
         let (sender, receiver) = mpsc::sync_channel(SHADOW_QUEUE_CAPACITY);
         let actor_disabled = Arc::clone(&disabled);
+        let actor_comparisons = Arc::clone(&comparisons);
         std::thread::Builder::new()
             .name("kakehashi-tree-worker-shadow".into())
             .spawn(move || {
@@ -69,6 +100,7 @@ impl TreeWorkerShadow {
                     compute_threads,
                     worker_generation,
                     actor_disabled,
+                    actor_comparisons,
                 );
             })
             .expect("tree worker shadow actor thread must spawn");
@@ -81,6 +113,7 @@ impl TreeWorkerShadow {
             disabled,
             next_request_id: AtomicU64::new(1),
             worker_generation,
+            comparisons,
         }
     }
 
@@ -141,15 +174,43 @@ impl TreeWorkerShadow {
         content_version: u64,
         configuration_generation: u64,
     ) {
+        self.comparisons.clear_uri(uri);
         self.submit(ShadowCommand::Close(CloseDocument {
             context: self.context(uri, incarnation, content_version, configuration_generation),
         }));
     }
 
     pub(super) fn shutdown(&self) {
+        log::info!(
+            target: "kakehashi::tree_worker_shadow_metrics",
+            "shadow comparisons matched={} mismatched={} superseded={} pending={}",
+            self.comparisons.matched.load(Ordering::Relaxed),
+            self.comparisons.mismatched.load(Ordering::Relaxed),
+            self.comparisons.superseded.load(Ordering::Relaxed),
+            self.comparisons.pending.len(),
+        );
         if let Some(sender) = &self.sender {
             let _ = sender.try_send(ShadowCommand::Shutdown);
         }
+    }
+
+    pub(super) fn record_authoritative(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        language: &str,
+        tree: &tree_sitter::Tree,
+    ) {
+        if !self.is_enabled() {
+            return;
+        }
+        self.comparisons.record(
+            uri.as_str(),
+            incarnation,
+            content_version,
+            ComparisonSide::Authoritative(TreeSummary::from_tree(language, tree)),
+        );
     }
 
     fn sync_request(
@@ -233,6 +294,7 @@ fn run_actor(
     compute_threads: usize,
     worker_generation: u64,
     disabled: Arc<AtomicBool>,
+    comparisons: Arc<ComparisonStore>,
 ) {
     let client = match Client::spawn(&executable, compute_threads, worker_generation) {
         Ok(client) => client,
@@ -263,15 +325,23 @@ fn run_actor(
             ShadowCommand::Shutdown => unreachable!(),
         };
         match response {
-            Ok(Response::Snapshot(snapshot)) => log::debug!(
-                target: "kakehashi::tree_worker_shadow_metrics",
-                "uri={} version={} parent_us={} queue_us={} compute_us={}",
-                snapshot.context.uri,
-                snapshot.context.content_version,
-                started.elapsed().as_micros(),
-                snapshot.queue_wait_ns / 1_000,
-                snapshot.compute_ns / 1_000,
-            ),
+            Ok(Response::Snapshot(snapshot)) => {
+                log::debug!(
+                    target: "kakehashi::tree_worker_shadow_metrics",
+                    "uri={} version={} parent_us={} queue_us={} compute_us={}",
+                    snapshot.context.uri,
+                    snapshot.context.content_version,
+                    started.elapsed().as_micros(),
+                    snapshot.queue_wait_ns / 1_000,
+                    snapshot.compute_ns / 1_000,
+                );
+                comparisons.record(
+                    &snapshot.context.uri,
+                    snapshot.context.incarnation,
+                    snapshot.context.content_version,
+                    ComparisonSide::Shadow(TreeSummary::from_snapshot(&snapshot)),
+                );
+            }
             Ok(Response::WorkerRestartRequired(required)) => {
                 disabled.store(true, Ordering::Release);
                 log::error!(
@@ -299,6 +369,103 @@ fn run_actor(
     }
 }
 
+enum ComparisonSide {
+    Authoritative(TreeSummary),
+    Shadow(TreeSummary),
+}
+
+impl ComparisonStore {
+    fn record(&self, uri: &str, incarnation: u64, content_version: u64, side: ComparisonSide) {
+        let incoming = (incarnation, content_version);
+        let mut pending = self.pending.entry(uri.to_string()).or_default();
+        let current = (pending.incarnation, pending.content_version);
+        if incoming < current {
+            self.superseded.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+        if incoming > current {
+            if pending.authoritative.is_some() || pending.shadow.is_some() {
+                self.superseded.fetch_add(1, Ordering::Relaxed);
+            }
+            *pending = PendingComparison {
+                incarnation,
+                content_version,
+                ..Default::default()
+            };
+        }
+        match side {
+            ComparisonSide::Authoritative(summary) => pending.authoritative = Some(summary),
+            ComparisonSide::Shadow(summary) => pending.shadow = Some(summary),
+        }
+        let completed = pending
+            .authoritative
+            .as_ref()
+            .zip(pending.shadow.as_ref())
+            .map(|(authoritative, shadow)| (authoritative.clone(), shadow.clone()));
+        drop(pending);
+        let Some((authoritative, shadow)) = completed else {
+            return;
+        };
+        self.pending.remove_if(uri, |_, pending| {
+            pending.incarnation == incarnation
+                && pending.content_version == content_version
+                && pending.authoritative.is_some()
+                && pending.shadow.is_some()
+        });
+        if authoritative == shadow {
+            self.matched.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.mismatched.fetch_add(1, Ordering::Relaxed);
+            log::error!(
+                target: "kakehashi::tree_worker_shadow",
+                "tree mismatch uri={uri} incarnation={incarnation} version={content_version} authoritative={authoritative:?} shadow={shadow:?}"
+            );
+        }
+    }
+
+    fn clear_uri(&self, uri: &url::Url) {
+        self.pending.remove(uri.as_str());
+    }
+}
+
+impl TreeSummary {
+    fn from_tree(language: &str, tree: &tree_sitter::Tree) -> Self {
+        let root = tree.root_node();
+        Self {
+            language: language.to_string(),
+            root_kind: root.kind().to_string(),
+            root_start_byte: root.start_byte(),
+            root_end_byte: root.end_byte(),
+            has_error: root.has_error(),
+            named_node_count: named_node_count(root),
+        }
+    }
+
+    fn from_snapshot(snapshot: &crate::tree_worker::DerivedSnapshot) -> Self {
+        Self {
+            language: snapshot.language.clone(),
+            root_kind: snapshot.root_kind.clone(),
+            root_start_byte: snapshot.root_start_byte,
+            root_end_byte: snapshot.root_end_byte,
+            has_error: snapshot.has_error,
+            named_node_count: snapshot.named_node_count,
+        }
+    }
+}
+
+fn named_node_count(root: tree_sitter::Node<'_>) -> usize {
+    let mut count = 0;
+    let mut pending = vec![root];
+    while let Some(node) = pending.pop() {
+        if node.is_named() {
+            count += 1;
+        }
+        let mut cursor = node.walk();
+        pending.extend(node.children(&mut cursor));
+    }
+    count
+}
+
 fn sync_and_derive(client: &Client, request: SyncDocument) -> std::io::Result<Response> {
     let context = request.context.clone();
     match client.sync_document(request)? {
@@ -319,6 +486,7 @@ mod tests {
             disabled: Arc::new(AtomicBool::new(false)),
             next_request_id: AtomicU64::new(1),
             worker_generation: 7,
+            comparisons: Arc::new(ComparisonStore::default()),
         }
     }
 
@@ -327,6 +495,17 @@ mod tests {
             parser_path: "/parser/rust.so".into(),
             grammar_symbol: "rust".into(),
             configuration_generation: 3,
+        }
+    }
+
+    fn summary(root_kind: &str) -> TreeSummary {
+        TreeSummary {
+            language: "rust".into(),
+            root_kind: root_kind.into(),
+            root_start_byte: 0,
+            root_end_byte: 10,
+            has_error: false,
+            named_node_count: 3,
         }
     }
 
@@ -376,5 +555,52 @@ mod tests {
         shadow.submit(ShadowCommand::Shutdown);
 
         assert!(!shadow.is_enabled());
+    }
+
+    #[test]
+    fn comparisons_match_regardless_of_arrival_order() {
+        for authoritative_first in [true, false] {
+            let store = ComparisonStore::default();
+            let authoritative = ComparisonSide::Authoritative(summary("source_file"));
+            let shadow = ComparisonSide::Shadow(summary("source_file"));
+            if authoritative_first {
+                store.record("file:///a.rs", 1, 2, authoritative);
+                store.record("file:///a.rs", 1, 2, shadow);
+            } else {
+                store.record("file:///a.rs", 1, 2, shadow);
+                store.record("file:///a.rs", 1, 2, authoritative);
+            }
+            assert_eq!(store.matched.load(Ordering::Relaxed), 1);
+            assert!(store.pending.is_empty());
+        }
+    }
+
+    #[test]
+    fn comparisons_keep_only_the_latest_document_version() {
+        let store = ComparisonStore::default();
+        store.record(
+            "file:///a.rs",
+            1,
+            1,
+            ComparisonSide::Authoritative(summary("old")),
+        );
+        store.record(
+            "file:///a.rs",
+            1,
+            2,
+            ComparisonSide::Authoritative(summary("new")),
+        );
+        store.record("file:///a.rs", 1, 1, ComparisonSide::Shadow(summary("old")));
+        store.record(
+            "file:///a.rs",
+            1,
+            2,
+            ComparisonSide::Shadow(summary("different")),
+        );
+
+        assert_eq!(store.matched.load(Ordering::Relaxed), 0);
+        assert_eq!(store.mismatched.load(Ordering::Relaxed), 1);
+        assert_eq!(store.superseded.load(Ordering::Relaxed), 2);
+        assert!(store.pending.is_empty());
     }
 }

--- a/src/lsp/text_sync.rs
+++ b/src/lsp/text_sync.rs
@@ -17,6 +17,21 @@ use tree_sitter::{InputEdit, Point};
 
 use crate::text::PositionMapper;
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SequentialByteEdit {
+    pub(crate) start_byte: usize,
+    pub(crate) old_end_byte: usize,
+    pub(crate) new_text: String,
+}
+
+pub(crate) struct AppliedContentChanges {
+    pub(crate) text: String,
+    pub(crate) input_edits: Vec<InputEdit>,
+    /// `Some` preserves the ordered ranged-edit stream. `None` means at least
+    /// one full replacement occurred, so an incremental consumer must resync.
+    pub(crate) sequential_byte_edits: Option<Vec<SequentialByteEdit>>,
+}
+
 /// Apply LSP content changes to `old_text`, returning the updated text and the
 /// matching tree-sitter `InputEdit`s. Changes with `range` build an `InputEdit`;
 /// rangeless full-sync changes replace the whole text and emit no edit.
@@ -31,12 +46,13 @@ use crate::text::PositionMapper;
 /// text, not `old_text`, so they can neither diff against `old_text` nor seed a
 /// tree parsed from `old_text` (the #348 incremental-contract hazard). The whole
 /// batch is therefore a full sync.
-pub(crate) fn apply_content_changes_with_edits(
+pub(crate) fn apply_content_changes_detailed(
     old_text: &str,
     content_changes: Vec<TextDocumentContentChangeEvent>,
-) -> (String, Vec<InputEdit>) {
+) -> AppliedContentChanges {
     let mut text = old_text.to_string();
     let mut edits = Vec::new();
+    let mut sequential_byte_edits = Vec::new();
     // Once a full replacement lands, no `InputEdit` in this batch can describe
     // `old_text → final` incrementally, so the batch is a full sync regardless of
     // any ranged changes that follow.
@@ -59,6 +75,12 @@ pub(crate) fn apply_content_changes_with_edits(
             let mapper = PositionMapper::new(&text);
             let start_offset = mapper.position_to_byte_clamped(range.start);
             let end_offset = mapper.position_to_byte_clamped(range.end).max(start_offset);
+
+            sequential_byte_edits.push(SequentialByteEdit {
+                start_byte: start_offset,
+                old_end_byte: end_offset,
+                new_text: change.text.clone(),
+            });
 
             // Once a full replacement has landed in this batch the edits will be
             // discarded at the end (the batch is a full sync), so skip building the
@@ -128,7 +150,20 @@ pub(crate) fn apply_content_changes_with_edits(
         edits.clear();
     }
 
-    (text, edits)
+    AppliedContentChanges {
+        text,
+        input_edits: edits,
+        sequential_byte_edits: (!saw_full_replacement).then_some(sequential_byte_edits),
+    }
+}
+
+#[cfg(test)]
+fn apply_content_changes_with_edits(
+    old_text: &str,
+    content_changes: Vec<TextDocumentContentChangeEvent>,
+) -> (String, Vec<InputEdit>) {
+    let result = apply_content_changes_detailed(old_text, content_changes);
+    (result.text, result.input_edits)
 }
 
 #[cfg(test)]
@@ -176,6 +211,63 @@ mod tests {
         assert_eq!(edits[0].start_byte, 6);
         assert_eq!(edits[0].old_end_byte, 11);
         assert_eq!(edits[0].new_end_byte, 10); // "rust" is 4 bytes
+    }
+
+    #[test]
+    fn detailed_changes_preserve_sequential_intermediate_coordinates() {
+        let changes = vec![
+            TextDocumentContentChangeEvent {
+                range: Some(Range::new(Position::new(0, 1), Position::new(0, 1))),
+                range_length: Some(0),
+                text: "XX".to_string(),
+            },
+            TextDocumentContentChangeEvent {
+                range: Some(Range::new(Position::new(0, 4), Position::new(0, 5))),
+                range_length: Some(1),
+                text: "Y".to_string(),
+            },
+        ];
+
+        let result = apply_content_changes_detailed("abcde", changes);
+
+        assert_eq!(result.text, "aXXbYde");
+        assert_eq!(
+            result.sequential_byte_edits,
+            Some(vec![
+                SequentialByteEdit {
+                    start_byte: 1,
+                    old_end_byte: 1,
+                    new_text: "XX".to_string(),
+                },
+                SequentialByteEdit {
+                    start_byte: 4,
+                    old_end_byte: 5,
+                    new_text: "Y".to_string(),
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn detailed_changes_require_resync_after_any_full_replacement() {
+        let changes = vec![
+            TextDocumentContentChangeEvent {
+                range: Some(Range::new(Position::new(0, 0), Position::new(0, 1))),
+                range_length: Some(1),
+                text: "A".to_string(),
+            },
+            TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: "replacement".to_string(),
+            },
+        ];
+
+        let result = apply_content_changes_detailed("abc", changes);
+
+        assert_eq!(result.text, "replacement");
+        assert!(result.input_edits.is_empty());
+        assert_eq!(result.sequential_byte_edits, None);
     }
 
     #[test]

--- a/src/lsp/text_sync.rs
+++ b/src/lsp/text_sync.rs
@@ -76,11 +76,13 @@ pub(crate) fn apply_content_changes_detailed(
             let start_offset = mapper.position_to_byte_clamped(range.start);
             let end_offset = mapper.position_to_byte_clamped(range.end).max(start_offset);
 
-            sequential_byte_edits.push(SequentialByteEdit {
-                start_byte: start_offset,
-                old_end_byte: end_offset,
-                new_text: change.text.clone(),
-            });
+            if !saw_full_replacement {
+                sequential_byte_edits.push(SequentialByteEdit {
+                    start_byte: start_offset,
+                    old_end_byte: end_offset,
+                    new_text: change.text.clone(),
+                });
+            }
 
             // Once a full replacement has landed in this batch the edits will be
             // discarded at the end (the batch is a full sync), so skip building the
@@ -135,6 +137,7 @@ pub(crate) fn apply_content_changes_detailed(
             // Full document change - no incremental parsing
             text = change.text;
             edits.clear(); // Clear any previous edits since it's a full replacement
+            sequential_byte_edits.clear();
             saw_full_replacement = true;
         }
     }
@@ -148,6 +151,7 @@ pub(crate) fn apply_content_changes_detailed(
     // seed) into the returned vec.
     if saw_full_replacement {
         edits.clear();
+        sequential_byte_edits.clear();
     }
 
     AppliedContentChanges {
@@ -261,11 +265,16 @@ mod tests {
                 range_length: None,
                 text: "replacement".to_string(),
             },
+            TextDocumentContentChangeEvent {
+                range: Some(Range::new(Position::new(0, 0), Position::new(0, 1))),
+                range_length: Some(1),
+                text: "R".to_string(),
+            },
         ];
 
         let result = apply_content_changes_detailed("abc", changes);
 
-        assert_eq!(result.text, "replacement");
+        assert_eq!(result.text, "Replacement");
         assert!(result.input_edits.is_empty());
         assert_eq!(result.sequential_byte_edits, None);
     }

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -452,10 +452,23 @@ pub fn decode_frame<R: Read, T: DeserializeOwned>(reader: &mut R) -> io::Result<
 
 fn named_node_count(root: tree_sitter::Node<'_>) -> usize {
     let mut count = 0;
-    let mut pending = vec![root];
-    while let Some(node) = pending.pop() {
-        count += usize::from(node.is_named());
-        pending.extend((0..node.child_count() as u32).filter_map(|index| node.child(index)));
+    let mut cursor = root.walk();
+    let mut ascending = false;
+    loop {
+        if !ascending {
+            count += usize::from(cursor.node().is_named());
+            if cursor.goto_first_child() {
+                continue;
+            }
+        }
+        if cursor.goto_next_sibling() {
+            ascending = false;
+            continue;
+        }
+        if !cursor.goto_parent() {
+            break;
+        }
+        ascending = true;
     }
     count
 }
@@ -1940,8 +1953,8 @@ mod tests {
         LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS, MAX_RETAINED_DOCUMENT_BYTES,
         PROTOCOL_VERSION, Request, RequestContext, Response, Route, SyncDocument, WorkerError,
         close_document, decode_frame, derive_snapshot_with_language, encode_frame,
-        replace_retained_bytes, reserve_retained_growth, route_response, run, submit_document_job,
-        sync_document, validate_document_size,
+        named_node_count, replace_retained_bytes, reserve_retained_growth, route_response, run,
+        submit_document_job, sync_document, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -2130,6 +2143,31 @@ mod tests {
         assert_eq!(snapshot.root_kind, "source_file");
         assert!(!snapshot.has_error);
         assert!(snapshot.named_node_count >= 2);
+    }
+
+    #[test]
+    fn cursor_named_node_count_visits_each_node_once() {
+        fn recursive_count(node: tree_sitter::Node<'_>) -> usize {
+            usize::from(node.is_named())
+                + (0..node.child_count() as u32)
+                    .filter_map(|index| node.child(index))
+                    .map(recursive_count)
+                    .sum::<usize>()
+        }
+
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let tree = parser
+            .parse(
+                "fn main() { let answer = if true { 42 } else { 0 }; }",
+                None,
+            )
+            .unwrap();
+        let root = tree.root_node();
+
+        assert_eq!(named_node_count(root), recursive_count(root));
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -450,7 +450,7 @@ pub fn decode_frame<R: Read, T: DeserializeOwned>(reader: &mut R) -> io::Result<
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
 }
 
-fn named_node_count(root: tree_sitter::Node<'_>) -> usize {
+pub(crate) fn named_node_count(root: tree_sitter::Node<'_>) -> usize {
     let mut count = 0;
     let mut cursor = root.walk();
     let mut ascending = false;

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1,0 +1,97 @@
+#![cfg(feature = "e2e")]
+
+mod helpers;
+
+use std::time::Duration;
+
+use helpers::lsp_client::LspClient;
+use serde_json::json;
+
+#[test]
+fn shadow_worker_matches_authoritative_incremental_lifecycle() {
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_SHADOW", "true")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env(
+            "RUST_LOG",
+            "kakehashi::tree_worker_shadow=info,kakehashi::tree_worker_shadow_metrics=info",
+        )
+        .build();
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {
+                "textDocument": {
+                    "semanticTokens": {
+                        "requests": { "full": true },
+                        "tokenTypes": ["keyword", "variable", "number"],
+                        "tokenModifiers": [],
+                        "formats": ["relative"]
+                    }
+                }
+            },
+            "initializationOptions": {
+                "searchPaths": ["${KAKEHASHI_DATA_DIR}"]
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    let uri = "file:///tree-worker-shadow.rs";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "rust",
+                "version": 1,
+                "text": "fn main() { let value = 100000; }\n"
+            }
+        }),
+    );
+    std::thread::sleep(Duration::from_millis(500));
+
+    for version in 2..=21 {
+        client.send_notification(
+            "textDocument/didChange",
+            json!({
+                "textDocument": { "uri": uri, "version": version },
+                "contentChanges": [{
+                    "range": {
+                        "start": { "line": 0, "character": 24 },
+                        "end": { "line": 0, "character": 30 }
+                    },
+                    "rangeLength": 6,
+                    "text": format!("{version:06}")
+                }]
+            }),
+        );
+        let response = client.send_request(
+            "textDocument/semanticTokens/full",
+            json!({ "textDocument": { "uri": uri } }),
+        );
+        assert!(response.get("result").is_some());
+    }
+    std::thread::sleep(Duration::from_millis(500));
+    client.send_notification(
+        "textDocument/didClose",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+    std::thread::sleep(Duration::from_millis(100));
+
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+    let status = client
+        .wait_for_exit(Duration::from_secs(5))
+        .expect("server must exit after shutdown");
+    assert!(status.success());
+    let stderr = client.drain_stderr();
+    assert!(
+        stderr.contains("shadow comparisons matched="),
+        "missing shadow summary: {stderr}"
+    );
+    assert!(!stderr.contains("tree mismatch"), "{stderr}");
+    assert!(!stderr.contains("worker transport failed"), "{stderr}");
+}

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -92,6 +92,21 @@ fn shadow_worker_matches_authoritative_incremental_lifecycle() {
         stderr.contains("shadow comparisons matched="),
         "missing shadow summary: {stderr}"
     );
+    let summary = stderr
+        .lines()
+        .find(|line| line.contains("shadow comparisons matched="))
+        .expect("shadow summary was checked above");
+    let metric = |name: &str| {
+        summary
+            .split_whitespace()
+            .find_map(|field| field.strip_prefix(&format!("{name}=")))
+            .and_then(|value| value.trim_end_matches(',').parse::<u64>().ok())
+            .unwrap_or_else(|| panic!("missing {name} in shadow summary: {summary}"))
+    };
+    assert!(metric("matched") > 0, "{summary}");
+    assert_eq!(metric("mismatched"), 0, "{summary}");
+    assert_eq!(metric("pending"), 0, "{summary}");
+    assert!(!stderr.contains("shadow validation incomplete"), "{stderr}");
     assert!(!stderr.contains("tree mismatch"), "{stderr}");
     assert!(!stderr.contains("worker transport failed"), "{stderr}");
 }


### PR DESCRIPTION
## Summary

- preserve ordered byte edits for sequential LSP content changes
- mirror open/change/close into one bounded resident worker actor behind `KAKEHASHI_TREE_WORKER_SHADOW=true`
- compare only the latest authoritative and shadow tree summaries without publishing worker results
- fence comparison by open URI incarnation and exact language configuration generation
- force full sync when the replica language or grammar identity changes
- fail closed by disabling only the shadow session on queue, transport, or worker-state failure
- drain accepted actor work within a bounded shutdown deadline before emitting final metrics
- bind pooled trees and bindings queries to the same reload generation
- avoid comparison-key and per-node traversal allocations, and keep summary traversal on the compute pool
- record real-LSP agreement and the foreground cost of duplicate parsing

## Stack

- Base: #865
- This PR is the Stage 3 shadow-validation layer; it does not cut over authoritative parsing.

## Measurement

Two 200-cycle Rust edit + `semanticTokens/full` batches reversed execution order.

- comparison: 201/201 versions matched in each shadow run; 0 mismatched, superseded, or pending
- wall cost: +7.92% and +6.27%
- semantic p50 cost: +11.02% and +10.58%
- semantic p90-p99 cost: +0.62% to +16.61%
- release binary SHA-256: `90902453b256fcbab027fa84fbf87f2483aad1e077df3ae37ecdebc4590eb1ca`

The overhead is duplicate CPU parsing in validation mode, not a synchronous IPC wait. The next performance gate is worker-authoritative cutover, where the parent parse is removed.

## Validation

- `make check`
- `cargo test --locked` — 3,080 library tests passed, 2 ignored; all other targets passed
- `cargo test --locked --quiet --features e2e --test e2e_tree_worker_shadow -- --nocapture`
- generation, delayed-close/reopen, queue-full shutdown, grammar-identity, and cursor traversal regression tests
- clean-build binary attestation, byte-verified runtime provenance, and alternating real-process measurements recorded in `single_worker_stage3_shadow_2026-07-19.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional “tree worker shadow” LSP validation that mirrors document open/change/close and compares shadow vs authoritative tree results.
  * Shadow coordination is now generation-aware to keep parsing and bindings consistent.
* **Documentation**
  * Added ADRs describing Stage 3 shadow measurement and benchmark methodology, with reproduction guidance.
* **Tests**
  * Added gated end-to-end coverage for repeated incremental edits plus semantic-token and shadow comparison assertions.
  * Extended unit tests and shadow benchmark parsing utilities.
* **Chores**
  * Added benchmark collectors, new shadow benchmark result artifacts, and updated benchmark harness/provenance checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->