### PR TITLE
fix(worker): terminate owned Unix process groups

### DIFF
--- a/benches/profile/results/single_worker_stage20_descendant_cleanup_2026-07-20.json
+++ b/benches/profile/results/single_worker_stage20_descendant_cleanup_2026-07-20.json
@@ -1,0 +1,51 @@
+{
+  "schema": 1,
+  "experiment": "single-tree-worker-stage20-descendant-cleanup",
+  "date": "2026-07-20",
+  "environment": {
+    "source_commit": "38840cd6d561b3cf99dfc5bb5fd85fb787867649",
+    "baseline_stage": 19,
+    "baseline_binary_sha256": "72dda444029ebdb9122e71401e36b960dca67b3165ebf5c3649480d5c2e35468",
+    "candidate_stage": 20,
+    "candidate_binary_sha256": "ac0b197a425cb5812270cc89d9e108448d83f09b7ede7973b8b18658882a1761",
+    "release_build": "cargo build --locked --release --bin kakehashi",
+    "features": "default",
+    "platform": "macOS"
+  },
+  "cold_start": {
+    "scenario": {
+      "language": "rust",
+      "generated_size": 15,
+      "documents": 1,
+      "measured_requests": 1,
+      "settle_seconds": 0,
+      "worker_threads": 4,
+      "isolation": "fresh XDG config and state directory for every run",
+      "order": "baseline-candidate on odd runs; candidate-baseline on even runs"
+    },
+    "runs": [
+      {"run": 1, "baseline": {"elapsed_ms": 3381.901, "request_ms": 3030.3, "wall_ms_per_cycle": 3030.85}, "candidate": {"elapsed_ms": 3376.098, "request_ms": 2040.7, "wall_ms_per_cycle": 2041.29}},
+      {"run": 2, "baseline": {"elapsed_ms": 2331.929, "request_ms": 2012.7, "wall_ms_per_cycle": 2013.14}, "candidate": {"elapsed_ms": 2328.621, "request_ms": 2021.3, "wall_ms_per_cycle": 2021.76}},
+      {"run": 3, "baseline": {"elapsed_ms": 2343.896, "request_ms": 2034.7, "wall_ms_per_cycle": 2035.36}, "candidate": {"elapsed_ms": 2393.226, "request_ms": 2073.4, "wall_ms_per_cycle": 2074.10}},
+      {"run": 4, "baseline": {"elapsed_ms": 2319.304, "request_ms": 2007.8, "wall_ms_per_cycle": 2008.42}, "candidate": {"elapsed_ms": 2337.631, "request_ms": 2031.1, "wall_ms_per_cycle": 2031.64}},
+      {"run": 5, "baseline": {"elapsed_ms": 2335.081, "request_ms": 2028.2, "wall_ms_per_cycle": 2028.84}, "candidate": {"elapsed_ms": 2396.653, "request_ms": 2093.8, "wall_ms_per_cycle": 2094.43}},
+      {"run": 6, "baseline": {"elapsed_ms": 2373.920, "request_ms": 2035.6, "wall_ms_per_cycle": 2036.32}, "candidate": {"elapsed_ms": 2350.667, "request_ms": 2013.1, "wall_ms_per_cycle": 2013.76}},
+      {"run": 7, "baseline": {"elapsed_ms": 2332.368, "request_ms": 2030.6, "wall_ms_per_cycle": 2031.18}, "candidate": {"elapsed_ms": 2348.747, "request_ms": 2022.0, "wall_ms_per_cycle": 2022.66}},
+      {"run": 8, "baseline": {"elapsed_ms": 2469.494, "request_ms": 2119.6, "wall_ms_per_cycle": 2120.25}, "candidate": {"elapsed_ms": 2453.343, "request_ms": 2104.8, "wall_ms_per_cycle": 2105.49}},
+      {"run": 9, "baseline": {"elapsed_ms": 2367.868, "request_ms": 2045.3, "wall_ms_per_cycle": 2045.98}, "candidate": {"elapsed_ms": 2339.682, "request_ms": 2025.9, "wall_ms_per_cycle": 2026.52}},
+      {"run": 10, "baseline": {"elapsed_ms": 2423.287, "request_ms": 2081.7, "wall_ms_per_cycle": 2082.33}, "candidate": {"elapsed_ms": 2409.411, "request_ms": 2086.9, "wall_ms_per_cycle": 2087.45}},
+      {"run": 11, "baseline": {"elapsed_ms": 2358.570, "request_ms": 2037.7, "wall_ms_per_cycle": 2038.35}, "candidate": {"elapsed_ms": 2320.973, "request_ms": 2012.3, "wall_ms_per_cycle": 2012.73}},
+      {"run": 12, "baseline": {"elapsed_ms": 2446.028, "request_ms": 2105.9, "wall_ms_per_cycle": 2106.43}, "candidate": {"elapsed_ms": 2317.170, "request_ms": 2011.3, "wall_ms_per_cycle": 2012.00}}
+    ]
+  },
+  "descendant_cleanup_e2e": {
+    "platform": "unix",
+    "fixture_descendant_seconds": 300,
+    "note": "elapsed time covers LSP initialization, worker and descendant startup, normal shutdown, process-group termination, liveness assertion, and server exit",
+    "runs": [
+      {"run": 1, "elapsed_ms": 4239.503, "passed": true},
+      {"run": 2, "elapsed_ms": 4078.988, "passed": true},
+      {"run": 3, "elapsed_ms": 3937.486, "passed": true}
+    ]
+  }
+}

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage20-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage20-measurement.md
@@ -1,0 +1,102 @@
+# Single Tree Worker Stage 20 Descendant-Cleanup Measurement
+
+## Scope
+
+Stage 20 makes explicit worker cleanup descendant-safe on Unix. The parent
+spawns the resident worker as its own process-group leader, retains the owned
+group identity beside the direct `Child`, and targets that group from failed
+handshake, request timeout, transport failure, drop, and graceful shutdown
+paths. The parent still reaps the direct worker with a bounded wait; terminated
+descendants are reparented and reaped by the operating system.
+
+This stage does not claim the ADR's abnormal-parent-death contract. The
+close-on-exec liveness pipe, Linux parent-death signal, hung-native-thread
+fixture, and Windows Job Object remain separate gates.
+
+## Method
+
+### Lifecycle proof
+
+A Unix unit fixture spawned a worker-like process-group leader with a live
+descendant. Before the implementation, killing only the direct child left the
+descendant alive and the RED test failed. The GREEN implementation terminates
+the owned group and still reaps the direct child.
+
+A process E2E then started the real LSP parent, resident worker, and an E2E-only
+five-minute descendant. Normal LSP shutdown had to remove that descendant
+within two seconds; natural fixture expiry cannot satisfy the assertion. The
+complete scenario was repeated three times.
+
+### Default release A/B
+
+The Stage 19 and Stage 20 default-feature release binaries ran in authoritative
+mode with four worker compute threads. The source commit was
+`38840cd6d561b3cf99dfc5bb5fd85fb787867649`. Baseline SHA-256 was
+`72dda444029ebdb9122e71401e36b960dca67b3165ebf5c3649480d5c2e35468`;
+candidate SHA-256 was
+`ac0b197a425cb5812270cc89d9e108448d83f09b7ede7973b8b18658882a1761`.
+
+Twelve order-reversed cold-start runs per binary used fresh config and state
+directories, one small Rust document, no settle delay, and one semantic
+request. This targets the only ordinary-path change: assigning the worker's
+Unix process group during spawn. Request execution itself is unchanged. Raw
+values are in
+`benches/profile/results/single_worker_stage20_descendant_cleanup_2026-07-20.json`.
+
+## Result
+
+The descendant-cleanup E2E passed 3/3 runs. Full-test elapsed median was
+4.079 seconds, with a 3.937–4.240 second range.
+
+Cold-start results were:
+
+| Metric | Stage 19 median | Stage 20 median | Median paired delta |
+| --- | ---: | ---: | ---: |
+| Driver elapsed | 2,363.22 ms | 2,349.71 ms | -0.4% |
+| First request | 2,036.65 ms | 2,028.50 ms | -0.6% |
+| Wall time per cycle | 2,037.25 ms | 2,029.14 ms | -0.6% |
+
+Stage 20 was faster in 8 of 12 driver-elapsed pairs and 7 of 12 first-request
+pairs. Paired driver differences ranged from -128.86 to +61.57 milliseconds;
+paired first-request differences ranged from -989.6 to +65.6 milliseconds.
+The large first pair is an outlier in both process elapsed and request timing,
+so the median is the gate and no startup improvement is claimed.
+
+Validation passed:
+
+* `cargo fmt --all -- --check`;
+* `cargo test --lib` (3,148 passed, 2 ignored);
+* the focused process-group unit tests;
+* the real descendant-cleanup E2E in every focused and measurement run;
+* `cargo test --features e2e --test tree_worker_process` (9 passed); and
+* `cargo clippy --all-targets --all-features -- -D warnings`.
+
+## Findings
+
+### Ownership must include the cleanup target
+
+Deriving a process-group ID from an arbitrary child at kill time couples
+cleanup correctness to an unstated spawn assumption and risks targeting the
+wrong group. `OwnedChild` establishes the group during spawn and retains that
+identity through every termination path.
+
+### Graceful worker exit does not prove descendant exit
+
+Waiting for the direct worker is necessary for reaping but insufficient for
+cleanup. Stage 20 explicitly targets the owned group even after the worker has
+already exited successfully. The five-minute fixture exposed and prevents the
+false-positive test that a short-lived descendant would create.
+
+### Process groups solve explicit Unix cleanup, not parent death
+
+If the parent is killed, its cleanup code cannot send the group signal. The
+worker still needs an independent liveness thread and platform primitive. That
+work remains visible rather than being implied by this stage.
+
+## Decision
+
+Keep Stage 20. It closes explicit Unix descendant cleanup without adding state,
+branches, allocation, or synchronization to the compute/request path. Keep the
+ADR `proposed` until abnormal parent-death handling, Windows ownership, native
+hazard/quarantine control, protocol and compatibility gates, and legacy-path
+removal are complete.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1242,6 +1242,16 @@ the ADR's future OS/native-segment evidence; descendant cleanup, grammar hazard
 and quarantine readiness, protocol and compatibility gates, and legacy-path
 removal remain open.
 
+The [Stage 20 descendant-cleanup measurement](single-resident-multithreaded-tree-worker-stage20-measurement.md)
+proves that explicit worker termination and normal LSP shutdown kill the Unix
+process group owned by the worker, including a five-minute descendant that
+cannot expire naturally within the test. The parent still reaps the direct
+worker with a bounded wait. Twelve order-reversed cold-start pairs found no
+regression: median paired driver and first-request deltas were -0.4% and -0.6%.
+This does not satisfy abnormal parent-death or Windows Job Object requirements;
+those remain open with native hazard/quarantine, protocol and compatibility
+gates, and legacy-path removal.
+
 The implementation should proceed in measured stages:
 
 1. Prototype the framed transport, supervision, and one high-level

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4214,7 +4214,11 @@ fn spawn_test_descendant() -> io::Result<()> {
         return Ok(());
     };
     let _descendant = Command::new("sh")
-        .args(["-c", "echo $$ > \"$1\"; exec sleep 300", "worker-descendant"])
+        .args([
+            "-c",
+            "echo $$ > \"$1\"; exec sleep 300",
+            "worker-descendant",
+        ])
         .arg(pid_path)
         .stdin(Stdio::null())
         .stdout(Stdio::null())

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4955,7 +4955,8 @@ mod tests {
         encode_frame, enforce_derived_memory_budget, named_node_count, parse_request_timeout,
         pressure_checkpoint_required, replace_retained_bytes, replace_retained_estimated_bytes,
         request_may_grow_derived_state, request_priority, reserve_retained_growth, route_response,
-        run, submit_document_job, sync_document, terminate_by_transport, validate_document_size,
+        run, submit_document_job, sync_document, terminate, terminate_by_transport,
+        validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -4969,6 +4970,49 @@ mod tests {
         fn flush(&mut self) -> std::io::Result<()> {
             Ok(())
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn termination_reaps_the_owned_process_group() {
+        use std::os::unix::process::CommandExt as _;
+
+        use nix::errno::Errno;
+        use nix::sys::signal::{Signal, kill};
+        use nix::unistd::Pid;
+
+        let directory = tempfile::tempdir().unwrap();
+        let pid_path = directory.path().join("descendant.pid");
+        let script = format!("sleep 30 & echo $! > '{}'; wait", pid_path.display());
+        let mut command = std::process::Command::new("sh");
+        command.args(["-c", &script]).process_group(0);
+        let mut owner = command.spawn().unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let descendant = loop {
+            if let Ok(pid) = std::fs::read_to_string(&pid_path) {
+                break Pid::from_raw(pid.trim().parse().unwrap());
+            }
+            assert!(Instant::now() < deadline, "descendant pid was not published");
+            std::thread::sleep(Duration::from_millis(5));
+        };
+
+        terminate(&mut owner, Duration::from_secs(1));
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let descendant_survived = loop {
+            match kill(descendant, None) {
+                Err(Errno::ESRCH) => break false,
+                Ok(()) | Err(Errno::EPERM) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                Ok(()) | Err(Errno::EPERM) => break true,
+                Err(error) => panic!("unexpected descendant liveness error: {error}"),
+            }
+        };
+        if descendant_survived {
+            let _ = kill(descendant, Signal::SIGKILL);
+        }
+        assert!(!descendant_survived, "worker descendant survived cleanup");
     }
 
     #[cfg(unix)]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4196,6 +4196,8 @@ pub fn run_stdio_with_memory_budgets(
     compute_threads: usize,
     memory_budgets: WorkerMemoryBudgets,
 ) -> io::Result<()> {
+    #[cfg(all(unix, feature = "e2e"))]
+    spawn_test_descendant()?;
     let build_id = artifact_digest(&std::env::current_exe()?)?;
     run_with_build_id(
         std::io::stdin(),
@@ -4204,6 +4206,21 @@ pub fn run_stdio_with_memory_budgets(
         &build_id,
         memory_budgets,
     )
+}
+
+#[cfg(all(unix, feature = "e2e"))]
+fn spawn_test_descendant() -> io::Result<()> {
+    let Some(pid_path) = std::env::var_os("KAKEHASHI_TREE_WORKER_DESCENDANT_PID_FILE") else {
+        return Ok(());
+    };
+    let _descendant = Command::new("sh")
+        .args(["-c", "echo $$ > \"$1\"; exec sleep 30", "worker-descendant"])
+        .arg(pid_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    Ok(())
 }
 
 pub fn artifact_digest(path: &std::path::Path) -> io::Result<String> {
@@ -4220,8 +4237,59 @@ pub fn artifact_digest(path: &std::path::Path) -> io::Result<String> {
     Ok(format!("sha256:{:x}", digest.finalize()))
 }
 
+struct OwnedChild {
+    child: Child,
+    #[cfg(unix)]
+    process_group: nix::unistd::Pid,
+}
+
+impl OwnedChild {
+    fn spawn(mut command: Command) -> io::Result<Self> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt as _;
+
+            command.process_group(0);
+        }
+        let child = command.spawn()?;
+        #[cfg(unix)]
+        let process_group = nix::unistd::Pid::from_raw(child.id() as i32);
+        Ok(Self {
+            child,
+            #[cfg(unix)]
+            process_group,
+        })
+    }
+
+    fn kill_all(&mut self) {
+        #[cfg(unix)]
+        {
+            use nix::sys::signal::{Signal, killpg};
+
+            if killpg(self.process_group, Signal::SIGKILL).is_ok() {
+                return;
+            }
+        }
+        let _ = self.child.kill();
+    }
+}
+
+impl std::ops::Deref for OwnedChild {
+    type Target = Child;
+
+    fn deref(&self) -> &Self::Target {
+        &self.child
+    }
+}
+
+impl std::ops::DerefMut for OwnedChild {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.child
+    }
+}
+
 pub struct Client {
-    child: Arc<Mutex<Child>>,
+    child: Arc<Mutex<OwnedChild>>,
     terminated_by_transport: Arc<AtomicBool>,
     outbound: Mutex<Option<mpsc::Sender<Request>>>,
     routes: Arc<Mutex<HashMap<u64, Route>>>,
@@ -4313,7 +4381,8 @@ impl Client {
         let derived_cache_soft_bytes = memory_budgets.derived_cache_soft_bytes.to_string();
         let non_evictable_estimate_hard_bytes =
             memory_budgets.non_evictable_estimate_hard_bytes.to_string();
-        let mut child = Command::new(executable)
+        let mut command = Command::new(executable);
+        command
             .args([
                 "__tree-worker",
                 "--threads",
@@ -4325,8 +4394,8 @@ impl Client {
             ])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
-            .spawn()?;
+            .stderr(Stdio::inherit());
+        let mut child = OwnedChild::spawn(command)?;
         let mut stdin = child
             .stdin
             .take()
@@ -4744,7 +4813,9 @@ impl Client {
                 .child
                 .lock()
                 .map_err(|_| io::Error::other("worker child lock is poisoned"))?;
-            wait_until(&mut child, Duration::from_secs(2))?
+            let status = wait_until(&mut child, Duration::from_secs(2))?;
+            child.kill_all();
+            status
         };
         if let Some(writer) = self.writer.take() {
             let _ = writer.join();
@@ -4763,7 +4834,7 @@ impl Client {
 }
 
 fn failed_spawn(
-    child: Arc<Mutex<Child>>,
+    child: Arc<Mutex<OwnedChild>>,
     stdin: ChildStdin,
     reader: std::thread::JoinHandle<()>,
     error: io::Error,
@@ -4887,26 +4958,24 @@ fn fail_routes(
     }
 }
 
-fn wait_until(child: &mut Child, timeout: Duration) -> io::Result<std::process::ExitStatus> {
+fn wait_until(child: &mut OwnedChild, timeout: Duration) -> io::Result<std::process::ExitStatus> {
     let deadline = Instant::now() + timeout;
     loop {
         if let Some(status) = child.try_wait()? {
             return Ok(status);
         }
         if Instant::now() >= deadline {
-            let kill_error = child.kill().err();
+            child.kill_all();
             let reap_deadline = Instant::now() + timeout;
             loop {
                 if let Some(status) = child.try_wait()? {
                     return Ok(status);
                 }
                 if Instant::now() >= reap_deadline {
-                    return Err(kill_error.unwrap_or_else(|| {
-                        io::Error::new(
-                            io::ErrorKind::TimedOut,
-                            "tree worker did not exit after kill",
-                        )
-                    }));
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "tree worker did not exit after kill",
+                    ));
                 }
                 std::thread::sleep(Duration::from_millis(5));
             }
@@ -4915,19 +4984,18 @@ fn wait_until(child: &mut Child, timeout: Duration) -> io::Result<std::process::
     }
 }
 
-fn terminate(child: &mut Child, timeout: Duration) {
-    if child.try_wait().ok().flatten().is_some() {
-        return;
+fn terminate(child: &mut OwnedChild, timeout: Duration) {
+    let exited = child.try_wait().ok().flatten().is_some();
+    child.kill_all();
+    if !exited {
+        let _ = wait_until(child, timeout);
     }
-    let _ = child.kill();
-    let _ = wait_until(child, timeout);
 }
 
-fn terminate_by_transport(child: &mut Child, marker: &AtomicBool, timeout: Duration) {
-    if child.try_wait().ok().flatten().is_some() {
-        return;
+fn terminate_by_transport(child: &mut OwnedChild, marker: &AtomicBool, timeout: Duration) {
+    if child.try_wait().ok().flatten().is_none() {
+        marker.store(true, Ordering::Release);
     }
-    marker.store(true, Ordering::Release);
     terminate(child, timeout);
 }
 
@@ -4947,8 +5015,8 @@ mod tests {
         GrammarKey, Handshake, HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES,
         MAX_DOCUMENT_REPLICAS, MAX_RETAINED_DOCUMENT_BYTES, MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
         NavigateNode, NodeLayerSelector, NodeNavigation, NodeScalarOperation, NodeScalarValue,
-        OpaqueNodeId, PROTOCOL_VERSION, Request, RequestCancelled, RequestContext, ResolveNode,
-        Response, Route, RunCaptures, RunNodeScalar, RunnableDocuments,
+        OpaqueNodeId, OwnedChild, PROTOCOL_VERSION, Request, RequestCancelled, RequestContext,
+        ResolveNode, Response, Route, RunCaptures, RunNodeScalar, RunnableDocuments,
         SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES, SyncDocument, WireByteRange, WirePosition,
         WireRange, WireSemanticToken, WorkPriority, WorkerError, WorkerQuerySources,
         cache_eviction_plan, close_document, decode_frame, derive_snapshot_with_language,
@@ -4974,9 +5042,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn termination_reaps_the_owned_process_group() {
-        use std::os::unix::process::CommandExt as _;
-
+    fn termination_kills_the_owned_process_group() {
         use nix::errno::Errno;
         use nix::sys::signal::{Signal, kill};
         use nix::unistd::Pid;
@@ -4985,15 +5051,18 @@ mod tests {
         let pid_path = directory.path().join("descendant.pid");
         let script = format!("sleep 30 & echo $! > '{}'; wait", pid_path.display());
         let mut command = std::process::Command::new("sh");
-        command.args(["-c", &script]).process_group(0);
-        let mut owner = command.spawn().unwrap();
+        command.args(["-c", &script]);
+        let mut owner = OwnedChild::spawn(command).unwrap();
 
         let deadline = Instant::now() + Duration::from_secs(2);
         let descendant = loop {
             if let Ok(pid) = std::fs::read_to_string(&pid_path) {
                 break Pid::from_raw(pid.trim().parse().unwrap());
             }
-            assert!(Instant::now() < deadline, "descendant pid was not published");
+            assert!(
+                Instant::now() < deadline,
+                "descendant pid was not published"
+            );
             std::thread::sleep(Duration::from_millis(5));
         };
 
@@ -5019,18 +5088,16 @@ mod tests {
     #[test]
     fn transport_termination_marker_excludes_already_exited_workers() {
         let marker = AtomicBool::new(false);
-        let mut running = std::process::Command::new("sh")
-            .args(["-c", "sleep 10"])
-            .spawn()
-            .unwrap();
+        let mut running_command = std::process::Command::new("sh");
+        running_command.args(["-c", "sleep 10"]);
+        let mut running = OwnedChild::spawn(running_command).unwrap();
         terminate_by_transport(&mut running, &marker, Duration::from_secs(1));
         assert!(marker.load(Ordering::Acquire));
 
         let marker = AtomicBool::new(false);
-        let mut exited = std::process::Command::new("sh")
-            .args(["-c", "exit 0"])
-            .spawn()
-            .unwrap();
+        let mut exited_command = std::process::Command::new("sh");
+        exited_command.args(["-c", "exit 0"]);
+        let mut exited = OwnedChild::spawn(exited_command).unwrap();
         exited.wait().unwrap();
         terminate_by_transport(&mut exited, &marker, Duration::from_secs(1));
         assert!(!marker.load(Ordering::Acquire));

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4214,7 +4214,7 @@ fn spawn_test_descendant() -> io::Result<()> {
         return Ok(());
     };
     let _descendant = Command::new("sh")
-        .args(["-c", "echo $$ > \"$1\"; exec sleep 30", "worker-descendant"])
+        .args(["-c", "echo $$ > \"$1\"; exec sleep 300", "worker-descendant"])
         .arg(pid_path)
         .stdin(Stdio::null())
         .stdout(Stdio::null())

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -95,6 +95,50 @@ fn assert_host_tier_available(client: &mut LspClient, command: &str) {
     assert!(response.get("result").is_some(), "{response:?}");
 }
 
+#[cfg(unix)]
+#[test]
+fn normal_shutdown_terminates_worker_descendants() {
+    use nix::errno::Errno;
+    use nix::sys::signal::{Signal, kill};
+    use nix::unistd::Pid;
+
+    let directory = tempfile::tempdir().unwrap();
+    let pid_path = directory.path().join("worker-descendant.pid");
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_MODE", "authoritative")
+        .env(
+            "KAKEHASHI_TREE_WORKER_DESCENDANT_PID_FILE",
+            pid_path.to_string_lossy(),
+        )
+        .build();
+    initialize(&mut client);
+    wait_for_file(&pid_path, "worker descendant pid was not published");
+    let descendant = Pid::from_raw(
+        std::fs::read_to_string(&pid_path)
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap(),
+    );
+
+    let _stderr = shutdown_and_stderr(client);
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    let descendant_survived = loop {
+        match kill(descendant, None) {
+            Err(Errno::ESRCH) => break false,
+            Ok(()) | Err(Errno::EPERM) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            Ok(()) | Err(Errno::EPERM) => break true,
+            Err(error) => panic!("unexpected descendant liveness error: {error}"),
+        }
+    };
+    if descendant_survived {
+        let _ = kill(descendant, Signal::SIGKILL);
+    }
+    assert!(!descendant_survived, "worker descendant survived shutdown");
+}
+
 #[test]
 fn shadow_worker_matches_authoritative_incremental_lifecycle() {
     let mut client = LspClient::builder()


### PR DESCRIPTION
## Summary

- spawn the resident Unix worker as an explicitly owned process group
- terminate descendants on failed handshake, timeout, transport failure, drop, and graceful shutdown
- prove real LSP → worker → five-minute descendant cleanup without natural-expiry false positives
- record Stage 19 vs Stage 20 cold-start A/B and remaining platform lifecycle gaps

## Measurement

- descendant cleanup E2E: 3/3, median 4.079 s full scenario
- cold-start median paired deltas: driver -0.4%, first request -0.6%

## Validation

- `cargo fmt --all -- --check`
- `cargo test --lib` (3,148 passed, 2 ignored)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --features e2e --test tree_worker_process` (9 passed)
- descendant cleanup focused and repeated E2Es

## Boundary

This closes explicit Unix cleanup only. Parent-death liveness and Windows Job Object ownership remain open ADR gates.

## Stack

Depends on #882. This remains draft while later ADR stages and the full revise pipeline are in progress.