### PR TITLE
perf(worker): consolidate authoritative ownership

### DIFF
--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -59,11 +59,16 @@ struct Server {
 impl Server {
     /// Spawn `bin`, run the LSP handshake, and return a ready server.
     fn start(bin: &str, data_dir: &str) -> Server {
+        let stderr = if std::env::var_os("KAKEHASHI_BENCH_SERVER_STDERR").is_some() {
+            Stdio::inherit()
+        } else {
+            Stdio::null()
+        };
         let mut child = Command::new(bin)
             .env("KAKEHASHI_DATA_DIR", data_dir)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stderr(stderr)
             .spawn()
             .unwrap_or_else(|e| panic!("failed to spawn server binary {bin:?}: {e}"));
 

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage8-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage8-measurement.md
@@ -1,0 +1,109 @@
+# Single Tree Worker Stage 8 Ownership Measurement
+
+## Scope
+
+Stage 8 moves authoritative `didOpen` parsing and parser-install recovery into
+the resident worker, preserves worker replicas incrementally across edits, and
+adds current-version semantic-fact reuse. It also avoids deriving injection
+facts for languages without an injection query and avoids producing a full
+snapshot merely to acknowledge an authoritative edit.
+
+This remains an intermediate measurement. Authoritative startup still asks the
+parent language coordinator to load grammar and query metadata, and the legacy
+implementation remains available for rollback. The ADR therefore remains
+`proposed`.
+
+## Method
+
+The release Stage 8 binary was measured on macOS with the existing LSP
+semantic-token harness. Both columns use the same binary; only the rollout mode
+changes:
+
+```text
+iterations = 40
+warmup = 10
+legacy = KAKEHASHI_TREE_WORKER_MODE unset
+worker = authoritative, KAKEHASHI_TREE_WORKER_THREADS=4
+```
+
+The edit scenarios include real `didChange`, incremental parse, injection and
+diagnostic lifecycle, semantic-token calculation, delta calculation, and IPC.
+The cold-open scenarios use a fresh URI for each iteration.
+
+## Results
+
+Lower is better. Values are medians from the final Stage 8 commit.
+
+| Scenario | Legacy | Authoritative worker | Change |
+|---|---:|---:|---:|
+| Markdown, 60 injections, full | 0.270 ms | 0.303 ms | +12% |
+| Markdown, 60 injections, edit + delta | 6.853 ms | 7.542 ms | +10% |
+| Large Rust, edit + delta | 25.326 ms | 39.016 ms | +54% |
+| Markdown, 150 injections, cold open + first token | 21.832 ms | 27.590 ms | +26% |
+| Large Rust, cold open + first token | 527.047 ms | 554.410 ms | +5% |
+
+The large Rust edit distribution remains bimodal:
+
+| Percentile | Legacy | Authoritative worker |
+|---|---:|---:|
+| p25 | 18.025 ms | 0.635 ms |
+| p75 | 31.258 ms | 41.548 ms |
+
+The approximately 0.6 ms worker p25 confirms that an exact current-version
+resident cache hit can outperform the in-process reader substantially. Cache
+misses are frequent enough that the median and p75 still regress.
+
+## Findings
+
+### Stage 7 did not measure incremental worker edits
+
+Stage 8 telemetry exposed an identity check that compared the replica's current
+content version with the target version. Every advancing `didChange` therefore
+selected full document synchronization instead of `ApplyDocumentEdits`.
+Checking the replica against the edit's base version and advancing its identity
+after a successful apply restores actual worker-side incremental parsing.
+
+This means the Stage 7 edit numbers are valid end-to-end observations of that
+implementation, but they are not evidence about worker incremental-parse
+performance. After the fix and the Stage 8 ownership changes, the four-thread
+large Rust median fell from 64.686 ms to 39.016 ms and Markdown edit + delta
+fell from 11.746 ms to 7.542 ms. Neither result yet beats legacy.
+
+### The internal worker queue is not the primary bottleneck
+
+A four-iteration telemetry run measured large Rust semantic-token queue waits
+of 6--12 microseconds without contention and 6.9 ms in one contended sample.
+Worker semantic computation took approximately 19--25 ms. Adding worker threads
+or processes would not remove this per-document miss work and would add routing
+and replica state.
+
+The worker count therefore remains fixed at one. The next performance work
+should reduce cache-miss computation and transferred results rather than tune
+the pool size.
+
+### Acknowledgement-only edits do not close the gap
+
+Authoritative edits no longer derive a full worker snapshot solely for shadow
+comparison. The worker applies the edit and returns a compact document
+acknowledgement; shadow mode retains snapshot derivation for comparison. The
+final result still regresses against legacy, showing that redundant snapshot
+derivation was not the dominant cost.
+
+### Cold ownership removes duplication but not process-boundary cost
+
+The authoritative parent no longer creates its own `Tree` during `didOpen`, yet
+cold open remains 5% slower for large Rust and 26% slower for injection-heavy
+Markdown. Removing the duplicate parent parse is structurally necessary for
+single ownership, but it does not by itself establish a performance win.
+
+## Decision
+
+Stage 8 improves the worker path materially and validates very fast
+current-version cache hits, but it does not pass the performance non-regression
+gate. Keep one resident worker with an internal thread pool, keep the rollout
+guarded, and do not claim that the worker architecture is faster overall.
+
+Before acceptance, the implementation must move grammar/query loading out of
+the authoritative parent, reduce semantic cache-miss computation or result
+transfer, and repeat the same paired workload together with failure-injection,
+protocol, compatibility, and memory gates.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1137,6 +1137,14 @@ not yet pass a performance non-regression gate. It identifies lazy shared facts,
 single-flight derivation, and large-result transfer as the next optimization
 targets; it does not change this ADR's `proposed` status.
 
+The [Stage 8 ownership measurement](single-resident-multithreaded-tree-worker-stage8-measurement.md)
+records authoritative open/install ownership, true incremental worker edits,
+semantic-path telemetry, and same-version fact reuse. It finds substantially
+faster exact-version cache hits and a material improvement over Stage 7, but
+the paired legacy mode remains faster in every measured end-to-end scenario.
+Queue wait is not the dominant miss cost, so the result supports keeping one
+worker while rejecting an overall performance-win claim.
+
 The implementation should proceed in measured stages:
 
 1. Prototype the framed transport, supervision, and one high-level

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -208,15 +208,24 @@ impl InjectionCoordinator {
         incarnation: u64,
         content_version: u64,
     ) -> bool {
-        let generation = self.language.configuration_generation();
-        let Some(regions) = self
-            .tree_worker_shadow
-            .worker_injection_regions(uri, incarnation, content_version, generation)
-            .await
-        else {
+        let Some(host_language) = self.get_language_for_document(uri) else {
             return false;
         };
-        let injections = bridge_injections_from_resolved(&regions);
+        let injections = if should_query_worker_injections(
+            self.language.injection_query(&host_language).is_some(),
+        ) {
+            let generation = self.language.configuration_generation();
+            let Some(regions) = self
+                .tree_worker_shadow
+                .worker_injection_regions(uri, incarnation, content_version, generation)
+                .await
+            else {
+                return false;
+            };
+            bridge_injections_from_resolved(&regions)
+        } else {
+            Vec::new()
+        };
         self.process_injections_after_lifecycle_lock(
             uri,
             forward_did_change,
@@ -542,9 +551,22 @@ fn parser_enabled_injection_language(language: &str) -> bool {
     language != "plaintext"
 }
 
+fn should_query_worker_injections(has_injection_query: bool) -> bool {
+    has_injection_query
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{bridge_injections_from_resolved, parser_enabled_injection_language};
+    use super::{
+        bridge_injections_from_resolved, parser_enabled_injection_language,
+        should_query_worker_injections,
+    };
+
+    #[test]
+    fn worker_derivation_is_skipped_without_an_injection_query() {
+        assert!(!should_query_worker_injections(false));
+        assert!(should_query_worker_injections(true));
+    }
 
     #[test]
     fn worker_bridge_injection_preserves_identity_language_and_content() {

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -40,6 +40,10 @@ fn updated_settings_after_install(
     (updated_raw_settings, updated_settings)
 }
 
+fn should_reparse_installed_document_in_parent(authoritative: bool, is_injection: bool) -> bool {
+    !authoritative && !is_injection
+}
+
 pub(super) struct InstallCoordinatorDeps {
     pub(super) client: Client,
     pub(super) language: std::sync::Arc<LanguageCoordinator>,
@@ -206,11 +210,8 @@ impl InstallCoordinator {
         }
 
         if self.language.has_parser_available(language) {
-            if !is_injection && self.same_document_incarnation(&uri, expected_incarnation) {
-                self.parse_coordinator()
-                    .reparse_installed_document(uri.clone(), language, expected_incarnation)
-                    .await;
-            }
+            self.recover_installed_document(&uri, language, is_injection, expected_incarnation)
+                .await;
             if !self.same_document_incarnation(&uri, expected_incarnation) {
                 return false;
             }
@@ -273,11 +274,8 @@ impl InstallCoordinator {
             if terminal.data_dir().is_some()
                 && self.same_document_incarnation(&uri, expected_incarnation)
             {
-                if !is_injection {
-                    self.parse_coordinator()
-                        .reparse_installed_document(uri.clone(), language, expected_incarnation)
-                        .await;
-                }
+                self.recover_installed_document(&uri, language, is_injection, expected_incarnation)
+                    .await;
                 if self.install_reparse_recovered(
                     language,
                     &uri,
@@ -360,14 +358,35 @@ impl InstallCoordinator {
             .log_language_events(&load_result.events)
             .await;
 
-        if global_loaded && !is_injection {
-            // Resurrection-safe, off-ingress reparse: re-detects the language from
-            // the current document lifetime and persists through a non-inserting
-            // CAS, so a didClose/reopen during the install can't receive a tree for
-            // the old language. A host waiter whose install claim was won by an
-            // injection reaches this same per-URI path after the claim completes.
+        if global_loaded {
+            // Resurrection-safe recovery: legacy reparses through its guarded CAS;
+            // authoritative re-mirrors current text into the worker. A host waiter
+            // whose install claim was won by an injection reaches this same per-URI
+            // path after the claim completes.
+            self.recover_installed_document(&uri, language, is_injection, expected_incarnation)
+                .await;
+        }
+    }
+
+    async fn recover_installed_document(
+        &self,
+        uri: &Url,
+        language: &str,
+        is_injection: bool,
+        expected_incarnation: Option<u64>,
+    ) {
+        if !self.same_document_incarnation(uri, expected_incarnation) {
+            return;
+        }
+        let authoritative = self.tree_worker_shadow.is_authoritative();
+        if authoritative {
+            // Settings reload already configured the worker catalog. Re-mirror the
+            // current document so the newly installed grammar owns the first tree;
+            // do not recreate a parent parser/Tree as a recovery side effect.
+            self.refresh_tree_worker_documents(std::slice::from_ref(uri));
+        } else if should_reparse_installed_document_in_parent(authoritative, is_injection) {
             self.parse_coordinator()
-                .reparse_installed_document(uri, language, expected_incarnation)
+                .reparse_installed_document(uri.clone(), language, expected_incarnation)
                 .await;
         }
     }
@@ -418,6 +437,8 @@ impl InstallCoordinator {
         self.same_document_incarnation(uri, expected_incarnation)
             && self.language.has_parser_available(language)
             && (is_injection
+                || (self.tree_worker_shadow.is_authoritative()
+                    && self.language.worker_grammar_descriptor(language).is_some())
                 || self
                     .documents
                     .get(uri)
@@ -450,6 +471,14 @@ mod tests {
     use std::path::Path;
     use std::task::Poll;
     use tower_lsp_server::LspService;
+
+    #[test]
+    fn authoritative_install_recovery_never_reparses_in_parent() {
+        assert!(!should_reparse_installed_document_in_parent(true, false));
+        assert!(!should_reparse_installed_document_in_parent(true, true));
+        assert!(should_reparse_installed_document_in_parent(false, false));
+        assert!(!should_reparse_installed_document_in_parent(false, true));
+    }
 
     #[test]
     fn reload_after_install_preserves_explicit_matching_override_in_raw_settings() {

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -151,6 +151,7 @@ impl Kakehashi {
                     let documents = std::sync::Arc::clone(&self.documents);
                     let lang = lang.clone();
                     let install_uri = uri.clone();
+                    let authoritative = self.tree_worker_shadow.is_authoritative();
                     // Mirror the handler's `!is_cli_mode()` gate on the synthetic
                     // diagnostic (#489): in one-shot CLI mode no editor consumes the
                     // proactive publishDiagnostics, so re-firing it from the install
@@ -169,46 +170,56 @@ impl Kakehashi {
                         if !same_lifetime {
                             return;
                         }
-                        // The skipped inline parse meant the handler's
-                        // process_injections (below) ran with no tree. Now that the
-                        // off-ingress reparse may have produced one, run the normal
-                        // post-parse injection workflow — injected-language install
-                        // and eager bridge spawn — which also keeps that injected
-                        // install off the ingress ticket. forward=false: open path.
-                        //
-                        // Gate on the document actually having a tree: install can
-                        // fail or be deduped (AlreadyInstalling) with no reparse, and
-                        // process_injections would otherwise cancel the eager-open
-                        // for a still-tree-less document.
-                        let has_tree = documents.get(&install_uri).is_some_and(|doc| {
+                        // Resume the open downstream from the owner selected by the
+                        // atomic mode. Authoritative recovery mirrors the newly
+                        // installed grammar into the worker and intentionally leaves
+                        // the parent document tree-less; legacy recovery reparses and
+                        // retains its existing tree gate.
+                        let recovered = if authoritative {
+                            let Some(content_version) =
+                                documents.get(&install_uri).and_then(|doc| {
+                                    (doc.incarnation() == incarnation)
+                                        .then(|| doc.content_version())
+                                })
+                            else {
+                                return;
+                            };
+                            injection
+                                .process_worker_injections_for_incarnation(
+                                    &install_uri,
+                                    false,
+                                    incarnation,
+                                    content_version,
+                                )
+                                .await
+                        } else if documents.get(&install_uri).is_some_and(|doc| {
                             doc.incarnation() == incarnation && doc.tree().is_some()
-                        });
-                        if has_tree {
-                            let same_lifetime = injection
+                        }) {
+                            injection
                                 .process_injections_for_incarnation(
                                     &install_uri,
                                     false,
                                     incarnation,
                                 )
-                                .await;
-                            if !same_lifetime {
-                                return;
-                            }
-                            // Re-fire the proactive synthetic diagnostic now that a
-                            // tree exists: the handler's spawn (below) ran in the
-                            // skip-parse path with no tree, so its snapshot was None
-                            // and the pull-layer diagnostics were skipped on this
-                            // first open of a just-installed parser. Skipped in CLI
-                            // mode (#489), matching the handler's own gate.
+                                .await
+                        } else {
+                            false
+                        };
+                        if recovered {
                             if !is_cli_mode {
-                                spawn_synthetic_diagnostic_for_incarnation(
-                                    &documents,
-                                    &diagnostic_scheduler,
-                                    install_uri,
-                                    incarnation,
-                                    std::future::ready(()),
-                                )
-                                .await;
+                                if authoritative {
+                                    diagnostic_scheduler
+                                        .spawn_synthetic_diagnostic_task(install_uri);
+                                } else {
+                                    spawn_synthetic_diagnostic_for_incarnation(
+                                        &documents,
+                                        &diagnostic_scheduler,
+                                        install_uri,
+                                        incarnation,
+                                        std::future::ready(()),
+                                    )
+                                    .await;
+                                }
                             }
                         }
                     });

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -229,6 +229,61 @@ impl Kakehashi {
         // has resolved.
         let ticket = crate::lsp::current_writer_ticket();
 
+        // The authoritative cutover owns the open parse in the worker as well as
+        // subsequent edits. Re-submit after language loading so the replica sees
+        // the final query sources, then continue the former post-parse workflows
+        // from worker-owned injection facts. The parent document deliberately
+        // remains tree-less: spawning ParseCoordinator here would recreate the
+        // duplicate parser/Tree/cache ownership this mode exists to remove.
+        if self.tree_worker_shadow.is_authoritative() && !skip_parse {
+            if let Some(language_name) = language_name.clone()
+                && let Some(grammar) = self.language.worker_grammar_descriptor(&language_name)
+            {
+                self.tree_worker_shadow.mirror_full(
+                    &uri,
+                    incarnation,
+                    0,
+                    language_name,
+                    grammar,
+                    text.clone(),
+                );
+            }
+            if let Some(ticket) = ticket {
+                self.documents
+                    .advance_watermark_for_incarnation(&uri, ticket, incarnation);
+            }
+            if !deferred_events.is_empty() {
+                self.notifier().log_language_events(&deferred_events).await;
+            }
+
+            let injection = self.injection_coordinator();
+            if self.is_cli_mode() {
+                injection
+                    .process_worker_injections_for_incarnation(&uri, false, incarnation, 0)
+                    .await;
+            } else {
+                let diagnostic_scheduler = self.diagnostic_scheduler();
+                let worker_uri = uri.clone();
+                tokio::spawn(async move {
+                    injection
+                        .process_worker_injections_for_incarnation(
+                            &worker_uri,
+                            false,
+                            incarnation,
+                            0,
+                        )
+                        .await;
+                    diagnostic_scheduler.spawn_synthetic_diagnostic_task(worker_uri);
+                });
+            }
+            log::info!(
+                target: "kakehashi::tree_worker_shadow",
+                "authoritative worker owns didOpen parsing for {uri}"
+            );
+            self.notifier().log_info("file opened!").await;
+            return;
+        }
+
         // Parse the document and run its tree-dependent downstream. Three shapes:
         //
         // - **auto-install (`skip_parse`)**: the install task spawned above reparses

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -971,13 +971,14 @@ impl TreeWorkerShadow {
         }
         log::debug!(
             target: "kakehashi::tree_worker_shadow_metrics",
-            "semantic uri={} version={} parent_us={} queue_us={} compute_us={} tokens={}",
+            "semantic uri={} version={} parent_us={} queue_us={} compute_us={} tokens={} cache_hit={}",
             result.context.uri,
             result.context.content_version,
             started.elapsed().as_micros(),
             result.queue_wait_ns / 1_000,
             result.compute_ns / 1_000,
             result.tokens.len(),
+            result.cache_hit,
         );
         let current = self
             .open_documents
@@ -2890,11 +2891,13 @@ fn execute_command(
         ShadowCommand::Apply { request, fallback } => {
             let uri = fallback.context.uri.clone();
             let identity = ReplicaIdentity::from_sync(&fallback);
-            if replica_requires_sync(replicas, &uri, &identity) {
+            if replica_requires_sync(replicas, &uri, &identity, request.base_version) {
                 (sync_and_derive(client, fallback), Some(identity))
             } else {
                 match client.apply_document_edits_and_derive(request) {
-                    Ok(Response::Snapshot(snapshot)) => (Ok(Response::Snapshot(snapshot)), None),
+                    Ok(Response::Snapshot(snapshot)) => {
+                        (Ok(Response::Snapshot(snapshot)), Some(identity))
+                    }
                     Ok(Response::WorkerRestartRequired(required)) => {
                         (Ok(Response::WorkerRestartRequired(required)), None)
                     }
@@ -3298,8 +3301,20 @@ fn replica_requires_sync(
     replicas: &HashMap<String, ReplicaIdentity>,
     uri: &str,
     desired: &ReplicaIdentity,
+    base_version: u64,
 ) -> bool {
-    replicas.get(uri) != Some(desired)
+    replicas.get(uri).is_none_or(|current| {
+        current.incarnation != desired.incarnation
+            || current.content_version != base_version
+            || desired.content_version <= base_version
+            || current.language != desired.language
+            || current.grammar_symbol != desired.grammar_symbol
+            || current.source_path != desired.source_path
+            || current.parser_path != desired.parser_path
+            || current.artifact_digest != desired.artifact_digest
+            || current.queries != desired.queries
+            || current.configuration_generation != desired.configuration_generation
+    })
 }
 
 enum ComparisonSide {
@@ -3902,6 +3917,34 @@ mod tests {
     }
 
     #[test]
+    fn advancing_version_uses_incremental_replica_when_stable_identity_matches() {
+        let current = ReplicaIdentity::from_sync(&sync("file:///a.rs", 1, 1, 7));
+        let desired = ReplicaIdentity::from_sync(&sync("file:///a.rs", 1, 2, 7));
+        let replicas = HashMap::from([("file:///a.rs".to_string(), current)]);
+
+        assert!(!replica_requires_sync(
+            &replicas,
+            "file:///a.rs",
+            &desired,
+            1,
+        ));
+        assert!(replica_requires_sync(
+            &replicas,
+            "file:///a.rs",
+            &desired,
+            0,
+        ));
+        let mut changed_grammar = desired;
+        changed_grammar.artifact_digest = "sha256:rust-v2".into();
+        assert!(replica_requires_sync(
+            &replicas,
+            "file:///a.rs",
+            &changed_grammar,
+            1,
+        ));
+    }
+
+    #[test]
     fn configuration_mirroring_publishes_a_complete_registry_before_enqueue() {
         let (sender, receiver) = mpsc::sync_channel(4);
         let shadow = shadow(sender);
@@ -4139,27 +4182,29 @@ mod tests {
             shadow.sync_request(&uri, 2, 4, "rust".into(), grammar(), "fn main() {}".into());
         let identity = ReplicaIdentity::from_sync(&request);
         let mut replicas = HashMap::from([(uri.as_str().to_string(), identity.clone())]);
+        let mut desired = identity.clone();
+        desired.content_version = 5;
 
-        assert!(!replica_requires_sync(&replicas, uri.as_str(), &identity));
+        assert!(!replica_requires_sync(&replicas, uri.as_str(), &desired, 4,));
 
-        let mut changed = identity.clone();
+        let mut changed = desired.clone();
         changed.language = "bash".into();
-        assert!(replica_requires_sync(&replicas, uri.as_str(), &changed));
+        assert!(replica_requires_sync(&replicas, uri.as_str(), &changed, 4,));
 
-        changed = identity.clone();
+        changed = desired.clone();
         changed.grammar_symbol = "rust_with_changes".into();
-        assert!(replica_requires_sync(&replicas, uri.as_str(), &changed));
+        assert!(replica_requires_sync(&replicas, uri.as_str(), &changed, 4,));
 
-        changed = identity.clone();
+        changed = desired.clone();
         changed.configuration_generation += 1;
-        assert!(replica_requires_sync(&replicas, uri.as_str(), &changed));
+        assert!(replica_requires_sync(&replicas, uri.as_str(), &changed, 4,));
 
-        changed = identity.clone();
+        changed = desired.clone();
         changed.queries.bindings = Some("(identifier) @reference".into());
-        assert!(replica_requires_sync(&replicas, uri.as_str(), &changed));
+        assert!(replica_requires_sync(&replicas, uri.as_str(), &changed, 4,));
 
         replicas.remove(uri.as_str());
-        assert!(replica_requires_sync(&replicas, uri.as_str(), &identity));
+        assert!(replica_requires_sync(&replicas, uri.as_str(), &desired, 4,));
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -11,13 +11,13 @@ use crate::error::LockResultExt;
 use crate::language::coordinator::WorkerGrammarDescriptor;
 use crate::lsp::text_sync::SequentialByteEdit;
 use crate::tree_worker::{
-    ApplyDocumentEditsAndDerive, ByteEdit, CapturesResult, Client, CloseDocument,
-    ConfigureLanguages, DeriveDocumentSnapshot, DeriveInjectionRegions, DeriveNativeBindings,
-    DeriveSelectionRanges, DeriveSemanticTokens, DerivedSemanticTokens, InjectionRegionsResult,
-    NativeBindingsFacts, NativeBindingsResult, NavigateNode, NodeNavigation, NodeResult,
-    NodeScalarOperation, NodeScalarValue, OpaqueNodeId, RequestContext, ResolveNode, Response,
-    RunCaptures, RunNodeScalar, SelectionRangesResult, SyncDocument, WirePosition, WireRange,
-    WorkerLanguageCatalog, named_node_count,
+    ApplyDocumentEdits, ApplyDocumentEditsAndDerive, ByteEdit, CapturesResult, Client,
+    CloseDocument, ConfigureLanguages, DeriveDocumentSnapshot, DeriveInjectionRegions,
+    DeriveNativeBindings, DeriveSelectionRanges, DeriveSemanticTokens, DerivedSemanticTokens,
+    InjectionRegionsResult, NativeBindingsFacts, NativeBindingsResult, NavigateNode,
+    NodeNavigation, NodeResult, NodeScalarOperation, NodeScalarValue, OpaqueNodeId, RequestContext,
+    ResolveNode, Response, RunCaptures, RunNodeScalar, SelectionRangesResult, SyncDocument,
+    WirePosition, WireRange, WorkerLanguageCatalog, named_node_count,
 };
 
 use super::Kakehashi;
@@ -56,6 +56,7 @@ enum ShadowCommand {
     Apply {
         request: ApplyDocumentEditsAndDerive,
         fallback: SyncDocument,
+        derive_snapshot: bool,
     },
     Close(CloseDocument),
     Forget(RequestContext),
@@ -1610,7 +1611,11 @@ impl TreeWorkerShadow {
                 })
                 .collect(),
         };
-        self.observe_and_submit(ShadowCommand::Apply { request, fallback });
+        self.observe_and_submit(ShadowCommand::Apply {
+            request,
+            fallback,
+            derive_snapshot: should_derive_edit_snapshot(self.mode),
+        });
     }
 
     pub(super) fn mirror_close(
@@ -2333,6 +2338,10 @@ fn configured_mode() -> TreeWorkerMode {
     )
 }
 
+fn should_derive_edit_snapshot(mode: TreeWorkerMode) -> bool {
+    mode == TreeWorkerMode::Shadow
+}
+
 fn parse_mode(mode: Option<&str>, legacy_shadow: Option<&str>) -> TreeWorkerMode {
     match mode {
         Some("authoritative") => TreeWorkerMode::Authoritative,
@@ -2648,6 +2657,16 @@ fn run_actor(
                     ComparisonSide::Shadow(TreeSummary::from_snapshot(&snapshot)),
                 );
             }
+            Ok(Response::DocumentAck(ack)) => {
+                if let Some(identity) = synced_identity {
+                    state.replicas.insert(ack.context.uri.clone(), identity);
+                }
+                state
+                    .open_documents
+                    .lock()
+                    .recover_poison("run_actor(acknowledge edit)")
+                    .acknowledge(ack.context);
+            }
             Ok(Response::WorkerRestartRequired(required)) => {
                 log::warn!(
                     target: "kakehashi::tree_worker_shadow",
@@ -2888,15 +2907,31 @@ fn execute_command(
             comparisons.open(&request.context.uri, request.context.incarnation);
             (sync_and_derive(client, request), Some(identity))
         }
-        ShadowCommand::Apply { request, fallback } => {
+        ShadowCommand::Apply {
+            request,
+            fallback,
+            derive_snapshot,
+        } => {
             let uri = fallback.context.uri.clone();
             let identity = ReplicaIdentity::from_sync(&fallback);
             if replica_requires_sync(replicas, &uri, &identity, request.base_version) {
                 (sync_and_derive(client, fallback), Some(identity))
             } else {
-                match client.apply_document_edits_and_derive(request) {
+                let response = if derive_snapshot {
+                    client.apply_document_edits_and_derive(request)
+                } else {
+                    client.apply_document_edits(ApplyDocumentEdits {
+                        context: request.context,
+                        base_version: request.base_version,
+                        edits: request.edits,
+                    })
+                };
+                match response {
                     Ok(Response::Snapshot(snapshot)) => {
                         (Ok(Response::Snapshot(snapshot)), Some(identity))
+                    }
+                    Ok(Response::DocumentAck(ack)) => {
+                        (Ok(Response::DocumentAck(ack)), Some(identity))
                     }
                     Ok(Response::WorkerRestartRequired(required)) => {
                         (Ok(Response::WorkerRestartRequired(required)), None)
@@ -3211,7 +3246,9 @@ fn replica_was_closed(
 fn retag_command(command: &mut ShadowCommand, generation: u64) {
     match command {
         ShadowCommand::Sync(request) => request.context.worker_generation = generation,
-        ShadowCommand::Apply { request, fallback } => {
+        ShadowCommand::Apply {
+            request, fallback, ..
+        } => {
             request.context.worker_generation = generation;
             fallback.context.worker_generation = generation;
         }
@@ -3524,6 +3561,8 @@ mod tests {
             parse_mode(Some("invalid"), Some("true")),
             TreeWorkerMode::Legacy
         );
+        assert!(should_derive_edit_snapshot(TreeWorkerMode::Shadow));
+        assert!(!should_derive_edit_snapshot(TreeWorkerMode::Authoritative));
     }
 
     #[test]
@@ -3671,6 +3710,7 @@ mod tests {
                 edits: Vec::new(),
             },
             fallback: sync("file:///a.rs", 1, 2, 7),
+            derive_snapshot: true,
         });
 
         let latest = documents.current.get("file:///a.rs").unwrap();
@@ -3704,6 +3744,7 @@ mod tests {
                 edits: Vec::new(),
             },
             fallback: sync(uri, 1, 2, 7),
+            derive_snapshot: true,
         });
 
         assert!(!documents.worker_regions.contains_key(uri));
@@ -3892,10 +3933,14 @@ mod tests {
                 edits: Vec::new(),
             },
             fallback: sync("file:///a.rs", 1, 2, 7),
+            derive_snapshot: true,
         };
         retag_command(&mut command, 11);
 
-        let ShadowCommand::Apply { request, fallback } = command else {
+        let ShadowCommand::Apply {
+            request, fallback, ..
+        } = command
+        else {
             unreachable!();
         };
         assert_eq!(request.context.worker_generation, 11);
@@ -4139,7 +4184,10 @@ mod tests {
             ]),
         );
 
-        let ShadowCommand::Apply { request, fallback } = receiver.recv().unwrap() else {
+        let ShadowCommand::Apply {
+            request, fallback, ..
+        } = receiver.recv().unwrap()
+        else {
             panic!("incremental mirror must enqueue an apply command");
         };
         assert_eq!(request.base_version, 4);

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -953,6 +953,7 @@ impl TreeWorkerShadow {
             .synchronized_query_read(uri, incarnation, content_version, configuration_generation)
             .await?;
         let expected = context.clone();
+        let started = Instant::now();
         let response = tokio::task::spawn_blocking(move || {
             client.derive_semantic_tokens(DeriveSemanticTokens {
                 context,
@@ -968,6 +969,16 @@ impl TreeWorkerShadow {
         if result.context != expected {
             return None;
         }
+        log::debug!(
+            target: "kakehashi::tree_worker_shadow_metrics",
+            "semantic uri={} version={} parent_us={} queue_us={} compute_us={} tokens={}",
+            result.context.uri,
+            result.context.content_version,
+            started.elapsed().as_micros(),
+            result.queue_wait_ns / 1_000,
+            result.compute_ns / 1_000,
+            result.tokens.len(),
+        );
         let current = self
             .open_documents
             .lock()

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -22,7 +22,7 @@ use sha2::{Digest, Sha256};
 
 use crate::language::node_tracker::{EditInfo, NodeTracker};
 
-pub const PROTOCOL_VERSION: u32 = 13;
+pub const PROTOCOL_VERSION: u32 = 14;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_REPLICAS: usize = 4_096;
 pub const MAX_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
@@ -354,6 +354,8 @@ pub struct InjectionRegionsResult {
 pub struct DerivedSemanticTokens {
     pub context: RequestContext,
     pub tokens: Vec<WireSemanticToken>,
+    pub queue_wait_ns: u64,
+    pub compute_ns: u64,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -1129,9 +1131,19 @@ impl DocumentReplica {
         })
     }
 
+    #[cfg(test)]
     fn derive_semantic_tokens(
         &mut self,
         request: DeriveSemanticTokens,
+    ) -> Result<DerivedSemanticTokens, String> {
+        self.derive_semantic_tokens_with_telemetry(request, Duration::ZERO, Instant::now())
+    }
+
+    fn derive_semantic_tokens_with_telemetry(
+        &mut self,
+        request: DeriveSemanticTokens,
+        queue_wait: Duration,
+        started: Instant,
     ) -> Result<DerivedSemanticTokens, String> {
         self.validate_read_identity(&request.context)?;
         worker_analysis(
@@ -1183,6 +1195,8 @@ impl DocumentReplica {
         Ok(DerivedSemanticTokens {
             context: request.context,
             tokens,
+            queue_wait_ns: duration_ns(queue_wait),
+            compute_ns: duration_ns(started.elapsed()),
         })
     }
 
@@ -2396,7 +2410,9 @@ fn handle_work(
         Request::RunNodeScalar(request) => run_node_scalar(request, documents),
         Request::DeriveSelectionRanges(request) => derive_selection_ranges(request, documents),
         Request::DeriveInjectionRegions(request) => derive_injection_regions(request, documents),
-        Request::DeriveSemanticTokens(request) => derive_semantic_tokens(request, documents),
+        Request::DeriveSemanticTokens(request) => {
+            derive_semantic_tokens(request, documents, queue_wait, started)
+        }
         Request::RunCaptures(request) => run_captures(request, documents),
         Request::DeriveNativeBindings(request) => derive_native_bindings(request, documents),
         Request::ConfigureLanguages(request) => configure_languages(request, analysis),
@@ -2571,7 +2587,12 @@ fn derive_injection_regions(
     }
 }
 
-fn derive_semantic_tokens(request: DeriveSemanticTokens, documents: &DocumentStore) -> Response {
+fn derive_semantic_tokens(
+    request: DeriveSemanticTokens,
+    documents: &DocumentStore,
+    queue_wait: Duration,
+    started: Instant,
+) -> Response {
     let context = request.context.clone();
     let Some(replica) = documents
         .get(&DocumentKey::from(&context))
@@ -2583,13 +2604,15 @@ fn derive_semantic_tokens(request: DeriveSemanticTokens, documents: &DocumentSto
         });
     };
     match replica.lock() {
-        Ok(mut replica) => match replica.derive_semantic_tokens(request) {
-            Ok(result) => Response::SemanticTokens(result),
-            Err(message) => Response::Error(WorkerError {
-                context: Some(context),
-                message,
-            }),
-        },
+        Ok(mut replica) => {
+            match replica.derive_semantic_tokens_with_telemetry(request, queue_wait, started) {
+                Ok(result) => Response::SemanticTokens(result),
+                Err(message) => Response::Error(WorkerError {
+                    context: Some(context),
+                    message,
+                }),
+            }
+        }
         Err(_) => poisoned_document_restart(context),
     }
 }
@@ -5037,6 +5060,8 @@ mod tests {
         assert_eq!(result.tokens.len(), 1);
         assert_eq!(result.tokens[0].delta_start, 3);
         assert_eq!(result.tokens[0].length, 4);
+        assert!(result.compute_ns > 0);
+        assert_eq!(result.queue_wait_ns, 0);
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -356,6 +356,7 @@ pub struct DerivedSemanticTokens {
     pub tokens: Vec<WireSemanticToken>,
     pub queue_wait_ns: u64,
     pub compute_ns: u64,
+    pub cache_hit: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -583,6 +584,7 @@ struct DocumentReplica {
     captures_match_cache: crate::lsp::lsp_impl::kakehashi::captures_match_cache::CapturesMatchCache,
     injection_token_cache: Arc<crate::analysis::InjectionTokenCache>,
     injection_cache_edits: u8,
+    cached_semantic_tokens: Option<(u64, bool, Arc<Vec<WireSemanticToken>>)>,
     semantic_discovery: Option<Arc<crate::document::DiscoveredInjections>>,
     resolved_injections: Option<(u64, Arc<Vec<crate::language::injection::ResolvedInjection>>)>,
     injection_layers: Vec<CachedInjectionLayer>,
@@ -654,6 +656,7 @@ impl DocumentReplica {
                 captures_match_cache: Default::default(),
                 injection_token_cache: Arc::new(crate::analysis::InjectionTokenCache::new()),
                 injection_cache_edits: 0,
+                cached_semantic_tokens: None,
                 semantic_discovery: None,
                 resolved_injections: None,
                 injection_layers: Vec::new(),
@@ -730,6 +733,7 @@ impl DocumentReplica {
         self.node_tracker
             .apply_input_edits(&self.uri, &tracker_edits);
         self.context = request.context;
+        self.cached_semantic_tokens = None;
         Ok(DocumentAck {
             context: self.context.clone(),
             incremental: true,
@@ -1146,6 +1150,18 @@ impl DocumentReplica {
         started: Instant,
     ) -> Result<DerivedSemanticTokens, String> {
         self.validate_read_identity(&request.context)?;
+        if let Some((generation, supports_multiline, tokens)) = &self.cached_semantic_tokens
+            && *generation == request.context.configuration_generation
+            && *supports_multiline == request.supports_multiline
+        {
+            return Ok(DerivedSemanticTokens {
+                context: request.context,
+                tokens: tokens.as_ref().clone(),
+                queue_wait_ns: duration_ns(queue_wait),
+                compute_ns: duration_ns(started.elapsed()),
+                cache_hit: true,
+            });
+        }
         worker_analysis(
             &self.analysis,
             &self.language,
@@ -1179,7 +1195,7 @@ impl DocumentReplica {
             None,
         )
         .ok_or_else(|| "worker semantic token derivation was cancelled".to_string())?;
-        let tokens = match result {
+        let tokens: Vec<WireSemanticToken> = match result {
             tower_lsp_server::ls_types::SemanticTokensResult::Tokens(tokens) => tokens.data,
             tower_lsp_server::ls_types::SemanticTokensResult::Partial(partial) => partial.data,
         }
@@ -1192,11 +1208,17 @@ impl DocumentReplica {
             token_modifiers_bitset: token.token_modifiers_bitset,
         })
         .collect();
+        self.cached_semantic_tokens = Some((
+            request.context.configuration_generation,
+            request.supports_multiline,
+            Arc::new(tokens.clone()),
+        ));
         Ok(DerivedSemanticTokens {
             context: request.context,
             tokens,
             queue_wait_ns: duration_ns(queue_wait),
             compute_ns: duration_ns(started.elapsed()),
+            cache_hit: false,
         })
     }
 
@@ -5062,6 +5084,25 @@ mod tests {
         assert_eq!(result.tokens[0].length, 4);
         assert!(result.compute_ns > 0);
         assert_eq!(result.queue_wait_ns, 0);
+        assert!(!result.cache_hit);
+
+        let cached = replica
+            .derive_semantic_tokens(DeriveSemanticTokens {
+                context: RequestContext {
+                    request_id: 2,
+                    worker_generation: 3,
+                    uri: "file:///semantic.rs".into(),
+                    incarnation: 4,
+                    content_version: 1,
+                    configuration_generation: 2,
+                },
+                supports_multiline: false,
+            })
+            .unwrap();
+        assert!(
+            cached.cache_hit,
+            "same-version semantic requests should reuse worker facts"
+        );
     }
 
     #[test]

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -306,6 +306,10 @@ fn authoritative_worker_serves_injected_node_accessors() {
 
     let stderr = shutdown_and_stderr(client);
     assert!(stderr.contains("Authoritative tree worker"), "{stderr}");
+    assert!(
+        stderr.contains("authoritative worker owns didOpen parsing"),
+        "authoritative didOpen must not create a parent-owned tree: {stderr}"
+    );
     assert!(!stderr.contains("node mismatch"), "{stderr}");
 }
 


### PR DESCRIPTION
## Summary

- move authoritative didOpen parsing and install recovery into the resident worker while keeping the parent document tree-less
- preserve worker document replicas across true incremental edits instead of accidentally full-syncing every advancing version
- reuse exact current-version semantic facts, skip empty injection derivation, and acknowledge authoritative edits without shadow snapshots
- expose semantic queue, compute, and cache telemetry and record paired Stage 8 measurements

## Stack

- Depends on #870
- Advances the ownership and performance stage from ADR #862
- Remains draft because authoritative grammar/query metadata loading still starts in the parent and the performance, failure, protocol, compatibility, and memory gates are not complete

## Measurement

Release benchmark, same Stage 8 binary, 40 iterations after 10 warmups:

| workload | legacy | authoritative 4 threads |
| --- | ---: | ---: |
| markdown full | 0.270 ms | 0.303 ms |
| large Rust edit delta | 25.326 ms | 39.016 ms |
| markdown edit delta | 6.853 ms | 7.542 ms |
| markdown cold open + first token | 21.832 ms | 27.590 ms |
| large Rust cold open + first token | 527.047 ms | 554.410 ms |

Stage 8 improves the Stage 7 large Rust edit median from 64.686 ms to 39.016 ms after fixing the replica identity check, but it still fails the paired legacy non-regression gate. Exact-version worker cache hits reach 0.635 ms at p25. Telemetry shows semantic computation around 19-25 ms while uncontended queue wait is only 6-12 microseconds, so the evidence does not justify more workers.

## Validation

- cargo test --lib: 3115 passed, 2 ignored
- cargo test --features e2e --test tree_worker_process -- --test-threads=1: 4 passed
- cargo test --features e2e --test e2e_tree_worker_shadow -- --test-threads=1: 33 passed
- cargo fmt --check
- cargo check --lib
- git diff --check

## Rollback

Select legacy mode to restore the complete in-process path. The authoritative and shadow paths retain strict document incarnation, content version, configuration generation, and worker generation fences.