### PR TITLE
feat(worker): acknowledge active grammar hazards

### DIFF
--- a/benches/profile/results/single_worker_stage24_grammar_hazard_2026-07-20.json
+++ b/benches/profile/results/single_worker_stage24_grammar_hazard_2026-07-20.json
@@ -1,0 +1,2819 @@
+{
+  "baseline": {
+    "binary_sha256": "b5ef5e8b4b39a84433fd6c337f1fd90af7dcf2324f5d76d6270083ce77c3c9c1",
+    "commit": "82f4b9218817b82930ad9f15fed37694bfb35988",
+    "harness_sha256": "e76fac356bd426a0b175f649fcb6c9497673175bdd28f897ddd19adef5a85be4",
+    "stage": 23
+  },
+  "candidate": {
+    "binary_sha256": "f64e66521e12e5e19d51454833cb8526bc6a404fb11594a290e3d2906d3627fd",
+    "commit": "f8b647522",
+    "harness_sha256": "052bca0015337cb7bfdef7bd4cef14f67eb2bef09c218c0c55b5a8a234f7ab09",
+    "stage": 24
+  },
+  "environment": {
+    "cpu": "Apple M4",
+    "os": "macOS 26.5 Darwin 25.5.0 arm64"
+  },
+  "measured_at": "2026-07-20",
+  "method": {
+    "measured_batches": 2,
+    "measured_pairs_per_batch": 12,
+    "order": "alternating; batch B reverses batch A first order",
+    "requests_per_run": 500,
+    "source_lines": 200,
+    "threads": 4,
+    "warmup_runs_per_stage": 1
+  },
+  "pairs": [
+    {
+      "batch": "a",
+      "order": [
+        "stage23",
+        "stage24"
+      ],
+      "pair": 1,
+      "stage23": {
+        "cold_start_us": 367600.70900000003,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1783.834736,
+            "p50_us": 1692.0,
+            "p95_us": 2113.333,
+            "p99_us": 2784.959
+          },
+          "direct_requests_per_second": 2180.4627268975887,
+          "direct_wall_ms": 229.309125,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 2032.549426,
+            "p50_us": 1938.417,
+            "p95_us": 2487.625,
+            "p99_us": 2959.25
+          },
+          "worker_requests_per_second": 1949.3712572023128,
+          "worker_wall_ms": 256.492958
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1387.51102,
+            "p50_us": 1367.875,
+            "p95_us": 1463.959,
+            "p99_us": 1613.125
+          },
+          "worker_compute": {
+            "mean_us": 1300.85918,
+            "p50_us": 1277.0,
+            "p95_us": 1370.375,
+            "p99_us": 1578.5
+          },
+          "worker_parent_observed": {
+            "mean_us": 1521.4375220000002,
+            "p50_us": 1497.042,
+            "p95_us": 1637.958,
+            "p99_us": 1909.125
+          },
+          "worker_queue": {
+            "mean_us": 15.141422,
+            "p50_us": 13.542,
+            "p95_us": 26.959,
+            "p99_us": 35.958
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 373755.542,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1908.693974,
+            "p50_us": 1810.167,
+            "p95_us": 2411.5,
+            "p99_us": 2821.917
+          },
+          "direct_requests_per_second": 2086.061145113977,
+          "direct_wall_ms": 239.686167,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1960.056074,
+            "p50_us": 1854.541,
+            "p95_us": 2447.958,
+            "p99_us": 2795.875
+          },
+          "worker_requests_per_second": 1992.875803804534,
+          "worker_wall_ms": 250.893708
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1381.033838,
+            "p50_us": 1373.709,
+            "p95_us": 1407.125,
+            "p99_us": 1492.416
+          },
+          "worker_compute": {
+            "mean_us": 1287.7575060000001,
+            "p50_us": 1280.625,
+            "p95_us": 1324.833,
+            "p99_us": 1387.916
+          },
+          "worker_parent_observed": {
+            "mean_us": 1530.618088,
+            "p50_us": 1523.333,
+            "p95_us": 1590.459,
+            "p99_us": 1691.5
+          },
+          "worker_queue": {
+            "mean_us": 71.537262,
+            "p50_us": 69.917,
+            "p95_us": 94.208,
+            "p99_us": 105.708
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "a",
+      "order": [
+        "stage24",
+        "stage23"
+      ],
+      "pair": 2,
+      "stage23": {
+        "cold_start_us": 366221.625,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1646.3509920000001,
+            "p50_us": 1579.25,
+            "p95_us": 1872.667,
+            "p99_us": 2749.417
+          },
+          "direct_requests_per_second": 2390.533011169168,
+          "direct_wall_ms": 209.158375,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1922.961324,
+            "p50_us": 1812.917,
+            "p95_us": 2372.084,
+            "p99_us": 2610.541
+          },
+          "worker_requests_per_second": 2073.5136564761156,
+          "worker_wall_ms": 241.136584
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1377.632004,
+            "p50_us": 1375.708,
+            "p95_us": 1401.292,
+            "p99_us": 1412.75
+          },
+          "worker_compute": {
+            "mean_us": 1295.275436,
+            "p50_us": 1289.959,
+            "p95_us": 1336.583,
+            "p99_us": 1368.792
+          },
+          "worker_parent_observed": {
+            "mean_us": 1452.78085,
+            "p50_us": 1441.208,
+            "p95_us": 1538.083,
+            "p99_us": 1596.917
+          },
+          "worker_queue": {
+            "mean_us": 9.280940000000001,
+            "p50_us": 8.208,
+            "p95_us": 25.375,
+            "p99_us": 40.0
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 368135.792,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1840.432486,
+            "p50_us": 1764.334,
+            "p95_us": 2355.292,
+            "p99_us": 2529.541
+          },
+          "direct_requests_per_second": 2052.702100068201,
+          "direct_wall_ms": 243.58137499999998,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1875.082764,
+            "p50_us": 1803.083,
+            "p95_us": 2128.125,
+            "p99_us": 2681.5
+          },
+          "worker_requests_per_second": 2126.2322844983846,
+          "worker_wall_ms": 235.15775
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1385.434744,
+            "p50_us": 1371.875,
+            "p95_us": 1475.125,
+            "p99_us": 1524.833
+          },
+          "worker_compute": {
+            "mean_us": 1318.319062,
+            "p50_us": 1293.875,
+            "p95_us": 1470.042,
+            "p99_us": 1632.75
+          },
+          "worker_parent_observed": {
+            "mean_us": 1592.4534939999999,
+            "p50_us": 1559.75,
+            "p95_us": 1841.458,
+            "p99_us": 2030.042
+          },
+          "worker_queue": {
+            "mean_us": 86.098498,
+            "p50_us": 80.167,
+            "p95_us": 109.792,
+            "p99_us": 131.125
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "a",
+      "order": [
+        "stage23",
+        "stage24"
+      ],
+      "pair": 3,
+      "stage23": {
+        "cold_start_us": 362403.583,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1705.441738,
+            "p50_us": 1661.834,
+            "p95_us": 1982.291,
+            "p99_us": 2143.875
+          },
+          "direct_requests_per_second": 2307.802375663766,
+          "direct_wall_ms": 216.65633300000002,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1907.586576,
+            "p50_us": 1806.583,
+            "p95_us": 2316.125,
+            "p99_us": 2557.208
+          },
+          "worker_requests_per_second": 2075.7259361590395,
+          "worker_wall_ms": 240.879584
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1383.5628179999999,
+            "p50_us": 1381.084,
+            "p95_us": 1411.875,
+            "p99_us": 1444.917
+          },
+          "worker_compute": {
+            "mean_us": 1288.781534,
+            "p50_us": 1284.208,
+            "p95_us": 1320.792,
+            "p99_us": 1369.542
+          },
+          "worker_parent_observed": {
+            "mean_us": 1469.3602520000002,
+            "p50_us": 1458.25,
+            "p95_us": 1549.459,
+            "p99_us": 1598.833
+          },
+          "worker_queue": {
+            "mean_us": 14.51267,
+            "p50_us": 9.458,
+            "p95_us": 37.5,
+            "p99_us": 48.875
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 365264.833,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1644.800862,
+            "p50_us": 1632.0,
+            "p95_us": 1853.708,
+            "p99_us": 2100.958
+          },
+          "direct_requests_per_second": 2343.255261926144,
+          "direct_wall_ms": 213.378375,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1862.5762479999999,
+            "p50_us": 1797.875,
+            "p95_us": 2090.125,
+            "p99_us": 2348.333
+          },
+          "worker_requests_per_second": 2107.7910250148548,
+          "worker_wall_ms": 237.215167
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1396.559544,
+            "p50_us": 1381.542,
+            "p95_us": 1478.959,
+            "p99_us": 1619.792
+          },
+          "worker_compute": {
+            "mean_us": 1296.236064,
+            "p50_us": 1285.125,
+            "p95_us": 1383.5,
+            "p99_us": 1440.917
+          },
+          "worker_parent_observed": {
+            "mean_us": 1537.568178,
+            "p50_us": 1525.458,
+            "p95_us": 1661.667,
+            "p99_us": 1738.708
+          },
+          "worker_queue": {
+            "mean_us": 72.713358,
+            "p50_us": 71.583,
+            "p95_us": 96.0,
+            "p99_us": 110.5
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "a",
+      "order": [
+        "stage24",
+        "stage23"
+      ],
+      "pair": 4,
+      "stage23": {
+        "cold_start_us": 361027.375,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1801.07706,
+            "p50_us": 1703.166,
+            "p95_us": 2368.417,
+            "p99_us": 2605.875
+          },
+          "direct_requests_per_second": 2186.0694907769725,
+          "direct_wall_ms": 228.721,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1893.716816,
+            "p50_us": 1814.625,
+            "p95_us": 2227.791,
+            "p99_us": 2570.458
+          },
+          "worker_requests_per_second": 2103.5887720898804,
+          "worker_wall_ms": 237.689042
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1370.102828,
+            "p50_us": 1368.625,
+            "p95_us": 1380.375,
+            "p99_us": 1414.042
+          },
+          "worker_compute": {
+            "mean_us": 1290.417666,
+            "p50_us": 1287.0,
+            "p95_us": 1318.417,
+            "p99_us": 1346.833
+          },
+          "worker_parent_observed": {
+            "mean_us": 1451.712186,
+            "p50_us": 1442.708,
+            "p95_us": 1524.666,
+            "p99_us": 1569.416
+          },
+          "worker_queue": {
+            "mean_us": 10.466734,
+            "p50_us": 8.25,
+            "p95_us": 28.458,
+            "p99_us": 42.416
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 359931.95900000003,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1871.63382,
+            "p50_us": 1775.666,
+            "p95_us": 2222.333,
+            "p99_us": 2399.458
+          },
+          "direct_requests_per_second": 2101.010632756792,
+          "direct_wall_ms": 237.98070900000002,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1805.962268,
+            "p50_us": 1759.041,
+            "p95_us": 1985.708,
+            "p99_us": 2155.375
+          },
+          "worker_requests_per_second": 2207.100318531808,
+          "worker_wall_ms": 226.541583
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1407.606014,
+            "p50_us": 1406.25,
+            "p95_us": 1417.708,
+            "p99_us": 1451.625
+          },
+          "worker_compute": {
+            "mean_us": 1313.05058,
+            "p50_us": 1281.25,
+            "p95_us": 1526.292,
+            "p99_us": 1620.542
+          },
+          "worker_parent_observed": {
+            "mean_us": 1590.258202,
+            "p50_us": 1558.709,
+            "p95_us": 1814.417,
+            "p99_us": 1974.416
+          },
+          "worker_queue": {
+            "mean_us": 83.648686,
+            "p50_us": 83.417,
+            "p95_us": 112.125,
+            "p99_us": 132.792
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "a",
+      "order": [
+        "stage23",
+        "stage24"
+      ],
+      "pair": 5,
+      "stage23": {
+        "cold_start_us": 363113.917,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1734.5271699999998,
+            "p50_us": 1687.541,
+            "p95_us": 2027.417,
+            "p99_us": 2282.833
+          },
+          "direct_requests_per_second": 2267.035211024139,
+          "direct_wall_ms": 220.55237499999998,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1937.6908600000002,
+            "p50_us": 1814.458,
+            "p95_us": 2395.834,
+            "p99_us": 2692.916
+          },
+          "worker_requests_per_second": 2021.111177255343,
+          "worker_wall_ms": 247.388667
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1374.426264,
+            "p50_us": 1373.125,
+            "p95_us": 1384.833,
+            "p99_us": 1422.416
+          },
+          "worker_compute": {
+            "mean_us": 1291.511264,
+            "p50_us": 1282.042,
+            "p95_us": 1353.792,
+            "p99_us": 1473.958
+          },
+          "worker_parent_observed": {
+            "mean_us": 1478.4438400000001,
+            "p50_us": 1462.834,
+            "p95_us": 1570.666,
+            "p99_us": 1715.375
+          },
+          "worker_queue": {
+            "mean_us": 14.383514,
+            "p50_us": 10.917,
+            "p95_us": 32.667,
+            "p99_us": 47.5
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 361523.333,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1688.562974,
+            "p50_us": 1646.041,
+            "p95_us": 2037.958,
+            "p99_us": 2251.625
+          },
+          "direct_requests_per_second": 2290.1471311436817,
+          "direct_wall_ms": 218.326584,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1817.8276839999999,
+            "p50_us": 1772.5,
+            "p95_us": 1932.708,
+            "p99_us": 2152.333
+          },
+          "worker_requests_per_second": 2173.13748850231,
+          "worker_wall_ms": 230.08208299999998
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1387.7490619999999,
+            "p50_us": 1376.292,
+            "p95_us": 1455.666,
+            "p99_us": 1523.5
+          },
+          "worker_compute": {
+            "mean_us": 1286.589324,
+            "p50_us": 1283.375,
+            "p95_us": 1321.625,
+            "p99_us": 1368.291
+          },
+          "worker_parent_observed": {
+            "mean_us": 1524.475254,
+            "p50_us": 1522.0,
+            "p95_us": 1588.917,
+            "p99_us": 1665.625
+          },
+          "worker_queue": {
+            "mean_us": 69.75542,
+            "p50_us": 70.209,
+            "p95_us": 94.833,
+            "p99_us": 106.292
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "a",
+      "order": [
+        "stage24",
+        "stage23"
+      ],
+      "pair": 6,
+      "stage23": {
+        "cold_start_us": 363738.08400000003,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1748.225346,
+            "p50_us": 1623.667,
+            "p95_us": 2280.042,
+            "p99_us": 2845.958
+          },
+          "direct_requests_per_second": 2249.843642616369,
+          "direct_wall_ms": 222.237666,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1976.969028,
+            "p50_us": 1859.209,
+            "p95_us": 2411.583,
+            "p99_us": 3782.042
+          },
+          "worker_requests_per_second": 2017.460108509092,
+          "worker_wall_ms": 247.836375
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1402.88896,
+            "p50_us": 1401.541,
+            "p95_us": 1423.458,
+            "p99_us": 1442.75
+          },
+          "worker_compute": {
+            "mean_us": 1192.5373319999999,
+            "p50_us": 1274.458,
+            "p95_us": 1306.792,
+            "p99_us": 1338.875
+          },
+          "worker_parent_observed": {
+            "mean_us": 1336.60601,
+            "p50_us": 1422.583,
+            "p95_us": 1469.792,
+            "p99_us": 1498.042
+          },
+          "worker_queue": {
+            "mean_us": 8.058908,
+            "p50_us": 7.583,
+            "p95_us": 13.125,
+            "p99_us": 31.916
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 360588.167,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1892.549392,
+            "p50_us": 1743.75,
+            "p95_us": 2323.208,
+            "p99_us": 3296.292
+          },
+          "direct_requests_per_second": 2070.350510341401,
+          "direct_wall_ms": 241.505,
+          "worker_parser_cache_hits": 498,
+          "worker_request_latency": {
+            "mean_us": 1887.070916,
+            "p50_us": 1811.25,
+            "p95_us": 2250.0,
+            "p99_us": 3098.083
+          },
+          "worker_requests_per_second": 2113.707977503806,
+          "worker_wall_ms": 236.551125
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1387.855498,
+            "p50_us": 1362.667,
+            "p95_us": 1447.75,
+            "p99_us": 1706.541
+          },
+          "worker_compute": {
+            "mean_us": 1344.213748,
+            "p50_us": 1293.541,
+            "p95_us": 1562.625,
+            "p99_us": 1630.583
+          },
+          "worker_parent_observed": {
+            "mean_us": 1666.453178,
+            "p50_us": 1603.875,
+            "p95_us": 1894.666,
+            "p99_us": 2324.25
+          },
+          "worker_queue": {
+            "mean_us": 96.596092,
+            "p50_us": 86.375,
+            "p95_us": 118.042,
+            "p99_us": 243.208
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "a",
+      "order": [
+        "stage23",
+        "stage24"
+      ],
+      "pair": 7,
+      "stage23": {
+        "cold_start_us": 362106.375,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1636.563254,
+            "p50_us": 1603.708,
+            "p95_us": 1835.208,
+            "p99_us": 2026.125
+          },
+          "direct_requests_per_second": 2419.32703205737,
+          "direct_wall_ms": 206.669042,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1939.051332,
+            "p50_us": 1838.208,
+            "p95_us": 2346.041,
+            "p99_us": 3116.792
+          },
+          "worker_requests_per_second": 2047.3951503351072,
+          "worker_wall_ms": 244.21275
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1384.0932460000001,
+            "p50_us": 1379.792,
+            "p95_us": 1408.5,
+            "p99_us": 1437.917
+          },
+          "worker_compute": {
+            "mean_us": 1287.1051699999998,
+            "p50_us": 1283.042,
+            "p95_us": 1316.666,
+            "p99_us": 1370.542
+          },
+          "worker_parent_observed": {
+            "mean_us": 1461.436574,
+            "p50_us": 1448.583,
+            "p95_us": 1543.541,
+            "p99_us": 1591.292
+          },
+          "worker_queue": {
+            "mean_us": 12.910008,
+            "p50_us": 8.833,
+            "p95_us": 30.708,
+            "p99_us": 41.542
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 375626.083,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1810.9254979999998,
+            "p50_us": 1712.958,
+            "p95_us": 2174.333,
+            "p99_us": 2366.791
+          },
+          "direct_requests_per_second": 2194.5714317353736,
+          "direct_wall_ms": 227.834917,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1899.97384,
+            "p50_us": 1812.0,
+            "p95_us": 2294.25,
+            "p99_us": 3471.917
+          },
+          "worker_requests_per_second": 2095.61889912948,
+          "worker_wall_ms": 238.593
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1383.497508,
+            "p50_us": 1371.166,
+            "p95_us": 1433.75,
+            "p99_us": 1716.625
+          },
+          "worker_compute": {
+            "mean_us": 1297.583758,
+            "p50_us": 1279.209,
+            "p95_us": 1364.125,
+            "p99_us": 1591.584
+          },
+          "worker_parent_observed": {
+            "mean_us": 1570.113902,
+            "p50_us": 1551.708,
+            "p95_us": 1688.583,
+            "p99_us": 1897.833
+          },
+          "worker_queue": {
+            "mean_us": 81.092328,
+            "p50_us": 80.666,
+            "p95_us": 106.875,
+            "p99_us": 121.458
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "a",
+      "order": [
+        "stage24",
+        "stage23"
+      ],
+      "pair": 8,
+      "stage23": {
+        "cold_start_us": 387304.334,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1820.08852,
+            "p50_us": 1757.333,
+            "p95_us": 2295.209,
+            "p99_us": 2701.209
+          },
+          "direct_requests_per_second": 2141.6624011890513,
+          "direct_wall_ms": 233.46349999999998,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 2018.557272,
+            "p50_us": 1942.375,
+            "p95_us": 2477.875,
+            "p99_us": 2736.958
+          },
+          "worker_requests_per_second": 1951.6825236447899,
+          "worker_wall_ms": 256.189208
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1402.024176,
+            "p50_us": 1363.458,
+            "p95_us": 1647.083,
+            "p99_us": 1783.584
+          },
+          "worker_compute": {
+            "mean_us": 1291.4313200000001,
+            "p50_us": 1281.459,
+            "p95_us": 1352.541,
+            "p99_us": 1447.25
+          },
+          "worker_parent_observed": {
+            "mean_us": 1483.428434,
+            "p50_us": 1467.834,
+            "p95_us": 1576.583,
+            "p99_us": 1735.042
+          },
+          "worker_queue": {
+            "mean_us": 15.496746,
+            "p50_us": 12.666,
+            "p95_us": 35.083,
+            "p99_us": 46.334
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 370767.417,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1980.7444699999999,
+            "p50_us": 1874.667,
+            "p95_us": 2532.791,
+            "p99_us": 2783.166
+          },
+          "direct_requests_per_second": 2009.1991181625071,
+          "direct_wall_ms": 248.85537499999998,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1913.5765660000002,
+            "p50_us": 1808.625,
+            "p95_us": 2253.875,
+            "p99_us": 3498.916
+          },
+          "worker_requests_per_second": 2076.548496645961,
+          "worker_wall_ms": 240.784167
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1387.472552,
+            "p50_us": 1368.542,
+            "p95_us": 1463.375,
+            "p99_us": 1672.0
+          },
+          "worker_compute": {
+            "mean_us": 1289.264246,
+            "p50_us": 1281.292,
+            "p95_us": 1341.167,
+            "p99_us": 1409.375
+          },
+          "worker_parent_observed": {
+            "mean_us": 1544.4768359999998,
+            "p50_us": 1524.333,
+            "p95_us": 1608.0,
+            "p99_us": 1815.708
+          },
+          "worker_queue": {
+            "mean_us": 75.013988,
+            "p50_us": 70.708,
+            "p95_us": 98.792,
+            "p99_us": 122.75
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "a",
+      "order": [
+        "stage23",
+        "stage24"
+      ],
+      "pair": 9,
+      "stage23": {
+        "cold_start_us": 360001.083,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1738.34899,
+            "p50_us": 1607.833,
+            "p95_us": 2204.792,
+            "p99_us": 2444.125
+          },
+          "direct_requests_per_second": 2289.4851803181127,
+          "direct_wall_ms": 218.38970799999998,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1925.70911,
+            "p50_us": 1845.333,
+            "p95_us": 2315.334,
+            "p99_us": 2458.583
+          },
+          "worker_requests_per_second": 2056.4312116130354,
+          "worker_wall_ms": 243.139667
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1365.909596,
+            "p50_us": 1383.708,
+            "p95_us": 1399.0,
+            "p99_us": 1425.583
+          },
+          "worker_compute": {
+            "mean_us": 1184.45419,
+            "p50_us": 1265.375,
+            "p95_us": 1298.458,
+            "p99_us": 1334.917
+          },
+          "worker_parent_observed": {
+            "mean_us": 1334.8856899999998,
+            "p50_us": 1404.709,
+            "p95_us": 1469.25,
+            "p99_us": 1542.958
+          },
+          "worker_queue": {
+            "mean_us": 8.000018,
+            "p50_us": 7.417,
+            "p95_us": 13.458,
+            "p99_us": 35.167
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 363383.29099999997,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1947.91066,
+            "p50_us": 1822.875,
+            "p95_us": 2427.959,
+            "p99_us": 2985.75
+          },
+          "direct_requests_per_second": 1942.9259064467262,
+          "direct_wall_ms": 257.343833,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1926.853326,
+            "p50_us": 1849.208,
+            "p95_us": 2260.75,
+            "p99_us": 2545.833
+          },
+          "worker_requests_per_second": 2069.368681637992,
+          "worker_wall_ms": 241.619584
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1431.938272,
+            "p50_us": 1400.791,
+            "p95_us": 1709.417,
+            "p99_us": 1807.791
+          },
+          "worker_compute": {
+            "mean_us": 1357.717498,
+            "p50_us": 1283.375,
+            "p95_us": 1609.667,
+            "p99_us": 1662.916
+          },
+          "worker_parent_observed": {
+            "mean_us": 1657.743436,
+            "p50_us": 1603.125,
+            "p95_us": 1935.083,
+            "p99_us": 2018.958
+          },
+          "worker_queue": {
+            "mean_us": 83.69227400000001,
+            "p50_us": 84.958,
+            "p95_us": 113.917,
+            "p99_us": 137.75
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "a",
+      "order": [
+        "stage24",
+        "stage23"
+      ],
+      "pair": 10,
+      "stage23": {
+        "cold_start_us": 363113.29199999996,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1629.129336,
+            "p50_us": 1537.209,
+            "p95_us": 1861.333,
+            "p99_us": 1994.0
+          },
+          "direct_requests_per_second": 2416.3013392210028,
+          "direct_wall_ms": 206.927833,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1877.996736,
+            "p50_us": 1817.791,
+            "p95_us": 2188.125,
+            "p99_us": 2424.666
+          },
+          "worker_requests_per_second": 2119.136443761683,
+          "worker_wall_ms": 235.945166
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1382.494466,
+            "p50_us": 1381.5,
+            "p95_us": 1399.5,
+            "p99_us": 1425.292
+          },
+          "worker_compute": {
+            "mean_us": 1284.6299080000001,
+            "p50_us": 1282.208,
+            "p95_us": 1302.625,
+            "p99_us": 1328.875
+          },
+          "worker_parent_observed": {
+            "mean_us": 1442.8261,
+            "p50_us": 1435.5,
+            "p95_us": 1484.333,
+            "p99_us": 1518.125
+          },
+          "worker_queue": {
+            "mean_us": 8.517896,
+            "p50_us": 8.291,
+            "p95_us": 12.875,
+            "p99_us": 32.5
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 364183.833,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1732.937644,
+            "p50_us": 1644.208,
+            "p95_us": 2256.291,
+            "p99_us": 2668.375
+          },
+          "direct_requests_per_second": 2272.791840677292,
+          "direct_wall_ms": 219.99374999999998,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1826.46969,
+            "p50_us": 1786.542,
+            "p95_us": 1997.542,
+            "p99_us": 2126.208
+          },
+          "worker_requests_per_second": 2181.1031733690165,
+          "worker_wall_ms": 229.241792
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1358.58167,
+            "p50_us": 1416.292,
+            "p95_us": 1435.083,
+            "p99_us": 1461.792
+          },
+          "worker_compute": {
+            "mean_us": 1201.183354,
+            "p50_us": 1274.666,
+            "p95_us": 1310.25,
+            "p99_us": 1330.875
+          },
+          "worker_parent_observed": {
+            "mean_us": 1403.85599,
+            "p50_us": 1475.166,
+            "p95_us": 1553.5,
+            "p99_us": 1593.584
+          },
+          "worker_queue": {
+            "mean_us": 52.078838000000005,
+            "p50_us": 47.791,
+            "p95_us": 76.458,
+            "p99_us": 94.333
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "a",
+      "order": [
+        "stage23",
+        "stage24"
+      ],
+      "pair": 11,
+      "stage23": {
+        "cold_start_us": 361002.125,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1600.831874,
+            "p50_us": 1487.417,
+            "p95_us": 1975.375,
+            "p99_us": 2082.666
+          },
+          "direct_requests_per_second": 2452.7678707894443,
+          "direct_wall_ms": 203.85133299999998,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1922.9389199999998,
+            "p50_us": 1836.708,
+            "p95_us": 2307.875,
+            "p99_us": 2477.667
+          },
+          "worker_requests_per_second": 2058.8243844294207,
+          "worker_wall_ms": 242.857042
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1376.8239680000001,
+            "p50_us": 1374.75,
+            "p95_us": 1390.125,
+            "p99_us": 1435.667
+          },
+          "worker_compute": {
+            "mean_us": 1238.290058,
+            "p50_us": 1275.292,
+            "p95_us": 1300.417,
+            "p99_us": 1332.791
+          },
+          "worker_parent_observed": {
+            "mean_us": 1386.516788,
+            "p50_us": 1425.542,
+            "p95_us": 1462.541,
+            "p99_us": 1525.166
+          },
+          "worker_queue": {
+            "mean_us": 7.74183,
+            "p50_us": 7.958,
+            "p95_us": 10.958,
+            "p99_us": 27.625
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 359234.292,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1758.21039,
+            "p50_us": 1685.709,
+            "p95_us": 2360.666,
+            "p99_us": 2499.666
+          },
+          "direct_requests_per_second": 2134.149805552916,
+          "direct_wall_ms": 234.285334,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1845.1378160000002,
+            "p50_us": 1786.958,
+            "p95_us": 2050.625,
+            "p99_us": 2538.208
+          },
+          "worker_requests_per_second": 2158.661238364719,
+          "worker_wall_ms": 231.625042
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1382.498934,
+            "p50_us": 1372.667,
+            "p95_us": 1420.875,
+            "p99_us": 1466.792
+          },
+          "worker_compute": {
+            "mean_us": 1287.685824,
+            "p50_us": 1284.417,
+            "p95_us": 1308.458,
+            "p99_us": 1364.25
+          },
+          "worker_parent_observed": {
+            "mean_us": 1517.8524320000001,
+            "p50_us": 1512.584,
+            "p95_us": 1571.083,
+            "p99_us": 1618.125
+          },
+          "worker_queue": {
+            "mean_us": 65.018774,
+            "p50_us": 65.667,
+            "p95_us": 92.5,
+            "p99_us": 105.417
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "a",
+      "order": [
+        "stage24",
+        "stage23"
+      ],
+      "pair": 12,
+      "stage23": {
+        "cold_start_us": 358879.70800000004,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1668.495932,
+            "p50_us": 1579.125,
+            "p95_us": 2131.834,
+            "p99_us": 2331.25
+          },
+          "direct_requests_per_second": 2267.7215351340933,
+          "direct_wall_ms": 220.485625,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 2044.477012,
+            "p50_us": 1862.125,
+            "p95_us": 2640.417,
+            "p99_us": 5180.958
+          },
+          "worker_requests_per_second": 1908.7691128296176,
+          "worker_wall_ms": 261.948916
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1379.355162,
+            "p50_us": 1376.792,
+            "p95_us": 1398.667,
+            "p99_us": 1442.208
+          },
+          "worker_compute": {
+            "mean_us": 1239.792222,
+            "p50_us": 1281.167,
+            "p95_us": 1306.25,
+            "p99_us": 1361.583
+          },
+          "worker_parent_observed": {
+            "mean_us": 1400.874254,
+            "p50_us": 1443.584,
+            "p95_us": 1488.666,
+            "p99_us": 1567.417
+          },
+          "worker_queue": {
+            "mean_us": 8.509495999999999,
+            "p50_us": 8.0,
+            "p95_us": 16.084,
+            "p99_us": 30.542
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 365607.625,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1707.377258,
+            "p50_us": 1609.458,
+            "p95_us": 2255.125,
+            "p99_us": 2373.833
+          },
+          "direct_requests_per_second": 2337.593735054302,
+          "direct_wall_ms": 213.895166,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1805.134908,
+            "p50_us": 1768.459,
+            "p95_us": 1951.542,
+            "p99_us": 2105.333
+          },
+          "worker_requests_per_second": 2194.8917616783365,
+          "worker_wall_ms": 227.801666
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1387.51176,
+            "p50_us": 1384.375,
+            "p95_us": 1407.0,
+            "p99_us": 1448.916
+          },
+          "worker_compute": {
+            "mean_us": 1295.493092,
+            "p50_us": 1290.083,
+            "p95_us": 1336.167,
+            "p99_us": 1400.542
+          },
+          "worker_parent_observed": {
+            "mean_us": 1515.096662,
+            "p50_us": 1510.833,
+            "p95_us": 1586.25,
+            "p99_us": 1654.042
+          },
+          "worker_queue": {
+            "mean_us": 56.863485999999995,
+            "p50_us": 51.541,
+            "p95_us": 80.75,
+            "p99_us": 96.375
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "b",
+      "order": [
+        "stage24",
+        "stage23"
+      ],
+      "pair": 1,
+      "stage23": {
+        "cold_start_us": 388562.542,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1774.221396,
+            "p50_us": 1702.25,
+            "p95_us": 2036.0,
+            "p99_us": 2400.75
+          },
+          "direct_requests_per_second": 2170.698672883455,
+          "direct_wall_ms": 230.34058399999998,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1941.0140079999999,
+            "p50_us": 1827.791,
+            "p95_us": 2358.417,
+            "p99_us": 2742.042
+          },
+          "worker_requests_per_second": 2054.013716777545,
+          "worker_wall_ms": 243.425833
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1491.0358899999999,
+            "p50_us": 1420.042,
+            "p95_us": 1755.416,
+            "p99_us": 1898.5
+          },
+          "worker_compute": {
+            "mean_us": 1326.664906,
+            "p50_us": 1272.75,
+            "p95_us": 1577.875,
+            "p99_us": 1655.583
+          },
+          "worker_parent_observed": {
+            "mean_us": 1560.806884,
+            "p50_us": 1498.833,
+            "p95_us": 1839.959,
+            "p99_us": 2033.166
+          },
+          "worker_queue": {
+            "mean_us": 14.461254,
+            "p50_us": 13.209,
+            "p95_us": 25.833,
+            "p99_us": 31.125
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 227741.04200000002,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1702.136346,
+            "p50_us": 1652.334,
+            "p95_us": 2111.875,
+            "p99_us": 2321.709
+          },
+          "direct_requests_per_second": 2344.0727605060533,
+          "direct_wall_ms": 213.303959,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1847.473522,
+            "p50_us": 1793.083,
+            "p95_us": 2039.458,
+            "p99_us": 2410.209
+          },
+          "worker_requests_per_second": 2116.1490742376836,
+          "worker_wall_ms": 236.27824999999999
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1009.657156,
+            "p50_us": 994.0,
+            "p95_us": 1160.0,
+            "p99_us": 1174.958
+          },
+          "worker_compute": {
+            "mean_us": 1121.6992420000001,
+            "p50_us": 1081.333,
+            "p95_us": 1293.375,
+            "p99_us": 1307.75
+          },
+          "worker_parent_observed": {
+            "mean_us": 1311.014994,
+            "p50_us": 1267.334,
+            "p95_us": 1509.791,
+            "p99_us": 1539.417
+          },
+          "worker_queue": {
+            "mean_us": 49.048339999999996,
+            "p50_us": 44.958,
+            "p95_us": 71.5,
+            "p99_us": 79.375
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "b",
+      "order": [
+        "stage23",
+        "stage24"
+      ],
+      "pair": 2,
+      "stage23": {
+        "cold_start_us": 363743.16699999996,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1757.19391,
+            "p50_us": 1694.375,
+            "p95_us": 2143.291,
+            "p99_us": 2470.416
+          },
+          "direct_requests_per_second": 2150.4127717315337,
+          "direct_wall_ms": 232.51350000000002,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 2025.780446,
+            "p50_us": 1868.042,
+            "p95_us": 2637.125,
+            "p99_us": 2811.416
+          },
+          "worker_requests_per_second": 1885.209296746765,
+          "worker_wall_ms": 265.222541
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1417.3376540000002,
+            "p50_us": 1380.166,
+            "p95_us": 1641.625,
+            "p99_us": 1843.916
+          },
+          "worker_compute": {
+            "mean_us": 1341.771864,
+            "p50_us": 1280.708,
+            "p95_us": 1559.542,
+            "p99_us": 1624.541
+          },
+          "worker_parent_observed": {
+            "mean_us": 1543.368284,
+            "p50_us": 1478.25,
+            "p95_us": 1791.042,
+            "p99_us": 2000.708
+          },
+          "worker_queue": {
+            "mean_us": 25.235514,
+            "p50_us": 12.667,
+            "p95_us": 30.959,
+            "p99_us": 44.292
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 362261.08400000003,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1735.029216,
+            "p50_us": 1652.625,
+            "p95_us": 2261.875,
+            "p99_us": 2500.166
+          },
+          "direct_requests_per_second": 2187.861047667152,
+          "direct_wall_ms": 228.533709,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1838.8134,
+            "p50_us": 1789.667,
+            "p95_us": 2015.75,
+            "p99_us": 2187.667
+          },
+          "worker_requests_per_second": 2140.333463439924,
+          "worker_wall_ms": 233.60845799999998
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1259.72774,
+            "p50_us": 1229.167,
+            "p95_us": 1385.333,
+            "p99_us": 1413.0
+          },
+          "worker_compute": {
+            "mean_us": 1200.3076740000001,
+            "p50_us": 1277.125,
+            "p95_us": 1312.042,
+            "p99_us": 1323.875
+          },
+          "worker_parent_observed": {
+            "mean_us": 1404.1708259999998,
+            "p50_us": 1474.75,
+            "p95_us": 1549.917,
+            "p99_us": 1586.75
+          },
+          "worker_queue": {
+            "mean_us": 51.61641,
+            "p50_us": 46.916,
+            "p95_us": 75.5,
+            "p99_us": 89.834
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "b",
+      "order": [
+        "stage24",
+        "stage23"
+      ],
+      "pair": 3,
+      "stage23": {
+        "cold_start_us": 358875.0,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1756.921496,
+            "p50_us": 1643.875,
+            "p95_us": 2318.416,
+            "p99_us": 2651.25
+          },
+          "direct_requests_per_second": 2102.2937631107975,
+          "direct_wall_ms": 237.835458,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1836.173342,
+            "p50_us": 1776.417,
+            "p95_us": 2177.209,
+            "p99_us": 2432.916
+          },
+          "worker_requests_per_second": 2118.757044231545,
+          "worker_wall_ms": 235.987416
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1368.266556,
+            "p50_us": 1365.791,
+            "p95_us": 1381.416,
+            "p99_us": 1412.834
+          },
+          "worker_compute": {
+            "mean_us": 1267.968494,
+            "p50_us": 1285.25,
+            "p95_us": 1308.25,
+            "p99_us": 1330.125
+          },
+          "worker_parent_observed": {
+            "mean_us": 1421.817872,
+            "p50_us": 1437.208,
+            "p95_us": 1476.625,
+            "p99_us": 1542.125
+          },
+          "worker_queue": {
+            "mean_us": 8.969312,
+            "p50_us": 8.166,
+            "p95_us": 21.167,
+            "p99_us": 39.959
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 357959.95800000004,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1706.114274,
+            "p50_us": 1628.916,
+            "p95_us": 2156.041,
+            "p99_us": 2338.042
+          },
+          "direct_requests_per_second": 2337.9462274892658,
+          "direct_wall_ms": 213.862917,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1862.0283200000001,
+            "p50_us": 1791.416,
+            "p95_us": 2135.292,
+            "p99_us": 3602.042
+          },
+          "worker_requests_per_second": 2139.7720500835044,
+          "worker_wall_ms": 233.66975000000002
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1399.03489,
+            "p50_us": 1403.167,
+            "p95_us": 1426.875,
+            "p99_us": 1452.416
+          },
+          "worker_compute": {
+            "mean_us": 1231.455316,
+            "p50_us": 1275.167,
+            "p95_us": 1306.25,
+            "p99_us": 1354.541
+          },
+          "worker_parent_observed": {
+            "mean_us": 1441.632482,
+            "p50_us": 1487.917,
+            "p95_us": 1546.042,
+            "p99_us": 1602.667
+          },
+          "worker_queue": {
+            "mean_us": 53.587086000000006,
+            "p50_us": 49.584,
+            "p95_us": 76.667,
+            "p99_us": 96.875
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "b",
+      "order": [
+        "stage23",
+        "stage24"
+      ],
+      "pair": 4,
+      "stage23": {
+        "cold_start_us": 362686.375,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1585.606992,
+            "p50_us": 1476.25,
+            "p95_us": 1939.583,
+            "p99_us": 2144.083
+          },
+          "direct_requests_per_second": 2436.2627972316745,
+          "direct_wall_ms": 205.232375,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1989.368402,
+            "p50_us": 1950.042,
+            "p95_us": 2388.875,
+            "p99_us": 2546.875
+          },
+          "worker_requests_per_second": 2003.7339582311638,
+          "worker_wall_ms": 249.534125
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1365.244318,
+            "p50_us": 1401.708,
+            "p95_us": 1430.125,
+            "p99_us": 1453.917
+          },
+          "worker_compute": {
+            "mean_us": 1189.718286,
+            "p50_us": 1266.25,
+            "p95_us": 1308.708,
+            "p99_us": 1329.541
+          },
+          "worker_parent_observed": {
+            "mean_us": 1337.109,
+            "p50_us": 1413.833,
+            "p95_us": 1475.708,
+            "p99_us": 1510.875
+          },
+          "worker_queue": {
+            "mean_us": 7.834408000000001,
+            "p50_us": 7.125,
+            "p95_us": 18.375,
+            "p99_us": 30.084
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 360155.875,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1623.7775020000001,
+            "p50_us": 1500.0,
+            "p95_us": 2080.125,
+            "p99_us": 2309.417
+          },
+          "direct_requests_per_second": 2451.9584711793736,
+          "direct_wall_ms": 203.918625,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1803.633478,
+            "p50_us": 1760.959,
+            "p95_us": 1977.5,
+            "p99_us": 2611.5
+          },
+          "worker_requests_per_second": 2176.2331729733846,
+          "worker_wall_ms": 229.754792
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1372.9485020000002,
+            "p50_us": 1362.75,
+            "p95_us": 1415.084,
+            "p99_us": 1455.167
+          },
+          "worker_compute": {
+            "mean_us": 1229.023466,
+            "p50_us": 1272.709,
+            "p95_us": 1308.916,
+            "p99_us": 1337.584
+          },
+          "worker_parent_observed": {
+            "mean_us": 1426.5666640000002,
+            "p50_us": 1477.625,
+            "p95_us": 1524.625,
+            "p99_us": 1583.959
+          },
+          "worker_queue": {
+            "mean_us": 52.085758,
+            "p50_us": 47.625,
+            "p95_us": 72.875,
+            "p99_us": 90.25
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "b",
+      "order": [
+        "stage24",
+        "stage23"
+      ],
+      "pair": 5,
+      "stage23": {
+        "cold_start_us": 359491.292,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1633.32424,
+            "p50_us": 1522.667,
+            "p95_us": 1968.917,
+            "p99_us": 2118.875
+          },
+          "direct_requests_per_second": 2441.4703266748334,
+          "direct_wall_ms": 204.794625,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1914.398978,
+            "p50_us": 1815.5,
+            "p95_us": 2313.709,
+            "p99_us": 2508.541
+          },
+          "worker_requests_per_second": 2049.6363803636323,
+          "worker_wall_ms": 243.94570900000002
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1370.023932,
+            "p50_us": 1364.708,
+            "p95_us": 1405.5,
+            "p99_us": 1443.125
+          },
+          "worker_compute": {
+            "mean_us": 1277.0600020000002,
+            "p50_us": 1274.25,
+            "p95_us": 1300.542,
+            "p99_us": 1332.084
+          },
+          "worker_parent_observed": {
+            "mean_us": 1445.639502,
+            "p50_us": 1434.167,
+            "p95_us": 1530.458,
+            "p99_us": 1555.958
+          },
+          "worker_queue": {
+            "mean_us": 10.975245999999999,
+            "p50_us": 8.5,
+            "p95_us": 28.583,
+            "p99_us": 40.792
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 356810.0,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1778.47826,
+            "p50_us": 1673.959,
+            "p95_us": 2359.333,
+            "p99_us": 2760.125
+          },
+          "direct_requests_per_second": 2155.65209284178,
+          "direct_wall_ms": 231.948375,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1786.37593,
+            "p50_us": 1765.75,
+            "p95_us": 1896.5,
+            "p99_us": 1995.208
+          },
+          "worker_requests_per_second": 2220.1217403756336,
+          "worker_wall_ms": 225.212875
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1410.9370020000001,
+            "p50_us": 1394.042,
+            "p95_us": 1509.958,
+            "p99_us": 1525.583
+          },
+          "worker_compute": {
+            "mean_us": 1152.763814,
+            "p50_us": 1090.375,
+            "p95_us": 1310.458,
+            "p99_us": 1331.166
+          },
+          "worker_parent_observed": {
+            "mean_us": 1342.853918,
+            "p50_us": 1273.166,
+            "p95_us": 1536.458,
+            "p99_us": 1565.0
+          },
+          "worker_queue": {
+            "mean_us": 48.511843999999996,
+            "p50_us": 44.542,
+            "p95_us": 69.541,
+            "p99_us": 81.834
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "b",
+      "order": [
+        "stage23",
+        "stage24"
+      ],
+      "pair": 6,
+      "stage23": {
+        "cold_start_us": 362582.91599999997,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1769.399022,
+            "p50_us": 1659.0,
+            "p95_us": 2409.625,
+            "p99_us": 2528.75
+          },
+          "direct_requests_per_second": 2250.871646668865,
+          "direct_wall_ms": 222.136167,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1854.71233,
+            "p50_us": 1785.792,
+            "p95_us": 2156.833,
+            "p99_us": 2353.875
+          },
+          "worker_requests_per_second": 2093.0328662420725,
+          "worker_wall_ms": 238.887792
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1367.831198,
+            "p50_us": 1369.75,
+            "p95_us": 1391.042,
+            "p99_us": 1415.666
+          },
+          "worker_compute": {
+            "mean_us": 1158.126676,
+            "p50_us": 1081.417,
+            "p95_us": 1297.791,
+            "p99_us": 1318.041
+          },
+          "worker_parent_observed": {
+            "mean_us": 1302.58176,
+            "p50_us": 1223.917,
+            "p95_us": 1476.375,
+            "p99_us": 1525.708
+          },
+          "worker_queue": {
+            "mean_us": 8.329892,
+            "p50_us": 7.375,
+            "p95_us": 19.0,
+            "p99_us": 35.166
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 357220.125,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1854.436008,
+            "p50_us": 1734.709,
+            "p95_us": 2360.0,
+            "p99_us": 3045.667
+          },
+          "direct_requests_per_second": 2092.4131772297687,
+          "direct_wall_ms": 238.958541,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1928.922906,
+            "p50_us": 1819.25,
+            "p95_us": 2336.416,
+            "p99_us": 2894.25
+          },
+          "worker_requests_per_second": 2056.445666126718,
+          "worker_wall_ms": 243.137958
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1389.038568,
+            "p50_us": 1385.917,
+            "p95_us": 1407.375,
+            "p99_us": 1444.458
+          },
+          "worker_compute": {
+            "mean_us": 1333.08156,
+            "p50_us": 1292.417,
+            "p95_us": 1554.084,
+            "p99_us": 1588.834
+          },
+          "worker_parent_observed": {
+            "mean_us": 1617.283842,
+            "p50_us": 1562.875,
+            "p95_us": 1874.042,
+            "p99_us": 2735.875
+          },
+          "worker_queue": {
+            "mean_us": 86.534508,
+            "p50_us": 78.5,
+            "p95_us": 106.417,
+            "p99_us": 127.958
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "b",
+      "order": [
+        "stage24",
+        "stage23"
+      ],
+      "pair": 7,
+      "stage23": {
+        "cold_start_us": 362576.08400000003,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1715.09819,
+            "p50_us": 1573.5,
+            "p95_us": 2329.708,
+            "p99_us": 2507.542
+          },
+          "direct_requests_per_second": 2320.0999380264184,
+          "direct_wall_ms": 215.507958,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1939.80818,
+            "p50_us": 1843.709,
+            "p95_us": 2300.375,
+            "p99_us": 2592.666
+          },
+          "worker_requests_per_second": 2033.316227992788,
+          "worker_wall_ms": 245.903708
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1341.73093,
+            "p50_us": 1380.917,
+            "p95_us": 1419.166,
+            "p99_us": 1443.75
+          },
+          "worker_compute": {
+            "mean_us": 1282.759066,
+            "p50_us": 1191.792,
+            "p95_us": 1430.25,
+            "p99_us": 1459.542
+          },
+          "worker_parent_observed": {
+            "mean_us": 1428.649904,
+            "p50_us": 1330.542,
+            "p95_us": 1609.458,
+            "p99_us": 1653.167
+          },
+          "worker_queue": {
+            "mean_us": 8.257084,
+            "p50_us": 7.459,
+            "p95_us": 19.125,
+            "p99_us": 37.333
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 370568.709,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1713.806234,
+            "p50_us": 1576.625,
+            "p95_us": 2371.792,
+            "p99_us": 2575.708
+          },
+          "direct_requests_per_second": 2159.566013613904,
+          "direct_wall_ms": 231.52800000000002,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 2126.090606,
+            "p50_us": 2076.792,
+            "p95_us": 2439.959,
+            "p99_us": 2629.625
+          },
+          "worker_requests_per_second": 1875.888113433844,
+          "worker_wall_ms": 266.540417
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1393.085508,
+            "p50_us": 1387.667,
+            "p95_us": 1416.25,
+            "p99_us": 1455.75
+          },
+          "worker_compute": {
+            "mean_us": 1202.0356740000002,
+            "p50_us": 1279.125,
+            "p95_us": 1324.208,
+            "p99_us": 1388.083
+          },
+          "worker_parent_observed": {
+            "mean_us": 1404.642562,
+            "p50_us": 1476.417,
+            "p95_us": 1561.625,
+            "p99_us": 1647.875
+          },
+          "worker_queue": {
+            "mean_us": 52.770336,
+            "p50_us": 48.25,
+            "p95_us": 75.834,
+            "p99_us": 93.166
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "b",
+      "order": [
+        "stage23",
+        "stage24"
+      ],
+      "pair": 8,
+      "stage23": {
+        "cold_start_us": 358243.79099999997,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1629.872408,
+            "p50_us": 1500.625,
+            "p95_us": 2005.0,
+            "p99_us": 2243.125
+          },
+          "direct_requests_per_second": 2445.523912829261,
+          "direct_wall_ms": 204.455167,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 2009.38308,
+            "p50_us": 1981.958,
+            "p95_us": 2399.791,
+            "p99_us": 2589.5
+          },
+          "worker_requests_per_second": 1985.1940889718408,
+          "worker_wall_ms": 251.86454200000003
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1383.394834,
+            "p50_us": 1385.667,
+            "p95_us": 1408.958,
+            "p99_us": 1438.5
+          },
+          "worker_compute": {
+            "mean_us": 1224.336834,
+            "p50_us": 1278.916,
+            "p95_us": 1303.958,
+            "p99_us": 1339.834
+          },
+          "worker_parent_observed": {
+            "mean_us": 1374.44486,
+            "p50_us": 1431.708,
+            "p95_us": 1472.167,
+            "p99_us": 1524.459
+          },
+          "worker_queue": {
+            "mean_us": 7.854926000000001,
+            "p50_us": 7.75,
+            "p95_us": 12.709,
+            "p99_us": 27.167
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 361257.208,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1656.8908359999998,
+            "p50_us": 1556.5,
+            "p95_us": 2134.125,
+            "p99_us": 2289.125
+          },
+          "direct_requests_per_second": 2335.035574266974,
+          "direct_wall_ms": 214.1295,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1806.307932,
+            "p50_us": 1768.041,
+            "p95_us": 1988.875,
+            "p99_us": 2123.0
+          },
+          "worker_requests_per_second": 2180.7305951678727,
+          "worker_wall_ms": 229.280958
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1382.64078,
+            "p50_us": 1378.0,
+            "p95_us": 1414.0,
+            "p99_us": 1467.041
+          },
+          "worker_compute": {
+            "mean_us": 1171.3074,
+            "p50_us": 1096.125,
+            "p95_us": 1316.792,
+            "p99_us": 1344.333
+          },
+          "worker_parent_observed": {
+            "mean_us": 1360.891244,
+            "p50_us": 1278.667,
+            "p95_us": 1546.041,
+            "p99_us": 1589.958
+          },
+          "worker_queue": {
+            "mean_us": 49.499998,
+            "p50_us": 45.625,
+            "p95_us": 73.0,
+            "p99_us": 86.875
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "b",
+      "order": [
+        "stage24",
+        "stage23"
+      ],
+      "pair": 9,
+      "stage23": {
+        "cold_start_us": 365720.58400000003,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1668.522168,
+            "p50_us": 1565.542,
+            "p95_us": 2177.166,
+            "p99_us": 2345.334
+          },
+          "direct_requests_per_second": 2390.9373909134815,
+          "direct_wall_ms": 209.123,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1868.213938,
+            "p50_us": 1787.583,
+            "p95_us": 2260.125,
+            "p99_us": 2460.208
+          },
+          "worker_requests_per_second": 2071.2278008082662,
+          "worker_wall_ms": 241.402708
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1396.064022,
+            "p50_us": 1393.417,
+            "p95_us": 1531.083,
+            "p99_us": 1570.5
+          },
+          "worker_compute": {
+            "mean_us": 1173.959028,
+            "p50_us": 1105.584,
+            "p95_us": 1296.166,
+            "p99_us": 1319.292
+          },
+          "worker_parent_observed": {
+            "mean_us": 1324.20349,
+            "p50_us": 1252.958,
+            "p95_us": 1473.125,
+            "p99_us": 1512.0
+          },
+          "worker_queue": {
+            "mean_us": 8.03555,
+            "p50_us": 7.375,
+            "p95_us": 15.875,
+            "p99_us": 30.959
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 357853.75,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1759.142816,
+            "p50_us": 1637.0,
+            "p95_us": 2220.916,
+            "p99_us": 2463.709
+          },
+          "direct_requests_per_second": 2260.7031578066885,
+          "direct_wall_ms": 221.17012499999998,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1807.0594979999998,
+            "p50_us": 1774.875,
+            "p95_us": 1904.125,
+            "p99_us": 2146.083
+          },
+          "worker_requests_per_second": 2203.4023069939444,
+          "worker_wall_ms": 226.921792
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1368.7508799999998,
+            "p50_us": 1363.792,
+            "p95_us": 1393.375,
+            "p99_us": 1463.667
+          },
+          "worker_compute": {
+            "mean_us": 1245.881474,
+            "p50_us": 1286.042,
+            "p95_us": 1323.458,
+            "p99_us": 1356.041
+          },
+          "worker_parent_observed": {
+            "mean_us": 1460.035224,
+            "p50_us": 1504.083,
+            "p95_us": 1559.583,
+            "p99_us": 1599.042
+          },
+          "worker_queue": {
+            "mean_us": 53.095906,
+            "p50_us": 49.0,
+            "p95_us": 76.542,
+            "p99_us": 86.875
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "b",
+      "order": [
+        "stage23",
+        "stage24"
+      ],
+      "pair": 10,
+      "stage23": {
+        "cold_start_us": 361757.792,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1679.248092,
+            "p50_us": 1536.042,
+            "p95_us": 2252.209,
+            "p99_us": 2499.166
+          },
+          "direct_requests_per_second": 2252.277189627622,
+          "direct_wall_ms": 221.99754199999998,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1983.787914,
+            "p50_us": 1868.5,
+            "p95_us": 2456.0,
+            "p99_us": 2603.333
+          },
+          "worker_requests_per_second": 1971.9914738030081,
+          "worker_wall_ms": 253.55079200000003
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1362.064718,
+            "p50_us": 1389.833,
+            "p95_us": 1421.583,
+            "p99_us": 1452.792
+          },
+          "worker_compute": {
+            "mean_us": 1149.707678,
+            "p50_us": 1093.083,
+            "p95_us": 1301.042,
+            "p99_us": 1315.25
+          },
+          "worker_parent_observed": {
+            "mean_us": 1286.8198200000002,
+            "p50_us": 1221.375,
+            "p95_us": 1462.584,
+            "p99_us": 1484.375
+          },
+          "worker_queue": {
+            "mean_us": 7.695412,
+            "p50_us": 7.166,
+            "p95_us": 11.917,
+            "p99_us": 27.791
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 364268.375,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1682.070168,
+            "p50_us": 1644.458,
+            "p95_us": 1860.209,
+            "p99_us": 5465.333
+          },
+          "direct_requests_per_second": 2355.5123761870855,
+          "direct_wall_ms": 212.26804199999998,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 2042.06874,
+            "p50_us": 1823.583,
+            "p95_us": 3292.042,
+            "p99_us": 5893.833
+          },
+          "worker_requests_per_second": 1948.6896985134226,
+          "worker_wall_ms": 256.582667
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1385.141328,
+            "p50_us": 1381.0,
+            "p95_us": 1407.458,
+            "p99_us": 1446.125
+          },
+          "worker_compute": {
+            "mean_us": 1193.112248,
+            "p50_us": 1272.292,
+            "p95_us": 1300.708,
+            "p99_us": 1338.0
+          },
+          "worker_parent_observed": {
+            "mean_us": 1404.060832,
+            "p50_us": 1480.167,
+            "p95_us": 1546.25,
+            "p99_us": 1592.042
+          },
+          "worker_queue": {
+            "mean_us": 53.484924,
+            "p50_us": 48.417,
+            "p95_us": 77.459,
+            "p99_us": 93.708
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "b",
+      "order": [
+        "stage24",
+        "stage23"
+      ],
+      "pair": 11,
+      "stage23": {
+        "cold_start_us": 360279.917,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1505.54727,
+            "p50_us": 1402.625,
+            "p95_us": 1965.542,
+            "p99_us": 2156.917
+          },
+          "direct_requests_per_second": 2637.2084713718573,
+          "direct_wall_ms": 189.594416,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1930.668228,
+            "p50_us": 1843.709,
+            "p95_us": 2333.708,
+            "p99_us": 2490.375
+          },
+          "worker_requests_per_second": 2024.2051127688514,
+          "worker_wall_ms": 247.010541
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1214.459862,
+            "p50_us": 1161.625,
+            "p95_us": 1399.375,
+            "p99_us": 1423.833
+          },
+          "worker_compute": {
+            "mean_us": 1084.8564979999999,
+            "p50_us": 1083.667,
+            "p95_us": 1105.959,
+            "p99_us": 1135.708
+          },
+          "worker_parent_observed": {
+            "mean_us": 1215.005642,
+            "p50_us": 1209.125,
+            "p95_us": 1254.0,
+            "p99_us": 1305.375
+          },
+          "worker_queue": {
+            "mean_us": 7.252508,
+            "p50_us": 6.917,
+            "p95_us": 10.583,
+            "p99_us": 26.291
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 368175.333,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1927.988314,
+            "p50_us": 1788.583,
+            "p95_us": 2473.167,
+            "p99_us": 2910.084
+          },
+          "direct_requests_per_second": 2068.2676580585035,
+          "direct_wall_ms": 241.748208,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 2044.35535,
+            "p50_us": 1943.584,
+            "p95_us": 2508.958,
+            "p99_us": 2922.75
+          },
+          "worker_requests_per_second": 1948.334076947506,
+          "worker_wall_ms": 256.6295
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1520.463414,
+            "p50_us": 1407.208,
+            "p95_us": 1797.583,
+            "p99_us": 2084.125
+          },
+          "worker_compute": {
+            "mean_us": 1334.5777420000002,
+            "p50_us": 1283.834,
+            "p95_us": 1588.375,
+            "p99_us": 1640.125
+          },
+          "worker_parent_observed": {
+            "mean_us": 1646.952168,
+            "p50_us": 1600.458,
+            "p95_us": 1919.25,
+            "p99_us": 2032.875
+          },
+          "worker_queue": {
+            "mean_us": 89.126648,
+            "p50_us": 84.791,
+            "p95_us": 110.5,
+            "p99_us": 131.459
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    },
+    {
+      "batch": "b",
+      "order": [
+        "stage23",
+        "stage24"
+      ],
+      "pair": 12,
+      "stage23": {
+        "cold_start_us": 358700.0,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1652.0038359999999,
+            "p50_us": 1542.0,
+            "p95_us": 2165.208,
+            "p99_us": 2327.166
+          },
+          "direct_requests_per_second": 2414.4830311508827,
+          "direct_wall_ms": 207.083667,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 2154.6293459999997,
+            "p50_us": 2089.583,
+            "p95_us": 2592.291,
+            "p99_us": 2791.75
+          },
+          "worker_requests_per_second": 1831.0541287066255,
+          "worker_wall_ms": 273.06675
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1273.803162,
+            "p50_us": 1360.917,
+            "p95_us": 1400.333,
+            "p99_us": 1449.833
+          },
+          "worker_compute": {
+            "mean_us": 1127.610486,
+            "p50_us": 1075.5,
+            "p95_us": 1288.417,
+            "p99_us": 1299.625
+          },
+          "worker_parent_observed": {
+            "mean_us": 1264.9506399999998,
+            "p50_us": 1207.833,
+            "p95_us": 1447.0,
+            "p99_us": 1473.75
+          },
+          "worker_queue": {
+            "mean_us": 7.800252,
+            "p50_us": 7.084,
+            "p95_us": 14.0,
+            "p99_us": 29.167
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      },
+      "stage24": {
+        "cold_start_us": 358437.458,
+        "parallel": {
+          "direct_parser_cache_hits": 496,
+          "direct_request_latency": {
+            "mean_us": 1864.01765,
+            "p50_us": 1725.125,
+            "p95_us": 2613.209,
+            "p99_us": 2928.875
+          },
+          "direct_requests_per_second": 2137.1033706043872,
+          "direct_wall_ms": 233.961542,
+          "worker_parser_cache_hits": 497,
+          "worker_request_latency": {
+            "mean_us": 1785.640148,
+            "p50_us": 1768.125,
+            "p95_us": 1873.125,
+            "p99_us": 1974.459
+          },
+          "worker_requests_per_second": 2233.1609891339967,
+          "worker_wall_ms": 223.897875
+        },
+        "request_frame_bytes": 8216,
+        "requests": 500,
+        "schema": 1,
+        "sequential": {
+          "direct": {
+            "mean_us": 1389.7668079999999,
+            "p50_us": 1375.5,
+            "p95_us": 1433.167,
+            "p99_us": 1465.292
+          },
+          "worker_compute": {
+            "mean_us": 1230.206518,
+            "p50_us": 1283.125,
+            "p95_us": 1308.708,
+            "p99_us": 1355.042
+          },
+          "worker_parent_observed": {
+            "mean_us": 1430.0918980000001,
+            "p50_us": 1486.875,
+            "p95_us": 1542.0,
+            "p99_us": 1595.291
+          },
+          "worker_queue": {
+            "mean_us": 52.323356,
+            "p50_us": 47.708,
+            "p95_us": 75.292,
+            "p99_us": 92.333
+          }
+        },
+        "source_lines": 200,
+        "threads": 4
+      }
+    }
+  ],
+  "parser": {
+    "language": "rust",
+    "sha256": "dd56bbd4235a84111ae3fab2b5ecd4c8a60799a8811a49342c79b13d49decb0f"
+  },
+  "schema": 1
+}

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage24-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage24-measurement.md
@@ -1,0 +1,80 @@
+# Single Tree Worker Stage 24 Grammar Hazard Measurement
+
+## Scope
+
+Stage 24 prototypes the ADR's parent-visible grammar hazard lease. Before a
+worker thread enters a grammar-backed operation, it reports the request's
+resolved host grammar symbol and artifact digest. The parent records that lease before acknowledging
+it; only then may the worker proceed. A release frame removes the lease before
+the terminal response. If the worker dies after acknowledgment, the supervisor
+uses the still-active lease instead of inferring a grammar from the failed
+request.
+
+This stage uses the existing unbounded control writer rather than the ADR's
+future independently bounded control transport. It also selects only the first
+active lease for quarantine when several concurrent leases survive a crash.
+Discovering and leasing every runtime injection grammar separately also remains
+future work. Those limitations remain explicit follow-up work.
+
+## Correctness result
+
+The protocol version advances to 17 and round-trip tests cover the arm,
+acknowledgment, and release frames. The worker rejects stale-generation and
+unknown acknowledgments. The parent rejects duplicate arms, stale releases, and
+unknown releases.
+
+The crash E2E aborts the worker only after it has consumed the parent's
+acknowledgment. The parent logs the acknowledged Rust grammar identity,
+quarantines that grammar for the current session, restarts the worker, full
+resynchronizes the open document, and continues serving a healthy Lua grammar.
+The focused worker suite passed 61 tests, and the crash E2E completed recovery
+in 1.375 seconds in the validation run.
+
+## Performance result
+
+The measurement compares immutable release binaries and matching Stage 23 and
+Stage 24 (`f8b647522`) benchmark harnesses on macOS 26.5 (`Darwin 25.5.0`, Apple M4). Both use
+the same Rust parser artifact, four worker threads, 200 source lines, and 500
+requests per run. After one warmup per generation, two batches of twelve
+measured pairs alternate baseline-candidate and candidate-baseline order. The
+second batch reverses the first order of the first batch.
+
+| Metric | Stage 23 median | Stage 24 median | Median paired delta |
+| --- | ---: | ---: | ---: |
+| Sequential parent-observed p50 | 1.435 ms | 1.512 ms | +5.382% |
+| Sequential parent-observed p95 | 1.486 ms | 1.579 ms | +5.795% |
+| Sequential queue/arm wait p50 | 0.008 ms | 0.059 ms | +566.414% |
+| Four-way parallel parent-observed p50 | 1.841 ms | 1.792 ms | -2.358% |
+| Four-way parallel parent-observed p95 | 2.352 ms | 2.070 ms | -10.021% |
+| Four-way parallel throughput | 2040 req/s | 2133 req/s | +3.898% |
+
+The sequential p50 absolute paired increase is 77 microseconds, and Stage 24 is
+slower in 20 of 24 pairs. The queue/arm wait increases in all 24 pairs, so the
+measured sequential regression is concentrated in the parent-visible
+arm/acknowledgment wait.
+
+Under four-way concurrency, Stage 24 improves throughput in 20 of 24 pairs and
+p95 in 20 of 24 pairs. The ACK serializes the start of otherwise simultaneous
+compute work just enough to act as accidental admission pacing: its wait can
+overlap another request while reducing contention among the four parses. This
+is a real result for this benchmark, but it does not turn the safety handshake
+into a sound scheduling policy. Raw samples and artifact digests are in
+`benches/profile/results/single_worker_stage24_grammar_hazard_2026-07-20.json`.
+
+## Decision
+
+Keep the acknowledged lease as the correctness reference, but do not count
+Stage 24 as passing the fine-grained latency gate. An extra synchronous control
+round trip for every grammar-backed high-level request produces a small but
+repeatable sequential regression, and the ADR requires additional native
+segment arms inside those leases. Adding those handshakes unchanged would
+compound the same cost.
+
+The next stage must preserve the invariant that the parent records activity
+before native entry while removing the per-request pipe round trip from the hot
+path, for example through the ADR's shared-memory activity-slot optimization.
+It must separately test explicit admission pacing, because blindly removing the
+handshake may give back the measured parallel contention reduction. Dedicated
+control capacity is still required for saturation correctness, but queue
+isolation alone cannot remove the causal context switch measured here. The ADR
+remains `proposed`.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1281,6 +1281,22 @@ while clean shutdown was effectively unchanged at +0.171%. Native hazard and
 quarantine control, protocol and compatibility gates, and legacy-path removal
 remain open.
 
+The [Stage 24 grammar-hazard measurement](single-resident-multithreaded-tree-worker-stage24-measurement.md)
+prototypes an acknowledged parent-visible lease around grammar-backed work. A
+post-acknowledgment crash was attributed to the exact Rust artifact, quarantined
+only for the current session, and recovered through worker restart and document
+resynchronization while a healthy Lua grammar remained available. Twenty-four
+order-reversed release pairs found a repeatable hot-path cost: sequential p50
+rose by a median paired 5.382%, or 77 microseconds. The same handshake acted as
+accidental admission pacing under four-way concurrency, improving throughput by
+3.898% and p95 by 10.021%; that scheduling effect must be preserved or replaced
+explicitly rather than coupled to safety IPC. Keep the lease as the correctness
+reference, but do not pass the fine-grained latency gate until a
+parent-visible-before-entry mechanism removes the synchronous pipe round trip.
+Multiple-hazard quarantine, independently bounded control transport, native
+segment deadlines, protocol and compatibility gates, and legacy-path removal
+remain open.
+
 The implementation should proceed in measured stages:
 
 1. Prototype the framed transport, supervision, and one high-level

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -2798,6 +2798,36 @@ fn run_actor(
             }
             Ok(_) => {}
             Err(error) => {
+                let acknowledged_hazards = state
+                    .client
+                    .as_ref()
+                    .expect("failed request retains its worker client")
+                    .active_grammar_hazards();
+                if !acknowledged_hazards.is_empty() {
+                    log::error!(
+                        target: "kakehashi::tree_worker_shadow",
+                        "worker generation {} failed with {} acknowledged active grammar hazard(s): {}",
+                        state.worker_generation,
+                        acknowledged_hazards.len(),
+                        acknowledged_hazards
+                            .iter()
+                            .map(|hazard| format!(
+                                "lease={} request={} symbol={} artifact_digest={}",
+                                hazard.lease_id,
+                                hazard.context.request_id,
+                                hazard.grammar.grammar_symbol,
+                                hazard.grammar.artifact_digest,
+                            ))
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                    );
+                }
+                let acknowledged_grammar =
+                    acknowledged_hazards.first().map(|hazard| GrammarIdentity {
+                        grammar_symbol: hazard.grammar.grammar_symbol.clone(),
+                        artifact_digest: hazard.grammar.artifact_digest.clone(),
+                    });
+                let implicated_grammar = acknowledged_grammar.or(implicated_grammar);
                 let class = classify_transport_failure(
                     state
                         .client

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -22,7 +22,7 @@ use sha2::{Digest, Sha256};
 
 use crate::language::node_tracker::{EditInfo, NodeTracker};
 
-pub const PROTOCOL_VERSION: u32 = 16;
+pub const PROTOCOL_VERSION: u32 = 17;
 pub const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_REPLICAS: usize = 4_096;
 pub const MAX_DOCUMENT_BYTES: usize = 32 * 1024 * 1024;
@@ -582,10 +582,36 @@ pub struct RequestCancelled {
     pub context: RequestContext,
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct WorkerGrammarIdentity {
+    pub grammar_symbol: String,
+    pub artifact_digest: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct GrammarHazardAck {
+    pub lease_id: u64,
+    pub worker_generation: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct GrammarHazardArmed {
+    pub lease_id: u64,
+    pub context: RequestContext,
+    pub grammar: WorkerGrammarIdentity,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct GrammarHazardReleased {
+    pub lease_id: u64,
+    pub worker_generation: u64,
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Request {
     Handshake(Handshake),
     Cancel(CancelRequest),
+    GrammarHazardAck(GrammarHazardAck),
     DeriveSnapshot(DeriveSnapshot),
     SyncDocument(SyncDocument),
     ApplyDocumentEdits(ApplyDocumentEdits),
@@ -635,6 +661,8 @@ pub struct WorkerError {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Response {
     HandshakeReady(HandshakeReady),
+    GrammarHazardArmed(GrammarHazardArmed),
+    GrammarHazardReleased(GrammarHazardReleased),
     DocumentAck(DocumentAck),
     DocumentClosed(DocumentClosed),
     WorkerRestartRequired(WorkerRestartRequired),
@@ -2288,6 +2316,14 @@ struct GrammarKey {
 }
 
 impl GrammarKey {
+    #[cfg(not(test))]
+    fn identity(&self) -> WorkerGrammarIdentity {
+        WorkerGrammarIdentity {
+            grammar_symbol: self.grammar_symbol.clone(),
+            artifact_digest: self.artifact_digest.clone(),
+        }
+    }
+
     fn from_sync(request: &SyncDocument) -> Self {
         Self {
             parser_path: request
@@ -2888,6 +2924,7 @@ fn request_priority(request: &Request) -> WorkPriority {
         | Request::DeriveSemanticTokens(_) => WorkPriority::Background,
         Request::Handshake(_)
         | Request::Cancel(_)
+        | Request::GrammarHazardAck(_)
         | Request::SyncDocument(_)
         | Request::ApplyDocumentEdits(_)
         | Request::ApplyDocumentEditsAndDerive(_)
@@ -2947,7 +2984,7 @@ fn handle_work(
         non_evictable_estimate_hard_bytes: memory_budgets.non_evictable_estimate_hard_bytes,
     };
     let response = match request {
-        Request::Handshake(_) | Request::Cancel(_) => {
+        Request::Handshake(_) | Request::Cancel(_) | Request::GrammarHazardAck(_) => {
             unreachable!("control requests are not scheduled")
         }
         Request::DeriveSnapshot(request) => derive_snapshot(request, queue_wait),
@@ -3034,7 +3071,7 @@ fn request_may_grow_derived_state(request: &Request) -> bool {
 
 fn request_context(request: &Request) -> Option<&RequestContext> {
     match request {
-        Request::Handshake(_) | Request::Cancel(_) => None,
+        Request::Handshake(_) | Request::Cancel(_) | Request::GrammarHazardAck(_) => None,
         Request::DeriveSnapshot(request) => Some(&request.context),
         Request::SyncDocument(request) => Some(&request.context),
         Request::ApplyDocumentEdits(request) => Some(&request.context),
@@ -3072,8 +3109,51 @@ fn document_key(request: &Request) -> Option<DocumentKey> {
         Request::CloseDocument(request) => Some(DocumentKey::from(&request.context)),
         Request::Handshake(_)
         | Request::Cancel(_)
+        | Request::GrammarHazardAck(_)
         | Request::DeriveSnapshot(_)
         | Request::ConfigureLanguages(_) => None,
+    }
+}
+
+#[cfg(not(test))]
+fn request_grammar_identity(
+    request: &Request,
+    documents: &DocumentStore,
+) -> Option<WorkerGrammarIdentity> {
+    match request {
+        Request::DeriveSnapshot(request) => Some(WorkerGrammarIdentity {
+            grammar_symbol: request.grammar_symbol.clone(),
+            artifact_digest: request.artifact_digest.clone(),
+        }),
+        Request::SyncDocument(request) => Some(WorkerGrammarIdentity {
+            grammar_symbol: request.grammar_symbol.clone(),
+            artifact_digest: request.artifact_digest.clone(),
+        }),
+        Request::ApplyDocumentEdits(_)
+        | Request::ApplyDocumentEditsAndDerive(_)
+        | Request::DeriveDocumentSnapshot(_)
+        | Request::ResolveNode(_)
+        | Request::NavigateNode(_)
+        | Request::RunNodeScalar(_)
+        | Request::DeriveSelectionRanges(_)
+        | Request::DeriveInjectionRegions(_)
+        | Request::DeriveSemanticTokens(_)
+        | Request::RunCaptures(_)
+        | Request::DeriveNativeBindings(_) => request_context(request).and_then(|context| {
+            documents.get(&DocumentKey::from(context)).map(|replica| {
+                replica
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .grammar_key
+                    .identity()
+            })
+        }),
+        Request::Handshake(_)
+        | Request::Cancel(_)
+        | Request::GrammarHazardAck(_)
+        | Request::ConfigureLanguages(_)
+        | Request::InspectDocumentMemory(_)
+        | Request::CloseDocument(_) => None,
     }
 }
 
@@ -3854,6 +3934,8 @@ where
     let document_lanes: DocumentLanes = Arc::new(dashmap::DashMap::new());
     let runnable_documents = Arc::new(RunnableDocuments::default());
     let cancellations = Arc::new(dashmap::DashMap::<u64, crate::cancel::CancelToken>::new());
+    let hazard_waiters = Arc::new(dashmap::DashMap::<u64, mpsc::Sender<()>>::new());
+    let next_hazard_lease = Arc::new(std::sync::atomic::AtomicU64::new(1));
     // The client permits at most four requests per compute thread. Decode one
     // frame beyond this pending window so cancellation stays observable under
     // saturation, but wait before scheduling any excess ordinary work.
@@ -3877,6 +3959,22 @@ where
     let injected_hung_compute = 0_usize;
     let mut pending = injected_hung_compute;
     while let Some(request) = decode_frame::<_, Request>(&mut reader)? {
+        if let Request::GrammarHazardAck(ack) = request {
+            if ack.worker_generation != worker_generation {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "stale grammar hazard acknowledgment",
+                ));
+            }
+            let Some((_, waiter)) = hazard_waiters.remove(&ack.lease_id) else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "unknown grammar hazard acknowledgment",
+                ));
+            };
+            let _ = waiter.send(());
+            continue;
+        }
         if let Request::Cancel(cancel) = request {
             if cancel.worker_generation == worker_generation {
                 cancellations.entry(cancel.request_id).or_default().cancel();
@@ -3924,6 +4022,10 @@ where
         }
         pending += 1;
         let enqueued = Instant::now();
+        #[cfg(not(test))]
+        let grammar_hazard = request_grammar_identity(&request, &documents);
+        #[cfg(test)]
+        let grammar_hazard = None;
         let responses = responses.clone();
         let permits = permits.clone();
         let permit_rx = Arc::clone(&permit_rx);
@@ -3936,6 +4038,8 @@ where
         let retained_estimated_document_bytes = Arc::clone(&retained_estimated_document_bytes);
         let derived_pressure_lock = Arc::clone(&derived_pressure_lock);
         let job_cancellations = Arc::clone(&cancellations);
+        let job_hazard_waiters = Arc::clone(&hazard_waiters);
+        let job_next_hazard_lease = Arc::clone(&next_hazard_lease);
         let lane_key = document_key(&request);
         let priority = request_priority(&request);
         let runnable_guard = lane_key
@@ -3977,6 +4081,53 @@ where
                 .recv()
                 .expect("worker admission queue stopped before its jobs");
             let permit = AdmissionPermit(permits);
+            let mut announced_lease = None;
+            let hazard_error = grammar_hazard.and_then(|grammar| {
+                let lease_id = job_next_hazard_lease.fetch_add(1, Ordering::Relaxed);
+                let (ack_tx, ack_rx) = mpsc::channel();
+                job_hazard_waiters.insert(lease_id, ack_tx);
+                if responses
+                    .send((
+                        Response::GrammarHazardArmed(GrammarHazardArmed {
+                            lease_id,
+                            context: context.clone(),
+                            grammar,
+                        }),
+                        None,
+                    ))
+                    .is_err()
+                {
+                    job_hazard_waiters.remove(&lease_id);
+                    return Some(Response::WorkerRestartRequired(WorkerRestartRequired {
+                        context: context.clone(),
+                        reason: "worker writer stopped before grammar hazard acknowledgment".into(),
+                    }));
+                }
+                announced_lease = Some(lease_id);
+                match ack_rx.recv_timeout(Duration::from_secs(5)) {
+                    Ok(()) => {
+                        #[cfg(feature = "e2e")]
+                        if let Ok(marker) =
+                            std::env::var("KAKEHASHI_TREE_WORKER_CRASH_AFTER_HAZARD_ARMED_FILE")
+                            && std::fs::OpenOptions::new()
+                                .write(true)
+                                .create_new(true)
+                                .open(marker)
+                                .is_ok()
+                        {
+                            std::process::abort();
+                        }
+                        None
+                    }
+                    Err(_) => {
+                        job_hazard_waiters.remove(&lease_id);
+                        Some(Response::WorkerRestartRequired(WorkerRestartRequired {
+                            context: context.clone(),
+                            reason: "grammar hazard acknowledgment timed out".into(),
+                        }))
+                    }
+                }
+            });
             #[cfg(feature = "e2e")]
             let nested_parallelism_was_allowed = AtomicBool::new(false);
             #[cfg(feature = "e2e")]
@@ -4026,20 +4177,36 @@ where
                 }
                 policy
             };
-            let response = handle_work(
-                request,
-                &analysis,
-                &documents,
-                &closed_documents,
-                &document_capacity,
-                &retained_document_bytes,
-                &retained_estimated_document_bytes,
-                &derived_pressure_lock,
-                memory_budgets,
-                enqueued.elapsed(),
-                &cancellation,
-                &nested_work_policy,
-            );
+            let response = hazard_error.unwrap_or_else(|| {
+                handle_work(
+                    request,
+                    &analysis,
+                    &documents,
+                    &closed_documents,
+                    &document_capacity,
+                    &retained_document_bytes,
+                    &retained_estimated_document_bytes,
+                    &derived_pressure_lock,
+                    memory_budgets,
+                    enqueued.elapsed(),
+                    &cancellation,
+                    &nested_work_policy,
+                )
+            });
+            // Once the arm frame was handed to the response writer, the parent
+            // may have recorded it even when its acknowledgment times out in
+            // transit. Release that announced lease before the terminal
+            // response so a non-entered scope cannot survive as false crash
+            // attribution.
+            if let Some(lease_id) = announced_lease {
+                let _ = responses.send((
+                    Response::GrammarHazardReleased(GrammarHazardReleased {
+                        lease_id,
+                        worker_generation,
+                    }),
+                    None,
+                ));
+            }
             job_cancellations.remove(&request_id);
             let action = if action_key
                 .as_ref()
@@ -4776,7 +4943,8 @@ impl std::ops::DerefMut for OwnedChild {
 pub struct Client {
     child: Arc<Mutex<OwnedChild>>,
     terminated_by_transport: Arc<AtomicBool>,
-    outbound: Mutex<Option<mpsc::Sender<Request>>>,
+    outbound: Arc<Mutex<Option<mpsc::Sender<Request>>>>,
+    active_grammar_hazards: Arc<Mutex<HashMap<u64, GrammarHazardArmed>>>,
     routes: Arc<Mutex<HashMap<u64, Route>>>,
     reader: Option<std::thread::JoinHandle<()>>,
     writer: Option<std::thread::JoinHandle<()>>,
@@ -4892,7 +5060,12 @@ impl Client {
         let child = Arc::new(Mutex::new(child));
         let terminated_by_transport = Arc::new(AtomicBool::new(false));
         let routes = Arc::new(Mutex::new(HashMap::<u64, Route>::new()));
+        let outbound = Arc::new(Mutex::new(None::<mpsc::Sender<Request>>));
+        let active_grammar_hazards =
+            Arc::new(Mutex::new(HashMap::<u64, GrammarHazardArmed>::new()));
         let reader_routes = Arc::clone(&routes);
+        let reader_outbound = Arc::clone(&outbound);
+        let reader_hazards = Arc::clone(&active_grammar_hazards);
         let reader_child = Arc::clone(&child);
         let reader_terminated_by_transport = Arc::clone(&terminated_by_transport);
         let (handshake_tx, handshake_rx) = mpsc::channel();
@@ -4905,11 +5078,82 @@ impl Client {
                             let _ = handshake.send(Ok(response));
                             continue;
                         }
-                        if let Err(error) = route_response(&reader_routes, response) {
-                            let kind = error.kind();
-                            let message = error.to_string();
-                            fail_routes(None, &reader_routes, kind, &message);
-                            break;
+                        match response {
+                            Response::GrammarHazardArmed(armed) => {
+                                let valid = armed.context.worker_generation == worker_generation
+                                    && !reader_hazards
+                                        .lock()
+                                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                        .contains_key(&armed.lease_id);
+                                if !valid {
+                                    fail_routes(
+                                        None,
+                                        &reader_routes,
+                                        io::ErrorKind::InvalidData,
+                                        "invalid grammar hazard arm",
+                                    );
+                                    break;
+                                }
+                                let ack = Request::GrammarHazardAck(GrammarHazardAck {
+                                    lease_id: armed.lease_id,
+                                    worker_generation: armed.context.worker_generation,
+                                });
+                                reader_hazards
+                                    .lock()
+                                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                    .insert(armed.lease_id, armed);
+                                let ack_result = reader_outbound
+                                    .lock()
+                                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                    .as_ref()
+                                    .ok_or_else(|| {
+                                        io::Error::new(
+                                            io::ErrorKind::BrokenPipe,
+                                            "worker control writer is unavailable",
+                                        )
+                                    })
+                                    .and_then(|outbound| {
+                                        outbound.send(ack).map_err(|_| {
+                                            io::Error::new(
+                                                io::ErrorKind::BrokenPipe,
+                                                "worker control writer stopped",
+                                            )
+                                        })
+                                    });
+                                if let Err(error) = ack_result {
+                                    let kind = error.kind();
+                                    let message = error.to_string();
+                                    fail_routes(None, &reader_routes, kind, &message);
+                                    break;
+                                }
+                                continue;
+                            }
+                            Response::GrammarHazardReleased(released) => {
+                                if released.worker_generation != worker_generation
+                                    || reader_hazards
+                                        .lock()
+                                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                        .remove(&released.lease_id)
+                                        .is_none()
+                                {
+                                    fail_routes(
+                                        None,
+                                        &reader_routes,
+                                        io::ErrorKind::InvalidData,
+                                        "invalid grammar hazard release",
+                                    );
+                                    break;
+                                }
+                                continue;
+                            }
+                            response => {
+                                if let Err(error) = route_response(&reader_routes, response) {
+                                    let kind = error.kind();
+                                    let message = error.to_string();
+                                    fail_routes(None, &reader_routes, kind, &message);
+                                    break;
+                                }
+                            }
                         }
                     }
                     Ok(None) => {
@@ -4994,7 +5238,10 @@ impl Client {
         // The route table is the bounded admission control. Keep the transport
         // channel unbounded so a cancellation control frame never competes
         // with work for the final queue slot.
-        let (outbound, outbound_rx) = mpsc::channel::<Request>();
+        let (outbound_tx, outbound_rx) = mpsc::channel::<Request>();
+        *outbound
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(outbound_tx);
         let writer_routes = Arc::clone(&routes);
         let writer_child = Arc::clone(&child);
         let writer_terminated_by_transport = Arc::clone(&terminated_by_transport);
@@ -5018,7 +5265,8 @@ impl Client {
         Ok(Self {
             child,
             terminated_by_transport,
-            outbound: Mutex::new(Some(outbound)),
+            outbound,
+            active_grammar_hazards,
             routes,
             reader: Some(reader),
             writer: Some(writer),
@@ -5044,6 +5292,15 @@ impl Client {
 
     pub fn worker_generation(&self) -> u64 {
         self.ready.worker_generation
+    }
+
+    pub fn active_grammar_hazards(&self) -> Vec<GrammarHazardArmed> {
+        self.active_grammar_hazards
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .values()
+            .cloned()
+            .collect()
     }
 
     /// Idempotently cancel queued or cooperatively running work in this worker
@@ -5290,7 +5547,7 @@ impl Client {
 
     pub fn shutdown(mut self) -> io::Result<()> {
         self.outbound
-            .get_mut()
+            .lock()
             .map_err(|_| io::Error::other("worker outbound lock is poisoned"))?
             .take();
         let status = {
@@ -5334,7 +5591,7 @@ fn failed_spawn(
 
 impl Drop for Client {
     fn drop(&mut self) {
-        if let Ok(outbound) = self.outbound.get_mut() {
+        if let Ok(mut outbound) = self.outbound.lock() {
             outbound.take();
         }
         if let Ok(mut child) = self.child.lock() {
@@ -5366,7 +5623,9 @@ fn response_request_id(response: &Response) -> Option<u64> {
         Response::LanguageCatalogAck(ack) => Some(ack.context.request_id),
         Response::DocumentMemory(result) => Some(result.context.request_id),
         Response::Error(error) => error.context.as_ref().map(|context| context.request_id),
-        Response::HandshakeReady(_) => None,
+        Response::HandshakeReady(_)
+        | Response::GrammarHazardArmed(_)
+        | Response::GrammarHazardReleased(_) => None,
     }
 }
 
@@ -5387,7 +5646,9 @@ fn response_context(response: &Response) -> Option<&RequestContext> {
         Response::LanguageCatalogAck(ack) => Some(&ack.context),
         Response::DocumentMemory(result) => Some(&result.context),
         Response::Error(error) => error.context.as_ref(),
-        Response::HandshakeReady(_) => None,
+        Response::HandshakeReady(_)
+        | Response::GrammarHazardArmed(_)
+        | Response::GrammarHazardReleased(_) => None,
     }
 }
 
@@ -5497,13 +5758,14 @@ mod tests {
         CachedInjectionLayer, CancelRequest, CapturesResult, CloseDocument, DeriveInjectionRegions,
         DeriveNativeBindings, DeriveSelectionRanges, DeriveSemanticTokens, DeriveSnapshot,
         DocumentCompetition, DocumentKey, DocumentLane, DocumentMemoryAdmission, DocumentReplica,
-        GrammarKey, Handshake, HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES,
-        MAX_DOCUMENT_REPLICAS, MAX_RETAINED_DOCUMENT_BYTES, MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES,
-        NavigateNode, NodeLayerSelector, NodeNavigation, NodeScalarOperation, NodeScalarValue,
-        OpaqueNodeId, OwnedChild, PROTOCOL_VERSION, ParentLiveness, Request, RequestCancelled,
-        RequestContext, ResolveNode, Response, Route, RunCaptures, RunNodeScalar,
-        RunnableDocuments, SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES, SyncDocument,
-        WireByteRange, WirePosition, WireRange, WireSemanticToken, WorkPriority, WorkerError,
+        GrammarHazardAck, GrammarHazardArmed, GrammarHazardReleased, GrammarKey, Handshake,
+        HandshakeReady, LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
+        MAX_RETAINED_DOCUMENT_BYTES, MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES, NavigateNode,
+        NodeLayerSelector, NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId,
+        OwnedChild, PROTOCOL_VERSION, ParentLiveness, Request, RequestCancelled, RequestContext,
+        ResolveNode, Response, Route, RunCaptures, RunNodeScalar, RunnableDocuments,
+        SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES, SyncDocument, WireByteRange, WirePosition,
+        WireRange, WireSemanticToken, WorkPriority, WorkerError, WorkerGrammarIdentity,
         WorkerQuerySources, cache_eviction_plan, close_document, decode_frame,
         derive_snapshot_with_language, encode_frame, enforce_derived_memory_budget,
         named_node_count, parse_request_timeout, pressure_checkpoint_required,
@@ -5524,10 +5786,19 @@ mod tests {
         assert!(ParentLiveness::from_parts(Some(7), Some(42)).is_ok());
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(all(unix, not(target_os = "linux")))]
     #[test]
     fn non_linux_parent_liveness_rejects_linux_identity() {
         assert!(ParentLiveness::from_parts(None, Some(42)).is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_parent_liveness_requires_a_positive_parent_identity() {
+        assert!(ParentLiveness::from_parts(None, None).is_ok());
+        assert!(ParentLiveness::from_parts(None, Some(0)).is_err());
+        assert!(ParentLiveness::from_parts(Some(7), Some(42)).is_err());
+        assert!(ParentLiveness::from_parts(None, Some(42)).is_ok());
     }
 
     impl Write for SharedWriter {
@@ -5764,6 +6035,49 @@ mod tests {
             decode_frame(&mut Cursor::new(bytes)).unwrap(),
             Some(request)
         );
+    }
+
+    #[test]
+    fn frame_round_trip_preserves_acknowledged_grammar_hazard_lifecycle() {
+        let context = RequestContext {
+            request_id: 42,
+            worker_generation: 7,
+            uri: "file:///hazard.rs".into(),
+            incarnation: 3,
+            content_version: 5,
+            configuration_generation: 11,
+        };
+        let grammar = WorkerGrammarIdentity {
+            grammar_symbol: "rust".into(),
+            artifact_digest: "sha256:rust-v1".into(),
+        };
+        let frames = [
+            Response::GrammarHazardArmed(GrammarHazardArmed {
+                lease_id: 9,
+                context,
+                grammar,
+            }),
+            Response::GrammarHazardReleased(GrammarHazardReleased {
+                lease_id: 9,
+                worker_generation: 7,
+            }),
+        ];
+        for response in frames {
+            let mut bytes = Vec::new();
+            encode_frame(&mut bytes, &response).unwrap();
+            assert_eq!(
+                decode_frame(&mut Cursor::new(bytes)).unwrap(),
+                Some(response)
+            );
+        }
+
+        let ack = Request::GrammarHazardAck(GrammarHazardAck {
+            lease_id: 9,
+            worker_generation: 7,
+        });
+        let mut bytes = Vec::new();
+        encode_frame(&mut bytes, &ack).unwrap();
+        assert_eq!(decode_frame(&mut Cursor::new(bytes)).unwrap(), Some(ack));
     }
 
     #[test]

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1027,7 +1027,7 @@ fn crashed_grammar_is_quarantined_only_in_session_and_other_grammar_recovers() {
         .env("KAKEHASHI_TREE_WORKER_SHADOW", "true")
         .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
         .env(
-            "KAKEHASHI_TREE_WORKER_CRASH_ONCE_FILE",
+            "KAKEHASHI_TREE_WORKER_CRASH_AFTER_HAZARD_ARMED_FILE",
             marker.to_string_lossy().into_owned(),
         )
         .env(
@@ -1070,6 +1070,10 @@ fn crashed_grammar_is_quarantined_only_in_session_and_other_grammar_recovers() {
 
     let stderr = shutdown_and_stderr(client);
     assert!(marker.exists(), "failure injection did not run: {stderr}");
+    assert!(
+        stderr.contains("acknowledged active grammar hazard(s)"),
+        "{stderr}"
+    );
     assert!(
         stderr.contains("quarantined grammar conservatively for this session"),
         "{stderr}"


### PR DESCRIPTION
## Summary

- add a protocol-17 acknowledged grammar-hazard lease before grammar-backed work
- retain acknowledged leases in the parent for exact in-session crash attribution
- prove post-ack crash quarantine and healthy-grammar recovery end to end
- record 24 order-reversed Stage 23/24 release pairs and the resulting ADR decision

## Correctness

- cargo check --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --lib tree_worker::tests -- --quiet (61 passed)
- focused crash E2E: acknowledged Rust hazard logged and quarantined, worker restarted and resynced, healthy Lua grammar recovered

## Measurement

On macOS 26.5 / Apple M4, 24 paired runs with 500 Rust requests and 4 worker threads measured:

- sequential p50: +5.382%, +77 microseconds paired median; Stage 24 slower in 20/24 pairs
- arm/ack queue wait: increased in 24/24 pairs
- four-way throughput: +3.898%; Stage 24 improved in 20/24 pairs
- four-way p95: -10.021%; Stage 24 improved in 20/24 pairs

The ACK acts as accidental admission pacing under concurrency, but adds a repeatable synchronous hot-path cost. This stage is the correctness reference and does not pass the fine-grained latency gate.

## Follow-up boundary

This stage leases the request host grammar and quarantines only the first surviving lease. Runtime injection identities, complete multi-hazard quarantine, independently bounded control transport, and native-segment deadlines remain later stages. The next stage must remove the synchronous pipe round trip while separately preserving or replacing the measured admission-pacing effect.

Stacked on #886.