### PR TITLE
feat(worker): begin authoritative tree read cutover

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,3 +153,7 @@ harness = false
 [[bench]]
 name = "tree_worker_stage2"
 harness = false
+
+[[bench]]
+name = "tree_worker_stage6"
+harness = false

--- a/benches/profile/results/single_worker_stage6_node_2026-07-20.json
+++ b/benches/profile/results/single_worker_stage6_node_2026-07-20.json
@@ -1,0 +1,48 @@
+{
+  "schema": 1,
+  "date": "2026-07-20",
+  "source_commit": "4b0884ef941a3b29e8c9692b3c2b0a89e7a4e131",
+  "binary_sha256": "02c0d7717dcac03e7f168a2b11758da33169a6bec918fb778aa2d56be7ebdb61",
+  "parser_sha256": "74a21f5ff92f409170d6fc605b44773911842c54757744af71a95fd4aeccd28a",
+  "requests_per_batch": 5000,
+  "threads": 4,
+  "source_lines": 200,
+  "source_bytes": 8270,
+  "batches": [
+    {
+      "direct_p50_us": 0.833,
+      "worker_resolve_p50_us": 53.041,
+      "worker_resolve_parent_p50_us": 107.292,
+      "concurrent_worker_p50_us": 77.167,
+      "concurrent_worker_requests_per_second": 49739.2420236908
+    },
+    {
+      "direct_p50_us": 0.667,
+      "worker_resolve_p50_us": 42.791,
+      "worker_resolve_parent_p50_us": 87.167,
+      "concurrent_worker_p50_us": 72.083,
+      "concurrent_worker_requests_per_second": 53224.0936487721
+    },
+    {
+      "direct_p50_us": 0.875,
+      "worker_resolve_p50_us": 54.792,
+      "worker_resolve_parent_p50_us": 110.375,
+      "concurrent_worker_p50_us": 87.167,
+      "concurrent_worker_requests_per_second": 43983.20721148665
+    },
+    {
+      "direct_p50_us": 0.917,
+      "worker_resolve_p50_us": 57.417,
+      "worker_resolve_parent_p50_us": 115.916,
+      "concurrent_worker_p50_us": 86.708,
+      "concurrent_worker_requests_per_second": 44124.44416989235
+    }
+  ],
+  "median_of_batches": {
+    "direct_p50_us": 0.854,
+    "worker_resolve_p50_us": 53.9165,
+    "worker_resolve_parent_p50_us": 108.8335,
+    "concurrent_worker_p50_us": 81.9375,
+    "concurrent_worker_requests_per_second": 46931.8430967915
+  }
+}

--- a/benches/tree_worker_stage2.rs
+++ b/benches/tree_worker_stage2.rs
@@ -48,6 +48,7 @@ fn sync_request(document: usize, parser: &Path, text: &str) -> SyncDocument {
         artifact_digest: DIGEST
             .get_or_init(|| kakehashi::tree_worker::artifact_digest(parser).unwrap())
             .clone(),
+        queries: Default::default(),
         text: text.into(),
     }
 }

--- a/benches/tree_worker_stage6.rs
+++ b/benches/tree_worker_stage6.rs
@@ -1,0 +1,234 @@
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Instant;
+
+use clap::Parser;
+use kakehashi::tree_worker::{
+    Client, NavigateNode, NodeNavigation, RequestContext, ResolveNode, Response, SyncDocument,
+};
+use serde_json::json;
+
+#[derive(Parser)]
+struct Args {
+    #[arg(long = "bench", hide = true)]
+    _bench: bool,
+    #[arg(long)]
+    bin: PathBuf,
+    #[arg(long)]
+    parser: PathBuf,
+    #[arg(long, default_value_t = 10_000)]
+    requests: usize,
+    #[arg(long, default_value_t = 4)]
+    threads: usize,
+    #[arg(long, default_value_t = 200)]
+    lines: usize,
+}
+
+fn context(document: usize, request_id: u64) -> RequestContext {
+    RequestContext {
+        request_id,
+        worker_generation: 1,
+        uri: format!("file:///stage6-node-benchmark-{document}.rs"),
+        incarnation: 1,
+        content_version: 1,
+        configuration_generation: 0,
+    }
+}
+
+fn sync_request(document: usize, parser: &Path, digest: &str, text: &str) -> SyncDocument {
+    SyncDocument {
+        context: context(document, document as u64 + 1),
+        language: "rust".into(),
+        grammar_symbol: "rust".into(),
+        source_path: parser.to_path_buf(),
+        parser_path: parser.to_path_buf(),
+        artifact_digest: digest.into(),
+        text: text.into(),
+    }
+}
+
+fn elapsed_ns(started: Instant) -> u64 {
+    started.elapsed().as_nanos().min(u128::from(u64::MAX)) as u64
+}
+
+fn percentile(samples: &[u64], percentile: usize) -> f64 {
+    let mut samples = samples.to_vec();
+    samples.sort_unstable();
+    samples[(samples.len() * percentile).div_ceil(100).saturating_sub(1)] as f64 / 1_000.0
+}
+
+fn summary(samples: &[u64]) -> serde_json::Value {
+    json!({
+        "p50_us": percentile(samples, 50),
+        "p95_us": percentile(samples, 95),
+        "p99_us": percentile(samples, 99),
+        "mean_us": samples.iter().sum::<u64>() as f64 / samples.len() as f64 / 1_000.0,
+    })
+}
+
+fn parse_rust(text: &str) -> tree_sitter::Tree {
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(&tree_sitter_rust::LANGUAGE.into())
+        .unwrap();
+    parser.parse(text, None).unwrap()
+}
+
+fn direct_round(tree: &tree_sitter::Tree, byte: usize) -> u64 {
+    let started = Instant::now();
+    let node = tree
+        .root_node()
+        .descendant_for_byte_range(byte, byte)
+        .unwrap();
+    black_box(node.parent().unwrap().kind());
+    elapsed_ns(started)
+}
+
+fn worker_resolve(worker: &Client, document: usize, request_id: u64, byte: usize) -> (u64, String) {
+    let started = Instant::now();
+    let response = worker
+        .resolve_node(ResolveNode {
+            context: context(document, request_id),
+            byte_offset: byte,
+            named: false,
+        })
+        .unwrap();
+    let Response::Nodes(result) = response else {
+        panic!("node resolve failed: {response:?}");
+    };
+    let node = result.nodes.into_iter().next().expect("resolved node");
+    black_box(&node.kind);
+    (elapsed_ns(started), node.id.local_id)
+}
+
+fn worker_resolve_and_parent(
+    worker: &Client,
+    document: usize,
+    request_id: u64,
+    byte: usize,
+) -> u64 {
+    let started = Instant::now();
+    let (_, local_id) = worker_resolve(worker, document, request_id, byte);
+    let response = worker
+        .navigate_node(NavigateNode {
+            context: context(document, request_id + 1),
+            node_id: kakehashi::tree_worker::OpaqueNodeId {
+                worker_generation: 1,
+                local_id,
+            },
+            operation: NodeNavigation::Parent,
+        })
+        .unwrap();
+    let Response::Nodes(result) = response else {
+        panic!("node navigation failed: {response:?}");
+    };
+    black_box(result.nodes.first().expect("parent node").kind.as_str());
+    elapsed_ns(started)
+}
+
+fn concurrent_worker(
+    worker: Arc<Client>,
+    documents: usize,
+    requests: usize,
+    byte: usize,
+) -> (Vec<u64>, f64) {
+    let per_document = requests / documents;
+    let started = Instant::now();
+    let samples = std::thread::scope(|scope| {
+        let handles = (0..documents)
+            .map(|document| {
+                let worker = Arc::clone(&worker);
+                scope.spawn(move || {
+                    (0..per_document)
+                        .map(|index| {
+                            worker_resolve(
+                                &worker,
+                                document + 1,
+                                3_000_000 + (document * per_document + index) as u64,
+                                byte,
+                            )
+                            .0
+                        })
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect::<Vec<_>>();
+        handles
+            .into_iter()
+            .flat_map(|handle| handle.join().unwrap())
+            .collect::<Vec<_>>()
+    });
+    let throughput = requests as f64 / started.elapsed().as_secs_f64();
+    (samples, throughput)
+}
+
+fn main() {
+    let args = Args::parse();
+    assert!(args.requests > 0, "--requests must be positive");
+    assert!(args.threads > 0, "--threads must be positive");
+    assert_eq!(
+        args.requests % args.threads,
+        0,
+        "--requests must be divisible by --threads"
+    );
+
+    let mut text = String::new();
+    for index in 0..args.lines {
+        text.push_str(&format!(
+            "fn function_{index}() {{ let value_{index} = {index}; }}\n"
+        ));
+    }
+    let marker = text.find("value_0").unwrap();
+    let direct_tree = parse_rust(&text);
+    let digest = kakehashi::tree_worker::artifact_digest(&args.parser).unwrap();
+    let worker = Arc::new(Client::spawn(&args.bin, args.threads, 1).unwrap());
+    for document in 0..=args.threads {
+        let response = worker
+            .sync_document(sync_request(document, &args.parser, &digest, &text))
+            .unwrap();
+        assert!(matches!(response, Response::DocumentAck(_)));
+    }
+
+    let mut direct = Vec::with_capacity(args.requests);
+    let mut worker_resolve_samples = Vec::with_capacity(args.requests);
+    let mut worker_navigation_samples = Vec::with_capacity(args.requests);
+    for index in 0..args.requests {
+        direct.push(direct_round(&direct_tree, marker));
+        worker_resolve_samples.push(worker_resolve(&worker, 0, 1_000_000 + index as u64, marker).0);
+        worker_navigation_samples.push(worker_resolve_and_parent(
+            &worker,
+            0,
+            2_000_000 + index as u64 * 2,
+            marker,
+        ));
+    }
+    let (concurrent_samples, concurrent_throughput) =
+        concurrent_worker(Arc::clone(&worker), args.threads, args.requests, marker);
+
+    Arc::try_unwrap(worker)
+        .ok()
+        .expect("benchmark threads released worker")
+        .shutdown()
+        .unwrap();
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({
+            "schema": 1,
+            "requests": args.requests,
+            "threads": args.threads,
+            "source_lines": args.lines,
+            "source_bytes": text.len(),
+            "direct_resolve_and_parent": summary(&direct),
+            "worker_resolve_one_round_trip": summary(&worker_resolve_samples),
+            "worker_resolve_and_parent_two_round_trips": summary(&worker_navigation_samples),
+            "concurrent_documents_worker_resolve": {
+                "documents": args.threads,
+                "latency": summary(&concurrent_samples),
+                "requests_per_second": concurrent_throughput,
+            }
+        }))
+        .unwrap()
+    );
+}

--- a/benches/tree_worker_stage6.rs
+++ b/benches/tree_worker_stage6.rs
@@ -93,6 +93,7 @@ fn worker_resolve(worker: &Client, document: usize, request_id: u64, byte: usize
             context: context(document, request_id),
             byte_offset: byte,
             named: false,
+            layer: kakehashi::tree_worker::NodeLayerSelector::Host,
         })
         .unwrap();
     let Response::Nodes(result) = response else {

--- a/benches/tree_worker_stage6.rs
+++ b/benches/tree_worker_stage6.rs
@@ -44,6 +44,7 @@ fn sync_request(document: usize, parser: &Path, digest: &str, text: &str) -> Syn
         source_path: parser.to_path_buf(),
         parser_path: parser.to_path_buf(),
         artifact_digest: digest.into(),
+        queries: Default::default(),
         text: text.into(),
     }
 }

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage6-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage6-measurement.md
@@ -1,0 +1,54 @@
+# Stage 6 node-operation measurement
+
+Date: 2026-07-20
+
+This measurement evaluates the first worker-owned reader operation from
+`single-resident-multithreaded-tree-worker`: host-tree node resolution and
+parent navigation. It is a microbenchmark of the internal worker protocol, not
+an end-to-end LSP latency claim.
+
+## Attestation
+
+- source commit: `4b0884ef941a3b29e8c9692b3c2b0a89e7a4e131`
+- release binary SHA-256:
+  `02c0d7717dcac03e7f168a2b11758da33169a6bec918fb778aa2d56be7ebdb61`
+- Rust parser SHA-256:
+  `74a21f5ff92f409170d6fc605b44773911842c54757744af71a95fd4aeccd28a`
+- four batches of 5,000 requests against an 8,270-byte, 200-line Rust source
+- one resident worker with four compute threads
+
+The raw batch summary is committed at
+`benches/profile/results/single_worker_stage6_node_2026-07-20.json`.
+
+## Results
+
+Median of the four batch p50 values:
+
+| operation | p50 |
+| --- | ---: |
+| direct local resolve + parent | 0.854 us |
+| worker resolve, one round trip | 53.917 us |
+| worker resolve + parent, two round trips | 108.834 us |
+| worker resolve, four concurrent documents | 81.938 us |
+
+The four-document run sustained a median 46,932 requests/second. This proves
+the concurrent read router reaches the worker without the supervisor actor
+serializing all reads. It does not make the fine-grained RPC shape acceptable:
+one local traversal is about 63 times cheaper than one worker round trip at the
+median, and the two-round-trip operation is almost exactly twice the one-round-
+trip latency.
+
+## Decision impact
+
+Do not translate the public node accessor protocol into one internal RPC per
+Tree-sitter primitive. The process boundary must fuse the complete public
+request: resolve the opaque ID, perform its navigation or scalar operation,
+mint any returned IDs, and serialize the final public result in one worker
+operation. Bulk endpoints such as children must return the complete owned list
+in one response.
+
+The `ResolveNode` and `NavigateNode` prototype remains useful for identity and
+generation-fence validation, but the authoritative cutover must route each
+public handler through a fused high-level operation. The same rule applies to
+captures, selection ranges, symbols, and tokens: worker-side tree locality can
+offset repeated tree walks only when the boundary avoids N+1 IPC.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1122,6 +1122,14 @@ records real LSP lifecycle comparison and the foreground cost of running both
 the authoritative and worker parse for every edit. It validates the comparison
 path, not the performance of a worker-authoritative cutover.
 
+The [Stage 6 node-operation measurement](single-resident-multithreaded-tree-worker-stage6-measurement.md)
+measures the first worker-owned reader path. A resident worker sustains
+concurrent reads across documents, but each fine-grained process round trip
+costs about 54 microseconds at the median on the measured host. Public handlers
+must therefore be fused into one high-level worker operation; the cutover must
+not expose remote Tree-sitter primitives or translate a local parent/child walk
+into N+1 internal RPCs.
+
 The implementation should proceed in measured stages:
 
 1. Prototype the framed transport, supervision, and one high-level

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -15,4 +15,6 @@ pub(crate) use semantic_cache::{
 };
 
 // Re-export crate-internal functions used by LSP layer
-pub(crate) use semantic::{filter_semantic_tokens_by_range, handle_semantic_tokens_full};
+pub(crate) use semantic::{
+    compute_semantic_tokens_full, filter_semantic_tokens_by_range, handle_semantic_tokens_full,
+};

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -85,13 +85,10 @@ fn run_sequential_injection<T>(
     (!cancelled && host_complete).then(injection_work)
 }
 
-/// Compute full-document semantic tokens (host + injections) as one work-unit
-/// on the bounded compute pool; the injection fan-out's `par_iter` runs on the
-/// same pool (a Rayon parallel iterator invoked from a pool thread stays on
-/// that pool), so tokenization can no longer occupy every core via the
-/// process-global Rayon pool (parse-snapshot ADR §4). Thread-local parser
-/// caches avoid cross-thread synchronization on parse. Returns `None` on
-/// cancellation/failure. `text` and `tree` are moved into the work-unit.
+/// Synchronous full-document semantic computation shared by the parent and
+/// isolated worker. The caller must already be running on its bounded Rayon
+/// pool; nested injection fan-out stays on that same pool. Thread-local parser
+/// caches avoid cross-thread synchronization on parse.
 ///
 /// `cancel` (when provided) doubles as the work-unit's dequeue hook (a request
 /// superseded while queued never starts) and is polled during the host-query
@@ -100,6 +97,171 @@ fn run_sequential_injection<T>(
 /// completion. Returns `None` once cancelled: the caller drops the (partial)
 /// result rather than storing it (see the compute-superseded checkpoints in the
 /// handlers).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn compute_semantic_tokens_full(
+    compute_threads: usize,
+    text: std::sync::Arc<str>,
+    tree: Tree,
+    query: std::sync::Arc<Query>,
+    filetype: Option<String>,
+    capture_mappings: Option<std::sync::Arc<CaptureMappings>>,
+    coordinator: std::sync::Arc<crate::language::LanguageCoordinator>,
+    supports_multiline: bool,
+    injection_cache: Option<InjectionCacheParams>,
+    cancel: Option<crate::cancel::CancelToken>,
+) -> Option<SemanticTokensResult> {
+    let is_cancelled = || crate::cancel::is_cancelled(cancel.as_ref());
+    let compute_started = std::time::Instant::now();
+    let mut host_tokens: Vec<RawToken> = Vec::with_capacity(1000);
+    let lines: Vec<&str> = text.lines().collect();
+    let line_starts = build_line_start_bytes(&text);
+
+    // Borrow the owned cache handle into a request-scoped context for the
+    // injection pass (#529); `None` keeps the uncached behavior.
+    let cache_ctx = injection_cache.as_ref().map(|p| InjectionCacheCtx {
+        uri: &p.uri,
+        tracker: p.tracker.as_ref(),
+        cache: p.cache.as_ref(),
+        generation: p.generation,
+        incarnation: p.incarnation,
+        // Currency latch for region-id minting, taken here inside the
+        // work-unit so the race window is the compute itself, not the
+        // pool-queue wait. A stale serve goes read-only on the tracker
+        // (reuse for unshifted regions, no cache entry for unknown ones).
+        mint_regions: p.documents.latest_snapshot(&p.uri).is_some_and(|view| {
+            view.slot.current_incarnation == p.incarnation
+                && view.content_version == p.parsed_version
+        }),
+        discovery: p.discovery.as_deref(),
+    });
+
+    let should_parallelize = cache_ctx.as_ref().is_some_and(|ctx| {
+        should_parallelize_host_and_injections(
+            compute_threads,
+            ctx.generation,
+            ctx.discovery.map(|discovery| {
+                (
+                    discovery.generation,
+                    discovery.complete,
+                    discovery.regions.len(),
+                )
+            }),
+        )
+    });
+    let mut host_work = || {
+        let started = std::time::Instant::now();
+        let complete = collect_host_tokens(
+            &text,
+            &tree,
+            &query,
+            filetype.as_deref(),
+            capture_mappings.as_deref(),
+            &text,
+            &lines,
+            &line_starts,
+            0,
+            0,
+            supports_multiline,
+            &[],
+            &[],
+            cancel.as_ref(),
+            &mut host_tokens,
+        );
+        (complete, started.elapsed())
+    };
+    let injection_work = || {
+        let started = std::time::Instant::now();
+        let result = collect_injection_tokens_parallel(
+            &text,
+            &lines,
+            &line_starts,
+            &tree,
+            filetype.as_deref(),
+            &coordinator,
+            capture_mappings.as_deref(),
+            supports_multiline,
+            cache_ctx.as_ref(),
+            cancel.as_ref(),
+        );
+        (result, started.elapsed())
+    };
+
+    // Host highlighting and a substantial injection pass read the same
+    // immutable snapshot and only meet during finalization. Overlap them
+    // when discovery proves enough injection work exists to amortize the
+    // second Rayon branch; otherwise retain the sequential fast path.
+    let ((host_complete, host_elapsed), (injection_result, injections_elapsed)) =
+        if should_parallelize {
+            // Match the sequential injection boundary: do not dispatch
+            // either Rayon branch when supersession has already landed.
+            if is_cancelled() {
+                return None;
+            }
+            rayon::join(host_work, injection_work)
+        } else {
+            let host_result = host_work();
+            let injection_result =
+                run_sequential_injection(host_result.0, is_cancelled(), injection_work)?;
+            (host_result, injection_result)
+        };
+
+    if !host_complete {
+        return None;
+    }
+    let (injection_tokens, active_injection_regions) = injection_result;
+
+    // A supersede observed during the injection pass leaves a partial token
+    // set; drop it so the handler never stores partial results.
+    if is_cancelled() {
+        return None;
+    }
+
+    // Merge injection tokens with host tokens
+    host_tokens.extend(injection_tokens);
+
+    let finalize_start = std::time::Instant::now();
+    let result = finalize_tokens_cancellable(
+        host_tokens,
+        &active_injection_regions,
+        &lines,
+        cancel.as_ref(),
+    );
+    let finalize_elapsed = finalize_start.elapsed();
+    let compute_elapsed = compute_started.elapsed();
+    if is_cancelled() {
+        return None;
+    }
+
+    // Host/injection durations overlap when `parallel=true`, so `compute`
+    // is the authoritative wall time; branch durations must not be summed.
+    log::debug!(
+        target: "kakehashi::semantic",
+        "[SEMANTIC_TOKENS] compute phases: compute={}us host={}us injections={}us finalize={}us parallel={} regions_reused={}",
+        compute_elapsed.as_micros(),
+        host_elapsed.as_micros(),
+        injections_elapsed.as_micros(),
+        finalize_elapsed.as_micros(),
+        should_parallelize,
+        injection_cache
+            .as_ref()
+            // The same generation gate the reuse path applies: a
+            // present-but-reload-stale discovery is NOT reused, and
+            // reporting its count would mislead profiling.
+            .and_then(|p| {
+                p.discovery
+                    .as_ref()
+                    .filter(|d| d.generation == p.generation && d.complete)
+            })
+            .map(|d| d.regions.len().to_string())
+            .unwrap_or_else(|| "none".to_string()),
+    );
+
+    result
+}
+
+/// Dispatch the shared semantic computation as one parent compute-pool unit.
+/// The isolated worker calls the synchronous core directly because its request
+/// is already admitted onto the worker compute pool.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn handle_semantic_tokens_full(
     pool: &crate::compute_pool::ComputePool,
@@ -114,154 +276,20 @@ pub(crate) async fn handle_semantic_tokens_full(
     cancel: Option<crate::cancel::CancelToken>,
 ) -> Option<SemanticTokensResult> {
     let compute_threads = pool.thread_count();
-    pool.run(cancel.clone(), move || {
-        let is_cancelled = || crate::cancel::is_cancelled(cancel.as_ref());
-        let compute_started = std::time::Instant::now();
-        let mut host_tokens: Vec<RawToken> = Vec::with_capacity(1000);
-        let lines: Vec<&str> = text.lines().collect();
-        let line_starts = build_line_start_bytes(&text);
-
-        // Borrow the owned cache handle into a request-scoped context for the
-        // injection pass (#529); `None` keeps the uncached behavior.
-        let cache_ctx = injection_cache.as_ref().map(|p| InjectionCacheCtx {
-            uri: &p.uri,
-            tracker: p.tracker.as_ref(),
-            cache: p.cache.as_ref(),
-            generation: p.generation,
-            incarnation: p.incarnation,
-            // Currency latch for region-id minting, taken here inside the
-            // work-unit so the race window is the compute itself, not the
-            // pool-queue wait. A stale serve goes read-only on the tracker
-            // (reuse for unshifted regions, no cache entry for unknown ones).
-            mint_regions: p.documents.latest_snapshot(&p.uri).is_some_and(|view| {
-                view.slot.current_incarnation == p.incarnation
-                    && view.content_version == p.parsed_version
-            }),
-            discovery: p.discovery.as_deref(),
-        });
-
-        let should_parallelize = cache_ctx.as_ref().is_some_and(|ctx| {
-            should_parallelize_host_and_injections(
-                compute_threads,
-                ctx.generation,
-                ctx.discovery.map(|discovery| {
-                    (
-                        discovery.generation,
-                        discovery.complete,
-                        discovery.regions.len(),
-                    )
-                }),
-            )
-        });
-        let mut host_work = || {
-            let started = std::time::Instant::now();
-            let complete = collect_host_tokens(
-                &text,
-                &tree,
-                &query,
-                filetype.as_deref(),
-                capture_mappings.as_deref(),
-                &text,
-                &lines,
-                &line_starts,
-                0,
-                0,
-                supports_multiline,
-                &[],
-                &[],
-                cancel.as_ref(),
-                &mut host_tokens,
-            );
-            (complete, started.elapsed())
-        };
-        let injection_work = || {
-            let started = std::time::Instant::now();
-            let result = collect_injection_tokens_parallel(
-                &text,
-                &lines,
-                &line_starts,
-                &tree,
-                filetype.as_deref(),
-                &coordinator,
-                capture_mappings.as_deref(),
-                supports_multiline,
-                cache_ctx.as_ref(),
-                cancel.as_ref(),
-            );
-            (result, started.elapsed())
-        };
-
-        // Host highlighting and a substantial injection pass read the same
-        // immutable snapshot and only meet during finalization. Overlap them
-        // when discovery proves enough injection work exists to amortize the
-        // second Rayon branch; otherwise retain the sequential fast path.
-        let ((host_complete, host_elapsed), (injection_result, injections_elapsed)) =
-            if should_parallelize {
-                // Match the sequential injection boundary: do not dispatch
-                // either Rayon branch when supersession has already landed.
-                if is_cancelled() {
-                    return None;
-                }
-                rayon::join(host_work, injection_work)
-            } else {
-                let host_result = host_work();
-                let injection_result =
-                    run_sequential_injection(host_result.0, is_cancelled(), injection_work)?;
-                (host_result, injection_result)
-            };
-
-        if !host_complete {
-            return None;
-        }
-        let (injection_tokens, active_injection_regions) = injection_result;
-
-        // A supersede observed during the injection pass leaves a partial token
-        // set; drop it so the handler never stores partial results.
-        if is_cancelled() {
-            return None;
-        }
-
-        // Merge injection tokens with host tokens
-        host_tokens.extend(injection_tokens);
-
-        let finalize_start = std::time::Instant::now();
-        let result = finalize_tokens_cancellable(
-            host_tokens,
-            &active_injection_regions,
-            &lines,
-            cancel.as_ref(),
-        );
-        let finalize_elapsed = finalize_start.elapsed();
-        let compute_elapsed = compute_started.elapsed();
-        if is_cancelled() {
-            return None;
-        }
-
-        // Host/injection durations overlap when `parallel=true`, so `compute`
-        // is the authoritative wall time; branch durations must not be summed.
-        log::debug!(
-            target: "kakehashi::semantic",
-            "[SEMANTIC_TOKENS] compute phases: compute={}us host={}us injections={}us finalize={}us parallel={} regions_reused={}",
-            compute_elapsed.as_micros(),
-            host_elapsed.as_micros(),
-            injections_elapsed.as_micros(),
-            finalize_elapsed.as_micros(),
-            should_parallelize,
-            injection_cache
-                .as_ref()
-                // The same generation gate the reuse path applies: a
-                // present-but-reload-stale discovery is NOT reused, and
-                // reporting its count would mislead profiling.
-                .and_then(|p| {
-                    p.discovery
-                        .as_ref()
-                        .filter(|d| d.generation == p.generation && d.complete)
-                })
-                .map(|d| d.regions.len().to_string())
-                .unwrap_or_else(|| "none".to_string()),
-        );
-
-        result
+    let dequeue_cancel = cancel.clone();
+    pool.run(dequeue_cancel, move || {
+        compute_semantic_tokens_full(
+            compute_threads,
+            text,
+            tree,
+            query,
+            filetype,
+            capture_mappings,
+            coordinator,
+            supports_multiline,
+            injection_cache,
+            cancel,
+        )
     })
     .await
     .flatten()

--- a/src/language/config_store.rs
+++ b/src/language/config_store.rs
@@ -25,6 +25,23 @@ impl ConfigStore {
         self.set_search_paths(settings.search_paths.clone());
     }
 
+    pub(crate) fn configure_worker(
+        &self,
+        search_paths: Vec<PathBuf>,
+        capture_mappings: CaptureMappings,
+    ) {
+        *self
+            .capture_mappings
+            .write()
+            .recover_poison("ConfigStore::configure_worker(capture mappings)") =
+            Arc::new(capture_mappings);
+        *self
+            .search_paths
+            .write()
+            .recover_poison("ConfigStore::configure_worker(search paths)") =
+            search_paths.into_iter().map(|path| path.clean()).collect();
+    }
+
     fn set_capture_mappings(&self, mappings: CaptureMappings) {
         *self
             .capture_mappings

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1981,7 +1981,9 @@ impl LanguageCoordinator {
             .keys()
             .cloned()
             .collect::<Vec<_>>();
+        language_ids.extend(self.language_registry.language_ids());
         language_ids.sort();
+        language_ids.dedup();
         let assets = language_ids
             .into_iter()
             .filter_map(|language| {

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1830,6 +1830,15 @@ impl LanguageCoordinator {
         self.config_store.search_paths()
     }
 
+    pub(crate) fn configure_worker_runtime(
+        &self,
+        search_paths: Vec<std::path::PathBuf>,
+        capture_mappings: CaptureMappings,
+    ) {
+        self.config_store
+            .configure_worker(search_paths, capture_mappings);
+    }
+
     /// Resolve the dynamic grammar identity the isolated tree worker must load.
     /// Derived languages that share a base parser use the base export symbol;
     /// standalone derived parsers retain their own symbol.
@@ -1963,7 +1972,7 @@ impl LanguageCoordinator {
     /// The catalog is built after settings loading, so query sources are the
     /// exact tolerant-compilation output and parser paths point at private,
     /// content-addressed imports.
-    pub(crate) fn worker_language_catalog(&self) -> Vec<crate::tree_worker::WorkerLanguageAsset> {
+    pub(crate) fn worker_language_catalog(&self) -> crate::tree_worker::WorkerLanguageCatalog {
         let mut language_ids = self
             .worker_settings
             .read()
@@ -1973,7 +1982,7 @@ impl LanguageCoordinator {
             .cloned()
             .collect::<Vec<_>>();
         language_ids.sort();
-        language_ids
+        let assets = language_ids
             .into_iter()
             .filter_map(|language| {
                 let descriptor = self.worker_grammar_descriptor(&language)?;
@@ -1986,7 +1995,12 @@ impl LanguageCoordinator {
                     queries: descriptor.queries,
                 })
             })
-            .collect()
+            .collect();
+        crate::tree_worker::WorkerLanguageCatalog {
+            assets,
+            search_paths: self.search_paths(),
+            capture_mappings: (*self.capture_mappings()).clone(),
+        }
     }
 
     pub(crate) fn configuration_generation(&self) -> u64 {

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1959,6 +1959,36 @@ impl LanguageCoordinator {
         })
     }
 
+    /// Snapshot every configured language into immutable worker-owned assets.
+    /// The catalog is built after settings loading, so query sources are the
+    /// exact tolerant-compilation output and parser paths point at private,
+    /// content-addressed imports.
+    pub(crate) fn worker_language_catalog(&self) -> Vec<crate::tree_worker::WorkerLanguageAsset> {
+        let mut language_ids = self
+            .worker_settings
+            .read()
+            .recover_poison("LanguageCoordinator::worker_language_catalog(settings)")
+            .languages
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        language_ids.sort();
+        language_ids
+            .into_iter()
+            .filter_map(|language| {
+                let descriptor = self.worker_grammar_descriptor(&language)?;
+                Some(crate::tree_worker::WorkerLanguageAsset {
+                    language,
+                    grammar_symbol: descriptor.grammar_symbol,
+                    source_path: descriptor.source_path,
+                    parser_path: descriptor.parser_path,
+                    artifact_digest: descriptor.artifact_digest,
+                    queries: descriptor.queries,
+                })
+            })
+            .collect()
+    }
+
     pub(crate) fn configuration_generation(&self) -> u64 {
         self.load_generation
             .load(std::sync::atomic::Ordering::Acquire)

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -652,8 +652,17 @@ impl LanguageCoordinator {
         } else {
             for kind in QueryKind::ALL {
                 if let Some(query) = self.query_store.get_query(kind, base_name) {
-                    self.query_store
-                        .insert_query(kind, derived_name.to_string(), query);
+                    if let Some(source) = self.query_store.query_source(kind, base_name) {
+                        self.query_store.insert_query_with_source(
+                            kind,
+                            derived_name.to_string(),
+                            query,
+                            source.to_string(),
+                        );
+                    } else {
+                        self.query_store
+                            .insert_query(kind, derived_name.to_string(), query);
+                    }
                 }
             }
         }
@@ -1027,7 +1036,9 @@ impl LanguageCoordinator {
                 },
                 context,
                 events,
-                |store, query| store.insert_query(query_kind, lang_name.to_string(), query),
+                |store, query, source| {
+                    store.insert_query_with_source(query_kind, lang_name.to_string(), query, source)
+                },
             );
         }
     }
@@ -1040,7 +1051,7 @@ impl LanguageCoordinator {
         ctx: QueryLoadContext<'_>,
         context: &str,
         events: &mut Vec<LanguageEvent>,
-        insert_fn: impl FnOnce(&QueryStore, Arc<tree_sitter::Query>),
+        insert_fn: impl FnOnce(&QueryStore, Arc<tree_sitter::Query>, String),
     ) {
         let filename = ctx.query_kind.filename();
         let result = match QueryLoader::load_query_with_inheritance(
@@ -1076,7 +1087,7 @@ impl LanguageCoordinator {
         paths: &[P],
         ctx: QueryLoadContext<'_>,
         events: &mut Vec<LanguageEvent>,
-        insert_fn: impl FnOnce(&QueryStore, Arc<tree_sitter::Query>),
+        insert_fn: impl FnOnce(&QueryStore, Arc<tree_sitter::Query>, String),
     ) {
         let result = match QueryLoader::load_query_from_paths(language, paths) {
             Ok(r) => r,
@@ -1109,7 +1120,7 @@ impl LanguageCoordinator {
         query_label: &str,
         success_prefix: &str,
         events: &mut Vec<LanguageEvent>,
-        insert_fn: impl FnOnce(&QueryStore, Arc<tree_sitter::Query>),
+        insert_fn: impl FnOnce(&QueryStore, Arc<tree_sitter::Query>, String),
     ) {
         // Log warnings for skipped patterns
         for skipped in &result.skipped {
@@ -1130,9 +1141,9 @@ impl LanguageCoordinator {
             ));
         }
 
-        match result.query {
-            Some(query) => {
-                insert_fn(&self.query_store, Arc::new(query));
+        match (result.query, result.compiled_source) {
+            (Some(query), Some(source)) => {
+                insert_fn(&self.query_store, Arc::new(query), source);
                 let skipped_count = result.skipped.len();
                 let msg = if skipped_count > 0 {
                     format!("{success_prefix} ({skipped_count} pattern(s) skipped)")
@@ -1141,7 +1152,7 @@ impl LanguageCoordinator {
                 };
                 events.push(LanguageEvent::log(LanguageLogLevel::Info, msg));
             }
-            None => {
+            _ => {
                 if let Some(reason) = &result.failure_reason {
                     let msg = match reason {
                         ParseFailure::PatternSplitFailed(err) => {
@@ -1787,7 +1798,14 @@ impl LanguageCoordinator {
                         query_kind,
                     },
                     &mut events,
-                    |store, q| store.insert_query(query_kind, lang_name.to_string(), q),
+                    |store, query, source| {
+                        store.insert_query_with_source(
+                            query_kind,
+                            lang_name.to_string(),
+                            query,
+                            source,
+                        )
+                    },
                 );
             }
         }

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -129,6 +129,7 @@ pub(crate) struct WorkerGrammarDescriptor {
     pub(crate) parser_path: PathBuf,
     pub(crate) grammar_symbol: String,
     pub(crate) artifact_digest: String,
+    pub(crate) queries: crate::tree_worker::WorkerQuerySources,
     pub(crate) configuration_generation: u64,
 }
 
@@ -1940,6 +1941,20 @@ impl LanguageCoordinator {
             parser_path: artifact.path,
             grammar_symbol,
             artifact_digest: artifact.digest,
+            queries: crate::tree_worker::WorkerQuerySources {
+                highlights: self
+                    .query_store
+                    .query_source(QueryKind::Highlights, language_id)
+                    .map(|source| source.to_string()),
+                bindings: self
+                    .query_store
+                    .query_source(QueryKind::Bindings, language_id)
+                    .map(|source| source.to_string()),
+                injections: self
+                    .query_store
+                    .query_source(QueryKind::Injections, language_id)
+                    .map(|source| source.to_string()),
+            },
             configuration_generation,
         })
     }

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -56,6 +56,10 @@ pub(crate) enum ParseFailure {
 pub(crate) struct ParseResult {
     /// The successfully compiled query (None if all patterns failed)
     pub query: Option<Query>,
+    /// Exact source used to compile `query` after tolerant invalid-pattern
+    /// removal. This is retained so an isolated worker can reconstruct the
+    /// same query rather than re-reading mutable files.
+    pub compiled_source: Option<String>,
     /// Patterns that were skipped due to errors
     pub skipped: Vec<SkippedPattern>,
     /// If `query` is `None`, this indicates why parsing failed.
@@ -262,6 +266,7 @@ impl QueryLoader {
         if let Ok(query) = Query::new(language, query_str) {
             return ParseResult {
                 query: Some(query),
+                compiled_source: Some(query_str.to_string()),
                 skipped: Vec::new(),
                 failure_reason: None,
                 used_inheritance,
@@ -277,6 +282,7 @@ impl QueryLoader {
                 warn!("Failed to split query patterns: {}", reason);
                 return ParseResult {
                     query: None,
+                    compiled_source: None,
                     skipped: Vec::new(),
                     failure_reason: Some(ParseFailure::PatternSplitFailed(reason)),
                     used_inheritance,
@@ -307,6 +313,7 @@ impl QueryLoader {
         if valid_patterns.is_empty() {
             return ParseResult {
                 query: None,
+                compiled_source: None,
                 skipped,
                 failure_reason: Some(ParseFailure::AllPatternsInvalid),
                 used_inheritance,
@@ -317,6 +324,7 @@ impl QueryLoader {
         match Query::new(language, &combined) {
             Ok(q) => ParseResult {
                 query: Some(q),
+                compiled_source: Some(combined),
                 skipped,
                 failure_reason: None,
                 used_inheritance,
@@ -331,6 +339,7 @@ impl QueryLoader {
                 );
                 ParseResult {
                     query: None,
+                    compiled_source: None,
                     skipped,
                     failure_reason: Some(ParseFailure::CombinationFailed(e.message)),
                     used_inheritance,

--- a/src/language/query_store.rs
+++ b/src/language/query_store.rs
@@ -9,6 +9,7 @@ pub(crate) struct QueryStore {
     highlight_queries: RwLock<HashMap<String, Arc<Query>>>,
     bindings_queries: RwLock<HashMap<String, Arc<Query>>>,
     injection_queries: RwLock<HashMap<String, Arc<Query>>>,
+    query_sources: RwLock<HashMap<(String, QueryKind), Arc<str>>>,
 }
 
 impl QueryStore {
@@ -17,6 +18,7 @@ impl QueryStore {
             highlight_queries: RwLock::new(HashMap::new()),
             bindings_queries: RwLock::new(HashMap::new()),
             injection_queries: RwLock::new(HashMap::new()),
+            query_sources: RwLock::new(HashMap::new()),
         }
     }
 
@@ -35,6 +37,10 @@ impl QueryStore {
             .write()
             .recover_poison(format_args!("QueryStore::remove_queries({})", lang_name))
             .remove(lang_name);
+        self.query_sources
+            .write()
+            .recover_poison(format_args!("QueryStore::remove_queries({})", lang_name))
+            .retain(|(language, _), _| language != lang_name);
         self.bindings_queries
             .write()
             .recover_poison(format_args!("QueryStore::remove_queries({})", lang_name))
@@ -106,6 +112,30 @@ impl QueryStore {
             QueryKind::Bindings => self.insert_bindings_query(lang_name, query),
             QueryKind::Injections => self.insert_injection_query(lang_name, query),
         }
+    }
+
+    pub(crate) fn insert_query_with_source(
+        &self,
+        kind: QueryKind,
+        lang_name: String,
+        query: Arc<Query>,
+        source: String,
+    ) {
+        self.insert_query(kind, lang_name.clone(), query);
+        self.query_sources
+            .write()
+            .recover_poison(format_args!(
+                "QueryStore::insert_query_with_source({lang_name})"
+            ))
+            .insert((lang_name, kind), Arc::from(source));
+    }
+
+    pub(crate) fn query_source(&self, kind: QueryKind, lang_name: &str) -> Option<Arc<str>> {
+        self.query_sources
+            .read()
+            .recover_poison(format_args!("QueryStore::query_source({lang_name})"))
+            .get(&(lang_name.to_string(), kind))
+            .cloned()
     }
 
     /// Get a query by kind, dispatching to the appropriate store.

--- a/src/language/registry.rs
+++ b/src/language/registry.rs
@@ -42,6 +42,13 @@ impl LanguageRegistry {
     pub(crate) fn contains(&self, language_id: &str) -> bool {
         self.languages.contains_key(language_id)
     }
+
+    pub(crate) fn language_ids(&self) -> Vec<String> {
+        self.languages
+            .iter()
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -12,7 +12,7 @@ mod text_sync;
 
 mod aggregation;
 mod ingress_order;
-mod lsp_impl;
+pub(crate) mod lsp_impl;
 mod progress;
 mod request_id;
 mod semantic_request_tracker;

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -604,8 +604,11 @@ impl Kakehashi {
                 })
             })
             .collect();
-        self.tree_worker_shadow
-            .mirror_configuration(self.language.configuration_generation(), documents);
+        self.tree_worker_shadow.mirror_configuration_with_catalog(
+            self.language.configuration_generation(),
+            self.language.worker_language_catalog(),
+            documents,
+        );
     }
 
     async fn apply_initial_settings(

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -95,8 +95,11 @@ impl InstallCoordinator {
                 })
             })
             .collect();
-        self.tree_worker_shadow
-            .mirror_configuration(self.language.configuration_generation(), documents);
+        self.tree_worker_shadow.mirror_configuration_with_catalog(
+            self.language.configuration_generation(),
+            self.language.worker_language_catalog(),
+            documents,
+        );
     }
 
     pub(crate) fn new(server: &Kakehashi) -> Self {

--- a/src/lsp/lsp_impl/kakehashi.rs
+++ b/src/lsp/lsp_impl/kakehashi.rs
@@ -1,4 +1,4 @@
-pub(in crate::lsp::lsp_impl) mod captures;
-pub(in crate::lsp::lsp_impl) mod captures_match_cache;
+pub(crate) mod captures;
+pub(crate) mod captures_match_cache;
 mod internal;
 pub(crate) mod node;

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -968,6 +968,18 @@ impl Kakehashi {
         // Settings generation for the kind-query compile cache — the same
         // reload discipline the token caches use.
         let generation = self.cache.semantic_token_generation();
+        let worker_configuration_generation = self.language.configuration_generation();
+        if let Some(grammar) = self.language.worker_grammar_descriptor(&language_id)
+            && self.tree_worker_shadow.needs_document_sync(
+                &uri,
+                incarnation,
+                snapshot.parsed_version,
+                worker_configuration_generation,
+                &grammar.queries,
+            )
+        {
+            self.refresh_tree_worker_documents(std::slice::from_ref(&uri));
+        }
 
         // Walk-result memo (full mode only — range results depend on the
         // viewport): a typing client sends captures/full AND full/delta per
@@ -1310,7 +1322,7 @@ impl Kakehashi {
                 &uri,
                 incarnation,
                 snapshot.parsed_version,
-                generation,
+                worker_configuration_generation,
                 worker_kind,
                 worker_range,
                 injection,

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -1136,6 +1136,17 @@ impl Kakehashi {
         let mut flight_guard = flight_guard;
 
         let uri_for_walk = uri.clone();
+        let worker_kind = kind.to_string();
+        let worker_range = lsp_range.map(|range| crate::tree_worker::WireRange {
+            start: crate::tree_worker::WirePosition {
+                line: range.start.line,
+                character: range.start.character,
+            },
+            end: crate::tree_worker::WirePosition {
+                line: range.end.line,
+                character: range.end.character,
+            },
+        });
         let kind = kind.to_string();
         let language = std::sync::Arc::clone(&self.language);
         let tracker = self.bridge.node_tracker_arc();
@@ -1238,7 +1249,7 @@ impl Kakehashi {
                     layers,
                     &language,
                     &tracker,
-                    &documents,
+                    &|| documents.latest_snapshot(&uri_for_walk).is_some(),
                     entry_mint_epoch,
                     incarnation,
                     mint_into_tracker,
@@ -1292,6 +1303,26 @@ impl Kakehashi {
         // internal checkpoint. Never cache or serve that obsolete result.
         if walk_cancel.is_cancelled() {
             return Ok(None);
+        }
+        if let Some(worker) = self
+            .tree_worker_shadow
+            .captures(
+                &uri,
+                incarnation,
+                snapshot.parsed_version,
+                generation,
+                worker_kind,
+                worker_range,
+                injection,
+            )
+            .await
+        {
+            self.tree_worker_shadow.compare_captures(
+                &uri,
+                snapshot.parsed_version,
+                walked.as_ref(),
+                &worker,
+            );
         }
         // Arc once; the memo and the returned ComputedCaptures share the
         // arrays by refcount instead of deep-cloning ~20k `Value`s. A `None`
@@ -1347,7 +1378,7 @@ impl Kakehashi {
 /// Returns `None` when no visited language compiled a kind file (→ `null` on
 /// the wire), `Some((matches, skipped))` otherwise.
 #[allow(clippy::too_many_arguments)]
-fn execute_captures_walk(
+pub(crate) fn execute_captures_walk(
     uri: &Url,
     kind: &str,
     lsp_range: Option<Range>,
@@ -1358,7 +1389,7 @@ fn execute_captures_walk(
     layer_trees: Option<&[crate::document::SnapshotLayerTree]>,
     language: &crate::language::LanguageCoordinator,
     tracker: &crate::language::NodeTracker,
-    documents: &crate::document::DocumentStore,
+    document_is_open: &dyn Fn() -> bool,
     entry_mint_epoch: (u64, u64),
     incarnation: u64,
     mint_into_tracker: bool,
@@ -1490,7 +1521,6 @@ fn execute_captures_walk(
                 // per-document slot (first store after open, or a walk racing
                 // its own didClose) — see the resurrection-leak note on
                 // `store_host`.
-                let doc_open = || documents.latest_snapshot(uri).is_some();
                 if depth == 0 {
                     match_cache.store_host(
                         uri,
@@ -1498,7 +1528,7 @@ fn execute_captures_walk(
                         hash,
                         generation,
                         std::sync::Arc::clone(&arc),
-                        doc_open,
+                        document_is_open,
                     );
                 } else {
                     match_cache.store_layer(
@@ -1507,7 +1537,7 @@ fn execute_captures_walk(
                         hash,
                         generation,
                         std::sync::Arc::clone(&arc),
-                        doc_open,
+                        document_is_open,
                     );
                     touched_layer_hashes.insert(hash);
                 }
@@ -2787,7 +2817,7 @@ mod tests {
             None,
             &coordinator,
             &tracker,
-            &store,
+            &|| store.latest_snapshot(&uri).is_some(),
             tracker.mint_epoch(&uri),
             0,
             true,
@@ -2818,7 +2848,7 @@ mod tests {
             None,
             &coordinator,
             &tracker,
-            &store,
+            &|| store.latest_snapshot(&uri).is_some(),
             tracker.mint_epoch(&uri),
             0,
             false,
@@ -2851,7 +2881,7 @@ mod tests {
             None,
             &coordinator,
             &stale_tracker,
-            &store,
+            &|| store.latest_snapshot(&uri).is_some(),
             stale_tracker.mint_epoch(&uri),
             0,
             false,
@@ -3006,7 +3036,7 @@ mod tests {
                 injection.then_some(layers),
                 &self.coordinator,
                 &self.tracker,
-                &self.store,
+                &|| self.store.latest_snapshot(&self.uri).is_some(),
                 entry_mint_epoch,
                 incarnation,
                 mint_into_tracker,

--- a/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
@@ -203,7 +203,7 @@ struct DocMatchCache {
 /// See the module docs. One instance lives on the server, shared with the
 /// compute-pool walks by `Arc`.
 #[derive(Default)]
-pub(in crate::lsp::lsp_impl) struct CapturesMatchCache {
+pub(crate) struct CapturesMatchCache {
     cache: dashmap::DashMap<Url, DocMatchCache>,
 }
 

--- a/src/lsp/lsp_impl/kakehashi/node/children.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/children.rs
@@ -160,7 +160,7 @@ impl Kakehashi {
                 &uri,
                 incarnation,
                 snapshot.parsed_version,
-                self.cache.semantic_token_generation(),
+                self.language.configuration_generation(),
                 &params.id,
                 crate::tree_worker::NodeNavigation::Children,
                 &authoritative,

--- a/src/lsp/lsp_impl/kakehashi/node/children.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/children.rs
@@ -154,6 +154,24 @@ impl Kakehashi {
             return Ok(Value::Null);
         };
 
-        Ok(Value::Array(infos))
+        let authoritative = Value::Array(infos);
+        self.tree_worker_shadow
+            .compare_node_navigation(
+                &uri,
+                incarnation,
+                snapshot.parsed_version,
+                self.cache.semantic_token_generation(),
+                &params.id,
+                crate::tree_worker::NodeNavigation::Children,
+                &authoritative,
+            )
+            .await;
+        if !self.documents.latest_snapshot(&uri).is_some_and(|view| {
+            view.content_version == snapshot.parsed_version
+                && view.slot.current_incarnation == incarnation
+        }) {
+            return Ok(Value::Null);
+        }
+        Ok(authoritative)
     }
 }

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -306,6 +306,30 @@ impl Kakehashi {
         }
     }
 
+    pub(super) async fn navigate_to_node_shadowed(
+        &self,
+        lsp_uri: &Uri,
+        id: &str,
+        operation: crate::tree_worker::NodeNavigation,
+        f: impl FnMut(tree_sitter::Node<'_>) -> Option<NodeTriple> + Send + 'static,
+    ) -> Value {
+        let uri = uri_to_url(lsp_uri).ok();
+        let worker = match uri.as_ref() {
+            Some(uri) => {
+                self.tree_worker_shadow
+                    .node_navigation(uri, id, operation.clone())
+                    .await
+            }
+            None => None,
+        };
+        let authoritative = self.navigate_to_node(lsp_uri, id, f).await;
+        if let (Some(uri), Some(worker)) = (uri.as_ref(), worker.as_ref()) {
+            self.tree_worker_shadow
+                .compare_node_result(uri, &operation, &authoritative, worker);
+        }
+        authoritative
+    }
+
     /// Like [`navigate_to_node`](Self::navigate_to_node), but `f` also receives
     /// the host text and the minting layer's included ranges. Used by the
     /// coordinate-input accessors so they can reject byte/point arguments
@@ -327,6 +351,32 @@ impl Kakehashi {
             Some(triple) => self.mint_node_info(&uri, layer, incarnation, triple),
             None => Value::Null,
         }
+    }
+
+    pub(super) async fn navigate_to_node_in_ranges_shadowed(
+        &self,
+        lsp_uri: &Uri,
+        id: &str,
+        operation: crate::tree_worker::NodeNavigation,
+        f: impl FnMut(tree_sitter::Node<'_>, &str, &[tree_sitter::Range]) -> Option<NodeTriple>
+        + Send
+        + 'static,
+    ) -> Value {
+        let uri = uri_to_url(lsp_uri).ok();
+        let worker = match uri.as_ref() {
+            Some(uri) => {
+                self.tree_worker_shadow
+                    .node_navigation(uri, id, operation.clone())
+                    .await
+            }
+            None => None,
+        };
+        let authoritative = self.navigate_to_node_in_ranges(lsp_uri, id, f).await;
+        if let (Some(uri), Some(worker)) = (uri.as_ref(), worker.as_ref()) {
+            self.tree_worker_shadow
+                .compare_node_result(uri, &operation, &authoritative, worker);
+        }
+        authoritative
     }
 
     /// Resolve `id` **and** `descendant_id` in the layer that minted them, run
@@ -458,5 +508,29 @@ impl Kakehashi {
             })
             .collect();
         infos.map_or(Value::Null, Value::Array)
+    }
+
+    pub(super) async fn navigate_to_nodes_shadowed(
+        &self,
+        lsp_uri: &Uri,
+        id: &str,
+        operation: crate::tree_worker::NodeNavigation,
+        f: impl FnMut(tree_sitter::Node<'_>) -> Vec<NodeTriple> + Send + 'static,
+    ) -> Value {
+        let uri = uri_to_url(lsp_uri).ok();
+        let worker = match uri.as_ref() {
+            Some(uri) => {
+                self.tree_worker_shadow
+                    .node_navigation(uri, id, operation.clone())
+                    .await
+            }
+            None => None,
+        };
+        let authoritative = self.navigate_to_nodes(lsp_uri, id, f).await;
+        if let (Some(uri), Some(worker)) = (uri.as_ref(), worker.as_ref()) {
+            self.tree_worker_shadow
+                .compare_node_result(uri, &operation, &authoritative, worker);
+        }
+        authoritative
     }
 }

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -484,6 +484,38 @@ impl Kakehashi {
         }
     }
 
+    pub(super) async fn navigate_with_descendant_shadowed(
+        &self,
+        lsp_uri: &Uri,
+        id: &str,
+        descendant_id: &str,
+        f: impl FnMut(tree_sitter::Node<'_>, tree_sitter::Node<'_>) -> Option<NodeTriple>
+        + Send
+        + 'static,
+    ) -> Value {
+        let uri = uri_to_url(lsp_uri).ok();
+        let worker = match uri.as_ref() {
+            Some(uri) => {
+                self.tree_worker_shadow
+                    .node_navigation_with_descendant(uri, id, descendant_id)
+                    .await
+            }
+            None => None,
+        };
+        let authoritative = self
+            .navigate_with_descendant(lsp_uri, id, descendant_id, f)
+            .await;
+        if let (Some(uri), Some(worker)) = (uri.as_ref(), worker.as_ref()) {
+            self.tree_worker_shadow.compare_node_result_label(
+                uri,
+                "ChildWithDescendant",
+                &authoritative,
+                worker,
+            );
+        }
+        authoritative
+    }
+
     /// Resolve `id`, run `f` to collect a list of related nodes (children,
     /// named children, field children, …), and return them as a `NodeInfo[]`.
     ///

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -212,7 +212,35 @@ impl Kakehashi {
         // keeps the no-injection request shape (the dominant case for plain
         // documents) at PR-1 cost.
         if matches!(selector, InjectionSelector::Host) {
-            return Ok(self.resolve_host_layer_node(&uri, tree, byte, doc_len, incarnation));
+            let authoritative =
+                self.resolve_host_layer_node(&uri, tree, byte, doc_len, incarnation);
+            if let Some(shadow) = self
+                .tree_worker_shadow
+                .resolve_node(
+                    &uri,
+                    incarnation,
+                    snapshot.parsed_version,
+                    self.cache.semantic_token_generation(),
+                    byte.min(doc_len.saturating_sub(1)),
+                    false,
+                )
+                .await
+                && let Some(node) = shadow.nodes.first()
+            {
+                let authoritative_kind = authoritative.get("kind").and_then(Value::as_str);
+                if authoritative_kind != Some(node.kind.as_str()) {
+                    log::warn!(
+                        target: "kakehashi::tree_worker_shadow",
+                        "host node mismatch uri={} version={} byte={} authoritative_kind={:?} worker_kind={}",
+                        uri,
+                        snapshot.parsed_version,
+                        byte,
+                        authoritative_kind,
+                        node.kind,
+                    );
+                }
+            }
+            return Ok(authoritative);
         }
 
         // We need the host language to seed `injection_stack_at` with the

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -228,17 +228,42 @@ impl Kakehashi {
                 && let Some(node) = shadow.nodes.first()
             {
                 let authoritative_kind = authoritative.get("kind").and_then(Value::as_str);
-                if authoritative_kind != Some(node.kind.as_str()) {
-                    log::warn!(
+                let authoritative_identity = authoritative
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .and_then(|id| id.parse::<ulid::Ulid>().ok())
+                    .and_then(|id| self.bridge.node_tracker().lookup_node(&uri, &id));
+                let identities_match = authoritative_identity.is_some_and(
+                    |(start, end, kind, layer, tracked_incarnation)| {
+                        start == node.start_byte
+                            && end == node.end_byte
+                            && kind == node.kind
+                            && layer == 0
+                            && tracked_incarnation == incarnation
+                    },
+                );
+                if authoritative_kind != Some(node.kind.as_str()) || !identities_match {
+                    log::debug!(
                         target: "kakehashi::tree_worker_shadow",
-                        "host node mismatch uri={} version={} byte={} authoritative_kind={:?} worker_kind={}",
+                        "host node mismatch uri={} version={} byte={} authoritative={:?} worker=({}, {}, {})",
                         uri,
                         snapshot.parsed_version,
                         byte,
-                        authoritative_kind,
+                        authoritative_identity,
+                        node.start_byte,
+                        node.end_byte,
                         node.kind,
                     );
+                } else {
+                    self.tree_worker_shadow
+                        .record_node_mapping(&uri, &authoritative, node);
                 }
+            }
+            if !self.documents.latest_snapshot(&uri).is_some_and(|view| {
+                view.content_version == snapshot.parsed_version
+                    && view.slot.current_incarnation == incarnation
+            }) {
+                return Ok(Value::Null);
             }
             return Ok(authoritative);
         }

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -77,6 +77,7 @@ where
 /// handler keep the `true` saturation case and the strict-index case
 /// visibly distinct — they share the result for `-1` but differ in
 /// the bounds-check semantics node-reference-protocol spells out.
+#[derive(Clone, Copy)]
 enum InjectionSelector {
     /// Host layer (stack[0]). Triggered by absent, `false`, or `0`.
     Host,
@@ -87,6 +88,17 @@ enum InjectionSelector {
     Index(i64),
     /// Unsupported JSON shape (non-bool / non-integer). Treated as null.
     Invalid,
+}
+
+impl InjectionSelector {
+    fn worker_layer(self) -> crate::tree_worker::NodeLayerSelector {
+        match self {
+            Self::Host => crate::tree_worker::NodeLayerSelector::Host,
+            Self::Saturating => crate::tree_worker::NodeLayerSelector::Deepest,
+            Self::Index(index) => crate::tree_worker::NodeLayerSelector::Index(index),
+            Self::Invalid => unreachable!("invalid selectors return before worker dispatch"),
+        }
+    }
 }
 
 /// Parse the `injection` parameter into an [`InjectionSelector`].
@@ -212,6 +224,19 @@ impl Kakehashi {
         // keeps the no-injection request shape (the dominant case for plain
         // documents) at PR-1 cost.
         if matches!(selector, InjectionSelector::Host) {
+            let worker_configuration_generation = self.language.configuration_generation();
+            if let Some(language) = snapshot.language.as_deref()
+                && let Some(grammar) = self.language.worker_grammar_descriptor(language)
+                && self.tree_worker_shadow.needs_document_sync(
+                    &uri,
+                    incarnation,
+                    snapshot.parsed_version,
+                    worker_configuration_generation,
+                    &grammar.queries,
+                )
+            {
+                self.refresh_tree_worker_documents(std::slice::from_ref(&uri));
+            }
             let authoritative =
                 self.resolve_host_layer_node(&uri, tree, byte, doc_len, incarnation);
             if let Some(shadow) = self
@@ -220,9 +245,9 @@ impl Kakehashi {
                     &uri,
                     incarnation,
                     snapshot.parsed_version,
-                    self.language.configuration_generation(),
-                    byte.min(doc_len.saturating_sub(1)),
-                    false,
+                    worker_configuration_generation,
+                    byte,
+                    crate::tree_worker::NodeLayerSelector::Host,
                 )
                 .await
                 && let Some(node) = shadow.nodes.first()
@@ -239,6 +264,7 @@ impl Kakehashi {
                             && end == node.end_byte
                             && kind == node.kind
                             && layer == 0
+                            && node.layer == 0
                             && tracked_incarnation == incarnation
                     },
                 );
@@ -331,61 +357,128 @@ impl Kakehashi {
         // together with the layer selection and the mint over its result.
         let language = std::sync::Arc::clone(&self.language);
         let tracker = self.bridge.node_tracker_arc();
-        let result = self
-            .compute_pool
-            .run(None, move || {
-                let stack = injection_stack_at(&language, &host_language, &text, &tree, byte);
+        let worker_configuration_generation = self.language.configuration_generation();
+        if let Some(grammar) = self.language.worker_grammar_descriptor(&host_language)
+            && self.tree_worker_shadow.needs_document_sync(
+                &uri,
+                incarnation,
+                snapshot.parsed_version,
+                worker_configuration_generation,
+                &grammar.queries,
+            )
+        {
+            self.refresh_tree_worker_documents(std::slice::from_ref(&uri));
+        }
+        let worker = self.tree_worker_shadow.resolve_node(
+            &uri,
+            incarnation,
+            snapshot.parsed_version,
+            worker_configuration_generation,
+            byte,
+            selector.worker_layer(),
+        );
+        let compute_uri = uri.clone();
+        let authoritative = self.compute_pool.run(None, move || {
+            let stack = injection_stack_at(&language, &host_language, &text, &tree, byte);
 
-                let layer_index = match selector {
-                    InjectionSelector::Host => unreachable!("handled above"),
-                    InjectionSelector::Invalid => unreachable!("handled above"),
-                    InjectionSelector::Saturating => {
-                        // `true` saturates to the deepest layer. The stack always
-                        // contains at least the host (layer 0), so this never
-                        // under-indexes.
-                        stack.len() - 1
-                    }
-                    InjectionSelector::Index(n) => {
-                        let Some(idx) = resolve_index(n, stack.len()) else {
-                            return Value::Null;
-                        };
-                        idx
-                    }
-                };
+            let layer_index = match selector {
+                InjectionSelector::Host => unreachable!("handled above"),
+                InjectionSelector::Invalid => unreachable!("handled above"),
+                InjectionSelector::Saturating => {
+                    // `true` saturates to the deepest layer. The stack always
+                    // contains at least the host (layer 0), so this never
+                    // under-indexes.
+                    stack.len() - 1
+                }
+                InjectionSelector::Index(n) => {
+                    let Some(idx) = resolve_index(n, stack.len()) else {
+                        return Value::Null;
+                    };
+                    idx
+                }
+            };
 
-                let Some(layer) = stack.get(layer_index) else {
-                    return Value::Null;
-                };
+            let Some(layer) = stack.get(layer_index) else {
+                return Value::Null;
+            };
 
-                let Some(node) = smallest_containing_node(&layer.tree, byte, doc_len) else {
-                    return Value::Null;
-                };
+            let Some(node) = smallest_containing_node(&layer.tree, byte, doc_len) else {
+                return Value::Null;
+            };
 
-                // Mint with the resolved layer index so a host and injected node
-                // sharing (start, end, kind) get distinct ULIDs and stay navigable
-                // in their own tree (lazy-node-identity-tracking §"Node Uniqueness
-                // Key", issue #313).
-                let ulid = tracker.get_or_create_in_layer_for_incarnation(
-                    &uri,
-                    node.start_byte(),
-                    node.end_byte(),
-                    node.kind(),
-                    layer_index,
-                    incarnation,
-                );
-                let Some(ulid) = ulid else {
-                    return Value::Null;
-                };
+            // Mint with the resolved layer index so a host and injected node
+            // sharing (start, end, kind) get distinct ULIDs and stay navigable
+            // in their own tree (lazy-node-identity-tracking §"Node Uniqueness
+            // Key", issue #313).
+            let ulid = tracker.get_or_create_in_layer_for_incarnation(
+                &compute_uri,
+                node.start_byte(),
+                node.end_byte(),
+                node.kind(),
+                layer_index,
+                incarnation,
+            );
+            let Some(ulid) = ulid else {
+                return Value::Null;
+            };
 
-                json!({
-                    "id": ulid.to_string(),
-                    "kind": node.kind(),
-                })
+            json!({
+                "id": ulid.to_string(),
+                "kind": node.kind(),
             })
-            .await;
+        });
+        let (worker, result) = tokio::join!(worker, authoritative);
 
         // None = the work-unit panicked (logged by the pool) → protocol null.
-        Ok(result.unwrap_or(Value::Null))
+        let authoritative = result.unwrap_or(Value::Null);
+        if let Some(worker) = worker {
+            let worker_node = worker.nodes.first();
+            let authoritative_identity = authoritative
+                .get("id")
+                .and_then(Value::as_str)
+                .and_then(|id| id.parse::<ulid::Ulid>().ok())
+                .and_then(|id| self.bridge.node_tracker().lookup_node(&uri, &id));
+            let matches = match (authoritative_identity, worker_node) {
+                (None, None) => true,
+                (Some((start, end, kind, layer, tracked_incarnation)), Some(node)) => {
+                    start == node.start_byte
+                        && end == node.end_byte
+                        && kind == node.kind
+                        && layer == node.layer
+                        && tracked_incarnation == incarnation
+                        && match selector {
+                            InjectionSelector::Host => layer == 0,
+                            InjectionSelector::Saturating | InjectionSelector::Index(_) => true,
+                            InjectionSelector::Invalid => unreachable!(),
+                        }
+                }
+                _ => false,
+            };
+            if matches {
+                log::debug!(
+                    target: "kakehashi::tree_worker_shadow",
+                    "injection node matched uri={} version={} byte={}",
+                    uri,
+                    snapshot.parsed_version,
+                    byte,
+                );
+                if let Some(node) = worker_node {
+                    self.tree_worker_shadow
+                        .record_node_mapping(&uri, &authoritative, node);
+                }
+            } else {
+                log::debug!(
+                    target: "kakehashi::tree_worker_shadow",
+                    "injection node mismatch uri={} version={} byte={} authoritative={:?} worker={:?}",
+                    uri,
+                    snapshot.parsed_version,
+                    byte,
+                    authoritative_identity,
+                    worker_node,
+                );
+            }
+        }
+        Ok(authoritative)
     }
 
     /// Host-layer lookup, factored out so the no-injection request keeps

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -220,7 +220,7 @@ impl Kakehashi {
                     &uri,
                     incarnation,
                     snapshot.parsed_version,
-                    self.cache.semantic_token_generation(),
+                    self.language.configuration_generation(),
                     byte.min(doc_len.saturating_sub(1)),
                     false,
                 )

--- a/src/lsp/lsp_impl/kakehashi/node/field.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/field.rs
@@ -14,8 +14,8 @@
 use serde_json::{Value, json};
 use tower_lsp_server::jsonrpc::Result;
 
-use crate::lsp::lsp_impl::Kakehashi;
 use crate::lsp::lsp_impl::kakehashi::node::common::{NodeFieldNameParams, NodeIndexParams};
+use crate::lsp::lsp_impl::{Kakehashi, uri_to_url};
 
 impl Kakehashi {
     /// `kakehashi/node/childByFieldName` — the child labelled `name`, per
@@ -26,11 +26,17 @@ impl Kakehashi {
         params: NodeFieldNameParams,
     ) -> Result<Value> {
         let name = params.name;
+        let worker_name = name.clone();
         Ok(self
-            .navigate_to_node(&params.text_document.uri, &params.id, move |n| {
-                n.child_by_field_name(&name)
-                    .map(|c| (c.start_byte(), c.end_byte(), c.kind()))
-            })
+            .navigate_to_node_shadowed(
+                &params.text_document.uri,
+                &params.id,
+                crate::tree_worker::NodeNavigation::ChildByFieldName { name: worker_name },
+                move |n| {
+                    n.child_by_field_name(&name)
+                        .map(|c| (c.start_byte(), c.end_byte(), c.kind()))
+                },
+            )
             .await)
     }
 
@@ -42,13 +48,19 @@ impl Kakehashi {
         params: NodeFieldNameParams,
     ) -> Result<Value> {
         let name = params.name;
+        let worker_name = name.clone();
         Ok(self
-            .navigate_to_nodes(&params.text_document.uri, &params.id, move |n| {
-                let mut cursor = n.walk();
-                n.children_by_field_name(&name, &mut cursor)
-                    .map(|c| (c.start_byte(), c.end_byte(), c.kind()))
-                    .collect()
-            })
+            .navigate_to_nodes_shadowed(
+                &params.text_document.uri,
+                &params.id,
+                crate::tree_worker::NodeNavigation::ChildrenByFieldName { name: worker_name },
+                move |n| {
+                    let mut cursor = n.walk();
+                    n.children_by_field_name(&name, &mut cursor)
+                        .map(|c| (c.start_byte(), c.end_byte(), c.kind()))
+                        .collect()
+                },
+            )
             .await)
     }
 
@@ -63,6 +75,21 @@ impl Kakehashi {
         params: NodeIndexParams,
     ) -> Result<Value> {
         let index = u32::try_from(params.index).ok();
+        let shadow = match (index, uri_to_url(&params.text_document.uri).ok()) {
+            (Some(index), Some(uri)) => {
+                self.tree_worker_shadow
+                    .node_scalar(
+                        &uri,
+                        &params.id,
+                        crate::tree_worker::NodeScalarOperation::FieldNameForChild {
+                            index,
+                            named: false,
+                        },
+                    )
+                    .await
+            }
+            _ => None,
+        };
         let value = self
             .with_node_by_id(&params.text_document.uri, &params.id, move |n| {
                 index.and_then(|i| n.field_name_for_child(i))
@@ -70,6 +97,7 @@ impl Kakehashi {
             .await
             .map(|(_uri, _layer, _incarnation, field)| json!({ "fieldName": field }))
             .unwrap_or(Value::Null);
+        compare_field_name(shadow, &value, false);
         Ok(value)
     }
 
@@ -81,6 +109,21 @@ impl Kakehashi {
         params: NodeIndexParams,
     ) -> Result<Value> {
         let index = u32::try_from(params.index).ok();
+        let shadow = match (index, uri_to_url(&params.text_document.uri).ok()) {
+            (Some(index), Some(uri)) => {
+                self.tree_worker_shadow
+                    .node_scalar(
+                        &uri,
+                        &params.id,
+                        crate::tree_worker::NodeScalarOperation::FieldNameForChild {
+                            index,
+                            named: true,
+                        },
+                    )
+                    .await
+            }
+            _ => None,
+        };
         let value = self
             .with_node_by_id(&params.text_document.uri, &params.id, move |n| {
                 index.and_then(|i| n.field_name_for_named_child(i))
@@ -88,6 +131,24 @@ impl Kakehashi {
             .await
             .map(|(_uri, _layer, _incarnation, field)| json!({ "fieldName": field }))
             .unwrap_or(Value::Null);
+        compare_field_name(shadow, &value, true);
         Ok(value)
+    }
+}
+
+fn compare_field_name(
+    shadow: Option<crate::tree_worker::NodeScalarValue>,
+    authoritative: &Value,
+    named: bool,
+) {
+    let Some(crate::tree_worker::NodeScalarValue::NullableString(field)) = shadow else {
+        return;
+    };
+    let worker = json!({ "fieldName": field });
+    if &worker != authoritative {
+        log::debug!(
+            target: "kakehashi::tree_worker_shadow",
+            "node field-name mismatch named={named} authoritative={authoritative} worker={worker}",
+        );
     }
 }

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -30,15 +30,15 @@ use crate::lsp::lsp_impl::kakehashi::node::lookup::find_node_at;
 /// and so the host layer can carry the document tree without cloning lifetime
 /// dependencies. Byte coordinates inside `tree` are in original-document
 /// space (the same space the host text uses).
-pub(super) struct InjectionLayer {
+pub(crate) struct InjectionLayer {
     /// Tree-sitter syntax tree for this layer.
-    pub(super) tree: tree_sitter::Tree,
+    pub(crate) tree: tree_sitter::Tree,
     /// Absolute ranges in host coordinates that this layer's tree was parsed
     /// against. The host layer spans the whole document; each deeper layer's
     /// ranges are the intersection of its own effective ranges with its
     /// parent's, so container exclusions (e.g. blockquote `> ` prefixes) are
     /// inherited down the nesting chain.
-    pub(super) ranges: Vec<tree_sitter::Range>,
+    pub(crate) ranges: Vec<tree_sitter::Range>,
 }
 
 /// Whether `pattern_index` carries an `#offset!` directive. Used to decide if
@@ -74,7 +74,7 @@ fn whole_document_range(host_text: &str) -> tree_sitter::Range {
 /// The returned `Vec` always contains at least the host layer (layer 0); the
 /// function never fails — a parse/registry miss at any depth simply stops the
 /// walk and returns the layers gathered so far.
-pub(super) fn injection_stack_at(
+pub(crate) fn injection_stack_at(
     coordinator: &LanguageCoordinator,
     host_language: &str,
     host_text: &str,
@@ -622,9 +622,9 @@ fn absolutize_range(
 /// end-of-document exception (`byte == host_len` includes nodes whose
 /// `end_byte == host_len`).
 ///
-/// `pub(super)` so the coordinate accessors can apply the same rule the entry
-/// point uses to their byte / start-position arguments (#341).
-pub(super) fn ranges_contain_byte(
+/// `pub(crate)` so both the coordinate accessors and the worker-owned node
+/// implementation apply the same gap rule as the entry point (#341).
+pub(crate) fn ranges_contain_byte(
     ranges: &[tree_sitter::Range],
     byte: usize,
     host_len: usize,

--- a/src/lsp/lsp_impl/kakehashi/node/metadata.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/metadata.rs
@@ -22,18 +22,51 @@
 use serde_json::{Value, json};
 use tower_lsp_server::jsonrpc::Result;
 
-use crate::lsp::lsp_impl::Kakehashi;
 use crate::lsp::lsp_impl::kakehashi::node::common::NodeIdParams;
+use crate::lsp::lsp_impl::{Kakehashi, uri_to_url};
+use crate::tree_worker::{NodeScalarOperation, NodeScalarValue};
+
+fn scalar_json(field: &str, value: NodeScalarValue) -> Option<Value> {
+    let value = match value {
+        NodeScalarValue::String(value) => Value::String(value),
+        NodeScalarValue::Bool(value) => Value::Bool(value),
+        NodeScalarValue::U64(value) => Value::Number(value.into()),
+        NodeScalarValue::ByteRange { .. } => return None,
+    };
+    let mut object = serde_json::Map::new();
+    object.insert(field.into(), value);
+    Some(Value::Object(object))
+}
 
 /// Run `f` on the resolved node and wrap its result under `field`, or return
 /// JSON `null` if the id does not resolve.
 macro_rules! scalar_accessor {
-    ($self:ident, $params:ident, $field:literal, $f:expr) => {{
+    ($self:ident, $params:ident, $field:literal, $operation:expr, $f:expr) => {{
+        let shadow = match uri_to_url(&$params.text_document.uri) {
+            Ok(uri) => {
+                $self
+                    .tree_worker_shadow
+                    .node_scalar(&uri, &$params.id, $operation)
+                    .await
+            }
+            Err(_) => None,
+        };
         let value = $self
             .with_node_by_id(&$params.text_document.uri, &$params.id, $f)
             .await
             .map(|(_uri, _layer, _incarnation, v)| json!({ $field: v }))
             .unwrap_or(Value::Null);
+        if let Some(shadow) = shadow.and_then(|shadow| scalar_json($field, shadow))
+            && shadow != value
+        {
+            log::debug!(
+                target: "kakehashi::tree_worker_shadow",
+                "node scalar mismatch operation={:?} authoritative={} worker={}",
+                $operation,
+                value,
+                shadow,
+            );
+        }
         Ok(value)
     }};
 }
@@ -41,60 +74,97 @@ macro_rules! scalar_accessor {
 impl Kakehashi {
     /// `kakehashi/node/kind` — the node's grammar symbol name (`Node::kind`).
     pub async fn kakehashi_node_kind(&self, params: NodeIdParams) -> Result<Value> {
-        scalar_accessor!(self, params, "kind", |n| n.kind())
+        scalar_accessor!(self, params, "kind", NodeScalarOperation::Kind, |n| n
+            .kind())
     }
 
     /// `kakehashi/node/grammarName` — the node's grammar name, which differs
     /// from `kind` for nodes aliased by the grammar (`Node::grammar_name`).
     pub async fn kakehashi_node_grammar_name(&self, params: NodeIdParams) -> Result<Value> {
-        scalar_accessor!(self, params, "grammarName", |n| n.grammar_name())
+        scalar_accessor!(
+            self,
+            params,
+            "grammarName",
+            NodeScalarOperation::GrammarName,
+            |n| n.grammar_name()
+        )
     }
 
     /// `kakehashi/node/isNamed` — whether the node is *named* (vs an anonymous
     /// token), per `Node::is_named`.
     pub async fn kakehashi_node_is_named(&self, params: NodeIdParams) -> Result<Value> {
-        scalar_accessor!(self, params, "isNamed", |n| n.is_named())
+        scalar_accessor!(self, params, "isNamed", NodeScalarOperation::IsNamed, |n| n
+            .is_named())
     }
 
     /// `kakehashi/node/isExtra` — whether the node is an *extra* (e.g. a comment
     /// the grammar permits anywhere), per `Node::is_extra`.
     pub async fn kakehashi_node_is_extra(&self, params: NodeIdParams) -> Result<Value> {
-        scalar_accessor!(self, params, "isExtra", |n| n.is_extra())
+        scalar_accessor!(self, params, "isExtra", NodeScalarOperation::IsExtra, |n| n
+            .is_extra())
     }
 
     /// `kakehashi/node/hasError` — whether the node's subtree contains a syntax
     /// error, per `Node::has_error`.
     pub async fn kakehashi_node_has_error(&self, params: NodeIdParams) -> Result<Value> {
-        scalar_accessor!(self, params, "hasError", |n| n.has_error())
+        scalar_accessor!(
+            self,
+            params,
+            "hasError",
+            NodeScalarOperation::HasError,
+            |n| n.has_error()
+        )
     }
 
     /// `kakehashi/node/isError` — whether the node itself is an `ERROR` node,
     /// per `Node::is_error`.
     pub async fn kakehashi_node_is_error(&self, params: NodeIdParams) -> Result<Value> {
-        scalar_accessor!(self, params, "isError", |n| n.is_error())
+        scalar_accessor!(self, params, "isError", NodeScalarOperation::IsError, |n| n
+            .is_error())
     }
 
     /// `kakehashi/node/isMissing` — whether the node is a zero-width `MISSING`
     /// node the parser inserted during error recovery, per `Node::is_missing`.
     pub async fn kakehashi_node_is_missing(&self, params: NodeIdParams) -> Result<Value> {
-        scalar_accessor!(self, params, "isMissing", |n| n.is_missing())
+        scalar_accessor!(
+            self,
+            params,
+            "isMissing",
+            NodeScalarOperation::IsMissing,
+            |n| n.is_missing()
+        )
     }
 
     /// `kakehashi/node/startByte` — the node's start byte (UTF-8, host coords),
     /// per `Node::start_byte`.
     pub async fn kakehashi_node_start_byte(&self, params: NodeIdParams) -> Result<Value> {
-        scalar_accessor!(self, params, "startByte", |n| n.start_byte())
+        scalar_accessor!(
+            self,
+            params,
+            "startByte",
+            NodeScalarOperation::StartByte,
+            |n| n.start_byte()
+        )
     }
 
     /// `kakehashi/node/endByte` — the node's end byte (UTF-8, host coords),
     /// per `Node::end_byte`.
     pub async fn kakehashi_node_end_byte(&self, params: NodeIdParams) -> Result<Value> {
-        scalar_accessor!(self, params, "endByte", |n| n.end_byte())
+        scalar_accessor!(self, params, "endByte", NodeScalarOperation::EndByte, |n| n
+            .end_byte())
     }
 
     /// `kakehashi/node/byteRange` — the node's `[startByte, endByte)` span
     /// (UTF-8, host coords) in one call, per `Node::byte_range`.
     pub async fn kakehashi_node_byte_range(&self, params: NodeIdParams) -> Result<Value> {
+        let shadow = match uri_to_url(&params.text_document.uri) {
+            Ok(uri) => {
+                self.tree_worker_shadow
+                    .node_scalar(&uri, &params.id, NodeScalarOperation::ByteRange)
+                    .await
+            }
+            Err(_) => None,
+        };
         let value = self
             .with_node_by_id(
                 &params.text_document.uri,
@@ -104,30 +174,70 @@ impl Kakehashi {
             .await
             .map(|(_uri, _layer, _incarnation, v)| v)
             .unwrap_or(Value::Null);
+        if let Some(NodeScalarValue::ByteRange {
+            start_byte,
+            end_byte,
+        }) = shadow
+        {
+            let shadow = json!({ "startByte": start_byte, "endByte": end_byte });
+            if shadow != value {
+                log::debug!(
+                    target: "kakehashi::tree_worker_shadow",
+                    "node scalar mismatch operation={:?} authoritative={} worker={}",
+                    NodeScalarOperation::ByteRange,
+                    value,
+                    shadow,
+                );
+            }
+        }
         Ok(value)
     }
 
     /// `kakehashi/node/childCount` — number of children (named + anonymous),
     /// per `Node::child_count`.
     pub async fn kakehashi_node_child_count(&self, params: NodeIdParams) -> Result<Value> {
-        scalar_accessor!(self, params, "childCount", |n| n.child_count())
+        scalar_accessor!(
+            self,
+            params,
+            "childCount",
+            NodeScalarOperation::ChildCount,
+            |n| n.child_count()
+        )
     }
 
     /// `kakehashi/node/namedChildCount` — number of *named* children, per
     /// `Node::named_child_count`.
     pub async fn kakehashi_node_named_child_count(&self, params: NodeIdParams) -> Result<Value> {
-        scalar_accessor!(self, params, "namedChildCount", |n| n.named_child_count())
+        scalar_accessor!(
+            self,
+            params,
+            "namedChildCount",
+            NodeScalarOperation::NamedChildCount,
+            |n| n.named_child_count()
+        )
     }
 
     /// `kakehashi/node/descendantCount` — number of descendants including the
     /// node itself, per `Node::descendant_count`.
     pub async fn kakehashi_node_descendant_count(&self, params: NodeIdParams) -> Result<Value> {
-        scalar_accessor!(self, params, "descendantCount", |n| n.descendant_count())
+        scalar_accessor!(
+            self,
+            params,
+            "descendantCount",
+            NodeScalarOperation::DescendantCount,
+            |n| n.descendant_count()
+        )
     }
 
     /// `kakehashi/node/toSexp` — the node's subtree as an s-expression string,
     /// per `Node::to_sexp`. Useful for debugging and snapshot tests.
     pub async fn kakehashi_node_to_sexp(&self, params: NodeIdParams) -> Result<Value> {
-        scalar_accessor!(self, params, "sexp", |n| n.to_sexp())
+        scalar_accessor!(
+            self,
+            params,
+            "sexp",
+            NodeScalarOperation::SExpression,
+            |n| n.to_sexp()
+        )
     }
 }

--- a/src/lsp/lsp_impl/kakehashi/node/metadata.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/metadata.rs
@@ -33,6 +33,7 @@ fn scalar_json(field: &str, value: NodeScalarValue) -> Option<Value> {
         NodeScalarValue::U64(value) => Value::Number(value.into()),
         NodeScalarValue::ByteRange { .. } => return None,
         NodeScalarValue::NullableString(value) => value.map_or(Value::Null, Value::String),
+        NodeScalarValue::Position(_) | NodeScalarValue::Range { .. } => return None,
     };
     let mut object = serde_json::Map::new();
     object.insert(field.into(), value);

--- a/src/lsp/lsp_impl/kakehashi/node/metadata.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/metadata.rs
@@ -32,6 +32,7 @@ fn scalar_json(field: &str, value: NodeScalarValue) -> Option<Value> {
         NodeScalarValue::Bool(value) => Value::Bool(value),
         NodeScalarValue::U64(value) => Value::Number(value.into()),
         NodeScalarValue::ByteRange { .. } => return None,
+        NodeScalarValue::NullableString(value) => value.map_or(Value::Null, Value::String),
     };
     let mut object = serde_json::Map::new();
     object.insert(field.into(), value);

--- a/src/lsp/lsp_impl/kakehashi/node/navigation.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/navigation.rs
@@ -94,7 +94,7 @@ impl Kakehashi {
         params: NodeDescendantParams,
     ) -> Result<Value> {
         Ok(self
-            .navigate_with_descendant(
+            .navigate_with_descendant_shadowed(
                 &params.text_document.uri,
                 &params.id,
                 &params.descendant_id,

--- a/src/lsp/lsp_impl/kakehashi/node/navigation.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/navigation.rs
@@ -35,10 +35,16 @@ impl Kakehashi {
         // tree-sitter child indices are u32; anything outside that range can
         // never match and is treated as "no such child".
         let index = u32::try_from(params.index).ok();
+        let Some(index) = index else {
+            return Ok(Value::Null);
+        };
         Ok(self
-            .navigate_to_node(&params.text_document.uri, &params.id, move |n| {
-                index.and_then(|i| n.child(i)).map(triple)
-            })
+            .navigate_to_node_shadowed(
+                &params.text_document.uri,
+                &params.id,
+                crate::tree_worker::NodeNavigation::Child { index },
+                move |n| n.child(index).map(triple),
+            )
             .await)
     }
 
@@ -46,10 +52,16 @@ impl Kakehashi {
     /// `Node::named_child`. Out-of-range / negative indices resolve to `null`.
     pub async fn kakehashi_node_named_child(&self, params: NodeIndexParams) -> Result<Value> {
         let index = u32::try_from(params.index).ok();
+        let Some(index) = index else {
+            return Ok(Value::Null);
+        };
         Ok(self
-            .navigate_to_node(&params.text_document.uri, &params.id, move |n| {
-                index.and_then(|i| n.named_child(i)).map(triple)
-            })
+            .navigate_to_node_shadowed(
+                &params.text_document.uri,
+                &params.id,
+                crate::tree_worker::NodeNavigation::NamedChild { index },
+                move |n| n.named_child(index).map(triple),
+            )
             .await)
     }
 
@@ -58,10 +70,15 @@ impl Kakehashi {
     /// (named + anonymous) and mints IDs only for named nodes.
     pub async fn kakehashi_node_named_children(&self, params: NodeIdParams) -> Result<Value> {
         Ok(self
-            .navigate_to_nodes(&params.text_document.uri, &params.id, move |n| {
-                let mut cursor = n.walk();
-                n.named_children(&mut cursor).map(triple).collect()
-            })
+            .navigate_to_nodes_shadowed(
+                &params.text_document.uri,
+                &params.id,
+                crate::tree_worker::NodeNavigation::NamedChildren,
+                move |n| {
+                    let mut cursor = n.walk();
+                    n.named_children(&mut cursor).map(triple).collect()
+                },
+            )
             .await)
     }
 
@@ -105,9 +122,12 @@ impl Kakehashi {
     /// `Node::next_sibling`. `null` for the last child or an unresolvable id.
     pub async fn kakehashi_node_next_sibling(&self, params: NodeIdParams) -> Result<Value> {
         Ok(self
-            .navigate_to_node(&params.text_document.uri, &params.id, move |n| {
-                n.next_sibling().map(triple)
-            })
+            .navigate_to_node_shadowed(
+                &params.text_document.uri,
+                &params.id,
+                crate::tree_worker::NodeNavigation::NextSibling,
+                move |n| n.next_sibling().map(triple),
+            )
             .await)
     }
 
@@ -115,9 +135,12 @@ impl Kakehashi {
     /// per `Node::prev_sibling`. `null` for the first child or an unresolvable id.
     pub async fn kakehashi_node_prev_sibling(&self, params: NodeIdParams) -> Result<Value> {
         Ok(self
-            .navigate_to_node(&params.text_document.uri, &params.id, move |n| {
-                n.prev_sibling().map(triple)
-            })
+            .navigate_to_node_shadowed(
+                &params.text_document.uri,
+                &params.id,
+                crate::tree_worker::NodeNavigation::PreviousSibling,
+                move |n| n.prev_sibling().map(triple),
+            )
             .await)
     }
 
@@ -125,9 +148,12 @@ impl Kakehashi {
     /// `Node::next_named_sibling`.
     pub async fn kakehashi_node_next_named_sibling(&self, params: NodeIdParams) -> Result<Value> {
         Ok(self
-            .navigate_to_node(&params.text_document.uri, &params.id, move |n| {
-                n.next_named_sibling().map(triple)
-            })
+            .navigate_to_node_shadowed(
+                &params.text_document.uri,
+                &params.id,
+                crate::tree_worker::NodeNavigation::NextNamedSibling,
+                move |n| n.next_named_sibling().map(triple),
+            )
             .await)
     }
 
@@ -135,9 +161,12 @@ impl Kakehashi {
     /// `Node::prev_named_sibling`.
     pub async fn kakehashi_node_prev_named_sibling(&self, params: NodeIdParams) -> Result<Value> {
         Ok(self
-            .navigate_to_node(&params.text_document.uri, &params.id, move |n| {
-                n.prev_named_sibling().map(triple)
-            })
+            .navigate_to_node_shadowed(
+                &params.text_document.uri,
+                &params.id,
+                crate::tree_worker::NodeNavigation::PreviousNamedSibling,
+                move |n| n.prev_named_sibling().map(triple),
+            )
             .await)
     }
 
@@ -152,16 +181,21 @@ impl Kakehashi {
         params: NodeByteParams,
     ) -> Result<Value> {
         let byte = usize::try_from(params.byte).ok();
+        let Some(byte) = byte else {
+            return Ok(Value::Null);
+        };
         Ok(self
-            .navigate_to_node_in_ranges(
+            .navigate_to_node_in_ranges_shadowed(
                 &params.text_document.uri,
                 &params.id,
+                crate::tree_worker::NodeNavigation::FirstChildForByte { byte },
                 move |n, text, ranges| {
                     // Keep the byte inside the node's own span before handing it to
                     // tree-sitter, whose behaviour for offsets outside the queried
                     // node is version-dependent (mirrors lookup::find_node_at). These
                     // are node-scoped accessors, so an out-of-node argument is null.
-                    byte.filter(|&b| n.start_byte() <= b && b <= n.end_byte())
+                    Some(byte)
+                        .filter(|&b| n.start_byte() <= b && b <= n.end_byte())
                         .filter(|&b| ranges_contain_byte(ranges, b, text.len()))
                         .and_then(|b| n.first_child_for_byte(b))
                         .map(triple)
@@ -181,12 +215,20 @@ impl Kakehashi {
         params: NodeByteRangeParams,
     ) -> Result<Value> {
         let range = byte_range(&params);
+        let Some((start_byte, end_byte)) = range else {
+            return Ok(Value::Null);
+        };
         Ok(self
-            .navigate_to_node_in_ranges(
+            .navigate_to_node_in_ranges_shadowed(
                 &params.text_document.uri,
                 &params.id,
+                crate::tree_worker::NodeNavigation::DescendantForByteRange {
+                    start_byte,
+                    end_byte,
+                    named: false,
+                },
                 move |n, text, ranges| {
-                    range
+                    Some((start_byte, end_byte))
                         .filter(|&(s, e)| n.start_byte() <= s && e <= n.end_byte())
                         .filter(|&(s, e)| range_bounds_in_ranges(ranges, s, e, text.len()))
                         .and_then(|(s, e)| n.descendant_for_byte_range(s, e))
@@ -207,12 +249,20 @@ impl Kakehashi {
         params: NodeByteRangeParams,
     ) -> Result<Value> {
         let range = byte_range(&params);
+        let Some((start_byte, end_byte)) = range else {
+            return Ok(Value::Null);
+        };
         Ok(self
-            .navigate_to_node_in_ranges(
+            .navigate_to_node_in_ranges_shadowed(
                 &params.text_document.uri,
                 &params.id,
+                crate::tree_worker::NodeNavigation::DescendantForByteRange {
+                    start_byte,
+                    end_byte,
+                    named: true,
+                },
                 move |n, text, ranges| {
-                    range
+                    Some((start_byte, end_byte))
                         .filter(|&(s, e)| n.start_byte() <= s && e <= n.end_byte())
                         .filter(|&(s, e)| range_bounds_in_ranges(ranges, s, e, text.len()))
                         .and_then(|(s, e)| n.named_descendant_for_byte_range(s, e))

--- a/src/lsp/lsp_impl/kakehashi/node/parent.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/parent.rs
@@ -142,9 +142,27 @@ impl Kakehashi {
             return Ok(Value::Null);
         };
 
-        Ok(json!({
+        let authoritative = json!({
             "id": parent_ulid.to_string(),
             "kind": p_kind,
-        }))
+        });
+        self.tree_worker_shadow
+            .compare_node_navigation(
+                &uri,
+                incarnation,
+                snapshot.parsed_version,
+                self.cache.semantic_token_generation(),
+                &params.id,
+                crate::tree_worker::NodeNavigation::Parent,
+                &authoritative,
+            )
+            .await;
+        if !self.documents.latest_snapshot(&uri).is_some_and(|view| {
+            view.content_version == snapshot.parsed_version
+                && view.slot.current_incarnation == incarnation
+        }) {
+            return Ok(Value::Null);
+        }
+        Ok(authoritative)
     }
 }

--- a/src/lsp/lsp_impl/kakehashi/node/parent.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/parent.rs
@@ -151,7 +151,7 @@ impl Kakehashi {
                 &uri,
                 incarnation,
                 snapshot.parsed_version,
-                self.cache.semantic_token_generation(),
+                self.language.configuration_generation(),
                 &params.id,
                 crate::tree_worker::NodeNavigation::Parent,
                 &authoritative,

--- a/src/lsp/lsp_impl/kakehashi/node/position.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/position.rs
@@ -27,9 +27,9 @@
 use serde_json::{Value, json};
 use tower_lsp_server::jsonrpc::Result;
 
-use crate::lsp::lsp_impl::Kakehashi;
 use crate::lsp::lsp_impl::kakehashi::node::common::{NodeIdParams, NodePointRangeParams};
 use crate::lsp::lsp_impl::kakehashi::node::navigation::range_bounds_in_ranges;
+use crate::lsp::lsp_impl::{Kakehashi, uri_to_url};
 use crate::text::PositionMapper;
 
 impl Kakehashi {
@@ -37,6 +37,13 @@ impl Kakehashi {
     /// per `Node::range`. Returns `{ "start": Position, "end": Position }` or
     /// `null`.
     pub async fn kakehashi_node_range(&self, params: NodeIdParams) -> Result<Value> {
+        let shadow = self
+            .shadow_position_scalar(
+                &params.text_document.uri,
+                &params.id,
+                crate::tree_worker::NodeScalarOperation::Range,
+            )
+            .await;
         let value = self
             .with_node_text(&params.text_document.uri, &params.id, move |n, text| {
                 let mapper = PositionMapper::new(text);
@@ -49,6 +56,7 @@ impl Kakehashi {
             .and_then(|(_uri, _layer, _incarnation, span)| span)
             .map(|(start, end)| json!({ "start": start, "end": end }))
             .unwrap_or(Value::Null);
+        compare_position_scalar(shadow, &value, "range");
         Ok(value)
     }
 
@@ -56,6 +64,13 @@ impl Kakehashi {
     /// per `Node::start_position`. Returns `{ "startPosition": Position }` or
     /// `null`.
     pub async fn kakehashi_node_start_position(&self, params: NodeIdParams) -> Result<Value> {
+        let shadow = self
+            .shadow_position_scalar(
+                &params.text_document.uri,
+                &params.id,
+                crate::tree_worker::NodeScalarOperation::StartPosition,
+            )
+            .await;
         let value = self
             .with_node_text(&params.text_document.uri, &params.id, move |n, text| {
                 PositionMapper::new(text).byte_to_position(n.start_byte())
@@ -64,12 +79,20 @@ impl Kakehashi {
             .and_then(|(_uri, _layer, _incarnation, pos)| pos)
             .map(|pos| json!({ "startPosition": pos }))
             .unwrap_or(Value::Null);
+        compare_position_scalar(shadow, &value, "startPosition");
         Ok(value)
     }
 
     /// `kakehashi/node/endPosition` — the node's end as an LSP `Position`, per
     /// `Node::end_position`. Returns `{ "endPosition": Position }` or `null`.
     pub async fn kakehashi_node_end_position(&self, params: NodeIdParams) -> Result<Value> {
+        let shadow = self
+            .shadow_position_scalar(
+                &params.text_document.uri,
+                &params.id,
+                crate::tree_worker::NodeScalarOperation::EndPosition,
+            )
+            .await;
         let value = self
             .with_node_text(&params.text_document.uri, &params.id, move |n, text| {
                 PositionMapper::new(text).byte_to_position(n.end_byte())
@@ -78,6 +101,7 @@ impl Kakehashi {
             .and_then(|(_uri, _layer, _incarnation, pos)| pos)
             .map(|pos| json!({ "endPosition": pos }))
             .unwrap_or(Value::Null);
+        compare_position_scalar(shadow, &value, "endPosition");
         Ok(value)
     }
 
@@ -115,10 +139,21 @@ impl Kakehashi {
     ) -> Result<Value> {
         let start = params.start;
         let end = params.end;
-        let resolved = self
-            .with_node_text_ranges(
+        let value = self
+            .navigate_to_node_in_ranges_shadowed(
                 &params.text_document.uri,
                 &params.id,
+                crate::tree_worker::NodeNavigation::DescendantForPointRange {
+                    start: crate::tree_worker::WirePosition {
+                        line: start.line,
+                        character: start.character,
+                    },
+                    end: crate::tree_worker::WirePosition {
+                        line: end.line,
+                        character: end.character,
+                    },
+                    named,
+                },
                 move |n, text, ranges| {
                     let mapper = PositionMapper::new(text);
                     // Strict conversion: a `character` past a line's end must mean
@@ -150,13 +185,46 @@ impl Kakehashi {
                 },
             )
             .await;
-
-        let value = match resolved {
-            Some((uri, layer, incarnation, Some(triple))) => {
-                self.mint_node_info(&uri, layer, incarnation, triple)
-            }
-            _ => Value::Null,
-        };
         Ok(value)
+    }
+
+    async fn shadow_position_scalar(
+        &self,
+        lsp_uri: &tower_lsp_server::ls_types::Uri,
+        id: &str,
+        operation: crate::tree_worker::NodeScalarOperation,
+    ) -> Option<crate::tree_worker::NodeScalarValue> {
+        let uri = uri_to_url(lsp_uri).ok()?;
+        self.tree_worker_shadow
+            .node_scalar(&uri, id, operation)
+            .await
+    }
+}
+
+fn wire_position_json(position: crate::tree_worker::WirePosition) -> Value {
+    json!({ "line": position.line, "character": position.character })
+}
+
+fn compare_position_scalar(
+    shadow: Option<crate::tree_worker::NodeScalarValue>,
+    authoritative: &Value,
+    field: &str,
+) {
+    let worker = match shadow {
+        Some(crate::tree_worker::NodeScalarValue::Position(position)) => {
+            let mut object = serde_json::Map::new();
+            object.insert(field.into(), wire_position_json(position));
+            Value::Object(object)
+        }
+        Some(crate::tree_worker::NodeScalarValue::Range { start, end }) => {
+            json!({ "start": wire_position_json(start), "end": wire_position_json(end) })
+        }
+        _ => return,
+    };
+    if &worker != authoritative {
+        log::debug!(
+            target: "kakehashi::tree_worker_shadow",
+            "node position mismatch field={field} authoritative={authoritative} worker={worker}",
+        );
     }
 }

--- a/src/lsp/lsp_impl/kakehashi/node/text.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/text.rs
@@ -38,6 +38,14 @@ impl Kakehashi {
             log::warn!(target: "kakehashi::node::text", "invalid URI: {}", lsp_uri.as_str());
             return Ok(Value::Null);
         };
+        let shadow = self
+            .tree_worker_shadow
+            .node_scalar(
+                &uri,
+                &params.id,
+                crate::tree_worker::NodeScalarOperation::Text,
+            )
+            .await;
 
         // Malformed ULID: node-reference-protocol says any unresolvable reference collapses to null,
         // so we treat a parse failure the same as a never-issued ULID rather than
@@ -87,6 +95,18 @@ impl Kakehashi {
             slice.to_string()
         };
 
-        Ok(json!({ "text": slice }))
+        let authoritative = json!({ "text": slice });
+        if let Some(crate::tree_worker::NodeScalarValue::String(text)) = shadow {
+            let worker = json!({ "text": text });
+            if worker != authoritative {
+                log::debug!(
+                    target: "kakehashi::tree_worker_shadow",
+                    "node text mismatch authoritative={} worker={}",
+                    authoritative,
+                    worker,
+                );
+            }
+        }
+        Ok(authoritative)
     }
 }

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -40,7 +40,7 @@ impl Kakehashi {
         self.ensure_document_parsed(&uri).await;
 
         // Get document snapshot (minimizes lock duration)
-        let snapshot = match self.documents.get(&uri) {
+        let (snapshot, content_version) = match self.documents.get(&uri) {
             None => {
                 log::debug!("documentColor: No document found for {}", uri);
                 return Ok(Vec::new());
@@ -50,7 +50,7 @@ impl Kakehashi {
                     log::debug!("documentColor: Document not fully initialized for {}", uri);
                     return Ok(Vec::new());
                 }
-                Some(snapshot) => snapshot,
+                Some(snapshot) => (snapshot, doc.content_version()),
             },
             // doc automatically dropped here, lock released
         };
@@ -96,29 +96,13 @@ impl Kakehashi {
         // consumes every injection. Issuing this RPC from the parse hot path
         // can overtake queued edits on the document lane and makes the shadow
         // observation causally stale under a typing burst.
-        if let Some(view) = self.documents.latest_snapshot(&uri)
-            && view.slot.current_incarnation == snapshot.incarnation()
-            && view.slot.snapshot.as_ref().is_some_and(|current| {
-                current.incarnation == snapshot.incarnation()
-                    && current.parsed_version == view.content_version
-            })
-            && let Some(worker_regions) = self
-                .tree_worker_shadow
-                .injection_regions(
-                    &uri,
-                    snapshot.incarnation(),
-                    view.content_version,
-                    self.cache.semantic_token_generation(),
-                )
-                .await
-        {
-            self.tree_worker_shadow.compare_injection_regions(
-                &uri,
-                view.content_version,
-                &all_regions,
-                &worker_regions,
-            );
-        }
+        self.shadow_compare_current_injection_regions(
+            &uri,
+            snapshot.incarnation(),
+            content_version,
+            &all_regions,
+        )
+        .await;
 
         if all_regions.is_empty() {
             return Ok(Vec::new());

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -92,6 +92,34 @@ impl Kakehashi {
             )),
         };
 
+        // Compare the fused worker derivation only for a reader that already
+        // consumes every injection. Issuing this RPC from the parse hot path
+        // can overtake queued edits on the document lane and makes the shadow
+        // observation causally stale under a typing burst.
+        if let Some(view) = self.documents.latest_snapshot(&uri)
+            && view.slot.current_incarnation == snapshot.incarnation()
+            && view.slot.snapshot.as_ref().is_some_and(|current| {
+                current.incarnation == snapshot.incarnation()
+                    && current.parsed_version == view.content_version
+            })
+            && let Some(worker_regions) = self
+                .tree_worker_shadow
+                .injection_regions(
+                    &uri,
+                    snapshot.incarnation(),
+                    view.content_version,
+                    self.cache.semantic_token_generation(),
+                )
+                .await
+        {
+            self.tree_worker_shadow.compare_injection_regions(
+                &uri,
+                view.content_version,
+                &all_regions,
+                &worker_regions,
+            );
+        }
+
         if all_regions.is_empty() {
             return Ok(Vec::new());
         }

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -72,7 +72,7 @@ impl Kakehashi {
         self.ensure_document_parsed(&uri).await;
 
         // Get document snapshot (minimizes lock duration)
-        let snapshot = match self.documents.get(&uri) {
+        let (snapshot, content_version) = match self.documents.get(&uri) {
             None => {
                 log::debug!("documentSymbol: No document found for {}", uri);
                 return Ok(None);
@@ -82,7 +82,7 @@ impl Kakehashi {
                     log::debug!("documentSymbol: Document not fully initialized for {}", uri);
                     return Ok(None);
                 }
-                Some(snapshot) => snapshot,
+                Some(snapshot) => (snapshot, doc.content_version()),
             },
             // doc automatically dropped here, lock released
         };
@@ -114,6 +114,14 @@ impl Kakehashi {
                 snapshot.incarnation(),
             )),
         };
+
+        self.shadow_compare_current_injection_regions(
+            &uri,
+            snapshot.incarnation(),
+            content_version,
+            &all_regions,
+        )
+        .await;
 
         if all_regions.is_empty() {
             return Ok(None);

--- a/src/lsp/lsp_impl/text_document/native_bindings.rs
+++ b/src/lsp/lsp_impl/text_document/native_bindings.rs
@@ -11,8 +11,6 @@
 //! tree is parsed with included ranges; results map back through the
 //! region's content offset). `#offset!`-shifted regions stay bridge-only.
 
-use std::ops::Range;
-
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{
     DocumentHighlight, DocumentHighlightKind, Location, LocationLink, Position,
@@ -24,26 +22,22 @@ use crate::analysis::bindings::collect::collect_cancellable;
 use crate::analysis::bindings::model::BindingsModel;
 use crate::text::PositionMapper;
 
-/// Everything a native answer is computed from: the resolved model, the
-/// cursor's byte offset **within the layer**, the host-text mapper, and the
-/// layer's byte offset into the host text (0 for the host layer).
+/// Everything a native answer is computed from: worker-wire-compatible facts
+/// in host byte coordinates plus the host-text position mapper.
 pub(crate) struct NativeBindingsContext<'a> {
-    pub(crate) model: &'a BindingsModel,
-    pub(crate) byte: usize,
+    pub(crate) facts: &'a crate::tree_worker::NativeBindingsFacts,
     pub(crate) mapper: &'a PositionMapper<'a>,
-    pub(crate) layer_offset: usize,
 }
 
 impl NativeBindingsContext<'_> {
-    /// A layer-relative byte range as a host-document LSP range.
-    fn to_host_range(&self, range: &Range<usize>) -> Option<tower_lsp_server::ls_types::Range> {
+    /// A host-document byte range as an LSP range.
+    fn to_host_range(
+        &self,
+        range: crate::tree_worker::WireByteRange,
+    ) -> Option<tower_lsp_server::ls_types::Range> {
         Some(tower_lsp_server::ls_types::Range {
-            start: self
-                .mapper
-                .byte_to_position(range.start + self.layer_offset)?,
-            end: self
-                .mapper
-                .byte_to_position(range.end + self.layer_offset)?,
+            start: self.mapper.byte_to_position(range.start)?,
+            end: self.mapper.byte_to_position(range.end)?,
         })
     }
 }
@@ -98,6 +92,7 @@ impl Kakehashi {
         // (every edit and reopen installs a fresh allocation).
         self.ensure_document_parsed(&uri).await;
         let settings_generation = self.cache.semantic_token_generation();
+        let worker_configuration_generation = self.language.configuration_generation();
         let Some((text, tree, content_version, incarnation)) = ({
             let doc = self.documents.get(&uri);
             doc.and_then(|doc| {
@@ -112,6 +107,17 @@ impl Kakehashi {
         }) else {
             return Ok(None);
         };
+        if let Some(grammar) = self.language.worker_grammar_descriptor(&language)
+            && self.tree_worker_shadow.needs_document_sync(
+                &uri,
+                incarnation,
+                content_version,
+                worker_configuration_generation,
+                &grammar.queries,
+            )
+        {
+            self.refresh_tree_worker_documents(std::slice::from_ref(&uri));
+        }
 
         // Strict conversion: a client-supplied `character` past its line
         // end must silence, not spill onto a later line's identifier.
@@ -120,33 +126,80 @@ impl Kakehashi {
             return Ok(None);
         };
 
+        let local = self.local_native_bindings_facts(&uri, &text, &tree, &language, byte);
+        let worker = self.tree_worker_shadow.native_bindings(
+            &uri,
+            incarnation,
+            content_version,
+            worker_configuration_generation,
+            crate::tree_worker::WirePosition {
+                line: position.line,
+                character: position.character,
+            },
+        );
+        let (facts, worker) = tokio::join!(local, worker);
+        if let Some(worker) = worker.as_ref() {
+            self.tree_worker_shadow.compare_native_bindings(
+                &uri,
+                content_version,
+                facts.as_ref(),
+                worker,
+            );
+        }
+        let Some(facts) = facts else {
+            return Ok(None);
+        };
+        let answer = f(NativeBindingsContext {
+            facts: &facts,
+            mapper: &mapper,
+        });
+
+        // A didChange between the snapshot and here makes every computed
+        // range stale — worst case a rename WorkspaceEdit applied to newer
+        // text. Publish only while the snapshot's text is still current.
+        let unchanged = self.documents.get(&uri).is_some_and(|doc| {
+            doc.content_version() == content_version
+                && doc.incarnation() == incarnation
+                && std::sync::Arc::ptr_eq(&doc.text_arc(), &text)
+        });
+        if !unchanged || self.cache.semantic_token_generation() != settings_generation {
+            return Ok(None);
+        }
+        Ok(answer)
+    }
+
+    async fn local_native_bindings_facts(
+        &self,
+        uri: &url::Url,
+        text: &std::sync::Arc<str>,
+        tree: &tree_sitter::Tree,
+        language: &str,
+        byte: usize,
+    ) -> Option<crate::tree_worker::NativeBindingsFacts> {
         // Scope trees are per layer and resolution never crosses layer
         // boundaries: a cursor inside an injected region resolves in that
         // region's layer alone.
         let (query, layer_text, layer_tree, layer_offset) = match self
-            .injected_bindings_layer(&uri, &text, &tree, &language, byte)
+            .injected_bindings_layer(uri, text, tree, language, byte)
             .await
         {
             Some(Some(layer)) => layer,
             // Inside a region the resolver cannot serve: silence, never
             // a host-layer answer for an injected-code cursor.
-            Some(None) => return Ok(None),
-            None => {
-                let Some(query) = self.language.bindings_query(&language) else {
-                    return Ok(None);
-                };
-                (query, std::sync::Arc::clone(&text), tree.clone(), 0)
-            }
+            Some(None) => return None,
+            None => (
+                self.language.bindings_query(language)?,
+                std::sync::Arc::clone(text),
+                tree.clone(),
+                0,
+            ),
         };
 
         // The query walk and model build are CPU work proportional to the
         // layer, not the request: keep them off the async worker like every
         // other tree-CPU site. Dropping a spawn_blocking JoinHandle does NOT
-        // stop the task, so when the cross-layer race drops this future (a
-        // higher-priority bridge answer won) the guard flips the cooperative
-        // flag and the collection walk exits at its next match instead of
-        // burning a blocking thread on an answer nobody can use. A failed or
-        // cancelled task degrades to silence.
+        // stop the task, so a dropped cross-layer race cooperatively cancels
+        // the collection walk at its next match.
         let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         struct CancelOnDrop {
             flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
@@ -169,36 +222,21 @@ impl Kakehashi {
         })
         .await;
         guard.armed = false;
-        let model = match task {
-            Ok(Some(model)) => model,
-            Ok(None) => return Ok(None),
+        match task {
+            Ok(Some(model)) => Some(native_bindings_facts(
+                &model,
+                byte - layer_offset,
+                layer_offset,
+            )),
+            Ok(None) => None,
             Err(join_error) => {
                 log::warn!(
                     target: "kakehashi::bindings",
                     "bindings model task failed for {uri}: {join_error}"
                 );
-                return Ok(None);
+                None
             }
-        };
-        let answer = f(NativeBindingsContext {
-            model: &model,
-            byte: byte - layer_offset,
-            mapper: &mapper,
-            layer_offset,
-        });
-
-        // A didChange between the snapshot and here makes every computed
-        // range stale — worst case a rename WorkspaceEdit applied to newer
-        // text. Publish only while the snapshot's text is still current.
-        let unchanged = self.documents.get(&uri).is_some_and(|doc| {
-            doc.content_version() == content_version
-                && doc.incarnation() == incarnation
-                && std::sync::Arc::ptr_eq(&doc.text_arc(), &text)
-        });
-        if !unchanged || self.cache.semantic_token_generation() != settings_generation {
-            return Ok(None);
         }
-        Ok(answer)
     }
 
     /// The injected layer under the cursor, prepared for resolution.
@@ -305,13 +343,12 @@ pub(crate) fn native_definition(
     ctx: NativeBindingsContext<'_>,
     lsp_uri: &Uri,
 ) -> Option<Vec<LocationLink>> {
-    let target = ctx.model.definition_range_at(ctx.byte)?;
-    let range = ctx.to_host_range(&target)?;
+    let range = ctx.to_host_range(ctx.facts.definition?)?;
     Some(vec![LocationLink {
         origin_selection_range: ctx
-            .model
-            .resolvable_identifier_at(ctx.byte)
-            .and_then(|r| ctx.to_host_range(&r)),
+            .facts
+            .identifier
+            .and_then(|identifier| ctx.to_host_range(identifier)),
         target_uri: lsp_uri.clone(),
         target_range: range,
         target_selection_range: range,
@@ -328,7 +365,7 @@ pub(crate) fn native_references(
     let ranges = binding_ranges(&ctx, include_declaration)?;
     let locations: Vec<Location> = ranges
         .iter()
-        .filter_map(|r| ctx.to_host_range(r))
+        .filter_map(|range| ctx.to_host_range(*range))
         .map(|range| Location {
             uri: lsp_uri.clone(),
             range,
@@ -346,7 +383,7 @@ pub(crate) fn native_document_highlight(
     let ranges = binding_ranges(&ctx, true)?;
     let highlights: Vec<DocumentHighlight> = ranges
         .iter()
-        .filter_map(|r| ctx.to_host_range(r))
+        .filter_map(|range| ctx.to_host_range(*range))
         .map(|range| DocumentHighlight {
             range,
             kind: Some(DocumentHighlightKind::TEXT),
@@ -374,7 +411,7 @@ pub(crate) fn native_rename(
     let ranges = binding_ranges(&ctx, true)?;
     let edits: Vec<TextEdit> = ranges
         .iter()
-        .filter_map(|r| ctx.to_host_range(r))
+        .filter_map(|range| ctx.to_host_range(*range))
         .map(|range| TextEdit {
             range,
             new_text: new_name.to_string(),
@@ -404,8 +441,8 @@ fn is_conservative_identifier(name: &str) -> bool {
 pub(crate) fn native_prepare_rename(
     ctx: NativeBindingsContext<'_>,
 ) -> Option<PrepareRenameResponse> {
-    let range = ctx.model.resolvable_identifier_at(ctx.byte)?;
-    ctx.to_host_range(&range).map(PrepareRenameResponse::Range)
+    ctx.to_host_range(ctx.facts.identifier?)
+        .map(PrepareRenameResponse::Range)
 }
 
 /// The byte ranges of the cursor binding's references (and, when included,
@@ -413,20 +450,55 @@ pub(crate) fn native_prepare_rename(
 fn binding_ranges(
     ctx: &NativeBindingsContext<'_>,
     include_definitions: bool,
-) -> Option<Vec<Range<usize>>> {
-    let binding = ctx.model.binding_at(ctx.byte)?;
-    let mut ranges = ctx.model.references_resolving_to(binding);
+) -> Option<Vec<crate::tree_worker::WireByteRange>> {
+    let mut ranges = ctx.facts.references.clone();
     if include_definitions {
-        ranges.extend(
-            ctx.model
-                .sites(binding)
-                .iter()
-                .map(|s| s.byte_range.clone()),
-        );
+        ranges.extend(ctx.facts.definitions.iter().copied());
     }
     ranges.sort_by_key(|r| (r.start, r.end));
     ranges.dedup();
-    Some(ranges)
+    (!ctx.facts.definitions.is_empty()).then_some(ranges)
+}
+
+fn native_bindings_facts(
+    model: &BindingsModel,
+    byte: usize,
+    layer_offset: usize,
+) -> crate::tree_worker::NativeBindingsFacts {
+    let to_wire = |range: std::ops::Range<usize>| crate::tree_worker::WireByteRange {
+        start: range.start + layer_offset,
+        end: range.end + layer_offset,
+    };
+    let identifier = model.resolvable_identifier_at(byte).map(&to_wire);
+    let definition = model.definition_range_at(byte).map(&to_wire);
+    let Some(binding) = model.binding_at(byte) else {
+        return crate::tree_worker::NativeBindingsFacts {
+            identifier,
+            definition,
+            references: Vec::new(),
+            definitions: Vec::new(),
+        };
+    };
+    let mut references = model
+        .references_resolving_to(binding)
+        .into_iter()
+        .map(&to_wire)
+        .collect::<Vec<_>>();
+    let mut definitions = model
+        .sites(binding)
+        .iter()
+        .map(|site| to_wire(site.byte_range.clone()))
+        .collect::<Vec<_>>();
+    references.sort_by_key(|range| (range.start, range.end));
+    references.dedup();
+    definitions.sort_by_key(|range| (range.start, range.end));
+    definitions.dedup();
+    crate::tree_worker::NativeBindingsFacts {
+        identifier,
+        definition,
+        references,
+        definitions,
+    }
 }
 
 #[cfg(test)]

--- a/src/lsp/lsp_impl/text_document/selection_range.rs
+++ b/src/lsp/lsp_impl/text_document/selection_range.rs
@@ -98,6 +98,21 @@ impl Kakehashi {
         let expected_incarnation = snapshot.incarnation;
         let expected_settings_generation = self.cache.semantic_token_generation();
 
+        let worker_positions = positions
+            .iter()
+            .map(|position| crate::tree_worker::WirePosition {
+                line: position.line,
+                character: position.character,
+            })
+            .collect();
+        let worker = self.tree_worker_shadow.selection_ranges(
+            &uri,
+            expected_incarnation,
+            expected_version,
+            expected_settings_generation,
+            worker_positions,
+        );
+
         // Run the synchronous injection-aware walk as one work-unit on the
         // compute pool against the snapshot's consistent (text, tree). The
         // walk uses a TRANSIENT parser pool: holding the shared parser-pool
@@ -108,20 +123,18 @@ impl Kakehashi {
         // a user-triggered, infrequent read, so per-request parsers beat
         // cross-request reuse here.
         let language = std::sync::Arc::clone(&self.language);
-        let result = self
-            .compute_pool
-            .run(None, move || {
-                let mut pool = language.create_document_parser_pool();
-                handle_selection_range(
-                    &snapshot.text,
-                    snapshot.tree.as_ref(),
-                    snapshot.language.as_deref(),
-                    &positions,
-                    &language,
-                    &mut pool,
-                )
-            })
-            .await;
+        let authoritative = self.compute_pool.run(None, move || {
+            let mut pool = language.create_document_parser_pool();
+            handle_selection_range(
+                &snapshot.text,
+                snapshot.tree.as_ref(),
+                snapshot.language.as_deref(),
+                &positions,
+                &language,
+                &mut pool,
+            )
+        });
+        let (worker, result) = tokio::join!(worker, authoritative);
 
         let still_current = self.documents.latest_snapshot(&uri).is_some_and(|view| {
             view.content_version == expected_version
@@ -136,8 +149,44 @@ impl Kakehashi {
             return Err(crate::error::content_modified_error());
         }
 
+        if let (Some(worker), Some(authoritative)) = (worker, result.as_ref()) {
+            let worker = worker
+                .ranges
+                .into_iter()
+                .map(selection_range_from_wire)
+                .collect::<Vec<_>>();
+            if &worker != authoritative {
+                log::debug!(
+                    target: "kakehashi::tree_worker_shadow",
+                    "host-only selectionRange mismatch uri={} version={} authoritative={:?} worker={:?}",
+                    uri,
+                    expected_version,
+                    authoritative,
+                    worker,
+                );
+            }
+        }
+
         // None = the work-unit panicked (logged by the pool); serve the
         // no-result fallback rather than an error.
         Ok(result)
     }
+}
+
+fn selection_range_from_wire(range: crate::tree_worker::WireSelectionRange) -> SelectionRange {
+    SelectionRange {
+        range: tower_lsp_server::ls_types::Range::new(
+            position_from_wire(range.range.start),
+            position_from_wire(range.range.end),
+        ),
+        parent: range
+            .parent
+            .map(|parent| Box::new(selection_range_from_wire(*parent))),
+    }
+}
+
+fn position_from_wire(
+    position: crate::tree_worker::WirePosition,
+) -> tower_lsp_server::ls_types::Position {
+    tower_lsp_server::ls_types::Position::new(position.line, position.character)
 }

--- a/src/lsp/lsp_impl/text_document/selection_range.rs
+++ b/src/lsp/lsp_impl/text_document/selection_range.rs
@@ -158,7 +158,7 @@ impl Kakehashi {
             if &worker != authoritative {
                 log::debug!(
                     target: "kakehashi::tree_worker_shadow",
-                    "host-only selectionRange mismatch uri={} version={} authoritative={:?} worker={:?}",
+                    "selectionRange mismatch uri={} version={} authoritative={:?} worker={:?}",
                     uri,
                     expected_version,
                     authoritative,

--- a/src/lsp/lsp_impl/text_document/selection_range.rs
+++ b/src/lsp/lsp_impl/text_document/selection_range.rs
@@ -97,6 +97,18 @@ impl Kakehashi {
         let expected_version = snapshot.parsed_version;
         let expected_incarnation = snapshot.incarnation;
         let expected_settings_generation = self.cache.semantic_token_generation();
+        let worker_configuration_generation = self.language.configuration_generation();
+        if let Some(grammar) = self.language.worker_grammar_descriptor(&language_name)
+            && self.tree_worker_shadow.needs_document_sync(
+                &uri,
+                expected_incarnation,
+                expected_version,
+                worker_configuration_generation,
+                &grammar.queries,
+            )
+        {
+            self.refresh_tree_worker_documents(std::slice::from_ref(&uri));
+        }
 
         let worker_positions = positions
             .iter()
@@ -109,7 +121,7 @@ impl Kakehashi {
             &uri,
             expected_incarnation,
             expected_version,
-            expected_settings_generation,
+            worker_configuration_generation,
             worker_positions,
         );
 

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -428,6 +428,18 @@ impl Kakehashi {
         // landing after the resolution supersedes this request via the client's
         // next didChange-driven request; the CancelToken then reclaims the
         // compute mid-flight.
+        let worker_configuration_generation = self.language.configuration_generation();
+        if let Some(grammar) = self.language.worker_grammar_descriptor(&language_name)
+            && self.tree_worker_shadow.needs_document_sync(
+                &uri,
+                snapshot.incarnation,
+                snapshot.parsed_version,
+                worker_configuration_generation,
+                &grammar.queries,
+            )
+        {
+            self.refresh_tree_worker_documents(std::slice::from_ref(&uri));
+        }
         let (result, worker_tokens) = {
             // Snapshot-identical repeat request: tokens already cached for this
             // exact text are still correct, so skip re-tokenizing. Returns the
@@ -502,7 +514,7 @@ impl Kakehashi {
                 &uri,
                 snapshot.incarnation,
                 snapshot.parsed_version,
-                token_generation,
+                worker_configuration_generation,
                 supports_multiline,
             );
             let combined = async { tokio::join!(compute_future, worker_future) };

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -428,7 +428,7 @@ impl Kakehashi {
         // landing after the resolution supersedes this request via the client's
         // next didChange-driven request; the CancelToken then reclaims the
         // compute mid-flight.
-        let result = {
+        let (result, worker_tokens) = {
             // Snapshot-identical repeat request: tokens already cached for this
             // exact text are still correct, so skip re-tokenizing. Returns the
             // cached tokens with their original `result_id`, keeping a client's
@@ -498,6 +498,14 @@ impl Kakehashi {
                 injection_cache,
                 Some(cancel_token.clone()),
             );
+            let worker_future = self.tree_worker_shadow.semantic_tokens(
+                &uri,
+                snapshot.incarnation,
+                snapshot.parsed_version,
+                token_generation,
+                supports_multiline,
+            );
+            let combined = async { tokio::join!(compute_future, worker_future) };
 
             if let Some(cancel_rx) = cancel_rx {
                 // Race between computation and cancel notification
@@ -520,13 +528,26 @@ impl Kakehashi {
                     }
 
                     // Computation completed
-                    result = compute_future => result,
+                    result = combined => result,
                 }
             } else {
                 // No cancel support - just await the computation
-                compute_future.await
+                combined.await
             }
         };
+
+        if let (Some(authoritative), Some(worker)) = (result.as_ref(), worker_tokens.as_ref()) {
+            let authoritative = match authoritative {
+                SemanticTokensResult::Tokens(tokens) => tokens.data.as_slice(),
+                SemanticTokensResult::Partial(partial) => partial.data.as_slice(),
+            };
+            self.tree_worker_shadow.compare_semantic_tokens(
+                &uri,
+                snapshot.parsed_version,
+                authoritative,
+                worker,
+            );
+        }
 
         // A supersede/close between compute start and here flips the token; the
         // compute then bailed at a checkpoint and returned `None` (a partial

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -18,6 +18,8 @@ use crate::tree_worker::{
     WirePosition, WorkerLanguageAsset, named_node_count,
 };
 
+use super::Kakehashi;
+
 const SHADOW_ENV: &str = "KAKEHASHI_TREE_WORKER_SHADOW";
 const SHADOW_THREADS_ENV: &str = "KAKEHASHI_TREE_WORKER_THREADS";
 const SHADOW_QUEUE_CAPACITY: usize = 256;
@@ -1342,6 +1344,46 @@ impl TreeWorkerShadow {
             self.sender.as_ref(),
             &self.comparisons,
             timeout,
+        );
+    }
+}
+
+impl Kakehashi {
+    pub(super) async fn shadow_compare_current_injection_regions(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        parsed_version: u64,
+        authoritative: &[crate::language::injection::ResolvedInjection],
+    ) {
+        let Some(view) = self.documents.latest_snapshot(uri) else {
+            return;
+        };
+        if view.slot.current_incarnation != incarnation
+            || view.content_version != parsed_version
+            || view.slot.snapshot.as_ref().is_none_or(|current| {
+                current.incarnation != incarnation || current.parsed_version != parsed_version
+            })
+        {
+            return;
+        }
+        let Some(worker_regions) = self
+            .tree_worker_shadow
+            .injection_regions(
+                uri,
+                incarnation,
+                parsed_version,
+                self.cache.semantic_token_generation(),
+            )
+            .await
+        else {
+            return;
+        };
+        self.tree_worker_shadow.compare_injection_regions(
+            uri,
+            parsed_version,
+            authoritative,
+            &worker_regions,
         );
     }
 }

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -200,6 +200,13 @@ struct OpenDocuments {
     catalog: Option<(u64, WorkerLanguageCatalog)>,
     catalog_preload: Option<(u64, u64)>,
     catalog_acknowledged: Option<(u64, u64)>,
+    worker_regions: HashMap<String, WorkerRegionSnapshot>,
+}
+
+#[derive(Clone)]
+struct WorkerRegionSnapshot {
+    context: RequestContext,
+    regions: Arc<Vec<crate::language::injection::ResolvedInjection>>,
 }
 
 struct SupervisorState {
@@ -358,17 +365,20 @@ impl OpenDocuments {
         match command {
             ShadowCommand::Sync(request) => {
                 self.closed_incarnations.remove(&request.context.uri);
+                self.worker_regions.remove(&request.context.uri);
                 self.current
                     .insert(request.context.uri.clone(), request.clone());
             }
             ShadowCommand::Apply { fallback, .. } => {
                 self.closed_incarnations.remove(&fallback.context.uri);
+                self.worker_regions.remove(&fallback.context.uri);
                 self.current
                     .insert(fallback.context.uri.clone(), fallback.clone());
             }
             ShadowCommand::Close(request) => {
                 self.current.remove(&request.context.uri);
                 self.acknowledged.remove(&request.context.uri);
+                self.worker_regions.remove(&request.context.uri);
                 self.closed_incarnations
                     .entry(request.context.uri.clone())
                     .and_modify(|closed| *closed = (*closed).max(request.context.incarnation))
@@ -377,6 +387,7 @@ impl OpenDocuments {
             ShadowCommand::Forget(context) => {
                 self.current.remove(&context.uri);
                 self.acknowledged.remove(&context.uri);
+                self.worker_regions.remove(&context.uri);
             }
             ShadowCommand::Shutdown(_) => {}
         }
@@ -430,6 +441,25 @@ struct ComparableInjection<'a> {
     virtual_content: &'a str,
     line_column_offsets: &'a [u32],
     contiguous: bool,
+}
+
+fn worker_region_to_resolved(
+    region: &crate::tree_worker::WireInjectionRegion,
+) -> crate::language::injection::ResolvedInjection {
+    crate::language::injection::ResolvedInjection {
+        region: crate::language::injection::CacheableInjectionRegion {
+            language: region.language.clone(),
+            byte_range: region.byte_start..region.byte_end,
+            line_range: region.line_start..region.line_end,
+            start_column: region.start_column,
+            region_id: region.region_id.clone(),
+            content_hash: region.content_hash,
+        },
+        injection_language: region.language.clone(),
+        virtual_content: region.virtual_content.clone(),
+        line_column_offsets: region.line_column_offsets.clone(),
+        contiguous: region.contiguous,
+    }
 }
 
 fn remove_capture_ids(value: &mut Value) {
@@ -754,17 +784,9 @@ impl TreeWorkerShadow {
         content_version: u64,
         configuration_generation: u64,
     ) -> Option<InjectionRegionsResult> {
-        let client = self.read_client.load_full()?;
-        if !self.is_enabled() {
-            return None;
-        }
-        let context = self.synchronized_read_context(
-            &client,
-            uri,
-            incarnation,
-            content_version,
-            configuration_generation,
-        )?;
+        let (client, context) = self
+            .synchronized_query_read(uri, incarnation, content_version, configuration_generation)
+            .await?;
         let expected = context.clone();
         let response = tokio::task::spawn_blocking(move || {
             client.derive_injection_regions(DeriveInjectionRegions { context })
@@ -797,7 +819,60 @@ impl TreeWorkerShadow {
         {
             return None;
         }
+        self.cache_worker_regions(uri, &result);
         Some(result)
+    }
+
+    fn cache_worker_regions(&self, uri: &url::Url, result: &InjectionRegionsResult) {
+        let regions = Arc::new(
+            result
+                .regions
+                .iter()
+                .map(worker_region_to_resolved)
+                .collect::<Vec<_>>(),
+        );
+        for region in result.regions.iter() {
+            self.worker_nodes.insert(
+                (uri.as_str().to_string(), region.region_id.clone()),
+                OpaqueNodeId {
+                    worker_generation: result.context.worker_generation,
+                    local_id: region.region_id.clone(),
+                },
+            );
+        }
+        let mut documents = self
+            .open_documents
+            .lock()
+            .recover_poison("TreeWorkerShadow::cache_worker_regions");
+        if documents.acknowledges(&result.context) {
+            documents.worker_regions.insert(
+                uri.as_str().to_string(),
+                WorkerRegionSnapshot {
+                    context: result.context.clone(),
+                    regions,
+                },
+            );
+        }
+    }
+
+    pub(super) fn cached_injection_regions(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        configuration_generation: u64,
+    ) -> Option<Arc<Vec<crate::language::injection::ResolvedInjection>>> {
+        let client = self.read_client.load_full()?;
+        let documents = self
+            .open_documents
+            .lock()
+            .recover_poison("TreeWorkerShadow::cached_injection_regions");
+        let snapshot = documents.worker_regions.get(uri.as_str())?;
+        (snapshot.context.worker_generation == client.worker_generation()
+            && snapshot.context.incarnation == incarnation
+            && snapshot.context.content_version == content_version
+            && snapshot.context.configuration_generation == configuration_generation)
+            .then(|| Arc::clone(&snapshot.regions))
     }
 
     pub(super) async fn semantic_tokens(
@@ -1069,9 +1144,9 @@ impl TreeWorkerShadow {
         uri: &url::Url,
         content_version: u64,
         authoritative: &[crate::language::injection::ResolvedInjection],
-        worker: &InjectionRegionsResult,
+        worker_result: &InjectionRegionsResult,
     ) {
-        let authoritative = authoritative
+        let comparable_authoritative = authoritative
             .iter()
             .map(|region| ComparableInjection {
                 language: &region.injection_language,
@@ -1084,7 +1159,7 @@ impl TreeWorkerShadow {
                 contiguous: region.contiguous,
             })
             .collect::<Vec<_>>();
-        let worker = worker
+        let comparable_worker = worker_result
             .regions
             .iter()
             .map(|region| ComparableInjection {
@@ -1098,12 +1173,36 @@ impl TreeWorkerShadow {
                 contiguous: region.contiguous,
             })
             .collect::<Vec<_>>();
-        if authoritative != worker {
+        if comparable_authoritative != comparable_worker {
             log::debug!(
                 target: "kakehashi::tree_worker_shadow",
-                "injection region mismatch uri={uri} version={content_version} authoritative={authoritative:?} worker={worker:?}",
+                "injection region mismatch uri={uri} version={content_version} authoritative={comparable_authoritative:?} worker={comparable_worker:?}",
+            );
+            return;
+        }
+        for (authoritative_region, worker_region) in
+            authoritative.iter().zip(worker_result.regions.iter())
+        {
+            let opaque = OpaqueNodeId {
+                worker_generation: worker_result.context.worker_generation,
+                local_id: worker_region.region_id.clone(),
+            };
+            self.worker_nodes.insert(
+                (
+                    uri.as_str().to_string(),
+                    authoritative_region.region.region_id.clone(),
+                ),
+                opaque.clone(),
+            );
+            self.worker_nodes.insert(
+                (uri.as_str().to_string(), worker_region.region_id.clone()),
+                opaque,
             );
         }
+        log::debug!(
+            target: "kakehashi::tree_worker_shadow",
+            "injection regions matched uri={uri} version={content_version}",
+        );
     }
 
     pub(super) fn record_node_mapping(
@@ -1656,28 +1755,6 @@ impl TreeWorkerShadow {
         }
     }
 
-    fn synchronized_read_context(
-        &self,
-        client: &Client,
-        uri: &url::Url,
-        incarnation: u64,
-        content_version: u64,
-        configuration_generation: u64,
-    ) -> Option<RequestContext> {
-        let context = self.read_context(
-            client,
-            uri,
-            incarnation,
-            content_version,
-            configuration_generation,
-        );
-        self.open_documents
-            .lock()
-            .recover_poison("TreeWorkerShadow::synchronized_read_context")
-            .acknowledges(&context)
-            .then_some(context)
-    }
-
     async fn synchronized_query_read(
         &self,
         uri: &url::Url,
@@ -1907,14 +1984,29 @@ impl Kakehashi {
         {
             return;
         }
-        let Some(worker_regions) = self
-            .tree_worker_shadow
-            .injection_regions(
+        let configuration_generation = self.language.configuration_generation();
+        let Some(language) = view
+            .slot
+            .snapshot
+            .as_ref()
+            .and_then(|snapshot| snapshot.language.as_deref())
+        else {
+            return;
+        };
+        if let Some(grammar) = self.language.worker_grammar_descriptor(language)
+            && self.tree_worker_shadow.needs_document_sync(
                 uri,
                 incarnation,
                 parsed_version,
-                self.language.configuration_generation(),
+                configuration_generation,
+                &grammar.queries,
             )
+        {
+            self.refresh_tree_worker_documents(std::slice::from_ref(uri));
+        }
+        let Some(worker_regions) = self
+            .tree_worker_shadow
+            .injection_regions(uri, incarnation, parsed_version, configuration_generation)
             .await
         else {
             return;
@@ -1925,6 +2017,16 @@ impl Kakehashi {
             authoritative,
             &worker_regions,
         );
+        if self
+            .tree_worker_shadow
+            .cached_injection_regions(uri, incarnation, parsed_version, configuration_generation)
+            .is_none()
+        {
+            log::debug!(
+                target: "kakehashi::tree_worker_shadow",
+                "current worker injection snapshot was not cached uri={uri} version={parsed_version}",
+            );
+        }
     }
 }
 
@@ -3200,6 +3302,68 @@ mod tests {
         assert!(matches!(receiver.recv().unwrap(), ShadowCommand::Close(_)));
     }
 
+    #[test]
+    fn accepted_worker_regions_are_cached_and_generation_fenced_as_node_ids() {
+        let (sender, _receiver) = mpsc::sync_channel(1);
+        let shadow = shadow(sender);
+        let uri = url::Url::parse("file:///regions.md").unwrap();
+        let sync = sync(uri.as_str(), 2, 3, 7);
+        {
+            let mut documents = shadow.open_documents.lock().unwrap();
+            documents.current.insert(uri.as_str().into(), sync.clone());
+            documents
+                .acknowledged
+                .insert(uri.as_str().into(), sync.context.clone());
+        }
+        let result = InjectionRegionsResult {
+            context: sync.context,
+            regions: vec![crate::tree_worker::WireInjectionRegion {
+                language: "lua".into(),
+                byte_start: 10,
+                byte_end: 20,
+                line_start: 2,
+                line_end: 3,
+                start_column: 0,
+                region_id: "worker-region".into(),
+                content_hash: 42,
+                virtual_content: "local x = 1".into(),
+                line_column_offsets: vec![0],
+                contiguous: true,
+            }],
+        };
+
+        shadow.cache_worker_regions(&uri, &result);
+        let mut authoritative = worker_region_to_resolved(&result.regions[0]);
+        authoritative.region.region_id = "legacy-region".into();
+        shadow.compare_injection_regions(&uri, 3, &[authoritative], &result);
+
+        let documents = shadow.open_documents.lock().unwrap();
+        let cached = documents.worker_regions.get(uri.as_str()).unwrap();
+        assert_eq!(cached.context, result.context);
+        assert_eq!(cached.regions[0].region.region_id, "worker-region");
+        drop(documents);
+        assert_eq!(
+            shadow
+                .worker_nodes
+                .get(&(uri.as_str().into(), "worker-region".into()))
+                .map(|entry| entry.clone()),
+            Some(OpaqueNodeId {
+                worker_generation: 7,
+                local_id: "worker-region".into(),
+            })
+        );
+        assert_eq!(
+            shadow
+                .worker_nodes
+                .get(&(uri.as_str().into(), "legacy-region".into()))
+                .map(|entry| entry.clone()),
+            Some(OpaqueNodeId {
+                worker_generation: 7,
+                local_id: "worker-region".into(),
+            })
+        );
+    }
+
     fn grammar() -> WorkerGrammarDescriptor {
         WorkerGrammarDescriptor {
             source_path: "/parser/rust.so".into(),
@@ -3264,6 +3428,61 @@ mod tests {
             context: latest.context.clone(),
         }));
         assert!(documents.current.is_empty());
+    }
+
+    #[test]
+    fn document_change_invalidates_cached_worker_regions() {
+        let uri = "file:///a.rs";
+        let mut documents = OpenDocuments::default();
+        let first = sync(uri, 1, 1, 7);
+        documents.observe(&ShadowCommand::Sync(first.clone()));
+        documents.worker_regions.insert(
+            uri.into(),
+            WorkerRegionSnapshot {
+                context: first.context,
+                regions: Arc::new(Vec::new()),
+            },
+        );
+
+        documents.observe(&ShadowCommand::Apply {
+            request: ApplyDocumentEditsAndDerive {
+                context: sync(uri, 1, 2, 7).context,
+                base_version: 1,
+                edits: Vec::new(),
+            },
+            fallback: sync(uri, 1, 2, 7),
+        });
+
+        assert!(!documents.worker_regions.contains_key(uri));
+    }
+
+    #[test]
+    fn worker_region_conversion_preserves_bridge_geometry_and_identity() {
+        let wire = crate::tree_worker::WireInjectionRegion {
+            language: "lua".into(),
+            byte_start: 10,
+            byte_end: 20,
+            line_start: 2,
+            line_end: 4,
+            start_column: 3,
+            region_id: "worker-region".into(),
+            content_hash: 42,
+            virtual_content: "x\ny".into(),
+            line_column_offsets: vec![3, 0],
+            contiguous: false,
+        };
+
+        let resolved = worker_region_to_resolved(&wire);
+
+        assert_eq!(resolved.injection_language, "lua");
+        assert_eq!(resolved.region.byte_range, 10..20);
+        assert_eq!(resolved.region.line_range, 2..4);
+        assert_eq!(resolved.region.start_column, 3);
+        assert_eq!(resolved.region.region_id, "worker-region");
+        assert_eq!(resolved.region.content_hash, 42);
+        assert_eq!(resolved.virtual_content, "x\ny");
+        assert_eq!(resolved.line_column_offsets, vec![3, 0]);
+        assert!(!resolved.contiguous);
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -660,25 +660,39 @@ impl TreeWorkerShadow {
         content_version: u64,
         configuration_generation: u64,
         byte_offset: usize,
-        named: bool,
+        layer: crate::tree_worker::NodeLayerSelector,
     ) -> Option<NodeResult> {
-        let client = self.read_client.load_full()?;
-        if !self.is_enabled() {
-            return None;
-        }
-        let context = self.synchronized_read_context(
-            &client,
-            uri,
-            incarnation,
-            content_version,
-            configuration_generation,
-        )?;
+        let (client, context) = if layer == crate::tree_worker::NodeLayerSelector::Host {
+            let client = self.read_client_wait().await?;
+            if !self.is_enabled() {
+                return None;
+            }
+            let context = self
+                .synchronized_read_context_wait(
+                    &client,
+                    uri,
+                    incarnation,
+                    content_version,
+                    configuration_generation,
+                )
+                .await?;
+            (client, context)
+        } else {
+            self.synchronized_query_read(
+                uri,
+                incarnation,
+                content_version,
+                configuration_generation,
+            )
+            .await?
+        };
         let expected = context.clone();
         let response = tokio::task::spawn_blocking(move || {
             client.resolve_node(ResolveNode {
                 context,
                 byte_offset,
-                named,
+                named: false,
+                layer,
             })
         })
         .await
@@ -1183,6 +1197,12 @@ impl TreeWorkerShadow {
         {
             self.record_node_mapping(uri, authoritative_node, worker_node);
         }
+        log::debug!(
+            target: "kakehashi::tree_worker_shadow",
+            "node navigation matched uri={} version={}",
+            uri,
+            content_version,
+        );
     }
 
     pub(super) async fn node_scalar(
@@ -1372,6 +1392,10 @@ impl TreeWorkerShadow {
         {
             self.record_node_mapping(uri, authoritative_node, worker_node);
         }
+        log::debug!(
+            target: "kakehashi::tree_worker_shadow",
+            "node navigation matched operation={operation} uri={uri}",
+        );
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -3165,6 +3189,7 @@ mod tests {
                 end_byte: 1,
                 named: true,
                 has_error: false,
+                layer: 0,
             },
         );
         assert_eq!(shadow.worker_nodes.len(), 1);

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -12,10 +12,10 @@ use crate::language::coordinator::WorkerGrammarDescriptor;
 use crate::lsp::text_sync::SequentialByteEdit;
 use crate::tree_worker::{
     ApplyDocumentEditsAndDerive, ByteEdit, Client, CloseDocument, ConfigureLanguages,
-    DeriveDocumentSnapshot, DeriveSelectionRanges, NavigateNode, NodeNavigation, NodeResult,
-    NodeScalarOperation, NodeScalarValue, OpaqueNodeId, RequestContext, ResolveNode, Response,
-    RunNodeScalar, SelectionRangesResult, SyncDocument, WirePosition, WorkerLanguageAsset,
-    named_node_count,
+    DeriveDocumentSnapshot, DeriveInjectionRegions, DeriveSelectionRanges, InjectionRegionsResult,
+    NavigateNode, NodeNavigation, NodeResult, NodeScalarOperation, NodeScalarValue, OpaqueNodeId,
+    RequestContext, ResolveNode, Response, RunNodeScalar, SelectionRangesResult, SyncDocument,
+    WirePosition, WorkerLanguageAsset, named_node_count,
 };
 
 const SHADOW_ENV: &str = "KAKEHASHI_TREE_WORKER_SHADOW";
@@ -31,9 +31,9 @@ const WORKER_LIVENESS_POLL: Duration = Duration::from_millis(250);
 const FAST_HEALTHY_INTERVAL: Duration = Duration::from_secs(60);
 const LONG_HEALTHY_INTERVAL: Duration = Duration::from_secs(10 * 60);
 static NEXT_WORKER_GENERATION: AtomicU64 = AtomicU64::new(1);
+static NEXT_CATALOG_REQUEST_ID: AtomicU64 = AtomicU64::new(1_u64 << 63);
 
 enum ShadowCommand {
-    Configure(ConfigureLanguages),
     Sync(SyncDocument),
     Apply {
         request: ApplyDocumentEditsAndDerive,
@@ -189,6 +189,8 @@ enum RecoveryMode {
 struct OpenDocuments {
     current: HashMap<String, SyncDocument>,
     closed_incarnations: HashMap<String, u64>,
+    catalog: Option<(u64, Vec<WorkerLanguageAsset>)>,
+    catalog_preload: Option<(u64, u64)>,
 }
 
 struct SupervisorState {
@@ -261,7 +263,7 @@ impl OpenDocuments {
                                     && current.context.content_version > context.content_version)))
                 })
             }
-            ShadowCommand::Configure(_) | ShadowCommand::Shutdown(_) => false,
+            ShadowCommand::Shutdown(_) => false,
         }
     }
 
@@ -274,10 +276,7 @@ impl OpenDocuments {
         let incoming = match command {
             ShadowCommand::Sync(request) => Some(request),
             ShadowCommand::Apply { fallback, .. } => Some(fallback),
-            ShadowCommand::Close(_)
-            | ShadowCommand::Forget(_)
-            | ShadowCommand::Configure(_)
-            | ShadowCommand::Shutdown(_) => None,
+            ShadowCommand::Close(_) | ShadowCommand::Forget(_) | ShadowCommand::Shutdown(_) => None,
         };
         if incoming.is_some_and(|incoming| {
             self.closed_incarnations
@@ -344,7 +343,7 @@ impl OpenDocuments {
             ShadowCommand::Forget(context) => {
                 self.current.remove(&context.uri);
             }
-            ShadowCommand::Configure(_) | ShadowCommand::Shutdown(_) => {}
+            ShadowCommand::Shutdown(_) => {}
         }
         Observation::Accepted { artifact_replaced }
     }
@@ -383,6 +382,18 @@ pub(super) struct TreeSummary {
     root_end_byte: usize,
     has_error: bool,
     named_node_count: usize,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct ComparableInjection<'a> {
+    language: &'a str,
+    byte_range: std::ops::Range<usize>,
+    line_range: std::ops::Range<u32>,
+    start_column: u32,
+    content_hash: u64,
+    virtual_content: &'a str,
+    line_column_offsets: &'a [u32],
+    contiguous: bool,
 }
 
 pub(super) struct MirrorDocument {
@@ -590,6 +601,7 @@ impl TreeWorkerShadow {
         configuration_generation: u64,
         positions: Vec<WirePosition>,
     ) -> Option<SelectionRangesResult> {
+        self.preload_catalog_async();
         let client = self.read_client.load_full()?;
         if !self.is_enabled() {
             return None;
@@ -634,6 +646,101 @@ impl TreeWorkerShadow {
             return None;
         }
         Some(result)
+    }
+
+    pub(super) async fn injection_regions(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        configuration_generation: u64,
+    ) -> Option<InjectionRegionsResult> {
+        let client = self.read_client.load_full()?;
+        if !self.is_enabled() {
+            return None;
+        }
+        let context = self.read_context(
+            &client,
+            uri,
+            incarnation,
+            content_version,
+            configuration_generation,
+        );
+        let expected = context.clone();
+        let response = tokio::task::spawn_blocking(move || {
+            client.derive_injection_regions(DeriveInjectionRegions { context })
+        })
+        .await
+        .ok()?
+        .ok()?;
+        let Response::InjectionRegions(result) = response else {
+            return None;
+        };
+        if result.context != expected {
+            return None;
+        }
+        let current = self
+            .open_documents
+            .lock()
+            .recover_poison("TreeWorkerShadow::injection_regions(admission)")
+            .current
+            .get(uri.as_str())
+            .map(|current| current.context.clone());
+        if current.as_ref().is_none_or(|current| {
+            current.incarnation != expected.incarnation
+                || current.content_version != expected.content_version
+                || current.configuration_generation != expected.configuration_generation
+        }) || self
+            .read_client
+            .load()
+            .as_ref()
+            .is_none_or(|client| client.worker_generation() != expected.worker_generation)
+        {
+            return None;
+        }
+        Some(result)
+    }
+
+    pub(super) fn compare_injection_regions(
+        &self,
+        uri: &url::Url,
+        content_version: u64,
+        authoritative: &[crate::language::injection::ResolvedInjection],
+        worker: &InjectionRegionsResult,
+    ) {
+        let authoritative = authoritative
+            .iter()
+            .map(|region| ComparableInjection {
+                language: &region.injection_language,
+                byte_range: region.region.byte_range.clone(),
+                line_range: region.region.line_range.clone(),
+                start_column: region.region.start_column,
+                content_hash: region.region.content_hash,
+                virtual_content: &region.virtual_content,
+                line_column_offsets: &region.line_column_offsets,
+                contiguous: region.contiguous,
+            })
+            .collect::<Vec<_>>();
+        let worker = worker
+            .regions
+            .iter()
+            .map(|region| ComparableInjection {
+                language: &region.language,
+                byte_range: region.byte_start..region.byte_end,
+                line_range: region.line_start..region.line_end,
+                start_column: region.start_column,
+                content_hash: region.content_hash,
+                virtual_content: &region.virtual_content,
+                line_column_offsets: &region.line_column_offsets,
+                contiguous: region.contiguous,
+            })
+            .collect::<Vec<_>>();
+        if authoritative != worker {
+            log::debug!(
+                target: "kakehashi::tree_worker_shadow",
+                "injection region mismatch uri={uri} version={content_version} authoritative={authoritative:?} worker={worker:?}",
+            );
+        }
     }
 
     pub(super) fn record_node_mapping(
@@ -982,20 +1089,8 @@ impl TreeWorkerShadow {
         assets: Vec<WorkerLanguageAsset>,
         documents: Vec<MirrorDocument>,
     ) {
-        let mut commands = Vec::with_capacity(documents.len() + usize::from(!assets.is_empty()));
-        if !assets.is_empty() {
-            commands.push(ShadowCommand::Configure(ConfigureLanguages {
-                context: RequestContext {
-                    request_id: self.next_request_id.fetch_add(1, Ordering::Relaxed),
-                    worker_generation: self.worker_generation,
-                    uri: "kakehashi://language-catalog".into(),
-                    incarnation: 0,
-                    content_version: 0,
-                    configuration_generation: generation,
-                },
-                assets,
-            }));
-        }
+        self.remember_catalog(generation, assets);
+        let mut commands = Vec::with_capacity(documents.len());
         for document in documents {
             let command = if let Some(grammar) = document.grammar {
                 ShadowCommand::Sync(self.sync_request(
@@ -1042,6 +1137,48 @@ impl TreeWorkerShadow {
         for command in commands {
             self.submit(command);
         }
+    }
+
+    fn remember_catalog(&self, generation: u64, assets: Vec<WorkerLanguageAsset>) {
+        if assets.is_empty() {
+            return;
+        }
+        let mut documents = self
+            .open_documents
+            .lock()
+            .recover_poison("TreeWorkerShadow::remember_catalog");
+        documents.catalog = Some((generation, assets));
+        documents.catalog_preload = None;
+    }
+
+    fn preload_catalog_async(&self) {
+        if !self.is_enabled() {
+            return;
+        }
+        let Some(client) = self.read_client.load_full() else {
+            return;
+        };
+        let worker_generation = client.worker_generation();
+        let (configuration_generation, assets) = {
+            let mut documents = self
+                .open_documents
+                .lock()
+                .recover_poison("TreeWorkerShadow::preload_catalog_async");
+            let Some((configuration_generation, assets)) = documents.catalog.clone() else {
+                return;
+            };
+            if documents.catalog_preload == Some((worker_generation, configuration_generation)) {
+                return;
+            }
+            documents.catalog_preload = Some((worker_generation, configuration_generation));
+            (configuration_generation, assets)
+        };
+        spawn_catalog_preload(
+            client,
+            configuration_generation,
+            assets,
+            Arc::clone(&self.open_documents),
+        );
     }
 
     pub(super) async fn shutdown(&self) {
@@ -1257,6 +1394,41 @@ fn shutdown_with_timeout(
         comparisons.superseded.load(Ordering::Relaxed),
         comparisons.pending_count(),
     );
+}
+
+fn spawn_catalog_preload(
+    client: Arc<Client>,
+    configuration_generation: u64,
+    assets: Vec<WorkerLanguageAsset>,
+    open_documents: Arc<Mutex<OpenDocuments>>,
+) {
+    let worker_generation = client.worker_generation();
+    let context = RequestContext {
+        request_id: NEXT_CATALOG_REQUEST_ID.fetch_add(1, Ordering::Relaxed),
+        worker_generation: client.worker_generation(),
+        uri: "kakehashi://language-catalog".into(),
+        incarnation: 0,
+        content_version: 0,
+        configuration_generation,
+    };
+    let _ = std::thread::Builder::new()
+        .name("kakehashi-worker-catalog".into())
+        .spawn(move || {
+            let outcome = client.configure_languages(ConfigureLanguages { context, assets });
+            if !matches!(outcome, Ok(Response::LanguageCatalogAck(_))) {
+                let mut documents = open_documents
+                    .lock()
+                    .recover_poison("spawn_catalog_preload(error)");
+                if documents.catalog_preload == Some((worker_generation, configuration_generation))
+                {
+                    documents.catalog_preload = None;
+                }
+                log::debug!(
+                    target: "kakehashi::tree_worker_shadow",
+                    "worker catalog preload did not complete: {outcome:?}",
+                );
+            }
+        });
 }
 
 fn log_incomplete_shutdown(reason: &str) {
@@ -1793,7 +1965,6 @@ fn execute_command(
     comparisons: &ComparisonStore,
 ) -> (std::io::Result<Response>, Option<ReplicaIdentity>) {
     match command {
-        ShadowCommand::Configure(request) => (client.configure_languages(request), None),
         ShadowCommand::Sync(request) => {
             let identity = ReplicaIdentity::from_sync(&request);
             comparisons.open(&request.context.uri, request.context.incarnation);
@@ -2101,7 +2272,6 @@ fn replica_was_closed(
 
 fn retag_command(command: &mut ShadowCommand, generation: u64) {
     match command {
-        ShadowCommand::Configure(request) => request.context.worker_generation = generation,
         ShadowCommand::Sync(request) => request.context.worker_generation = generation,
         ShadowCommand::Apply { request, fallback } => {
             request.context.worker_generation = generation;
@@ -2143,7 +2313,6 @@ fn classify_transport_failure(
 
 fn command_uri(command: &ShadowCommand) -> Option<&str> {
     match command {
-        ShadowCommand::Configure(_) => None,
         ShadowCommand::Sync(request) => Some(&request.context.uri),
         ShadowCommand::Apply { fallback, .. } => Some(&fallback.context.uri),
         ShadowCommand::Close(request) => Some(&request.context.uri),
@@ -2154,7 +2323,6 @@ fn command_uri(command: &ShadowCommand) -> Option<&str> {
 
 fn command_document(command: &ShadowCommand) -> Option<(&str, u64)> {
     match command {
-        ShadowCommand::Configure(_) => None,
         ShadowCommand::Sync(request) => Some((&request.context.uri, request.context.incarnation)),
         ShadowCommand::Apply { fallback, .. } => {
             Some((&fallback.context.uri, fallback.context.incarnation))
@@ -2169,10 +2337,7 @@ fn command_grammar(command: &ShadowCommand) -> Option<GrammarIdentity> {
     match command {
         ShadowCommand::Sync(request) => Some(GrammarIdentity::from_sync(request)),
         ShadowCommand::Apply { fallback, .. } => Some(GrammarIdentity::from_sync(fallback)),
-        ShadowCommand::Configure(_)
-        | ShadowCommand::Close(_)
-        | ShadowCommand::Forget(_)
-        | ShadowCommand::Shutdown(_) => None,
+        ShadowCommand::Close(_) | ShadowCommand::Forget(_) | ShadowCommand::Shutdown(_) => None,
     }
 }
 
@@ -2180,10 +2345,7 @@ fn command_sync(command: &ShadowCommand) -> Option<&SyncDocument> {
     match command {
         ShadowCommand::Sync(request) => Some(request),
         ShadowCommand::Apply { fallback, .. } => Some(fallback),
-        ShadowCommand::Configure(_)
-        | ShadowCommand::Close(_)
-        | ShadowCommand::Forget(_)
-        | ShadowCommand::Shutdown(_) => None,
+        ShadowCommand::Close(_) | ShadowCommand::Forget(_) | ShadowCommand::Shutdown(_) => None,
     }
 }
 

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -12,8 +12,9 @@ use crate::language::coordinator::WorkerGrammarDescriptor;
 use crate::lsp::text_sync::SequentialByteEdit;
 use crate::tree_worker::{
     ApplyDocumentEditsAndDerive, ByteEdit, Client, CloseDocument, DeriveDocumentSnapshot,
-    NavigateNode, NodeNavigation, NodeResult, NodeScalarOperation, NodeScalarValue, OpaqueNodeId,
-    RequestContext, ResolveNode, Response, RunNodeScalar, SyncDocument, named_node_count,
+    DeriveSelectionRanges, NavigateNode, NodeNavigation, NodeResult, NodeScalarOperation,
+    NodeScalarValue, OpaqueNodeId, RequestContext, ResolveNode, Response, RunNodeScalar,
+    SelectionRangesResult, SyncDocument, WirePosition, named_node_count,
 };
 
 const SHADOW_ENV: &str = "KAKEHASHI_TREE_WORKER_SHADOW";
@@ -574,6 +575,60 @@ impl TreeWorkerShadow {
         .ok()?
         .ok()?;
         self.admit_node_response(response, &expected)
+    }
+
+    pub(super) async fn selection_ranges(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        configuration_generation: u64,
+        positions: Vec<WirePosition>,
+    ) -> Option<SelectionRangesResult> {
+        let client = self.read_client.load_full()?;
+        if !self.is_enabled() {
+            return None;
+        }
+        let context = self.read_context(
+            &client,
+            uri,
+            incarnation,
+            content_version,
+            configuration_generation,
+        );
+        let expected = context.clone();
+        let response = tokio::task::spawn_blocking(move || {
+            client.derive_selection_ranges(DeriveSelectionRanges { context, positions })
+        })
+        .await
+        .ok()?
+        .ok()?;
+        let Response::SelectionRanges(result) = response else {
+            return None;
+        };
+        if result.context != expected {
+            return None;
+        }
+        let current = self
+            .open_documents
+            .lock()
+            .recover_poison("TreeWorkerShadow::selection_ranges(admission)")
+            .current
+            .get(uri.as_str())
+            .map(|current| current.context.clone());
+        if current.as_ref().is_none_or(|current| {
+            current.incarnation != expected.incarnation
+                || current.content_version != expected.content_version
+                || current.configuration_generation != expected.configuration_generation
+        }) || self
+            .read_client
+            .load()
+            .as_ref()
+            .is_none_or(|client| client.worker_generation() != expected.worker_generation)
+        {
+            return None;
+        }
+        Some(result)
     }
 
     pub(super) fn record_node_mapping(

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -5,13 +5,15 @@ use std::sync::{Arc, Mutex, mpsc};
 use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwapOption;
+use serde_json::Value;
 
 use crate::error::LockResultExt;
 use crate::language::coordinator::WorkerGrammarDescriptor;
 use crate::lsp::text_sync::SequentialByteEdit;
 use crate::tree_worker::{
     ApplyDocumentEditsAndDerive, ByteEdit, Client, CloseDocument, DeriveDocumentSnapshot,
-    NodeResult, RequestContext, ResolveNode, Response, SyncDocument, named_node_count,
+    NavigateNode, NodeNavigation, NodeResult, OpaqueNodeId, RequestContext, ResolveNode, Response,
+    SyncDocument, named_node_count,
 };
 
 const SHADOW_ENV: &str = "KAKEHASHI_TREE_WORKER_SHADOW";
@@ -189,6 +191,7 @@ struct OpenDocuments {
 struct SupervisorState {
     client: Option<Arc<Client>>,
     read_client: Arc<ArcSwapOption<Client>>,
+    worker_nodes: Arc<dashmap::DashMap<(String, String), OpaqueNodeId>>,
     worker_generation: u64,
     replicas: HashMap<String, ReplicaIdentity>,
     open_documents: Arc<Mutex<OpenDocuments>>,
@@ -206,6 +209,7 @@ struct ActorShared {
     open_documents: Arc<Mutex<OpenDocuments>>,
     registry_epoch: Arc<AtomicU64>,
     read_client: Arc<ArcSwapOption<Client>>,
+    worker_nodes: Arc<dashmap::DashMap<(String, String), OpaqueNodeId>>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -361,6 +365,7 @@ pub(super) struct TreeWorkerShadow {
     open_documents: Arc<Mutex<OpenDocuments>>,
     registry_epoch: Arc<AtomicU64>,
     read_client: Arc<ArcSwapOption<Client>>,
+    worker_nodes: Arc<dashmap::DashMap<(String, String), OpaqueNodeId>>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -416,6 +421,7 @@ impl TreeWorkerShadow {
         let open_documents = Arc::new(Mutex::new(OpenDocuments::default()));
         let registry_epoch = Arc::new(AtomicU64::new(0));
         let read_client = Arc::new(ArcSwapOption::empty());
+        let worker_nodes = Arc::new(dashmap::DashMap::new());
         let worker_generation = NEXT_WORKER_GENERATION.fetch_add(1, Ordering::Relaxed);
         if !shadow_enabled() {
             return Self {
@@ -429,6 +435,7 @@ impl TreeWorkerShadow {
                 open_documents,
                 registry_epoch,
                 read_client,
+                worker_nodes,
             };
         }
         let executable = match std::env::current_exe() {
@@ -447,6 +454,7 @@ impl TreeWorkerShadow {
                     open_documents,
                     registry_epoch,
                     read_client,
+                    worker_nodes,
                 };
             }
         };
@@ -459,6 +467,7 @@ impl TreeWorkerShadow {
             open_documents: Arc::clone(&open_documents),
             registry_epoch: Arc::clone(&registry_epoch),
             read_client: Arc::clone(&read_client),
+            worker_nodes: Arc::clone(&worker_nodes),
         };
         let spawn = std::thread::Builder::new()
             .name("kakehashi-tree-worker-shadow".into())
@@ -488,6 +497,7 @@ impl TreeWorkerShadow {
                 open_documents,
                 registry_epoch,
                 read_client,
+                worker_nodes,
             };
         }
         accepting.store(true, Ordering::Release);
@@ -506,6 +516,7 @@ impl TreeWorkerShadow {
             open_documents,
             registry_epoch,
             read_client,
+            worker_nodes,
         }
     }
 
@@ -565,6 +576,99 @@ impl TreeWorkerShadow {
         self.admit_node_response(response, &expected)
     }
 
+    pub(super) fn record_node_mapping(
+        &self,
+        uri: &url::Url,
+        authoritative: &Value,
+        worker: &crate::tree_worker::OwnedNode,
+    ) {
+        let Some(id) = authoritative.get("id").and_then(Value::as_str) else {
+            return;
+        };
+        self.worker_nodes.insert(
+            (uri.as_str().to_string(), id.to_string()),
+            worker.id.clone(),
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn compare_node_navigation(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        configuration_generation: u64,
+        authoritative_input_id: &str,
+        operation: NodeNavigation,
+        authoritative: &Value,
+    ) {
+        let key = (uri.as_str().to_string(), authoritative_input_id.to_string());
+        let Some(node_id) = self.worker_nodes.get(&key).map(|entry| entry.clone()) else {
+            return;
+        };
+        let Some(client) = self.read_client.load_full() else {
+            return;
+        };
+        if !self.is_enabled() || node_id.worker_generation != client.worker_generation() {
+            self.worker_nodes.remove(&key);
+            return;
+        }
+        let context = self.read_context(
+            &client,
+            uri,
+            incarnation,
+            content_version,
+            configuration_generation,
+        );
+        let expected = context.clone();
+        let response = tokio::task::spawn_blocking(move || {
+            client.navigate_node(NavigateNode {
+                context,
+                node_id,
+                operation,
+            })
+        })
+        .await
+        .ok()
+        .and_then(Result::ok);
+        let Some(result) =
+            response.and_then(|response| self.admit_node_response(response, &expected))
+        else {
+            return;
+        };
+        let authoritative_nodes = match authoritative {
+            Value::Null => Vec::new(),
+            Value::Object(_) => vec![authoritative],
+            Value::Array(nodes) => nodes.iter().collect(),
+            _ => return,
+        };
+        let authoritative_kinds = authoritative_nodes
+            .iter()
+            .filter_map(|node| node.get("kind").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+        let worker_kinds = result
+            .nodes
+            .iter()
+            .map(|node| node.kind.as_str())
+            .collect::<Vec<_>>();
+        if authoritative_kinds != worker_kinds {
+            log::debug!(
+                target: "kakehashi::tree_worker_shadow",
+                "node navigation mismatch uri={} version={} authoritative={:?} worker={:?}",
+                uri,
+                content_version,
+                authoritative_kinds,
+                worker_kinds,
+            );
+            return;
+        }
+        for (authoritative_node, worker_node) in
+            authoritative_nodes.into_iter().zip(result.nodes.iter())
+        {
+            self.record_node_mapping(uri, authoritative_node, worker_node);
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(super) fn mirror_change(
         &self,
@@ -606,6 +710,8 @@ impl TreeWorkerShadow {
         configuration_generation: u64,
     ) {
         self.comparisons.mark_closed(uri.as_str(), incarnation);
+        self.worker_nodes
+            .retain(|(mapped_uri, _), _| mapped_uri != uri.as_str());
         self.observe_and_submit(ShadowCommand::Close(CloseDocument {
             context: self.context(uri, incarnation, content_version, configuration_generation),
         }));
@@ -919,6 +1025,7 @@ fn run_actor(
         open_documents,
         registry_epoch,
         read_client,
+        worker_nodes,
     } = shared;
     let initial_client = match Client::spawn(&executable, compute_threads, worker_generation) {
         Ok(client) => Some(Arc::new(client)),
@@ -932,6 +1039,7 @@ fn run_actor(
     let mut state = SupervisorState {
         client: initial_client,
         read_client,
+        worker_nodes,
         worker_generation,
         replicas: HashMap::new(),
         open_documents,
@@ -1340,6 +1448,7 @@ fn breaker_probe_allowed(state: BreakerState, generation: u64, now: Instant) -> 
 
 fn retire_client(state: &mut SupervisorState) -> std::io::Result<()> {
     state.read_client.store(None);
+    state.worker_nodes.clear();
     let Some(client) = state.client.take() else {
         return Ok(());
     };
@@ -1998,7 +2107,36 @@ mod tests {
             open_documents: Arc::new(Mutex::new(OpenDocuments::default())),
             registry_epoch: Arc::new(AtomicU64::new(0)),
             read_client: Arc::new(ArcSwapOption::empty()),
+            worker_nodes: Arc::new(dashmap::DashMap::new()),
         }
+    }
+
+    #[test]
+    fn closing_document_discards_legacy_to_worker_node_mappings() {
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let shadow = shadow(sender);
+        let uri = url::Url::parse("file:///mapped.rs").unwrap();
+        shadow.record_node_mapping(
+            &uri,
+            &serde_json::json!({"id": "legacy", "kind": "identifier"}),
+            &crate::tree_worker::OwnedNode {
+                id: OpaqueNodeId {
+                    worker_generation: 7,
+                    local_id: "worker".into(),
+                },
+                kind: "identifier".into(),
+                start_byte: 0,
+                end_byte: 1,
+                named: true,
+                has_error: false,
+            },
+        );
+        assert_eq!(shadow.worker_nodes.len(), 1);
+
+        shadow.mirror_close(&uri, 1, 1, 0);
+
+        assert!(shadow.worker_nodes.is_empty());
+        assert!(matches!(receiver.recv().unwrap(), ShadowCommand::Close(_)));
     }
 
     fn grammar() -> WorkerGrammarDescriptor {
@@ -2302,6 +2440,7 @@ mod tests {
         let mut state = SupervisorState {
             client: None,
             read_client: Arc::new(ArcSwapOption::empty()),
+            worker_nodes: Arc::new(dashmap::DashMap::new()),
             worker_generation: 1,
             replicas: HashMap::new(),
             open_documents: Arc::new(Mutex::new(OpenDocuments::default())),

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -12,8 +12,8 @@ use crate::language::coordinator::WorkerGrammarDescriptor;
 use crate::lsp::text_sync::SequentialByteEdit;
 use crate::tree_worker::{
     ApplyDocumentEditsAndDerive, ByteEdit, Client, CloseDocument, DeriveDocumentSnapshot,
-    NavigateNode, NodeNavigation, NodeResult, OpaqueNodeId, RequestContext, ResolveNode, Response,
-    SyncDocument, named_node_count,
+    NavigateNode, NodeNavigation, NodeResult, NodeScalarOperation, NodeScalarValue, OpaqueNodeId,
+    RequestContext, ResolveNode, Response, RunNodeScalar, SyncDocument, named_node_count,
 };
 
 const SHADOW_ENV: &str = "KAKEHASHI_TREE_WORKER_SHADOW";
@@ -667,6 +667,72 @@ impl TreeWorkerShadow {
         {
             self.record_node_mapping(uri, authoritative_node, worker_node);
         }
+    }
+
+    pub(super) async fn node_scalar(
+        &self,
+        uri: &url::Url,
+        authoritative_input_id: &str,
+        operation: NodeScalarOperation,
+    ) -> Option<NodeScalarValue> {
+        let key = (uri.as_str().to_string(), authoritative_input_id.to_string());
+        let node_id = self.worker_nodes.get(&key).map(|entry| entry.clone())?;
+        let sync = self
+            .open_documents
+            .lock()
+            .recover_poison("TreeWorkerShadow::node_scalar(context)")
+            .current
+            .get(uri.as_str())
+            .cloned()?;
+        let client = self.read_client.load_full()?;
+        if !self.is_enabled() || node_id.worker_generation != client.worker_generation() {
+            self.worker_nodes.remove(&key);
+            return None;
+        }
+        let context = self.read_context(
+            &client,
+            uri,
+            sync.context.incarnation,
+            sync.context.content_version,
+            sync.context.configuration_generation,
+        );
+        let expected = context.clone();
+        let response = tokio::task::spawn_blocking(move || {
+            client.run_node_scalar(RunNodeScalar {
+                context,
+                node_id,
+                operation,
+            })
+        })
+        .await
+        .ok()?
+        .ok()?;
+        let Response::NodeScalar(result) = response else {
+            return None;
+        };
+        if result.context != expected {
+            return None;
+        }
+        let current = self
+            .open_documents
+            .lock()
+            .recover_poison("TreeWorkerShadow::node_scalar(admission)")
+            .current
+            .get(uri.as_str())
+            .map(|current| current.context.clone());
+        if current.as_ref().is_none_or(|current| {
+            current.incarnation != expected.incarnation
+                || current.content_version != expected.content_version
+                || current.configuration_generation != expected.configuration_generation
+        }) || self
+            .read_client
+            .load()
+            .as_ref()
+            .is_none_or(|client| client.worker_generation() != expected.worker_generation)
+        {
+            return None;
+        }
+        result.value
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -735,6 +735,98 @@ impl TreeWorkerShadow {
         result.value
     }
 
+    pub(super) async fn node_navigation(
+        &self,
+        uri: &url::Url,
+        authoritative_input_id: &str,
+        operation: NodeNavigation,
+    ) -> Option<NodeResult> {
+        let key = (uri.as_str().to_string(), authoritative_input_id.to_string());
+        let node_id = self.worker_nodes.get(&key).map(|entry| entry.clone())?;
+        let sync = self
+            .open_documents
+            .lock()
+            .recover_poison("TreeWorkerShadow::node_navigation(context)")
+            .current
+            .get(uri.as_str())
+            .cloned()?;
+        let client = self.read_client.load_full()?;
+        if !self.is_enabled() || node_id.worker_generation != client.worker_generation() {
+            self.worker_nodes.remove(&key);
+            return None;
+        }
+        let context = self.read_context(
+            &client,
+            uri,
+            sync.context.incarnation,
+            sync.context.content_version,
+            sync.context.configuration_generation,
+        );
+        let expected = context.clone();
+        let response = tokio::task::spawn_blocking(move || {
+            client.navigate_node(NavigateNode {
+                context,
+                node_id,
+                operation,
+            })
+        })
+        .await
+        .ok()?
+        .ok()?;
+        let result = self.admit_node_response(response, &expected)?;
+        let current = self
+            .open_documents
+            .lock()
+            .recover_poison("TreeWorkerShadow::node_navigation(admission)")
+            .current
+            .get(uri.as_str())
+            .map(|current| current.context.clone());
+        if current.as_ref().is_none_or(|current| {
+            current.incarnation != expected.incarnation
+                || current.content_version != expected.content_version
+                || current.configuration_generation != expected.configuration_generation
+        }) {
+            return None;
+        }
+        Some(result)
+    }
+
+    pub(super) fn compare_node_result(
+        &self,
+        uri: &url::Url,
+        operation: &NodeNavigation,
+        authoritative: &Value,
+        worker: &NodeResult,
+    ) {
+        let authoritative_nodes = match authoritative {
+            Value::Null => Vec::new(),
+            Value::Object(_) => vec![authoritative],
+            Value::Array(nodes) => nodes.iter().collect(),
+            _ => return,
+        };
+        let authoritative_kinds = authoritative_nodes
+            .iter()
+            .filter_map(|node| node.get("kind").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+        let worker_kinds = worker
+            .nodes
+            .iter()
+            .map(|node| node.kind.as_str())
+            .collect::<Vec<_>>();
+        if authoritative_kinds != worker_kinds {
+            log::debug!(
+                target: "kakehashi::tree_worker_shadow",
+                "node navigation mismatch operation={operation:?} uri={uri} authoritative={authoritative_kinds:?} worker={worker_kinds:?}",
+            );
+            return;
+        }
+        for (authoritative_node, worker_node) in
+            authoritative_nodes.into_iter().zip(worker.nodes.iter())
+        {
+            self.record_node_mapping(uri, authoritative_node, worker_node);
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(super) fn mirror_change(
         &self,

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -791,10 +791,41 @@ impl TreeWorkerShadow {
         Some(result)
     }
 
+    pub(super) async fn node_navigation_with_descendant(
+        &self,
+        uri: &url::Url,
+        authoritative_input_id: &str,
+        authoritative_descendant_id: &str,
+    ) -> Option<NodeResult> {
+        let descendant_id = self
+            .worker_nodes
+            .get(&(
+                uri.as_str().to_string(),
+                authoritative_descendant_id.to_string(),
+            ))
+            .map(|entry| entry.clone())?;
+        self.node_navigation(
+            uri,
+            authoritative_input_id,
+            NodeNavigation::ChildWithDescendant { descendant_id },
+        )
+        .await
+    }
+
     pub(super) fn compare_node_result(
         &self,
         uri: &url::Url,
         operation: &NodeNavigation,
+        authoritative: &Value,
+        worker: &NodeResult,
+    ) {
+        self.compare_node_result_label(uri, &format!("{operation:?}"), authoritative, worker);
+    }
+
+    pub(super) fn compare_node_result_label(
+        &self,
+        uri: &url::Url,
+        operation: &str,
         authoritative: &Value,
         worker: &NodeResult,
     ) {
@@ -816,7 +847,7 @@ impl TreeWorkerShadow {
         if authoritative_kinds != worker_kinds {
             log::debug!(
                 target: "kakehashi::tree_worker_shadow",
-                "node navigation mismatch operation={operation:?} uri={uri} authoritative={authoritative_kinds:?} worker={worker_kinds:?}",
+                "node navigation mismatch operation={operation} uri={uri} authoritative={authoritative_kinds:?} worker={worker_kinds:?}",
             );
             return;
         }

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -11,12 +11,12 @@ use crate::error::LockResultExt;
 use crate::language::coordinator::WorkerGrammarDescriptor;
 use crate::lsp::text_sync::SequentialByteEdit;
 use crate::tree_worker::{
-    ApplyDocumentEditsAndDerive, ByteEdit, Client, CloseDocument, ConfigureLanguages,
-    DeriveDocumentSnapshot, DeriveInjectionRegions, DeriveSelectionRanges, DeriveSemanticTokens,
-    DerivedSemanticTokens, InjectionRegionsResult, NavigateNode, NodeNavigation, NodeResult,
-    NodeScalarOperation, NodeScalarValue, OpaqueNodeId, RequestContext, ResolveNode, Response,
-    RunNodeScalar, SelectionRangesResult, SyncDocument, WirePosition, WorkerLanguageCatalog,
-    named_node_count,
+    ApplyDocumentEditsAndDerive, ByteEdit, CapturesResult, Client, CloseDocument,
+    ConfigureLanguages, DeriveDocumentSnapshot, DeriveInjectionRegions, DeriveSelectionRanges,
+    DeriveSemanticTokens, DerivedSemanticTokens, InjectionRegionsResult, NavigateNode,
+    NodeNavigation, NodeResult, NodeScalarOperation, NodeScalarValue, OpaqueNodeId, RequestContext,
+    ResolveNode, Response, RunCaptures, RunNodeScalar, SelectionRangesResult, SyncDocument,
+    WirePosition, WireRange, WorkerLanguageCatalog, named_node_count,
 };
 
 use super::Kakehashi;
@@ -413,6 +413,34 @@ struct ComparableInjection<'a> {
     contiguous: bool,
 }
 
+fn remove_capture_ids(value: &mut Value) {
+    match value {
+        Value::Array(values) => values.iter_mut().for_each(remove_capture_ids),
+        Value::Object(map) => {
+            if let Some(Value::Object(node)) = map.get_mut("node") {
+                node.remove("id");
+            }
+            map.values_mut().for_each(remove_capture_ids);
+        }
+        _ => {}
+    }
+}
+
+fn capture_node_ids(value: &Value, ids: &mut Vec<String>) {
+    match value {
+        Value::Array(values) => values.iter().for_each(|value| capture_node_ids(value, ids)),
+        Value::Object(map) => {
+            if let Some(Value::Object(node)) = map.get("node")
+                && let Some(Value::String(id)) = node.get("id")
+            {
+                ids.push(id.clone());
+            }
+            map.values().for_each(|value| capture_node_ids(value, ids));
+        }
+        _ => {}
+    }
+}
+
 pub(super) struct MirrorDocument {
     pub(super) uri: url::Url,
     pub(super) incarnation: u64,
@@ -801,6 +829,126 @@ impl TreeWorkerShadow {
                 authoritative.len(),
                 worker.len(),
             );
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn captures(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        configuration_generation: u64,
+        kind: String,
+        range: Option<WireRange>,
+        injection: bool,
+    ) -> Option<CapturesResult> {
+        self.preload_catalog_async();
+        let client = self.read_client.load_full()?;
+        if !self.is_enabled() {
+            return None;
+        }
+        let context = self.synchronized_read_context(
+            &client,
+            uri,
+            incarnation,
+            content_version,
+            configuration_generation,
+        )?;
+        let expected = context.clone();
+        let response = tokio::task::spawn_blocking(move || {
+            client.run_captures(RunCaptures {
+                context,
+                kind,
+                range,
+                injection,
+            })
+        })
+        .await
+        .ok()?
+        .ok()?;
+        let Response::Captures(result) = response else {
+            return None;
+        };
+        if result.context != expected {
+            return None;
+        }
+        let current = self
+            .open_documents
+            .lock()
+            .recover_poison("TreeWorkerShadow::captures(admission)")
+            .current
+            .get(uri.as_str())
+            .map(|current| current.context.clone());
+        if current.as_ref().is_none_or(|current| {
+            current.incarnation != expected.incarnation
+                || current.content_version != expected.content_version
+                || current.configuration_generation != expected.configuration_generation
+        }) || self
+            .read_client
+            .load()
+            .as_ref()
+            .is_none_or(|client| client.worker_generation() != expected.worker_generation)
+        {
+            return None;
+        }
+        Some(result)
+    }
+
+    pub(super) fn compare_captures(
+        &self,
+        uri: &url::Url,
+        content_version: u64,
+        authoritative: Option<&(Vec<Value>, Vec<Value>)>,
+        worker: &CapturesResult,
+    ) {
+        let normalize = |values: &[Value]| {
+            let mut values = values.to_vec();
+            for value in &mut values {
+                remove_capture_ids(value);
+            }
+            values
+        };
+        let authoritative_available = authoritative.is_some();
+        let authoritative_matches = authoritative
+            .map(|(matches, _)| normalize(matches))
+            .unwrap_or_default();
+        let worker_matches = normalize(&worker.matches);
+        let authoritative_skipped = authoritative
+            .map(|(_, skipped)| skipped.as_slice())
+            .unwrap_or_default();
+        let matches = authoritative_available == worker.available
+            && authoritative_matches == worker_matches
+            && authoritative_skipped == worker.skipped;
+        if !matches {
+            log::debug!(
+                target: "kakehashi::tree_worker_shadow",
+                "captures mismatch uri={uri} version={content_version} authoritative={} worker={}",
+                authoritative_matches.len(),
+                worker_matches.len(),
+            );
+            return;
+        }
+        let mut authoritative_ids = Vec::new();
+        if let Some((matches, _)) = authoritative {
+            matches
+                .iter()
+                .for_each(|value| capture_node_ids(value, &mut authoritative_ids));
+        }
+        let mut worker_ids = Vec::new();
+        worker
+            .matches
+            .iter()
+            .for_each(|value| capture_node_ids(value, &mut worker_ids));
+        for (authoritative_id, worker_id) in authoritative_ids.into_iter().zip(worker_ids) {
+            let opaque = OpaqueNodeId {
+                worker_generation: worker.context.worker_generation,
+                local_id: worker_id.clone(),
+            };
+            self.worker_nodes
+                .insert((uri.as_str().to_string(), authoritative_id), opaque.clone());
+            self.worker_nodes
+                .insert((uri.as_str().to_string(), worker_id), opaque);
         }
     }
 

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -1073,6 +1073,7 @@ impl TreeWorkerShadow {
             source_path: grammar.source_path,
             parser_path: grammar.parser_path,
             artifact_digest: grammar.artifact_digest,
+            queries: grammar.queries,
             text,
         }
     }
@@ -2389,6 +2390,7 @@ mod tests {
             parser_path: "/parser/rust.so".into(),
             grammar_symbol: "rust".into(),
             artifact_digest: "sha256:rust-v1".into(),
+            queries: Default::default(),
             configuration_generation: 3,
         }
     }
@@ -2420,6 +2422,7 @@ mod tests {
             source_path: "/parser/rust.so".into(),
             parser_path: "/parser/rust.so".into(),
             artifact_digest: "sha256:rust-v1".into(),
+            queries: Default::default(),
             text: format!("version {version}"),
         }
     }

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -12,10 +12,11 @@ use crate::language::coordinator::WorkerGrammarDescriptor;
 use crate::lsp::text_sync::SequentialByteEdit;
 use crate::tree_worker::{
     ApplyDocumentEditsAndDerive, ByteEdit, Client, CloseDocument, ConfigureLanguages,
-    DeriveDocumentSnapshot, DeriveInjectionRegions, DeriveSelectionRanges, InjectionRegionsResult,
-    NavigateNode, NodeNavigation, NodeResult, NodeScalarOperation, NodeScalarValue, OpaqueNodeId,
-    RequestContext, ResolveNode, Response, RunNodeScalar, SelectionRangesResult, SyncDocument,
-    WirePosition, WorkerLanguageAsset, named_node_count,
+    DeriveDocumentSnapshot, DeriveInjectionRegions, DeriveSelectionRanges, DeriveSemanticTokens,
+    DerivedSemanticTokens, InjectionRegionsResult, NavigateNode, NodeNavigation, NodeResult,
+    NodeScalarOperation, NodeScalarValue, OpaqueNodeId, RequestContext, ResolveNode, Response,
+    RunNodeScalar, SelectionRangesResult, SyncDocument, WirePosition, WorkerLanguageAsset,
+    named_node_count,
 };
 
 use super::Kakehashi;
@@ -191,6 +192,7 @@ enum RecoveryMode {
 struct OpenDocuments {
     current: HashMap<String, SyncDocument>,
     closed_incarnations: HashMap<String, u64>,
+    acknowledged: HashMap<String, RequestContext>,
     catalog: Option<(u64, Vec<WorkerLanguageAsset>)>,
     catalog_preload: Option<(u64, u64)>,
 }
@@ -232,6 +234,17 @@ struct ResyncFailure {
 }
 
 impl OpenDocuments {
+    fn acknowledges(&self, context: &RequestContext) -> bool {
+        self.acknowledged
+            .get(&context.uri)
+            .is_some_and(|acknowledged| {
+                acknowledged.worker_generation == context.worker_generation
+                    && acknowledged.incarnation == context.incarnation
+                    && acknowledged.content_version == context.content_version
+                    && acknowledged.configuration_generation == context.configuration_generation
+            })
+    }
+
     fn supersedes(&self, command: &ShadowCommand) -> bool {
         match command {
             ShadowCommand::Sync(incoming)
@@ -337,6 +350,7 @@ impl OpenDocuments {
             }
             ShadowCommand::Close(request) => {
                 self.current.remove(&request.context.uri);
+                self.acknowledged.remove(&request.context.uri);
                 self.closed_incarnations
                     .entry(request.context.uri.clone())
                     .and_modify(|closed| *closed = (*closed).max(request.context.incarnation))
@@ -344,6 +358,7 @@ impl OpenDocuments {
             }
             ShadowCommand::Forget(context) => {
                 self.current.remove(&context.uri);
+                self.acknowledged.remove(&context.uri);
             }
             ShadowCommand::Shutdown(_) => {}
         }
@@ -574,13 +589,13 @@ impl TreeWorkerShadow {
         if !self.is_enabled() {
             return None;
         }
-        let context = self.read_context(
+        let context = self.synchronized_read_context(
             &client,
             uri,
             incarnation,
             content_version,
             configuration_generation,
-        );
+        )?;
         let expected = context.clone();
         let response = tokio::task::spawn_blocking(move || {
             client.resolve_node(ResolveNode {
@@ -608,13 +623,13 @@ impl TreeWorkerShadow {
         if !self.is_enabled() {
             return None;
         }
-        let context = self.read_context(
+        let context = self.synchronized_read_context(
             &client,
             uri,
             incarnation,
             content_version,
             configuration_generation,
-        );
+        )?;
         let expected = context.clone();
         let response = tokio::task::spawn_blocking(move || {
             client.derive_selection_ranges(DeriveSelectionRanges { context, positions })
@@ -661,13 +676,13 @@ impl TreeWorkerShadow {
         if !self.is_enabled() {
             return None;
         }
-        let context = self.read_context(
+        let context = self.synchronized_read_context(
             &client,
             uri,
             incarnation,
             content_version,
             configuration_generation,
-        );
+        )?;
         let expected = context.clone();
         let response = tokio::task::spawn_blocking(move || {
             client.derive_injection_regions(DeriveInjectionRegions { context })
@@ -701,6 +716,92 @@ impl TreeWorkerShadow {
             return None;
         }
         Some(result)
+    }
+
+    pub(super) async fn semantic_tokens(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        configuration_generation: u64,
+        supports_multiline: bool,
+    ) -> Option<DerivedSemanticTokens> {
+        self.preload_catalog_async();
+        let client = self.read_client.load_full()?;
+        if !self.is_enabled() {
+            return None;
+        }
+        let context = self.synchronized_read_context(
+            &client,
+            uri,
+            incarnation,
+            content_version,
+            configuration_generation,
+        )?;
+        let expected = context.clone();
+        let response = tokio::task::spawn_blocking(move || {
+            client.derive_semantic_tokens(DeriveSemanticTokens {
+                context,
+                supports_multiline,
+            })
+        })
+        .await
+        .ok()?
+        .ok()?;
+        let Response::SemanticTokens(result) = response else {
+            return None;
+        };
+        if result.context != expected {
+            return None;
+        }
+        let current = self
+            .open_documents
+            .lock()
+            .recover_poison("TreeWorkerShadow::semantic_tokens(admission)")
+            .current
+            .get(uri.as_str())
+            .map(|current| current.context.clone());
+        if current.as_ref().is_none_or(|current| {
+            current.incarnation != expected.incarnation
+                || current.content_version != expected.content_version
+                || current.configuration_generation != expected.configuration_generation
+        }) || self
+            .read_client
+            .load()
+            .as_ref()
+            .is_none_or(|client| client.worker_generation() != expected.worker_generation)
+        {
+            return None;
+        }
+        Some(result)
+    }
+
+    pub(super) fn compare_semantic_tokens(
+        &self,
+        uri: &url::Url,
+        content_version: u64,
+        authoritative: &[tower_lsp_server::ls_types::SemanticToken],
+        worker: &DerivedSemanticTokens,
+    ) {
+        let worker = worker
+            .tokens
+            .iter()
+            .map(|token| tower_lsp_server::ls_types::SemanticToken {
+                delta_line: token.delta_line,
+                delta_start: token.delta_start,
+                length: token.length,
+                token_type: token.token_type,
+                token_modifiers_bitset: token.token_modifiers_bitset,
+            })
+            .collect::<Vec<_>>();
+        if authoritative != worker {
+            log::debug!(
+                target: "kakehashi::tree_worker_shadow",
+                "semantic token mismatch uri={uri} version={content_version} authoritative={} worker={}",
+                authoritative.len(),
+                worker.len(),
+            );
+        }
     }
 
     pub(super) fn compare_injection_regions(
@@ -1280,6 +1381,28 @@ impl TreeWorkerShadow {
         }
     }
 
+    fn synchronized_read_context(
+        &self,
+        client: &Client,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        configuration_generation: u64,
+    ) -> Option<RequestContext> {
+        let context = self.read_context(
+            client,
+            uri,
+            incarnation,
+            content_version,
+            configuration_generation,
+        );
+        self.open_documents
+            .lock()
+            .recover_poison("TreeWorkerShadow::synchronized_read_context")
+            .acknowledges(&context)
+            .then_some(context)
+    }
+
     fn admit_node_response(
         &self,
         response: Response,
@@ -1756,6 +1879,12 @@ fn run_actor(
                         .replicas
                         .insert(snapshot.context.uri.clone(), identity);
                 }
+                state
+                    .open_documents
+                    .lock()
+                    .recover_poison("run_actor(acknowledge snapshot)")
+                    .acknowledged
+                    .insert(snapshot.context.uri.clone(), snapshot.context.clone());
                 log::debug!(
                     target: "kakehashi::tree_worker_shadow_metrics",
                     "uri={} version={} parent_us={} queue_us={} compute_us={}",
@@ -2090,6 +2219,12 @@ fn recover_worker(
             }
         };
         state.replicas.clear();
+        state
+            .open_documents
+            .lock()
+            .recover_poison("recover_worker(clear acknowledgements)")
+            .acknowledged
+            .clear();
         match resync_open_documents(
             &replacement,
             generation,
@@ -2255,6 +2390,11 @@ fn resync_open_documents(
         match sync_and_derive(client, request) {
             Ok(Response::Snapshot(snapshot)) => {
                 replicas.insert(snapshot.context.uri.clone(), identity);
+                open_documents
+                    .lock()
+                    .recover_poison("resync_open_documents(acknowledge snapshot)")
+                    .acknowledged
+                    .insert(snapshot.context.uri.clone(), snapshot.context.clone());
                 comparisons.record(
                     &snapshot.context.uri,
                     snapshot.context.incarnation,
@@ -2690,6 +2830,27 @@ mod tests {
             context: latest.context.clone(),
         }));
         assert!(documents.current.is_empty());
+    }
+
+    #[test]
+    fn read_requires_the_actor_to_acknowledge_the_exact_version() {
+        let mut documents = OpenDocuments::default();
+        let version_one = sync("file:///a.rs", 1, 1, 7).context;
+        documents
+            .acknowledged
+            .insert(version_one.uri.clone(), version_one.clone());
+        assert!(documents.acknowledges(&version_one));
+
+        let version_two = sync("file:///a.rs", 1, 2, 7).context;
+        assert!(!documents.acknowledges(&version_two));
+
+        documents
+            .acknowledged
+            .insert(version_two.uri.clone(), version_two.clone());
+        assert!(documents.acknowledges(&version_two));
+
+        let restarted = sync("file:///a.rs", 1, 2, 8).context;
+        assert!(!documents.acknowledges(&restarted));
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -11,10 +11,11 @@ use crate::error::LockResultExt;
 use crate::language::coordinator::WorkerGrammarDescriptor;
 use crate::lsp::text_sync::SequentialByteEdit;
 use crate::tree_worker::{
-    ApplyDocumentEditsAndDerive, ByteEdit, Client, CloseDocument, DeriveDocumentSnapshot,
-    DeriveSelectionRanges, NavigateNode, NodeNavigation, NodeResult, NodeScalarOperation,
-    NodeScalarValue, OpaqueNodeId, RequestContext, ResolveNode, Response, RunNodeScalar,
-    SelectionRangesResult, SyncDocument, WirePosition, named_node_count,
+    ApplyDocumentEditsAndDerive, ByteEdit, Client, CloseDocument, ConfigureLanguages,
+    DeriveDocumentSnapshot, DeriveSelectionRanges, NavigateNode, NodeNavigation, NodeResult,
+    NodeScalarOperation, NodeScalarValue, OpaqueNodeId, RequestContext, ResolveNode, Response,
+    RunNodeScalar, SelectionRangesResult, SyncDocument, WirePosition, WorkerLanguageAsset,
+    named_node_count,
 };
 
 const SHADOW_ENV: &str = "KAKEHASHI_TREE_WORKER_SHADOW";
@@ -32,6 +33,7 @@ const LONG_HEALTHY_INTERVAL: Duration = Duration::from_secs(10 * 60);
 static NEXT_WORKER_GENERATION: AtomicU64 = AtomicU64::new(1);
 
 enum ShadowCommand {
+    Configure(ConfigureLanguages),
     Sync(SyncDocument),
     Apply {
         request: ApplyDocumentEditsAndDerive,
@@ -259,7 +261,7 @@ impl OpenDocuments {
                                     && current.context.content_version > context.content_version)))
                 })
             }
-            ShadowCommand::Shutdown(_) => false,
+            ShadowCommand::Configure(_) | ShadowCommand::Shutdown(_) => false,
         }
     }
 
@@ -272,7 +274,10 @@ impl OpenDocuments {
         let incoming = match command {
             ShadowCommand::Sync(request) => Some(request),
             ShadowCommand::Apply { fallback, .. } => Some(fallback),
-            ShadowCommand::Close(_) | ShadowCommand::Forget(_) | ShadowCommand::Shutdown(_) => None,
+            ShadowCommand::Close(_)
+            | ShadowCommand::Forget(_)
+            | ShadowCommand::Configure(_)
+            | ShadowCommand::Shutdown(_) => None,
         };
         if incoming.is_some_and(|incoming| {
             self.closed_incarnations
@@ -339,7 +344,7 @@ impl OpenDocuments {
             ShadowCommand::Forget(context) => {
                 self.current.remove(&context.uri);
             }
-            ShadowCommand::Shutdown(_) => {}
+            ShadowCommand::Configure(_) | ShadowCommand::Shutdown(_) => {}
         }
         Observation::Accepted { artifact_replaced }
     }
@@ -966,8 +971,31 @@ impl TreeWorkerShadow {
             .fetch_max(generation, Ordering::AcqRel);
     }
 
+    #[cfg(test)]
     pub(super) fn mirror_configuration(&self, generation: u64, documents: Vec<MirrorDocument>) {
-        let mut commands = Vec::with_capacity(documents.len());
+        self.mirror_configuration_with_catalog(generation, Vec::new(), documents);
+    }
+
+    pub(super) fn mirror_configuration_with_catalog(
+        &self,
+        generation: u64,
+        assets: Vec<WorkerLanguageAsset>,
+        documents: Vec<MirrorDocument>,
+    ) {
+        let mut commands = Vec::with_capacity(documents.len() + usize::from(!assets.is_empty()));
+        if !assets.is_empty() {
+            commands.push(ShadowCommand::Configure(ConfigureLanguages {
+                context: RequestContext {
+                    request_id: self.next_request_id.fetch_add(1, Ordering::Relaxed),
+                    worker_generation: self.worker_generation,
+                    uri: "kakehashi://language-catalog".into(),
+                    incarnation: 0,
+                    content_version: 0,
+                    configuration_generation: generation,
+                },
+                assets,
+            }));
+        }
         for document in documents {
             let command = if let Some(grammar) = document.grammar {
                 ShadowCommand::Sync(self.sync_request(
@@ -1765,6 +1793,7 @@ fn execute_command(
     comparisons: &ComparisonStore,
 ) -> (std::io::Result<Response>, Option<ReplicaIdentity>) {
     match command {
+        ShadowCommand::Configure(request) => (client.configure_languages(request), None),
         ShadowCommand::Sync(request) => {
             let identity = ReplicaIdentity::from_sync(&request);
             comparisons.open(&request.context.uri, request.context.incarnation);
@@ -2072,6 +2101,7 @@ fn replica_was_closed(
 
 fn retag_command(command: &mut ShadowCommand, generation: u64) {
     match command {
+        ShadowCommand::Configure(request) => request.context.worker_generation = generation,
         ShadowCommand::Sync(request) => request.context.worker_generation = generation,
         ShadowCommand::Apply { request, fallback } => {
             request.context.worker_generation = generation;
@@ -2113,6 +2143,7 @@ fn classify_transport_failure(
 
 fn command_uri(command: &ShadowCommand) -> Option<&str> {
     match command {
+        ShadowCommand::Configure(_) => None,
         ShadowCommand::Sync(request) => Some(&request.context.uri),
         ShadowCommand::Apply { fallback, .. } => Some(&fallback.context.uri),
         ShadowCommand::Close(request) => Some(&request.context.uri),
@@ -2123,6 +2154,7 @@ fn command_uri(command: &ShadowCommand) -> Option<&str> {
 
 fn command_document(command: &ShadowCommand) -> Option<(&str, u64)> {
     match command {
+        ShadowCommand::Configure(_) => None,
         ShadowCommand::Sync(request) => Some((&request.context.uri, request.context.incarnation)),
         ShadowCommand::Apply { fallback, .. } => {
             Some((&fallback.context.uri, fallback.context.incarnation))
@@ -2137,7 +2169,10 @@ fn command_grammar(command: &ShadowCommand) -> Option<GrammarIdentity> {
     match command {
         ShadowCommand::Sync(request) => Some(GrammarIdentity::from_sync(request)),
         ShadowCommand::Apply { fallback, .. } => Some(GrammarIdentity::from_sync(fallback)),
-        ShadowCommand::Close(_) | ShadowCommand::Forget(_) | ShadowCommand::Shutdown(_) => None,
+        ShadowCommand::Configure(_)
+        | ShadowCommand::Close(_)
+        | ShadowCommand::Forget(_)
+        | ShadowCommand::Shutdown(_) => None,
     }
 }
 
@@ -2145,7 +2180,10 @@ fn command_sync(command: &ShadowCommand) -> Option<&SyncDocument> {
     match command {
         ShadowCommand::Sync(request) => Some(request),
         ShadowCommand::Apply { fallback, .. } => Some(fallback),
-        ShadowCommand::Close(_) | ShadowCommand::Forget(_) | ShadowCommand::Shutdown(_) => None,
+        ShadowCommand::Configure(_)
+        | ShadowCommand::Close(_)
+        | ShadowCommand::Forget(_)
+        | ShadowCommand::Shutdown(_) => None,
     }
 }
 

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -15,7 +15,7 @@ use crate::tree_worker::{
     DeriveDocumentSnapshot, DeriveInjectionRegions, DeriveSelectionRanges, DeriveSemanticTokens,
     DerivedSemanticTokens, InjectionRegionsResult, NavigateNode, NodeNavigation, NodeResult,
     NodeScalarOperation, NodeScalarValue, OpaqueNodeId, RequestContext, ResolveNode, Response,
-    RunNodeScalar, SelectionRangesResult, SyncDocument, WirePosition, WorkerLanguageAsset,
+    RunNodeScalar, SelectionRangesResult, SyncDocument, WirePosition, WorkerLanguageCatalog,
     named_node_count,
 };
 
@@ -193,7 +193,7 @@ struct OpenDocuments {
     current: HashMap<String, SyncDocument>,
     closed_incarnations: HashMap<String, u64>,
     acknowledged: HashMap<String, RequestContext>,
-    catalog: Option<(u64, Vec<WorkerLanguageAsset>)>,
+    catalog: Option<(u64, WorkerLanguageCatalog)>,
     catalog_preload: Option<(u64, u64)>,
 }
 
@@ -1183,16 +1183,20 @@ impl TreeWorkerShadow {
 
     #[cfg(test)]
     pub(super) fn mirror_configuration(&self, generation: u64, documents: Vec<MirrorDocument>) {
-        self.mirror_configuration_with_catalog(generation, Vec::new(), documents);
+        self.mirror_configuration_with_catalog(
+            generation,
+            WorkerLanguageCatalog::default(),
+            documents,
+        );
     }
 
     pub(super) fn mirror_configuration_with_catalog(
         &self,
         generation: u64,
-        assets: Vec<WorkerLanguageAsset>,
+        catalog: WorkerLanguageCatalog,
         documents: Vec<MirrorDocument>,
     ) {
-        self.remember_catalog(generation, assets);
+        self.remember_catalog(generation, catalog);
         let mut commands = Vec::with_capacity(documents.len());
         for document in documents {
             let command = if let Some(grammar) = document.grammar {
@@ -1242,15 +1246,15 @@ impl TreeWorkerShadow {
         }
     }
 
-    fn remember_catalog(&self, generation: u64, assets: Vec<WorkerLanguageAsset>) {
-        if assets.is_empty() {
+    fn remember_catalog(&self, generation: u64, catalog: WorkerLanguageCatalog) {
+        if catalog.assets.is_empty() {
             return;
         }
         let mut documents = self
             .open_documents
             .lock()
             .recover_poison("TreeWorkerShadow::remember_catalog");
-        documents.catalog = Some((generation, assets));
+        documents.catalog = Some((generation, catalog));
         documents.catalog_preload = None;
     }
 
@@ -1262,24 +1266,24 @@ impl TreeWorkerShadow {
             return;
         };
         let worker_generation = client.worker_generation();
-        let (configuration_generation, assets) = {
+        let (configuration_generation, catalog) = {
             let mut documents = self
                 .open_documents
                 .lock()
                 .recover_poison("TreeWorkerShadow::preload_catalog_async");
-            let Some((configuration_generation, assets)) = documents.catalog.clone() else {
+            let Some((configuration_generation, catalog)) = documents.catalog.clone() else {
                 return;
             };
             if documents.catalog_preload == Some((worker_generation, configuration_generation)) {
                 return;
             }
             documents.catalog_preload = Some((worker_generation, configuration_generation));
-            (configuration_generation, assets)
+            (configuration_generation, catalog)
         };
         spawn_catalog_preload(
             client,
             configuration_generation,
-            assets,
+            catalog,
             Arc::clone(&self.open_documents),
         );
     }
@@ -1564,7 +1568,7 @@ fn shutdown_with_timeout(
 fn spawn_catalog_preload(
     client: Arc<Client>,
     configuration_generation: u64,
-    assets: Vec<WorkerLanguageAsset>,
+    catalog: WorkerLanguageCatalog,
     open_documents: Arc<Mutex<OpenDocuments>>,
 ) {
     let worker_generation = client.worker_generation();
@@ -1579,7 +1583,7 @@ fn spawn_catalog_preload(
     let _ = std::thread::Builder::new()
         .name("kakehashi-worker-catalog".into())
         .spawn(move || {
-            let outcome = client.configure_languages(ConfigureLanguages { context, assets });
+            let outcome = client.configure_languages(ConfigureLanguages { context, catalog });
             if !matches!(outcome, Ok(Response::LanguageCatalogAck(_))) {
                 let mut documents = open_documents
                     .lock()

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -12,11 +12,12 @@ use crate::language::coordinator::WorkerGrammarDescriptor;
 use crate::lsp::text_sync::SequentialByteEdit;
 use crate::tree_worker::{
     ApplyDocumentEditsAndDerive, ByteEdit, CapturesResult, Client, CloseDocument,
-    ConfigureLanguages, DeriveDocumentSnapshot, DeriveInjectionRegions, DeriveSelectionRanges,
-    DeriveSemanticTokens, DerivedSemanticTokens, InjectionRegionsResult, NavigateNode,
-    NodeNavigation, NodeResult, NodeScalarOperation, NodeScalarValue, OpaqueNodeId, RequestContext,
-    ResolveNode, Response, RunCaptures, RunNodeScalar, SelectionRangesResult, SyncDocument,
-    WirePosition, WireRange, WorkerLanguageCatalog, named_node_count,
+    ConfigureLanguages, DeriveDocumentSnapshot, DeriveInjectionRegions, DeriveNativeBindings,
+    DeriveSelectionRanges, DeriveSemanticTokens, DerivedSemanticTokens, InjectionRegionsResult,
+    NativeBindingsFacts, NativeBindingsResult, NavigateNode, NodeNavigation, NodeResult,
+    NodeScalarOperation, NodeScalarValue, OpaqueNodeId, RequestContext, ResolveNode, Response,
+    RunCaptures, RunNodeScalar, SelectionRangesResult, SyncDocument, WirePosition, WireRange,
+    WorkerLanguageCatalog, named_node_count,
 };
 
 use super::Kakehashi;
@@ -56,6 +57,7 @@ struct ReplicaIdentity {
     source_path: PathBuf,
     parser_path: PathBuf,
     artifact_digest: String,
+    queries: crate::tree_worker::WorkerQuerySources,
     configuration_generation: u64,
 }
 
@@ -69,6 +71,7 @@ impl ReplicaIdentity {
             source_path: request.source_path.clone(),
             parser_path: request.parser_path.clone(),
             artifact_digest: request.artifact_digest.clone(),
+            queries: request.queries.clone(),
             configuration_generation: request.context.configuration_generation,
         }
     }
@@ -193,8 +196,10 @@ struct OpenDocuments {
     current: HashMap<String, SyncDocument>,
     closed_incarnations: HashMap<String, u64>,
     acknowledged: HashMap<String, RequestContext>,
+    replica_changed: Arc<tokio::sync::Notify>,
     catalog: Option<(u64, WorkerLanguageCatalog)>,
     catalog_preload: Option<(u64, u64)>,
+    catalog_acknowledged: Option<(u64, u64)>,
 }
 
 struct SupervisorState {
@@ -234,6 +239,11 @@ struct ResyncFailure {
 }
 
 impl OpenDocuments {
+    fn acknowledge(&mut self, context: RequestContext) {
+        self.acknowledged.insert(context.uri.clone(), context);
+        self.replica_changed.notify_waiters();
+    }
+
     fn acknowledges(&self, context: &RequestContext) -> bool {
         self.acknowledged
             .get(&context.uri)
@@ -243,6 +253,14 @@ impl OpenDocuments {
                     && acknowledged.content_version == context.content_version
                     && acknowledged.configuration_generation == context.configuration_generation
             })
+    }
+
+    fn expects(&self, context: &RequestContext) -> bool {
+        self.current.get(&context.uri).is_some_and(|current| {
+            current.context.incarnation == context.incarnation
+                && current.context.content_version == context.content_version
+                && current.context.configuration_generation == context.configuration_generation
+        })
     }
 
     fn supersedes(&self, command: &ShadowCommand) -> bool {
@@ -362,6 +380,7 @@ impl OpenDocuments {
             }
             ShadowCommand::Shutdown(_) => {}
         }
+        self.replica_changed.notify_waiters();
         Observation::Accepted { artifact_replaced }
     }
 
@@ -604,6 +623,36 @@ impl TreeWorkerShadow {
         self.sender.is_some() && self.accepting.load(Ordering::Acquire)
     }
 
+    pub(super) fn needs_document_sync(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        configuration_generation: u64,
+        expected_queries: &crate::tree_worker::WorkerQuerySources,
+    ) -> bool {
+        if !self.is_enabled() {
+            return false;
+        }
+        let documents = self
+            .open_documents
+            .lock()
+            .recover_poison("TreeWorkerShadow::needs_document_sync");
+        let document_stale = documents.current.get(uri.as_str()).is_none_or(|document| {
+            document.context.incarnation != incarnation
+                || document.context.content_version != content_version
+                || document.context.configuration_generation != configuration_generation
+                || &document.queries != expected_queries
+        });
+        let catalog_stale = documents
+            .catalog
+            .as_ref()
+            .is_none_or(|(generation, catalog)| {
+                *generation != configuration_generation || catalog.assets.is_empty()
+            });
+        document_stale || catalog_stale
+    }
+
     pub(super) async fn resolve_node(
         &self,
         uri: &url::Url,
@@ -646,18 +695,9 @@ impl TreeWorkerShadow {
         configuration_generation: u64,
         positions: Vec<WirePosition>,
     ) -> Option<SelectionRangesResult> {
-        self.preload_catalog_async();
-        let client = self.read_client.load_full()?;
-        if !self.is_enabled() {
-            return None;
-        }
-        let context = self.synchronized_read_context(
-            &client,
-            uri,
-            incarnation,
-            content_version,
-            configuration_generation,
-        )?;
+        let (client, context) = self
+            .synchronized_query_read(uri, incarnation, content_version, configuration_generation)
+            .await?;
         let expected = context.clone();
         let response = tokio::task::spawn_blocking(move || {
             client.derive_selection_ranges(DeriveSelectionRanges { context, positions })
@@ -754,18 +794,9 @@ impl TreeWorkerShadow {
         configuration_generation: u64,
         supports_multiline: bool,
     ) -> Option<DerivedSemanticTokens> {
-        self.preload_catalog_async();
-        let client = self.read_client.load_full()?;
-        if !self.is_enabled() {
-            return None;
-        }
-        let context = self.synchronized_read_context(
-            &client,
-            uri,
-            incarnation,
-            content_version,
-            configuration_generation,
-        )?;
+        let (client, context) = self
+            .synchronized_query_read(uri, incarnation, content_version, configuration_generation)
+            .await?;
         let expected = context.clone();
         let response = tokio::task::spawn_blocking(move || {
             client.derive_semantic_tokens(DeriveSemanticTokens {
@@ -843,18 +874,9 @@ impl TreeWorkerShadow {
         range: Option<WireRange>,
         injection: bool,
     ) -> Option<CapturesResult> {
-        self.preload_catalog_async();
-        let client = self.read_client.load_full()?;
-        if !self.is_enabled() {
-            return None;
-        }
-        let context = self.synchronized_read_context(
-            &client,
-            uri,
-            incarnation,
-            content_version,
-            configuration_generation,
-        )?;
+        let (client, context) = self
+            .synchronized_query_read(uri, incarnation, content_version, configuration_generation)
+            .await?;
         let expected = context.clone();
         let response = tokio::task::spawn_blocking(move || {
             client.run_captures(RunCaptures {
@@ -949,6 +971,82 @@ impl TreeWorkerShadow {
                 .insert((uri.as_str().to_string(), authoritative_id), opaque.clone());
             self.worker_nodes
                 .insert((uri.as_str().to_string(), worker_id), opaque);
+        }
+    }
+
+    pub(super) async fn native_bindings(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        configuration_generation: u64,
+        position: WirePosition,
+    ) -> Option<NativeBindingsResult> {
+        let Some((client, context)) = self
+            .synchronized_query_read(uri, incarnation, content_version, configuration_generation)
+            .await
+        else {
+            log::debug!(target: "kakehashi::tree_worker_shadow", "native bindings skipped before worker inputs synchronized uri={uri} version={content_version}");
+            return None;
+        };
+        let expected = context.clone();
+        let response = tokio::task::spawn_blocking(move || {
+            client.derive_native_bindings(DeriveNativeBindings { context, position })
+        })
+        .await;
+        let Ok(Ok(response)) = response else {
+            log::debug!(target: "kakehashi::tree_worker_shadow", "native bindings worker request failed uri={uri}");
+            return None;
+        };
+        let Response::NativeBindings(result) = response else {
+            log::debug!(target: "kakehashi::tree_worker_shadow", "native bindings worker returned a non-bindings response uri={uri}: {response:?}");
+            return None;
+        };
+        if result.context != expected {
+            log::debug!(target: "kakehashi::tree_worker_shadow", "native bindings response context mismatch uri={uri}");
+            return None;
+        }
+        let current = self
+            .open_documents
+            .lock()
+            .recover_poison("TreeWorkerShadow::native_bindings(admission)")
+            .current
+            .get(uri.as_str())
+            .map(|current| current.context.clone());
+        if current.as_ref().is_none_or(|current| {
+            current.incarnation != expected.incarnation
+                || current.content_version != expected.content_version
+                || current.configuration_generation != expected.configuration_generation
+        }) || self
+            .read_client
+            .load()
+            .as_ref()
+            .is_none_or(|client| client.worker_generation() != expected.worker_generation)
+        {
+            log::debug!(target: "kakehashi::tree_worker_shadow", "native bindings response became stale uri={uri} version={content_version}");
+            return None;
+        }
+        Some(result)
+    }
+
+    pub(super) fn compare_native_bindings(
+        &self,
+        uri: &url::Url,
+        content_version: u64,
+        authoritative: Option<&NativeBindingsFacts>,
+        worker: &NativeBindingsResult,
+    ) {
+        if authoritative != worker.facts.as_ref() {
+            log::debug!(
+                target: "kakehashi::tree_worker_shadow",
+                "native bindings mismatch uri={uri} version={content_version} authoritative={authoritative:?} worker={:?}",
+                worker.facts,
+            );
+        } else {
+            log::debug!(
+                target: "kakehashi::tree_worker_shadow",
+                "native bindings matched uri={uri} version={content_version}",
+            );
         }
     }
 
@@ -1404,6 +1502,7 @@ impl TreeWorkerShadow {
             .recover_poison("TreeWorkerShadow::remember_catalog");
         documents.catalog = Some((generation, catalog));
         documents.catalog_preload = None;
+        documents.catalog_acknowledged = None;
     }
 
     fn preload_catalog_async(&self) {
@@ -1555,6 +1654,148 @@ impl TreeWorkerShadow {
             .then_some(context)
     }
 
+    async fn synchronized_query_read(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        configuration_generation: u64,
+    ) -> Option<(Arc<Client>, RequestContext)> {
+        let client = self.read_client_wait().await?;
+        if !self.is_enabled() {
+            return None;
+        }
+        self.preload_catalog_async();
+        if !self
+            .catalog_ready_wait(&client, configuration_generation)
+            .await
+        {
+            return None;
+        }
+        let context = self
+            .synchronized_read_context_wait(
+                &client,
+                uri,
+                incarnation,
+                content_version,
+                configuration_generation,
+            )
+            .await?;
+        Some((client, context))
+    }
+
+    async fn read_client_wait(&self) -> Option<Arc<Client>> {
+        let changed = self
+            .open_documents
+            .lock()
+            .recover_poison("TreeWorkerShadow::read_client_wait(notify)")
+            .replica_changed
+            .clone();
+        loop {
+            let notified = changed.notified();
+            if let Some(client) = self.read_client.load_full() {
+                return Some(client);
+            }
+            if self.disabled.load(Ordering::Acquire)
+                || self.sender.is_none()
+                || tokio::time::timeout(Duration::from_secs(2), notified)
+                    .await
+                    .is_err()
+            {
+                return None;
+            }
+        }
+    }
+
+    async fn catalog_ready_wait(&self, client: &Client, configuration_generation: u64) -> bool {
+        let expected = (client.worker_generation(), configuration_generation);
+        let changed = self
+            .open_documents
+            .lock()
+            .recover_poison("TreeWorkerShadow::catalog_ready_wait(notify)")
+            .replica_changed
+            .clone();
+        loop {
+            let notified = changed.notified();
+            {
+                let documents = self
+                    .open_documents
+                    .lock()
+                    .recover_poison("TreeWorkerShadow::catalog_ready_wait(check)");
+                if documents.catalog_acknowledged == Some(expected) {
+                    return true;
+                }
+                if documents
+                    .catalog
+                    .as_ref()
+                    .is_none_or(|(generation, _)| *generation != configuration_generation)
+                {
+                    return false;
+                }
+            }
+            if !self.is_enabled()
+                || tokio::time::timeout(Duration::from_secs(2), notified)
+                    .await
+                    .is_err()
+            {
+                return false;
+            }
+        }
+    }
+
+    async fn synchronized_read_context_wait(
+        &self,
+        client: &Client,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        configuration_generation: u64,
+    ) -> Option<RequestContext> {
+        let context = self.read_context(
+            client,
+            uri,
+            incarnation,
+            content_version,
+            configuration_generation,
+        );
+        let changed = self
+            .open_documents
+            .lock()
+            .recover_poison("TreeWorkerShadow::synchronized_read_context_wait(notify)")
+            .replica_changed
+            .clone();
+        loop {
+            let notified = changed.notified();
+            {
+                let documents = self
+                    .open_documents
+                    .lock()
+                    .recover_poison("TreeWorkerShadow::synchronized_read_context_wait(check)");
+                if documents.acknowledges(&context) {
+                    return Some(context);
+                }
+                if !documents.expects(&context) {
+                    log::debug!(
+                        target: "kakehashi::tree_worker_shadow",
+                        "read context is not current expected={context:?} current={:?}",
+                        documents
+                            .current
+                            .get(&context.uri)
+                            .map(|document| &document.context),
+                    );
+                    return None;
+                }
+            }
+            if !self.is_enabled()
+                || tokio::time::timeout(Duration::from_secs(2), notified)
+                    .await
+                    .is_err()
+            {
+                return None;
+            }
+        }
+    }
+
     fn admit_node_response(
         &self,
         response: Response,
@@ -1648,7 +1889,7 @@ impl Kakehashi {
                 uri,
                 incarnation,
                 parsed_version,
-                self.cache.semantic_token_generation(),
+                self.language.configuration_generation(),
             )
             .await
         else {
@@ -1732,14 +1973,19 @@ fn spawn_catalog_preload(
         .name("kakehashi-worker-catalog".into())
         .spawn(move || {
             let outcome = client.configure_languages(ConfigureLanguages { context, catalog });
-            if !matches!(outcome, Ok(Response::LanguageCatalogAck(_))) {
-                let mut documents = open_documents
-                    .lock()
-                    .recover_poison("spawn_catalog_preload(error)");
+            let mut documents = open_documents
+                .lock()
+                .recover_poison("spawn_catalog_preload(completion)");
+            if matches!(outcome, Ok(Response::LanguageCatalogAck(_))) {
+                documents.catalog_acknowledged =
+                    Some((worker_generation, configuration_generation));
+                documents.replica_changed.notify_waiters();
+            } else {
                 if documents.catalog_preload == Some((worker_generation, configuration_generation))
                 {
                     documents.catalog_preload = None;
                 }
+                documents.replica_changed.notify_waiters();
                 log::debug!(
                     target: "kakehashi::tree_worker_shadow",
                     "worker catalog preload did not complete: {outcome:?}",
@@ -1798,6 +2044,11 @@ fn run_actor(
     };
     let initial_healthy_since = initial_client.as_ref().map(|_| Instant::now());
     read_client.store(initial_client.clone());
+    open_documents
+        .lock()
+        .recover_poison("run_actor(notify initial client)")
+        .replica_changed
+        .notify_waiters();
     let mut state = SupervisorState {
         client: initial_client,
         read_client,
@@ -2035,8 +2286,7 @@ fn run_actor(
                     .open_documents
                     .lock()
                     .recover_poison("run_actor(acknowledge snapshot)")
-                    .acknowledged
-                    .insert(snapshot.context.uri.clone(), snapshot.context.clone());
+                    .acknowledge(snapshot.context.clone());
                 log::debug!(
                     target: "kakehashi::tree_worker_shadow_metrics",
                     "uri={} version={} parent_us={} queue_us={} compute_us={}",
@@ -2371,12 +2621,14 @@ fn recover_worker(
             }
         };
         state.replicas.clear();
-        state
-            .open_documents
-            .lock()
-            .recover_poison("recover_worker(clear acknowledgements)")
-            .acknowledged
-            .clear();
+        {
+            let mut documents = state
+                .open_documents
+                .lock()
+                .recover_poison("recover_worker(clear acknowledgements)");
+            documents.acknowledged.clear();
+            documents.replica_changed.notify_waiters();
+        }
         match resync_open_documents(
             &replacement,
             generation,
@@ -2389,6 +2641,12 @@ fn recover_worker(
                 state.worker_generation = generation;
                 let replacement = Arc::new(replacement);
                 state.read_client.store(Some(Arc::clone(&replacement)));
+                state
+                    .open_documents
+                    .lock()
+                    .recover_poison("recover_worker(notify replacement client)")
+                    .replica_changed
+                    .notify_waiters();
                 state.client = Some(replacement);
                 let healthy_since = Instant::now();
                 state.healthy_since = Some(healthy_since);
@@ -2545,8 +2803,7 @@ fn resync_open_documents(
                 open_documents
                     .lock()
                     .recover_poison("resync_open_documents(acknowledge snapshot)")
-                    .acknowledged
-                    .insert(snapshot.context.uri.clone(), snapshot.context.clone());
+                    .acknowledge(snapshot.context.clone());
                 comparisons.record(
                     &snapshot.context.uri,
                     snapshot.context.incarnation,
@@ -3413,6 +3670,10 @@ mod tests {
 
         changed = identity.clone();
         changed.configuration_generation += 1;
+        assert!(replica_requires_sync(&replicas, uri.as_str(), &changed));
+
+        changed = identity.clone();
+        changed.queries.bindings = Some("(identifier) @reference".into());
         assert!(replica_requires_sync(&replicas, uri.as_str(), &changed));
 
         replicas.remove(uri.as_str());

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -4,12 +4,14 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::time::{Duration, Instant};
 
+use arc_swap::ArcSwapOption;
+
 use crate::error::LockResultExt;
 use crate::language::coordinator::WorkerGrammarDescriptor;
 use crate::lsp::text_sync::SequentialByteEdit;
 use crate::tree_worker::{
     ApplyDocumentEditsAndDerive, ByteEdit, Client, CloseDocument, DeriveDocumentSnapshot,
-    RequestContext, Response, SyncDocument, named_node_count,
+    NodeResult, RequestContext, ResolveNode, Response, SyncDocument, named_node_count,
 };
 
 const SHADOW_ENV: &str = "KAKEHASHI_TREE_WORKER_SHADOW";
@@ -185,7 +187,8 @@ struct OpenDocuments {
 }
 
 struct SupervisorState {
-    client: Option<Client>,
+    client: Option<Arc<Client>>,
+    read_client: Arc<ArcSwapOption<Client>>,
     worker_generation: u64,
     replicas: HashMap<String, ReplicaIdentity>,
     open_documents: Arc<Mutex<OpenDocuments>>,
@@ -202,6 +205,7 @@ struct ActorShared {
     pending_configuration_generation: Arc<AtomicU64>,
     open_documents: Arc<Mutex<OpenDocuments>>,
     registry_epoch: Arc<AtomicU64>,
+    read_client: Arc<ArcSwapOption<Client>>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -356,6 +360,7 @@ pub(super) struct TreeWorkerShadow {
     pending_configuration_generation: Arc<AtomicU64>,
     open_documents: Arc<Mutex<OpenDocuments>>,
     registry_epoch: Arc<AtomicU64>,
+    read_client: Arc<ArcSwapOption<Client>>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -410,6 +415,7 @@ impl TreeWorkerShadow {
         let pending_configuration_generation = Arc::new(AtomicU64::new(0));
         let open_documents = Arc::new(Mutex::new(OpenDocuments::default()));
         let registry_epoch = Arc::new(AtomicU64::new(0));
+        let read_client = Arc::new(ArcSwapOption::empty());
         let worker_generation = NEXT_WORKER_GENERATION.fetch_add(1, Ordering::Relaxed);
         if !shadow_enabled() {
             return Self {
@@ -422,6 +428,7 @@ impl TreeWorkerShadow {
                 pending_configuration_generation,
                 open_documents,
                 registry_epoch,
+                read_client,
             };
         }
         let executable = match std::env::current_exe() {
@@ -439,6 +446,7 @@ impl TreeWorkerShadow {
                     pending_configuration_generation,
                     open_documents,
                     registry_epoch,
+                    read_client,
                 };
             }
         };
@@ -450,6 +458,7 @@ impl TreeWorkerShadow {
             pending_configuration_generation: Arc::clone(&pending_configuration_generation),
             open_documents: Arc::clone(&open_documents),
             registry_epoch: Arc::clone(&registry_epoch),
+            read_client: Arc::clone(&read_client),
         };
         let spawn = std::thread::Builder::new()
             .name("kakehashi-tree-worker-shadow".into())
@@ -478,6 +487,7 @@ impl TreeWorkerShadow {
                 pending_configuration_generation,
                 open_documents,
                 registry_epoch,
+                read_client,
             };
         }
         accepting.store(true, Ordering::Release);
@@ -495,6 +505,7 @@ impl TreeWorkerShadow {
             pending_configuration_generation,
             open_documents,
             registry_epoch,
+            read_client,
         }
     }
 
@@ -518,6 +529,40 @@ impl TreeWorkerShadow {
 
     pub(super) fn is_configured(&self) -> bool {
         self.sender.is_some() && self.accepting.load(Ordering::Acquire)
+    }
+
+    pub(super) async fn resolve_node(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        configuration_generation: u64,
+        byte_offset: usize,
+        named: bool,
+    ) -> Option<NodeResult> {
+        let client = self.read_client.load_full()?;
+        if !self.is_enabled() {
+            return None;
+        }
+        let context = self.read_context(
+            &client,
+            uri,
+            incarnation,
+            content_version,
+            configuration_generation,
+        );
+        let expected = context.clone();
+        let response = tokio::task::spawn_blocking(move || {
+            client.resolve_node(ResolveNode {
+                context,
+                byte_offset,
+                named,
+            })
+        })
+        .await
+        .ok()?
+        .ok()?;
+        self.admit_node_response(response, &expected)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -699,6 +744,44 @@ impl TreeWorkerShadow {
         }
     }
 
+    fn read_context(
+        &self,
+        client: &Client,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        configuration_generation: u64,
+    ) -> RequestContext {
+        RequestContext {
+            request_id: self.next_request_id.fetch_add(1, Ordering::Relaxed),
+            worker_generation: client.worker_generation(),
+            uri: uri.as_str().to_string(),
+            incarnation,
+            content_version,
+            configuration_generation,
+        }
+    }
+
+    fn admit_node_response(
+        &self,
+        response: Response,
+        expected: &RequestContext,
+    ) -> Option<NodeResult> {
+        let Response::Nodes(result) = response else {
+            return None;
+        };
+        if &result.context != expected
+            || self
+                .read_client
+                .load()
+                .as_ref()
+                .is_none_or(|client| client.worker_generation() != expected.worker_generation)
+        {
+            return None;
+        }
+        Some(result)
+    }
+
     fn submit(&self, command: ShadowCommand) {
         if !self.accepting.load(Ordering::Acquire) {
             return;
@@ -835,17 +918,20 @@ fn run_actor(
         pending_configuration_generation,
         open_documents,
         registry_epoch,
+        read_client,
     } = shared;
     let initial_client = match Client::spawn(&executable, compute_threads, worker_generation) {
-        Ok(client) => Some(client),
+        Ok(client) => Some(Arc::new(client)),
         Err(error) => {
             log::error!(target: "kakehashi::tree_worker_shadow", "worker spawn failed: {error}");
             None
         }
     };
     let initial_healthy_since = initial_client.as_ref().map(|_| Instant::now());
+    read_client.store(initial_client.clone());
     let mut state = SupervisorState {
         client: initial_client,
+        read_client,
         worker_generation,
         replicas: HashMap::new(),
         open_documents,
@@ -1163,9 +1249,7 @@ fn run_actor(
             }
         }
     }
-    if let Some(client) = state.client
-        && let Err(error) = client.shutdown()
-    {
+    if let Err(error) = retire_client(&mut state) {
         log::warn!(target: "kakehashi::tree_worker_shadow", "worker shutdown failed: {error}");
     }
     if let Some(ack) = shutdown_ack {
@@ -1254,14 +1338,26 @@ fn breaker_probe_allowed(state: BreakerState, generation: u64, now: Instant) -> 
     )
 }
 
+fn retire_client(state: &mut SupervisorState) -> std::io::Result<()> {
+    state.read_client.store(None);
+    let Some(client) = state.client.take() else {
+        return Ok(());
+    };
+    match Arc::try_unwrap(client) {
+        Ok(client) => client.shutdown(),
+        Err(client) => {
+            client.terminate_shared(SHADOW_SHUTDOWN_TIMEOUT);
+            Ok(())
+        }
+    }
+}
+
 fn mark_tree_tier_unavailable(
     state: &mut SupervisorState,
     disabled: &AtomicBool,
     pending_configuration_generation: &AtomicU64,
 ) {
-    if let Some(client) = state.client.take()
-        && let Err(error) = client.shutdown()
-    {
+    if let Err(error) = retire_client(state) {
         log::warn!(target: "kakehashi::tree_worker_shadow", "failed worker cleanup while opening breaker: {error}");
     }
     state.healthy_since = None;
@@ -1375,9 +1471,7 @@ fn recover_worker(
             );
             return false;
         }
-        if let Some(old_client) = state.client.take()
-            && let Err(error) = old_client.shutdown()
-        {
+        if let Err(error) = retire_client(state) {
             log::warn!(target: "kakehashi::tree_worker_shadow", "failed worker cleanup: {error}");
         }
         if charged {
@@ -1410,6 +1504,8 @@ fn recover_worker(
         ) {
             Ok(resynced) => {
                 state.worker_generation = generation;
+                let replacement = Arc::new(replacement);
+                state.read_client.store(Some(Arc::clone(&replacement)));
                 state.client = Some(replacement);
                 let healthy_since = Instant::now();
                 state.healthy_since = Some(healthy_since);
@@ -1424,7 +1520,7 @@ fn recover_worker(
                 return true;
             }
             Err(failure) => {
-                state.client = Some(replacement);
+                state.client = Some(Arc::new(replacement));
                 if let Some(grammar) = failure.implicated_grammar {
                     quarantine_grammar(state, grammar, failure.class, comparisons);
                 }
@@ -1901,6 +1997,7 @@ mod tests {
             pending_configuration_generation: Arc::new(AtomicU64::new(0)),
             open_documents: Arc::new(Mutex::new(OpenDocuments::default())),
             registry_epoch: Arc::new(AtomicU64::new(0)),
+            read_client: Arc::new(ArcSwapOption::empty()),
         }
     }
 
@@ -2204,6 +2301,7 @@ mod tests {
         let started = Instant::now();
         let mut state = SupervisorState {
             client: None,
+            read_client: Arc::new(ArcSwapOption::empty()),
             worker_generation: 1,
             replicas: HashMap::new(),
             open_documents: Arc::new(Mutex::new(OpenDocuments::default())),

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -22,7 +22,7 @@ use sha2::{Digest, Sha256};
 
 use crate::language::node_tracker::{EditInfo, NodeTracker};
 
-pub const PROTOCOL_VERSION: u32 = 10;
+pub const PROTOCOL_VERSION: u32 = 11;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_REPLICAS: usize = 4_096;
 pub const MAX_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
@@ -174,6 +174,12 @@ pub struct RunCaptures {
     pub injection: bool,
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DeriveNativeBindings {
+    pub context: RequestContext,
+    pub position: WirePosition,
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NodeScalarOperation {
@@ -268,6 +274,12 @@ pub struct WireRange {
     pub end: WirePosition,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct WireByteRange {
+    pub start: usize,
+    pub end: usize,
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct WireSelectionRange {
     pub range: WireRange,
@@ -353,6 +365,20 @@ pub struct CapturesResult {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct NativeBindingsFacts {
+    pub identifier: Option<WireByteRange>,
+    pub definition: Option<WireByteRange>,
+    pub references: Vec<WireByteRange>,
+    pub definitions: Vec<WireByteRange>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct NativeBindingsResult {
+    pub context: RequestContext,
+    pub facts: Option<NativeBindingsFacts>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct LanguageCatalogAck {
     pub context: RequestContext,
     pub languages: usize,
@@ -396,6 +422,7 @@ pub enum Request {
     DeriveInjectionRegions(DeriveInjectionRegions),
     DeriveSemanticTokens(DeriveSemanticTokens),
     RunCaptures(RunCaptures),
+    DeriveNativeBindings(DeriveNativeBindings),
     ConfigureLanguages(ConfigureLanguages),
     CloseDocument(CloseDocument),
 }
@@ -442,6 +469,7 @@ pub enum Response {
     InjectionRegions(InjectionRegionsResult),
     SemanticTokens(DerivedSemanticTokens),
     Captures(CapturesResult),
+    NativeBindings(NativeBindingsResult),
     LanguageCatalogAck(LanguageCatalogAck),
     Error(WorkerError),
 }
@@ -989,6 +1017,105 @@ impl DocumentReplica {
         })
     }
 
+    fn derive_native_bindings(
+        &self,
+        request: DeriveNativeBindings,
+    ) -> Result<NativeBindingsResult, String> {
+        self.validate_read_identity(&request.context)?;
+        worker_analysis(
+            &self.analysis,
+            &self.language,
+            self.grammar_language.clone(),
+            self.queries.clone(),
+            WorkerQuerySet::Bindings,
+        )?;
+        let position = tower_lsp_server::ls_types::Position::new(
+            request.position.line,
+            request.position.character,
+        );
+        let Some(byte) =
+            crate::text::PositionMapper::new(&self.text).position_to_byte_strict(position)
+        else {
+            return Ok(NativeBindingsResult {
+                context: request.context,
+                facts: None,
+            });
+        };
+        let Some((query, layer_text, layer_tree, layer_offset)) = self.native_bindings_inputs(byte)
+        else {
+            return Ok(NativeBindingsResult {
+                context: request.context,
+                facts: None,
+            });
+        };
+        let cancel = AtomicBool::new(false);
+        let facts = crate::analysis::bindings::collect::collect_cancellable(
+            &layer_text,
+            layer_tree.root_node(),
+            &query,
+            &cancel,
+        )
+        .map(crate::analysis::bindings::model::BindingsModel::build)
+        .map(|model| native_bindings_facts(&model, byte - layer_offset, layer_offset));
+        Ok(NativeBindingsResult {
+            context: request.context,
+            facts,
+        })
+    }
+
+    fn native_bindings_inputs(
+        &self,
+        byte: usize,
+    ) -> Option<(Arc<tree_sitter::Query>, Arc<str>, tree_sitter::Tree, usize)> {
+        use crate::language::injection::{
+            collect_all_injections, compute_included_ranges, parse_with_ranges,
+        };
+
+        if let Some(injection_query) = self.analysis.injection_query(&self.language)
+            && let Some(regions) =
+                collect_all_injections(&self.tree.root_node(), &self.text, Some(&injection_query))
+            && let Some(region) = regions
+                .iter()
+                .filter(|region| {
+                    region.content_node.start_byte() <= byte
+                        && byte < region.content_node.end_byte()
+                })
+                .min_by_key(|region| {
+                    region.content_node.end_byte() - region.content_node.start_byte()
+                })
+        {
+            if region.offset.is_some() {
+                return None;
+            }
+            let content_range = region.content_node.byte_range();
+            let content_text = self.text.get(content_range.clone()).map(Arc::<str>::from)?;
+            let (layer_language, load) = self
+                .analysis
+                .resolve_injection_language(&region.language, &content_text)?;
+            if !load.success {
+                return None;
+            }
+            let included_ranges =
+                compute_included_ranges(&region.content_node, region.include_children);
+            let mut parser_pool = self.analysis.create_document_parser_pool();
+            let mut parser = parser_pool.acquire(&layer_language)?;
+            let layer_tree = parse_with_ranges(
+                &mut parser,
+                &content_text,
+                included_ranges.as_deref(),
+                "kakehashi::tree_worker",
+                &layer_language,
+            );
+            parser_pool.release(layer_language.clone(), parser);
+            let layer_tree = layer_tree?;
+            let query = self.analysis.bindings_query(&layer_language)?;
+            return Some((query, content_text, layer_tree, content_range.start));
+        }
+
+        let query = self.analysis.bindings_query(&self.language)?;
+        Some((query, Arc::from(self.text.as_str()), self.tree.clone(), 0))
+    }
+
     fn tracked_node<'tree>(
         &'tree self,
         node_id: &OpaqueNodeId,
@@ -1066,6 +1193,7 @@ impl DocumentReplica {
         context: &RequestContext,
         language: &str,
         grammar_key: &GrammarKey,
+        queries: &WorkerQuerySources,
     ) -> Result<(), String> {
         if context.worker_generation != self.context.worker_generation
             || context.uri != self.context.uri
@@ -1092,6 +1220,7 @@ impl DocumentReplica {
             }
             if context.configuration_generation == self.context.configuration_generation
                 && context.content_version == self.context.content_version
+                && queries == &self.queries
             {
                 return Err("full sync must advance the content version".into());
             }
@@ -1118,6 +1247,7 @@ fn selection_range_to_wire(
 enum WorkerQuerySet {
     Injections,
     Semantic,
+    Bindings,
     All,
 }
 
@@ -1152,6 +1282,11 @@ fn worker_analysis(
                 crate::config::settings::QueryKind::Highlights
                     | crate::config::settings::QueryKind::Injections
             ),
+            WorkerQuerySet::Bindings => matches!(
+                kind,
+                crate::config::settings::QueryKind::Bindings
+                    | crate::config::settings::QueryKind::Injections
+            ),
             WorkerQuerySet::All => true,
         };
         if !selected {
@@ -1177,6 +1312,47 @@ fn worker_analysis(
         );
     }
     Ok(())
+}
+
+fn native_bindings_facts(
+    model: &crate::analysis::bindings::model::BindingsModel,
+    byte: usize,
+    layer_offset: usize,
+) -> NativeBindingsFacts {
+    let to_wire = |range: std::ops::Range<usize>| WireByteRange {
+        start: range.start + layer_offset,
+        end: range.end + layer_offset,
+    };
+    let identifier = model.resolvable_identifier_at(byte).map(&to_wire);
+    let definition = model.definition_range_at(byte).map(&to_wire);
+    let Some(binding) = model.binding_at(byte) else {
+        return NativeBindingsFacts {
+            identifier,
+            definition,
+            references: Vec::new(),
+            definitions: Vec::new(),
+        };
+    };
+    let mut references = model
+        .references_resolving_to(binding)
+        .into_iter()
+        .map(&to_wire)
+        .collect::<Vec<_>>();
+    let mut definitions = model
+        .sites(binding)
+        .iter()
+        .map(|site| to_wire(site.byte_range.clone()))
+        .collect::<Vec<_>>();
+    references.sort_by_key(|range| (range.start, range.end));
+    references.dedup();
+    definitions.sort_by_key(|range| (range.start, range.end));
+    definitions.dedup();
+    NativeBindingsFacts {
+        identifier,
+        definition,
+        references,
+        definitions,
+    }
 }
 
 fn validate_document_size(bytes: usize) -> Result<(), String> {
@@ -1475,8 +1651,12 @@ impl LocalDocumentReplica {
         let grammar_key = GrammarKey::from_sync(&request);
         let Self { state, replica } = self;
         if let Some(existing) = replica.as_ref()
-            && let Err(message) =
-                existing.validate_replacement(&context, &request.language, &grammar_key)
+            && let Err(message) = existing.validate_replacement(
+                &context,
+                &request.language,
+                &grammar_key,
+                &request.queries,
+            )
         {
             return Response::Error(WorkerError {
                 context: Some(context),
@@ -1824,6 +2004,7 @@ fn handle_work(
         Request::DeriveInjectionRegions(request) => derive_injection_regions(request, documents),
         Request::DeriveSemanticTokens(request) => derive_semantic_tokens(request, documents),
         Request::RunCaptures(request) => run_captures(request, documents),
+        Request::DeriveNativeBindings(request) => derive_native_bindings(request, documents),
         Request::ConfigureLanguages(request) => configure_languages(request, analysis),
         Request::CloseDocument(request) => close_document(
             request,
@@ -1853,6 +2034,7 @@ fn request_context(request: &Request) -> Option<&RequestContext> {
         Request::DeriveInjectionRegions(request) => Some(&request.context),
         Request::DeriveSemanticTokens(request) => Some(&request.context),
         Request::RunCaptures(request) => Some(&request.context),
+        Request::DeriveNativeBindings(request) => Some(&request.context),
         Request::ConfigureLanguages(request) => Some(&request.context),
         Request::CloseDocument(request) => Some(&request.context),
     }
@@ -1871,6 +2053,7 @@ fn document_key(request: &Request) -> Option<DocumentKey> {
         Request::DeriveInjectionRegions(request) => Some(DocumentKey::from(&request.context)),
         Request::DeriveSemanticTokens(request) => Some(DocumentKey::from(&request.context)),
         Request::RunCaptures(request) => Some(DocumentKey::from(&request.context)),
+        Request::DeriveNativeBindings(request) => Some(DocumentKey::from(&request.context)),
         Request::CloseDocument(request) => Some(DocumentKey::from(&request.context)),
         Request::Handshake(_) | Request::DeriveSnapshot(_) | Request::ConfigureLanguages(_) => None,
     }
@@ -2040,6 +2223,29 @@ fn run_captures(request: RunCaptures, documents: &DocumentStore) -> Response {
     }
 }
 
+fn derive_native_bindings(request: DeriveNativeBindings, documents: &DocumentStore) -> Response {
+    let context = request.context.clone();
+    let Some(replica) = documents
+        .get(&DocumentKey::from(&context))
+        .map(|entry| Arc::clone(entry.value()))
+    else {
+        return Response::Error(WorkerError {
+            context: Some(context),
+            message: "document replica is missing; full sync required".into(),
+        });
+    };
+    match replica.lock() {
+        Ok(replica) => match replica.derive_native_bindings(request) {
+            Ok(result) => Response::NativeBindings(result),
+            Err(message) => Response::Error(WorkerError {
+                context: Some(context),
+                message,
+            }),
+        },
+        Err(_) => poisoned_document_restart(context),
+    }
+}
+
 fn configure_languages(
     request: ConfigureLanguages,
     analysis: &Arc<crate::language::LanguageCoordinator>,
@@ -2146,7 +2352,12 @@ fn sync_document_with_analysis(
     {
         match existing.lock() {
             Ok(replica) => {
-                match replica.validate_replacement(&context, &request.language, &grammar_key) {
+                match replica.validate_replacement(
+                    &context,
+                    &request.language,
+                    &grammar_key,
+                    &request.queries,
+                ) {
                     Ok(()) => replica.text.len(),
                     Err(message) => {
                         return Response::Error(WorkerError {
@@ -3015,6 +3226,15 @@ impl Client {
         )
     }
 
+    pub fn derive_native_bindings(&self, request: DeriveNativeBindings) -> io::Result<Response> {
+        let context = request.context.clone();
+        self.request_with_timeout(
+            Request::DeriveNativeBindings(request),
+            context,
+            Duration::from_secs(60),
+        )
+    }
+
     pub fn configure_languages(&self, request: ConfigureLanguages) -> io::Result<Response> {
         let context = request.context.clone();
         self.request_with_timeout(
@@ -3194,6 +3414,7 @@ fn response_request_id(response: &Response) -> Option<u64> {
         Response::InjectionRegions(result) => Some(result.context.request_id),
         Response::SemanticTokens(result) => Some(result.context.request_id),
         Response::Captures(result) => Some(result.context.request_id),
+        Response::NativeBindings(result) => Some(result.context.request_id),
         Response::LanguageCatalogAck(ack) => Some(ack.context.request_id),
         Response::Error(error) => error.context.as_ref().map(|context| context.request_id),
         Response::HandshakeReady(_) => None,
@@ -3212,6 +3433,7 @@ fn response_context(response: &Response) -> Option<&RequestContext> {
         Response::InjectionRegions(result) => Some(&result.context),
         Response::SemanticTokens(result) => Some(&result.context),
         Response::Captures(result) => Some(&result.context),
+        Response::NativeBindings(result) => Some(&result.context),
         Response::LanguageCatalogAck(ack) => Some(&ack.context),
         Response::Error(error) => error.context.as_ref(),
         Response::HandshakeReady(_) => None,
@@ -3324,15 +3546,16 @@ mod tests {
 
     use super::{
         ApplyDocumentEdits, BUILD_ID, ByteEdit, CloseDocument, DeriveInjectionRegions,
-        DeriveSelectionRanges, DeriveSemanticTokens, DeriveSnapshot, DocumentKey, DocumentLane,
-        DocumentReplica, GrammarKey, Handshake, HandshakeReady, LaneAction, LaneRegistry,
-        MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS, MAX_RETAINED_DOCUMENT_BYTES, NavigateNode,
-        NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION,
-        Request, RequestContext, ResolveNode, Response, Route, RunCaptures, RunNodeScalar,
-        SyncDocument, WirePosition, WireRange, WorkerError, WorkerQuerySources, close_document,
-        decode_frame, derive_snapshot_with_language, encode_frame, named_node_count,
-        replace_retained_bytes, reserve_retained_growth, route_response, run, submit_document_job,
-        sync_document, terminate_by_transport, validate_document_size,
+        DeriveNativeBindings, DeriveSelectionRanges, DeriveSemanticTokens, DeriveSnapshot,
+        DocumentKey, DocumentLane, DocumentReplica, GrammarKey, Handshake, HandshakeReady,
+        LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
+        MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeNavigation, NodeScalarOperation,
+        NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION, Request, RequestContext, ResolveNode,
+        Response, Route, RunCaptures, RunNodeScalar, SyncDocument, WireByteRange, WirePosition,
+        WireRange, WorkerError, WorkerQuerySources, close_document, decode_frame,
+        derive_snapshot_with_language, encode_frame, named_node_count, replace_retained_bytes,
+        reserve_retained_growth, route_response, run, submit_document_job, sync_document,
+        terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -4289,6 +4512,135 @@ mod tests {
     }
 
     #[test]
+    fn native_bindings_are_resolved_from_the_worker_owned_tree() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let context = RequestContext {
+            request_id: 1,
+            worker_generation: 3,
+            uri: "file:///bindings.rs".into(),
+            incarnation: 4,
+            content_version: 1,
+            configuration_generation: 2,
+        };
+        let (replica, _) = DocumentReplica::sync(
+            SyncDocument {
+                context: context.clone(),
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: "/unused/static-language".into(),
+                parser_path: "/unused/static-language".into(),
+                artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources {
+                    bindings: Some(
+                        r#"
+                        (block) @scope
+                        (let_declaration pattern: (identifier) @definition)
+                        (identifier) @reference
+                        "#
+                        .into(),
+                    ),
+                    ..WorkerQuerySources::default()
+                },
+                text: "fn main() { let target = 1; target; }".into(),
+            },
+            &mut parser,
+        )
+        .unwrap();
+
+        let result = replica
+            .derive_native_bindings(DeriveNativeBindings {
+                context,
+                position: WirePosition {
+                    line: 0,
+                    character: 28,
+                },
+            })
+            .unwrap();
+        let facts = result.facts.expect("reference must resolve");
+
+        assert_eq!(facts.definition, Some(WireByteRange { start: 16, end: 22 }));
+        assert_eq!(facts.references, vec![WireByteRange { start: 28, end: 34 }]);
+        assert_eq!(
+            facts.definitions,
+            vec![WireByteRange { start: 16, end: 22 }]
+        );
+    }
+
+    #[test]
+    fn native_bindings_are_resolved_in_the_innermost_injected_layer() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_md::LANGUAGE.into())
+            .unwrap();
+        let context = RequestContext {
+            request_id: 1,
+            worker_generation: 3,
+            uri: "file:///bindings.md".into(),
+            incarnation: 4,
+            content_version: 1,
+            configuration_generation: 2,
+        };
+        let analysis = Arc::new(crate::language::LanguageCoordinator::new());
+        super::worker_analysis(
+            &analysis,
+            "lua",
+            tree_sitter_lua::LANGUAGE.into(),
+            WorkerQuerySources {
+                bindings: Some(include_str!("../assets/queries/lua/bindings.scm").into()),
+                ..WorkerQuerySources::default()
+            },
+            super::WorkerQuerySet::Bindings,
+        )
+        .unwrap();
+        let (replica, _) = DocumentReplica::sync_with_analysis(
+            SyncDocument {
+                context: context.clone(),
+                language: "markdown".into(),
+                grammar_symbol: "markdown".into(),
+                source_path: "/unused/static-language".into(),
+                parser_path: "/unused/static-language".into(),
+                artifact_digest: "sha256:markdown-v1".into(),
+                queries: WorkerQuerySources {
+                    injections: Some(
+                        r#"
+                        (fenced_code_block
+                          (info_string (language) @injection.language)
+                          (code_fence_content) @injection.content)
+                        "#
+                        .into(),
+                    ),
+                    ..WorkerQuerySources::default()
+                },
+                text: "# t\n\n```lua\nlocal v = 1\nprint(v)\n```\n".into(),
+            },
+            &mut parser,
+            analysis,
+        )
+        .unwrap();
+
+        let result = replica
+            .derive_native_bindings(DeriveNativeBindings {
+                context,
+                position: WirePosition {
+                    line: 4,
+                    character: 6,
+                },
+            })
+            .unwrap();
+        let facts = result.facts.expect("injected reference must resolve");
+
+        assert_eq!(facts.definition, Some(WireByteRange { start: 18, end: 19 }));
+        assert_eq!(facts.references, vec![WireByteRange { start: 30, end: 31 }]);
+        assert_eq!(
+            facts.definitions,
+            vec![WireByteRange { start: 18, end: 19 }]
+        );
+    }
+
+    #[test]
     fn captures_are_derived_from_worker_owned_tree_and_query_paths() {
         let directory = tempfile::tempdir().unwrap();
         let query_dir = directory.path().join("queries/rust");
@@ -4421,9 +4773,68 @@ mod tests {
 
         assert!(
             replica
-                .validate_replacement(&stale, &replica.language, &replica.grammar_key)
+                .validate_replacement(
+                    &stale,
+                    &replica.language,
+                    &replica.grammar_key,
+                    &replica.queries,
+                )
                 .unwrap_err()
                 .contains("stale content version")
+        );
+    }
+
+    #[test]
+    fn document_replica_allows_same_version_query_asset_refresh() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let context = RequestContext {
+            request_id: 1,
+            worker_generation: 3,
+            uri: "file:///query-refresh.rs".into(),
+            incarnation: 4,
+            content_version: 3,
+            configuration_generation: 2,
+        };
+        let (replica, _) = DocumentReplica::sync(
+            SyncDocument {
+                context: context.clone(),
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: "/unused/static-language".into(),
+                parser_path: "/unused/static-language".into(),
+                artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
+                text: "fn current() {}".into(),
+            },
+            &mut parser,
+        )
+        .unwrap();
+        let refreshed = WorkerQuerySources {
+            bindings: Some("(identifier) @reference".into()),
+            ..WorkerQuerySources::default()
+        };
+
+        replica
+            .validate_replacement(
+                &context,
+                &replica.language,
+                &replica.grammar_key,
+                &refreshed,
+            )
+            .expect("query-only refresh must be accepted at the same content version");
+        assert!(
+            replica
+                .validate_replacement(
+                    &context,
+                    &replica.language,
+                    &replica.grammar_key,
+                    &replica.queries,
+                )
+                .unwrap_err()
+                .contains("must advance")
         );
     }
 
@@ -4461,7 +4872,12 @@ mod tests {
 
         assert!(
             replica
-                .validate_replacement(&replacement, "python", &replica.grammar_key)
+                .validate_replacement(
+                    &replacement,
+                    "python",
+                    &replica.grammar_key,
+                    &replica.queries,
+                )
                 .unwrap_err()
                 .contains("language change")
         );
@@ -4471,7 +4887,7 @@ mod tests {
             artifact_digest: "sha256:rust-v1".into(),
         };
         replica
-            .validate_replacement(&replacement, "rust", &alias_grammar)
+            .validate_replacement(&replacement, "rust", &alias_grammar, &replica.queries)
             .unwrap();
 
         let different_grammar = GrammarKey {
@@ -4481,7 +4897,7 @@ mod tests {
         };
         assert!(
             replica
-                .validate_replacement(&replacement, "rust", &different_grammar)
+                .validate_replacement(&replacement, "rust", &different_grammar, &replica.queries,)
                 .unwrap_err()
                 .contains("grammar change")
         );

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -73,10 +73,17 @@ pub struct WorkerLanguageAsset {
     pub queries: WorkerQuerySources,
 }
 
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct WorkerLanguageCatalog {
+    pub assets: Vec<WorkerLanguageAsset>,
+    pub search_paths: Vec<PathBuf>,
+    pub capture_mappings: crate::config::settings::CaptureMappings,
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConfigureLanguages {
     pub context: RequestContext,
-    pub assets: Vec<WorkerLanguageAsset>,
+    pub catalog: WorkerLanguageCatalog,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -1953,8 +1960,12 @@ fn configure_languages(
     analysis: &Arc<crate::language::LanguageCoordinator>,
 ) -> Response {
     let context = request.context;
+    analysis.configure_worker_runtime(
+        request.catalog.search_paths,
+        request.catalog.capture_mappings,
+    );
     let mut configured = 0;
-    for asset in request.assets {
+    for asset in request.catalog.assets {
         let key = GrammarKey::from_asset(&asset);
         let language_name = asset.language;
         let queries = asset.queries;

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -22,7 +22,7 @@ use sha2::{Digest, Sha256};
 
 use crate::language::node_tracker::{EditInfo, NodeTracker};
 
-pub const PROTOCOL_VERSION: u32 = 8;
+pub const PROTOCOL_VERSION: u32 = 9;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_REPLICAS: usize = 4_096;
 pub const MAX_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
@@ -151,6 +151,12 @@ pub struct DeriveSelectionRanges {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct DeriveInjectionRegions {
     pub context: RequestContext,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DeriveSemanticTokens {
+    pub context: RequestContext,
+    pub supports_multiline: bool,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -309,6 +315,21 @@ pub struct InjectionRegionsResult {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DerivedSemanticTokens {
+    pub context: RequestContext,
+    pub tokens: Vec<WireSemanticToken>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct WireSemanticToken {
+    pub delta_line: u32,
+    pub delta_start: u32,
+    pub length: u32,
+    pub token_type: u32,
+    pub token_modifiers_bitset: u32,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct LanguageCatalogAck {
     pub context: RequestContext,
     pub languages: usize,
@@ -350,6 +371,7 @@ pub enum Request {
     RunNodeScalar(RunNodeScalar),
     DeriveSelectionRanges(DeriveSelectionRanges),
     DeriveInjectionRegions(DeriveInjectionRegions),
+    DeriveSemanticTokens(DeriveSemanticTokens),
     ConfigureLanguages(ConfigureLanguages),
     CloseDocument(CloseDocument),
 }
@@ -394,6 +416,7 @@ pub enum Response {
     NodeScalar(NodeScalarResult),
     SelectionRanges(SelectionRangesResult),
     InjectionRegions(InjectionRegionsResult),
+    SemanticTokens(DerivedSemanticTokens),
     LanguageCatalogAck(LanguageCatalogAck),
     Error(WorkerError),
 }
@@ -407,6 +430,8 @@ struct DocumentReplica {
     uri: url::Url,
     node_tracker: NodeTracker,
     analysis: Arc<crate::language::LanguageCoordinator>,
+    grammar_language: tree_sitter::Language,
+    queries: WorkerQuerySources,
 }
 
 impl DocumentReplica {
@@ -450,9 +475,9 @@ impl DocumentReplica {
         worker_analysis(
             &analysis,
             &request.language,
-            grammar_language,
-            request.queries,
-            false,
+            grammar_language.clone(),
+            request.queries.clone(),
+            WorkerQuerySet::Injections,
         )?;
         Ok((
             Self {
@@ -464,6 +489,8 @@ impl DocumentReplica {
                 uri,
                 node_tracker,
                 analysis,
+                grammar_language,
+                queries: request.queries,
             },
             ack,
         ))
@@ -848,6 +875,54 @@ impl DocumentReplica {
         })
     }
 
+    fn derive_semantic_tokens(
+        &self,
+        request: DeriveSemanticTokens,
+    ) -> Result<DerivedSemanticTokens, String> {
+        self.validate_read_identity(&request.context)?;
+        worker_analysis(
+            &self.analysis,
+            &self.language,
+            self.grammar_language.clone(),
+            self.queries.clone(),
+            WorkerQuerySet::Semantic,
+        )?;
+        let query = self
+            .analysis
+            .highlight_query(&self.language)
+            .ok_or_else(|| "worker highlight query is unavailable".to_string())?;
+        let result = crate::analysis::compute_semantic_tokens_full(
+            rayon::current_num_threads(),
+            Arc::from(self.text.as_str()),
+            self.tree.clone(),
+            query,
+            Some(self.language.clone()),
+            Some(self.analysis.capture_mappings()),
+            Arc::clone(&self.analysis),
+            request.supports_multiline,
+            None,
+            None,
+        )
+        .ok_or_else(|| "worker semantic token derivation was cancelled".to_string())?;
+        let tokens = match result {
+            tower_lsp_server::ls_types::SemanticTokensResult::Tokens(tokens) => tokens.data,
+            tower_lsp_server::ls_types::SemanticTokensResult::Partial(partial) => partial.data,
+        }
+        .into_iter()
+        .map(|token| WireSemanticToken {
+            delta_line: token.delta_line,
+            delta_start: token.delta_start,
+            length: token.length,
+            token_type: token.token_type,
+            token_modifiers_bitset: token.token_modifiers_bitset,
+        })
+        .collect();
+        Ok(DerivedSemanticTokens {
+            context: request.context,
+            tokens,
+        })
+    }
+
     fn tracked_node<'tree>(
         &'tree self,
         node_id: &OpaqueNodeId,
@@ -973,12 +1048,19 @@ fn selection_range_to_wire(
     }
 }
 
+#[derive(Clone, Copy)]
+enum WorkerQuerySet {
+    Injections,
+    Semantic,
+    All,
+}
+
 fn worker_analysis(
     analysis: &crate::language::LanguageCoordinator,
     language_name: &str,
     language: tree_sitter::Language,
     queries: WorkerQuerySources,
-    compile_all_queries: bool,
+    query_set: WorkerQuerySet,
 ) -> Result<(), String> {
     analysis
         .language_registry_for_parallel()
@@ -997,7 +1079,16 @@ fn worker_analysis(
             queries.injections,
         ),
     ] {
-        if !compile_all_queries && kind != crate::config::settings::QueryKind::Injections {
+        let selected = match query_set {
+            WorkerQuerySet::Injections => kind == crate::config::settings::QueryKind::Injections,
+            WorkerQuerySet::Semantic => matches!(
+                kind,
+                crate::config::settings::QueryKind::Highlights
+                    | crate::config::settings::QueryKind::Injections
+            ),
+            WorkerQuerySet::All => true,
+        };
+        if !selected {
             continue;
         }
         let Some(source) = source else {
@@ -1665,6 +1756,7 @@ fn handle_work(
         Request::RunNodeScalar(request) => run_node_scalar(request, documents),
         Request::DeriveSelectionRanges(request) => derive_selection_ranges(request, documents),
         Request::DeriveInjectionRegions(request) => derive_injection_regions(request, documents),
+        Request::DeriveSemanticTokens(request) => derive_semantic_tokens(request, documents),
         Request::ConfigureLanguages(request) => configure_languages(request, analysis),
         Request::CloseDocument(request) => close_document(
             request,
@@ -1692,6 +1784,7 @@ fn request_context(request: &Request) -> Option<&RequestContext> {
         Request::RunNodeScalar(request) => Some(&request.context),
         Request::DeriveSelectionRanges(request) => Some(&request.context),
         Request::DeriveInjectionRegions(request) => Some(&request.context),
+        Request::DeriveSemanticTokens(request) => Some(&request.context),
         Request::ConfigureLanguages(request) => Some(&request.context),
         Request::CloseDocument(request) => Some(&request.context),
     }
@@ -1708,6 +1801,7 @@ fn document_key(request: &Request) -> Option<DocumentKey> {
         Request::RunNodeScalar(request) => Some(DocumentKey::from(&request.context)),
         Request::DeriveSelectionRanges(request) => Some(DocumentKey::from(&request.context)),
         Request::DeriveInjectionRegions(request) => Some(DocumentKey::from(&request.context)),
+        Request::DeriveSemanticTokens(request) => Some(DocumentKey::from(&request.context)),
         Request::CloseDocument(request) => Some(DocumentKey::from(&request.context)),
         Request::Handshake(_) | Request::DeriveSnapshot(_) | Request::ConfigureLanguages(_) => None,
     }
@@ -1831,6 +1925,29 @@ fn derive_injection_regions(
     }
 }
 
+fn derive_semantic_tokens(request: DeriveSemanticTokens, documents: &DocumentStore) -> Response {
+    let context = request.context.clone();
+    let Some(replica) = documents
+        .get(&DocumentKey::from(&context))
+        .map(|entry| Arc::clone(entry.value()))
+    else {
+        return Response::Error(WorkerError {
+            context: Some(context),
+            message: "document replica is missing; full sync required".into(),
+        });
+    };
+    match replica.lock() {
+        Ok(replica) => match replica.derive_semantic_tokens(request) {
+            Ok(result) => Response::SemanticTokens(result),
+            Err(message) => Response::Error(WorkerError {
+                context: Some(context),
+                message,
+            }),
+        },
+        Err(_) => poisoned_document_restart(context),
+    }
+}
+
 fn configure_languages(
     request: ConfigureLanguages,
     analysis: &Arc<crate::language::LanguageCoordinator>,
@@ -1852,7 +1969,13 @@ fn configure_languages(
                             message: "parser has no configured language".into(),
                         });
                     };
-                    match worker_analysis(analysis, &language_name, language, queries, true) {
+                    match worker_analysis(
+                        analysis,
+                        &language_name,
+                        language,
+                        queries,
+                        WorkerQuerySet::All,
+                    ) {
                         Ok(()) => Response::LanguageCatalogAck(LanguageCatalogAck {
                             context: context.clone(),
                             languages: configured + 1,
@@ -2778,6 +2901,15 @@ impl Client {
         )
     }
 
+    pub fn derive_semantic_tokens(&self, request: DeriveSemanticTokens) -> io::Result<Response> {
+        let context = request.context.clone();
+        self.request_with_timeout(
+            Request::DeriveSemanticTokens(request),
+            context,
+            Duration::from_secs(60),
+        )
+    }
+
     pub fn configure_languages(&self, request: ConfigureLanguages) -> io::Result<Response> {
         let context = request.context.clone();
         self.request_with_timeout(
@@ -2955,6 +3087,7 @@ fn response_request_id(response: &Response) -> Option<u64> {
         Response::NodeScalar(result) => Some(result.context.request_id),
         Response::SelectionRanges(result) => Some(result.context.request_id),
         Response::InjectionRegions(result) => Some(result.context.request_id),
+        Response::SemanticTokens(result) => Some(result.context.request_id),
         Response::LanguageCatalogAck(ack) => Some(ack.context.request_id),
         Response::Error(error) => error.context.as_ref().map(|context| context.request_id),
         Response::HandshakeReady(_) => None,
@@ -2971,6 +3104,7 @@ fn response_context(response: &Response) -> Option<&RequestContext> {
         Response::NodeScalar(result) => Some(&result.context),
         Response::SelectionRanges(result) => Some(&result.context),
         Response::InjectionRegions(result) => Some(&result.context),
+        Response::SemanticTokens(result) => Some(&result.context),
         Response::LanguageCatalogAck(ack) => Some(&ack.context),
         Response::Error(error) => error.context.as_ref(),
         Response::HandshakeReady(_) => None,
@@ -3083,12 +3217,12 @@ mod tests {
 
     use super::{
         ApplyDocumentEdits, BUILD_ID, ByteEdit, CloseDocument, DeriveInjectionRegions,
-        DeriveSelectionRanges, DeriveSnapshot, DocumentKey, DocumentLane, DocumentReplica,
-        GrammarKey, Handshake, HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES,
-        MAX_DOCUMENT_REPLICAS, MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeNavigation,
-        NodeScalarOperation, NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION, Request,
-        RequestContext, ResolveNode, Response, Route, RunNodeScalar, SyncDocument, WirePosition,
-        WireRange, WorkerError, WorkerQuerySources, close_document, decode_frame,
+        DeriveSelectionRanges, DeriveSemanticTokens, DeriveSnapshot, DocumentKey, DocumentLane,
+        DocumentReplica, GrammarKey, Handshake, HandshakeReady, LaneAction, LaneRegistry,
+        MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS, MAX_RETAINED_DOCUMENT_BYTES, NavigateNode,
+        NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION,
+        Request, RequestContext, ResolveNode, Response, Route, RunNodeScalar, SyncDocument,
+        WirePosition, WireRange, WorkerError, WorkerQuerySources, close_document, decode_frame,
         derive_snapshot_with_language, encode_frame, named_node_count, replace_retained_bytes,
         reserve_retained_growth, route_response, run, submit_document_job, sync_document,
         terminate_by_transport, validate_document_size,
@@ -3981,6 +4115,70 @@ mod tests {
         assert_eq!(regions.regions.len(), 1);
         assert_eq!(regions.regions[0].language, "rust");
         assert_eq!(regions.regions[0].virtual_content, "fn inner() {}");
+
+        let tokens = replica
+            .derive_semantic_tokens(DeriveSemanticTokens {
+                context: RequestContext {
+                    request_id: 3,
+                    worker_generation: 3,
+                    uri: "file:///injected.rs".into(),
+                    incarnation: 4,
+                    content_version: 1,
+                    configuration_generation: 2,
+                },
+                supports_multiline: false,
+            })
+            .unwrap();
+        assert!(
+            tokens
+                .tokens
+                .iter()
+                .any(|token| token.delta_start == 6 && token.length == 5)
+        );
+    }
+
+    #[test]
+    fn semantic_tokens_are_derived_from_worker_owned_queries() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let context = RequestContext {
+            request_id: 1,
+            worker_generation: 3,
+            uri: "file:///semantic.rs".into(),
+            incarnation: 4,
+            content_version: 1,
+            configuration_generation: 2,
+        };
+        let (replica, _) = DocumentReplica::sync(
+            SyncDocument {
+                context: context.clone(),
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: "/unused/static-language".into(),
+                parser_path: "/unused/static-language".into(),
+                artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources {
+                    highlights: Some("(identifier) @variable".into()),
+                    ..WorkerQuerySources::default()
+                },
+                text: "fn main() {}".into(),
+            },
+            &mut parser,
+        )
+        .unwrap();
+
+        let result = replica
+            .derive_semantic_tokens(DeriveSemanticTokens {
+                context,
+                supports_multiline: false,
+            })
+            .unwrap();
+
+        assert_eq!(result.tokens.len(), 1);
+        assert_eq!(result.tokens[0].delta_start, 3);
+        assert_eq!(result.tokens[0].length, 4);
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -137,6 +137,9 @@ pub enum NodeScalarOperation {
     SExpression,
     Text,
     FieldNameForChild { index: u32, named: bool },
+    StartPosition,
+    EndPosition,
+    Range,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -145,8 +148,16 @@ pub enum NodeScalarValue {
     String(String),
     Bool(bool),
     U64(u64),
-    ByteRange { start_byte: u64, end_byte: u64 },
+    ByteRange {
+        start_byte: u64,
+        end_byte: u64,
+    },
     NullableString(Option<String>),
+    Position(WirePosition),
+    Range {
+        start: WirePosition,
+        end: WirePosition,
+    },
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -179,6 +190,20 @@ pub enum NodeNavigation {
     ChildrenByFieldName {
         name: String,
     },
+    DescendantForPointRange {
+        start: WirePosition,
+        end: WirePosition,
+        named: bool,
+    },
+    ChildWithDescendant {
+        descendant_id: OpaqueNodeId,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct WirePosition {
+    pub line: u32,
+    pub character: u32,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -510,6 +535,40 @@ impl DocumentReplica {
                 let mut cursor = node.walk();
                 node.children_by_field_name(&name, &mut cursor).collect()
             }
+            NodeNavigation::DescendantForPointRange { start, end, named } => {
+                let mapper = crate::text::PositionMapper::new(&self.text);
+                let start = tower_lsp_server::ls_types::Position::new(start.line, start.character);
+                let end = tower_lsp_server::ls_types::Position::new(end.line, end.character);
+                let range = mapper
+                    .position_to_byte_strict(start)
+                    .zip(mapper.position_to_byte_strict(end))
+                    .filter(|(start, end)| {
+                        node.start_byte() <= *start && start <= end && *end <= node.end_byte()
+                    });
+                match range {
+                    Some((start, end)) if named => node
+                        .named_descendant_for_byte_range(start, end)
+                        .into_iter()
+                        .collect(),
+                    Some((start, end)) => node
+                        .descendant_for_byte_range(start, end)
+                        .into_iter()
+                        .collect(),
+                    None => Vec::new(),
+                }
+            }
+            NodeNavigation::ChildWithDescendant { descendant_id } => self
+                .tracked_node(&descendant_id, &request.context)
+                .and_then(|descendant| {
+                    let answer = node.child_with_descendant(descendant)?;
+                    let mut current = answer;
+                    while current.id() != descendant.id() {
+                        current = current.child_with_descendant(descendant)?;
+                    }
+                    Some(answer)
+                })
+                .into_iter()
+                .collect(),
         };
         let nodes = selected
             .into_iter()
@@ -570,6 +629,31 @@ impl DocumentReplica {
                     node.field_name_for_child(index)
                 };
                 NodeScalarValue::NullableString(field.map(str::to_string))
+            }
+            NodeScalarOperation::StartPosition => NodeScalarValue::Position(wire_position(
+                crate::text::PositionMapper::new(&self.text)
+                    .byte_to_position(node.start_byte())
+                    .ok_or_else(|| "node start byte has no LSP position".to_string())?,
+            )),
+            NodeScalarOperation::EndPosition => NodeScalarValue::Position(wire_position(
+                crate::text::PositionMapper::new(&self.text)
+                    .byte_to_position(node.end_byte())
+                    .ok_or_else(|| "node end byte has no LSP position".to_string())?,
+            )),
+            NodeScalarOperation::Range => {
+                let mapper = crate::text::PositionMapper::new(&self.text);
+                NodeScalarValue::Range {
+                    start: wire_position(
+                        mapper
+                            .byte_to_position(node.start_byte())
+                            .ok_or_else(|| "node start byte has no LSP position".to_string())?,
+                    ),
+                    end: wire_position(
+                        mapper
+                            .byte_to_position(node.end_byte())
+                            .ok_or_else(|| "node end byte has no LSP position".to_string())?,
+                    ),
+                }
             }
         };
         Ok(NodeScalarResult {
@@ -746,6 +830,13 @@ fn point_at_byte(text: &str, byte: usize) -> tree_sitter::Point {
         .rposition(|&value| value == b'\n')
         .map_or(prefix.len(), |index| prefix.len() - index - 1);
     tree_sitter::Point::new(row, column)
+}
+
+fn wire_position(position: tower_lsp_server::ls_types::Position) -> WirePosition {
+    WirePosition {
+        line: position.line,
+        character: position.character,
+    }
 }
 
 fn find_exact_node<'tree>(
@@ -2574,10 +2665,10 @@ mod tests {
         LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS, MAX_RETAINED_DOCUMENT_BYTES,
         NavigateNode, NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId,
         PROTOCOL_VERSION, Request, RequestContext, ResolveNode, Response, Route, RunNodeScalar,
-        SyncDocument, WorkerError, close_document, decode_frame, derive_snapshot_with_language,
-        encode_frame, named_node_count, replace_retained_bytes, reserve_retained_growth,
-        route_response, run, submit_document_job, sync_document, terminate_by_transport,
-        validate_document_size,
+        SyncDocument, WirePosition, WorkerError, close_document, decode_frame,
+        derive_snapshot_with_language, encode_frame, named_node_count, replace_retained_bytes,
+        reserve_retained_growth, route_response, run, submit_document_job, sync_document,
+        terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -3209,6 +3300,27 @@ mod tests {
             .unwrap();
         assert_eq!(scalar.value, Some(NodeScalarValue::String("main".into())));
 
+        let range = replica
+            .run_node_scalar(RunNodeScalar {
+                context: context.clone(),
+                node_id: node_id.clone(),
+                operation: NodeScalarOperation::Range,
+            })
+            .unwrap();
+        assert_eq!(
+            range.value,
+            Some(NodeScalarValue::Range {
+                start: WirePosition {
+                    line: 0,
+                    character: 3,
+                },
+                end: WirePosition {
+                    line: 0,
+                    character: 7,
+                },
+            })
+        );
+
         let parent = replica
             .navigate_node(NavigateNode {
                 context: context.clone(),
@@ -3245,6 +3357,38 @@ mod tests {
             .unwrap();
         assert_eq!(descendant.nodes.len(), 1);
         assert_eq!(descendant.nodes[0].kind, "identifier");
+
+        let point_descendant = replica
+            .navigate_node(NavigateNode {
+                context: context.clone(),
+                node_id: parent.nodes[0].id.clone(),
+                operation: NodeNavigation::DescendantForPointRange {
+                    start: WirePosition {
+                        line: 0,
+                        character: 3,
+                    },
+                    end: WirePosition {
+                        line: 0,
+                        character: 7,
+                    },
+                    named: true,
+                },
+            })
+            .unwrap();
+        assert_eq!(point_descendant.nodes.len(), 1);
+        assert_eq!(point_descendant.nodes[0].kind, "identifier");
+
+        let child_with_descendant = replica
+            .navigate_node(NavigateNode {
+                context: context.clone(),
+                node_id: parent.nodes[0].id.clone(),
+                operation: NodeNavigation::ChildWithDescendant {
+                    descendant_id: node_id.clone(),
+                },
+            })
+            .unwrap();
+        assert_eq!(child_with_descendant.nodes.len(), 1);
+        assert_eq!(child_with_descendant.nodes[0].kind, "identifier");
 
         let mut edited = context.clone();
         edited.request_id = 2;

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -1993,6 +1993,25 @@ impl Client {
         self.ready.compute_threads
     }
 
+    pub fn worker_generation(&self) -> u64 {
+        self.ready.worker_generation
+    }
+
+    /// Stops this generation without requiring unique ownership of the client.
+    ///
+    /// Supervisors use this after atomically removing a generation from the
+    /// read router. In-flight requests then observe transport failure while a
+    /// replacement generation can be published independently.
+    pub fn terminate_shared(&self, timeout: Duration) {
+        self.outbound
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        if let Ok(mut child) = self.child.lock() {
+            terminate_by_transport(&mut child, &self.terminated_by_transport, timeout);
+        }
+    }
+
     pub fn derive(&self, request: DeriveSnapshot) -> io::Result<Response> {
         self.derive_with_timeout(request, Duration::from_secs(60))
     }

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -22,7 +22,7 @@ use sha2::{Digest, Sha256};
 
 use crate::language::node_tracker::{EditInfo, NodeTracker};
 
-pub const PROTOCOL_VERSION: u32 = 9;
+pub const PROTOCOL_VERSION: u32 = 10;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_REPLICAS: usize = 4_096;
 pub const MAX_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
@@ -164,6 +164,14 @@ pub struct DeriveInjectionRegions {
 pub struct DeriveSemanticTokens {
     pub context: RequestContext,
     pub supports_multiline: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct RunCaptures {
+    pub context: RequestContext,
+    pub kind: String,
+    pub range: Option<WireRange>,
+    pub injection: bool,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -337,6 +345,14 @@ pub struct WireSemanticToken {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CapturesResult {
+    pub context: RequestContext,
+    pub available: bool,
+    pub matches: Vec<serde_json::Value>,
+    pub skipped: Vec<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct LanguageCatalogAck {
     pub context: RequestContext,
     pub languages: usize,
@@ -379,6 +395,7 @@ pub enum Request {
     DeriveSelectionRanges(DeriveSelectionRanges),
     DeriveInjectionRegions(DeriveInjectionRegions),
     DeriveSemanticTokens(DeriveSemanticTokens),
+    RunCaptures(RunCaptures),
     ConfigureLanguages(ConfigureLanguages),
     CloseDocument(CloseDocument),
 }
@@ -424,6 +441,7 @@ pub enum Response {
     SelectionRanges(SelectionRangesResult),
     InjectionRegions(InjectionRegionsResult),
     SemanticTokens(DerivedSemanticTokens),
+    Captures(CapturesResult),
     LanguageCatalogAck(LanguageCatalogAck),
     Error(WorkerError),
 }
@@ -439,6 +457,7 @@ struct DocumentReplica {
     analysis: Arc<crate::language::LanguageCoordinator>,
     grammar_language: tree_sitter::Language,
     queries: WorkerQuerySources,
+    captures_match_cache: crate::lsp::lsp_impl::kakehashi::captures_match_cache::CapturesMatchCache,
 }
 
 impl DocumentReplica {
@@ -498,6 +517,7 @@ impl DocumentReplica {
                 analysis,
                 grammar_language,
                 queries: request.queries,
+                captures_match_cache: Default::default(),
             },
             ack,
         ))
@@ -927,6 +947,45 @@ impl DocumentReplica {
         Ok(DerivedSemanticTokens {
             context: request.context,
             tokens,
+        })
+    }
+
+    fn run_captures(&self, request: RunCaptures) -> Result<CapturesResult, String> {
+        self.validate_read_identity(&request.context)?;
+        let range = request.range.map(|range| {
+            tower_lsp_server::ls_types::Range::new(
+                tower_lsp_server::ls_types::Position::new(range.start.line, range.start.character),
+                tower_lsp_server::ls_types::Position::new(range.end.line, range.end.character),
+            )
+        });
+        let result = crate::lsp::lsp_impl::kakehashi::captures::execute_captures_walk(
+            &self.uri,
+            &request.kind,
+            range,
+            request.injection,
+            &self.language,
+            &self.text,
+            &self.tree,
+            None,
+            &self.analysis,
+            &self.node_tracker,
+            &|| true,
+            self.node_tracker.mint_epoch(&self.uri),
+            request.context.incarnation,
+            true,
+            request.context.configuration_generation,
+            &self.captures_match_cache,
+            None,
+        );
+        let (available, matches, skipped) = match result {
+            Some((matches, skipped)) => (true, matches, skipped),
+            None => (false, Vec::new(), Vec::new()),
+        };
+        Ok(CapturesResult {
+            context: request.context,
+            available,
+            matches,
+            skipped,
         })
     }
 
@@ -1764,6 +1823,7 @@ fn handle_work(
         Request::DeriveSelectionRanges(request) => derive_selection_ranges(request, documents),
         Request::DeriveInjectionRegions(request) => derive_injection_regions(request, documents),
         Request::DeriveSemanticTokens(request) => derive_semantic_tokens(request, documents),
+        Request::RunCaptures(request) => run_captures(request, documents),
         Request::ConfigureLanguages(request) => configure_languages(request, analysis),
         Request::CloseDocument(request) => close_document(
             request,
@@ -1792,6 +1852,7 @@ fn request_context(request: &Request) -> Option<&RequestContext> {
         Request::DeriveSelectionRanges(request) => Some(&request.context),
         Request::DeriveInjectionRegions(request) => Some(&request.context),
         Request::DeriveSemanticTokens(request) => Some(&request.context),
+        Request::RunCaptures(request) => Some(&request.context),
         Request::ConfigureLanguages(request) => Some(&request.context),
         Request::CloseDocument(request) => Some(&request.context),
     }
@@ -1809,6 +1870,7 @@ fn document_key(request: &Request) -> Option<DocumentKey> {
         Request::DeriveSelectionRanges(request) => Some(DocumentKey::from(&request.context)),
         Request::DeriveInjectionRegions(request) => Some(DocumentKey::from(&request.context)),
         Request::DeriveSemanticTokens(request) => Some(DocumentKey::from(&request.context)),
+        Request::RunCaptures(request) => Some(DocumentKey::from(&request.context)),
         Request::CloseDocument(request) => Some(DocumentKey::from(&request.context)),
         Request::Handshake(_) | Request::DeriveSnapshot(_) | Request::ConfigureLanguages(_) => None,
     }
@@ -1946,6 +2008,29 @@ fn derive_semantic_tokens(request: DeriveSemanticTokens, documents: &DocumentSto
     match replica.lock() {
         Ok(replica) => match replica.derive_semantic_tokens(request) {
             Ok(result) => Response::SemanticTokens(result),
+            Err(message) => Response::Error(WorkerError {
+                context: Some(context),
+                message,
+            }),
+        },
+        Err(_) => poisoned_document_restart(context),
+    }
+}
+
+fn run_captures(request: RunCaptures, documents: &DocumentStore) -> Response {
+    let context = request.context.clone();
+    let Some(replica) = documents
+        .get(&DocumentKey::from(&context))
+        .map(|entry| Arc::clone(entry.value()))
+    else {
+        return Response::Error(WorkerError {
+            context: Some(context),
+            message: "document replica is missing; full sync required".into(),
+        });
+    };
+    match replica.lock() {
+        Ok(replica) => match replica.run_captures(request) {
+            Ok(result) => Response::Captures(result),
             Err(message) => Response::Error(WorkerError {
                 context: Some(context),
                 message,
@@ -2921,6 +3006,15 @@ impl Client {
         )
     }
 
+    pub fn run_captures(&self, request: RunCaptures) -> io::Result<Response> {
+        let context = request.context.clone();
+        self.request_with_timeout(
+            Request::RunCaptures(request),
+            context,
+            Duration::from_secs(60),
+        )
+    }
+
     pub fn configure_languages(&self, request: ConfigureLanguages) -> io::Result<Response> {
         let context = request.context.clone();
         self.request_with_timeout(
@@ -3099,6 +3193,7 @@ fn response_request_id(response: &Response) -> Option<u64> {
         Response::SelectionRanges(result) => Some(result.context.request_id),
         Response::InjectionRegions(result) => Some(result.context.request_id),
         Response::SemanticTokens(result) => Some(result.context.request_id),
+        Response::Captures(result) => Some(result.context.request_id),
         Response::LanguageCatalogAck(ack) => Some(ack.context.request_id),
         Response::Error(error) => error.context.as_ref().map(|context| context.request_id),
         Response::HandshakeReady(_) => None,
@@ -3116,6 +3211,7 @@ fn response_context(response: &Response) -> Option<&RequestContext> {
         Response::SelectionRanges(result) => Some(&result.context),
         Response::InjectionRegions(result) => Some(&result.context),
         Response::SemanticTokens(result) => Some(&result.context),
+        Response::Captures(result) => Some(&result.context),
         Response::LanguageCatalogAck(ack) => Some(&ack.context),
         Response::Error(error) => error.context.as_ref(),
         Response::HandshakeReady(_) => None,
@@ -3232,11 +3328,11 @@ mod tests {
         DocumentReplica, GrammarKey, Handshake, HandshakeReady, LaneAction, LaneRegistry,
         MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS, MAX_RETAINED_DOCUMENT_BYTES, NavigateNode,
         NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION,
-        Request, RequestContext, ResolveNode, Response, Route, RunNodeScalar, SyncDocument,
-        WirePosition, WireRange, WorkerError, WorkerQuerySources, close_document, decode_frame,
-        derive_snapshot_with_language, encode_frame, named_node_count, replace_retained_bytes,
-        reserve_retained_growth, route_response, run, submit_document_job, sync_document,
-        terminate_by_transport, validate_document_size,
+        Request, RequestContext, ResolveNode, Response, Route, RunCaptures, RunNodeScalar,
+        SyncDocument, WirePosition, WireRange, WorkerError, WorkerQuerySources, close_document,
+        decode_frame, derive_snapshot_with_language, encode_frame, named_node_count,
+        replace_retained_bytes, reserve_retained_growth, route_response, run, submit_document_job,
+        sync_document, terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -4190,6 +4286,58 @@ mod tests {
         assert_eq!(result.tokens.len(), 1);
         assert_eq!(result.tokens[0].delta_start, 3);
         assert_eq!(result.tokens[0].length, 4);
+    }
+
+    #[test]
+    fn captures_are_derived_from_worker_owned_tree_and_query_paths() {
+        let directory = tempfile::tempdir().unwrap();
+        let query_dir = directory.path().join("queries/rust");
+        std::fs::create_dir_all(&query_dir).unwrap();
+        std::fs::write(query_dir.join("context.scm"), "(identifier) @name").unwrap();
+
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let context = RequestContext {
+            request_id: 1,
+            worker_generation: 3,
+            uri: "file:///captures.rs".into(),
+            incarnation: 4,
+            content_version: 1,
+            configuration_generation: 2,
+        };
+        let analysis = Arc::new(crate::language::LanguageCoordinator::new());
+        analysis.configure_worker_runtime(vec![directory.path().into()], Default::default());
+        let (replica, _) = DocumentReplica::sync_with_analysis(
+            SyncDocument {
+                context: context.clone(),
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: "/unused/static-language".into(),
+                parser_path: "/unused/static-language".into(),
+                artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
+                text: "fn main() {}".into(),
+            },
+            &mut parser,
+            analysis,
+        )
+        .unwrap();
+
+        let result = replica
+            .run_captures(RunCaptures {
+                context,
+                kind: "context".into(),
+                range: None,
+                injection: false,
+            })
+            .unwrap();
+
+        assert_eq!(result.matches.len(), 1);
+        assert_eq!(result.matches[0]["language"], "rust");
+        assert_eq!(result.matches[0]["captures"][0]["name"], "name");
+        assert!(result.skipped.is_empty());
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -22,7 +22,7 @@ use sha2::{Digest, Sha256};
 
 use crate::language::node_tracker::{EditInfo, NodeTracker};
 
-pub const PROTOCOL_VERSION: u32 = 11;
+pub const PROTOCOL_VERSION: u32 = 12;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_REPLICAS: usize = 4_096;
 pub const MAX_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
@@ -133,6 +133,15 @@ pub struct ResolveNode {
     pub context: RequestContext,
     pub byte_offset: usize,
     pub named: bool,
+    pub layer: NodeLayerSelector,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeLayerSelector {
+    Host,
+    Deepest,
+    Index(i64),
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -300,6 +309,7 @@ pub struct OwnedNode {
     pub end_byte: usize,
     pub named: bool,
     pub has_error: bool,
+    pub layer: usize,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -486,6 +496,13 @@ struct DocumentReplica {
     grammar_language: tree_sitter::Language,
     queries: WorkerQuerySources,
     captures_match_cache: crate::lsp::lsp_impl::kakehashi::captures_match_cache::CapturesMatchCache,
+    injection_layers: Vec<CachedInjectionLayer>,
+}
+
+struct CachedInjectionLayer {
+    depth: usize,
+    tree: tree_sitter::Tree,
+    ranges: Vec<tree_sitter::Range>,
 }
 
 impl DocumentReplica {
@@ -546,6 +563,7 @@ impl DocumentReplica {
                 grammar_language,
                 queries: request.queries,
                 captures_match_cache: Default::default(),
+                injection_layers: Vec::new(),
             },
             ack,
         ))
@@ -609,6 +627,7 @@ impl DocumentReplica {
         }
         self.text = text;
         self.tree = tree;
+        self.injection_layers.clear();
         self.node_tracker
             .apply_input_edits(&self.uri, &tracker_edits);
         self.context = request.context;
@@ -656,9 +675,75 @@ impl DocumentReplica {
         if request.byte_offset > self.text.len() {
             return Err("node byte offset exceeds document length".into());
         }
-        let root = self.tree.root_node();
-        let mut node = root
-            .descendant_for_byte_range(request.byte_offset, request.byte_offset)
+        if self.text.is_empty() {
+            return Ok(NodeResult {
+                context: request.context,
+                nodes: Vec::new(),
+            });
+        }
+        let layer = match request.layer {
+            NodeLayerSelector::Host => 0,
+            NodeLayerSelector::Deepest | NodeLayerSelector::Index(_) => {
+                self.cache_injection_stack(request.byte_offset);
+                let depth = self
+                    .injection_layers
+                    .iter()
+                    .filter(|layer| {
+                        crate::lsp::lsp_impl::kakehashi::node::injection_stack::ranges_contain_byte(
+                            &layer.ranges,
+                            request.byte_offset,
+                            self.text.len(),
+                        )
+                    })
+                    .map(|layer| layer.depth)
+                    .max()
+                    .unwrap_or(0);
+                match request.layer {
+                    NodeLayerSelector::Deepest => depth,
+                    NodeLayerSelector::Index(index) => {
+                        let stack_len = depth.saturating_add(1);
+                        let selected = if index >= 0 {
+                            usize::try_from(index)
+                                .ok()
+                                .filter(|index| *index < stack_len)
+                        } else {
+                            i64::try_from(stack_len)
+                                .ok()
+                                .and_then(|len| len.checked_add(index))
+                                .filter(|index| *index >= 0)
+                                .and_then(|index| usize::try_from(index).ok())
+                        };
+                        let Some(selected) = selected else {
+                            return Ok(NodeResult {
+                                context: request.context,
+                                nodes: Vec::new(),
+                            });
+                        };
+                        selected
+                    }
+                    NodeLayerSelector::Host => unreachable!(),
+                }
+            }
+        };
+        let tree = if layer == 0 {
+            &self.tree
+        } else {
+            let Some(layer) = self.injection_layers.iter().find(|candidate| {
+                candidate.depth == layer
+                    && crate::lsp::lsp_impl::kakehashi::node::injection_stack::ranges_contain_byte(
+                        &candidate.ranges,
+                        request.byte_offset,
+                        self.text.len(),
+                    )
+            }) else {
+                return Ok(NodeResult {
+                    context: request.context,
+                    nodes: Vec::new(),
+                });
+            };
+            &layer.tree
+        };
+        let mut node = smallest_containing_worker_node(tree, request.byte_offset, self.text.len())
             .ok_or_else(|| "no node exists at byte offset".to_string())?;
         if request.named {
             while !node.is_named() {
@@ -667,7 +752,7 @@ impl DocumentReplica {
                     .ok_or_else(|| "no named node exists at byte offset".to_string())?;
             }
         }
-        let owned = self.register_node(node, &request.context)?;
+        let owned = self.register_node_in_layer(node, layer, &request.context)?;
         Ok(NodeResult {
             context: request.context,
             nodes: vec![owned],
@@ -676,7 +761,13 @@ impl DocumentReplica {
 
     fn navigate_node(&mut self, request: NavigateNode) -> Result<NodeResult, String> {
         self.validate_read_identity(&request.context)?;
-        let Some(node) = self.tracked_node(&request.node_id, &request.context) else {
+        self.ensure_tracked_layer(&request.node_id, &request.context);
+        if let NodeNavigation::ChildWithDescendant { descendant_id } = &request.operation {
+            self.ensure_tracked_layer(descendant_id, &request.context);
+        }
+        let Some((node, layer, included_ranges)) =
+            self.tracked_node(&request.node_id, &request.context)
+        else {
             return Ok(NodeResult {
                 context: request.context,
                 nodes: Vec::new(),
@@ -697,7 +788,17 @@ impl DocumentReplica {
             NodeNavigation::NextNamedSibling => node.next_named_sibling().into_iter().collect(),
             NodeNavigation::PreviousNamedSibling => node.prev_named_sibling().into_iter().collect(),
             NodeNavigation::FirstChildForByte { byte } => {
-                if node.start_byte() <= byte && byte <= node.end_byte() && byte <= self.text.len() {
+                if node.start_byte() <= byte
+                    && byte <= node.end_byte()
+                    && byte <= self.text.len()
+                    && included_ranges.is_none_or(|ranges| {
+                        crate::lsp::lsp_impl::kakehashi::node::injection_stack::ranges_contain_byte(
+                            ranges,
+                            byte,
+                            self.text.len(),
+                        )
+                    })
+                {
                     node.first_child_for_byte(byte).into_iter().collect()
                 } else {
                     Vec::new()
@@ -711,6 +812,9 @@ impl DocumentReplica {
                 if node.start_byte() <= start_byte
                     && start_byte <= end_byte
                     && end_byte <= node.end_byte()
+                    && included_ranges.is_none_or(|ranges| {
+                        ranges_cover_query(ranges, start_byte, end_byte, self.text.len())
+                    })
                 {
                     if named {
                         node.named_descendant_for_byte_range(start_byte, end_byte)
@@ -740,7 +844,12 @@ impl DocumentReplica {
                     .position_to_byte_strict(start)
                     .zip(mapper.position_to_byte_strict(end))
                     .filter(|(start, end)| {
-                        node.start_byte() <= *start && start <= end && *end <= node.end_byte()
+                        node.start_byte() <= *start
+                            && start <= end
+                            && *end <= node.end_byte()
+                            && included_ranges.is_none_or(|ranges| {
+                                ranges_cover_query(ranges, *start, *end, self.text.len())
+                            })
                     });
                 match range {
                     Some((start, end)) if named => node
@@ -756,7 +865,8 @@ impl DocumentReplica {
             }
             NodeNavigation::ChildWithDescendant { descendant_id } => self
                 .tracked_node(&descendant_id, &request.context)
-                .and_then(|descendant| {
+                .filter(|(_, descendant_layer, _)| *descendant_layer == layer)
+                .and_then(|(descendant, _, _)| {
                     let answer = node.child_with_descendant(descendant)?;
                     let mut current = answer;
                     while current.id() != descendant.id() {
@@ -769,7 +879,7 @@ impl DocumentReplica {
         };
         let nodes = selected
             .into_iter()
-            .map(|node| self.register_node(node, &request.context))
+            .map(|node| self.register_node_in_layer(node, layer, &request.context))
             .collect::<Result<_, _>>()?;
         Ok(NodeResult {
             context: request.context,
@@ -777,9 +887,10 @@ impl DocumentReplica {
         })
     }
 
-    fn run_node_scalar(&self, request: RunNodeScalar) -> Result<NodeScalarResult, String> {
+    fn run_node_scalar(&mut self, request: RunNodeScalar) -> Result<NodeScalarResult, String> {
         self.validate_read_identity(&request.context)?;
-        let Some(node) = self.tracked_node(&request.node_id, &request.context) else {
+        self.ensure_tracked_layer(&request.node_id, &request.context);
+        let Some((node, _, _)) = self.tracked_node(&request.node_id, &request.context) else {
             return Ok(NodeScalarResult {
                 context: request.context,
                 value: None,
@@ -1116,35 +1227,92 @@ impl DocumentReplica {
         Some((query, Arc::from(self.text.as_str()), self.tree.clone(), 0))
     }
 
+    fn cache_injection_stack(&mut self, byte: usize) {
+        let stack = crate::lsp::lsp_impl::kakehashi::node::injection_stack::injection_stack_at(
+            &self.analysis,
+            &self.language,
+            &self.text,
+            &self.tree,
+            byte,
+        );
+        for (depth, layer) in stack.into_iter().enumerate().skip(1) {
+            if self
+                .injection_layers
+                .iter()
+                .any(|cached| cached.depth == depth && cached.ranges == layer.ranges)
+            {
+                continue;
+            }
+            self.injection_layers.push(CachedInjectionLayer {
+                depth,
+                tree: layer.tree,
+                ranges: layer.ranges,
+            });
+        }
+    }
+
+    fn ensure_tracked_layer(&mut self, node_id: &OpaqueNodeId, context: &RequestContext) {
+        if node_id.worker_generation != context.worker_generation {
+            return;
+        }
+        let Some((start_byte, _, _, layer, incarnation)) = node_id
+            .local_id
+            .parse::<ulid::Ulid>()
+            .ok()
+            .and_then(|id| self.node_tracker.lookup_node(&self.uri, &id))
+        else {
+            return;
+        };
+        if layer > 0 && incarnation == context.incarnation {
+            self.cache_injection_stack(start_byte);
+        }
+    }
+
     fn tracked_node<'tree>(
         &'tree self,
         node_id: &OpaqueNodeId,
         context: &RequestContext,
-    ) -> Option<tree_sitter::Node<'tree>> {
+    ) -> Option<(
+        tree_sitter::Node<'tree>,
+        usize,
+        Option<&'tree [tree_sitter::Range]>,
+    )> {
         if node_id.worker_generation != context.worker_generation {
             return None;
         }
         let ulid = node_id.local_id.parse::<ulid::Ulid>().ok()?;
         let (start_byte, end_byte, kind, layer, incarnation) =
             self.node_tracker.lookup_node(&self.uri, &ulid)?;
-        if layer != 0 || incarnation != context.incarnation {
+        if incarnation != context.incarnation {
             return None;
         }
-        find_exact_node(self.tree.root_node(), start_byte, end_byte, kind)
+        if layer == 0 {
+            return find_exact_node(self.tree.root_node(), start_byte, end_byte, kind)
+                .map(|node| (node, 0, None));
+        }
+        self.injection_layers
+            .iter()
+            .filter(|candidate| candidate.depth == layer)
+            .find_map(|candidate| {
+                find_exact_node(candidate.tree.root_node(), start_byte, end_byte, kind)
+                    .map(|node| (node, layer, Some(candidate.ranges.as_slice())))
+            })
     }
 
-    fn register_node(
+    fn register_node_in_layer(
         &self,
         node: tree_sitter::Node<'_>,
+        layer: usize,
         context: &RequestContext,
     ) -> Result<OwnedNode, String> {
         let local_id = self
             .node_tracker
-            .get_or_create_for_incarnation(
+            .get_or_create_in_layer_for_incarnation(
                 &self.uri,
                 node.start_byte(),
                 node.end_byte(),
                 node.kind(),
+                layer,
                 context.incarnation,
             )
             .ok_or_else(|| "document incarnation cannot mint a node ID".to_string())?
@@ -1159,6 +1327,7 @@ impl DocumentReplica {
             end_byte: node.end_byte(),
             named: node.is_named(),
             has_error: node.has_error(),
+            layer,
         })
     }
 
@@ -1434,6 +1603,45 @@ fn find_exact_node<'tree>(
         }
         node = node.parent()?;
     }
+}
+
+fn smallest_containing_worker_node(
+    tree: &tree_sitter::Tree,
+    byte: usize,
+    document_len: usize,
+) -> Option<tree_sitter::Node<'_>> {
+    if byte == document_len {
+        let mut cursor = tree.root_node().walk();
+        let mut current = tree.root_node();
+        while cursor.goto_first_child() {
+            while cursor.goto_next_sibling() {}
+            let child = cursor.node();
+            if child.end_byte() != document_len {
+                break;
+            }
+            current = child;
+        }
+        return (current.end_byte() == document_len).then_some(current);
+    }
+    let mut current = tree.root_node().descendant_for_byte_range(byte, byte);
+    while let Some(node) = current {
+        if node.start_byte() <= byte && byte < node.end_byte() {
+            return Some(node);
+        }
+        current = node.parent();
+    }
+    None
+}
+
+fn ranges_cover_query(
+    ranges: &[tree_sitter::Range],
+    start: usize,
+    end: usize,
+    document_len: usize,
+) -> bool {
+    let contains = crate::lsp::lsp_impl::kakehashi::node::injection_stack::ranges_contain_byte;
+    contains(ranges, start, document_len)
+        && (end == start || contains(ranges, end - 1, document_len))
 }
 
 pub fn encode_frame<W: Write, T: Serialize>(writer: &mut W, value: &T) -> io::Result<()> {
@@ -2117,7 +2325,7 @@ fn run_node_scalar(request: RunNodeScalar, documents: &DocumentStore) -> Respons
         });
     };
     match replica.lock() {
-        Ok(replica) => match replica.run_node_scalar(request) {
+        Ok(mut replica) => match replica.run_node_scalar(request) {
             Ok(result) => Response::NodeScalar(result),
             Err(message) => Response::Error(WorkerError {
                 context: Some(context),
@@ -3549,13 +3757,13 @@ mod tests {
         DeriveNativeBindings, DeriveSelectionRanges, DeriveSemanticTokens, DeriveSnapshot,
         DocumentKey, DocumentLane, DocumentReplica, GrammarKey, Handshake, HandshakeReady,
         LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
-        MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeNavigation, NodeScalarOperation,
-        NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION, Request, RequestContext, ResolveNode,
-        Response, Route, RunCaptures, RunNodeScalar, SyncDocument, WireByteRange, WirePosition,
-        WireRange, WorkerError, WorkerQuerySources, close_document, decode_frame,
-        derive_snapshot_with_language, encode_frame, named_node_count, replace_retained_bytes,
-        reserve_retained_growth, route_response, run, submit_document_job, sync_document,
-        terminate_by_transport, validate_document_size,
+        MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeLayerSelector, NodeNavigation,
+        NodeScalarOperation, NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION, Request,
+        RequestContext, ResolveNode, Response, Route, RunCaptures, RunNodeScalar, SyncDocument,
+        WireByteRange, WirePosition, WireRange, WorkerError, WorkerQuerySources, close_document,
+        decode_frame, derive_snapshot_with_language, encode_frame, named_node_count,
+        replace_retained_bytes, reserve_retained_growth, route_response, run, submit_document_job,
+        sync_document, terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -4177,6 +4385,7 @@ mod tests {
                 context: context.clone(),
                 byte_offset: 3,
                 named: true,
+                layer: NodeLayerSelector::Host,
             })
             .unwrap();
         assert_eq!(resolved.nodes.len(), 1);
@@ -4362,6 +4571,116 @@ mod tests {
             })
             .unwrap();
         assert!(stale.nodes.is_empty());
+    }
+
+    #[test]
+    fn node_operations_stay_inside_worker_owned_injection_layer() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_md::LANGUAGE.into())
+            .unwrap();
+        let context = RequestContext {
+            request_id: 1,
+            worker_generation: 3,
+            uri: "file:///node.md".into(),
+            incarnation: 4,
+            content_version: 1,
+            configuration_generation: 2,
+        };
+        let analysis = Arc::new(crate::language::LanguageCoordinator::new());
+        super::worker_analysis(
+            &analysis,
+            "lua",
+            tree_sitter_lua::LANGUAGE.into(),
+            WorkerQuerySources::default(),
+            super::WorkerQuerySet::Injections,
+        )
+        .unwrap();
+        let text = "# t\n\n```lua\nlocal v = 1\nprint(v)\n```\n";
+        let (mut replica, _) = DocumentReplica::sync_with_analysis(
+            SyncDocument {
+                context: context.clone(),
+                language: "markdown".into(),
+                grammar_symbol: "markdown".into(),
+                source_path: "/unused/static-language".into(),
+                parser_path: "/unused/static-language".into(),
+                artifact_digest: "sha256:markdown-v1".into(),
+                queries: WorkerQuerySources {
+                    injections: Some(
+                        r#"
+                        (fenced_code_block
+                          (info_string (language) @injection.language)
+                          (code_fence_content) @injection.content)
+                        "#
+                        .into(),
+                    ),
+                    ..WorkerQuerySources::default()
+                },
+                text: text.into(),
+            },
+            &mut parser,
+            analysis,
+        )
+        .unwrap();
+
+        let byte_offset = text.find("v)").unwrap();
+        let resolved = replica
+            .resolve_node(ResolveNode {
+                context: context.clone(),
+                byte_offset,
+                named: true,
+                layer: NodeLayerSelector::Deepest,
+            })
+            .unwrap();
+        assert_eq!(resolved.nodes.len(), 1);
+        assert_eq!(resolved.nodes[0].kind, "identifier");
+        assert_eq!(resolved.nodes[0].start_byte, byte_offset);
+        assert_eq!(resolved.nodes[0].layer, 1);
+
+        let scalar = replica
+            .run_node_scalar(RunNodeScalar {
+                context: context.clone(),
+                node_id: resolved.nodes[0].id.clone(),
+                operation: NodeScalarOperation::Text,
+            })
+            .unwrap();
+        assert_eq!(scalar.value, Some(NodeScalarValue::String("v".into())));
+
+        let parent = replica
+            .navigate_node(NavigateNode {
+                context: context.clone(),
+                node_id: resolved.nodes[0].id.clone(),
+                operation: NodeNavigation::Parent,
+            })
+            .unwrap();
+        assert_eq!(parent.nodes.len(), 1);
+        assert_eq!(parent.nodes[0].kind, "arguments");
+
+        for (selector, expected_kind) in [
+            (NodeLayerSelector::Index(0), "code_fence_content"),
+            (NodeLayerSelector::Index(1), "identifier"),
+            (NodeLayerSelector::Index(-1), "identifier"),
+            (NodeLayerSelector::Index(-2), "code_fence_content"),
+        ] {
+            let result = replica
+                .resolve_node(ResolveNode {
+                    context: context.clone(),
+                    byte_offset,
+                    named: false,
+                    layer: selector,
+                })
+                .unwrap();
+            assert_eq!(result.nodes[0].kind, expected_kind);
+        }
+        let out_of_bounds = replica
+            .resolve_node(ResolveNode {
+                context,
+                byte_offset,
+                named: false,
+                layer: NodeLayerSelector::Index(2),
+            })
+            .unwrap();
+        assert!(out_of_bounds.nodes.is_empty());
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -22,7 +22,7 @@ use sha2::{Digest, Sha256};
 
 use crate::language::node_tracker::{EditInfo, NodeTracker};
 
-pub const PROTOCOL_VERSION: u32 = 4;
+pub const PROTOCOL_VERSION: u32 = 5;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_REPLICAS: usize = 4_096;
 pub const MAX_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
@@ -118,6 +118,12 @@ pub struct RunNodeScalar {
     pub operation: NodeScalarOperation,
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DeriveSelectionRanges {
+    pub context: RequestContext,
+    pub positions: Vec<WirePosition>,
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NodeScalarOperation {
@@ -206,6 +212,18 @@ pub struct WirePosition {
     pub character: u32,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct WireRange {
+    pub start: WirePosition,
+    pub end: WirePosition,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct WireSelectionRange {
+    pub range: WireRange,
+    pub parent: Option<Box<WireSelectionRange>>,
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct OpaqueNodeId {
     pub worker_generation: u64,
@@ -232,6 +250,12 @@ pub struct NodeResult {
 pub struct NodeScalarResult {
     pub context: RequestContext,
     pub value: Option<NodeScalarValue>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct SelectionRangesResult {
+    pub context: RequestContext,
+    pub ranges: Vec<WireSelectionRange>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -268,6 +292,7 @@ pub enum Request {
     ResolveNode(ResolveNode),
     NavigateNode(NavigateNode),
     RunNodeScalar(RunNodeScalar),
+    DeriveSelectionRanges(DeriveSelectionRanges),
     CloseDocument(CloseDocument),
 }
 
@@ -309,6 +334,7 @@ pub enum Response {
     Snapshot(DerivedSnapshot),
     Nodes(NodeResult),
     NodeScalar(NodeScalarResult),
+    SelectionRanges(SelectionRangesResult),
     Error(WorkerError),
 }
 
@@ -662,6 +688,38 @@ impl DocumentReplica {
         })
     }
 
+    fn derive_selection_ranges(
+        &self,
+        request: DeriveSelectionRanges,
+    ) -> Result<SelectionRangesResult, String> {
+        self.validate_read_identity(&request.context)?;
+        let mapper = crate::text::PositionMapper::new(&self.text);
+        let root = self.tree.root_node();
+        let ranges = request
+            .positions
+            .into_iter()
+            .map(|position| {
+                let lsp_position =
+                    tower_lsp_server::ls_types::Position::new(position.line, position.character);
+                mapper
+                    .position_to_byte(lsp_position)
+                    .and_then(|byte| root.descendant_for_byte_range(byte, byte))
+                    .map(|node| build_wire_selection_range(node, &mapper))
+                    .unwrap_or(WireSelectionRange {
+                        range: WireRange {
+                            start: position,
+                            end: position,
+                        },
+                        parent: None,
+                    })
+            })
+            .collect();
+        Ok(SelectionRangesResult {
+            context: request.context,
+            ranges,
+        })
+    }
+
     fn tracked_node<'tree>(
         &'tree self,
         node_id: &OpaqueNodeId,
@@ -770,6 +828,36 @@ impl DocumentReplica {
             }
         }
         Ok(())
+    }
+}
+
+fn build_wire_selection_range(
+    node: tree_sitter::Node<'_>,
+    mapper: &crate::text::PositionMapper<'_>,
+) -> WireSelectionRange {
+    let current_range = node.byte_range();
+    let mut parent = node.parent();
+    while parent.is_some_and(|parent| parent.byte_range() == current_range) {
+        parent = parent.and_then(|parent| parent.parent());
+    }
+    WireSelectionRange {
+        range: WireRange {
+            start: mapper
+                .byte_to_position(node.start_byte())
+                .map(wire_position)
+                .unwrap_or(WirePosition {
+                    line: node.start_position().row as u32,
+                    character: 0,
+                }),
+            end: mapper
+                .byte_to_position(node.end_byte())
+                .map(wire_position)
+                .unwrap_or(WirePosition {
+                    line: node.end_position().row as u32,
+                    character: 0,
+                }),
+        },
+        parent: parent.map(|parent| Box::new(build_wire_selection_range(parent, mapper))),
     }
 }
 
@@ -1401,6 +1489,7 @@ fn handle_work(
         Request::ResolveNode(request) => resolve_node(request, documents),
         Request::NavigateNode(request) => navigate_node(request, documents),
         Request::RunNodeScalar(request) => run_node_scalar(request, documents),
+        Request::DeriveSelectionRanges(request) => derive_selection_ranges(request, documents),
         Request::CloseDocument(request) => close_document(
             request,
             documents,
@@ -1425,6 +1514,7 @@ fn request_context(request: &Request) -> Option<&RequestContext> {
         Request::ResolveNode(request) => Some(&request.context),
         Request::NavigateNode(request) => Some(&request.context),
         Request::RunNodeScalar(request) => Some(&request.context),
+        Request::DeriveSelectionRanges(request) => Some(&request.context),
         Request::CloseDocument(request) => Some(&request.context),
     }
 }
@@ -1438,6 +1528,7 @@ fn document_key(request: &Request) -> Option<DocumentKey> {
         Request::ResolveNode(request) => Some(DocumentKey::from(&request.context)),
         Request::NavigateNode(request) => Some(DocumentKey::from(&request.context)),
         Request::RunNodeScalar(request) => Some(DocumentKey::from(&request.context)),
+        Request::DeriveSelectionRanges(request) => Some(DocumentKey::from(&request.context)),
         Request::CloseDocument(request) => Some(DocumentKey::from(&request.context)),
         Request::Handshake(_) | Request::DeriveSnapshot(_) => None,
     }
@@ -1503,6 +1594,29 @@ fn run_node_scalar(request: RunNodeScalar, documents: &DocumentStore) -> Respons
     match replica.lock() {
         Ok(replica) => match replica.run_node_scalar(request) {
             Ok(result) => Response::NodeScalar(result),
+            Err(message) => Response::Error(WorkerError {
+                context: Some(context),
+                message,
+            }),
+        },
+        Err(_) => poisoned_document_restart(context),
+    }
+}
+
+fn derive_selection_ranges(request: DeriveSelectionRanges, documents: &DocumentStore) -> Response {
+    let context = request.context.clone();
+    let Some(replica) = documents
+        .get(&DocumentKey::from(&context))
+        .map(|entry| Arc::clone(entry.value()))
+    else {
+        return Response::Error(WorkerError {
+            context: Some(context),
+            message: "document replica is missing; full sync required".into(),
+        });
+    };
+    match replica.lock() {
+        Ok(replica) => match replica.derive_selection_ranges(request) {
+            Ok(result) => Response::SelectionRanges(result),
             Err(message) => Response::Error(WorkerError {
                 context: Some(context),
                 message,
@@ -2371,6 +2485,15 @@ impl Client {
         )
     }
 
+    pub fn derive_selection_ranges(&self, request: DeriveSelectionRanges) -> io::Result<Response> {
+        let context = request.context.clone();
+        self.request_with_timeout(
+            Request::DeriveSelectionRanges(request),
+            context,
+            Duration::from_secs(60),
+        )
+    }
+
     pub fn close_document(&self, request: CloseDocument) -> io::Result<Response> {
         let context = request.context.clone();
         self.request_with_timeout(
@@ -2537,6 +2660,7 @@ fn response_request_id(response: &Response) -> Option<u64> {
         Response::Snapshot(snapshot) => Some(snapshot.context.request_id),
         Response::Nodes(result) => Some(result.context.request_id),
         Response::NodeScalar(result) => Some(result.context.request_id),
+        Response::SelectionRanges(result) => Some(result.context.request_id),
         Response::Error(error) => error.context.as_ref().map(|context| context.request_id),
         Response::HandshakeReady(_) => None,
     }
@@ -2550,6 +2674,7 @@ fn response_context(response: &Response) -> Option<&RequestContext> {
         Response::Snapshot(snapshot) => Some(&snapshot.context),
         Response::Nodes(result) => Some(&result.context),
         Response::NodeScalar(result) => Some(&result.context),
+        Response::SelectionRanges(result) => Some(&result.context),
         Response::Error(error) => error.context.as_ref(),
         Response::HandshakeReady(_) => None,
     }
@@ -2660,15 +2785,15 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        ApplyDocumentEdits, BUILD_ID, ByteEdit, CloseDocument, DeriveSnapshot, DocumentKey,
-        DocumentLane, DocumentReplica, GrammarKey, Handshake, HandshakeReady, LaneAction,
-        LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS, MAX_RETAINED_DOCUMENT_BYTES,
-        NavigateNode, NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId,
-        PROTOCOL_VERSION, Request, RequestContext, ResolveNode, Response, Route, RunNodeScalar,
-        SyncDocument, WirePosition, WorkerError, close_document, decode_frame,
-        derive_snapshot_with_language, encode_frame, named_node_count, replace_retained_bytes,
-        reserve_retained_growth, route_response, run, submit_document_job, sync_document,
-        terminate_by_transport, validate_document_size,
+        ApplyDocumentEdits, BUILD_ID, ByteEdit, CloseDocument, DeriveSelectionRanges,
+        DeriveSnapshot, DocumentKey, DocumentLane, DocumentReplica, GrammarKey, Handshake,
+        HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
+        MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeNavigation, NodeScalarOperation,
+        NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION, Request, RequestContext, ResolveNode,
+        Response, Route, RunNodeScalar, SyncDocument, WirePosition, WorkerError, close_document,
+        decode_frame, derive_snapshot_with_language, encode_frame, named_node_count,
+        replace_retained_bytes, reserve_retained_growth, route_response, run, submit_document_job,
+        sync_document, terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -3389,6 +3514,46 @@ mod tests {
             .unwrap();
         assert_eq!(child_with_descendant.nodes.len(), 1);
         assert_eq!(child_with_descendant.nodes[0].kind, "identifier");
+
+        let selections = replica
+            .derive_selection_ranges(DeriveSelectionRanges {
+                context: context.clone(),
+                positions: vec![
+                    WirePosition {
+                        line: 0,
+                        character: 3,
+                    },
+                    WirePosition {
+                        line: 99,
+                        character: 0,
+                    },
+                ],
+            })
+            .unwrap();
+        assert_eq!(selections.ranges.len(), 2);
+        assert_eq!(
+            selections.ranges[0].range.start,
+            WirePosition {
+                line: 0,
+                character: 3,
+            }
+        );
+        assert_eq!(
+            selections.ranges[0].range.end,
+            WirePosition {
+                line: 0,
+                character: 7,
+            }
+        );
+        assert!(selections.ranges[0].parent.is_some());
+        assert_eq!(
+            selections.ranges[1].range.start,
+            WirePosition {
+                line: 99,
+                character: 0,
+            }
+        );
+        assert!(selections.ranges[1].parent.is_none());
 
         let mut edited = context.clone();
         edited.request_id = 2;

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -111,6 +111,42 @@ pub struct NavigateNode {
     pub operation: NodeNavigation,
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct RunNodeScalar {
+    pub context: RequestContext,
+    pub node_id: OpaqueNodeId,
+    pub operation: NodeScalarOperation,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeScalarOperation {
+    Kind,
+    GrammarName,
+    IsNamed,
+    IsExtra,
+    HasError,
+    IsError,
+    IsMissing,
+    StartByte,
+    EndByte,
+    ByteRange,
+    ChildCount,
+    NamedChildCount,
+    DescendantCount,
+    SExpression,
+    Text,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum NodeScalarValue {
+    String(String),
+    Bool(bool),
+    U64(u64),
+    ByteRange { start_byte: u64, end_byte: u64 },
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NodeNavigation {
@@ -139,6 +175,12 @@ pub struct OwnedNode {
 pub struct NodeResult {
     pub context: RequestContext,
     pub nodes: Vec<OwnedNode>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct NodeScalarResult {
+    pub context: RequestContext,
+    pub value: Option<NodeScalarValue>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -174,6 +216,7 @@ pub enum Request {
     DeriveDocumentSnapshot(DeriveDocumentSnapshot),
     ResolveNode(ResolveNode),
     NavigateNode(NavigateNode),
+    RunNodeScalar(RunNodeScalar),
     CloseDocument(CloseDocument),
 }
 
@@ -214,6 +257,7 @@ pub enum Response {
     WorkerRestartRequired(WorkerRestartRequired),
     Snapshot(DerivedSnapshot),
     Nodes(NodeResult),
+    NodeScalar(NodeScalarResult),
     Error(WorkerError),
 }
 
@@ -384,33 +428,7 @@ impl DocumentReplica {
 
     fn navigate_node(&mut self, request: NavigateNode) -> Result<NodeResult, String> {
         self.validate_read_identity(&request.context)?;
-        if request.node_id.worker_generation != request.context.worker_generation {
-            return Ok(NodeResult {
-                context: request.context,
-                nodes: Vec::new(),
-            });
-        }
-        let Ok(ulid) = request.node_id.local_id.parse::<ulid::Ulid>() else {
-            return Ok(NodeResult {
-                context: request.context,
-                nodes: Vec::new(),
-            });
-        };
-        let Some((start_byte, end_byte, kind, layer, incarnation)) =
-            self.node_tracker.lookup_node(&self.uri, &ulid)
-        else {
-            return Ok(NodeResult {
-                context: request.context,
-                nodes: Vec::new(),
-            });
-        };
-        if layer != 0 || incarnation != request.context.incarnation {
-            return Ok(NodeResult {
-                context: request.context,
-                nodes: Vec::new(),
-            });
-        }
-        let Some(node) = find_exact_node(self.tree.root_node(), start_byte, end_byte, kind) else {
+        let Some(node) = self.tracked_node(&request.node_id, &request.context) else {
             return Ok(NodeResult {
                 context: request.context,
                 nodes: Vec::new(),
@@ -433,6 +451,72 @@ impl DocumentReplica {
             context: request.context,
             nodes,
         })
+    }
+
+    fn run_node_scalar(&self, request: RunNodeScalar) -> Result<NodeScalarResult, String> {
+        self.validate_read_identity(&request.context)?;
+        let Some(node) = self.tracked_node(&request.node_id, &request.context) else {
+            return Ok(NodeScalarResult {
+                context: request.context,
+                value: None,
+            });
+        };
+        let value = match request.operation {
+            NodeScalarOperation::Kind => NodeScalarValue::String(node.kind().into()),
+            NodeScalarOperation::GrammarName => NodeScalarValue::String(node.grammar_name().into()),
+            NodeScalarOperation::IsNamed => NodeScalarValue::Bool(node.is_named()),
+            NodeScalarOperation::IsExtra => NodeScalarValue::Bool(node.is_extra()),
+            NodeScalarOperation::HasError => NodeScalarValue::Bool(node.has_error()),
+            NodeScalarOperation::IsError => NodeScalarValue::Bool(node.is_error()),
+            NodeScalarOperation::IsMissing => NodeScalarValue::Bool(node.is_missing()),
+            NodeScalarOperation::StartByte => {
+                NodeScalarValue::U64(node.start_byte().try_into().unwrap_or(u64::MAX))
+            }
+            NodeScalarOperation::EndByte => {
+                NodeScalarValue::U64(node.end_byte().try_into().unwrap_or(u64::MAX))
+            }
+            NodeScalarOperation::ByteRange => NodeScalarValue::ByteRange {
+                start_byte: node.start_byte().try_into().unwrap_or(u64::MAX),
+                end_byte: node.end_byte().try_into().unwrap_or(u64::MAX),
+            },
+            NodeScalarOperation::ChildCount => {
+                NodeScalarValue::U64(node.child_count().try_into().unwrap_or(u64::MAX))
+            }
+            NodeScalarOperation::NamedChildCount => {
+                NodeScalarValue::U64(node.named_child_count().try_into().unwrap_or(u64::MAX))
+            }
+            NodeScalarOperation::DescendantCount => {
+                NodeScalarValue::U64(node.descendant_count().try_into().unwrap_or(u64::MAX))
+            }
+            NodeScalarOperation::SExpression => NodeScalarValue::String(node.to_sexp()),
+            NodeScalarOperation::Text => NodeScalarValue::String(
+                self.text
+                    .get(node.start_byte()..node.end_byte())
+                    .ok_or_else(|| "node text is not a valid UTF-8 slice".to_string())?
+                    .to_string(),
+            ),
+        };
+        Ok(NodeScalarResult {
+            context: request.context,
+            value: Some(value),
+        })
+    }
+
+    fn tracked_node<'tree>(
+        &'tree self,
+        node_id: &OpaqueNodeId,
+        context: &RequestContext,
+    ) -> Option<tree_sitter::Node<'tree>> {
+        if node_id.worker_generation != context.worker_generation {
+            return None;
+        }
+        let ulid = node_id.local_id.parse::<ulid::Ulid>().ok()?;
+        let (start_byte, end_byte, kind, layer, incarnation) =
+            self.node_tracker.lookup_node(&self.uri, &ulid)?;
+        if layer != 0 || incarnation != context.incarnation {
+            return None;
+        }
+        find_exact_node(self.tree.root_node(), start_byte, end_byte, kind)
     }
 
     fn register_node(
@@ -1149,6 +1233,7 @@ fn handle_work(
         }
         Request::ResolveNode(request) => resolve_node(request, documents),
         Request::NavigateNode(request) => navigate_node(request, documents),
+        Request::RunNodeScalar(request) => run_node_scalar(request, documents),
         Request::CloseDocument(request) => close_document(
             request,
             documents,
@@ -1172,6 +1257,7 @@ fn request_context(request: &Request) -> Option<&RequestContext> {
         Request::DeriveDocumentSnapshot(request) => Some(&request.context),
         Request::ResolveNode(request) => Some(&request.context),
         Request::NavigateNode(request) => Some(&request.context),
+        Request::RunNodeScalar(request) => Some(&request.context),
         Request::CloseDocument(request) => Some(&request.context),
     }
 }
@@ -1184,6 +1270,7 @@ fn document_key(request: &Request) -> Option<DocumentKey> {
         Request::DeriveDocumentSnapshot(request) => Some(DocumentKey::from(&request.context)),
         Request::ResolveNode(request) => Some(DocumentKey::from(&request.context)),
         Request::NavigateNode(request) => Some(DocumentKey::from(&request.context)),
+        Request::RunNodeScalar(request) => Some(DocumentKey::from(&request.context)),
         Request::CloseDocument(request) => Some(DocumentKey::from(&request.context)),
         Request::Handshake(_) | Request::DeriveSnapshot(_) => None,
     }
@@ -1226,6 +1313,29 @@ fn navigate_node(request: NavigateNode, documents: &DocumentStore) -> Response {
     match replica.lock() {
         Ok(mut replica) => match replica.navigate_node(request) {
             Ok(result) => Response::Nodes(result),
+            Err(message) => Response::Error(WorkerError {
+                context: Some(context),
+                message,
+            }),
+        },
+        Err(_) => poisoned_document_restart(context),
+    }
+}
+
+fn run_node_scalar(request: RunNodeScalar, documents: &DocumentStore) -> Response {
+    let context = request.context.clone();
+    let Some(replica) = documents
+        .get(&DocumentKey::from(&context))
+        .map(|entry| Arc::clone(entry.value()))
+    else {
+        return Response::Error(WorkerError {
+            context: Some(context),
+            message: "document replica is missing; full sync required".into(),
+        });
+    };
+    match replica.lock() {
+        Ok(replica) => match replica.run_node_scalar(request) {
+            Ok(result) => Response::NodeScalar(result),
             Err(message) => Response::Error(WorkerError {
                 context: Some(context),
                 message,
@@ -2085,6 +2195,15 @@ impl Client {
         )
     }
 
+    pub fn run_node_scalar(&self, request: RunNodeScalar) -> io::Result<Response> {
+        let context = request.context.clone();
+        self.request_with_timeout(
+            Request::RunNodeScalar(request),
+            context,
+            Duration::from_secs(60),
+        )
+    }
+
     pub fn close_document(&self, request: CloseDocument) -> io::Result<Response> {
         let context = request.context.clone();
         self.request_with_timeout(
@@ -2250,6 +2369,7 @@ fn response_request_id(response: &Response) -> Option<u64> {
         Response::WorkerRestartRequired(required) => Some(required.context.request_id),
         Response::Snapshot(snapshot) => Some(snapshot.context.request_id),
         Response::Nodes(result) => Some(result.context.request_id),
+        Response::NodeScalar(result) => Some(result.context.request_id),
         Response::Error(error) => error.context.as_ref().map(|context| context.request_id),
         Response::HandshakeReady(_) => None,
     }
@@ -2262,6 +2382,7 @@ fn response_context(response: &Response) -> Option<&RequestContext> {
         Response::WorkerRestartRequired(required) => Some(&required.context),
         Response::Snapshot(snapshot) => Some(&snapshot.context),
         Response::Nodes(result) => Some(&result.context),
+        Response::NodeScalar(result) => Some(&result.context),
         Response::Error(error) => error.context.as_ref(),
         Response::HandshakeReady(_) => None,
     }
@@ -2375,11 +2496,12 @@ mod tests {
         ApplyDocumentEdits, BUILD_ID, ByteEdit, CloseDocument, DeriveSnapshot, DocumentKey,
         DocumentLane, DocumentReplica, GrammarKey, Handshake, HandshakeReady, LaneAction,
         LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS, MAX_RETAINED_DOCUMENT_BYTES,
-        NavigateNode, NodeNavigation, OpaqueNodeId, PROTOCOL_VERSION, Request, RequestContext,
-        ResolveNode, Response, Route, SyncDocument, WorkerError, close_document, decode_frame,
-        derive_snapshot_with_language, encode_frame, named_node_count, replace_retained_bytes,
-        reserve_retained_growth, route_response, run, submit_document_job, sync_document,
-        terminate_by_transport, validate_document_size,
+        NavigateNode, NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId,
+        PROTOCOL_VERSION, Request, RequestContext, ResolveNode, Response, Route, RunNodeScalar,
+        SyncDocument, WorkerError, close_document, decode_frame, derive_snapshot_with_language,
+        encode_frame, named_node_count, replace_retained_bytes, reserve_retained_growth,
+        route_response, run, submit_document_job, sync_document, terminate_by_transport,
+        validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -3001,6 +3123,15 @@ mod tests {
         assert_eq!(resolved.nodes[0].kind, "identifier");
         assert_eq!(resolved.nodes[0].id.worker_generation, 3);
         let node_id = resolved.nodes[0].id.clone();
+
+        let scalar = replica
+            .run_node_scalar(RunNodeScalar {
+                context: context.clone(),
+                node_id: node_id.clone(),
+                operation: NodeScalarOperation::Text,
+            })
+            .unwrap();
+        assert_eq!(scalar.value, Some(NodeScalarValue::String("main".into())));
 
         let parent = replica
             .navigate_node(NavigateNode {

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -20,7 +20,7 @@ use std::{
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use sha2::{Digest, Sha256};
 
-pub const PROTOCOL_VERSION: u32 = 3;
+pub const PROTOCOL_VERSION: u32 = 4;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_REPLICAS: usize = 4_096;
 pub const MAX_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
@@ -96,6 +96,50 @@ pub struct DeriveDocumentSnapshot {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ResolveNode {
+    pub context: RequestContext,
+    pub byte_offset: usize,
+    pub named: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct NavigateNode {
+    pub context: RequestContext,
+    pub node_id: OpaqueNodeId,
+    pub operation: NodeNavigation,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeNavigation {
+    Parent,
+    Children,
+    NamedChildren,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct OpaqueNodeId {
+    pub worker_generation: u64,
+    pub local_id: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct OwnedNode {
+    pub id: OpaqueNodeId,
+    pub kind: String,
+    pub start_byte: usize,
+    pub end_byte: usize,
+    pub named: bool,
+    pub has_error: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct NodeResult {
+    pub context: RequestContext,
+    pub nodes: Vec<OwnedNode>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CloseDocument {
     pub context: RequestContext,
 }
@@ -126,6 +170,8 @@ pub enum Request {
     ApplyDocumentEdits(ApplyDocumentEdits),
     ApplyDocumentEditsAndDerive(ApplyDocumentEditsAndDerive),
     DeriveDocumentSnapshot(DeriveDocumentSnapshot),
+    ResolveNode(ResolveNode),
+    NavigateNode(NavigateNode),
     CloseDocument(CloseDocument),
 }
 
@@ -165,6 +211,7 @@ pub enum Response {
     DocumentClosed(DocumentClosed),
     WorkerRestartRequired(WorkerRestartRequired),
     Snapshot(DerivedSnapshot),
+    Nodes(NodeResult),
     Error(WorkerError),
 }
 
@@ -174,6 +221,9 @@ struct DocumentReplica {
     grammar_key: GrammarKey,
     text: String,
     tree: tree_sitter::Tree,
+    node_paths: HashMap<u64, Vec<u32>>,
+    path_ids: HashMap<Vec<u32>, u64>,
+    next_node_id: u64,
 }
 
 impl DocumentReplica {
@@ -197,6 +247,9 @@ impl DocumentReplica {
                 grammar_key,
                 text: request.text,
                 tree,
+                node_paths: HashMap::new(),
+                path_ids: HashMap::new(),
+                next_node_id: 1,
             },
             ack,
         ))
@@ -254,6 +307,8 @@ impl DocumentReplica {
         }
         self.text = text;
         self.tree = tree;
+        self.node_paths.clear();
+        self.path_ids.clear();
         self.context = request.context;
         Ok(DocumentAck {
             context: self.context.clone(),
@@ -292,6 +347,102 @@ impl DocumentReplica {
             queue_wait_ns: duration_ns(queue_wait),
             compute_ns: duration_ns(started.elapsed()),
         })
+    }
+
+    fn resolve_node(&mut self, request: ResolveNode) -> Result<NodeResult, String> {
+        self.validate_identity(&request.context)?;
+        if request.byte_offset > self.text.len() {
+            return Err("node byte offset exceeds document length".into());
+        }
+        let root = self.tree.root_node();
+        let mut node = root
+            .descendant_for_byte_range(request.byte_offset, request.byte_offset)
+            .ok_or_else(|| "no node exists at byte offset".to_string())?;
+        if request.named {
+            while !node.is_named() {
+                node = node
+                    .parent()
+                    .ok_or_else(|| "no named node exists at byte offset".to_string())?;
+            }
+        }
+        let descriptor = describe_node(node)?;
+        let owned = self.register_node(descriptor, &request.context);
+        Ok(NodeResult {
+            context: request.context,
+            nodes: vec![owned],
+        })
+    }
+
+    fn navigate_node(&mut self, request: NavigateNode) -> Result<NodeResult, String> {
+        self.validate_identity(&request.context)?;
+        if request.node_id.worker_generation != request.context.worker_generation {
+            return Ok(NodeResult {
+                context: request.context,
+                nodes: Vec::new(),
+            });
+        }
+        let Some(path) = self.node_paths.get(&request.node_id.local_id).cloned() else {
+            return Ok(NodeResult {
+                context: request.context,
+                nodes: Vec::new(),
+            });
+        };
+        let Some(node) = node_at_path(self.tree.root_node(), &path) else {
+            return Ok(NodeResult {
+                context: request.context,
+                nodes: Vec::new(),
+            });
+        };
+        let selected = match request.operation {
+            NodeNavigation::Parent => node.parent().into_iter().collect::<Vec<_>>(),
+            NodeNavigation::Children => (0..node.child_count() as u32)
+                .filter_map(|index| node.child(index))
+                .collect(),
+            NodeNavigation::NamedChildren => (0..node.named_child_count() as u32)
+                .filter_map(|index| node.named_child(index))
+                .collect(),
+        };
+        let selected: Vec<NodeDescriptor> = selected
+            .into_iter()
+            .map(describe_node)
+            .collect::<Result<_, _>>()?;
+        let nodes = selected
+            .into_iter()
+            .map(|descriptor| self.register_node(descriptor, &request.context))
+            .collect();
+        Ok(NodeResult {
+            context: request.context,
+            nodes,
+        })
+    }
+
+    fn register_node(&mut self, descriptor: NodeDescriptor, context: &RequestContext) -> OwnedNode {
+        let NodeDescriptor {
+            path,
+            kind,
+            start_byte,
+            end_byte,
+            named,
+            has_error,
+        } = descriptor;
+        let local_id = self.path_ids.get(&path).copied().unwrap_or_else(|| {
+            let id = self.next_node_id;
+            self.next_node_id = self.next_node_id.saturating_add(1);
+            self.node_paths.insert(id, path.clone());
+            self.path_ids.insert(path, id);
+            id
+        });
+        OwnedNode {
+            id: OpaqueNodeId {
+                worker_generation: context.worker_generation,
+                local_id,
+            },
+            kind,
+            start_byte,
+            end_byte,
+            named,
+            has_error,
+        }
     }
 
     fn validate_identity(&self, context: &RequestContext) -> Result<(), String> {
@@ -408,6 +559,53 @@ fn point_at_byte(text: &str, byte: usize) -> tree_sitter::Point {
         .rposition(|&value| value == b'\n')
         .map_or(prefix.len(), |index| prefix.len() - index - 1);
     tree_sitter::Point::new(row, column)
+}
+
+struct NodeDescriptor {
+    path: Vec<u32>,
+    kind: String,
+    start_byte: usize,
+    end_byte: usize,
+    named: bool,
+    has_error: bool,
+}
+
+fn describe_node(node: tree_sitter::Node<'_>) -> Result<NodeDescriptor, String> {
+    Ok(NodeDescriptor {
+        path: path_to_node(node)?,
+        kind: node.kind().into(),
+        start_byte: node.start_byte(),
+        end_byte: node.end_byte(),
+        named: node.is_named(),
+        has_error: node.has_error(),
+    })
+}
+
+fn path_to_node(mut node: tree_sitter::Node<'_>) -> Result<Vec<u32>, String> {
+    let mut reversed = Vec::new();
+    while let Some(parent) = node.parent() {
+        let index = (0..parent.child_count() as u32)
+            .find(|index| {
+                parent
+                    .child(*index)
+                    .is_some_and(|child| child.id() == node.id())
+            })
+            .ok_or_else(|| "node is not reachable from its parent".to_string())?;
+        reversed.push(index);
+        node = parent;
+    }
+    reversed.reverse();
+    Ok(reversed)
+}
+
+fn node_at_path<'tree>(
+    mut node: tree_sitter::Node<'tree>,
+    path: &[u32],
+) -> Option<tree_sitter::Node<'tree>> {
+    for index in path {
+        node = node.child(*index)?;
+    }
+    Some(node)
 }
 
 pub fn encode_frame<W: Write, T: Serialize>(writer: &mut W, value: &T) -> io::Result<()> {
@@ -954,6 +1152,8 @@ fn handle_work(
         Request::DeriveDocumentSnapshot(request) => {
             derive_document_snapshot(request, documents, queue_wait, started)
         }
+        Request::ResolveNode(request) => resolve_node(request, documents),
+        Request::NavigateNode(request) => navigate_node(request, documents),
         Request::CloseDocument(request) => close_document(
             request,
             documents,
@@ -975,6 +1175,8 @@ fn request_context(request: &Request) -> Option<&RequestContext> {
         Request::ApplyDocumentEdits(request) => Some(&request.context),
         Request::ApplyDocumentEditsAndDerive(request) => Some(&request.context),
         Request::DeriveDocumentSnapshot(request) => Some(&request.context),
+        Request::ResolveNode(request) => Some(&request.context),
+        Request::NavigateNode(request) => Some(&request.context),
         Request::CloseDocument(request) => Some(&request.context),
     }
 }
@@ -985,8 +1187,56 @@ fn document_key(request: &Request) -> Option<DocumentKey> {
         Request::ApplyDocumentEdits(request) => Some(DocumentKey::from(&request.context)),
         Request::ApplyDocumentEditsAndDerive(request) => Some(DocumentKey::from(&request.context)),
         Request::DeriveDocumentSnapshot(request) => Some(DocumentKey::from(&request.context)),
+        Request::ResolveNode(request) => Some(DocumentKey::from(&request.context)),
+        Request::NavigateNode(request) => Some(DocumentKey::from(&request.context)),
         Request::CloseDocument(request) => Some(DocumentKey::from(&request.context)),
         Request::Handshake(_) | Request::DeriveSnapshot(_) => None,
+    }
+}
+
+fn resolve_node(request: ResolveNode, documents: &DocumentStore) -> Response {
+    let context = request.context.clone();
+    let Some(replica) = documents
+        .get(&DocumentKey::from(&context))
+        .map(|entry| Arc::clone(entry.value()))
+    else {
+        return Response::Error(WorkerError {
+            context: Some(context),
+            message: "document replica is missing; full sync required".into(),
+        });
+    };
+    match replica.lock() {
+        Ok(mut replica) => match replica.resolve_node(request) {
+            Ok(result) => Response::Nodes(result),
+            Err(message) => Response::Error(WorkerError {
+                context: Some(context),
+                message,
+            }),
+        },
+        Err(_) => poisoned_document_restart(context),
+    }
+}
+
+fn navigate_node(request: NavigateNode, documents: &DocumentStore) -> Response {
+    let context = request.context.clone();
+    let Some(replica) = documents
+        .get(&DocumentKey::from(&context))
+        .map(|entry| Arc::clone(entry.value()))
+    else {
+        return Response::Error(WorkerError {
+            context: Some(context),
+            message: "document replica is missing; full sync required".into(),
+        });
+    };
+    match replica.lock() {
+        Ok(mut replica) => match replica.navigate_node(request) {
+            Ok(result) => Response::Nodes(result),
+            Err(message) => Response::Error(WorkerError {
+                context: Some(context),
+                message,
+            }),
+        },
+        Err(_) => poisoned_document_restart(context),
     }
 }
 
@@ -1803,6 +2053,24 @@ impl Client {
         )
     }
 
+    pub fn resolve_node(&self, request: ResolveNode) -> io::Result<Response> {
+        let context = request.context.clone();
+        self.request_with_timeout(
+            Request::ResolveNode(request),
+            context,
+            Duration::from_secs(60),
+        )
+    }
+
+    pub fn navigate_node(&self, request: NavigateNode) -> io::Result<Response> {
+        let context = request.context.clone();
+        self.request_with_timeout(
+            Request::NavigateNode(request),
+            context,
+            Duration::from_secs(60),
+        )
+    }
+
     pub fn close_document(&self, request: CloseDocument) -> io::Result<Response> {
         let context = request.context.clone();
         self.request_with_timeout(
@@ -1967,6 +2235,7 @@ fn response_request_id(response: &Response) -> Option<u64> {
         Response::DocumentClosed(closed) => Some(closed.context.request_id),
         Response::WorkerRestartRequired(required) => Some(required.context.request_id),
         Response::Snapshot(snapshot) => Some(snapshot.context.request_id),
+        Response::Nodes(result) => Some(result.context.request_id),
         Response::Error(error) => error.context.as_ref().map(|context| context.request_id),
         Response::HandshakeReady(_) => None,
     }
@@ -1978,6 +2247,7 @@ fn response_context(response: &Response) -> Option<&RequestContext> {
         Response::DocumentClosed(closed) => Some(&closed.context),
         Response::WorkerRestartRequired(required) => Some(&required.context),
         Response::Snapshot(snapshot) => Some(&snapshot.context),
+        Response::Nodes(result) => Some(&result.context),
         Response::Error(error) => error.context.as_ref(),
         Response::HandshakeReady(_) => None,
     }
@@ -2091,10 +2361,11 @@ mod tests {
         ApplyDocumentEdits, BUILD_ID, ByteEdit, CloseDocument, DeriveSnapshot, DocumentKey,
         DocumentLane, DocumentReplica, GrammarKey, Handshake, HandshakeReady, LaneAction,
         LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS, MAX_RETAINED_DOCUMENT_BYTES,
-        PROTOCOL_VERSION, Request, RequestContext, Response, Route, SyncDocument, WorkerError,
-        close_document, decode_frame, derive_snapshot_with_language, encode_frame,
-        named_node_count, replace_retained_bytes, reserve_retained_growth, route_response, run,
-        submit_document_job, sync_document, terminate_by_transport, validate_document_size,
+        NavigateNode, NodeNavigation, OpaqueNodeId, PROTOCOL_VERSION, Request, RequestContext,
+        ResolveNode, Response, Route, SyncDocument, WorkerError, close_document, decode_frame,
+        derive_snapshot_with_language, encode_frame, named_node_count, replace_retained_bytes,
+        reserve_retained_growth, route_response, run, submit_document_job, sync_document,
+        terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -2675,6 +2946,68 @@ mod tests {
         assert_eq!(snapshot.root_end_byte, "fn main() { value + 2 }".len());
         assert_eq!(snapshot.parser_cache_hit, None);
         assert!(snapshot.compute_ns > 0);
+    }
+
+    #[test]
+    fn node_operations_return_generation_fenced_owned_data() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let context = RequestContext {
+            request_id: 1,
+            worker_generation: 3,
+            uri: "file:///example.rs".into(),
+            incarnation: 4,
+            content_version: 1,
+            configuration_generation: 2,
+        };
+        let (mut replica, _) = DocumentReplica::sync(
+            SyncDocument {
+                context: context.clone(),
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: "/unused/static-language".into(),
+                parser_path: "/unused/static-language".into(),
+                artifact_digest: "sha256:rust-v1".into(),
+                text: "fn main() {}".into(),
+            },
+            &mut parser,
+        )
+        .unwrap();
+
+        let resolved = replica
+            .resolve_node(ResolveNode {
+                context: context.clone(),
+                byte_offset: 3,
+                named: true,
+            })
+            .unwrap();
+        assert_eq!(resolved.nodes.len(), 1);
+        assert_eq!(resolved.nodes[0].kind, "identifier");
+        assert_eq!(resolved.nodes[0].id.worker_generation, 3);
+
+        let parent = replica
+            .navigate_node(NavigateNode {
+                context: context.clone(),
+                node_id: resolved.nodes[0].id,
+                operation: NodeNavigation::Parent,
+            })
+            .unwrap();
+        assert_eq!(parent.nodes.len(), 1);
+        assert_eq!(parent.nodes[0].kind, "function_item");
+
+        let stale = replica
+            .navigate_node(NavigateNode {
+                context,
+                node_id: OpaqueNodeId {
+                    worker_generation: 2,
+                    local_id: resolved.nodes[0].id.local_id,
+                },
+                operation: NodeNavigation::Parent,
+            })
+            .unwrap();
+        assert!(stale.nodes.is_empty());
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -20,6 +20,8 @@ use std::{
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use sha2::{Digest, Sha256};
 
+use crate::language::node_tracker::{EditInfo, NodeTracker};
+
 pub const PROTOCOL_VERSION: u32 = 4;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_REPLICAS: usize = 4_096;
@@ -117,10 +119,10 @@ pub enum NodeNavigation {
     NamedChildren,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct OpaqueNodeId {
     pub worker_generation: u64,
-    pub local_id: u64,
+    pub local_id: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -221,9 +223,8 @@ struct DocumentReplica {
     grammar_key: GrammarKey,
     text: String,
     tree: tree_sitter::Tree,
-    node_paths: HashMap<u64, Vec<u32>>,
-    path_ids: HashMap<Vec<u32>, u64>,
-    next_node_id: u64,
+    uri: url::Url,
+    node_tracker: NodeTracker,
 }
 
 impl DocumentReplica {
@@ -240,6 +241,10 @@ impl DocumentReplica {
             incremental: false,
         };
         let grammar_key = GrammarKey::from_sync(&request);
+        let uri = url::Url::parse(&request.context.uri)
+            .map_err(|error| format!("document URI is invalid: {error}"))?;
+        let node_tracker = NodeTracker::new();
+        node_tracker.open_incarnation(&uri, request.context.incarnation);
         Ok((
             Self {
                 context: request.context,
@@ -247,9 +252,8 @@ impl DocumentReplica {
                 grammar_key,
                 text: request.text,
                 tree,
-                node_paths: HashMap::new(),
-                path_ids: HashMap::new(),
-                next_node_id: 1,
+                uri,
+                node_tracker,
             },
             ack,
         ))
@@ -273,6 +277,7 @@ impl DocumentReplica {
         }
         let mut text = self.text.clone();
         let mut edited_tree = self.tree.clone();
+        let mut tracker_edits = Vec::with_capacity(request.edits.len());
         for edit in request.edits {
             if edit.start_byte > edit.old_end_byte
                 || edit.old_end_byte > text.len()
@@ -287,6 +292,11 @@ impl DocumentReplica {
                 .start_byte
                 .checked_add(edit.new_text.len())
                 .ok_or_else(|| "edit length overflows byte offsets".to_string())?;
+            tracker_edits.push(EditInfo::new(
+                edit.start_byte,
+                edit.old_end_byte,
+                new_end_byte,
+            ));
             text.replace_range(edit.start_byte..edit.old_end_byte, &edit.new_text);
             validate_document_size(text.len())?;
             let new_end_position = point_at_byte(&text, new_end_byte);
@@ -307,8 +317,8 @@ impl DocumentReplica {
         }
         self.text = text;
         self.tree = tree;
-        self.node_paths.clear();
-        self.path_ids.clear();
+        self.node_tracker
+            .apply_input_edits(&self.uri, &tracker_edits);
         self.context = request.context;
         Ok(DocumentAck {
             context: self.context.clone(),
@@ -350,7 +360,7 @@ impl DocumentReplica {
     }
 
     fn resolve_node(&mut self, request: ResolveNode) -> Result<NodeResult, String> {
-        self.validate_identity(&request.context)?;
+        self.validate_read_identity(&request.context)?;
         if request.byte_offset > self.text.len() {
             return Err("node byte offset exceeds document length".into());
         }
@@ -365,8 +375,7 @@ impl DocumentReplica {
                     .ok_or_else(|| "no named node exists at byte offset".to_string())?;
             }
         }
-        let descriptor = describe_node(node)?;
-        let owned = self.register_node(descriptor, &request.context);
+        let owned = self.register_node(node, &request.context)?;
         Ok(NodeResult {
             context: request.context,
             nodes: vec![owned],
@@ -374,20 +383,34 @@ impl DocumentReplica {
     }
 
     fn navigate_node(&mut self, request: NavigateNode) -> Result<NodeResult, String> {
-        self.validate_identity(&request.context)?;
+        self.validate_read_identity(&request.context)?;
         if request.node_id.worker_generation != request.context.worker_generation {
             return Ok(NodeResult {
                 context: request.context,
                 nodes: Vec::new(),
             });
         }
-        let Some(path) = self.node_paths.get(&request.node_id.local_id).cloned() else {
+        let Ok(ulid) = request.node_id.local_id.parse::<ulid::Ulid>() else {
             return Ok(NodeResult {
                 context: request.context,
                 nodes: Vec::new(),
             });
         };
-        let Some(node) = node_at_path(self.tree.root_node(), &path) else {
+        let Some((start_byte, end_byte, kind, layer, incarnation)) =
+            self.node_tracker.lookup_node(&self.uri, &ulid)
+        else {
+            return Ok(NodeResult {
+                context: request.context,
+                nodes: Vec::new(),
+            });
+        };
+        if layer != 0 || incarnation != request.context.incarnation {
+            return Ok(NodeResult {
+                context: request.context,
+                nodes: Vec::new(),
+            });
+        }
+        let Some(node) = find_exact_node(self.tree.root_node(), start_byte, end_byte, kind) else {
             return Ok(NodeResult {
                 context: request.context,
                 nodes: Vec::new(),
@@ -402,53 +425,57 @@ impl DocumentReplica {
                 .filter_map(|index| node.named_child(index))
                 .collect(),
         };
-        let selected: Vec<NodeDescriptor> = selected
-            .into_iter()
-            .map(describe_node)
-            .collect::<Result<_, _>>()?;
         let nodes = selected
             .into_iter()
-            .map(|descriptor| self.register_node(descriptor, &request.context))
-            .collect();
+            .map(|node| self.register_node(node, &request.context))
+            .collect::<Result<_, _>>()?;
         Ok(NodeResult {
             context: request.context,
             nodes,
         })
     }
 
-    fn register_node(&mut self, descriptor: NodeDescriptor, context: &RequestContext) -> OwnedNode {
-        let NodeDescriptor {
-            path,
-            kind,
-            start_byte,
-            end_byte,
-            named,
-            has_error,
-        } = descriptor;
-        let local_id = self.path_ids.get(&path).copied().unwrap_or_else(|| {
-            let id = self.next_node_id;
-            self.next_node_id = self.next_node_id.saturating_add(1);
-            self.node_paths.insert(id, path.clone());
-            self.path_ids.insert(path, id);
-            id
-        });
-        OwnedNode {
+    fn register_node(
+        &self,
+        node: tree_sitter::Node<'_>,
+        context: &RequestContext,
+    ) -> Result<OwnedNode, String> {
+        let local_id = self
+            .node_tracker
+            .get_or_create_for_incarnation(
+                &self.uri,
+                node.start_byte(),
+                node.end_byte(),
+                node.kind(),
+                context.incarnation,
+            )
+            .ok_or_else(|| "document incarnation cannot mint a node ID".to_string())?
+            .to_string();
+        Ok(OwnedNode {
             id: OpaqueNodeId {
                 worker_generation: context.worker_generation,
                 local_id,
             },
-            kind,
-            start_byte,
-            end_byte,
-            named,
-            has_error,
-        }
+            kind: node.kind().into(),
+            start_byte: node.start_byte(),
+            end_byte: node.end_byte(),
+            named: node.is_named(),
+            has_error: node.has_error(),
+        })
     }
 
     fn validate_identity(&self, context: &RequestContext) -> Result<(), String> {
         self.validate_lifetime(context)?;
         if context.configuration_generation != self.context.configuration_generation {
             return Err("document identity does not match worker replica".into());
+        }
+        Ok(())
+    }
+
+    fn validate_read_identity(&self, context: &RequestContext) -> Result<(), String> {
+        self.validate_identity(context)?;
+        if context.content_version != self.context.content_version {
+            return Err("document content version does not match worker replica".into());
         }
         Ok(())
     }
@@ -561,51 +588,19 @@ fn point_at_byte(text: &str, byte: usize) -> tree_sitter::Point {
     tree_sitter::Point::new(row, column)
 }
 
-struct NodeDescriptor {
-    path: Vec<u32>,
-    kind: String,
+fn find_exact_node<'tree>(
+    root: tree_sitter::Node<'tree>,
     start_byte: usize,
     end_byte: usize,
-    named: bool,
-    has_error: bool,
-}
-
-fn describe_node(node: tree_sitter::Node<'_>) -> Result<NodeDescriptor, String> {
-    Ok(NodeDescriptor {
-        path: path_to_node(node)?,
-        kind: node.kind().into(),
-        start_byte: node.start_byte(),
-        end_byte: node.end_byte(),
-        named: node.is_named(),
-        has_error: node.has_error(),
-    })
-}
-
-fn path_to_node(mut node: tree_sitter::Node<'_>) -> Result<Vec<u32>, String> {
-    let mut reversed = Vec::new();
-    while let Some(parent) = node.parent() {
-        let index = (0..parent.child_count() as u32)
-            .find(|index| {
-                parent
-                    .child(*index)
-                    .is_some_and(|child| child.id() == node.id())
-            })
-            .ok_or_else(|| "node is not reachable from its parent".to_string())?;
-        reversed.push(index);
-        node = parent;
-    }
-    reversed.reverse();
-    Ok(reversed)
-}
-
-fn node_at_path<'tree>(
-    mut node: tree_sitter::Node<'tree>,
-    path: &[u32],
+    kind: &str,
 ) -> Option<tree_sitter::Node<'tree>> {
-    for index in path {
-        node = node.child(*index)?;
+    let mut node = root.descendant_for_byte_range(start_byte, end_byte)?;
+    loop {
+        if node.start_byte() == start_byte && node.end_byte() == end_byte && node.kind() == kind {
+            return Some(node);
+        }
+        node = node.parent()?;
     }
-    Some(node)
 }
 
 pub fn encode_frame<W: Write, T: Serialize>(writer: &mut W, value: &T) -> io::Result<()> {
@@ -3005,23 +3000,52 @@ mod tests {
         assert_eq!(resolved.nodes.len(), 1);
         assert_eq!(resolved.nodes[0].kind, "identifier");
         assert_eq!(resolved.nodes[0].id.worker_generation, 3);
+        let node_id = resolved.nodes[0].id.clone();
 
         let parent = replica
             .navigate_node(NavigateNode {
                 context: context.clone(),
-                node_id: resolved.nodes[0].id,
+                node_id: node_id.clone(),
                 operation: NodeNavigation::Parent,
             })
             .unwrap();
         assert_eq!(parent.nodes.len(), 1);
         assert_eq!(parent.nodes[0].kind, "function_item");
 
+        let mut edited = context.clone();
+        edited.request_id = 2;
+        edited.content_version = 2;
+        replica
+            .apply(
+                ApplyDocumentEdits {
+                    context: edited.clone(),
+                    base_version: 1,
+                    edits: vec![ByteEdit {
+                        start_byte: 0,
+                        old_end_byte: 0,
+                        new_text: "pub ".into(),
+                    }],
+                },
+                &mut parser,
+                None,
+            )
+            .unwrap();
+        let shifted = replica
+            .navigate_node(NavigateNode {
+                context: edited.clone(),
+                node_id: node_id.clone(),
+                operation: NodeNavigation::Parent,
+            })
+            .unwrap();
+        assert_eq!(shifted.nodes.len(), 1);
+        assert_eq!(shifted.nodes[0].kind, "function_item");
+
         let stale = replica
             .navigate_node(NavigateNode {
-                context,
+                context: edited,
                 node_id: OpaqueNodeId {
                     worker_generation: 2,
-                    local_id: resolved.nodes[0].id.local_id,
+                    local_id: node_id.local_id,
                 },
                 operation: NodeNavigation::Parent,
             })

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -22,7 +22,7 @@ use sha2::{Digest, Sha256};
 
 use crate::language::node_tracker::{EditInfo, NodeTracker};
 
-pub const PROTOCOL_VERSION: u32 = 7;
+pub const PROTOCOL_VERSION: u32 = 8;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_REPLICAS: usize = 4_096;
 pub const MAX_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
@@ -146,6 +146,11 @@ pub struct RunNodeScalar {
 pub struct DeriveSelectionRanges {
     pub context: RequestContext,
     pub positions: Vec<WirePosition>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DeriveInjectionRegions {
+    pub context: RequestContext,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -283,6 +288,27 @@ pub struct SelectionRangesResult {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct WireInjectionRegion {
+    pub language: String,
+    pub byte_start: usize,
+    pub byte_end: usize,
+    pub line_start: u32,
+    pub line_end: u32,
+    pub start_column: u32,
+    pub region_id: String,
+    pub content_hash: u64,
+    pub virtual_content: String,
+    pub line_column_offsets: Vec<u32>,
+    pub contiguous: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct InjectionRegionsResult {
+    pub context: RequestContext,
+    pub regions: Vec<WireInjectionRegion>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct LanguageCatalogAck {
     pub context: RequestContext,
     pub languages: usize,
@@ -323,6 +349,7 @@ pub enum Request {
     NavigateNode(NavigateNode),
     RunNodeScalar(RunNodeScalar),
     DeriveSelectionRanges(DeriveSelectionRanges),
+    DeriveInjectionRegions(DeriveInjectionRegions),
     ConfigureLanguages(ConfigureLanguages),
     CloseDocument(CloseDocument),
 }
@@ -366,6 +393,7 @@ pub enum Response {
     Nodes(NodeResult),
     NodeScalar(NodeScalarResult),
     SelectionRanges(SelectionRangesResult),
+    InjectionRegions(InjectionRegionsResult),
     LanguageCatalogAck(LanguageCatalogAck),
     Error(WorkerError),
 }
@@ -415,11 +443,16 @@ impl DocumentReplica {
             .language()
             .map(|language| (*language).clone())
             .ok_or_else(|| "parser has no configured language".to_string())?;
+        // Parsing and node reads do not consume highlight/binding queries.
+        // Compile only the injection query needed by the current fused
+        // readers; the catalog path prepares the full query set lazily before
+        // readers that need it. This keeps document sync and recovery cheap.
         worker_analysis(
             &analysis,
             &request.language,
             grammar_language,
             request.queries,
+            false,
         )?;
         Ok((
             Self {
@@ -774,6 +807,47 @@ impl DocumentReplica {
         })
     }
 
+    fn derive_injection_regions(
+        &self,
+        request: DeriveInjectionRegions,
+    ) -> Result<InjectionRegionsResult, String> {
+        self.validate_read_identity(&request.context)?;
+        let regions = self
+            .analysis
+            .injection_query(&self.language)
+            .map(|query| {
+                crate::language::InjectionResolver::resolve_all(
+                    &self.analysis,
+                    &self.node_tracker,
+                    &self.uri,
+                    &self.tree,
+                    &self.text,
+                    query.as_ref(),
+                    request.context.incarnation,
+                )
+            })
+            .unwrap_or_default()
+            .into_iter()
+            .map(|resolved| WireInjectionRegion {
+                language: resolved.injection_language,
+                byte_start: resolved.region.byte_range.start,
+                byte_end: resolved.region.byte_range.end,
+                line_start: resolved.region.line_range.start,
+                line_end: resolved.region.line_range.end,
+                start_column: resolved.region.start_column,
+                region_id: resolved.region.region_id,
+                content_hash: resolved.region.content_hash,
+                virtual_content: resolved.virtual_content,
+                line_column_offsets: resolved.line_column_offsets,
+                contiguous: resolved.contiguous,
+            })
+            .collect();
+        Ok(InjectionRegionsResult {
+            context: request.context,
+            regions,
+        })
+    }
+
     fn tracked_node<'tree>(
         &'tree self,
         node_id: &OpaqueNodeId,
@@ -904,6 +978,7 @@ fn worker_analysis(
     language_name: &str,
     language: tree_sitter::Language,
     queries: WorkerQuerySources,
+    compile_all_queries: bool,
 ) -> Result<(), String> {
     analysis
         .language_registry_for_parallel()
@@ -922,9 +997,19 @@ fn worker_analysis(
             queries.injections,
         ),
     ] {
+        if !compile_all_queries && kind != crate::config::settings::QueryKind::Injections {
+            continue;
+        }
         let Some(source) = source else {
             continue;
         };
+        if analysis
+            .query_store()
+            .query_source(kind, language_name)
+            .is_some_and(|current| current.as_ref() == source)
+        {
+            continue;
+        }
         let query = tree_sitter::Query::new(&language, &source)
             .map_err(|error| format!("worker query reconstruction failed: {error}"))?;
         analysis.query_store().insert_query_with_source(
@@ -1579,6 +1664,7 @@ fn handle_work(
         Request::NavigateNode(request) => navigate_node(request, documents),
         Request::RunNodeScalar(request) => run_node_scalar(request, documents),
         Request::DeriveSelectionRanges(request) => derive_selection_ranges(request, documents),
+        Request::DeriveInjectionRegions(request) => derive_injection_regions(request, documents),
         Request::ConfigureLanguages(request) => configure_languages(request, analysis),
         Request::CloseDocument(request) => close_document(
             request,
@@ -1605,6 +1691,7 @@ fn request_context(request: &Request) -> Option<&RequestContext> {
         Request::NavigateNode(request) => Some(&request.context),
         Request::RunNodeScalar(request) => Some(&request.context),
         Request::DeriveSelectionRanges(request) => Some(&request.context),
+        Request::DeriveInjectionRegions(request) => Some(&request.context),
         Request::ConfigureLanguages(request) => Some(&request.context),
         Request::CloseDocument(request) => Some(&request.context),
     }
@@ -1620,6 +1707,7 @@ fn document_key(request: &Request) -> Option<DocumentKey> {
         Request::NavigateNode(request) => Some(DocumentKey::from(&request.context)),
         Request::RunNodeScalar(request) => Some(DocumentKey::from(&request.context)),
         Request::DeriveSelectionRanges(request) => Some(DocumentKey::from(&request.context)),
+        Request::DeriveInjectionRegions(request) => Some(DocumentKey::from(&request.context)),
         Request::CloseDocument(request) => Some(DocumentKey::from(&request.context)),
         Request::Handshake(_) | Request::DeriveSnapshot(_) | Request::ConfigureLanguages(_) => None,
     }
@@ -1717,6 +1805,32 @@ fn derive_selection_ranges(request: DeriveSelectionRanges, documents: &DocumentS
     }
 }
 
+fn derive_injection_regions(
+    request: DeriveInjectionRegions,
+    documents: &DocumentStore,
+) -> Response {
+    let context = request.context.clone();
+    let Some(replica) = documents
+        .get(&DocumentKey::from(&context))
+        .map(|entry| Arc::clone(entry.value()))
+    else {
+        return Response::Error(WorkerError {
+            context: Some(context),
+            message: "document replica is missing; full sync required".into(),
+        });
+    };
+    match replica.lock() {
+        Ok(replica) => match replica.derive_injection_regions(request) {
+            Ok(result) => Response::InjectionRegions(result),
+            Err(message) => Response::Error(WorkerError {
+                context: Some(context),
+                message,
+            }),
+        },
+        Err(_) => poisoned_document_restart(context),
+    }
+}
+
 fn configure_languages(
     request: ConfigureLanguages,
     analysis: &Arc<crate::language::LanguageCoordinator>,
@@ -1738,7 +1852,7 @@ fn configure_languages(
                             message: "parser has no configured language".into(),
                         });
                     };
-                    match worker_analysis(analysis, &language_name, language, queries) {
+                    match worker_analysis(analysis, &language_name, language, queries, true) {
                         Ok(()) => Response::LanguageCatalogAck(LanguageCatalogAck {
                             context: context.clone(),
                             languages: configured + 1,
@@ -2652,6 +2766,18 @@ impl Client {
         )
     }
 
+    pub fn derive_injection_regions(
+        &self,
+        request: DeriveInjectionRegions,
+    ) -> io::Result<Response> {
+        let context = request.context.clone();
+        self.request_with_timeout(
+            Request::DeriveInjectionRegions(request),
+            context,
+            Duration::from_secs(60),
+        )
+    }
+
     pub fn configure_languages(&self, request: ConfigureLanguages) -> io::Result<Response> {
         let context = request.context.clone();
         self.request_with_timeout(
@@ -2828,6 +2954,7 @@ fn response_request_id(response: &Response) -> Option<u64> {
         Response::Nodes(result) => Some(result.context.request_id),
         Response::NodeScalar(result) => Some(result.context.request_id),
         Response::SelectionRanges(result) => Some(result.context.request_id),
+        Response::InjectionRegions(result) => Some(result.context.request_id),
         Response::LanguageCatalogAck(ack) => Some(ack.context.request_id),
         Response::Error(error) => error.context.as_ref().map(|context| context.request_id),
         Response::HandshakeReady(_) => None,
@@ -2843,6 +2970,7 @@ fn response_context(response: &Response) -> Option<&RequestContext> {
         Response::Nodes(result) => Some(&result.context),
         Response::NodeScalar(result) => Some(&result.context),
         Response::SelectionRanges(result) => Some(&result.context),
+        Response::InjectionRegions(result) => Some(&result.context),
         Response::LanguageCatalogAck(ack) => Some(&ack.context),
         Response::Error(error) => error.context.as_ref(),
         Response::HandshakeReady(_) => None,
@@ -2954,16 +3082,16 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        ApplyDocumentEdits, BUILD_ID, ByteEdit, CloseDocument, DeriveSelectionRanges,
-        DeriveSnapshot, DocumentKey, DocumentLane, DocumentReplica, GrammarKey, Handshake,
-        HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
-        MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeNavigation, NodeScalarOperation,
-        NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION, Request, RequestContext, ResolveNode,
-        Response, Route, RunNodeScalar, SyncDocument, WirePosition, WireRange, WorkerError,
-        WorkerQuerySources, close_document, decode_frame, derive_snapshot_with_language,
-        encode_frame, named_node_count, replace_retained_bytes, reserve_retained_growth,
-        route_response, run, submit_document_job, sync_document, terminate_by_transport,
-        validate_document_size,
+        ApplyDocumentEdits, BUILD_ID, ByteEdit, CloseDocument, DeriveInjectionRegions,
+        DeriveSelectionRanges, DeriveSnapshot, DocumentKey, DocumentLane, DocumentReplica,
+        GrammarKey, Handshake, HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES,
+        MAX_DOCUMENT_REPLICAS, MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeNavigation,
+        NodeScalarOperation, NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION, Request,
+        RequestContext, ResolveNode, Response, Route, RunNodeScalar, SyncDocument, WirePosition,
+        WireRange, WorkerError, WorkerQuerySources, close_document, decode_frame,
+        derive_snapshot_with_language, encode_frame, named_node_count, replace_retained_bytes,
+        reserve_retained_growth, route_response, run, submit_document_job, sync_document,
+        terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -3795,6 +3923,7 @@ mod tests {
                 parser_path: "/unused/static-language".into(),
                 artifact_digest: "sha256:rust-v1".into(),
                 queries: WorkerQuerySources {
+                    highlights: Some("(identifier) @variable".into()),
                     injections: Some(
                         r#"((line_comment) @injection.content
                             (#set! injection.language "rust")
@@ -3808,6 +3937,8 @@ mod tests {
             &mut parser,
         )
         .unwrap();
+        assert!(replica.analysis.highlight_query("rust").is_none());
+        assert!(replica.analysis.injection_query("rust").is_some());
 
         let result = replica
             .derive_selection_ranges(DeriveSelectionRanges {
@@ -3834,6 +3965,22 @@ mod tests {
             }
         );
         assert!(result.ranges[0].parent.is_some());
+
+        let regions = replica
+            .derive_injection_regions(DeriveInjectionRegions {
+                context: RequestContext {
+                    request_id: 2,
+                    worker_generation: 3,
+                    uri: "file:///injected.rs".into(),
+                    incarnation: 4,
+                    content_version: 1,
+                    configuration_generation: 2,
+                },
+            })
+            .unwrap();
+        assert_eq!(regions.regions.len(), 1);
+        assert_eq!(regions.regions[0].language, "rust");
+        assert_eq!(regions.regions[0].virtual_content, "fn inner() {}");
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -22,7 +22,7 @@ use sha2::{Digest, Sha256};
 
 use crate::language::node_tracker::{EditInfo, NodeTracker};
 
-pub const PROTOCOL_VERSION: u32 = 6;
+pub const PROTOCOL_VERSION: u32 = 7;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_REPLICAS: usize = 4_096;
 pub const MAX_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
@@ -61,6 +61,22 @@ pub struct WorkerQuerySources {
     pub highlights: Option<String>,
     pub bindings: Option<String>,
     pub injections: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct WorkerLanguageAsset {
+    pub language: String,
+    pub grammar_symbol: String,
+    pub source_path: PathBuf,
+    pub parser_path: PathBuf,
+    pub artifact_digest: String,
+    pub queries: WorkerQuerySources,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ConfigureLanguages {
+    pub context: RequestContext,
+    pub assets: Vec<WorkerLanguageAsset>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -267,6 +283,12 @@ pub struct SelectionRangesResult {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct LanguageCatalogAck {
+    pub context: RequestContext,
+    pub languages: usize,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CloseDocument {
     pub context: RequestContext,
 }
@@ -301,6 +323,7 @@ pub enum Request {
     NavigateNode(NavigateNode),
     RunNodeScalar(RunNodeScalar),
     DeriveSelectionRanges(DeriveSelectionRanges),
+    ConfigureLanguages(ConfigureLanguages),
     CloseDocument(CloseDocument),
 }
 
@@ -343,6 +366,7 @@ pub enum Response {
     Nodes(NodeResult),
     NodeScalar(NodeScalarResult),
     SelectionRanges(SelectionRangesResult),
+    LanguageCatalogAck(LanguageCatalogAck),
     Error(WorkerError),
 }
 
@@ -1129,6 +1153,17 @@ impl GrammarKey {
             artifact_digest: request.artifact_digest.clone(),
         }
     }
+
+    fn from_asset(asset: &WorkerLanguageAsset) -> Self {
+        Self {
+            parser_path: asset
+                .parser_path
+                .canonicalize()
+                .unwrap_or_else(|_| asset.parser_path.clone()),
+            grammar_symbol: asset.grammar_symbol.clone(),
+            artifact_digest: asset.artifact_digest.clone(),
+        }
+    }
 }
 
 impl PartialEq for GrammarKey {
@@ -1544,6 +1579,7 @@ fn handle_work(
         Request::NavigateNode(request) => navigate_node(request, documents),
         Request::RunNodeScalar(request) => run_node_scalar(request, documents),
         Request::DeriveSelectionRanges(request) => derive_selection_ranges(request, documents),
+        Request::ConfigureLanguages(request) => configure_languages(request, analysis),
         Request::CloseDocument(request) => close_document(
             request,
             documents,
@@ -1569,6 +1605,7 @@ fn request_context(request: &Request) -> Option<&RequestContext> {
         Request::NavigateNode(request) => Some(&request.context),
         Request::RunNodeScalar(request) => Some(&request.context),
         Request::DeriveSelectionRanges(request) => Some(&request.context),
+        Request::ConfigureLanguages(request) => Some(&request.context),
         Request::CloseDocument(request) => Some(&request.context),
     }
 }
@@ -1584,7 +1621,7 @@ fn document_key(request: &Request) -> Option<DocumentKey> {
         Request::RunNodeScalar(request) => Some(DocumentKey::from(&request.context)),
         Request::DeriveSelectionRanges(request) => Some(DocumentKey::from(&request.context)),
         Request::CloseDocument(request) => Some(DocumentKey::from(&request.context)),
-        Request::Handshake(_) | Request::DeriveSnapshot(_) => None,
+        Request::Handshake(_) | Request::DeriveSnapshot(_) | Request::ConfigureLanguages(_) => None,
     }
 }
 
@@ -1678,6 +1715,53 @@ fn derive_selection_ranges(request: DeriveSelectionRanges, documents: &DocumentS
         },
         Err(_) => poisoned_document_restart(context),
     }
+}
+
+fn configure_languages(
+    request: ConfigureLanguages,
+    analysis: &Arc<crate::language::LanguageCoordinator>,
+) -> Response {
+    let context = request.context;
+    let mut configured = 0;
+    for asset in request.assets {
+        let key = GrammarKey::from_asset(&asset);
+        let language_name = asset.language;
+        let queries = asset.queries;
+        let response = WORKER_THREAD_STATE.with(|state| {
+            state
+                .borrow_mut()
+                .with_parser(key, context.clone(), |parser, _| {
+                    let Some(language) = parser.language().map(|language| (*language).clone())
+                    else {
+                        return Response::Error(WorkerError {
+                            context: Some(context.clone()),
+                            message: "parser has no configured language".into(),
+                        });
+                    };
+                    match worker_analysis(analysis, &language_name, language, queries) {
+                        Ok(()) => Response::LanguageCatalogAck(LanguageCatalogAck {
+                            context: context.clone(),
+                            languages: configured + 1,
+                        }),
+                        Err(message) => Response::Error(WorkerError {
+                            context: Some(context.clone()),
+                            message,
+                        }),
+                    }
+                })
+        });
+        if matches!(
+            response,
+            Response::Error(_) | Response::WorkerRestartRequired(_)
+        ) {
+            return response;
+        }
+        configured += 1;
+    }
+    Response::LanguageCatalogAck(LanguageCatalogAck {
+        context,
+        languages: configured,
+    })
 }
 
 fn poisoned_document_restart(context: RequestContext) -> Response {
@@ -2568,6 +2652,15 @@ impl Client {
         )
     }
 
+    pub fn configure_languages(&self, request: ConfigureLanguages) -> io::Result<Response> {
+        let context = request.context.clone();
+        self.request_with_timeout(
+            Request::ConfigureLanguages(request),
+            context,
+            Duration::from_secs(60),
+        )
+    }
+
     pub fn close_document(&self, request: CloseDocument) -> io::Result<Response> {
         let context = request.context.clone();
         self.request_with_timeout(
@@ -2735,6 +2828,7 @@ fn response_request_id(response: &Response) -> Option<u64> {
         Response::Nodes(result) => Some(result.context.request_id),
         Response::NodeScalar(result) => Some(result.context.request_id),
         Response::SelectionRanges(result) => Some(result.context.request_id),
+        Response::LanguageCatalogAck(ack) => Some(ack.context.request_id),
         Response::Error(error) => error.context.as_ref().map(|context| context.request_id),
         Response::HandshakeReady(_) => None,
     }
@@ -2749,6 +2843,7 @@ fn response_context(response: &Response) -> Option<&RequestContext> {
         Response::Nodes(result) => Some(&result.context),
         Response::NodeScalar(result) => Some(&result.context),
         Response::SelectionRanges(result) => Some(&result.context),
+        Response::LanguageCatalogAck(ack) => Some(&ack.context),
         Response::Error(error) => error.context.as_ref(),
         Response::HandshakeReady(_) => None,
     }

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -2959,7 +2959,7 @@ mod tests {
         HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
         MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeNavigation, NodeScalarOperation,
         NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION, Request, RequestContext, ResolveNode,
-        Response, Route, RunNodeScalar, SyncDocument, WirePosition, WorkerError,
+        Response, Route, RunNodeScalar, SyncDocument, WirePosition, WireRange, WorkerError,
         WorkerQuerySources, close_document, decode_frame, derive_snapshot_with_language,
         encode_frame, named_node_count, replace_retained_bytes, reserve_retained_growth,
         route_response, run, submit_document_job, sync_document, terminate_by_transport,
@@ -3770,6 +3770,70 @@ mod tests {
             })
             .unwrap();
         assert!(stale.nodes.is_empty());
+    }
+
+    #[test]
+    fn selection_ranges_descend_into_worker_owned_injections() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let context = RequestContext {
+            request_id: 1,
+            worker_generation: 3,
+            uri: "file:///injected.rs".into(),
+            incarnation: 4,
+            content_version: 1,
+            configuration_generation: 2,
+        };
+        let (replica, _) = DocumentReplica::sync(
+            SyncDocument {
+                context: context.clone(),
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: "/unused/static-language".into(),
+                parser_path: "/unused/static-language".into(),
+                artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources {
+                    injections: Some(
+                        r#"((line_comment) @injection.content
+                            (#set! injection.language "rust")
+                            (#offset! @injection.content 0 3 0 0))"#
+                            .into(),
+                    ),
+                    ..WorkerQuerySources::default()
+                },
+                text: "// fn inner() {}\n".into(),
+            },
+            &mut parser,
+        )
+        .unwrap();
+
+        let result = replica
+            .derive_selection_ranges(DeriveSelectionRanges {
+                context,
+                positions: vec![WirePosition {
+                    line: 0,
+                    character: 6,
+                }],
+            })
+            .unwrap();
+
+        assert_eq!(result.ranges.len(), 1);
+        assert_eq!(
+            result.ranges[0].range,
+            WireRange {
+                start: WirePosition {
+                    line: 0,
+                    character: 6,
+                },
+                end: WirePosition {
+                    line: 0,
+                    character: 11,
+                },
+            }
+        );
+        assert!(result.ranges[0].parent.is_some());
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -22,7 +22,7 @@ use sha2::{Digest, Sha256};
 
 use crate::language::node_tracker::{EditInfo, NodeTracker};
 
-pub const PROTOCOL_VERSION: u32 = 5;
+pub const PROTOCOL_VERSION: u32 = 6;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_REPLICAS: usize = 4_096;
 pub const MAX_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
@@ -56,6 +56,13 @@ pub struct DeriveSnapshot {
     pub text: String,
 }
 
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct WorkerQuerySources {
+    pub highlights: Option<String>,
+    pub bindings: Option<String>,
+    pub injections: Option<String>,
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SyncDocument {
     pub context: RequestContext,
@@ -64,6 +71,7 @@ pub struct SyncDocument {
     pub source_path: PathBuf,
     pub parser_path: PathBuf,
     pub artifact_digest: String,
+    pub queries: WorkerQuerySources,
     pub text: String,
 }
 
@@ -346,12 +354,25 @@ struct DocumentReplica {
     tree: tree_sitter::Tree,
     uri: url::Url,
     node_tracker: NodeTracker,
+    analysis: Arc<crate::language::LanguageCoordinator>,
 }
 
 impl DocumentReplica {
     fn sync(
         request: SyncDocument,
         parser: &mut tree_sitter::Parser,
+    ) -> Result<(Self, DocumentAck), String> {
+        Self::sync_with_analysis(
+            request,
+            parser,
+            Arc::new(crate::language::LanguageCoordinator::new()),
+        )
+    }
+
+    fn sync_with_analysis(
+        request: SyncDocument,
+        parser: &mut tree_sitter::Parser,
+        analysis: Arc<crate::language::LanguageCoordinator>,
     ) -> Result<(Self, DocumentAck), String> {
         validate_document_size(request.text.len())?;
         let tree = parser
@@ -366,6 +387,16 @@ impl DocumentReplica {
             .map_err(|error| format!("document URI is invalid: {error}"))?;
         let node_tracker = NodeTracker::new();
         node_tracker.open_incarnation(&uri, request.context.incarnation);
+        let grammar_language = parser
+            .language()
+            .map(|language| (*language).clone())
+            .ok_or_else(|| "parser has no configured language".to_string())?;
+        worker_analysis(
+            &analysis,
+            &request.language,
+            grammar_language,
+            request.queries,
+        )?;
         Ok((
             Self {
                 context: request.context,
@@ -375,6 +406,7 @@ impl DocumentReplica {
                 tree,
                 uri,
                 node_tracker,
+                analysis,
             },
             ack,
         ))
@@ -693,27 +725,25 @@ impl DocumentReplica {
         request: DeriveSelectionRanges,
     ) -> Result<SelectionRangesResult, String> {
         self.validate_read_identity(&request.context)?;
-        let mapper = crate::text::PositionMapper::new(&self.text);
-        let root = self.tree.root_node();
-        let ranges = request
+        let positions = request
             .positions
             .into_iter()
             .map(|position| {
-                let lsp_position =
-                    tower_lsp_server::ls_types::Position::new(position.line, position.character);
-                mapper
-                    .position_to_byte(lsp_position)
-                    .and_then(|byte| root.descendant_for_byte_range(byte, byte))
-                    .map(|node| build_wire_selection_range(node, &mapper))
-                    .unwrap_or(WireSelectionRange {
-                        range: WireRange {
-                            start: position,
-                            end: position,
-                        },
-                        parent: None,
-                    })
+                tower_lsp_server::ls_types::Position::new(position.line, position.character)
             })
-            .collect();
+            .collect::<Vec<_>>();
+        let mut parser_pool = self.analysis.create_document_parser_pool();
+        let ranges = crate::analysis::handle_selection_range(
+            &self.text,
+            Some(&self.tree),
+            Some(&self.language),
+            &positions,
+            &self.analysis,
+            &mut parser_pool,
+        )
+        .into_iter()
+        .map(selection_range_to_wire)
+        .collect();
         Ok(SelectionRangesResult {
             context: request.context,
             ranges,
@@ -831,34 +861,56 @@ impl DocumentReplica {
     }
 }
 
-fn build_wire_selection_range(
-    node: tree_sitter::Node<'_>,
-    mapper: &crate::text::PositionMapper<'_>,
+fn selection_range_to_wire(
+    selection: tower_lsp_server::ls_types::SelectionRange,
 ) -> WireSelectionRange {
-    let current_range = node.byte_range();
-    let mut parent = node.parent();
-    while parent.is_some_and(|parent| parent.byte_range() == current_range) {
-        parent = parent.and_then(|parent| parent.parent());
-    }
     WireSelectionRange {
         range: WireRange {
-            start: mapper
-                .byte_to_position(node.start_byte())
-                .map(wire_position)
-                .unwrap_or(WirePosition {
-                    line: node.start_position().row as u32,
-                    character: 0,
-                }),
-            end: mapper
-                .byte_to_position(node.end_byte())
-                .map(wire_position)
-                .unwrap_or(WirePosition {
-                    line: node.end_position().row as u32,
-                    character: 0,
-                }),
+            start: wire_position(selection.range.start),
+            end: wire_position(selection.range.end),
         },
-        parent: parent.map(|parent| Box::new(build_wire_selection_range(parent, mapper))),
+        parent: selection
+            .parent
+            .map(|parent| Box::new(selection_range_to_wire(*parent))),
     }
+}
+
+fn worker_analysis(
+    analysis: &crate::language::LanguageCoordinator,
+    language_name: &str,
+    language: tree_sitter::Language,
+    queries: WorkerQuerySources,
+) -> Result<(), String> {
+    analysis
+        .language_registry_for_parallel()
+        .register(language_name.to_string(), language.clone());
+    for (kind, source) in [
+        (
+            crate::config::settings::QueryKind::Highlights,
+            queries.highlights,
+        ),
+        (
+            crate::config::settings::QueryKind::Bindings,
+            queries.bindings,
+        ),
+        (
+            crate::config::settings::QueryKind::Injections,
+            queries.injections,
+        ),
+    ] {
+        let Some(source) = source else {
+            continue;
+        };
+        let query = tree_sitter::Query::new(&language, &source)
+            .map_err(|error| format!("worker query reconstruction failed: {error}"))?;
+        analysis.query_store().insert_query_with_source(
+            kind,
+            language_name.to_string(),
+            Arc::new(query),
+            source,
+        );
+    }
+    Ok(())
 }
 
 fn validate_document_size(bytes: usize) -> Result<(), String> {
@@ -1457,6 +1509,7 @@ fn submit_document_job(
 
 fn handle_work(
     request: Request,
+    analysis: &Arc<crate::language::LanguageCoordinator>,
     documents: &DocumentStore,
     closed_documents: &ClosedDocuments,
     document_capacity: &DocumentCapacity,
@@ -1466,8 +1519,9 @@ fn handle_work(
     let started = Instant::now();
     match request {
         Request::DeriveSnapshot(request) => derive_snapshot(request, queue_wait),
-        Request::SyncDocument(request) => sync_document(
+        Request::SyncDocument(request) => sync_document_with_analysis(
             request,
+            analysis,
             documents,
             closed_documents,
             document_capacity,
@@ -1633,8 +1687,27 @@ fn poisoned_document_restart(context: RequestContext) -> Response {
     })
 }
 
+#[cfg(test)]
 fn sync_document(
     request: SyncDocument,
+    documents: &DocumentStore,
+    closed_documents: &ClosedDocuments,
+    document_capacity: &DocumentCapacity,
+    retained_document_bytes: &RetainedDocumentBytes,
+) -> Response {
+    sync_document_with_analysis(
+        request,
+        &Arc::new(crate::language::LanguageCoordinator::new()),
+        documents,
+        closed_documents,
+        document_capacity,
+        retained_document_bytes,
+    )
+}
+
+fn sync_document_with_analysis(
+    request: SyncDocument,
+    analysis: &Arc<crate::language::LanguageCoordinator>,
     documents: &DocumentStore,
     closed_documents: &ClosedDocuments,
     document_capacity: &DocumentCapacity,
@@ -1716,10 +1789,8 @@ fn sync_document(
     let response = WORKER_THREAD_STATE.with(|state| {
         state
             .borrow_mut()
-            .with_parser(
-                grammar_key,
-                context.clone(),
-                |parser, _| match DocumentReplica::sync(request, parser) {
+            .with_parser(grammar_key, context.clone(), |parser, _| {
+                match DocumentReplica::sync_with_analysis(request, parser, Arc::clone(analysis)) {
                     Ok((replica, ack)) => {
                         documents.insert(document_key, Arc::new(Mutex::new(replica)));
                         closed_documents.remove(&DocumentKey::from(&ack.context));
@@ -1729,8 +1800,8 @@ fn sync_document(
                         context: Some(context),
                         message,
                     }),
-                },
-            )
+                }
+            })
     });
     if reserves_slot && !matches!(&response, Response::DocumentAck(_)) {
         let mut known_documents = document_capacity
@@ -2009,6 +2080,7 @@ where
     inject_idle_worker_crash_once();
 
     let documents = Arc::new(dashmap::DashMap::new());
+    let analysis = Arc::new(crate::language::LanguageCoordinator::new());
     let closed_documents = Arc::new(dashmap::DashMap::new());
     let document_capacity = Arc::new(Mutex::new(0));
     let retained_document_bytes = Arc::new(AtomicUsize::new(0));
@@ -2046,6 +2118,7 @@ where
         let responses = responses.clone();
         let permit = AdmissionPermit(permits.clone());
         let documents = Arc::clone(&documents);
+        let analysis = Arc::clone(&analysis);
         let closed_documents = Arc::clone(&closed_documents);
         let document_capacity = Arc::clone(&document_capacity);
         let retained_document_bytes = Arc::clone(&retained_document_bytes);
@@ -2054,6 +2127,7 @@ where
         let job: LaneJob = Box::new(move || {
             let response = handle_work(
                 request,
+                &analysis,
                 &documents,
                 &closed_documents,
                 &document_capacity,
@@ -2790,10 +2864,11 @@ mod tests {
         HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
         MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeNavigation, NodeScalarOperation,
         NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION, Request, RequestContext, ResolveNode,
-        Response, Route, RunNodeScalar, SyncDocument, WirePosition, WorkerError, close_document,
-        decode_frame, derive_snapshot_with_language, encode_frame, named_node_count,
-        replace_retained_bytes, reserve_retained_growth, route_response, run, submit_document_job,
-        sync_document, terminate_by_transport, validate_document_size,
+        Response, Route, RunNodeScalar, SyncDocument, WirePosition, WorkerError,
+        WorkerQuerySources, close_document, decode_frame, derive_snapshot_with_language,
+        encode_frame, named_node_count, replace_retained_bytes, reserve_retained_growth,
+        route_response, run, submit_document_job, sync_document, terminate_by_transport,
+        validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -3341,6 +3416,7 @@ mod tests {
                 source_path: "/unused/static-language".into(),
                 parser_path: "/unused/static-language".into(),
                 artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
                 text: "fn main() { 1 }".into(),
             },
             &mut parser,
@@ -3398,11 +3474,16 @@ mod tests {
                 source_path: "/unused/static-language".into(),
                 parser_path: "/unused/static-language".into(),
                 artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources {
+                    injections: Some("(identifier) @injection.content".into()),
+                    ..WorkerQuerySources::default()
+                },
                 text: "fn main() {}".into(),
             },
             &mut parser,
         )
         .unwrap();
+        assert!(replica.analysis.injection_query("rust").is_some());
 
         let resolved = replica
             .resolve_node(ResolveNode {
@@ -3618,6 +3699,7 @@ mod tests {
                 source_path: "/unused/static-language".into(),
                 parser_path: "/unused/static-language".into(),
                 artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
                 text: "fn main() {}".into(),
             },
             &mut parser,
@@ -3664,6 +3746,7 @@ mod tests {
                 source_path: "/unused/static-language".into(),
                 parser_path: "/unused/static-language".into(),
                 artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
                 text: "fn current() {}".into(),
             },
             &mut parser,
@@ -3703,6 +3786,7 @@ mod tests {
                 source_path: "/unused/rust".into(),
                 parser_path: "/unused/rust".into(),
                 artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
                 text: "fn current() {}".into(),
             },
             &mut parser,
@@ -3760,6 +3844,7 @@ mod tests {
                 source_path: "/unused/rust".into(),
                 parser_path: "/unused/rust".into(),
                 artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
                 text: "fn main() {}".into(),
             },
             &documents,
@@ -3794,6 +3879,7 @@ mod tests {
                 source_path: "/unused/rust".into(),
                 parser_path: "/unused/rust".into(),
                 artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
                 text: text.into(),
             },
             &mut parser,
@@ -3823,6 +3909,7 @@ mod tests {
                 source_path: "/unused/rust".into(),
                 parser_path: "/unused/rust".into(),
                 artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
                 text: "fn replacement() {}".into(),
             },
             &documents,
@@ -3936,6 +4023,7 @@ mod tests {
                 source_path: "/unused/static-language".into(),
                 parser_path: "/unused/static-language".into(),
                 artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
                 text: original.into(),
             },
             &mut parser,
@@ -3997,6 +4085,7 @@ mod tests {
                 source_path: "/unused/static-language".into(),
                 parser_path: "/unused/static-language".into(),
                 artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
                 text: "fn main() { 1 }".into(),
             },
             &mut parser,

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -136,6 +136,7 @@ pub enum NodeScalarOperation {
     DescendantCount,
     SExpression,
     Text,
+    FieldNameForChild { index: u32, named: bool },
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -145,14 +146,39 @@ pub enum NodeScalarValue {
     Bool(bool),
     U64(u64),
     ByteRange { start_byte: u64, end_byte: u64 },
+    NullableString(Option<String>),
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NodeNavigation {
     Parent,
     Children,
     NamedChildren,
+    Child {
+        index: u32,
+    },
+    NamedChild {
+        index: u32,
+    },
+    NextSibling,
+    PreviousSibling,
+    NextNamedSibling,
+    PreviousNamedSibling,
+    FirstChildForByte {
+        byte: usize,
+    },
+    DescendantForByteRange {
+        start_byte: usize,
+        end_byte: usize,
+        named: bool,
+    },
+    ChildByFieldName {
+        name: String,
+    },
+    ChildrenByFieldName {
+        name: String,
+    },
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -442,6 +468,48 @@ impl DocumentReplica {
             NodeNavigation::NamedChildren => (0..node.named_child_count() as u32)
                 .filter_map(|index| node.named_child(index))
                 .collect(),
+            NodeNavigation::Child { index } => node.child(index).into_iter().collect(),
+            NodeNavigation::NamedChild { index } => node.named_child(index).into_iter().collect(),
+            NodeNavigation::NextSibling => node.next_sibling().into_iter().collect(),
+            NodeNavigation::PreviousSibling => node.prev_sibling().into_iter().collect(),
+            NodeNavigation::NextNamedSibling => node.next_named_sibling().into_iter().collect(),
+            NodeNavigation::PreviousNamedSibling => node.prev_named_sibling().into_iter().collect(),
+            NodeNavigation::FirstChildForByte { byte } => {
+                if node.start_byte() <= byte && byte <= node.end_byte() && byte <= self.text.len() {
+                    node.first_child_for_byte(byte).into_iter().collect()
+                } else {
+                    Vec::new()
+                }
+            }
+            NodeNavigation::DescendantForByteRange {
+                start_byte,
+                end_byte,
+                named,
+            } => {
+                if node.start_byte() <= start_byte
+                    && start_byte <= end_byte
+                    && end_byte <= node.end_byte()
+                {
+                    if named {
+                        node.named_descendant_for_byte_range(start_byte, end_byte)
+                            .into_iter()
+                            .collect()
+                    } else {
+                        node.descendant_for_byte_range(start_byte, end_byte)
+                            .into_iter()
+                            .collect()
+                    }
+                } else {
+                    Vec::new()
+                }
+            }
+            NodeNavigation::ChildByFieldName { name } => {
+                node.child_by_field_name(&name).into_iter().collect()
+            }
+            NodeNavigation::ChildrenByFieldName { name } => {
+                let mut cursor = node.walk();
+                node.children_by_field_name(&name, &mut cursor).collect()
+            }
         };
         let nodes = selected
             .into_iter()
@@ -495,6 +563,14 @@ impl DocumentReplica {
                     .ok_or_else(|| "node text is not a valid UTF-8 slice".to_string())?
                     .to_string(),
             ),
+            NodeScalarOperation::FieldNameForChild { index, named } => {
+                let field = if named {
+                    node.field_name_for_named_child(index)
+                } else {
+                    node.field_name_for_child(index)
+                };
+                NodeScalarValue::NullableString(field.map(str::to_string))
+            }
         };
         Ok(NodeScalarResult {
             context: request.context,
@@ -3142,6 +3218,33 @@ mod tests {
             .unwrap();
         assert_eq!(parent.nodes.len(), 1);
         assert_eq!(parent.nodes[0].kind, "function_item");
+
+        let named = replica
+            .navigate_node(NavigateNode {
+                context: context.clone(),
+                node_id: parent.nodes[0].id.clone(),
+                operation: NodeNavigation::ChildByFieldName {
+                    name: "name".into(),
+                },
+            })
+            .unwrap();
+        assert_eq!(named.nodes.len(), 1);
+        assert_eq!(named.nodes[0].kind, "identifier");
+        assert_eq!(named.nodes[0].start_byte, 3);
+
+        let descendant = replica
+            .navigate_node(NavigateNode {
+                context: context.clone(),
+                node_id: parent.nodes[0].id.clone(),
+                operation: NodeNavigation::DescendantForByteRange {
+                    start_byte: 3,
+                    end_byte: 7,
+                    named: true,
+                },
+            })
+            .unwrap();
+        assert_eq!(descendant.nodes.len(), 1);
+        assert_eq!(descendant.nodes[0].kind, "identifier");
 
         let mut edited = context.clone();
         edited.request_id = 2;

--- a/tests/e2e_native_definition.rs
+++ b/tests/e2e_native_definition.rs
@@ -11,6 +11,8 @@
 
 mod helpers;
 
+use std::time::Duration;
+
 use helpers::lsp_client::LspClient;
 use serde_json::json;
 
@@ -105,6 +107,81 @@ fn native_definition_resolves_without_a_bridge_server() {
     let start = &range.expect("range")["start"];
     assert_eq!(start["line"], 0, "definition is the `local greeting` line");
     assert_eq!(start["character"], 6);
+}
+
+#[test]
+fn shadow_worker_matches_native_definition_facts() {
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_EXPERIMENTAL", "true")
+        .env("KAKEHASHI_TREE_WORKER_SHADOW", "true")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env("RUST_LOG", "kakehashi::tree_worker_shadow=debug")
+        .build();
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "initializationOptions": init_options()
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": URI,
+                "languageId": "lua",
+                "version": 1,
+                "text": LUA_SOURCE
+            }
+        }),
+    );
+    std::thread::sleep(Duration::from_millis(500));
+    let response = client.send_request(
+        "textDocument/definition",
+        json!({
+            "textDocument": { "uri": URI },
+            "position": use_position()
+        }),
+    );
+    assert!(!response["result"].is_null(), "{response:?}");
+
+    let markdown_uri = "file:///native_bindings_shadow.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": markdown_uri,
+                "languageId": "markdown",
+                "version": 1,
+                "text": "# t\n\n```lua\nlocal v = 1\nprint(v)\n```\n"
+            }
+        }),
+    );
+    std::thread::sleep(Duration::from_millis(500));
+    let response = client.send_request(
+        "textDocument/definition",
+        json!({
+            "textDocument": { "uri": markdown_uri },
+            "position": { "line": 4, "character": 6 }
+        }),
+    );
+    assert!(!response["result"].is_null(), "{response:?}");
+
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+    let status = client
+        .wait_for_exit(Duration::from_secs(5))
+        .expect("server must exit");
+    assert!(status.success());
+    let stderr = client.drain_stderr();
+    assert!(
+        stderr.matches("native bindings matched").count() >= 2,
+        "worker comparison did not complete: {stderr}"
+    );
+    assert!(!stderr.contains("native bindings mismatch"), "{stderr}");
 }
 
 #[test]

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -154,6 +154,50 @@ fn shadow_worker_matches_authoritative_incremental_lifecycle() {
 }
 
 #[test]
+fn shadow_worker_matches_injected_node_and_navigation() {
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_SHADOW", "true")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env("RUST_LOG", "kakehashi::tree_worker_shadow=debug")
+        .build();
+    initialize(&mut client);
+    let uri = "file:///tree-worker-injected-node.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "markdown",
+                "version": 1,
+                "text": "# Heading\n\n```python\ny = 1 + 2\n```\n"
+            }
+        }),
+    );
+    let node = client.send_request(
+        "kakehashi/node",
+        json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": 3, "character": 4 },
+            "injection": true
+        }),
+    );
+    let id = node["result"]["id"]
+        .as_str()
+        .expect("injected node must have an id");
+    let parent = client.send_request(
+        "kakehashi/node/parent",
+        json!({ "textDocument": { "uri": uri }, "id": id }),
+    );
+    assert!(parent["result"].is_object(), "{parent:?}");
+
+    let stderr = shutdown_and_stderr(client);
+    assert!(stderr.contains("injection node matched"), "{stderr}");
+    assert!(stderr.contains("node navigation matched"), "{stderr}");
+    assert!(!stderr.contains("node mismatch"), "{stderr}");
+    assert!(!stderr.contains("node navigation mismatch"), "{stderr}");
+}
+
+#[test]
 fn systemic_worker_restart_full_resyncs_the_open_document() {
     let directory = tempfile::tempdir().unwrap();
     let marker = directory.path().join("restart-once");

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -372,7 +372,10 @@ fn idle_worker_exit_is_detected_and_restarted_before_the_next_document() {
         )
         .build();
     initialize(&mut client);
-    std::thread::sleep(Duration::from_secs(2));
+    // The debug E2E binary is hashed during the replacement handshake. Leave
+    // enough room for idle detection, backoff, hashing, and the zero-document
+    // resync before introducing the document whose service we verify below.
+    std::thread::sleep(Duration::from_secs(5));
 
     let uri = "file:///after-idle-restart.rs";
     client.send_notification(

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -4,9 +4,9 @@ use std::sync::{Arc, Barrier};
 #[cfg(feature = "e2e")]
 use kakehashi::tree_worker::{
     ApplyDocumentEdits, ByteEdit, CloseDocument, ConfigureLanguages, DeriveDocumentSnapshot,
-    DeriveSemanticTokens, NavigateNode, NodeNavigation, NodeScalarOperation, NodeScalarValue,
-    OpaqueNodeId, ResolveNode, RunCaptures, RunNodeScalar, SyncDocument, WorkerLanguageAsset,
-    WorkerLanguageCatalog, WorkerQuerySources,
+    DeriveNativeBindings, DeriveSemanticTokens, NavigateNode, NodeNavigation, NodeScalarOperation,
+    NodeScalarValue, OpaqueNodeId, ResolveNode, RunCaptures, RunNodeScalar, SyncDocument,
+    WireByteRange, WirePosition, WorkerLanguageAsset, WorkerLanguageCatalog, WorkerQuerySources,
 };
 use kakehashi::tree_worker::{Client, DeriveSnapshot, RequestContext, Response};
 
@@ -366,6 +366,56 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
         panic!("stale node navigation must be contained: {response:?}");
     };
     assert!(nodes.nodes.is_empty());
+
+    let bindings_context = RequestContext {
+        request_id: 351,
+        worker_generation: 44,
+        uri: "file:///bindings-process.rs".into(),
+        incarnation: 1,
+        content_version: 1,
+        configuration_generation: 0,
+    };
+    let response = worker
+        .sync_document(SyncDocument {
+            context: bindings_context.clone(),
+            language: "rust".into(),
+            grammar_symbol: "rust".into(),
+            source_path: parser.clone(),
+            parser_path: parser.clone(),
+            artifact_digest: digest(&parser),
+            queries: WorkerQuerySources {
+                bindings: Some(
+                    r#"
+                    (block) @scope
+                    (let_declaration pattern: (identifier) @definition)
+                    (identifier) @reference
+                    "#
+                    .into(),
+                ),
+                ..Default::default()
+            },
+            text: "fn main() { let target = 1; target; }".into(),
+        })
+        .unwrap();
+    assert!(matches!(response, Response::DocumentAck(_)));
+    let response = worker
+        .derive_native_bindings(DeriveNativeBindings {
+            context: RequestContext {
+                request_id: 352,
+                ..bindings_context
+            },
+            position: WirePosition {
+                line: 0,
+                character: 28,
+            },
+        })
+        .unwrap();
+    let Response::NativeBindings(bindings) = response else {
+        panic!("native bindings must be worker-owned: {response:?}");
+    };
+    let facts = bindings.facts.expect("reference must resolve");
+    assert_eq!(facts.definition, Some(WireByteRange { start: 16, end: 22 }));
+    assert_eq!(facts.references, vec![WireByteRange { start: 28, end: 34 }]);
 
     let mut closed = snapshot.context;
     closed.request_id = 36;

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -4,8 +4,9 @@ use std::sync::{Arc, Barrier};
 #[cfg(feature = "e2e")]
 use kakehashi::tree_worker::{
     ApplyDocumentEdits, ByteEdit, CloseDocument, ConfigureLanguages, DeriveDocumentSnapshot,
-    NavigateNode, NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId, ResolveNode,
-    RunNodeScalar, SyncDocument, WorkerLanguageAsset, WorkerQuerySources,
+    DeriveSemanticTokens, NavigateNode, NodeNavigation, NodeScalarOperation, NodeScalarValue,
+    OpaqueNodeId, ResolveNode, RunNodeScalar, SyncDocument, WorkerLanguageAsset,
+    WorkerLanguageCatalog, WorkerQuerySources,
 };
 use kakehashi::tree_worker::{Client, DeriveSnapshot, RequestContext, Response};
 
@@ -212,17 +213,24 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
                 content_version: 0,
                 configuration_generation: 0,
             },
-            assets: vec![WorkerLanguageAsset {
-                language: "rust".into(),
-                grammar_symbol: "rust".into(),
-                source_path: parser.clone(),
-                parser_path: parser.clone(),
-                artifact_digest: digest(&parser),
-                queries: WorkerQuerySources {
-                    injections: Some("(identifier) @injection.content".into()),
-                    ..Default::default()
-                },
-            }],
+            catalog: WorkerLanguageCatalog {
+                assets: vec![WorkerLanguageAsset {
+                    language: "rust".into(),
+                    grammar_symbol: "rust".into(),
+                    source_path: parser.clone(),
+                    parser_path: parser.clone(),
+                    artifact_digest: digest(&parser),
+                    queries: WorkerQuerySources {
+                        injections: Some("(identifier) @injection.content".into()),
+                        ..Default::default()
+                    },
+                }],
+                capture_mappings: serde_json::from_value(serde_json::json!({
+                    "rust": { "highlights": { "variable": "keyword" } }
+                }))
+                .unwrap(),
+                ..Default::default()
+            },
         })
         .unwrap();
     let Response::LanguageCatalogAck(ack) = response else {
@@ -238,7 +246,10 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
             source_path: parser.clone(),
             parser_path: parser.clone(),
             artifact_digest: digest(&parser),
-            queries: Default::default(),
+            queries: WorkerQuerySources {
+                highlights: Some("(identifier) @variable".into()),
+                ..Default::default()
+            },
             text: "fn main() { 1 }".into(),
         })
         .unwrap();
@@ -276,6 +287,20 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
     assert_eq!(snapshot.root_end_byte, "fn main() { value + 2 }".len());
     assert_eq!(snapshot.parser_cache_hit, None);
     assert!(snapshot.compute_ns > 0);
+
+    let mut semantic_context = snapshot.context.clone();
+    semantic_context.request_id = 321;
+    let response = worker
+        .derive_semantic_tokens(DeriveSemanticTokens {
+            context: semantic_context,
+            supports_multiline: false,
+        })
+        .unwrap();
+    let Response::SemanticTokens(tokens) = response else {
+        panic!("semantic tokens must be worker-owned: {response:?}");
+    };
+    assert!(!tokens.tokens.is_empty());
+    assert!(tokens.tokens.iter().all(|token| token.token_type == 1));
 
     let mut node_context = snapshot.context.clone();
     node_context.request_id = 33;

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -268,7 +268,7 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
             context: node_context,
             node_id: OpaqueNodeId {
                 worker_generation: 43,
-                local_id: nodes.nodes[0].id.local_id,
+                local_id: nodes.nodes[0].id.local_id.clone(),
             },
             operation: NodeNavigation::Parent,
         })

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -3,7 +3,8 @@ use std::sync::{Arc, Barrier};
 
 #[cfg(feature = "e2e")]
 use kakehashi::tree_worker::{
-    ApplyDocumentEdits, ByteEdit, CloseDocument, DeriveDocumentSnapshot, SyncDocument,
+    ApplyDocumentEdits, ByteEdit, CloseDocument, DeriveDocumentSnapshot, NavigateNode,
+    NodeNavigation, OpaqueNodeId, ResolveNode, SyncDocument,
 };
 use kakehashi::tree_worker::{Client, DeriveSnapshot, RequestContext, Response};
 
@@ -246,8 +247,39 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
     assert_eq!(snapshot.parser_cache_hit, None);
     assert!(snapshot.compute_ns > 0);
 
+    let mut node_context = snapshot.context.clone();
+    node_context.request_id = 33;
+    let response = worker
+        .resolve_node(ResolveNode {
+            context: node_context.clone(),
+            byte_offset: 12,
+            named: true,
+        })
+        .unwrap();
+    let Response::Nodes(nodes) = response else {
+        panic!("node resolve must return owned data: {response:?}");
+    };
+    assert_eq!(nodes.nodes[0].kind, "identifier");
+    assert_eq!(nodes.nodes[0].id.worker_generation, 44);
+
+    node_context.request_id = 34;
+    let response = worker
+        .navigate_node(NavigateNode {
+            context: node_context,
+            node_id: OpaqueNodeId {
+                worker_generation: 43,
+                local_id: nodes.nodes[0].id.local_id,
+            },
+            operation: NodeNavigation::Parent,
+        })
+        .unwrap();
+    let Response::Nodes(nodes) = response else {
+        panic!("stale node navigation must be contained: {response:?}");
+    };
+    assert!(nodes.nodes.is_empty());
+
     let mut closed = snapshot.context;
-    closed.request_id = 33;
+    closed.request_id = 35;
     closed.content_version = 3;
     closed.configuration_generation = 1;
     let response = worker
@@ -257,7 +289,7 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
         .unwrap();
     assert!(matches!(response, Response::DocumentClosed(_)));
 
-    closed.request_id = 34;
+    closed.request_id = 36;
     let response = worker
         .sync_document(SyncDocument {
             context: closed.clone(),
@@ -274,7 +306,7 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
     };
     assert!(error.message.contains("closed document incarnation"));
 
-    closed.request_id = 35;
+    closed.request_id = 37;
     let response = worker
         .derive_document_snapshot(DeriveDocumentSnapshot { context: closed })
         .unwrap();

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -4,7 +4,8 @@ use std::sync::{Arc, Barrier};
 #[cfg(feature = "e2e")]
 use kakehashi::tree_worker::{
     ApplyDocumentEdits, ByteEdit, CloseDocument, DeriveDocumentSnapshot, NavigateNode,
-    NodeNavigation, OpaqueNodeId, ResolveNode, SyncDocument,
+    NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId, ResolveNode, RunNodeScalar,
+    SyncDocument,
 };
 use kakehashi::tree_worker::{Client, DeriveSnapshot, RequestContext, Response};
 
@@ -264,6 +265,19 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
 
     node_context.request_id = 34;
     let response = worker
+        .run_node_scalar(RunNodeScalar {
+            context: node_context.clone(),
+            node_id: nodes.nodes[0].id.clone(),
+            operation: NodeScalarOperation::Text,
+        })
+        .unwrap();
+    let Response::NodeScalar(scalar) = response else {
+        panic!("node scalar must return typed owned data: {response:?}");
+    };
+    assert_eq!(scalar.value, Some(NodeScalarValue::String("value".into())));
+
+    node_context.request_id = 35;
+    let response = worker
         .navigate_node(NavigateNode {
             context: node_context,
             node_id: OpaqueNodeId {
@@ -279,7 +293,7 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
     assert!(nodes.nodes.is_empty());
 
     let mut closed = snapshot.context;
-    closed.request_id = 35;
+    closed.request_id = 36;
     closed.content_version = 3;
     closed.configuration_generation = 1;
     let response = worker
@@ -289,7 +303,7 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
         .unwrap();
     assert!(matches!(response, Response::DocumentClosed(_)));
 
-    closed.request_id = 36;
+    closed.request_id = 37;
     let response = worker
         .sync_document(SyncDocument {
             context: closed.clone(),
@@ -306,7 +320,7 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
     };
     assert!(error.message.contains("closed document incarnation"));
 
-    closed.request_id = 37;
+    closed.request_id = 38;
     let response = worker
         .derive_document_snapshot(DeriveDocumentSnapshot { context: closed })
         .unwrap();

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -330,6 +330,7 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
             context: node_context.clone(),
             byte_offset: 12,
             named: true,
+            layer: kakehashi::tree_worker::NodeLayerSelector::Host,
         })
         .unwrap();
     let Response::Nodes(nodes) = response else {

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -3,9 +3,9 @@ use std::sync::{Arc, Barrier};
 
 #[cfg(feature = "e2e")]
 use kakehashi::tree_worker::{
-    ApplyDocumentEdits, ByteEdit, CloseDocument, DeriveDocumentSnapshot, NavigateNode,
-    NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId, ResolveNode, RunNodeScalar,
-    SyncDocument,
+    ApplyDocumentEdits, ByteEdit, CloseDocument, ConfigureLanguages, DeriveDocumentSnapshot,
+    NavigateNode, NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId, ResolveNode,
+    RunNodeScalar, SyncDocument, WorkerLanguageAsset, WorkerQuerySources,
 };
 use kakehashi::tree_worker::{Client, DeriveSnapshot, RequestContext, Response};
 
@@ -201,6 +201,34 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
         content_version: 1,
         configuration_generation: 0,
     };
+
+    let response = worker
+        .configure_languages(ConfigureLanguages {
+            context: RequestContext {
+                request_id: 29,
+                worker_generation: 44,
+                uri: "kakehashi://language-catalog".into(),
+                incarnation: 0,
+                content_version: 0,
+                configuration_generation: 0,
+            },
+            assets: vec![WorkerLanguageAsset {
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: parser.clone(),
+                parser_path: parser.clone(),
+                artifact_digest: digest(&parser),
+                queries: WorkerQuerySources {
+                    injections: Some("(identifier) @injection.content".into()),
+                    ..Default::default()
+                },
+            }],
+        })
+        .unwrap();
+    let Response::LanguageCatalogAck(ack) = response else {
+        panic!("language catalog must be acknowledged: {response:?}");
+    };
+    assert_eq!(ack.languages, 1);
 
     let response = worker
         .sync_document(SyncDocument {

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -210,6 +210,7 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
             source_path: parser.clone(),
             parser_path: parser.clone(),
             artifact_digest: digest(&parser),
+            queries: Default::default(),
             text: "fn main() { 1 }".into(),
         })
         .unwrap();
@@ -312,6 +313,7 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
             source_path: parser.clone(),
             parser_path: parser.clone(),
             artifact_digest: digest(&parser),
+            queries: Default::default(),
             text: "fn stale() {}".into(),
         })
         .unwrap();

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Barrier};
 use kakehashi::tree_worker::{
     ApplyDocumentEdits, ByteEdit, CloseDocument, ConfigureLanguages, DeriveDocumentSnapshot,
     DeriveSemanticTokens, NavigateNode, NodeNavigation, NodeScalarOperation, NodeScalarValue,
-    OpaqueNodeId, ResolveNode, RunNodeScalar, SyncDocument, WorkerLanguageAsset,
+    OpaqueNodeId, ResolveNode, RunCaptures, RunNodeScalar, SyncDocument, WorkerLanguageAsset,
     WorkerLanguageCatalog, WorkerQuerySources,
 };
 use kakehashi::tree_worker::{Client, DeriveSnapshot, RequestContext, Response};
@@ -194,6 +194,10 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
         .join(format!("rust.{}", std::env::consts::DLL_EXTENSION));
     let executable = PathBuf::from(env!("CARGO_BIN_EXE_kakehashi"));
     let worker = Client::spawn(&executable, 2, 44).unwrap();
+    let capture_queries = tempfile::tempdir().unwrap();
+    let capture_query_dir = capture_queries.path().join("queries/rust");
+    std::fs::create_dir_all(&capture_query_dir).unwrap();
+    std::fs::write(capture_query_dir.join("context.scm"), "(identifier) @name").unwrap();
     let context = RequestContext {
         request_id: 30,
         worker_generation: 44,
@@ -229,6 +233,7 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
                     "rust": { "highlights": { "variable": "keyword" } }
                 }))
                 .unwrap(),
+                search_paths: vec![capture_queries.path().into()],
                 ..Default::default()
             },
         })
@@ -301,6 +306,22 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
     };
     assert!(!tokens.tokens.is_empty());
     assert!(tokens.tokens.iter().all(|token| token.token_type == 1));
+
+    let mut captures_context = snapshot.context.clone();
+    captures_context.request_id = 322;
+    let response = worker
+        .run_captures(RunCaptures {
+            context: captures_context,
+            kind: "context".into(),
+            range: None,
+            injection: false,
+        })
+        .unwrap();
+    let Response::Captures(captures) = response else {
+        panic!("captures must be worker-owned: {response:?}");
+    };
+    assert!(captures.available);
+    assert_eq!(captures.matches.len(), 2);
 
     let mut node_context = snapshot.context.clone();
     node_context.request_id = 33;


### PR DESCRIPTION
## Summary

- add protocol-v12 worker-owned node resolution/navigation, selection ranges, injection discovery, semantic tokens, arbitrary captures, and native lexical bindings
- keep every migrated reader coarse-grained: one request returns the complete owned result instead of mirroring Tree-sitter primitives over IPC
- preserve host and injected node identity across edits with generation-fenced opaque IDs and snapshot-local injection-tree caching
- retain current worker injection facts for all downstream bridge consumers and map legacy/worker region IDs into the worker node namespace
- replicate immutable query sources, normalized search paths, capture mappings, configured languages, and dynamically loaded languages
- causally order query reads behind worker readiness, exact document-replica acknowledgement, and exact catalog acknowledgement
- treat query-source changes as replica identity changes, including same-content-version refreshes
- shadow-check host and injected results while the parent remains the public source

## Stack

- depends on #868
- implements the Stage 6 complete shadow reader migration from #862

## Measurement

Release microbenchmarks show why the boundary is fused:

- direct local resolve + parent: about 0.85 us p50
- one worker round trip: about 54 us p50
- two worker round trips: about 109 us p50
- four concurrent documents: about 47k worker requests/s

A fresh thread sweep on Apple M4 kept one worker process fixed and varied only its internal compute threads.

- 7.7 KB incremental edit + derive: 2.86k, 5.10k, 7.28k, and 14.22k worker requests/s at 1, 2, 4, and 8 threads
- 80 KB incremental edit + derive: 351, 538, 852, and 1,120 worker requests/s at 1, 2, 4, and 8 threads
- single-request worker overhead was about 12-13% for the small document and about 1.5% for the large document

The fixed worker therefore uses internal parallelism materially, but does not yet beat the process-local baseline. Current shadow mode also performs the parent computation: the 200-edit semantic-token workload measured 39.7 ms versus 50.3 ms p50 and 11.60 s versus 13.92 s wall time, about +26.7% and +20.0%. This is duplicate validation work, not an authoritative-worker performance claim. Parent-side tree computation must be removed before the final performance gate.

Lazy query compilation previously reduced the fully parallel 31-test wall time from 41.52 s to 21.70 s and aggregate maximum RSS from 2.99 GB to 2.35 GB. Query-dependent reads now wait on explicit acknowledgements without restoring query compilation to the parse hot path.

## Validation

- `make check`
- `cargo test --lib tree_worker::tests` (35 passed)
- focused worker-region cache/identity unit tests
- `cargo test --features e2e --test tree_worker_process -- --test-threads=1` (4 passed)
- `cargo test --features e2e --test e2e_native_definition -- --test-threads=1` (30 passed)
- `cargo test --features e2e --test e2e_tree_worker_shadow -- --test-threads=1` (32 passed)
- `cargo test --features e2e --test e2e_kakehashi_node` (54 passed)
- `cargo test --features e2e --test e2e_kakehashi_captures -- --test-threads=1` (43 passed)
- `cargo test --features e2e --test e2e_selection_range -- --test-threads=1` (30 passed)
- `cargo test --features e2e --test e2e_semantic_tokens_refresh -- --test-threads=1` (28 passed)

## Status

Draft. Every distinct tree-derived reader family now has a worker-owned high-level operation in shadow mode. The next stacked PR performs the single guarded all-reader ownership cutover. Remaining stack work includes moving dynamic loading and parse lifecycle fully out of the parent, cancellation/fairness and failure gates, the complete benchmark and memory matrix, legacy-path removal, and ADR status/supersession updates.
