### PR TITLE
feat(worker): supervise and recover the shadow process

### DIFF
--- a/benches/profile/results/single_worker_stage4_recovery_2026-07-19.json
+++ b/benches/profile/results/single_worker_stage4_recovery_2026-07-19.json
@@ -7,8 +7,8 @@
     "rustc": "rustc 1.95.0 (59807616e 2026-04-14)",
     "profile": "release",
     "features": ["e2e"],
-    "source_commit": "de6343766e4d9669c71066081f519d6111fdd8a0",
-    "binary_sha256": "30ad55b1d67f6a34edf31cb32e791f3e9869607b32ca32519d9c4f777b031401"
+    "source_commit": "0d6763b36f1aa6bb32576f9b5882514678e30805",
+    "binary_sha256": "d75ff167c973a17e3d1f842284c376eee794f0672f9f9aeac8e8cca4012aaad6"
   },
   "method": {
     "trials_per_scenario": 5,
@@ -22,39 +22,39 @@
     "systemic_one_document": {
       "open_documents": 1,
       "resynced_bytes": 34,
-      "recovery_ms": [529, 551, 547, 494, 615],
-      "median_ms": 547,
-      "mean_ms": 547.2,
-      "min_ms": 494,
-      "max_ms": 615
+      "recovery_ms": [557, 625, 515, 508, 512],
+      "median_ms": 515,
+      "mean_ms": 543.4,
+      "min_ms": 508,
+      "max_ms": 625
     },
     "systemic_many_documents": {
       "open_documents": 17,
       "resynced_bytes": 248037,
-      "recovery_ms": [509, 538, 512, 529, 527],
-      "median_ms": 527,
-      "mean_ms": 523.0,
-      "min_ms": 509,
-      "max_ms": 538
+      "recovery_ms": [517, 522, 522, 527, 543],
+      "median_ms": 522,
+      "mean_ms": 526.2,
+      "min_ms": 517,
+      "max_ms": 543
     },
     "request_crash_with_grammar_quarantine": {
       "open_documents": 1,
       "resynced_documents": 0,
       "resynced_bytes": 0,
-      "recovery_ms": [501, 601, 477, 553, 490],
-      "median_ms": 501,
-      "mean_ms": 524.4,
-      "min_ms": 477,
-      "max_ms": 601
+      "recovery_ms": [600, 486, 550, 500, 504],
+      "median_ms": 504,
+      "mean_ms": 528.0,
+      "min_ms": 486,
+      "max_ms": 600
     },
     "idle_process_exit": {
       "open_documents": 0,
       "resynced_bytes": 0,
-      "recovery_ms": [476, 499, 481, 486, 497],
-      "median_ms": 486,
-      "mean_ms": 487.8,
-      "min_ms": 476,
-      "max_ms": 499
+      "recovery_ms": [493, 503, 476, 550, 470],
+      "median_ms": 493,
+      "mean_ms": 498.4,
+      "min_ms": 470,
+      "max_ms": 550
     }
   }
 }

--- a/benches/profile/results/single_worker_stage4_recovery_2026-07-19.json
+++ b/benches/profile/results/single_worker_stage4_recovery_2026-07-19.json
@@ -21,6 +21,7 @@
   "scenarios": {
     "systemic_one_document": {
       "open_documents": 1,
+      "resynced_documents": 1,
       "resynced_bytes": 34,
       "recovery_ms": [557, 625, 515, 508, 512],
       "median_ms": 515,
@@ -30,6 +31,7 @@
     },
     "systemic_many_documents": {
       "open_documents": 17,
+      "resynced_documents": 17,
       "resynced_bytes": 248037,
       "recovery_ms": [517, 522, 522, 527, 543],
       "median_ms": 522,
@@ -49,6 +51,7 @@
     },
     "idle_process_exit": {
       "open_documents": 0,
+      "resynced_documents": 0,
       "resynced_bytes": 0,
       "recovery_ms": [493, 503, 476, 550, 470],
       "median_ms": 493,

--- a/benches/profile/results/single_worker_stage4_recovery_2026-07-19.json
+++ b/benches/profile/results/single_worker_stage4_recovery_2026-07-19.json
@@ -1,0 +1,60 @@
+{
+  "schema": 1,
+  "experiment": "single-tree-worker-stage4-recovery",
+  "environment": {
+    "platform": "macOS 26.5.1 (25F80)",
+    "cpu_model": "Apple M4",
+    "rustc": "rustc 1.95.0 (59807616e 2026-04-14)",
+    "profile": "release",
+    "features": ["e2e"],
+    "source_commit": "de6343766e4d9669c71066081f519d6111fdd8a0",
+    "binary_sha256": "30ad55b1d67f6a34edf31cb32e791f3e9869607b32ca32519d9c4f777b031401"
+  },
+  "method": {
+    "trials_per_scenario": 5,
+    "worker_compute_threads": 4,
+    "initial_backoff_ms": 250,
+    "recovery_ms_definition": "failure handling start through cleanup, backoff, spawn, handshake, and full resync completion",
+    "idle_detection_poll_ms": 250,
+    "idle_detection_delay_included": false
+  },
+  "scenarios": {
+    "systemic_one_document": {
+      "open_documents": 1,
+      "resynced_bytes": 34,
+      "recovery_ms": [529, 551, 547, 494, 615],
+      "median_ms": 547,
+      "mean_ms": 547.2,
+      "min_ms": 494,
+      "max_ms": 615
+    },
+    "systemic_many_documents": {
+      "open_documents": 17,
+      "resynced_bytes": 248037,
+      "recovery_ms": [509, 538, 512, 529, 527],
+      "median_ms": 527,
+      "mean_ms": 523.0,
+      "min_ms": 509,
+      "max_ms": 538
+    },
+    "request_crash_with_grammar_quarantine": {
+      "open_documents": 1,
+      "resynced_documents": 0,
+      "resynced_bytes": 0,
+      "recovery_ms": [501, 601, 477, 553, 490],
+      "median_ms": 501,
+      "mean_ms": 524.4,
+      "min_ms": 477,
+      "max_ms": 601
+    },
+    "idle_process_exit": {
+      "open_documents": 0,
+      "resynced_bytes": 0,
+      "recovery_ms": [476, 499, 481, 486, 497],
+      "median_ms": 486,
+      "mean_ms": 487.8,
+      "min_ms": 476,
+      "max_ms": 499
+    }
+  }
+}

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage4-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage4-measurement.md
@@ -22,8 +22,8 @@ release binary was built with the `e2e` feature from commit
 The run used an Apple M4, macOS 26.5.1, Rust 1.95.0, and four worker compute
 threads.
 
-Deterministic one-shot hooks injected four failure shapes. Each scenario ran
-five fresh LSP server sessions. `recovery_ms` starts when the actor begins
+Deterministic one-shot hooks injected three failure shapes across four replay
+scenarios. Each scenario ran five fresh LSP server sessions. `recovery_ms` starts when the actor begins
 handling the failure and ends after worker cleanup, the configured 250 ms
 backoff, replacement spawn and handshake, and full-text resynchronization.
 For idle exit, the separate detection delay is not included; the supervisor

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage4-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage4-measurement.md
@@ -17,8 +17,8 @@ persisted and therefore does not create a next-start blacklist.
 The committed raw result is
 `benches/profile/results/single_worker_stage4_recovery_2026-07-19.json`. The
 release binary was built with the `e2e` feature from commit
-`de6343766e4d9669c71066081f519d6111fdd8a0` and has SHA-256
-`30ad55b1d67f6a34edf31cb32e791f3e9869607b32ca32519d9c4f777b031401`.
+`0d6763b36f1aa6bb32576f9b5882514678e30805` and has SHA-256
+`d75ff167c973a17e3d1f842284c376eee794f0672f9f9aeac8e8cca4012aaad6`.
 The run used an Apple M4, macOS 26.5.1, Rust 1.95.0, and four worker compute
 threads.
 
@@ -33,13 +33,13 @@ polls at 250 ms, so up to another 250 ms precedes the logged recovery interval.
 
 | Scenario | Replayed documents / bytes | Recovery median | Mean | Range |
 |---|---:|---:|---:|---:|
-| Explicit systemic restart | 1 / 34 B | 547 ms | 547.2 ms | 494--615 ms |
-| Explicit systemic restart, larger session | 17 / 248,037 B | 527 ms | 523.0 ms | 509--538 ms |
-| Request-time process crash, implicated grammar quarantined | 0 / 0 B | 501 ms | 524.4 ms | 477--601 ms |
-| Idle process exit | 0 / 0 B | 486 ms | 487.8 ms | 476--499 ms |
+| Explicit systemic restart | 1 / 34 B | 515 ms | 543.4 ms | 508--625 ms |
+| Explicit systemic restart, larger session | 17 / 248,037 B | 522 ms | 526.2 ms | 517--543 ms |
+| Request-time process crash, implicated grammar quarantined | 0 / 0 B | 504 ms | 528.0 ms | 486--600 ms |
+| Idle process exit | 0 / 0 B | 493 ms | 498.4 ms | 470--550 ms |
 
 The 17-document replay did not measure slower than the one-document replay;
-their ranges overlap and the larger replay's median was 20 ms lower. At this
+their ranges overlap and the larger replay's median was only 7 ms higher. At this
 scale, replaying roughly 248 KB is below run-to-run worker cleanup and spawn
 jitter. The fixed 250 ms backoff plus cleanup, process creation, binary digest,
 handshake, and parser loading dominates the observed roughly 0.5 second

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage4-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage4-measurement.md
@@ -1,0 +1,96 @@
+# Single Tree Worker Stage 4 Supervision Measurement
+
+## Scope
+
+Stage 4 keeps the Stage 3 shadow path non-authoritative and adds a supervisor
+around its single resident worker. The supervisor detects request-time
+transport loss, explicit `WorkerRestartRequired` responses, and process exit
+while idle. It starts a new worker generation, replays the latest full text of
+all open documents, and fences queued commands to the replacement generation.
+
+An implicated grammar is conservatively quarantined for the current session.
+The worker still restarts so other grammars can continue. The quarantine is not
+persisted and therefore does not create a next-start blacklist.
+
+## Method
+
+The committed raw result is
+`benches/profile/results/single_worker_stage4_recovery_2026-07-19.json`. The
+release binary was built with the `e2e` feature from commit
+`de6343766e4d9669c71066081f519d6111fdd8a0` and has SHA-256
+`30ad55b1d67f6a34edf31cb32e791f3e9869607b32ca32519d9c4f777b031401`.
+The run used an Apple M4, macOS 26.5.1, Rust 1.95.0, and four worker compute
+threads.
+
+Deterministic one-shot hooks injected four failure shapes. Each scenario ran
+five fresh LSP server sessions. `recovery_ms` starts when the actor begins
+handling the failure and ends after worker cleanup, the configured 250 ms
+backoff, replacement spawn and handshake, and full-text resynchronization.
+For idle exit, the separate detection delay is not included; the supervisor
+polls at 250 ms, so up to another 250 ms precedes the logged recovery interval.
+
+## Results
+
+| Scenario | Replayed documents / bytes | Recovery median | Mean | Range |
+|---|---:|---:|---:|---:|
+| Explicit systemic restart | 1 / 34 B | 547 ms | 547.2 ms | 494--615 ms |
+| Explicit systemic restart, larger session | 17 / 248,037 B | 527 ms | 523.0 ms | 509--538 ms |
+| Request-time process crash, implicated grammar quarantined | 0 / 0 B | 501 ms | 524.4 ms | 477--601 ms |
+| Idle process exit | 0 / 0 B | 486 ms | 487.8 ms | 476--499 ms |
+
+The 17-document replay did not measure slower than the one-document replay;
+their ranges overlap and the larger replay's median was 20 ms lower. At this
+scale, replaying roughly 248 KB is below run-to-run worker cleanup and spawn
+jitter. The fixed 250 ms backoff plus cleanup, process creation, binary digest,
+handshake, and parser loading dominates the observed roughly 0.5 second
+recovery interval.
+
+This does not prove replay cost is constant. Larger retained text, more
+languages, expensive parsers, and query-derived state can make replay visible.
+The supervisor therefore logs both document and byte counts beside recovery
+time so later production observations can expose that scaling.
+
+## Architectural consequences
+
+One worker is compatible with bounded recovery, but it is also one shared
+failure domain. A systemic worker loss temporarily interrupts every grammar,
+even when only one document was active. Session quarantine prevents a parser
+with failure-correlated evidence from repeatedly taking down healthy grammars;
+the replacement process then recovers the non-quarantined documents.
+
+The result supports the ADR's decision not to persist a parser blacklist.
+Restarting Kakehashi can retry the same parser safely because it remains behind
+the process boundary and will be quarantined again if it fails. Persistence
+would add stale cross-session state without reducing the approximately
+half-second bounded recovery measured here.
+
+The current grammar identity is parser path, grammar symbol, and configuration
+generation rather than a content-addressed artifact identity. Restart budgets
+are bounded but do not yet restore tokens after a healthy period or implement
+circuit half-open transitions. Those are follow-up supervision stages before
+authoritative cutover; this measurement must not be read as completion of the
+entire ADR supervision model.
+
+## Reproduction
+
+```sh
+for test_name in \
+  systemic_worker_restart_full_resyncs_the_open_document \
+  systemic_worker_restart_measures_many_document_full_resync \
+  crashed_grammar_is_quarantined_only_in_session_and_other_grammar_recovers \
+  idle_worker_exit_is_detected_and_restarted_before_the_next_document
+do
+  for trial in 1 2 3 4 5
+  do
+    cargo test --release --locked --features e2e \
+      --test e2e_tree_worker_shadow "$test_name" -- --nocapture
+  done
+done
+```
+
+The Stage 3 normal-workload result remains the steady-state measurement:
+full-rate duplicate shadow parsing costs 6.3--7.9% wall time in that workload.
+Stage 4 changes failure handling rather than the successful request path, so
+its new acceptance evidence is recovery latency and replay volume. The later
+authoritative cutover still requires a fresh steady-state comparison with the
+parent's duplicate parse removed.

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -124,6 +124,12 @@ struct ResyncStats {
     bytes: usize,
 }
 
+struct ResyncFailure {
+    error: std::io::Error,
+    class: FailureClass,
+    implicated_grammar: Option<GrammarIdentity>,
+}
+
 impl OpenDocuments {
     fn observe(&mut self, command: &ShadowCommand) {
         match command {
@@ -180,6 +186,7 @@ struct PendingComparison {
 struct ComparisonSlot {
     open_incarnation: u64,
     pending: Option<PendingComparison>,
+    completed: Option<(u64, u64, u64)>,
 }
 
 #[derive(Default)]
@@ -469,6 +476,13 @@ fn shutdown_with_timeout(
         log_incomplete_shutdown("timed out waiting for actor drain");
         return;
     }
+    let pending_uris = comparisons.pending_uris();
+    if !pending_uris.is_empty() {
+        log::warn!(
+            target: "kakehashi::tree_worker_shadow_metrics",
+            "shadow comparisons still pending for URIs: {pending_uris:?}",
+        );
+    }
     log::info!(
         target: "kakehashi::tree_worker_shadow_metrics",
         "shadow comparisons matched={} mismatched={} superseded={} pending={}",
@@ -588,14 +602,16 @@ fn run_actor(
         let implicated_grammar = command_grammar(&command).or_else(|| {
             command_uri(&command).and_then(|uri| state.open_documents.grammar_for(uri))
         });
+        let command_document =
+            command_document(&command).map(|(uri, incarnation)| (uri.to_string(), incarnation));
         state.open_documents.observe(&command);
         retag_command(&mut command, state.worker_generation);
         if implicated_grammar
             .as_ref()
             .is_some_and(|grammar| state.quarantined.contains(grammar))
         {
-            if let Some((uri, incarnation)) = command_document(&command) {
-                comparisons.mark_closed(uri, incarnation);
+            if let Some((uri, incarnation)) = command_document.as_ref() {
+                comparisons.mark_closed(uri, *incarnation);
             }
             continue;
         }
@@ -651,11 +667,16 @@ fn run_actor(
                     break;
                 }
             }
-            Ok(Response::Error(error)) => log::warn!(
-                target: "kakehashi::tree_worker_shadow",
-                "shadow request rejected: {}",
-                error.message
-            ),
+            Ok(Response::Error(error)) => {
+                if let Some((uri, incarnation)) = command_document {
+                    comparisons.mark_closed(&uri, incarnation);
+                }
+                log::warn!(
+                    target: "kakehashi::tree_worker_shadow",
+                    "shadow request rejected: {}",
+                    error.message
+                );
+            }
             Ok(_) => {}
             Err(error) => {
                 let class = classify_transport_failure(
@@ -741,22 +762,8 @@ fn recover_worker(
     comparisons: &ComparisonStore,
 ) -> bool {
     let recovery_started = Instant::now();
-    if let Some(grammar) = implicated_grammar
-        && state.quarantined.insert(grammar.clone())
-    {
-        for request in state.open_documents.current.values() {
-            if GrammarIdentity::from_sync(request) == grammar {
-                comparisons.mark_closed(&request.context.uri, request.context.incarnation);
-            }
-        }
-        log::error!(
-            target: "kakehashi::tree_worker_shadow",
-            "quarantined grammar conservatively for this session after {:?} worker loss: symbol={} path={} configuration_generation={}",
-            class,
-            grammar.grammar_symbol,
-            grammar.parser_path.display(),
-            grammar.configuration_generation,
-        );
+    if let Some(grammar) = implicated_grammar {
+        quarantine_grammar(state, grammar, class, comparisons);
     }
 
     loop {
@@ -809,16 +816,44 @@ fn recover_worker(
                 );
                 return true;
             }
-            Err(error) => {
+            Err(failure) => {
                 state.client = Some(replacement);
+                if let Some(grammar) = failure.implicated_grammar {
+                    quarantine_grammar(state, grammar, failure.class, comparisons);
+                }
                 log::error!(
                     target: "kakehashi::tree_worker_shadow",
-                    "worker generation {generation} full resync failed: {error}"
+                    "worker generation {generation} full resync failed: {}",
+                    failure.error,
                 );
-                class = FailureClass::Systemic;
+                class = failure.class;
             }
         }
     }
+}
+
+fn quarantine_grammar(
+    state: &mut SupervisorState,
+    grammar: GrammarIdentity,
+    class: FailureClass,
+    comparisons: &ComparisonStore,
+) {
+    if !state.quarantined.insert(grammar.clone()) {
+        return;
+    }
+    for request in state.open_documents.current.values() {
+        if GrammarIdentity::from_sync(request) == grammar {
+            comparisons.mark_closed(&request.context.uri, request.context.incarnation);
+        }
+    }
+    log::error!(
+        target: "kakehashi::tree_worker_shadow",
+        "quarantined grammar conservatively for this session after {:?} worker loss: symbol={} path={} configuration_generation={}",
+        class,
+        grammar.grammar_symbol,
+        grammar.parser_path.display(),
+        grammar.configuration_generation,
+    );
 }
 
 fn resync_open_documents(
@@ -828,20 +863,22 @@ fn resync_open_documents(
     quarantined: &HashSet<GrammarIdentity>,
     replicas: &mut HashMap<String, ReplicaIdentity>,
     comparisons: &ComparisonStore,
-) -> std::io::Result<ResyncStats> {
+) -> Result<ResyncStats, ResyncFailure> {
     let mut requests = open_documents.current.values().cloned().collect::<Vec<_>>();
     requests.sort_unstable_by(|left, right| left.context.uri.cmp(&right.context.uri));
     let mut resynced = ResyncStats::default();
     for mut request in requests {
-        if quarantined.contains(&GrammarIdentity::from_sync(&request)) {
+        let grammar = GrammarIdentity::from_sync(&request);
+        if quarantined.contains(&grammar) {
             continue;
         }
-        resynced.bytes = resynced.bytes.saturating_add(request.text.len());
+        let request_bytes = request.text.len();
+        let request_uri = request.context.uri.clone();
         request.context.worker_generation = generation;
         let identity = ReplicaIdentity::from_sync(&request);
         comparisons.open(&request.context.uri, request.context.incarnation);
-        match sync_and_derive(client, request)? {
-            Response::Snapshot(snapshot) => {
+        match sync_and_derive(client, request) {
+            Ok(Response::Snapshot(snapshot)) => {
                 replicas.insert(snapshot.context.uri.clone(), identity);
                 comparisons.record(
                     &snapshot.context.uri,
@@ -850,15 +887,39 @@ fn resync_open_documents(
                     ComparisonSide::Shadow(TreeSummary::from_snapshot(&snapshot)),
                 );
                 resynced.documents += 1;
+                resynced.bytes = resynced.bytes.saturating_add(request_bytes);
             }
-            Response::WorkerRestartRequired(required) => {
-                return Err(std::io::Error::other(required.reason));
+            Ok(Response::WorkerRestartRequired(required)) => {
+                return Err(ResyncFailure {
+                    error: std::io::Error::other(required.reason),
+                    class: FailureClass::Systemic,
+                    implicated_grammar: None,
+                });
             }
-            Response::Error(error) => return Err(std::io::Error::other(error.message)),
-            response => {
-                return Err(std::io::Error::other(format!(
-                    "unexpected resync response: {response:?}"
-                )));
+            Ok(Response::Error(error)) => {
+                comparisons.mark_closed(&request_uri, identity.incarnation);
+                log::warn!(
+                    target: "kakehashi::tree_worker_shadow",
+                    "skipped shadow resync for {request_uri}: {}",
+                    error.message,
+                );
+            }
+            Ok(response) => {
+                return Err(ResyncFailure {
+                    error: std::io::Error::other(format!(
+                        "unexpected resync response: {response:?}"
+                    )),
+                    class: FailureClass::Systemic,
+                    implicated_grammar: None,
+                });
+            }
+            Err(error) => {
+                let class = classify_transport_failure(client, &error, Some(&grammar));
+                return Err(ResyncFailure {
+                    error,
+                    class,
+                    implicated_grammar: Some(grammar),
+                });
             }
         }
     }
@@ -962,6 +1023,14 @@ impl ComparisonStore {
             self.superseded.fetch_add(1, Ordering::Relaxed);
             return;
         }
+        if let Some(completed) = slot.completed
+            && incoming <= completed
+        {
+            if incoming < completed {
+                self.superseded.fetch_add(1, Ordering::Relaxed);
+            }
+            return;
+        }
 
         let pending = slot.pending.get_or_insert_with(|| PendingComparison {
             incarnation,
@@ -1006,6 +1075,7 @@ impl ComparisonStore {
         let shadow = completed
             .shadow
             .expect("completed comparison has a shadow summary");
+        slot.completed = Some(incoming);
         drop(slot);
         if authoritative == shadow {
             self.matched.fetch_add(1, Ordering::Relaxed);
@@ -1039,6 +1109,7 @@ impl ComparisonStore {
             *slot = ComparisonSlot {
                 open_incarnation: incarnation,
                 pending: None,
+                completed: None,
             };
         }
     }
@@ -1048,6 +1119,14 @@ impl ComparisonStore {
             .iter()
             .filter(|slot| slot.pending.is_some())
             .count()
+    }
+
+    fn pending_uris(&self) -> Vec<String> {
+        self.slots
+            .iter()
+            .filter(|slot| slot.pending.is_some())
+            .map(|slot| slot.key().clone())
+            .collect()
     }
 }
 
@@ -1310,6 +1389,26 @@ mod tests {
             assert_eq!(store.matched.load(Ordering::Relaxed), 1);
             assert_eq!(store.pending_count(), 0);
         }
+    }
+
+    #[test]
+    fn replayed_shadow_for_an_already_completed_version_is_ignored() {
+        let store = ComparisonStore::default();
+        let uri = "file:///a.rs";
+        store.open(uri, 1);
+        store.record(
+            uri,
+            1,
+            2,
+            ComparisonSide::Authoritative(summary("source_file")),
+        );
+        store.record(uri, 1, 2, ComparisonSide::Shadow(summary("source_file")));
+
+        store.record(uri, 1, 2, ComparisonSide::Shadow(summary("source_file")));
+
+        assert_eq!(store.matched.load(Ordering::Relaxed), 1);
+        assert_eq!(store.superseded.load(Ordering::Relaxed), 0);
+        assert_eq!(store.pending_count(), 0);
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, mpsc};
@@ -15,6 +15,12 @@ const SHADOW_ENV: &str = "KAKEHASHI_TREE_WORKER_SHADOW";
 const SHADOW_THREADS_ENV: &str = "KAKEHASHI_TREE_WORKER_THREADS";
 const SHADOW_QUEUE_CAPACITY: usize = 256;
 const SHADOW_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_SYSTEMIC_RESTARTS: u8 = 3;
+const MAX_NATIVE_RESTARTS: u8 = 8;
+const MAX_SESSION_RESTARTS: u8 = 16;
+const INITIAL_RESTART_BACKOFF: Duration = Duration::from_millis(250);
+const MAX_RESTART_BACKOFF: Duration = Duration::from_secs(300);
+const WORKER_LIVENESS_POLL: Duration = Duration::from_millis(250);
 static NEXT_WORKER_GENERATION: AtomicU64 = AtomicU64::new(1);
 
 enum ShadowCommand {
@@ -45,6 +51,99 @@ impl ReplicaIdentity {
             parser_path: request.parser_path.clone(),
             configuration_generation: request.context.configuration_generation,
         }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct GrammarIdentity {
+    grammar_symbol: String,
+    parser_path: PathBuf,
+    configuration_generation: u64,
+}
+
+impl GrammarIdentity {
+    fn from_sync(request: &SyncDocument) -> Self {
+        Self {
+            grammar_symbol: request.grammar_symbol.clone(),
+            parser_path: request.parser_path.clone(),
+            configuration_generation: request.context.configuration_generation,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FailureClass {
+    Systemic,
+    NativeEvidenced,
+}
+
+#[derive(Default)]
+struct RestartBudget {
+    systemic: u8,
+    native: u8,
+    total: u8,
+}
+
+impl RestartBudget {
+    fn consume(&mut self, class: FailureClass) -> bool {
+        self.total = self.total.saturating_add(1);
+        match class {
+            FailureClass::Systemic => self.systemic = self.systemic.saturating_add(1),
+            FailureClass::NativeEvidenced => self.native = self.native.saturating_add(1),
+        }
+        self.total <= MAX_SESSION_RESTARTS
+            && self.systemic <= MAX_SYSTEMIC_RESTARTS
+            && self.native <= MAX_NATIVE_RESTARTS
+    }
+
+    fn backoff(&self) -> Duration {
+        let exponent = self.total.saturating_sub(1).min(10) as u32;
+        INITIAL_RESTART_BACKOFF
+            .saturating_mul(1_u32 << exponent)
+            .min(MAX_RESTART_BACKOFF)
+    }
+}
+
+#[derive(Default)]
+struct OpenDocuments {
+    current: HashMap<String, SyncDocument>,
+}
+
+struct SupervisorState {
+    client: Option<Client>,
+    worker_generation: u64,
+    replicas: HashMap<String, ReplicaIdentity>,
+    open_documents: OpenDocuments,
+    quarantined: HashSet<GrammarIdentity>,
+    restart_budget: RestartBudget,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct ResyncStats {
+    documents: usize,
+    bytes: usize,
+}
+
+impl OpenDocuments {
+    fn observe(&mut self, command: &ShadowCommand) {
+        match command {
+            ShadowCommand::Sync(request) => {
+                self.current
+                    .insert(request.context.uri.clone(), request.clone());
+            }
+            ShadowCommand::Apply { fallback, .. } => {
+                self.current
+                    .insert(fallback.context.uri.clone(), fallback.clone());
+            }
+            ShadowCommand::Close(request) => {
+                self.current.remove(&request.context.uri);
+            }
+            ShadowCommand::Shutdown(_) => {}
+        }
+    }
+
+    fn grammar_for(&self, uri: &str) -> Option<GrammarIdentity> {
+        self.current.get(uri).map(GrammarIdentity::from_sync)
     }
 }
 
@@ -413,17 +512,72 @@ fn run_actor(
     disabled: Arc<AtomicBool>,
     comparisons: Arc<ComparisonStore>,
 ) {
-    let client = match Client::spawn(&executable, compute_threads, worker_generation) {
-        Ok(client) => client,
+    let initial_client = match Client::spawn(&executable, compute_threads, worker_generation) {
+        Ok(client) => Some(client),
         Err(error) => {
-            disabled.store(true, Ordering::Release);
             log::error!(target: "kakehashi::tree_worker_shadow", "worker spawn failed: {error}");
-            return;
+            None
         }
     };
-    let mut replicas = HashMap::<String, ReplicaIdentity>::new();
+    let mut state = SupervisorState {
+        client: initial_client,
+        worker_generation,
+        replicas: HashMap::new(),
+        open_documents: OpenDocuments::default(),
+        quarantined: HashSet::new(),
+        restart_budget: RestartBudget::default(),
+    };
+    if state.client.is_none()
+        && !recover_worker(
+            &mut state,
+            &executable,
+            compute_threads,
+            FailureClass::Systemic,
+            None,
+            &comparisons,
+        )
+    {
+        disabled.store(true, Ordering::Release);
+        return;
+    }
     let mut shutdown_ack = None;
-    while let Ok(command) = receiver.recv() {
+    loop {
+        let mut command = match receiver.recv_timeout(WORKER_LIVENESS_POLL) {
+            Ok(command) => command,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                let status = state
+                    .client
+                    .as_ref()
+                    .expect("an enabled shadow actor has a worker client")
+                    .try_wait();
+                match status {
+                    Ok(None) => continue,
+                    Ok(Some(status)) => log::error!(
+                        target: "kakehashi::tree_worker_shadow",
+                        "worker generation {} exited while idle: {status}",
+                        state.worker_generation,
+                    ),
+                    Err(error) => log::error!(
+                        target: "kakehashi::tree_worker_shadow",
+                        "worker generation {} liveness check failed: {error}",
+                        state.worker_generation,
+                    ),
+                }
+                if !recover_worker(
+                    &mut state,
+                    &executable,
+                    compute_threads,
+                    FailureClass::Systemic,
+                    None,
+                    &comparisons,
+                ) {
+                    disabled.store(true, Ordering::Release);
+                    break;
+                }
+                continue;
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        };
         if let ShadowCommand::Shutdown(ack) = command {
             shutdown_ack = Some(ack);
             break;
@@ -431,42 +585,36 @@ fn run_actor(
         if disabled.load(Ordering::Acquire) {
             break;
         }
+        let implicated_grammar = command_grammar(&command).or_else(|| {
+            command_uri(&command).and_then(|uri| state.open_documents.grammar_for(uri))
+        });
+        state.open_documents.observe(&command);
+        retag_command(&mut command, state.worker_generation);
+        if implicated_grammar
+            .as_ref()
+            .is_some_and(|grammar| state.quarantined.contains(grammar))
+        {
+            if let Some((uri, incarnation)) = command_document(&command) {
+                comparisons.mark_closed(uri, incarnation);
+            }
+            continue;
+        }
         let started = Instant::now();
-        let (response, synced_identity) = match command {
-            ShadowCommand::Sync(request) => {
-                let identity = ReplicaIdentity::from_sync(&request);
-                comparisons.open(&request.context.uri, request.context.incarnation);
-                (sync_and_derive(&client, request), Some(identity))
-            }
-            ShadowCommand::Apply { request, fallback } => {
-                let uri = fallback.context.uri.clone();
-                let identity = ReplicaIdentity::from_sync(&fallback);
-                if replica_requires_sync(&replicas, &uri, &identity) {
-                    (sync_and_derive(&client, fallback), Some(identity))
-                } else {
-                    match client.apply_document_edits_and_derive(request) {
-                        Ok(Response::Snapshot(snapshot)) => {
-                            (Ok(Response::Snapshot(snapshot)), None)
-                        }
-                        Ok(Response::WorkerRestartRequired(required)) => {
-                            (Ok(Response::WorkerRestartRequired(required)), None)
-                        }
-                        Ok(_) => (sync_and_derive(&client, fallback), Some(identity)),
-                        Err(error) => (Err(error), None),
-                    }
-                }
-            }
-            ShadowCommand::Close(request) => {
-                replicas.remove(&request.context.uri);
-                comparisons.mark_closed(&request.context.uri, request.context.incarnation);
-                (client.close_document(request), None)
-            }
-            ShadowCommand::Shutdown(_) => unreachable!(),
-        };
+        let (response, synced_identity) = execute_command(
+            state
+                .client
+                .as_ref()
+                .expect("an enabled shadow actor has a worker client"),
+            command,
+            &mut state.replicas,
+            &comparisons,
+        );
         match response {
             Ok(Response::Snapshot(snapshot)) => {
                 if let Some(identity) = synced_identity {
-                    replicas.insert(snapshot.context.uri.clone(), identity);
+                    state
+                        .replicas
+                        .insert(snapshot.context.uri.clone(), identity);
                 }
                 log::debug!(
                     target: "kakehashi::tree_worker_shadow_metrics",
@@ -485,13 +633,23 @@ fn run_actor(
                 );
             }
             Ok(Response::WorkerRestartRequired(required)) => {
-                disabled.store(true, Ordering::Release);
-                log::error!(
+                log::warn!(
                     target: "kakehashi::tree_worker_shadow",
-                    "disabled shadow worker pending restart: {}",
+                    "worker generation {} requested restart: {}",
+                    state.worker_generation,
                     required.reason
                 );
-                break;
+                if !recover_worker(
+                    &mut state,
+                    &executable,
+                    compute_threads,
+                    FailureClass::Systemic,
+                    None,
+                    &comparisons,
+                ) {
+                    disabled.store(true, Ordering::Release);
+                    break;
+                }
             }
             Ok(Response::Error(error)) => log::warn!(
                 target: "kakehashi::tree_worker_shadow",
@@ -500,17 +658,277 @@ fn run_actor(
             ),
             Ok(_) => {}
             Err(error) => {
-                disabled.store(true, Ordering::Release);
-                log::error!(target: "kakehashi::tree_worker_shadow", "worker transport failed: {error}");
-                break;
+                let class = classify_transport_failure(
+                    state
+                        .client
+                        .as_ref()
+                        .expect("failed request retains its worker client"),
+                    &error,
+                    implicated_grammar.as_ref(),
+                );
+                log::error!(
+                    target: "kakehashi::tree_worker_shadow",
+                    "worker generation {} transport failed: {error}",
+                    state.worker_generation,
+                );
+                if !recover_worker(
+                    &mut state,
+                    &executable,
+                    compute_threads,
+                    class,
+                    implicated_grammar,
+                    &comparisons,
+                ) {
+                    disabled.store(true, Ordering::Release);
+                    break;
+                }
             }
         }
     }
-    if let Err(error) = client.shutdown() {
+    if let Some(client) = state.client
+        && let Err(error) = client.shutdown()
+    {
         log::warn!(target: "kakehashi::tree_worker_shadow", "worker shutdown failed: {error}");
     }
     if let Some(ack) = shutdown_ack {
         let _ = ack.send(());
+    }
+}
+
+fn execute_command(
+    client: &Client,
+    command: ShadowCommand,
+    replicas: &mut HashMap<String, ReplicaIdentity>,
+    comparisons: &ComparisonStore,
+) -> (std::io::Result<Response>, Option<ReplicaIdentity>) {
+    match command {
+        ShadowCommand::Sync(request) => {
+            let identity = ReplicaIdentity::from_sync(&request);
+            comparisons.open(&request.context.uri, request.context.incarnation);
+            (sync_and_derive(client, request), Some(identity))
+        }
+        ShadowCommand::Apply { request, fallback } => {
+            let uri = fallback.context.uri.clone();
+            let identity = ReplicaIdentity::from_sync(&fallback);
+            if replica_requires_sync(replicas, &uri, &identity) {
+                (sync_and_derive(client, fallback), Some(identity))
+            } else {
+                match client.apply_document_edits_and_derive(request) {
+                    Ok(Response::Snapshot(snapshot)) => (Ok(Response::Snapshot(snapshot)), None),
+                    Ok(Response::WorkerRestartRequired(required)) => {
+                        (Ok(Response::WorkerRestartRequired(required)), None)
+                    }
+                    Ok(_) => (sync_and_derive(client, fallback), Some(identity)),
+                    Err(error) => (Err(error), None),
+                }
+            }
+        }
+        ShadowCommand::Close(request) => {
+            replicas.remove(&request.context.uri);
+            comparisons.mark_closed(&request.context.uri, request.context.incarnation);
+            (client.close_document(request), None)
+        }
+        ShadowCommand::Shutdown(_) => unreachable!(),
+    }
+}
+
+fn recover_worker(
+    state: &mut SupervisorState,
+    executable: &std::path::Path,
+    compute_threads: usize,
+    mut class: FailureClass,
+    implicated_grammar: Option<GrammarIdentity>,
+    comparisons: &ComparisonStore,
+) -> bool {
+    let recovery_started = Instant::now();
+    if let Some(grammar) = implicated_grammar
+        && state.quarantined.insert(grammar.clone())
+    {
+        for request in state.open_documents.current.values() {
+            if GrammarIdentity::from_sync(request) == grammar {
+                comparisons.mark_closed(&request.context.uri, request.context.incarnation);
+            }
+        }
+        log::error!(
+            target: "kakehashi::tree_worker_shadow",
+            "quarantined grammar conservatively for this session after {:?} worker loss: symbol={} path={} configuration_generation={}",
+            class,
+            grammar.grammar_symbol,
+            grammar.parser_path.display(),
+            grammar.configuration_generation,
+        );
+    }
+
+    loop {
+        if !state.restart_budget.consume(class) {
+            log::error!(
+                target: "kakehashi::tree_worker_shadow",
+                "disabled shadow tree tier after restart budget exhaustion: systemic={} native={} total={}",
+                state.restart_budget.systemic,
+                state.restart_budget.native,
+                state.restart_budget.total,
+            );
+            return false;
+        }
+        if let Some(old_client) = state.client.take()
+            && let Err(error) = old_client.shutdown()
+        {
+            log::warn!(target: "kakehashi::tree_worker_shadow", "failed worker cleanup: {error}");
+        }
+        std::thread::sleep(state.restart_budget.backoff());
+        let generation = NEXT_WORKER_GENERATION.fetch_add(1, Ordering::Relaxed);
+        let replacement = match Client::spawn(executable, compute_threads, generation) {
+            Ok(client) => client,
+            Err(error) => {
+                log::error!(
+                    target: "kakehashi::tree_worker_shadow",
+                    "worker generation {generation} restart failed: {error}"
+                );
+                class = FailureClass::Systemic;
+                continue;
+            }
+        };
+        state.replicas.clear();
+        match resync_open_documents(
+            &replacement,
+            generation,
+            &state.open_documents,
+            &state.quarantined,
+            &mut state.replicas,
+            comparisons,
+        ) {
+            Ok(resynced) => {
+                state.worker_generation = generation;
+                state.client = Some(replacement);
+                log::info!(
+                    target: "kakehashi::tree_worker_shadow",
+                    "restarted worker generation {generation} and full-resynced {} open documents (bytes={} recovery_ms={})",
+                    resynced.documents,
+                    resynced.bytes,
+                    recovery_started.elapsed().as_millis(),
+                );
+                return true;
+            }
+            Err(error) => {
+                state.client = Some(replacement);
+                log::error!(
+                    target: "kakehashi::tree_worker_shadow",
+                    "worker generation {generation} full resync failed: {error}"
+                );
+                class = FailureClass::Systemic;
+            }
+        }
+    }
+}
+
+fn resync_open_documents(
+    client: &Client,
+    generation: u64,
+    open_documents: &OpenDocuments,
+    quarantined: &HashSet<GrammarIdentity>,
+    replicas: &mut HashMap<String, ReplicaIdentity>,
+    comparisons: &ComparisonStore,
+) -> std::io::Result<ResyncStats> {
+    let mut requests = open_documents.current.values().cloned().collect::<Vec<_>>();
+    requests.sort_unstable_by(|left, right| left.context.uri.cmp(&right.context.uri));
+    let mut resynced = ResyncStats::default();
+    for mut request in requests {
+        if quarantined.contains(&GrammarIdentity::from_sync(&request)) {
+            continue;
+        }
+        resynced.bytes = resynced.bytes.saturating_add(request.text.len());
+        request.context.worker_generation = generation;
+        let identity = ReplicaIdentity::from_sync(&request);
+        comparisons.open(&request.context.uri, request.context.incarnation);
+        match sync_and_derive(client, request)? {
+            Response::Snapshot(snapshot) => {
+                replicas.insert(snapshot.context.uri.clone(), identity);
+                comparisons.record(
+                    &snapshot.context.uri,
+                    snapshot.context.incarnation,
+                    snapshot.context.content_version,
+                    ComparisonSide::Shadow(TreeSummary::from_snapshot(&snapshot)),
+                );
+                resynced.documents += 1;
+            }
+            Response::WorkerRestartRequired(required) => {
+                return Err(std::io::Error::other(required.reason));
+            }
+            Response::Error(error) => return Err(std::io::Error::other(error.message)),
+            response => {
+                return Err(std::io::Error::other(format!(
+                    "unexpected resync response: {response:?}"
+                )));
+            }
+        }
+    }
+    Ok(resynced)
+}
+
+fn retag_command(command: &mut ShadowCommand, generation: u64) {
+    match command {
+        ShadowCommand::Sync(request) => request.context.worker_generation = generation,
+        ShadowCommand::Apply { request, fallback } => {
+            request.context.worker_generation = generation;
+            fallback.context.worker_generation = generation;
+        }
+        ShadowCommand::Close(request) => request.context.worker_generation = generation,
+        ShadowCommand::Shutdown(_) => {}
+    }
+}
+
+fn classify_transport_failure(
+    client: &Client,
+    error: &std::io::Error,
+    implicated_grammar: Option<&GrammarIdentity>,
+) -> FailureClass {
+    if implicated_grammar.is_none() {
+        return FailureClass::Systemic;
+    }
+    if error.kind() == std::io::ErrorKind::TimedOut {
+        return FailureClass::NativeEvidenced;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+
+        if client
+            .try_wait()
+            .ok()
+            .flatten()
+            .is_some_and(|status| status.signal().is_some())
+        {
+            return FailureClass::NativeEvidenced;
+        }
+    }
+    FailureClass::Systemic
+}
+
+fn command_uri(command: &ShadowCommand) -> Option<&str> {
+    match command {
+        ShadowCommand::Sync(request) => Some(&request.context.uri),
+        ShadowCommand::Apply { fallback, .. } => Some(&fallback.context.uri),
+        ShadowCommand::Close(request) => Some(&request.context.uri),
+        ShadowCommand::Shutdown(_) => None,
+    }
+}
+
+fn command_document(command: &ShadowCommand) -> Option<(&str, u64)> {
+    match command {
+        ShadowCommand::Sync(request) => Some((&request.context.uri, request.context.incarnation)),
+        ShadowCommand::Apply { fallback, .. } => {
+            Some((&fallback.context.uri, fallback.context.incarnation))
+        }
+        ShadowCommand::Close(request) => Some((&request.context.uri, request.context.incarnation)),
+        ShadowCommand::Shutdown(_) => None,
+    }
+}
+
+fn command_grammar(command: &ShadowCommand) -> Option<GrammarIdentity> {
+    match command {
+        ShadowCommand::Sync(request) => Some(GrammarIdentity::from_sync(request)),
+        ShadowCommand::Apply { fallback, .. } => Some(GrammarIdentity::from_sync(fallback)),
+        ShadowCommand::Close(_) | ShadowCommand::Shutdown(_) => None,
     }
 }
 
@@ -706,6 +1124,82 @@ mod tests {
             has_error: false,
             named_node_count: 3,
         }
+    }
+
+    fn sync(uri: &str, incarnation: u64, version: u64, generation: u64) -> SyncDocument {
+        SyncDocument {
+            context: RequestContext {
+                request_id: version,
+                worker_generation: generation,
+                uri: uri.into(),
+                incarnation,
+                content_version: version,
+                configuration_generation: 3,
+            },
+            language: "rust".into(),
+            grammar_symbol: "rust".into(),
+            parser_path: "/parser/rust.so".into(),
+            text: format!("version {version}"),
+        }
+    }
+
+    #[test]
+    fn open_document_registry_keeps_only_latest_authoritative_text() {
+        let mut documents = OpenDocuments::default();
+        documents.observe(&ShadowCommand::Sync(sync("file:///a.rs", 1, 1, 7)));
+        documents.observe(&ShadowCommand::Apply {
+            request: ApplyDocumentEditsAndDerive {
+                context: sync("file:///a.rs", 1, 2, 7).context,
+                base_version: 1,
+                edits: Vec::new(),
+            },
+            fallback: sync("file:///a.rs", 1, 2, 7),
+        });
+
+        let latest = documents.current.get("file:///a.rs").unwrap();
+        assert_eq!(latest.context.content_version, 2);
+        assert_eq!(latest.text, "version 2");
+
+        documents.observe(&ShadowCommand::Close(CloseDocument {
+            context: latest.context.clone(),
+        }));
+        assert!(documents.current.is_empty());
+    }
+
+    #[test]
+    fn command_retagging_fences_queued_work_to_replacement_generation() {
+        let mut command = ShadowCommand::Apply {
+            request: ApplyDocumentEditsAndDerive {
+                context: sync("file:///a.rs", 1, 2, 7).context,
+                base_version: 1,
+                edits: Vec::new(),
+            },
+            fallback: sync("file:///a.rs", 1, 2, 7),
+        };
+        retag_command(&mut command, 11);
+
+        let ShadowCommand::Apply { request, fallback } = command else {
+            unreachable!();
+        };
+        assert_eq!(request.context.worker_generation, 11);
+        assert_eq!(fallback.context.worker_generation, 11);
+    }
+
+    #[test]
+    fn restart_budgets_are_independent_and_session_bounded() {
+        let mut systemic = RestartBudget::default();
+        assert!(systemic.consume(FailureClass::Systemic));
+        assert!(systemic.consume(FailureClass::Systemic));
+        assert!(systemic.consume(FailureClass::Systemic));
+        assert!(!systemic.consume(FailureClass::Systemic));
+
+        let mut native = RestartBudget::default();
+        for _ in 0..MAX_NATIVE_RESTARTS {
+            assert!(native.consume(FailureClass::NativeEvidenced));
+        }
+        assert!(!native.consume(FailureClass::NativeEvidenced));
+
+        assert_eq!(systemic.backoff(), Duration::from_secs(2));
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -864,10 +864,15 @@ fn resync_open_documents(
     replicas: &mut HashMap<String, ReplicaIdentity>,
     comparisons: &ComparisonStore,
 ) -> Result<ResyncStats, ResyncFailure> {
-    let mut requests = open_documents.current.values().cloned().collect::<Vec<_>>();
-    requests.sort_unstable_by(|left, right| left.context.uri.cmp(&right.context.uri));
+    let mut uris = open_documents.current.keys().collect::<Vec<_>>();
+    uris.sort_unstable();
     let mut resynced = ResyncStats::default();
-    for mut request in requests {
+    for uri in uris {
+        let mut request = open_documents
+            .current
+            .get(uri)
+            .expect("resync URI came from the open-document registry")
+            .clone();
         let grammar = GrammarIdentity::from_sync(&request);
         if quarantined.contains(&grammar) {
             continue;

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -892,11 +892,12 @@ fn classify_transport_failure(
     {
         use std::os::unix::process::ExitStatusExt;
 
-        if client
-            .try_wait()
-            .ok()
-            .flatten()
-            .is_some_and(|status| status.signal().is_some())
+        if !client.was_terminated_by_transport()
+            && client
+                .try_wait()
+                .ok()
+                .flatten()
+                .is_some_and(|status| status.signal().is_some())
         {
             return FailureClass::NativeEvidenced;
         }

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -1330,6 +1330,8 @@ where
             None,
         ))
         .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
+    #[cfg(feature = "e2e")]
+    inject_idle_worker_crash_once();
 
     let documents = Arc::new(dashmap::DashMap::new());
     let closed_documents = Arc::new(dashmap::DashMap::new());
@@ -1352,6 +1354,13 @@ where
                     }),
                     None,
                 ))
+                .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
+            continue;
+        }
+        #[cfg(feature = "e2e")]
+        if let Some(response) = inject_worker_failure_once(&request) {
+            responses
+                .send((response, None))
                 .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
             continue;
         }
@@ -1402,6 +1411,54 @@ where
     }
     drop(responses);
     join_writer(writer_thread)
+}
+
+#[cfg(feature = "e2e")]
+fn inject_worker_failure_once(request: &Request) -> Option<Response> {
+    let Request::SyncDocument(sync) = request else {
+        return None;
+    };
+    if let Ok(marker) = std::env::var("KAKEHASHI_TREE_WORKER_CRASH_ONCE_FILE")
+        && std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(marker)
+            .is_ok()
+    {
+        std::process::exit(86);
+    }
+    if let Ok(marker) = std::env::var("KAKEHASHI_TREE_WORKER_RESTART_ONCE_FILE")
+        && std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(marker)
+            .is_ok()
+    {
+        return Some(Response::WorkerRestartRequired(WorkerRestartRequired {
+            context: sync.context.clone(),
+            reason: "injected systemic restart".into(),
+        }));
+    }
+    None
+}
+
+#[cfg(feature = "e2e")]
+fn inject_idle_worker_crash_once() {
+    let Ok(marker) = std::env::var("KAKEHASHI_TREE_WORKER_IDLE_CRASH_ONCE_FILE") else {
+        return;
+    };
+    if std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(marker)
+        .is_err()
+    {
+        return;
+    }
+    std::thread::spawn(|| {
+        std::thread::sleep(Duration::from_millis(100));
+        std::process::exit(87);
+    });
 }
 
 fn join_writer(thread: std::thread::JoinHandle<io::Result<()>>) -> io::Result<()> {
@@ -1605,6 +1662,13 @@ impl Client {
             ready,
             max_inflight,
         })
+    }
+
+    pub fn try_wait(&self) -> io::Result<Option<std::process::ExitStatus>> {
+        self.child
+            .lock()
+            .map_err(|_| io::Error::other("worker child lock is poisoned"))?
+            .try_wait()
     }
 
     pub fn compute_threads(&self) -> usize {

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -1428,6 +1428,9 @@ fn inject_worker_failure_once(request: &Request) -> Option<Response> {
         std::process::exit(86);
     }
     if let Ok(marker) = std::env::var("KAKEHASHI_TREE_WORKER_RESTART_ONCE_FILE")
+        && std::env::var("KAKEHASHI_TREE_WORKER_RESTART_URI_SUFFIX")
+            .ok()
+            .is_none_or(|suffix| sync.context.uri.ends_with(&suffix))
         && std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -1442,6 +1442,15 @@ fn inject_worker_failure_once(request: &Request) -> Option<Response> {
             reason: "injected systemic restart".into(),
         }));
     }
+    if std::env::var("KAKEHASHI_TREE_WORKER_ERROR_URI_SUFFIX")
+        .ok()
+        .is_some_and(|suffix| sync.context.uri.ends_with(&suffix))
+    {
+        return Some(Response::Error(WorkerError {
+            context: Some(sync.context.clone()),
+            message: "injected document rejection".into(),
+        }));
+    }
     None
 }
 

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -13,7 +13,7 @@ use std::{
     collections::{HashMap, VecDeque},
     sync::{
         Arc, Mutex, Weak,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
 
@@ -1504,6 +1504,7 @@ fn executable_digest(path: &std::path::Path) -> io::Result<String> {
 
 pub struct Client {
     child: Arc<Mutex<Child>>,
+    terminated_by_transport: Arc<AtomicBool>,
     outbound: Mutex<Option<mpsc::SyncSender<Request>>>,
     routes: Arc<Mutex<HashMap<u64, Route>>>,
     reader: Option<std::thread::JoinHandle<()>>,
@@ -1545,9 +1546,11 @@ impl Client {
             .take()
             .ok_or_else(|| io::Error::other("worker stdout was not piped"))?;
         let child = Arc::new(Mutex::new(child));
+        let terminated_by_transport = Arc::new(AtomicBool::new(false));
         let routes = Arc::new(Mutex::new(HashMap::<u64, Route>::new()));
         let reader_routes = Arc::clone(&routes);
         let reader_child = Arc::clone(&child);
+        let reader_terminated_by_transport = Arc::clone(&terminated_by_transport);
         let (handshake_tx, handshake_rx) = mpsc::channel();
         let reader = std::thread::spawn(move || {
             let mut handshake_tx = Some(handshake_tx);
@@ -1583,7 +1586,11 @@ impl Client {
                 }
             }
             if let Ok(mut child) = reader_child.lock() {
-                terminate(&mut child, Duration::from_secs(1));
+                terminate_by_transport(
+                    &mut child,
+                    &reader_terminated_by_transport,
+                    Duration::from_secs(1),
+                );
             }
         });
         if let Err(error) = encode_frame(
@@ -1643,6 +1650,7 @@ impl Client {
         let (outbound, outbound_rx) = mpsc::sync_channel::<Request>(max_inflight);
         let writer_routes = Arc::clone(&routes);
         let writer_child = Arc::clone(&child);
+        let writer_terminated_by_transport = Arc::clone(&terminated_by_transport);
         let writer = std::thread::spawn(move || {
             for request in outbound_rx {
                 if let Err(error) = encode_frame(&mut stdin, &request) {
@@ -1650,7 +1658,11 @@ impl Client {
                     let message = error.to_string();
                     fail_routes(None, &writer_routes, kind, &message);
                     if let Ok(mut child) = writer_child.lock() {
-                        terminate(&mut child, Duration::from_secs(1));
+                        terminate_by_transport(
+                            &mut child,
+                            &writer_terminated_by_transport,
+                            Duration::from_secs(1),
+                        );
                     }
                     break;
                 }
@@ -1658,6 +1670,7 @@ impl Client {
         });
         Ok(Self {
             child,
+            terminated_by_transport,
             outbound: Mutex::new(Some(outbound)),
             routes,
             reader: Some(reader),
@@ -1672,6 +1685,10 @@ impl Client {
             .lock()
             .map_err(|_| io::Error::other("worker child lock is poisoned"))?
             .try_wait()
+    }
+
+    pub fn was_terminated_by_transport(&self) -> bool {
+        self.terminated_by_transport.load(Ordering::Acquire)
     }
 
     pub fn compute_threads(&self) -> usize {
@@ -2006,11 +2023,19 @@ fn terminate(child: &mut Child, timeout: Duration) {
     let _ = wait_until(child, timeout);
 }
 
+fn terminate_by_transport(child: &mut Child, marker: &AtomicBool, timeout: Duration) {
+    if child.try_wait().ok().flatten().is_some() {
+        return;
+    }
+    marker.store(true, Ordering::Release);
+    terminate(child, timeout);
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
     use std::io::{Cursor, Read, Write};
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Condvar, Mutex};
     use std::time::Duration;
 
@@ -2021,7 +2046,7 @@ mod tests {
         PROTOCOL_VERSION, Request, RequestContext, Response, Route, SyncDocument, WorkerError,
         close_document, decode_frame, derive_snapshot_with_language, encode_frame,
         named_node_count, replace_retained_bytes, reserve_retained_growth, route_response, run,
-        submit_document_job, sync_document, validate_document_size,
+        submit_document_job, sync_document, terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -2035,6 +2060,27 @@ mod tests {
         fn flush(&mut self) -> std::io::Result<()> {
             Ok(())
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn transport_termination_marker_excludes_already_exited_workers() {
+        let marker = AtomicBool::new(false);
+        let mut running = std::process::Command::new("sh")
+            .args(["-c", "sleep 10"])
+            .spawn()
+            .unwrap();
+        terminate_by_transport(&mut running, &marker, Duration::from_secs(1));
+        assert!(marker.load(Ordering::Acquire));
+
+        let marker = AtomicBool::new(false);
+        let mut exited = std::process::Command::new("sh")
+            .args(["-c", "exit 0"])
+            .spawn()
+            .unwrap();
+        exited.wait().unwrap();
+        terminate_by_transport(&mut exited, &marker, Duration::from_secs(1));
+        assert!(!marker.load(Ordering::Acquire));
     }
 
     #[derive(Clone, Default)]

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -276,6 +276,77 @@ fn systemic_worker_restart_measures_many_document_full_resync() {
 }
 
 #[test]
+fn rejected_document_does_not_block_other_documents_during_full_resync() {
+    let directory = tempfile::tempdir().unwrap();
+    let marker = directory.path().join("restart-after-rejection");
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_SHADOW", "true")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env(
+            "KAKEHASHI_TREE_WORKER_RESTART_ONCE_FILE",
+            marker.to_string_lossy().into_owned(),
+        )
+        .env("KAKEHASHI_TREE_WORKER_RESTART_URI_SUFFIX", "/trigger.rs")
+        .env("KAKEHASHI_TREE_WORKER_ERROR_URI_SUFFIX", "/rejected.rs")
+        .env(
+            "RUST_LOG",
+            "kakehashi::tree_worker_shadow=info,kakehashi::tree_worker_shadow_metrics=info",
+        )
+        .build();
+    initialize(&mut client);
+    for (uri, language, text) in [
+        ("file:///rejected.rs", "rust", "fn rejected() {}\n"),
+        ("file:///healthy.lua", "lua", "local healthy = true\n"),
+    ] {
+        client.send_notification(
+            "textDocument/didOpen",
+            json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": language,
+                    "version": 1,
+                    "text": text
+                }
+            }),
+        );
+    }
+    std::thread::sleep(Duration::from_secs(1));
+
+    let trigger_uri = "file:///trigger.rs";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": trigger_uri,
+                "languageId": "rust",
+                "version": 1,
+                "text": "fn trigger_recovery() {}\n"
+            }
+        }),
+    );
+    let response = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": trigger_uri } }),
+    );
+    assert!(response.get("result").is_some());
+    std::thread::sleep(Duration::from_secs(2));
+
+    let stderr = shutdown_and_stderr(client);
+    assert!(
+        stderr.contains("skipped shadow resync for file:///rejected.rs"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("full-resynced 2 open documents"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("shadow comparisons matched=2"), "{stderr}");
+    assert!(stderr.contains("pending=0"), "{stderr}");
+    assert!(!stderr.contains("quarantined grammar"), "{stderr}");
+    assert!(!stderr.contains("disabled shadow tree tier"), "{stderr}");
+}
+
+#[test]
 fn idle_worker_exit_is_detected_and_restarted_before_the_next_document() {
     let directory = tempfile::tempdir().unwrap();
     let marker = directory.path().join("idle-crash-once");

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -7,6 +7,40 @@ use std::time::Duration;
 use helpers::lsp_client::LspClient;
 use serde_json::json;
 
+fn initialize(client: &mut LspClient) {
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {
+                "textDocument": {
+                    "semanticTokens": {
+                        "requests": { "full": true },
+                        "tokenTypes": ["keyword", "variable", "number"],
+                        "tokenModifiers": [],
+                        "formats": ["relative"]
+                    }
+                }
+            },
+            "initializationOptions": {
+                "searchPaths": ["${KAKEHASHI_DATA_DIR}"]
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+}
+
+fn shutdown_and_stderr(mut client: LspClient) -> String {
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+    let status = client
+        .wait_for_exit(Duration::from_secs(5))
+        .expect("server must exit after shutdown");
+    assert!(status.success());
+    client.drain_stderr()
+}
+
 #[test]
 fn shadow_worker_matches_authoritative_incremental_lifecycle() {
     let mut client = LspClient::builder()
@@ -109,4 +143,259 @@ fn shadow_worker_matches_authoritative_incremental_lifecycle() {
     assert!(!stderr.contains("shadow validation incomplete"), "{stderr}");
     assert!(!stderr.contains("tree mismatch"), "{stderr}");
     assert!(!stderr.contains("worker transport failed"), "{stderr}");
+}
+
+#[test]
+fn systemic_worker_restart_full_resyncs_the_open_document() {
+    let directory = tempfile::tempdir().unwrap();
+    let marker = directory.path().join("restart-once");
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_SHADOW", "true")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env(
+            "KAKEHASHI_TREE_WORKER_RESTART_ONCE_FILE",
+            marker.to_string_lossy().into_owned(),
+        )
+        .env(
+            "RUST_LOG",
+            "kakehashi::tree_worker_shadow=info,kakehashi::tree_worker_shadow_metrics=info",
+        )
+        .build();
+    initialize(&mut client);
+    let uri = "file:///tree-worker-restart.rs";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "rust",
+                "version": 1,
+                "text": "fn restarted() { let value = 1; }\n"
+            }
+        }),
+    );
+    let response = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+    assert!(response.get("result").is_some());
+    std::thread::sleep(Duration::from_secs(1));
+
+    let stderr = shutdown_and_stderr(client);
+    assert!(marker.exists(), "failure injection did not run: {stderr}");
+    assert!(stderr.contains("requested restart"), "{stderr}");
+    assert!(
+        stderr.contains("full-resynced 1 open documents"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("shadow comparisons matched=1"), "{stderr}");
+    assert!(stderr.contains("pending=0"), "{stderr}");
+    assert!(!stderr.contains("quarantined grammar"), "{stderr}");
+    eprintln!(
+        "systemic recovery measurement: {}",
+        stderr
+            .lines()
+            .find(|line| line.contains("restarted worker generation"))
+            .expect("restart measurement log must be present")
+    );
+}
+
+#[test]
+fn systemic_worker_restart_measures_many_document_full_resync() {
+    let directory = tempfile::tempdir().unwrap();
+    let marker = directory.path().join("restart-many-once");
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_SHADOW", "true")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env(
+            "KAKEHASHI_TREE_WORKER_RESTART_ONCE_FILE",
+            marker.to_string_lossy().into_owned(),
+        )
+        .env("KAKEHASHI_TREE_WORKER_RESTART_URI_SUFFIX", "/trigger.rs")
+        .env(
+            "RUST_LOG",
+            "kakehashi::tree_worker_shadow=info,kakehashi::tree_worker_shadow_metrics=info",
+        )
+        .build();
+    initialize(&mut client);
+
+    let mut expected_bytes = 0;
+    for index in 0..16 {
+        let uri = format!("file:///resync-{index}.rs");
+        let text = format!("fn document_{index}() {{}}\n").repeat(800);
+        expected_bytes += text.len();
+        client.send_notification(
+            "textDocument/didOpen",
+            json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "rust",
+                    "version": 1,
+                    "text": text
+                }
+            }),
+        );
+    }
+    std::thread::sleep(Duration::from_secs(1));
+    let trigger_uri = "file:///trigger.rs";
+    let trigger_text = "fn trigger_many_document_resync() {}\n";
+    expected_bytes += trigger_text.len();
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": trigger_uri,
+                "languageId": "rust",
+                "version": 1,
+                "text": trigger_text
+            }
+        }),
+    );
+    let response = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": trigger_uri } }),
+    );
+    assert!(response.get("result").is_some());
+    std::thread::sleep(Duration::from_secs(2));
+
+    let stderr = shutdown_and_stderr(client);
+    let recovery = stderr
+        .lines()
+        .find(|line| line.contains("restarted worker generation"))
+        .unwrap_or_else(|| panic!("restart measurement log must be present: {stderr}"));
+    assert!(
+        recovery.contains("full-resynced 17 open documents"),
+        "{stderr}"
+    );
+    assert!(
+        recovery.contains(&format!("bytes={expected_bytes}")),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("quarantined grammar"), "{stderr}");
+    eprintln!("many-document recovery measurement: {recovery}");
+}
+
+#[test]
+fn idle_worker_exit_is_detected_and_restarted_before_the_next_document() {
+    let directory = tempfile::tempdir().unwrap();
+    let marker = directory.path().join("idle-crash-once");
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_SHADOW", "true")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env(
+            "KAKEHASHI_TREE_WORKER_IDLE_CRASH_ONCE_FILE",
+            marker.to_string_lossy().into_owned(),
+        )
+        .env(
+            "RUST_LOG",
+            "kakehashi::tree_worker_shadow=info,kakehashi::tree_worker_shadow_metrics=info",
+        )
+        .build();
+    initialize(&mut client);
+    std::thread::sleep(Duration::from_secs(2));
+
+    let uri = "file:///after-idle-restart.rs";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "rust",
+                "version": 1,
+                "text": "fn after_idle_restart() {}\n"
+            }
+        }),
+    );
+    let response = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+    assert!(response.get("result").is_some());
+    std::thread::sleep(Duration::from_secs(1));
+
+    let stderr = shutdown_and_stderr(client);
+    assert!(marker.exists(), "failure injection did not run: {stderr}");
+    assert!(stderr.contains("exited while idle"), "{stderr}");
+    assert!(
+        stderr.contains("full-resynced 0 open documents"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("shadow comparisons matched=1"), "{stderr}");
+    assert!(!stderr.contains("quarantined grammar"), "{stderr}");
+    eprintln!(
+        "idle recovery measurement: {}",
+        stderr
+            .lines()
+            .find(|line| line.contains("restarted worker generation"))
+            .expect("restart measurement log must be present")
+    );
+}
+
+#[test]
+fn crashed_grammar_is_quarantined_only_in_session_and_other_grammar_recovers() {
+    let directory = tempfile::tempdir().unwrap();
+    let marker = directory.path().join("crash-once");
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_SHADOW", "true")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env(
+            "KAKEHASHI_TREE_WORKER_CRASH_ONCE_FILE",
+            marker.to_string_lossy().into_owned(),
+        )
+        .env(
+            "RUST_LOG",
+            "kakehashi::tree_worker_shadow=info,kakehashi::tree_worker_shadow_metrics=info",
+        )
+        .build();
+    initialize(&mut client);
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": "file:///crashing.rs",
+                "languageId": "rust",
+                "version": 1,
+                "text": "fn crashing() {}\n"
+            }
+        }),
+    );
+    std::thread::sleep(Duration::from_secs(1));
+
+    let healthy_uri = "file:///healthy.lua";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": healthy_uri,
+                "languageId": "lua",
+                "version": 1,
+                "text": "local value = 1\n"
+            }
+        }),
+    );
+    let response = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": healthy_uri } }),
+    );
+    assert!(response.get("result").is_some());
+    std::thread::sleep(Duration::from_secs(1));
+
+    let stderr = shutdown_and_stderr(client);
+    assert!(marker.exists(), "failure injection did not run: {stderr}");
+    assert!(
+        stderr.contains("quarantined grammar conservatively for this session"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("symbol=rust"), "{stderr}");
+    assert!(stderr.contains("restarted worker generation"), "{stderr}");
+    assert!(stderr.contains("shadow comparisons matched=1"), "{stderr}");
+    assert!(stderr.contains("pending=0"), "{stderr}");
+    assert!(!stderr.contains("disabled shadow tree tier"), "{stderr}");
+    eprintln!(
+        "crash recovery measurement: {}",
+        stderr
+            .lines()
+            .find(|line| line.contains("restarted worker generation"))
+            .expect("restart measurement log must be present")
+    );
 }

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -41,6 +41,25 @@ fn shutdown_and_stderr(mut client: LspClient) -> String {
     client.drain_stderr()
 }
 
+fn log_metric(line: &str, name: &str) -> u64 {
+    line.split_whitespace()
+        .find_map(|field| {
+            field
+                .trim_start_matches('(')
+                .strip_prefix(&format!("{name}="))
+        })
+        .and_then(|value| value.trim_end_matches([',', ')']).parse::<u64>().ok())
+        .unwrap_or_else(|| panic!("missing {name} in log line: {line}"))
+}
+
+fn shadow_metric(stderr: &str, name: &str) -> u64 {
+    let summary = stderr
+        .lines()
+        .find(|line| line.contains("shadow comparisons matched="))
+        .unwrap_or_else(|| panic!("missing shadow comparison summary: {stderr}"));
+    log_metric(summary, name)
+}
+
 #[test]
 fn shadow_worker_matches_authoritative_incremental_lifecycle() {
     let mut client = LspClient::builder()
@@ -126,20 +145,9 @@ fn shadow_worker_matches_authoritative_incremental_lifecycle() {
         stderr.contains("shadow comparisons matched="),
         "missing shadow summary: {stderr}"
     );
-    let summary = stderr
-        .lines()
-        .find(|line| line.contains("shadow comparisons matched="))
-        .expect("shadow summary was checked above");
-    let metric = |name: &str| {
-        summary
-            .split_whitespace()
-            .find_map(|field| field.strip_prefix(&format!("{name}=")))
-            .and_then(|value| value.trim_end_matches(',').parse::<u64>().ok())
-            .unwrap_or_else(|| panic!("missing {name} in shadow summary: {summary}"))
-    };
-    assert!(metric("matched") > 0, "{summary}");
-    assert_eq!(metric("mismatched"), 0, "{summary}");
-    assert_eq!(metric("pending"), 0, "{summary}");
+    assert!(shadow_metric(&stderr, "matched") > 0, "{stderr}");
+    assert_eq!(shadow_metric(&stderr, "mismatched"), 0, "{stderr}");
+    assert_eq!(shadow_metric(&stderr, "pending"), 0, "{stderr}");
     assert!(!stderr.contains("shadow validation incomplete"), "{stderr}");
     assert!(!stderr.contains("tree mismatch"), "{stderr}");
     assert!(!stderr.contains("worker transport failed"), "{stderr}");
@@ -188,7 +196,7 @@ fn systemic_worker_restart_full_resyncs_the_open_document() {
         stderr.contains("full-resynced 1 open documents"),
         "{stderr}"
     );
-    assert!(stderr.contains("shadow comparisons matched=1"), "{stderr}");
+    assert_eq!(shadow_metric(&stderr, "matched"), 1, "{stderr}");
     assert!(stderr.contains("pending=0"), "{stderr}");
     assert!(!stderr.contains("quarantined grammar"), "{stderr}");
     eprintln!(
@@ -267,8 +275,9 @@ fn systemic_worker_restart_measures_many_document_full_resync() {
         recovery.contains("full-resynced 17 open documents"),
         "{stderr}"
     );
-    assert!(
-        recovery.contains(&format!("bytes={expected_bytes}")),
+    assert_eq!(
+        log_metric(recovery, "bytes"),
+        expected_bytes as u64,
         "{stderr}"
     );
     assert!(!stderr.contains("quarantined grammar"), "{stderr}");
@@ -340,7 +349,7 @@ fn rejected_document_does_not_block_other_documents_during_full_resync() {
         stderr.contains("full-resynced 2 open documents"),
         "{stderr}"
     );
-    assert!(stderr.contains("shadow comparisons matched=2"), "{stderr}");
+    assert_eq!(shadow_metric(&stderr, "matched"), 2, "{stderr}");
     assert!(stderr.contains("pending=0"), "{stderr}");
     assert!(!stderr.contains("quarantined grammar"), "{stderr}");
     assert!(!stderr.contains("disabled shadow tree tier"), "{stderr}");
@@ -391,7 +400,7 @@ fn idle_worker_exit_is_detected_and_restarted_before_the_next_document() {
         stderr.contains("full-resynced 0 open documents"),
         "{stderr}"
     );
-    assert!(stderr.contains("shadow comparisons matched=1"), "{stderr}");
+    assert_eq!(shadow_metric(&stderr, "matched"), 1, "{stderr}");
     assert!(!stderr.contains("quarantined grammar"), "{stderr}");
     eprintln!(
         "idle recovery measurement: {}",
@@ -459,7 +468,7 @@ fn crashed_grammar_is_quarantined_only_in_session_and_other_grammar_recovers() {
     );
     assert!(stderr.contains("symbol=rust"), "{stderr}");
     assert!(stderr.contains("restarted worker generation"), "{stderr}");
-    assert!(stderr.contains("shadow comparisons matched=1"), "{stderr}");
+    assert_eq!(shadow_metric(&stderr, "matched"), 1, "{stderr}");
     assert!(stderr.contains("pending=0"), "{stderr}");
     assert!(!stderr.contains("disabled shadow tree tier"), "{stderr}");
     eprintln!(


### PR DESCRIPTION
## Summary

- supervise the single resident shadow worker across request failures and idle exits
- restart with a fresh generation and full-resync the latest authoritative text for open documents
- quarantine only the implicated grammar for the current session while allowing healthy grammars to recover
- isolate document-scoped replay rejection instead of exhausting the worker restart budget
- enforce separate systemic/native/session restart budgets with exponential backoff
- add deterministic crash/restart/idle-exit E2E coverage and measured release-profile recovery evidence

## Stack

- Base: #866 (`feat/tree-worker-stage3-shadow`)
- This is the Stage 4 supervision PR in the ADR rollout.
- It remains shadow-only and non-authoritative; authoritative cutover is a later stacked PR.

## Measurement

Release profile, Apple M4, macOS 26.5.1, Rust 1.95.0, four worker threads, five fresh sessions per scenario:

| Scenario | Replay | Median recovery | Range |
|---|---:|---:|---:|
| Explicit systemic restart | 1 doc / 34 B | 515 ms | 508–625 ms |
| Larger session restart | 17 docs / 248,037 B | 522 ms | 517–543 ms |
| Request crash + grammar quarantine | 0 docs | 504 ms | 486–600 ms |
| Idle exit | 0 docs | 493 ms | 470–550 ms |

`recovery_ms` includes cleanup, 250 ms backoff, spawn, handshake, and replay. Idle detection polling (up to another 250 ms) is outside that interval. At 248 KB, replay cost remained below cleanup/spawn jitter.

Evidence: `benches/profile/results/single_worker_stage4_recovery_2026-07-19.json` and `docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage4-measurement.md`.

## Validation

- `make check`
- `cargo test --locked` (library 3,084 passed, 2 ignored; all other targets passed)
- `cargo test --locked --features e2e --test e2e_tree_worker_shadow` (31 passed)
- focused supervisor, replay idempotency, and transport-classification unit tests
- release-profile recovery trials, 5 per scenario, rerun against commit `0d6763b36`

## Deliberate limits

- grammar identity is path + symbol + configuration generation, not yet content-addressed
- restart budgets are bounded but do not yet restore tokens after a healthy period or implement half-open circuit transitions
- shadow mode remains validation-only and still pays the Stage 3 duplicate-parse overhead


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bounded, failure-aware worker recovery with restart budgets/backoff and command generation retagging, including fuller resync after crash/exit.
  * Added session-only grammar quarantine for implicated grammars.
  * Improved transport-failure observability and graceful shutdown, with client accessors for termination state.
* **Bug Fixes**
  * Prevented outdated or duplicated shadow results from overwriting completed comparisons.
  * Ensured single-document failures (restart/error/rejection) don’t block recovery of other documents.
* **Tests**
  * Expanded end-to-end scenarios and improved stderr/metric assertions for recovery, idle crashes, and quarantine behavior.
* **Documentation**
  * Updated the Stage 4 supervision ADR and added the corresponding benchmark results artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->