### PR TITLE
feat(worker): bound retained parser memory

### DIFF
--- a/benches/profile/results/single_worker_stage17_memory_admission_cache_hit_2026-07-20.json
+++ b/benches/profile/results/single_worker_stage17_memory_admission_cache_hit_2026-07-20.json
@@ -1,0 +1,51 @@
+{
+  "experiment": "single worker stage 17 memory admission exact-version cache hit",
+  "date": "2026-07-20",
+  "baseline": {
+    "stage": 16,
+    "binary_sha256": "810f3a43b16002eebdb15a30f0da765131d485c82760894aa18b69790decca78"
+  },
+  "candidate": {
+    "stage": 17,
+    "binary_sha256": "fb44ffe210efa84f088914bc38e81e0b98120789f4c066d709d6cef77eb6c57d"
+  },
+  "scenario": {
+    "language": "markdown",
+    "generated_size": 5000,
+    "documents": 1,
+    "measured_requests": 20,
+    "warm_semantic_cache": true,
+    "settle_seconds": 0.5,
+    "memory_sampling": false,
+    "order": [
+      ["baseline", "candidate"],
+      ["candidate", "baseline"],
+      ["baseline", "candidate"],
+      ["candidate", "baseline"],
+      ["baseline", "candidate"],
+      ["candidate", "baseline"]
+    ]
+  },
+  "runs": {
+    "baseline": [
+      {"p50_ms": 78.1, "p95_ms": 82.4, "wall_ms_per_cycle": 125.54},
+      {"p50_ms": 75.6, "p95_ms": 80.5, "wall_ms_per_cycle": 118.32},
+      {"p50_ms": 74.9, "p95_ms": 79.7, "wall_ms_per_cycle": 117.74},
+      {"p50_ms": 75.3, "p95_ms": 79.1, "wall_ms_per_cycle": 117.78},
+      {"p50_ms": 75.1, "p95_ms": 80.0, "wall_ms_per_cycle": 117.77},
+      {"p50_ms": 76.6, "p95_ms": 78.9, "wall_ms_per_cycle": 117.45}
+    ],
+    "candidate": [
+      {"p50_ms": 76.8, "p95_ms": 80.9, "wall_ms_per_cycle": 119.48},
+      {"p50_ms": 76.2, "p95_ms": 81.5, "wall_ms_per_cycle": 122.68},
+      {"p50_ms": 75.5, "p95_ms": 79.9, "wall_ms_per_cycle": 117.33},
+      {"p50_ms": 76.2, "p95_ms": 80.2, "wall_ms_per_cycle": 119.22},
+      {"p50_ms": 76.9, "p95_ms": 79.8, "wall_ms_per_cycle": 118.99},
+      {"p50_ms": 76.3, "p95_ms": 80.4, "wall_ms_per_cycle": 118.64}
+    ]
+  },
+  "medians": {
+    "baseline": {"p50_ms": 75.45, "p95_ms": 79.85, "wall_ms_per_cycle": 117.775},
+    "candidate": {"p50_ms": 76.25, "p95_ms": 80.30, "wall_ms_per_cycle": 119.105}
+  }
+}

--- a/benches/profile/results/single_worker_stage17_memory_admission_multidoc_2026-07-20.json
+++ b/benches/profile/results/single_worker_stage17_memory_admission_multidoc_2026-07-20.json
@@ -1,0 +1,390 @@
+{
+  "schema": 1,
+  "experiment": "single-tree-worker-stage15-memory",
+  "environment": {
+    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "python": "3.12.13",
+    "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)",
+    "cpu_model": "Apple M4",
+    "binary_sha256": "810f3a43b16002eebdb15a30f0da765131d485c82760894aa18b69790decca78",
+    "compare_binary_sha256": "fb44ffe210efa84f088914bc38e81e0b98120789f4c066d709d6cef77eb6c57d",
+    "retained_environment": {
+      "PATH": "<redacted-search-path>",
+      "TMPDIR": "<redacted-path>",
+      "LANG": "C.UTF-8",
+      "LC_ALL": "C.UTF-8"
+    }
+  },
+  "artifacts": [
+    19,
+    "29155eed68053f56c0d92f15e013d75bf8be33e47bf265901ff084778f868c3d"
+  ],
+  "harness": {
+    "source_files_sha256": {
+      "collect_worker_proxy.py": "e7a1aaaa180791f83dacbd6e135b64dcab806a3fa2f9f4887c91a941c65f3755",
+      "collect_worker_shadow.py": "c4696420ae0b47920dfaea45ec636c68f07373bcbdc260fc733e091ae17a7e9e",
+      "collect_worker_cold_start.py": "7648e2b0eba60b20b7f11a641c07c6ccdd5a1d3b75bc91492f32acfa90750109",
+      "collect_worker_capture_pilot.py": "3a709d50253dc23060ca99f885978e71a8b58f07a71af6c492d2fa73916a75f5",
+      "collect_worker_memory.py": "6eebdbbdc1314e9bd7b42f976434b5b2eb5adc28f0eaec88f02a617a356f20c7",
+      "drive.py": "53f19b370212839aba3236337cb177cb6ef69ca1b0c1f4ded5f459625ec602ff",
+      "worker_proxy.py": "e3fe07d73168835e71fb976109e034b121b1112d6c7a746be1575ac07a6fd542",
+      "gen_session.py": "6f4f6b8388c607db1c70fe29579ce14fe00d57668cab17601432ff123cfb15a3"
+    }
+  },
+  "collector": {
+    "batches": 6,
+    "order": "legacy-authoritative on odd batches; reversed on even batches",
+    "worker_threads": 4,
+    "sample_interval_ms": 20.0,
+    "footprint_interval_ms": 250.0,
+    "metric": "sum of RSS for every descendant of the benchmark driver",
+    "comparison": "two authoritative binaries"
+  },
+  "scenario": [
+    "--lang",
+    "markdown",
+    "--size",
+    "5000",
+    "--requests",
+    "6",
+    "--documents",
+    "3",
+    "--warm-semantic-cache",
+    "--settle",
+    "0.5",
+    "--hold-open",
+    "1.0"
+  ],
+  "batches": [
+    {
+      "batch": 1,
+      "order": [
+        "baseline",
+        "candidate"
+      ],
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 77.3,
+        "p90": 80.7,
+        "p95": 80.7,
+        "p99": 80.7,
+        "max": 80.7,
+        "wall": 763.8738329987973,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 48,
+          "peak_total_rss_kib": 559920,
+          "stable_median_total_rss_kib": 523792,
+          "peak_process_count": 2,
+          "footprint_sample_count": 29,
+          "peak_total_footprint_bytes": 513738072,
+          "stable_median_total_footprint_bytes": 478528832
+        }
+      },
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 78.9,
+        "p90": 80.5,
+        "p95": 80.5,
+        "p99": 80.5,
+        "max": 80.5,
+        "wall": 761.3005000166595,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 46,
+          "peak_total_rss_kib": 548864,
+          "stable_median_total_rss_kib": 530576,
+          "peak_process_count": 2,
+          "footprint_sample_count": 24,
+          "peak_total_footprint_bytes": 509150552,
+          "stable_median_total_footprint_bytes": 496207168
+        }
+      }
+    },
+    {
+      "batch": 2,
+      "order": [
+        "candidate",
+        "baseline"
+      ],
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 74.1,
+        "p90": 77.6,
+        "p95": 77.6,
+        "p99": 77.6,
+        "max": 77.6,
+        "wall": 747.2953330725431,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 41,
+          "peak_total_rss_kib": 525264,
+          "stable_median_total_rss_kib": 525232,
+          "peak_process_count": 2,
+          "footprint_sample_count": 23,
+          "peak_total_footprint_bytes": 487245120,
+          "stable_median_total_footprint_bytes": 475489600
+        }
+      },
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 73.8,
+        "p90": 79.1,
+        "p95": 79.1,
+        "p99": 79.1,
+        "max": 79.1,
+        "wall": 726.8276250688359,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 38,
+          "peak_total_rss_kib": 558128,
+          "stable_median_total_rss_kib": 558112,
+          "peak_process_count": 2,
+          "footprint_sample_count": 22,
+          "peak_total_footprint_bytes": 518358384,
+          "stable_median_total_footprint_bytes": 518342000
+        }
+      }
+    },
+    {
+      "batch": 3,
+      "order": [
+        "baseline",
+        "candidate"
+      ],
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 75.0,
+        "p90": 78.5,
+        "p95": 78.5,
+        "p99": 78.5,
+        "max": 78.5,
+        "wall": 723.8102920819074,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 36,
+          "peak_total_rss_kib": 563760,
+          "stable_median_total_rss_kib": 563744,
+          "peak_process_count": 2,
+          "footprint_sample_count": 25,
+          "peak_total_footprint_bytes": 519341400,
+          "stable_median_total_footprint_bytes": 484214080
+        }
+      },
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 74.6,
+        "p90": 79.2,
+        "p95": 79.2,
+        "p99": 79.2,
+        "max": 79.2,
+        "wall": 728.0826659407467,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 40,
+          "peak_total_rss_kib": 569040,
+          "stable_median_total_rss_kib": 559864,
+          "peak_process_count": 2,
+          "footprint_sample_count": 21,
+          "peak_total_footprint_bytes": 528155968,
+          "stable_median_total_footprint_bytes": 504661288
+        }
+      }
+    },
+    {
+      "batch": 4,
+      "order": [
+        "candidate",
+        "baseline"
+      ],
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 75.7,
+        "p90": 78.2,
+        "p95": 78.2,
+        "p99": 78.2,
+        "max": 78.2,
+        "wall": 747.315458022058,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 41,
+          "peak_total_rss_kib": 560624,
+          "stable_median_total_rss_kib": 560512,
+          "peak_process_count": 2,
+          "footprint_sample_count": 21,
+          "peak_total_footprint_bytes": 522421592,
+          "stable_median_total_footprint_bytes": 511198552
+        }
+      },
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 75.8,
+        "p90": 78.9,
+        "p95": 78.9,
+        "p99": 78.9,
+        "max": 78.9,
+        "wall": 739.8899591062218,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 37,
+          "peak_total_rss_kib": 549968,
+          "stable_median_total_rss_kib": 549936,
+          "peak_process_count": 2,
+          "footprint_sample_count": 24,
+          "peak_total_footprint_bytes": 506135920,
+          "stable_median_total_footprint_bytes": 488334680
+        }
+      }
+    },
+    {
+      "batch": 5,
+      "order": [
+        "baseline",
+        "candidate"
+      ],
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 76.2,
+        "p90": 76.6,
+        "p95": 76.6,
+        "p99": 76.6,
+        "max": 76.6,
+        "wall": 734.8469999851659,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 35,
+          "peak_total_rss_kib": 559776,
+          "stable_median_total_rss_kib": 559616,
+          "peak_process_count": 2,
+          "footprint_sample_count": 26,
+          "peak_total_footprint_bytes": 517621080,
+          "stable_median_total_footprint_bytes": 481772864
+        }
+      },
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 75.7,
+        "p90": 84.6,
+        "p95": 84.6,
+        "p99": 84.6,
+        "max": 84.6,
+        "wall": 739.4211660139263,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 39,
+          "peak_total_rss_kib": 573024,
+          "stable_median_total_rss_kib": 572992,
+          "peak_process_count": 2,
+          "footprint_sample_count": 22,
+          "peak_total_footprint_bytes": 529909080,
+          "stable_median_total_footprint_bytes": 494667072
+        }
+      }
+    },
+    {
+      "batch": 6,
+      "order": [
+        "candidate",
+        "baseline"
+      ],
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 75.4,
+        "p90": 79.3,
+        "p95": 79.3,
+        "p99": 79.3,
+        "max": 79.3,
+        "wall": 741.7913749814034,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 41,
+          "peak_total_rss_kib": 533376,
+          "stable_median_total_rss_kib": 533376,
+          "peak_process_count": 2,
+          "footprint_sample_count": 22,
+          "peak_total_footprint_bytes": 490390848,
+          "stable_median_total_footprint_bytes": 490390848
+        }
+      },
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 75.0,
+        "p90": 77.1,
+        "p95": 77.1,
+        "p99": 77.1,
+        "max": 77.1,
+        "wall": 731.9680829532444,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 37,
+          "peak_total_rss_kib": 567264,
+          "stable_median_total_rss_kib": 567264,
+          "peak_process_count": 2,
+          "footprint_sample_count": 23,
+          "peak_total_footprint_bytes": 524600664,
+          "stable_median_total_footprint_bytes": 489432384
+        }
+      }
+    }
+  ]
+}

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage17-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage17-measurement.md
@@ -1,0 +1,126 @@
+# Single Tree Worker Stage 17 Memory-Admission Measurement
+
+## Scope
+
+Stage 17 replaces document-size proxies with worker-wide estimated-memory
+accounting. It separately tracks non-evictable document state, reusable result
+caches, and recomputable auxiliary caches. A 128 MiB soft budget triggers a
+deterministic largest-first cache sweep, while a 512 MiB independent hard budget
+rejects growth of retained source and host-tree state transactionally.
+
+The Tree estimate uses 64 bytes per visible node because Tree-sitter does not
+expose native allocation size. The hard limit is therefore a deterministic
+admission contract over a conservative model, not a claim that process RSS is
+exactly bounded to 512 MiB.
+
+## Method
+
+### Memory
+
+The Stage 16 baseline and Stage 17 candidate release binaries ran in
+authoritative mode with one worker and four compute threads. Each batch opened
+three copies of the 1,121,182-byte, 5,000-injection Markdown fixture, warmed
+semantic tokens for every document, round-robined six measured requests, and
+held the documents open for stable sampling.
+
+Six batches alternated baseline-candidate and candidate-baseline order. The
+collector sampled aggregate RSS every 20 ms and macOS shared-aware physical
+footprint every 250 ms. Raw results are retained in
+`benches/profile/results/single_worker_stage17_memory_admission_multidoc_2026-07-20.json`.
+
+### Cache-hit latency
+
+Latency was measured separately without `footprint` sampling. Six
+order-reversed runs per binary used one 5,000-injection document and 20 measured
+exact-version semantic requests after warmup. Raw per-run results and binary
+hashes are retained in
+`benches/profile/results/single_worker_stage17_memory_admission_cache_hit_2026-07-20.json`.
+
+### Correctness
+
+Unit tests cover every accounted memory class, deterministic eviction order,
+soft-budget enforcement, transactional hard admission, counter replacement and
+release, and the exact-version checkpoint bypass. The process and
+authoritative/shadow E2E suites cover the unchanged public lifecycle.
+
+## Result
+
+Three-document memory medians were:
+
+| Metric | Stage 16 | Stage 17 | Change |
+| --- | ---: | ---: | ---: |
+| Stable physical footprint | 463.75 MiB | 472.49 MiB | +8.74 MiB (+1.9%) |
+| Peak physical footprint | 493.99 MiB | 491.89 MiB | -2.10 MiB (-0.4%) |
+| Stable aggregate RSS | 545.77 MiB | 533.81 MiB | -11.96 MiB (-2.2%) |
+| Peak aggregate RSS | 546.73 MiB | 541.74 MiB | -4.98 MiB (-0.9%) |
+
+The maximum stable physical footprint narrowed from 494.33 MiB to 487.52 MiB,
+while the peak maximum widened from 500.30 MiB to 505.36 MiB. The metrics move
+in opposite directions and vary more between runs than between medians; this
+fixture does not show a material memory change.
+
+Unsampled exact-version latency medians were:
+
+| Metric | Stage 16 | Stage 17 | Change |
+| --- | ---: | ---: | ---: |
+| p50 | 75.45 ms | 76.25 ms | +1.1% |
+| p95 | 79.85 ms | 80.30 ms | +0.6% |
+| Wall time per cycle | 117.78 ms | 119.10 ms | +1.1% |
+
+These differences are below the observed run-to-run variation. Skipping the
+worker-wide pressure scan on an exact-version result-cache hit keeps the hot
+path effectively unchanged.
+
+Validation passed:
+
+* `cargo fmt --all -- --check`;
+* `cargo check --lib --tests --features e2e`;
+* `cargo test --lib`;
+* `cargo test --features e2e --test tree_worker_process` (4 passed);
+* `cargo test --features e2e --test e2e_tree_worker_shadow` (37 passed); and
+* `cargo clippy --all-targets --all-features -- -D warnings`.
+
+## Findings
+
+### Accounting can improve the contract without lowering ordinary RSS
+
+The measured three-document fixture stays below the new soft budget after
+Stage 16 has already removed oversized auxiliary caches. Stage 17 should not
+evict additional state in this case, and the mixed physical-footprint and RSS
+deltas confirm no repeatable memory reduction. Its value here is making memory
+classes visible and enforceable before the process reaches an OS-defined
+failure state.
+
+### The hot-path checkpoint must remain conditional
+
+The first implementation checkpointed every semantic request, which would scan
+all open documents even when the exact-version result already existed. Stage 17
+instead checkpoints only requests that can grow caches. The measured +0.6% to
++1.1% medians are noise-scale evidence that the admission machinery does not
+materially tax the common cache-hit path.
+
+### Native Tree memory remains the largest uncertainty
+
+Rust-owned buffers can be counted from capacities, but Tree-sitter exposes node
+count rather than allocation bytes. Weighting each visible node by 64 bytes
+makes admission deterministic and conservative enough to prevent unbounded
+growth, but it can both overestimate compact trees and underestimate hidden
+allocator overhead. RSS remains supporting measurement evidence, not a runtime
+input or the hard-limit definition.
+
+### A hard-limit stress benchmark is still useful
+
+Tests prove rejection and rollback at a synthetic boundary without allocating
+hundreds of MiB. This measurement deliberately exercises the admitted common
+case, so it does not quantify latency or reclamation when the 128 MiB soft
+budget or 512 MiB hard budget is crossed. A configurable-limit stress fixture
+would make that path observable without destabilizing the benchmark host.
+
+## Decision
+
+Keep the Stage 17 accounting and admission policy. It establishes deterministic
+soft eviction and transactional hard rejection without a material common-case
+memory or latency regression. Do not claim an RSS cap or a memory reduction from
+this fixture. Failure injection, configurable-boundary stress, protocol and
+compatibility gates, and legacy-path removal remain required before accepting
+the ADR.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1209,6 +1209,15 @@ soft pressure hygiene but uses semantic-token size only as a proxy; worker-wide
 derived-state accounting, a hard admission contract, and compatibility gates
 remain open.
 
+The [Stage 17 memory-admission measurement](single-resident-multithreaded-tree-worker-stage17-measurement.md)
+adds worker-wide estimates for non-evictable, result-cache, and auxiliary-cache
+memory, deterministic soft eviction, and transactional rejection of growth over
+an independent hard bound. A three-document admitted workload showed mixed
+noise-scale memory deltas and exact-version latency moved by only +0.6% to
++1.1%. This establishes a deterministic admission contract without claiming an
+RSS cap; configurable-boundary stress, failure injection, protocol and
+compatibility gates remain open.
+
 The implementation should proceed in measured stages:
 
 1. Prototype the framed transport, supervision, and one high-level

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -64,10 +64,8 @@ use token_collector::{build_line_start_bytes, collect_host_tokens};
 // Region-local token type persisted by the injection-token cache (#529). Lives
 // in `token_collector`; re-exported here so `semantic_cache` can name it.
 pub(crate) use token_collector::RawToken;
-// `TokenKind` is only needed to construct `RawToken`s in `semantic_cache` tests
-// (the production re-anchor path touches only line/column), so its re-export is
-// test-gated to avoid an unused import in release builds.
-#[cfg(test)]
+// Memory admission also inspects the only heap-owning variant so its boxed
+// name is included in the retained-cache estimate.
 pub(crate) use token_collector::TokenKind;
 
 // Test-only imports

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -593,6 +593,26 @@ impl InjectionTokenCache {
         self.cache.remove(uri);
     }
 
+    pub(crate) fn estimated_document_bytes(&self, uri: &Url) -> usize {
+        self.cache.get(uri).map_or(0, |document| {
+            let entries = document
+                .capacity()
+                .saturating_mul(std::mem::size_of::<(u64, CachedRegionTokens)>());
+            document.iter().fold(entries, |bytes, (_, cached)| {
+                let tokens = cached.tokens.as_ref();
+                let payload = std::mem::size_of::<Vec<RawToken>>()
+                    .saturating_add(tokens.capacity() * std::mem::size_of::<RawToken>());
+                let boxed_names = tokens.iter().fold(0_usize, |names, token| {
+                    names.saturating_add(match &token.kind {
+                        crate::analysis::semantic::TokenKind::MappedUnknown(name) => name.len(),
+                        _ => 0,
+                    })
+                });
+                bytes.saturating_add(payload).saturating_add(boxed_names)
+            })
+        })
+    }
+
     /// Drop every cached entry. Used on a settings/query reload (alongside the
     /// generation bump) to reclaim memory: the generation fold already makes
     /// old-generation entries unreachable — this just stops them leaking until
@@ -1263,6 +1283,18 @@ mod tests {
         // Non-existent URI returns None
         let other_uri = Url::parse("file:///other.md").unwrap();
         assert!(cache.get(&other_uri, 0xAA, 0).is_none());
+    }
+
+    #[test]
+    fn injection_token_cache_reports_document_token_capacity() {
+        let cache = InjectionTokenCache::new();
+        let uri = Url::parse("file:///memory.md").unwrap();
+        let mut tokens = Vec::with_capacity(32);
+        tokens.push(raw_token(0, 0, 5));
+        let token_bytes = tokens.capacity() * std::mem::size_of::<RawToken>();
+        cache.store(&uri, 0xAA, 0, tokens);
+
+        assert!(cache.estimated_document_bytes(&uri) >= token_bytes);
     }
 
     #[test]

--- a/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
@@ -45,7 +45,7 @@ use std::sync::Arc;
 
 use url::Url;
 
-use crate::language::query_exec::MatchData;
+use crate::language::query_exec::{CapturedNode, MatchData};
 
 const FNV_OFFSET: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x100000001b3;
@@ -207,6 +207,41 @@ pub(crate) struct CapturesMatchCache {
     cache: dashmap::DashMap<Url, DocMatchCache>,
 }
 
+fn estimated_metadata_bytes(metadata: &[(String, Option<String>)], capacity: usize) -> usize {
+    (capacity * std::mem::size_of::<(String, Option<String>)>()).saturating_add(
+        metadata.iter().fold(0, |bytes, (key, value)| {
+            bytes
+                .saturating_add(key.capacity())
+                .saturating_add(value.as_ref().map(String::capacity).unwrap_or_default())
+        }),
+    )
+}
+
+fn estimated_match_bytes(matches: &[MatchData], capacity: usize) -> usize {
+    std::mem::size_of::<Vec<MatchData>>()
+        .saturating_add(capacity * std::mem::size_of::<MatchData>())
+        .saturating_add(matches.iter().fold(0, |bytes, matched| {
+            let captures = matched
+                .captures
+                .iter()
+                .fold(0_usize, |capture_bytes, capture| {
+                    capture_bytes
+                        .saturating_add(capture.name.capacity())
+                        .saturating_add(estimated_metadata_bytes(
+                            &capture.metadata,
+                            capture.metadata.capacity(),
+                        ))
+                });
+            bytes
+                .saturating_add(matched.captures.capacity() * std::mem::size_of::<CapturedNode>())
+                .saturating_add(captures)
+                .saturating_add(estimated_metadata_bytes(
+                    &matched.metadata,
+                    matched.metadata.capacity(),
+                ))
+        }))
+}
+
 impl CapturesMatchCache {
     pub(in crate::lsp::lsp_impl) fn new() -> Self {
         Self::default()
@@ -347,6 +382,35 @@ impl CapturesMatchCache {
 
     pub(in crate::lsp::lsp_impl) fn clear_document(&self, uri: &Url) {
         self.cache.remove(uri);
+    }
+
+    pub(crate) fn estimated_document_bytes(&self, uri: &Url) -> usize {
+        self.cache.get(uri).map_or(0, |document| {
+            let host = document
+                .host
+                .capacity()
+                .saturating_mul(std::mem::size_of::<(String, CachedHostMatches)>());
+            let layers = document
+                .layers
+                .capacity()
+                .saturating_mul(std::mem::size_of::<(u64, CachedLayerMatches)>());
+            let host = document.host.iter().fold(host, |bytes, (kind, cached)| {
+                bytes
+                    .saturating_add(kind.capacity())
+                    .saturating_add(estimated_match_bytes(
+                        cached.matches.as_ref(),
+                        cached.matches.capacity(),
+                    ))
+            });
+            document
+                .layers
+                .values()
+                .fold(host.saturating_add(layers), |bytes, cached| {
+                    bytes.saturating_add(cached.kind.capacity()).saturating_add(
+                        estimated_match_bytes(cached.matches.as_ref(), cached.matches.capacity()),
+                    )
+                })
+        })
     }
 }
 
@@ -598,6 +662,18 @@ mod tests {
             panic!("existing doc slot must not probe liveness")
         });
         assert!(cache.get_layer(&uri, 2, 7).is_some());
+    }
+
+    #[test]
+    fn cache_reports_document_match_capacity() {
+        let cache = CapturesMatchCache::new();
+        let uri = uri();
+        let mut matches = Vec::with_capacity(32);
+        matches.push(match_data(&[(0, 3)]));
+        let match_bytes = matches.capacity() * std::mem::size_of::<MatchData>();
+        cache.store_host(&uri, "highlights", 1, 7, Arc::new(matches), || true);
+
+        assert!(cache.estimated_document_bytes(&uri) >= match_bytes);
     }
 
     #[test]

--- a/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
@@ -380,7 +380,7 @@ impl CapturesMatchCache {
         }
     }
 
-    pub(in crate::lsp::lsp_impl) fn clear_document(&self, uri: &Url) {
+    pub(crate) fn clear_document(&self, uri: &Url) {
         self.cache.remove(uri);
     }
 

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -738,11 +738,21 @@ impl DocumentReplica {
         if semantic_bytes <= SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES {
             return false;
         }
+        self.clear_auxiliary_caches()
+    }
+
+    fn clear_auxiliary_caches(&mut self) -> bool {
+        let retained = self.estimated_memory().auxiliary_cache_bytes;
         self.semantic_discovery = None;
         self.resolved_injections = None;
         self.injection_layers.clear();
         self.injection_token_cache.clear_document(&self.uri);
-        true
+        self.captures_match_cache.clear_document(&self.uri);
+        retained > 0
+    }
+
+    fn clear_result_cache(&mut self) -> bool {
+        self.cached_semantic_tokens.take().is_some()
     }
 
     fn sync(
@@ -2494,6 +2504,53 @@ fn cache_eviction_plan(
         }
     }
     plan
+}
+
+fn enforce_derived_memory_budget(
+    documents: &DocumentStore,
+    pressure_lock: &Mutex<()>,
+    current: &DocumentKey,
+    target_bytes: usize,
+) -> Result<(), String> {
+    let _pressure = pressure_lock
+        .lock()
+        .map_err(|_| "worker memory-pressure lock is poisoned".to_string())?;
+    let mut candidates = Vec::with_capacity(documents.len());
+    for entry in documents.iter() {
+        let key = entry.key().clone();
+        let replica = Arc::clone(entry.value());
+        drop(entry);
+        let estimate = replica
+            .lock()
+            .map_err(|_| "document replica lock is poisoned during memory pressure".to_string())?
+            .estimated_memory();
+        candidates.push(CacheEvictionCandidate {
+            current: key == *current,
+            key,
+            result_bytes: estimate.result_cache_bytes,
+            auxiliary_bytes: estimate.auxiliary_cache_bytes,
+        });
+    }
+    for eviction in cache_eviction_plan(candidates, target_bytes) {
+        let key = match &eviction {
+            CacheEviction::Auxiliary(key) | CacheEviction::Result(key) => key,
+        };
+        let Some(replica) = documents.get(key).map(|entry| Arc::clone(entry.value())) else {
+            continue;
+        };
+        let mut replica = replica
+            .lock()
+            .map_err(|_| "document replica lock is poisoned during cache eviction".to_string())?;
+        match eviction {
+            CacheEviction::Auxiliary(_) => {
+                replica.clear_auxiliary_caches();
+            }
+            CacheEviction::Result(_) => {
+                replica.clear_result_cache();
+            }
+        }
+    }
+    Ok(())
 }
 
 type DocumentStore = Arc<dashmap::DashMap<DocumentKey, Arc<Mutex<DocumentReplica>>>>;
@@ -4555,9 +4612,10 @@ mod tests {
         RunnableDocuments, SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES, SyncDocument,
         WireByteRange, WirePosition, WireRange, WireSemanticToken, WorkPriority, WorkerError,
         WorkerQuerySources, cache_eviction_plan, close_document, decode_frame,
-        derive_snapshot_with_language, encode_frame, named_node_count, parse_request_timeout,
-        replace_retained_bytes, request_priority, reserve_retained_growth, route_response, run,
-        submit_document_job, sync_document, terminate_by_transport, validate_document_size,
+        derive_snapshot_with_language, encode_frame, enforce_derived_memory_budget,
+        named_node_count, parse_request_timeout, replace_retained_bytes, request_priority,
+        reserve_retained_growth, route_response, run, submit_document_job, sync_document,
+        terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -6087,6 +6145,89 @@ mod tests {
                 }),
             ]
         );
+    }
+
+    #[test]
+    fn worker_pressure_evicts_auxiliary_then_non_current_result_state() {
+        let documents: super::DocumentStore = Arc::new(dashmap::DashMap::new());
+        let make_replica = |uri: &str| {
+            let mut parser = tree_sitter::Parser::new();
+            parser
+                .set_language(&tree_sitter_rust::LANGUAGE.into())
+                .unwrap();
+            DocumentReplica::sync(
+                SyncDocument {
+                    context: RequestContext {
+                        request_id: 1,
+                        worker_generation: 3,
+                        uri: uri.into(),
+                        incarnation: 4,
+                        content_version: 1,
+                        configuration_generation: 2,
+                    },
+                    language: "rust".into(),
+                    grammar_symbol: "rust".into(),
+                    source_path: "/unused/static-language".into(),
+                    parser_path: "/unused/static-language".into(),
+                    artifact_digest: "sha256:rust-v1".into(),
+                    queries: WorkerQuerySources::default(),
+                    text: "fn main() {}".into(),
+                },
+                &mut parser,
+            )
+            .unwrap()
+            .0
+        };
+        for uri in ["file:///a.rs", "file:///b.rs"] {
+            let mut replica = make_replica(uri);
+            replica.cached_semantic_tokens = Some((
+                2,
+                false,
+                Arc::new(vec![
+                    WireSemanticToken {
+                        delta_line: 0,
+                        delta_start: 0,
+                        length: 1,
+                        token_type: 0,
+                        token_modifiers_bitset: 0,
+                    };
+                    16
+                ]),
+            ));
+            replica.semantic_discovery = Some(Arc::new(crate::document::DiscoveredInjections {
+                generation: 2,
+                complete: true,
+                regions: Vec::with_capacity(16),
+            }));
+            documents.insert(
+                DocumentKey { uri: uri.into() },
+                Arc::new(Mutex::new(replica)),
+            );
+        }
+        let current = DocumentKey {
+            uri: "file:///b.rs".into(),
+        };
+        let get = |key: &DocumentKey| Arc::clone(documents.get(key).unwrap().value());
+        let current_replica = get(&current);
+        let target = current_replica
+            .lock()
+            .unwrap()
+            .estimated_memory()
+            .result_cache_bytes;
+
+        enforce_derived_memory_budget(&documents, &Mutex::new(()), &current, target).unwrap();
+
+        let a_key = DocumentKey {
+            uri: "file:///a.rs".into(),
+        };
+        let a_replica = get(&a_key);
+        let b_replica = get(&current);
+        let a = a_replica.lock().unwrap();
+        let b = b_replica.lock().unwrap();
+        assert!(a.semantic_discovery.is_none());
+        assert!(b.semantic_discovery.is_none());
+        assert!(a.cached_semantic_tokens.is_none());
+        assert!(b.cached_semantic_tokens.is_some());
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -31,6 +31,10 @@ pub const MAX_RETAINED_DOCUMENT_BYTES: usize = 512 * 1024 * 1024;
 // result from retaining a second full set of injection-derived caches. Stage 15
 // measured 74 KiB for the small fixture and 2.35 MiB for the pressure fixture.
 const SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES: usize = 2 * 1024 * 1024;
+// tree-sitter does not expose allocation size. Admission therefore assigns a
+// conservative portable weight per retained subtree node; Stage 17 compares
+// the estimate with process footprint rather than treating it as measured RSS.
+const TREE_NODE_ADMISSION_BYTES: usize = 64;
 pub const BUILD_ID: &str = concat!(env!("CARGO_PKG_NAME"), "-", env!("CARGO_PKG_VERSION"));
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -672,6 +676,13 @@ fn estimated_injection_layer_bytes(layers: &[CachedInjectionLayer], capacity: us
         |bytes, layer| {
             bytes
                 .saturating_add(layer.ranges.capacity() * std::mem::size_of::<tree_sitter::Range>())
+                .saturating_add(
+                    layer
+                        .tree
+                        .root_node()
+                        .descendant_count()
+                        .saturating_mul(TREE_NODE_ADMISSION_BYTES),
+                )
         },
     ))
 }
@@ -679,7 +690,12 @@ fn estimated_injection_layer_bytes(layers: &[CachedInjectionLayer], capacity: us
 impl DocumentReplica {
     fn estimated_memory(&self) -> EstimatedDocumentMemory {
         EstimatedDocumentMemory {
-            non_evictable_bytes: self.text.capacity(),
+            non_evictable_bytes: self.text.capacity().saturating_add(
+                self.tree
+                    .root_node()
+                    .descendant_count()
+                    .saturating_mul(TREE_NODE_ADMISSION_BYTES),
+            ),
             result_cache_bytes: self
                 .cached_semantic_tokens
                 .as_ref()
@@ -5946,6 +5962,37 @@ mod tests {
             after.evictable_bytes(),
             before.evictable_bytes() + semantic_bytes
         );
+    }
+
+    #[test]
+    fn parsed_tree_contributes_to_non_evictable_memory() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let (replica, _) = DocumentReplica::sync(
+            SyncDocument {
+                context: RequestContext {
+                    request_id: 1,
+                    worker_generation: 3,
+                    uri: "file:///tree-accounting.rs".into(),
+                    incarnation: 4,
+                    content_version: 1,
+                    configuration_generation: 2,
+                },
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: "/unused/static-language".into(),
+                parser_path: "/unused/static-language".into(),
+                artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
+                text: "fn main() { let answer = 42; }".into(),
+            },
+            &mut parser,
+        )
+        .unwrap();
+
+        assert!(replica.estimated_memory().non_evictable_bytes > replica.text.capacity());
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -616,20 +616,27 @@ struct CachedInjectionLayer {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 struct EstimatedDocumentMemory {
     non_evictable_bytes: usize,
-    evictable_bytes: usize,
+    result_cache_bytes: usize,
+    auxiliary_cache_bytes: usize,
+}
+
+impl EstimatedDocumentMemory {
+    fn evictable_bytes(self) -> usize {
+        self.result_cache_bytes
+            .saturating_add(self.auxiliary_cache_bytes)
+    }
 }
 
 impl DocumentReplica {
     fn estimated_memory(&self) -> EstimatedDocumentMemory {
         EstimatedDocumentMemory {
             non_evictable_bytes: self.text.capacity(),
-            evictable_bytes: self
+            result_cache_bytes: self
                 .cached_semantic_tokens
                 .as_ref()
-                .map(|(_, _, tokens)| {
-                    tokens.capacity() * std::mem::size_of::<WireSemanticToken>()
-                })
+                .map(|(_, _, tokens)| tokens.capacity() * std::mem::size_of::<WireSemanticToken>())
                 .unwrap_or_default(),
+            auxiliary_cache_bytes: 0,
         }
     }
 
@@ -5861,7 +5868,10 @@ mod tests {
 
         let after = replica.estimated_memory();
         assert_eq!(after.non_evictable_bytes, before.non_evictable_bytes);
-        assert_eq!(after.evictable_bytes, before.evictable_bytes + semantic_bytes);
+        assert_eq!(
+            after.evictable_bytes(),
+            before.evictable_bytes() + semantic_bytes
+        );
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -701,7 +701,11 @@ impl DocumentReplica {
                 .saturating_add(estimated_injection_layer_bytes(
                     &self.injection_layers,
                     self.injection_layers.capacity(),
-                )),
+                ))
+                .saturating_add(
+                    self.injection_token_cache
+                        .estimated_document_bytes(&self.uri),
+                ),
         }
     }
 

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -613,7 +613,26 @@ struct CachedInjectionLayer {
     ranges: Vec<tree_sitter::Range>,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct EstimatedDocumentMemory {
+    non_evictable_bytes: usize,
+    evictable_bytes: usize,
+}
+
 impl DocumentReplica {
+    fn estimated_memory(&self) -> EstimatedDocumentMemory {
+        EstimatedDocumentMemory {
+            non_evictable_bytes: self.text.capacity(),
+            evictable_bytes: self
+                .cached_semantic_tokens
+                .as_ref()
+                .map(|(_, _, tokens)| {
+                    tokens.capacity() * std::mem::size_of::<WireSemanticToken>()
+                })
+                .unwrap_or_default(),
+        }
+    }
+
     fn trim_auxiliary_caches_for_pressure(&mut self) -> bool {
         let semantic_bytes = self
             .cached_semantic_tokens
@@ -5798,6 +5817,51 @@ mod tests {
 
         assert!(!replica.trim_auxiliary_caches_for_pressure());
         assert!(replica.semantic_discovery.is_some());
+    }
+
+    #[test]
+    fn semantic_cache_capacity_is_reported_as_evictable_memory() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let context = RequestContext {
+            request_id: 1,
+            worker_generation: 3,
+            uri: "file:///memory-accounting.rs".into(),
+            incarnation: 4,
+            content_version: 1,
+            configuration_generation: 2,
+        };
+        let (mut replica, _) = DocumentReplica::sync(
+            SyncDocument {
+                context,
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: "/unused/static-language".into(),
+                parser_path: "/unused/static-language".into(),
+                artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
+                text: "fn main() {}".into(),
+            },
+            &mut parser,
+        )
+        .unwrap();
+        let before = replica.estimated_memory();
+        let token = WireSemanticToken {
+            delta_line: 0,
+            delta_start: 0,
+            length: 1,
+            token_type: 0,
+            token_modifiers_bitset: 0,
+        };
+        let tokens = vec![token; 16];
+        let semantic_bytes = tokens.capacity() * std::mem::size_of::<WireSemanticToken>();
+        replica.cached_semantic_tokens = Some((2, false, Arc::new(tokens)));
+
+        let after = replica.estimated_memory();
+        assert_eq!(after.non_evictable_bytes, before.non_evictable_bytes);
+        assert_eq!(after.evictable_bytes, before.evictable_bytes + semantic_bytes);
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -27,6 +27,9 @@ pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_REPLICAS: usize = 4_096;
 pub const MAX_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
 pub const MAX_RETAINED_DOCUMENT_BYTES: usize = 512 * 1024 * 1024;
+// Independent hard admission bound for retained source allocation plus the
+// conservative host-Tree weight. Recomputable caches use the lower soft cap.
+const MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES: usize = 512 * 1024 * 1024;
 // Preserve ordinary exact-version hits, but stop a multi-megabyte semantic
 // result from retaining a second full set of injection-derived caches. Stage 15
 // measured 74 KiB for the small fixture and 2.35 MiB for the pressure fixture.
@@ -692,15 +695,18 @@ fn estimated_injection_layer_bytes(layers: &[CachedInjectionLayer], capacity: us
     ))
 }
 
+fn estimated_non_evictable_bytes(text_capacity: usize, tree: &tree_sitter::Tree) -> usize {
+    text_capacity.saturating_add(
+        tree.root_node()
+            .descendant_count()
+            .saturating_mul(TREE_NODE_ADMISSION_BYTES),
+    )
+}
+
 impl DocumentReplica {
     fn estimated_memory(&self) -> EstimatedDocumentMemory {
         EstimatedDocumentMemory {
-            non_evictable_bytes: self.text.capacity().saturating_add(
-                self.tree
-                    .root_node()
-                    .descendant_count()
-                    .saturating_mul(TREE_NODE_ADMISSION_BYTES),
-            ),
+            non_evictable_bytes: estimated_non_evictable_bytes(self.text.capacity(), &self.tree),
             result_cache_bytes: self
                 .cached_semantic_tokens
                 .as_ref()
@@ -832,7 +838,7 @@ impl DocumentReplica {
         &mut self,
         request: ApplyDocumentEdits,
         parser: &mut tree_sitter::Parser,
-        retained_bytes: Option<&AtomicUsize>,
+        retained_bytes: Option<(&AtomicUsize, &AtomicUsize)>,
     ) -> Result<DocumentAck, String> {
         self.validate_identity(&request.context)?;
         if request.base_version != self.context.content_version {
@@ -881,8 +887,20 @@ impl DocumentReplica {
         let tree = parser
             .parse(text.as_bytes(), Some(&edited_tree))
             .ok_or_else(|| "parser returned no tree during incremental parse".to_string())?;
-        if let Some(retained_bytes) = retained_bytes {
-            replace_retained_bytes(retained_bytes, self.text.len(), text.len())?;
+        if let Some((retained_text_bytes, retained_estimated_bytes)) = retained_bytes {
+            replace_retained_bytes(retained_text_bytes, self.text.len(), text.len())?;
+            let old_estimated = self.estimated_memory().non_evictable_bytes;
+            let new_estimated = estimated_non_evictable_bytes(text.capacity(), &tree);
+            if let Err(message) = replace_retained_estimated_bytes(
+                retained_estimated_bytes,
+                old_estimated,
+                new_estimated,
+            ) {
+                replace_retained_bytes(retained_text_bytes, text.len(), self.text.len()).expect(
+                    "rolling back retained text after estimated admission cannot exceed its budget",
+                );
+                return Err(message);
+            }
         }
         self.text = text;
         self.tree = tree;
@@ -1980,6 +1998,34 @@ fn replace_retained_bytes(
     }
 }
 
+fn replace_retained_estimated_bytes(
+    retained_bytes: &AtomicUsize,
+    old_bytes: usize,
+    new_bytes: usize,
+) -> Result<(), String> {
+    let mut retained = retained_bytes.load(Ordering::Relaxed);
+    loop {
+        let next = retained
+            .checked_sub(old_bytes)
+            .and_then(|bytes| bytes.checked_add(new_bytes))
+            .ok_or_else(|| "estimated document byte accounting overflowed".to_string())?;
+        if next > MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES {
+            return Err(format!(
+                "worker estimated non-evictable budget {MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES} bytes exceeded"
+            ));
+        }
+        match retained_bytes.compare_exchange_weak(
+            retained,
+            next,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => return Ok(()),
+            Err(current) => retained = current,
+        }
+    }
+}
+
 fn reserve_retained_growth(
     retained_bytes: &AtomicUsize,
     old_bytes: usize,
@@ -2562,6 +2608,7 @@ type DocumentStore = Arc<dashmap::DashMap<DocumentKey, Arc<Mutex<DocumentReplica
 type ClosedDocuments = Arc<dashmap::DashMap<DocumentKey, u64>>;
 type DocumentCapacity = Arc<Mutex<usize>>;
 type RetainedDocumentBytes = Arc<AtomicUsize>;
+type RetainedEstimatedDocumentBytes = Arc<AtomicUsize>;
 type LaneJob = Box<dyn FnOnce() -> LaneAction + Send + 'static>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -2806,6 +2853,7 @@ fn handle_work(
     closed_documents: &ClosedDocuments,
     document_capacity: &DocumentCapacity,
     retained_document_bytes: &RetainedDocumentBytes,
+    retained_estimated_document_bytes: &RetainedEstimatedDocumentBytes,
     derived_pressure_lock: &Mutex<()>,
     queue_wait: Duration,
     cancellation: &crate::cancel::CancelToken,
@@ -2831,14 +2879,19 @@ fn handle_work(
             closed_documents,
             document_capacity,
             retained_document_bytes,
+            retained_estimated_document_bytes,
         ),
-        Request::ApplyDocumentEdits(request) => {
-            apply_document_edits(request, documents, retained_document_bytes)
-        }
+        Request::ApplyDocumentEdits(request) => apply_document_edits(
+            request,
+            documents,
+            retained_document_bytes,
+            retained_estimated_document_bytes,
+        ),
         Request::ApplyDocumentEditsAndDerive(request) => apply_document_edits_and_derive(
             request,
             documents,
             retained_document_bytes,
+            retained_estimated_document_bytes,
             queue_wait,
             started,
         ),
@@ -2866,6 +2919,7 @@ fn handle_work(
             documents,
             closed_documents,
             retained_document_bytes,
+            retained_estimated_document_bytes,
         ),
     };
     if may_grow_derived_state
@@ -3232,6 +3286,7 @@ fn sync_document(
     document_capacity: &DocumentCapacity,
     retained_document_bytes: &RetainedDocumentBytes,
 ) -> Response {
+    let retained_estimated_document_bytes = Arc::new(AtomicUsize::new(0));
     sync_document_with_analysis(
         request,
         &Arc::new(crate::language::LanguageCoordinator::new()),
@@ -3239,6 +3294,7 @@ fn sync_document(
         closed_documents,
         document_capacity,
         retained_document_bytes,
+        &retained_estimated_document_bytes,
     )
 }
 
@@ -3249,6 +3305,7 @@ fn sync_document_with_analysis(
     closed_documents: &ClosedDocuments,
     document_capacity: &DocumentCapacity,
     retained_document_bytes: &RetainedDocumentBytes,
+    retained_estimated_document_bytes: &RetainedEstimatedDocumentBytes,
 ) -> Response {
     let context = request.context.clone();
     let request_text_len = request.text.len();
@@ -3260,7 +3317,7 @@ fn sync_document_with_analysis(
     }
     let document_key = DocumentKey::from(&context);
     let grammar_key = GrammarKey::from_sync(&request);
-    let replaced_bytes = if let Some(existing) = documents
+    let (replaced_bytes, replaced_estimated_bytes) = if let Some(existing) = documents
         .get(&document_key)
         .map(|entry| Arc::clone(entry.value()))
     {
@@ -3272,7 +3329,10 @@ fn sync_document_with_analysis(
                     &grammar_key,
                     &request.queries,
                 ) {
-                    Ok(()) => replica.text.len(),
+                    Ok(()) => (
+                        replica.text.len(),
+                        replica.estimated_memory().non_evictable_bytes,
+                    ),
                     Err(message) => {
                         return Response::Error(WorkerError {
                             context: Some(context),
@@ -3294,7 +3354,7 @@ fn sync_document_with_analysis(
                 message: "full sync targets a closed document incarnation".into(),
             });
         }
-        0
+        (0, 0)
     };
     let reserves_slot =
         !documents.contains_key(&document_key) && !closed_documents.contains_key(&document_key);
@@ -3334,6 +3394,17 @@ fn sync_document_with_analysis(
             .with_parser(grammar_key, context.clone(), |parser, _| {
                 match DocumentReplica::sync_with_analysis(request, parser, Arc::clone(analysis)) {
                     Ok((replica, ack)) => {
+                        let estimated_bytes = replica.estimated_memory().non_evictable_bytes;
+                        if let Err(message) = replace_retained_estimated_bytes(
+                            retained_estimated_document_bytes,
+                            replaced_estimated_bytes,
+                            estimated_bytes,
+                        ) {
+                            return Response::Error(WorkerError {
+                                context: Some(context),
+                                message,
+                            });
+                        }
                         documents.insert(document_key, Arc::new(Mutex::new(replica)));
                         closed_documents.remove(&DocumentKey::from(&ack.context));
                         Response::DocumentAck(ack)
@@ -3365,6 +3436,7 @@ fn apply_document_edits(
     request: ApplyDocumentEdits,
     documents: &DocumentStore,
     retained_document_bytes: &RetainedDocumentBytes,
+    retained_estimated_document_bytes: &RetainedEstimatedDocumentBytes,
 ) -> Response {
     let context = request.context.clone();
     let document_key = DocumentKey::from(&context);
@@ -3390,7 +3462,11 @@ fn apply_document_edits(
                 let Ok(mut replica) = replica.lock() else {
                     return poisoned_document_restart(context);
                 };
-                match replica.apply(request, parser, Some(retained_document_bytes)) {
+                match replica.apply(
+                    request,
+                    parser,
+                    Some((retained_document_bytes, retained_estimated_document_bytes)),
+                ) {
                     Ok(ack) => Response::DocumentAck(ack),
                     Err(message) => Response::Error(WorkerError {
                         context: Some(context),
@@ -3405,6 +3481,7 @@ fn apply_document_edits_and_derive(
     request: ApplyDocumentEditsAndDerive,
     documents: &DocumentStore,
     retained_document_bytes: &RetainedDocumentBytes,
+    retained_estimated_document_bytes: &RetainedEstimatedDocumentBytes,
     queue_wait: Duration,
     started: Instant,
 ) -> Response {
@@ -3437,7 +3514,11 @@ fn apply_document_edits_and_derive(
                     base_version: request.base_version,
                     edits: request.edits,
                 };
-                if let Err(message) = replica.apply(edits, parser, Some(retained_document_bytes)) {
+                if let Err(message) = replica.apply(
+                    edits,
+                    parser,
+                    Some((retained_document_bytes, retained_estimated_document_bytes)),
+                ) {
                     return Response::Error(WorkerError {
                         context: Some(context),
                         message,
@@ -3495,6 +3576,7 @@ fn close_document(
     documents: &DocumentStore,
     closed_documents: &ClosedDocuments,
     retained_document_bytes: &RetainedDocumentBytes,
+    retained_estimated_document_bytes: &RetainedEstimatedDocumentBytes,
 ) -> Response {
     let context = request.context;
     let document_key = DocumentKey::from(&context);
@@ -3507,7 +3589,7 @@ fn close_document(
             message: "document replica is missing".into(),
         });
     };
-    let removed_bytes = match replica.lock() {
+    let (removed_bytes, removed_estimated_bytes) = match replica.lock() {
         Ok(replica) => {
             if let Err(message) = replica.validate_lifetime(&context) {
                 return Response::Error(WorkerError {
@@ -3515,13 +3597,22 @@ fn close_document(
                     message,
                 });
             }
-            replica.text.len()
+            (
+                replica.text.len(),
+                replica.estimated_memory().non_evictable_bytes,
+            )
         }
         Err(_) => return poisoned_document_restart(context),
     };
     documents.remove(&document_key);
     replace_retained_bytes(retained_document_bytes, removed_bytes, 0)
         .expect("removing a document cannot exceed the retained-byte budget");
+    replace_retained_estimated_bytes(
+        retained_estimated_document_bytes,
+        removed_estimated_bytes,
+        0,
+    )
+    .expect("removing a document cannot exceed the estimated non-evictable budget");
     closed_documents.insert(document_key, context.incarnation);
     Response::DocumentClosed(DocumentClosed { context })
 }
@@ -3627,6 +3718,7 @@ where
     let closed_documents = Arc::new(dashmap::DashMap::new());
     let document_capacity = Arc::new(Mutex::new(0));
     let retained_document_bytes = Arc::new(AtomicUsize::new(0));
+    let retained_estimated_document_bytes = Arc::new(AtomicUsize::new(0));
     let derived_pressure_lock = Arc::new(Mutex::new(()));
     let document_lanes: DocumentLanes = Arc::new(dashmap::DashMap::new());
     let runnable_documents = Arc::new(RunnableDocuments::default());
@@ -3694,6 +3786,7 @@ where
         let closed_documents = Arc::clone(&closed_documents);
         let document_capacity = Arc::clone(&document_capacity);
         let retained_document_bytes = Arc::clone(&retained_document_bytes);
+        let retained_estimated_document_bytes = Arc::clone(&retained_estimated_document_bytes);
         let derived_pressure_lock = Arc::clone(&derived_pressure_lock);
         let job_cancellations = Arc::clone(&cancellations);
         let lane_key = document_key(&request);
@@ -3793,6 +3886,7 @@ where
                 &closed_documents,
                 &document_capacity,
                 &retained_document_bytes,
+                &retained_estimated_document_bytes,
                 &derived_pressure_lock,
                 enqueued.elapsed(),
                 &cancellation,
@@ -4638,16 +4732,17 @@ mod tests {
         DeriveNativeBindings, DeriveSelectionRanges, DeriveSemanticTokens, DeriveSnapshot,
         DocumentCompetition, DocumentKey, DocumentLane, DocumentReplica, GrammarKey, Handshake,
         HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
-        MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeLayerSelector, NodeNavigation,
-        NodeScalarOperation, NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION, Request,
-        RequestCancelled, RequestContext, ResolveNode, Response, Route, RunCaptures, RunNodeScalar,
-        RunnableDocuments, SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES, SyncDocument,
-        WireByteRange, WirePosition, WireRange, WireSemanticToken, WorkPriority, WorkerError,
-        WorkerQuerySources, cache_eviction_plan, close_document, decode_frame,
-        derive_snapshot_with_language, encode_frame, enforce_derived_memory_budget,
-        named_node_count, parse_request_timeout, replace_retained_bytes,
-        request_may_grow_derived_state, request_priority, reserve_retained_growth, route_response,
-        run, submit_document_job, sync_document, terminate_by_transport, validate_document_size,
+        MAX_RETAINED_DOCUMENT_BYTES, MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES, NavigateNode,
+        NodeLayerSelector, NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId,
+        PROTOCOL_VERSION, Request, RequestCancelled, RequestContext, ResolveNode, Response, Route,
+        RunCaptures, RunNodeScalar, RunnableDocuments,
+        SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES, SyncDocument, WireByteRange, WirePosition,
+        WireRange, WireSemanticToken, WorkPriority, WorkerError, WorkerQuerySources,
+        cache_eviction_plan, close_document, decode_frame, derive_snapshot_with_language,
+        encode_frame, enforce_derived_memory_budget, named_node_count, parse_request_timeout,
+        replace_retained_bytes, replace_retained_estimated_bytes, request_may_grow_derived_state,
+        request_priority, reserve_retained_growth, route_response, run, submit_document_job,
+        sync_document, terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -6969,6 +7064,7 @@ mod tests {
         let mut close_context = context;
         close_context.request_id = 3;
         close_context.content_version = 2;
+        let retained_estimated = Arc::new(AtomicUsize::new(0));
         let close_response = close_document(
             CloseDocument {
                 context: close_context,
@@ -6976,10 +7072,12 @@ mod tests {
             &documents,
             &closed_documents,
             &retained,
+            &retained_estimated,
         );
         assert!(matches!(close_response, Response::WorkerRestartRequired(_)));
         assert!(documents.contains_key(&key));
         assert_eq!(retained.load(Ordering::Relaxed), text.len());
+        assert_eq!(retained_estimated.load(Ordering::Relaxed), 0);
     }
 
     #[test]
@@ -7010,6 +7108,22 @@ mod tests {
         assert_eq!(
             retained.load(Ordering::Relaxed),
             MAX_RETAINED_DOCUMENT_BYTES
+        );
+    }
+
+    #[test]
+    fn estimated_non_evictable_budget_is_transactional() {
+        let retained = AtomicUsize::new(MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES - 8);
+
+        assert!(replace_retained_estimated_bytes(&retained, 0, 9).is_err());
+        assert_eq!(
+            retained.load(Ordering::Relaxed),
+            MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES - 8
+        );
+        replace_retained_estimated_bytes(&retained, 0, 8).unwrap();
+        assert_eq!(
+            retained.load(Ordering::Relaxed),
+            MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES
         );
     }
 

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -627,6 +627,25 @@ impl EstimatedDocumentMemory {
     }
 }
 
+fn estimated_discovery_bytes(discovery: &crate::document::DiscoveredInjections) -> usize {
+    std::mem::size_of::<crate::document::DiscoveredInjections>()
+        .saturating_add(
+            discovery.regions.capacity() * std::mem::size_of::<crate::document::DiscoveredRegion>(),
+        )
+        .saturating_add(discovery.regions.iter().fold(0, |bytes, region| {
+            bytes
+                .saturating_add(region.resolved_lang.capacity())
+                .saturating_add(
+                    region
+                        .included_ranges
+                        .as_ref()
+                        .map(|ranges| ranges.capacity() * std::mem::size_of::<tree_sitter::Range>())
+                        .unwrap_or_default(),
+                )
+                .saturating_add(region.prefix_byte_widths.capacity() * std::mem::size_of::<usize>())
+        }))
+}
+
 impl DocumentReplica {
     fn estimated_memory(&self) -> EstimatedDocumentMemory {
         EstimatedDocumentMemory {
@@ -636,7 +655,11 @@ impl DocumentReplica {
                 .as_ref()
                 .map(|(_, _, tokens)| tokens.capacity() * std::mem::size_of::<WireSemanticToken>())
                 .unwrap_or_default(),
-            auxiliary_cache_bytes: 0,
+            auxiliary_cache_bytes: self
+                .semantic_discovery
+                .as_deref()
+                .map(estimated_discovery_bytes)
+                .unwrap_or_default(),
         }
     }
 
@@ -5871,6 +5894,51 @@ mod tests {
         assert_eq!(
             after.evictable_bytes(),
             before.evictable_bytes() + semantic_bytes
+        );
+    }
+
+    #[test]
+    fn semantic_discovery_capacity_is_reported_as_auxiliary_memory() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let context = RequestContext {
+            request_id: 1,
+            worker_generation: 3,
+            uri: "file:///discovery-accounting.rs".into(),
+            incarnation: 4,
+            content_version: 1,
+            configuration_generation: 2,
+        };
+        let (mut replica, _) = DocumentReplica::sync(
+            SyncDocument {
+                context,
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: "/unused/static-language".into(),
+                parser_path: "/unused/static-language".into(),
+                artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
+                text: "fn main() {}".into(),
+            },
+            &mut parser,
+        )
+        .unwrap();
+        let before = replica.estimated_memory();
+        let regions = Vec::with_capacity(32);
+        let discovery_bytes = std::mem::size_of::<crate::document::DiscoveredInjections>()
+            + regions.capacity() * std::mem::size_of::<crate::document::DiscoveredRegion>();
+        replica.semantic_discovery = Some(Arc::new(crate::document::DiscoveredInjections {
+            generation: 2,
+            complete: true,
+            regions,
+        }));
+
+        let after = replica.estimated_memory();
+        assert_eq!(
+            after.auxiliary_cache_bytes,
+            before.auxiliary_cache_bytes + discovery_bytes
         );
     }
 

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -646,6 +646,26 @@ fn estimated_discovery_bytes(discovery: &crate::document::DiscoveredInjections) 
         }))
 }
 
+fn estimated_resolved_injection_bytes(
+    resolved: &[crate::language::injection::ResolvedInjection],
+    capacity: usize,
+) -> usize {
+    std::mem::size_of::<Vec<crate::language::injection::ResolvedInjection>>()
+        .saturating_add(
+            capacity * std::mem::size_of::<crate::language::injection::ResolvedInjection>(),
+        )
+        .saturating_add(resolved.iter().fold(0, |bytes, injection| {
+            bytes
+                .saturating_add(injection.region.language.capacity())
+                .saturating_add(injection.region.region_id.capacity())
+                .saturating_add(injection.injection_language.capacity())
+                .saturating_add(injection.virtual_content.capacity())
+                .saturating_add(
+                    injection.line_column_offsets.capacity() * std::mem::size_of::<u32>(),
+                )
+        }))
+}
+
 impl DocumentReplica {
     fn estimated_memory(&self) -> EstimatedDocumentMemory {
         EstimatedDocumentMemory {
@@ -659,7 +679,15 @@ impl DocumentReplica {
                 .semantic_discovery
                 .as_deref()
                 .map(estimated_discovery_bytes)
-                .unwrap_or_default(),
+                .unwrap_or_default()
+                .saturating_add(
+                    self.resolved_injections
+                        .as_ref()
+                        .map(|(_, resolved)| {
+                            estimated_resolved_injection_bytes(resolved, resolved.capacity())
+                        })
+                        .unwrap_or_default(),
+                ),
         }
     }
 
@@ -5939,6 +5967,49 @@ mod tests {
         assert_eq!(
             after.auxiliary_cache_bytes,
             before.auxiliary_cache_bytes + discovery_bytes
+        );
+    }
+
+    #[test]
+    fn resolved_injection_capacity_is_reported_as_auxiliary_memory() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let context = RequestContext {
+            request_id: 1,
+            worker_generation: 3,
+            uri: "file:///resolved-accounting.rs".into(),
+            incarnation: 4,
+            content_version: 1,
+            configuration_generation: 2,
+        };
+        let (mut replica, _) = DocumentReplica::sync(
+            SyncDocument {
+                context,
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: "/unused/static-language".into(),
+                parser_path: "/unused/static-language".into(),
+                artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
+                text: "fn main() {}".into(),
+            },
+            &mut parser,
+        )
+        .unwrap();
+        let before = replica.estimated_memory();
+        let resolved = Vec::with_capacity(16);
+        let resolved_bytes =
+            std::mem::size_of::<Vec<crate::language::injection::ResolvedInjection>>()
+                + resolved.capacity()
+                    * std::mem::size_of::<crate::language::injection::ResolvedInjection>();
+        replica.resolved_injections = Some((2, Arc::new(resolved)));
+
+        let after = replica.estimated_memory();
+        assert_eq!(
+            after.auxiliary_cache_bytes,
+            before.auxiliary_cache_bytes + resolved_bytes
         );
     }
 

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -666,6 +666,16 @@ fn estimated_resolved_injection_bytes(
         }))
 }
 
+fn estimated_injection_layer_bytes(layers: &[CachedInjectionLayer], capacity: usize) -> usize {
+    (capacity * std::mem::size_of::<CachedInjectionLayer>()).saturating_add(layers.iter().fold(
+        0,
+        |bytes, layer| {
+            bytes
+                .saturating_add(layer.ranges.capacity() * std::mem::size_of::<tree_sitter::Range>())
+        },
+    ))
+}
+
 impl DocumentReplica {
     fn estimated_memory(&self) -> EstimatedDocumentMemory {
         EstimatedDocumentMemory {
@@ -687,7 +697,11 @@ impl DocumentReplica {
                             estimated_resolved_injection_bytes(resolved, resolved.capacity())
                         })
                         .unwrap_or_default(),
-                ),
+                )
+                .saturating_add(estimated_injection_layer_bytes(
+                    &self.injection_layers,
+                    self.injection_layers.capacity(),
+                )),
         }
     }
 
@@ -4449,19 +4463,20 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use super::{
-        ApplyDocumentEdits, BUILD_ID, ByteEdit, CancelRequest, CapturesResult, CloseDocument,
-        DeriveInjectionRegions, DeriveNativeBindings, DeriveSelectionRanges, DeriveSemanticTokens,
-        DeriveSnapshot, DocumentCompetition, DocumentKey, DocumentLane, DocumentReplica,
-        GrammarKey, Handshake, HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES,
-        MAX_DOCUMENT_REPLICAS, MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeLayerSelector,
-        NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION,
-        Request, RequestCancelled, RequestContext, ResolveNode, Response, Route, RunCaptures,
-        RunNodeScalar, RunnableDocuments, SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES,
-        SyncDocument, WireByteRange, WirePosition, WireRange, WireSemanticToken, WorkPriority,
-        WorkerError, WorkerQuerySources, close_document, decode_frame,
-        derive_snapshot_with_language, encode_frame, named_node_count, parse_request_timeout,
-        replace_retained_bytes, request_priority, reserve_retained_growth, route_response, run,
-        submit_document_job, sync_document, terminate_by_transport, validate_document_size,
+        ApplyDocumentEdits, BUILD_ID, ByteEdit, CachedInjectionLayer, CancelRequest,
+        CapturesResult, CloseDocument, DeriveInjectionRegions, DeriveNativeBindings,
+        DeriveSelectionRanges, DeriveSemanticTokens, DeriveSnapshot, DocumentCompetition,
+        DocumentKey, DocumentLane, DocumentReplica, GrammarKey, Handshake, HandshakeReady,
+        LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
+        MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeLayerSelector, NodeNavigation,
+        NodeScalarOperation, NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION, Request,
+        RequestCancelled, RequestContext, ResolveNode, Response, Route, RunCaptures, RunNodeScalar,
+        RunnableDocuments, SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES, SyncDocument,
+        WireByteRange, WirePosition, WireRange, WireSemanticToken, WorkPriority, WorkerError,
+        WorkerQuerySources, close_document, decode_frame, derive_snapshot_with_language,
+        encode_frame, named_node_count, parse_request_timeout, replace_retained_bytes,
+        request_priority, reserve_retained_growth, route_response, run, submit_document_job,
+        sync_document, terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -6010,6 +6025,46 @@ mod tests {
         assert_eq!(
             after.auxiliary_cache_bytes,
             before.auxiliary_cache_bytes + resolved_bytes
+        );
+    }
+
+    #[test]
+    fn injection_layer_capacity_is_reported_as_auxiliary_memory() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let context = RequestContext {
+            request_id: 1,
+            worker_generation: 3,
+            uri: "file:///layer-accounting.rs".into(),
+            incarnation: 4,
+            content_version: 1,
+            configuration_generation: 2,
+        };
+        let (mut replica, _) = DocumentReplica::sync(
+            SyncDocument {
+                context,
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: "/unused/static-language".into(),
+                parser_path: "/unused/static-language".into(),
+                artifact_digest: "sha256:rust-v1".into(),
+                queries: WorkerQuerySources::default(),
+                text: "fn main() {}".into(),
+            },
+            &mut parser,
+        )
+        .unwrap();
+        let before = replica.estimated_memory();
+        replica.injection_layers = Vec::with_capacity(8);
+        let layer_bytes =
+            replica.injection_layers.capacity() * std::mem::size_of::<CachedInjectionLayer>();
+
+        let after = replica.estimated_memory();
+        assert_eq!(
+            after.auxiliary_cache_bytes,
+            before.auxiliary_cache_bytes + layer_bytes
         );
     }
 

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -2439,6 +2439,63 @@ impl From<&RequestContext> for DocumentKey {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CacheEvictionCandidate {
+    key: DocumentKey,
+    result_bytes: usize,
+    auxiliary_bytes: usize,
+    current: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum CacheEviction {
+    Auxiliary(DocumentKey),
+    Result(DocumentKey),
+}
+
+fn cache_eviction_plan(
+    mut candidates: Vec<CacheEvictionCandidate>,
+    target_bytes: usize,
+) -> Vec<CacheEviction> {
+    let mut retained = candidates.iter().fold(0_usize, |bytes, candidate| {
+        bytes
+            .saturating_add(candidate.result_bytes)
+            .saturating_add(candidate.auxiliary_bytes)
+    });
+    let mut plan = Vec::new();
+    candidates.sort_by(|left, right| {
+        right
+            .auxiliary_bytes
+            .cmp(&left.auxiliary_bytes)
+            .then_with(|| left.key.uri.cmp(&right.key.uri))
+    });
+    for candidate in &candidates {
+        if retained <= target_bytes {
+            return plan;
+        }
+        if candidate.auxiliary_bytes > 0 {
+            retained = retained.saturating_sub(candidate.auxiliary_bytes);
+            plan.push(CacheEviction::Auxiliary(candidate.key.clone()));
+        }
+    }
+    candidates.sort_by(|left, right| {
+        left.current
+            .cmp(&right.current)
+            .then_with(|| right.result_bytes.cmp(&left.result_bytes))
+            .then_with(|| left.key.uri.cmp(&right.key.uri))
+    });
+    for candidate in candidates {
+        if retained <= target_bytes {
+            break;
+        }
+        if candidate.result_bytes > 0 {
+            retained = retained.saturating_sub(candidate.result_bytes);
+            plan.push(CacheEviction::Result(candidate.key));
+        }
+    }
+    plan
+}
+
 type DocumentStore = Arc<dashmap::DashMap<DocumentKey, Arc<Mutex<DocumentReplica>>>>;
 type ClosedDocuments = Arc<dashmap::DashMap<DocumentKey, u64>>;
 type DocumentCapacity = Arc<Mutex<usize>>;
@@ -4487,20 +4544,20 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use super::{
-        ApplyDocumentEdits, BUILD_ID, ByteEdit, CachedInjectionLayer, CancelRequest,
-        CapturesResult, CloseDocument, DeriveInjectionRegions, DeriveNativeBindings,
-        DeriveSelectionRanges, DeriveSemanticTokens, DeriveSnapshot, DocumentCompetition,
-        DocumentKey, DocumentLane, DocumentReplica, GrammarKey, Handshake, HandshakeReady,
-        LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
+        ApplyDocumentEdits, BUILD_ID, ByteEdit, CacheEviction, CacheEvictionCandidate,
+        CachedInjectionLayer, CancelRequest, CapturesResult, CloseDocument, DeriveInjectionRegions,
+        DeriveNativeBindings, DeriveSelectionRanges, DeriveSemanticTokens, DeriveSnapshot,
+        DocumentCompetition, DocumentKey, DocumentLane, DocumentReplica, GrammarKey, Handshake,
+        HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
         MAX_RETAINED_DOCUMENT_BYTES, NavigateNode, NodeLayerSelector, NodeNavigation,
         NodeScalarOperation, NodeScalarValue, OpaqueNodeId, PROTOCOL_VERSION, Request,
         RequestCancelled, RequestContext, ResolveNode, Response, Route, RunCaptures, RunNodeScalar,
         RunnableDocuments, SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES, SyncDocument,
         WireByteRange, WirePosition, WireRange, WireSemanticToken, WorkPriority, WorkerError,
-        WorkerQuerySources, close_document, decode_frame, derive_snapshot_with_language,
-        encode_frame, named_node_count, parse_request_timeout, replace_retained_bytes,
-        request_priority, reserve_retained_growth, route_response, run, submit_document_job,
-        sync_document, terminate_by_transport, validate_document_size,
+        WorkerQuerySources, cache_eviction_plan, close_document, decode_frame,
+        derive_snapshot_with_language, encode_frame, named_node_count, parse_request_timeout,
+        replace_retained_bytes, request_priority, reserve_retained_growth, route_response, run,
+        submit_document_job, sync_document, terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -5993,6 +6050,43 @@ mod tests {
         .unwrap();
 
         assert!(replica.estimated_memory().non_evictable_bytes > replica.text.capacity());
+    }
+
+    #[test]
+    fn cache_eviction_prefers_largest_auxiliary_then_non_current_results() {
+        let candidates = vec![
+            CacheEvictionCandidate {
+                key: DocumentKey {
+                    uri: "file:///a.rs".into(),
+                },
+                result_bytes: 40,
+                auxiliary_bytes: 20,
+                current: false,
+            },
+            CacheEvictionCandidate {
+                key: DocumentKey {
+                    uri: "file:///b.rs".into(),
+                },
+                result_bytes: 50,
+                auxiliary_bytes: 30,
+                current: true,
+            },
+        ];
+
+        assert_eq!(
+            cache_eviction_plan(candidates, 50),
+            vec![
+                CacheEviction::Auxiliary(DocumentKey {
+                    uri: "file:///b.rs".into(),
+                }),
+                CacheEviction::Auxiliary(DocumentKey {
+                    uri: "file:///a.rs".into(),
+                }),
+                CacheEviction::Result(DocumentKey {
+                    uri: "file:///a.rs".into(),
+                }),
+            ]
+        );
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -2922,7 +2922,7 @@ fn handle_work(
             retained_estimated_document_bytes,
         ),
     };
-    if may_grow_derived_state
+    if pressure_checkpoint_required(may_grow_derived_state, &response)
         && let Err(reason) = enforce_derived_memory_budget(
             documents,
             derived_pressure_lock,
@@ -2937,6 +2937,14 @@ fn handle_work(
     } else {
         response
     }
+}
+
+fn pressure_checkpoint_required(may_grow_derived_state: bool, response: &Response) -> bool {
+    may_grow_derived_state
+        && !matches!(
+            response,
+            Response::SemanticTokens(result) if result.cache_hit
+        )
 }
 
 fn request_may_grow_derived_state(request: &Request) -> bool {
@@ -4740,9 +4748,9 @@ mod tests {
         WireRange, WireSemanticToken, WorkPriority, WorkerError, WorkerQuerySources,
         cache_eviction_plan, close_document, decode_frame, derive_snapshot_with_language,
         encode_frame, enforce_derived_memory_budget, named_node_count, parse_request_timeout,
-        replace_retained_bytes, replace_retained_estimated_bytes, request_may_grow_derived_state,
-        request_priority, reserve_retained_growth, route_response, run, submit_document_job,
-        sync_document, terminate_by_transport, validate_document_size,
+        pressure_checkpoint_required, replace_retained_bytes, replace_retained_estimated_bytes,
+        request_may_grow_derived_state, request_priority, reserve_retained_growth, route_response,
+        run, submit_document_job, sync_document, terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -6388,6 +6396,29 @@ mod tests {
                 operation: NodeNavigation::Parent,
             }
         )));
+    }
+
+    #[test]
+    fn semantic_cache_hits_skip_memory_pressure_checkpoint() {
+        let result = |cache_hit| {
+            Response::SemanticTokens(super::DerivedSemanticTokens {
+                context: RequestContext {
+                    request_id: 1,
+                    worker_generation: 3,
+                    uri: "file:///pressure-hit.rs".into(),
+                    incarnation: 4,
+                    content_version: 1,
+                    configuration_generation: 2,
+                },
+                tokens: Vec::new(),
+                queue_wait_ns: 0,
+                compute_ns: 0,
+                cache_hit,
+            })
+        };
+
+        assert!(!pressure_checkpoint_required(true, &result(true)));
+        assert!(pressure_checkpoint_required(true, &result(false)));
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -705,6 +705,10 @@ impl DocumentReplica {
                 .saturating_add(
                     self.injection_token_cache
                         .estimated_document_bytes(&self.uri),
+                )
+                .saturating_add(
+                    self.captures_match_cache
+                        .estimated_document_bytes(&self.uri),
                 ),
         }
     }

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -35,6 +35,10 @@ const SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES: usize = 2 * 1024 * 1024;
 // conservative portable weight per retained subtree node; Stage 17 compares
 // the estimate with process footprint rather than treating it as measured RSS.
 const TREE_NODE_ADMISSION_BYTES: usize = 64;
+// Soft cap for recomputable worker-owned caches. This is deliberately below
+// the 512 MiB retained-text guard so cache growth cannot consume the whole
+// worker allowance; Stage 17 measurement validates the initial quarter-share.
+const MAX_RETAINED_DERIVED_BYTES: usize = 128 * 1024 * 1024;
 pub const BUILD_ID: &str = concat!(env!("CARGO_PKG_NAME"), "-", env!("CARGO_PKG_VERSION"));
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -625,6 +629,7 @@ struct EstimatedDocumentMemory {
 }
 
 impl EstimatedDocumentMemory {
+    #[cfg(test)]
     fn evictable_bytes(self) -> usize {
         self.result_cache_bytes
             .saturating_add(self.auxiliary_cache_bytes)
@@ -2801,6 +2806,7 @@ fn handle_work(
     closed_documents: &ClosedDocuments,
     document_capacity: &DocumentCapacity,
     retained_document_bytes: &RetainedDocumentBytes,
+    derived_pressure_lock: &Mutex<()>,
     queue_wait: Duration,
     cancellation: &crate::cancel::CancelToken,
     nested_work_policy: &(dyn Fn() -> crate::analysis::semantic::NestedWorkPolicy + Sync),
@@ -2812,6 +2818,7 @@ fn handle_work(
         return Response::RequestCancelled(RequestCancelled { context });
     }
     let started = Instant::now();
+    let may_grow_derived_state = request_may_grow_derived_state(&request);
     let response = match request {
         Request::Handshake(_) | Request::Cancel(_) => {
             unreachable!("control requests are not scheduled")
@@ -2861,11 +2868,33 @@ fn handle_work(
             retained_document_bytes,
         ),
     };
+    if may_grow_derived_state
+        && let Err(reason) = enforce_derived_memory_budget(
+            documents,
+            derived_pressure_lock,
+            &DocumentKey::from(&context),
+            MAX_RETAINED_DERIVED_BYTES,
+        )
+    {
+        return Response::WorkerRestartRequired(WorkerRestartRequired { context, reason });
+    }
     if cancellation.is_cancelled() {
         Response::RequestCancelled(RequestCancelled { context })
     } else {
         response
     }
+}
+
+fn request_may_grow_derived_state(request: &Request) -> bool {
+    matches!(
+        request,
+        Request::ResolveNode(_)
+            | Request::DeriveSelectionRanges(_)
+            | Request::DeriveInjectionRegions(_)
+            | Request::DeriveSemanticTokens(_)
+            | Request::RunCaptures(_)
+            | Request::DeriveNativeBindings(_)
+    )
 }
 
 fn request_context(request: &Request) -> Option<&RequestContext> {
@@ -3598,6 +3627,7 @@ where
     let closed_documents = Arc::new(dashmap::DashMap::new());
     let document_capacity = Arc::new(Mutex::new(0));
     let retained_document_bytes = Arc::new(AtomicUsize::new(0));
+    let derived_pressure_lock = Arc::new(Mutex::new(()));
     let document_lanes: DocumentLanes = Arc::new(dashmap::DashMap::new());
     let runnable_documents = Arc::new(RunnableDocuments::default());
     let cancellations = Arc::new(dashmap::DashMap::<u64, crate::cancel::CancelToken>::new());
@@ -3664,6 +3694,7 @@ where
         let closed_documents = Arc::clone(&closed_documents);
         let document_capacity = Arc::clone(&document_capacity);
         let retained_document_bytes = Arc::clone(&retained_document_bytes);
+        let derived_pressure_lock = Arc::clone(&derived_pressure_lock);
         let job_cancellations = Arc::clone(&cancellations);
         let lane_key = document_key(&request);
         let priority = request_priority(&request);
@@ -3762,6 +3793,7 @@ where
                 &closed_documents,
                 &document_capacity,
                 &retained_document_bytes,
+                &derived_pressure_lock,
                 enqueued.elapsed(),
                 &cancellation,
                 &nested_work_policy,
@@ -4613,9 +4645,9 @@ mod tests {
         WireByteRange, WirePosition, WireRange, WireSemanticToken, WorkPriority, WorkerError,
         WorkerQuerySources, cache_eviction_plan, close_document, decode_frame,
         derive_snapshot_with_language, encode_frame, enforce_derived_memory_budget,
-        named_node_count, parse_request_timeout, replace_retained_bytes, request_priority,
-        reserve_retained_growth, route_response, run, submit_document_job, sync_document,
-        terminate_by_transport, validate_document_size,
+        named_node_count, parse_request_timeout, replace_retained_bytes,
+        request_may_grow_derived_state, request_priority, reserve_retained_growth, route_response,
+        run, submit_document_job, sync_document, terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -6228,6 +6260,39 @@ mod tests {
         assert!(b.semantic_discovery.is_none());
         assert!(a.cached_semantic_tokens.is_none());
         assert!(b.cached_semantic_tokens.is_some());
+    }
+
+    #[test]
+    fn only_cache_growing_requests_run_memory_pressure_checkpoint() {
+        let context = RequestContext {
+            request_id: 1,
+            worker_generation: 3,
+            uri: "file:///pressure.rs".into(),
+            incarnation: 4,
+            content_version: 1,
+            configuration_generation: 2,
+        };
+        assert!(request_may_grow_derived_state(
+            &Request::DeriveSemanticTokens(DeriveSemanticTokens {
+                context: context.clone(),
+                supports_multiline: false,
+            })
+        ));
+        assert!(request_may_grow_derived_state(
+            &Request::DeriveInjectionRegions(DeriveInjectionRegions {
+                context: context.clone(),
+            })
+        ));
+        assert!(!request_may_grow_derived_state(&Request::NavigateNode(
+            NavigateNode {
+                context,
+                node_id: OpaqueNodeId {
+                    worker_generation: 3,
+                    local_id: "node-1".into(),
+                },
+                operation: NodeNavigation::Parent,
+            }
+        )));
     }
 
     #[test]

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -234,7 +234,6 @@ fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
                 }))
                 .unwrap(),
                 search_paths: vec![capture_queries.path().into()],
-                ..Default::default()
             },
         })
         .unwrap();


### PR DESCRIPTION
## Summary

- account non-evictable document state, reusable result caches, and recomputable auxiliary caches across the resident worker
- deterministically evict derived caches above a 128 MiB soft budget
- transactionally reject source/host-tree growth above an independent 512 MiB estimated-memory bound
- skip worker-wide pressure scans on exact-version semantic cache hits
- record order-reversed release A/B measurements against Stage 16

## Measurement

Three simultaneous 1.07 MiB / 5,000-injection Markdown documents, six alternating-order batches:

| Metric | Stage 16 | Stage 17 | Change |
| --- | ---: | ---: | ---: |
| Stable physical footprint | 463.75 MiB | 472.49 MiB | +1.9% |
| Peak physical footprint | 493.99 MiB | 491.89 MiB | -0.4% |
| Stable aggregate RSS | 545.77 MiB | 533.81 MiB | -2.2% |
| Peak aggregate RSS | 546.73 MiB | 541.74 MiB | -0.9% |

The mixed deltas are run-to-run noise, not a memory-reduction claim. This stage establishes deterministic accounting and admission. Tree-sitter does not expose native allocation size, so the 512 MiB contract is defined over a conservative node-weight estimate rather than RSS.

Exact-version cache-hit latency, six order-reversed unsampled runs per binary:

| Metric | Stage 16 | Stage 17 | Change |
| --- | ---: | ---: | ---: |
| p50 | 75.45 ms | 76.25 ms | +1.1% |
| p95 | 79.85 ms | 80.30 ms | +0.6% |

These differences are below run-to-run variation.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --lib --tests --features e2e`
- `cargo test --lib`
- `cargo test --features e2e --test tree_worker_process`
- `cargo test --features e2e --test e2e_tree_worker_shadow`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Stack

- base: #879
- ADR: #862