### PR TITLE
feat(worker): cut tree readers over atomically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,6 +999,7 @@ name = "kakehashi"
 version = "0.8.0"
 dependencies = [
  "arc-swap",
+ "bincode",
  "clap",
  "dashmap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ opt-level = 3
 
 [dependencies]
 arc-swap = "1"
+bincode = "1.3"
 clap = { version = "4", features = ["derive"] }
 dashmap = "6"
 dirs = "6"

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage7-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage7-measurement.md
@@ -1,0 +1,126 @@
+# Single Tree Worker Stage 7 Authoritative-Reader Measurement
+
+## Scope
+
+Stage 7 adds a guarded `authoritative` rollout mode to the
+[single resident multithreaded tree worker](single-resident-multithreaded-tree-worker.md).
+In this mode, public tree readers consume worker-owned nodes, captures, native
+bindings, selection ranges, semantic tokens, injection regions, bridge
+contexts, formatting regions, diagnostic regions, and exact live region
+geometry. After `didChange`, the parent does not schedule its local reparse;
+virtual-document lifecycle and diagnostics continue from worker facts.
+
+This is an intermediate ownership measurement, not acceptance of the ADR. The
+parent still contains the legacy parser/snapshot implementation for rollback,
+and Stage 8 must remove authoritative-mode didOpen/install dependencies on
+parent parsing before the guarded cutover is structurally complete.
+
+## Questions
+
+1. Does one authoritative worker avoid the shadow mode's duplicate parent
+   reparse cost?
+2. Can worker-owned caches make current-version repeated reads faster?
+3. Does increasing the one worker's internal thread budget hide IPC and
+   cache-miss costs?
+4. Which work must be fused before the rollout can meet a non-regression gate?
+
+## Method
+
+Measurements used the release `kakehashi` binary built from Stage 7 on macOS.
+The existing LSP semantic-token harness drove the same binary for every mode:
+
+```text
+iterations = 40
+warmup = 10
+legacy = KAKEHASHI_TREE_WORKER_MODE unset
+worker-4 = authoritative, KAKEHASHI_TREE_WORKER_THREADS=4
+worker-8 = authoritative, KAKEHASHI_TREE_WORKER_THREADS=8
+```
+
+The harness sends real `didOpen`, `didChange`, semantic full, and semantic
+full/delta messages. The edit cases therefore include incremental parse,
+injection lifecycle, diagnostic scheduling, semantic discovery, token shaping,
+and IPC rather than timing an isolated tree walk.
+
+## Results
+
+Lower is better. Values are medians unless a percentile is named.
+
+| Scenario | Legacy | Authoritative, 4 threads | Authoritative, 8 threads |
+|---|---:|---:|---:|
+| Markdown, 60 injections, full | 0.305 ms | 0.339 ms | 0.395 ms |
+| Markdown, 60 injections, edit + delta | 7.009 ms | 11.746 ms | 10.387 ms |
+| Large Rust, edit + delta | 29.568 ms | 64.686 ms | 69.315 ms |
+
+The large Rust distribution is bimodal:
+
+| Percentile | Legacy | Authoritative, 4 threads | Authoritative, 8 threads |
+|---|---:|---:|---:|
+| p25, cache-hit side | 18.565 ms | 0.725 ms | 0.712 ms |
+| p75, cache-miss side | 32.022 ms | 70.256 ms | 77.039 ms |
+
+Earlier raw resident-worker throughput measurements explain why extra internal
+threads help injection-heavy work but not this single-host miss:
+
+| Payload | 1 thread | 2 threads | 4 threads | 8 threads |
+|---|---:|---:|---:|---:|
+| Small, approximately 7.7 KiB | 2,859 RPS | 5,102 RPS | 7,280 RPS | 14,222 RPS |
+| Large, approximately 80 KiB | 351 RPS | 538 RPS | 852 RPS | 1,120 RPS |
+
+## Findings
+
+### Parent reparse removal is necessary but insufficient
+
+Stopping the authoritative parent reparse removed about 1.6 ms from the
+Markdown edit path during development. Removing an eager duplicate worker
+region derivation removed a further approximately 3.1 ms. Those improvements
+confirm that duplicate ownership and duplicate discovery are material, but the
+complete post-edit workflow still remains slower than legacy.
+
+### Worker cache hits can be substantially faster
+
+The large Rust p25 fell from 18.565 ms to approximately 0.7 ms. A resident
+worker can therefore turn an exact current-version repeated request into a
+cheap cache read and process round trip. The median alone hides this win because
+the alternating edit corpus also forces expensive misses.
+
+### Worker cache misses are the current blocker
+
+The large Rust p75 more than doubled. The miss path combines worker-side token
+calculation with process serialization and a large response payload. Switching
+the internal protocol from JSON to bincode improved the large-miss distribution
+modestly, but encoding alone does not close the gap.
+
+### Internal threads help parallel regions, not a serial host miss
+
+Eight threads improved Markdown edit + delta from 11.746 ms to 10.387 ms, but
+it remained 48% slower than the 7.009 ms legacy result. Eight threads did not
+improve the large Rust miss. This supports the ADR's one-process internal pool,
+but rejects thread-count tuning as the primary Stage 8 optimization.
+
+### Shared facts must be lazy and generation-fenced
+
+Bridge lifecycle, diagnostics, and semantic tokens can request injection facts
+for the same document version concurrently. Stage 7 shares resolved injection
+facts and semantic discovery inside the worker and invalidates them on edit or
+configuration generation change. Forcing all facts eagerly before they are
+needed did not improve edit latency and regressed idle full reads, so the final
+Stage 7 path keeps semantic-only and region-consuming work lazy.
+
+## Consequence for the next stage
+
+Stage 7 validates the authoritative reader contracts and the potential of a
+resident worker cache. It does not pass a general performance non-regression
+gate. Stage 8 should prioritize:
+
+1. removing the remaining authoritative parent parser/snapshot ownership;
+2. single-flight derivation for identical document/version/generation facts;
+3. avoiding large token payload transfers on cache hits and deltas;
+4. measuring compute, serialization, bytes, queue wait, and parent resume
+   separately for the large miss; and
+5. preserving lazy derivation so bridge-only work does not penalize
+   semantic-only documents, and vice versa.
+
+The worker count remains fixed at one. These measurements do not justify
+sharding: the limiting path is per-request miss work and payload transfer, not
+aggregate resident-worker throughput.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1130,6 +1130,13 @@ must therefore be fused into one high-level worker operation; the cutover must
 not expose remote Tree-sitter primitives or translate a local parent/child walk
 into N+1 internal RPCs.
 
+The [Stage 7 authoritative-reader measurement](single-resident-multithreaded-tree-worker-stage7-measurement.md)
+records the first guarded worker-authoritative LSP workloads. Exact-version
+cache hits can be substantially faster, but edit and large cache-miss paths do
+not yet pass a performance non-regression gate. It identifies lazy shared facts,
+single-flight derivation, and large-result transfer as the next optimization
+targets; it does not change this ADR's `proposed` status.
+
 The implementation should proceed in measured stages:
 
 1. Prototype the framed transport, supervision, and one high-level

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -35,8 +35,7 @@ pub(crate) struct InjectionCacheParams {
     /// re-checked INSIDE the work-unit: region-id minting writes into the
     /// live-coordinate `NodeTracker`, which a stale serve must not do (the
     /// same "a stale read never mints" invariant the captures walk enforces).
-    pub documents: std::sync::Arc<crate::document::DocumentStore>,
-    pub parsed_version: u64,
+    pub currency: InjectionCacheCurrency,
     pub incarnation: u64,
     /// Owned injection discovery from the snapshot being tokenized
     /// (parse-snapshot ADR §3, the don't-discover-twice lever): rebuilt into
@@ -45,6 +44,14 @@ pub(crate) struct InjectionCacheParams {
     /// inline (below the region gate, combined groups, or discovery
     /// incomplete at parse time).
     pub discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
+}
+
+pub(crate) enum InjectionCacheCurrency {
+    Document {
+        documents: std::sync::Arc<crate::document::DocumentStore>,
+        parsed_version: u64,
+    },
+    Current,
 }
 
 // Internal re-exports for production code
@@ -128,10 +135,16 @@ pub(crate) fn compute_semantic_tokens_full(
         // work-unit so the race window is the compute itself, not the
         // pool-queue wait. A stale serve goes read-only on the tracker
         // (reuse for unshifted regions, no cache entry for unknown ones).
-        mint_regions: p.documents.latest_snapshot(&p.uri).is_some_and(|view| {
-            view.slot.current_incarnation == p.incarnation
-                && view.content_version == p.parsed_version
-        }),
+        mint_regions: match &p.currency {
+            InjectionCacheCurrency::Document {
+                documents,
+                parsed_version,
+            } => documents.latest_snapshot(&p.uri).is_some_and(|view| {
+                view.slot.current_incarnation == p.incarnation
+                    && view.content_version == *parsed_version
+            }),
+            InjectionCacheCurrency::Current => true,
+        },
         discovery: p.discovery.as_deref(),
     });
 

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -97,6 +97,7 @@ pub(super) struct ApplyEditTranslator {
     documents: Arc<DocumentStore>,
     language: Arc<LanguageCoordinator>,
     bridge: Arc<BridgeCoordinator>,
+    tree_worker_shadow: Option<Arc<crate::lsp::lsp_impl::tree_worker_shadow::TreeWorkerShadow>>,
 }
 
 impl ApplyEditTranslator {
@@ -104,11 +105,13 @@ impl ApplyEditTranslator {
         documents: Arc<DocumentStore>,
         language: Arc<LanguageCoordinator>,
         bridge: Arc<BridgeCoordinator>,
+        tree_worker_shadow: Option<Arc<crate::lsp::lsp_impl::tree_worker_shadow::TreeWorkerShadow>>,
     ) -> Self {
         Self {
             documents,
             language,
             bridge,
+            tree_worker_shadow,
         }
     }
 
@@ -175,9 +178,12 @@ impl ApplyEditTranslator {
             &self.documents,
             &self.language,
             &self.bridge,
+            self.tree_worker_shadow.as_ref(),
             &host_url,
             &region_id,
-        ) else {
+        )
+        .await
+        else {
             // The region moved or was removed since the downstream produced
             // the edit; translating against a stale offset would edit the
             // wrong host text.
@@ -509,6 +515,7 @@ mod tests {
             Arc::new(DocumentStore::new()),
             Arc::new(LanguageCoordinator::new()),
             bridge,
+            None,
         )
     }
 

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -708,6 +708,59 @@ impl Kakehashi {
             position.character
         );
 
+        if self.tree_worker_shadow.is_authoritative() {
+            let (text, incarnation, content_version, language_id) =
+                self.documents.get(&uri).map(|document| {
+                    (
+                        document.text_arc(),
+                        document.incarnation(),
+                        document.content_version(),
+                        document.language_id().map(str::to_owned),
+                    )
+                })?;
+            let language_name =
+                self.language
+                    .detect_language(uri.path(), &text, None, language_id.as_deref())?;
+            if !self
+                .language
+                .ensure_language_loaded_async(&language_name)
+                .await
+                .success
+            {
+                return None;
+            }
+            let byte_offset = PositionMapper::new(&text).position_to_byte(position)?;
+            let current = self.documents.get(&uri)?;
+            if current.incarnation() != incarnation || current.content_version() != content_version
+            {
+                return None;
+            }
+            drop(current);
+            let resolved = self
+                .worker_injection_region_at_snapshot(
+                    &uri,
+                    incarnation,
+                    content_version,
+                    &language_name,
+                    byte_offset,
+                )
+                .await?;
+            let current = self.documents.get(&uri)?;
+            if current.incarnation() != incarnation || current.content_version() != content_version
+            {
+                return None;
+            }
+            if !resolved.contiguous && method_requires_contiguous_injection(method_name) {
+                return None;
+            }
+            return Some(PreambleResult {
+                uri,
+                resolved,
+                language_name,
+                upstream_request_id: current_upstream_id(),
+            });
+        }
+
         // Get document snapshot (minimizes lock duration)
         let (snapshot, content_version) = match self.documents.get(&uri) {
             None => {
@@ -1311,6 +1364,9 @@ impl Kakehashi {
     /// Wait for / on-demand the document's tree before a sync bridge-preamble
     /// snapshot (shared by the position and range resolvers).
     async fn ensure_fresh_tree_for_bridge(&self, lsp_uri: &Uri) {
+        if self.tree_worker_shadow.is_authoritative() {
+            return;
+        }
         if let Ok(uri) = uri_to_url(lsp_uri) {
             self.ensure_document_parsed(&uri).await;
         }
@@ -1372,11 +1428,22 @@ impl Kakehashi {
         let Ok(uri) = uri_to_url(lsp_uri) else {
             return Vec::new();
         };
-        let Some((snapshot, content_version)) = self
-            .documents
-            .get(&uri)
-            .and_then(|d| d.snapshot().map(|snapshot| (snapshot, d.content_version())))
-        else {
+        if self.tree_worker_shadow.is_authoritative() {
+            let Some(view) = self.current_worker_injection_view(&uri).await else {
+                return Vec::new();
+            };
+            return self
+                .bridge_contexts_for_overlapping_regions(
+                    uri,
+                    &view.text,
+                    view.language,
+                    view.regions.as_ref().clone(),
+                    range,
+                    method_name,
+                )
+                .await;
+        }
+        let Some(snapshot) = self.documents.get(&uri).and_then(|d| d.snapshot()) else {
             return Vec::new();
         };
         let Some(language_name) = self.document_language(&uri) else {
@@ -1395,20 +1462,26 @@ impl Kakehashi {
             injection_query.as_ref(),
             snapshot.incarnation(),
         );
-        let regions = if self.tree_worker_shadow.is_authoritative() {
-            self.worker_injection_regions_for_snapshot(
-                &uri,
-                snapshot.incarnation(),
-                content_version,
-                &language_name,
-            )
-            .await
-            .map(|regions| regions.as_ref().clone())
-            .unwrap_or_default()
-        } else {
-            legacy_regions
-        };
+        self.bridge_contexts_for_overlapping_regions(
+            uri,
+            snapshot.text(),
+            language_name,
+            legacy_regions,
+            range,
+            method_name,
+        )
+        .await
+    }
 
+    async fn bridge_contexts_for_overlapping_regions(
+        &self,
+        uri: url::Url,
+        text: &str,
+        language_name: String,
+        regions: Vec<crate::language::injection::ResolvedInjection>,
+        range: Range,
+        method_name: &str,
+    ) -> Vec<RangeRequestContext> {
         // One upstream request ID for the whole scan: every overlapping
         // region's context shares it — with the OTHER layers too, so nothing
         // in the virt walk may wipe the registry for it; `run_layer_race`'s
@@ -1417,7 +1490,7 @@ impl Kakehashi {
         // can't drift if this scan is reused under a different request-id scope.
         let upstream_request_id = current_upstream_id();
 
-        let mapper = PositionMapper::new(snapshot.text());
+        let mapper = PositionMapper::new(text);
         let mut contexts = Vec::new();
         for resolved in regions {
             if !resolved.contiguous && method_requires_contiguous_injection(method_name) {

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -688,7 +688,7 @@ impl Kakehashi {
     ///
     /// Returns `None` for any early-exit condition (invalid URI, no document,
     /// no language, no injection at position).
-    fn resolve_bridge_preamble(
+    async fn resolve_bridge_preamble(
         &self,
         lsp_uri: &Uri,
         position: Position,
@@ -709,7 +709,7 @@ impl Kakehashi {
         );
 
         // Get document snapshot (minimizes lock duration)
-        let snapshot = match self.documents.get(&uri) {
+        let (snapshot, content_version) = match self.documents.get(&uri) {
             None => {
                 log::debug!("{}: No document found for {}", method_name, uri);
                 return None;
@@ -723,7 +723,7 @@ impl Kakehashi {
                     );
                     return None;
                 }
-                Some(snapshot) => snapshot,
+                Some(snapshot) => (snapshot, doc.content_version()),
             },
             // doc automatically dropped here, lock released
         };
@@ -741,7 +741,7 @@ impl Kakehashi {
         let mapper = PositionMapper::new(snapshot.text());
         let byte_offset = mapper.position_to_byte(position)?;
 
-        let Some(resolved) = crate::language::InjectionResolver::resolve_at_byte_offset(
+        let legacy_resolved = crate::language::InjectionResolver::resolve_at_byte_offset(
             &self.language,
             self.bridge.node_tracker(),
             &uri,
@@ -750,7 +750,20 @@ impl Kakehashi {
             injection_query.as_ref(),
             byte_offset,
             snapshot.incarnation(),
-        ) else {
+        );
+        let resolved = if self.tree_worker_shadow.is_authoritative() {
+            self.worker_injection_region_at_snapshot(
+                &uri,
+                snapshot.incarnation(),
+                content_version,
+                &language_name,
+                byte_offset,
+            )
+            .await
+        } else {
+            legacy_resolved
+        };
+        let Some(resolved) = resolved else {
             // Not in an injection region - return None
             return None;
         };
@@ -1285,7 +1298,9 @@ impl Kakehashi {
         // request (hover / definition / completion / …) issued in the reparse window
         // would find `snapshot()` empty and return null after every edit.
         self.ensure_fresh_tree_for_bridge(lsp_uri).await;
-        let preamble = self.resolve_bridge_preamble(lsp_uri, position, method_name)?;
+        let preamble = self
+            .resolve_bridge_preamble(lsp_uri, position, method_name)
+            .await?;
         let document = self
             .preamble_to_document_context(preamble, method_name)
             .await?;
@@ -1312,7 +1327,9 @@ impl Kakehashi {
         method_name: &str,
     ) -> Option<RangeRequestContext> {
         self.ensure_fresh_tree_for_bridge(lsp_uri).await;
-        let preamble = self.resolve_bridge_preamble(lsp_uri, range.start, method_name)?;
+        let preamble = self
+            .resolve_bridge_preamble(lsp_uri, range.start, method_name)
+            .await?;
         let document = self
             .preamble_to_document_context(preamble, method_name)
             .await?;
@@ -1355,7 +1372,11 @@ impl Kakehashi {
         let Ok(uri) = uri_to_url(lsp_uri) else {
             return Vec::new();
         };
-        let Some(snapshot) = self.documents.get(&uri).and_then(|d| d.snapshot()) else {
+        let Some((snapshot, content_version)) = self
+            .documents
+            .get(&uri)
+            .and_then(|d| d.snapshot().map(|snapshot| (snapshot, d.content_version())))
+        else {
             return Vec::new();
         };
         let Some(language_name) = self.document_language(&uri) else {
@@ -1365,7 +1386,7 @@ impl Kakehashi {
             return Vec::new();
         };
 
-        let regions = crate::language::InjectionResolver::resolve_all(
+        let legacy_regions = crate::language::InjectionResolver::resolve_all(
             &self.language,
             self.bridge.node_tracker(),
             &uri,
@@ -1374,6 +1395,19 @@ impl Kakehashi {
             injection_query.as_ref(),
             snapshot.incarnation(),
         );
+        let regions = if self.tree_worker_shadow.is_authoritative() {
+            self.worker_injection_regions_for_snapshot(
+                &uri,
+                snapshot.incarnation(),
+                content_version,
+                &language_name,
+            )
+            .await
+            .map(|regions| regions.as_ref().clone())
+            .unwrap_or_default()
+        } else {
+            legacy_regions
+        };
 
         // One upstream request ID for the whole scan: every overlapping
         // region's context shares it — with the OTHER layers too, so nothing

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -124,20 +124,34 @@ impl Kakehashi {
         let mut configs = Vec::new();
 
         // Virt layer: servers configured for the document's injection regions.
-        if let Some(language_name) = self.document_language(uri)
-            && let Some(injection_query) = self.language.injection_query(&language_name)
-            && let Some(snapshot) = self.documents.get(uri).and_then(|doc| doc.snapshot())
-        {
-            let regions = InjectionResolver::resolve_all(
-                &self.language,
-                self.bridge.node_tracker(),
-                uri,
-                snapshot.tree(),
-                snapshot.text(),
-                injection_query.as_ref(),
-                snapshot.incarnation(),
-            );
-            for resolved in regions {
+        let worker_view = if self.tree_worker_shadow.is_authoritative() {
+            self.current_worker_injection_view(uri).await
+        } else {
+            None
+        };
+        let language_name = worker_view
+            .as_ref()
+            .map(|view| view.language.clone())
+            .or_else(|| self.document_language(uri));
+        if let Some(language_name) = language_name {
+            let regions = if let Some(view) = worker_view {
+                view.regions
+            } else if let Some(injection_query) = self.language.injection_query(&language_name)
+                && let Some(snapshot) = self.documents.get(uri).and_then(|doc| doc.snapshot())
+            {
+                std::sync::Arc::new(InjectionResolver::resolve_all(
+                    &self.language,
+                    self.bridge.node_tracker(),
+                    uri,
+                    snapshot.tree(),
+                    snapshot.text(),
+                    injection_query.as_ref(),
+                    snapshot.incarnation(),
+                ))
+            } else {
+                std::sync::Arc::new(Vec::new())
+            };
+            for resolved in regions.iter() {
                 configs.extend(self.bridge_configs_for_injection_language(
                     &language_name,
                     &resolved.injection_language,

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -50,6 +50,7 @@ pub(crate) struct DiagnosticSnapshotPreparer {
     bridge: std::sync::Arc<BridgeCoordinator>,
     settings_manager: std::sync::Arc<SettingsManager>,
     cache: std::sync::Arc<crate::lsp::cache::CacheCoordinator>,
+    tree_worker_shadow: std::sync::Arc<crate::lsp::lsp_impl::tree_worker_shadow::TreeWorkerShadow>,
 }
 
 impl DiagnosticSnapshotPreparer {
@@ -60,10 +61,12 @@ impl DiagnosticSnapshotPreparer {
             bridge: std::sync::Arc::clone(&server.bridge),
             settings_manager: std::sync::Arc::clone(&server.settings_manager),
             cache: std::sync::Arc::clone(&server.cache),
+            tree_worker_shadow: std::sync::Arc::clone(&server.tree_worker_shadow),
         }
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct DiagnosticScheduler {
     documents: std::sync::Arc<DocumentStore>,
     bridge: std::sync::Arc<BridgeCoordinator>,
@@ -93,30 +96,29 @@ impl DiagnosticScheduler {
 
     /// Schedule a debounced diagnostic for a document (pull-first-diagnostic-forwarding Phase 3).
     ///
-    /// A later change cancels and replaces the pending timer. The snapshot is
-    /// captured now, at schedule time, so diagnostics stay consistent with the
-    /// document state that triggered the change.
+    /// A later change cancels and replaces the pending timer. Snapshot preparation
+    /// runs off ingress and preserves its exact document lineage, including when
+    /// authoritative region facts must be awaited from the worker first.
     pub(crate) fn schedule_debounced_diagnostic(&self, uri: Url) {
-        let snapshot_data = self.prepare_diagnostic_snapshot(&uri);
-
-        // Apply the current `diagnostics_debounce_ms` setting (#533). The snapshot
-        // is a cheap arc-swap clone, so reading it per schedule keeps the debounce
-        // in sync with config reloads without a dedicated apply hook.
-        self.debounced_diagnostics.set_debounce_millis(
-            self.settings_manager
-                .load_settings()
-                .diagnostics_debounce_ms,
-        );
-
-        self.debounced_diagnostics.schedule(
-            uri,
-            snapshot_data,
-            self.bridge.pool_arc(),
-            std::sync::Arc::clone(&self.bridge),
-            std::sync::Arc::clone(&self.synthetic_diagnostics),
-            std::sync::Arc::clone(&self.publisher),
-            std::sync::Arc::clone(&self.documents),
-        );
+        let scheduler = self.clone();
+        tokio::spawn(async move {
+            let snapshot_data = scheduler.prepare_diagnostic_snapshot_async(&uri).await;
+            scheduler.debounced_diagnostics.set_debounce_millis(
+                scheduler
+                    .settings_manager
+                    .load_settings()
+                    .diagnostics_debounce_ms,
+            );
+            scheduler.debounced_diagnostics.schedule(
+                uri,
+                snapshot_data,
+                scheduler.bridge.pool_arc(),
+                std::sync::Arc::clone(&scheduler.bridge),
+                std::sync::Arc::clone(&scheduler.synthetic_diagnostics),
+                std::sync::Arc::clone(&scheduler.publisher),
+                std::sync::Arc::clone(&scheduler.documents),
+            );
+        });
     }
 
     /// Spawn a background task to collect and publish diagnostics.
@@ -126,12 +128,15 @@ impl DiagnosticScheduler {
     /// fans out to downstream servers and publishes via
     /// `textDocument/publishDiagnostics`.
     pub(crate) fn spawn_synthetic_diagnostic_task(&self, uri: Url) {
-        let snapshot_data = self.prepare_diagnostic_snapshot(&uri);
+        let snapshot_preparer = self.snapshot_preparer.clone();
         let bridge_pool = self.bridge.pool_arc();
         let publisher = std::sync::Arc::clone(&self.publisher);
         let uri_clone = uri.clone();
 
         let task = tokio::spawn(async move {
+            let snapshot_data = snapshot_preparer
+                .prepare_diagnostic_snapshot_async(&uri_clone)
+                .await;
             let diagnostics =
                 collect_push_diagnostics(snapshot_data, &bridge_pool, &uri_clone, LOG_TARGET).await;
 
@@ -167,8 +172,18 @@ impl DiagnosticScheduler {
     /// collection returns `Clear`, evicting any stale `PullLayer`; a
     /// configured-but-pull-gated host still lands here so its re-sync runs), and
     /// `Some(snapshot)` with virt regions and/or a pullable host context.
+    #[cfg(test)]
     pub(crate) fn prepare_diagnostic_snapshot(&self, uri: &Url) -> Option<DiagnosticSnapshot> {
         self.snapshot_preparer.prepare_diagnostic_snapshot(uri)
+    }
+
+    pub(crate) async fn prepare_diagnostic_snapshot_async(
+        &self,
+        uri: &Url,
+    ) -> Option<DiagnosticSnapshot> {
+        self.snapshot_preparer
+            .prepare_diagnostic_snapshot_async(uri)
+            .await
     }
 }
 
@@ -186,7 +201,101 @@ impl DiagnosticSnapshotPreparer {
             let content_version = doc.content_version();
             (snapshot, language_name, content_version)
         };
+        let incarnation = snapshot.incarnation();
+        let text = snapshot.text_arc();
+        let resolved_regions =
+            self.language.injection_query(&language_name).map(|query| {
+                match self
+                    .documents
+                    .current_resolved_regions(uri, self.cache.semantic_token_generation())
+                {
+                    Some(regions) => regions,
+                    None => std::sync::Arc::new(InjectionResolver::resolve_all(
+                        &self.language,
+                        self.bridge.node_tracker(),
+                        uri,
+                        snapshot.tree(),
+                        snapshot.text(),
+                        query.as_ref(),
+                        incarnation,
+                    )),
+                }
+            });
+        self.prepare_diagnostic_snapshot_from(
+            uri,
+            text,
+            language_name,
+            incarnation,
+            content_version,
+            resolved_regions,
+        )
+    }
 
+    pub(crate) async fn prepare_diagnostic_snapshot_async(
+        &self,
+        uri: &Url,
+    ) -> Option<DiagnosticSnapshot> {
+        if !self.tree_worker_shadow.is_authoritative() {
+            return self.prepare_diagnostic_snapshot(uri);
+        }
+        let (text, language_id, incarnation, content_version) =
+            self.documents.get(uri).map(|document| {
+                (
+                    document.text_arc(),
+                    document.language_id().map(str::to_owned),
+                    document.incarnation(),
+                    document.content_version(),
+                )
+            })?;
+        let language_name =
+            self.language
+                .detect_language(uri.path(), &text, None, language_id.as_deref())?;
+        if !self
+            .language
+            .ensure_language_loaded_async(&language_name)
+            .await
+            .success
+        {
+            return None;
+        }
+        let resolved_regions = if self.language.injection_query(&language_name).is_some() {
+            self.tree_worker_shadow
+                .worker_injection_regions(
+                    uri,
+                    incarnation,
+                    content_version,
+                    self.language.configuration_generation(),
+                )
+                .await
+        } else {
+            None
+        };
+        let current = self.documents.get(uri)?;
+        if current.incarnation() != incarnation || current.content_version() != content_version {
+            return None;
+        }
+        drop(current);
+        self.prepare_diagnostic_snapshot_from(
+            uri,
+            text,
+            language_name,
+            incarnation,
+            content_version,
+            resolved_regions,
+        )
+    }
+
+    fn prepare_diagnostic_snapshot_from(
+        &self,
+        uri: &Url,
+        text: std::sync::Arc<str>,
+        language_name: String,
+        incarnation: u64,
+        content_version: u64,
+        resolved_regions: Option<
+            std::sync::Arc<Vec<crate::language::injection::ResolvedInjection>>,
+        >,
+    ) -> Option<DiagnosticSnapshot> {
         // Cross-layer gating, keyed by the same method name as the
         // aggregation configs below. A layer gated off still yields a
         // snapshot (with that layer absent) so that publishing an empty list
@@ -201,117 +310,96 @@ impl DiagnosticSnapshotPreparer {
         // Virt layer: `None` = the document can never have virt diagnostics
         // (no injection query), distinct from `Some(vec![])` = gated off or
         // currently no regions (publish-empty-to-clear).
-        let virt_contexts: Option<Vec<DocumentRequestContext>> =
-            if !layer_cfg.allows(crate::config::settings::LayerSource::Virt) {
-                log::debug!(
-                    target: LOG_TARGET,
-                    "virt layer disabled for {} via layers.aggregation priorities",
-                    language_name
-                );
-                Some(Vec::new())
-            } else {
-                self.language
-                    .injection_query(&language_name)
-                    .map(|injection_query| {
-                        // Prefer the populate pass's regions riding the current
-                        // parse snapshot (never discover twice, ADR §3); fall
-                        // back to the inline resolution when absent/stale.
-                        let all_regions = match self
-                            .documents
-                            .current_resolved_regions(uri, self.cache.semantic_token_generation())
-                        {
-                            Some(regions) => regions,
-                            None => std::sync::Arc::new(InjectionResolver::resolve_all(
-                                &self.language,
-                                self.bridge.node_tracker(),
-                                uri,
-                                snapshot.tree(),
-                                snapshot.text(),
-                                injection_query.as_ref(),
-                                snapshot.incarnation(),
-                            )),
-                        };
-
-                        let mut contexts = Vec::new();
-                        // Configs + aggregation are keyed by injection language, so
-                        // resolve them once per distinct language (a document can
-                        // hold many regions of one language). `None` caches a skipped
-                        // language: no configured server, OR the pull would dispatch
-                        // to none. The key is cloned only on the resolving miss, not
-                        // on every region.
-                        type ResolvedLang =
-                            Option<(Vec<ResolvedServerConfig>, ResolvedAggregationConfig)>;
-                        let mut resolved_by_lang: std::collections::HashMap<String, ResolvedLang> =
-                            std::collections::HashMap::new();
-                        for resolved in all_regions.iter() {
-                            // `get` on the common (cache-hit) path is a single lookup;
-                            // only the resolving miss touches the map again, cloning
-                            // the language key just for that insert.
-                            let entry = match resolved_by_lang.get(&resolved.injection_language) {
-                                Some(entry) => entry,
-                                None => {
-                                    let lang = &resolved.injection_language;
-                                    let computed: ResolvedLang = {
-                                        let configs = self.bridge.get_all_configs_for_language(
-                                            &settings,
-                                            &language_name,
-                                            lang,
-                                        );
-                                        if configs.is_empty() {
-                                            None
-                                        } else {
-                                            let agg = resolve_aggregation_config_from_settings(
-                                                &settings,
-                                                &language_name,
-                                                lang,
-                                                "textDocument/publishDiagnostics",
-                                            );
-                                            // Only keep a language the pull will actually
-                                            // dispatch (#425): drop it when `pullFallback =
-                                            // false` OR its effective server selection is
-                                            // empty (`priorities = []`, `maxFanOut = 0`, or
-                                            // names only unconfigured servers). This keeps
-                                            // the invariant "PullLayer present ⟺ a pull
-                                            // dispatched to ≥1 server", so an absent/Clear
-                                            // pull layer never falsely suppresses a
-                                            // server's spontaneous push. The push path is
-                                            // untouched — only kakehashi's pulling stops.
-                                            if !agg.pull_fallback
-                                                || !dispatches_to_any_server(
-                                                    &agg.priorities,
-                                                    &configs,
-                                                    agg.max_fan_out,
-                                                )
-                                            {
-                                                None
-                                            } else {
-                                                Some((configs, agg))
-                                            }
-                                        }
-                                    };
-                                    resolved_by_lang
-                                        .entry(resolved.injection_language.clone())
-                                        .or_insert(computed)
+        let virt_contexts: Option<Vec<DocumentRequestContext>> = if !layer_cfg
+            .allows(crate::config::settings::LayerSource::Virt)
+        {
+            log::debug!(
+                target: LOG_TARGET,
+                "virt layer disabled for {} via layers.aggregation priorities",
+                language_name
+            );
+            Some(Vec::new())
+        } else {
+            resolved_regions.map(|all_regions| {
+                let mut contexts = Vec::new();
+                // Configs + aggregation are keyed by injection language, so
+                // resolve them once per distinct language (a document can
+                // hold many regions of one language). `None` caches a skipped
+                // language: no configured server, OR the pull would dispatch
+                // to none. The key is cloned only on the resolving miss, not
+                // on every region.
+                type ResolvedLang = Option<(Vec<ResolvedServerConfig>, ResolvedAggregationConfig)>;
+                let mut resolved_by_lang: std::collections::HashMap<String, ResolvedLang> =
+                    std::collections::HashMap::new();
+                for resolved in all_regions.iter() {
+                    // `get` on the common (cache-hit) path is a single lookup;
+                    // only the resolving miss touches the map again, cloning
+                    // the language key just for that insert.
+                    let entry = match resolved_by_lang.get(&resolved.injection_language) {
+                        Some(entry) => entry,
+                        None => {
+                            let lang = &resolved.injection_language;
+                            let computed: ResolvedLang = {
+                                let configs = self.bridge.get_all_configs_for_language(
+                                    &settings,
+                                    &language_name,
+                                    lang,
+                                );
+                                if configs.is_empty() {
+                                    None
+                                } else {
+                                    let agg = resolve_aggregation_config_from_settings(
+                                        &settings,
+                                        &language_name,
+                                        lang,
+                                        "textDocument/publishDiagnostics",
+                                    );
+                                    // Only keep a language the pull will actually
+                                    // dispatch (#425): drop it when `pullFallback =
+                                    // false` OR its effective server selection is
+                                    // empty (`priorities = []`, `maxFanOut = 0`, or
+                                    // names only unconfigured servers). This keeps
+                                    // the invariant "PullLayer present ⟺ a pull
+                                    // dispatched to ≥1 server", so an absent/Clear
+                                    // pull layer never falsely suppresses a
+                                    // server's spontaneous push. The push path is
+                                    // untouched — only kakehashi's pulling stops.
+                                    if !agg.pull_fallback
+                                        || !dispatches_to_any_server(
+                                            &agg.priorities,
+                                            &configs,
+                                            agg.max_fan_out,
+                                        )
+                                    {
+                                        None
+                                    } else {
+                                        Some((configs, agg))
+                                    }
                                 }
                             };
-                            let Some((configs, agg)) = entry else {
-                                continue;
-                            };
-
-                            contexts.push(DocumentRequestContext {
-                                uri: uri.clone(),
-                                resolved: resolved.clone(),
-                                configs: configs.clone(),
-                                upstream_request_id: None,
-                                priorities: agg.priorities.clone(),
-                                strategy: agg.strategy,
-                                max_fan_out: agg.max_fan_out,
-                                client_progress_token: None,
-                            });
+                            resolved_by_lang
+                                .entry(resolved.injection_language.clone())
+                                .or_insert(computed)
                         }
-                        contexts
-                    })
-            };
+                    };
+                    let Some((configs, agg)) = entry else {
+                        continue;
+                    };
+
+                    contexts.push(DocumentRequestContext {
+                        uri: uri.clone(),
+                        resolved: resolved.clone(),
+                        configs: configs.clone(),
+                        upstream_request_id: None,
+                        priorities: agg.priorities.clone(),
+                        strategy: agg.strategy,
+                        max_fan_out: agg.max_fan_out,
+                        client_progress_token: None,
+                    });
+                }
+                contexts
+            })
+        };
 
         // Host layer (host-document-bridge): participates when listed in the
         // layer priorities AND opted in via bridge._self.enabled with a
@@ -349,7 +437,7 @@ impl DiagnosticSnapshotPreparer {
             Some(HostRequestContext {
                 uri: uri.clone(),
                 language_id: language_name.clone(),
-                text: snapshot.text_arc(),
+                text: std::sync::Arc::clone(&text),
                 configs,
                 priorities: agg.priorities,
                 strategy: agg.strategy,
@@ -369,7 +457,7 @@ impl DiagnosticSnapshotPreparer {
 
         Some(DiagnosticSnapshot {
             lineage: DiagnosticSnapshotLineage {
-                incarnation: snapshot.incarnation(),
+                incarnation,
                 content_version,
             },
             virt_contexts,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -116,6 +116,7 @@ pub(crate) struct DiagnosticPublisher {
     bridge: Arc<BridgeCoordinator>,
     settings_manager: Arc<SettingsManager>,
     cache: Arc<crate::lsp::cache::CacheCoordinator>,
+    tree_worker_shadow: Arc<crate::lsp::lsp_impl::tree_worker_shadow::TreeWorkerShadow>,
     snapshot_preparer: DiagnosticSnapshotPreparer,
     aggregator: Arc<DiagnosticAggregator>,
     shutdown: tokio_util::sync::CancellationToken,
@@ -130,6 +131,7 @@ impl DiagnosticPublisher {
             bridge: Arc::clone(&server.bridge),
             settings_manager: Arc::clone(&server.settings_manager),
             cache: Arc::clone(&server.cache),
+            tree_worker_shadow: Arc::clone(&server.tree_worker_shadow),
             snapshot_preparer: DiagnosticSnapshotPreparer::new(server),
             aggregator: Arc::clone(&server.diagnostics),
             shutdown: server.shutdown_token.clone(),
@@ -888,7 +890,7 @@ impl DiagnosticPublisher {
         // exactly that check.
         let needs_geometry = crate::lsp::diagnostic_cache::has_live_region_slots(&snapshot);
         let region_offsets = if needs_geometry {
-            match self.current_region_offsets(host) {
+            match self.current_region_offsets(host).await {
                 Some(offsets) => offsets,
                 // The document is open but has no parse snapshot: `did_change`
                 // cleared the tree and the off-ingress reparse hasn't landed yet,
@@ -1349,12 +1351,53 @@ impl DiagnosticPublisher {
     /// regions as gone. `Some(empty)` means there legitimately are no regions to
     /// anchor: the document is closed, or its language resolves to no injection
     /// query — stale region slots drop from the merge.
-    fn current_region_offsets(&self, host: &Url) -> Option<HashMap<String, RegionOffset>> {
+    async fn current_region_offsets(&self, host: &Url) -> Option<HashMap<String, RegionOffset>> {
         let mut offsets = HashMap::new();
 
         let Some(doc) = self.documents.get(host) else {
             return Some(offsets); // closed host: nothing to anchor against
         };
+        if self.tree_worker_shadow.is_authoritative() {
+            let text = doc.text_arc();
+            let language_id = doc.language_id().map(str::to_owned);
+            let incarnation = doc.incarnation();
+            let content_version = doc.content_version();
+            let Some(language_name) = self.language.detect_language_trace(
+                host.path(),
+                &text,
+                None,
+                language_id.as_deref(),
+            ) else {
+                return Some(offsets);
+            };
+            drop(doc);
+            if self.language.injection_query(&language_name).is_none() {
+                return Some(offsets);
+            }
+            if !self
+                .language
+                .ensure_language_loaded_async(&language_name)
+                .await
+                .success
+            {
+                return None;
+            }
+            let regions = self
+                .tree_worker_shadow
+                .worker_injection_regions(
+                    host,
+                    incarnation,
+                    content_version,
+                    self.language.configuration_generation(),
+                )
+                .await?;
+            let current = self.documents.get(host)?;
+            if current.incarnation() != incarnation || current.content_version() != content_version
+            {
+                return None;
+            }
+            return Some(region_offsets_from_resolved(&regions));
+        }
         let Some(snapshot) = doc.snapshot() else {
             return None; // open but tree pending: geometry unknown, defer
         };
@@ -1402,6 +1445,23 @@ impl DiagnosticPublisher {
     }
 }
 
+fn region_offsets_from_resolved(
+    regions: &[crate::language::injection::ResolvedInjection],
+) -> HashMap<String, RegionOffset> {
+    regions
+        .iter()
+        .map(|resolved| {
+            (
+                resolved.region.region_id.clone(),
+                RegionOffset::with_per_line_offsets(
+                    resolved.region.line_range.start,
+                    resolved.line_column_offsets.clone(),
+                ),
+            )
+        })
+        .collect()
+}
+
 /// Remove `Region`/`Host` push slots whose server is in `pull_driven` when a
 /// `PullLayer` blob is present in `snapshot`, dropping any source left empty.
 /// The pure core of [`DiagnosticPublisher::filter_pull_driven_push_slots`],
@@ -1442,6 +1502,27 @@ mod tests {
             range: Range::new(Position::new(0, 0), Position::new(0, 1)),
             message: message.to_string(),
             ..Default::default()
+        }
+    }
+
+    fn resolved_region(
+        region_id: &str,
+        line: u32,
+        line_column_offsets: Vec<u32>,
+    ) -> crate::language::injection::ResolvedInjection {
+        crate::language::injection::ResolvedInjection {
+            region: crate::language::injection::CacheableInjectionRegion {
+                language: "rust".to_string(),
+                byte_range: 0..1,
+                line_range: line..line + 1,
+                start_column: 0,
+                region_id: region_id.to_string(),
+                content_hash: 0,
+            },
+            injection_language: "rust".to_string(),
+            virtual_content: "x".to_string(),
+            line_column_offsets,
+            contiguous: true,
         }
     }
 
@@ -2397,7 +2478,7 @@ mod tests {
             None,
         );
         assert!(
-            publisher.current_region_offsets(&pending).is_none(),
+            publisher.current_region_offsets(&pending).await.is_none(),
             "an open document with no parse snapshot has unknown geometry"
         );
 
@@ -2407,8 +2488,28 @@ mod tests {
         assert!(
             publisher
                 .current_region_offsets(&closed)
+                .await
                 .is_some_and(|offsets| offsets.is_empty()),
             "a closed document has no regions to anchor, not unknown geometry"
+        );
+    }
+
+    #[test]
+    fn region_offsets_preserve_every_worker_region_identity() {
+        let regions = vec![
+            resolved_region("first", 2, vec![1]),
+            resolved_region("second", 8, vec![3, 4]),
+        ];
+
+        let offsets = region_offsets_from_resolved(&regions);
+
+        assert_eq!(
+            offsets["first"],
+            RegionOffset::with_per_line_offsets(2, vec![1])
+        );
+        assert_eq!(
+            offsets["second"],
+            RegionOffset::with_per_line_offsets(8, vec![3, 4])
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -301,7 +301,11 @@ impl DiagnosticPublisher {
     async fn prefetch_open_pull_fallback_diagnostics(&self) -> bool {
         let mut tasks = tokio::task::JoinSet::new();
         for uri in self.documents.open_uris() {
-            let Some(snapshot) = self.snapshot_preparer.prepare_diagnostic_snapshot(&uri) else {
+            let Some(snapshot) = self
+                .snapshot_preparer
+                .prepare_diagnostic_snapshot_async(&uri)
+                .await
+            else {
                 continue;
             };
             let lineage = snapshot.lineage;

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -179,6 +179,7 @@ impl InjectionCoordinator {
                 uri,
                 forward_did_change,
                 None,
+                None,
                 std::future::ready(()),
             )
             .await;
@@ -194,6 +195,40 @@ impl InjectionCoordinator {
             uri,
             forward_did_change,
             Some(incarnation),
+            None,
+            std::future::ready(()),
+        )
+        .await
+    }
+
+    pub(crate) async fn process_worker_injections_for_incarnation(
+        &self,
+        uri: &Url,
+        forward_did_change: bool,
+        incarnation: u64,
+        content_version: u64,
+    ) -> bool {
+        let generation = self.language.configuration_generation();
+        let Some(regions) = self
+            .tree_worker_shadow
+            .worker_injection_regions(uri, incarnation, content_version, generation)
+            .await
+        else {
+            return false;
+        };
+        let injections = regions
+            .iter()
+            .map(|region| BridgeInjection {
+                language: region.injection_language.clone(),
+                region_id: region.region.region_id.clone(),
+                content: region.virtual_content.clone(),
+            })
+            .collect();
+        self.process_injections_after_lifecycle_lock(
+            uri,
+            forward_did_change,
+            Some(incarnation),
+            Some(injections),
             std::future::ready(()),
         )
         .await
@@ -204,6 +239,7 @@ impl InjectionCoordinator {
         uri: &Url,
         forward_did_change: bool,
         required_incarnation: Option<u64>,
+        worker_injections: Option<Vec<BridgeInjection>>,
         after_lifecycle_lock: F,
     ) -> bool
     where
@@ -230,7 +266,8 @@ impl InjectionCoordinator {
             self.bridge.cancel_eager_open(uri);
             return false;
         };
-        let injections = self.resolve_injection_data(uri, &host_language);
+        let injections =
+            worker_injections.unwrap_or_else(|| self.resolve_injection_data(uri, &host_language));
         if injections.is_empty() {
             self.bridge.cancel_eager_open(uri);
             return true;
@@ -506,10 +543,16 @@ mod tests {
         let process_release = Arc::clone(&release);
         let process = tokio::spawn(async move {
             injection
-                .process_injections_after_lifecycle_lock(&process_uri, false, None, async move {
-                    process_entered.notify_one();
-                    process_release.notified().await;
-                })
+                .process_injections_after_lifecycle_lock(
+                    &process_uri,
+                    false,
+                    None,
+                    None,
+                    async move {
+                        process_entered.notify_one();
+                        process_release.notified().await;
+                    },
+                )
                 .await;
         });
         entered.notified().await;
@@ -586,16 +629,22 @@ mod tests {
 
         let processed = server
             .injection_coordinator()
-            .process_injections_after_lifecycle_lock(&uri, false, Some(old_incarnation), async {
-                server.documents.remove_preserving_edit_lock(&uri);
-                let new_incarnation =
-                    server
-                        .documents
-                        .insert(uri.clone(), "new".to_string(), None, None);
-                assert_ne!(new_incarnation, old_incarnation);
-                let token = server.bridge.begin_test_eager_open_batch(&uri);
-                let _ = token_tx.send(token);
-            })
+            .process_injections_after_lifecycle_lock(
+                &uri,
+                false,
+                Some(old_incarnation),
+                None,
+                async {
+                    server.documents.remove_preserving_edit_lock(&uri);
+                    let new_incarnation =
+                        server
+                            .documents
+                            .insert(uri.clone(), "new".to_string(), None, None);
+                    assert_ne!(new_incarnation, old_incarnation);
+                    let token = server.bridge.begin_test_eager_open_batch(&uri);
+                    let _ = token_tx.send(token);
+                },
+            )
             .await;
         let token = token_rx.await.unwrap();
 

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -216,14 +216,7 @@ impl InjectionCoordinator {
         else {
             return false;
         };
-        let injections = regions
-            .iter()
-            .map(|region| BridgeInjection {
-                language: region.injection_language.clone(),
-                region_id: region.region.region_id.clone(),
-                content: region.virtual_content.clone(),
-            })
-            .collect();
+        let injections = bridge_injections_from_resolved(&regions);
         self.process_injections_after_lifecycle_lock(
             uri,
             forward_did_change,
@@ -481,8 +474,35 @@ impl InjectionCoordinator {
     /// when the document has no detectable language. Lets a caller re-derive the
     /// injected regions on demand (executeCommand doc-sync), mirroring the
     /// didOpen/didChange discovery.
-    pub(crate) fn bridge_injections(&self, uri: &Url) -> Option<(String, Vec<BridgeInjection>)> {
+    pub(crate) async fn bridge_injections(
+        &self,
+        uri: &Url,
+    ) -> Option<(String, Vec<BridgeInjection>)> {
         let host_language = self.get_language_for_document(uri)?;
+        if self.tree_worker_shadow.is_authoritative() {
+            let (incarnation, content_version) = self
+                .documents
+                .get(uri)
+                .map(|document| (document.incarnation(), document.content_version()))?;
+            if self.language.injection_query(&host_language).is_none() {
+                return Some((host_language, Vec::new()));
+            }
+            let regions = self
+                .tree_worker_shadow
+                .worker_injection_regions(
+                    uri,
+                    incarnation,
+                    content_version,
+                    self.language.configuration_generation(),
+                )
+                .await?;
+            let current = self.documents.get(uri)?;
+            if current.incarnation() != incarnation || current.content_version() != content_version
+            {
+                return None;
+            }
+            return Some((host_language, bridge_injections_from_resolved(&regions)));
+        }
         let injections = self.resolve_injection_data(uri, &host_language);
         Some((host_language, injections))
     }
@@ -503,6 +523,19 @@ impl InjectionCoordinator {
     }
 }
 
+fn bridge_injections_from_resolved(
+    regions: &[crate::language::injection::ResolvedInjection],
+) -> Vec<BridgeInjection> {
+    regions
+        .iter()
+        .map(|region| BridgeInjection {
+            language: region.injection_language.clone(),
+            region_id: region.region.region_id.clone(),
+            content: region.virtual_content.clone(),
+        })
+        .collect()
+}
+
 fn parser_enabled_injection_language(language: &str) -> bool {
     // Explicit, unconfigured plaintext is deliberately featureless. An eligible
     // configured plaintext base is canonicalized before reaching this loop.
@@ -511,7 +544,31 @@ fn parser_enabled_injection_language(language: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::parser_enabled_injection_language;
+    use super::{bridge_injections_from_resolved, parser_enabled_injection_language};
+
+    #[test]
+    fn worker_bridge_injection_preserves_identity_language_and_content() {
+        let resolved = crate::language::injection::ResolvedInjection {
+            region: crate::language::injection::CacheableInjectionRegion {
+                language: "python".to_string(),
+                byte_range: 10..15,
+                line_range: 2..3,
+                start_column: 0,
+                region_id: "stable-id".to_string(),
+                content_hash: 0,
+            },
+            injection_language: "python".to_string(),
+            virtual_content: "x = 1".to_string(),
+            line_column_offsets: vec![0],
+            contiguous: true,
+        };
+
+        let injections = bridge_injections_from_resolved(std::slice::from_ref(&resolved));
+
+        assert_eq!(injections[0].region_id, "stable-id");
+        assert_eq!(injections[0].language, "python");
+        assert_eq!(injections[0].content, "x = 1");
+    }
 
     #[test]
     fn explicit_plaintext_does_not_request_a_parser() {

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -1316,7 +1316,7 @@ impl Kakehashi {
         if walk_cancel.is_cancelled() {
             return Ok(None);
         }
-        if let Some(worker) = self
+        let worker = self
             .tree_worker_shadow
             .captures(
                 &uri,
@@ -1327,8 +1327,8 @@ impl Kakehashi {
                 worker_range,
                 injection,
             )
-            .await
-        {
+            .await;
+        if let Some(worker) = worker.as_ref() {
             self.tree_worker_shadow.compare_captures(
                 &uri,
                 snapshot.parsed_version,
@@ -1340,8 +1340,18 @@ impl Kakehashi {
         // arrays by refcount instead of deep-cloning ~20k `Value`s. A `None`
         // walk (no kind file) is memoized too — the negative entry, see
         // `CachedCapturesWalk::result`.
-        let result = walked
-            .map(|(matches, skipped)| (std::sync::Arc::new(matches), std::sync::Arc::new(skipped)));
+        let result = if self.tree_worker_shadow.is_authoritative() {
+            worker.filter(|worker| worker.available).map(|worker| {
+                (
+                    std::sync::Arc::new(worker.matches),
+                    std::sync::Arc::new(worker.skipped),
+                )
+            })
+        } else {
+            walked.map(|(matches, skipped)| {
+                (std::sync::Arc::new(matches), std::sync::Arc::new(skipped))
+            })
+        };
         if let Some(key) = walk_key {
             // Serialize the final currency check and memo installation with
             // didChange/didClose. This prevents a close from clearing the memo

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -862,6 +862,86 @@ impl Kakehashi {
         let (mut cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
         let cancel_token = crate::cancel::CancelToken::default();
 
+        if self.tree_worker_shadow.is_authoritative() {
+            let Some(language_id) = self.document_language(&uri) else {
+                return Ok(None);
+            };
+            if !self
+                .language
+                .ensure_language_loaded_async(&language_id)
+                .await
+                .success
+            {
+                return Ok(None);
+            }
+            let Some((incarnation, content_version)) = self
+                .documents
+                .get(&uri)
+                .map(|document| (document.incarnation(), document.content_version()))
+            else {
+                return Ok(None);
+            };
+            let generation = self.cache.semantic_token_generation();
+            let worker_generation = self.language.configuration_generation();
+            let Some(grammar) = self.language.worker_grammar_descriptor(&language_id) else {
+                return Ok(None);
+            };
+            if self.tree_worker_shadow.needs_document_sync(
+                &uri,
+                incarnation,
+                content_version,
+                worker_generation,
+                &grammar.queries,
+            ) {
+                self.refresh_tree_worker_documents(std::slice::from_ref(&uri));
+            }
+            let worker = self.tree_worker_shadow.captures(
+                &uri,
+                incarnation,
+                content_version,
+                worker_generation,
+                kind.to_string(),
+                lsp_range.map(|range| crate::tree_worker::WireRange {
+                    start: crate::tree_worker::WirePosition {
+                        line: range.start.line,
+                        character: range.start.character,
+                    },
+                    end: crate::tree_worker::WirePosition {
+                        line: range.end.line,
+                        character: range.end.character,
+                    },
+                }),
+                injection,
+            );
+            let worker = match cancel_rx.as_mut() {
+                Some(rx) => {
+                    tokio::select! {
+                        biased;
+                        _ = rx => return Err(JsonRpcError::request_cancelled()),
+                        worker = worker => worker,
+                    }
+                }
+                None => worker.await,
+            };
+            if !self.documents.get(&uri).is_some_and(|document| {
+                document.incarnation() == incarnation
+                    && document.content_version() == content_version
+            }) || self.cache.semantic_token_generation() != generation
+            {
+                return Ok(None);
+            }
+            return Ok(worker
+                .filter(|worker| worker.available)
+                .map(|worker| ComputedCaptures {
+                    uri,
+                    incarnation,
+                    generation,
+                    entry_content_version: content_version,
+                    matches: Arc::new(worker.matches),
+                    skipped: Arc::new(worker.skipped),
+                }));
+        }
+
         // Serve-current (parse-snapshot ADR §3, revised like semanticTokens):
         // park — racing the client's cancel — until the latest snapshot
         // matches the live text, then walk THAT. The previous serve-stale

--- a/src/lsp/lsp_impl/kakehashi/node/children.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/children.rs
@@ -51,6 +51,17 @@ impl Kakehashi {
             log::warn!(target: "kakehashi::node::children", "invalid URI: {}", lsp_uri.as_str());
             return Ok(Value::Null);
         };
+        if self.tree_worker_shadow.is_authoritative() {
+            let worker = self
+                .tree_worker_shadow
+                .node_navigation(
+                    &uri,
+                    &params.id,
+                    crate::tree_worker::NodeNavigation::Children,
+                )
+                .await;
+            return Ok(self.tree_worker_shadow.public_node_result(worker, true));
+        }
 
         // Malformed ULID collapses to null per node-reference-protocol §"Invalidate vs Not-Found".
         let Ok(ulid) = params.id.parse::<Ulid>() else {
@@ -155,7 +166,8 @@ impl Kakehashi {
         };
 
         let authoritative = Value::Array(infos);
-        self.tree_worker_shadow
+        let worker = self
+            .tree_worker_shadow
             .compare_node_navigation(
                 &uri,
                 incarnation,
@@ -172,6 +184,10 @@ impl Kakehashi {
         }) {
             return Ok(Value::Null);
         }
-        Ok(authoritative)
+        if self.tree_worker_shadow.is_authoritative() {
+            Ok(self.tree_worker_shadow.public_node_result(worker, true))
+        } else {
+            Ok(authoritative)
+        }
     }
 }

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -322,16 +322,15 @@ impl Kakehashi {
             }
             None => None,
         };
+        if self.tree_worker_shadow.is_authoritative() {
+            return self.tree_worker_shadow.public_node_result(worker, false);
+        }
         let authoritative = self.navigate_to_node(lsp_uri, id, f).await;
         if let (Some(uri), Some(worker)) = (uri.as_ref(), worker.as_ref()) {
             self.tree_worker_shadow
                 .compare_node_result(uri, &operation, &authoritative, worker);
         }
-        if self.tree_worker_shadow.is_authoritative() {
-            self.tree_worker_shadow.public_node_result(worker, false)
-        } else {
-            authoritative
-        }
+        authoritative
     }
 
     /// Like [`navigate_to_node`](Self::navigate_to_node), but `f` also receives
@@ -375,16 +374,15 @@ impl Kakehashi {
             }
             None => None,
         };
+        if self.tree_worker_shadow.is_authoritative() {
+            return self.tree_worker_shadow.public_node_result(worker, false);
+        }
         let authoritative = self.navigate_to_node_in_ranges(lsp_uri, id, f).await;
         if let (Some(uri), Some(worker)) = (uri.as_ref(), worker.as_ref()) {
             self.tree_worker_shadow
                 .compare_node_result(uri, &operation, &authoritative, worker);
         }
-        if self.tree_worker_shadow.is_authoritative() {
-            self.tree_worker_shadow.public_node_result(worker, false)
-        } else {
-            authoritative
-        }
+        authoritative
     }
 
     /// Resolve `id` **and** `descendant_id` in the layer that minted them, run
@@ -510,6 +508,9 @@ impl Kakehashi {
             }
             None => None,
         };
+        if self.tree_worker_shadow.is_authoritative() {
+            return self.tree_worker_shadow.public_node_result(worker, false);
+        }
         let authoritative = self
             .navigate_with_descendant(lsp_uri, id, descendant_id, f)
             .await;
@@ -521,11 +522,7 @@ impl Kakehashi {
                 worker,
             );
         }
-        if self.tree_worker_shadow.is_authoritative() {
-            self.tree_worker_shadow.public_node_result(worker, false)
-        } else {
-            authoritative
-        }
+        authoritative
     }
 
     /// Resolve `id`, run `f` to collect a list of related nodes (children,
@@ -570,15 +567,14 @@ impl Kakehashi {
             }
             None => None,
         };
+        if self.tree_worker_shadow.is_authoritative() {
+            return self.tree_worker_shadow.public_node_result(worker, true);
+        }
         let authoritative = self.navigate_to_nodes(lsp_uri, id, f).await;
         if let (Some(uri), Some(worker)) = (uri.as_ref(), worker.as_ref()) {
             self.tree_worker_shadow
                 .compare_node_result(uri, &operation, &authoritative, worker);
         }
-        if self.tree_worker_shadow.is_authoritative() {
-            self.tree_worker_shadow.public_node_result(worker, true)
-        } else {
-            authoritative
-        }
+        authoritative
     }
 }

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -327,7 +327,11 @@ impl Kakehashi {
             self.tree_worker_shadow
                 .compare_node_result(uri, &operation, &authoritative, worker);
         }
-        authoritative
+        if self.tree_worker_shadow.is_authoritative() {
+            self.tree_worker_shadow.public_node_result(worker, false)
+        } else {
+            authoritative
+        }
     }
 
     /// Like [`navigate_to_node`](Self::navigate_to_node), but `f` also receives
@@ -376,7 +380,11 @@ impl Kakehashi {
             self.tree_worker_shadow
                 .compare_node_result(uri, &operation, &authoritative, worker);
         }
-        authoritative
+        if self.tree_worker_shadow.is_authoritative() {
+            self.tree_worker_shadow.public_node_result(worker, false)
+        } else {
+            authoritative
+        }
     }
 
     /// Resolve `id` **and** `descendant_id` in the layer that minted them, run
@@ -513,7 +521,11 @@ impl Kakehashi {
                 worker,
             );
         }
-        authoritative
+        if self.tree_worker_shadow.is_authoritative() {
+            self.tree_worker_shadow.public_node_result(worker, false)
+        } else {
+            authoritative
+        }
     }
 
     /// Resolve `id`, run `f` to collect a list of related nodes (children,
@@ -563,6 +575,10 @@ impl Kakehashi {
             self.tree_worker_shadow
                 .compare_node_result(uri, &operation, &authoritative, worker);
         }
-        authoritative
+        if self.tree_worker_shadow.is_authoritative() {
+            self.tree_worker_shadow.public_node_result(worker, true)
+        } else {
+            authoritative
+        }
     }
 }

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -239,7 +239,7 @@ impl Kakehashi {
             }
             let authoritative =
                 self.resolve_host_layer_node(&uri, tree, byte, doc_len, incarnation);
-            if let Some(shadow) = self
+            let worker = self
                 .tree_worker_shadow
                 .resolve_node(
                     &uri,
@@ -249,7 +249,8 @@ impl Kakehashi {
                     byte,
                     crate::tree_worker::NodeLayerSelector::Host,
                 )
-                .await
+                .await;
+            if let Some(shadow) = worker.as_ref()
                 && let Some(node) = shadow.nodes.first()
             {
                 let authoritative_kind = authoritative.get("kind").and_then(Value::as_str);
@@ -291,7 +292,11 @@ impl Kakehashi {
             }) {
                 return Ok(Value::Null);
             }
-            return Ok(authoritative);
+            return if self.tree_worker_shadow.is_authoritative() {
+                Ok(self.tree_worker_shadow.public_node_result(worker, false))
+            } else {
+                Ok(authoritative)
+            };
         }
 
         // We need the host language to seed `injection_stack_at` with the
@@ -431,7 +436,7 @@ impl Kakehashi {
 
         // None = the work-unit panicked (logged by the pool) → protocol null.
         let authoritative = result.unwrap_or(Value::Null);
-        if let Some(worker) = worker {
+        if let Some(worker) = worker.as_ref() {
             let worker_node = worker.nodes.first();
             let authoritative_identity = authoritative
                 .get("id")
@@ -478,7 +483,11 @@ impl Kakehashi {
                 );
             }
         }
-        Ok(authoritative)
+        if self.tree_worker_shadow.is_authoritative() {
+            Ok(self.tree_worker_shadow.public_node_result(worker, false))
+        } else {
+            Ok(authoritative)
+        }
     }
 
     /// Host-layer lookup, factored out so the no-injection request keeps

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -187,6 +187,81 @@ impl Kakehashi {
             return Ok(Value::Null);
         };
 
+        if self.tree_worker_shadow.is_authoritative() {
+            let Some((text, incarnation, content_version, language_name)) =
+                self.documents.get(&uri).and_then(|document| {
+                    let text = document.text_arc();
+                    let language = self.language.detect_language(
+                        uri.path(),
+                        &text,
+                        None,
+                        document.language_id(),
+                    )?;
+                    Some((
+                        text,
+                        document.incarnation(),
+                        document.content_version(),
+                        language,
+                    ))
+                })
+            else {
+                return Ok(Value::Null);
+            };
+            if text.is_empty() {
+                return Ok(Value::Null);
+            }
+            let Some(byte) = PositionMapper::new(&text).position_to_byte(position) else {
+                return Ok(Value::Null);
+            };
+            let load = self
+                .language
+                .ensure_language_loaded_async(&language_name)
+                .await;
+            if !load.success {
+                return Ok(Value::Null);
+            }
+            let Some(current) = self.documents.get(&uri) else {
+                return Ok(Value::Null);
+            };
+            if current.incarnation() != incarnation || current.content_version() != content_version
+            {
+                return Ok(Value::Null);
+            }
+            drop(current);
+            let Some(grammar) = self.language.worker_grammar_descriptor(&language_name) else {
+                return Ok(Value::Null);
+            };
+            let generation = self.language.configuration_generation();
+            if self.tree_worker_shadow.needs_document_sync(
+                &uri,
+                incarnation,
+                content_version,
+                generation,
+                &grammar.queries,
+            ) {
+                self.refresh_tree_worker_documents(std::slice::from_ref(&uri));
+            }
+            let worker = self
+                .tree_worker_shadow
+                .resolve_node(
+                    &uri,
+                    incarnation,
+                    content_version,
+                    generation,
+                    byte,
+                    selector.worker_layer(),
+                )
+                .await;
+            if let Some(result) = worker.as_ref() {
+                for node in &result.nodes {
+                    let public = serde_json::json!({ "id": node.id.local_id, "kind": node.kind });
+                    self.tree_worker_shadow
+                        .record_node_mapping(&uri, &public, node);
+                }
+            }
+            return Ok(self.tree_worker_shadow.public_node_result(worker, false));
+        }
+
         // Resolve a CURRENT parse snapshot (parse-snapshot ADR §3): the
         // request's position is authored against the live text, so a trailing
         // snapshot rejects immediately with the universal null; only the

--- a/src/lsp/lsp_impl/kakehashi/node/field.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/field.rs
@@ -97,8 +97,13 @@ impl Kakehashi {
             .await
             .map(|(_uri, _layer, _incarnation, field)| json!({ "fieldName": field }))
             .unwrap_or(Value::Null);
-        compare_field_name(shadow, &value, false);
-        Ok(value)
+        let worker = field_name_json(shadow);
+        compare_field_name(worker.as_ref(), &value, false);
+        if self.tree_worker_shadow.is_authoritative() {
+            Ok(worker.unwrap_or(Value::Null))
+        } else {
+            Ok(value)
+        }
     }
 
     /// `kakehashi/node/fieldNameForNamedChild` — the field name of the *named*
@@ -131,21 +136,28 @@ impl Kakehashi {
             .await
             .map(|(_uri, _layer, _incarnation, field)| json!({ "fieldName": field }))
             .unwrap_or(Value::Null);
-        compare_field_name(shadow, &value, true);
-        Ok(value)
+        let worker = field_name_json(shadow);
+        compare_field_name(worker.as_ref(), &value, true);
+        if self.tree_worker_shadow.is_authoritative() {
+            Ok(worker.unwrap_or(Value::Null))
+        } else {
+            Ok(value)
+        }
     }
 }
 
-fn compare_field_name(
-    shadow: Option<crate::tree_worker::NodeScalarValue>,
-    authoritative: &Value,
-    named: bool,
-) {
-    let Some(crate::tree_worker::NodeScalarValue::NullableString(field)) = shadow else {
+fn field_name_json(shadow: Option<crate::tree_worker::NodeScalarValue>) -> Option<Value> {
+    let crate::tree_worker::NodeScalarValue::NullableString(field) = shadow? else {
+        return None;
+    };
+    Some(json!({ "fieldName": field }))
+}
+
+fn compare_field_name(shadow: Option<&Value>, authoritative: &Value, named: bool) {
+    let Some(worker) = shadow else {
         return;
     };
-    let worker = json!({ "fieldName": field });
-    if &worker != authoritative {
+    if worker != authoritative {
         log::debug!(
             target: "kakehashi::tree_worker_shadow",
             "node field-name mismatch named={named} authoritative={authoritative} worker={worker}",

--- a/src/lsp/lsp_impl/kakehashi/node/field.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/field.rs
@@ -90,6 +90,10 @@ impl Kakehashi {
             }
             _ => None,
         };
+        let worker = field_name_json(shadow);
+        if self.tree_worker_shadow.is_authoritative() {
+            return Ok(worker.unwrap_or(Value::Null));
+        }
         let value = self
             .with_node_by_id(&params.text_document.uri, &params.id, move |n| {
                 index.and_then(|i| n.field_name_for_child(i))
@@ -97,7 +101,6 @@ impl Kakehashi {
             .await
             .map(|(_uri, _layer, _incarnation, field)| json!({ "fieldName": field }))
             .unwrap_or(Value::Null);
-        let worker = field_name_json(shadow);
         compare_field_name(worker.as_ref(), &value, false);
         if self.tree_worker_shadow.is_authoritative() {
             Ok(worker.unwrap_or(Value::Null))
@@ -129,6 +132,10 @@ impl Kakehashi {
             }
             _ => None,
         };
+        let worker = field_name_json(shadow);
+        if self.tree_worker_shadow.is_authoritative() {
+            return Ok(worker.unwrap_or(Value::Null));
+        }
         let value = self
             .with_node_by_id(&params.text_document.uri, &params.id, move |n| {
                 index.and_then(|i| n.field_name_for_named_child(i))
@@ -136,7 +143,6 @@ impl Kakehashi {
             .await
             .map(|(_uri, _layer, _incarnation, field)| json!({ "fieldName": field }))
             .unwrap_or(Value::Null);
-        let worker = field_name_json(shadow);
         compare_field_name(worker.as_ref(), &value, true);
         if self.tree_worker_shadow.is_authoritative() {
             Ok(worker.unwrap_or(Value::Null))

--- a/src/lsp/lsp_impl/kakehashi/node/metadata.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/metadata.rs
@@ -53,12 +53,15 @@ macro_rules! scalar_accessor {
             }
             Err(_) => None,
         };
+        let worker = shadow.and_then(|shadow| scalar_json($field, shadow));
+        if $self.tree_worker_shadow.is_authoritative() {
+            return Ok(worker.unwrap_or(Value::Null));
+        }
         let value = $self
             .with_node_by_id(&$params.text_document.uri, &$params.id, $f)
             .await
             .map(|(_uri, _layer, _incarnation, v)| json!({ $field: v }))
             .unwrap_or(Value::Null);
-        let worker = shadow.and_then(|shadow| scalar_json($field, shadow));
         if let Some(shadow) = worker.as_ref()
             && shadow != &value
         {
@@ -172,6 +175,15 @@ impl Kakehashi {
             }
             Err(_) => None,
         };
+        if self.tree_worker_shadow.is_authoritative() {
+            return Ok(match shadow {
+                Some(NodeScalarValue::ByteRange {
+                    start_byte,
+                    end_byte,
+                }) => json!({ "startByte": start_byte, "endByte": end_byte }),
+                _ => Value::Null,
+            });
+        }
         let value = self
             .with_node_by_id(
                 &params.text_document.uri,

--- a/src/lsp/lsp_impl/kakehashi/node/metadata.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/metadata.rs
@@ -58,8 +58,9 @@ macro_rules! scalar_accessor {
             .await
             .map(|(_uri, _layer, _incarnation, v)| json!({ $field: v }))
             .unwrap_or(Value::Null);
-        if let Some(shadow) = shadow.and_then(|shadow| scalar_json($field, shadow))
-            && shadow != value
+        let worker = shadow.and_then(|shadow| scalar_json($field, shadow));
+        if let Some(shadow) = worker.as_ref()
+            && shadow != &value
         {
             log::debug!(
                 target: "kakehashi::tree_worker_shadow",
@@ -69,7 +70,11 @@ macro_rules! scalar_accessor {
                 shadow,
             );
         }
-        Ok(value)
+        if $self.tree_worker_shadow.is_authoritative() {
+            Ok(worker.unwrap_or(Value::Null))
+        } else {
+            Ok(value)
+        }
     }};
 }
 
@@ -176,7 +181,7 @@ impl Kakehashi {
             .await
             .map(|(_uri, _layer, _incarnation, v)| v)
             .unwrap_or(Value::Null);
-        if let Some(NodeScalarValue::ByteRange {
+        let worker = if let Some(NodeScalarValue::ByteRange {
             start_byte,
             end_byte,
         }) = shadow
@@ -191,8 +196,15 @@ impl Kakehashi {
                     shadow,
                 );
             }
+            Some(shadow)
+        } else {
+            None
+        };
+        if self.tree_worker_shadow.is_authoritative() {
+            Ok(worker.unwrap_or(Value::Null))
+        } else {
+            Ok(value)
         }
-        Ok(value)
     }
 
     /// `kakehashi/node/childCount` — number of children (named + anonymous),

--- a/src/lsp/lsp_impl/kakehashi/node/parent.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/parent.rs
@@ -51,6 +51,13 @@ impl Kakehashi {
             log::warn!(target: "kakehashi::node::parent", "invalid URI: {}", lsp_uri.as_str());
             return Ok(Value::Null);
         };
+        if self.tree_worker_shadow.is_authoritative() {
+            let worker = self
+                .tree_worker_shadow
+                .node_navigation(&uri, &params.id, crate::tree_worker::NodeNavigation::Parent)
+                .await;
+            return Ok(self.tree_worker_shadow.public_node_result(worker, false));
+        }
 
         // Malformed ULID collapses to null per node-reference-protocol §"Invalidate vs Not-Found".
         let Ok(ulid) = params.id.parse::<Ulid>() else {
@@ -146,7 +153,8 @@ impl Kakehashi {
             "id": parent_ulid.to_string(),
             "kind": p_kind,
         });
-        self.tree_worker_shadow
+        let worker = self
+            .tree_worker_shadow
             .compare_node_navigation(
                 &uri,
                 incarnation,
@@ -163,6 +171,10 @@ impl Kakehashi {
         }) {
             return Ok(Value::Null);
         }
-        Ok(authoritative)
+        if self.tree_worker_shadow.is_authoritative() {
+            Ok(self.tree_worker_shadow.public_node_result(worker, false))
+        } else {
+            Ok(authoritative)
+        }
     }
 }

--- a/src/lsp/lsp_impl/kakehashi/node/position.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/position.rs
@@ -56,8 +56,12 @@ impl Kakehashi {
             .and_then(|(_uri, _layer, _incarnation, span)| span)
             .map(|(start, end)| json!({ "start": start, "end": end }))
             .unwrap_or(Value::Null);
-        compare_position_scalar(shadow, &value, "range");
-        Ok(value)
+        let worker = compare_position_scalar(shadow, &value, "range");
+        if self.tree_worker_shadow.is_authoritative() {
+            Ok(worker.unwrap_or(Value::Null))
+        } else {
+            Ok(value)
+        }
     }
 
     /// `kakehashi/node/startPosition` — the node's start as an LSP `Position`,
@@ -79,8 +83,12 @@ impl Kakehashi {
             .and_then(|(_uri, _layer, _incarnation, pos)| pos)
             .map(|pos| json!({ "startPosition": pos }))
             .unwrap_or(Value::Null);
-        compare_position_scalar(shadow, &value, "startPosition");
-        Ok(value)
+        let worker = compare_position_scalar(shadow, &value, "startPosition");
+        if self.tree_worker_shadow.is_authoritative() {
+            Ok(worker.unwrap_or(Value::Null))
+        } else {
+            Ok(value)
+        }
     }
 
     /// `kakehashi/node/endPosition` — the node's end as an LSP `Position`, per
@@ -101,8 +109,12 @@ impl Kakehashi {
             .and_then(|(_uri, _layer, _incarnation, pos)| pos)
             .map(|pos| json!({ "endPosition": pos }))
             .unwrap_or(Value::Null);
-        compare_position_scalar(shadow, &value, "endPosition");
-        Ok(value)
+        let worker = compare_position_scalar(shadow, &value, "endPosition");
+        if self.tree_worker_shadow.is_authoritative() {
+            Ok(worker.unwrap_or(Value::Null))
+        } else {
+            Ok(value)
+        }
     }
 
     /// `kakehashi/node/descendantForPointRange` — the smallest descendant
@@ -209,7 +221,7 @@ fn compare_position_scalar(
     shadow: Option<crate::tree_worker::NodeScalarValue>,
     authoritative: &Value,
     field: &str,
-) {
+) -> Option<Value> {
     let worker = match shadow {
         Some(crate::tree_worker::NodeScalarValue::Position(position)) => {
             let mut object = serde_json::Map::new();
@@ -219,7 +231,7 @@ fn compare_position_scalar(
         Some(crate::tree_worker::NodeScalarValue::Range { start, end }) => {
             json!({ "start": wire_position_json(start), "end": wire_position_json(end) })
         }
-        _ => return,
+        _ => return None,
     };
     if &worker != authoritative {
         log::debug!(
@@ -227,4 +239,5 @@ fn compare_position_scalar(
             "node position mismatch field={field} authoritative={authoritative} worker={worker}",
         );
     }
+    Some(worker)
 }

--- a/src/lsp/lsp_impl/kakehashi/node/position.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/position.rs
@@ -44,6 +44,9 @@ impl Kakehashi {
                 crate::tree_worker::NodeScalarOperation::Range,
             )
             .await;
+        if self.tree_worker_shadow.is_authoritative() {
+            return Ok(position_scalar_json(shadow, "range").unwrap_or(Value::Null));
+        }
         let value = self
             .with_node_text(&params.text_document.uri, &params.id, move |n, text| {
                 let mapper = PositionMapper::new(text);
@@ -75,6 +78,9 @@ impl Kakehashi {
                 crate::tree_worker::NodeScalarOperation::StartPosition,
             )
             .await;
+        if self.tree_worker_shadow.is_authoritative() {
+            return Ok(position_scalar_json(shadow, "startPosition").unwrap_or(Value::Null));
+        }
         let value = self
             .with_node_text(&params.text_document.uri, &params.id, move |n, text| {
                 PositionMapper::new(text).byte_to_position(n.start_byte())
@@ -101,6 +107,9 @@ impl Kakehashi {
                 crate::tree_worker::NodeScalarOperation::EndPosition,
             )
             .await;
+        if self.tree_worker_shadow.is_authoritative() {
+            return Ok(position_scalar_json(shadow, "endPosition").unwrap_or(Value::Null));
+        }
         let value = self
             .with_node_text(&params.text_document.uri, &params.id, move |n, text| {
                 PositionMapper::new(text).byte_to_position(n.end_byte())
@@ -222,7 +231,21 @@ fn compare_position_scalar(
     authoritative: &Value,
     field: &str,
 ) -> Option<Value> {
-    let worker = match shadow {
+    let worker = position_scalar_json(shadow, field)?;
+    if &worker != authoritative {
+        log::debug!(
+            target: "kakehashi::tree_worker_shadow",
+            "node position mismatch field={field} authoritative={authoritative} worker={worker}",
+        );
+    }
+    Some(worker)
+}
+
+fn position_scalar_json(
+    shadow: Option<crate::tree_worker::NodeScalarValue>,
+    field: &str,
+) -> Option<Value> {
+    Some(match shadow {
         Some(crate::tree_worker::NodeScalarValue::Position(position)) => {
             let mut object = serde_json::Map::new();
             object.insert(field.into(), wire_position_json(position));
@@ -232,12 +255,5 @@ fn compare_position_scalar(
             json!({ "start": wire_position_json(start), "end": wire_position_json(end) })
         }
         _ => return None,
-    };
-    if &worker != authoritative {
-        log::debug!(
-            target: "kakehashi::tree_worker_shadow",
-            "node position mismatch field={field} authoritative={authoritative} worker={worker}",
-        );
-    }
-    Some(worker)
+    })
 }

--- a/src/lsp/lsp_impl/kakehashi/node/text.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/text.rs
@@ -46,6 +46,13 @@ impl Kakehashi {
                 crate::tree_worker::NodeScalarOperation::Text,
             )
             .await;
+        if self.tree_worker_shadow.is_authoritative() {
+            let worker = match shadow.as_ref() {
+                Some(crate::tree_worker::NodeScalarValue::String(text)) => json!({ "text": text }),
+                _ => Value::Null,
+            };
+            return Ok(worker);
+        }
 
         // Malformed ULID: node-reference-protocol says any unresolvable reference collapses to null,
         // so we treat a parse failure the same as a never-issued ULID rather than
@@ -96,9 +103,14 @@ impl Kakehashi {
         };
 
         let authoritative = json!({ "text": slice });
-        if let Some(crate::tree_worker::NodeScalarValue::String(text)) = shadow {
-            let worker = json!({ "text": text });
-            if worker != authoritative {
+        let worker = match shadow {
+            Some(crate::tree_worker::NodeScalarValue::String(text)) => {
+                Some(json!({ "text": text }))
+            }
+            _ => None,
+        };
+        if let Some(worker) = worker.as_ref() {
+            if worker != &authoritative {
                 log::debug!(
                     target: "kakehashi::tree_worker_shadow",
                     "node text mismatch authoritative={} worker={}",
@@ -107,6 +119,10 @@ impl Kakehashi {
                 );
             }
         }
-        Ok(authoritative)
+        if self.tree_worker_shadow.is_authoritative() {
+            Ok(worker.unwrap_or(Value::Null))
+        } else {
+            Ok(authoritative)
+        }
     }
 }

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -499,11 +499,13 @@ impl Kakehashi {
                     Arc::clone(&self.documents),
                     Arc::clone(&self.language),
                     Arc::clone(&self.bridge),
+                    Some(Arc::clone(&self.tree_worker_shadow)),
                 ),
                 apply_edit: ApplyEditTranslator::new(
                     Arc::clone(&self.documents),
                     Arc::clone(&self.language),
                     Arc::clone(&self.bridge),
+                    Some(Arc::clone(&self.tree_worker_shadow)),
                 ),
             }));
             let inbound_request_registry = self.bridge.pool().inbound_request_registry();
@@ -3250,11 +3252,13 @@ mod tests {
                 Arc::new(crate::document::DocumentStore::new()),
                 Arc::new(crate::language::LanguageCoordinator::new()),
                 Arc::new(BridgeCoordinator::new()),
+                None,
             ),
             apply_edit: ApplyEditTranslator::new(
                 Arc::new(crate::document::DocumentStore::new()),
                 Arc::new(crate::language::LanguageCoordinator::new()),
                 Arc::new(BridgeCoordinator::new()),
+                None,
             ),
         }));
         let loop_handle = tokio::spawn(upstream_forwarding_loop(
@@ -3376,11 +3380,13 @@ mod tests {
                 Arc::new(crate::document::DocumentStore::new()),
                 Arc::new(crate::language::LanguageCoordinator::new()),
                 Arc::new(BridgeCoordinator::new()),
+                None,
             ),
             apply_edit: ApplyEditTranslator::new(
                 Arc::new(crate::document::DocumentStore::new()),
                 Arc::new(crate::language::LanguageCoordinator::new()),
                 Arc::new(BridgeCoordinator::new()),
+                None,
             ),
         }));
         let loop_handle = tokio::spawn(upstream_forwarding_loop(

--- a/src/lsp/lsp_impl/region_offset.rs
+++ b/src/lsp/lsp_impl/region_offset.rs
@@ -29,13 +29,51 @@ use crate::lsp::bridge::{BridgeCoordinator, RegionOffset, region_host_end};
 /// whose tracked geometry/layer no longer exists in the live parse, or a
 /// missing document/snapshot/language/query. The third tuple field reports
 /// whether the virtual content maps to one contiguous host span.
-pub(super) fn resolve_region_offset(
+pub(super) async fn resolve_region_offset(
     documents: &DocumentStore,
     language: &Arc<LanguageCoordinator>,
     bridge: &BridgeCoordinator,
+    tree_worker_shadow: Option<&Arc<crate::lsp::lsp_impl::tree_worker_shadow::TreeWorkerShadow>>,
     host_url: &Url,
     region_id: &str,
 ) -> Option<(RegionOffset, Position, bool)> {
+    if let Some(tree_worker_shadow) = tree_worker_shadow
+        && tree_worker_shadow.is_authoritative()
+    {
+        let (text, language_id, incarnation, content_version) =
+            documents.get(host_url).map(|document| {
+                (
+                    document.text_arc(),
+                    document.language_id().map(str::to_owned),
+                    document.incarnation(),
+                    document.content_version(),
+                )
+            })?;
+        let language_name =
+            language.detect_language(host_url.path(), &text, None, language_id.as_deref())?;
+        if !language
+            .ensure_language_loaded_async(&language_name)
+            .await
+            .success
+        {
+            return None;
+        }
+        let regions = tree_worker_shadow
+            .worker_injection_regions(
+                host_url,
+                incarnation,
+                content_version,
+                language.configuration_generation(),
+            )
+            .await?;
+        let current = documents.get(host_url)?;
+        if current.incarnation() != incarnation || current.content_version() != content_version {
+            return None;
+        }
+        drop(current);
+        return resolved_region_by_id(&regions, region_id).map(resolved_region_geometry);
+    }
+
     // Snapshot is owned, so the document handle (a store lock) is released
     // before `detect_document_language` reaches back into the store.
     let snapshot = documents.get(host_url)?.snapshot()?;
@@ -55,6 +93,16 @@ pub(super) fn resolve_region_offset(
     // an edit race: if this snapshot no longer contains the tracked layer, no
     // candidate has the ID and callers fall back safely.
     Some(resolved_region_geometry(resolved))
+}
+
+fn resolved_region_by_id(
+    regions: &[ResolvedInjection],
+    region_id: &str,
+) -> Option<ResolvedInjection> {
+    regions
+        .iter()
+        .find(|resolved| resolved.region.region_id == region_id)
+        .cloned()
 }
 
 /// Consume a resolved region into the geometry shared by freshness and edit
@@ -92,5 +140,29 @@ mod tests {
         let (_, region_end, _) = resolved_region_geometry(resolved);
 
         assert_eq!(region_end, Position::new(2, 4));
+    }
+
+    #[test]
+    fn worker_region_lookup_requires_the_exact_region_id() {
+        let make = |region_id: &str, line: u32| ResolvedInjection {
+            region: CacheableInjectionRegion {
+                language: "rust".to_string(),
+                byte_range: 10..20,
+                line_range: line..line + 1,
+                start_column: 0,
+                region_id: region_id.to_string(),
+                content_hash: 0,
+            },
+            injection_language: "rust".to_string(),
+            virtual_content: "x".to_string(),
+            line_column_offsets: vec![0],
+            contiguous: true,
+        };
+        let regions = vec![make("older", 2), make("current", 7)];
+
+        let selected = resolved_region_by_id(&regions, "current").expect("exact region");
+
+        assert_eq!(selected.region.line_range.start, 7);
+        assert!(resolved_region_by_id(&regions, "missing").is_none());
     }
 }

--- a/src/lsp/lsp_impl/show_document_translation.rs
+++ b/src/lsp/lsp_impl/show_document_translation.rs
@@ -48,6 +48,7 @@ pub(super) struct ShowDocumentTranslator {
     documents: Arc<DocumentStore>,
     language: Arc<LanguageCoordinator>,
     bridge: Arc<BridgeCoordinator>,
+    tree_worker_shadow: Option<Arc<crate::lsp::lsp_impl::tree_worker_shadow::TreeWorkerShadow>>,
 }
 
 impl ShowDocumentTranslator {
@@ -55,11 +56,13 @@ impl ShowDocumentTranslator {
         documents: Arc<DocumentStore>,
         language: Arc<LanguageCoordinator>,
         bridge: Arc<BridgeCoordinator>,
+        tree_worker_shadow: Option<Arc<crate::lsp::lsp_impl::tree_worker_shadow::TreeWorkerShadow>>,
     ) -> Self {
         Self {
             documents,
             language,
             bridge,
+            tree_worker_shadow,
         }
     }
 
@@ -87,7 +90,7 @@ impl ShowDocumentTranslator {
         // Only a selection needs the (live-parse) region offset, so skip
         // resolving it when there's nothing to translate.
         if params.selection.is_some() {
-            match self.region_offset(&host_url, &region_id) {
+            match self.region_offset(&host_url, &region_id).await {
                 Some(offset) => return Self::apply_host_translation(params, host_uri, &offset),
                 // Offset unavailable (region invalidated by edits, or otherwise
                 // unresolvable): drop the selection we can't translate — a
@@ -120,14 +123,16 @@ impl ShowDocumentTranslator {
     /// document without a selection rather than risk a wrong one. showDocument
     /// only needs the offset (it translates a single selection position, not an
     /// edit), so the region-end bound and contiguity marker are discarded.
-    fn region_offset(&self, host_url: &Url, region_id: &str) -> Option<RegionOffset> {
+    async fn region_offset(&self, host_url: &Url, region_id: &str) -> Option<RegionOffset> {
         resolve_region_offset(
             &self.documents,
             &self.language,
             &self.bridge,
+            self.tree_worker_shadow.as_ref(),
             host_url,
             region_id,
         )
+        .await
         .map(|(offset, _region_end, _contiguous)| offset)
     }
 }
@@ -144,6 +149,7 @@ mod tests {
             Arc::new(DocumentStore::new()),
             Arc::new(LanguageCoordinator::new()),
             Arc::new(BridgeCoordinator::new()),
+            None,
         )
     }
 

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -26,17 +26,16 @@ use tower_lsp_server::ls_types::{
 use ulid::Ulid;
 use url::Url;
 
+use super::super::Kakehashi;
 use super::super::bridge_context::RangeRequestContext;
-use super::super::{Kakehashi, detect_document_language};
 use crate::config::settings::AggregationStrategy;
-use crate::language::InjectionResolver;
 use crate::lsp::aggregation::server::{
     FanInResult, FanOutTask, HostFanOutTask, dispatch_concatenated, dispatch_host_concatenated,
     dispatch_host_preferred, dispatch_preferred,
 };
 use crate::lsp::bridge::{
     CodeActionEnvelope, HostDocument, RegionOffset, UpstreamCodeActionCaps, bridge_code_actions,
-    extract_code_action_envelope, parse_code_actions_leniently, region_host_end,
+    extract_code_action_envelope, parse_code_actions_leniently,
 };
 
 const METHOD: &str = "textDocument/codeAction";
@@ -187,7 +186,7 @@ impl Kakehashi {
         let region_end = if envelope.is_host_layer() {
             Position::default()
         } else {
-            match self.code_action_region_end_if_fresh(&envelope) {
+            match self.code_action_region_end_if_fresh(&envelope).await {
                 Ok(region_end) => region_end,
                 Err(RegionEndUnavailable::MalformedEnvelope) => {
                     // Already warned with the malformed field; no stale-debug.
@@ -267,7 +266,7 @@ impl Kakehashi {
     /// never matches and resolve always fails soft for those regions. That errs
     /// in the safe direction (the action stays unresolved) and frontmatter code
     /// actions have no known real-world producer; revisit if one appears.
-    fn code_action_region_end_if_fresh(
+    async fn code_action_region_end_if_fresh(
         &self,
         envelope: &CodeActionEnvelope,
     ) -> std::result::Result<Position, RegionEndUnavailable> {
@@ -292,45 +291,31 @@ impl Kakehashi {
             return Err(RegionEndUnavailable::MalformedEnvelope);
         }
         self.code_action_region_end_live(envelope, &host_url)
+            .await
             .ok_or(RegionEndUnavailable::Stale)
     }
 
     /// The live-lookup half of [`Self::code_action_region_end_if_fresh`]:
     /// every `None` here is the STALE class (region moved, invalidated, or
     /// diverged), never a malformed envelope.
-    fn code_action_region_end_live(
+    async fn code_action_region_end_live(
         &self,
         envelope: &CodeActionEnvelope,
         host_url: &Url,
     ) -> Option<Position> {
-        // Re-resolve the region from the LIVE parse (same construction as the
-        // goto/showDocument offset path), yielding the current per-line offset
-        // and virtual content used to derive the exact mapped host end.
-        let snapshot = self.documents.get(host_url)?.snapshot()?;
-        let language_name = detect_document_language(&self.language, &self.documents, host_url)?;
-        let injection_query = self.language.injection_query(&language_name)?;
-        let resolved = InjectionResolver::resolve_by_region_id(
-            &self.language,
-            self.bridge.node_tracker(),
-            host_url,
-            snapshot.tree(),
-            snapshot.text(),
-            injection_query.as_ref(),
-            &envelope.region_id,
-            snapshot.incarnation(),
-        )?;
-        // The action may have been created while a single combined capture was
-        // contiguous, then resolved after another capture introduced a masked
-        // host gap. The stable first-region ID/offset alone cannot detect that
-        // geometry change, so re-check live edit safety here.
-        if !resolved.contiguous {
+        let (live_offset, region_end, contiguous) =
+            crate::lsp::lsp_impl::region_offset::resolve_region_offset(
+                &self.documents,
+                &self.language,
+                &self.bridge,
+                Some(&self.tree_worker_shadow),
+                host_url,
+                &envelope.region_id,
+            )
+            .await?;
+        if !contiguous {
             return None;
         }
-        let live_offset = RegionOffset::with_per_line_offsets(
-            resolved.region.line_range.start,
-            resolved.line_column_offsets,
-        );
-        let region_end = region_host_end(&resolved.virtual_content, &live_offset);
         // Compare the WHOLE offset, not just the start: a diverged interior
         // per-line column offset (e.g. a blockquote-prefix edit that left the
         // start line intact) would translate the resolved edit to wrong host

--- a/src/lsp/lsp_impl/text_document/completion_item.rs
+++ b/src/lsp/lsp_impl/text_document/completion_item.rs
@@ -28,7 +28,7 @@ impl Kakehashi {
         // combined document into one with masked host gaps. Fail closed for
         // legacy/stale envelopes before the downstream can add new edits.
         if let Some(envelope) = extract_envelope(&params)
-            && !self.completion_envelope_is_fresh(&envelope)
+            && !self.completion_envelope_is_fresh(&envelope).await
         {
             return Ok(params);
         }
@@ -41,7 +41,7 @@ impl Kakehashi {
         Ok(item)
     }
 
-    fn completion_envelope_is_fresh(&self, envelope: &KakehashiEnvelope) -> bool {
+    async fn completion_envelope_is_fresh(&self, envelope: &KakehashiEnvelope) -> bool {
         let Ok(host_url) = Url::parse(&envelope.host_uri) else {
             return false;
         };
@@ -49,9 +49,12 @@ impl Kakehashi {
             &self.documents,
             &self.language,
             &self.bridge,
+            Some(&self.tree_worker_shadow),
             &host_url,
             &envelope.region_id,
-        ) else {
+        )
+        .await
+        else {
             return false;
         };
         completion_geometry_matches(envelope, &offset, region_end, contiguous)

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -170,7 +170,10 @@ impl Kakehashi {
         // (parse pending/failed) yields `None` — host still pulls, virt skips.
         let snapshot = if virt_enabled {
             self.ensure_document_parsed(&uri).await;
-            self.documents.get(&uri).and_then(|doc| doc.snapshot())
+            self.documents.get(&uri).and_then(|doc| {
+                doc.snapshot()
+                    .map(|snapshot| (snapshot, doc.content_version()))
+            })
         } else {
             None
         };
@@ -187,7 +190,7 @@ impl Kakehashi {
         // Resolve injection regions once: the live virt pull below and the
         // pushFallback fold (#425) after the join share them.
         let virt_regions = match (virt_enabled, snapshot.as_ref()) {
-            (true, Some(snapshot)) => self
+            (true, Some((snapshot, _))) => self
                 .language
                 .injection_query(&language_name)
                 .map(|injection_query| {
@@ -212,6 +215,20 @@ impl Kakehashi {
             // wait+on-demand above already tried, so a missing tree here is the
             // rare parse-failure case, self-healing on the next pull.
             _ => std::sync::Arc::new(Vec::new()),
+        };
+        let virt_regions = if self.tree_worker_shadow.is_authoritative()
+            && let Some((snapshot, content_version)) = snapshot.as_ref()
+        {
+            self.worker_injection_regions_for_snapshot(
+                &uri,
+                snapshot.incarnation(),
+                *content_version,
+                &language_name,
+            )
+            .await
+            .unwrap_or_default()
+        } else {
+            virt_regions
         };
         // Lightweight per-region metadata `(region_id, injection_language,
         // current offset)` for the pushFallback fold; the live pull below moves

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -168,7 +168,14 @@ impl Kakehashi {
         // the reparse window after each edit. The HOST layer needs no tree, so a
         // host-only document must not pay the freshness wait. A still-missing tree
         // (parse pending/failed) yields `None` — host still pulls, virt skips.
-        let snapshot = if virt_enabled {
+        let worker_regions = if virt_enabled && self.tree_worker_shadow.is_authoritative() {
+            self.current_worker_injection_view(&uri)
+                .await
+                .map(|view| view.regions)
+        } else {
+            None
+        };
+        let snapshot = if virt_enabled && !self.tree_worker_shadow.is_authoritative() {
             self.ensure_document_parsed(&uri).await;
             self.documents.get(&uri).and_then(|doc| {
                 doc.snapshot()
@@ -189,46 +196,36 @@ impl Kakehashi {
 
         // Resolve injection regions once: the live virt pull below and the
         // pushFallback fold (#425) after the join share them.
-        let virt_regions = match (virt_enabled, snapshot.as_ref()) {
-            (true, Some((snapshot, _))) => self
-                .language
-                .injection_query(&language_name)
-                .map(|injection_query| {
-                    match self
-                        .documents
-                        .current_resolved_regions(&uri, self.cache.semantic_token_generation())
-                    {
-                        Some(regions) => regions,
-                        None => std::sync::Arc::new(InjectionResolver::resolve_all(
-                            &self.language,
-                            self.bridge.node_tracker(),
-                            &uri,
-                            snapshot.tree(),
-                            snapshot.text(),
-                            injection_query.as_ref(),
-                            snapshot.incarnation(),
-                        )),
-                    }
-                })
-                .unwrap_or_default(),
-            // Virt gated off, or no tree yet (the host layer still pulls). The
-            // wait+on-demand above already tried, so a missing tree here is the
-            // rare parse-failure case, self-healing on the next pull.
-            _ => std::sync::Arc::new(Vec::new()),
-        };
-        let virt_regions = if self.tree_worker_shadow.is_authoritative()
-            && let Some((snapshot, content_version)) = snapshot.as_ref()
-        {
-            self.worker_injection_regions_for_snapshot(
-                &uri,
-                snapshot.incarnation(),
-                *content_version,
-                &language_name,
-            )
-            .await
-            .unwrap_or_default()
+        let virt_regions = if self.tree_worker_shadow.is_authoritative() {
+            worker_regions.unwrap_or_default()
         } else {
-            virt_regions
+            match (virt_enabled, snapshot.as_ref()) {
+                (true, Some((snapshot, _))) => self
+                    .language
+                    .injection_query(&language_name)
+                    .map(|injection_query| {
+                        match self
+                            .documents
+                            .current_resolved_regions(&uri, self.cache.semantic_token_generation())
+                        {
+                            Some(regions) => regions,
+                            None => std::sync::Arc::new(InjectionResolver::resolve_all(
+                                &self.language,
+                                self.bridge.node_tracker(),
+                                &uri,
+                                snapshot.tree(),
+                                snapshot.text(),
+                                injection_query.as_ref(),
+                                snapshot.incarnation(),
+                            )),
+                        }
+                    })
+                    .unwrap_or_default(),
+                // Virt gated off, or no tree yet (the host layer still pulls). The
+                // wait+on-demand above already tried, so a missing tree here is the
+                // rare parse-failure case, self-healing on the next pull.
+                _ => std::sync::Arc::new(Vec::new()),
+            }
         };
         // Lightweight per-region metadata `(region_id, injection_language,
         // current offset)` for the pushFallback fold; the live pull below moves

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -159,19 +159,28 @@ impl Kakehashi {
             .close_invalidated_virtual_docs(&uri, &invalidated_ulids)
             .await;
 
-        // Schedule the OFF-INGRESS reparse: this replaces the inline parse_document,
-        // the post-parse process_injections (didChange forwarding + injected-language
-        // processing + eager bridge spawn), the geometry re-merge republish, AND the
-        // debounced diagnostic — all of which need the fresh tree and so run in the
-        // spawned, coalescing parse loop instead of holding the writer ticket.
+        // Legacy/shadow ownership schedules the OFF-INGRESS parent reparse, which
+        // runs the tree-dependent post-parse workflows. Authoritative ownership
+        // already submitted this exact edit to the worker replica above; it must
+        // not parse the same text again in the parent. Advance the same-incarnation
+        // ingress watermark immediately instead: worker readers fence on the
+        // replica acknowledgment and do not consume the parent's parse watermark.
         //
-        // The debounced diagnostic in particular MUST run post-parse, not here: this
+        // In legacy/shadow mode, the debounced diagnostic in particular MUST run
+        // post-parse, not here: this
         // handler just cleared the tree, and `prepare_diagnostic_snapshot` returns
         // `None` without one (`Document::snapshot()` requires a tree). A `None`
         // snapshot makes the debounce a no-op, skipping the on-edit host re-sync
         // (#431) that keeps a push-only `_self` host server's diagnostics following
         // edits. The handler returns without waiting on the parse.
-        self.schedule_reparse(uri, ticket);
+        if self.tree_worker_shadow.is_authoritative() {
+            if let Some(ticket) = ticket {
+                self.documents
+                    .advance_watermark_for_incarnation(&uri, ticket, incarnation);
+            }
+        } else {
+            self.schedule_reparse(uri, ticket);
+        }
 
         // NOTE: We intentionally do NOT call semantic_tokens_refresh() here.
         // LSP clients already request new tokens after didChange (via semanticTokens/full/delta).

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -178,6 +178,24 @@ impl Kakehashi {
                 self.documents
                     .advance_watermark_for_incarnation(&uri, ticket, incarnation);
             }
+            // Continue the post-parse bridge lifecycle from worker-owned facts.
+            // Keep it off ingress just like the legacy reparse actor: the worker
+            // document lane orders this derivation after the mirrored edit.
+            let coordinator = self.injection_coordinator();
+            let diagnostic_scheduler = self.diagnostic_scheduler();
+            let worker_uri = uri.clone();
+            let worker_version = base_version.wrapping_add(1);
+            tokio::spawn(async move {
+                coordinator
+                    .process_worker_injections_for_incarnation(
+                        &worker_uri,
+                        true,
+                        incarnation,
+                        worker_version,
+                    )
+                    .await;
+                diagnostic_scheduler.schedule_debounced_diagnostic(worker_uri);
+            });
         } else {
             self.schedule_reparse(uri, ticket);
         }

--- a/src/lsp/lsp_impl/text_document/did_save.rs
+++ b/src/lsp/lsp_impl/text_document/did_save.rs
@@ -33,12 +33,9 @@ impl Kakehashi {
             .forward_did_save_to_virtual_docs(&uri)
             .await;
 
-        // Ensure a fresh tree before the synthetic task snapshots it: a save
-        // batched right after an edit (autosave / format-on-save) races the
-        // off-ingress reparse, and `prepare_diagnostic_snapshot` returns `None`
-        // without a tree — making the synthetic diagnostic a no-op for the virt
-        // layer.
-        self.ensure_document_parsed(&uri).await;
+        if !self.tree_worker_shadow.is_authoritative() {
+            self.ensure_document_parsed(&uri).await;
+        }
 
         // Spawn background task for synthetic diagnostic collection
         self.diagnostic_scheduler()

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -103,6 +103,18 @@ impl Kakehashi {
             &all_regions,
         )
         .await;
+        let all_regions = if self.tree_worker_shadow.is_authoritative() {
+            self.worker_injection_regions_for_snapshot(
+                &uri,
+                snapshot.incarnation(),
+                content_version,
+                &language_name,
+            )
+            .await
+            .unwrap_or_default()
+        } else {
+            all_regions
+        };
 
         if all_regions.is_empty() {
             return Ok(Vec::new());

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -34,31 +34,57 @@ impl Kakehashi {
 
         log::debug!("documentColor called for {}", uri);
 
-        // Ensure a fresh tree before snapshotting: `didChange` clears the tree and
-        // reparses off-ingress, so without this documentColor (virt-only) returns
-        // empty for the whole reparse window after every edit.
-        self.ensure_document_parsed(&uri).await;
-
-        // Get document snapshot (minimizes lock duration)
-        let (snapshot, content_version) = match self.documents.get(&uri) {
-            None => {
-                log::debug!("documentColor: No document found for {}", uri);
+        let (language_name, all_regions) = if self.tree_worker_shadow.is_authoritative() {
+            let Some(view) = self.current_worker_injection_view(&uri).await else {
                 return Ok(Vec::new());
-            }
-            Some(doc) => match doc.snapshot() {
+            };
+            (view.language, view.regions)
+        } else {
+            // Legacy/shadow readers retain the bounded parent-owned parse path.
+            self.ensure_document_parsed(&uri).await;
+            let (snapshot, content_version) = match self.documents.get(&uri) {
                 None => {
-                    log::debug!("documentColor: Document not fully initialized for {}", uri);
+                    log::debug!("documentColor: No document found for {}", uri);
                     return Ok(Vec::new());
                 }
-                Some(snapshot) => (snapshot, doc.content_version()),
-            },
-            // doc automatically dropped here, lock released
-        };
-
-        // Get the language for this document
-        let Some(language_name) = self.document_language(&uri) else {
-            log::debug!(target: "kakehashi::document_color", "No language detected");
-            return Ok(Vec::new());
+                Some(doc) => match doc.snapshot() {
+                    None => {
+                        log::debug!("documentColor: Document not fully initialized for {}", uri);
+                        return Ok(Vec::new());
+                    }
+                    Some(snapshot) => (snapshot, doc.content_version()),
+                },
+            };
+            let Some(language_name) = self.document_language(&uri) else {
+                log::debug!(target: "kakehashi::document_color", "No language detected");
+                return Ok(Vec::new());
+            };
+            let Some(injection_query) = self.language.injection_query(&language_name) else {
+                return Ok(Vec::new());
+            };
+            let all_regions = match self
+                .documents
+                .current_resolved_regions(&uri, self.cache.semantic_token_generation())
+            {
+                Some(regions) => regions,
+                None => std::sync::Arc::new(InjectionResolver::resolve_all(
+                    &self.language,
+                    self.bridge.node_tracker(),
+                    &uri,
+                    snapshot.tree(),
+                    snapshot.text(),
+                    injection_query.as_ref(),
+                    snapshot.incarnation(),
+                )),
+            };
+            self.shadow_compare_current_injection_regions(
+                &uri,
+                snapshot.incarnation(),
+                content_version,
+                &all_regions,
+            )
+            .await;
+            (language_name, all_regions)
         };
 
         if !self.virt_layer_enabled(&language_name, "textDocument/documentColor") {
@@ -69,52 +95,6 @@ impl Kakehashi {
             );
             return Ok(Vec::new());
         }
-
-        // Get injection query to detect injection regions
-        let Some(injection_query) = self.language.injection_query(&language_name) else {
-            return Ok(Vec::new());
-        };
-
-        // Collect all injection regions
-        let all_regions = match self
-            .documents
-            .current_resolved_regions(&uri, self.cache.semantic_token_generation())
-        {
-            Some(regions) => regions,
-            None => std::sync::Arc::new(InjectionResolver::resolve_all(
-                &self.language,
-                self.bridge.node_tracker(),
-                &uri,
-                snapshot.tree(),
-                snapshot.text(),
-                injection_query.as_ref(),
-                snapshot.incarnation(),
-            )),
-        };
-
-        // Compare the fused worker derivation only for a reader that already
-        // consumes every injection. Issuing this RPC from the parse hot path
-        // can overtake queued edits on the document lane and makes the shadow
-        // observation causally stale under a typing burst.
-        self.shadow_compare_current_injection_regions(
-            &uri,
-            snapshot.incarnation(),
-            content_version,
-            &all_regions,
-        )
-        .await;
-        let all_regions = if self.tree_worker_shadow.is_authoritative() {
-            self.worker_injection_regions_for_snapshot(
-                &uri,
-                snapshot.incarnation(),
-                content_version,
-                &language_name,
-            )
-            .await
-            .unwrap_or_default()
-        } else {
-            all_regions
-        };
 
         if all_regions.is_empty() {
             return Ok(Vec::new());

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -122,6 +122,18 @@ impl Kakehashi {
             &all_regions,
         )
         .await;
+        let all_regions = if self.tree_worker_shadow.is_authoritative() {
+            self.worker_injection_regions_for_snapshot(
+                &uri,
+                snapshot.incarnation(),
+                content_version,
+                &language_name,
+            )
+            .await
+            .unwrap_or_default()
+        } else {
+            all_regions
+        };
 
         if all_regions.is_empty() {
             return Ok(None);

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -66,73 +66,56 @@ impl Kakehashi {
 
         log::debug!("documentSymbol called for {}", uri);
 
-        // Ensure a fresh tree before snapshotting: `didChange` clears the tree and
-        // reparses off-ingress, so without this the (tree-driven) virt layer drops
-        // injection-region symbols for the whole reparse window after every edit.
-        self.ensure_document_parsed(&uri).await;
-
-        // Get document snapshot (minimizes lock duration)
-        let (snapshot, content_version) = match self.documents.get(&uri) {
-            None => {
-                log::debug!("documentSymbol: No document found for {}", uri);
+        let (language_name, all_regions) = if self.tree_worker_shadow.is_authoritative() {
+            let Some(view) = self.current_worker_injection_view(&uri).await else {
                 return Ok(None);
-            }
-            Some(doc) => match doc.snapshot() {
+            };
+            (view.language, view.regions)
+        } else {
+            self.ensure_document_parsed(&uri).await;
+            let (snapshot, content_version) = match self.documents.get(&uri) {
                 None => {
-                    log::debug!("documentSymbol: Document not fully initialized for {}", uri);
+                    log::debug!("documentSymbol: No document found for {}", uri);
                     return Ok(None);
                 }
-                Some(snapshot) => (snapshot, doc.content_version()),
-            },
-            // doc automatically dropped here, lock released
-        };
-
-        // Get the language for this document
-        let Some(language_name) = self.document_language(&uri) else {
-            log::debug!(target: "kakehashi::document_symbol", "No language detected");
-            return Ok(None);
-        };
-
-        // Get injection query to detect injection regions
-        let Some(injection_query) = self.language.injection_query(&language_name) else {
-            return Ok(None);
-        };
-
-        // Collect all injection regions
-        let all_regions = match self
-            .documents
-            .current_resolved_regions(&uri, self.cache.semantic_token_generation())
-        {
-            Some(regions) => regions,
-            None => std::sync::Arc::new(InjectionResolver::resolve_all(
-                &self.language,
-                self.bridge.node_tracker(),
-                &uri,
-                snapshot.tree(),
-                snapshot.text(),
-                injection_query.as_ref(),
-                snapshot.incarnation(),
-            )),
-        };
-
-        self.shadow_compare_current_injection_regions(
-            &uri,
-            snapshot.incarnation(),
-            content_version,
-            &all_regions,
-        )
-        .await;
-        let all_regions = if self.tree_worker_shadow.is_authoritative() {
-            self.worker_injection_regions_for_snapshot(
+                Some(doc) => match doc.snapshot() {
+                    None => {
+                        log::debug!("documentSymbol: Document not fully initialized for {}", uri);
+                        return Ok(None);
+                    }
+                    Some(snapshot) => (snapshot, doc.content_version()),
+                },
+            };
+            let Some(language_name) = self.document_language(&uri) else {
+                log::debug!(target: "kakehashi::document_symbol", "No language detected");
+                return Ok(None);
+            };
+            let Some(injection_query) = self.language.injection_query(&language_name) else {
+                return Ok(None);
+            };
+            let all_regions = match self
+                .documents
+                .current_resolved_regions(&uri, self.cache.semantic_token_generation())
+            {
+                Some(regions) => regions,
+                None => std::sync::Arc::new(InjectionResolver::resolve_all(
+                    &self.language,
+                    self.bridge.node_tracker(),
+                    &uri,
+                    snapshot.tree(),
+                    snapshot.text(),
+                    injection_query.as_ref(),
+                    snapshot.incarnation(),
+                )),
+            };
+            self.shadow_compare_current_injection_regions(
                 &uri,
                 snapshot.incarnation(),
                 content_version,
-                &language_name,
+                &all_regions,
             )
-            .await
-            .unwrap_or_default()
-        } else {
-            all_regions
+            .await;
+            (language_name, all_regions)
         };
 
         if all_regions.is_empty() {

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -95,36 +95,54 @@ impl Kakehashi {
 
         log::debug!("formatting called for {}", uri);
 
-        // Explicit-action bounded wait (parse-snapshot ADR §3): formatting is
-        // user-triggered and infrequent, so it may briefly wait for the
-        // in-flight parse; a still-stale snapshot after the wait rejects with
-        // ContentModified rather than silently no-opping an action the user
-        // consciously triggered. Never-parsed/gone falls through to the
-        // existing empty fallbacks below.
-        if let crate::lsp::lsp_impl::snapshot_read::SnapshotWait::Stale = self
-            .wait_for_current_snapshot(&uri, std::time::Duration::from_millis(500))
-            .await
-        {
-            return Err(crate::error::content_modified_error());
-        }
-
-        let (snapshot, content_version) = match self.documents.get(&uri) {
-            None => {
-                log::debug!("formatting: No document found for {}", uri);
+        let (original, language_name, all_regions) = if self.tree_worker_shadow.is_authoritative() {
+            let Some(view) = self.current_worker_injection_view(&uri).await else {
                 return Ok(None);
+            };
+            (view.text, view.language, view.regions)
+        } else {
+            if let crate::lsp::lsp_impl::snapshot_read::SnapshotWait::Stale = self
+                .wait_for_current_snapshot(&uri, std::time::Duration::from_millis(500))
+                .await
+            {
+                return Err(crate::error::content_modified_error());
             }
-            Some(doc) => match doc.snapshot() {
+            let snapshot = match self.documents.get(&uri) {
                 None => {
-                    log::debug!("formatting: Document not fully initialized for {}", uri);
+                    log::debug!("formatting: No document found for {}", uri);
                     return Ok(None);
                 }
-                Some(snapshot) => (snapshot, doc.content_version()),
-            },
-        };
-
-        let Some(language_name) = self.document_language(&uri) else {
-            log::debug!(target: "kakehashi::formatting", "No language detected");
-            return Ok(None);
+                Some(doc) => match doc.snapshot() {
+                    None => {
+                        log::debug!("formatting: Document not fully initialized for {}", uri);
+                        return Ok(None);
+                    }
+                    Some(snapshot) => snapshot,
+                },
+            };
+            let Some(language_name) = self.document_language(&uri) else {
+                log::debug!(target: "kakehashi::formatting", "No language detected");
+                return Ok(None);
+            };
+            let Some(injection_query) = self.language.injection_query(&language_name) else {
+                return Ok(None);
+            };
+            let all_regions = match self
+                .documents
+                .current_resolved_regions(&uri, self.cache.semantic_token_generation())
+            {
+                Some(regions) => regions,
+                None => std::sync::Arc::new(InjectionResolver::resolve_all(
+                    &self.language,
+                    self.bridge.node_tracker(),
+                    &uri,
+                    snapshot.tree(),
+                    snapshot.text(),
+                    injection_query.as_ref(),
+                    snapshot.incarnation(),
+                )),
+            };
+            (snapshot.text_arc(), language_name, all_regions)
         };
 
         // Formatting consumes the full layer config (order AND strategy):
@@ -144,8 +162,6 @@ impl Kakehashi {
         );
         let mut cancel_state = self.setup_formatting_cancel_token(upstream_request_id.as_ref());
         cancel_state.request_error_sink = request_error_sink;
-        let original = snapshot.text_arc();
-
         let result = match layer_cfg.strategy {
             AggregationStrategy::Preferred => {
                 // Concurrent fan-out with priority decision
@@ -153,8 +169,8 @@ impl Kakehashi {
                 // flight at once; the highest-priority non-empty result wins.
                 let virt = self.virt_format_edits(
                     &uri,
-                    &snapshot,
-                    content_version,
+                    &original,
+                    Arc::clone(&all_regions),
                     &language_name,
                     &options,
                     &upstream_request_id,
@@ -197,8 +213,8 @@ impl Kakehashi {
                             }
                             self.virt_format_edits(
                                 &uri,
-                                &snapshot,
-                                content_version,
+                                &original,
+                                Arc::clone(&all_regions),
                                 &language_name,
                                 &options,
                                 &upstream_request_id,
@@ -248,46 +264,14 @@ impl Kakehashi {
     async fn virt_format_edits(
         &self,
         uri: &url::Url,
-        snapshot: &crate::document::model::DocumentSnapshot,
-        content_version: u64,
+        original: &Arc<str>,
+        all_regions: Arc<Vec<crate::language::injection::ResolvedInjection>>,
         language_name: &str,
         options: &tower_lsp_server::ls_types::FormattingOptions,
         upstream_request_id: &Option<UpstreamId>,
         cancel_state: &FormattingCancelState<'_>,
         client_progress_token: Option<NumberOrString>,
     ) -> Result<Option<Vec<TextEdit>>> {
-        let Some(injection_query) = self.language.injection_query(language_name) else {
-            return Ok(None);
-        };
-
-        let all_regions = match self
-            .documents
-            .current_resolved_regions(uri, self.cache.semantic_token_generation())
-        {
-            Some(regions) => regions,
-            None => std::sync::Arc::new(InjectionResolver::resolve_all(
-                &self.language,
-                self.bridge.node_tracker(),
-                uri,
-                snapshot.tree(),
-                snapshot.text(),
-                injection_query.as_ref(),
-                snapshot.incarnation(),
-            )),
-        };
-        let all_regions = if self.tree_worker_shadow.is_authoritative() {
-            self.worker_injection_regions_for_snapshot(
-                uri,
-                snapshot.incarnation(),
-                content_version,
-                language_name,
-            )
-            .await
-            .unwrap_or_default()
-        } else {
-            all_regions
-        };
-
         if all_regions.is_empty() {
             return Ok(None);
         }
@@ -420,10 +404,10 @@ impl Kakehashi {
                     let virtual_line_count =
                         region_ctx.resolved.virtual_content.matches('\n').count() + 1;
                     let mapper = host_mapper
-                        .get_or_insert_with(|| crate::text::PositionMapper::new(snapshot.text()));
+                        .get_or_insert_with(|| crate::text::PositionMapper::new(original));
                     let host_line_prefixes = extract_host_line_prefixes(
                         mapper,
-                        snapshot.text(),
+                        original,
                         region_ctx.resolved.region.line_range.start,
                         &region_ctx.resolved.line_column_offsets,
                         virtual_line_count,

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -108,7 +108,7 @@ impl Kakehashi {
             return Err(crate::error::content_modified_error());
         }
 
-        let snapshot = match self.documents.get(&uri) {
+        let (snapshot, content_version) = match self.documents.get(&uri) {
             None => {
                 log::debug!("formatting: No document found for {}", uri);
                 return Ok(None);
@@ -118,7 +118,7 @@ impl Kakehashi {
                     log::debug!("formatting: Document not fully initialized for {}", uri);
                     return Ok(None);
                 }
-                Some(snapshot) => snapshot,
+                Some(snapshot) => (snapshot, doc.content_version()),
             },
         };
 
@@ -154,6 +154,7 @@ impl Kakehashi {
                 let virt = self.virt_format_edits(
                     &uri,
                     &snapshot,
+                    content_version,
                     &language_name,
                     &options,
                     &upstream_request_id,
@@ -197,6 +198,7 @@ impl Kakehashi {
                             self.virt_format_edits(
                                 &uri,
                                 &snapshot,
+                                content_version,
                                 &language_name,
                                 &options,
                                 &upstream_request_id,
@@ -247,6 +249,7 @@ impl Kakehashi {
         &self,
         uri: &url::Url,
         snapshot: &crate::document::model::DocumentSnapshot,
+        content_version: u64,
         language_name: &str,
         options: &tower_lsp_server::ls_types::FormattingOptions,
         upstream_request_id: &Option<UpstreamId>,
@@ -271,6 +274,18 @@ impl Kakehashi {
                 injection_query.as_ref(),
                 snapshot.incarnation(),
             )),
+        };
+        let all_regions = if self.tree_worker_shadow.is_authoritative() {
+            self.worker_injection_regions_for_snapshot(
+                uri,
+                snapshot.incarnation(),
+                content_version,
+                language_name,
+            )
+            .await
+            .unwrap_or_default()
+        } else {
+            all_regions
         };
 
         if all_regions.is_empty() {

--- a/src/lsp/lsp_impl/text_document/native_bindings.rs
+++ b/src/lsp/lsp_impl/text_document/native_bindings.rs
@@ -146,6 +146,11 @@ impl Kakehashi {
                 worker,
             );
         }
+        let facts = if self.tree_worker_shadow.is_authoritative() {
+            worker.and_then(|worker| worker.facts)
+        } else {
+            facts
+        };
         let Some(facts) = facts else {
             return Ok(None);
         };

--- a/src/lsp/lsp_impl/text_document/native_bindings.rs
+++ b/src/lsp/lsp_impl/text_document/native_bindings.rs
@@ -86,6 +86,60 @@ impl Kakehashi {
             return Ok(None);
         }
 
+        if self.tree_worker_shadow.is_authoritative() {
+            let Some((text, content_version, incarnation)) = self
+                .documents
+                .get(&uri)
+                .map(|doc| (doc.text_arc(), doc.content_version(), doc.incarnation()))
+            else {
+                return Ok(None);
+            };
+            let mapper = PositionMapper::new(&text);
+            if mapper.position_to_byte_strict(position).is_none() {
+                return Ok(None);
+            }
+            let generation = self.language.configuration_generation();
+            let Some(grammar) = self.language.worker_grammar_descriptor(&language) else {
+                return Ok(None);
+            };
+            if self.tree_worker_shadow.needs_document_sync(
+                &uri,
+                incarnation,
+                content_version,
+                generation,
+                &grammar.queries,
+            ) {
+                self.refresh_tree_worker_documents(std::slice::from_ref(&uri));
+            }
+            let facts = self
+                .tree_worker_shadow
+                .native_bindings(
+                    &uri,
+                    incarnation,
+                    content_version,
+                    generation,
+                    crate::tree_worker::WirePosition {
+                        line: position.line,
+                        character: position.character,
+                    },
+                )
+                .await
+                .and_then(|worker| worker.facts);
+            if !self.documents.get(&uri).is_some_and(|doc| {
+                doc.content_version() == content_version
+                    && doc.incarnation() == incarnation
+                    && std::sync::Arc::ptr_eq(&doc.text_arc(), &text)
+            }) {
+                return Ok(None);
+            }
+            return Ok(facts.and_then(|facts| {
+                f(NativeBindingsContext {
+                    facts: &facts,
+                    mapper: &mapper,
+                })
+            }));
+        }
+
         // Wait for / trigger the off-ingress parse, then snapshot text and
         // tree without holding the store Ref across compute. The text Arc
         // doubles as the staleness witness for the publish-time check below

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -58,7 +58,8 @@ impl Kakehashi {
         // region) is the jarring outcome §3 forbids. Hoisted above the layer
         // closures so it applies under every layer-order configuration.
         // Never-parsed/gone falls through to the layers' empty fallbacks.
-        if let Ok(wait_uri) = uri_to_url(&lsp_uri)
+        if !self.tree_worker_shadow.is_authoritative()
+            && let Ok(wait_uri) = uri_to_url(&lsp_uri)
             && let crate::lsp::lsp_impl::snapshot_read::SnapshotWait::Stale = self
                 .wait_for_current_snapshot(&wait_uri, std::time::Duration::from_millis(500))
                 .await
@@ -78,26 +79,51 @@ impl Kakehashi {
 
             log::debug!("rangeFormatting called for {} range {:?}", uri, host_range);
 
-            let (snapshot, content_version) = match self.documents.get(&uri) {
-                None => {
-                    log::debug!("rangeFormatting: No document found for {}", uri);
+            let (text, language_name, all_regions) = if self.tree_worker_shadow.is_authoritative() {
+                let Some(view) = self.current_worker_injection_view(&uri).await else {
                     return Ok(None);
-                }
-                Some(doc) => match doc.snapshot() {
+                };
+                (view.text, view.language, view.regions)
+            } else {
+                let snapshot = match self.documents.get(&uri) {
                     None => {
-                        log::debug!(
-                            "rangeFormatting: Document not fully initialized for {}",
-                            uri
-                        );
+                        log::debug!("rangeFormatting: No document found for {}", uri);
                         return Ok(None);
                     }
-                    Some(snapshot) => (snapshot, doc.content_version()),
-                },
-            };
-
-            let Some(language_name) = self.document_language(&uri) else {
-                log::debug!(target: "kakehashi::rangeFormatting", "No language detected");
-                return Ok(None);
+                    Some(doc) => match doc.snapshot() {
+                        None => {
+                            log::debug!(
+                                "rangeFormatting: Document not fully initialized for {}",
+                                uri
+                            );
+                            return Ok(None);
+                        }
+                        Some(snapshot) => snapshot,
+                    },
+                };
+                let Some(language_name) = self.document_language(&uri) else {
+                    log::debug!(target: "kakehashi::rangeFormatting", "No language detected");
+                    return Ok(None);
+                };
+                let Some(injection_query) = self.language.injection_query(&language_name) else {
+                    return Ok(None);
+                };
+                let all_regions = match self
+                    .documents
+                    .current_resolved_regions(&uri, self.cache.semantic_token_generation())
+                {
+                    Some(regions) => regions,
+                    None => std::sync::Arc::new(InjectionResolver::resolve_all(
+                        &self.language,
+                        self.bridge.node_tracker(),
+                        &uri,
+                        snapshot.tree(),
+                        snapshot.text(),
+                        injection_query.as_ref(),
+                        snapshot.incarnation(),
+                    )),
+                };
+                (snapshot.text_arc(), language_name, all_regions)
             };
 
             // Layer gating keys off "textDocument/formatting", matching the
@@ -111,38 +137,6 @@ impl Kakehashi {
                 );
                 return Ok(None);
             }
-
-            let Some(injection_query) = self.language.injection_query(&language_name) else {
-                return Ok(None);
-            };
-
-            let all_regions = match self
-                .documents
-                .current_resolved_regions(&uri, self.cache.semantic_token_generation())
-            {
-                Some(regions) => regions,
-                None => std::sync::Arc::new(InjectionResolver::resolve_all(
-                    &self.language,
-                    self.bridge.node_tracker(),
-                    &uri,
-                    snapshot.tree(),
-                    snapshot.text(),
-                    injection_query.as_ref(),
-                    snapshot.incarnation(),
-                )),
-            };
-            let all_regions = if self.tree_worker_shadow.is_authoritative() {
-                self.worker_injection_regions_for_snapshot(
-                    &uri,
-                    snapshot.incarnation(),
-                    content_version,
-                    &language_name,
-                )
-                .await
-                .unwrap_or_default()
-            } else {
-                all_regions
-            };
 
             if all_regions.is_empty() {
                 return Ok(None);
@@ -170,7 +164,7 @@ impl Kakehashi {
             //
             // Multi-line code-fence injections (`start_column == 0`) are
             // unchanged because their line and byte bounds are equivalent.
-            let mapper = PositionMapper::new(snapshot.text());
+            let mapper = PositionMapper::new(&text);
             let request_bytes = clamp_request_to_document(&mapper, host_range);
 
             let mut outer_join_set: JoinSet<Option<Vec<TextEdit>>> = JoinSet::new();

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -78,7 +78,7 @@ impl Kakehashi {
 
             log::debug!("rangeFormatting called for {} range {:?}", uri, host_range);
 
-            let snapshot = match self.documents.get(&uri) {
+            let (snapshot, content_version) = match self.documents.get(&uri) {
                 None => {
                     log::debug!("rangeFormatting: No document found for {}", uri);
                     return Ok(None);
@@ -91,7 +91,7 @@ impl Kakehashi {
                         );
                         return Ok(None);
                     }
-                    Some(snapshot) => snapshot,
+                    Some(snapshot) => (snapshot, doc.content_version()),
                 },
             };
 
@@ -130,6 +130,18 @@ impl Kakehashi {
                     injection_query.as_ref(),
                     snapshot.incarnation(),
                 )),
+            };
+            let all_regions = if self.tree_worker_shadow.is_authoritative() {
+                self.worker_injection_regions_for_snapshot(
+                    &uri,
+                    snapshot.incarnation(),
+                    content_version,
+                    &language_name,
+                )
+                .await
+                .unwrap_or_default()
+            } else {
+                all_regions
             };
 
             if all_regions.is_empty() {

--- a/src/lsp/lsp_impl/text_document/selection_range.rs
+++ b/src/lsp/lsp_impl/text_document/selection_range.rs
@@ -161,13 +161,15 @@ impl Kakehashi {
             return Err(crate::error::content_modified_error());
         }
 
-        if let (Some(worker), Some(authoritative)) = (worker, result.as_ref()) {
-            let worker = worker
+        let worker = worker.map(|worker| {
+            worker
                 .ranges
                 .into_iter()
                 .map(selection_range_from_wire)
-                .collect::<Vec<_>>();
-            if &worker != authoritative {
+                .collect::<Vec<_>>()
+        });
+        if let (Some(worker), Some(authoritative)) = (worker.as_ref(), result.as_ref()) {
+            if worker != authoritative {
                 log::debug!(
                     target: "kakehashi::tree_worker_shadow",
                     "selectionRange mismatch uri={} version={} authoritative={:?} worker={:?}",
@@ -181,7 +183,11 @@ impl Kakehashi {
 
         // None = the work-unit panicked (logged by the pool); serve the
         // no-result fallback rather than an error.
-        Ok(result)
+        if self.tree_worker_shadow.is_authoritative() {
+            Ok(worker)
+        } else {
+            Ok(result)
+        }
     }
 }
 

--- a/src/lsp/lsp_impl/text_document/selection_range.rs
+++ b/src/lsp/lsp_impl/text_document/selection_range.rs
@@ -42,6 +42,58 @@ impl Kakehashi {
             return Ok(None);
         }
 
+        if self.tree_worker_shadow.is_authoritative() {
+            let Some((incarnation, content_version)) = self
+                .documents
+                .get(&uri)
+                .map(|document| (document.incarnation(), document.content_version()))
+            else {
+                return Ok(None);
+            };
+            let generation = self.language.configuration_generation();
+            let Some(grammar) = self.language.worker_grammar_descriptor(&language_name) else {
+                return Ok(None);
+            };
+            if self.tree_worker_shadow.needs_document_sync(
+                &uri,
+                incarnation,
+                content_version,
+                generation,
+                &grammar.queries,
+            ) {
+                self.refresh_tree_worker_documents(std::slice::from_ref(&uri));
+            }
+            let worker = self
+                .tree_worker_shadow
+                .selection_ranges(
+                    &uri,
+                    incarnation,
+                    content_version,
+                    generation,
+                    positions
+                        .into_iter()
+                        .map(|position| crate::tree_worker::WirePosition {
+                            line: position.line,
+                            character: position.character,
+                        })
+                        .collect(),
+                )
+                .await;
+            if !self.documents.get(&uri).is_some_and(|document| {
+                document.incarnation() == incarnation
+                    && document.content_version() == content_version
+            }) {
+                return Err(crate::error::content_modified_error());
+            }
+            return Ok(worker.map(|worker| {
+                worker
+                    .ranges
+                    .into_iter()
+                    .map(selection_range_from_wire)
+                    .collect()
+            }));
+        }
+
         // Resolve the latest parse snapshot, waiting briefly (bounded) for a
         // *current* one — this reader's coordinates are authored against the
         // live text, so a trailing snapshot cannot answer it (ADR §3

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -20,13 +20,12 @@ use tower_lsp_server::jsonrpc::{Error, Result};
 use tower_lsp_server::ls_types::{
     SemanticTokens, SemanticTokensDeltaParams, SemanticTokensFullDeltaResult, SemanticTokensParams,
     SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult,
+    TextDocumentIdentifier,
 };
 use url::Url;
 
 #[cfg(test)]
-use tower_lsp_server::ls_types::{
-    PartialResultParams, Position, Range, TextDocumentIdentifier, WorkDoneProgressParams,
-};
+use tower_lsp_server::ls_types::{PartialResultParams, Position, Range, WorkDoneProgressParams};
 
 use crate::analysis::{
     SemanticSnapshotIdentity, calculate_delta_or_full, filter_semantic_tokens_by_range,
@@ -1243,6 +1242,30 @@ impl Kakehashi {
         // key on the old generation — invisible to post-reload requests (which
         // compute the new-generation key) — so a stale entry can never be served.
         let generation = self.cache.semantic_token_generation();
+
+        // The authoritative worker already owns full-document token discovery
+        // and its cache. Reuse that current live-text path, then perform the
+        // cheap viewport filter in the parent; never wait for a parent Tree.
+        if self.tree_worker_shadow.is_authoritative() {
+            let full = self
+                .semantic_tokens_full_impl(SemanticTokensParams {
+                    text_document: TextDocumentIdentifier {
+                        uri: lsp_uri.clone(),
+                    },
+                    work_done_progress_params: Default::default(),
+                    partial_result_params: Default::default(),
+                })
+                .await?;
+            return Ok(full.map(|result| match result {
+                SemanticTokensResult::Tokens(tokens) => {
+                    let tokens = filter_semantic_tokens_by_range(&tokens, &domain_range);
+                    SemanticTokensRangeResult::Tokens(tokens)
+                }
+                SemanticTokensResult::Partial(partial) => {
+                    SemanticTokensRangeResult::Partial(partial)
+                }
+            }));
+        }
 
         // First-parse bound (parse-snapshot ADR §3): resolve through the same
         // bounded first-parse wait as full/delta. Without it, a range request

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -105,6 +105,47 @@ impl CurrentTokens {
 }
 
 impl Kakehashi {
+    async fn semantic_input_for_tokens(
+        &self,
+        uri: &Url,
+        cancel_rx: Option<&mut crate::lsp::request_id::CancelReceiver>,
+        supersede: &crate::cancel::CancelToken,
+    ) -> TokenSnapshot {
+        if !self.tree_worker_shadow.is_authoritative() {
+            return self
+                .current_snapshot_for_tokens(uri, cancel_rx, supersede)
+                .await;
+        }
+        let Some((text, incarnation, content_version, language_id)) =
+            self.documents.get(uri).map(|document| {
+                (
+                    document.text_arc(),
+                    document.incarnation(),
+                    document.content_version(),
+                    document.language_id().map(str::to_owned),
+                )
+            })
+        else {
+            return TokenSnapshot::Absent;
+        };
+        let language =
+            self.language
+                .detect_language(uri.path(), &text, None, language_id.as_deref());
+        TokenSnapshot::Current(std::sync::Arc::new(
+            crate::document::snapshot::ParseSnapshot {
+                text,
+                tree: None,
+                language,
+                parsed_version: content_version,
+                incarnation,
+                injection_regions: None,
+                bridge_regions: None,
+                resolved_regions: None,
+                layer_trees: std::sync::OnceLock::new(),
+            },
+        ))
+    }
+
     fn semantic_snapshot_is_current(
         &self,
         uri: &Url,
@@ -277,7 +318,7 @@ impl Kakehashi {
         // the snapshot's own detected language — never a live re-detection
         // that could diverge from the tree's grammar.
         let snapshot = match self
-            .current_snapshot_for_tokens(&uri, cancel_rx.as_mut(), &cancel_token)
+            .semantic_input_for_tokens(&uri, cancel_rx.as_mut(), &cancel_token)
             .await
         {
             TokenSnapshot::Current(snapshot) => snapshot,
@@ -321,8 +362,7 @@ impl Kakehashi {
                 return Ok(None);
             }
         };
-        let (Some(language_name), Some(tree)) = (snapshot.language.clone(), snapshot.tree.clone())
-        else {
+        let Some(language_name) = snapshot.language.clone() else {
             // No detectable language, or resolved-but-tree-less (no parser
             // installed / crashed grammar): nothing to tokenize. The empty set
             // IS this snapshot's served state — record it so the parse loop
@@ -335,6 +375,16 @@ impl Kakehashi {
                 data: vec![],
             })));
         };
+        let tree = snapshot.tree.clone();
+        if !self.tree_worker_shadow.is_authoritative() && tree.is_none() {
+            self.cache
+                .record_served_semantic_version(&uri, snapshot.parsed_version);
+            self.cache.finish_request(&uri, request_id);
+            return Ok(Some(SemanticTokensResult::Tokens(SemanticTokens {
+                result_id: None,
+                data: vec![],
+            })));
+        }
         let text = std::sync::Arc::clone(&snapshot.text);
 
         // Ensure language is loaded before trying to get queries.
@@ -488,8 +538,10 @@ impl Kakehashi {
                 tracker: self.bridge.node_tracker_arc(),
                 cache: self.cache.injection_token_cache_arc(),
                 generation: token_generation,
-                documents: std::sync::Arc::clone(&self.documents),
-                parsed_version: snapshot.parsed_version,
+                currency: crate::analysis::semantic::InjectionCacheCurrency::Document {
+                    documents: std::sync::Arc::clone(&self.documents),
+                    parsed_version: snapshot.parsed_version,
+                },
                 incarnation: snapshot.incarnation,
                 // The snapshot's own discovery (ADR §3, don't-discover-twice):
                 // rebuilt into contexts instead of re-running the injection
@@ -498,18 +550,22 @@ impl Kakehashi {
             });
 
             // Compute tokens, racing against cancel notification if provided
-            let compute_future = handle_semantic_tokens_full(
-                &self.compute_pool,
-                text.clone(),
-                tree.clone(),
-                query,
-                Some(language_name.clone()),
-                Some(capture_mappings),
-                coordinator,
-                supports_multiline,
-                injection_cache,
-                Some(cancel_token.clone()),
-            );
+            let compute_future = async {
+                handle_semantic_tokens_full(
+                    &self.compute_pool,
+                    text.clone(),
+                    tree.clone()
+                        .expect("legacy semantic token computation requires a parse tree"),
+                    query,
+                    Some(language_name.clone()),
+                    Some(capture_mappings),
+                    coordinator,
+                    supports_multiline,
+                    injection_cache,
+                    Some(cancel_token.clone()),
+                )
+                .await
+            };
             let worker_future = self.tree_worker_shadow.semantic_tokens(
                 &uri,
                 snapshot.incarnation,
@@ -707,7 +763,7 @@ impl Kakehashi {
         // steady-state typing path where a stale answer corrupts the editor's
         // existing highlights AND poisons the client's delta baseline).
         let snapshot = match self
-            .current_snapshot_for_tokens(&uri, cancel_rx.as_mut(), &cancel_token)
+            .semantic_input_for_tokens(&uri, cancel_rx.as_mut(), &cancel_token)
             .await
         {
             TokenSnapshot::Current(snapshot) => snapshot,
@@ -753,8 +809,7 @@ impl Kakehashi {
                 return Ok(None);
             }
         };
-        let (Some(language_name), Some(tree)) = (snapshot.language.clone(), snapshot.tree.clone())
-        else {
+        let Some(language_name) = snapshot.language.clone() else {
             self.cache
                 .record_served_semantic_version(&uri, snapshot.parsed_version);
             self.cache.finish_request(&uri, request_id);
@@ -765,6 +820,18 @@ impl Kakehashi {
                 },
             )));
         };
+        let tree = snapshot.tree.clone();
+        if !self.tree_worker_shadow.is_authoritative() && tree.is_none() {
+            self.cache
+                .record_served_semantic_version(&uri, snapshot.parsed_version);
+            self.cache.finish_request(&uri, request_id);
+            return Ok(Some(SemanticTokensFullDeltaResult::Tokens(
+                SemanticTokens {
+                    result_id: None,
+                    data: vec![],
+                },
+            )));
+        }
         let text = std::sync::Arc::clone(&snapshot.text);
 
         // Ensure language is loaded before trying to get queries.
@@ -929,26 +996,32 @@ impl Kakehashi {
                     tracker: self.bridge.node_tracker_arc(),
                     cache: self.cache.injection_token_cache_arc(),
                     generation: token_generation,
-                    documents: std::sync::Arc::clone(&self.documents),
-                    parsed_version: snapshot.parsed_version,
+                    currency: crate::analysis::semantic::InjectionCacheCurrency::Document {
+                        documents: std::sync::Arc::clone(&self.documents),
+                        parsed_version: snapshot.parsed_version,
+                    },
                     incarnation: snapshot.incarnation,
                     // The snapshot's own discovery (ADR §3, don't-discover-twice).
                     discovery: snapshot.injection_regions.clone(),
                 });
 
                 // Compute tokens, racing against cancel notification if provided
-                let compute_future = handle_semantic_tokens_full(
-                    &self.compute_pool,
-                    text.clone(),
-                    tree.clone(),
-                    query,
-                    Some(language_name.clone()),
-                    Some(capture_mappings),
-                    coordinator,
-                    supports_multiline,
-                    injection_cache,
-                    Some(cancel_token.clone()),
-                );
+                let compute_future = async {
+                    handle_semantic_tokens_full(
+                        &self.compute_pool,
+                        text.clone(),
+                        tree.clone()
+                            .expect("legacy semantic token computation requires a parse tree"),
+                        query,
+                        Some(language_name.clone()),
+                        Some(capture_mappings),
+                        coordinator,
+                        supports_multiline,
+                        injection_cache,
+                        Some(cancel_token.clone()),
+                    )
+                    .await
+                };
                 let worker_future = self.tree_worker_shadow.semantic_tokens(
                     &uri,
                     snapshot.incarnation,

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -423,11 +423,6 @@ impl Kakehashi {
         // snapshot's own text hash means a compute racing a fresh edit stores
         // under its own text's hash, which a post-edit request never looks up.
         let cache_key = self.cache.cache_key_for(&text, token_generation);
-
-        // Compute tokens against the (current-at-resolution) snapshot. An edit
-        // landing after the resolution supersedes this request via the client's
-        // next didChange-driven request; the CancelToken then reclaims the
-        // compute mid-flight.
         let worker_configuration_generation = self.language.configuration_generation();
         if let Some(grammar) = self.language.worker_grammar_descriptor(&language_name)
             && self.tree_worker_shadow.needs_document_sync(
@@ -440,6 +435,11 @@ impl Kakehashi {
         {
             self.refresh_tree_worker_documents(std::slice::from_ref(&uri));
         }
+
+        // Compute tokens against the (current-at-resolution) snapshot. An edit
+        // landing after the resolution supersedes this request via the client's
+        // next didChange-driven request; the CancelToken then reclaims the
+        // compute mid-flight.
         let (result, worker_tokens) = {
             // Snapshot-identical repeat request: tokens already cached for this
             // exact text are still correct, so skip re-tokenizing. Returns the
@@ -517,7 +517,14 @@ impl Kakehashi {
                 worker_configuration_generation,
                 supports_multiline,
             );
-            let combined = async { tokio::join!(compute_future, worker_future) };
+            let authoritative_worker = self.tree_worker_shadow.is_authoritative();
+            let combined = async {
+                if authoritative_worker {
+                    (None, worker_future.await)
+                } else {
+                    tokio::join!(compute_future, worker_future)
+                }
+            };
 
             if let Some(cancel_rx) = cancel_rx {
                 // Race between computation and cancel notification
@@ -560,6 +567,11 @@ impl Kakehashi {
                 worker,
             );
         }
+        let result = if self.tree_worker_shadow.is_authoritative() {
+            worker_tokens.map(worker_semantic_tokens_result)
+        } else {
+            result
+        };
 
         // A supersede/close between compute start and here flips the token; the
         // compute then bailed at a checkpoint and returned `None` (a partial
@@ -846,6 +858,18 @@ impl Kakehashi {
         // the top (see semanticTokens/full for why snapshot-text keying makes
         // a compute racing a fresh edit cache-safe).
         let cache_key = self.cache.cache_key_for(&text, token_generation);
+        let worker_configuration_generation = self.language.configuration_generation();
+        if let Some(grammar) = self.language.worker_grammar_descriptor(&language_name)
+            && self.tree_worker_shadow.needs_document_sync(
+                &uri,
+                snapshot.incarnation,
+                snapshot.parsed_version,
+                worker_configuration_generation,
+                &grammar.queries,
+            )
+        {
+            self.refresh_tree_worker_documents(std::slice::from_ref(&uri));
+        }
 
         // Compute tokens against the (current-at-resolution) snapshot; same as
         // semanticTokens/full.
@@ -925,6 +949,21 @@ impl Kakehashi {
                     injection_cache,
                     Some(cancel_token.clone()),
                 );
+                let worker_future = self.tree_worker_shadow.semantic_tokens(
+                    &uri,
+                    snapshot.incarnation,
+                    snapshot.parsed_version,
+                    worker_configuration_generation,
+                    supports_multiline,
+                );
+                let authoritative_worker = self.tree_worker_shadow.is_authoritative();
+                let combined = async {
+                    if authoritative_worker {
+                        (None, worker_future.await)
+                    } else {
+                        tokio::join!(compute_future, worker_future)
+                    }
+                };
 
                 let computed = if let Some(cancel_rx) = cancel_rx {
                     // Race between computation and cancel notification
@@ -948,13 +987,34 @@ impl Kakehashi {
                         }
 
                         // Computation completed
-                        result = compute_future => result,
+                        result = combined => result,
                     }
                 } else {
                     // No cancel support - just await the computation
-                    compute_future.await
+                    combined.await
                 };
-                computed.map(CurrentTokens::from_result)
+                if let (Some(authoritative), Some(worker)) =
+                    (computed.0.as_ref(), computed.1.as_ref())
+                {
+                    let authoritative = match authoritative {
+                        SemanticTokensResult::Tokens(tokens) => tokens.data.as_slice(),
+                        SemanticTokensResult::Partial(partial) => partial.data.as_slice(),
+                    };
+                    self.tree_worker_shadow.compare_semantic_tokens(
+                        &uri,
+                        snapshot.parsed_version,
+                        authoritative,
+                        worker,
+                    );
+                }
+                if self.tree_worker_shadow.is_authoritative() {
+                    computed
+                        .1
+                        .map(worker_semantic_tokens)
+                        .map(CurrentTokens::Owned)
+                } else {
+                    computed.0.map(CurrentTokens::from_result)
+                }
             }
         };
 
@@ -1255,8 +1315,20 @@ impl Kakehashi {
         // Use Rayon-based parallel injection processing
         let supports_multiline = self.settings_manager.supports_multiline_tokens();
         let coordinator = std::sync::Arc::clone(&self.language);
+        let worker_configuration_generation = self.language.configuration_generation();
+        if let Some(grammar) = self.language.worker_grammar_descriptor(&language_name)
+            && self.tree_worker_shadow.needs_document_sync(
+                &uri,
+                snapshot.incarnation,
+                snapshot.parsed_version,
+                worker_configuration_generation,
+                &grammar.queries,
+            )
+        {
+            self.refresh_tree_worker_documents(std::slice::from_ref(&uri));
+        }
 
-        let result = handle_semantic_tokens_full(
+        let local = handle_semantic_tokens_full(
             &self.compute_pool,
             text,
             tree,
@@ -1267,8 +1339,36 @@ impl Kakehashi {
             supports_multiline,
             None,
             None,
-        )
-        .await;
+        );
+        let worker = self.tree_worker_shadow.semantic_tokens(
+            &uri,
+            snapshot.incarnation,
+            snapshot.parsed_version,
+            worker_configuration_generation,
+            supports_multiline,
+        );
+        let (result, worker) = if self.tree_worker_shadow.is_authoritative() {
+            (None, worker.await)
+        } else {
+            tokio::join!(local, worker)
+        };
+        if let (Some(authoritative), Some(worker)) = (result.as_ref(), worker.as_ref()) {
+            let authoritative = match authoritative {
+                SemanticTokensResult::Tokens(tokens) => tokens.data.as_slice(),
+                SemanticTokensResult::Partial(partial) => partial.data.as_slice(),
+            };
+            self.tree_worker_shadow.compare_semantic_tokens(
+                &uri,
+                snapshot.parsed_version,
+                authoritative,
+                worker,
+            );
+        }
+        let result = if self.tree_worker_shadow.is_authoritative() {
+            worker.map(worker_semantic_tokens_result)
+        } else {
+            result
+        };
 
         // Shape immutable payloads before taking the edit lock. Only the final
         // live-snapshot validation and cache commits need to exclude edits.
@@ -1332,6 +1432,31 @@ impl Kakehashi {
         }
 
         Ok(Some(domain_range_result))
+    }
+}
+
+fn worker_semantic_tokens_result(
+    worker: crate::tree_worker::DerivedSemanticTokens,
+) -> tower_lsp_server::ls_types::SemanticTokensResult {
+    tower_lsp_server::ls_types::SemanticTokensResult::Tokens(worker_semantic_tokens(worker))
+}
+
+fn worker_semantic_tokens(
+    worker: crate::tree_worker::DerivedSemanticTokens,
+) -> tower_lsp_server::ls_types::SemanticTokens {
+    tower_lsp_server::ls_types::SemanticTokens {
+        result_id: None,
+        data: worker
+            .tokens
+            .into_iter()
+            .map(|token| tower_lsp_server::ls_types::SemanticToken {
+                delta_line: token.delta_line,
+                delta_start: token.delta_start,
+                length: token.length,
+                token_type: token.token_type,
+                token_modifiers_bitset: token.token_modifiers_bitset,
+            })
+            .collect(),
     }
 }
 

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -3448,7 +3448,7 @@ mod tests {
     }
 
     #[test]
-    fn closing_document_discards_legacy_to_worker_node_mappings() {
+    fn closing_document_discards_all_public_to_worker_node_mappings() {
         let (sender, receiver) = mpsc::sync_channel(1);
         let shadow = shadow(sender);
         let uri = url::Url::parse("file:///mapped.rs").unwrap();
@@ -3468,7 +3468,7 @@ mod tests {
                 layer: 0,
             },
         );
-        assert_eq!(shadow.worker_nodes.len(), 1);
+        assert_eq!(shadow.worker_nodes.len(), 2);
 
         shadow.mirror_close(&uri, 1, 1, 0);
 

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -23,6 +23,7 @@ use crate::tree_worker::{
 use super::Kakehashi;
 
 const SHADOW_ENV: &str = "KAKEHASHI_TREE_WORKER_SHADOW";
+const MODE_ENV: &str = "KAKEHASHI_TREE_WORKER_MODE";
 const SHADOW_THREADS_ENV: &str = "KAKEHASHI_TREE_WORKER_THREADS";
 const SHADOW_QUEUE_CAPACITY: usize = 256;
 const SHADOW_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
@@ -36,6 +37,13 @@ const FAST_HEALTHY_INTERVAL: Duration = Duration::from_secs(60);
 const LONG_HEALTHY_INTERVAL: Duration = Duration::from_secs(10 * 60);
 static NEXT_WORKER_GENERATION: AtomicU64 = AtomicU64::new(1);
 static NEXT_CATALOG_REQUEST_ID: AtomicU64 = AtomicU64::new(1_u64 << 63);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TreeWorkerMode {
+    Legacy,
+    Shadow,
+    Authoritative,
+}
 
 enum ShadowCommand {
     Sync(SyncDocument),
@@ -407,6 +415,7 @@ enum Observation {
 }
 
 pub(super) struct TreeWorkerShadow {
+    mode: TreeWorkerMode,
     sender: Option<mpsc::SyncSender<ShadowCommand>>,
     accepting: Arc<AtomicBool>,
     disabled: Arc<AtomicBool>,
@@ -460,6 +469,13 @@ fn worker_region_to_resolved(
         line_column_offsets: region.line_column_offsets.clone(),
         contiguous: region.contiguous,
     }
+}
+
+fn worker_node_info(node: crate::tree_worker::OwnedNode) -> Value {
+    serde_json::json!({
+        "id": node.id.local_id,
+        "kind": node.kind,
+    })
 }
 
 fn remove_capture_ids(value: &mut Value) {
@@ -525,6 +541,7 @@ struct ComparisonStore {
 
 impl TreeWorkerShadow {
     pub(super) fn from_environment() -> Self {
+        let mode = configured_mode();
         let disabled = Arc::new(AtomicBool::new(false));
         let accepting = Arc::new(AtomicBool::new(false));
         let comparisons = Arc::new(ComparisonStore::default());
@@ -534,8 +551,9 @@ impl TreeWorkerShadow {
         let read_client = Arc::new(ArcSwapOption::empty());
         let worker_nodes = Arc::new(dashmap::DashMap::new());
         let worker_generation = NEXT_WORKER_GENERATION.fetch_add(1, Ordering::Relaxed);
-        if !shadow_enabled() {
+        if mode == TreeWorkerMode::Legacy {
             return Self {
+                mode,
                 sender: None,
                 accepting,
                 disabled,
@@ -555,6 +573,7 @@ impl TreeWorkerShadow {
                 log::error!(target: "kakehashi::tree_worker_shadow", "cannot resolve worker executable: {error}");
                 disabled.store(true, Ordering::Release);
                 return Self {
+                    mode,
                     sender: None,
                     accepting,
                     disabled,
@@ -598,6 +617,7 @@ impl TreeWorkerShadow {
                 "disabled shadow worker because actor thread could not spawn: {error}"
             );
             return Self {
+                mode,
                 sender: None,
                 accepting,
                 disabled,
@@ -614,9 +634,10 @@ impl TreeWorkerShadow {
         accepting.store(true, Ordering::Release);
         log::info!(
             target: "kakehashi::tree_worker_shadow",
-            "enabled one shadow worker with {compute_threads} compute threads"
+            "enabled one {mode:?} tree worker with {compute_threads} compute threads"
         );
         Self {
+            mode,
             sender: Some(sender),
             accepting,
             disabled,
@@ -647,6 +668,25 @@ impl TreeWorkerShadow {
 
     pub(super) fn is_enabled(&self) -> bool {
         self.is_configured() && !self.disabled.load(Ordering::Acquire)
+    }
+
+    pub(super) fn is_authoritative(&self) -> bool {
+        self.mode == TreeWorkerMode::Authoritative && self.is_enabled()
+    }
+
+    pub(super) fn public_node_result(&self, result: Option<NodeResult>, list: bool) -> Value {
+        if !self.is_authoritative() {
+            return Value::Null;
+        }
+        let Some(result) = result else {
+            return Value::Null;
+        };
+        let mut nodes = result.nodes.into_iter().map(worker_node_info);
+        if list {
+            Value::Array(nodes.collect())
+        } else {
+            nodes.next().unwrap_or(Value::Null)
+        }
     }
 
     pub(super) fn is_configured(&self) -> bool {
@@ -873,6 +913,26 @@ impl TreeWorkerShadow {
             && snapshot.context.content_version == content_version
             && snapshot.context.configuration_generation == configuration_generation)
             .then(|| Arc::clone(&snapshot.regions))
+    }
+
+    pub(super) async fn worker_injection_regions(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        content_version: u64,
+        configuration_generation: u64,
+    ) -> Option<Arc<Vec<crate::language::injection::ResolvedInjection>>> {
+        if let Some(regions) = self.cached_injection_regions(
+            uri,
+            incarnation,
+            content_version,
+            configuration_generation,
+        ) {
+            return Some(regions);
+        }
+        self.injection_regions(uri, incarnation, content_version, configuration_generation)
+            .await?;
+        self.cached_injection_regions(uri, incarnation, content_version, configuration_generation)
     }
 
     pub(super) async fn semantic_tokens(
@@ -1218,6 +1278,10 @@ impl TreeWorkerShadow {
             (uri.as_str().to_string(), id.to_string()),
             worker.id.clone(),
         );
+        self.worker_nodes.insert(
+            (uri.as_str().to_string(), worker.id.local_id.clone()),
+            worker.id.clone(),
+        );
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1230,17 +1294,17 @@ impl TreeWorkerShadow {
         authoritative_input_id: &str,
         operation: NodeNavigation,
         authoritative: &Value,
-    ) {
+    ) -> Option<NodeResult> {
         let key = (uri.as_str().to_string(), authoritative_input_id.to_string());
         let Some(node_id) = self.worker_nodes.get(&key).map(|entry| entry.clone()) else {
-            return;
+            return None;
         };
         let Some(client) = self.read_client.load_full() else {
-            return;
+            return None;
         };
         if !self.is_enabled() || node_id.worker_generation != client.worker_generation() {
             self.worker_nodes.remove(&key);
-            return;
+            return None;
         }
         let context = self.read_context(
             &client,
@@ -1263,13 +1327,13 @@ impl TreeWorkerShadow {
         let Some(result) =
             response.and_then(|response| self.admit_node_response(response, &expected))
         else {
-            return;
+            return None;
         };
         let authoritative_nodes = match authoritative {
             Value::Null => Vec::new(),
             Value::Object(_) => vec![authoritative],
             Value::Array(nodes) => nodes.iter().collect(),
-            _ => return,
+            _ => return None,
         };
         let authoritative_kinds = authoritative_nodes
             .iter()
@@ -1289,7 +1353,7 @@ impl TreeWorkerShadow {
                 authoritative_kinds,
                 worker_kinds,
             );
-            return;
+            return Some(result);
         }
         for (authoritative_node, worker_node) in
             authoritative_nodes.into_iter().zip(result.nodes.iter())
@@ -1302,6 +1366,7 @@ impl TreeWorkerShadow {
             uri,
             content_version,
         );
+        Some(result)
     }
 
     pub(super) async fn node_scalar(
@@ -1966,6 +2031,75 @@ impl TreeWorkerShadow {
 }
 
 impl Kakehashi {
+    pub(super) async fn worker_injection_region_at_snapshot(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        parsed_version: u64,
+        language: &str,
+        byte_offset: usize,
+    ) -> Option<crate::language::injection::ResolvedInjection> {
+        let configuration_generation = self.language.configuration_generation();
+        if let Some(grammar) = self.language.worker_grammar_descriptor(language)
+            && self.tree_worker_shadow.needs_document_sync(
+                uri,
+                incarnation,
+                parsed_version,
+                configuration_generation,
+                &grammar.queries,
+            )
+        {
+            self.refresh_tree_worker_documents(std::slice::from_ref(uri));
+        }
+        let node = self
+            .tree_worker_shadow
+            .resolve_node(
+                uri,
+                incarnation,
+                parsed_version,
+                configuration_generation,
+                byte_offset,
+                crate::tree_worker::NodeLayerSelector::Deepest,
+            )
+            .await?
+            .nodes
+            .into_iter()
+            .next()?;
+        if node.layer == 0 {
+            return None;
+        }
+        self.tree_worker_shadow
+            .worker_injection_regions(uri, incarnation, parsed_version, configuration_generation)
+            .await?
+            .iter()
+            .find(|resolved| resolved.region.byte_range.contains(&byte_offset))
+            .cloned()
+    }
+
+    pub(super) async fn worker_injection_regions_for_snapshot(
+        &self,
+        uri: &url::Url,
+        incarnation: u64,
+        parsed_version: u64,
+        language: &str,
+    ) -> Option<Arc<Vec<crate::language::injection::ResolvedInjection>>> {
+        let configuration_generation = self.language.configuration_generation();
+        if let Some(grammar) = self.language.worker_grammar_descriptor(language)
+            && self.tree_worker_shadow.needs_document_sync(
+                uri,
+                incarnation,
+                parsed_version,
+                configuration_generation,
+                &grammar.queries,
+            )
+        {
+            self.refresh_tree_worker_documents(std::slice::from_ref(uri));
+        }
+        self.tree_worker_shadow
+            .worker_injection_regions(uri, incarnation, parsed_version, configuration_generation)
+            .await
+    }
+
     pub(super) async fn shadow_compare_current_injection_regions(
         &self,
         uri: &url::Url,
@@ -2127,10 +2261,30 @@ fn log_incomplete_shutdown(reason: &str) {
     );
 }
 
-fn shadow_enabled() -> bool {
-    std::env::var(SHADOW_ENV)
-        .ok()
-        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "TRUE"))
+fn configured_mode() -> TreeWorkerMode {
+    parse_mode(
+        std::env::var(MODE_ENV).ok().as_deref(),
+        std::env::var(SHADOW_ENV).ok().as_deref(),
+    )
+}
+
+fn parse_mode(mode: Option<&str>, legacy_shadow: Option<&str>) -> TreeWorkerMode {
+    match mode {
+        Some("authoritative") => TreeWorkerMode::Authoritative,
+        Some("shadow") => TreeWorkerMode::Shadow,
+        Some("legacy") => TreeWorkerMode::Legacy,
+        Some(value) => {
+            log::warn!(
+                target: "kakehashi::tree_worker_shadow",
+                "unsupported {MODE_ENV}={value:?}; using legacy tree ownership",
+            );
+            TreeWorkerMode::Legacy
+        }
+        None if legacy_shadow.is_some_and(|value| matches!(value, "1" | "true" | "TRUE")) => {
+            TreeWorkerMode::Shadow
+        }
+        None => TreeWorkerMode::Legacy,
+    }
 }
 
 fn configured_compute_threads() -> usize {
@@ -3259,6 +3413,7 @@ mod tests {
 
     fn shadow(sender: mpsc::SyncSender<ShadowCommand>) -> TreeWorkerShadow {
         TreeWorkerShadow {
+            mode: TreeWorkerMode::Shadow,
             sender: Some(sender),
             accepting: Arc::new(AtomicBool::new(true)),
             disabled: Arc::new(AtomicBool::new(false)),
@@ -3271,6 +3426,25 @@ mod tests {
             read_client: Arc::new(ArcSwapOption::empty()),
             worker_nodes: Arc::new(dashmap::DashMap::new()),
         }
+    }
+
+    #[test]
+    fn worker_mode_is_explicit_and_legacy_shadow_env_remains_compatible() {
+        assert_eq!(
+            parse_mode(Some("authoritative"), None),
+            TreeWorkerMode::Authoritative
+        );
+        assert_eq!(parse_mode(Some("shadow"), None), TreeWorkerMode::Shadow);
+        assert_eq!(
+            parse_mode(Some("legacy"), Some("true")),
+            TreeWorkerMode::Legacy
+        );
+        assert_eq!(parse_mode(None, Some("true")), TreeWorkerMode::Shadow);
+        assert_eq!(parse_mode(None, None), TreeWorkerMode::Legacy);
+        assert_eq!(
+            parse_mode(Some("invalid"), Some("true")),
+            TreeWorkerMode::Legacy
+        );
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -45,6 +45,12 @@ enum TreeWorkerMode {
     Authoritative,
 }
 
+pub(super) struct WorkerInjectionView {
+    pub(super) text: Arc<str>,
+    pub(super) language: String,
+    pub(super) regions: Arc<Vec<crate::language::injection::ResolvedInjection>>,
+}
+
 enum ShadowCommand {
     Sync(SyncDocument),
     Apply {
@@ -2031,6 +2037,53 @@ impl TreeWorkerShadow {
 }
 
 impl Kakehashi {
+    /// Resolve injection facts from the worker against one current live-text
+    /// identity. Authoritative readers use this instead of waiting for (or
+    /// accidentally reviving) a parent-owned parse snapshot after an edit.
+    pub(super) async fn current_worker_injection_view(
+        &self,
+        uri: &url::Url,
+    ) -> Option<WorkerInjectionView> {
+        let (text, incarnation, content_version, language_id) =
+            self.documents.get(uri).map(|document| {
+                (
+                    document.text_arc(),
+                    document.incarnation(),
+                    document.content_version(),
+                    document.language_id().map(str::to_owned),
+                )
+            })?;
+        let language =
+            self.language
+                .detect_language(uri.path(), &text, None, language_id.as_deref())?;
+        if !self
+            .language
+            .ensure_language_loaded_async(&language)
+            .await
+            .success
+        {
+            return None;
+        }
+        let current = self.documents.get(uri)?;
+        if current.incarnation() != incarnation || current.content_version() != content_version {
+            return None;
+        }
+        drop(current);
+        let regions = self
+            .worker_injection_regions_for_snapshot(uri, incarnation, content_version, &language)
+            .await?;
+        let current = self.documents.get(uri)?;
+        if current.incarnation() != incarnation || current.content_version() != content_version {
+            return None;
+        }
+        drop(current);
+        Some(WorkerInjectionView {
+            text,
+            language,
+            regions,
+        })
+    }
+
     pub(super) async fn worker_injection_region_at_snapshot(
         &self,
         uri: &url::Url,

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -122,6 +122,18 @@ impl Kakehashi {
                     snapshot.incarnation,
                 )),
             };
+            let all_regions = if self.tree_worker_shadow.is_authoritative() {
+                self.worker_injection_regions_for_snapshot(
+                    &uri,
+                    snapshot.incarnation,
+                    snapshot.parsed_version,
+                    &language_name,
+                )
+                .await
+                .unwrap_or_default()
+            } else {
+                all_regions
+            };
 
             if all_regions.is_empty() {
                 return Ok(None);

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -67,72 +67,53 @@ impl Kakehashi {
 
             log::debug!("{} called for {}", method_name, uri);
 
-            // Resolve a CURRENT parse snapshot with a bounded wait (parse-snapshot
-            // ADR §3). This family is nominally serve-stale, but the region
-            // resolution below MINTS tracker ULIDs — a live-position index — so a
-            // stale snapshot must not feed it (a stale read never mints); until the
-            // snapshot-owned region ordinals land, staleness degrades to `Ok(None)`
-            // (the native/empty fallback), self-correcting on the client's next
-            // request. The former parse-on-demand fallback is gone: readers never
-            // parse inline.
-            let snapshot = match self
-                .wait_for_current_snapshot(&uri, std::time::Duration::from_millis(200))
-                .await
-            {
-                crate::lsp::lsp_impl::snapshot_read::SnapshotWait::Current(snapshot) => snapshot,
-                _ => {
-                    log::debug!("{}: no current parse snapshot for {}", method_name, uri);
+            let (language_name, all_regions) = if self.tree_worker_shadow.is_authoritative() {
+                let Some(view) = self.current_worker_injection_view(&uri).await else {
                     return Ok(None);
-                }
-            };
-            let Some(language_name) = snapshot.language.clone() else {
-                log::debug!("{}: No language detected", method_name);
-                return Ok(None);
-            };
-            let Some(snapshot_tree) = snapshot.tree.as_ref() else {
-                log::debug!("{}: no tree (parser unavailable) for {}", method_name, uri);
-                return Ok(None);
-            };
-
-            // Get injection query to detect injection regions
-            let Some(injection_query) = self.language.injection_query(&language_name) else {
-                return Ok(None);
-            };
-
-            // Collect all injection regions — from THIS snapshot's own
-            // resolved_regions (generation-gated), never a store re-read: a
-            // parse publishing between the wait above and a store lookup
-            // could pair this snapshot's tree/text with a NEWER snapshot's
-            // regions. Snapshot immutability makes tree, text, and regions
-            // one value; absent/reload-stale falls back inline over the same
-            // tree.
-            let all_regions = match snapshot
-                .resolved_regions
-                .as_ref()
-                .filter(|(stamped, _)| *stamped == self.cache.semantic_token_generation())
-            {
-                Some((_, regions)) => std::sync::Arc::clone(regions),
-                None => std::sync::Arc::new(InjectionResolver::resolve_all(
-                    &self.language,
-                    self.bridge.node_tracker(),
-                    &uri,
-                    snapshot_tree,
-                    &snapshot.text,
-                    injection_query.as_ref(),
-                    snapshot.incarnation,
-                )),
-            };
-            let all_regions = if self.tree_worker_shadow.is_authoritative() {
-                self.worker_injection_regions_for_snapshot(
-                    &uri,
-                    snapshot.incarnation,
-                    snapshot.parsed_version,
-                    &language_name,
-                )
-                .await
-                .unwrap_or_default()
+                };
+                (view.language, view.regions)
             } else {
-                all_regions
+                // Legacy/shadow readers retain the immutable parent snapshot path.
+                let snapshot = match self
+                    .wait_for_current_snapshot(&uri, std::time::Duration::from_millis(200))
+                    .await
+                {
+                    crate::lsp::lsp_impl::snapshot_read::SnapshotWait::Current(snapshot) => {
+                        snapshot
+                    }
+                    _ => {
+                        log::debug!("{}: no current parse snapshot for {}", method_name, uri);
+                        return Ok(None);
+                    }
+                };
+                let Some(language_name) = snapshot.language.clone() else {
+                    log::debug!("{}: No language detected", method_name);
+                    return Ok(None);
+                };
+                let Some(snapshot_tree) = snapshot.tree.as_ref() else {
+                    log::debug!("{}: no tree (parser unavailable) for {}", method_name, uri);
+                    return Ok(None);
+                };
+                let Some(injection_query) = self.language.injection_query(&language_name) else {
+                    return Ok(None);
+                };
+                let all_regions = match snapshot
+                    .resolved_regions
+                    .as_ref()
+                    .filter(|(stamped, _)| *stamped == self.cache.semantic_token_generation())
+                {
+                    Some((_, regions)) => std::sync::Arc::clone(regions),
+                    None => std::sync::Arc::new(InjectionResolver::resolve_all(
+                        &self.language,
+                        self.bridge.node_tracker(),
+                        &uri,
+                        snapshot_tree,
+                        &snapshot.text,
+                        injection_query.as_ref(),
+                        snapshot.incarnation,
+                    )),
+                };
+                (language_name, all_regions)
             };
 
             if all_regions.is_empty() {

--- a/src/lsp/lsp_impl/workspace/execute_command.rs
+++ b/src/lsp/lsp_impl/workspace/execute_command.rs
@@ -84,11 +84,9 @@ impl Kakehashi {
         let Ok(host_url) = url::Url::parse(route.host_uri) else {
             return;
         };
-        // didChange clears the tree and reparses off-ingress: an executeCommand
-        // landing right after an edit would otherwise find no injections and
-        // silently skip the heal (the request paths await the fresh tree the
-        // same way).
-        self.ensure_document_parsed(&host_url).await;
+        if !self.tree_worker_shadow.is_authoritative() {
+            self.ensure_document_parsed(&host_url).await;
+        }
         let Some(host_incarnation) = self
             .documents
             .get(&host_url)
@@ -96,8 +94,10 @@ impl Kakehashi {
         else {
             return;
         };
-        let Some((host_language, injections)) =
-            self.injection_coordinator().bridge_injections(&host_url)
+        let Some((host_language, injections)) = self
+            .injection_coordinator()
+            .bridge_injections(&host_url)
+            .await
         else {
             return;
         };

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -22,7 +22,7 @@ use sha2::{Digest, Sha256};
 
 use crate::language::node_tracker::{EditInfo, NodeTracker};
 
-pub const PROTOCOL_VERSION: u32 = 12;
+pub const PROTOCOL_VERSION: u32 = 13;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_REPLICAS: usize = 4_096;
 pub const MAX_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
@@ -214,7 +214,6 @@ pub enum NodeScalarOperation {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(tag = "type", content = "value", rename_all = "snake_case")]
 pub enum NodeScalarValue {
     String(String),
     Bool(bool),
@@ -417,7 +416,6 @@ pub struct WorkerRestartRequired {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
 pub enum Request {
     Handshake(Handshake),
     DeriveSnapshot(DeriveSnapshot),
@@ -466,7 +464,6 @@ pub struct WorkerError {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
 pub enum Response {
     HandshakeReady(HandshakeReady),
     DocumentAck(DocumentAck),
@@ -491,11 +488,14 @@ struct DocumentReplica {
     text: String,
     tree: tree_sitter::Tree,
     uri: url::Url,
-    node_tracker: NodeTracker,
+    node_tracker: Arc<NodeTracker>,
     analysis: Arc<crate::language::LanguageCoordinator>,
     grammar_language: tree_sitter::Language,
     queries: WorkerQuerySources,
     captures_match_cache: crate::lsp::lsp_impl::kakehashi::captures_match_cache::CapturesMatchCache,
+    injection_token_cache: Arc<crate::analysis::InjectionTokenCache>,
+    injection_cache_edits: u8,
+    semantic_discovery: Option<Arc<crate::document::DiscoveredInjections>>,
     injection_layers: Vec<CachedInjectionLayer>,
 }
 
@@ -533,7 +533,7 @@ impl DocumentReplica {
         let grammar_key = GrammarKey::from_sync(&request);
         let uri = url::Url::parse(&request.context.uri)
             .map_err(|error| format!("document URI is invalid: {error}"))?;
-        let node_tracker = NodeTracker::new();
+        let node_tracker = Arc::new(NodeTracker::new());
         node_tracker.open_incarnation(&uri, request.context.incarnation);
         let grammar_language = parser
             .language()
@@ -563,6 +563,9 @@ impl DocumentReplica {
                 grammar_language,
                 queries: request.queries,
                 captures_match_cache: Default::default(),
+                injection_token_cache: Arc::new(crate::analysis::InjectionTokenCache::new()),
+                injection_cache_edits: 0,
+                semantic_discovery: None,
                 injection_layers: Vec::new(),
             },
             ack,
@@ -628,6 +631,11 @@ impl DocumentReplica {
         self.text = text;
         self.tree = tree;
         self.injection_layers.clear();
+        self.semantic_discovery = None;
+        self.injection_cache_edits = self.injection_cache_edits.wrapping_add(1);
+        if self.injection_cache_edits == 0 {
+            self.injection_token_cache.clear_document(&self.uri);
+        }
         self.node_tracker
             .apply_input_edits(&self.uri, &tracker_edits);
         self.context = request.context;
@@ -1042,7 +1050,7 @@ impl DocumentReplica {
     }
 
     fn derive_semantic_tokens(
-        &self,
+        &mut self,
         request: DeriveSemanticTokens,
     ) -> Result<DerivedSemanticTokens, String> {
         self.validate_read_identity(&request.context)?;
@@ -1057,6 +1065,7 @@ impl DocumentReplica {
             .analysis
             .highlight_query(&self.language)
             .ok_or_else(|| "worker highlight query is unavailable".to_string())?;
+        let discovery = self.semantic_discovery(request.context.configuration_generation);
         let result = crate::analysis::compute_semantic_tokens_full(
             rayon::current_num_threads(),
             Arc::from(self.text.as_str()),
@@ -1066,7 +1075,15 @@ impl DocumentReplica {
             Some(self.analysis.capture_mappings()),
             Arc::clone(&self.analysis),
             request.supports_multiline,
-            None,
+            Some(crate::analysis::semantic::InjectionCacheParams {
+                uri: self.uri.clone(),
+                tracker: Arc::clone(&self.node_tracker),
+                cache: Arc::clone(&self.injection_token_cache),
+                generation: request.context.configuration_generation,
+                currency: crate::analysis::semantic::InjectionCacheCurrency::Current,
+                incarnation: request.context.incarnation,
+                discovery,
+            }),
             None,
         )
         .ok_or_else(|| "worker semantic token derivation was cancelled".to_string())?;
@@ -1087,6 +1104,56 @@ impl DocumentReplica {
             context: request.context,
             tokens,
         })
+    }
+
+    fn semantic_discovery(
+        &mut self,
+        generation: u64,
+    ) -> Option<Arc<crate::document::DiscoveredInjections>> {
+        if self
+            .semantic_discovery
+            .as_ref()
+            .is_some_and(|discovery| discovery.generation == generation)
+        {
+            return self.semantic_discovery.clone();
+        }
+        let injection_query = self.analysis.injection_query(&self.language)?;
+        let regions = crate::language::injection::collect_all_injections(
+            &self.tree.root_node(),
+            &self.text,
+            Some(injection_query.as_ref()),
+        )?;
+        let cacheable = regions
+            .iter()
+            .map(|region| {
+                let id = crate::language::InjectionResolver::calculate_region_id(
+                    &self.node_tracker,
+                    &self.uri,
+                    region,
+                    self.context.incarnation,
+                )?;
+                Some(
+                    crate::language::injection::CacheableInjectionRegion::from_region_info(
+                        region,
+                        &id.to_string(),
+                        &self.text,
+                    ),
+                )
+            })
+            .collect::<Option<Vec<_>>>()?;
+        self.semantic_discovery = crate::analysis::semantic::build_document_discovery(
+            &regions,
+            &cacheable,
+            injection_query.as_ref(),
+            &self.text,
+            &self.analysis,
+            &self.uri,
+            &self.node_tracker,
+            generation,
+            self.context.incarnation,
+        )
+        .map(Arc::new);
+        self.semantic_discovery.clone()
     }
 
     fn run_captures(&self, request: RunCaptures) -> Result<CapturesResult, String> {
@@ -1645,7 +1712,7 @@ fn ranges_cover_query(
 }
 
 pub fn encode_frame<W: Write, T: Serialize>(writer: &mut W, value: &T) -> io::Result<()> {
-    let payload = serde_json::to_vec(value)
+    let payload = bincode::serialize(value)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     if payload.len() > MAX_FRAME_BYTES {
         return Err(io::Error::new(
@@ -1676,7 +1743,7 @@ pub fn decode_frame<R: Read, T: DeserializeOwned>(reader: &mut R) -> io::Result<
     }
     let mut payload = vec![0_u8; length];
     reader.read_exact(&mut payload)?;
-    serde_json::from_slice(&payload)
+    bincode::deserialize(&payload)
         .map(Some)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
 }
@@ -2397,7 +2464,7 @@ fn derive_semantic_tokens(request: DeriveSemanticTokens, documents: &DocumentSto
         });
     };
     match replica.lock() {
-        Ok(replica) => match replica.derive_semantic_tokens(request) {
+        Ok(mut replica) => match replica.derive_semantic_tokens(request) {
             Ok(result) => Response::SemanticTokens(result),
             Err(message) => Response::Error(WorkerError {
                 context: Some(context),
@@ -4697,7 +4764,7 @@ mod tests {
             content_version: 1,
             configuration_generation: 2,
         };
-        let (replica, _) = DocumentReplica::sync(
+        let (mut replica, _) = DocumentReplica::sync(
             SyncDocument {
                 context: context.clone(),
                 language: "rust".into(),
@@ -4800,7 +4867,7 @@ mod tests {
             content_version: 1,
             configuration_generation: 2,
         };
-        let (replica, _) = DocumentReplica::sync(
+        let (mut replica, _) = DocumentReplica::sync(
             SyncDocument {
                 context: context.clone(),
                 language: "rust".into(),

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -496,6 +496,7 @@ struct DocumentReplica {
     injection_token_cache: Arc<crate::analysis::InjectionTokenCache>,
     injection_cache_edits: u8,
     semantic_discovery: Option<Arc<crate::document::DiscoveredInjections>>,
+    resolved_injections: Option<(u64, Arc<Vec<crate::language::injection::ResolvedInjection>>)>,
     injection_layers: Vec<CachedInjectionLayer>,
 }
 
@@ -566,6 +567,7 @@ impl DocumentReplica {
                 injection_token_cache: Arc::new(crate::analysis::InjectionTokenCache::new()),
                 injection_cache_edits: 0,
                 semantic_discovery: None,
+                resolved_injections: None,
                 injection_layers: Vec::new(),
             },
             ack,
@@ -632,6 +634,7 @@ impl DocumentReplica {
         self.tree = tree;
         self.injection_layers.clear();
         self.semantic_discovery = None;
+        self.resolved_injections = None;
         self.injection_cache_edits = self.injection_cache_edits.wrapping_add(1);
         if self.injection_cache_edits == 0 {
             self.injection_token_cache.clear_document(&self.uri);
@@ -1009,37 +1012,28 @@ impl DocumentReplica {
     }
 
     fn derive_injection_regions(
-        &self,
+        &mut self,
         request: DeriveInjectionRegions,
     ) -> Result<InjectionRegionsResult, String> {
         self.validate_read_identity(&request.context)?;
+        self.ensure_injection_facts(request.context.configuration_generation, true);
         let regions = self
-            .analysis
-            .injection_query(&self.language)
-            .map(|query| {
-                crate::language::InjectionResolver::resolve_all(
-                    &self.analysis,
-                    &self.node_tracker,
-                    &self.uri,
-                    &self.tree,
-                    &self.text,
-                    query.as_ref(),
-                    request.context.incarnation,
-                )
-            })
-            .unwrap_or_default()
+            .resolved_injections
+            .as_ref()
+            .map(|(_, regions)| regions.iter())
             .into_iter()
+            .flatten()
             .map(|resolved| WireInjectionRegion {
-                language: resolved.injection_language,
+                language: resolved.injection_language.clone(),
                 byte_start: resolved.region.byte_range.start,
                 byte_end: resolved.region.byte_range.end,
                 line_start: resolved.region.line_range.start,
                 line_end: resolved.region.line_range.end,
                 start_column: resolved.region.start_column,
-                region_id: resolved.region.region_id,
+                region_id: resolved.region.region_id.clone(),
                 content_hash: resolved.region.content_hash,
-                virtual_content: resolved.virtual_content,
-                line_column_offsets: resolved.line_column_offsets,
+                virtual_content: resolved.virtual_content.clone(),
+                line_column_offsets: resolved.line_column_offsets.clone(),
                 contiguous: resolved.contiguous,
             })
             .collect();
@@ -1117,13 +1111,38 @@ impl DocumentReplica {
         {
             return self.semantic_discovery.clone();
         }
-        let injection_query = self.analysis.injection_query(&self.language)?;
+        self.ensure_injection_facts(generation, false);
+        self.semantic_discovery.clone()
+    }
+
+    fn ensure_injection_facts(&mut self, generation: u64, needs_resolved: bool) {
+        if self
+            .resolved_injections
+            .as_ref()
+            .is_some_and(|(cached_generation, _)| *cached_generation == generation)
+        {
+            return;
+        }
+        if !needs_resolved
+            && self
+                .semantic_discovery
+                .as_ref()
+                .is_some_and(|discovery| discovery.generation == generation)
+        {
+            return;
+        }
+        self.semantic_discovery = None;
+        let Some(injection_query) = self.analysis.injection_query(&self.language) else {
+            self.resolved_injections = Some((generation, Arc::new(Vec::new())));
+            return;
+        };
         let regions = crate::language::injection::collect_all_injections(
             &self.tree.root_node(),
             &self.text,
             Some(injection_query.as_ref()),
-        )?;
-        let cacheable = regions
+        )
+        .unwrap_or_default();
+        let Some(cacheable) = regions
             .iter()
             .map(|region| {
                 let id = crate::language::InjectionResolver::calculate_region_id(
@@ -1140,7 +1159,19 @@ impl DocumentReplica {
                     ),
                 )
             })
-            .collect::<Option<Vec<_>>>()?;
+            .collect::<Option<Vec<_>>>()
+        else {
+            self.resolved_injections = Some((generation, Arc::new(Vec::new())));
+            return;
+        };
+        let resolved = needs_resolved.then(|| {
+            crate::language::InjectionResolver::resolve_from_prebuilt(
+                &self.analysis,
+                &regions,
+                &cacheable,
+                &self.text,
+            )
+        });
         self.semantic_discovery = crate::analysis::semantic::build_document_discovery(
             &regions,
             &cacheable,
@@ -1153,7 +1184,9 @@ impl DocumentReplica {
             self.context.incarnation,
         )
         .map(Arc::new);
-        self.semantic_discovery.clone()
+        if let Some(resolved) = resolved {
+            self.resolved_injections = Some((generation, Arc::new(resolved)));
+        }
     }
 
     fn run_captures(&self, request: RunCaptures) -> Result<CapturesResult, String> {
@@ -2441,7 +2474,7 @@ fn derive_injection_regions(
         });
     };
     match replica.lock() {
-        Ok(replica) => match replica.derive_injection_regions(request) {
+        Ok(mut replica) => match replica.derive_injection_regions(request) {
             Ok(result) => Response::InjectionRegions(result),
             Err(message) => Response::Error(WorkerError {
                 context: Some(context),

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -369,8 +369,94 @@ pub struct WireSemanticToken {
 pub struct CapturesResult {
     pub context: RequestContext,
     pub available: bool,
+    #[serde(with = "wire_json_values")]
     pub matches: Vec<serde_json::Value>,
+    #[serde(with = "wire_json_values")]
     pub skipped: Vec<serde_json::Value>,
+}
+
+/// Encode schemaless capture payloads without asking the binary codec to
+/// implement serde's self-describing `deserialize_any` entry point.
+mod wire_json_values {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[derive(Deserialize, Serialize)]
+    enum WireJsonValue {
+        Null,
+        Bool(bool),
+        Number(String),
+        String(String),
+        Array(Vec<WireJsonValue>),
+        Object(Vec<(String, WireJsonValue)>),
+    }
+
+    impl From<&serde_json::Value> for WireJsonValue {
+        fn from(value: &serde_json::Value) -> Self {
+            match value {
+                serde_json::Value::Null => Self::Null,
+                serde_json::Value::Bool(value) => Self::Bool(*value),
+                serde_json::Value::Number(value) => Self::Number(value.to_string()),
+                serde_json::Value::String(value) => Self::String(value.clone()),
+                serde_json::Value::Array(values) => {
+                    Self::Array(values.iter().map(Self::from).collect())
+                }
+                serde_json::Value::Object(values) => Self::Object(
+                    values
+                        .iter()
+                        .map(|(key, value)| (key.clone(), Self::from(value)))
+                        .collect(),
+                ),
+            }
+        }
+    }
+
+    impl WireJsonValue {
+        fn into_json(self) -> Result<serde_json::Value, String> {
+            Ok(match self {
+                Self::Null => serde_json::Value::Null,
+                Self::Bool(value) => serde_json::Value::Bool(value),
+                Self::Number(value) => serde_json::Value::Number(
+                    value
+                        .parse()
+                        .map_err(|error| format!("invalid JSON number in worker frame: {error}"))?,
+                ),
+                Self::String(value) => serde_json::Value::String(value),
+                Self::Array(values) => serde_json::Value::Array(
+                    values
+                        .into_iter()
+                        .map(Self::into_json)
+                        .collect::<Result<_, _>>()?,
+                ),
+                Self::Object(values) => serde_json::Value::Object(
+                    values
+                        .into_iter()
+                        .map(|(key, value)| Ok((key, value.into_json()?)))
+                        .collect::<Result<_, String>>()?,
+                ),
+            })
+        }
+    }
+
+    pub fn serialize<S>(values: &[serde_json::Value], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        values
+            .iter()
+            .map(WireJsonValue::from)
+            .collect::<Vec<_>>()
+            .serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<serde_json::Value>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Vec::<WireJsonValue>::deserialize(deserializer)?
+            .into_iter()
+            .map(|value| value.into_json().map_err(serde::de::Error::custom))
+            .collect()
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -3853,10 +3939,10 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        ApplyDocumentEdits, BUILD_ID, ByteEdit, CloseDocument, DeriveInjectionRegions,
-        DeriveNativeBindings, DeriveSelectionRanges, DeriveSemanticTokens, DeriveSnapshot,
-        DocumentKey, DocumentLane, DocumentReplica, GrammarKey, Handshake, HandshakeReady,
-        LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
+        ApplyDocumentEdits, BUILD_ID, ByteEdit, CapturesResult, CloseDocument,
+        DeriveInjectionRegions, DeriveNativeBindings, DeriveSelectionRanges, DeriveSemanticTokens,
+        DeriveSnapshot, DocumentKey, DocumentLane, DocumentReplica, GrammarKey, Handshake,
+        HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
         MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeLayerSelector, NodeNavigation,
         NodeScalarOperation, NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION, Request,
         RequestContext, ResolveNode, Response, Route, RunCaptures, RunNodeScalar, SyncDocument,
@@ -4045,6 +4131,29 @@ mod tests {
         assert_eq!(
             decode_frame(&mut Cursor::new(bytes)).unwrap(),
             Some(request)
+        );
+    }
+
+    #[test]
+    fn frame_round_trip_preserves_capture_json_without_self_describing_codec() {
+        let Request::DeriveSnapshot(snapshot_request) = request() else {
+            unreachable!()
+        };
+        let response = Response::Captures(CapturesResult {
+            context: snapshot_request.context,
+            available: true,
+            matches: vec![serde_json::json!({
+                "node": {"id": "opaque", "named": true},
+                "captures": [1, null, "text"]
+            })],
+            skipped: vec![serde_json::json!({"reason": "missing query"})],
+        });
+        let mut bytes = Vec::new();
+        encode_frame(&mut bytes, &response).unwrap();
+
+        assert_eq!(
+            decode_frame(&mut Cursor::new(bytes)).unwrap(),
+            Some(response)
         );
     }
 

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -244,6 +244,11 @@ fn authoritative_worker_serves_injected_node_accessors() {
         json!({ "textDocument": { "uri": uri }, "id": id }),
     );
     assert_eq!(kind["result"]["kind"], "identifier");
+    let semantic = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+    assert!(semantic["result"]["data"].is_array(), "{semantic:?}");
 
     let stderr = shutdown_and_stderr(client);
     assert!(stderr.contains("Authoritative tree worker"), "{stderr}");

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -289,6 +289,20 @@ fn authoritative_worker_serves_injected_node_accessors() {
         }),
     );
     assert!(selection["result"].is_array(), "{selection:?}");
+    let semantic_range = client.send_request(
+        "textDocument/semanticTokens/range",
+        json!({
+            "textDocument": { "uri": uri },
+            "range": {
+                "start": { "line": 3, "character": 0 },
+                "end": { "line": 5, "character": 0 }
+            }
+        }),
+    );
+    assert!(
+        semantic_range["result"]["data"].is_array(),
+        "{semantic_range:?}"
+    );
 
     let stderr = shutdown_and_stderr(client);
     assert!(stderr.contains("Authoritative tree worker"), "{stderr}");

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -198,6 +198,59 @@ fn shadow_worker_matches_injected_node_and_navigation() {
 }
 
 #[test]
+fn authoritative_worker_serves_injected_node_accessors() {
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_MODE", "authoritative")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env("RUST_LOG", "kakehashi::tree_worker_shadow=debug")
+        .build();
+    initialize(&mut client);
+    let uri = "file:///tree-worker-authoritative-node.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "markdown",
+                "version": 1,
+                "text": "# Heading\n\n```python\ny = 1 + 2\n```\n"
+            }
+        }),
+    );
+    let node = client.send_request(
+        "kakehashi/node",
+        json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": 3, "character": 0 },
+            "injection": true
+        }),
+    );
+    let node = &node["result"];
+    let id = node["id"].as_str().expect("worker node must have an id");
+    assert_eq!(node["kind"], "identifier");
+
+    let text = client.send_request(
+        "kakehashi/node/text",
+        json!({ "textDocument": { "uri": uri }, "id": id }),
+    );
+    assert_eq!(text["result"]["text"], "y");
+    let parent = client.send_request(
+        "kakehashi/node/parent",
+        json!({ "textDocument": { "uri": uri }, "id": id }),
+    );
+    assert!(parent["result"].is_object(), "{parent:?}");
+    let kind = client.send_request(
+        "kakehashi/node/kind",
+        json!({ "textDocument": { "uri": uri }, "id": id }),
+    );
+    assert_eq!(kind["result"]["kind"], "identifier");
+
+    let stderr = shutdown_and_stderr(client);
+    assert!(stderr.contains("Authoritative tree worker"), "{stderr}");
+    assert!(!stderr.contains("node mismatch"), "{stderr}");
+}
+
+#[test]
 fn systemic_worker_restart_full_resyncs_the_open_document() {
     let directory = tempfile::tempdir().unwrap();
     let marker = directory.path().join("restart-once");

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -250,6 +250,46 @@ fn authoritative_worker_serves_injected_node_accessors() {
     );
     assert!(semantic["result"]["data"].is_array(), "{semantic:?}");
 
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": uri, "version": 2 },
+            "contentChanges": [{
+                "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 0, "character": 0 }
+                },
+                "text": "\n"
+            }]
+        }),
+    );
+    let edited_node = client.send_request(
+        "kakehashi/node",
+        json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": 4, "character": 0 },
+            "injection": true
+        }),
+    );
+    assert_eq!(
+        edited_node["result"]["kind"], "identifier",
+        "{edited_node:?}"
+    );
+    let edited_id = edited_node["result"]["id"].as_str().unwrap();
+    let edited_range = client.send_request(
+        "kakehashi/node/range",
+        json!({ "textDocument": { "uri": uri }, "id": edited_id }),
+    );
+    assert_eq!(edited_range["result"]["start"]["line"], 4);
+    let selection = client.send_request(
+        "textDocument/selectionRange",
+        json!({
+            "textDocument": { "uri": uri },
+            "positions": [{ "line": 4, "character": 0 }]
+        }),
+    );
+    assert!(selection["result"].is_array(), "{selection:?}");
+
     let stderr = shutdown_and_stderr(client);
     assert!(stderr.contains("Authoritative tree worker"), "{stderr}");
     assert!(!stderr.contains("node mismatch"), "{stderr}");


### PR DESCRIPTION
## Summary

- add guarded legacy, shadow, and authoritative modes and route all tree-derived readers through one fixed resident worker
- stop parent reparsing after authoritative didChange while preserving virtual-document and diagnostic workflows from worker-owned facts
- keep strict incarnation, content-version, configuration-generation, and worker-generation fencing with opaque node identities
- use binary worker frames and lazy worker-owned semantic, injection, discovery, and capture facts

## Stack

- Depends on #869
- Implements the guarded all-reader cutover stage from ADR #862
- Remains draft because later stacked stages still remove parent-side parser ownership and finish recovery and performance gates

## Measurement

Release benchmark, 40 iterations after 10 warmups:

| workload | legacy | authoritative 4 threads |
| --- | ---: | ---: |
| markdown full sync | 0.305 ms | 0.339 ms |
| large Rust edit delta median | 29.568 ms | 64.686 ms |
| markdown edit delta | 7.009 ms | 11.746 ms |

Large Rust authoritative cache hits were about 0.725 ms at p25, but cache misses and edits remain slower. This stage therefore does not pass the general performance gate. Detailed results and next targets are recorded in the Stage 7 measurement note.

## Validation

- cargo test --lib: 3111 passed, 2 ignored
- cargo test --features e2e --test tree_worker_process -- --test-threads=1: 4 passed
- cargo test --features e2e --test e2e_tree_worker_shadow -- --test-threads=1: 33 passed
- cargo fmt --check
- git diff --check

## Rollback

Set KAKEHASHI_TREE_WORKER_MODE=legacy to select the complete legacy path. The cutover is atomic; mixed reader ownership is not a supported production mode.