### PR TITLE
perf(worker): yield nested fanout at chunk boundaries

### DIFF
--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage13-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage13-measurement.md
@@ -1,0 +1,91 @@
+# Single Tree Worker Stage 13 Dynamic Fairness Measurement
+
+## Scope
+
+Stage 13 turns Stage 12's admission-time semantic policy into a dynamically
+rechecked policy. Injection cache misses are divided into chunks no larger than
+the worker compute-thread count. Before every chunk, the semantic request asks
+whether another document is runnable:
+
+* no competitor: process the next chunk in parallel and borrow idle capacity;
+* competitor present: process the next chunk sequentially, leaving the other
+  worker threads available to outer document jobs; and
+* competitor gone: resume parallel chunks without restarting the request.
+
+The legacy parent semantic path passes no gate and retains its previous nested
+parallel behavior.
+
+## Method
+
+### Late-arrival behavior
+
+The E2E test uses one worker with four compute threads and a Markdown document
+with eight Rust injection regions, which creates exactly two four-region
+chunks. E2E-only barriers establish this causal order:
+
+1. A begins its first chunk while no other document is runnable.
+2. The first chunk pauses after proving idle capacity was observed.
+3. B is opened and its worker request is registered in the runnable-document
+   set, even though A's nested work currently occupies the pool.
+4. A's first chunk is released.
+5. Before the second chunk, A observes B and records a yield.
+
+The B worker job remains behind a test-only barrier until that yield is
+recorded. This makes the assertion independent of process startup, CPU
+contention, and Rayon scheduling speed.
+
+### No-competitor regression
+
+The Stage 12 and Stage 13 debug server binaries were driven by the same release
+benchmark harness in authoritative-worker mode. Each scenario used 40 measured
+requests after 10 warmups, with no artificial delay.
+
+## Result
+
+The late-arrival E2E test observed the required allowed-to-denied transition.
+The focused run completed B's node request in 919 ms and A in 2.405 seconds.
+Under the full parallel E2E suite it still observed the yield, with B at 912 ms
+and A at 11.332 seconds; all 36 tests passed.
+
+Single-document medians were:
+
+| Scenario | Stage 12 | Stage 13 | Change |
+| --- | ---: | ---: | ---: |
+| Markdown, 60 injections, full | 2.545 ms | 2.537 ms | -0.3% |
+| Markdown, 150 injections, full | 5.650 ms | 5.640 ms | -0.2% |
+
+The chunk-boundary overhead was below the noise floor in both measured
+no-competitor workloads.
+
+## Findings
+
+### Runnable registration must precede compute admission
+
+The deterministic test exposed a useful scheduler property: nested work can
+temporarily occupy every Rayon thread, so a competing outer job may not begin.
+Its document must therefore enter the runnable set when the worker reader
+accepts it, before pool admission. Waiting for the competing job body to start
+would make the fairness signal itself vulnerable to starvation.
+
+### Rayon work stealing handles short competitors well
+
+An early late-arrival fixture used a small node request that completed in about
+42 ms, before A reached its next 50 ms chunk boundary. No yield was necessary.
+The final fixture holds B runnable until the boundary to test the policy rather
+than a timing accident. Dynamic chunking adds an upper bound; it does not claim
+that every short competitor needs explicit intervention.
+
+### This is bounded yielding, not full max-min scheduling
+
+Stage 13 rechecks after at most one compute-width injection chunk and restores
+idle borrowing dynamically. It still gives a competing set the aggregate
+remaining threads rather than round-robin chunk admission per document. It
+does not define user-blocking versus speculative priority classes, split other
+long tree walks, or prove useful cooperative progress with a one-thread worker.
+
+## Decision
+
+Keep bounded dynamic injection chunks. They close the late-arrival hole without
+a measurable single-document regression. Continue with explicit priority and
+multi-document scheduler admission before claiming the ADR's full max-min
+fairness gate.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1175,6 +1175,13 @@ user-blocking node latency by 9.3% without partitioning the worker pool. The
 decision is still made only at derivation admission; late-arrival chunking,
 priority classes, and one-thread cooperative fairness remain open gates.
 
+The [Stage 13 dynamic-fairness measurement](single-resident-multithreaded-tree-worker-stage13-measurement.md)
+splits injection fan-out into compute-width chunks and rechecks cross-document
+competition at every boundary. A causal E2E barrier proves a late competitor
+changes the next chunk's policy, while 40-request single-document benchmarks
+show no measurable regression. Per-document max-min admission, explicit
+priority classes, other long tree walks, and one-thread fairness remain open.
+
 The implementation should proceed in measured stages:
 
 1. Prototype the framed transport, supervision, and one high-level

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -118,8 +118,13 @@ pub(crate) fn compute_semantic_tokens_full(
     supports_multiline: bool,
     injection_cache: Option<InjectionCacheParams>,
     cancel: Option<crate::cancel::CancelToken>,
+    nested_parallelism: Option<&(dyn Fn() -> bool + Sync)>,
 ) -> Option<SemanticTokensResult> {
     let is_cancelled = || crate::cancel::is_cancelled(cancel.as_ref());
+    let allow_nested_parallelism = || {
+        compute_threads > 1
+            && nested_parallelism.is_none_or(|allow_parallelism| allow_parallelism())
+    };
     let compute_started = std::time::Instant::now();
     let mut host_tokens: Vec<RawToken> = Vec::with_capacity(1000);
     let lines: Vec<&str> = text.lines().collect();
@@ -150,19 +155,20 @@ pub(crate) fn compute_semantic_tokens_full(
         discovery: p.discovery.as_deref(),
     });
 
-    let should_parallelize = cache_ctx.as_ref().is_some_and(|ctx| {
-        should_parallelize_host_and_injections(
-            compute_threads,
-            ctx.generation,
-            ctx.discovery.map(|discovery| {
-                (
-                    discovery.generation,
-                    discovery.complete,
-                    discovery.regions.len(),
-                )
-            }),
-        )
-    });
+    let should_parallelize = allow_nested_parallelism()
+        && cache_ctx.as_ref().is_some_and(|ctx| {
+            should_parallelize_host_and_injections(
+                compute_threads,
+                ctx.generation,
+                ctx.discovery.map(|discovery| {
+                    (
+                        discovery.generation,
+                        discovery.complete,
+                        discovery.regions.len(),
+                    )
+                }),
+            )
+        });
     let mut host_work = || {
         let started = std::time::Instant::now();
         let complete = collect_host_tokens(
@@ -197,7 +203,7 @@ pub(crate) fn compute_semantic_tokens_full(
             supports_multiline,
             cache_ctx.as_ref(),
             cancel.as_ref(),
-            compute_threads > 1,
+            &allow_nested_parallelism,
         );
         (result, started.elapsed())
     };
@@ -305,6 +311,7 @@ pub(crate) async fn handle_semantic_tokens_full(
             supports_multiline,
             injection_cache,
             cancel,
+            None,
         )
     })
     .await

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -1254,8 +1254,33 @@ pub(crate) fn collect_injection_tokens_parallel(
         supports_multiline,
         cache_ctx,
         cancel,
-        true,
+        &|| true,
     )
+}
+
+fn map_fanout_chunks<T, R, Parallel, Map>(
+    items: &[T],
+    chunk_size: usize,
+    should_parallelize: Parallel,
+    map: Map,
+) -> Vec<R>
+where
+    T: Sync,
+    R: Send,
+    Parallel: Fn() -> bool,
+    Map: Fn(&T) -> R + Sync,
+{
+    use rayon::prelude::*;
+
+    let mut output = Vec::with_capacity(items.len());
+    for chunk in items.chunks(chunk_size.max(1)) {
+        if should_parallelize() {
+            output.extend(chunk.par_iter().map(&map).collect::<Vec<_>>());
+        } else {
+            output.extend(chunk.iter().map(&map));
+        }
+    }
+    output
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1270,10 +1295,9 @@ pub(crate) fn collect_injection_tokens_with_parallelism(
     supports_multiline: bool,
     cache_ctx: Option<&InjectionCacheCtx>,
     cancel: Option<&crate::cancel::CancelToken>,
-    allow_parallelism: bool,
+    allow_parallelism: &(dyn Fn() -> bool + Sync),
 ) -> (Vec<RawToken>, Vec<ActiveInjectionBounds>) {
     use crate::cancel::is_cancelled;
-    use rayon::prelude::*;
 
     // Reuse the discovery `populate_injections` already ran on this exact tree,
     // when present and still generation-current (#529 companion lever): rebuild
@@ -1407,6 +1431,21 @@ pub(crate) fn collect_injection_tokens_with_parallelism(
             );
         }
         #[cfg(feature = "e2e")]
+        if let Ok(path) = std::env::var("KAKEHASHI_TREE_WORKER_FANOUT_STARTED_FILE") {
+            let _ = std::fs::write(path, b"started");
+        }
+        #[cfg(feature = "e2e")]
+        if std::env::var("KAKEHASHI_TREE_WORKER_FAIRNESS_ALLOWED_FILE")
+            .ok()
+            .is_some_and(|path| std::path::Path::new(&path).exists())
+            && let Ok(path) = std::env::var("KAKEHASHI_TREE_WORKER_FANOUT_RELEASE_FILE")
+        {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            while !std::path::Path::new(&path).exists() && std::time::Instant::now() < deadline {
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+        }
+        #[cfg(feature = "e2e")]
         if let Some(cache_ctx) = cache_ctx
             && std::env::var("KAKEHASHI_TREE_WORKER_INJECTION_DELAY_URI_SUFFIX")
                 .ok()
@@ -1433,12 +1472,16 @@ pub(crate) fn collect_injection_tokens_with_parallelism(
             ),
         )
     };
-    let processed: Vec<(usize, InjectionTokens)> =
-        if allow_parallelism && miss_indices.len() >= PARALLEL_THRESHOLD {
-            miss_indices.par_iter().map(|&i| process_one(i)).collect()
-        } else {
-            miss_indices.iter().map(|&i| process_one(i)).collect()
-        };
+    let processed: Vec<(usize, InjectionTokens)> = if miss_indices.len() >= PARALLEL_THRESHOLD {
+        map_fanout_chunks(
+            &miss_indices,
+            rayon::current_num_threads(),
+            allow_parallelism,
+            |&i| process_one(i),
+        )
+    } else {
+        miss_indices.iter().map(|&i| process_one(i)).collect()
+    };
 
     // Store region-local tokens for newly computed eligible, fully-loaded regions
     // (#529, write half), single-threaded after fan-in so cache writes never run
@@ -1632,11 +1675,28 @@ fn byte_to_line_col(
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use tree_sitter::Query;
 
     use super::super::token_collector::build_line_start_bytes;
     use super::*;
+
+    #[test]
+    fn fanout_rechecks_parallelism_before_each_bounded_chunk() {
+        let checks = AtomicUsize::new(0);
+        let items = (0..10).collect::<Vec<_>>();
+
+        let output = map_fanout_chunks(
+            &items,
+            4,
+            || checks.fetch_add(1, Ordering::SeqCst) == 0,
+            |item| *item,
+        );
+
+        assert_eq!(output, items);
+        assert_eq!(checks.load(Ordering::SeqCst), 3);
+    }
 
     #[test]
     fn reusable_region_visit_stops_on_mid_loop_cancel() {

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -1159,6 +1159,7 @@ impl DocumentReplica {
             Instant::now(),
             rayon::current_num_threads(),
             None,
+            None,
         )
     }
 
@@ -1169,6 +1170,7 @@ impl DocumentReplica {
         started: Instant,
         compute_threads: usize,
         cancellation: Option<&crate::cancel::CancelToken>,
+        nested_parallelism: Option<&(dyn Fn() -> bool + Sync)>,
     ) -> Result<DerivedSemanticTokens, String> {
         self.validate_read_identity(&request.context)?;
         if let Some((generation, supports_multiline, tokens)) = &self.cached_semantic_tokens
@@ -1214,6 +1216,7 @@ impl DocumentReplica {
                 discovery,
             }),
             cancellation.cloned(),
+            nested_parallelism,
         )
         .ok_or_else(|| "worker semantic token derivation was cancelled".to_string())?;
         let tokens: Vec<WireSemanticToken> = match result {
@@ -2485,7 +2488,7 @@ fn handle_work(
     retained_document_bytes: &RetainedDocumentBytes,
     queue_wait: Duration,
     cancellation: &crate::cancel::CancelToken,
-    allow_nested_parallelism: bool,
+    nested_parallelism: &(dyn Fn() -> bool + Sync),
 ) -> Response {
     let context = request_context(&request)
         .expect("scheduled worker request must have context")
@@ -2531,7 +2534,7 @@ fn handle_work(
             queue_wait,
             started,
             cancellation,
-            allow_nested_parallelism,
+            nested_parallelism,
         ),
         Request::RunCaptures(request) => run_captures(request, documents),
         Request::DeriveNativeBindings(request) => derive_native_bindings(request, documents),
@@ -2733,7 +2736,7 @@ fn derive_semantic_tokens(
     queue_wait: Duration,
     started: Instant,
     cancellation: &crate::cancel::CancelToken,
-    allow_nested_parallelism: bool,
+    nested_parallelism: &(dyn Fn() -> bool + Sync),
 ) -> Response {
     let context = request.context.clone();
     let Some(replica) = documents
@@ -2751,8 +2754,9 @@ fn derive_semantic_tokens(
                 request,
                 queue_wait,
                 started,
-                semantic_compute_threads(rayon::current_num_threads(), allow_nested_parallelism),
+                rayon::current_num_threads(),
                 Some(cancellation),
+                Some(nested_parallelism),
             ) {
                 Ok(result) => Response::SemanticTokens(result),
                 Err(message) => Response::Error(WorkerError {
@@ -2762,14 +2766,6 @@ fn derive_semantic_tokens(
             }
         }
         Err(_) => poisoned_document_restart(context),
-    }
-}
-
-fn semantic_compute_threads(pool_threads: usize, allow_nested_parallelism: bool) -> usize {
-    if allow_nested_parallelism {
-        pool_threads
-    } else {
-        1
     }
 }
 
@@ -3358,6 +3354,15 @@ where
         let runnable_guard = lane_key
             .as_ref()
             .map(|key| runnable_documents.enter(key.clone()));
+        #[cfg(feature = "e2e")]
+        if lane_key.as_ref().is_some_and(|key| {
+            std::env::var("KAKEHASHI_TREE_WORKER_RUNNABLE_ENTERED_URI_SUFFIX")
+                .ok()
+                .is_some_and(|suffix| key.uri.ends_with(&suffix))
+        }) && let Ok(path) = std::env::var("KAKEHASHI_TREE_WORKER_RUNNABLE_ENTERED_FILE")
+        {
+            let _ = std::fs::write(path, b"runnable");
+        }
         let job_runnable_documents = Arc::clone(&runnable_documents);
         let action_key = lane_key.clone();
         let job: LaneJob = Box::new(move || {
@@ -3372,6 +3377,12 @@ where
                     .parse::<u64>()
             {
                 std::thread::sleep(Duration::from_millis(milliseconds));
+                if let Ok(path) = std::env::var("KAKEHASHI_TREE_WORKER_ADMISSION_RELEASE_FILE") {
+                    let deadline = Instant::now() + Duration::from_secs(10);
+                    while !std::path::Path::new(&path).exists() && Instant::now() < deadline {
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                }
             }
             permit_rx
                 .lock()
@@ -3379,10 +3390,41 @@ where
                 .recv()
                 .expect("worker admission queue stopped before its jobs");
             let permit = AdmissionPermit(permits);
-            let allow_nested_parallelism = !job_runnable_documents.has_competitor();
             #[cfg(feature = "e2e")]
-            let allow_nested_parallelism = allow_nested_parallelism
-                || std::env::var_os("KAKEHASHI_TREE_WORKER_FORCE_NESTED_PARALLELISM").is_some();
+            let nested_parallelism_was_allowed = AtomicBool::new(false);
+            #[cfg(feature = "e2e")]
+            let nested_parallelism_yield_was_reported = AtomicBool::new(false);
+            let allow_nested_parallelism = || {
+                #[cfg(feature = "e2e")]
+                if std::env::var_os("KAKEHASHI_TREE_WORKER_FORCE_NESTED_PARALLELISM").is_some() {
+                    return true;
+                }
+                let allowed = !job_runnable_documents.has_competitor();
+                #[cfg(feature = "e2e")]
+                let trace_fairness = action_key.as_ref().is_some_and(|key| {
+                    std::env::var("KAKEHASHI_TREE_WORKER_FAIRNESS_TRACE_URI_SUFFIX")
+                        .ok()
+                        .is_some_and(|suffix| key.uri.ends_with(&suffix))
+                });
+                #[cfg(feature = "e2e")]
+                if allowed {
+                    if trace_fairness
+                        && let Ok(path) =
+                            std::env::var("KAKEHASHI_TREE_WORKER_FAIRNESS_ALLOWED_FILE")
+                    {
+                        let _ = std::fs::write(path, b"allowed");
+                    }
+                    nested_parallelism_was_allowed.store(true, Ordering::Relaxed);
+                } else if nested_parallelism_was_allowed.load(Ordering::Relaxed)
+                    && !nested_parallelism_yield_was_reported.swap(true, Ordering::Relaxed)
+                    && trace_fairness
+                {
+                    if let Ok(path) = std::env::var("KAKEHASHI_TREE_WORKER_FAIRNESS_YIELDED_FILE") {
+                        let _ = std::fs::write(path, b"yielded");
+                    }
+                }
+                allowed
+            };
             let response = handle_work(
                 request,
                 &analysis,
@@ -3392,7 +3434,7 @@ where
                 &retained_document_bytes,
                 enqueued.elapsed(),
                 &cancellation,
-                allow_nested_parallelism,
+                &allow_nested_parallelism,
             );
             job_cancellations.remove(&request_id);
             let action = if action_key
@@ -4216,8 +4258,8 @@ mod tests {
         RunnableDocuments, SyncDocument, WireByteRange, WirePosition, WireRange, WorkerError,
         WorkerQuerySources, close_document, decode_frame, derive_snapshot_with_language,
         encode_frame, named_node_count, parse_request_timeout, replace_retained_bytes,
-        reserve_retained_growth, route_response, run, semantic_compute_threads,
-        submit_document_job, sync_document, terminate_by_transport, validate_document_size,
+        reserve_retained_growth, route_response, run, submit_document_job, sync_document,
+        terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -4796,9 +4838,21 @@ mod tests {
     }
 
     #[test]
-    fn competing_document_disables_nested_semantic_parallelism() {
-        assert_eq!(semantic_compute_threads(4, true), 4);
-        assert_eq!(semantic_compute_threads(4, false), 1);
+    fn nested_parallelism_gate_tracks_competing_document_lifetime() {
+        let runnable = Arc::new(RunnableDocuments::default());
+        let first = runnable.enter(DocumentKey {
+            uri: "file:///a.rs".into(),
+        });
+        let allow_nested_parallelism = || !runnable.has_competitor();
+        assert!(allow_nested_parallelism());
+
+        let competitor = runnable.enter(DocumentKey {
+            uri: "file:///b.rs".into(),
+        });
+        assert!(!allow_nested_parallelism());
+        drop(competitor);
+        assert!(allow_nested_parallelism());
+        drop(first);
     }
 
     #[test]
@@ -5506,6 +5560,7 @@ mod tests {
             Instant::now(),
             rayon::current_num_threads(),
             Some(&cancellation),
+            None,
         );
 
         assert_eq!(

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -827,3 +827,151 @@ fn competing_document_finishes_while_injection_fanout_is_running() {
         "cross-document force_nested={force_nested} foreground_latency={foreground_elapsed:?} heavy_completion={heavy_elapsed:?}"
     );
 }
+
+#[test]
+fn late_competing_document_reduces_fanout_at_a_chunk_boundary() {
+    let force_nested = std::env::var_os("KAKEHASHI_E2E_FORCE_NESTED_PARALLELISM").is_some();
+    let marker_dir = tempfile::tempdir().expect("create fanout marker directory");
+    let fanout_started = marker_dir.path().join("started");
+    let fanout_release = marker_dir.path().join("release");
+    let fanout_allowed = marker_dir.path().join("allowed");
+    let fanout_yielded = marker_dir.path().join("yielded");
+    let competitor_runnable = marker_dir.path().join("competitor-runnable");
+    let mut builder = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_MODE", "authoritative")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env(
+            "KAKEHASHI_TREE_WORKER_INJECTION_DELAY_URI_SUFFIX",
+            "/late-fair-a.md",
+        )
+        .env("KAKEHASHI_TREE_WORKER_INJECTION_DELAY_MS", "50")
+        .env(
+            "KAKEHASHI_TREE_WORKER_ADMISSION_DELAY_URI_SUFFIX",
+            "/late-fair-b.rs",
+        )
+        .env("KAKEHASHI_TREE_WORKER_ADMISSION_DELAY_MS", "200")
+        .env(
+            "KAKEHASHI_TREE_WORKER_ADMISSION_RELEASE_FILE",
+            fanout_yielded.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_RUNNABLE_ENTERED_URI_SUFFIX",
+            "/late-fair-b.rs",
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_RUNNABLE_ENTERED_FILE",
+            competitor_runnable.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_FAIRNESS_TRACE_URI_SUFFIX",
+            "/late-fair-a.md",
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_FANOUT_STARTED_FILE",
+            fanout_started.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_FANOUT_RELEASE_FILE",
+            fanout_release.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_FAIRNESS_YIELDED_FILE",
+            fanout_yielded.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_FAIRNESS_ALLOWED_FILE",
+            fanout_allowed.to_string_lossy(),
+        );
+    if force_nested {
+        builder = builder.env("KAKEHASHI_TREE_WORKER_FORCE_NESTED_PARALLELISM", "1");
+    }
+    let mut client = builder.build();
+    initialize(&mut client);
+    let heavy_uri = "file:///late-fair-a.md";
+    let heavy = (0..8)
+        .map(|index| format!("```rust\nfn late_injected_{index}() {{}}\n```\n"))
+        .collect::<String>();
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": heavy_uri,
+                "languageId": "markdown",
+                "version": 1,
+                "text": heavy
+            }
+        }),
+    );
+    let foreground_uri = "file:///late-fair-b.rs";
+    let heavy_started = std::time::Instant::now();
+    let heavy_request = client.send_request_async(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": heavy_uri } }),
+    );
+    let marker_deadline = std::time::Instant::now() + Duration::from_secs(30);
+    while (!fanout_started.exists() || !fanout_allowed.exists())
+        && std::time::Instant::now() < marker_deadline
+    {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(fanout_started.exists(), "heavy fanout did not start");
+    assert!(
+        fanout_allowed.exists(),
+        "heavy fanout never observed idle capacity"
+    );
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": foreground_uri,
+                "languageId": "rust",
+                "version": 1,
+                "text": "fn late_foreground() {}\n"
+            }
+        }),
+    );
+    let foreground_started = std::time::Instant::now();
+    let foreground_request = client.send_request_async(
+        "kakehashi/node",
+        json!({
+            "textDocument": { "uri": foreground_uri },
+            "position": { "line": 0, "character": 4 }
+        }),
+    );
+    let competitor_deadline = std::time::Instant::now() + Duration::from_secs(30);
+    while !competitor_runnable.exists() && std::time::Instant::now() < competitor_deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(
+        competitor_runnable.exists(),
+        "competing worker job was not registered as runnable"
+    );
+    std::fs::write(&fanout_release, b"release").expect("release the first fanout chunk");
+
+    let mut foreground_elapsed = None;
+    let mut heavy_elapsed = None;
+    for _ in 0..2 {
+        let response = client.receive_next_response_public();
+        assert!(response.get("result").is_some(), "{response:?}");
+        match response.get("id").and_then(|id| id.as_i64()) {
+            Some(id) if id == foreground_request => {
+                foreground_elapsed = Some(foreground_started.elapsed())
+            }
+            Some(id) if id == heavy_request => heavy_elapsed = Some(heavy_started.elapsed()),
+            _ => panic!("unexpected response while measuring late fairness: {response:?}"),
+        }
+    }
+    let foreground_elapsed = foreground_elapsed.expect("foreground response must arrive");
+    let heavy_elapsed = heavy_elapsed.expect("heavy response must arrive");
+    let _stderr = shutdown_and_stderr(client);
+    eprintln!(
+        "late cross-document force_nested={force_nested} foreground_latency={foreground_elapsed:?} heavy_completion={heavy_elapsed:?} yielded={}",
+        fanout_yielded.exists(),
+    );
+    if !force_nested {
+        assert!(
+            fanout_yielded.exists(),
+            "late competitor did not change a later chunk's admission"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- split semantic injection misses into compute-width chunks
- recheck cross-document competition before every chunk
- resume nested parallelism after competitors leave
- prove late-arrival yielding with a causal E2E barrier
- record no-competitor A/B measurements and remaining scheduler gates

## Measurement

Authoritative worker, 40 requests after 10 warmups, Stage 12 vs Stage 13:

| Scenario | Stage 12 | Stage 13 | Change |
| --- | ---: | ---: | ---: |
| Markdown 60 injections/full | 2.545 ms | 2.537 ms | -0.3% |
| Markdown 150 injections/full | 5.650 ms | 5.640 ms | -0.2% |

The late-arrival E2E test causally registers B as runnable while A's first nested chunk occupies the pool, then proves A yields at the next chunk boundary.

## Remaining gates

- per-document max-min chunk admission across more than two documents
- explicit user-blocking/speculative priority classes
- cooperative chunking for other long tree walks
- one-thread priority/fairness behavior

## Validation

- `cargo fmt --all -- --check`
- `cargo check --lib --tests --features e2e`
- `cargo test --lib` (3127 passed, 2 ignored)
- `cargo test --features e2e --test tree_worker_process` (4 passed)
- `cargo test --features e2e --test e2e_tree_worker_shadow -- --nocapture` (36 passed)
