### PR TITLE
Stage 10: cancel obsolete worker reads

### DIFF
--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -125,6 +125,13 @@ impl Server {
         )
     }
 
+    fn send_semantic_full(&mut self, uri: &str) -> i64 {
+        self.send_request(
+            "textDocument/semanticTokens/full",
+            json!({ "textDocument": { "uri": uri } }),
+        )
+    }
+
     /// `semanticTokens/full/delta` against `previous_result_id`.
     fn semantic_delta(&mut self, uri: &str, previous_result_id: &str) -> Value {
         self.request(
@@ -183,6 +190,11 @@ impl Server {
     }
 
     fn request(&mut self, method: &str, params: Value) -> Value {
+        let id = self.send_request(method, params);
+        self.recv_response(id)
+    }
+
+    fn send_request(&mut self, method: &str, params: Value) -> i64 {
         self.next_id += 1;
         let id = self.next_id;
         self.send(&json!({
@@ -191,7 +203,7 @@ impl Server {
             "method": method,
             "params": params,
         }));
-        self.recv_response(id)
+        id
     }
 
     fn notify(&mut self, method: &str, params: Value) {
@@ -418,6 +430,10 @@ enum Kind {
     /// so each measured request pays incremental reparse + cache invalidation +
     /// delta diff on top of the (full) token recompute.
     EditDelta,
+    /// Rapid edits supersede several already-issued full requests. Measures
+    /// latency from the final edit/request until the only result the editor can
+    /// still use, while obsolete computation is cooperatively reclaimed.
+    SupersedeBurst { obsolete: usize },
     /// Cold-open latency: each iteration opens a FRESH document and times
     /// `didOpen` → first `semanticTokens/full` response — the editor-visible
     /// "open the file, see highlights" latency. The one scenario that captures
@@ -463,6 +479,9 @@ fn measure(
     if let Kind::OpenFirstToken = scn.kind {
         return measure_open(bin, scn, data_dir, iters, warmup);
     }
+    if let Kind::SupersedeBurst { obsolete } = scn.kind {
+        return measure_supersede_burst(bin, scn, data_dir, iters, warmup, obsolete);
+    }
     let mut server = Server::start(&bin.path, data_dir);
     server.did_open(scn.uri, scn.language_id, &scn.content);
     // Let the initial parse settle (didOpen parse may be async).
@@ -491,6 +510,44 @@ fn measure(
         let start = Instant::now();
         run_once(&mut server, scn, &mut prev_result_id, &mut edit);
         samples.push(start.elapsed());
+    }
+    samples
+}
+
+fn measure_supersede_burst(
+    bin: &Binary,
+    scn: &Scenario,
+    data_dir: &str,
+    iters: usize,
+    warmup: usize,
+    obsolete: usize,
+) -> Vec<Duration> {
+    let mut server = Server::start(&bin.path, data_dir);
+    server.did_open(scn.uri, scn.language_id, &scn.content);
+    std::thread::sleep(Duration::from_millis(300));
+    let mut version = 1_i64;
+    let mut insert = true;
+    let line = (scn.content.lines().count() / 2) as u32;
+    let mut samples = Vec::with_capacity(iters);
+    for iteration in 0..(warmup + iters) {
+        for _ in 0..obsolete {
+            version += 1;
+            server.did_change_toggle(scn.uri, version, line, insert);
+            insert = !insert;
+            let _ = server.send_semantic_full(scn.uri);
+            // Give ingress enough time to start worker computation; without
+            // this the burst only measures request coalescing before dispatch.
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        version += 1;
+        let started = Instant::now();
+        server.did_change_toggle(scn.uri, version, line, insert);
+        insert = !insert;
+        let final_id = server.send_semantic_full(scn.uri);
+        let _ = server.recv_response(final_id);
+        if iteration >= warmup {
+            samples.push(started.elapsed());
+        }
     }
     samples
 }
@@ -531,7 +588,9 @@ fn measure_open(
 
 fn seed_result_id(server: &mut Server, scn: &Scenario) -> String {
     match scn.kind {
-        Kind::Full | Kind::Range { .. } | Kind::OpenFirstToken => String::new(),
+        Kind::Full | Kind::Range { .. } | Kind::OpenFirstToken | Kind::SupersedeBurst { .. } => {
+            String::new()
+        }
         // Both delta-based scenarios need an initial result_id to diff against.
         Kind::DeltaNoop | Kind::EditDelta => {
             result_id_of(&server.semantic_full(scn.uri)).unwrap_or_default()
@@ -548,6 +607,9 @@ fn run_once(
     match scn.kind {
         // Handled by `measure_open`, which never calls `run_once`.
         Kind::OpenFirstToken => unreachable!("OpenFirstToken uses measure_open"),
+        Kind::SupersedeBurst { .. } => {
+            unreachable!("SupersedeBurst uses measure_supersede_burst")
+        }
         Kind::Full => {
             let _ = server.semantic_full(scn.uri);
         }
@@ -698,6 +760,14 @@ fn main() {
             content: gen_rust(150),
             kind: Kind::EditDelta,
             targets: "edit→reparse→retokenize→delta diff (host path under typing)",
+        },
+        Scenario {
+            name: "rust_large/supersede_burst",
+            language_id: "rust",
+            uri: "file:///bench/large_supersede.rs",
+            content: gen_rust(150),
+            kind: Kind::SupersedeBurst { obsolete: 8 },
+            targets: "latest request latency after eight superseded semantic computations",
         },
         Scenario {
             name: "markdown_injections/edit_delta",

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -430,10 +430,10 @@ enum Kind {
     /// so each measured request pays incremental reparse + cache invalidation +
     /// delta diff on top of the (full) token recompute.
     EditDelta,
-    /// Rapid edits supersede several already-issued full requests. Measures
-    /// latency from the final edit/request until the only result the editor can
-    /// still use, while obsolete computation is cooperatively reclaimed.
-    SupersedeBurst { obsolete: usize },
+    /// Rapid edits explicitly cancel several already-issued full requests.
+    /// Measures latency from the final edit/request until the only result the
+    /// editor can still use, while obsolete computation is reclaimed.
+    CancelBurst { obsolete: usize },
     /// Cold-open latency: each iteration opens a FRESH document and times
     /// `didOpen` → first `semanticTokens/full` response — the editor-visible
     /// "open the file, see highlights" latency. The one scenario that captures
@@ -479,8 +479,8 @@ fn measure(
     if let Kind::OpenFirstToken = scn.kind {
         return measure_open(bin, scn, data_dir, iters, warmup);
     }
-    if let Kind::SupersedeBurst { obsolete } = scn.kind {
-        return measure_supersede_burst(bin, scn, data_dir, iters, warmup, obsolete);
+    if let Kind::CancelBurst { obsolete } = scn.kind {
+        return measure_cancel_burst(bin, scn, data_dir, iters, warmup, obsolete);
     }
     let mut server = Server::start(&bin.path, data_dir);
     server.did_open(scn.uri, scn.language_id, &scn.content);
@@ -514,7 +514,7 @@ fn measure(
     samples
 }
 
-fn measure_supersede_burst(
+fn measure_cancel_burst(
     bin: &Binary,
     scn: &Scenario,
     data_dir: &str,
@@ -534,10 +534,12 @@ fn measure_supersede_burst(
             version += 1;
             server.did_change_toggle(scn.uri, version, line, insert);
             insert = !insert;
-            let _ = server.send_semantic_full(scn.uri);
-            // Give ingress enough time to start worker computation; without
-            // this the burst only measures request coalescing before dispatch.
-            std::thread::sleep(Duration::from_millis(5));
+            let obsolete_id = server.send_semantic_full(scn.uri);
+            // Let the request enter worker compute before explicitly
+            // cancelling it; immediate cancellation would only benchmark
+            // ingress coalescing.
+            std::thread::sleep(Duration::from_millis(20));
+            server.notify("$/cancelRequest", json!({ "id": obsolete_id }));
         }
         version += 1;
         let started = Instant::now();
@@ -588,7 +590,7 @@ fn measure_open(
 
 fn seed_result_id(server: &mut Server, scn: &Scenario) -> String {
     match scn.kind {
-        Kind::Full | Kind::Range { .. } | Kind::OpenFirstToken | Kind::SupersedeBurst { .. } => {
+        Kind::Full | Kind::Range { .. } | Kind::OpenFirstToken | Kind::CancelBurst { .. } => {
             String::new()
         }
         // Both delta-based scenarios need an initial result_id to diff against.
@@ -607,8 +609,8 @@ fn run_once(
     match scn.kind {
         // Handled by `measure_open`, which never calls `run_once`.
         Kind::OpenFirstToken => unreachable!("OpenFirstToken uses measure_open"),
-        Kind::SupersedeBurst { .. } => {
-            unreachable!("SupersedeBurst uses measure_supersede_burst")
+        Kind::CancelBurst { .. } => {
+            unreachable!("CancelBurst uses measure_cancel_burst")
         }
         Kind::Full => {
             let _ = server.semantic_full(scn.uri);
@@ -762,12 +764,12 @@ fn main() {
             targets: "edit→reparse→retokenize→delta diff (host path under typing)",
         },
         Scenario {
-            name: "rust_large/supersede_burst",
+            name: "rust_xlarge/cancel_burst",
             language_id: "rust",
             uri: "file:///bench/large_supersede.rs",
-            content: gen_rust(150),
-            kind: Kind::SupersedeBurst { obsolete: 8 },
-            targets: "latest request latency after eight superseded semantic computations",
+            content: gen_rust(600),
+            kind: Kind::CancelBurst { obsolete: 4 },
+            targets: "latest request latency after four explicitly cancelled computations",
         },
         Scenario {
             name: "markdown_injections/edit_delta",

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage10-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage10-measurement.md
@@ -1,0 +1,109 @@
+# Single Tree Worker Stage 10 Cancellation Measurement
+
+## Scope
+
+Stage 10 adds an explicit, idempotent cancellation frame for tree-dependent
+reader work. Dropping an LSP semantic-token future, `$/cancelRequest`, request
+supersession, and `didClose` now cancel the matching worker request. Queued work
+is skipped before tree access; running semantic computation polls the shared
+token and publishes no result or cache entry after cancellation.
+
+The worker keeps reading one bounded lookahead frame when its ordinary pending
+window is full, so cancellation cannot be trapped behind compute admission.
+Permits are acquired when a document-lane job actually starts rather than when
+it is queued. Thus a single document retains at most one active outer job and
+cannot reserve every permit with its FIFO backlog.
+
+This is still an intermediate measurement. Nested injection fan-out is not yet
+split into scheduler-visible fair chunks, and reader priority classes are not
+implemented.
+
+## Method
+
+All end-to-end measurements used release binaries on macOS, 40 measured
+iterations, and 10 warmups. The ordinary workload comparison ran the same Stage
+10 binary in both modes:
+
+```text
+legacy = KAKEHASHI_TREE_WORKER_MODE unset
+worker = authoritative, KAKEHASHI_TREE_WORKER_THREADS=4
+```
+
+The cancellation comparison ran the Stage 9 and Stage 10 authoritative
+binaries back-to-back. Each iteration used a 600-function Rust document, issued
+four semantic-token requests, waited 20 ms after each so computation could
+start, explicitly cancelled it, then measured latency from the final edit and
+request to the final usable response. This deliberately measures running-work
+reclamation rather than ingress-only request coalescing.
+
+## Results
+
+Lower is better. Ordinary workloads remain mixed:
+
+| Scenario | Legacy | Stage 10 authoritative | Change |
+|---|---:|---:|---:|
+| Markdown, 60 injections, full | 0.403 ms | 0.570 ms | +41.4% |
+| Markdown, 60 injections, edit + delta | 7.786 ms | 7.027 ms | -9.7% |
+| Large Rust, edit + delta | 31.220 ms | 38.440 ms | +23.1% |
+| Markdown, 150 injections, cold open + first token | 27.090 ms | 28.343 ms | +4.6% |
+| Large Rust, cold open + first token | 615.623 ms | 589.512 ms | -4.2% |
+
+The sub-millisecond Markdown full result is sensitive to process scheduling: an
+isolated repeat measured 0.344 ms legacy and 0.330 ms authoritative. It should
+therefore be treated as transport-floor noise, not as evidence for either a 41%
+regression or a 4% win. The edit and cold measurements remain the useful gates.
+
+Running cancellation produced a stable material improvement:
+
+| Scenario | Stage 9 authoritative | Stage 10 authoritative | Change |
+|---|---:|---:|---:|
+| Xlarge Rust, four cancelled requests, then latest | 302.323 ms | 199.860 ms | -33.9% |
+
+## Findings
+
+### Cross-process cancellation reclaims user-visible latency
+
+Before Stage 10, the parent could stop awaiting an obsolete worker future, but
+the worker continued its semantic computation. Explicit worker cancellation
+reduced latest-result latency by about one third once the benchmark guaranteed
+that obsolete work had actually entered compute. A smaller workload mostly
+measured ingress coalescing and showed only a low-single-digit change; it was
+not a valid stress test of running cancellation.
+
+### Control responsiveness does not require an unconditional dispatcher hop
+
+An intermediate implementation put every request through a dispatcher thread.
+It preserved cancellation delivery but raised the small Markdown full median
+from the Stage 9 range near 0.24 ms to about 0.57 ms. The final design decodes a
+single bounded lookahead frame at saturation and schedules normal work directly.
+This retained backpressure and early-cancel tests while removing the extra hot
+path hop. The isolated Markdown full repeat returned to roughly 0.33 ms.
+
+### Cancellation may overtake request execution
+
+Dropping the async future immediately after creating its blocking worker task
+can send cancellation before that task writes the request frame. The worker
+therefore retains an idempotent same-generation cancellation token for an
+unknown request ID and consumes it when the matching reader request arrives.
+Lifecycle requests are not cancellable and discard such a token. This closes a
+real scheduling race; assuming source-level creation order implies wire order
+was incorrect.
+
+### Outer fairness improved, but the ADR fairness gate remains open
+
+Moving permit acquisition into the active lane job prevents queued work for one
+document from reserving all compute capacity. This is a useful outer
+per-document cap, not the ADR's complete max-min fairness contract. Nested
+semantic/injection parallelism can still borrow Rayon threads without
+scheduler-visible document tags, and user-blocking priority is still absent.
+
+## Decision
+
+Keep the one-worker design and Stage 10 cancellation protocol. It provides a
+measured 33.9% latest-result win under running cancellation and fixes a real
+resource-reclamation gap without increasing worker count.
+
+Do not accept the ADR or remove legacy mode yet. Large Rust edit remains 23.1%
+slower in this run, ordinary measurements are mixed, and nested fairness,
+priority, native-call handshakes, failure injection, memory, compatibility, and
+legacy-removal gates remain incomplete.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -393,15 +393,19 @@ generation. A queued request is removed before execution; a running request
 flips the same cancellation token polled by its tree walks and nested fan-out.
 Cancellation racing a terminal response may observe either terminal outcome,
 but a canceled or stale result cannot populate a cache, mint node state, or be
-published in the parent. Canceling an unknown, completed, or prior-generation
-request is a no-op. A non-cooperative native call remains governed by its hard
+published in the parent. Canceling a completed or prior-generation request is a
+no-op; a same-generation unknown ID is retained for the request-delivery race
+described below. A non-cooperative native call remains governed by its hard
 native-call deadline; cancellation alone does not kill the whole worker.
 
 High-level request admission and cancellation share the parent-to-worker control
-writer. If cancellation wins before admission is enqueued, the request is never
-sent. Otherwise the request frame precedes its cancel frame on that ordered
-stream, so an unknown-cancel no-op cannot be followed by first observation of
-the canceled request. Duplicate terminal and cancel frames remain harmless.
+writer, but parent task scheduling does not guarantee that a blocking request
+sender runs before the async owner is dropped. Cancellation may therefore
+overtake first observation of the request. The worker retains an idempotent
+same-generation cancellation token for that unknown request ID and consumes it
+if the matching cancellable reader request arrives later; a non-cancellable
+lifecycle request with that ID discards the token. Canceling a prior generation
+remains a no-op, and duplicate terminal and cancel frames remain harmless.
 
 Cancellation during a handshake has explicit cleanup. A hazard that was armed
 but never entered its grammar-backed scope is released; a native segment that
@@ -1151,6 +1155,12 @@ worker boundary. One fixed worker is measurably faster than legacy for the two
 injection-heavy steady-state workloads, while large serial misses and cold open
 remain slower. The mixed result confirms performance potential without passing
 the general non-regression gate or justifying worker sharding.
+
+The [Stage 10 cancellation measurement](single-resident-multithreaded-tree-worker-stage10-measurement.md)
+adds explicit queued/running cancellation and an outer per-document admission
+cap. Reclaiming four already-running obsolete semantic requests improves the
+latest usable response by 33.9% against Stage 9, but ordinary latency remains
+mixed and nested max-min fairness is not yet implemented.
 
 The implementation should proceed in measured stages:
 

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -572,6 +572,7 @@ impl Kakehashi {
                 snapshot.parsed_version,
                 worker_configuration_generation,
                 supports_multiline,
+                Some(cancel_token.clone()),
             );
             let authoritative_worker = self.tree_worker_shadow.is_authoritative();
             let combined = async {
@@ -1029,6 +1030,7 @@ impl Kakehashi {
                     snapshot.parsed_version,
                     worker_configuration_generation,
                     supports_multiline,
+                    Some(cancel_token.clone()),
                 );
                 let authoritative_worker = self.tree_worker_shadow.is_authoritative();
                 let combined = async {
@@ -1453,6 +1455,7 @@ impl Kakehashi {
             snapshot.parsed_version,
             worker_configuration_generation,
             supports_multiline,
+            None,
         );
         let (result, worker) = if self.tree_worker_shadow.is_authoritative() {
             (None, worker.await)

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -33,6 +33,7 @@ const MAX_SESSION_RESTARTS: u8 = 16;
 const INITIAL_RESTART_BACKOFF: Duration = Duration::from_millis(250);
 const MAX_RESTART_BACKOFF: Duration = Duration::from_secs(300);
 const WORKER_LIVENESS_POLL: Duration = Duration::from_millis(250);
+const WORKER_READ_READY_TIMEOUT: Duration = Duration::from_secs(15);
 const FAST_HEALTHY_INTERVAL: Duration = Duration::from_secs(60);
 const LONG_HEALTHY_INTERVAL: Duration = Duration::from_secs(10 * 60);
 static NEXT_WORKER_GENERATION: AtomicU64 = AtomicU64::new(1);
@@ -1937,7 +1938,7 @@ impl TreeWorkerShadow {
             }
             if self.disabled.load(Ordering::Acquire)
                 || self.sender.is_none()
-                || tokio::time::timeout(Duration::from_secs(2), notified)
+                || tokio::time::timeout(WORKER_READ_READY_TIMEOUT, notified)
                     .await
                     .is_err()
             {
@@ -1973,7 +1974,7 @@ impl TreeWorkerShadow {
                 }
             }
             if !self.is_enabled()
-                || tokio::time::timeout(Duration::from_secs(2), notified)
+                || tokio::time::timeout(WORKER_READ_READY_TIMEOUT, notified)
                     .await
                     .is_err()
             {
@@ -2026,7 +2027,7 @@ impl TreeWorkerShadow {
                 }
             }
             if !self.is_enabled()
-                || tokio::time::timeout(Duration::from_secs(2), notified)
+                || tokio::time::timeout(WORKER_READ_READY_TIMEOUT, notified)
                     .await
                     .is_err()
             {

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -45,6 +45,36 @@ enum TreeWorkerMode {
     Authoritative,
 }
 
+/// Cancels worker-side reader work when the async LSP request that owns it is
+/// superseded, explicitly cancelled, or dropped during shutdown.
+struct WorkerRequestCancellation {
+    client: Arc<Client>,
+    request_id: u64,
+    armed: bool,
+}
+
+impl WorkerRequestCancellation {
+    fn new(client: Arc<Client>, request_id: u64) -> Self {
+        Self {
+            client,
+            request_id,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for WorkerRequestCancellation {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = self.client.cancel_request(self.request_id);
+        }
+    }
+}
+
 pub(super) struct WorkerInjectionView {
     pub(super) text: Arc<str>,
     pub(super) language: String,
@@ -949,21 +979,32 @@ impl TreeWorkerShadow {
         content_version: u64,
         configuration_generation: u64,
         supports_multiline: bool,
+        supersede: Option<crate::cancel::CancelToken>,
     ) -> Option<DerivedSemanticTokens> {
         let (client, context) = self
             .synchronized_query_read(uri, incarnation, content_version, configuration_generation)
             .await?;
         let expected = context.clone();
         let started = Instant::now();
+        let mut cancellation =
+            WorkerRequestCancellation::new(Arc::clone(&client), context.request_id);
         let response = tokio::task::spawn_blocking(move || {
             client.derive_semantic_tokens(DeriveSemanticTokens {
                 context,
                 supports_multiline,
             })
-        })
-        .await
-        .ok()?
-        .ok()?;
+        });
+        let response = if let Some(supersede) = supersede {
+            tokio::select! {
+                biased;
+                _ = supersede.cancelled() => return None,
+                response = response => response,
+            }
+        } else {
+            response.await
+        };
+        cancellation.disarm();
+        let response = response.ok()?.ok()?;
         let Response::SemanticTokens(result) = response else {
             return None;
         };

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -22,7 +22,7 @@ use sha2::{Digest, Sha256};
 
 use crate::language::node_tracker::{EditInfo, NodeTracker};
 
-pub const PROTOCOL_VERSION: u32 = 14;
+pub const PROTOCOL_VERSION: u32 = 15;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_REPLICAS: usize = 4_096;
 pub const MAX_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
@@ -505,8 +505,20 @@ pub struct WorkerRestartRequired {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CancelRequest {
+    pub request_id: u64,
+    pub worker_generation: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct RequestCancelled {
+    pub context: RequestContext,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Request {
     Handshake(Handshake),
+    Cancel(CancelRequest),
     DeriveSnapshot(DeriveSnapshot),
     SyncDocument(SyncDocument),
     ApplyDocumentEdits(ApplyDocumentEdits),
@@ -558,6 +570,7 @@ pub enum Response {
     DocumentAck(DocumentAck),
     DocumentClosed(DocumentClosed),
     WorkerRestartRequired(WorkerRestartRequired),
+    RequestCancelled(RequestCancelled),
     Snapshot(DerivedSnapshot),
     Nodes(NodeResult),
     NodeScalar(NodeScalarResult),
@@ -1140,7 +1153,7 @@ impl DocumentReplica {
         &mut self,
         request: DeriveSemanticTokens,
     ) -> Result<DerivedSemanticTokens, String> {
-        self.derive_semantic_tokens_with_telemetry(request, Duration::ZERO, Instant::now())
+        self.derive_semantic_tokens_with_telemetry(request, Duration::ZERO, Instant::now(), None)
     }
 
     fn derive_semantic_tokens_with_telemetry(
@@ -1148,6 +1161,7 @@ impl DocumentReplica {
         request: DeriveSemanticTokens,
         queue_wait: Duration,
         started: Instant,
+        cancellation: Option<&crate::cancel::CancelToken>,
     ) -> Result<DerivedSemanticTokens, String> {
         self.validate_read_identity(&request.context)?;
         if let Some((generation, supports_multiline, tokens)) = &self.cached_semantic_tokens
@@ -1192,7 +1206,7 @@ impl DocumentReplica {
                 incarnation: request.context.incarnation,
                 discovery,
             }),
-            None,
+            cancellation.cloned(),
         )
         .ok_or_else(|| "worker semantic token derivation was cancelled".to_string())?;
         let tokens: Vec<WireSemanticToken> = match result {
@@ -2422,9 +2436,19 @@ fn handle_work(
     document_capacity: &DocumentCapacity,
     retained_document_bytes: &RetainedDocumentBytes,
     queue_wait: Duration,
+    cancellation: &crate::cancel::CancelToken,
 ) -> Response {
+    let context = request_context(&request)
+        .expect("scheduled worker request must have context")
+        .clone();
+    if cancellation.is_cancelled() {
+        return Response::RequestCancelled(RequestCancelled { context });
+    }
     let started = Instant::now();
-    match request {
+    let response = match request {
+        Request::Handshake(_) | Request::Cancel(_) => {
+            unreachable!("control requests are not scheduled")
+        }
         Request::DeriveSnapshot(request) => derive_snapshot(request, queue_wait),
         Request::SyncDocument(request) => sync_document_with_analysis(
             request,
@@ -2453,7 +2477,7 @@ fn handle_work(
         Request::DeriveSelectionRanges(request) => derive_selection_ranges(request, documents),
         Request::DeriveInjectionRegions(request) => derive_injection_regions(request, documents),
         Request::DeriveSemanticTokens(request) => {
-            derive_semantic_tokens(request, documents, queue_wait, started)
+            derive_semantic_tokens(request, documents, queue_wait, started, cancellation)
         }
         Request::RunCaptures(request) => run_captures(request, documents),
         Request::DeriveNativeBindings(request) => derive_native_bindings(request, documents),
@@ -2464,16 +2488,17 @@ fn handle_work(
             closed_documents,
             retained_document_bytes,
         ),
-        Request::Handshake(_) => Response::Error(WorkerError {
-            context: None,
-            message: "handshake may only be sent once".into(),
-        }),
+    };
+    if cancellation.is_cancelled() {
+        Response::RequestCancelled(RequestCancelled { context })
+    } else {
+        response
     }
 }
 
 fn request_context(request: &Request) -> Option<&RequestContext> {
     match request {
-        Request::Handshake(_) => None,
+        Request::Handshake(_) | Request::Cancel(_) => None,
         Request::DeriveSnapshot(request) => Some(&request.context),
         Request::SyncDocument(request) => Some(&request.context),
         Request::ApplyDocumentEdits(request) => Some(&request.context),
@@ -2507,8 +2532,27 @@ fn document_key(request: &Request) -> Option<DocumentKey> {
         Request::RunCaptures(request) => Some(DocumentKey::from(&request.context)),
         Request::DeriveNativeBindings(request) => Some(DocumentKey::from(&request.context)),
         Request::CloseDocument(request) => Some(DocumentKey::from(&request.context)),
-        Request::Handshake(_) | Request::DeriveSnapshot(_) | Request::ConfigureLanguages(_) => None,
+        Request::Handshake(_)
+        | Request::Cancel(_)
+        | Request::DeriveSnapshot(_)
+        | Request::ConfigureLanguages(_) => None,
     }
+}
+
+fn is_cancellable_reader_request(request: &Request) -> bool {
+    matches!(
+        request,
+        Request::DeriveSnapshot(_)
+            | Request::DeriveDocumentSnapshot(_)
+            | Request::ResolveNode(_)
+            | Request::NavigateNode(_)
+            | Request::RunNodeScalar(_)
+            | Request::DeriveSelectionRanges(_)
+            | Request::DeriveInjectionRegions(_)
+            | Request::DeriveSemanticTokens(_)
+            | Request::RunCaptures(_)
+            | Request::DeriveNativeBindings(_)
+    )
 }
 
 fn resolve_node(request: ResolveNode, documents: &DocumentStore) -> Response {
@@ -2634,6 +2678,7 @@ fn derive_semantic_tokens(
     documents: &DocumentStore,
     queue_wait: Duration,
     started: Instant,
+    cancellation: &crate::cancel::CancelToken,
 ) -> Response {
     let context = request.context.clone();
     let Some(replica) = documents
@@ -2647,7 +2692,12 @@ fn derive_semantic_tokens(
     };
     match replica.lock() {
         Ok(mut replica) => {
-            match replica.derive_semantic_tokens_with_telemetry(request, queue_wait, started) {
+            match replica.derive_semantic_tokens_with_telemetry(
+                request,
+                queue_wait,
+                started,
+                Some(cancellation),
+            ) {
                 Ok(result) => Response::SemanticTokens(result),
                 Err(message) => Response::Error(WorkerError {
                     context: Some(context),
@@ -3110,6 +3160,7 @@ where
             .send(())
             .map_err(|_| io::Error::other("worker admission queue stopped"))?;
     }
+    let permit_rx = Arc::new(Mutex::new(permit_rx));
     let (responses, response_rx) =
         mpsc::sync_channel::<(Response, Option<AdmissionPermit>)>(max_inflight);
     let writer_thread = std::thread::spawn(move || -> io::Result<()> {
@@ -3173,7 +3224,105 @@ where
     let document_capacity = Arc::new(Mutex::new(0));
     let retained_document_bytes = Arc::new(AtomicUsize::new(0));
     let document_lanes: DocumentLanes = Arc::new(dashmap::DashMap::new());
+    let cancellations = Arc::new(dashmap::DashMap::<u64, crate::cancel::CancelToken>::new());
+    // The client permits at most four requests per compute thread. Let the
+    // dispatcher own exactly that bounded pending window while leaving one
+    // transport lookahead slot; cancellation frames bypass this work queue.
+    let max_pending = compute_threads.saturating_mul(4).max(1);
+    let (work_tx, work_rx) =
+        mpsc::sync_channel::<(Request, RequestContext, Instant, crate::cancel::CancelToken)>(1);
+    let (completion_tx, completion_rx) = mpsc::channel::<()>();
+    let dispatcher = {
+        let pool = Arc::clone(&pool);
+        let permits = permits.clone();
+        let permit_rx = Arc::clone(&permit_rx);
+        let responses = responses.clone();
+        let documents = Arc::clone(&documents);
+        let analysis = Arc::clone(&analysis);
+        let closed_documents = Arc::clone(&closed_documents);
+        let document_capacity = Arc::clone(&document_capacity);
+        let retained_document_bytes = Arc::clone(&retained_document_bytes);
+        let document_lanes = Arc::clone(&document_lanes);
+        let cancellations = Arc::clone(&cancellations);
+        std::thread::spawn(move || {
+            let mut pending = 0_usize;
+            loop {
+                if pending == max_pending {
+                    completion_rx
+                        .recv()
+                        .expect("worker completion queue stopped before its jobs");
+                    pending -= 1;
+                    continue;
+                }
+                let Ok((request, context, enqueued, cancellation)) = work_rx.recv() else {
+                    break;
+                };
+                pending += 1;
+                let responses = responses.clone();
+                let permits = permits.clone();
+                let permit_rx = Arc::clone(&permit_rx);
+                let completion_tx = completion_tx.clone();
+                let documents = Arc::clone(&documents);
+                let analysis = Arc::clone(&analysis);
+                let closed_documents = Arc::clone(&closed_documents);
+                let document_capacity = Arc::clone(&document_capacity);
+                let retained_document_bytes = Arc::clone(&retained_document_bytes);
+                let request_id = context.request_id;
+                let job_cancellations = Arc::clone(&cancellations);
+                let lane_key = document_key(&request);
+                let action_key = lane_key.clone();
+                let job: LaneJob = Box::new(move || {
+                    permit_rx
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .recv()
+                        .expect("worker admission queue stopped before its jobs");
+                    let permit = AdmissionPermit(permits);
+                    let response = handle_work(
+                        request,
+                        &analysis,
+                        &documents,
+                        &closed_documents,
+                        &document_capacity,
+                        &retained_document_bytes,
+                        enqueued.elapsed(),
+                        &cancellation,
+                    );
+                    job_cancellations.remove(&request_id);
+                    let action = if action_key
+                        .as_ref()
+                        .is_some_and(|key| documents.contains_key(key))
+                    {
+                        LaneAction::Keep
+                    } else {
+                        LaneAction::Retire
+                    };
+                    let _ = responses.send((response, Some(permit)));
+                    let _ = completion_tx.send(());
+                    action
+                });
+                if let Some(lane_key) = lane_key {
+                    submit_document_job(&document_lanes, lane_key, &pool, job);
+                } else {
+                    pool.spawn(move || {
+                        let _ = job();
+                    });
+                }
+            }
+            for _ in 0..pending {
+                completion_rx
+                    .recv()
+                    .expect("worker completion queue stopped before its jobs");
+            }
+        })
+    };
     while let Some(request) = decode_frame::<_, Request>(&mut reader)? {
+        if let Request::Cancel(cancel) = request {
+            if cancel.worker_generation == worker_generation {
+                cancellations.entry(cancel.request_id).or_default().cancel();
+            }
+            continue;
+        }
         let Some(context) = request_context(&request) else {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -3199,53 +3348,26 @@ where
                 .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "worker writer stopped"))?;
             continue;
         }
-        let enqueued = Instant::now();
-        permit_rx
-            .recv()
-            .map_err(|_| io::Error::other("worker admission queue stopped"))?;
-        let responses = responses.clone();
-        let permit = AdmissionPermit(permits.clone());
-        let documents = Arc::clone(&documents);
-        let analysis = Arc::clone(&analysis);
-        let closed_documents = Arc::clone(&closed_documents);
-        let document_capacity = Arc::clone(&document_capacity);
-        let retained_document_bytes = Arc::clone(&retained_document_bytes);
-        let lane_key = document_key(&request);
-        let action_key = lane_key.clone();
-        let job: LaneJob = Box::new(move || {
-            let response = handle_work(
-                request,
-                &analysis,
-                &documents,
-                &closed_documents,
-                &document_capacity,
-                &retained_document_bytes,
-                enqueued.elapsed(),
-            );
-            let action = if action_key
-                .as_ref()
-                .is_some_and(|key| documents.contains_key(key))
-            {
-                LaneAction::Keep
-            } else {
-                LaneAction::Retire
-            };
-            let _ = responses.send((response, Some(permit)));
-            action
-        });
-        if let Some(lane_key) = lane_key {
-            submit_document_job(&document_lanes, lane_key, &pool, job);
+        let context = context.clone();
+        let request_id = context.request_id;
+        let cancellation = if is_cancellable_reader_request(&request) {
+            cancellations.entry(request_id).or_default().clone()
         } else {
-            pool.spawn(move || {
-                let _ = job();
-            });
+            cancellations.remove(&request_id);
+            crate::cancel::CancelToken::default()
+        };
+        if work_tx
+            .send((request, context, Instant::now(), cancellation))
+            .is_err()
+        {
+            cancellations.remove(&request_id);
+            return Err(io::Error::other("worker dispatcher stopped"));
         }
     }
-    for _ in 0..max_inflight {
-        permit_rx
-            .recv()
-            .map_err(|_| io::Error::other("worker admission queue stopped"))?;
-    }
+    drop(work_tx);
+    dispatcher
+        .join()
+        .map_err(|_| io::Error::other("worker dispatcher panicked"))?;
     drop(responses);
     join_writer(writer_thread)
 }
@@ -3351,7 +3473,7 @@ pub fn artifact_digest(path: &std::path::Path) -> io::Result<String> {
 pub struct Client {
     child: Arc<Mutex<Child>>,
     terminated_by_transport: Arc<AtomicBool>,
-    outbound: Mutex<Option<mpsc::SyncSender<Request>>>,
+    outbound: Mutex<Option<mpsc::Sender<Request>>>,
     routes: Arc<Mutex<HashMap<u64, Route>>>,
     reader: Option<std::thread::JoinHandle<()>>,
     writer: Option<std::thread::JoinHandle<()>>,
@@ -3493,7 +3615,10 @@ impl Client {
             }
         };
         let max_inflight = compute_threads.saturating_mul(4).max(1);
-        let (outbound, outbound_rx) = mpsc::sync_channel::<Request>(max_inflight);
+        // The route table is the bounded admission control. Keep the transport
+        // channel unbounded so a cancellation control frame never competes
+        // with work for the final queue slot.
+        let (outbound, outbound_rx) = mpsc::channel::<Request>();
         let writer_routes = Arc::clone(&routes);
         let writer_child = Arc::clone(&child);
         let writer_terminated_by_transport = Arc::clone(&terminated_by_transport);
@@ -3543,6 +3668,25 @@ impl Client {
 
     pub fn worker_generation(&self) -> u64 {
         self.ready.worker_generation
+    }
+
+    /// Idempotently cancel queued or cooperatively running work in this worker
+    /// generation. The original request route remains until its terminal
+    /// response arrives.
+    pub fn cancel_request(&self, request_id: u64) -> io::Result<()> {
+        let outbound = self
+            .outbound
+            .lock()
+            .map_err(|_| io::Error::other("worker outbound lock is poisoned"))?;
+        let outbound = outbound
+            .as_ref()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker is shut down"))?;
+        outbound
+            .send(Request::Cancel(CancelRequest {
+                request_id,
+                worker_generation: self.ready.worker_generation,
+            }))
+            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "tree worker writer stopped"))
     }
 
     /// Stops this generation without requiring unique ownership of the client.
@@ -3761,17 +3905,12 @@ impl Client {
             let outbound = outbound
                 .as_ref()
                 .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker is shut down"))?;
-            if let Err(error) = outbound.try_send(request) {
+            if outbound.send(request).is_err() {
                 self.remove_route(request_id);
-                return Err(match error {
-                    mpsc::TrySendError::Full(_) => io::Error::new(
-                        io::ErrorKind::WouldBlock,
-                        "tree worker outbound queue is full",
-                    ),
-                    mpsc::TrySendError::Disconnected(_) => {
-                        io::Error::new(io::ErrorKind::BrokenPipe, "tree worker writer stopped")
-                    }
-                });
+                return Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "tree worker writer stopped",
+                ));
             }
         }
         let remaining = timeout.saturating_sub(started.elapsed());
@@ -3867,6 +4006,7 @@ fn response_request_id(response: &Response) -> Option<u64> {
         Response::DocumentAck(ack) => Some(ack.context.request_id),
         Response::DocumentClosed(closed) => Some(closed.context.request_id),
         Response::WorkerRestartRequired(required) => Some(required.context.request_id),
+        Response::RequestCancelled(cancelled) => Some(cancelled.context.request_id),
         Response::Snapshot(snapshot) => Some(snapshot.context.request_id),
         Response::Nodes(result) => Some(result.context.request_id),
         Response::NodeScalar(result) => Some(result.context.request_id),
@@ -3886,6 +4026,7 @@ fn response_context(response: &Response) -> Option<&RequestContext> {
         Response::DocumentAck(ack) => Some(&ack.context),
         Response::DocumentClosed(closed) => Some(&closed.context),
         Response::WorkerRestartRequired(required) => Some(&required.context),
+        Response::RequestCancelled(cancelled) => Some(&cancelled.context),
         Response::Snapshot(snapshot) => Some(&snapshot.context),
         Response::Nodes(result) => Some(&result.context),
         Response::NodeScalar(result) => Some(&result.context),
@@ -4002,20 +4143,20 @@ mod tests {
     use std::io::{Cursor, Read, Write};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Condvar, Mutex};
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use super::{
-        ApplyDocumentEdits, BUILD_ID, ByteEdit, CapturesResult, CloseDocument,
+        ApplyDocumentEdits, BUILD_ID, ByteEdit, CancelRequest, CapturesResult, CloseDocument,
         DeriveInjectionRegions, DeriveNativeBindings, DeriveSelectionRanges, DeriveSemanticTokens,
         DeriveSnapshot, DocumentKey, DocumentLane, DocumentReplica, GrammarKey, Handshake,
         HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
         MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeLayerSelector, NodeNavigation,
         NodeScalarOperation, NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION, Request,
-        RequestContext, ResolveNode, Response, Route, RunCaptures, RunNodeScalar, SyncDocument,
-        WireByteRange, WirePosition, WireRange, WorkerError, WorkerQuerySources, close_document,
-        decode_frame, derive_snapshot_with_language, encode_frame, named_node_count,
-        replace_retained_bytes, reserve_retained_growth, route_response, run, submit_document_job,
-        sync_document, terminate_by_transport, validate_document_size,
+        RequestCancelled, RequestContext, ResolveNode, Response, Route, RunCaptures, RunNodeScalar,
+        SyncDocument, WireByteRange, WirePosition, WireRange, WorkerError, WorkerQuerySources,
+        close_document, decode_frame, derive_snapshot_with_language, encode_frame,
+        named_node_count, replace_retained_bytes, reserve_retained_growth, route_response, run,
+        submit_document_job, sync_document, terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -4191,6 +4332,21 @@ mod tests {
     #[test]
     fn frame_round_trip_preserves_request() {
         let request = request();
+        let mut bytes = Vec::new();
+        encode_frame(&mut bytes, &request).unwrap();
+
+        assert_eq!(
+            decode_frame(&mut Cursor::new(bytes)).unwrap(),
+            Some(request)
+        );
+    }
+
+    #[test]
+    fn frame_round_trip_preserves_idempotent_cancellation() {
+        let request = Request::Cancel(CancelRequest {
+            request_id: 42,
+            worker_generation: 7,
+        });
         let mut bytes = Vec::new();
         encode_frame(&mut bytes, &request).unwrap();
 
@@ -4395,6 +4551,36 @@ mod tests {
     }
 
     #[test]
+    fn worker_honors_cancellation_that_arrives_before_reader_work() {
+        let output = SharedWriter::default();
+        let captured = output.clone();
+        let cancel = Request::Cancel(CancelRequest {
+            request_id: 7,
+            worker_generation: 3,
+        });
+
+        run(
+            Cursor::new(framed(&[handshake(PROTOCOL_VERSION), cancel, request()])),
+            output,
+            1,
+        )
+        .unwrap();
+
+        let bytes = captured.0.lock().unwrap().clone();
+        let mut bytes = Cursor::new(bytes);
+        assert!(matches!(
+            decode_frame::<_, Response>(&mut bytes).unwrap(),
+            Some(Response::HandshakeReady(_))
+        ));
+        let response = decode_frame::<_, Response>(&mut bytes).unwrap().unwrap();
+        assert!(matches!(
+            response,
+            Response::RequestCancelled(RequestCancelled { context })
+                if context.request_id == 7
+        ));
+    }
+
+    #[test]
     fn worker_backpressures_until_the_response_writer_resumes() {
         let writer = GatedWriter::default();
         let gate = writer.clone();
@@ -4406,7 +4592,7 @@ mod tests {
             request.context.request_id = request_id;
             requests.push(Request::DeriveSnapshot(request));
         }
-        let admitted_prefix_bytes = framed(&requests[..4]).len();
+        let admitted_prefix_bytes = framed(&requests[..8]).len();
         let framed_requests = framed(&requests);
         let progress = Arc::new((AtomicUsize::new(0), Condvar::new(), Mutex::new(())));
         let reader = CountingReader {
@@ -4422,7 +4608,7 @@ mod tests {
         wait_for_read_progress(&progress, admitted_prefix_bytes);
         assert!(
             progress.0.load(Ordering::Relaxed) <= admitted_prefix_bytes,
-            "worker read past two admitted requests plus one bounded lookahead"
+            "worker read past its pending, response, and lookahead bounds"
         );
         assert!(
             progress.0.load(Ordering::Relaxed) < framed_requests.len(),
@@ -5169,6 +5355,60 @@ mod tests {
         assert!(
             cached.cache_hit,
             "same-version semantic requests should reuse worker facts"
+        );
+    }
+
+    #[test]
+    fn cancelled_semantic_tokens_are_not_published_or_cached() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let context = RequestContext {
+            request_id: 1,
+            worker_generation: 3,
+            uri: "file:///cancelled-semantic.rs".into(),
+            incarnation: 4,
+            content_version: 1,
+            configuration_generation: 2,
+        };
+        let (mut replica, _) = DocumentReplica::sync(
+            SyncDocument {
+                context: context.clone(),
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: "/unused/static-language".into(),
+                parser_path: "/unused/static-language".into(),
+                artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources {
+                    highlights: Some("(identifier) @variable".into()),
+                    ..WorkerQuerySources::default()
+                },
+                text: "fn main() {}".into(),
+            },
+            &mut parser,
+        )
+        .unwrap();
+        let cancellation = crate::cancel::CancelToken::default();
+        cancellation.cancel_after_polls(1);
+
+        let result = replica.derive_semantic_tokens_with_telemetry(
+            DeriveSemanticTokens {
+                context,
+                supports_multiline: false,
+            },
+            Duration::ZERO,
+            Instant::now(),
+            Some(&cancellation),
+        );
+
+        assert_eq!(
+            result.unwrap_err(),
+            "worker semantic token derivation was cancelled"
+        );
+        assert!(
+            replica.cached_semantic_tokens.is_none(),
+            "cancelled results must never become reusable worker facts"
         );
     }
 

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -3225,97 +3225,12 @@ where
     let retained_document_bytes = Arc::new(AtomicUsize::new(0));
     let document_lanes: DocumentLanes = Arc::new(dashmap::DashMap::new());
     let cancellations = Arc::new(dashmap::DashMap::<u64, crate::cancel::CancelToken>::new());
-    // The client permits at most four requests per compute thread. Let the
-    // dispatcher own exactly that bounded pending window while leaving one
-    // transport lookahead slot; cancellation frames bypass this work queue.
+    // The client permits at most four requests per compute thread. Decode one
+    // frame beyond this pending window so cancellation stays observable under
+    // saturation, but wait before scheduling any excess ordinary work.
     let max_pending = compute_threads.saturating_mul(4).max(1);
-    let (work_tx, work_rx) =
-        mpsc::sync_channel::<(Request, RequestContext, Instant, crate::cancel::CancelToken)>(1);
     let (completion_tx, completion_rx) = mpsc::channel::<()>();
-    let dispatcher = {
-        let pool = Arc::clone(&pool);
-        let permits = permits.clone();
-        let permit_rx = Arc::clone(&permit_rx);
-        let responses = responses.clone();
-        let documents = Arc::clone(&documents);
-        let analysis = Arc::clone(&analysis);
-        let closed_documents = Arc::clone(&closed_documents);
-        let document_capacity = Arc::clone(&document_capacity);
-        let retained_document_bytes = Arc::clone(&retained_document_bytes);
-        let document_lanes = Arc::clone(&document_lanes);
-        let cancellations = Arc::clone(&cancellations);
-        std::thread::spawn(move || {
-            let mut pending = 0_usize;
-            loop {
-                if pending == max_pending {
-                    completion_rx
-                        .recv()
-                        .expect("worker completion queue stopped before its jobs");
-                    pending -= 1;
-                    continue;
-                }
-                let Ok((request, context, enqueued, cancellation)) = work_rx.recv() else {
-                    break;
-                };
-                pending += 1;
-                let responses = responses.clone();
-                let permits = permits.clone();
-                let permit_rx = Arc::clone(&permit_rx);
-                let completion_tx = completion_tx.clone();
-                let documents = Arc::clone(&documents);
-                let analysis = Arc::clone(&analysis);
-                let closed_documents = Arc::clone(&closed_documents);
-                let document_capacity = Arc::clone(&document_capacity);
-                let retained_document_bytes = Arc::clone(&retained_document_bytes);
-                let request_id = context.request_id;
-                let job_cancellations = Arc::clone(&cancellations);
-                let lane_key = document_key(&request);
-                let action_key = lane_key.clone();
-                let job: LaneJob = Box::new(move || {
-                    permit_rx
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner)
-                        .recv()
-                        .expect("worker admission queue stopped before its jobs");
-                    let permit = AdmissionPermit(permits);
-                    let response = handle_work(
-                        request,
-                        &analysis,
-                        &documents,
-                        &closed_documents,
-                        &document_capacity,
-                        &retained_document_bytes,
-                        enqueued.elapsed(),
-                        &cancellation,
-                    );
-                    job_cancellations.remove(&request_id);
-                    let action = if action_key
-                        .as_ref()
-                        .is_some_and(|key| documents.contains_key(key))
-                    {
-                        LaneAction::Keep
-                    } else {
-                        LaneAction::Retire
-                    };
-                    let _ = responses.send((response, Some(permit)));
-                    let _ = completion_tx.send(());
-                    action
-                });
-                if let Some(lane_key) = lane_key {
-                    submit_document_job(&document_lanes, lane_key, &pool, job);
-                } else {
-                    pool.spawn(move || {
-                        let _ = job();
-                    });
-                }
-            }
-            for _ in 0..pending {
-                completion_rx
-                    .recv()
-                    .expect("worker completion queue stopped before its jobs");
-            }
-        })
-    };
+    let mut pending = 0_usize;
     while let Some(request) = decode_frame::<_, Request>(&mut reader)? {
         if let Request::Cancel(cancel) = request {
             if cancel.worker_generation == worker_generation {
@@ -3356,18 +3271,69 @@ where
             cancellations.remove(&request_id);
             crate::cancel::CancelToken::default()
         };
-        if work_tx
-            .send((request, context, Instant::now(), cancellation))
-            .is_err()
-        {
-            cancellations.remove(&request_id);
-            return Err(io::Error::other("worker dispatcher stopped"));
+        if pending == max_pending {
+            completion_rx
+                .recv()
+                .map_err(|_| io::Error::other("worker completion queue stopped"))?;
+            pending -= 1;
+        }
+        pending += 1;
+        let enqueued = Instant::now();
+        let responses = responses.clone();
+        let permits = permits.clone();
+        let permit_rx = Arc::clone(&permit_rx);
+        let completion_tx = completion_tx.clone();
+        let documents = Arc::clone(&documents);
+        let analysis = Arc::clone(&analysis);
+        let closed_documents = Arc::clone(&closed_documents);
+        let document_capacity = Arc::clone(&document_capacity);
+        let retained_document_bytes = Arc::clone(&retained_document_bytes);
+        let job_cancellations = Arc::clone(&cancellations);
+        let lane_key = document_key(&request);
+        let action_key = lane_key.clone();
+        let job: LaneJob = Box::new(move || {
+            permit_rx
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .recv()
+                .expect("worker admission queue stopped before its jobs");
+            let permit = AdmissionPermit(permits);
+            let response = handle_work(
+                request,
+                &analysis,
+                &documents,
+                &closed_documents,
+                &document_capacity,
+                &retained_document_bytes,
+                enqueued.elapsed(),
+                &cancellation,
+            );
+            job_cancellations.remove(&request_id);
+            let action = if action_key
+                .as_ref()
+                .is_some_and(|key| documents.contains_key(key))
+            {
+                LaneAction::Keep
+            } else {
+                LaneAction::Retire
+            };
+            let _ = responses.send((response, Some(permit)));
+            let _ = completion_tx.send(());
+            action
+        });
+        if let Some(lane_key) = lane_key {
+            submit_document_job(&document_lanes, lane_key, &pool, job);
+        } else {
+            pool.spawn(move || {
+                let _ = job();
+            });
         }
     }
-    drop(work_tx);
-    dispatcher
-        .join()
-        .map_err(|_| io::Error::other("worker dispatcher panicked"))?;
+    for _ in 0..pending {
+        completion_rx
+            .recv()
+            .map_err(|_| io::Error::other("worker completion queue stopped"))?;
+    }
     drop(responses);
     join_writer(writer_thread)
 }


### PR DESCRIPTION
## Summary

- add a versioned idempotent cancellation frame for queued and running reader work
- propagate LSP cancellation, supersession, didClose, and handler drop across the process boundary
- keep cancellation readable under bounded load and prevent one document backlog from reserving every permit
- add a running-cancellation benchmark and Stage 10 ADR measurement
- extend bounded cold-readiness waiting so healthy workers do not return null under contended startup

## Measurement

With 40 measured iterations and 10 warmups, an xlarge Rust burst with four already-running requests explicitly cancelled improved final usable response latency from 302.323 ms on Stage 9 to 199.860 ms on Stage 10 (-33.9%). Ordinary workloads remain mixed; large Rust edit was still +23.1%, so the ADR stays proposed.

## Validation

- `cargo test --lib --quiet` (3123 passed, 2 ignored)
- `cargo test --test tree_worker_process --features e2e` (4 passed)
- `cargo test --test e2e_tree_worker_shadow --features e2e --quiet` (33 passed)
- release paired benchmark, 40 iterations / 10 warmups
