### PR TITLE
perf(worker): trim auxiliary caches under pressure

### DIFF
--- a/benches/profile/collect_worker_memory.py
+++ b/benches/profile/collect_worker_memory.py
@@ -13,6 +13,7 @@ import tempfile
 import threading
 import time
 import re
+import shutil
 
 from collect_worker_proxy import (
     artifact_identity,
@@ -31,9 +32,10 @@ from collect_worker_proxy import (
 )
 
 
-def scenario_arguments(language, size, requests):
+def scenario_arguments(language, size, requests, documents=1):
     return [
         "--lang", language, "--size", str(size), "--requests", str(requests),
+        "--documents", str(documents),
         "--warm-semantic-cache", "--settle", "0.5", "--hold-open", "1.0",
     ]
 
@@ -212,23 +214,43 @@ def order(batch_index):
     return ("authoritative", "legacy")
 
 
+def comparison_order(batch_index):
+    if batch_index % 2 == 0:
+        return ("baseline", "candidate")
+    return ("candidate", "baseline")
+
+
 def collect(args):
     source_script_dir = pathlib.Path(__file__).resolve().parent
     binary_sha256 = sha256_file(args.bin)
+    compare_binary_sha256 = sha256_file(args.compare_bin) if args.compare_bin else None
     source_harness = harness_identity(source_script_dir)
     source_artifacts = artifact_identity(args.data_dir)
     staging, binary, data_dir, script_dir = stage_measurement_inputs(
         args.bin, args.data_dir, source_script_dir
     )
-    scenario = scenario_arguments(args.lang, args.size, args.requests)
+    compare_binary = None
+    if args.compare_bin:
+        compare_binary = pathlib.Path(staging.name) / "kakehashi-compare"
+        shutil.copy2(args.compare_bin, compare_binary)
+    scenario = scenario_arguments(args.lang, args.size, args.requests, args.documents)
     try:
         batches = []
         for index in range(args.batches):
-            batch = {"batch": index + 1, "order": list(order(index))}
-            for kind in order(index):
+            variant_order = (
+                comparison_order(index) if compare_binary else order(index)
+            )
+            batch = {"batch": index + 1, "order": list(variant_order)}
+            for kind in variant_order:
+                mode = "authoritative" if compare_binary else kind
+                variant_binary = (
+                    binary
+                    if not compare_binary or kind == "baseline"
+                    else compare_binary
+                )
                 batch[kind] = run_variant(
-                    kind,
-                    binary,
+                    mode,
+                    variant_binary,
                     data_dir,
                     script_dir,
                     scenario,
@@ -243,6 +265,8 @@ def collect(args):
         if artifact_identity(data_dir) != source_artifacts:
             raise RuntimeError("runtime artifacts changed during collection")
         verify_file_sha256(binary, binary_sha256)
+        if compare_binary:
+            verify_file_sha256(compare_binary, compare_binary_sha256)
         if harness_identity(source_script_dir) != source_harness:
             raise RuntimeError("benchmark harness changed during collection")
     finally:
@@ -256,6 +280,7 @@ def collect(args):
             "rustc": tool_version(["rustc", "--version"]),
             "cpu_model": cpu_model(),
             "binary_sha256": binary_sha256,
+            "compare_binary_sha256": compare_binary_sha256,
             "retained_environment": portable_environment(os.environ),
         },
         "artifacts": source_artifacts,
@@ -267,6 +292,10 @@ def collect(args):
             "sample_interval_ms": args.sample_interval_ms,
             "footprint_interval_ms": args.footprint_interval_ms,
             "metric": "sum of RSS for every descendant of the benchmark driver",
+            "comparison": (
+                "two authoritative binaries" if compare_binary_sha256
+                else "legacy versus authoritative in one binary"
+            ),
         },
         "scenario": scenario,
         "batches": batches,
@@ -278,12 +307,14 @@ def main():
     require_posix()
     parser = argparse.ArgumentParser()
     parser.add_argument("--bin", type=pathlib.Path, required=True)
+    parser.add_argument("--compare-bin", type=pathlib.Path)
     parser.add_argument("--data-dir", type=pathlib.Path, required=True)
     parser.add_argument("--output", type=pathlib.Path, required=True)
     parser.add_argument("--batches", type=int, default=4)
     parser.add_argument("--lang", choices=("rust", "markdown"), default="markdown")
     parser.add_argument("--size", type=int, default=150)
     parser.add_argument("--requests", type=int, default=500)
+    parser.add_argument("--documents", type=int, default=1)
     parser.add_argument("--worker-threads", type=int, default=4)
     parser.add_argument("--sample-interval-ms", type=float, default=10)
     parser.add_argument("--footprint-interval-ms", type=float, default=250)
@@ -293,6 +324,7 @@ def main():
         args.batches,
         args.size,
         args.requests,
+        args.documents,
         args.worker_threads,
         args.sample_interval_ms,
         args.footprint_interval_ms,

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -222,6 +222,17 @@ def warm_semantic_tokens(request, uri):
     semantic_token_data(response)
 
 
+def sibling_document_uris(uri, count):
+    stem, separator, extension = uri.rpartition(".")
+    if not separator:
+        stem, extension = uri, ""
+    uris = [uri]
+    for index in range(2, count + 1):
+        suffix = f"-{index}"
+        uris.append(f"{stem}{suffix}.{extension}" if extension else f"{stem}{suffix}")
+    return uris
+
+
 def terminate_server(server, timeout_seconds=3):
     """Give a server (and relay cleanup handler) a bounded graceful exit."""
     if server.poll() is not None:
@@ -253,6 +264,9 @@ def main() -> None:
     ap.add_argument("--lang", choices=["rust", "markdown"], default="rust")
     ap.add_argument("--size", type=int, default=150)
     ap.add_argument("--requests", type=int, default=300)
+    ap.add_argument(
+        "--documents", type=int, default=1,
+        help="open this many copies and round-robin measured requests across them")
     ap.add_argument(
         "--warm-semantic-cache", action="store_true",
         help="issue one unmeasured semanticTokens/full request before timing")
@@ -301,6 +315,8 @@ def main() -> None:
     args = ap.parse_args()
     if args.requests <= 0:
         ap.error("--requests must be positive")  # avoids divide-by-zero in the summary
+    if args.documents <= 0:
+        ap.error("--documents must be positive")
     if args.burst <= 0:
         ap.error("--burst must be positive")
     if args.burst_edits and args.burst <= 1:
@@ -313,6 +329,8 @@ def main() -> None:
         ap.error("--burst cannot be combined with captures modes")
     if args.concurrent_captures:
         args.captures = True
+    if args.documents > 1 and (args.edits or args.burst_edits or args.captures):
+        ap.error("multiple documents cannot be combined with edits or captures modes")
 
     if args.file:
         if args.file.endswith(".md"):
@@ -328,6 +346,7 @@ def main() -> None:
         uri, lang, text = "file:///profile/large.rs", "rust", gen_rust(args.size)
     else:
         uri, lang, text = "file:///profile/inj.md", "markdown", gen_markdown_injections(args.size)
+    document_uris = sibling_document_uris(uri, args.documents)
 
     env = dict(os.environ, KAKEHASHI_DATA_DIR=args.data_dir)
     # Let the server's stderr through (it's silent unless RUST_LOG is set) so a
@@ -506,12 +525,14 @@ def main() -> None:
                                                 "tokenTypes": [], "tokenModifiers": [],
                                                 "formats": ["relative"]}}}})
         notify("initialized", {})
-        notify("textDocument/didOpen", {"textDocument": {
-            "uri": uri, "languageId": lang, "version": 1, "text": text}})
+        for document_uri in document_uris:
+            notify("textDocument/didOpen", {"textDocument": {
+                "uri": document_uri, "languageId": lang, "version": 1, "text": text}})
         if args.settle > 0:
             time.sleep(args.settle)  # let the initial parse settle
         if args.warm_semantic_cache:
-            warm_semantic_tokens(request, uri)
+            for document_uri in document_uris:
+                warm_semantic_tokens(request, document_uri)
 
         captures_result_id = None
         if args.captures:
@@ -548,6 +569,7 @@ def main() -> None:
             })
 
         for i in range(args.requests):
+            request_uri = document_uris[i % len(document_uris)]
             for j in range(args.edits):
                 # A no-op didChange would be deduped by hashes.
                 send_toggle_edit()
@@ -559,7 +581,7 @@ def main() -> None:
             )
             semantic_request = (
                 "textDocument/semanticTokens/full",
-                {"textDocument": {"uri": uri}},
+                {"textDocument": {"uri": request_uri}},
             )
             captures_requests = [
                 ("kakehashi/captures/full/delta",
@@ -634,6 +656,7 @@ def main() -> None:
     n_lines = len(text.splitlines())
     source = (f"file={args.file} ({n_bytes}B/{n_lines}L)"
               if args.file else f"size={args.size}")
+    source += f" documents={args.documents}"
     firsts = " ".join(f"{t*1000:.0f}" for t in req_times[:5])
     measured_responses = sum(len(samples) for samples in request_samples.values())
     sys.stderr.write(f"[drive] first-cycle ms: {firsts}\n")

--- a/benches/profile/results/single_worker_stage16_cache_pressure_multidoc_2026-07-20.json
+++ b/benches/profile/results/single_worker_stage16_cache_pressure_multidoc_2026-07-20.json
@@ -1,0 +1,390 @@
+{
+  "schema": 1,
+  "experiment": "single-tree-worker-stage15-memory",
+  "environment": {
+    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "python": "3.12.13",
+    "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)",
+    "cpu_model": "Apple M4",
+    "binary_sha256": "0a72535f4a3fcc417d20121ec28a2befb6595c2d7ca099448365de3afbcecf02",
+    "compare_binary_sha256": "810f3a43b16002eebdb15a30f0da765131d485c82760894aa18b69790decca78",
+    "retained_environment": {
+      "PATH": "<redacted-search-path>",
+      "TMPDIR": "<redacted-path>",
+      "LANG": "C.UTF-8",
+      "LC_ALL": "C.UTF-8"
+    }
+  },
+  "artifacts": [
+    19,
+    "bc92f96ed727aa191b09d565a288c1ca270ceb4709242543007e076483739935"
+  ],
+  "harness": {
+    "source_files_sha256": {
+      "collect_worker_proxy.py": "e7a1aaaa180791f83dacbd6e135b64dcab806a3fa2f9f4887c91a941c65f3755",
+      "collect_worker_shadow.py": "c4696420ae0b47920dfaea45ec636c68f07373bcbdc260fc733e091ae17a7e9e",
+      "collect_worker_cold_start.py": "7648e2b0eba60b20b7f11a641c07c6ccdd5a1d3b75bc91492f32acfa90750109",
+      "collect_worker_capture_pilot.py": "3a709d50253dc23060ca99f885978e71a8b58f07a71af6c492d2fa73916a75f5",
+      "collect_worker_memory.py": "6eebdbbdc1314e9bd7b42f976434b5b2eb5adc28f0eaec88f02a617a356f20c7",
+      "drive.py": "53f19b370212839aba3236337cb177cb6ef69ca1b0c1f4ded5f459625ec602ff",
+      "worker_proxy.py": "e3fe07d73168835e71fb976109e034b121b1112d6c7a746be1575ac07a6fd542",
+      "gen_session.py": "6f4f6b8388c607db1c70fe29579ce14fe00d57668cab17601432ff123cfb15a3"
+    }
+  },
+  "collector": {
+    "batches": 6,
+    "order": "legacy-authoritative on odd batches; reversed on even batches",
+    "worker_threads": 4,
+    "sample_interval_ms": 20.0,
+    "footprint_interval_ms": 250.0,
+    "metric": "sum of RSS for every descendant of the benchmark driver",
+    "comparison": "two authoritative binaries"
+  },
+  "scenario": [
+    "--lang",
+    "markdown",
+    "--size",
+    "5000",
+    "--requests",
+    "6",
+    "--documents",
+    "3",
+    "--warm-semantic-cache",
+    "--settle",
+    "0.5",
+    "--hold-open",
+    "1.0"
+  ],
+  "batches": [
+    {
+      "batch": 1,
+      "order": [
+        "baseline",
+        "candidate"
+      ],
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 80.8,
+        "p90": 87.7,
+        "p95": 87.7,
+        "p99": 87.7,
+        "max": 87.7,
+        "wall": 822.5947499740869,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 37,
+          "peak_total_rss_kib": 584560,
+          "stable_median_total_rss_kib": 547616,
+          "peak_process_count": 2,
+          "footprint_sample_count": 35,
+          "peak_total_footprint_bytes": 546817344,
+          "stable_median_total_footprint_bytes": 508970280
+        }
+      },
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 82.4,
+        "p90": 84.6,
+        "p95": 84.6,
+        "p99": 84.6,
+        "max": 84.6,
+        "wall": 802.3018329404294,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 34,
+          "peak_total_rss_kib": 561744,
+          "stable_median_total_rss_kib": 527312,
+          "peak_process_count": 2,
+          "footprint_sample_count": 31,
+          "peak_total_footprint_bytes": 525026624,
+          "stable_median_total_footprint_bytes": 489743656
+        }
+      }
+    },
+    {
+      "batch": 2,
+      "order": [
+        "candidate",
+        "baseline"
+      ],
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 85.5,
+        "p90": 91.5,
+        "p95": 91.5,
+        "p99": 91.5,
+        "max": 91.5,
+        "wall": 860.1075829938054,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 29,
+          "peak_total_rss_kib": 574528,
+          "stable_median_total_rss_kib": 551104,
+          "peak_process_count": 2,
+          "footprint_sample_count": 28,
+          "peak_total_footprint_bytes": 538969456,
+          "stable_median_total_footprint_bytes": 521413988
+        }
+      },
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 81.4,
+        "p90": 86.9,
+        "p95": 86.9,
+        "p99": 86.9,
+        "max": 86.9,
+        "wall": 819.5948339998722,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 30,
+          "peak_total_rss_kib": 584064,
+          "stable_median_total_rss_kib": 582416,
+          "peak_process_count": 2,
+          "footprint_sample_count": 28,
+          "peak_total_footprint_bytes": 546342256,
+          "stable_median_total_footprint_bytes": 516883812
+        }
+      }
+    },
+    {
+      "batch": 3,
+      "order": [
+        "baseline",
+        "candidate"
+      ],
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 80.7,
+        "p90": 84.1,
+        "p95": 84.1,
+        "p99": 84.1,
+        "max": 84.1,
+        "wall": 801.4961670851335,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 30,
+          "peak_total_rss_kib": 583984,
+          "stable_median_total_rss_kib": 554688,
+          "peak_process_count": 2,
+          "footprint_sample_count": 27,
+          "peak_total_footprint_bytes": 546768240,
+          "stable_median_total_footprint_bytes": 527844708
+        }
+      },
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 83.8,
+        "p90": 89.1,
+        "p95": 89.1,
+        "p99": 89.1,
+        "max": 89.1,
+        "wall": 860.2179159643129,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 29,
+          "peak_total_rss_kib": 553968,
+          "stable_median_total_rss_kib": 535728,
+          "peak_process_count": 2,
+          "footprint_sample_count": 28,
+          "peak_total_footprint_bytes": 515425576,
+          "stable_median_total_footprint_bytes": 506062108
+        }
+      }
+    },
+    {
+      "batch": 4,
+      "order": [
+        "candidate",
+        "baseline"
+      ],
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 89.0,
+        "p90": 91.2,
+        "p95": 91.2,
+        "p99": 91.2,
+        "max": 91.2,
+        "wall": 888.8595420867205,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 29,
+          "peak_total_rss_kib": 555248,
+          "stable_median_total_rss_kib": 536976,
+          "peak_process_count": 2,
+          "footprint_sample_count": 29,
+          "peak_total_footprint_bytes": 517096768,
+          "stable_median_total_footprint_bytes": 498369832
+        }
+      },
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 89.2,
+        "p90": 92.9,
+        "p95": 92.9,
+        "p99": 92.9,
+        "max": 92.9,
+        "wall": 882.9402920091525,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 29,
+          "peak_total_rss_kib": 566976,
+          "stable_median_total_rss_kib": 529920,
+          "peak_process_count": 2,
+          "footprint_sample_count": 28,
+          "peak_total_footprint_bytes": 529761600,
+          "stable_median_total_footprint_bytes": 516506932
+        }
+      }
+    },
+    {
+      "batch": 5,
+      "order": [
+        "baseline",
+        "candidate"
+      ],
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 89.9,
+        "p90": 92.3,
+        "p95": 92.3,
+        "p99": 92.3,
+        "max": 92.3,
+        "wall": 889.1738329548389,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 29,
+          "peak_total_rss_kib": 562032,
+          "stable_median_total_rss_kib": 525008,
+          "peak_process_count": 2,
+          "footprint_sample_count": 28,
+          "peak_total_footprint_bytes": 523715928,
+          "stable_median_total_footprint_bytes": 501359924
+        }
+      },
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 88.7,
+        "p90": 89.9,
+        "p95": 89.9,
+        "p99": 89.9,
+        "max": 89.9,
+        "wall": 877.3824170930311,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 29,
+          "peak_total_rss_kib": 539008,
+          "stable_median_total_rss_kib": 522704,
+          "peak_process_count": 2,
+          "footprint_sample_count": 28,
+          "peak_total_footprint_bytes": 500188480,
+          "stable_median_total_footprint_bytes": 491832628
+        }
+      }
+    },
+    {
+      "batch": 6,
+      "order": [
+        "candidate",
+        "baseline"
+      ],
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 87.3,
+        "p90": 89.7,
+        "p95": 89.7,
+        "p99": 89.7,
+        "max": 89.7,
+        "wall": 859.6085839672014,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 29,
+          "peak_total_rss_kib": 559264,
+          "stable_median_total_rss_kib": 524912,
+          "peak_process_count": 2,
+          "footprint_sample_count": 28,
+          "peak_total_footprint_bytes": 520160576,
+          "stable_median_total_footprint_bytes": 489833780
+        }
+      },
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 84.9,
+        "p90": 87.4,
+        "p95": 87.4,
+        "p99": 87.4,
+        "max": 87.4,
+        "wall": 839.6423750091344,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 29,
+          "peak_total_rss_kib": 566128,
+          "stable_median_total_rss_kib": 540224,
+          "peak_process_count": 2,
+          "footprint_sample_count": 28,
+          "peak_total_footprint_bytes": 527959384,
+          "stable_median_total_footprint_bytes": 508953920
+        }
+      }
+    }
+  ]
+}

--- a/benches/profile/test_collect_worker_memory.py
+++ b/benches/profile/test_collect_worker_memory.py
@@ -7,6 +7,7 @@ import unittest
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
 from collect_worker_memory import (
+    comparison_order,
     descendant_pids,
     order,
     parse_footprint_bytes,
@@ -21,11 +22,16 @@ class WorkerMemoryCollectorTest(unittest.TestCase):
         self.assertEqual(order(0), ("legacy", "authoritative"))
         self.assertEqual(order(1), ("authoritative", "legacy"))
 
+    def test_comparison_order_reverses_each_batch(self):
+        self.assertEqual(comparison_order(0), ("baseline", "candidate"))
+        self.assertEqual(comparison_order(1), ("candidate", "baseline"))
+
     def test_scenario_arguments_preserve_requested_scale(self):
         self.assertEqual(
-            scenario_arguments("rust", 5000, 10),
+            scenario_arguments("rust", 5000, 10, 3),
             [
                 "--lang", "rust", "--size", "5000", "--requests", "10",
+                "--documents", "3",
                 "--warm-semantic-cache", "--settle", "0.5",
                 "--hold-open", "1.0",
             ],

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -17,6 +17,7 @@ from drive import (
     count_semantic_outcomes,
     next_toggle_change,
     response_result_id,
+    sibling_document_uris,
     send_timed_request,
     server_request_result,
     summarize_samples,
@@ -28,6 +29,16 @@ from process_test_utils import readline_with_timeout
 
 
 class RequestSummaryTest(unittest.TestCase):
+    def test_sibling_document_uris_preserve_extension_and_first_uri(self):
+        self.assertEqual(
+            sibling_document_uris("file:///profile/input.md", 3),
+            [
+                "file:///profile/input.md",
+                "file:///profile/input-2.md",
+                "file:///profile/input-3.md",
+            ],
+        )
+
     def test_capture_result_validates_full_and_delta_lineage(self):
         self.assertEqual(capture_result_id({
             "result": {"resultId": "full", "matches": [], "skipped": []}

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage16-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage16-measurement.md
@@ -1,0 +1,124 @@
+# Single Tree Worker Stage 16 Cache-Pressure Measurement
+
+## Scope
+
+Stage 16 adds document-local soft pressure hygiene. When a worker semantic-token
+cache retains more than 2 MiB of allocated token storage, the document keeps
+that exact-version semantic cache but drops recomputable auxiliary state:
+
+* semantic injection discovery;
+* resolved injection regions and virtual content;
+* injection-region token caches; and
+* lazily parsed injection layers.
+
+The worker retains source text, the host Tree, semantic tokens, and node-tracker
+identity. It therefore does not restart a healthy worker, invalidate public node
+IDs, or sacrifice the large-result cache hit that avoids recomputation.
+
+This is a soft cache policy, not a complete process-memory admission bound.
+
+## Method
+
+### Memory
+
+The Stage 15 baseline and Stage 16 candidate release binaries both ran in
+authoritative mode with one worker and four compute threads. The enhanced
+Stage 15 collector opened three copies of the 1,121,182-byte, 5,000-injection
+Markdown fixture. It warmed semantic tokens for each document, round-robined six
+measured requests, and held all documents open for stable sampling.
+
+Six batches alternated baseline-candidate and candidate-baseline order. The
+collector sampled aggregate RSS every 20 ms and macOS shared-aware physical
+footprint every 250 ms. Raw results are retained in
+`benches/profile/results/single_worker_stage16_cache_pressure_multidoc_2026-07-20.json`.
+
+### Cache-hit latency
+
+Because macOS `footprint` inspection perturbs target timing, latency was measured
+separately without a memory sampler. Six order-reversed runs per binary used one
+5,000-injection document and 20 measured exact-version semantic requests after
+warmup.
+
+### Correctness
+
+Unit tests establish both sides of the threshold. An oversized semantic cache
+drops auxiliary state while retaining semantic tokens, Tree, document version,
+and node identity; a small cache keeps auxiliary state. The full worker process
+and authoritative/shadow E2E suites cover the unchanged public lifecycle.
+
+## Result
+
+Three-document memory medians were:
+
+| Metric | Stage 15 | Stage 16 | Change |
+| --- | ---: | ---: | ---: |
+| Stable physical footprint | 488.99 MiB | 472.17 MiB | -16.82 MiB (-3.4%) |
+| Peak physical footprint | 513.13 MiB | 494.60 MiB | -18.52 MiB (-3.6%) |
+| Stable aggregate RSS | 531.17 MiB | 519.06 MiB | -12.11 MiB (-2.3%) |
+
+The stable physical-footprint maximum narrowed from 503.39 MiB to 497.26 MiB,
+while the peak maximum narrowed from 521.49 MiB to 514.00 MiB.
+
+Unsampled exact-version latency medians were:
+
+| Metric | Stage 15 | Stage 16 | Change |
+| --- | ---: | ---: | ---: |
+| p50 | 81.95 ms | 81.20 ms | -0.9% |
+| p95 | 85.90 ms | 86.60 ms | +0.8% |
+
+The latency differences are below the observed run-to-run variation. Preserving
+the semantic cache avoided a measurable cache-hit regression.
+
+Validation passed:
+
+* `cargo fmt --all -- --check`;
+* `cargo check --lib --tests --features e2e`;
+* `cargo test --lib` (3,132 passed, 2 ignored);
+* `cargo test --features e2e --test tree_worker_process` (4 passed);
+* `cargo test --features e2e --test e2e_tree_worker_shadow` (37 passed); and
+* profile Python tests (119 passed).
+
+## Findings
+
+### Logical eviction is not immediate RSS reclamation
+
+A single-document trial did not improve physical footprint. The allocator can
+retain pages after Rust drops many small cache allocations, so immediate OS
+memory is a poor test of logical eviction. With three documents, later
+allocations can reuse released space and the cumulative stable distribution
+improves. This is why the final fixture measures multiple simultaneously open
+documents rather than one post-request snapshot.
+
+### Retaining the expensive result isolates a useful tradeoff
+
+Dropping all worker semantic state would reduce more memory but force the next
+exact-version request to repeat injection discovery, parsing, and tokenization.
+Stage 16 instead keeps the 2.35 MiB semantic result in the measured large
+fixture and removes auxiliary copies. The modest memory win arrives without a
+latency loss.
+
+### A token-size threshold is only a proxy
+
+The semantic allocation is observable and cheap to count, but it does not
+directly measure Trees, resolved virtual content, captures caches, or allocator
+pages. Documents with small semantic output can still have expensive derived
+state, and several individually sub-threshold documents can exceed a global
+budget. Stage 16 therefore improves hygiene but does not close the ADR memory
+gate.
+
+### Hard pressure needs worker-wide accounting
+
+The next memory step requires document-scoped estimates across all derived
+caches, a worker-wide soft and hard budget, deterministic eviction order, and a
+bounded rejection contract when non-evictable state alone exceeds the hard
+limit. OS RSS must remain measurement evidence rather than an unstable runtime
+correctness input.
+
+## Decision
+
+Keep the Stage 16 auxiliary trim. It reduces cumulative multi-document memory
+and tightens the observed tail without regressing exact-version latency or node
+identity. Continue to treat the current text budget plus token-size trigger as
+soft safeguards, not proof of bounded total memory. Worker-wide derived-state
+accounting and concurrent-document admission remain required before accepting
+the ADR or removing the legacy path.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1200,6 +1200,15 @@ growth is much larger than duplicated source text, proving that the existing
 accounting, pressure-driven eviction, concurrent-document memory tests, and
 compatibility gates remain open.
 
+The [Stage 16 cache-pressure measurement](single-resident-multithreaded-tree-worker-stage16-measurement.md)
+keeps oversized exact-version semantic results while evicting recomputable
+injection-derived auxiliary caches. Across three simultaneous 1.07 MiB
+injection-heavy documents, stable physical footprint fell 16.82 MiB and peak
+fell 18.52 MiB without a measurable cache-hit latency regression. This improves
+soft pressure hygiene but uses semantic-token size only as a proxy; worker-wide
+derived-state accounting, a hard admission contract, and compatibility gates
+remain open.
+
 The implementation should proceed in measured stages:
 
 1. Prototype the framed transport, supervision, and one high-level

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -1413,7 +1413,7 @@ impl Kakehashi {
                 &uri,
                 snapshot.parsed_version,
                 walked.as_ref(),
-                &worker,
+                worker,
             );
         }
         // Arc once; the memo and the returned ComputedCaptures share the

--- a/src/lsp/lsp_impl/kakehashi/node/text.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/text.rs
@@ -109,15 +109,15 @@ impl Kakehashi {
             }
             _ => None,
         };
-        if let Some(worker) = worker.as_ref() {
-            if worker != &authoritative {
-                log::debug!(
-                    target: "kakehashi::tree_worker_shadow",
-                    "node text mismatch authoritative={} worker={}",
-                    authoritative,
-                    worker,
-                );
-            }
+        if let Some(worker) = worker.as_ref()
+            && worker != &authoritative
+        {
+            log::debug!(
+                target: "kakehashi::tree_worker_shadow",
+                "node text mismatch authoritative={} worker={}",
+                authoritative,
+                worker,
+            );
         }
         if self.tree_worker_shadow.is_authoritative() {
             Ok(worker.unwrap_or(Value::Null))

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -205,21 +205,18 @@ impl Kakehashi {
                         } else {
                             false
                         };
-                        if recovered {
-                            if !is_cli_mode {
-                                if authoritative {
-                                    diagnostic_scheduler
-                                        .spawn_synthetic_diagnostic_task(install_uri);
-                                } else {
-                                    spawn_synthetic_diagnostic_for_incarnation(
-                                        &documents,
-                                        &diagnostic_scheduler,
-                                        install_uri,
-                                        incarnation,
-                                        std::future::ready(()),
-                                    )
-                                    .await;
-                                }
+                        if recovered && !is_cli_mode {
+                            if authoritative {
+                                diagnostic_scheduler.spawn_synthetic_diagnostic_task(install_uri);
+                            } else {
+                                spawn_synthetic_diagnostic_for_incarnation(
+                                    &documents,
+                                    &diagnostic_scheduler,
+                                    install_uri,
+                                    incarnation,
+                                    std::future::ready(()),
+                                )
+                                .await;
                             }
                         }
                     });

--- a/src/lsp/lsp_impl/text_document/selection_range.rs
+++ b/src/lsp/lsp_impl/text_document/selection_range.rs
@@ -220,17 +220,17 @@ impl Kakehashi {
                 .map(selection_range_from_wire)
                 .collect::<Vec<_>>()
         });
-        if let (Some(worker), Some(authoritative)) = (worker.as_ref(), result.as_ref()) {
-            if worker != authoritative {
-                log::debug!(
-                    target: "kakehashi::tree_worker_shadow",
-                    "selectionRange mismatch uri={} version={} authoritative={:?} worker={:?}",
-                    uri,
-                    expected_version,
-                    authoritative,
-                    worker,
-                );
-            }
+        if let (Some(worker), Some(authoritative)) = (worker.as_ref(), result.as_ref())
+            && worker != authoritative
+        {
+            log::debug!(
+                target: "kakehashi::tree_worker_shadow",
+                "selectionRange mismatch uri={} version={} authoritative={:?} worker={:?}",
+                uri,
+                expected_version,
+                authoritative,
+                worker,
+            );
         }
 
         // None = the work-unit panicked (logged by the pool); serve the

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -1357,12 +1357,8 @@ impl TreeWorkerShadow {
         authoritative: &Value,
     ) -> Option<NodeResult> {
         let key = (uri.as_str().to_string(), authoritative_input_id.to_string());
-        let Some(node_id) = self.worker_nodes.get(&key).map(|entry| entry.clone()) else {
-            return None;
-        };
-        let Some(client) = self.read_client.load_full() else {
-            return None;
-        };
+        let node_id = self.worker_nodes.get(&key).map(|entry| entry.clone())?;
+        let client = self.read_client.load_full()?;
         if !self.is_enabled() || node_id.worker_generation != client.worker_generation() {
             self.worker_nodes.remove(&key);
             return None;
@@ -1385,11 +1381,7 @@ impl TreeWorkerShadow {
         .await
         .ok()
         .and_then(Result::ok);
-        let Some(result) =
-            response.and_then(|response| self.admit_node_response(response, &expected))
-        else {
-            return None;
-        };
+        let result = response.and_then(|response| self.admit_node_response(response, &expected))?;
         let authoritative_nodes = match authoritative {
             Value::Null => Vec::new(),
             Value::Object(_) => vec![authoritative],

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -27,6 +27,10 @@ pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_REPLICAS: usize = 4_096;
 pub const MAX_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
 pub const MAX_RETAINED_DOCUMENT_BYTES: usize = 512 * 1024 * 1024;
+// Preserve ordinary exact-version hits, but stop a multi-megabyte semantic
+// result from retaining a second full set of injection-derived caches. Stage 15
+// measured 74 KiB for the small fixture and 2.35 MiB for the pressure fixture.
+const SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES: usize = 2 * 1024 * 1024;
 pub const BUILD_ID: &str = concat!(env!("CARGO_PKG_NAME"), "-", env!("CARGO_PKG_VERSION"));
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -610,6 +614,22 @@ struct CachedInjectionLayer {
 }
 
 impl DocumentReplica {
+    fn trim_auxiliary_caches_for_pressure(&mut self) -> bool {
+        let semantic_bytes = self
+            .cached_semantic_tokens
+            .as_ref()
+            .map(|(_, _, tokens)| tokens.capacity() * std::mem::size_of::<WireSemanticToken>())
+            .unwrap_or_default();
+        if semantic_bytes <= SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES {
+            return false;
+        }
+        self.semantic_discovery = None;
+        self.resolved_injections = None;
+        self.injection_layers.clear();
+        self.injection_token_cache.clear_document(&self.uri);
+        true
+    }
+
     fn sync(
         request: SyncDocument,
         parser: &mut tree_sitter::Parser,
@@ -1239,6 +1259,7 @@ impl DocumentReplica {
             request.supports_multiline,
             Arc::new(tokens.clone()),
         ));
+        self.trim_auxiliary_caches_for_pressure();
         Ok(DerivedSemanticTokens {
             context: request.context,
             tokens,
@@ -4358,8 +4379,9 @@ mod tests {
         MAX_DOCUMENT_REPLICAS, MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeLayerSelector,
         NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION,
         Request, RequestCancelled, RequestContext, ResolveNode, Response, Route, RunCaptures,
-        RunNodeScalar, RunnableDocuments, SyncDocument, WireByteRange, WirePosition, WireRange,
-        WorkPriority, WorkerError, WorkerQuerySources, close_document, decode_frame,
+        RunNodeScalar, RunnableDocuments, SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES,
+        SyncDocument, WireByteRange, WirePosition, WireRange, WireSemanticToken, WorkPriority,
+        WorkerError, WorkerQuerySources, close_document, decode_frame,
         derive_snapshot_with_language, encode_frame, named_node_count, parse_request_timeout,
         replace_retained_bytes, request_priority, reserve_retained_growth, route_response, run,
         submit_document_job, sync_document, terminate_by_transport, validate_document_size,
@@ -5685,6 +5707,97 @@ mod tests {
             cached.cache_hit,
             "same-version semantic requests should reuse worker facts"
         );
+    }
+
+    #[test]
+    fn oversized_semantic_cache_trims_only_recomputable_auxiliary_state() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let context = RequestContext {
+            request_id: 1,
+            worker_generation: 3,
+            uri: "file:///memory-pressure.rs".into(),
+            incarnation: 4,
+            content_version: 1,
+            configuration_generation: 2,
+        };
+        let (mut replica, _) = DocumentReplica::sync(
+            SyncDocument {
+                context,
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: "/unused/static-language".into(),
+                parser_path: "/unused/static-language".into(),
+                artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
+                text: "fn main() {}".into(),
+            },
+            &mut parser,
+        )
+        .unwrap();
+        let token = WireSemanticToken {
+            delta_line: 0,
+            delta_start: 0,
+            length: 1,
+            token_type: 0,
+            token_modifiers_bitset: 0,
+        };
+        let token_count = SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES
+            / std::mem::size_of::<WireSemanticToken>()
+            + 1;
+        replica.cached_semantic_tokens = Some((2, false, Arc::new(vec![token; token_count])));
+        replica.semantic_discovery = Some(Arc::new(crate::document::DiscoveredInjections {
+            generation: 2,
+            complete: true,
+            regions: Vec::new(),
+        }));
+
+        assert!(replica.trim_auxiliary_caches_for_pressure());
+        assert!(replica.cached_semantic_tokens.is_some());
+        assert!(replica.semantic_discovery.is_none());
+        assert_eq!(replica.context.content_version, 1);
+        assert_eq!(replica.tree.root_node().kind(), "source_file");
+    }
+
+    #[test]
+    fn small_semantic_cache_keeps_auxiliary_state() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let context = RequestContext {
+            request_id: 1,
+            worker_generation: 3,
+            uri: "file:///small-cache.rs".into(),
+            incarnation: 4,
+            content_version: 1,
+            configuration_generation: 2,
+        };
+        let (mut replica, _) = DocumentReplica::sync(
+            SyncDocument {
+                context,
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: "/unused/static-language".into(),
+                parser_path: "/unused/static-language".into(),
+                artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
+                text: "fn main() {}".into(),
+            },
+            &mut parser,
+        )
+        .unwrap();
+        replica.cached_semantic_tokens = Some((2, false, Arc::new(Vec::new())));
+        replica.semantic_discovery = Some(Arc::new(crate::document::DiscoveredInjections {
+            generation: 2,
+            complete: true,
+            regions: Vec::new(),
+        }));
+
+        assert!(!replica.trim_auxiliary_caches_for_pressure());
+        assert!(replica.semantic_discovery.is_some());
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -2564,6 +2564,7 @@ fn submit_document_job(
     lane.submit(pool, job);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_work(
     request: Request,
     analysis: &Arc<crate::language::LanguageCoordinator>,
@@ -3519,10 +3520,9 @@ where
                 } else if nested_parallelism_was_allowed.load(Ordering::Relaxed)
                     && !nested_parallelism_yield_was_reported.swap(true, Ordering::Relaxed)
                     && trace_fairness
+                    && let Ok(path) = std::env::var("KAKEHASHI_TREE_WORKER_FAIRNESS_YIELDED_FILE")
                 {
-                    if let Ok(path) = std::env::var("KAKEHASHI_TREE_WORKER_FAIRNESS_YIELDED_FILE") {
-                        let _ = std::fs::write(path, b"yielded");
-                    }
+                    let _ = std::fs::write(path, b"yielded");
                 }
                 policy
             };
@@ -3734,11 +3734,11 @@ fn request_timeout(_uri: &str) -> Duration {
         {
             return DEFAULT_REQUEST_TIMEOUT;
         }
-        return parse_request_timeout(
+        parse_request_timeout(
             std::env::var("KAKEHASHI_TREE_WORKER_REQUEST_TIMEOUT_MS")
                 .ok()
                 .as_deref(),
-        );
+        )
     }
     #[cfg(not(feature = "e2e"))]
     DEFAULT_REQUEST_TIMEOUT


### PR DESCRIPTION
## Summary

- retain exact-version semantic results while trimming recomputable injection-derived state once a document semantic cache exceeds 2 MiB
- extend the process-tree memory harness to compare two authoritative binaries across multiple simultaneously open documents
- record order-balanced memory and cache-hit latency evidence in the ADR

## Measurement

Across three simultaneous 1.07 MiB injection-heavy Markdown documents (six reversed-order batches):

| Metric | Stage 15 | Stage 16 | Change |
| --- | ---: | ---: | ---: |
| Stable physical footprint | 488.99 MiB | 472.17 MiB | -16.82 MiB (-3.4%) |
| Peak physical footprint | 513.13 MiB | 494.60 MiB | -18.52 MiB (-3.6%) |
| Stable aggregate RSS | 531.17 MiB | 519.06 MiB | -12.11 MiB (-2.3%) |

Unsampled exact-version latency remained within run-to-run variation (p50 -0.9%, p95 +0.8%).

This is intentionally a soft cache policy. Worker-wide derived-state accounting, deterministic global eviction, and a hard admission contract remain open ADR gates.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --lib --tests --features e2e`
- `cargo test --lib` (3,132 passed, 2 ignored)
- `cargo test --features e2e --test tree_worker_process` (4 passed)
- `cargo test --features e2e --test e2e_tree_worker_shadow` (37 passed)
- profile Python tests (119 passed)