### PR TITLE
feat(worker): converge systemic failures with a breaker

### DIFF
--- a/benches/profile/results/single_worker_stage19_breaker_2026-07-20.json
+++ b/benches/profile/results/single_worker_stage19_breaker_2026-07-20.json
@@ -1,0 +1,81 @@
+{
+  "schema": 1,
+  "experiment": "single-tree-worker-stage19-systemic-breaker",
+  "date": "2026-07-20",
+  "environment": {
+    "source_commit": "f03392f45eb74c0530cb6298c99657e144cc9115",
+    "baseline_stage": 18,
+    "baseline_binary_sha256": "ce06bbfd7bce95d7b0867142008e5a381a16d3ef26b6d0064c230d288b75dfc4",
+    "candidate_stage": 19,
+    "candidate_binary_sha256": "72dda444029ebdb9122e71401e36b960dca67b3165ebf5c3649480d5c2e35468",
+    "release_build": "cargo build --locked --release --bin kakehashi",
+    "features": "default"
+  },
+  "cache_hit": {
+    "scenario": {
+      "language": "markdown",
+      "generated_size": 5000,
+      "documents": 1,
+      "measured_requests": 20,
+      "warm_semantic_cache": true,
+      "settle_seconds": 0.5,
+      "worker_threads": 4,
+      "order": "baseline-candidate on odd runs; candidate-baseline on even runs"
+    },
+    "runs": [
+      {"run": 1, "baseline": {"p50_ms": 73.8, "p95_ms": 76.0, "wall_ms_per_cycle": 115.64}, "candidate": {"p50_ms": 73.9, "p95_ms": 79.8, "wall_ms_per_cycle": 116.87}},
+      {"run": 2, "baseline": {"p50_ms": 72.5, "p95_ms": 78.1, "wall_ms_per_cycle": 112.92}, "candidate": {"p50_ms": 72.3, "p95_ms": 79.0, "wall_ms_per_cycle": 115.86}},
+      {"run": 3, "baseline": {"p50_ms": 73.4, "p95_ms": 78.7, "wall_ms_per_cycle": 114.93}, "candidate": {"p50_ms": 73.7, "p95_ms": 77.3, "wall_ms_per_cycle": 114.85}},
+      {"run": 4, "baseline": {"p50_ms": 72.2, "p95_ms": 73.6, "wall_ms_per_cycle": 110.59}, "candidate": {"p50_ms": 72.1, "p95_ms": 75.2, "wall_ms_per_cycle": 112.73}},
+      {"run": 5, "baseline": {"p50_ms": 71.8, "p95_ms": 75.8, "wall_ms_per_cycle": 111.39}, "candidate": {"p50_ms": 73.1, "p95_ms": 77.3, "wall_ms_per_cycle": 114.12}},
+      {"run": 6, "baseline": {"p50_ms": 72.2, "p95_ms": 86.5, "wall_ms_per_cycle": 116.82}, "candidate": {"p50_ms": 72.7, "p95_ms": 75.5, "wall_ms_per_cycle": 112.70}},
+      {"run": 7, "baseline": {"p50_ms": 73.2, "p95_ms": 77.3, "wall_ms_per_cycle": 112.42}, "candidate": {"p50_ms": 72.1, "p95_ms": 75.3, "wall_ms_per_cycle": 114.33}},
+      {"run": 8, "baseline": {"p50_ms": 74.8, "p95_ms": 78.2, "wall_ms_per_cycle": 118.98}, "candidate": {"p50_ms": 74.8, "p95_ms": 88.1, "wall_ms_per_cycle": 119.33}},
+      {"run": 9, "baseline": {"p50_ms": 71.6, "p95_ms": 96.4, "wall_ms_per_cycle": 115.48}, "candidate": {"p50_ms": 76.7, "p95_ms": 81.3, "wall_ms_per_cycle": 121.49}},
+      {"run": 10, "baseline": {"p50_ms": 71.5, "p95_ms": 74.1, "wall_ms_per_cycle": 111.95}, "candidate": {"p50_ms": 72.1, "p95_ms": 74.7, "wall_ms_per_cycle": 110.56}},
+      {"run": 11, "baseline": {"p50_ms": 72.9, "p95_ms": 75.3, "wall_ms_per_cycle": 113.09}, "candidate": {"p50_ms": 71.4, "p95_ms": 75.6, "wall_ms_per_cycle": 111.38}},
+      {"run": 12, "baseline": {"p50_ms": 72.4, "p95_ms": 75.1, "wall_ms_per_cycle": 111.78}, "candidate": {"p50_ms": 74.8, "p95_ms": 95.3, "wall_ms_per_cycle": 120.39}}
+    ]
+  },
+  "cold_start": {
+    "scenario": {
+      "language": "rust",
+      "generated_size": 15,
+      "documents": 1,
+      "measured_requests": 1,
+      "settle_seconds": 0,
+      "worker_threads": 4,
+      "isolation": "fresh XDG config and state directory for every run",
+      "order": "baseline-candidate on odd runs; candidate-baseline on even runs"
+    },
+    "runs": [
+      {"run": 1, "baseline": {"elapsed_ms": 2330.833, "request_ms": 1819.5, "wall_ms_per_cycle": 1820.01}, "candidate": {"elapsed_ms": 2373.443, "request_ms": 2052.7, "wall_ms_per_cycle": 2053.15}},
+      {"run": 2, "baseline": {"elapsed_ms": 2142.772, "request_ms": 1834.2, "wall_ms_per_cycle": 1834.70}, "candidate": {"elapsed_ms": 2334.161, "request_ms": 2028.7, "wall_ms_per_cycle": 2029.13}},
+      {"run": 3, "baseline": {"elapsed_ms": 2195.586, "request_ms": 1904.6, "wall_ms_per_cycle": 1905.05}, "candidate": {"elapsed_ms": 2223.188, "request_ms": 1922.9, "wall_ms_per_cycle": 1923.34}},
+      {"run": 4, "baseline": {"elapsed_ms": 2159.006, "request_ms": 1847.2, "wall_ms_per_cycle": 1847.69}, "candidate": {"elapsed_ms": 2250.144, "request_ms": 1936.7, "wall_ms_per_cycle": 1937.15}},
+      {"run": 5, "baseline": {"elapsed_ms": 2205.964, "request_ms": 1892.7, "wall_ms_per_cycle": 1893.14}, "candidate": {"elapsed_ms": 2229.558, "request_ms": 1930.6, "wall_ms_per_cycle": 1931.04}},
+      {"run": 6, "baseline": {"elapsed_ms": 2221.514, "request_ms": 1913.7, "wall_ms_per_cycle": 1914.19}, "candidate": {"elapsed_ms": 2174.503, "request_ms": 1872.8, "wall_ms_per_cycle": 1873.33}},
+      {"run": 7, "baseline": {"elapsed_ms": 2196.746, "request_ms": 1888.2, "wall_ms_per_cycle": 1888.68}, "candidate": {"elapsed_ms": 2295.373, "request_ms": 1995.4, "wall_ms_per_cycle": 1995.87}},
+      {"run": 8, "baseline": {"elapsed_ms": 2324.842, "request_ms": 2021.7, "wall_ms_per_cycle": 2022.21}, "candidate": {"elapsed_ms": 2200.254, "request_ms": 1894.2, "wall_ms_per_cycle": 1894.68}},
+      {"run": 9, "baseline": {"elapsed_ms": 2305.127, "request_ms": 2002.6, "wall_ms_per_cycle": 2003.10}, "candidate": {"elapsed_ms": 2317.742, "request_ms": 2002.9, "wall_ms_per_cycle": 2003.36}},
+      {"run": 10, "baseline": {"elapsed_ms": 2332.483, "request_ms": 2019.9, "wall_ms_per_cycle": 2020.40}, "candidate": {"elapsed_ms": 2280.736, "request_ms": 1968.9, "wall_ms_per_cycle": 1969.37}},
+      {"run": 11, "baseline": {"elapsed_ms": 2262.957, "request_ms": 1958.0, "wall_ms_per_cycle": 1958.51}, "candidate": {"elapsed_ms": 2271.339, "request_ms": 1964.9, "wall_ms_per_cycle": 1965.43}},
+      {"run": 12, "baseline": {"elapsed_ms": 2322.185, "request_ms": 2022.1, "wall_ms_per_cycle": 2022.81}, "candidate": {"elapsed_ms": 2298.531, "request_ms": 1989.0, "wall_ms_per_cycle": 1989.51}}
+    ]
+  },
+  "failure_e2e": {
+    "build": "debug integration-test binary with e2e feature",
+    "note": "elapsed time covers complete LSP test setup, breaker transitions, assertions, and shutdown; it is not a fine-grained recovery latency",
+    "runs": [
+      {"case": "repeated_systemic_failures_open_the_breaker_once_and_keep_lsp_alive", "run": 1, "elapsed_ms": 21703.473, "passed": true},
+      {"case": "repeated_systemic_failures_open_the_breaker_once_and_keep_lsp_alive", "run": 2, "elapsed_ms": 21564.337, "passed": true},
+      {"case": "repeated_systemic_failures_open_the_breaker_once_and_keep_lsp_alive", "run": 3, "elapsed_ms": 21321.163, "passed": true},
+      {"case": "configuration_change_allows_one_failed_half_open_probe", "run": 1, "elapsed_ms": 23293.143, "passed": true},
+      {"case": "configuration_change_allows_one_failed_half_open_probe", "run": 2, "elapsed_ms": 23248.555, "passed": true},
+      {"case": "configuration_change_allows_one_failed_half_open_probe", "run": 3, "elapsed_ms": 23052.772, "passed": true},
+      {"case": "successful_half_open_resync_closes_the_breaker", "run": 1, "elapsed_ms": 23838.508, "passed": true},
+      {"case": "successful_half_open_resync_closes_the_breaker", "run": 2, "elapsed_ms": 23593.228, "passed": true},
+      {"case": "successful_half_open_resync_closes_the_breaker", "run": 3, "elapsed_ms": 23805.842, "passed": true}
+    ]
+  }
+}

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage19-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage19-measurement.md
@@ -1,0 +1,157 @@
+# Single Tree Worker Stage 19 Systemic-Breaker Measurement
+
+## Scope
+
+Stage 19 proves that repeated systemic worker failures converge to one degraded
+tree tier instead of creating an unbounded restart loop. It also proves both
+outcomes of the configuration-fenced half-open state: one failed probe returns
+immediately to the open state, while a healthy replacement full-resyncs every
+open document and closes the breaker only after its probation interval.
+
+The production policy remains three fast systemic generation failures (the
+initial failed generation plus at most two replacement restarts), eight fast
+native-evidenced restarts, sixteen long-horizon restart tokens, a 60-second fast
+healthy interval, a 10-minute long interval, and exponential backoff from 250
+milliseconds to five minutes. Stage 19 groups those immutable values into a
+supervisor policy. Only E2E builds can shorten the fast interval, and each test
+sets that override on its isolated LSP child process.
+
+This stage deliberately injects `WorkerRestartRequired`, which is unambiguously
+systemic. It does not treat the existing generic request timeout or `exit(86)`
+fixture as proof of an ADR-native failure. Native attribution requires the
+future parent-acknowledged grammar-hazard and `NativeSegmentEntered` control
+protocol.
+
+## Method
+
+### Failure convergence
+
+Three process E2E scenarios used the real LSP parent and resident worker:
+
+1. repeated systemic failure exhausted the three-failure fast budget, emitted
+   the terminal unavailable state once, ignored later document edits as respawn
+   pressure, avoided spawning a fourth generation, and kept parser-independent
+   `workspace/executeCommand` service and LSP shutdown available;
+2. after the open state and cooldown, one configuration-generation change
+   admitted one half-open worker, whose injected resync failure immediately
+   reopened the breaker; and
+3. a file-gated failure was removed after opening the breaker, allowing one
+   replacement to full-resync the open document, enter probation, close the
+   breaker, and serve semantic tokens again.
+
+Markers expose only completed state transitions, so the tests do not infer
+breaker state from fixed sleeps. Each scenario was run three times. The elapsed
+measure covers the complete debug E2E test, including LSP initialization,
+parser work, transitions, assertions, and shutdown; it is not a fine-grained
+recovery-latency benchmark.
+
+### Default release A/B
+
+The Stage 18 release binary and the Stage 19 default-feature release binary ran
+in authoritative mode with four worker compute threads. The source commit was
+`f03392f45eb74c0530cb6298c99657e144cc9115`. Baseline SHA-256 was
+`ce06bbfd7bce95d7b0867142008e5a381a16d3ef26b6d0064c230d288b75dfc4`;
+candidate SHA-256 was
+`72dda444029ebdb9122e71401e36b960dca67b3165ebf5c3649480d5c2e35468`.
+
+Twelve order-reversed cache-hit runs used one 5,000-injection Markdown document
+and twenty exact-version semantic requests after warmup. Twelve independent
+cold-start runs per binary used fresh config and state directories, one small
+Rust document, no settle delay, and one semantic request. Raw values are in
+`benches/profile/results/single_worker_stage19_breaker_2026-07-20.json`.
+
+## Result
+
+Every failure scenario passed in every repetition:
+
+| Scenario | Passed | Median full-test elapsed | Range |
+| --- | ---: | ---: | ---: |
+| Systemic exhaustion and host-tier survival | 3/3 | 21.564 s | 21.321–21.703 s |
+| Failed one-shot half-open | 3/3 | 23.249 s | 23.053–23.293 s |
+| Successful full-resync and breaker close | 3/3 | 23.806 s | 23.593–23.839 s |
+
+Default release cache-hit medians were:
+
+| Metric | Stage 18 median | Stage 19 median | Median paired delta |
+| --- | ---: | ---: | ---: |
+| p50 | 72.45 ms | 72.90 ms | +0.3% |
+| p95 | 76.65 ms | 77.30 ms | +1.0% |
+| Wall time per cycle | 113.01 ms | 114.59 ms | +1.4% |
+
+The paired wall-time delta ranged from -4.12 to +8.61 ms and favored Stage 19
+in 4 of 12 runs. The median difference is much smaller than the sign-changing
+run-to-run variation.
+
+Fresh-process medians were:
+
+| Metric | Stage 18 median | Stage 19 median | Median paired delta |
+| --- | ---: | ---: | ---: |
+| Driver elapsed | 2,242.24 ms | 2,276.04 ms | +0.8% |
+| First request | 1,909.15 ms | 1,966.90 ms | +0.7% |
+| Wall time per cycle | 1,909.62 ms | 1,967.40 ms | +0.7% |
+
+The paired first-request delta ranged from -127.5 to +233.2 ms and favored
+Stage 19 in 4 of 12 runs. The independently computed medians differ more than
+the median of the paired deltas because the run-to-run ordering crosses; this
+does not isolate a Stage 19 cold-start effect. Reading one optional E2E override
+while constructing the supervisor policy shows no separable cold-start cost,
+and the policy does not run on the exact-version request path.
+
+Validation passed:
+
+* `cargo fmt --all -- --check`;
+* `cargo test --lib` (3,147 passed, 2 ignored);
+* the 32 tree-worker supervisor unit tests;
+* `cargo check --lib --tests --features e2e`;
+* `cargo test --features e2e --test tree_worker_process` (9 passed);
+* all three new breaker E2Es in every focused and measurement run; and
+* `cargo clippy --all-targets --all-features -- -D warnings`.
+
+The complete shadow E2E binary also passed 37 tests, but the existing
+`late_competing_document_reduces_fanout_at_a_chunk_boundary` test timed out in
+this checkout. The same test failed identically on the unmodified Stage 18
+baseline, so it is recorded as a pre-existing local failure rather than hidden
+or attributed to Stage 19.
+
+## Findings
+
+### Systemic failure now has a bounded process-level proof
+
+Unit tests already described the restart counters, but they could not prove the
+supervisor stops spawning real processes or that the LSP remains responsive.
+The new convergence fixture crosses the LSP/worker boundary through three failed
+generations, observes one terminal transition, and proves later edits cannot
+turn the open breaker into a respawn loop.
+
+### Half-open authority is configuration-fenced
+
+Ordinary edits after breaker exhaustion are inert. A newer configuration
+generation plus the completed cooldown admits one candidate. A candidate that
+cannot full-resync returns directly to the open state; it does not recursively
+consume the normal recovery loop. A successful candidate stays in probation
+until the healthy interval elapses, then restores tree-backed service.
+
+### Existing crash and hang fixtures do not prove native attribution
+
+The current crash fixture exits normally with code 86, while the timeout starts
+at generic request admission. The ADR classifies a native failure only from OS
+crash evidence or an expired segment after the parent has received
+`NativeSegmentEntered`. Therefore the older fixtures demonstrate containment
+and recovery, but not the final grammar-attribution contract. Extending their
+current heuristic would risk quarantining the command whose response happened
+to fail rather than every parent-acknowledged active grammar.
+
+### Immutable policy keeps the ordinary path unchanged
+
+Restart durations are fixed once when the supervisor actor starts. Healthy
+polls and failure recovery read plain fields; ordinary worker requests add no
+state, allocation, environment lookup, or branch. The noise-scale A/B results
+are consistent with that structure.
+
+## Decision
+
+Keep Stage 19. It closes the systemic convergence and configuration-fenced
+half-open portions of the ADR without broadening the unsupported native-failure
+claim. Keep the ADR `proposed`. Descendant-safe process ownership, the grammar
+hazard/quarantine control plane, native-segment deadlines, protocol corruption,
+compatibility gates, and legacy-path removal remain required.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1229,6 +1229,19 @@ wide margin. This validates the admission policy end to end without claiming a
 total-RSS cap or a repeatable default-memory change. Failure injection,
 protocol and compatibility gates, and legacy-path removal remain open.
 
+The [Stage 19 systemic-breaker measurement](single-resident-multithreaded-tree-worker-stage19-measurement.md)
+proves that three rapid systemic failures converge to one unavailable tree tier
+while parser-independent LSP service remains alive and later edits cannot cause
+respawn. A newer configuration generation admits one cooldown-fenced half-open
+candidate: failed full resync immediately reopens the breaker, while successful
+full resync and a healthy probation interval restore tree-backed service.
+Default release median paired cache-hit and cold-start differences remained at
+or below 1.4% and inside wide sign-changing variation. The measurement also
+distinguishes the existing generic timeout and normal `exit(86)` fixtures from
+the ADR's future OS/native-segment evidence; descendant cleanup, grammar hazard
+and quarantine readiness, protocol and compatibility gates, and legacy-path
+removal remain open.
+
 The implementation should proceed in measured stages:
 
 1. Prototype the framed transport, supervision, and one high-level

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -144,6 +144,44 @@ enum FailureClass {
     NativeEvidenced,
 }
 
+#[derive(Clone, Copy)]
+struct RestartPolicy {
+    initial_backoff: Duration,
+    max_backoff: Duration,
+    fast_healthy_interval: Duration,
+    long_healthy_interval: Duration,
+}
+
+impl RestartPolicy {
+    fn from_environment() -> Self {
+        let policy = Self::default();
+        #[cfg(feature = "e2e")]
+        let policy = {
+            let mut policy = policy;
+            if let Some(milliseconds) = std::env::var("KAKEHASHI_TREE_WORKER_FAST_COOLDOWN_MS")
+                .ok()
+                .and_then(|value| value.parse::<u64>().ok())
+                .filter(|milliseconds| *milliseconds > 0)
+            {
+                policy.fast_healthy_interval = Duration::from_millis(milliseconds);
+            }
+            policy
+        };
+        policy
+    }
+}
+
+impl Default for RestartPolicy {
+    fn default() -> Self {
+        Self {
+            initial_backoff: INITIAL_RESTART_BACKOFF,
+            max_backoff: MAX_RESTART_BACKOFF,
+            fast_healthy_interval: FAST_HEALTHY_INTERVAL,
+            long_healthy_interval: LONG_HEALTHY_INTERVAL,
+        }
+    }
+}
+
 struct RestartBudget {
     systemic: u8,
     native: u8,
@@ -207,11 +245,12 @@ impl RestartBudget {
         self.tokens
     }
 
-    fn backoff(&self) -> Duration {
+    fn backoff(&self, policy: RestartPolicy) -> Duration {
         let exponent = self.backoff_count.saturating_sub(1).min(10) as u32;
-        INITIAL_RESTART_BACKOFF
+        policy
+            .initial_backoff
             .saturating_mul(1_u32 << exponent)
-            .min(MAX_RESTART_BACKOFF)
+            .min(policy.max_backoff)
     }
 }
 
@@ -264,6 +303,7 @@ struct SupervisorState {
     open_documents: Arc<Mutex<OpenDocuments>>,
     quarantined: HashSet<GrammarIdentity>,
     restart_budget: RestartBudget,
+    restart_policy: RestartPolicy,
     breaker: BreakerState,
     healthy_since: Option<Instant>,
     long_healthy_since: Option<Instant>,
@@ -2455,6 +2495,7 @@ fn run_actor(
         open_documents,
         quarantined: HashSet::new(),
         restart_budget: RestartBudget::default(),
+        restart_policy: RestartPolicy::from_environment(),
         breaker: BreakerState::Closed,
         healthy_since: initial_healthy_since,
         long_healthy_since: initial_healthy_since,
@@ -2900,9 +2941,9 @@ fn mark_tree_tier_unavailable(
         opened_at: Instant::now(),
         baseline_generation: pending_configuration_generation.load(Ordering::Acquire),
         cooldown: if state.restart_budget.tokens_remaining() == 0 {
-            LONG_HEALTHY_INTERVAL
+            state.restart_policy.long_healthy_interval
         } else {
-            FAST_HEALTHY_INTERVAL
+            state.restart_policy.fast_healthy_interval
         },
     };
     disabled.store(true, Ordering::Release);
@@ -2916,7 +2957,7 @@ fn observe_healthy_service(state: &mut SupervisorState, now: Instant) {
     let Some(healthy_since) = state.healthy_since else {
         return;
     };
-    if now.saturating_duration_since(healthy_since) >= FAST_HEALTHY_INTERVAL {
+    if now.saturating_duration_since(healthy_since) >= state.restart_policy.fast_healthy_interval {
         state.restart_budget.reset_fast();
         if let BreakerState::HalfOpen {
             probe_generation, ..
@@ -2933,13 +2974,18 @@ fn observe_healthy_service(state: &mut SupervisorState, now: Instant) {
         return;
     };
     let elapsed = now.saturating_duration_since(last_restore);
-    let intervals = elapsed.as_secs() / LONG_HEALTHY_INTERVAL.as_secs();
+    let intervals = elapsed.as_secs() / state.restart_policy.long_healthy_interval.as_secs();
     if intervals == 0 {
         return;
     }
     state.restart_budget.restore_long(intervals);
-    state.long_healthy_since =
-        Some(last_restore + LONG_HEALTHY_INTERVAL.saturating_mul(intervals as u32));
+    state.long_healthy_since = Some(
+        last_restore
+            + state
+                .restart_policy
+                .long_healthy_interval
+                .saturating_mul(intervals as u32),
+    );
 }
 
 fn execute_command(
@@ -3031,7 +3077,7 @@ fn recover_worker(
             log::warn!(target: "kakehashi::tree_worker_shadow", "failed worker cleanup: {error}");
         }
         if charged {
-            std::thread::sleep(state.restart_budget.backoff());
+            std::thread::sleep(state.restart_budget.backoff(state.restart_policy));
         }
         let generation = NEXT_WORKER_GENERATION.fetch_add(1, Ordering::Relaxed);
         let replacement = match Client::spawn(executable, compute_threads, generation) {
@@ -4107,7 +4153,10 @@ mod tests {
         }
         assert!(!native.consume(FailureClass::NativeEvidenced));
 
-        assert_eq!(systemic.backoff(), Duration::from_secs(1));
+        assert_eq!(
+            systemic.backoff(RestartPolicy::default()),
+            Duration::from_secs(1)
+        );
     }
 
     #[test]
@@ -4122,6 +4171,7 @@ mod tests {
             open_documents: Arc::new(Mutex::new(OpenDocuments::default())),
             quarantined: HashSet::new(),
             restart_budget: RestartBudget::default(),
+            restart_policy: RestartPolicy::default(),
             breaker: BreakerState::HalfOpen {
                 probe_generation: 7,
                 synchronized_epoch: 0,
@@ -4145,7 +4195,10 @@ mod tests {
             state.restart_budget.tokens_remaining(),
             MAX_SESSION_RESTARTS - 4
         );
-        assert_eq!(state.restart_budget.backoff(), Duration::from_secs(2));
+        assert_eq!(
+            state.restart_budget.backoff(state.restart_policy),
+            Duration::from_secs(2)
+        );
 
         observe_healthy_service(
             &mut state,
@@ -4155,7 +4208,10 @@ mod tests {
             state.restart_budget.tokens_remaining(),
             MAX_SESSION_RESTARTS - 3
         );
-        assert_eq!(state.restart_budget.backoff(), INITIAL_RESTART_BACKOFF);
+        assert_eq!(
+            state.restart_budget.backoff(state.restart_policy),
+            INITIAL_RESTART_BACKOFF
+        );
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -2906,6 +2906,10 @@ fn mark_tree_tier_unavailable(
         },
     };
     disabled.store(true, Ordering::Release);
+    #[cfg(feature = "e2e")]
+    if let Ok(path) = std::env::var("KAKEHASHI_TREE_WORKER_BREAKER_OPEN_FILE") {
+        let _ = std::fs::write(path, b"open");
+    }
 }
 
 fn observe_healthy_service(state: &mut SupervisorState, now: Instant) {

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -2968,6 +2968,10 @@ fn observe_healthy_service(state: &mut SupervisorState, now: Instant) {
                 target: "kakehashi::tree_worker_shadow",
                 "closed shadow worker breaker after configuration generation {probe_generation} completed 60 seconds of healthy service",
             );
+            #[cfg(feature = "e2e")]
+            if let Ok(path) = std::env::var("KAKEHASHI_TREE_WORKER_BREAKER_CLOSED_FILE") {
+                let _ = std::fs::write(path, b"closed");
+            }
         }
     }
     let Some(last_restore) = state.long_healthy_since else {

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -202,16 +202,25 @@ impl Default for RestartBudget {
 
 impl RestartBudget {
     fn consume(&mut self, class: FailureClass) -> bool {
-        let class_available = match class {
-            FailureClass::Systemic => self.systemic < MAX_SYSTEMIC_RESTARTS,
-            FailureClass::NativeEvidenced => self.native < MAX_NATIVE_RESTARTS,
-        };
-        if self.tokens == 0 || !class_available {
+        if self.tokens == 0 {
             return false;
         }
         match class {
-            FailureClass::Systemic => self.systemic = self.systemic.saturating_add(1),
-            FailureClass::NativeEvidenced => self.native = self.native.saturating_add(1),
+            FailureClass::Systemic => {
+                if self.systemic >= MAX_SYSTEMIC_RESTARTS {
+                    return false;
+                }
+                self.systemic = self.systemic.saturating_add(1);
+                if self.systemic == MAX_SYSTEMIC_RESTARTS {
+                    return false;
+                }
+            }
+            FailureClass::NativeEvidenced => {
+                if self.native >= MAX_NATIVE_RESTARTS {
+                    return false;
+                }
+                self.native = self.native.saturating_add(1);
+            }
         }
         self.tokens -= 1;
         self.backoff_count = self.backoff_count.saturating_add(1);
@@ -4147,9 +4156,8 @@ mod tests {
         let mut systemic = RestartBudget::default();
         assert!(systemic.consume(FailureClass::Systemic));
         assert!(systemic.consume(FailureClass::Systemic));
-        assert!(systemic.consume(FailureClass::Systemic));
         assert!(!systemic.consume(FailureClass::Systemic));
-        assert_eq!(systemic.tokens_remaining(), MAX_SESSION_RESTARTS - 3);
+        assert_eq!(systemic.tokens_remaining(), MAX_SESSION_RESTARTS - 2);
 
         let mut native = RestartBudget::default();
         for _ in 0..MAX_NATIVE_RESTARTS {
@@ -4159,8 +4167,19 @@ mod tests {
 
         assert_eq!(
             systemic.backoff(RestartPolicy::default()),
-            Duration::from_secs(1)
+            Duration::from_millis(500)
         );
+    }
+
+    #[test]
+    fn third_systemic_generation_failure_denies_a_replacement() {
+        let mut budget = RestartBudget::default();
+
+        assert!(budget.consume(FailureClass::Systemic));
+        assert!(budget.consume(FailureClass::Systemic));
+        assert!(!budget.consume(FailureClass::Systemic));
+        assert_eq!(budget.systemic, MAX_SYSTEMIC_RESTARTS);
+        assert_eq!(budget.tokens_remaining(), MAX_SESSION_RESTARTS - 2);
     }
 
     #[test]
@@ -4184,12 +4203,13 @@ mod tests {
             healthy_since: Some(started),
             long_healthy_since: Some(started),
         };
-        for _ in 0..MAX_SYSTEMIC_RESTARTS {
+        for _ in 0..MAX_SYSTEMIC_RESTARTS - 1 {
             assert!(state.restart_budget.consume(FailureClass::Systemic));
         }
+        assert!(!state.restart_budget.consume(FailureClass::Systemic));
         assert_eq!(
             state.restart_budget.tokens_remaining(),
-            MAX_SESSION_RESTARTS - 3
+            MAX_SESSION_RESTARTS - 2
         );
 
         observe_healthy_service(&mut state, started + FAST_HEALTHY_INTERVAL);
@@ -4197,11 +4217,11 @@ mod tests {
         assert!(state.restart_budget.consume(FailureClass::Systemic));
         assert_eq!(
             state.restart_budget.tokens_remaining(),
-            MAX_SESSION_RESTARTS - 4
+            MAX_SESSION_RESTARTS - 3
         );
         assert_eq!(
             state.restart_budget.backoff(state.restart_policy),
-            Duration::from_secs(2)
+            Duration::from_secs(1)
         );
 
         observe_healthy_service(
@@ -4210,7 +4230,7 @@ mod tests {
         );
         assert_eq!(
             state.restart_budget.tokens_remaining(),
-            MAX_SESSION_RESTARTS - 3
+            MAX_SESSION_RESTARTS - 2
         );
         assert_eq!(
             state.restart_budget.backoff(state.restart_policy),

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4083,6 +4083,15 @@ fn inject_worker_failure_once(request: &Request) -> Option<Response> {
     let Request::SyncDocument(sync) = request else {
         return None;
     };
+    if std::env::var("KAKEHASHI_TREE_WORKER_RESTART_ALWAYS_URI_SUFFIX")
+        .ok()
+        .is_some_and(|suffix| sync.context.uri.ends_with(&suffix))
+    {
+        return Some(Response::WorkerRestartRequired(WorkerRestartRequired {
+            context: sync.context.clone(),
+            reason: "injected repeated systemic restart".into(),
+        }));
+    }
     if let Ok(marker) = std::env::var("KAKEHASHI_TREE_WORKER_HANG_ONCE_FILE")
         && std::env::var("KAKEHASHI_TREE_WORKER_HANG_URI_SUFFIX")
             .ok()

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4083,6 +4083,18 @@ fn inject_worker_failure_once(request: &Request) -> Option<Response> {
     let Request::SyncDocument(sync) = request else {
         return None;
     };
+    if std::env::var("KAKEHASHI_TREE_WORKER_RESTART_WHILE_FILE")
+        .ok()
+        .is_some_and(|path| std::path::Path::new(&path).exists())
+        && std::env::var("KAKEHASHI_TREE_WORKER_RESTART_WHILE_URI_SUFFIX")
+            .ok()
+            .is_none_or(|suffix| sync.context.uri.ends_with(&suffix))
+    {
+        return Some(Response::WorkerRestartRequired(WorkerRestartRequired {
+            context: sync.context.clone(),
+            reason: "injected gated systemic restart".into(),
+        }));
+    }
     if std::env::var("KAKEHASHI_TREE_WORKER_RESTART_ALWAYS_URI_SUFFIX")
         .ok()
         .is_some_and(|suffix| sync.context.uri.ends_with(&suffix))

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -60,6 +60,41 @@ fn shadow_metric(stderr: &str, name: &str) -> u64 {
     log_metric(summary, name)
 }
 
+fn wait_for_file(path: &std::path::Path, failure: &str) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !path.exists() && std::time::Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(path.exists(), "{failure}");
+}
+
+fn open_rust_and_request_tokens(client: &mut LspClient, uri: &str, text: &str) {
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "rust",
+                "version": 1,
+                "text": text
+            }
+        }),
+    );
+    let response = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+    assert!(response.get("result").is_some(), "{response:?}");
+}
+
+fn assert_host_tier_available(client: &mut LspClient, command: &str) {
+    let response = client.send_request(
+        "workspace/executeCommand",
+        json!({ "command": command, "arguments": [] }),
+    );
+    assert!(response.get("result").is_some(), "{response:?}");
+}
+
 #[test]
 fn shadow_worker_matches_authoritative_incremental_lifecycle() {
     let mut client = LspClient::builder()
@@ -400,31 +435,8 @@ fn repeated_systemic_failures_open_the_breaker_once_and_keep_lsp_alive() {
         .build();
     initialize(&mut client);
     let uri = "file:///breaker.rs";
-    client.send_notification(
-        "textDocument/didOpen",
-        json!({
-            "textDocument": {
-                "uri": uri,
-                "languageId": "rust",
-                "version": 1,
-                "text": "fn breaker() { let value = 1; }\n"
-            }
-        }),
-    );
-    let response = client.send_request(
-        "textDocument/semanticTokens/full",
-        json!({ "textDocument": { "uri": uri } }),
-    );
-    assert!(response.get("result").is_some(), "{response:?}");
-
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    while !breaker_open.exists() && std::time::Instant::now() < deadline {
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    assert!(
-        breaker_open.exists(),
-        "systemic failures did not open breaker"
-    );
+    open_rust_and_request_tokens(&mut client, uri, "fn breaker() { let value = 1; }\n");
+    wait_for_file(&breaker_open, "systemic failures did not open breaker");
 
     for version in 2..=5 {
         client.send_notification(
@@ -435,14 +447,7 @@ fn repeated_systemic_failures_open_the_breaker_once_and_keep_lsp_alive() {
             }),
         );
     }
-    let host_response = client.send_request(
-        "workspace/executeCommand",
-        json!({
-            "command": "kakehashi.test.host-tier-after-breaker",
-            "arguments": []
-        }),
-    );
-    assert!(host_response.get("result").is_some(), "{host_response:?}");
+    assert_host_tier_available(&mut client, "kakehashi.test.host-tier-after-breaker");
 
     let stderr = shutdown_and_stderr(client);
     assert_eq!(
@@ -479,41 +484,17 @@ fn configuration_change_allows_one_failed_half_open_probe() {
         .build();
     initialize(&mut client);
     let uri = "file:///half-open.rs";
-    client.send_notification(
-        "textDocument/didOpen",
-        json!({
-            "textDocument": {
-                "uri": uri,
-                "languageId": "rust",
-                "version": 1,
-                "text": "fn half_open() { let value = 1; }\n"
-            }
-        }),
-    );
-    let response = client.send_request(
-        "textDocument/semanticTokens/full",
-        json!({ "textDocument": { "uri": uri } }),
-    );
-    assert!(response.get("result").is_some(), "{response:?}");
-
-    let initial_deadline = std::time::Instant::now() + Duration::from_secs(5);
-    while !breaker_open.exists() && std::time::Instant::now() < initial_deadline {
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    assert!(breaker_open.exists(), "initial breaker did not open");
+    open_rust_and_request_tokens(&mut client, uri, "fn half_open() { let value = 1; }\n");
+    wait_for_file(&breaker_open, "initial breaker did not open");
     std::fs::remove_file(&breaker_open).unwrap();
 
     client.send_notification(
         "workspace/didChangeConfiguration",
         json!({ "settings": { "autoInstall": false } }),
     );
-    let reopen_deadline = std::time::Instant::now() + Duration::from_secs(5);
-    while !breaker_open.exists() && std::time::Instant::now() < reopen_deadline {
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    assert!(
-        breaker_open.exists(),
-        "failed half-open probe did not reopen breaker"
+    wait_for_file(
+        &breaker_open,
+        "failed half-open probe did not reopen breaker",
     );
 
     for version in 2..=5 {
@@ -525,14 +506,7 @@ fn configuration_change_allows_one_failed_half_open_probe() {
             }),
         );
     }
-    let host_response = client.send_request(
-        "workspace/executeCommand",
-        json!({
-            "command": "kakehashi.test.host-tier-after-half-open",
-            "arguments": []
-        }),
-    );
-    assert!(host_response.get("result").is_some(), "{host_response:?}");
+    assert_host_tier_available(&mut client, "kakehashi.test.host-tier-after-half-open");
 
     let stderr = shutdown_and_stderr(client);
     assert_eq!(
@@ -580,28 +554,12 @@ fn successful_half_open_resync_closes_the_breaker() {
         .build();
     initialize(&mut client);
     let uri = "file:///half-open-success.rs";
-    client.send_notification(
-        "textDocument/didOpen",
-        json!({
-            "textDocument": {
-                "uri": uri,
-                "languageId": "rust",
-                "version": 1,
-                "text": "fn half_open_success() { let value = 1; }\n"
-            }
-        }),
+    open_rust_and_request_tokens(
+        &mut client,
+        uri,
+        "fn half_open_success() { let value = 1; }\n",
     );
-    let response = client.send_request(
-        "textDocument/semanticTokens/full",
-        json!({ "textDocument": { "uri": uri } }),
-    );
-    assert!(response.get("result").is_some(), "{response:?}");
-
-    let initial_deadline = std::time::Instant::now() + Duration::from_secs(5);
-    while !breaker_open.exists() && std::time::Instant::now() < initial_deadline {
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    assert!(breaker_open.exists(), "initial breaker did not open");
+    wait_for_file(&breaker_open, "initial breaker did not open");
     std::fs::remove_file(&failure_gate).unwrap();
     std::fs::remove_file(&breaker_open).unwrap();
 
@@ -609,13 +567,9 @@ fn successful_half_open_resync_closes_the_breaker() {
         "workspace/didChangeConfiguration",
         json!({ "settings": { "autoInstall": false } }),
     );
-    let recovery_deadline = std::time::Instant::now() + Duration::from_secs(5);
-    while !breaker_closed.exists() && std::time::Instant::now() < recovery_deadline {
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    assert!(
-        breaker_closed.exists(),
-        "healthy half-open probe did not close breaker"
+    wait_for_file(
+        &breaker_closed,
+        "healthy half-open probe did not close breaker",
     );
     assert!(!breaker_open.exists(), "successful probe reopened breaker");
 

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -379,6 +379,84 @@ fn systemic_worker_restart_full_resyncs_the_open_document() {
 }
 
 #[test]
+fn repeated_systemic_failures_open_the_breaker_once_and_keep_lsp_alive() {
+    let directory = tempfile::tempdir().unwrap();
+    let breaker_open = directory.path().join("breaker-open");
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_SHADOW", "true")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env(
+            "KAKEHASHI_TREE_WORKER_RESTART_ALWAYS_URI_SUFFIX",
+            "/breaker.rs",
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_BREAKER_OPEN_FILE",
+            breaker_open.to_string_lossy().into_owned(),
+        )
+        .env(
+            "RUST_LOG",
+            "kakehashi::tree_worker_shadow=info,kakehashi::tree_worker_shadow_metrics=info",
+        )
+        .build();
+    initialize(&mut client);
+    let uri = "file:///breaker.rs";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "rust",
+                "version": 1,
+                "text": "fn breaker() { let value = 1; }\n"
+            }
+        }),
+    );
+    let response = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+    assert!(response.get("result").is_some(), "{response:?}");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !breaker_open.exists() && std::time::Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(
+        breaker_open.exists(),
+        "systemic failures did not open breaker"
+    );
+
+    for version in 2..=5 {
+        client.send_notification(
+            "textDocument/didChange",
+            json!({
+                "textDocument": { "uri": uri, "version": version },
+                "contentChanges": [{ "text": format!("fn breaker() {{ let value = {version}; }}\n") }]
+            }),
+        );
+    }
+    let host_response = client.send_request(
+        "workspace/executeCommand",
+        json!({
+            "command": "kakehashi.test.host-tier-after-breaker",
+            "arguments": []
+        }),
+    );
+    assert!(host_response.get("result").is_some(), "{host_response:?}");
+
+    let stderr = shutdown_and_stderr(client);
+    assert_eq!(
+        stderr
+            .matches("disabled shadow tree tier after restart budget exhaustion")
+            .count(),
+        1,
+        "{stderr}"
+    );
+    assert_eq!(stderr.matches("full resync failed").count(), 3, "{stderr}");
+    assert!(!stderr.contains("quarantined grammar"), "{stderr}");
+}
+
+#[test]
 fn systemic_worker_restart_measures_many_document_full_resync() {
     let directory = tempfile::tempdir().unwrap();
     let marker = directory.path().join("restart-many-once");

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -457,7 +457,7 @@ fn repeated_systemic_failures_open_the_breaker_once_and_keep_lsp_alive() {
         1,
         "{stderr}"
     );
-    assert_eq!(stderr.matches("full resync failed").count(), 3, "{stderr}");
+    assert_eq!(stderr.matches("full resync failed").count(), 2, "{stderr}");
     assert!(!stderr.contains("quarantined grammar"), "{stderr}");
 }
 
@@ -516,7 +516,7 @@ fn configuration_change_allows_one_failed_half_open_probe() {
         1,
         "{stderr}"
     );
-    assert_eq!(stderr.matches("full resync failed").count(), 4, "{stderr}");
+    assert_eq!(stderr.matches("full resync failed").count(), 3, "{stderr}");
     assert!(!stderr.contains("quarantined grammar"), "{stderr}");
 }
 
@@ -580,7 +580,7 @@ fn successful_half_open_resync_closes_the_breaker() {
     assert!(recovered.get("result").is_some(), "{recovered:?}");
 
     let stderr = shutdown_and_stderr(client);
-    assert_eq!(stderr.matches("full resync failed").count(), 3, "{stderr}");
+    assert_eq!(stderr.matches("full resync failed").count(), 2, "{stderr}");
     assert!(
         stderr.contains("entered shadow worker half-open probation"),
         "{stderr}"

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -457,6 +457,96 @@ fn repeated_systemic_failures_open_the_breaker_once_and_keep_lsp_alive() {
 }
 
 #[test]
+fn configuration_change_allows_one_failed_half_open_probe() {
+    let directory = tempfile::tempdir().unwrap();
+    let breaker_open = directory.path().join("breaker-open");
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_SHADOW", "true")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env(
+            "KAKEHASHI_TREE_WORKER_RESTART_ALWAYS_URI_SUFFIX",
+            "/half-open.rs",
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_BREAKER_OPEN_FILE",
+            breaker_open.to_string_lossy().into_owned(),
+        )
+        .env("KAKEHASHI_TREE_WORKER_FAST_COOLDOWN_MS", "25")
+        .env(
+            "RUST_LOG",
+            "kakehashi::tree_worker_shadow=info,kakehashi::tree_worker_shadow_metrics=info",
+        )
+        .build();
+    initialize(&mut client);
+    let uri = "file:///half-open.rs";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "rust",
+                "version": 1,
+                "text": "fn half_open() { let value = 1; }\n"
+            }
+        }),
+    );
+    let response = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+    assert!(response.get("result").is_some(), "{response:?}");
+
+    let initial_deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !breaker_open.exists() && std::time::Instant::now() < initial_deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(breaker_open.exists(), "initial breaker did not open");
+    std::fs::remove_file(&breaker_open).unwrap();
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": { "autoInstall": false } }),
+    );
+    let reopen_deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !breaker_open.exists() && std::time::Instant::now() < reopen_deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(
+        breaker_open.exists(),
+        "failed half-open probe did not reopen breaker"
+    );
+
+    for version in 2..=5 {
+        client.send_notification(
+            "textDocument/didChange",
+            json!({
+                "textDocument": { "uri": uri, "version": version },
+                "contentChanges": [{ "text": format!("fn half_open() {{ let value = {version}; }}\n") }]
+            }),
+        );
+    }
+    let host_response = client.send_request(
+        "workspace/executeCommand",
+        json!({
+            "command": "kakehashi.test.host-tier-after-half-open",
+            "arguments": []
+        }),
+    );
+    assert!(host_response.get("result").is_some(), "{host_response:?}");
+
+    let stderr = shutdown_and_stderr(client);
+    assert_eq!(
+        stderr
+            .matches("disabled shadow tree tier after restart budget exhaustion")
+            .count(),
+        1,
+        "{stderr}"
+    );
+    assert_eq!(stderr.matches("full resync failed").count(), 4, "{stderr}");
+    assert!(!stderr.contains("quarantined grammar"), "{stderr}");
+}
+
+#[test]
 fn systemic_worker_restart_measures_many_document_full_resync() {
     let directory = tempfile::tempdir().unwrap();
     let marker = directory.path().join("restart-many-once");

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -547,6 +547,95 @@ fn configuration_change_allows_one_failed_half_open_probe() {
 }
 
 #[test]
+fn successful_half_open_resync_closes_the_breaker() {
+    let directory = tempfile::tempdir().unwrap();
+    let failure_gate = directory.path().join("restart-while-present");
+    let breaker_open = directory.path().join("breaker-open");
+    let breaker_closed = directory.path().join("breaker-closed");
+    std::fs::write(&failure_gate, b"fail").unwrap();
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_SHADOW", "true")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env(
+            "KAKEHASHI_TREE_WORKER_RESTART_WHILE_FILE",
+            failure_gate.to_string_lossy().into_owned(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_RESTART_WHILE_URI_SUFFIX",
+            "/half-open-success.rs",
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_BREAKER_OPEN_FILE",
+            breaker_open.to_string_lossy().into_owned(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_BREAKER_CLOSED_FILE",
+            breaker_closed.to_string_lossy().into_owned(),
+        )
+        .env("KAKEHASHI_TREE_WORKER_FAST_COOLDOWN_MS", "25")
+        .env(
+            "RUST_LOG",
+            "kakehashi::tree_worker_shadow=info,kakehashi::tree_worker_shadow_metrics=info",
+        )
+        .build();
+    initialize(&mut client);
+    let uri = "file:///half-open-success.rs";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "rust",
+                "version": 1,
+                "text": "fn half_open_success() { let value = 1; }\n"
+            }
+        }),
+    );
+    let response = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+    assert!(response.get("result").is_some(), "{response:?}");
+
+    let initial_deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !breaker_open.exists() && std::time::Instant::now() < initial_deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(breaker_open.exists(), "initial breaker did not open");
+    std::fs::remove_file(&failure_gate).unwrap();
+    std::fs::remove_file(&breaker_open).unwrap();
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": { "autoInstall": false } }),
+    );
+    let recovery_deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !breaker_closed.exists() && std::time::Instant::now() < recovery_deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(
+        breaker_closed.exists(),
+        "healthy half-open probe did not close breaker"
+    );
+    assert!(!breaker_open.exists(), "successful probe reopened breaker");
+
+    let recovered = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+    assert!(recovered.get("result").is_some(), "{recovered:?}");
+
+    let stderr = shutdown_and_stderr(client);
+    assert_eq!(stderr.matches("full resync failed").count(), 3, "{stderr}");
+    assert!(
+        stderr.contains("entered shadow worker half-open probation"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("closed shadow worker breaker"), "{stderr}");
+    assert!(!stderr.contains("quarantined grammar"), "{stderr}");
+}
+
+#[test]
 fn systemic_worker_restart_measures_many_document_full_resync() {
     let directory = tempfile::tempdir().unwrap();
     let marker = directory.path().join("restart-many-once");


### PR DESCRIPTION
## Summary

- stop spawning tree workers after three systemic worker-generation failures
- admit exactly one configuration-fenced half-open worker after cooldown
- keep parser-independent LSP service and shutdown available while the tree tier is degraded
- record repeated breaker E2Es and Stage 18 vs Stage 19 release A/B measurements

## Measurement

- breaker convergence: 3/3, median 21.564 s full E2E
- failed half-open: 3/3, median 23.249 s full E2E
- successful resync/close: 3/3, median 23.806 s full E2E
- cache-hit median paired deltas: p50 +0.3%, p95 +1.0%, wall +1.4%
- cold-start median paired deltas: elapsed +0.8%, first request +0.7%

## Validation

- `cargo fmt --all -- --check`
- `cargo test --lib` (3,147 passed, 2 ignored)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --features e2e --test tree_worker_process` (9 passed)
- each new breaker E2E passed in all focused and measurement runs

## Stack

Depends on #881. This remains draft while later ADR stages and the full revise pipeline are in progress.