### PR TITLE
fix(worker): exit when the Unix parent dies

### DIFF
--- a/benches/profile/results/single_worker_stage21_parent_liveness_2026-07-20.json
+++ b/benches/profile/results/single_worker_stage21_parent_liveness_2026-07-20.json
@@ -1,0 +1,24 @@
+{
+  "schema": 1,
+  "experiment": "single-tree-worker-stage21-parent-liveness",
+  "date": "2026-07-20",
+  "environment": {"source_commit": "8e6549081d7609fc7e7eead0e97f4e3871f5587f", "baseline_stage": 20, "baseline_binary_sha256": "ac0b197a425cb5812270cc89d9e108448d83f09b7ede7973b8b18658882a1761", "candidate_stage": 21, "candidate_binary_sha256": "d1b321f0f1ef452627439110a4413647cd765f43c99014149c178139cdb6b25c", "release_build": "cargo build --locked --release --bin kakehashi", "features": "default", "platform": "macOS"},
+  "cold_start": {
+    "scenario": {"language": "rust", "generated_size": 15, "documents": 1, "measured_requests": 1, "settle_seconds": 0, "worker_threads": 4, "isolation": "fresh XDG config and state directory for every run", "order": "baseline-candidate on odd runs; candidate-baseline on even runs"},
+    "runs": [
+      {"run":1,"baseline":{"elapsed_ms":4348.445,"request_ms":3052.3,"wall_ms_per_cycle":3052.75},"candidate":{"elapsed_ms":3369.553,"request_ms":2041.2,"wall_ms_per_cycle":2041.69}},
+      {"run":2,"baseline":{"elapsed_ms":2366.088,"request_ms":2049.9,"wall_ms_per_cycle":2050.58},"candidate":{"elapsed_ms":2351.452,"request_ms":2042.7,"wall_ms_per_cycle":2043.34}},
+      {"run":3,"baseline":{"elapsed_ms":2358.166,"request_ms":2045.0,"wall_ms_per_cycle":2045.73},"candidate":{"elapsed_ms":2357.514,"request_ms":2032.9,"wall_ms_per_cycle":2033.61}},
+      {"run":4,"baseline":{"elapsed_ms":2340.460,"request_ms":2027.6,"wall_ms_per_cycle":2028.28},"candidate":{"elapsed_ms":2345.815,"request_ms":2033.4,"wall_ms_per_cycle":2034.05}},
+      {"run":5,"baseline":{"elapsed_ms":2349.929,"request_ms":2044.2,"wall_ms_per_cycle":2044.95},"candidate":{"elapsed_ms":2363.907,"request_ms":2042.0,"wall_ms_per_cycle":2042.52}},
+      {"run":6,"baseline":{"elapsed_ms":2364.614,"request_ms":2046.7,"wall_ms_per_cycle":2047.41},"candidate":{"elapsed_ms":2383.874,"request_ms":2063.4,"wall_ms_per_cycle":2064.17}},
+      {"run":7,"baseline":{"elapsed_ms":2353.760,"request_ms":2026.2,"wall_ms_per_cycle":2026.88},"candidate":{"elapsed_ms":2368.766,"request_ms":2048.7,"wall_ms_per_cycle":2049.56}},
+      {"run":8,"baseline":{"elapsed_ms":2354.104,"request_ms":2038.4,"wall_ms_per_cycle":2039.09},"candidate":{"elapsed_ms":2330.564,"request_ms":2023.8,"wall_ms_per_cycle":2024.63}},
+      {"run":9,"baseline":{"elapsed_ms":2327.614,"request_ms":2017.0,"wall_ms_per_cycle":2017.53},"candidate":{"elapsed_ms":2338.702,"request_ms":2032.5,"wall_ms_per_cycle":2032.93}},
+      {"run":10,"baseline":{"elapsed_ms":2352.116,"request_ms":2037.1,"wall_ms_per_cycle":2037.79},"candidate":{"elapsed_ms":2344.015,"request_ms":2027.8,"wall_ms_per_cycle":2028.45}},
+      {"run":11,"baseline":{"elapsed_ms":2336.480,"request_ms":2033.4,"wall_ms_per_cycle":2034.04},"candidate":{"elapsed_ms":2346.296,"request_ms":2040.7,"wall_ms_per_cycle":2041.18}},
+      {"run":12,"baseline":{"elapsed_ms":2340.083,"request_ms":2023.0,"wall_ms_per_cycle":2023.65},"candidate":{"elapsed_ms":2341.833,"request_ms":2027.4,"wall_ms_per_cycle":2028.17}}
+    ]
+  },
+  "parent_death_e2e": {"note": "complete debug E2E including initialization, hung compute admission, parent kill, and worker liveness assertion", "runs": [{"run":1,"elapsed_ms":16976.985,"passed":true},{"run":2,"elapsed_ms":3923.416,"passed":true},{"run":3,"elapsed_ms":3891.979,"passed":true}]}
+}

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage21-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage21-measurement.md
@@ -1,0 +1,47 @@
+# Single Tree Worker Stage 21 Parent-Liveness Measurement
+
+## Scope
+
+Stage 21 gives the Unix worker a parent-liveness channel independent of its
+compute pool and protocol reader. The parent owns a close-on-exec pipe writer;
+only the worker inherits the reader. A dedicated control thread blocks on that
+reader and calls `_exit` on EOF, so parent death cannot wait for a hung native
+compute thread or Rust destructors.
+
+This is the ADR's portable Unix baseline. Linux `PR_SET_PDEATHSIG` and its PID
+race check, plus Windows parent-handle and Job Object ownership, remain open.
+
+## Method and result
+
+The RED process E2E parked one worker compute thread forever, killed the real
+LSP parent, and observed that the worker remained orphaned. With the liveness
+pipe, the same worker exited within the two-second assertion window. Three
+measurement runs passed; full-test elapsed median was 3.923 seconds (range
+3.892–16.977 seconds). The first run included incremental test build work.
+
+Twelve order-reversed cold-start pairs compared default release Stage 20 and
+Stage 21 binaries in authoritative mode with four worker threads, fresh config
+and state directories, and one small Rust semantic request. Source commit was
+`8e6549081d7609fc7e7eead0e97f4e3871f5587f`; binary SHA-256 values were
+`ac0b197a425cb5812270cc89d9e108448d83f09b7ede7973b8b18658882a1761` and
+`d1b321f0f1ef452627439110a4413647cd765f43c99014149c178139cdb6b25c`.
+
+| Metric | Stage 20 median | Stage 21 median | Median paired delta |
+| --- | ---: | ---: | ---: |
+| Driver elapsed | 2,352.94 ms | 2,348.87 ms | +0.15% |
+| First request | 2,037.75 ms | 2,037.05 ms | +0.05% |
+
+The first pair was an approximately one-second baseline outlier. Median paired
+deltas are noise-scale; no startup regression or improvement is claimed. Raw
+values are in
+`benches/profile/results/single_worker_stage21_parent_liveness_2026-07-20.json`.
+
+Validation passed for rustfmt, both process-group unit tests, the repeated
+parent-death E2E, and Clippy across all targets and features.
+
+## Decision
+
+Keep Stage 21. It closes abnormal-parent-death containment on macOS and the
+portable Unix path without touching request execution. Keep the ADR `proposed`
+until Linux hardening, Windows ownership, native hazard/quarantine control,
+protocol and compatibility gates, and legacy-path removal are complete.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1252,6 +1252,14 @@ This does not satisfy abnormal parent-death or Windows Job Object requirements;
 those remain open with native hazard/quarantine, protocol and compatibility
 gates, and legacy-path removal.
 
+The [Stage 21 parent-liveness measurement](single-resident-multithreaded-tree-worker-stage21-measurement.md)
+proves that a close-on-exec Unix liveness pipe terminates the worker after
+abnormal parent death even while a compute thread is permanently hung. The
+dedicated control thread exits without joining compute work. Twelve cold-start
+pairs found noise-scale median paired deltas of +0.15% for driver elapsed and
++0.05% for the first request. Linux parent-death-signal hardening and Windows
+ownership remain open with the later protocol and migration gates.
+
 The implementation should proceed in measured stages:
 
 1. Prototype the framed transport, supervision, and one high-level

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -93,6 +93,9 @@ enum Commands {
         /// Internal hard budget for retained source and host-tree estimates.
         #[arg(long, default_value_t = 512 * 1024 * 1024)]
         non_evictable_estimate_hard_bytes: usize,
+        /// Parent-owned liveness pipe inherited by the worker on Unix.
+        #[arg(long)]
+        parent_liveness_fd: Option<i32>,
     },
     /// Report diagnostics for files via the configured downstream language servers
     ///
@@ -355,6 +358,7 @@ fn main() -> ExitCode {
             threads,
             derived_cache_soft_bytes,
             non_evictable_estimate_hard_bytes,
+            parent_liveness_fd,
         }) => kakehashi::tree_worker::WorkerMemoryBudgets::new(
             derived_cache_soft_bytes,
             non_evictable_estimate_hard_bytes,
@@ -364,12 +368,15 @@ fn main() -> ExitCode {
             ExitCode::FAILURE
         })
         .and_then(|memory_budgets| {
-            kakehashi::tree_worker::run_stdio_with_memory_budgets(threads, memory_budgets).map_err(
-                |error| {
-                    eprintln!("tree worker failed: {error}");
-                    ExitCode::FAILURE
-                },
+            kakehashi::tree_worker::run_stdio_with_parent_liveness(
+                threads,
+                memory_budgets,
+                parent_liveness_fd,
             )
+            .map_err(|error| {
+                eprintln!("tree worker failed: {error}");
+                ExitCode::FAILURE
+            })
         }),
         None => {
             // Start LSP server (backward compatible default behavior)

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4196,6 +4196,21 @@ pub fn run_stdio_with_memory_budgets(
     compute_threads: usize,
     memory_budgets: WorkerMemoryBudgets,
 ) -> io::Result<()> {
+    run_stdio_with_parent_liveness(compute_threads, memory_budgets, None)
+}
+
+#[doc(hidden)]
+pub fn run_stdio_with_parent_liveness(
+    compute_threads: usize,
+    memory_budgets: WorkerMemoryBudgets,
+    parent_liveness_fd: Option<i32>,
+) -> io::Result<()> {
+    #[cfg(unix)]
+    if let Some(fd) = parent_liveness_fd {
+        arm_parent_liveness(fd)?;
+    }
+    #[cfg(not(unix))]
+    let _ = parent_liveness_fd;
     #[cfg(feature = "e2e")]
     publish_test_worker_pid()?;
     #[cfg(all(unix, feature = "e2e"))]
@@ -4208,6 +4223,39 @@ pub fn run_stdio_with_memory_budgets(
         &build_id,
         memory_budgets,
     )
+}
+
+#[cfg(unix)]
+fn arm_parent_liveness(fd: i32) -> io::Result<()> {
+    use std::os::fd::FromRawFd as _;
+
+    if fd < 3 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "parent liveness fd must not alias standard I/O",
+        ));
+    }
+    // SAFETY: the parent passes ownership of this inherited descriptor to the
+    // worker. This function is called exactly once before any worker threads
+    // can otherwise acquire or close it.
+    let read_end = unsafe { std::os::fd::OwnedFd::from_raw_fd(fd) };
+    std::thread::Builder::new()
+        .name("kakehashi-tree-worker-parent-liveness".into())
+        .spawn(move || {
+            let mut byte = [0_u8; 1];
+            loop {
+                match nix::unistd::read(&read_end, &mut byte) {
+                    Ok(0) => break,
+                    Ok(_) | Err(nix::errno::Errno::EINTR) => continue,
+                    Err(_) => break,
+                }
+            }
+            // SAFETY: `_exit` is deliberately used from the control thread so
+            // parent death cannot wait for or run destructors held by a hung
+            // native compute thread.
+            unsafe { nix::libc::_exit(1) }
+        })
+        .map(|_| ())
 }
 
 #[cfg(feature = "e2e")]
@@ -4255,10 +4303,53 @@ struct OwnedChild {
     child: Child,
     #[cfg(unix)]
     process_group: nix::unistd::Pid,
+    #[cfg(unix)]
+    _parent_liveness: Option<std::os::fd::OwnedFd>,
 }
 
 impl OwnedChild {
-    fn spawn(mut command: Command) -> io::Result<Self> {
+    #[cfg(test)]
+    fn spawn(command: Command) -> io::Result<Self> {
+        Self::spawn_configured(command, None)
+    }
+
+    fn spawn_worker(mut command: Command) -> io::Result<Self> {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd as _;
+            use std::os::unix::process::CommandExt as _;
+
+            use nix::fcntl::{FcntlArg, FdFlag, fcntl};
+
+            let (read_end, write_end) = nix::unistd::pipe()?;
+            fcntl(&read_end, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC))?;
+            fcntl(&write_end, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC))?;
+            let read_fd = read_end.as_raw_fd();
+            command.arg("--parent-liveness-fd").arg(read_fd.to_string());
+            // SAFETY: `fcntl` is async-signal-safe. The closure only clears
+            // CLOEXEC on the one pipe end intentionally inherited by this
+            // worker and allocates nothing after fork.
+            unsafe {
+                command.pre_exec(move || {
+                    if nix::libc::fcntl(read_fd, nix::libc::F_SETFD, 0) == -1 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    Ok(())
+                });
+            }
+            let child = Self::spawn_configured(command, Some(write_end));
+            drop(read_end);
+            child
+        }
+        #[cfg(not(unix))]
+        Self::spawn_configured(command, None)
+    }
+
+    fn spawn_configured(
+        mut command: Command,
+        #[cfg(unix)] parent_liveness: Option<std::os::fd::OwnedFd>,
+        #[cfg(not(unix))] _parent_liveness: Option<()>,
+    ) -> io::Result<Self> {
         #[cfg(unix)]
         {
             use std::os::unix::process::CommandExt as _;
@@ -4272,6 +4363,8 @@ impl OwnedChild {
             child,
             #[cfg(unix)]
             process_group,
+            #[cfg(unix)]
+            _parent_liveness: parent_liveness,
         })
     }
 
@@ -4409,7 +4502,7 @@ impl Client {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit());
-        let mut child = OwnedChild::spawn(command)?;
+        let mut child = OwnedChild::spawn_worker(command)?;
         let mut stdin = child
             .stdin
             .take()

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4196,6 +4196,8 @@ pub fn run_stdio_with_memory_budgets(
     compute_threads: usize,
     memory_budgets: WorkerMemoryBudgets,
 ) -> io::Result<()> {
+    #[cfg(feature = "e2e")]
+    publish_test_worker_pid()?;
     #[cfg(all(unix, feature = "e2e"))]
     spawn_test_descendant()?;
     let build_id = artifact_digest(&std::env::current_exe()?)?;
@@ -4206,6 +4208,14 @@ pub fn run_stdio_with_memory_budgets(
         &build_id,
         memory_budgets,
     )
+}
+
+#[cfg(feature = "e2e")]
+fn publish_test_worker_pid() -> io::Result<()> {
+    let Some(pid_path) = std::env::var_os("KAKEHASHI_TREE_WORKER_PID_FILE") else {
+        return Ok(());
+    };
+    std::fs::write(pid_path, std::process::id().to_string())
 }
 
 #[cfg(all(unix, feature = "e2e"))]

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -139,6 +139,67 @@ fn normal_shutdown_terminates_worker_descendants() {
     assert!(!descendant_survived, "worker descendant survived shutdown");
 }
 
+#[cfg(unix)]
+#[test]
+fn parent_death_terminates_worker_with_a_hung_compute_thread() {
+    use nix::errno::Errno;
+    use nix::sys::signal::{Signal, kill};
+    use nix::unistd::Pid;
+
+    let directory = tempfile::tempdir().unwrap();
+    let worker_pid_path = directory.path().join("worker.pid");
+    let hang_marker = directory.path().join("hung-compute");
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_MODE", "authoritative")
+        .env(
+            "KAKEHASHI_TREE_WORKER_PID_FILE",
+            worker_pid_path.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_HANG_ONCE_FILE",
+            hang_marker.to_string_lossy(),
+        )
+        .env("KAKEHASHI_TREE_WORKER_HANG_URI_SUFFIX", "/hung.rs")
+        .build();
+    initialize(&mut client);
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": "file:///hung.rs",
+                "languageId": "rust",
+                "version": 1,
+                "text": "fn hangs_forever() {}\n"
+            }
+        }),
+    );
+    wait_for_file(&hang_marker, "worker compute thread did not enter the hang");
+    let worker = Pid::from_raw(
+        std::fs::read_to_string(&worker_pid_path)
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap(),
+    );
+
+    drop(client);
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    let worker_survived = loop {
+        match kill(worker, None) {
+            Err(Errno::ESRCH) => break false,
+            Ok(()) | Err(Errno::EPERM) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            Ok(()) | Err(Errno::EPERM) => break true,
+            Err(error) => panic!("unexpected worker liveness error: {error}"),
+        }
+    };
+    if worker_survived {
+        let _ = kill(worker, Signal::SIGKILL);
+    }
+    assert!(!worker_survived, "worker survived parent death");
+}
+
 #[test]
 fn shadow_worker_matches_authoritative_incremental_lifecycle() {
     let mut client = LspClient::builder()


### PR DESCRIPTION
## Summary

- add a close-on-exec Unix parent-liveness pipe to every resident worker
- monitor EOF from a dedicated control thread independent of the compute pool
- use `_exit` so parent death cannot join a permanently hung compute thread
- record repeated parent-death E2Es and Stage 20 vs Stage 21 cold-start A/B

## Measurement

- hung-compute parent-death E2E: 3/3, median 3.923 s full scenario
- cold-start median paired deltas: driver +0.15%, first request +0.05%

## Validation

- rustfmt
- process-group lifecycle unit tests
- repeated parent-death E2E
- `cargo clippy --all-targets --all-features -- -D warnings`

## Boundary

This closes the portable Unix/macOS liveness-pipe path. Linux PDEATHSIG hardening and Windows parent-handle/Job Object ownership remain open.

## Stack

Depends on #883. This remains draft while later ADR stages and the full revise pipeline are in progress.