### PR TITLE
feat(worker): move native loading behind worker boundary

### DIFF
--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage9-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage9-measurement.md
@@ -1,0 +1,97 @@
+# Single Tree Worker Stage 9 Native-Loading Measurement
+
+## Scope
+
+Stage 9 moves dynamic grammar loading and tolerant query compilation out of the
+authoritative parent. The parent resolves immutable parser artifacts and raw
+query text as data; the worker alone loads `tree_sitter::Language`, compiles
+queries, owns parser registries, and serves tree-dependent readers.
+
+Search-path parser filenames populate the worker catalog without `dlopen` in
+the parent. This preserves injected-language discovery when the parent registry
+is intentionally empty.
+
+## Method
+
+The same release Stage 9 binary was run in both modes on macOS:
+
+```text
+iterations = 40
+warmup = 10
+legacy = KAKEHASHI_TREE_WORKER_MODE unset
+worker = authoritative, KAKEHASHI_TREE_WORKER_THREADS=4
+```
+
+The semantic-token E2E contract was strengthened to require non-empty full and
+range results in authoritative mode. This matters because an intermediate
+build returned empty tokens in approximately 0.7 ms after mistaking the absent
+parent query for an unsupported language. Those invalid measurements are not
+included below.
+
+## Results
+
+Lower is better. These are paired medians from the final correctness-preserving
+Stage 9 binary.
+
+| Scenario | Legacy | Authoritative worker | Change |
+|---|---:|---:|---:|
+| Markdown, 60 injections, full | 0.266 ms | 0.237 ms | -11% |
+| Markdown, 60 injections, edit + delta | 7.604 ms | 7.150 ms | -6% |
+| Large Rust, edit + delta | 30.779 ms | 39.265 ms | +28% |
+| Markdown, 150 injections, cold open + first token | 22.675 ms | 33.679 ms | +49% |
+| Large Rust, cold open + first token | 548.209 ms | 597.798 ms | +9% |
+
+The large Rust authoritative edit distribution remains bimodal: p25 was
+1.302 ms and p75 was 41.547 ms. Resident exact-version reuse is faster than
+legacy, but cache misses still determine the median.
+
+## Findings
+
+### One fixed worker can improve real workloads
+
+The authoritative worker beats the paired legacy mode for both measured
+injection-heavy steady-state workloads. This is the first end-to-end evidence
+in the stack that one fixed worker with internal threads can improve user-facing
+latency rather than merely isolate crashes or win a synthetic cache-hit case.
+
+The result does not justify more workers. Stage 8 telemetry showed that queue
+wait was normally measured in microseconds while per-document semantic miss
+computation took tens of milliseconds.
+
+### Ownership and availability are different states
+
+Removing parent parser registration initially broke host-language detection and
+injected parser discovery. A language remains available when the worker has a
+resolvable artifact even though no parent `Language` exists. Separating that
+capability check from parent-loaded state lets every authoritative reader keep
+the existing detection contract without reintroducing native ownership.
+
+### Raw and compiled query identities must both be cached
+
+The worker receives raw query text so tolerant compilation can happen inside
+the crash boundary. Invalid patterns make the compiled source differ from the
+raw input. Comparing the next raw request only with compiled source caused a
+tolerant recompile on every semantic request: large Rust edit rose to
+101.229 ms and Markdown edit to 17.398 ms.
+
+The worker now records raw input identity separately from the filtered compiled
+source. Reusing that compilation restored large Rust edit to 39.265 ms and
+Markdown edit to 7.150 ms.
+
+### Cold and serial miss paths remain the acceptance blocker
+
+Worker-authoritative cold open is still slower, especially for
+injection-heavy Markdown. Large Rust edit misses also remain slower than
+legacy despite very fast cache-hit samples. The overall performance
+non-regression gate therefore remains open.
+
+## Decision
+
+Keep one worker and its internal thread pool. Stage 9 completes the guarded
+native loading ownership boundary and demonstrates measured steady-state wins,
+but it does not establish a universal performance win or change the ADR from
+`proposed`.
+
+Next work should target lazy catalog/parser/query preload, large semantic miss
+computation and transfer, then repeat cold, miss, memory, failure-injection,
+protocol, and compatibility gates before removing the legacy implementation.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1145,6 +1145,13 @@ the paired legacy mode remains faster in every measured end-to-end scenario.
 Queue wait is not the dominant miss cost, so the result supports keeping one
 worker while rejecting an overall performance-win claim.
 
+The [Stage 9 native-loading measurement](single-resident-multithreaded-tree-worker-stage9-measurement.md)
+moves dynamic grammar loading and tolerant query compilation fully behind the
+worker boundary. One fixed worker is measurably faster than legacy for the two
+injection-heavy steady-state workloads, while large serial misses and cold open
+remain slower. The mixed result confirms performance potential without passing
+the general non-regression gate or justifying worker sharding.
+
 The implementation should proceed in measured stages:
 
 1. Prototype the framed transport, supervision, and one high-level

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -109,6 +109,7 @@ pub(crate) struct LanguageCoordinator {
     worker_artifact_dir: Option<tempfile::TempDir>,
     worker_settings: RwLock<Arc<WorkspaceSettings>>,
     worker_settings_epoch: std::sync::atomic::AtomicU64,
+    worker_owns_native: std::sync::atomic::AtomicBool,
     /// Single-flight marker for [`ensure_language_loaded_async`](Self::ensure_language_loaded_async):
     /// a language with an in-flight first load has an entry here, so a
     /// concurrent request for the same language parks on the winner's
@@ -178,6 +179,7 @@ impl LanguageCoordinator {
                 .ok(),
             worker_settings: RwLock::new(Arc::new(WorkspaceSettings::default())),
             worker_settings_epoch: std::sync::atomic::AtomicU64::new(0),
+            worker_owns_native: std::sync::atomic::AtomicBool::new(false),
             config_warnings: RwLock::new(Vec::new()),
             load_inflight: dashmap::DashMap::new(),
         }
@@ -188,6 +190,16 @@ impl LanguageCoordinator {
     /// Visibility: pub(crate) - called by LSP layer (semantic_tokens, selection_range)
     /// and analysis modules to ensure parsers are available before use.
     pub(crate) fn ensure_language_loaded(&self, language_id: &str) -> LanguageLoadResult {
+        if self
+            .worker_owns_native
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return if self.worker_grammar_descriptor(language_id).is_some() {
+                LanguageLoadResult::success_with(Vec::new())
+            } else {
+                LanguageLoadResult::default()
+            };
+        }
         loop {
             let current_generation = self
                 .load_generation
@@ -296,6 +308,16 @@ impl LanguageCoordinator {
         self: &Arc<Self>,
         language_id: &str,
     ) -> LanguageLoadResult {
+        if self
+            .worker_owns_native
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return if self.worker_grammar_descriptor(language_id).is_some() {
+                LanguageLoadResult::success_with(Vec::new())
+            } else {
+                LanguageLoadResult::default()
+            };
+        }
         loop {
             let current_generation = self
                 .load_generation
@@ -440,6 +462,8 @@ impl LanguageCoordinator {
             .settings_reload_lock
             .lock()
             .recover_poison("LanguageCoordinator::load_settings(reload)");
+        self.worker_owns_native
+            .store(false, std::sync::atomic::Ordering::Release);
         self.worker_settings_epoch
             .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
         *self
@@ -519,6 +543,46 @@ impl LanguageCoordinator {
         self.worker_settings_epoch
             .fetch_add(1, std::sync::atomic::Ordering::Release);
         summary
+    }
+
+    /// Apply language settings while leaving every native parser and compiled
+    /// query exclusively owned by the isolated tree worker.
+    pub(crate) fn load_worker_owned_settings(
+        &self,
+        settings: &WorkspaceSettings,
+    ) -> LanguageLoadSummary {
+        let _reload = self
+            .settings_reload_lock
+            .lock()
+            .recover_poison("LanguageCoordinator::load_worker_owned_settings(reload)");
+        self.worker_owns_native
+            .store(true, std::sync::atomic::Ordering::Release);
+        self.worker_settings_epoch
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        *self
+            .worker_settings
+            .write()
+            .recover_poison("LanguageCoordinator::load_worker_owned_settings(worker_settings)") =
+            Arc::new(settings.clone());
+        self.config_store.update_from_settings(settings);
+        self.clear_derived_languages();
+        {
+            let _registration = self
+                .registration_lock
+                .lock()
+                .recover_poison("LanguageCoordinator::load_worker_owned_settings(generation)");
+            self.load_generation
+                .fetch_add(1, std::sync::atomic::Ordering::Release);
+        }
+        self.failed_loads.clear();
+        self.configured_load_failures.clear();
+        self.build_base_map(&settings.languages);
+        self.worker_settings_epoch
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
+        LanguageLoadSummary {
+            events: self.config_warning_events(),
+            ..LanguageLoadSummary::default()
+        }
     }
 
     /// Load a derived language by copying parser and queries from its base.
@@ -1265,6 +1329,12 @@ impl LanguageCoordinator {
     /// Visibility: pub(crate) - called by LSP layer (lsp_impl) to check parser
     /// availability before attempting language operations.
     pub(crate) fn has_parser_available(&self, language_name: &str) -> bool {
+        if self
+            .worker_owns_native
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return self.worker_grammar_descriptor(language_name).is_some();
+        }
         let generation = self
             .load_generation
             .load(std::sync::atomic::Ordering::Acquire);
@@ -1950,22 +2020,96 @@ impl LanguageCoordinator {
             parser_path: artifact.path,
             grammar_symbol,
             artifact_digest: artifact.digest,
-            queries: crate::tree_worker::WorkerQuerySources {
-                highlights: self
-                    .query_store
-                    .query_source(QueryKind::Highlights, language_id)
-                    .map(|source| source.to_string()),
-                bindings: self
-                    .query_store
-                    .query_source(QueryKind::Bindings, language_id)
-                    .map(|source| source.to_string()),
-                injections: self
-                    .query_store
-                    .query_source(QueryKind::Injections, language_id)
-                    .map(|source| source.to_string()),
-            },
+            queries: self.worker_query_sources(&settings, language_id),
             configuration_generation,
         })
+    }
+
+    fn worker_query_sources(
+        &self,
+        settings: &WorkspaceSettings,
+        language_id: &str,
+    ) -> crate::tree_worker::WorkerQuerySources {
+        self.worker_query_sources_inner(settings, language_id, &mut HashSet::new())
+    }
+
+    fn worker_query_sources_inner(
+        &self,
+        settings: &WorkspaceSettings,
+        language_id: &str,
+        visiting: &mut HashSet<String>,
+    ) -> crate::tree_worker::WorkerQuerySources {
+        if !visiting.insert(language_id.to_string()) {
+            return crate::tree_worker::WorkerQuerySources::default();
+        }
+        let configured = settings.languages.get(language_id);
+        let sources = match configured.and_then(|config| config.queries.as_ref()) {
+            Some(queries) => {
+                let source_for = |kind| {
+                    let paths = queries
+                        .iter()
+                        .filter(|query| {
+                            query.kind.or_else(|| infer_query_kind(&query.path)) == Some(kind)
+                        })
+                        .map(|query| query.path.as_str())
+                        .collect::<Vec<_>>();
+                    if paths.is_empty() {
+                        None
+                    } else {
+                        QueryLoader::load_query_source_from_paths(&paths).ok()
+                    }
+                };
+                crate::tree_worker::WorkerQuerySources {
+                    highlights: source_for(QueryKind::Highlights),
+                    bindings: source_for(QueryKind::Bindings),
+                    injections: source_for(QueryKind::Injections),
+                }
+            }
+            None if configured
+                .and_then(|config| config.base.as_deref())
+                .is_some() =>
+            {
+                let base = configured
+                    .and_then(|config| config.base.as_deref())
+                    .expect("base checked above");
+                self.worker_query_sources_inner(settings, base, visiting)
+            }
+            None => {
+                let search_paths = self.config_store.search_paths();
+                let source_for = |kind: QueryKind| {
+                    QueryLoader::load_query_source_with_inheritance(
+                        &search_paths,
+                        language_id,
+                        kind.filename(),
+                    )
+                    .ok()
+                };
+                crate::tree_worker::WorkerQuerySources {
+                    highlights: source_for(QueryKind::Highlights),
+                    bindings: source_for(QueryKind::Bindings),
+                    injections: source_for(QueryKind::Injections),
+                }
+            }
+        };
+        visiting.remove(language_id);
+
+        crate::tree_worker::WorkerQuerySources {
+            highlights: self
+                .query_store
+                .query_source(QueryKind::Highlights, language_id)
+                .map(|source| source.to_string())
+                .or(sources.highlights),
+            bindings: self
+                .query_store
+                .query_source(QueryKind::Bindings, language_id)
+                .map(|source| source.to_string())
+                .or(sources.bindings),
+            injections: self
+                .query_store
+                .query_source(QueryKind::Injections, language_id)
+                .map(|source| source.to_string())
+                .or(sources.injections),
+        }
     }
 
     /// Snapshot every configured language into immutable worker-owned assets.
@@ -1982,6 +2126,9 @@ impl LanguageCoordinator {
             .cloned()
             .collect::<Vec<_>>();
         language_ids.extend(self.language_registry.language_ids());
+        language_ids.extend(QueryLoader::discover_parser_languages(
+            &self.config_store.search_paths(),
+        ));
         language_ids.sort();
         language_ids.dedup();
         let assets = language_ids
@@ -2173,6 +2320,42 @@ mod tests {
         assert_ne!(replaced.artifact_digest, descriptor.artifact_digest);
         assert_ne!(replaced.parser_path, descriptor.parser_path);
         assert_eq!(fs::read(&replaced.parser_path).unwrap(), b"parser-v2");
+    }
+
+    #[test]
+    fn worker_owned_settings_resolve_assets_without_parent_native_loading() {
+        let coordinator = LanguageCoordinator::new();
+        let directory = tempdir().unwrap();
+        let parser_path = directory.path().join("tree-sitter-rust.so");
+        let query_path = directory.path().join("rust-highlights.scm");
+        fs::write(&parser_path, b"worker-only-parser").unwrap();
+        fs::write(&query_path, "(identifier) @variable\n").unwrap();
+        let settings = WorkspaceSettings {
+            languages: HashMap::from([(
+                "rust".to_string(),
+                LanguageSettings {
+                    parser: Some(parser_path.to_string_lossy().into_owned()),
+                    queries: Some(vec![crate::config::settings::QueryItem {
+                        path: query_path.to_string_lossy().into_owned(),
+                        kind: Some(QueryKind::Highlights),
+                    }]),
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        };
+
+        let summary = coordinator.load_worker_owned_settings(&settings);
+        let descriptor = coordinator.worker_grammar_descriptor("rust").unwrap();
+
+        assert!(summary.loaded.is_empty());
+        assert!(coordinator.ensure_language_loaded("rust").success);
+        assert!(!coordinator.language_registry.contains("rust"));
+        assert!(coordinator.highlight_query("rust").is_none());
+        assert_eq!(
+            descriptor.queries.highlights.as_deref(),
+            Some("(identifier) @variable\n\n")
+        );
     }
 
     /// Pins the #575 single-flight fix: a caller that arrives while another

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -387,6 +387,32 @@ impl QueryLoader {
         Ok(Self::parse_query(language, &query_str, used_inheritance))
     }
 
+    /// Resolve a search-path query into source without loading a native
+    /// grammar. The isolated worker compiles this source against its own
+    /// `Language`, so the parent can remain free of parser/query ownership.
+    pub(crate) fn load_query_source_with_inheritance<P: AsRef<Path>>(
+        runtime_bases: &[P],
+        lang_name: &str,
+        file_name: &str,
+    ) -> LspResult<String> {
+        let original_content = Self::load_query_file(runtime_bases, lang_name, file_name)?;
+        let mut visited = std::collections::HashSet::new();
+        Self::resolve_query_recursive(
+            runtime_bases,
+            lang_name,
+            file_name,
+            Some(original_content),
+            &mut visited,
+        )
+    }
+
+    /// Combine explicit query files without loading a native grammar.
+    pub(crate) fn load_query_source_from_paths<P: AsRef<Path>>(
+        paths: &[P],
+    ) -> LspResult<String> {
+        Self::load_content_from_paths(paths)
+    }
+
     /// Resolve library path for a language.
     ///
     /// An explicit `library` is normalized and returned as-is; otherwise searches
@@ -468,6 +494,46 @@ mod tests {
         let result = QueryLoader::load_content_from_paths(&paths).unwrap();
         assert!(result.contains("(identifier) @variable"));
         assert!(result.contains("(string) @string"));
+    }
+
+    #[test]
+    fn worker_source_loading_resolves_inheritance_without_a_language() {
+        let dir = tempdir().unwrap();
+        let base = dir.path().join("queries/base");
+        let child = dir.path().join("queries/child");
+        fs::create_dir_all(&base).unwrap();
+        fs::create_dir_all(&child).unwrap();
+        fs::write(base.join("highlights.scm"), "(identifier) @base\n").unwrap();
+        fs::write(
+            child.join("highlights.scm"),
+            "; inherits: base\n(string_literal) @child\n",
+        )
+        .unwrap();
+
+        let source = QueryLoader::load_query_source_with_inheritance(
+            &[dir.path()],
+            "child",
+            "highlights.scm",
+        )
+        .unwrap();
+
+        assert!(source.contains("(identifier) @base"));
+        assert!(source.contains("(string_literal) @child"));
+        assert!(!source.contains("inherits:"));
+    }
+
+    #[test]
+    fn worker_source_loading_combines_explicit_paths_without_a_language() {
+        let dir = tempdir().unwrap();
+        let first = dir.path().join("first.scm");
+        let second = dir.path().join("second.scm");
+        fs::write(&first, "(identifier) @first").unwrap();
+        fs::write(&second, "(string_literal) @second").unwrap();
+
+        let source = QueryLoader::load_query_source_from_paths(&[first, second]).unwrap();
+
+        assert!(source.contains("(identifier) @first"));
+        assert!(source.contains("(string_literal) @second"));
     }
 
     #[test]

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -407,10 +407,37 @@ impl QueryLoader {
     }
 
     /// Combine explicit query files without loading a native grammar.
-    pub(crate) fn load_query_source_from_paths<P: AsRef<Path>>(
-        paths: &[P],
-    ) -> LspResult<String> {
+    pub(crate) fn load_query_source_from_paths<P: AsRef<Path>>(paths: &[P]) -> LspResult<String> {
         Self::load_content_from_paths(paths)
+    }
+
+    /// Discover parser identities from filenames only. This deliberately does
+    /// not open or load a dynamic library; the worker validates and loads the
+    /// content-addressed artifact later.
+    pub(crate) fn discover_parser_languages<P: AsRef<Path>>(runtime_bases: &[P]) -> Vec<String> {
+        let mut languages = Vec::new();
+        for base in runtime_bases {
+            let Ok(entries) = fs::read_dir(base.as_ref().join("parser")) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if !path.is_file()
+                    || !path
+                        .extension()
+                        .and_then(|extension| extension.to_str())
+                        .is_some_and(|extension| PARSER_EXTENSIONS.contains(&extension))
+                {
+                    continue;
+                }
+                if let Some(language) = path.file_stem().and_then(|stem| stem.to_str()) {
+                    languages.push(language.to_string());
+                }
+            }
+        }
+        languages.sort();
+        languages.dedup();
+        languages
     }
 
     /// Resolve library path for a language.
@@ -534,6 +561,20 @@ mod tests {
 
         assert!(source.contains("(identifier) @first"));
         assert!(source.contains("(string_literal) @second"));
+    }
+
+    #[test]
+    fn worker_asset_discovery_lists_parser_files_without_loading_them() {
+        let dir = tempdir().unwrap();
+        let parser_dir = dir.path().join("parser");
+        fs::create_dir_all(&parser_dir).unwrap();
+        fs::write(parser_dir.join("rust.dylib"), b"not-a-library").unwrap();
+        fs::write(parser_dir.join("python.so"), b"not-a-library").unwrap();
+        fs::write(parser_dir.join("README.md"), b"ignored").unwrap();
+
+        let languages = QueryLoader::discover_parser_languages(&[dir.path()]);
+
+        assert_eq!(languages, vec!["python", "rust"]);
     }
 
     #[test]

--- a/src/language/query_store.rs
+++ b/src/language/query_store.rs
@@ -10,6 +10,7 @@ pub(crate) struct QueryStore {
     bindings_queries: RwLock<HashMap<String, Arc<Query>>>,
     injection_queries: RwLock<HashMap<String, Arc<Query>>>,
     query_sources: RwLock<HashMap<(String, QueryKind), Arc<str>>>,
+    query_inputs: RwLock<HashMap<(String, QueryKind), Arc<str>>>,
 }
 
 impl QueryStore {
@@ -19,6 +20,7 @@ impl QueryStore {
             bindings_queries: RwLock::new(HashMap::new()),
             injection_queries: RwLock::new(HashMap::new()),
             query_sources: RwLock::new(HashMap::new()),
+            query_inputs: RwLock::new(HashMap::new()),
         }
     }
 
@@ -38,6 +40,10 @@ impl QueryStore {
             .recover_poison(format_args!("QueryStore::remove_queries({})", lang_name))
             .remove(lang_name);
         self.query_sources
+            .write()
+            .recover_poison(format_args!("QueryStore::remove_queries({})", lang_name))
+            .retain(|(language, _), _| language != lang_name);
+        self.query_inputs
             .write()
             .recover_poison(format_args!("QueryStore::remove_queries({})", lang_name))
             .retain(|(language, _), _| language != lang_name);
@@ -121,19 +127,44 @@ impl QueryStore {
         query: Arc<Query>,
         source: String,
     ) {
+        self.insert_query_with_source_input(kind, lang_name, query, source.clone(), source);
+    }
+
+    pub(crate) fn insert_query_with_source_input(
+        &self,
+        kind: QueryKind,
+        lang_name: String,
+        query: Arc<Query>,
+        source: String,
+        input: String,
+    ) {
         self.insert_query(kind, lang_name.clone(), query);
         self.query_sources
             .write()
             .recover_poison(format_args!(
                 "QueryStore::insert_query_with_source({lang_name})"
             ))
-            .insert((lang_name, kind), Arc::from(source));
+            .insert((lang_name.clone(), kind), Arc::from(source));
+        self.query_inputs
+            .write()
+            .recover_poison(format_args!(
+                "QueryStore::insert_query_with_source_input({lang_name})"
+            ))
+            .insert((lang_name, kind), Arc::from(input));
     }
 
     pub(crate) fn query_source(&self, kind: QueryKind, lang_name: &str) -> Option<Arc<str>> {
         self.query_sources
             .read()
             .recover_poison(format_args!("QueryStore::query_source({lang_name})"))
+            .get(&(lang_name.to_string(), kind))
+            .cloned()
+    }
+
+    pub(crate) fn query_input(&self, kind: QueryKind, lang_name: &str) -> Option<Arc<str>> {
+        self.query_inputs
+            .read()
+            .recover_poison(format_args!("QueryStore::query_input({lang_name})"))
             .get(&(lang_name.to_string(), kind))
             .cloned()
     }

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -103,6 +103,7 @@ pub(super) struct ReloadLanguageState<'a> {
     language: &'a LanguageCoordinator,
     parser_pool: &'a std::sync::Mutex<DocumentParserPool>,
     documents: &'a DocumentStore,
+    worker_owns_native: bool,
     invalidate_documents: bool,
     request_semantic_refresh: bool,
 }
@@ -203,7 +204,13 @@ pub(super) async fn apply_shared_settings_locked(
     crate::analysis::semantic::invalidate_thread_local_parser_caches();
     let parser_reload =
         ParserReloadGuard::begin(language_state.parser_pool, language_state.language);
-    let mut summary = language_state.language.load_settings(&settings);
+    let mut summary = if language_state.worker_owns_native {
+        language_state
+            .language
+            .load_worker_owned_settings(&settings)
+    } else {
+        language_state.language.load_settings(&settings)
+    };
     let reparse_uris = if language_state.invalidate_documents {
         language_state.documents.invalidate_all_parses()
     } else {
@@ -559,6 +566,7 @@ impl Kakehashi {
                 language: &self.language,
                 parser_pool: &self.parser_pool,
                 documents: &self.documents,
+                worker_owns_native: self.tree_worker_shadow.is_authoritative(),
                 invalidate_documents: true,
                 request_semantic_refresh: true,
             },
@@ -623,6 +631,7 @@ impl Kakehashi {
                 language: &self.language,
                 parser_pool: &self.parser_pool,
                 documents: &self.documents,
+                worker_owns_native: self.tree_worker_shadow.is_authoritative(),
                 invalidate_documents: false,
                 request_semantic_refresh: false,
             },
@@ -635,6 +644,7 @@ impl Kakehashi {
         .await
         .into_iter()
         .for_each(|uri| self.schedule_reparse(uri, None));
+        self.refresh_tree_worker_documents(&[]);
         self.warn_on_misconfigured_settings(&warnings).await;
     }
 

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -212,7 +212,9 @@ impl InjectionCoordinator {
             return false;
         };
         let injections = if should_query_worker_injections(
-            self.language.injection_query(&host_language).is_some(),
+            self.language
+                .worker_grammar_descriptor(&host_language)
+                .is_some_and(|grammar| grammar.queries.injections.is_some()),
         ) {
             let generation = self.language.configuration_generation();
             let Some(regions) = self
@@ -493,7 +495,11 @@ impl InjectionCoordinator {
                 .documents
                 .get(uri)
                 .map(|document| (document.incarnation(), document.content_version()))?;
-            if self.language.injection_query(&host_language).is_none() {
+            if self
+                .language
+                .worker_grammar_descriptor(&host_language)
+                .is_none_or(|grammar| grammar.queries.injections.is_none())
+            {
                 return Some((host_language, Vec::new()));
             }
             let regions = self

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -404,6 +404,7 @@ impl InstallCoordinator {
                 language: &self.language,
                 parser_pool: &self.parser_pool,
                 documents: &self.documents,
+                worker_owns_native: self.tree_worker_shadow.is_authoritative(),
                 invalidate_documents: false,
                 request_semantic_refresh: true,
             },

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -411,13 +411,14 @@ impl Kakehashi {
             return Ok(None);
         }
 
-        let Some(query) = self.language.highlight_query(&language_name) else {
+        let query = self.language.highlight_query(&language_name);
+        if query.is_none() && !self.tree_worker_shadow.is_authoritative() {
             self.cache.finish_request(&uri, request_id);
             return Ok(Some(SemanticTokensResult::Tokens(SemanticTokens {
                 result_id: None,
                 data: vec![],
             })));
-        };
+        }
 
         // Read the remaining settings-dependent tokenization inputs HERE —
         // together with the query above, with no `.await` in between — so a
@@ -555,7 +556,7 @@ impl Kakehashi {
                     text.clone(),
                     tree.clone()
                         .expect("legacy semantic token computation requires a parse tree"),
-                    query,
+                    query.expect("legacy semantic token computation requires a compiled query"),
                     Some(language_name.clone()),
                     Some(capture_mappings),
                     coordinator,
@@ -860,7 +861,8 @@ impl Kakehashi {
             return Ok(None);
         }
 
-        let Some(query) = self.language.highlight_query(&language_name) else {
+        let query = self.language.highlight_query(&language_name);
+        if query.is_none() && !self.tree_worker_shadow.is_authoritative() {
             self.cache.finish_request(&uri, request_id);
             return Ok(Some(SemanticTokensFullDeltaResult::Tokens(
                 SemanticTokens {
@@ -868,7 +870,7 @@ impl Kakehashi {
                     data: vec![],
                 },
             )));
-        };
+        }
 
         // Read the remaining settings-dependent tokenization inputs HERE — with
         // the query above, no `.await` in between — so a settings reload can't
@@ -1011,7 +1013,7 @@ impl Kakehashi {
                         text.clone(),
                         tree.clone()
                             .expect("legacy semantic token computation requires a parse tree"),
-                        query,
+                        query.expect("legacy semantic token computation requires a compiled query"),
                         Some(language_name.clone()),
                         Some(capture_mappings),
                         coordinator,
@@ -1302,8 +1304,7 @@ impl Kakehashi {
             incarnation: snapshot.incarnation,
             generation,
         };
-        let (Some(language_name), Some(tree)) = (snapshot.language.clone(), snapshot.tree.clone())
-        else {
+        let Some(language_name) = snapshot.language.clone() else {
             self.cache
                 .record_served_semantic_version(&uri, snapshot.parsed_version);
             return Ok(Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
@@ -1311,6 +1312,15 @@ impl Kakehashi {
                 data: vec![],
             })));
         };
+        let tree = snapshot.tree.clone();
+        if tree.is_none() && !self.tree_worker_shadow.is_authoritative() {
+            self.cache
+                .record_served_semantic_version(&uri, snapshot.parsed_version);
+            return Ok(Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
+                result_id: None,
+                data: vec![],
+            })));
+        }
         let text = std::sync::Arc::clone(&snapshot.text);
 
         let language_loaded = self
@@ -1337,14 +1347,15 @@ impl Kakehashi {
                 data: vec![],
             })));
         }
-        let Some(query) = self.language.highlight_query(&language_name) else {
+        let query = self.language.highlight_query(&language_name);
+        if query.is_none() && !self.tree_worker_shadow.is_authoritative() {
             self.cache
                 .record_served_semantic_version(&uri, snapshot.parsed_version);
             return Ok(Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
                 result_id: None,
                 data: vec![],
             })));
-        };
+        }
         drop(_edit_guard);
 
         // Short-circuit an identical-viewport re-request of an unchanged document
@@ -1427,8 +1438,8 @@ impl Kakehashi {
         let local = handle_semantic_tokens_full(
             &self.compute_pool,
             text,
-            tree,
-            query,
+            tree.expect("legacy semantic token computation requires a parse tree"),
+            query.expect("legacy semantic token computation requires a compiled query"),
             Some(language_name.clone()),
             Some(capture_mappings),
             coordinator,

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -1705,8 +1705,17 @@ impl TreeWorkerShadow {
 
     fn remember_catalog(&self, generation: u64, catalog: WorkerLanguageCatalog) {
         if catalog.assets.is_empty() {
+            log::debug!(
+                target: "kakehashi::tree_worker_shadow",
+                "ignored empty worker language catalog for generation {generation}",
+            );
             return;
         }
+        log::debug!(
+            target: "kakehashi::tree_worker_shadow",
+            "remembered {} worker language assets for generation {generation}",
+            catalog.assets.len(),
+        );
         let mut documents = self
             .open_documents
             .lock()

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -1686,6 +1686,13 @@ fn worker_analysis(
         let Some(source) = source else {
             continue;
         };
+        if analysis
+            .query_store()
+            .query_input(kind, language_name)
+            .is_some_and(|current| current.as_ref() == source)
+        {
+            continue;
+        }
         let parsed =
             crate::language::query_loader::QueryLoader::parse_query(&language, &source, false);
         if !parsed.skipped.is_empty() {
@@ -1707,11 +1714,12 @@ fn worker_analysis(
         {
             continue;
         }
-        analysis.query_store().insert_query_with_source(
+        analysis.query_store().insert_query_with_source_input(
             kind,
             language_name.to_string(),
             Arc::new(query),
             compiled_source,
+            source,
         );
     }
     Ok(())
@@ -4967,6 +4975,27 @@ mod tests {
         .unwrap();
 
         assert!(analysis.highlight_query("rust").is_some());
+        let first = analysis.highlight_query("rust").unwrap();
+        super::worker_analysis(
+            &analysis,
+            "rust",
+            tree_sitter_rust::LANGUAGE.into(),
+            WorkerQuerySources {
+                highlights: Some("(identifier) @variable\n(nonexistent_node) @invalid\n".into()),
+                ..WorkerQuerySources::default()
+            },
+            super::WorkerQuerySet::Semantic,
+        )
+        .unwrap();
+        let second = analysis.highlight_query("rust").unwrap();
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(
+            analysis
+                .query_store()
+                .query_input(crate::config::settings::QueryKind::Highlights, "rust")
+                .as_deref(),
+            Some("(identifier) @variable\n(nonexistent_node) @invalid\n")
+        );
         let compiled = analysis
             .query_store()
             .query_source(crate::config::settings::QueryKind::Highlights, "rust")

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -1686,20 +1686,32 @@ fn worker_analysis(
         let Some(source) = source else {
             continue;
         };
+        let parsed =
+            crate::language::query_loader::QueryLoader::parse_query(&language, &source, false);
+        if !parsed.skipped.is_empty() {
+            log::warn!(
+                target: "kakehashi::tree_worker",
+                "worker skipped {} invalid {} query pattern(s) for {}",
+                parsed.skipped.len(),
+                kind.name(),
+                language_name,
+            );
+        }
+        let (Some(query), Some(compiled_source)) = (parsed.query, parsed.compiled_source) else {
+            continue;
+        };
         if analysis
             .query_store()
             .query_source(kind, language_name)
-            .is_some_and(|current| current.as_ref() == source)
+            .is_some_and(|current| current.as_ref() == compiled_source)
         {
             continue;
         }
-        let query = tree_sitter::Query::new(&language, &source)
-            .map_err(|error| format!("worker query reconstruction failed: {error}"))?;
         analysis.query_store().insert_query_with_source(
             kind,
             language_name.to_string(),
             Arc::new(query),
-            source,
+            compiled_source,
         );
     }
     Ok(())
@@ -2699,6 +2711,7 @@ fn configure_languages(
         let key = GrammarKey::from_asset(&asset);
         let language_name = asset.language;
         let queries = asset.queries;
+        analysis.query_store().remove_queries(&language_name);
         let response = WORKER_THREAD_STATE.with(|state| {
             state
                 .borrow_mut()
@@ -4935,6 +4948,31 @@ mod tests {
             })
             .unwrap();
         assert!(out_of_bounds.nodes.is_empty());
+    }
+
+    #[test]
+    fn worker_query_compilation_preserves_tolerant_parent_semantics() {
+        let analysis = crate::language::LanguageCoordinator::new();
+
+        super::worker_analysis(
+            &analysis,
+            "rust",
+            tree_sitter_rust::LANGUAGE.into(),
+            WorkerQuerySources {
+                highlights: Some("(identifier) @variable\n(nonexistent_node) @invalid\n".into()),
+                ..WorkerQuerySources::default()
+            },
+            super::WorkerQuerySet::Semantic,
+        )
+        .unwrap();
+
+        assert!(analysis.highlight_query("rust").is_some());
+        let compiled = analysis
+            .query_store()
+            .query_source(crate::config::settings::QueryKind::Highlights, "rust")
+            .unwrap();
+        assert!(compiled.contains("(identifier) @variable"));
+        assert!(!compiled.contains("nonexistent_node"));
     }
 
     #[test]

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -251,7 +251,12 @@ fn authoritative_worker_serves_injected_node_accessors() {
         "textDocument/semanticTokens/full",
         json!({ "textDocument": { "uri": uri } }),
     );
-    assert!(semantic["result"]["data"].is_array(), "{semantic:?}");
+    assert!(
+        semantic["result"]["data"]
+            .as_array()
+            .is_some_and(|data| !data.is_empty()),
+        "{semantic:?}"
+    );
 
     client.send_notification(
         "textDocument/didChange",
@@ -303,7 +308,9 @@ fn authoritative_worker_serves_injected_node_accessors() {
         }),
     );
     assert!(
-        semantic_range["result"]["data"].is_array(),
+        semantic_range["result"]["data"]
+            .as_array()
+            .is_some_and(|data| !data.is_empty()),
         "{semantic_range:?}"
     );
 

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -226,7 +226,10 @@ fn authoritative_worker_serves_injected_node_accessors() {
         }),
     );
     let node = &node["result"];
-    let id = node["id"].as_str().expect("worker node must have an id");
+    let Some(id) = node["id"].as_str() else {
+        let stderr = shutdown_and_stderr(client);
+        panic!("worker node must have an id: {node:?}\n{stderr}");
+    };
     assert_eq!(node["kind"], "identifier");
 
     let text = client.send_request(


### PR DESCRIPTION
## Summary

- resolve immutable parser artifacts and raw query sources in the parent without loading a Tree-sitter Language
- discover search-path parser identities as data and load/compile the complete language catalog only inside the resident worker
- treat worker assets as language availability while keeping the parent parser registry and compiled query store empty in authoritative mode
- preserve tolerant query semantics in the worker and cache raw-input identity separately from filtered compiled source
- make authoritative semantic full, delta, and range bypass parent Tree/query gates and strengthen E2E assertions against empty-token false positives

## Stack

- Depends on #871
- Completes the guarded native grammar/query loading ownership boundary from ADR #862
- Remains draft because cold-open and large serial-miss performance, protocol cancellation/fairness, memory, compatibility, and final failure gates remain open

## Measurement

Release benchmark, same Stage 9 binary, 40 iterations after 10 warmups:

| workload | legacy | authoritative 4 threads | change |
| --- | ---: | ---: | ---: |
| markdown full | 0.266 ms | 0.237 ms | -11% |
| markdown edit delta | 7.604 ms | 7.150 ms | -6% |
| large Rust edit delta | 30.779 ms | 39.265 ms | +28% |
| markdown cold open + first token | 22.675 ms | 33.679 ms | +49% |
| large Rust cold open + first token | 548.209 ms | 597.798 ms | +9% |

This is the first paired end-to-end evidence that one fixed worker improves injection-heavy steady-state workloads. It still fails the general non-regression gate on Rust misses and cold open. An intermediate empty-token response measured around 0.7 ms; the E2E contract now requires non-empty full and range tokens, and those invalid numbers are excluded.

Raw-versus-compiled query identity was also material: recompiling tolerant raw queries on every request regressed Rust edit to 101.229 ms and Markdown edit to 17.398 ms. Caching the raw input restored the final values above.

## Validation

- cargo test --lib: 3120 passed, 2 ignored
- cargo test --features e2e --test tree_worker_process -- --test-threads=1: 4 passed
- cargo test --features e2e --test e2e_tree_worker_shadow -- --test-threads=1: 33 passed
- cargo fmt --check
- cargo check --lib
- git diff --check

## Rollback

Select legacy mode to restore the complete in-process parser and query path. Authoritative mode keeps the parent document tree-less and no longer dynamically loads native grammars or compiles Tree-sitter queries in the parent.