### PR TITLE
perf(worker): prioritize foreground work at chunk boundaries

### DIFF
--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage14-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage14-measurement.md
@@ -1,0 +1,117 @@
+# Single Tree Worker Stage 14 Priority Measurement
+
+## Scope
+
+Stage 14 distinguishes foreground worker requests from bulk derivations.
+Semantic-token injection fan-out now chooses one of three policies at every
+compute-width chunk boundary:
+
+* no competing document: continue parallel fan-out;
+* a background-only document competes: process the chunk sequentially; or
+* a foreground document competes: yield once to the Rayon pool, then process
+  the chunk according to the newly observed policy.
+
+Document writes, node accessors, captures, selection ranges, native bindings,
+configuration, and close are foreground. Snapshot, injection-region, and
+semantic-token derivations are background. Runnable priority is registered by
+the worker reader before pool scheduling, so saturated nested work cannot hide
+a newly accepted foreground request.
+
+## Method
+
+### Priority contention
+
+The deterministic E2E fixture uses one worker process, a Markdown document with
+eight Rust injection regions, and a foreground node request for another
+document. Each injection has an E2E-only 500 ms delay. A barrier holds the
+foreground job after runnable registration and before pool scheduling until the
+background request observes the priority transition. This avoids depending on
+OS or Rayon scheduling timing.
+
+The test ran five times with four compute threads and five times with one
+compute thread. The same Stage 14 binary was also run five times with dynamic
+nested policy disabled. These absolute durations include artificial delays and
+test barriers; they compare scheduler policies rather than production latency.
+
+### No-competitor regression
+
+The Stage 13 and Stage 14 debug server binaries were driven by the same release
+benchmark harness in authoritative-worker mode. Each ordering used 100 measured
+requests after 20 warmups with no artificial delay. The binary order was then
+reversed to expose order-dependent drift. The reported value is the mean of
+the two medians for each stage.
+
+## Result
+
+Priority-contention medians were:
+
+| Compute threads | Policy | Foreground response | Background completion |
+| ---: | --- | ---: | ---: |
+| 4 | Stage 14 priority | 1.343 s | 3.602 s |
+| 4 | dynamic policy disabled | 1.839 s | 2.305 s |
+| 1 | Stage 14 priority | 4.872 s | 5.332 s |
+| 1 | dynamic policy disabled | 4.873 s | 5.125 s |
+
+With four threads, explicit priority reduced foreground latency by 27.0% while
+increasing background completion time by 56.3%. This is the intended tradeoff:
+capacity is reserved for an interactive request instead of minimizing the
+bulk request's makespan.
+
+With one compute thread, foreground latency differed by less than 0.1% and the
+priority policy made background completion 4.0% slower. A unit test proves
+that `rayon::yield_now` can run an externally queued foreground job between
+background chunks in a one-thread pool, but the process-level fixture shows no
+performance benefit over Rayon's existing cooperative scheduling for this
+workload.
+
+No-competitor medians were:
+
+| Scenario | Stage 13 | Stage 14 | Change |
+| --- | ---: | ---: | ---: |
+| Markdown, 60 injections, full | 1.223 ms | 1.224 ms | +0.1% |
+| Markdown, 150 injections, full | 2.798 ms | 2.711 ms | -3.1% |
+
+The small-workload direction reversed with binary order. The order-balanced
+result is effectively unchanged, while the larger workload improved modestly.
+No ordinary single-document regression was measured.
+
+## Findings
+
+### One worker process is not one compute thread
+
+The ADR's fixed worker count still allows the resident worker to use a bounded
+internal Rayon pool. The measured foreground benefit appears with four compute
+threads, so it is compatible with the one-worker architecture. Reducing the
+internal pool itself to one thread removes the measured benefit.
+
+### Priority improves tail choice, not total work
+
+The scheduler does not make the contended workload cheaper. It deliberately
+moves completion time from the foreground request to the background request.
+Throughput and user-blocking latency therefore need separate gates; a single
+aggregate makespan would conceal the useful effect.
+
+### A bounded yield must not spin
+
+The first implementation repeatedly called `rayon::yield_now` while a
+foreground guard remained registered. An idle pool can report a successful
+idle yield, which would turn that loop into CPU spin. Stage 14 yields at most
+once per chunk boundary and then falls back to sequential work.
+
+### Full scheduler fairness remains open
+
+This stage prioritizes a foreground document over semantic injection fan-out.
+It does not provide weighted admission across more than two documents, split
+other long tree walks, account memory by request priority, or define aging for
+background work. The one-thread result also does not justify promising a
+latency improvement when deployments explicitly reduce the compute pool to
+one.
+
+## Decision
+
+Keep explicit foreground/background classification and bounded foreground
+yielding. It materially improves the measured interactive response with the
+intended multi-threaded worker and does not regress the no-competitor path.
+Treat one-compute-thread progress as a correctness fallback, not a performance
+claim. Continue with memory-pressure admission and compatibility gates before
+accepting the ADR.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1182,6 +1182,15 @@ changes the next chunk's policy, while 40-request single-document benchmarks
 show no measurable regression. Per-document max-min admission, explicit
 priority classes, other long tree walks, and one-thread fairness remain open.
 
+The [Stage 14 priority measurement](single-resident-multithreaded-tree-worker-stage14-measurement.md)
+adds explicit foreground and background classes at chunk boundaries. With one
+worker and four compute threads, the deterministic contention fixture reduced
+median foreground latency by 27.0% while increasing background completion time
+by 56.3%; ordinary single-document benchmarks did not regress. With one compute
+thread, explicit yielding provided no measured latency benefit, so that path is
+a correctness fallback rather than a performance claim. Memory-pressure
+admission, broader long-walk scheduling, and compatibility gates remain open.
+
 The implementation should proceed in measured stages:
 
 1. Prototype the framed transport, supervision, and one high-level

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -20,6 +20,7 @@ pub(crate) use parallel::build_document_discovery;
 pub(crate) use range::filter_semantic_tokens_by_range;
 
 // Re-export for parallel processing
+pub(crate) use parallel::NestedWorkPolicy;
 use parallel::{
     INJECTION_CACHE_MIN_REGIONS, InjectionCacheCtx, collect_injection_tokens_with_parallelism,
 };
@@ -118,12 +119,16 @@ pub(crate) fn compute_semantic_tokens_full(
     supports_multiline: bool,
     injection_cache: Option<InjectionCacheParams>,
     cancel: Option<crate::cancel::CancelToken>,
-    nested_parallelism: Option<&(dyn Fn() -> bool + Sync)>,
+    nested_work_policy: Option<&(dyn Fn() -> NestedWorkPolicy + Sync)>,
 ) -> Option<SemanticTokensResult> {
     let is_cancelled = || crate::cancel::is_cancelled(cancel.as_ref());
-    let allow_nested_parallelism = || {
-        compute_threads > 1
-            && nested_parallelism.is_none_or(|allow_parallelism| allow_parallelism())
+    let nested_work_policy = || {
+        let policy = nested_work_policy.map_or(NestedWorkPolicy::Parallel, |policy| policy());
+        if compute_threads == 1 && policy == NestedWorkPolicy::Parallel {
+            NestedWorkPolicy::Sequential
+        } else {
+            policy
+        }
     };
     let compute_started = std::time::Instant::now();
     let mut host_tokens: Vec<RawToken> = Vec::with_capacity(1000);
@@ -155,7 +160,7 @@ pub(crate) fn compute_semantic_tokens_full(
         discovery: p.discovery.as_deref(),
     });
 
-    let should_parallelize = allow_nested_parallelism()
+    let should_parallelize = nested_work_policy() == NestedWorkPolicy::Parallel
         && cache_ctx.as_ref().is_some_and(|ctx| {
             should_parallelize_host_and_injections(
                 compute_threads,
@@ -203,7 +208,7 @@ pub(crate) fn compute_semantic_tokens_full(
             supports_multiline,
             cache_ctx.as_ref(),
             cancel.as_ref(),
-            &allow_nested_parallelism,
+            &nested_work_policy,
         );
         (result, started.elapsed())
     };

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -1254,27 +1254,39 @@ pub(crate) fn collect_injection_tokens_parallel(
         supports_multiline,
         cache_ctx,
         cancel,
-        &|| true,
+        &|| NestedWorkPolicy::Parallel,
     )
 }
 
-fn map_fanout_chunks<T, R, Parallel, Map>(
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum NestedWorkPolicy {
+    Parallel,
+    Sequential,
+    Yield,
+}
+
+fn map_fanout_chunks<T, R, Policy, Map>(
     items: &[T],
     chunk_size: usize,
-    should_parallelize: Parallel,
+    work_policy: Policy,
     map: Map,
 ) -> Vec<R>
 where
     T: Sync,
     R: Send,
-    Parallel: Fn() -> bool,
+    Policy: Fn() -> NestedWorkPolicy,
     Map: Fn(&T) -> R + Sync,
 {
     use rayon::prelude::*;
 
     let mut output = Vec::with_capacity(items.len());
     for chunk in items.chunks(chunk_size.max(1)) {
-        if should_parallelize() {
+        let mut policy = work_policy();
+        if policy == NestedWorkPolicy::Yield {
+            let _ = rayon::yield_now();
+            policy = work_policy();
+        }
+        if policy == NestedWorkPolicy::Parallel {
             output.extend(chunk.par_iter().map(&map).collect::<Vec<_>>());
         } else {
             output.extend(chunk.iter().map(&map));
@@ -1295,7 +1307,7 @@ pub(crate) fn collect_injection_tokens_with_parallelism(
     supports_multiline: bool,
     cache_ctx: Option<&InjectionCacheCtx>,
     cancel: Option<&crate::cancel::CancelToken>,
-    allow_parallelism: &(dyn Fn() -> bool + Sync),
+    work_policy: &(dyn Fn() -> NestedWorkPolicy + Sync),
 ) -> (Vec<RawToken>, Vec<ActiveInjectionBounds>) {
     use crate::cancel::is_cancelled;
 
@@ -1476,7 +1488,7 @@ pub(crate) fn collect_injection_tokens_with_parallelism(
         map_fanout_chunks(
             &miss_indices,
             rayon::current_num_threads(),
-            allow_parallelism,
+            work_policy,
             |&i| process_one(i),
         )
     } else {
@@ -1690,12 +1702,102 @@ mod tests {
         let output = map_fanout_chunks(
             &items,
             4,
-            || checks.fetch_add(1, Ordering::SeqCst) == 0,
+            || {
+                if checks.fetch_add(1, Ordering::SeqCst) == 0 {
+                    NestedWorkPolicy::Parallel
+                } else {
+                    NestedWorkPolicy::Sequential
+                }
+            },
             |item| *item,
         );
 
         assert_eq!(output, items);
         assert_eq!(checks.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn fanout_yields_a_single_thread_to_queued_foreground_work() {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap();
+        let foreground_ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        pool.install(|| {
+            let task_ran = Arc::clone(&foreground_ran);
+            rayon::spawn(move || task_ran.store(true, Ordering::SeqCst));
+
+            let output = map_fanout_chunks(
+                &[1],
+                1,
+                || {
+                    if foreground_ran.load(Ordering::SeqCst) {
+                        NestedWorkPolicy::Sequential
+                    } else {
+                        NestedWorkPolicy::Yield
+                    }
+                },
+                |item| *item,
+            );
+            assert_eq!(output, [1]);
+        });
+
+        assert!(foreground_ran.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn fanout_yields_a_single_thread_to_externally_scheduled_foreground_work() {
+        let pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(1)
+                .build()
+                .unwrap(),
+        );
+        let foreground_pending = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let order = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let first_chunk_release = Arc::new(std::sync::Barrier::new(2));
+        let (first_chunk_started, started_rx) = std::sync::mpsc::channel();
+
+        let background_pool = Arc::clone(&pool);
+        let background_pending = Arc::clone(&foreground_pending);
+        let background_order = Arc::clone(&order);
+        let background_release = Arc::clone(&first_chunk_release);
+        let background = std::thread::spawn(move || {
+            background_pool.install(|| {
+                map_fanout_chunks(
+                    &[0, 1, 2],
+                    1,
+                    || {
+                        if background_pending.load(Ordering::SeqCst) {
+                            NestedWorkPolicy::Yield
+                        } else {
+                            NestedWorkPolicy::Sequential
+                        }
+                    },
+                    |item| {
+                        if *item == 0 {
+                            first_chunk_started.send(()).unwrap();
+                            background_release.wait();
+                        }
+                        background_order.lock().unwrap().push(*item);
+                        *item
+                    },
+                )
+            })
+        });
+
+        started_rx.recv().unwrap();
+        foreground_pending.store(true, Ordering::SeqCst);
+        let task_pending = Arc::clone(&foreground_pending);
+        let task_order = Arc::clone(&order);
+        pool.spawn(move || {
+            task_order.lock().unwrap().push(99);
+            task_pending.store(false, Ordering::SeqCst);
+        });
+        first_chunk_release.wait();
+
+        assert_eq!(background.join().unwrap(), [0, 1, 2]);
+        assert_eq!(*order.lock().unwrap(), [0, 99, 1, 2]);
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -1170,7 +1170,9 @@ impl DocumentReplica {
         started: Instant,
         compute_threads: usize,
         cancellation: Option<&crate::cancel::CancelToken>,
-        nested_parallelism: Option<&(dyn Fn() -> bool + Sync)>,
+        nested_work_policy: Option<
+            &(dyn Fn() -> crate::analysis::semantic::NestedWorkPolicy + Sync),
+        >,
     ) -> Result<DerivedSemanticTokens, String> {
         self.validate_read_identity(&request.context)?;
         if let Some((generation, supports_multiline, tokens)) = &self.cached_semantic_tokens
@@ -1216,7 +1218,7 @@ impl DocumentReplica {
                 discovery,
             }),
             cancellation.cloned(),
-            nested_parallelism,
+            nested_work_policy,
         )
         .ok_or_else(|| "worker semantic token derivation was cancelled".to_string())?;
         let tokens: Vec<WireSemanticToken> = match result {
@@ -2307,6 +2309,12 @@ type DocumentCapacity = Arc<Mutex<usize>>;
 type RetainedDocumentBytes = Arc<AtomicUsize>;
 type LaneJob = Box<dyn FnOnce() -> LaneAction + Send + 'static>;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WorkPriority {
+    Foreground,
+    Background,
+}
+
 #[derive(Clone, Copy)]
 enum LaneAction {
     Keep,
@@ -2425,29 +2433,61 @@ type DocumentLanes = Arc<LaneRegistry>;
 
 #[derive(Default)]
 struct RunnableDocuments {
-    counts: dashmap::DashMap<DocumentKey, usize>,
+    counts: dashmap::DashMap<DocumentKey, RunnableDocumentCounts>,
+}
+
+#[derive(Default)]
+struct RunnableDocumentCounts {
+    total: usize,
+    foreground: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DocumentCompetition {
+    None,
+    Background,
+    Foreground,
 }
 
 impl RunnableDocuments {
-    fn enter(self: &Arc<Self>, key: DocumentKey) -> RunnableDocumentGuard {
+    fn enter(self: &Arc<Self>, key: DocumentKey, priority: WorkPriority) -> RunnableDocumentGuard {
         self.counts
             .entry(key.clone())
-            .and_modify(|count| *count += 1)
-            .or_insert(1);
+            .and_modify(|counts| {
+                counts.total += 1;
+                counts.foreground += usize::from(priority == WorkPriority::Foreground);
+            })
+            .or_insert(RunnableDocumentCounts {
+                total: 1,
+                foreground: usize::from(priority == WorkPriority::Foreground),
+            });
         RunnableDocumentGuard {
             runnable: Arc::clone(self),
             key,
+            priority,
         }
     }
 
-    fn has_competitor(&self) -> bool {
-        self.counts.len() > 1
+    fn competition_for(&self, current: &DocumentKey) -> DocumentCompetition {
+        if self.counts.len() <= 1 {
+            return DocumentCompetition::None;
+        }
+        if self
+            .counts
+            .iter()
+            .any(|entry| entry.key() != current && entry.value().foreground > 0)
+        {
+            DocumentCompetition::Foreground
+        } else {
+            DocumentCompetition::Background
+        }
     }
 }
 
 struct RunnableDocumentGuard {
     runnable: Arc<RunnableDocuments>,
     key: DocumentKey,
+    priority: WorkPriority,
 }
 
 impl Drop for RunnableDocumentGuard {
@@ -2455,12 +2495,36 @@ impl Drop for RunnableDocumentGuard {
         if let dashmap::mapref::entry::Entry::Occupied(mut entry) =
             self.runnable.counts.entry(self.key.clone())
         {
-            if *entry.get() == 1 {
+            if entry.get().total == 1 {
                 entry.remove();
             } else {
-                *entry.get_mut() -= 1;
+                let counts = entry.get_mut();
+                counts.total -= 1;
+                counts.foreground -= usize::from(self.priority == WorkPriority::Foreground);
             }
         }
+    }
+}
+
+fn request_priority(request: &Request) -> WorkPriority {
+    match request {
+        Request::DeriveSnapshot(_)
+        | Request::DeriveDocumentSnapshot(_)
+        | Request::DeriveInjectionRegions(_)
+        | Request::DeriveSemanticTokens(_) => WorkPriority::Background,
+        Request::Handshake(_)
+        | Request::Cancel(_)
+        | Request::SyncDocument(_)
+        | Request::ApplyDocumentEdits(_)
+        | Request::ApplyDocumentEditsAndDerive(_)
+        | Request::ResolveNode(_)
+        | Request::NavigateNode(_)
+        | Request::RunNodeScalar(_)
+        | Request::DeriveSelectionRanges(_)
+        | Request::RunCaptures(_)
+        | Request::DeriveNativeBindings(_)
+        | Request::ConfigureLanguages(_)
+        | Request::CloseDocument(_) => WorkPriority::Foreground,
     }
 }
 
@@ -2488,7 +2552,7 @@ fn handle_work(
     retained_document_bytes: &RetainedDocumentBytes,
     queue_wait: Duration,
     cancellation: &crate::cancel::CancelToken,
-    nested_parallelism: &(dyn Fn() -> bool + Sync),
+    nested_work_policy: &(dyn Fn() -> crate::analysis::semantic::NestedWorkPolicy + Sync),
 ) -> Response {
     let context = request_context(&request)
         .expect("scheduled worker request must have context")
@@ -2534,7 +2598,7 @@ fn handle_work(
             queue_wait,
             started,
             cancellation,
-            nested_parallelism,
+            nested_work_policy,
         ),
         Request::RunCaptures(request) => run_captures(request, documents),
         Request::DeriveNativeBindings(request) => derive_native_bindings(request, documents),
@@ -2736,7 +2800,7 @@ fn derive_semantic_tokens(
     queue_wait: Duration,
     started: Instant,
     cancellation: &crate::cancel::CancelToken,
-    nested_parallelism: &(dyn Fn() -> bool + Sync),
+    nested_work_policy: &(dyn Fn() -> crate::analysis::semantic::NestedWorkPolicy + Sync),
 ) -> Response {
     let context = request.context.clone();
     let Some(replica) = documents
@@ -2756,7 +2820,7 @@ fn derive_semantic_tokens(
                 started,
                 rayon::current_num_threads(),
                 Some(cancellation),
-                Some(nested_parallelism),
+                Some(nested_work_policy),
             ) {
                 Ok(result) => Response::SemanticTokens(result),
                 Err(message) => Response::Error(WorkerError {
@@ -3351,9 +3415,10 @@ where
         let retained_document_bytes = Arc::clone(&retained_document_bytes);
         let job_cancellations = Arc::clone(&cancellations);
         let lane_key = document_key(&request);
+        let priority = request_priority(&request);
         let runnable_guard = lane_key
             .as_ref()
-            .map(|key| runnable_documents.enter(key.clone()));
+            .map(|key| runnable_documents.enter(key.clone(), priority));
         #[cfg(feature = "e2e")]
         if lane_key.as_ref().is_some_and(|key| {
             std::env::var("KAKEHASHI_TREE_WORKER_RUNNABLE_ENTERED_URI_SUFFIX")
@@ -3394,12 +3459,27 @@ where
             let nested_parallelism_was_allowed = AtomicBool::new(false);
             #[cfg(feature = "e2e")]
             let nested_parallelism_yield_was_reported = AtomicBool::new(false);
-            let allow_nested_parallelism = || {
+            let nested_work_policy = || {
+                use crate::analysis::semantic::NestedWorkPolicy;
+
                 #[cfg(feature = "e2e")]
-                if std::env::var_os("KAKEHASHI_TREE_WORKER_FORCE_NESTED_PARALLELISM").is_some() {
-                    return true;
-                }
-                let allowed = !job_runnable_documents.has_competitor();
+                let force_nested =
+                    std::env::var_os("KAKEHASHI_TREE_WORKER_FORCE_NESTED_PARALLELISM").is_some();
+                #[cfg(not(feature = "e2e"))]
+                let force_nested = false;
+                let policy = if force_nested {
+                    NestedWorkPolicy::Parallel
+                } else {
+                    match action_key
+                        .as_ref()
+                        .map(|key| job_runnable_documents.competition_for(key))
+                        .unwrap_or(DocumentCompetition::None)
+                    {
+                        DocumentCompetition::None => NestedWorkPolicy::Parallel,
+                        DocumentCompetition::Background => NestedWorkPolicy::Sequential,
+                        DocumentCompetition::Foreground => NestedWorkPolicy::Yield,
+                    }
+                };
                 #[cfg(feature = "e2e")]
                 let trace_fairness = action_key.as_ref().is_some_and(|key| {
                     std::env::var("KAKEHASHI_TREE_WORKER_FAIRNESS_TRACE_URI_SUFFIX")
@@ -3407,7 +3487,7 @@ where
                         .is_some_and(|suffix| key.uri.ends_with(&suffix))
                 });
                 #[cfg(feature = "e2e")]
-                if allowed {
+                if policy == NestedWorkPolicy::Parallel {
                     if trace_fairness
                         && let Ok(path) =
                             std::env::var("KAKEHASHI_TREE_WORKER_FAIRNESS_ALLOWED_FILE")
@@ -3423,7 +3503,7 @@ where
                         let _ = std::fs::write(path, b"yielded");
                     }
                 }
-                allowed
+                policy
             };
             let response = handle_work(
                 request,
@@ -3434,7 +3514,7 @@ where
                 &retained_document_bytes,
                 enqueued.elapsed(),
                 &cancellation,
-                &allow_nested_parallelism,
+                &nested_work_policy,
             );
             job_cancellations.remove(&request_id);
             let action = if action_key
@@ -3450,12 +3530,35 @@ where
             drop(runnable_guard);
             action
         });
+        #[cfg(feature = "e2e")]
+        let scheduled_key = lane_key.clone();
+        #[cfg(feature = "e2e")]
+        if scheduled_key.as_ref().is_some_and(|key| {
+            std::env::var("KAKEHASHI_TREE_WORKER_SCHEDULE_RELEASE_URI_SUFFIX")
+                .ok()
+                .is_some_and(|suffix| key.uri.ends_with(&suffix))
+        }) && let Ok(path) = std::env::var("KAKEHASHI_TREE_WORKER_SCHEDULE_RELEASE_FILE")
+        {
+            let deadline = Instant::now() + Duration::from_secs(10);
+            while !std::path::Path::new(&path).exists() && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        }
         if let Some(lane_key) = lane_key {
             submit_document_job(&document_lanes, lane_key, &pool, job);
         } else {
             pool.spawn(move || {
                 let _ = job();
             });
+        }
+        #[cfg(feature = "e2e")]
+        if scheduled_key.as_ref().is_some_and(|key| {
+            std::env::var("KAKEHASHI_TREE_WORKER_SCHEDULED_URI_SUFFIX")
+                .ok()
+                .is_some_and(|suffix| key.uri.ends_with(&suffix))
+        }) && let Ok(path) = std::env::var("KAKEHASHI_TREE_WORKER_SCHEDULED_FILE")
+        {
+            let _ = std::fs::write(path, b"scheduled");
         }
     }
     for _ in 0..pending {
@@ -4250,16 +4353,16 @@ mod tests {
     use super::{
         ApplyDocumentEdits, BUILD_ID, ByteEdit, CancelRequest, CapturesResult, CloseDocument,
         DeriveInjectionRegions, DeriveNativeBindings, DeriveSelectionRanges, DeriveSemanticTokens,
-        DeriveSnapshot, DocumentKey, DocumentLane, DocumentReplica, GrammarKey, Handshake,
-        HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
-        MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeLayerSelector, NodeNavigation,
-        NodeScalarOperation, NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION, Request,
-        RequestCancelled, RequestContext, ResolveNode, Response, Route, RunCaptures, RunNodeScalar,
-        RunnableDocuments, SyncDocument, WireByteRange, WirePosition, WireRange, WorkerError,
-        WorkerQuerySources, close_document, decode_frame, derive_snapshot_with_language,
-        encode_frame, named_node_count, parse_request_timeout, replace_retained_bytes,
-        reserve_retained_growth, route_response, run, submit_document_job, sync_document,
-        terminate_by_transport, validate_document_size,
+        DeriveSnapshot, DocumentCompetition, DocumentKey, DocumentLane, DocumentReplica,
+        GrammarKey, Handshake, HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES,
+        MAX_DOCUMENT_REPLICAS, MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeLayerSelector,
+        NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION,
+        Request, RequestCancelled, RequestContext, ResolveNode, Response, Route, RunCaptures,
+        RunNodeScalar, RunnableDocuments, SyncDocument, WireByteRange, WirePosition, WireRange,
+        WorkPriority, WorkerError, WorkerQuerySources, close_document, decode_frame,
+        derive_snapshot_with_language, encode_frame, named_node_count, parse_request_timeout,
+        replace_retained_bytes, request_priority, reserve_retained_growth, route_response, run,
+        submit_document_job, sync_document, terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -4823,36 +4926,103 @@ mod tests {
             uri: "file:///b.rs".into(),
         };
 
-        let first_a = runnable.enter(a.clone());
-        let second_a = runnable.enter(a);
-        assert!(!runnable.has_competitor());
+        let first_a = runnable.enter(a.clone(), WorkPriority::Background);
+        let second_a = runnable.enter(a.clone(), WorkPriority::Foreground);
+        assert_eq!(runnable.competition_for(&a), DocumentCompetition::None);
 
-        let first_b = runnable.enter(b);
-        assert!(runnable.has_competitor());
+        let first_b = runnable.enter(b, WorkPriority::Background);
+        assert_eq!(
+            runnable.competition_for(&DocumentKey {
+                uri: "file:///a.rs".into()
+            }),
+            DocumentCompetition::Background
+        );
         drop(first_b);
-        assert!(!runnable.has_competitor());
+        assert_eq!(
+            runnable.competition_for(&DocumentKey {
+                uri: "file:///a.rs".into()
+            }),
+            DocumentCompetition::None
+        );
 
         drop(second_a);
         drop(first_a);
-        assert!(!runnable.has_competitor());
+        assert_eq!(
+            runnable.competition_for(&DocumentKey {
+                uri: "file:///a.rs".into()
+            }),
+            DocumentCompetition::None
+        );
     }
 
     #[test]
-    fn nested_parallelism_gate_tracks_competing_document_lifetime() {
+    fn runnable_documents_track_foreground_competitors_separately() {
         let runnable = Arc::new(RunnableDocuments::default());
-        let first = runnable.enter(DocumentKey {
+        let current = DocumentKey {
             uri: "file:///a.rs".into(),
-        });
-        let allow_nested_parallelism = || !runnable.has_competitor();
-        assert!(allow_nested_parallelism());
+        };
+        let first = runnable.enter(current.clone(), WorkPriority::Background);
+        assert_eq!(
+            runnable.competition_for(&current),
+            DocumentCompetition::None
+        );
 
-        let competitor = runnable.enter(DocumentKey {
-            uri: "file:///b.rs".into(),
-        });
-        assert!(!allow_nested_parallelism());
-        drop(competitor);
-        assert!(allow_nested_parallelism());
+        let background = runnable.enter(
+            DocumentKey {
+                uri: "file:///b.rs".into(),
+            },
+            WorkPriority::Background,
+        );
+        assert_eq!(
+            runnable.competition_for(&current),
+            DocumentCompetition::Background
+        );
+
+        let foreground = runnable.enter(
+            DocumentKey {
+                uri: "file:///c.rs".into(),
+            },
+            WorkPriority::Foreground,
+        );
+        assert_eq!(
+            runnable.competition_for(&current),
+            DocumentCompetition::Foreground
+        );
+        drop(foreground);
+        assert_eq!(
+            runnable.competition_for(&current),
+            DocumentCompetition::Background
+        );
+        drop(background);
         drop(first);
+    }
+
+    #[test]
+    fn request_priority_separates_bulk_derivation_from_interactive_reads() {
+        let context = RequestContext {
+            request_id: 1,
+            worker_generation: 1,
+            uri: "file:///priority.rs".into(),
+            incarnation: 1,
+            content_version: 1,
+            configuration_generation: 1,
+        };
+        assert_eq!(
+            request_priority(&Request::DeriveSemanticTokens(DeriveSemanticTokens {
+                context: context.clone(),
+                supports_multiline: false,
+            })),
+            WorkPriority::Background
+        );
+        assert_eq!(
+            request_priority(&Request::ResolveNode(ResolveNode {
+                context,
+                byte_offset: 0,
+                named: true,
+                layer: NodeLayerSelector::Host,
+            })),
+            WorkPriority::Foreground
+        );
     }
 
     #[test]

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -830,6 +830,15 @@ fn competing_document_finishes_while_injection_fanout_is_running() {
 
 #[test]
 fn late_competing_document_reduces_fanout_at_a_chunk_boundary() {
+    run_late_competitor_scenario(4);
+}
+
+#[test]
+fn one_thread_worker_yields_background_fanout_to_foreground_work() {
+    run_late_competitor_scenario(1);
+}
+
+fn run_late_competitor_scenario(worker_threads: usize) {
     let force_nested = std::env::var_os("KAKEHASHI_E2E_FORCE_NESTED_PARALLELISM").is_some();
     let marker_dir = tempfile::tempdir().expect("create fanout marker directory");
     let fanout_started = marker_dir.path().join("started");
@@ -837,23 +846,20 @@ fn late_competing_document_reduces_fanout_at_a_chunk_boundary() {
     let fanout_allowed = marker_dir.path().join("allowed");
     let fanout_yielded = marker_dir.path().join("yielded");
     let competitor_runnable = marker_dir.path().join("competitor-runnable");
+    let competitor_scheduled = marker_dir.path().join("competitor-scheduled");
     let mut builder = LspClient::builder()
         .env("KAKEHASHI_TREE_WORKER_MODE", "authoritative")
-        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", worker_threads.to_string())
         .env(
             "KAKEHASHI_TREE_WORKER_INJECTION_DELAY_URI_SUFFIX",
             "/late-fair-a.md",
         )
-        .env("KAKEHASHI_TREE_WORKER_INJECTION_DELAY_MS", "50")
+        .env("KAKEHASHI_TREE_WORKER_INJECTION_DELAY_MS", "500")
         .env(
             "KAKEHASHI_TREE_WORKER_ADMISSION_DELAY_URI_SUFFIX",
             "/late-fair-b.rs",
         )
         .env("KAKEHASHI_TREE_WORKER_ADMISSION_DELAY_MS", "200")
-        .env(
-            "KAKEHASHI_TREE_WORKER_ADMISSION_RELEASE_FILE",
-            fanout_yielded.to_string_lossy(),
-        )
         .env(
             "KAKEHASHI_TREE_WORKER_RUNNABLE_ENTERED_URI_SUFFIX",
             "/late-fair-b.rs",
@@ -861,6 +867,14 @@ fn late_competing_document_reduces_fanout_at_a_chunk_boundary() {
         .env(
             "KAKEHASHI_TREE_WORKER_RUNNABLE_ENTERED_FILE",
             competitor_runnable.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_SCHEDULED_URI_SUFFIX",
+            "/late-fair-b.rs",
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_SCHEDULED_FILE",
+            competitor_scheduled.to_string_lossy(),
         )
         .env(
             "KAKEHASHI_TREE_WORKER_FAIRNESS_TRACE_URI_SUFFIX",
@@ -884,6 +898,16 @@ fn late_competing_document_reduces_fanout_at_a_chunk_boundary() {
         );
     if force_nested {
         builder = builder.env("KAKEHASHI_TREE_WORKER_FORCE_NESTED_PARALLELISM", "1");
+    } else {
+        builder = builder
+            .env(
+                "KAKEHASHI_TREE_WORKER_SCHEDULE_RELEASE_URI_SUFFIX",
+                "/late-fair-b.rs",
+            )
+            .env(
+                "KAKEHASHI_TREE_WORKER_SCHEDULE_RELEASE_FILE",
+                fanout_yielded.to_string_lossy(),
+            );
     }
     let mut client = builder.build();
     initialize(&mut client);
@@ -946,7 +970,25 @@ fn late_competing_document_reduces_fanout_at_a_chunk_boundary() {
         competitor_runnable.exists(),
         "competing worker job was not registered as runnable"
     );
+    if force_nested {
+        while !competitor_scheduled.exists() && std::time::Instant::now() < competitor_deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            competitor_scheduled.exists(),
+            "competing worker job was not scheduled"
+        );
+    }
     std::fs::write(&fanout_release, b"release").expect("release the first fanout chunk");
+    if !force_nested {
+        while !competitor_scheduled.exists() && std::time::Instant::now() < competitor_deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            competitor_scheduled.exists(),
+            "competing worker job was not scheduled after the worker observed its priority"
+        );
+    }
 
     let mut foreground_elapsed = None;
     let mut heavy_elapsed = None;
@@ -972,6 +1014,10 @@ fn late_competing_document_reduces_fanout_at_a_chunk_boundary() {
         assert!(
             fanout_yielded.exists(),
             "late competitor did not change a later chunk's admission"
+        );
+        assert!(
+            foreground_elapsed < heavy_elapsed,
+            "foreground work did not complete before background fanout: foreground={foreground_elapsed:?} heavy={heavy_elapsed:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- classify worker requests as foreground or background at reader acceptance
- yield semantic injection fanout once when another document has foreground work
- keep background-only competition sequential and restore parallelism when contention clears
- preserve a constant-time single-document fast path
- prove P=1 cooperative order and deterministic late-arrival priority behavior

## Measurement

Authoritative worker, paired policy fixture with five runs per condition:

| Compute threads | Policy | Foreground | Background |
| ---: | --- | ---: | ---: |
| 4 | Stage 14 priority | 1.343 s | 3.602 s |
| 4 | dynamic policy disabled | 1.839 s | 2.305 s |
| 1 | Stage 14 priority | 4.872 s | 5.332 s |
| 1 | dynamic policy disabled | 4.873 s | 5.125 s |

With four threads, foreground latency improved 27.0% at the intentional cost of 56.3% later background completion. With one compute thread, foreground latency was unchanged; the one-thread path is a correctness fallback, not a performance claim.

Order-balanced no-competitor benchmark, 100 requests after 20 warmups per ordering:

| Scenario | Stage 13 | Stage 14 | Change |
| --- | ---: | ---: | ---: |
| Markdown 60 injections/full | 1.223 ms | 1.224 ms | +0.1% |
| Markdown 150 injections/full | 2.798 ms | 2.711 ms | -3.1% |

## Remaining gates

- memory-pressure-aware admission
- weighted fairness across more than two documents
- cooperative scheduling for other long tree walks
- compatibility gates and legacy-path removal

## Validation

- cargo fmt --all -- --check
- cargo check --lib --tests --features e2e
- cargo test --lib (3130 passed, 2 ignored)
- cargo test --features e2e --test tree_worker_process (4 passed)
- cargo test --features e2e --test e2e_tree_worker_shadow (37 passed)