### PR TITLE
Stage 11: prove hard-deadline worker recovery

### DIFF
--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage11-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage11-measurement.md
@@ -1,0 +1,81 @@
+# Single Tree Worker Stage 11 Hard-Deadline Measurement
+
+## Scope
+
+Stage 11 exercises the existing process-level recovery deadline against a
+deterministic non-cooperative worker hang. The E2E fixture hangs the worker while
+synchronizing a Rust document, after an unrelated Lua document has already been
+opened and served.
+
+The deadline override is available only in E2E builds and can be restricted to
+one URI suffix. Production keeps the 60-second process recovery deadline. This
+avoids accidentally applying the short injected deadline to healthy recovery
+work, which an intermediate test exposed as a restart storm.
+
+## Method
+
+The E2E test uses one worker with four compute threads:
+
+```text
+hung request deadline = 250 ms
+hung URI = file:///hung.rs
+implicated grammar = rust
+surviving open URI = file:///survives-hang.lua
+```
+
+The fixture creates a marker and parks forever when the worker first receives
+the matching Rust synchronization request. The client deadline must terminate
+that worker generation. The supervisor then classifies a timeout with an
+implicated grammar as native-evidenced, quarantines that grammar for the
+session, starts a new generation, and reconstructs all eligible open documents
+from parent-owned full text.
+
+## Result
+
+The focused debug-build E2E run completed in 8.56 seconds and recorded:
+
+```text
+restarted worker generation 2 and full-resynced 1 open documents
+(bytes=23 recovery_ms=856)
+```
+
+The test also proved that:
+
+* the LSP parent remained alive;
+* the timed-out generation was reaped;
+* the Rust grammar identity was session-quarantined;
+* the already-open Lua document was reconstructed in the new generation;
+* a subsequent Lua semantic-token request succeeded; and
+* the tree tier did not exhaust or trip its systemic restart budget.
+
+## Findings
+
+### A timeout must be scoped to the implicated operation
+
+An intermediate fixture shortened every worker request to 250 ms. Recovery then
+subjected healthy catalog and full-resync operations to the same artificial
+deadline and took roughly 42 seconds through repeated restarts. Restricting the
+override to the hung URI made the same proof complete in 8.56 seconds. Deadline
+policy is therefore part of failure attribution, not merely a global transport
+constant.
+
+### Existing recovery can reconstruct unrelated state
+
+The worker is disposable: after a hard kill, the parent can recreate an eligible
+open document from full text and continue serving it. The quarantined Rust
+document is deliberately excluded from resync, while the unrelated Lua document
+is restored.
+
+### The full native-attribution gate is still open
+
+This fixture hangs at the worker request boundary and proves timeout, kill,
+classification, quarantine, restart, and reconstruction. It does not yet prove
+the ADR's `GrammarHazardArmed`, `NativeSegmentEntered/Exited`, saturated control
+lane, delayed post-return crash, or descendant-process cleanup contracts.
+
+## Decision
+
+Keep the one-worker hard-deadline recovery path and its independent
+native-evidenced breaker classification. Stage 11 closes the basic
+non-cooperative hang/recovery proof but does not accept the ADR or authorize
+legacy removal.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1162,6 +1162,12 @@ cap. Reclaiming four already-running obsolete semantic requests improves the
 latest usable response by 33.9% against Stage 9, but ordinary latency remains
 mixed and nested max-min fairness is not yet implemented.
 
+The [Stage 11 hard-deadline measurement](single-resident-multithreaded-tree-worker-stage11-measurement.md)
+proves that a non-cooperative hung request is killed at its process deadline,
+the implicated Rust grammar is session-quarantined, and a replacement generation
+full-resyncs and serves an already-open Lua document. Native hazard handshakes,
+saturated reserved control traffic, and descendant cleanup remain open gates.
+
 The implementation should proceed in measured stages:
 
 1. Prototype the framed transport, supervision, and one high-level

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -3343,6 +3343,20 @@ fn inject_worker_failure_once(request: &Request) -> Option<Response> {
     let Request::SyncDocument(sync) = request else {
         return None;
     };
+    if let Ok(marker) = std::env::var("KAKEHASHI_TREE_WORKER_HANG_ONCE_FILE")
+        && std::env::var("KAKEHASHI_TREE_WORKER_HANG_URI_SUFFIX")
+            .ok()
+            .is_none_or(|suffix| sync.context.uri.ends_with(&suffix))
+        && std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(marker)
+            .is_ok()
+    {
+        loop {
+            std::thread::park();
+        }
+    }
     if let Ok(marker) = std::env::var("KAKEHASHI_TREE_WORKER_CRASH_ONCE_FILE")
         && std::fs::OpenOptions::new()
             .write(true)
@@ -3445,6 +3459,35 @@ pub struct Client {
     writer: Option<std::thread::JoinHandle<()>>,
     ready: HandshakeReady,
     max_inflight: usize,
+}
+
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+fn parse_request_timeout(value: Option<&str>) -> Duration {
+    value
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|milliseconds| *milliseconds > 0)
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_REQUEST_TIMEOUT)
+}
+
+fn request_timeout(_uri: &str) -> Duration {
+    #[cfg(feature = "e2e")]
+    {
+        if std::env::var("KAKEHASHI_TREE_WORKER_REQUEST_TIMEOUT_URI_SUFFIX")
+            .ok()
+            .is_some_and(|suffix| !_uri.ends_with(&suffix))
+        {
+            return DEFAULT_REQUEST_TIMEOUT;
+        }
+        return parse_request_timeout(
+            std::env::var("KAKEHASHI_TREE_WORKER_REQUEST_TIMEOUT_MS")
+                .ok()
+                .as_deref(),
+        );
+    }
+    #[cfg(not(feature = "e2e"))]
+    DEFAULT_REQUEST_TIMEOUT
 }
 
 struct Route {
@@ -3671,7 +3714,8 @@ impl Client {
     }
 
     pub fn derive(&self, request: DeriveSnapshot) -> io::Result<Response> {
-        self.derive_with_timeout(request, Duration::from_secs(60))
+        let timeout = request_timeout(&request.context.uri);
+        self.derive_with_timeout(request, timeout)
     }
 
     /// Sends one request with a process-level recovery deadline.
@@ -3690,20 +3734,14 @@ impl Client {
 
     pub fn sync_document(&self, request: SyncDocument) -> io::Result<Response> {
         let context = request.context.clone();
-        self.request_with_timeout(
-            Request::SyncDocument(request),
-            context,
-            Duration::from_secs(60),
-        )
+        let timeout = request_timeout(&context.uri);
+        self.request_with_timeout(Request::SyncDocument(request), context, timeout)
     }
 
     pub fn apply_document_edits(&self, request: ApplyDocumentEdits) -> io::Result<Response> {
         let context = request.context.clone();
-        self.request_with_timeout(
-            Request::ApplyDocumentEdits(request),
-            context,
-            Duration::from_secs(60),
-        )
+        let timeout = request_timeout(&context.uri);
+        self.request_with_timeout(Request::ApplyDocumentEdits(request), context, timeout)
     }
 
     pub fn apply_document_edits_and_derive(
@@ -3711,10 +3749,11 @@ impl Client {
         request: ApplyDocumentEditsAndDerive,
     ) -> io::Result<Response> {
         let context = request.context.clone();
+        let timeout = request_timeout(&context.uri);
         self.request_with_timeout(
             Request::ApplyDocumentEditsAndDerive(request),
             context,
-            Duration::from_secs(60),
+            timeout,
         )
     }
 
@@ -3723,47 +3762,32 @@ impl Client {
         request: DeriveDocumentSnapshot,
     ) -> io::Result<Response> {
         let context = request.context.clone();
-        self.request_with_timeout(
-            Request::DeriveDocumentSnapshot(request),
-            context,
-            Duration::from_secs(60),
-        )
+        let timeout = request_timeout(&context.uri);
+        self.request_with_timeout(Request::DeriveDocumentSnapshot(request), context, timeout)
     }
 
     pub fn resolve_node(&self, request: ResolveNode) -> io::Result<Response> {
         let context = request.context.clone();
-        self.request_with_timeout(
-            Request::ResolveNode(request),
-            context,
-            Duration::from_secs(60),
-        )
+        let timeout = request_timeout(&context.uri);
+        self.request_with_timeout(Request::ResolveNode(request), context, timeout)
     }
 
     pub fn navigate_node(&self, request: NavigateNode) -> io::Result<Response> {
         let context = request.context.clone();
-        self.request_with_timeout(
-            Request::NavigateNode(request),
-            context,
-            Duration::from_secs(60),
-        )
+        let timeout = request_timeout(&context.uri);
+        self.request_with_timeout(Request::NavigateNode(request), context, timeout)
     }
 
     pub fn run_node_scalar(&self, request: RunNodeScalar) -> io::Result<Response> {
         let context = request.context.clone();
-        self.request_with_timeout(
-            Request::RunNodeScalar(request),
-            context,
-            Duration::from_secs(60),
-        )
+        let timeout = request_timeout(&context.uri);
+        self.request_with_timeout(Request::RunNodeScalar(request), context, timeout)
     }
 
     pub fn derive_selection_ranges(&self, request: DeriveSelectionRanges) -> io::Result<Response> {
         let context = request.context.clone();
-        self.request_with_timeout(
-            Request::DeriveSelectionRanges(request),
-            context,
-            Duration::from_secs(60),
-        )
+        let timeout = request_timeout(&context.uri);
+        self.request_with_timeout(Request::DeriveSelectionRanges(request), context, timeout)
     }
 
     pub fn derive_injection_regions(
@@ -3771,56 +3795,38 @@ impl Client {
         request: DeriveInjectionRegions,
     ) -> io::Result<Response> {
         let context = request.context.clone();
-        self.request_with_timeout(
-            Request::DeriveInjectionRegions(request),
-            context,
-            Duration::from_secs(60),
-        )
+        let timeout = request_timeout(&context.uri);
+        self.request_with_timeout(Request::DeriveInjectionRegions(request), context, timeout)
     }
 
     pub fn derive_semantic_tokens(&self, request: DeriveSemanticTokens) -> io::Result<Response> {
         let context = request.context.clone();
-        self.request_with_timeout(
-            Request::DeriveSemanticTokens(request),
-            context,
-            Duration::from_secs(60),
-        )
+        let timeout = request_timeout(&context.uri);
+        self.request_with_timeout(Request::DeriveSemanticTokens(request), context, timeout)
     }
 
     pub fn run_captures(&self, request: RunCaptures) -> io::Result<Response> {
         let context = request.context.clone();
-        self.request_with_timeout(
-            Request::RunCaptures(request),
-            context,
-            Duration::from_secs(60),
-        )
+        let timeout = request_timeout(&context.uri);
+        self.request_with_timeout(Request::RunCaptures(request), context, timeout)
     }
 
     pub fn derive_native_bindings(&self, request: DeriveNativeBindings) -> io::Result<Response> {
         let context = request.context.clone();
-        self.request_with_timeout(
-            Request::DeriveNativeBindings(request),
-            context,
-            Duration::from_secs(60),
-        )
+        let timeout = request_timeout(&context.uri);
+        self.request_with_timeout(Request::DeriveNativeBindings(request), context, timeout)
     }
 
     pub fn configure_languages(&self, request: ConfigureLanguages) -> io::Result<Response> {
         let context = request.context.clone();
-        self.request_with_timeout(
-            Request::ConfigureLanguages(request),
-            context,
-            Duration::from_secs(60),
-        )
+        let timeout = request_timeout(&context.uri);
+        self.request_with_timeout(Request::ConfigureLanguages(request), context, timeout)
     }
 
     pub fn close_document(&self, request: CloseDocument) -> io::Result<Response> {
         let context = request.context.clone();
-        self.request_with_timeout(
-            Request::CloseDocument(request),
-            context,
-            Duration::from_secs(60),
-        )
+        let timeout = request_timeout(&context.uri);
+        self.request_with_timeout(Request::CloseDocument(request), context, timeout)
     }
 
     fn request_with_timeout(
@@ -4121,8 +4127,9 @@ mod tests {
         RequestCancelled, RequestContext, ResolveNode, Response, Route, RunCaptures, RunNodeScalar,
         SyncDocument, WireByteRange, WirePosition, WireRange, WorkerError, WorkerQuerySources,
         close_document, decode_frame, derive_snapshot_with_language, encode_frame,
-        named_node_count, replace_retained_bytes, reserve_retained_growth, route_response, run,
-        submit_document_job, sync_document, terminate_by_transport, validate_document_size,
+        named_node_count, parse_request_timeout, replace_retained_bytes, reserve_retained_growth,
+        route_response, run, submit_document_job, sync_document, terminate_by_transport,
+        validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -4320,6 +4327,20 @@ mod tests {
             decode_frame(&mut Cursor::new(bytes)).unwrap(),
             Some(request)
         );
+    }
+
+    #[test]
+    fn request_timeout_override_is_positive_milliseconds() {
+        assert_eq!(
+            parse_request_timeout(Some("125")),
+            Duration::from_millis(125)
+        );
+        assert_eq!(parse_request_timeout(Some("0")), Duration::from_secs(60));
+        assert_eq!(
+            parse_request_timeout(Some("invalid")),
+            Duration::from_secs(60)
+        );
+        assert_eq!(parse_request_timeout(None), Duration::from_secs(60));
     }
 
     #[test]

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -652,3 +652,89 @@ fn crashed_grammar_is_quarantined_only_in_session_and_other_grammar_recovers() {
             .expect("restart measurement log must be present")
     );
 }
+
+#[test]
+fn hung_grammar_hits_hard_deadline_and_other_grammar_recovers() {
+    let directory = tempfile::tempdir().unwrap();
+    let marker = directory.path().join("hang-once");
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_SHADOW", "true")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env("KAKEHASHI_TREE_WORKER_REQUEST_TIMEOUT_MS", "250")
+        .env(
+            "KAKEHASHI_TREE_WORKER_REQUEST_TIMEOUT_URI_SUFFIX",
+            "/hung.rs",
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_HANG_ONCE_FILE",
+            marker.to_string_lossy().into_owned(),
+        )
+        .env("KAKEHASHI_TREE_WORKER_HANG_URI_SUFFIX", "/hung.rs")
+        .env(
+            "RUST_LOG",
+            "kakehashi::tree_worker_shadow=info,kakehashi::tree_worker_shadow_metrics=info",
+        )
+        .build();
+    initialize(&mut client);
+    let healthy_uri = "file:///survives-hang.lua";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": healthy_uri,
+                "languageId": "lua",
+                "version": 1,
+                "text": "local recovered = true\n"
+            }
+        }),
+    );
+    let initial = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": healthy_uri } }),
+    );
+    assert!(initial.get("result").is_some(), "{initial:?}");
+
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": "file:///hung.rs",
+                "languageId": "rust",
+                "version": 1,
+                "text": "fn hangs_forever() {}\n"
+            }
+        }),
+    );
+    std::thread::sleep(Duration::from_secs(2));
+
+    let response = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": healthy_uri } }),
+    );
+    assert!(response.get("result").is_some(), "{response:?}");
+    std::thread::sleep(Duration::from_secs(1));
+
+    let stderr = shutdown_and_stderr(client);
+    assert!(marker.exists(), "failure injection did not run: {stderr}");
+    assert!(stderr.contains("timed out"), "{stderr}");
+    assert!(
+        stderr.contains("quarantined grammar conservatively for this session"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("symbol=rust"), "{stderr}");
+    assert!(stderr.contains("restarted worker generation"), "{stderr}");
+    assert!(
+        stderr.contains("full-resynced 1 open documents"),
+        "{stderr}"
+    );
+    assert_eq!(shadow_metric(&stderr, "matched"), 1, "{stderr}");
+    assert!(stderr.contains("pending=0"), "{stderr}");
+    assert!(!stderr.contains("disabled shadow tree tier"), "{stderr}");
+    eprintln!(
+        "hard-deadline recovery measurement: {}",
+        stderr
+            .lines()
+            .find(|line| line.contains("restarted worker generation"))
+            .expect("restart measurement log must be present")
+    );
+}


### PR DESCRIPTION
## Summary

- add a deterministic non-cooperative worker hang fixture
- allow E2E-only request deadlines scoped to the implicated URI
- prove timeout kill, native-evidenced classification, session quarantine, restart, and full resync of an unrelated open document
- record the Stage 11 recovery measurement and remaining hazard/control-lane gates

## Measurement

With a 250 ms injected deadline, generation 2 full-resynced one already-open Lua document (23 bytes) in 856 ms on the debug E2E build after the Rust request hung and was quarantined.

## Validation

- `cargo test --test e2e_tree_worker_shadow --features e2e --quiet` (34 passed)
- `cargo test --test tree_worker_process --features e2e --quiet` (4 passed)
- `cargo test --lib request_timeout_override_is_positive_milliseconds --quiet`
