### PR TITLE
bench(worker): measure aggregate process memory

### DIFF
--- a/benches/profile/collect_worker_memory.py
+++ b/benches/profile/collect_worker_memory.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Measure aggregate parent-plus-worker RSS for paired LSP workloads."""
+
+import argparse
+import json
+import os
+import pathlib
+import platform
+import statistics
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import re
+
+from collect_worker_proxy import (
+    artifact_identity,
+    build_driver_command,
+    controlled_environment,
+    cpu_model,
+    harness_identity,
+    parse_driver_summary,
+    portable_environment,
+    require_benchmark_artifacts,
+    require_posix,
+    sha256_file,
+    stage_measurement_inputs,
+    tool_version,
+    verify_file_sha256,
+)
+
+
+def scenario_arguments(language, size, requests):
+    return [
+        "--lang", language, "--size", str(size), "--requests", str(requests),
+        "--warm-semantic-cache", "--settle", "0.5", "--hold-open", "1.0",
+    ]
+
+
+def parse_ps_table(output):
+    table = {}
+    for line in output.splitlines():
+        fields = line.split(None, 3)
+        if len(fields) != 4:
+            continue
+        try:
+            pid, ppid, rss_kib = map(int, fields[:3])
+        except ValueError:
+            continue
+        table[pid] = {
+            "ppid": ppid,
+            "rss_kib": rss_kib,
+            "command": fields[3],
+        }
+    return table
+
+
+def descendant_pids(table, root_pid):
+    descendants = set()
+    frontier = {root_pid}
+    while frontier:
+        children = {
+            pid for pid, row in table.items()
+            if row["ppid"] in frontier and pid not in descendants
+        }
+        descendants.update(children)
+        frontier = children
+    return descendants
+
+
+def summarize_samples(samples):
+    if not samples:
+        raise ValueError("memory sampler did not observe a server process")
+    stable = samples[len(samples) // 2:]
+    result = {
+        "sample_count": len(samples),
+        "peak_total_rss_kib": max(row["total_rss_kib"] for row in samples),
+        "stable_median_total_rss_kib": int(statistics.median(
+            row["total_rss_kib"] for row in stable
+        )),
+        "peak_process_count": max(row["process_count"] for row in samples),
+    }
+    footprint = [
+        row["total_footprint_bytes"]
+        for row in samples
+        if "total_footprint_bytes" in row
+    ]
+    if footprint:
+        result.update({
+            "footprint_sample_count": len(footprint),
+            "peak_total_footprint_bytes": max(footprint),
+            "stable_median_total_footprint_bytes": int(statistics.median(
+                footprint[len(footprint) // 2:]
+            )),
+        })
+    return result
+
+
+def parse_footprint_bytes(output):
+    summary = re.search(r"Summary Footprint:\s*(\d+) B", output)
+    if summary:
+        return int(summary.group(1))
+    process = re.search(r"(?m)^.*?Footprint:\s*(\d+) B", output)
+    if process:
+        return int(process.group(1))
+    raise ValueError("footprint output did not contain a byte total")
+
+
+def read_total_footprint_bytes(pids):
+    command = ["footprint"]
+    for pid in sorted(pids):
+        command.extend(("-p", str(pid)))
+    command.extend(("-f", "bytes", "--noCategories"))
+    output = subprocess.run(
+        command,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    ).stdout
+    return parse_footprint_bytes(output)
+
+
+def read_process_table():
+    output = subprocess.run(
+        ["ps", "-axo", "pid=,ppid=,rss=,command="],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout
+    return parse_ps_table(output)
+
+
+def sample_descendants(
+    root_pid, stop, interval_seconds, footprint_interval_seconds, samples
+):
+    next_footprint = 0.0
+    while not stop.wait(interval_seconds):
+        table = read_process_table()
+        pids = descendant_pids(table, root_pid)
+        if not pids:
+            continue
+        sample = {
+            "total_rss_kib": sum(table[pid]["rss_kib"] for pid in pids),
+            "process_count": len(pids),
+        }
+        now = time.monotonic()
+        if sys.platform == "darwin" and now >= next_footprint:
+            try:
+                sample["total_footprint_bytes"] = read_total_footprint_bytes(pids)
+            except (OSError, subprocess.SubprocessError, ValueError):
+                pass
+            next_footprint = now + footprint_interval_seconds
+        samples.append(sample)
+
+
+def run_variant(
+    kind, binary, data_dir, script_dir, scenario, requests, threads, timeout,
+    interval, footprint_interval
+):
+    environment = controlled_environment(os.environ)
+    if kind == "authoritative":
+        environment["KAKEHASHI_TREE_WORKER_MODE"] = "authoritative"
+        environment["KAKEHASHI_TREE_WORKER_THREADS"] = str(threads)
+    command = build_driver_command(
+        "direct", binary, data_dir, scenario, script_dir
+    )
+    with tempfile.TemporaryDirectory(prefix="kakehashi-memory-xdg-") as xdg:
+        environment["XDG_CONFIG_HOME"] = str(pathlib.Path(xdg) / "config")
+        environment["XDG_STATE_HOME"] = str(pathlib.Path(xdg) / "state")
+        process = subprocess.Popen(
+            command,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=environment,
+            start_new_session=True,
+        )
+        stop = threading.Event()
+        samples = []
+        sampler = threading.Thread(
+            target=sample_descendants,
+            args=(process.pid, stop, interval, footprint_interval, samples),
+            daemon=True,
+        )
+        sampler.start()
+        try:
+            stdout, stderr = process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(process.pid, 15)
+            except ProcessLookupError:
+                pass
+            stdout, stderr = process.communicate(timeout=5)
+            raise subprocess.TimeoutExpired(command, timeout, stdout, stderr)
+        finally:
+            stop.set()
+            sampler.join(timeout=5)
+    if process.returncode:
+        raise subprocess.CalledProcessError(
+            process.returncode, command, output=stdout, stderr=stderr
+        )
+    result = parse_driver_summary(stderr, requests)
+    result["memory"] = summarize_samples(samples)
+    return result
+
+
+def order(batch_index):
+    if batch_index % 2 == 0:
+        return ("legacy", "authoritative")
+    return ("authoritative", "legacy")
+
+
+def collect(args):
+    source_script_dir = pathlib.Path(__file__).resolve().parent
+    binary_sha256 = sha256_file(args.bin)
+    source_harness = harness_identity(source_script_dir)
+    source_artifacts = artifact_identity(args.data_dir)
+    staging, binary, data_dir, script_dir = stage_measurement_inputs(
+        args.bin, args.data_dir, source_script_dir
+    )
+    scenario = scenario_arguments(args.lang, args.size, args.requests)
+    try:
+        batches = []
+        for index in range(args.batches):
+            batch = {"batch": index + 1, "order": list(order(index))}
+            for kind in order(index):
+                batch[kind] = run_variant(
+                    kind,
+                    binary,
+                    data_dir,
+                    script_dir,
+                    scenario,
+                    args.requests,
+                    args.worker_threads,
+                    args.run_timeout,
+                    args.sample_interval_ms / 1000,
+                    args.footprint_interval_ms / 1000,
+                )
+            batches.append(batch)
+            print(f"batch {index + 1}/{args.batches}", file=sys.stderr)
+        if artifact_identity(data_dir) != source_artifacts:
+            raise RuntimeError("runtime artifacts changed during collection")
+        verify_file_sha256(binary, binary_sha256)
+        if harness_identity(source_script_dir) != source_harness:
+            raise RuntimeError("benchmark harness changed during collection")
+    finally:
+        staging.cleanup()
+    result = {
+        "schema": 1,
+        "experiment": "single-tree-worker-stage15-memory",
+        "environment": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "rustc": tool_version(["rustc", "--version"]),
+            "cpu_model": cpu_model(),
+            "binary_sha256": binary_sha256,
+            "retained_environment": portable_environment(os.environ),
+        },
+        "artifacts": source_artifacts,
+        "harness": {"source_files_sha256": source_harness},
+        "collector": {
+            "batches": args.batches,
+            "order": "legacy-authoritative on odd batches; reversed on even batches",
+            "worker_threads": args.worker_threads,
+            "sample_interval_ms": args.sample_interval_ms,
+            "footprint_interval_ms": args.footprint_interval_ms,
+            "metric": "sum of RSS for every descendant of the benchmark driver",
+        },
+        "scenario": scenario,
+        "batches": batches,
+    }
+    args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+
+def main():
+    require_posix()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bin", type=pathlib.Path, required=True)
+    parser.add_argument("--data-dir", type=pathlib.Path, required=True)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    parser.add_argument("--batches", type=int, default=4)
+    parser.add_argument("--lang", choices=("rust", "markdown"), default="markdown")
+    parser.add_argument("--size", type=int, default=150)
+    parser.add_argument("--requests", type=int, default=500)
+    parser.add_argument("--worker-threads", type=int, default=4)
+    parser.add_argument("--sample-interval-ms", type=float, default=10)
+    parser.add_argument("--footprint-interval-ms", type=float, default=250)
+    parser.add_argument("--run-timeout", type=float, default=120)
+    args = parser.parse_args()
+    if min(
+        args.batches,
+        args.size,
+        args.requests,
+        args.worker_threads,
+        args.sample_interval_ms,
+        args.footprint_interval_ms,
+        args.run_timeout,
+    ) <= 0:
+        parser.error("batch, thread, interval, and timeout values must be positive")
+    require_benchmark_artifacts(args.data_dir)
+    collect(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/benches/profile/collect_worker_proxy.py
+++ b/benches/profile/collect_worker_proxy.py
@@ -57,6 +57,7 @@ HARNESS_SCRIPT_NAMES = (
     "collect_worker_shadow.py",
     "collect_worker_cold_start.py",
     "collect_worker_capture_pilot.py",
+    "collect_worker_memory.py",
     "drive.py",
     "worker_proxy.py",
     "gen_session.py",

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -283,6 +283,10 @@ def main() -> None:
         help="seconds to wait after didOpen before the first request "
              "(0 reproduces a client that requests immediately)")
     ap.add_argument(
+        "--hold-open", type=float, default=0,
+        help="seconds to keep the initialized server alive after the workload "
+             "so external steady-state samplers can observe it")
+    ap.add_argument(
         "--edits", type=int, default=0,
         help="simulate typing: before each request, send this many incremental "
              "didChange edits (appending/removing a char at the end of the first "
@@ -303,6 +307,8 @@ def main() -> None:
         ap.error("--burst-edits requires --burst greater than 1")
     if args.burst_delay_ms < 0:
         ap.error("--burst-delay-ms must be non-negative")
+    if args.hold_open < 0:
+        ap.error("--hold-open must be non-negative")
     if args.burst > 1 and (args.captures or args.concurrent_captures):
         ap.error("--burst cannot be combined with captures modes")
     if args.concurrent_captures:
@@ -614,6 +620,9 @@ def main() -> None:
             canceled += cycle_canceled
             superseded += cycle_superseded
         elapsed = benchmark_clock() - t0
+
+        if args.hold_open > 0:
+            time.sleep(args.hold_open)
 
         request("shutdown", None)
         notify("exit", {})

--- a/benches/profile/results/single_worker_stage15_memory_large_2026-07-20.json
+++ b/benches/profile/results/single_worker_stage15_memory_large_2026-07-20.json
@@ -1,0 +1,386 @@
+{
+  "schema": 1,
+  "experiment": "single-tree-worker-stage15-memory",
+  "environment": {
+    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "python": "3.12.13",
+    "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)",
+    "cpu_model": "Apple M4",
+    "binary_sha256": "0a72535f4a3fcc417d20121ec28a2befb6595c2d7ca099448365de3afbcecf02",
+    "retained_environment": {
+      "PATH": "<redacted-search-path>",
+      "TMPDIR": "<redacted-path>",
+      "LANG": "C.UTF-8",
+      "LC_ALL": "C.UTF-8"
+    }
+  },
+  "artifacts": [
+    19,
+    "bc92f96ed727aa191b09d565a288c1ca270ceb4709242543007e076483739935"
+  ],
+  "harness": {
+    "source_files_sha256": {
+      "collect_worker_proxy.py": "e7a1aaaa180791f83dacbd6e135b64dcab806a3fa2f9f4887c91a941c65f3755",
+      "collect_worker_shadow.py": "c4696420ae0b47920dfaea45ec636c68f07373bcbdc260fc733e091ae17a7e9e",
+      "collect_worker_cold_start.py": "7648e2b0eba60b20b7f11a641c07c6ccdd5a1d3b75bc91492f32acfa90750109",
+      "collect_worker_capture_pilot.py": "3a709d50253dc23060ca99f885978e71a8b58f07a71af6c492d2fa73916a75f5",
+      "collect_worker_memory.py": "50bd0d25c37127ed42cfc1b047bdbcc7f39c98ee5009293ba6c9100c49ae2c46",
+      "drive.py": "1c2838bef386da9a398b5881dbd33839f77dc1aa864a044c1650b8deb99e2296",
+      "worker_proxy.py": "e3fe07d73168835e71fb976109e034b121b1112d6c7a746be1575ac07a6fd542",
+      "gen_session.py": "6f4f6b8388c607db1c70fe29579ce14fe00d57668cab17601432ff123cfb15a3"
+    }
+  },
+  "collector": {
+    "batches": 6,
+    "order": "legacy-authoritative on odd batches; reversed on even batches",
+    "worker_threads": 4,
+    "sample_interval_ms": 10.0,
+    "footprint_interval_ms": 250.0,
+    "metric": "sum of RSS for every descendant of the benchmark driver"
+  },
+  "scenario": [
+    "--lang",
+    "markdown",
+    "--size",
+    "5000",
+    "--requests",
+    "10",
+    "--warm-semantic-cache",
+    "--settle",
+    "0.5",
+    "--hold-open",
+    "1.0"
+  ],
+  "batches": [
+    {
+      "batch": 1,
+      "order": [
+        "legacy",
+        "authoritative"
+      ],
+      "legacy": {
+        "count": 10,
+        "ok": 10,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 70.7,
+        "p90": 72.3,
+        "p95": 72.3,
+        "p99": 72.3,
+        "max": 72.3,
+        "wall": 1086.3660000031814,
+        "wire_kib": 12842.6,
+        "memory": {
+          "sample_count": 47,
+          "peak_total_rss_kib": 238752,
+          "stable_median_total_rss_kib": 238752,
+          "peak_process_count": 1,
+          "footprint_sample_count": 19,
+          "peak_total_footprint_bytes": 200786568,
+          "stable_median_total_footprint_bytes": 200786568
+        }
+      },
+      "authoritative": {
+        "count": 10,
+        "ok": 10,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 71.1,
+        "p90": 72.0,
+        "p95": 72.1,
+        "p99": 72.1,
+        "max": 72.1,
+        "wall": 1075.654917047359,
+        "wire_kib": 12842.6,
+        "memory": {
+          "sample_count": 45,
+          "peak_total_rss_kib": 275296,
+          "stable_median_total_rss_kib": 272688,
+          "peak_process_count": 2,
+          "footprint_sample_count": 18,
+          "peak_total_footprint_bytes": 232359016,
+          "stable_median_total_footprint_bytes": 232359016
+        }
+      }
+    },
+    {
+      "batch": 2,
+      "order": [
+        "authoritative",
+        "legacy"
+      ],
+      "authoritative": {
+        "count": 10,
+        "ok": 10,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 71.4,
+        "p90": 74.2,
+        "p95": 77.3,
+        "p99": 77.3,
+        "max": 77.3,
+        "wall": 1102.1335839759558,
+        "wire_kib": 12842.6,
+        "memory": {
+          "sample_count": 43,
+          "peak_total_rss_kib": 281424,
+          "stable_median_total_rss_kib": 280768,
+          "peak_process_count": 2,
+          "footprint_sample_count": 17,
+          "peak_total_footprint_bytes": 238863416,
+          "stable_median_total_footprint_bytes": 237519928
+        }
+      },
+      "legacy": {
+        "count": 10,
+        "ok": 10,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 70.3,
+        "p90": 71.7,
+        "p95": 71.8,
+        "p99": 71.8,
+        "max": 71.8,
+        "wall": 1073.7498329253867,
+        "wire_kib": 12842.6,
+        "memory": {
+          "sample_count": 30,
+          "peak_total_rss_kib": 236608,
+          "stable_median_total_rss_kib": 236608,
+          "peak_process_count": 1,
+          "footprint_sample_count": 11,
+          "peak_total_footprint_bytes": 198722208,
+          "stable_median_total_footprint_bytes": 198722208
+        }
+      }
+    },
+    {
+      "batch": 3,
+      "order": [
+        "legacy",
+        "authoritative"
+      ],
+      "legacy": {
+        "count": 10,
+        "ok": 10,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 69.9,
+        "p90": 71.2,
+        "p95": 72.3,
+        "p99": 72.3,
+        "max": 72.3,
+        "wall": 1074.6400420321152,
+        "wire_kib": 12842.6,
+        "memory": {
+          "sample_count": 29,
+          "peak_total_rss_kib": 232896,
+          "stable_median_total_rss_kib": 232896,
+          "peak_process_count": 1,
+          "footprint_sample_count": 11,
+          "peak_total_footprint_bytes": 194790048,
+          "stable_median_total_footprint_bytes": 194790048
+        }
+      },
+      "authoritative": {
+        "count": 10,
+        "ok": 10,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 70.5,
+        "p90": 73.2,
+        "p95": 74.4,
+        "p99": 74.4,
+        "max": 74.4,
+        "wall": 1087.3785000294447,
+        "wire_kib": 12842.6,
+        "memory": {
+          "sample_count": 55,
+          "peak_total_rss_kib": 274544,
+          "stable_median_total_rss_kib": 271600,
+          "peak_process_count": 2,
+          "footprint_sample_count": 20,
+          "peak_total_footprint_bytes": 233112656,
+          "stable_median_total_footprint_bytes": 230622288
+        }
+      }
+    },
+    {
+      "batch": 4,
+      "order": [
+        "authoritative",
+        "legacy"
+      ],
+      "authoritative": {
+        "count": 10,
+        "ok": 10,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 70.7,
+        "p90": 71.9,
+        "p95": 73.3,
+        "p99": 73.3,
+        "max": 73.3,
+        "wall": 1089.1093749087304,
+        "wire_kib": 12842.6,
+        "memory": {
+          "sample_count": 43,
+          "peak_total_rss_kib": 284912,
+          "stable_median_total_rss_kib": 283600,
+          "peak_process_count": 2,
+          "footprint_sample_count": 17,
+          "peak_total_footprint_bytes": 241992808,
+          "stable_median_total_footprint_bytes": 241992808
+        }
+      },
+      "legacy": {
+        "count": 10,
+        "ok": 10,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 68.8,
+        "p90": 71.2,
+        "p95": 71.4,
+        "p99": 71.4,
+        "max": 71.4,
+        "wall": 1064.848041976802,
+        "wire_kib": 12842.6,
+        "memory": {
+          "sample_count": 29,
+          "peak_total_rss_kib": 238416,
+          "stable_median_total_rss_kib": 238416,
+          "peak_process_count": 1,
+          "footprint_sample_count": 12,
+          "peak_total_footprint_bytes": 199934624,
+          "stable_median_total_footprint_bytes": 199934624
+        }
+      }
+    },
+    {
+      "batch": 5,
+      "order": [
+        "legacy",
+        "authoritative"
+      ],
+      "legacy": {
+        "count": 10,
+        "ok": 10,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 71.9,
+        "p90": 72.4,
+        "p95": 72.5,
+        "p99": 72.5,
+        "max": 72.5,
+        "wall": 1084.736542077735,
+        "wire_kib": 12842.6,
+        "memory": {
+          "sample_count": 29,
+          "peak_total_rss_kib": 238752,
+          "stable_median_total_rss_kib": 238752,
+          "peak_process_count": 1,
+          "footprint_sample_count": 12,
+          "peak_total_footprint_bytes": 199934624,
+          "stable_median_total_footprint_bytes": 199934624
+        }
+      },
+      "authoritative": {
+        "count": 10,
+        "ok": 10,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 71.7,
+        "p90": 72.3,
+        "p95": 72.9,
+        "p99": 72.9,
+        "max": 72.9,
+        "wall": 1091.9692090246826,
+        "wire_kib": 12842.6,
+        "memory": {
+          "sample_count": 44,
+          "peak_total_rss_kib": 273616,
+          "stable_median_total_rss_kib": 272224,
+          "peak_process_count": 2,
+          "footprint_sample_count": 18,
+          "peak_total_footprint_bytes": 232064080,
+          "stable_median_total_footprint_bytes": 232064080
+        }
+      }
+    },
+    {
+      "batch": 6,
+      "order": [
+        "authoritative",
+        "legacy"
+      ],
+      "authoritative": {
+        "count": 10,
+        "ok": 10,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 71.8,
+        "p90": 73.6,
+        "p95": 73.9,
+        "p99": 73.9,
+        "max": 73.9,
+        "wall": 1114.0019170707092,
+        "wire_kib": 12842.6,
+        "memory": {
+          "sample_count": 42,
+          "peak_total_rss_kib": 284368,
+          "stable_median_total_rss_kib": 284336,
+          "peak_process_count": 2,
+          "footprint_sample_count": 18,
+          "peak_total_footprint_bytes": 241255504,
+          "stable_median_total_footprint_bytes": 239879248
+        }
+      },
+      "legacy": {
+        "count": 10,
+        "ok": 10,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 71.3,
+        "p90": 73.4,
+        "p95": 74.0,
+        "p99": 74.0,
+        "max": 74.0,
+        "wall": 1102.2600829601288,
+        "wire_kib": 12842.6,
+        "memory": {
+          "sample_count": 29,
+          "peak_total_rss_kib": 239216,
+          "stable_median_total_rss_kib": 239216,
+          "peak_process_count": 1,
+          "footprint_sample_count": 12,
+          "peak_total_footprint_bytes": 200082080,
+          "stable_median_total_footprint_bytes": 200082080
+        }
+      }
+    }
+  ]
+}

--- a/benches/profile/results/single_worker_stage15_memory_small_2026-07-20.json
+++ b/benches/profile/results/single_worker_stage15_memory_small_2026-07-20.json
@@ -1,0 +1,386 @@
+{
+  "schema": 1,
+  "experiment": "single-tree-worker-stage15-memory",
+  "environment": {
+    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "python": "3.12.13",
+    "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)",
+    "cpu_model": "Apple M4",
+    "binary_sha256": "0a72535f4a3fcc417d20121ec28a2befb6595c2d7ca099448365de3afbcecf02",
+    "retained_environment": {
+      "PATH": "<redacted-search-path>",
+      "TMPDIR": "<redacted-path>",
+      "LANG": "C.UTF-8",
+      "LC_ALL": "C.UTF-8"
+    }
+  },
+  "artifacts": [
+    19,
+    "bc92f96ed727aa191b09d565a288c1ca270ceb4709242543007e076483739935"
+  ],
+  "harness": {
+    "source_files_sha256": {
+      "collect_worker_proxy.py": "e7a1aaaa180791f83dacbd6e135b64dcab806a3fa2f9f4887c91a941c65f3755",
+      "collect_worker_shadow.py": "c4696420ae0b47920dfaea45ec636c68f07373bcbdc260fc733e091ae17a7e9e",
+      "collect_worker_cold_start.py": "7648e2b0eba60b20b7f11a641c07c6ccdd5a1d3b75bc91492f32acfa90750109",
+      "collect_worker_capture_pilot.py": "3a709d50253dc23060ca99f885978e71a8b58f07a71af6c492d2fa73916a75f5",
+      "collect_worker_memory.py": "50bd0d25c37127ed42cfc1b047bdbcc7f39c98ee5009293ba6c9100c49ae2c46",
+      "drive.py": "1c2838bef386da9a398b5881dbd33839f77dc1aa864a044c1650b8deb99e2296",
+      "worker_proxy.py": "e3fe07d73168835e71fb976109e034b121b1112d6c7a746be1575ac07a6fd542",
+      "gen_session.py": "6f4f6b8388c607db1c70fe29579ce14fe00d57668cab17601432ff123cfb15a3"
+    }
+  },
+  "collector": {
+    "batches": 6,
+    "order": "legacy-authoritative on odd batches; reversed on even batches",
+    "worker_threads": 4,
+    "sample_interval_ms": 10.0,
+    "footprint_interval_ms": 250.0,
+    "metric": "sum of RSS for every descendant of the benchmark driver"
+  },
+  "scenario": [
+    "--lang",
+    "markdown",
+    "--size",
+    "150",
+    "--requests",
+    "500",
+    "--warm-semantic-cache",
+    "--settle",
+    "0.5",
+    "--hold-open",
+    "1.0"
+  ],
+  "batches": [
+    {
+      "batch": 1,
+      "order": [
+        "legacy",
+        "authoritative"
+      ],
+      "legacy": {
+        "count": 500,
+        "ok": 500,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 3700,
+        "p50": 1.8,
+        "p90": 2.2,
+        "p95": 2.2,
+        "p99": 2.2,
+        "max": 2.3,
+        "wall": 1461.1987080425024,
+        "wire_kib": 19292.4,
+        "memory": {
+          "sample_count": 44,
+          "peak_total_rss_kib": 34080,
+          "stable_median_total_rss_kib": 34080,
+          "peak_process_count": 1,
+          "footprint_sample_count": 14,
+          "peak_total_footprint_bytes": 18055624,
+          "stable_median_total_footprint_bytes": 18055624
+        }
+      },
+      "authoritative": {
+        "count": 500,
+        "ok": 500,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 3700,
+        "p50": 2.0,
+        "p90": 2.4,
+        "p95": 2.5,
+        "p99": 2.6,
+        "max": 2.9,
+        "wall": 1531.3596669584513,
+        "wire_kib": 19292.4,
+        "memory": {
+          "sample_count": 41,
+          "peak_total_rss_kib": 47408,
+          "stable_median_total_rss_kib": 47408,
+          "peak_process_count": 2,
+          "footprint_sample_count": 14,
+          "peak_total_footprint_bytes": 23528312,
+          "stable_median_total_footprint_bytes": 23528312
+        }
+      }
+    },
+    {
+      "batch": 2,
+      "order": [
+        "authoritative",
+        "legacy"
+      ],
+      "authoritative": {
+        "count": 500,
+        "ok": 500,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 3700,
+        "p50": 2.0,
+        "p90": 2.2,
+        "p95": 2.4,
+        "p99": 2.4,
+        "max": 3.2,
+        "wall": 1499.3927089963108,
+        "wire_kib": 19292.4,
+        "memory": {
+          "sample_count": 43,
+          "peak_total_rss_kib": 48352,
+          "stable_median_total_rss_kib": 48352,
+          "peak_process_count": 2,
+          "footprint_sample_count": 15,
+          "peak_total_footprint_bytes": 24494968,
+          "stable_median_total_footprint_bytes": 24494968
+        }
+      },
+      "legacy": {
+        "count": 500,
+        "ok": 500,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 3700,
+        "p50": 1.8,
+        "p90": 1.9,
+        "p95": 1.9,
+        "p99": 1.9,
+        "max": 2.1,
+        "wall": 1333.3811670308933,
+        "wire_kib": 19292.4,
+        "memory": {
+          "sample_count": 31,
+          "peak_total_rss_kib": 34064,
+          "stable_median_total_rss_kib": 34064,
+          "peak_process_count": 1,
+          "footprint_sample_count": 10,
+          "peak_total_footprint_bytes": 18072008,
+          "stable_median_total_footprint_bytes": 18072008
+        }
+      }
+    },
+    {
+      "batch": 3,
+      "order": [
+        "legacy",
+        "authoritative"
+      ],
+      "legacy": {
+        "count": 500,
+        "ok": 500,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 3700,
+        "p50": 1.8,
+        "p90": 1.9,
+        "p95": 1.9,
+        "p99": 1.9,
+        "max": 2.1,
+        "wall": 1341.4925410179421,
+        "wire_kib": 19292.4,
+        "memory": {
+          "sample_count": 30,
+          "peak_total_rss_kib": 32800,
+          "stable_median_total_rss_kib": 32800,
+          "peak_process_count": 1,
+          "footprint_sample_count": 10,
+          "peak_total_footprint_bytes": 16777672,
+          "stable_median_total_footprint_bytes": 16777672
+        }
+      },
+      "authoritative": {
+        "count": 500,
+        "ok": 500,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 3700,
+        "p50": 2.0,
+        "p90": 2.4,
+        "p95": 2.4,
+        "p99": 2.6,
+        "max": 2.7,
+        "wall": 1522.0602920744568,
+        "wire_kib": 19292.4,
+        "memory": {
+          "sample_count": 42,
+          "peak_total_rss_kib": 48720,
+          "stable_median_total_rss_kib": 48720,
+          "peak_process_count": 2,
+          "footprint_sample_count": 14,
+          "peak_total_footprint_bytes": 24888160,
+          "stable_median_total_footprint_bytes": 24888160
+        }
+      }
+    },
+    {
+      "batch": 4,
+      "order": [
+        "authoritative",
+        "legacy"
+      ],
+      "authoritative": {
+        "count": 500,
+        "ok": 500,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 3700,
+        "p50": 2.1,
+        "p90": 2.4,
+        "p95": 2.5,
+        "p99": 2.5,
+        "max": 2.9,
+        "wall": 1557.7831249684095,
+        "wire_kib": 19292.4,
+        "memory": {
+          "sample_count": 43,
+          "peak_total_rss_kib": 48432,
+          "stable_median_total_rss_kib": 48432,
+          "peak_process_count": 2,
+          "footprint_sample_count": 14,
+          "peak_total_footprint_bytes": 24609656,
+          "stable_median_total_footprint_bytes": 24609656
+        }
+      },
+      "legacy": {
+        "count": 500,
+        "ok": 500,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 3700,
+        "p50": 1.8,
+        "p90": 1.9,
+        "p95": 1.9,
+        "p99": 2.0,
+        "max": 2.3,
+        "wall": 1367.0949999941513,
+        "wire_kib": 19292.4,
+        "memory": {
+          "sample_count": 30,
+          "peak_total_rss_kib": 33184,
+          "stable_median_total_rss_kib": 33184,
+          "peak_process_count": 1,
+          "footprint_sample_count": 10,
+          "peak_total_footprint_bytes": 17170888,
+          "stable_median_total_footprint_bytes": 17170888
+        }
+      }
+    },
+    {
+      "batch": 5,
+      "order": [
+        "legacy",
+        "authoritative"
+      ],
+      "legacy": {
+        "count": 500,
+        "ok": 500,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 3700,
+        "p50": 1.8,
+        "p90": 1.8,
+        "p95": 1.8,
+        "p99": 1.9,
+        "max": 1.9,
+        "wall": 1343.2987079722807,
+        "wire_kib": 19292.4,
+        "memory": {
+          "sample_count": 31,
+          "peak_total_rss_kib": 32560,
+          "stable_median_total_rss_kib": 32560,
+          "peak_process_count": 1,
+          "footprint_sample_count": 10,
+          "peak_total_footprint_bytes": 16531912,
+          "stable_median_total_footprint_bytes": 16531912
+        }
+      },
+      "authoritative": {
+        "count": 500,
+        "ok": 500,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 3700,
+        "p50": 2.3,
+        "p90": 2.4,
+        "p95": 2.5,
+        "p99": 2.5,
+        "max": 2.9,
+        "wall": 1609.753833967261,
+        "wire_kib": 19292.4,
+        "memory": {
+          "sample_count": 42,
+          "peak_total_rss_kib": 48896,
+          "stable_median_total_rss_kib": 48896,
+          "peak_process_count": 2,
+          "footprint_sample_count": 14,
+          "peak_total_footprint_bytes": 25052024,
+          "stable_median_total_footprint_bytes": 25052024
+        }
+      }
+    },
+    {
+      "batch": 6,
+      "order": [
+        "authoritative",
+        "legacy"
+      ],
+      "authoritative": {
+        "count": 500,
+        "ok": 500,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 3700,
+        "p50": 2.1,
+        "p90": 2.4,
+        "p95": 2.5,
+        "p99": 2.6,
+        "max": 2.8,
+        "wall": 1594.047165941447,
+        "wire_kib": 19292.4,
+        "memory": {
+          "sample_count": 42,
+          "peak_total_rss_kib": 48368,
+          "stable_median_total_rss_kib": 48368,
+          "peak_process_count": 2,
+          "footprint_sample_count": 14,
+          "peak_total_footprint_bytes": 24511328,
+          "stable_median_total_footprint_bytes": 24511328
+        }
+      },
+      "legacy": {
+        "count": 500,
+        "ok": 500,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 3700,
+        "p50": 1.8,
+        "p90": 2.2,
+        "p95": 2.2,
+        "p99": 2.2,
+        "max": 2.3,
+        "wall": 1427.914208965376,
+        "wire_kib": 19292.4,
+        "memory": {
+          "sample_count": 30,
+          "peak_total_rss_kib": 33984,
+          "stable_median_total_rss_kib": 33984,
+          "peak_process_count": 1,
+          "footprint_sample_count": 10,
+          "peak_total_footprint_bytes": 18006496,
+          "stable_median_total_footprint_bytes": 18006496
+        }
+      }
+    }
+  ]
+}

--- a/benches/profile/test_collect_worker_memory.py
+++ b/benches/profile/test_collect_worker_memory.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from collect_worker_memory import (
+    descendant_pids,
+    order,
+    parse_footprint_bytes,
+    parse_ps_table,
+    scenario_arguments,
+    summarize_samples,
+)
+
+
+class WorkerMemoryCollectorTest(unittest.TestCase):
+    def test_order_reverses_each_batch(self):
+        self.assertEqual(order(0), ("legacy", "authoritative"))
+        self.assertEqual(order(1), ("authoritative", "legacy"))
+
+    def test_scenario_arguments_preserve_requested_scale(self):
+        self.assertEqual(
+            scenario_arguments("rust", 5000, 10),
+            [
+                "--lang", "rust", "--size", "5000", "--requests", "10",
+                "--warm-semantic-cache", "--settle", "0.5",
+                "--hold-open", "1.0",
+            ],
+        )
+
+    def test_parse_footprint_prefers_shared_aware_summary(self):
+        output = (
+            "parent [1]: Footprint: 100 B\n"
+            "worker [2]: Footprint: 200 B\n"
+            "Summary Footprint: 250 B\n"
+        )
+        self.assertEqual(parse_footprint_bytes(output), 250)
+        self.assertEqual(parse_footprint_bytes("proc: Footprint: 123 B\n"), 123)
+
+    def test_parse_ps_table_preserves_commands_with_spaces(self):
+        table = parse_ps_table(
+            "  10   1  2048 python3 drive.py --size 10\n"
+            "  11  10  4096 /tmp/kakehashi --tree-worker\n"
+        )
+        self.assertEqual(table[10], {"ppid": 1, "rss_kib": 2048,
+                                     "command": "python3 drive.py --size 10"})
+        self.assertEqual(table[11]["command"], "/tmp/kakehashi --tree-worker")
+
+    def test_descendant_pids_walks_the_full_process_tree(self):
+        table = {
+            10: {"ppid": 1, "rss_kib": 1, "command": "driver"},
+            11: {"ppid": 10, "rss_kib": 2, "command": "parent"},
+            12: {"ppid": 11, "rss_kib": 3, "command": "worker"},
+            13: {"ppid": 1, "rss_kib": 4, "command": "unrelated"},
+        }
+        self.assertEqual(descendant_pids(table, 10), {11, 12})
+
+    def test_summarize_samples_reports_peak_and_stable_median(self):
+        samples = [
+            {"total_rss_kib": 10, "process_count": 1},
+            {"total_rss_kib": 30, "process_count": 2},
+            {"total_rss_kib": 20, "process_count": 2},
+            {"total_rss_kib": 40, "process_count": 2},
+        ]
+        self.assertEqual(
+            summarize_samples(samples),
+            {
+                "sample_count": 4,
+                "peak_total_rss_kib": 40,
+                "stable_median_total_rss_kib": 30,
+                "peak_process_count": 2,
+            },
+        )
+
+    def test_summarize_samples_rejects_empty_input(self):
+        with self.assertRaises(ValueError):
+            summarize_samples([])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage15-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage15-measurement.md
@@ -1,0 +1,117 @@
+# Single Tree Worker Stage 15 Memory Measurement
+
+## Scope
+
+Stage 15 adds a reproducible parent-plus-worker memory collector and measures
+the fixed and document-scaled memory cost of the authoritative worker against
+the legacy in-process path. It does not change runtime admission yet.
+
+The existing worker limits a single document to 32 MiB, retained document text
+to 512 MiB, and document identities to 4,096. Those counters cover worker-owned
+text, but not the parent copy, Trees, injection facts, semantic caches, parser
+and query state, response buffers, or allocator retention. This measurement
+tests whether the text-only counter can stand in for total memory pressure.
+
+## Method
+
+The release Stage 15 binary was run in legacy and authoritative modes on macOS
+with one worker process and four compute threads. Six batches alternated the
+variant order. Every run used a fresh XDG directory and the same staged binary,
+queries, parsers, driver, and collector hashes.
+
+The collector samples the complete process tree rooted below the benchmark
+driver:
+
+* aggregate RSS every 10 ms; and
+* macOS shared-aware physical footprint every 250 ms.
+
+After semantic-token warmup and the measured requests, the driver holds the
+initialized server open for one second. The stable value is the median of the
+second half of samples; the reported result is the median across six runs.
+Physical footprint is the primary metric because summing per-process RSS counts
+shared pages more than once.
+
+Two generated Markdown documents were measured:
+
+| Workload | Source bytes | Requests |
+| --- | ---: | ---: |
+| Small | 32,550 | 500 |
+| Large | 1,121,182 | 10 |
+
+The retained raw results are
+`benches/profile/results/single_worker_stage15_memory_small_2026-07-20.json`
+and
+`benches/profile/results/single_worker_stage15_memory_large_2026-07-20.json`.
+
+## Result
+
+Stable physical-footprint medians were:
+
+| Workload | Legacy | Authoritative | Absolute change | Relative change |
+| --- | ---: | ---: | ---: | ---: |
+| Small | 16.77 MiB | 23.42 MiB | +6.65 MiB | +39.6% |
+| Large | 190.67 MiB | 224.06 MiB | +33.38 MiB | +17.5% |
+
+Peak physical-footprint medians were:
+
+| Workload | Legacy | Authoritative | Absolute change | Relative change |
+| --- | ---: | ---: | ---: | ---: |
+| Small | 16.77 MiB | 23.42 MiB | +6.65 MiB | +39.6% |
+| Large | 190.67 MiB | 225.06 MiB | +34.38 MiB | +18.0% |
+
+Aggregate RSS showed the expected larger shared-page overcount:
+
+| Workload | Legacy | Authoritative | Absolute change | Relative change |
+| --- | ---: | ---: | ---: | ---: |
+| Small stable | 32.80 MiB | 47.27 MiB | +14.47 MiB | +44.1% |
+| Large stable | 232.99 MiB | 270.24 MiB | +37.25 MiB | +16.0% |
+
+The collector also records request latency to validate successful work, but
+`footprint` temporarily inspects the target processes and materially perturbs
+timing. Those latency fields are not performance evidence; Stages 9, 13, and 14
+remain the relevant latency measurements.
+
+## Findings
+
+### One resident worker has a measurable fixed memory cost
+
+For the 32 KiB document, the shared-aware increase was 6.65 MiB. This is the
+cost of the second process, its bounded compute threads, worker-side language
+state, and duplicated live document-derived state. It is substantially smaller
+than the 14.47 MiB suggested by summing RSS, which confirms that RSS alone is an
+overly pessimistic acceptance gate on this platform.
+
+### Text duplication is not the dominant scaling term
+
+Increasing source text by about 1.04 MiB increased the authoritative-minus-
+legacy stable footprint gap by about 26.73 MiB. A second copy of source text
+cannot explain that slope. The worker also retains a Tree, injection discovery
+and resolved-region facts, injection token caches, and semantic tokens, while
+the parent retains reconstructable text and publication caches. IPC and
+allocator buffers retain additional peak capacity.
+
+### The current retained-text budget is not a total-memory budget
+
+A 1.07 MiB source remained far below the 512 MiB retained-text ceiling while
+the combined authoritative physical footprint reached 224 MiB. The text counter
+is still useful for transactional sync validation, but it cannot protect the
+single worker's queueing and memory-failure domain by itself.
+
+### Memory admission must account or evict derived state
+
+Blindly lowering the text limit would reject ordinary source based on a weak
+proxy and would not distinguish cheap text from injection-heavy derived state.
+A useful next gate needs worker-reported accounting for at least cached semantic
+tokens, resolved injection content, and other document-scoped derived caches,
+plus deterministic eviction or admission behavior. The ADR forbids routinely
+recycling healthy workers merely for memory pressure because restart invalidates
+node identities.
+
+## Decision
+
+Keep the fixed one-worker design, but do not pass the ADR memory gate yet. The
+measured cost is bounded for these fixtures and does not motivate worker
+sharding, but the current text-only budget is insufficient evidence against
+memory exhaustion. Add derived-state accounting and pressure-driven cache
+eviction/admission, then repeat this collector across concurrent documents
+before legacy removal.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1191,6 +1191,15 @@ thread, explicit yielding provided no measured latency benefit, so that path is
 a correctness fallback rather than a performance claim. Memory-pressure
 admission, broader long-walk scheduling, and compatibility gates remain open.
 
+The [Stage 15 memory measurement](single-resident-multithreaded-tree-worker-stage15-measurement.md)
+adds order-reversed release measurements of aggregate RSS and macOS shared-aware
+physical footprint. The authoritative worker added 6.65 MiB for a 32 KiB
+Markdown document and 33.38 MiB for a 1.07 MiB injection-heavy document. The
+growth is much larger than duplicated source text, proving that the existing
+512 MiB retained-text limit is not a total-memory admission bound. Derived-state
+accounting, pressure-driven eviction, concurrent-document memory tests, and
+compatibility gates remain open.
+
 The implementation should proceed in measured stages:
 
 1. Prototype the framed transport, supervision, and one high-level


### PR DESCRIPTION
## Summary

- add a process-tree memory collector with alternating legacy/authoritative order
- sample aggregate RSS and macOS shared-aware physical footprint
- hold initialized workloads briefly for steady-state observation
- retain six-batch release results for 32 KiB and 1.07 MiB Markdown documents
- document why the retained-text limit is not a total-memory bound

## Measurement

Shared-aware physical-footprint medians:

| Workload | Legacy | Authoritative | Change |
| --- | ---: | ---: | ---: |
| 32 KiB Markdown, stable | 16.77 MiB | 23.42 MiB | +6.65 MiB (+39.6%) |
| 1.07 MiB Markdown, stable | 190.67 MiB | 224.06 MiB | +33.38 MiB (+17.5%) |
| 1.07 MiB Markdown, peak | 190.67 MiB | 225.06 MiB | +34.38 MiB (+18.0%) |

The scaled gap is much larger than a second source-text copy. Tree, injection facts, semantic caches, IPC buffers, and allocator retention all contribute. Latency fields from this collector are not performance evidence because macOS footprint inspection perturbs the target.

## Decision

Keep one worker, but leave the ADR memory gate open. Add document-scoped derived-state accounting and pressure-driven eviction/admission before legacy removal.

## Validation

- python3 -m unittest discover -s benches/profile -p test_*.py (117 passed)
- python3 -m py_compile benches/profile/collect_worker_memory.py benches/profile/drive.py
- six order-reversed release batches for each retained workload
- JSON validation for both retained result files