### PR TITLE
perf(worker): preserve cross-document fairness

### DIFF
--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage12-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage12-measurement.md
@@ -1,0 +1,81 @@
+# Single Tree Worker Stage 12 Cross-Document Fairness Measurement
+
+## Scope
+
+Stage 12 protects an already-runnable user-blocking document from semantic-token
+injection fan-out in another document. The worker counts distinct runnable
+document URIs. A semantic request keeps nested Rayon parallelism while it is the
+only runnable document, but processes injection misses sequentially when another
+document is already runnable.
+
+This is admission-time protection, not the ADR's complete dynamic max-min
+scheduler. Work that becomes runnable after fan-out starts cannot yet reduce the
+running document's share until a cooperative boundary is reached.
+
+## Method
+
+The debug-build E2E fixture uses one worker with four compute threads and opens:
+
+```text
+A = Markdown with 60 Rust injection regions
+B = a small Rust document
+injected per-region test delay = 20 ms
+A admission delay = 100 ms
+foreground operation = kakehashi/node on B
+```
+
+The admission delay deterministically registers both document requests before A
+chooses its nested-parallelism policy. An E2E-only switch then forces the old
+unrestricted nested behavior in the same Stage 12 binary, providing a paired
+control without changing production behavior. Each mode ran in a fresh process
+10 times after warm compilation.
+
+## Result
+
+Lower is better:
+
+| Mode | B foreground median | B foreground mean | A completion median | A completion mean |
+| --- | ---: | ---: | ---: | ---: |
+| Competing document suppresses nested fan-out | 385.4 ms | 396.9 ms | 1.535 s | 1.532 s |
+| Nested fan-out forced | 424.9 ms | 467.7 ms | 1.594 s | 1.641 s |
+| Change | -9.3% | -15.1% | -3.7% | -6.6% |
+
+The foreground ranges were 346.0–563.9 ms with protection and 375.0–691.4 ms
+with nested fan-out forced. All protected runs completed B before A. The full
+parallel E2E suite also preserved this ordering under host contention: B
+completed in 6.37 seconds and A in 9.49 seconds, and all 35 tests passed.
+
+## Findings
+
+### Measure the user-blocking operation, not a second bulk derivation
+
+An initial experiment used semantic-token requests for both documents. Its
+five-run medians were 984 ms with protection and 944 ms with nested fan-out
+forced, so it showed no benefit. That workload measured equal-priority bulk
+throughput rather than the ADR's user-blocking fairness claim. Replacing B with
+`kakehashi/node` exposed the intended latency effect.
+
+### Rayon work stealing helps, but does not make admission free
+
+Even the forced control completed B before A in these isolated runs, showing
+that Rayon can steal outer work from nested fan-out. Explicitly retaining
+capacity for the competing document still reduced both foreground latency and
+total heavy-request completion in this fixture. The result supports one shared
+pool; it does not justify a second process or a permanently partitioned pool.
+
+### The dynamic fairness gate remains open
+
+The implementation detects competitors only before semantic derivation starts.
+It does not split fan-out into bounded scheduler-visible chunks, dynamically
+reduce a running document's share when a competitor arrives late, implement
+priority classes, or prove the `P == 1` cooperative degradation. The artificial
+delays also make this a deterministic contention experiment, not a claim about
+ordinary production latency.
+
+## Decision
+
+Keep admission-time nested-fan-out suppression as an incremental fairness
+improvement because it preserves the single-document parallel fast path and
+improves the measured user-blocking workload. Continue to bounded cooperative
+chunks and priority-aware admission before claiming the ADR's max-min fairness
+gate or accepting the ADR.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1168,6 +1168,13 @@ the implicated Rust grammar is session-quarantined, and a replacement generation
 full-resyncs and serves an already-open Lua document. Native hazard handshakes,
 saturated reserved control traffic, and descendant cleanup remain open gates.
 
+The [Stage 12 cross-document fairness measurement](single-resident-multithreaded-tree-worker-stage12-measurement.md)
+suppresses nested semantic fan-out when another document is already runnable.
+In a deterministic injection-contention fixture this reduced median
+user-blocking node latency by 9.3% without partitioning the worker pool. The
+decision is still made only at derivation admission; late-arrival chunking,
+priority classes, and one-thread cooperative fairness remain open gates.
+
 The implementation should proceed in measured stages:
 
 1. Prototype the framed transport, supervision, and one high-level

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -20,7 +20,9 @@ pub(crate) use parallel::build_document_discovery;
 pub(crate) use range::filter_semantic_tokens_by_range;
 
 // Re-export for parallel processing
-use parallel::{INJECTION_CACHE_MIN_REGIONS, InjectionCacheCtx, collect_injection_tokens_parallel};
+use parallel::{
+    INJECTION_CACHE_MIN_REGIONS, InjectionCacheCtx, collect_injection_tokens_with_parallelism,
+};
 
 /// Owned handle the LSP layer passes into [`handle_semantic_tokens_full`] to
 /// enable per-region injection-token caching (#529). `None` disables caching
@@ -184,7 +186,7 @@ pub(crate) fn compute_semantic_tokens_full(
     };
     let injection_work = || {
         let started = std::time::Instant::now();
-        let result = collect_injection_tokens_parallel(
+        let result = collect_injection_tokens_with_parallelism(
             &text,
             &lines,
             &line_starts,
@@ -195,6 +197,7 @@ pub(crate) fn compute_semantic_tokens_full(
             supports_multiline,
             cache_ctx.as_ref(),
             cancel.as_ref(),
+            compute_threads > 1,
         );
         (result, started.elapsed())
     };

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -1230,6 +1230,7 @@ fn build_combined_context<'a>(
 /// A region is *active* only if at least one token was produced from it (depth ≥ 1);
 /// resolved-but-empty injections don't suppress parent tokens.
 #[allow(clippy::too_many_arguments)]
+#[cfg(test)]
 pub(crate) fn collect_injection_tokens_parallel(
     host_text: &str,
     host_lines: &[&str],
@@ -1241,6 +1242,35 @@ pub(crate) fn collect_injection_tokens_parallel(
     supports_multiline: bool,
     cache_ctx: Option<&InjectionCacheCtx>,
     cancel: Option<&crate::cancel::CancelToken>,
+) -> (Vec<RawToken>, Vec<ActiveInjectionBounds>) {
+    collect_injection_tokens_with_parallelism(
+        host_text,
+        host_lines,
+        host_line_starts,
+        host_tree,
+        host_filetype,
+        coordinator,
+        capture_mappings,
+        supports_multiline,
+        cache_ctx,
+        cancel,
+        true,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn collect_injection_tokens_with_parallelism(
+    host_text: &str,
+    host_lines: &[&str],
+    host_line_starts: &[usize],
+    host_tree: &Tree,
+    host_filetype: Option<&str>,
+    coordinator: &LanguageCoordinator,
+    capture_mappings: Option<&CaptureMappings>,
+    supports_multiline: bool,
+    cache_ctx: Option<&InjectionCacheCtx>,
+    cancel: Option<&crate::cancel::CancelToken>,
+    allow_parallelism: bool,
 ) -> (Vec<RawToken>, Vec<ActiveInjectionBounds>) {
     use crate::cancel::is_cancelled;
     use rayon::prelude::*;
@@ -1376,6 +1406,17 @@ pub(crate) fn collect_injection_tokens_parallel(
                 },
             );
         }
+        #[cfg(feature = "e2e")]
+        if let Some(cache_ctx) = cache_ctx
+            && std::env::var("KAKEHASHI_TREE_WORKER_INJECTION_DELAY_URI_SUFFIX")
+                .ok()
+                .is_some_and(|suffix| cache_ctx.uri.as_str().ends_with(&suffix))
+            && let Ok(milliseconds) = std::env::var("KAKEHASHI_TREE_WORKER_INJECTION_DELAY_MS")
+                .unwrap_or_default()
+                .parse::<u64>()
+        {
+            std::thread::sleep(std::time::Duration::from_millis(milliseconds));
+        }
         (
             i,
             process_injection_sync(
@@ -1392,11 +1433,12 @@ pub(crate) fn collect_injection_tokens_parallel(
             ),
         )
     };
-    let processed: Vec<(usize, InjectionTokens)> = if miss_indices.len() >= PARALLEL_THRESHOLD {
-        miss_indices.par_iter().map(|&i| process_one(i)).collect()
-    } else {
-        miss_indices.iter().map(|&i| process_one(i)).collect()
-    };
+    let processed: Vec<(usize, InjectionTokens)> =
+        if allow_parallelism && miss_indices.len() >= PARALLEL_THRESHOLD {
+            miss_indices.par_iter().map(|&i| process_one(i)).collect()
+        } else {
+            miss_indices.iter().map(|&i| process_one(i)).collect()
+        };
 
     // Store region-local tokens for newly computed eligible, fully-loaded regions
     // (#529, write half), single-threaded after fan-in so cache writes never run

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -1153,7 +1153,13 @@ impl DocumentReplica {
         &mut self,
         request: DeriveSemanticTokens,
     ) -> Result<DerivedSemanticTokens, String> {
-        self.derive_semantic_tokens_with_telemetry(request, Duration::ZERO, Instant::now(), None)
+        self.derive_semantic_tokens_with_telemetry(
+            request,
+            Duration::ZERO,
+            Instant::now(),
+            rayon::current_num_threads(),
+            None,
+        )
     }
 
     fn derive_semantic_tokens_with_telemetry(
@@ -1161,6 +1167,7 @@ impl DocumentReplica {
         request: DeriveSemanticTokens,
         queue_wait: Duration,
         started: Instant,
+        compute_threads: usize,
         cancellation: Option<&crate::cancel::CancelToken>,
     ) -> Result<DerivedSemanticTokens, String> {
         self.validate_read_identity(&request.context)?;
@@ -1189,7 +1196,7 @@ impl DocumentReplica {
             .ok_or_else(|| "worker highlight query is unavailable".to_string())?;
         let discovery = self.semantic_discovery(request.context.configuration_generation);
         let result = crate::analysis::compute_semantic_tokens_full(
-            rayon::current_num_threads(),
+            compute_threads,
             Arc::from(self.text.as_str()),
             self.tree.clone(),
             query,
@@ -2413,6 +2420,47 @@ impl DocumentLane {
 type LaneRegistry = dashmap::DashMap<DocumentKey, Arc<DocumentLane>>;
 type DocumentLanes = Arc<LaneRegistry>;
 
+#[derive(Default)]
+struct RunnableDocuments {
+    counts: dashmap::DashMap<DocumentKey, usize>,
+}
+
+impl RunnableDocuments {
+    fn enter(self: &Arc<Self>, key: DocumentKey) -> RunnableDocumentGuard {
+        self.counts
+            .entry(key.clone())
+            .and_modify(|count| *count += 1)
+            .or_insert(1);
+        RunnableDocumentGuard {
+            runnable: Arc::clone(self),
+            key,
+        }
+    }
+
+    fn has_competitor(&self) -> bool {
+        self.counts.len() > 1
+    }
+}
+
+struct RunnableDocumentGuard {
+    runnable: Arc<RunnableDocuments>,
+    key: DocumentKey,
+}
+
+impl Drop for RunnableDocumentGuard {
+    fn drop(&mut self) {
+        if let dashmap::mapref::entry::Entry::Occupied(mut entry) =
+            self.runnable.counts.entry(self.key.clone())
+        {
+            if *entry.get() == 1 {
+                entry.remove();
+            } else {
+                *entry.get_mut() -= 1;
+            }
+        }
+    }
+}
+
 fn submit_document_job(
     lanes: &DocumentLanes,
     key: DocumentKey,
@@ -2437,6 +2485,7 @@ fn handle_work(
     retained_document_bytes: &RetainedDocumentBytes,
     queue_wait: Duration,
     cancellation: &crate::cancel::CancelToken,
+    allow_nested_parallelism: bool,
 ) -> Response {
     let context = request_context(&request)
         .expect("scheduled worker request must have context")
@@ -2476,9 +2525,14 @@ fn handle_work(
         Request::RunNodeScalar(request) => run_node_scalar(request, documents),
         Request::DeriveSelectionRanges(request) => derive_selection_ranges(request, documents),
         Request::DeriveInjectionRegions(request) => derive_injection_regions(request, documents),
-        Request::DeriveSemanticTokens(request) => {
-            derive_semantic_tokens(request, documents, queue_wait, started, cancellation)
-        }
+        Request::DeriveSemanticTokens(request) => derive_semantic_tokens(
+            request,
+            documents,
+            queue_wait,
+            started,
+            cancellation,
+            allow_nested_parallelism,
+        ),
         Request::RunCaptures(request) => run_captures(request, documents),
         Request::DeriveNativeBindings(request) => derive_native_bindings(request, documents),
         Request::ConfigureLanguages(request) => configure_languages(request, analysis),
@@ -2679,6 +2733,7 @@ fn derive_semantic_tokens(
     queue_wait: Duration,
     started: Instant,
     cancellation: &crate::cancel::CancelToken,
+    allow_nested_parallelism: bool,
 ) -> Response {
     let context = request.context.clone();
     let Some(replica) = documents
@@ -2696,6 +2751,7 @@ fn derive_semantic_tokens(
                 request,
                 queue_wait,
                 started,
+                semantic_compute_threads(rayon::current_num_threads(), allow_nested_parallelism),
                 Some(cancellation),
             ) {
                 Ok(result) => Response::SemanticTokens(result),
@@ -2706,6 +2762,14 @@ fn derive_semantic_tokens(
             }
         }
         Err(_) => poisoned_document_restart(context),
+    }
+}
+
+fn semantic_compute_threads(pool_threads: usize, allow_nested_parallelism: bool) -> usize {
+    if allow_nested_parallelism {
+        pool_threads
+    } else {
+        1
     }
 }
 
@@ -3224,6 +3288,7 @@ where
     let document_capacity = Arc::new(Mutex::new(0));
     let retained_document_bytes = Arc::new(AtomicUsize::new(0));
     let document_lanes: DocumentLanes = Arc::new(dashmap::DashMap::new());
+    let runnable_documents = Arc::new(RunnableDocuments::default());
     let cancellations = Arc::new(dashmap::DashMap::<u64, crate::cancel::CancelToken>::new());
     // The client permits at most four requests per compute thread. Decode one
     // frame beyond this pending window so cancellation stays observable under
@@ -3290,14 +3355,34 @@ where
         let retained_document_bytes = Arc::clone(&retained_document_bytes);
         let job_cancellations = Arc::clone(&cancellations);
         let lane_key = document_key(&request);
+        let runnable_guard = lane_key
+            .as_ref()
+            .map(|key| runnable_documents.enter(key.clone()));
+        let job_runnable_documents = Arc::clone(&runnable_documents);
         let action_key = lane_key.clone();
         let job: LaneJob = Box::new(move || {
+            #[cfg(feature = "e2e")]
+            if action_key.as_ref().is_some_and(|key| {
+                std::env::var("KAKEHASHI_TREE_WORKER_ADMISSION_DELAY_URI_SUFFIX")
+                    .ok()
+                    .is_some_and(|suffix| key.uri.ends_with(&suffix))
+            }) && let Ok(milliseconds) =
+                std::env::var("KAKEHASHI_TREE_WORKER_ADMISSION_DELAY_MS")
+                    .unwrap_or_default()
+                    .parse::<u64>()
+            {
+                std::thread::sleep(Duration::from_millis(milliseconds));
+            }
             permit_rx
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .recv()
                 .expect("worker admission queue stopped before its jobs");
             let permit = AdmissionPermit(permits);
+            let allow_nested_parallelism = !job_runnable_documents.has_competitor();
+            #[cfg(feature = "e2e")]
+            let allow_nested_parallelism = allow_nested_parallelism
+                || std::env::var_os("KAKEHASHI_TREE_WORKER_FORCE_NESTED_PARALLELISM").is_some();
             let response = handle_work(
                 request,
                 &analysis,
@@ -3307,6 +3392,7 @@ where
                 &retained_document_bytes,
                 enqueued.elapsed(),
                 &cancellation,
+                allow_nested_parallelism,
             );
             job_cancellations.remove(&request_id);
             let action = if action_key
@@ -3319,6 +3405,7 @@ where
             };
             let _ = responses.send((response, Some(permit)));
             let _ = completion_tx.send(());
+            drop(runnable_guard);
             action
         });
         if let Some(lane_key) = lane_key {
@@ -3463,6 +3550,7 @@ pub struct Client {
 
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
+#[cfg(any(test, feature = "e2e"))]
 fn parse_request_timeout(value: Option<&str>) -> Duration {
     value
         .and_then(|value| value.parse::<u64>().ok())
@@ -4125,11 +4213,11 @@ mod tests {
         MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeLayerSelector, NodeNavigation,
         NodeScalarOperation, NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION, Request,
         RequestCancelled, RequestContext, ResolveNode, Response, Route, RunCaptures, RunNodeScalar,
-        SyncDocument, WireByteRange, WirePosition, WireRange, WorkerError, WorkerQuerySources,
-        close_document, decode_frame, derive_snapshot_with_language, encode_frame,
-        named_node_count, parse_request_timeout, replace_retained_bytes, reserve_retained_growth,
-        route_response, run, submit_document_job, sync_document, terminate_by_transport,
-        validate_document_size,
+        RunnableDocuments, SyncDocument, WireByteRange, WirePosition, WireRange, WorkerError,
+        WorkerQuerySources, close_document, decode_frame, derive_snapshot_with_language,
+        encode_frame, named_node_count, parse_request_timeout, replace_retained_bytes,
+        reserve_retained_growth, route_response, run, semantic_compute_threads,
+        submit_document_job, sync_document, terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -4681,6 +4769,36 @@ mod tests {
         gate.1.notify_all();
         completed_rx.recv_timeout(Duration::from_secs(5)).unwrap();
         assert_eq!(*order.lock().unwrap(), [1, 2]);
+    }
+
+    #[test]
+    fn runnable_documents_count_distinct_uris_not_backlog_depth() {
+        let runnable = Arc::new(RunnableDocuments::default());
+        let a = DocumentKey {
+            uri: "file:///a.rs".into(),
+        };
+        let b = DocumentKey {
+            uri: "file:///b.rs".into(),
+        };
+
+        let first_a = runnable.enter(a.clone());
+        let second_a = runnable.enter(a);
+        assert!(!runnable.has_competitor());
+
+        let first_b = runnable.enter(b);
+        assert!(runnable.has_competitor());
+        drop(first_b);
+        assert!(!runnable.has_competitor());
+
+        drop(second_a);
+        drop(first_a);
+        assert!(!runnable.has_competitor());
+    }
+
+    #[test]
+    fn competing_document_disables_nested_semantic_parallelism() {
+        assert_eq!(semantic_compute_threads(4, true), 4);
+        assert_eq!(semantic_compute_threads(4, false), 1);
     }
 
     #[test]
@@ -5386,6 +5504,7 @@ mod tests {
             },
             Duration::ZERO,
             Instant::now(),
+            rayon::current_num_threads(),
             Some(&cancellation),
         );
 

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -738,3 +738,92 @@ fn hung_grammar_hits_hard_deadline_and_other_grammar_recovers() {
             .expect("restart measurement log must be present")
     );
 }
+
+#[test]
+fn competing_document_finishes_while_injection_fanout_is_running() {
+    let force_nested = std::env::var_os("KAKEHASHI_E2E_FORCE_NESTED_PARALLELISM").is_some();
+    let mut builder = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_MODE", "authoritative")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env(
+            "KAKEHASHI_TREE_WORKER_ADMISSION_DELAY_URI_SUFFIX",
+            "/fair-a.md",
+        )
+        .env("KAKEHASHI_TREE_WORKER_ADMISSION_DELAY_MS", "100")
+        .env(
+            "KAKEHASHI_TREE_WORKER_INJECTION_DELAY_URI_SUFFIX",
+            "/fair-a.md",
+        )
+        .env("KAKEHASHI_TREE_WORKER_INJECTION_DELAY_MS", "20");
+    if force_nested {
+        builder = builder.env("KAKEHASHI_TREE_WORKER_FORCE_NESTED_PARALLELISM", "1");
+    }
+    let mut client = builder.build();
+    initialize(&mut client);
+    let heavy_uri = "file:///fair-a.md";
+    let heavy = (0..60)
+        .map(|index| format!("```rust\nfn injected_{index}() {{}}\n```\n"))
+        .collect::<String>();
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": heavy_uri,
+                "languageId": "markdown",
+                "version": 1,
+                "text": heavy
+            }
+        }),
+    );
+    let foreground_uri = "file:///fair-b.rs";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": foreground_uri,
+                "languageId": "rust",
+                "version": 1,
+                "text": "fn foreground() {}\n"
+            }
+        }),
+    );
+    std::thread::sleep(Duration::from_secs(1));
+
+    let heavy_started = std::time::Instant::now();
+    let heavy_request = client.send_request_async(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": heavy_uri } }),
+    );
+    let started = std::time::Instant::now();
+    let foreground_request = client.send_request_async(
+        "kakehashi/node",
+        json!({
+            "textDocument": { "uri": foreground_uri },
+            "position": { "line": 0, "character": 4 }
+        }),
+    );
+    let mut foreground_elapsed = None;
+    let mut heavy_elapsed = None;
+    for _ in 0..2 {
+        let response = client.receive_next_response_public();
+        assert!(response.get("result").is_some(), "{response:?}");
+        match response.get("id").and_then(|id| id.as_i64()) {
+            Some(id) if id == foreground_request => foreground_elapsed = Some(started.elapsed()),
+            Some(id) if id == heavy_request => heavy_elapsed = Some(heavy_started.elapsed()),
+            _ => panic!("unexpected response while measuring fairness: {response:?}"),
+        }
+    }
+    let foreground_elapsed = foreground_elapsed.expect("foreground response must arrive");
+    let heavy_elapsed = heavy_elapsed.expect("heavy response must arrive");
+    if !force_nested {
+        assert!(
+            heavy_elapsed > foreground_elapsed,
+            "heavy fanout did not yield completion order to the foreground document: heavy={heavy_elapsed:?} foreground={foreground_elapsed:?}"
+        );
+    }
+
+    let _stderr = shutdown_and_stderr(client);
+    eprintln!(
+        "cross-document force_nested={force_nested} foreground_latency={foreground_elapsed:?} heavy_completion={heavy_elapsed:?}"
+    );
+}

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -607,6 +607,26 @@ impl LspClient {
         self.receive_response_for_id(expected_id)
     }
 
+    /// Receive the next client-request response without assuming completion order.
+    pub(crate) fn receive_next_response_public(&mut self) -> Value {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            assert!(!remaining.is_zero(), "timed out waiting for next response");
+            let message = match self.rx.recv_timeout(remaining) {
+                Ok(ReaderEvent::Message(value)) => value,
+                Ok(ReaderEvent::Error(error)) => panic!("{error}"),
+                Err(RecvTimeoutError::Timeout) => panic!("timed out waiting for next response"),
+                Err(RecvTimeoutError::Disconnected) => {
+                    panic!("server closed connection while waiting for next response")
+                }
+            };
+            if message.get("id").is_some() && message.get("method").is_none() {
+                return message;
+            }
+        }
+    }
+
     /// Receive a client-request response while retaining selected notifications
     /// that arrived before it. Useful for initialization tests, where the normal
     /// synchronous response helper intentionally discards notifications.


### PR DESCRIPTION
## Summary

- keep nested semantic fan-out for the single-document fast path
- suppress injection fan-out when another document is already runnable
- prove a user-blocking node request completes before injection-heavy work
- record paired Stage 12 measurements and remaining dynamic-fairness gates

## Measurement

Ten isolated debug E2E runs using the same Stage 12 binary:

| Mode | Foreground median | Heavy completion median |
| --- | ---: | ---: |
| fairness protection | 385.4 ms | 1.535 s |
| nested fan-out forced | 424.9 ms | 1.594 s |
| change | -9.3% | -3.7% |

This is admission-time protection. Late-arrival chunking, priority classes, and the one-thread cooperative guarantee remain open.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --lib --tests --features e2e`
- `cargo test --lib` (3126 passed, 2 ignored)
- `cargo test --test tree_worker_process` (2 passed)
- `cargo test --features e2e --test e2e_tree_worker_shadow -- --nocapture` (35 passed)
