### PR TITLE
feat(worker): stress memory admission boundaries

### DIFF
--- a/benches/profile/collect_worker_memory_stress.py
+++ b/benches/profile/collect_worker_memory_stress.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Collect repeated reduced-limit worker memory-admission stress runs."""
+
+import argparse
+import json
+import os
+import pathlib
+import platform
+import subprocess
+import sys
+import threading
+import time
+
+from collect_worker_memory import (
+    descendant_pids,
+    read_process_table,
+    read_total_footprint_bytes,
+    summarize_samples,
+)
+from collect_worker_proxy import (
+    artifact_identity,
+    controlled_environment,
+    cpu_model,
+    portable_environment,
+    require_benchmark_artifacts,
+    require_posix,
+    sha256_file,
+    tool_version,
+    verify_file_sha256,
+)
+
+
+def parse_report(stdout):
+    lines = [line for line in stdout.splitlines() if line.strip()]
+    if len(lines) != 1:
+        raise ValueError("stress driver must emit exactly one JSON report")
+    report = json.loads(lines[0])
+    if not report.get("recomputed_tokens_match"):
+        raise ValueError("recomputed semantic tokens did not match")
+    if not report.get("node_identity_survived"):
+        raise ValueError("node identity did not survive cache pressure")
+    for key in ("full_sync_rejection", "incremental_edit_rejection"):
+        if "non-evictable budget" not in report.get(key, ""):
+            raise ValueError(f"{key} was not a contained hard-budget rejection")
+    a = report["a_after_pressure"]
+    b = report["b_after_pressure"]
+    if a["result_cache_bytes"] != 0 or a["auxiliary_cache_bytes"] != 0:
+        raise ValueError("non-current document A was not fully evicted")
+    if b["result_cache_bytes"] <= 0 or b["auxiliary_cache_bytes"] != 0:
+        raise ValueError("current document B did not retain only its result cache")
+    return report
+
+
+def sample_process_tree(
+    root_pid, stop, interval_seconds, footprint_interval_seconds, samples
+):
+    next_footprint = 0.0
+    while not stop.wait(interval_seconds):
+        table = read_process_table()
+        if root_pid not in table:
+            continue
+        pids = {root_pid, *descendant_pids(table, root_pid)}
+        sample = {
+            "total_rss_kib": sum(table[pid]["rss_kib"] for pid in pids),
+            "process_count": len(pids),
+        }
+        now = time.monotonic()
+        if sys.platform == "darwin" and now >= next_footprint:
+            try:
+                sample["total_footprint_bytes"] = read_total_footprint_bytes(pids)
+            except (OSError, subprocess.SubprocessError, ValueError):
+                pass
+            next_footprint = now + footprint_interval_seconds
+        samples.append(sample)
+
+
+def run_once(args):
+    command = [
+        str(args.driver),
+        "--bin",
+        str(args.bin),
+        "--data-dir",
+        str(args.data_dir),
+        "--derived-cache-soft-bytes",
+        str(args.derived_cache_soft_bytes),
+        "--non-evictable-estimate-hard-bytes",
+        str(args.non_evictable_estimate_hard_bytes),
+        "--hold-open",
+        str(args.hold_open),
+    ]
+    process = subprocess.Popen(
+        command,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=controlled_environment(os.environ),
+        start_new_session=True,
+    )
+    stop = threading.Event()
+    samples = []
+    sampler = threading.Thread(
+        target=sample_process_tree,
+        args=(
+            process.pid,
+            stop,
+            args.sample_interval_ms / 1000,
+            args.footprint_interval_ms / 1000,
+            samples,
+        ),
+        daemon=True,
+    )
+    sampler.start()
+    try:
+        stdout, stderr = process.communicate(timeout=args.run_timeout)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, 15)
+        except ProcessLookupError:
+            pass
+        stdout, stderr = process.communicate(timeout=5)
+        raise subprocess.TimeoutExpired(command, args.run_timeout, stdout, stderr)
+    finally:
+        stop.set()
+        sampler.join(timeout=5)
+    if process.returncode:
+        raise subprocess.CalledProcessError(
+            process.returncode, command, output=stdout, stderr=stderr
+        )
+    return {
+        "report": parse_report(stdout),
+        "memory": summarize_samples(samples),
+    }
+
+
+def git_output(repo, *arguments):
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=repo,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
+
+
+def collect(args):
+    repo = pathlib.Path(__file__).resolve().parents[2]
+    if git_output(repo, "status", "--porcelain"):
+        raise RuntimeError("stress measurement requires a clean source tree")
+    source_commit = git_output(repo, "rev-parse", "HEAD")
+    worker_sha256 = sha256_file(args.bin)
+    driver_sha256 = sha256_file(args.driver)
+    artifacts = artifact_identity(args.data_dir)
+    batches = []
+    for index in range(args.batches):
+        batches.append({"batch": index + 1, **run_once(args)})
+        print(f"batch {index + 1}/{args.batches}", file=sys.stderr)
+    verify_file_sha256(args.bin, worker_sha256)
+    verify_file_sha256(args.driver, driver_sha256)
+    if artifact_identity(args.data_dir) != artifacts:
+        raise RuntimeError("runtime artifacts changed during stress collection")
+    if git_output(repo, "rev-parse", "HEAD") != source_commit:
+        raise RuntimeError("source commit changed during stress collection")
+    result = {
+        "schema": 1,
+        "experiment": "single-tree-worker-stage18-memory-boundary-stress",
+        "environment": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "rustc": tool_version(["rustc", "--version"]),
+            "cpu_model": cpu_model(),
+            "source_commit": source_commit,
+            "worker_binary_sha256": worker_sha256,
+            "driver_binary_sha256": driver_sha256,
+            "worker_build_command": "cargo build --locked --release --bin kakehashi",
+            "driver_build_command": (
+                "cargo build --locked --release --example tree_worker_memory_stress"
+            ),
+            "features": "default",
+            "retained_environment": portable_environment(os.environ),
+        },
+        "artifacts": artifacts,
+        "collector": {
+            "batches": args.batches,
+            "sample_interval_ms": args.sample_interval_ms,
+            "footprint_interval_ms": args.footprint_interval_ms,
+            "metric": "sum of RSS/footprint for the stress driver and worker child",
+        },
+        "scenario": {
+            "derived_cache_soft_bytes": args.derived_cache_soft_bytes,
+            "non_evictable_estimate_hard_bytes": (
+                args.non_evictable_estimate_hard_bytes
+            ),
+            "hold_open_seconds": args.hold_open,
+            "documents": 2,
+            "language": "rust",
+        },
+        "batches": batches,
+    }
+    args.output.write_text(json.dumps(result, indent=2) + "\n")
+
+
+def main():
+    require_posix()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bin", type=pathlib.Path, required=True)
+    parser.add_argument("--driver", type=pathlib.Path, required=True)
+    parser.add_argument("--data-dir", type=pathlib.Path, required=True)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    parser.add_argument("--batches", type=int, default=6)
+    parser.add_argument("--derived-cache-soft-bytes", type=int, default=20)
+    parser.add_argument("--non-evictable-estimate-hard-bytes", type=int, default=4096)
+    parser.add_argument("--hold-open", type=float, default=2.0)
+    parser.add_argument("--sample-interval-ms", type=float, default=20)
+    parser.add_argument("--footprint-interval-ms", type=float, default=250)
+    parser.add_argument("--run-timeout", type=float, default=30)
+    args = parser.parse_args()
+    if min(
+        args.batches,
+        args.derived_cache_soft_bytes,
+        args.non_evictable_estimate_hard_bytes,
+        args.hold_open,
+        args.sample_interval_ms,
+        args.footprint_interval_ms,
+        args.run_timeout,
+    ) <= 0:
+        parser.error("budgets, batches, intervals, and timeout must be positive")
+    require_benchmark_artifacts(args.data_dir)
+    collect(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/benches/profile/results/single_worker_stage18_memory_boundary_stress_2026-07-20.json
+++ b/benches/profile/results/single_worker_stage18_memory_boundary_stress_2026-07-20.json
@@ -1,0 +1,389 @@
+{
+  "schema": 1,
+  "experiment": "single-tree-worker-stage18-memory-boundary-stress",
+  "environment": {
+    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "python": "3.12.13",
+    "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)",
+    "cpu_model": "Apple M4",
+    "source_commit": "9b46c7360661fdf1294914b27b4e3a3c86df6c29",
+    "worker_binary_sha256": "ce06bbfd7bce95d7b0867142008e5a381a16d3ef26b6d0064c230d288b75dfc4",
+    "driver_binary_sha256": "9ac0590725fd23ea16d57394a95d76ea629b1fbc82c5bdc53291501f8c2e91ae",
+    "worker_build_command": "cargo build --locked --release --bin kakehashi",
+    "driver_build_command": "cargo build --locked --release --example tree_worker_memory_stress",
+    "features": "default",
+    "retained_environment": {
+      "PATH": "<redacted-search-path>",
+      "TMPDIR": "<redacted-path>",
+      "LANG": "C.UTF-8",
+      "LC_ALL": "C.UTF-8"
+    }
+  },
+  "artifacts": [
+    19,
+    "f8c2b2cabd37920d217a1d8712f7588dde2a57e530714e02693744e8b324d768"
+  ],
+  "collector": {
+    "batches": 6,
+    "sample_interval_ms": 20.0,
+    "footprint_interval_ms": 250.0,
+    "metric": "sum of RSS/footprint for the stress driver and worker child"
+  },
+  "scenario": {
+    "derived_cache_soft_bytes": 20,
+    "non_evictable_estimate_hard_bytes": 4096,
+    "hold_open_seconds": 2.0,
+    "documents": 2,
+    "language": "rust"
+  },
+  "batches": [
+    {
+      "batch": 1,
+      "report": {
+        "worker_generation": 1,
+        "derived_cache_soft_bytes": 20,
+        "non_evictable_estimate_hard_bytes": 4096,
+        "first_a_us": 4032,
+        "first_b_us": 109,
+        "recompute_a_us": 88,
+        "rejected_full_sync_us": 1368,
+        "rejected_incremental_edit_us": 993,
+        "recovery_edit_us": 125,
+        "token_count": 1,
+        "recomputed_tokens_match": true,
+        "node_identity_survived": true,
+        "full_sync_rejection": "worker estimated non-evictable budget 4096 bytes exceeded",
+        "incremental_edit_rejection": "worker estimated non-evictable budget 4096 bytes exceeded",
+        "a_after_pressure": {
+          "context": {
+            "request_id": 7,
+            "worker_generation": 1,
+            "uri": "file:///memory-stress-a.rs",
+            "incarnation": 1,
+            "content_version": 1,
+            "configuration_generation": 0
+          },
+          "derived_cache_soft_bytes": 20,
+          "non_evictable_estimate_hard_bytes": 4096,
+          "non_evictable_bytes": 652,
+          "result_cache_bytes": 0,
+          "auxiliary_cache_bytes": 0
+        },
+        "b_after_pressure": {
+          "context": {
+            "request_id": 8,
+            "worker_generation": 1,
+            "uri": "file:///memory-stress-b.rs",
+            "incarnation": 1,
+            "content_version": 1,
+            "configuration_generation": 0
+          },
+          "derived_cache_soft_bytes": 20,
+          "non_evictable_estimate_hard_bytes": 4096,
+          "non_evictable_bytes": 652,
+          "result_cache_bytes": 20,
+          "auxiliary_cache_bytes": 0
+        }
+      },
+      "memory": {
+        "sample_count": 23,
+        "peak_total_rss_kib": 20256,
+        "stable_median_total_rss_kib": 20256,
+        "peak_process_count": 2,
+        "footprint_sample_count": 11,
+        "peak_total_footprint_bytes": 6865640,
+        "stable_median_total_footprint_bytes": 6865640
+      }
+    },
+    {
+      "batch": 2,
+      "report": {
+        "worker_generation": 1,
+        "derived_cache_soft_bytes": 20,
+        "non_evictable_estimate_hard_bytes": 4096,
+        "first_a_us": 3337,
+        "first_b_us": 112,
+        "recompute_a_us": 88,
+        "rejected_full_sync_us": 1426,
+        "rejected_incremental_edit_us": 1071,
+        "recovery_edit_us": 116,
+        "token_count": 1,
+        "recomputed_tokens_match": true,
+        "node_identity_survived": true,
+        "full_sync_rejection": "worker estimated non-evictable budget 4096 bytes exceeded",
+        "incremental_edit_rejection": "worker estimated non-evictable budget 4096 bytes exceeded",
+        "a_after_pressure": {
+          "context": {
+            "request_id": 7,
+            "worker_generation": 1,
+            "uri": "file:///memory-stress-a.rs",
+            "incarnation": 1,
+            "content_version": 1,
+            "configuration_generation": 0
+          },
+          "derived_cache_soft_bytes": 20,
+          "non_evictable_estimate_hard_bytes": 4096,
+          "non_evictable_bytes": 652,
+          "result_cache_bytes": 0,
+          "auxiliary_cache_bytes": 0
+        },
+        "b_after_pressure": {
+          "context": {
+            "request_id": 8,
+            "worker_generation": 1,
+            "uri": "file:///memory-stress-b.rs",
+            "incarnation": 1,
+            "content_version": 1,
+            "configuration_generation": 0
+          },
+          "derived_cache_soft_bytes": 20,
+          "non_evictable_estimate_hard_bytes": 4096,
+          "non_evictable_bytes": 652,
+          "result_cache_bytes": 20,
+          "auxiliary_cache_bytes": 0
+        }
+      },
+      "memory": {
+        "sample_count": 15,
+        "peak_total_rss_kib": 20352,
+        "stable_median_total_rss_kib": 20352,
+        "peak_process_count": 2,
+        "footprint_sample_count": 8,
+        "peak_total_footprint_bytes": 6947536,
+        "stable_median_total_footprint_bytes": 6947536
+      }
+    },
+    {
+      "batch": 3,
+      "report": {
+        "worker_generation": 1,
+        "derived_cache_soft_bytes": 20,
+        "non_evictable_estimate_hard_bytes": 4096,
+        "first_a_us": 3002,
+        "first_b_us": 112,
+        "recompute_a_us": 76,
+        "rejected_full_sync_us": 1227,
+        "rejected_incremental_edit_us": 773,
+        "recovery_edit_us": 93,
+        "token_count": 1,
+        "recomputed_tokens_match": true,
+        "node_identity_survived": true,
+        "full_sync_rejection": "worker estimated non-evictable budget 4096 bytes exceeded",
+        "incremental_edit_rejection": "worker estimated non-evictable budget 4096 bytes exceeded",
+        "a_after_pressure": {
+          "context": {
+            "request_id": 7,
+            "worker_generation": 1,
+            "uri": "file:///memory-stress-a.rs",
+            "incarnation": 1,
+            "content_version": 1,
+            "configuration_generation": 0
+          },
+          "derived_cache_soft_bytes": 20,
+          "non_evictable_estimate_hard_bytes": 4096,
+          "non_evictable_bytes": 652,
+          "result_cache_bytes": 0,
+          "auxiliary_cache_bytes": 0
+        },
+        "b_after_pressure": {
+          "context": {
+            "request_id": 8,
+            "worker_generation": 1,
+            "uri": "file:///memory-stress-b.rs",
+            "incarnation": 1,
+            "content_version": 1,
+            "configuration_generation": 0
+          },
+          "derived_cache_soft_bytes": 20,
+          "non_evictable_estimate_hard_bytes": 4096,
+          "non_evictable_bytes": 652,
+          "result_cache_bytes": 20,
+          "auxiliary_cache_bytes": 0
+        }
+      },
+      "memory": {
+        "sample_count": 15,
+        "peak_total_rss_kib": 20304,
+        "stable_median_total_rss_kib": 20304,
+        "peak_process_count": 2,
+        "footprint_sample_count": 8,
+        "peak_total_footprint_bytes": 6898384,
+        "stable_median_total_footprint_bytes": 6898384
+      }
+    },
+    {
+      "batch": 4,
+      "report": {
+        "worker_generation": 1,
+        "derived_cache_soft_bytes": 20,
+        "non_evictable_estimate_hard_bytes": 4096,
+        "first_a_us": 4206,
+        "first_b_us": 123,
+        "recompute_a_us": 79,
+        "rejected_full_sync_us": 1361,
+        "rejected_incremental_edit_us": 1003,
+        "recovery_edit_us": 80,
+        "token_count": 1,
+        "recomputed_tokens_match": true,
+        "node_identity_survived": true,
+        "full_sync_rejection": "worker estimated non-evictable budget 4096 bytes exceeded",
+        "incremental_edit_rejection": "worker estimated non-evictable budget 4096 bytes exceeded",
+        "a_after_pressure": {
+          "context": {
+            "request_id": 7,
+            "worker_generation": 1,
+            "uri": "file:///memory-stress-a.rs",
+            "incarnation": 1,
+            "content_version": 1,
+            "configuration_generation": 0
+          },
+          "derived_cache_soft_bytes": 20,
+          "non_evictable_estimate_hard_bytes": 4096,
+          "non_evictable_bytes": 652,
+          "result_cache_bytes": 0,
+          "auxiliary_cache_bytes": 0
+        },
+        "b_after_pressure": {
+          "context": {
+            "request_id": 8,
+            "worker_generation": 1,
+            "uri": "file:///memory-stress-b.rs",
+            "incarnation": 1,
+            "content_version": 1,
+            "configuration_generation": 0
+          },
+          "derived_cache_soft_bytes": 20,
+          "non_evictable_estimate_hard_bytes": 4096,
+          "non_evictable_bytes": 652,
+          "result_cache_bytes": 20,
+          "auxiliary_cache_bytes": 0
+        }
+      },
+      "memory": {
+        "sample_count": 15,
+        "peak_total_rss_kib": 20224,
+        "stable_median_total_rss_kib": 20224,
+        "peak_process_count": 2,
+        "footprint_sample_count": 7,
+        "peak_total_footprint_bytes": 6832872,
+        "stable_median_total_footprint_bytes": 6832872
+      }
+    },
+    {
+      "batch": 5,
+      "report": {
+        "worker_generation": 1,
+        "derived_cache_soft_bytes": 20,
+        "non_evictable_estimate_hard_bytes": 4096,
+        "first_a_us": 3843,
+        "first_b_us": 83,
+        "recompute_a_us": 75,
+        "rejected_full_sync_us": 1279,
+        "rejected_incremental_edit_us": 922,
+        "recovery_edit_us": 82,
+        "token_count": 1,
+        "recomputed_tokens_match": true,
+        "node_identity_survived": true,
+        "full_sync_rejection": "worker estimated non-evictable budget 4096 bytes exceeded",
+        "incremental_edit_rejection": "worker estimated non-evictable budget 4096 bytes exceeded",
+        "a_after_pressure": {
+          "context": {
+            "request_id": 7,
+            "worker_generation": 1,
+            "uri": "file:///memory-stress-a.rs",
+            "incarnation": 1,
+            "content_version": 1,
+            "configuration_generation": 0
+          },
+          "derived_cache_soft_bytes": 20,
+          "non_evictable_estimate_hard_bytes": 4096,
+          "non_evictable_bytes": 652,
+          "result_cache_bytes": 0,
+          "auxiliary_cache_bytes": 0
+        },
+        "b_after_pressure": {
+          "context": {
+            "request_id": 8,
+            "worker_generation": 1,
+            "uri": "file:///memory-stress-b.rs",
+            "incarnation": 1,
+            "content_version": 1,
+            "configuration_generation": 0
+          },
+          "derived_cache_soft_bytes": 20,
+          "non_evictable_estimate_hard_bytes": 4096,
+          "non_evictable_bytes": 652,
+          "result_cache_bytes": 20,
+          "auxiliary_cache_bytes": 0
+        }
+      },
+      "memory": {
+        "sample_count": 16,
+        "peak_total_rss_kib": 20272,
+        "stable_median_total_rss_kib": 20272,
+        "peak_process_count": 2,
+        "footprint_sample_count": 8,
+        "peak_total_footprint_bytes": 6865616,
+        "stable_median_total_footprint_bytes": 6865616
+      }
+    },
+    {
+      "batch": 6,
+      "report": {
+        "worker_generation": 1,
+        "derived_cache_soft_bytes": 20,
+        "non_evictable_estimate_hard_bytes": 4096,
+        "first_a_us": 3113,
+        "first_b_us": 154,
+        "recompute_a_us": 71,
+        "rejected_full_sync_us": 1215,
+        "rejected_incremental_edit_us": 963,
+        "recovery_edit_us": 100,
+        "token_count": 1,
+        "recomputed_tokens_match": true,
+        "node_identity_survived": true,
+        "full_sync_rejection": "worker estimated non-evictable budget 4096 bytes exceeded",
+        "incremental_edit_rejection": "worker estimated non-evictable budget 4096 bytes exceeded",
+        "a_after_pressure": {
+          "context": {
+            "request_id": 7,
+            "worker_generation": 1,
+            "uri": "file:///memory-stress-a.rs",
+            "incarnation": 1,
+            "content_version": 1,
+            "configuration_generation": 0
+          },
+          "derived_cache_soft_bytes": 20,
+          "non_evictable_estimate_hard_bytes": 4096,
+          "non_evictable_bytes": 652,
+          "result_cache_bytes": 0,
+          "auxiliary_cache_bytes": 0
+        },
+        "b_after_pressure": {
+          "context": {
+            "request_id": 8,
+            "worker_generation": 1,
+            "uri": "file:///memory-stress-b.rs",
+            "incarnation": 1,
+            "content_version": 1,
+            "configuration_generation": 0
+          },
+          "derived_cache_soft_bytes": 20,
+          "non_evictable_estimate_hard_bytes": 4096,
+          "non_evictable_bytes": 652,
+          "result_cache_bytes": 20,
+          "auxiliary_cache_bytes": 0
+        }
+      },
+      "memory": {
+        "sample_count": 14,
+        "peak_total_rss_kib": 20304,
+        "stable_median_total_rss_kib": 20304,
+        "peak_process_count": 2,
+        "footprint_sample_count": 7,
+        "peak_total_footprint_bytes": 6914792,
+        "stable_median_total_footprint_bytes": 6914792
+      }
+    }
+  ]
+}

--- a/benches/profile/results/single_worker_stage18_memory_stress_default_cache_hit_2026-07-20.json
+++ b/benches/profile/results/single_worker_stage18_memory_stress_default_cache_hit_2026-07-20.json
@@ -1,0 +1,38 @@
+{
+  "experiment": "single worker stage 18 memory stress exact-version cache hit",
+  "date": "2026-07-20",
+  "baseline": {
+    "stage": 17,
+    "binary_sha256": "fb44ffe210efa84f088914bc38e81e0b98120789f4c066d709d6cef77eb6c57d"
+  },
+  "candidate": {
+    "stage": 18,
+    "source_commit": "9b46c7360661fdf1294914b27b4e3a3c86df6c29",
+    "binary_sha256": "ce06bbfd7bce95d7b0867142008e5a381a16d3ef26b6d0064c230d288b75dfc4"
+  },
+  "scenario": {
+    "language": "markdown",
+    "generated_size": 5000,
+    "documents": 1,
+    "measured_requests": 20,
+    "warm_semantic_cache": true,
+    "settle_seconds": 0.5,
+    "worker_threads": 4,
+    "memory_sampling": false,
+    "order": "baseline-candidate on odd runs; candidate-baseline on even runs"
+  },
+  "runs": [
+    {"run": 1, "baseline": {"p50_ms": 78.7, "p95_ms": 81.7, "wall_ms_per_cycle": 127.37}, "candidate": {"p50_ms": 75.5, "p95_ms": 81.7, "wall_ms_per_cycle": 118.90}},
+    {"run": 2, "baseline": {"p50_ms": 75.3, "p95_ms": 80.8, "wall_ms_per_cycle": 120.56}, "candidate": {"p50_ms": 77.6, "p95_ms": 81.8, "wall_ms_per_cycle": 121.71}},
+    {"run": 3, "baseline": {"p50_ms": 76.3, "p95_ms": 78.4, "wall_ms_per_cycle": 117.63}, "candidate": {"p50_ms": 76.6, "p95_ms": 80.3, "wall_ms_per_cycle": 118.53}},
+    {"run": 4, "baseline": {"p50_ms": 77.2, "p95_ms": 79.7, "wall_ms_per_cycle": 120.93}, "candidate": {"p50_ms": 76.7, "p95_ms": 80.7, "wall_ms_per_cycle": 121.63}},
+    {"run": 5, "baseline": {"p50_ms": 77.4, "p95_ms": 80.9, "wall_ms_per_cycle": 121.68}, "candidate": {"p50_ms": 76.4, "p95_ms": 81.0, "wall_ms_per_cycle": 120.43}},
+    {"run": 6, "baseline": {"p50_ms": 76.4, "p95_ms": 79.2, "wall_ms_per_cycle": 120.30}, "candidate": {"p50_ms": 77.7, "p95_ms": 79.9, "wall_ms_per_cycle": 121.69}},
+    {"run": 7, "baseline": {"p50_ms": 77.1, "p95_ms": 80.6, "wall_ms_per_cycle": 122.03}, "candidate": {"p50_ms": 76.4, "p95_ms": 78.7, "wall_ms_per_cycle": 118.48}},
+    {"run": 8, "baseline": {"p50_ms": 77.2, "p95_ms": 80.4, "wall_ms_per_cycle": 120.08}, "candidate": {"p50_ms": 75.6, "p95_ms": 79.6, "wall_ms_per_cycle": 119.54}},
+    {"run": 9, "baseline": {"p50_ms": 76.4, "p95_ms": 79.3, "wall_ms_per_cycle": 122.44}, "candidate": {"p50_ms": 75.3, "p95_ms": 77.4, "wall_ms_per_cycle": 118.50}},
+    {"run": 10, "baseline": {"p50_ms": 75.8, "p95_ms": 78.1, "wall_ms_per_cycle": 118.09}, "candidate": {"p50_ms": 76.3, "p95_ms": 79.8, "wall_ms_per_cycle": 118.02}},
+    {"run": 11, "baseline": {"p50_ms": 77.5, "p95_ms": 81.2, "wall_ms_per_cycle": 120.62}, "candidate": {"p50_ms": 75.3, "p95_ms": 77.6, "wall_ms_per_cycle": 117.06}},
+    {"run": 12, "baseline": {"p50_ms": 75.6, "p95_ms": 80.4, "wall_ms_per_cycle": 119.51}, "candidate": {"p50_ms": 78.3, "p95_ms": 83.1, "wall_ms_per_cycle": 125.32}}
+  ]
+}

--- a/benches/profile/results/single_worker_stage18_memory_stress_default_multidoc_2026-07-20.json
+++ b/benches/profile/results/single_worker_stage18_memory_stress_default_multidoc_2026-07-20.json
@@ -1,0 +1,720 @@
+{
+  "schema": 1,
+  "experiment": "single-tree-worker-stage15-memory",
+  "environment": {
+    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "python": "3.12.13",
+    "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)",
+    "cpu_model": "Apple M4",
+    "binary_sha256": "fb44ffe210efa84f088914bc38e81e0b98120789f4c066d709d6cef77eb6c57d",
+    "compare_binary_sha256": "ce06bbfd7bce95d7b0867142008e5a381a16d3ef26b6d0064c230d288b75dfc4",
+    "retained_environment": {
+      "PATH": "<redacted-search-path>",
+      "TMPDIR": "<redacted-path>",
+      "LANG": "C.UTF-8",
+      "LC_ALL": "C.UTF-8"
+    }
+  },
+  "artifacts": [
+    19,
+    "f8c2b2cabd37920d217a1d8712f7588dde2a57e530714e02693744e8b324d768"
+  ],
+  "harness": {
+    "source_files_sha256": {
+      "collect_worker_proxy.py": "e7a1aaaa180791f83dacbd6e135b64dcab806a3fa2f9f4887c91a941c65f3755",
+      "collect_worker_shadow.py": "c4696420ae0b47920dfaea45ec636c68f07373bcbdc260fc733e091ae17a7e9e",
+      "collect_worker_cold_start.py": "7648e2b0eba60b20b7f11a641c07c6ccdd5a1d3b75bc91492f32acfa90750109",
+      "collect_worker_capture_pilot.py": "3a709d50253dc23060ca99f885978e71a8b58f07a71af6c492d2fa73916a75f5",
+      "collect_worker_memory.py": "6eebdbbdc1314e9bd7b42f976434b5b2eb5adc28f0eaec88f02a617a356f20c7",
+      "drive.py": "53f19b370212839aba3236337cb177cb6ef69ca1b0c1f4ded5f459625ec602ff",
+      "worker_proxy.py": "e3fe07d73168835e71fb976109e034b121b1112d6c7a746be1575ac07a6fd542",
+      "gen_session.py": "6f4f6b8388c607db1c70fe29579ce14fe00d57668cab17601432ff123cfb15a3"
+    }
+  },
+  "collector": {
+    "batches": 12,
+    "order": "legacy-authoritative on odd batches; reversed on even batches",
+    "worker_threads": 4,
+    "sample_interval_ms": 20.0,
+    "footprint_interval_ms": 250.0,
+    "metric": "sum of RSS for every descendant of the benchmark driver",
+    "comparison": "two authoritative binaries"
+  },
+  "scenario": [
+    "--lang",
+    "markdown",
+    "--size",
+    "5000",
+    "--requests",
+    "6",
+    "--documents",
+    "3",
+    "--warm-semantic-cache",
+    "--settle",
+    "0.5",
+    "--hold-open",
+    "1.0"
+  ],
+  "batches": [
+    {
+      "batch": 1,
+      "order": [
+        "baseline",
+        "candidate"
+      ],
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 76.1,
+        "p90": 78.3,
+        "p95": 78.3,
+        "p99": 78.3,
+        "max": 78.3,
+        "wall": 732.2837919928133,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 53,
+          "peak_total_rss_kib": 563888,
+          "stable_median_total_rss_kib": 529568,
+          "peak_process_count": 2,
+          "footprint_sample_count": 27,
+          "peak_total_footprint_bytes": 522896728,
+          "stable_median_total_footprint_bytes": 486901056
+        }
+      },
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 78.1,
+        "p90": 84.8,
+        "p95": 84.8,
+        "p99": 84.8,
+        "max": 84.8,
+        "wall": 760.3465829743072,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 45,
+          "peak_total_rss_kib": 589088,
+          "stable_median_total_rss_kib": 554736,
+          "peak_process_count": 2,
+          "footprint_sample_count": 24,
+          "peak_total_footprint_bytes": 550618528,
+          "stable_median_total_footprint_bytes": 533013908
+        }
+      }
+    },
+    {
+      "batch": 2,
+      "order": [
+        "candidate",
+        "baseline"
+      ],
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 79.1,
+        "p90": 79.7,
+        "p95": 79.7,
+        "p99": 79.7,
+        "max": 79.7,
+        "wall": 753.3955830149353,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 40,
+          "peak_total_rss_kib": 593680,
+          "stable_median_total_rss_kib": 593408,
+          "peak_process_count": 2,
+          "footprint_sample_count": 22,
+          "peak_total_footprint_bytes": 552617352,
+          "stable_median_total_footprint_bytes": 533792112
+        }
+      },
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 75.4,
+        "p90": 77.4,
+        "p95": 77.4,
+        "p99": 77.4,
+        "max": 77.4,
+        "wall": 732.3537910124287,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 40,
+          "peak_total_rss_kib": 527856,
+          "stable_median_total_rss_kib": 527824,
+          "peak_process_count": 2,
+          "footprint_sample_count": 23,
+          "peak_total_footprint_bytes": 484459816,
+          "stable_median_total_footprint_bytes": 461923600
+        }
+      }
+    },
+    {
+      "batch": 3,
+      "order": [
+        "baseline",
+        "candidate"
+      ],
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 74.6,
+        "p90": 77.9,
+        "p95": 77.9,
+        "p99": 77.9,
+        "max": 77.9,
+        "wall": 754.8711670096964,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 39,
+          "peak_total_rss_kib": 564896,
+          "stable_median_total_rss_kib": 562784,
+          "peak_process_count": 2,
+          "footprint_sample_count": 22,
+          "peak_total_footprint_bytes": 523388248,
+          "stable_median_total_footprint_bytes": 523355480
+        }
+      },
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 75.9,
+        "p90": 78.9,
+        "p95": 78.9,
+        "p99": 78.9,
+        "max": 78.9,
+        "wall": 731.4400000032037,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 40,
+          "peak_total_rss_kib": 544928,
+          "stable_median_total_rss_kib": 544912,
+          "peak_process_count": 2,
+          "footprint_sample_count": 21,
+          "peak_total_footprint_bytes": 506643800,
+          "stable_median_total_footprint_bytes": 505431384
+        }
+      }
+    },
+    {
+      "batch": 4,
+      "order": [
+        "candidate",
+        "baseline"
+      ],
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 76.3,
+        "p90": 81.2,
+        "p95": 81.2,
+        "p99": 81.2,
+        "max": 81.2,
+        "wall": 758.2703341031447,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 37,
+          "peak_total_rss_kib": 562336,
+          "stable_median_total_rss_kib": 562320,
+          "peak_process_count": 2,
+          "footprint_sample_count": 23,
+          "peak_total_footprint_bytes": 522208576,
+          "stable_median_total_footprint_bytes": 495281460
+        }
+      },
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 79.2,
+        "p90": 81.4,
+        "p95": 81.4,
+        "p99": 81.4,
+        "max": 81.4,
+        "wall": 787.6950000645593,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 35,
+          "peak_total_rss_kib": 545344,
+          "stable_median_total_rss_kib": 523944,
+          "peak_process_count": 2,
+          "footprint_sample_count": 26,
+          "peak_total_footprint_bytes": 501400872,
+          "stable_median_total_footprint_bytes": 481232144
+        }
+      }
+    },
+    {
+      "batch": 5,
+      "order": [
+        "baseline",
+        "candidate"
+      ],
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 78.3,
+        "p90": 79.8,
+        "p95": 79.8,
+        "p99": 79.8,
+        "max": 79.8,
+        "wall": 770.1550829224288,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 35,
+          "peak_total_rss_kib": 523744,
+          "stable_median_total_rss_kib": 519000,
+          "peak_process_count": 2,
+          "footprint_sample_count": 26,
+          "peak_total_footprint_bytes": 482772264,
+          "stable_median_total_footprint_bytes": 459408680
+        }
+      },
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 76.0,
+        "p90": 80.9,
+        "p95": 80.9,
+        "p99": 80.9,
+        "max": 80.9,
+        "wall": 746.8112499918789,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 36,
+          "peak_total_rss_kib": 566576,
+          "stable_median_total_rss_kib": 565360,
+          "peak_process_count": 2,
+          "footprint_sample_count": 26,
+          "peak_total_footprint_bytes": 529450280,
+          "stable_median_total_footprint_bytes": 493045008
+        }
+      }
+    },
+    {
+      "batch": 6,
+      "order": [
+        "candidate",
+        "baseline"
+      ],
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 75.7,
+        "p90": 77.4,
+        "p95": 77.4,
+        "p99": 77.4,
+        "max": 77.4,
+        "wall": 733.1836660159752,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 39,
+          "peak_total_rss_kib": 568720,
+          "stable_median_total_rss_kib": 568712,
+          "peak_process_count": 2,
+          "footprint_sample_count": 22,
+          "peak_total_footprint_bytes": 527893872,
+          "stable_median_total_footprint_bytes": 504317272
+        }
+      },
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 75.2,
+        "p90": 79.5,
+        "p95": 79.5,
+        "p99": 79.5,
+        "max": 79.5,
+        "wall": 727.9104159679264,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 38,
+          "peak_total_rss_kib": 571632,
+          "stable_median_total_rss_kib": 571632,
+          "peak_process_count": 2,
+          "footprint_sample_count": 23,
+          "peak_total_footprint_bytes": 532792664,
+          "stable_median_total_footprint_bytes": 502908236
+        }
+      }
+    },
+    {
+      "batch": 7,
+      "order": [
+        "baseline",
+        "candidate"
+      ],
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 76.6,
+        "p90": 79.3,
+        "p95": 79.3,
+        "p99": 79.3,
+        "max": 79.3,
+        "wall": 743.0969999404624,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 38,
+          "peak_total_rss_kib": 549472,
+          "stable_median_total_rss_kib": 549440,
+          "peak_process_count": 2,
+          "footprint_sample_count": 25,
+          "peak_total_footprint_bytes": 509101376,
+          "stable_median_total_footprint_bytes": 504857920
+        }
+      },
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 77.0,
+        "p90": 77.5,
+        "p95": 77.5,
+        "p99": 77.5,
+        "max": 77.5,
+        "wall": 739.3711250042543,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 40,
+          "peak_total_rss_kib": 586336,
+          "stable_median_total_rss_kib": 586320,
+          "peak_process_count": 2,
+          "footprint_sample_count": 22,
+          "peak_total_footprint_bytes": 549193096,
+          "stable_median_total_footprint_bytes": 549176712
+        }
+      }
+    },
+    {
+      "batch": 8,
+      "order": [
+        "candidate",
+        "baseline"
+      ],
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 75.1,
+        "p90": 78.5,
+        "p95": 78.5,
+        "p99": 78.5,
+        "max": 78.5,
+        "wall": 742.5315829459578,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 40,
+          "peak_total_rss_kib": 577152,
+          "stable_median_total_rss_kib": 577152,
+          "peak_process_count": 2,
+          "footprint_sample_count": 22,
+          "peak_total_footprint_bytes": 539067760,
+          "stable_median_total_footprint_bytes": 503940440
+        }
+      },
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 75.0,
+        "p90": 77.3,
+        "p95": 77.3,
+        "p99": 77.3,
+        "max": 77.3,
+        "wall": 725.2413750393316,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 38,
+          "peak_total_rss_kib": 551328,
+          "stable_median_total_rss_kib": 551296,
+          "peak_process_count": 2,
+          "footprint_sample_count": 22,
+          "peak_total_footprint_bytes": 509986136,
+          "stable_median_total_footprint_bytes": 483329344
+        }
+      }
+    },
+    {
+      "batch": 9,
+      "order": [
+        "baseline",
+        "candidate"
+      ],
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 75.1,
+        "p90": 76.9,
+        "p95": 76.9,
+        "p99": 76.9,
+        "max": 76.9,
+        "wall": 729.8810420325026,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 39,
+          "peak_total_rss_kib": 545680,
+          "stable_median_total_rss_kib": 545584,
+          "peak_process_count": 2,
+          "footprint_sample_count": 23,
+          "peak_total_footprint_bytes": 507446592,
+          "stable_median_total_footprint_bytes": 484934952
+        }
+      },
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 75.7,
+        "p90": 78.1,
+        "p95": 78.1,
+        "p99": 78.1,
+        "max": 78.1,
+        "wall": 731.9949578959495,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 39,
+          "peak_total_rss_kib": 568640,
+          "stable_median_total_rss_kib": 568632,
+          "peak_process_count": 2,
+          "footprint_sample_count": 23,
+          "peak_total_footprint_bytes": 525796696,
+          "stable_median_total_footprint_bytes": 510272832
+        }
+      }
+    },
+    {
+      "batch": 10,
+      "order": [
+        "candidate",
+        "baseline"
+      ],
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 75.2,
+        "p90": 76.6,
+        "p95": 76.6,
+        "p99": 76.6,
+        "max": 76.6,
+        "wall": 740.2500420575961,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 40,
+          "peak_total_rss_kib": 547776,
+          "stable_median_total_rss_kib": 547776,
+          "peak_process_count": 2,
+          "footprint_sample_count": 24,
+          "peak_total_footprint_bytes": 508101928,
+          "stable_median_total_footprint_bytes": 473023760
+        }
+      },
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 78.4,
+        "p90": 83.5,
+        "p95": 83.5,
+        "p99": 83.5,
+        "max": 83.5,
+        "wall": 760.5856249574572,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 38,
+          "peak_total_rss_kib": 564784,
+          "stable_median_total_rss_kib": 563136,
+          "peak_process_count": 2,
+          "footprint_sample_count": 23,
+          "peak_total_footprint_bytes": 528106864,
+          "stable_median_total_footprint_bytes": 508839268
+        }
+      }
+    },
+    {
+      "batch": 11,
+      "order": [
+        "baseline",
+        "candidate"
+      ],
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 78.6,
+        "p90": 80.5,
+        "p95": 80.5,
+        "p99": 80.5,
+        "max": 80.5,
+        "wall": 741.0172909731045,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 38,
+          "peak_total_rss_kib": 547920,
+          "stable_median_total_rss_kib": 547872,
+          "peak_process_count": 2,
+          "footprint_sample_count": 23,
+          "peak_total_footprint_bytes": 507577712,
+          "stable_median_total_footprint_bytes": 495265112
+        }
+      },
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 76.9,
+        "p90": 77.9,
+        "p95": 77.9,
+        "p99": 77.9,
+        "max": 77.9,
+        "wall": 748.2196659548208,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 39,
+          "peak_total_rss_kib": 551536,
+          "stable_median_total_rss_kib": 551496,
+          "peak_process_count": 2,
+          "footprint_sample_count": 23,
+          "peak_total_footprint_bytes": 510657856,
+          "stable_median_total_footprint_bytes": 490898740
+        }
+      }
+    },
+    {
+      "batch": 12,
+      "order": [
+        "candidate",
+        "baseline"
+      ],
+      "candidate": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 75.6,
+        "p90": 79.2,
+        "p95": 79.2,
+        "p99": 79.2,
+        "max": 79.2,
+        "wall": 748.9473749883473,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 39,
+          "peak_total_rss_kib": 550544,
+          "stable_median_total_rss_kib": 550544,
+          "peak_process_count": 2,
+          "footprint_sample_count": 22,
+          "peak_total_footprint_bytes": 512525656,
+          "stable_median_total_footprint_bytes": 491013440
+        }
+      },
+      "baseline": {
+        "count": 6,
+        "ok": 6,
+        "canceled": 0,
+        "null": 0,
+        "errors": 0,
+        "tokens_per_request": 123336,
+        "p50": 75.8,
+        "p90": 78.2,
+        "p95": 78.2,
+        "p99": 78.2,
+        "max": 78.2,
+        "wall": 737.7736669732258,
+        "wire_kib": 7705.6,
+        "memory": {
+          "sample_count": 39,
+          "peak_total_rss_kib": 575072,
+          "stable_median_total_rss_kib": 557896,
+          "peak_process_count": 2,
+          "footprint_sample_count": 22,
+          "peak_total_footprint_bytes": 534136128,
+          "stable_median_total_footprint_bytes": 498992424
+        }
+      }
+    }
+  ]
+}

--- a/benches/profile/test_collect_worker_memory_stress.py
+++ b/benches/profile/test_collect_worker_memory_stress.py
@@ -1,0 +1,33 @@
+import json
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from collect_worker_memory_stress import parse_report
+
+
+class ParseReportTests(unittest.TestCase):
+    def test_rejects_a_report_that_did_not_preserve_identity(self):
+        report = {
+            "recomputed_tokens_match": True,
+            "node_identity_survived": False,
+            "full_sync_rejection": "non-evictable budget exceeded",
+            "incremental_edit_rejection": "non-evictable budget exceeded",
+            "a_after_pressure": {
+                "result_cache_bytes": 0,
+                "auxiliary_cache_bytes": 0,
+            },
+            "b_after_pressure": {
+                "result_cache_bytes": 20,
+                "auxiliary_cache_bytes": 0,
+            },
+        }
+
+        with self.assertRaisesRegex(ValueError, "node identity"):
+            parse_report(json.dumps(report))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage18-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage18-measurement.md
@@ -1,0 +1,154 @@
+# Single Tree Worker Stage 18 Memory-Stress Measurement
+
+## Scope
+
+Stage 18 makes the Stage 17 memory budgets immutable worker-process inputs and
+adds a deterministic internal inspection operation. The production defaults do
+not change: derived caches have a 128 MiB soft budget and estimated
+non-evictable state has an independent 512 MiB hard budget.
+
+The configurable budgets exist on the private parent-to-worker boundary. They
+allow process tests and release stress workloads to cross both boundaries with
+small fixtures instead of consuming hundreds of MiB. Inspection reports the
+current document estimates and cache classes; it does not add cumulative
+telemetry state to the worker.
+
+## Method
+
+### Reduced-budget boundary stress
+
+Six independent runs used the normal default-feature release binary with a
+20-byte derived-cache soft budget and a 4,096-byte estimated non-evictable hard
+budget. Each run:
+
+1. opened two Rust documents and derived semantic tokens for both;
+2. proved that pressure evicted the older document's result and auxiliary
+   caches while retaining the newer result;
+3. recomputed the evicted result and compared it byte-for-byte;
+4. rejected an oversized full replacement and an oversized incremental edit;
+5. verified the prior version, tree extent, and node identity after both
+   rejections; and
+6. applied a smaller recovery edit in the same worker generation.
+
+The collector sampled the stress driver and its worker child together every
+20 ms for aggregate RSS and every 250 ms for macOS shared-aware physical
+footprint. Raw reports, hashes, environment, and artifact checksums are in
+`benches/profile/results/single_worker_stage18_memory_boundary_stress_2026-07-20.json`.
+
+The source commit was `9b46c7360661fdf1294914b27b4e3a3c86df6c29`.
+The worker SHA-256 was
+`ce06bbfd7bce95d7b0867142008e5a381a16d3ef26b6d0064c230d288b75dfc4`,
+and the stress-driver SHA-256 was
+`9ac0590725fd23ea16d57394a95d76ea629b1fbc82c5bdc53291501f8c2e91ae`.
+
+### Default-budget A/B
+
+Twelve batches compared the Stage 17 release binary with the Stage 18 release
+binary in alternating order. Each process used one worker with four compute
+threads, opened three copies of the 1,121,182-byte, 5,000-injection Markdown
+fixture, warmed every semantic-result cache, round-robined six requests, and
+held all documents open while the collector sampled memory.
+
+An independent twelve-run, order-reversed measurement used one such document
+and twenty exact-version semantic requests after warmup without memory
+sampling. Raw results are in
+`benches/profile/results/single_worker_stage18_memory_stress_default_multidoc_2026-07-20.json`
+and
+`benches/profile/results/single_worker_stage18_memory_stress_default_cache_hit_2026-07-20.json`.
+
+## Result
+
+All six reduced-budget runs observed the intended cache state and passed every
+correctness invariant. Median operation times were:
+
+| Operation | Median | Range |
+| --- | ---: | ---: |
+| First derivation for document A | 3.590 ms | 3.002–4.206 ms |
+| First derivation for document B | 0.112 ms | 0.083–0.154 ms |
+| Recompute evicted document A | 0.078 ms | 0.071–0.088 ms |
+| Reject oversized full sync | 1.320 ms | 1.215–1.426 ms |
+| Reject oversized incremental edit | 0.978 ms | 0.773–1.071 ms |
+| Recovery edit | 0.097 ms | 0.080–0.125 ms |
+
+The small boundary fixture's median aggregate RSS was 19.81 MiB and median
+physical footprint was 6.56 MiB. These values describe the driver plus worker;
+they are not the enforced limit or evidence of production-scale reclamation.
+
+At the unchanged default budgets, three-document memory medians were:
+
+| Metric | Stage 17 | Stage 18 | Change |
+| --- | ---: | ---: | ---: |
+| Stable physical footprint | 468.33 MiB | 480.77 MiB | +12.44 MiB (+2.7%) |
+| Peak physical footprint | 485.94 MiB | 502.44 MiB | +16.50 MiB (+3.4%) |
+| Stable aggregate RSS | 535.80 MiB | 550.62 MiB | +14.83 MiB (+2.8%) |
+| Peak aggregate RSS | 537.50 MiB | 554.30 MiB | +16.80 MiB (+3.1%) |
+
+Paired stable-footprint deltas ranged from -34.16 MiB to +68.54 MiB, and
+paired stable-RSS deltas ranged from -17.45 MiB to +64.05 MiB. The candidate
+medians are higher, but both ranges cross zero and are much wider than the
+median differences. This run therefore records a possible noise-scale memory
+increase, not a repeatable regression or improvement.
+
+Exact-version latency medians were:
+
+| Metric | Stage 17 | Stage 18 | Change |
+| --- | ---: | ---: | ---: |
+| p50 | 76.75 ms | 76.40 ms | -0.5% |
+| p95 | 80.40 ms | 80.10 ms | -0.4% |
+| Wall time per cycle | 120.59 ms | 119.22 ms | -1.1% |
+
+Paired deltas were mixed: Stage 18 had lower p50 and wall time in 7 of 12 runs,
+but lower p95 in only 4 of 12. Immutable budget injection and stateless
+inspection are not on the ordinary request path, and this measurement finds no
+material cache-hit latency change.
+
+Validation passed:
+
+* `cargo fmt --all -- --check`;
+* `cargo test --lib` (3,146 passed, 2 ignored);
+* `cargo test --features e2e --test tree_worker_process` (9 passed);
+* `cargo test --features e2e --test e2e_tree_worker_shadow` (37 passed);
+* the profile Python tests (120 passed); and
+* `cargo clippy --all-targets --all-features -- -D warnings`.
+
+## Findings
+
+### The admission boundary is now observable end to end
+
+Stage 17 proved accounting and rollback primarily through unit and process
+tests. Stage 18 additionally drives a normal release parent and worker across
+both pressure boundaries. The observed state distinguishes eviction from an
+RSS coincidence: document A has zero derived-cache bytes after pressure,
+document B retains its result, and A recomputes identical tokens.
+
+### Rejection preserves useful resident state
+
+Both mutation paths reject before committing an over-budget replacement. The
+same worker generation subsequently serves the old tree and accepts a smaller
+next-version edit. Memory isolation therefore does not require restarting the
+worker or discarding every document when ordinary admission fails.
+
+### Reduced limits validate policy, not a total-RSS cap
+
+The hard budget remains an estimate over retained Rust state and a weighted
+Tree node count. It excludes allocator overhead, loaded grammars, code pages,
+stacks, transport buffers, and the parent process. Passing this fixture proves
+deterministic policy and rollback at the configured estimate; it does not prove
+that 512 MiB of configured state implies a 512 MiB process RSS ceiling.
+
+### Default-budget memory remains noisy
+
+Stage 18 does not change default budgets or add ordinary-path retained state.
+Even so, its default A/B medians were higher in this run. The large sign-changing
+paired ranges prevent attributing that difference to the implementation.
+Future memory gates should continue reporting both physical footprint and RSS,
+alternate execution order, and require repeatability before rejecting a stage.
+
+## Decision
+
+Keep Stage 18. It makes soft eviction and transactional hard rejection
+repeatable across a real release process boundary without a material hot-path
+latency change. Do not claim a total-RSS cap, lower default memory use, or a
+production-scale pressure result from the reduced-budget fixture. Failure
+injection, protocol and compatibility gates, and legacy-path removal remain
+required before accepting the ADR.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1218,6 +1218,17 @@ noise-scale memory deltas and exact-version latency moved by only +0.6% to
 RSS cap; configurable-boundary stress, failure injection, protocol and
 compatibility gates remain open.
 
+The [Stage 18 memory-stress measurement](single-resident-multithreaded-tree-worker-stage18-measurement.md)
+injects immutable worker-process budgets and exposes stateless internal memory
+inspection. Six reduced-budget release runs deterministically observed soft
+eviction, identical recomputation, node-identity preservation, transactional
+full-sync and incremental-edit rejection, and subsequent recovery without a
+worker restart. Default-budget exact-version latency remained noise-scale;
+three-document memory medians were higher but paired ranges crossed zero by a
+wide margin. This validates the admission policy end to end without claiming a
+total-RSS cap or a repeatable default-memory change. Failure injection,
+protocol and compatibility gates, and legacy-path removal remain open.
+
 The implementation should proceed in measured stages:
 
 1. Prototype the framed transport, supervision, and one high-level

--- a/examples/tree_worker_memory_stress.rs
+++ b/examples/tree_worker_memory_stress.rs
@@ -1,0 +1,375 @@
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use kakehashi::tree_worker::{
+    ApplyDocumentEdits, ByteEdit, Client, ConfigureLanguages, DeriveDocumentSnapshot,
+    DeriveSemanticTokens, DocumentMemoryStats, InspectDocumentMemory, NodeLayerSelector,
+    NodeScalarOperation, NodeScalarValue, RequestContext, ResolveNode, Response, RunNodeScalar,
+    SyncDocument, WorkerLanguageAsset, WorkerLanguageCatalog, WorkerMemoryBudgets,
+    WorkerQuerySources,
+};
+use serde::Serialize;
+
+#[derive(Debug)]
+struct Options {
+    worker_bin: PathBuf,
+    data_dir: PathBuf,
+    derived_cache_soft_bytes: usize,
+    non_evictable_estimate_hard_bytes: usize,
+    hold_open: Duration,
+}
+
+#[derive(Serialize)]
+struct StressReport {
+    worker_generation: u64,
+    derived_cache_soft_bytes: usize,
+    non_evictable_estimate_hard_bytes: usize,
+    first_a_us: u128,
+    first_b_us: u128,
+    recompute_a_us: u128,
+    rejected_full_sync_us: u128,
+    rejected_incremental_edit_us: u128,
+    recovery_edit_us: u128,
+    token_count: usize,
+    recomputed_tokens_match: bool,
+    node_identity_survived: bool,
+    full_sync_rejection: String,
+    incremental_edit_rejection: String,
+    a_after_pressure: DocumentMemoryStats,
+    b_after_pressure: DocumentMemoryStats,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let options = parse_options()?;
+    let parser = options
+        .data_dir
+        .join("parser")
+        .join(format!("rust.{}", std::env::consts::DLL_EXTENSION));
+    if !parser.is_file() {
+        return Err(format!("installed Rust parser not found at {}", parser.display()).into());
+    }
+    let parser_digest = kakehashi::tree_worker::artifact_digest(&parser)?;
+    let worker_generation = 1;
+    let worker = Client::spawn_with_memory_budgets(
+        &options.worker_bin,
+        1,
+        worker_generation,
+        WorkerMemoryBudgets::new(
+            options.derived_cache_soft_bytes,
+            options.non_evictable_estimate_hard_bytes,
+        )?,
+    )?;
+
+    configure_rust(&worker, &parser, &parser_digest, worker_generation)?;
+    let a = context(2, worker_generation, "file:///memory-stress-a.rs", 1);
+    let b = context(3, worker_generation, "file:///memory-stress-b.rs", 1);
+    sync_rust(&worker, &parser, &parser_digest, a.clone(), "fn main() {}")?;
+    sync_rust(&worker, &parser, &parser_digest, b.clone(), "fn main() {}")?;
+
+    let node = match worker.resolve_node(ResolveNode {
+        context: RequestContext {
+            request_id: 4,
+            ..a.clone()
+        },
+        byte_offset: 3,
+        named: true,
+        layer: NodeLayerSelector::Host,
+    })? {
+        Response::Nodes(nodes) => {
+            nodes
+                .nodes
+                .into_iter()
+                .next()
+                .ok_or("worker returned no node for document A")?
+                .id
+        }
+        response => return Err(format!("node lookup failed: {response:?}").into()),
+    };
+
+    let (a_first, first_a_us) = timed_semantic(&worker, 5, &a)?;
+    let (b_first, first_b_us) = timed_semantic(&worker, 6, &b)?;
+    if a_first.cache_hit || b_first.cache_hit {
+        return Err("first semantic derivations unexpectedly hit a cache".into());
+    }
+    let a_after_pressure = inspect_memory(&worker, 7, &a)?;
+    let b_after_pressure = inspect_memory(&worker, 8, &b)?;
+    if a_after_pressure.result_cache_bytes != 0
+        || a_after_pressure.auxiliary_cache_bytes != 0
+        || b_after_pressure.result_cache_bytes == 0
+        || b_after_pressure.auxiliary_cache_bytes != 0
+    {
+        return Err(format!(
+            "soft-pressure order was not observable: A={a_after_pressure:?} B={b_after_pressure:?}"
+        )
+        .into());
+    }
+
+    let (a_recomputed, recompute_a_us) = timed_semantic(&worker, 9, &a)?;
+    if a_recomputed.cache_hit {
+        return Err("evicted document A unexpectedly hit its semantic cache".into());
+    }
+    let recomputed_tokens_match = a_recomputed.tokens == a_first.tokens;
+    let node_identity_survived = matches!(
+        worker.run_node_scalar(RunNodeScalar {
+            context: RequestContext {
+                request_id: 10,
+                ..a.clone()
+            },
+            node_id: node,
+            operation: NodeScalarOperation::Text,
+        })?,
+        Response::NodeScalar(result)
+            if result.value == Some(NodeScalarValue::String("main".into()))
+    );
+
+    let oversized_body = (0..200)
+        .map(|index| format!("let value_{index} = {index};"))
+        .collect::<String>();
+    let oversized_source = format!("fn main() {{ {oversized_body} }}");
+    let full_started = Instant::now();
+    let full_response = sync_rust_response(
+        &worker,
+        &parser,
+        &parser_digest,
+        context(11, worker_generation, &a.uri, 2),
+        oversized_source,
+    )?;
+    let rejected_full_sync_us = full_started.elapsed().as_micros();
+    let full_sync_rejection = contained_budget_error(full_response)?;
+    assert_snapshot_version(&worker, 12, &a, "fn main() {}".len())?;
+
+    let edit_started = Instant::now();
+    let edit_response = worker.apply_document_edits(ApplyDocumentEdits {
+        context: context(13, worker_generation, &a.uri, 2),
+        base_version: 1,
+        edits: vec![ByteEdit {
+            start_byte: "fn main() {}".len() - 1,
+            old_end_byte: "fn main() {}".len() - 1,
+            new_text: oversized_body,
+        }],
+    })?;
+    let rejected_incremental_edit_us = edit_started.elapsed().as_micros();
+    let incremental_edit_rejection = contained_budget_error(edit_response)?;
+    assert_snapshot_version(&worker, 14, &a, "fn main() {}".len())?;
+
+    let recovery_started = Instant::now();
+    let recovery = worker.apply_document_edits(ApplyDocumentEdits {
+        context: context(15, worker_generation, &a.uri, 2),
+        base_version: 1,
+        edits: vec![ByteEdit {
+            start_byte: 3,
+            old_end_byte: 7,
+            new_text: "next".into(),
+        }],
+    })?;
+    let recovery_edit_us = recovery_started.elapsed().as_micros();
+    if !matches!(recovery, Response::DocumentAck(_)) {
+        return Err(format!("post-rejection recovery edit failed: {recovery:?}").into());
+    }
+    assert_snapshot_version(
+        &worker,
+        16,
+        &context(16, worker_generation, &a.uri, 2),
+        "fn next() {}".len(),
+    )?;
+
+    let report = StressReport {
+        worker_generation,
+        derived_cache_soft_bytes: options.derived_cache_soft_bytes,
+        non_evictable_estimate_hard_bytes: options.non_evictable_estimate_hard_bytes,
+        first_a_us,
+        first_b_us,
+        recompute_a_us,
+        rejected_full_sync_us,
+        rejected_incremental_edit_us,
+        recovery_edit_us,
+        token_count: a_first.tokens.len(),
+        recomputed_tokens_match,
+        node_identity_survived,
+        full_sync_rejection,
+        incremental_edit_rejection,
+        a_after_pressure,
+        b_after_pressure,
+    };
+    println!("{}", serde_json::to_string(&report)?);
+    std::thread::sleep(options.hold_open);
+    worker.shutdown()?;
+    Ok(())
+}
+
+fn parse_options() -> Result<Options, Box<dyn Error>> {
+    let mut worker_bin = None;
+    let mut data_dir = None;
+    let mut derived_cache_soft_bytes = 20;
+    let mut non_evictable_estimate_hard_bytes = 4096;
+    let mut hold_open = Duration::from_secs(1);
+    let mut args = std::env::args().skip(1);
+    while let Some(flag) = args.next() {
+        let value = args
+            .next()
+            .ok_or_else(|| format!("missing value for {flag}"))?;
+        match flag.as_str() {
+            "--bin" => worker_bin = Some(PathBuf::from(value)),
+            "--data-dir" => data_dir = Some(PathBuf::from(value)),
+            "--derived-cache-soft-bytes" => derived_cache_soft_bytes = value.parse()?,
+            "--non-evictable-estimate-hard-bytes" => {
+                non_evictable_estimate_hard_bytes = value.parse()?
+            }
+            "--hold-open" => hold_open = Duration::from_secs_f64(value.parse()?),
+            _ => return Err(format!("unknown option {flag}").into()),
+        }
+    }
+    Ok(Options {
+        worker_bin: worker_bin.ok_or("--bin is required")?,
+        data_dir: data_dir.ok_or("--data-dir is required")?,
+        derived_cache_soft_bytes,
+        non_evictable_estimate_hard_bytes,
+        hold_open,
+    })
+}
+
+fn context(
+    request_id: u64,
+    worker_generation: u64,
+    uri: &str,
+    content_version: u64,
+) -> RequestContext {
+    RequestContext {
+        request_id,
+        worker_generation,
+        uri: uri.into(),
+        incarnation: 1,
+        content_version,
+        configuration_generation: 0,
+    }
+}
+
+fn configure_rust(
+    worker: &Client,
+    parser: &Path,
+    parser_digest: &str,
+    worker_generation: u64,
+) -> Result<(), Box<dyn Error>> {
+    let response = worker.configure_languages(ConfigureLanguages {
+        context: context(1, worker_generation, "kakehashi://memory-stress-catalog", 0),
+        catalog: WorkerLanguageCatalog {
+            assets: vec![WorkerLanguageAsset {
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: parser.into(),
+                parser_path: parser.into(),
+                artifact_digest: parser_digest.into(),
+                queries: WorkerQuerySources::default(),
+            }],
+            capture_mappings: serde_json::from_value(serde_json::json!({
+                "rust": { "highlights": { "variable": "keyword" } }
+            }))?,
+            search_paths: Vec::new(),
+        },
+    })?;
+    if matches!(response, Response::LanguageCatalogAck(_)) {
+        Ok(())
+    } else {
+        Err(format!("language catalog failed: {response:?}").into())
+    }
+}
+
+fn sync_rust(
+    worker: &Client,
+    parser: &Path,
+    parser_digest: &str,
+    context: RequestContext,
+    text: &str,
+) -> Result<(), Box<dyn Error>> {
+    let response = sync_rust_response(worker, parser, parser_digest, context, text.into())?;
+    if matches!(response, Response::DocumentAck(_)) {
+        Ok(())
+    } else {
+        Err(format!("document sync failed: {response:?}").into())
+    }
+}
+
+fn sync_rust_response(
+    worker: &Client,
+    parser: &Path,
+    parser_digest: &str,
+    context: RequestContext,
+    text: String,
+) -> Result<Response, Box<dyn Error>> {
+    Ok(worker.sync_document(SyncDocument {
+        context,
+        language: "rust".into(),
+        grammar_symbol: "rust".into(),
+        source_path: parser.into(),
+        parser_path: parser.into(),
+        artifact_digest: parser_digest.into(),
+        queries: WorkerQuerySources {
+            highlights: Some("(identifier) @variable".into()),
+            ..Default::default()
+        },
+        text,
+    })?)
+}
+
+fn timed_semantic(
+    worker: &Client,
+    request_id: u64,
+    context: &RequestContext,
+) -> Result<(kakehashi::tree_worker::DerivedSemanticTokens, u128), Box<dyn Error>> {
+    let started = Instant::now();
+    let response = worker.derive_semantic_tokens(DeriveSemanticTokens {
+        context: RequestContext {
+            request_id,
+            ..context.clone()
+        },
+        supports_multiline: false,
+    })?;
+    let elapsed = started.elapsed().as_micros();
+    match response {
+        Response::SemanticTokens(result) => Ok((result, elapsed)),
+        response => Err(format!("semantic derivation failed: {response:?}").into()),
+    }
+}
+
+fn inspect_memory(
+    worker: &Client,
+    request_id: u64,
+    context: &RequestContext,
+) -> Result<DocumentMemoryStats, Box<dyn Error>> {
+    match worker.inspect_document_memory(InspectDocumentMemory {
+        context: RequestContext {
+            request_id,
+            ..context.clone()
+        },
+    })? {
+        Response::DocumentMemory(result) => Ok(result),
+        response => Err(format!("memory inspection failed: {response:?}").into()),
+    }
+}
+
+fn contained_budget_error(response: Response) -> Result<String, Box<dyn Error>> {
+    match response {
+        Response::Error(error) if error.message.contains("non-evictable budget") => {
+            Ok(error.message)
+        }
+        response => Err(format!("expected contained budget error, got {response:?}").into()),
+    }
+}
+
+fn assert_snapshot_version(
+    worker: &Client,
+    request_id: u64,
+    context: &RequestContext,
+    expected_len: usize,
+) -> Result<(), Box<dyn Error>> {
+    match worker.derive_document_snapshot(DeriveDocumentSnapshot {
+        context: RequestContext {
+            request_id,
+            ..context.clone()
+        },
+    })? {
+        Response::Snapshot(snapshot) if snapshot.root_end_byte == expected_len => Ok(()),
+        response => Err(format!("snapshot was not preserved: {response:?}").into()),
+    }
+}

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -361,18 +361,15 @@ mod tests {
     #[test]
     fn sequential_injection_does_not_start_after_host_cancel() {
         let starts = std::cell::Cell::new(0);
-        let mut work = || {
+        let work = || {
             starts.set(starts.get() + 1);
             "ran"
         };
 
-        assert_eq!(run_sequential_injection(false, false, &mut work), None);
-        assert_eq!(run_sequential_injection(true, true, &mut work), None);
+        assert_eq!(run_sequential_injection(false, false, work), None);
+        assert_eq!(run_sequential_injection(true, true, work), None);
         assert_eq!(starts.get(), 0);
-        assert_eq!(
-            run_sequential_injection(true, false, &mut work),
-            Some("ran")
-        );
+        assert_eq!(run_sequential_injection(true, false, work), Some("ran"));
         assert_eq!(starts.get(), 1);
     }
     use tower_lsp_server::ls_types::{Range, SemanticToken};

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -87,6 +87,12 @@ enum Commands {
         /// Fixed compute budget selected by the parent process.
         #[arg(long)]
         threads: usize,
+        /// Internal soft budget for recomputable worker caches.
+        #[arg(long, default_value_t = 128 * 1024 * 1024)]
+        derived_cache_soft_bytes: usize,
+        /// Internal hard budget for retained source and host-tree estimates.
+        #[arg(long, default_value_t = 512 * 1024 * 1024)]
+        non_evictable_estimate_hard_bytes: usize,
     },
     /// Report diagnostics for files via the configured downstream language servers
     ///
@@ -345,11 +351,26 @@ fn main() -> ExitCode {
             grammar_dir,
             output_path,
         }) => run_compile_parser(&grammar_dir, &output_path),
-        Some(Commands::TreeWorker { threads }) => kakehashi::tree_worker::run_stdio(threads)
-            .map_err(|error| {
-                eprintln!("tree worker failed: {error}");
-                ExitCode::FAILURE
-            }),
+        Some(Commands::TreeWorker {
+            threads,
+            derived_cache_soft_bytes,
+            non_evictable_estimate_hard_bytes,
+        }) => kakehashi::tree_worker::WorkerMemoryBudgets::new(
+            derived_cache_soft_bytes,
+            non_evictable_estimate_hard_bytes,
+        )
+        .map_err(|error| {
+            eprintln!("tree worker configuration failed: {error}");
+            ExitCode::FAILURE
+        })
+        .and_then(|memory_budgets| {
+            kakehashi::tree_worker::run_stdio_with_memory_budgets(threads, memory_budgets).map_err(
+                |error| {
+                    eprintln!("tree worker failed: {error}");
+                    ExitCode::FAILURE
+                },
+            )
+        }),
         None => {
             // Start LSP server (backward compatible default behavior)
             // Only LSP mode needs a tokio runtime; CLI subcommands are synchronous

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -1572,8 +1572,11 @@ mod tests {
     fn combined_content_snaps_stale_span_start_before_slicing() {
         let text = "éx\n";
 
-        let (content, offsets) =
-            build_combined_virtual_content(text, 1..text.len(), &[1..text.len()]);
+        let (content, offsets) = build_combined_virtual_content(
+            text,
+            1..text.len(),
+            std::slice::from_ref(&(1..text.len())),
+        );
 
         assert_eq!(content, "x\n");
         assert_eq!(offsets, vec![1, 0]);
@@ -1582,8 +1585,11 @@ mod tests {
     #[test]
     fn combined_blank_included_line_records_its_prefix_offset() {
         let text = "> \n";
-        let (content, offsets) =
-            build_combined_virtual_content(text, 0..text.len(), &[2..text.len()]);
+        let (content, offsets) = build_combined_virtual_content(
+            text,
+            0..text.len(),
+            std::slice::from_ref(&(2..text.len())),
+        );
 
         assert_eq!(content, "\n");
         assert_eq!(offsets, vec![2, 0]);

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -680,6 +680,7 @@ impl Kakehashi {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
     use tower_lsp_server::LspService;

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -269,14 +269,15 @@ mod tests {
 
     #[tokio::test]
     async fn panicked_region_task_is_counted_as_prefetch_failure() {
-        let sink = Some(Arc::new(AtomicUsize::new(0)));
+        let sink = Arc::new(AtomicUsize::new(0));
+        let optional_sink = Some(Arc::clone(&sink));
         let mut join_set = JoinSet::new();
         join_set.spawn(async { panic!("region task failed") });
 
-        let diagnostics = collect_joined_region_diagnostics(join_set, &sink, "test").await;
+        let diagnostics = collect_joined_region_diagnostics(join_set, &optional_sink, "test").await;
 
         assert!(diagnostics.is_empty());
-        assert_eq!(sink.unwrap().load(Ordering::Relaxed), 1);
+        assert_eq!(sink.load(Ordering::Relaxed), 1);
     }
 
     /// An all-incapable virt snapshot must still publish an (empty) pull layer,

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -44,14 +44,15 @@ const TREE_NODE_ADMISSION_BYTES: usize = 64;
 const MAX_RETAINED_DERIVED_BYTES: usize = 128 * 1024 * 1024;
 pub const BUILD_ID: &str = concat!(env!("CARGO_PKG_NAME"), "-", env!("CARGO_PKG_VERSION"));
 
+#[doc(hidden)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct WorkerMemoryBudgets {
+pub struct WorkerMemoryBudgets {
     derived_cache_soft_bytes: usize,
     non_evictable_estimate_hard_bytes: usize,
 }
 
 impl WorkerMemoryBudgets {
-    fn new(
+    pub fn new(
         derived_cache_soft_bytes: usize,
         non_evictable_estimate_hard_bytes: usize,
     ) -> Result<Self, String> {
@@ -67,6 +68,9 @@ impl WorkerMemoryBudgets {
         })
     }
 }
+
+#[cfg(feature = "e2e")]
+pub type WorkerTestMemoryBudgets = WorkerMemoryBudgets;
 
 impl Default for WorkerMemoryBudgets {
     fn default() -> Self {
@@ -871,7 +875,7 @@ impl DocumentReplica {
         &mut self,
         request: ApplyDocumentEdits,
         parser: &mut tree_sitter::Parser,
-        retained_bytes: Option<(&AtomicUsize, &AtomicUsize)>,
+        retained_bytes: Option<(&AtomicUsize, &AtomicUsize, usize)>,
     ) -> Result<DocumentAck, String> {
         self.validate_identity(&request.context)?;
         if request.base_version != self.context.content_version {
@@ -920,7 +924,9 @@ impl DocumentReplica {
         let tree = parser
             .parse(text.as_bytes(), Some(&edited_tree))
             .ok_or_else(|| "parser returned no tree during incremental parse".to_string())?;
-        if let Some((retained_text_bytes, retained_estimated_bytes)) = retained_bytes {
+        if let Some((retained_text_bytes, retained_estimated_bytes, hard_limit_bytes)) =
+            retained_bytes
+        {
             replace_retained_bytes(retained_text_bytes, self.text.len(), text.len())?;
             let old_estimated = self.estimated_memory().non_evictable_bytes;
             let new_estimated = estimated_non_evictable_bytes(text.capacity(), &tree);
@@ -928,7 +934,7 @@ impl DocumentReplica {
                 retained_estimated_bytes,
                 old_estimated,
                 new_estimated,
-                MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
+                hard_limit_bytes,
             ) {
                 replace_retained_bytes(retained_text_bytes, text.len(), self.text.len()).expect(
                     "rolling back retained text after estimated admission cannot exceed its budget",
@@ -2890,6 +2896,7 @@ fn handle_work(
     retained_document_bytes: &RetainedDocumentBytes,
     retained_estimated_document_bytes: &RetainedEstimatedDocumentBytes,
     derived_pressure_lock: &Mutex<()>,
+    memory_budgets: WorkerMemoryBudgets,
     queue_wait: Duration,
     cancellation: &crate::cancel::CancelToken,
     nested_work_policy: &(dyn Fn() -> crate::analysis::semantic::NestedWorkPolicy + Sync),
@@ -2915,18 +2922,21 @@ fn handle_work(
             document_capacity,
             retained_document_bytes,
             retained_estimated_document_bytes,
+            memory_budgets.non_evictable_estimate_hard_bytes,
         ),
         Request::ApplyDocumentEdits(request) => apply_document_edits(
             request,
             documents,
             retained_document_bytes,
             retained_estimated_document_bytes,
+            memory_budgets.non_evictable_estimate_hard_bytes,
         ),
         Request::ApplyDocumentEditsAndDerive(request) => apply_document_edits_and_derive(
             request,
             documents,
             retained_document_bytes,
             retained_estimated_document_bytes,
+            memory_budgets.non_evictable_estimate_hard_bytes,
             queue_wait,
             started,
         ),
@@ -2955,6 +2965,7 @@ fn handle_work(
             closed_documents,
             retained_document_bytes,
             retained_estimated_document_bytes,
+            memory_budgets.non_evictable_estimate_hard_bytes,
         ),
     };
     if pressure_checkpoint_required(may_grow_derived_state, &response)
@@ -2962,7 +2973,7 @@ fn handle_work(
             documents,
             derived_pressure_lock,
             &DocumentKey::from(&context),
-            MAX_RETAINED_DERIVED_BYTES,
+            memory_budgets.derived_cache_soft_bytes,
         )
     {
         return Response::WorkerRestartRequired(WorkerRestartRequired { context, reason });
@@ -3338,6 +3349,7 @@ fn sync_document(
         document_capacity,
         retained_document_bytes,
         &retained_estimated_document_bytes,
+        MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
     )
 }
 
@@ -3349,6 +3361,7 @@ fn sync_document_with_analysis(
     document_capacity: &DocumentCapacity,
     retained_document_bytes: &RetainedDocumentBytes,
     retained_estimated_document_bytes: &RetainedEstimatedDocumentBytes,
+    non_evictable_estimate_hard_bytes: usize,
 ) -> Response {
     let context = request.context.clone();
     let request_text_len = request.text.len();
@@ -3442,7 +3455,7 @@ fn sync_document_with_analysis(
                             retained_estimated_document_bytes,
                             replaced_estimated_bytes,
                             estimated_bytes,
-                            MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
+                            non_evictable_estimate_hard_bytes,
                         ) {
                             return Response::Error(WorkerError {
                                 context: Some(context),
@@ -3481,6 +3494,7 @@ fn apply_document_edits(
     documents: &DocumentStore,
     retained_document_bytes: &RetainedDocumentBytes,
     retained_estimated_document_bytes: &RetainedEstimatedDocumentBytes,
+    non_evictable_estimate_hard_bytes: usize,
 ) -> Response {
     let context = request.context.clone();
     let document_key = DocumentKey::from(&context);
@@ -3509,7 +3523,11 @@ fn apply_document_edits(
                 match replica.apply(
                     request,
                     parser,
-                    Some((retained_document_bytes, retained_estimated_document_bytes)),
+                    Some((
+                        retained_document_bytes,
+                        retained_estimated_document_bytes,
+                        non_evictable_estimate_hard_bytes,
+                    )),
                 ) {
                     Ok(ack) => Response::DocumentAck(ack),
                     Err(message) => Response::Error(WorkerError {
@@ -3526,6 +3544,7 @@ fn apply_document_edits_and_derive(
     documents: &DocumentStore,
     retained_document_bytes: &RetainedDocumentBytes,
     retained_estimated_document_bytes: &RetainedEstimatedDocumentBytes,
+    non_evictable_estimate_hard_bytes: usize,
     queue_wait: Duration,
     started: Instant,
 ) -> Response {
@@ -3561,7 +3580,11 @@ fn apply_document_edits_and_derive(
                 if let Err(message) = replica.apply(
                     edits,
                     parser,
-                    Some((retained_document_bytes, retained_estimated_document_bytes)),
+                    Some((
+                        retained_document_bytes,
+                        retained_estimated_document_bytes,
+                        non_evictable_estimate_hard_bytes,
+                    )),
                 ) {
                     return Response::Error(WorkerError {
                         context: Some(context),
@@ -3621,6 +3644,7 @@ fn close_document(
     closed_documents: &ClosedDocuments,
     retained_document_bytes: &RetainedDocumentBytes,
     retained_estimated_document_bytes: &RetainedEstimatedDocumentBytes,
+    non_evictable_estimate_hard_bytes: usize,
 ) -> Response {
     let context = request.context;
     let document_key = DocumentKey::from(&context);
@@ -3655,7 +3679,7 @@ fn close_document(
         retained_estimated_document_bytes,
         removed_estimated_bytes,
         0,
-        MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
+        non_evictable_estimate_hard_bytes,
     )
     .expect("removing a document cannot exceed the estimated non-evictable budget");
     closed_documents.insert(document_key, context.incarnation);
@@ -3667,7 +3691,13 @@ where
     R: Read,
     W: Write + Send + 'static,
 {
-    run_with_build_id(reader, writer, compute_threads, BUILD_ID)
+    run_with_build_id(
+        reader,
+        writer,
+        compute_threads,
+        BUILD_ID,
+        WorkerMemoryBudgets::default(),
+    )
 }
 
 fn run_with_build_id<R, W>(
@@ -3675,6 +3705,7 @@ fn run_with_build_id<R, W>(
     writer: W,
     compute_threads: usize,
     build_id: &str,
+    memory_budgets: WorkerMemoryBudgets,
 ) -> io::Result<()>
 where
     R: Read,
@@ -3933,6 +3964,7 @@ where
                 &retained_document_bytes,
                 &retained_estimated_document_bytes,
                 &derived_pressure_lock,
+                memory_budgets,
                 enqueued.elapsed(),
                 &cancellation,
                 &nested_work_policy,
@@ -4080,12 +4112,21 @@ impl Drop for AdmissionPermit {
 }
 
 pub fn run_stdio(compute_threads: usize) -> io::Result<()> {
+    run_stdio_with_memory_budgets(compute_threads, WorkerMemoryBudgets::default())
+}
+
+#[doc(hidden)]
+pub fn run_stdio_with_memory_budgets(
+    compute_threads: usize,
+    memory_budgets: WorkerMemoryBudgets,
+) -> io::Result<()> {
     let build_id = artifact_digest(&std::env::current_exe()?)?;
     run_with_build_id(
         std::io::stdin(),
         std::io::stdout(),
         compute_threads,
         &build_id,
+        memory_budgets,
     )
 }
 
@@ -4155,6 +4196,35 @@ impl Client {
         compute_threads: usize,
         worker_generation: u64,
     ) -> io::Result<Self> {
+        Self::spawn_with_memory_budgets(
+            executable,
+            compute_threads,
+            worker_generation,
+            WorkerMemoryBudgets::default(),
+        )
+    }
+
+    #[cfg(feature = "e2e")]
+    pub fn spawn_with_test_memory_budgets(
+        executable: &std::path::Path,
+        compute_threads: usize,
+        worker_generation: u64,
+        memory_budgets: WorkerTestMemoryBudgets,
+    ) -> io::Result<Self> {
+        Self::spawn_with_memory_budgets(
+            executable,
+            compute_threads,
+            worker_generation,
+            memory_budgets,
+        )
+    }
+
+    fn spawn_with_memory_budgets(
+        executable: &std::path::Path,
+        compute_threads: usize,
+        worker_generation: u64,
+        memory_budgets: WorkerMemoryBudgets,
+    ) -> io::Result<Self> {
         if compute_threads == 0 {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -4162,8 +4232,20 @@ impl Client {
             ));
         }
         let build_id = artifact_digest(executable)?;
+        let compute_threads_arg = compute_threads.to_string();
+        let derived_cache_soft_bytes = memory_budgets.derived_cache_soft_bytes.to_string();
+        let non_evictable_estimate_hard_bytes =
+            memory_budgets.non_evictable_estimate_hard_bytes.to_string();
         let mut child = Command::new(executable)
-            .args(["__tree-worker", "--threads", &compute_threads.to_string()])
+            .args([
+                "__tree-worker",
+                "--threads",
+                &compute_threads_arg,
+                "--derived-cache-soft-bytes",
+                &derived_cache_soft_bytes,
+                "--non-evictable-estimate-hard-bytes",
+                &non_evictable_estimate_hard_bytes,
+            ])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
@@ -7141,6 +7223,7 @@ mod tests {
             &closed_documents,
             &retained,
             &retained_estimated,
+            MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
         );
         assert!(matches!(close_response, Response::WorkerRestartRequired(_)));
         assert!(documents.contains_key(&key));

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -44,6 +44,39 @@ const TREE_NODE_ADMISSION_BYTES: usize = 64;
 const MAX_RETAINED_DERIVED_BYTES: usize = 128 * 1024 * 1024;
 pub const BUILD_ID: &str = concat!(env!("CARGO_PKG_NAME"), "-", env!("CARGO_PKG_VERSION"));
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct WorkerMemoryBudgets {
+    derived_cache_soft_bytes: usize,
+    non_evictable_estimate_hard_bytes: usize,
+}
+
+impl WorkerMemoryBudgets {
+    fn new(
+        derived_cache_soft_bytes: usize,
+        non_evictable_estimate_hard_bytes: usize,
+    ) -> Result<Self, String> {
+        if derived_cache_soft_bytes == 0 {
+            return Err("worker derived-cache soft budget must be positive".into());
+        }
+        if non_evictable_estimate_hard_bytes == 0 {
+            return Err("worker non-evictable estimate hard budget must be positive".into());
+        }
+        Ok(Self {
+            derived_cache_soft_bytes,
+            non_evictable_estimate_hard_bytes,
+        })
+    }
+}
+
+impl Default for WorkerMemoryBudgets {
+    fn default() -> Self {
+        Self {
+            derived_cache_soft_bytes: MAX_RETAINED_DERIVED_BYTES,
+            non_evictable_estimate_hard_bytes: MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RequestContext {
     pub request_id: u64,
@@ -7156,6 +7189,12 @@ mod tests {
             retained.load(Ordering::Relaxed),
             MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES
         );
+    }
+
+    #[test]
+    fn worker_memory_budgets_reject_zero_limits() {
+        assert!(super::WorkerMemoryBudgets::new(0, 1).is_err());
+        assert!(super::WorkerMemoryBudgets::new(1, 0).is_err());
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -928,6 +928,7 @@ impl DocumentReplica {
                 retained_estimated_bytes,
                 old_estimated,
                 new_estimated,
+                MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
             ) {
                 replace_retained_bytes(retained_text_bytes, text.len(), self.text.len()).expect(
                     "rolling back retained text after estimated admission cannot exceed its budget",
@@ -2035,6 +2036,7 @@ fn replace_retained_estimated_bytes(
     retained_bytes: &AtomicUsize,
     old_bytes: usize,
     new_bytes: usize,
+    hard_limit_bytes: usize,
 ) -> Result<(), String> {
     let mut retained = retained_bytes.load(Ordering::Relaxed);
     loop {
@@ -2042,9 +2044,9 @@ fn replace_retained_estimated_bytes(
             .checked_sub(old_bytes)
             .and_then(|bytes| bytes.checked_add(new_bytes))
             .ok_or_else(|| "estimated document byte accounting overflowed".to_string())?;
-        if next > MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES {
+        if next > hard_limit_bytes {
             return Err(format!(
-                "worker estimated non-evictable budget {MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES} bytes exceeded"
+                "worker estimated non-evictable budget {hard_limit_bytes} bytes exceeded"
             ));
         }
         match retained_bytes.compare_exchange_weak(
@@ -3440,6 +3442,7 @@ fn sync_document_with_analysis(
                             retained_estimated_document_bytes,
                             replaced_estimated_bytes,
                             estimated_bytes,
+                            MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
                         ) {
                             return Response::Error(WorkerError {
                                 context: Some(context),
@@ -3652,6 +3655,7 @@ fn close_document(
         retained_estimated_document_bytes,
         removed_estimated_bytes,
         0,
+        MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
     )
     .expect("removing a document cannot exceed the estimated non-evictable budget");
     closed_documents.insert(document_key, context.incarnation);
@@ -7179,16 +7183,38 @@ mod tests {
     fn estimated_non_evictable_budget_is_transactional() {
         let retained = AtomicUsize::new(MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES - 8);
 
-        assert!(replace_retained_estimated_bytes(&retained, 0, 9).is_err());
+        assert!(replace_retained_estimated_bytes(
+            &retained,
+            0,
+            9,
+            MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
+        )
+        .is_err());
         assert_eq!(
             retained.load(Ordering::Relaxed),
             MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES - 8
         );
-        replace_retained_estimated_bytes(&retained, 0, 8).unwrap();
+        replace_retained_estimated_bytes(
+            &retained,
+            0,
+            8,
+            MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
+        )
+        .unwrap();
         assert_eq!(
             retained.load(Ordering::Relaxed),
             MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES
         );
+    }
+
+    #[test]
+    fn estimated_non_evictable_accounting_obeys_injected_hard_budget() {
+        let retained = AtomicUsize::new(0);
+
+        assert!(replace_retained_estimated_bytes(&retained, 0, 9, 8).is_err());
+        assert_eq!(retained.load(Ordering::Relaxed), 0);
+        replace_retained_estimated_bytes(&retained, 0, 8, 8).unwrap();
+        assert_eq!(retained.load(Ordering::Relaxed), 8);
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -7183,24 +7183,21 @@ mod tests {
     fn estimated_non_evictable_budget_is_transactional() {
         let retained = AtomicUsize::new(MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES - 8);
 
-        assert!(replace_retained_estimated_bytes(
-            &retained,
-            0,
-            9,
-            MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
-        )
-        .is_err());
+        assert!(
+            replace_retained_estimated_bytes(
+                &retained,
+                0,
+                9,
+                MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
+            )
+            .is_err()
+        );
         assert_eq!(
             retained.load(Ordering::Relaxed),
             MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES - 8
         );
-        replace_retained_estimated_bytes(
-            &retained,
-            0,
-            8,
-            MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
-        )
-        .unwrap();
+        replace_retained_estimated_bytes(&retained, 0, 8, MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES)
+            .unwrap();
         assert_eq!(
             retained.load(Ordering::Relaxed),
             MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -892,7 +892,7 @@ impl DocumentReplica {
         &mut self,
         request: ApplyDocumentEdits,
         parser: &mut tree_sitter::Parser,
-        retained_bytes: Option<(&AtomicUsize, &AtomicUsize, usize)>,
+        memory_admission: Option<DocumentMemoryAdmission<'_>>,
     ) -> Result<DocumentAck, String> {
         self.validate_identity(&request.context)?;
         if request.base_version != self.context.content_version {
@@ -941,19 +941,26 @@ impl DocumentReplica {
         let tree = parser
             .parse(text.as_bytes(), Some(&edited_tree))
             .ok_or_else(|| "parser returned no tree during incremental parse".to_string())?;
-        if let Some((retained_text_bytes, retained_estimated_bytes, hard_limit_bytes)) =
-            retained_bytes
-        {
-            replace_retained_bytes(retained_text_bytes, self.text.len(), text.len())?;
+        if let Some(memory_admission) = memory_admission {
+            replace_retained_bytes(
+                memory_admission.retained_text_bytes,
+                self.text.len(),
+                text.len(),
+            )?;
             let old_estimated = self.estimated_memory().non_evictable_bytes;
             let new_estimated = estimated_non_evictable_bytes(text.capacity(), &tree);
             if let Err(message) = replace_retained_estimated_bytes(
-                retained_estimated_bytes,
+                memory_admission.retained_estimated_bytes,
                 old_estimated,
                 new_estimated,
-                hard_limit_bytes,
+                memory_admission.non_evictable_estimate_hard_bytes,
             ) {
-                replace_retained_bytes(retained_text_bytes, text.len(), self.text.len()).expect(
+                replace_retained_bytes(
+                    memory_admission.retained_text_bytes,
+                    text.len(),
+                    self.text.len(),
+                )
+                .expect(
                     "rolling back retained text after estimated admission cannot exceed its budget",
                 );
                 return Err(message);
@@ -2669,6 +2676,13 @@ type RetainedDocumentBytes = Arc<AtomicUsize>;
 type RetainedEstimatedDocumentBytes = Arc<AtomicUsize>;
 type LaneJob = Box<dyn FnOnce() -> LaneAction + Send + 'static>;
 
+#[derive(Clone, Copy)]
+struct DocumentMemoryAdmission<'a> {
+    retained_text_bytes: &'a AtomicUsize,
+    retained_estimated_bytes: &'a AtomicUsize,
+    non_evictable_estimate_hard_bytes: usize,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum WorkPriority {
     Foreground,
@@ -2927,6 +2941,11 @@ fn handle_work(
     }
     let started = Instant::now();
     let may_grow_derived_state = request_may_grow_derived_state(&request);
+    let memory_admission = DocumentMemoryAdmission {
+        retained_text_bytes: retained_document_bytes.as_ref(),
+        retained_estimated_bytes: retained_estimated_document_bytes.as_ref(),
+        non_evictable_estimate_hard_bytes: memory_budgets.non_evictable_estimate_hard_bytes,
+    };
     let response = match request {
         Request::Handshake(_) | Request::Cancel(_) => {
             unreachable!("control requests are not scheduled")
@@ -2938,23 +2957,15 @@ fn handle_work(
             documents,
             closed_documents,
             document_capacity,
-            retained_document_bytes,
-            retained_estimated_document_bytes,
-            memory_budgets.non_evictable_estimate_hard_bytes,
+            memory_admission,
         ),
-        Request::ApplyDocumentEdits(request) => apply_document_edits(
-            request,
-            documents,
-            retained_document_bytes,
-            retained_estimated_document_bytes,
-            memory_budgets.non_evictable_estimate_hard_bytes,
-        ),
+        Request::ApplyDocumentEdits(request) => {
+            apply_document_edits(request, documents, memory_admission)
+        }
         Request::ApplyDocumentEditsAndDerive(request) => apply_document_edits_and_derive(
             request,
             documents,
-            retained_document_bytes,
-            retained_estimated_document_bytes,
-            memory_budgets.non_evictable_estimate_hard_bytes,
+            memory_admission,
             queue_wait,
             started,
         ),
@@ -2980,14 +2991,9 @@ fn handle_work(
         Request::InspectDocumentMemory(request) => {
             inspect_document_memory(request, documents, memory_budgets)
         }
-        Request::CloseDocument(request) => close_document(
-            request,
-            documents,
-            closed_documents,
-            retained_document_bytes,
-            retained_estimated_document_bytes,
-            memory_budgets.non_evictable_estimate_hard_bytes,
-        ),
+        Request::CloseDocument(request) => {
+            close_document(request, documents, closed_documents, memory_admission)
+        }
     };
     if pressure_checkpoint_required(may_grow_derived_state, &response)
         && let Err(reason) = enforce_derived_memory_budget(
@@ -3407,9 +3413,11 @@ fn sync_document(
         documents,
         closed_documents,
         document_capacity,
-        retained_document_bytes,
-        &retained_estimated_document_bytes,
-        MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
+        DocumentMemoryAdmission {
+            retained_text_bytes: retained_document_bytes.as_ref(),
+            retained_estimated_bytes: retained_estimated_document_bytes.as_ref(),
+            non_evictable_estimate_hard_bytes: MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
+        },
     )
 }
 
@@ -3419,9 +3427,7 @@ fn sync_document_with_analysis(
     documents: &DocumentStore,
     closed_documents: &ClosedDocuments,
     document_capacity: &DocumentCapacity,
-    retained_document_bytes: &RetainedDocumentBytes,
-    retained_estimated_document_bytes: &RetainedEstimatedDocumentBytes,
-    non_evictable_estimate_hard_bytes: usize,
+    memory_admission: DocumentMemoryAdmission<'_>,
 ) -> Response {
     let context = request.context.clone();
     let request_text_len = request.text.len();
@@ -3488,22 +3494,25 @@ fn sync_document_with_analysis(
         }
         *known_documents += 1;
     }
-    let reserved_growth =
-        match reserve_retained_growth(retained_document_bytes, replaced_bytes, request_text_len) {
-            Ok(reserved) => reserved,
-            Err(message) => {
-                if reserves_slot {
-                    let mut known_documents = document_capacity
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    *known_documents = known_documents.saturating_sub(1);
-                }
-                return Response::Error(WorkerError {
-                    context: Some(context),
-                    message,
-                });
+    let reserved_growth = match reserve_retained_growth(
+        memory_admission.retained_text_bytes,
+        replaced_bytes,
+        request_text_len,
+    ) {
+        Ok(reserved) => reserved,
+        Err(message) => {
+            if reserves_slot {
+                let mut known_documents = document_capacity
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                *known_documents = known_documents.saturating_sub(1);
             }
-        };
+            return Response::Error(WorkerError {
+                context: Some(context),
+                message,
+            });
+        }
+    };
     let response = WORKER_THREAD_STATE.with(|state| {
         state
             .borrow_mut()
@@ -3512,10 +3521,10 @@ fn sync_document_with_analysis(
                     Ok((replica, ack)) => {
                         let estimated_bytes = replica.estimated_memory().non_evictable_bytes;
                         if let Err(message) = replace_retained_estimated_bytes(
-                            retained_estimated_document_bytes,
+                            memory_admission.retained_estimated_bytes,
                             replaced_estimated_bytes,
                             estimated_bytes,
-                            non_evictable_estimate_hard_bytes,
+                            memory_admission.non_evictable_estimate_hard_bytes,
                         ) {
                             return Response::Error(WorkerError {
                                 context: Some(context),
@@ -3540,11 +3549,19 @@ fn sync_document_with_analysis(
         *known_documents = known_documents.saturating_sub(1);
     }
     if matches!(&response, Response::DocumentAck(_)) && request_text_len < replaced_bytes {
-        replace_retained_bytes(retained_document_bytes, replaced_bytes, request_text_len)
-            .expect("committing a document shrink cannot exceed the retained-byte budget");
+        replace_retained_bytes(
+            memory_admission.retained_text_bytes,
+            replaced_bytes,
+            request_text_len,
+        )
+        .expect("committing a document shrink cannot exceed the retained-byte budget");
     } else if !matches!(&response, Response::DocumentAck(_)) && reserved_growth {
-        replace_retained_bytes(retained_document_bytes, request_text_len, replaced_bytes)
-            .expect("rolling back retained growth cannot exceed the retained-byte budget");
+        replace_retained_bytes(
+            memory_admission.retained_text_bytes,
+            request_text_len,
+            replaced_bytes,
+        )
+        .expect("rolling back retained growth cannot exceed the retained-byte budget");
     }
     response
 }
@@ -3552,9 +3569,7 @@ fn sync_document_with_analysis(
 fn apply_document_edits(
     request: ApplyDocumentEdits,
     documents: &DocumentStore,
-    retained_document_bytes: &RetainedDocumentBytes,
-    retained_estimated_document_bytes: &RetainedEstimatedDocumentBytes,
-    non_evictable_estimate_hard_bytes: usize,
+    memory_admission: DocumentMemoryAdmission<'_>,
 ) -> Response {
     let context = request.context.clone();
     let document_key = DocumentKey::from(&context);
@@ -3580,15 +3595,7 @@ fn apply_document_edits(
                 let Ok(mut replica) = replica.lock() else {
                     return poisoned_document_restart(context);
                 };
-                match replica.apply(
-                    request,
-                    parser,
-                    Some((
-                        retained_document_bytes,
-                        retained_estimated_document_bytes,
-                        non_evictable_estimate_hard_bytes,
-                    )),
-                ) {
+                match replica.apply(request, parser, Some(memory_admission)) {
                     Ok(ack) => Response::DocumentAck(ack),
                     Err(message) => Response::Error(WorkerError {
                         context: Some(context),
@@ -3602,9 +3609,7 @@ fn apply_document_edits(
 fn apply_document_edits_and_derive(
     request: ApplyDocumentEditsAndDerive,
     documents: &DocumentStore,
-    retained_document_bytes: &RetainedDocumentBytes,
-    retained_estimated_document_bytes: &RetainedEstimatedDocumentBytes,
-    non_evictable_estimate_hard_bytes: usize,
+    memory_admission: DocumentMemoryAdmission<'_>,
     queue_wait: Duration,
     started: Instant,
 ) -> Response {
@@ -3637,15 +3642,7 @@ fn apply_document_edits_and_derive(
                     base_version: request.base_version,
                     edits: request.edits,
                 };
-                if let Err(message) = replica.apply(
-                    edits,
-                    parser,
-                    Some((
-                        retained_document_bytes,
-                        retained_estimated_document_bytes,
-                        non_evictable_estimate_hard_bytes,
-                    )),
-                ) {
+                if let Err(message) = replica.apply(edits, parser, Some(memory_admission)) {
                     return Response::Error(WorkerError {
                         context: Some(context),
                         message,
@@ -3702,9 +3699,7 @@ fn close_document(
     request: CloseDocument,
     documents: &DocumentStore,
     closed_documents: &ClosedDocuments,
-    retained_document_bytes: &RetainedDocumentBytes,
-    retained_estimated_document_bytes: &RetainedEstimatedDocumentBytes,
-    non_evictable_estimate_hard_bytes: usize,
+    memory_admission: DocumentMemoryAdmission<'_>,
 ) -> Response {
     let context = request.context;
     let document_key = DocumentKey::from(&context);
@@ -3733,13 +3728,13 @@ fn close_document(
         Err(_) => return poisoned_document_restart(context),
     };
     documents.remove(&document_key);
-    replace_retained_bytes(retained_document_bytes, removed_bytes, 0)
+    replace_retained_bytes(memory_admission.retained_text_bytes, removed_bytes, 0)
         .expect("removing a document cannot exceed the retained-byte budget");
     replace_retained_estimated_bytes(
-        retained_estimated_document_bytes,
+        memory_admission.retained_estimated_bytes,
         removed_estimated_bytes,
         0,
-        non_evictable_estimate_hard_bytes,
+        memory_admission.non_evictable_estimate_hard_bytes,
     )
     .expect("removing a document cannot exceed the estimated non-evictable budget");
     closed_documents.insert(document_key, context.incarnation);
@@ -4927,12 +4922,12 @@ mod tests {
         ApplyDocumentEdits, BUILD_ID, ByteEdit, CacheEviction, CacheEvictionCandidate,
         CachedInjectionLayer, CancelRequest, CapturesResult, CloseDocument, DeriveInjectionRegions,
         DeriveNativeBindings, DeriveSelectionRanges, DeriveSemanticTokens, DeriveSnapshot,
-        DocumentCompetition, DocumentKey, DocumentLane, DocumentReplica, GrammarKey, Handshake,
-        HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
-        MAX_RETAINED_DOCUMENT_BYTES, MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES, NavigateNode,
-        NodeLayerSelector, NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId,
-        PROTOCOL_VERSION, Request, RequestCancelled, RequestContext, ResolveNode, Response, Route,
-        RunCaptures, RunNodeScalar, RunnableDocuments,
+        DocumentCompetition, DocumentKey, DocumentLane, DocumentMemoryAdmission, DocumentReplica,
+        GrammarKey, Handshake, HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES,
+        MAX_DOCUMENT_REPLICAS, MAX_RETAINED_DOCUMENT_BYTES, MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
+        NavigateNode, NodeLayerSelector, NodeNavigation, NodeScalarOperation, NodeScalarValue,
+        OpaqueNodeId, PROTOCOL_VERSION, Request, RequestCancelled, RequestContext, ResolveNode,
+        Response, Route, RunCaptures, RunNodeScalar, RunnableDocuments,
         SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES, SyncDocument, WireByteRange, WirePosition,
         WireRange, WireSemanticToken, WorkPriority, WorkerError, WorkerQuerySources,
         cache_eviction_plan, close_document, decode_frame, derive_snapshot_with_language,
@@ -7291,9 +7286,11 @@ mod tests {
             },
             &documents,
             &closed_documents,
-            &retained,
-            &retained_estimated,
-            MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
+            DocumentMemoryAdmission {
+                retained_text_bytes: retained.as_ref(),
+                retained_estimated_bytes: retained_estimated.as_ref(),
+                non_evictable_estimate_hard_bytes: MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
+            },
         );
         assert!(matches!(close_response, Response::WorkerRestartRequired(_)));
         assert!(documents.contains_key(&key));

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -22,7 +22,7 @@ use sha2::{Digest, Sha256};
 
 use crate::language::node_tracker::{EditInfo, NodeTracker};
 
-pub const PROTOCOL_VERSION: u32 = 15;
+pub const PROTOCOL_VERSION: u32 = 16;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_REPLICAS: usize = 4_096;
 pub const MAX_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
@@ -540,6 +540,21 @@ pub struct CloseDocument {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct InspectDocumentMemory {
+    pub context: RequestContext,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct DocumentMemoryStats {
+    pub context: RequestContext,
+    pub derived_cache_soft_bytes: usize,
+    pub non_evictable_estimate_hard_bytes: usize,
+    pub non_evictable_bytes: usize,
+    pub result_cache_bytes: usize,
+    pub auxiliary_cache_bytes: usize,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct DocumentAck {
     pub context: RequestContext,
     pub incremental: bool,
@@ -585,6 +600,7 @@ pub enum Request {
     RunCaptures(RunCaptures),
     DeriveNativeBindings(DeriveNativeBindings),
     ConfigureLanguages(ConfigureLanguages),
+    InspectDocumentMemory(InspectDocumentMemory),
     CloseDocument(CloseDocument),
 }
 
@@ -632,6 +648,7 @@ pub enum Response {
     Captures(CapturesResult),
     NativeBindings(NativeBindingsResult),
     LanguageCatalogAck(LanguageCatalogAck),
+    DocumentMemory(DocumentMemoryStats),
     Error(WorkerError),
 }
 
@@ -2867,6 +2884,7 @@ fn request_priority(request: &Request) -> WorkPriority {
         | Request::RunCaptures(_)
         | Request::DeriveNativeBindings(_)
         | Request::ConfigureLanguages(_)
+        | Request::InspectDocumentMemory(_)
         | Request::CloseDocument(_) => WorkPriority::Foreground,
     }
 }
@@ -2959,6 +2977,9 @@ fn handle_work(
         Request::RunCaptures(request) => run_captures(request, documents),
         Request::DeriveNativeBindings(request) => derive_native_bindings(request, documents),
         Request::ConfigureLanguages(request) => configure_languages(request, analysis),
+        Request::InspectDocumentMemory(request) => {
+            inspect_document_memory(request, documents, memory_budgets)
+        }
         Request::CloseDocument(request) => close_document(
             request,
             documents,
@@ -3022,6 +3043,7 @@ fn request_context(request: &Request) -> Option<&RequestContext> {
         Request::RunCaptures(request) => Some(&request.context),
         Request::DeriveNativeBindings(request) => Some(&request.context),
         Request::ConfigureLanguages(request) => Some(&request.context),
+        Request::InspectDocumentMemory(request) => Some(&request.context),
         Request::CloseDocument(request) => Some(&request.context),
     }
 }
@@ -3040,6 +3062,7 @@ fn document_key(request: &Request) -> Option<DocumentKey> {
         Request::DeriveSemanticTokens(request) => Some(DocumentKey::from(&request.context)),
         Request::RunCaptures(request) => Some(DocumentKey::from(&request.context)),
         Request::DeriveNativeBindings(request) => Some(DocumentKey::from(&request.context)),
+        Request::InspectDocumentMemory(request) => Some(DocumentKey::from(&request.context)),
         Request::CloseDocument(request) => Some(DocumentKey::from(&request.context)),
         Request::Handshake(_)
         | Request::Cancel(_)
@@ -3062,6 +3085,43 @@ fn is_cancellable_reader_request(request: &Request) -> bool {
             | Request::RunCaptures(_)
             | Request::DeriveNativeBindings(_)
     )
+}
+
+fn inspect_document_memory(
+    request: InspectDocumentMemory,
+    documents: &DocumentStore,
+    memory_budgets: WorkerMemoryBudgets,
+) -> Response {
+    let context = request.context;
+    let Some(replica) = documents
+        .get(&DocumentKey::from(&context))
+        .map(|entry| Arc::clone(entry.value()))
+    else {
+        return Response::Error(WorkerError {
+            context: Some(context),
+            message: "document replica is missing; full sync required".into(),
+        });
+    };
+    match replica.lock() {
+        Ok(replica) => {
+            if let Err(message) = replica.validate_read_identity(&context) {
+                return Response::Error(WorkerError {
+                    context: Some(context),
+                    message,
+                });
+            }
+            let estimated = replica.estimated_memory();
+            Response::DocumentMemory(DocumentMemoryStats {
+                context,
+                derived_cache_soft_bytes: memory_budgets.derived_cache_soft_bytes,
+                non_evictable_estimate_hard_bytes: memory_budgets.non_evictable_estimate_hard_bytes,
+                non_evictable_bytes: estimated.non_evictable_bytes,
+                result_cache_bytes: estimated.result_cache_bytes,
+                auxiliary_cache_bytes: estimated.auxiliary_cache_bytes,
+            })
+        }
+        Err(_) => poisoned_document_restart(context),
+    }
 }
 
 fn resolve_node(request: ResolveNode, documents: &DocumentStore) -> Response {
@@ -4559,6 +4619,13 @@ impl Client {
         self.request_with_timeout(Request::ConfigureLanguages(request), context, timeout)
     }
 
+    #[doc(hidden)]
+    pub fn inspect_document_memory(&self, request: InspectDocumentMemory) -> io::Result<Response> {
+        let context = request.context.clone();
+        let timeout = request_timeout(&context.uri);
+        self.request_with_timeout(Request::InspectDocumentMemory(request), context, timeout)
+    }
+
     pub fn close_document(&self, request: CloseDocument) -> io::Result<Response> {
         let context = request.context.clone();
         let timeout = request_timeout(&context.uri);
@@ -4724,6 +4791,7 @@ fn response_request_id(response: &Response) -> Option<u64> {
         Response::Captures(result) => Some(result.context.request_id),
         Response::NativeBindings(result) => Some(result.context.request_id),
         Response::LanguageCatalogAck(ack) => Some(ack.context.request_id),
+        Response::DocumentMemory(result) => Some(result.context.request_id),
         Response::Error(error) => error.context.as_ref().map(|context| context.request_id),
         Response::HandshakeReady(_) => None,
     }
@@ -4744,6 +4812,7 @@ fn response_context(response: &Response) -> Option<&RequestContext> {
         Response::Captures(result) => Some(&result.context),
         Response::NativeBindings(result) => Some(&result.context),
         Response::LanguageCatalogAck(ack) => Some(&ack.context),
+        Response::DocumentMemory(result) => Some(&result.context),
         Response::Error(error) => error.context.as_ref(),
         Response::HandshakeReady(_) => None,
     }

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4279,7 +4279,8 @@ impl Client {
         )
     }
 
-    fn spawn_with_memory_budgets(
+    #[doc(hidden)]
+    pub fn spawn_with_memory_budgets(
         executable: &std::path::Path,
         compute_threads: usize,
         worker_generation: u64,

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -7,6 +7,7 @@ use kakehashi::tree_worker::{
     DeriveNativeBindings, DeriveSemanticTokens, NavigateNode, NodeNavigation, NodeScalarOperation,
     NodeScalarValue, OpaqueNodeId, ResolveNode, RunCaptures, RunNodeScalar, SyncDocument,
     WireByteRange, WirePosition, WorkerLanguageAsset, WorkerLanguageCatalog, WorkerQuerySources,
+    WorkerTestMemoryBudgets,
 };
 use kakehashi::tree_worker::{Client, DeriveSnapshot, RequestContext, Response};
 
@@ -180,6 +181,57 @@ fn real_worker_derives_a_snapshot_from_an_installed_grammar() {
     };
     assert_eq!(snapshot.parser_cache_hit, Some(true));
     assert!(snapshot.compute_ns > 0);
+    worker.shutdown().unwrap();
+}
+
+#[cfg(feature = "e2e")]
+#[test]
+fn real_worker_contains_full_sync_above_injected_non_evictable_budget() {
+    let data_dir = kakehashi::install::test_support::test_data_dir_path();
+    std::fs::create_dir_all(&data_dir).unwrap();
+    kakehashi::install::test_support::ensure_test_languages_installed(&data_dir).unwrap();
+    let parser = data_dir
+        .join("parser")
+        .join(format!("rust.{}", std::env::consts::DLL_EXTENSION));
+    let executable = PathBuf::from(env!("CARGO_BIN_EXE_kakehashi"));
+    let worker = Client::spawn_with_test_memory_budgets(
+        &executable,
+        1,
+        45,
+        WorkerTestMemoryBudgets::new(1024, 1).unwrap(),
+    )
+    .unwrap();
+    let context = RequestContext {
+        request_id: 1,
+        worker_generation: 45,
+        uri: "file:///hard-budget.rs".into(),
+        incarnation: 1,
+        content_version: 1,
+        configuration_generation: 0,
+    };
+
+    let response = worker
+        .sync_document(SyncDocument {
+            context,
+            language: "rust".into(),
+            grammar_symbol: "rust".into(),
+            source_path: parser.clone(),
+            parser_path: parser.clone(),
+            artifact_digest: digest(&parser),
+            queries: WorkerQuerySources::default(),
+            text: "fn main() {}".into(),
+        })
+        .unwrap();
+
+    let Response::Error(error) = response else {
+        panic!("hard admission must be a contained worker error: {response:?}");
+    };
+    assert!(
+        error
+            .message
+            .contains("non-evictable budget 1 bytes exceeded")
+    );
+    assert_eq!(worker.worker_generation(), 45);
     worker.shutdown().unwrap();
 }
 

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -361,6 +361,134 @@ fn rejected_full_sync_preserves_replica_and_admission_capacity() {
 
 #[cfg(feature = "e2e")]
 #[test]
+fn rejected_incremental_edit_preserves_replica_and_admission_capacity() {
+    let data_dir = kakehashi::install::test_support::test_data_dir_path();
+    std::fs::create_dir_all(&data_dir).unwrap();
+    kakehashi::install::test_support::ensure_test_languages_installed(&data_dir).unwrap();
+    let parser = data_dir
+        .join("parser")
+        .join(format!("rust.{}", std::env::consts::DLL_EXTENSION));
+    let executable = PathBuf::from(env!("CARGO_BIN_EXE_kakehashi"));
+    let worker = Client::spawn_with_test_memory_budgets(
+        &executable,
+        1,
+        47,
+        WorkerTestMemoryBudgets::new(1024, 1024).unwrap(),
+    )
+    .unwrap();
+    let original = "fn main() {}";
+    let context = RequestContext {
+        request_id: 1,
+        worker_generation: 47,
+        uri: "file:///incremental-transaction.rs".into(),
+        incarnation: 1,
+        content_version: 1,
+        configuration_generation: 0,
+    };
+    let response = worker
+        .sync_document(SyncDocument {
+            context: context.clone(),
+            language: "rust".into(),
+            grammar_symbol: "rust".into(),
+            source_path: parser.clone(),
+            parser_path: parser.clone(),
+            artifact_digest: digest(&parser),
+            queries: WorkerQuerySources::default(),
+            text: original.into(),
+        })
+        .unwrap();
+    assert!(matches!(response, Response::DocumentAck(_)));
+    let response = worker
+        .resolve_node(ResolveNode {
+            context: RequestContext {
+                request_id: 11,
+                ..context.clone()
+            },
+            byte_offset: 3,
+            named: true,
+            layer: kakehashi::tree_worker::NodeLayerSelector::Host,
+        })
+        .unwrap();
+    let Response::Nodes(nodes) = response else {
+        panic!("original node identity must be minted: {response:?}");
+    };
+    let original_node = nodes.nodes[0].id.clone();
+
+    let oversized = (0..200)
+        .map(|index| format!("let value_{index} = {index};"))
+        .collect::<String>();
+    let rejected = worker
+        .apply_document_edits(ApplyDocumentEdits {
+            context: RequestContext {
+                request_id: 2,
+                content_version: 2,
+                ..context.clone()
+            },
+            base_version: 1,
+            edits: vec![ByteEdit {
+                start_byte: original.len() - 1,
+                old_end_byte: original.len() - 1,
+                new_text: oversized,
+            }],
+        })
+        .unwrap();
+    let Response::Error(error) = rejected else {
+        panic!("oversized incremental edit must be contained: {rejected:?}");
+    };
+    assert!(
+        error
+            .message
+            .contains("non-evictable budget 1024 bytes exceeded")
+    );
+
+    let response = worker
+        .derive_document_snapshot(DeriveDocumentSnapshot {
+            context: RequestContext {
+                request_id: 3,
+                ..context.clone()
+            },
+        })
+        .unwrap();
+    let Response::Snapshot(snapshot) = response else {
+        panic!("rejected edit must preserve version 1: {response:?}");
+    };
+    assert_eq!(snapshot.root_end_byte, original.len());
+    let response = worker
+        .run_node_scalar(RunNodeScalar {
+            context: RequestContext {
+                request_id: 31,
+                ..context.clone()
+            },
+            node_id: original_node,
+            operation: NodeScalarOperation::Text,
+        })
+        .unwrap();
+    let Response::NodeScalar(node) = response else {
+        panic!("rejected edit must preserve node identity: {response:?}");
+    };
+    assert_eq!(node.value, Some(NodeScalarValue::String("main".into())));
+
+    let response = worker
+        .apply_document_edits(ApplyDocumentEdits {
+            context: RequestContext {
+                request_id: 4,
+                content_version: 2,
+                ..context
+            },
+            base_version: 1,
+            edits: vec![ByteEdit {
+                start_byte: 3,
+                old_end_byte: 7,
+                new_text: "next".into(),
+            }],
+        })
+        .unwrap();
+    assert!(matches!(response, Response::DocumentAck(_)));
+    worker.shutdown().unwrap();
+}
+
+#[cfg(feature = "e2e")]
+#[test]
 fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
     let data_dir = kakehashi::install::test_support::test_data_dir_path();
     std::fs::create_dir_all(&data_dir).unwrap();

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -237,6 +237,130 @@ fn real_worker_contains_full_sync_above_injected_non_evictable_budget() {
 
 #[cfg(feature = "e2e")]
 #[test]
+fn rejected_full_sync_preserves_replica_and_admission_capacity() {
+    let data_dir = kakehashi::install::test_support::test_data_dir_path();
+    std::fs::create_dir_all(&data_dir).unwrap();
+    kakehashi::install::test_support::ensure_test_languages_installed(&data_dir).unwrap();
+    let parser = data_dir
+        .join("parser")
+        .join(format!("rust.{}", std::env::consts::DLL_EXTENSION));
+    let executable = PathBuf::from(env!("CARGO_BIN_EXE_kakehashi"));
+    let worker = Client::spawn_with_test_memory_budgets(
+        &executable,
+        1,
+        46,
+        WorkerTestMemoryBudgets::new(1024, 1024).unwrap(),
+    )
+    .unwrap();
+    let original = "fn main() {}";
+    let context = RequestContext {
+        request_id: 1,
+        worker_generation: 46,
+        uri: "file:///full-sync-transaction.rs".into(),
+        incarnation: 1,
+        content_version: 1,
+        configuration_generation: 0,
+    };
+    let sync = |context: RequestContext, text: String| SyncDocument {
+        context,
+        language: "rust".into(),
+        grammar_symbol: "rust".into(),
+        source_path: parser.clone(),
+        parser_path: parser.clone(),
+        artifact_digest: digest(&parser),
+        queries: WorkerQuerySources::default(),
+        text,
+    };
+
+    assert!(matches!(
+        worker
+            .sync_document(sync(context.clone(), original.into()))
+            .unwrap(),
+        Response::DocumentAck(_)
+    ));
+    let response = worker
+        .resolve_node(ResolveNode {
+            context: RequestContext {
+                request_id: 11,
+                ..context.clone()
+            },
+            byte_offset: 3,
+            named: true,
+            layer: kakehashi::tree_worker::NodeLayerSelector::Host,
+        })
+        .unwrap();
+    let Response::Nodes(nodes) = response else {
+        panic!("original node identity must be minted: {response:?}");
+    };
+    let original_node = nodes.nodes[0].id.clone();
+
+    let oversized = format!(
+        "fn main() {{ {} }}",
+        (0..200)
+            .map(|index| format!("let value_{index} = {index};"))
+            .collect::<String>()
+    );
+    let rejected_context = RequestContext {
+        request_id: 2,
+        content_version: 2,
+        ..context.clone()
+    };
+    let rejected = worker
+        .sync_document(sync(rejected_context, oversized))
+        .unwrap();
+    let Response::Error(error) = rejected else {
+        panic!("oversized replacement must be contained: {rejected:?}");
+    };
+    assert!(
+        error
+            .message
+            .contains("non-evictable budget 1024 bytes exceeded")
+    );
+
+    let response = worker
+        .derive_document_snapshot(DeriveDocumentSnapshot {
+            context: RequestContext {
+                request_id: 3,
+                ..context.clone()
+            },
+        })
+        .unwrap();
+    let Response::Snapshot(snapshot) = response else {
+        panic!("rejected replacement must preserve version 1: {response:?}");
+    };
+    assert_eq!(snapshot.root_end_byte, original.len());
+    let response = worker
+        .run_node_scalar(RunNodeScalar {
+            context: RequestContext {
+                request_id: 31,
+                ..context.clone()
+            },
+            node_id: original_node,
+            operation: NodeScalarOperation::Text,
+        })
+        .unwrap();
+    let Response::NodeScalar(node) = response else {
+        panic!("rejected replacement must preserve node identity: {response:?}");
+    };
+    assert_eq!(node.value, Some(NodeScalarValue::String("main".into())));
+
+    let replacement = "fn next() {}";
+    let response = worker
+        .sync_document(sync(
+            RequestContext {
+                request_id: 4,
+                content_version: 2,
+                ..context
+            },
+            replacement.into(),
+        ))
+        .unwrap();
+    assert!(matches!(response, Response::DocumentAck(_)));
+    worker.shutdown().unwrap();
+}
+
+#[cfg(feature = "e2e")]
+#[test]
 fn real_worker_keeps_document_text_and_tree_across_incremental_edits() {
     let data_dir = kakehashi::install::test_support::test_data_dir_path();
     std::fs::create_dir_all(&data_dir).unwrap();

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -4,10 +4,10 @@ use std::sync::{Arc, Barrier};
 #[cfg(feature = "e2e")]
 use kakehashi::tree_worker::{
     ApplyDocumentEdits, ByteEdit, CloseDocument, ConfigureLanguages, DeriveDocumentSnapshot,
-    DeriveNativeBindings, DeriveSemanticTokens, NavigateNode, NodeNavigation, NodeScalarOperation,
-    NodeScalarValue, OpaqueNodeId, ResolveNode, RunCaptures, RunNodeScalar, SyncDocument,
-    WireByteRange, WirePosition, WorkerLanguageAsset, WorkerLanguageCatalog, WorkerQuerySources,
-    WorkerTestMemoryBudgets,
+    DeriveNativeBindings, DeriveSemanticTokens, InspectDocumentMemory, NavigateNode,
+    NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId, ResolveNode, RunCaptures,
+    RunNodeScalar, SyncDocument, WireByteRange, WirePosition, WorkerLanguageAsset,
+    WorkerLanguageCatalog, WorkerQuerySources, WorkerTestMemoryBudgets,
 };
 use kakehashi::tree_worker::{Client, DeriveSnapshot, RequestContext, Response};
 
@@ -484,6 +484,160 @@ fn rejected_incremental_edit_preserves_replica_and_admission_capacity() {
         })
         .unwrap();
     assert!(matches!(response, Response::DocumentAck(_)));
+    worker.shutdown().unwrap();
+}
+
+#[cfg(feature = "e2e")]
+#[test]
+fn soft_budget_evicts_non_current_result_without_invalidating_identity() {
+    let data_dir = kakehashi::install::test_support::test_data_dir_path();
+    std::fs::create_dir_all(&data_dir).unwrap();
+    kakehashi::install::test_support::ensure_test_languages_installed(&data_dir).unwrap();
+    let parser = data_dir
+        .join("parser")
+        .join(format!("rust.{}", std::env::consts::DLL_EXTENSION));
+    let executable = PathBuf::from(env!("CARGO_BIN_EXE_kakehashi"));
+    let worker = Client::spawn_with_test_memory_budgets(
+        &executable,
+        1,
+        48,
+        WorkerTestMemoryBudgets::new(20, 4096).unwrap(),
+    )
+    .unwrap();
+    let catalog_context = RequestContext {
+        request_id: 1,
+        worker_generation: 48,
+        uri: "kakehashi://memory-stress-catalog".into(),
+        incarnation: 0,
+        content_version: 0,
+        configuration_generation: 0,
+    };
+    let response = worker
+        .configure_languages(ConfigureLanguages {
+            context: catalog_context,
+            catalog: WorkerLanguageCatalog {
+                assets: vec![WorkerLanguageAsset {
+                    language: "rust".into(),
+                    grammar_symbol: "rust".into(),
+                    source_path: parser.clone(),
+                    parser_path: parser.clone(),
+                    artifact_digest: digest(&parser),
+                    queries: WorkerQuerySources::default(),
+                }],
+                capture_mappings: serde_json::from_value(serde_json::json!({
+                    "rust": { "highlights": { "variable": "keyword" } }
+                }))
+                .unwrap(),
+                search_paths: Vec::new(),
+            },
+        })
+        .unwrap();
+    assert!(matches!(response, Response::LanguageCatalogAck(_)));
+
+    let context = |request_id, uri: &str| RequestContext {
+        request_id,
+        worker_generation: 48,
+        uri: uri.into(),
+        incarnation: 1,
+        content_version: 1,
+        configuration_generation: 0,
+    };
+    let a = context(2, "file:///soft-a.rs");
+    let b = context(3, "file:///soft-b.rs");
+    for document in [&a, &b] {
+        let response = worker
+            .sync_document(SyncDocument {
+                context: document.clone(),
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: parser.clone(),
+                parser_path: parser.clone(),
+                artifact_digest: digest(&parser),
+                queries: WorkerQuerySources {
+                    highlights: Some("(identifier) @variable".into()),
+                    ..Default::default()
+                },
+                text: "fn main() {}".into(),
+            })
+            .unwrap();
+        assert!(matches!(response, Response::DocumentAck(_)));
+    }
+    let response = worker
+        .resolve_node(ResolveNode {
+            context: RequestContext {
+                request_id: 4,
+                ..a.clone()
+            },
+            byte_offset: 3,
+            named: true,
+            layer: kakehashi::tree_worker::NodeLayerSelector::Host,
+        })
+        .unwrap();
+    let Response::Nodes(nodes) = response else {
+        panic!("document A node identity must be minted: {response:?}");
+    };
+    let a_node = nodes.nodes[0].id.clone();
+
+    let derive = |request_id, context: &RequestContext| {
+        worker
+            .derive_semantic_tokens(DeriveSemanticTokens {
+                context: RequestContext {
+                    request_id,
+                    ..context.clone()
+                },
+                supports_multiline: false,
+            })
+            .unwrap()
+    };
+    let Response::SemanticTokens(a_first) = derive(5, &a) else {
+        panic!("document A semantic derivation must succeed");
+    };
+    assert!(!a_first.cache_hit);
+    let Response::SemanticTokens(b_first) = derive(6, &b) else {
+        panic!("document B semantic derivation must succeed");
+    };
+    assert!(!b_first.cache_hit);
+
+    let inspect = |request_id, context: &RequestContext| {
+        worker
+            .inspect_document_memory(InspectDocumentMemory {
+                context: RequestContext {
+                    request_id,
+                    ..context.clone()
+                },
+            })
+            .unwrap()
+    };
+    let Response::DocumentMemory(a_memory) = inspect(7, &a) else {
+        panic!("document A memory must be inspectable");
+    };
+    let Response::DocumentMemory(b_memory) = inspect(8, &b) else {
+        panic!("document B memory must be inspectable");
+    };
+    assert_eq!(a_memory.result_cache_bytes, 0);
+    assert_eq!(a_memory.auxiliary_cache_bytes, 0);
+    assert_eq!(b_memory.result_cache_bytes, 20);
+    assert_eq!(b_memory.auxiliary_cache_bytes, 0);
+
+    let Response::SemanticTokens(a_recomputed) = derive(9, &a) else {
+        panic!("evicted document A must recompute");
+    };
+    assert!(!a_recomputed.cache_hit);
+    assert_eq!(a_recomputed.tokens, a_first.tokens);
+    let response = worker
+        .run_node_scalar(RunNodeScalar {
+            context: RequestContext {
+                request_id: 10,
+                ..a
+            },
+            node_id: a_node,
+            operation: NodeScalarOperation::Text,
+        })
+        .unwrap();
+    let Response::NodeScalar(node) = response else {
+        panic!("cache eviction must preserve node identity: {response:?}");
+    };
+    assert_eq!(node.value, Some(NodeScalarValue::String("main".into())));
     worker.shutdown().unwrap();
 }
 

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -634,6 +634,9 @@ fn soft_budget_evicts_non_current_result_without_invalidating_identity() {
     assert_eq!(a_memory.auxiliary_cache_bytes, 0);
     assert_eq!(b_memory.result_cache_bytes, 20);
     assert_eq!(b_memory.auxiliary_cache_bytes, 0);
+    assert_eq!(b_memory.derived_cache_soft_bytes, 20);
+    assert_eq!(b_memory.non_evictable_estimate_hard_bytes, 4096);
+    assert!(b_memory.non_evictable_bytes > 0);
 
     let Response::SemanticTokens(a_recomputed) = derive(9, &a) else {
         panic!("evicted document A must recompute");

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -248,6 +248,50 @@ fn real_worker_contains_full_sync_above_injected_non_evictable_budget() {
 
 #[cfg(feature = "e2e")]
 #[test]
+fn concurrent_workers_keep_injected_memory_budgets_isolated() {
+    let run = |worker_generation, hard_limit| {
+        let (worker, parser) = memory_test_worker(worker_generation, 1024, hard_limit);
+        let response = worker
+            .sync_document(SyncDocument {
+                context: RequestContext {
+                    request_id: 1,
+                    worker_generation,
+                    uri: format!("file:///isolated-{worker_generation}.rs"),
+                    incarnation: 1,
+                    content_version: 1,
+                    configuration_generation: 0,
+                },
+                language: "rust".into(),
+                grammar_symbol: "rust".into(),
+                source_path: parser.clone(),
+                parser_path: parser.clone(),
+                artifact_digest: digest(&parser),
+                queries: WorkerQuerySources::default(),
+                text: "fn main() {}".into(),
+            })
+            .unwrap();
+        worker.shutdown().unwrap();
+        response
+    };
+    let (restricted, admitted) = std::thread::scope(|scope| {
+        let restricted = scope.spawn(|| run(49, 1));
+        let admitted = scope.spawn(|| run(50, 4096));
+        (restricted.join().unwrap(), admitted.join().unwrap())
+    });
+
+    let Response::Error(error) = restricted else {
+        panic!("restricted worker must reject independently: {restricted:?}");
+    };
+    assert!(
+        error
+            .message
+            .contains("non-evictable budget 1 bytes exceeded")
+    );
+    assert!(matches!(admitted, Response::DocumentAck(_)));
+}
+
+#[cfg(feature = "e2e")]
+#[test]
 fn rejected_full_sync_preserves_replica_and_admission_capacity() {
     let (worker, parser) = memory_test_worker(46, 1024, 1024);
     let original = "fn main() {}";

--- a/tests/tree_worker_process.rs
+++ b/tests/tree_worker_process.rs
@@ -16,6 +16,30 @@ fn digest(path: &std::path::Path) -> String {
     kakehashi::tree_worker::artifact_digest(path).unwrap()
 }
 
+#[cfg(feature = "e2e")]
+fn memory_test_worker(
+    worker_generation: u64,
+    derived_cache_soft_bytes: usize,
+    non_evictable_estimate_hard_bytes: usize,
+) -> (Client, PathBuf) {
+    let data_dir = kakehashi::install::test_support::test_data_dir_path();
+    std::fs::create_dir_all(&data_dir).unwrap();
+    kakehashi::install::test_support::ensure_test_languages_installed(&data_dir).unwrap();
+    let parser = data_dir
+        .join("parser")
+        .join(format!("rust.{}", std::env::consts::DLL_EXTENSION));
+    let executable = PathBuf::from(env!("CARGO_BIN_EXE_kakehashi"));
+    let worker = Client::spawn_with_test_memory_budgets(
+        &executable,
+        1,
+        worker_generation,
+        WorkerTestMemoryBudgets::new(derived_cache_soft_bytes, non_evictable_estimate_hard_bytes)
+            .unwrap(),
+    )
+    .unwrap();
+    (worker, parser)
+}
+
 #[test]
 fn real_worker_handshakes_and_contains_request_errors() {
     let executable = PathBuf::from(env!("CARGO_BIN_EXE_kakehashi"));
@@ -187,20 +211,7 @@ fn real_worker_derives_a_snapshot_from_an_installed_grammar() {
 #[cfg(feature = "e2e")]
 #[test]
 fn real_worker_contains_full_sync_above_injected_non_evictable_budget() {
-    let data_dir = kakehashi::install::test_support::test_data_dir_path();
-    std::fs::create_dir_all(&data_dir).unwrap();
-    kakehashi::install::test_support::ensure_test_languages_installed(&data_dir).unwrap();
-    let parser = data_dir
-        .join("parser")
-        .join(format!("rust.{}", std::env::consts::DLL_EXTENSION));
-    let executable = PathBuf::from(env!("CARGO_BIN_EXE_kakehashi"));
-    let worker = Client::spawn_with_test_memory_budgets(
-        &executable,
-        1,
-        45,
-        WorkerTestMemoryBudgets::new(1024, 1).unwrap(),
-    )
-    .unwrap();
+    let (worker, parser) = memory_test_worker(45, 1024, 1);
     let context = RequestContext {
         request_id: 1,
         worker_generation: 45,
@@ -238,20 +249,7 @@ fn real_worker_contains_full_sync_above_injected_non_evictable_budget() {
 #[cfg(feature = "e2e")]
 #[test]
 fn rejected_full_sync_preserves_replica_and_admission_capacity() {
-    let data_dir = kakehashi::install::test_support::test_data_dir_path();
-    std::fs::create_dir_all(&data_dir).unwrap();
-    kakehashi::install::test_support::ensure_test_languages_installed(&data_dir).unwrap();
-    let parser = data_dir
-        .join("parser")
-        .join(format!("rust.{}", std::env::consts::DLL_EXTENSION));
-    let executable = PathBuf::from(env!("CARGO_BIN_EXE_kakehashi"));
-    let worker = Client::spawn_with_test_memory_budgets(
-        &executable,
-        1,
-        46,
-        WorkerTestMemoryBudgets::new(1024, 1024).unwrap(),
-    )
-    .unwrap();
+    let (worker, parser) = memory_test_worker(46, 1024, 1024);
     let original = "fn main() {}";
     let context = RequestContext {
         request_id: 1,
@@ -362,20 +360,7 @@ fn rejected_full_sync_preserves_replica_and_admission_capacity() {
 #[cfg(feature = "e2e")]
 #[test]
 fn rejected_incremental_edit_preserves_replica_and_admission_capacity() {
-    let data_dir = kakehashi::install::test_support::test_data_dir_path();
-    std::fs::create_dir_all(&data_dir).unwrap();
-    kakehashi::install::test_support::ensure_test_languages_installed(&data_dir).unwrap();
-    let parser = data_dir
-        .join("parser")
-        .join(format!("rust.{}", std::env::consts::DLL_EXTENSION));
-    let executable = PathBuf::from(env!("CARGO_BIN_EXE_kakehashi"));
-    let worker = Client::spawn_with_test_memory_budgets(
-        &executable,
-        1,
-        47,
-        WorkerTestMemoryBudgets::new(1024, 1024).unwrap(),
-    )
-    .unwrap();
+    let (worker, parser) = memory_test_worker(47, 1024, 1024);
     let original = "fn main() {}";
     let context = RequestContext {
         request_id: 1,
@@ -490,20 +475,7 @@ fn rejected_incremental_edit_preserves_replica_and_admission_capacity() {
 #[cfg(feature = "e2e")]
 #[test]
 fn soft_budget_evicts_non_current_result_without_invalidating_identity() {
-    let data_dir = kakehashi::install::test_support::test_data_dir_path();
-    std::fs::create_dir_all(&data_dir).unwrap();
-    kakehashi::install::test_support::ensure_test_languages_installed(&data_dir).unwrap();
-    let parser = data_dir
-        .join("parser")
-        .join(format!("rust.{}", std::env::consts::DLL_EXTENSION));
-    let executable = PathBuf::from(env!("CARGO_BIN_EXE_kakehashi"));
-    let worker = Client::spawn_with_test_memory_budgets(
-        &executable,
-        1,
-        48,
-        WorkerTestMemoryBudgets::new(20, 4096).unwrap(),
-    )
-    .unwrap();
+    let (worker, parser) = memory_test_worker(48, 20, 4096);
     let catalog_context = RequestContext {
         request_id: 1,
         worker_generation: 48,


### PR DESCRIPTION
## Summary

- inject immutable, child-specific derived-cache and non-evictable memory budgets into the resident worker while preserving the 128 MiB / 512 MiB defaults
- expose stateless internal document-memory inspection and process tests for soft eviction, full-sync and incremental rollback, recovery, and worker isolation
- add a normal-release boundary stress driver and collectors, then record reduced-budget and unchanged-default A/B evidence in the ADR

## Why

Stage 17 established deterministic accounting and admission, but its production-sized defaults made the pressure boundary impractical to exercise end to end. This stage makes both limits testable at the real parent/worker process boundary without ambient environment overrides or allocating hundreds of MiB.

## Measurement

Six reduced-budget release runs all observed:

- eviction of the older derived result while preserving resident tree/node identity
- byte-identical recomputation
- transactional rejection of oversized full sync and incremental edit
- a successful smaller recovery edit in the same worker generation

With unchanged defaults, 12 order-reversed cache-hit runs showed no material latency change (p50 -0.5%, p95 -0.4%, wall/cycle -1.1%). Three-document memory medians were 12.44–16.80 MiB higher, but paired ranges crossed zero and were much wider than the median differences, so the result is recorded as noisy rather than a repeatable regression.

This validates the admission policy, not a total process-RSS cap.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --lib` (3,146 passed, 2 ignored)
- `cargo test --features e2e --test tree_worker_process` (9 passed)
- `cargo test --features e2e --test e2e_tree_worker_shadow` (37 passed)
- profile Python tests (120 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`

## Stack

Depends on #880.
