### PR TITLE
fix(worker): quarantine complete active grammar sets

### DIFF
--- a/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
+++ b/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
@@ -1,0 +1,68 @@
+{
+  "baseline": {
+    "commit": "f6e0c2125f6f2c93e799ab3b0b4c7b6471691f53",
+    "stage": 25
+  },
+  "candidate": {
+    "commit": "370d13d2cdcdd7bf6e1b8927e768319116fe8a97",
+    "stage": 26
+  },
+  "environment": {
+    "cpu": "Apple M4",
+    "os": "macOS 26.5.1 Darwin 25.5.0 arm64",
+    "rustc": "1.95.0 (59807616e 2026-04-14)"
+  },
+  "measured_at": "2026-07-21",
+  "single_hazard_recovery": {
+    "method": {
+      "build_profile": "test (unoptimized + debuginfo)",
+      "measurement": "supervisor recovery_ms from recovery start through replacement spawn and full resync",
+      "order": "stage25 then stage26 in each pair",
+      "pairs": 7,
+      "test": "crashed_grammar_is_quarantined_only_in_session_and_other_grammar_recovers",
+      "threads": 4,
+      "warmup_runs_per_stage": 1
+    },
+    "samples_ms": [
+      { "pair": 1, "stage25": 1275, "stage26": 1251 },
+      { "pair": 2, "stage25": 1266, "stage26": 1277 },
+      { "pair": 3, "stage25": 1299, "stage26": 1283 },
+      { "pair": 4, "stage25": 1254, "stage26": 1571 },
+      { "pair": 5, "stage25": 1264, "stage26": 1281 },
+      { "pair": 6, "stage25": 1250, "stage26": 1450 },
+      { "pair": 7, "stage25": 1279, "stage26": 1278 }
+    ],
+    "summary": {
+      "median_paired_delta_ms": 11,
+      "median_paired_delta_percent": 0.869,
+      "stage25_mean_ms": 1269.571,
+      "stage25_median_ms": 1266,
+      "stage25_range_ms": [1250, 1299],
+      "stage26_mean_ms": 1341.571,
+      "stage26_median_ms": 1281,
+      "stage26_range_ms": [1251, 1571]
+    }
+  },
+  "two_active_grammars": {
+    "assertions_per_run": {
+      "full_resynced_bytes": 14,
+      "full_resynced_documents": 1,
+      "newly_quarantined_grammars": 2,
+      "restarts": 1
+    },
+    "method": {
+      "build_profile": "test (unoptimized + debuginfo)",
+      "measurement": "supervisor recovery_ms from recovery start through replacement spawn and quarantine-aware full resync",
+      "runs": 7,
+      "test": "crash_quarantines_every_unique_committed_grammar_hazard",
+      "threads": 4,
+      "warmup_runs": 1
+    },
+    "samples_ms": [959, 971, 974, 971, 1126, 981, 990],
+    "summary": {
+      "mean_ms": 996,
+      "median_ms": 974,
+      "range_ms": [959, 1126]
+    }
+  }
+}

--- a/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
+++ b/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
@@ -142,15 +142,17 @@
     "method": {
       "build_profile": "release (optimized)",
       "build_commands": [
+        "mkdir -p /tmp/kakehashi-stage26-semantic-ab",
         "git worktree add --detach /tmp/kakehashi-stage26-measured-67c338ca7 67c338ca7955faf1021c0951a8f039a915b5a0d0",
+        "git worktree add --detach /tmp/kakehashi-stage26-review-36842edc5 36842edc5fc2c13864d9d39cecc77a78a9ed56fa",
         "cargo build --release --locked --bin kakehashi --manifest-path /tmp/kakehashi-stage26-measured-67c338ca7/Cargo.toml --target-dir /tmp/kakehashi-stage26-measured-67c338ca7/target",
         "cp /tmp/kakehashi-stage26-measured-67c338ca7/target/release/kakehashi /tmp/kakehashi-stage26-semantic-ab/measured-67c338ca7",
-        "cargo build --release --locked --bin kakehashi",
-        "cp target/release/kakehashi /tmp/kakehashi-stage26-semantic-ab/final-36842edc5",
-        "cargo bench --locked --bench semantic_tokens --features e2e --no-run"
+        "cargo build --release --locked --bin kakehashi --manifest-path /tmp/kakehashi-stage26-review-36842edc5/Cargo.toml --target-dir /tmp/kakehashi-stage26-review-36842edc5/target",
+        "cp /tmp/kakehashi-stage26-review-36842edc5/target/release/kakehashi /tmp/kakehashi-stage26-semantic-ab/final-36842edc5",
+        "cargo bench --locked --bench semantic_tokens --features e2e --no-run --manifest-path /tmp/kakehashi-stage26-review-36842edc5/Cargo.toml --target-dir /tmp/kakehashi-stage26-review-36842edc5/target"
       ],
       "environment": ["KAKEHASHI_TREE_WORKER_MODE=authoritative", "KAKEHASHI_TREE_WORKER_THREADS=4"],
-      "execution_command_template": "KAKEHASHI_TREE_WORKER_MODE=authoritative KAKEHASHI_TREE_WORKER_THREADS=4 KAKEHASHI_BENCH_BIN_A=<A> KAKEHASHI_BENCH_BIN_B=<B> KAKEHASHI_BENCH_ITERS=40 KAKEHASHI_BENCH_WARMUP=10 KAKEHASHI_BENCH_SCENARIOS=rust_large/edit_delta target/release/deps/semantic_tokens-08ebd8d8c816111c --bench",
+      "execution_command_template": "KAKEHASHI_TREE_WORKER_MODE=authoritative KAKEHASHI_TREE_WORKER_THREADS=4 KAKEHASHI_BENCH_BIN_A=<A> KAKEHASHI_BENCH_BIN_B=<B> KAKEHASHI_BENCH_ITERS=40 KAKEHASHI_BENCH_WARMUP=10 KAKEHASHI_BENCH_SCENARIOS=rust_large/edit_delta /tmp/kakehashi-stage26-review-36842edc5/target/release/deps/semantic_tokens-08ebd8d8c816111c --bench",
       "iterations_per_binary_per_pair": 40,
       "pairs": 8,
       "revision_order": "odd measured->review-converged; even review-converged->measured",

--- a/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
+++ b/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
@@ -199,8 +199,8 @@
     "artifacts": {
       "review_converged_commit": "36842edc5fc2c13864d9d39cecc77a78a9ed56fa",
       "review_converged_server_sha256": "a3cdaa3de70efba44ec0a3d6835689c6939d9b924185b45ae4cd41e6f770e870",
-      "final_head_commit": "72f58a8b491f5270b796dd6ed61f70f43c0ac17b",
-      "final_head_server_sha256": "d6c0e512cef8250bcd6750685e5898c36635f08ca5c86cb2de72c8e36fa2b7c7",
+      "final_head_commit": "9b5605abdc06a48d5547b0b122bdfbdd083a57bf",
+      "final_head_server_sha256": "1afa1a2c5794be1f88ef00d152fb9e6152eb023b2b26f4dfdba72963854ba370",
       "harness_source_path": "benches/semantic_tokens.rs",
       "harness_source_sha256": "018cbd1750758496421073bdd3fbaf6588702a52d8986db5be5384f2faebd8bf",
       "harness_binary_sha256": "c9338da3fd92ad4150ed6db3630223ef19f3f5e5f70165d836272fa6c3dd0081",
@@ -211,7 +211,7 @@
       "build_profile": "release (optimized)",
       "build_commands": [
         "cargo build --release --locked --bin kakehashi",
-        "cp target/release/kakehashi /tmp/kakehashi-stage26-semantic-ab/final-72f58a8b4",
+        "cp target/release/kakehashi /tmp/kakehashi-stage26-semantic-ab/final-9b5605abd",
         "cargo bench --locked --bench semantic_tokens --features e2e --no-run"
       ],
       "environment": ["KAKEHASHI_TREE_WORKER_MODE=authoritative", "KAKEHASHI_TREE_WORKER_THREADS=4"],
@@ -225,23 +225,23 @@
       "sample_retention": "the harness emitted one median per binary per pair; per-iteration samples and p25/p75 were not retained"
     },
     "pairs_ms": [
-      { "pair": 1, "review_converged": 24.582, "final_head": 26.809 },
-      { "pair": 2, "review_converged": 26.788, "final_head": 28.910 },
-      { "pair": 3, "review_converged": 29.460, "final_head": 26.900 },
-      { "pair": 4, "review_converged": 26.830, "final_head": 26.707 },
-      { "pair": 5, "review_converged": 26.744, "final_head": 26.716 },
-      { "pair": 6, "review_converged": 26.826, "final_head": 26.954 },
-      { "pair": 7, "review_converged": 26.739, "final_head": 26.684 },
-      { "pair": 8, "review_converged": 26.687, "final_head": 26.825 }
+      { "pair": 1, "review_converged": 26.992, "final_head": 30.026 },
+      { "pair": 2, "review_converged": 29.669, "final_head": 29.764 },
+      { "pair": 3, "review_converged": 29.828, "final_head": 33.501 },
+      { "pair": 4, "review_converged": 29.827, "final_head": 29.698 },
+      { "pair": 5, "review_converged": 29.702, "final_head": 29.761 },
+      { "pair": 6, "review_converged": 29.483, "final_head": 29.885 },
+      { "pair": 7, "review_converged": 33.815, "final_head": 29.805 },
+      { "pair": 8, "review_converged": 29.968, "final_head": 29.945 }
     ],
     "summary": {
-      "review_converged_median_ms": 26.766,
-      "final_head_median_ms": 26.817,
-      "median_paired_delta_ms": 0.050,
-      "median_paired_delta_percent": 0.186,
+      "review_converged_median_ms": 29.765,
+      "final_head_median_ms": 29.845,
+      "median_paired_delta_ms": 0.077,
+      "median_paired_delta_percent": 0.259,
       "median_paired_delta_percent_calculation": "median((final_head - review_converged) / review_converged * 100 for each pair)",
-      "paired_delta_range_ms": [-2.560, 2.227],
-      "paired_delta_percent_range": [-8.690, 9.059],
+      "paired_delta_range_ms": [-4.010, 3.673],
+      "paired_delta_percent_range": [-11.859, 12.314],
       "interpretation": "central latency remained indistinguishable after the final hot-path review fixes; the wide early-pair range means this run does not establish tail equivalence"
     }
   }

--- a/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
+++ b/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
@@ -189,7 +189,8 @@
       "measured_candidate_median_ms": 39.013,
       "review_converged_median_ms": 39.021,
       "median_paired_delta_ms": 0.146,
-      "median_paired_delta_percent": 0.374,
+      "median_paired_delta_percent": 0.376,
+      "median_paired_delta_percent_calculation": "median((review_converged - measured_candidate) / measured_candidate * 100 for each pair)",
       "paired_delta_range_ms": [-0.522, 5.866],
       "interpretation": "central latency was indistinguishable; two late pairs widened the positive tail, so this run does not establish tail equivalence"
     }

--- a/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
+++ b/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
@@ -5,8 +5,8 @@
     "stage": 25
   },
   "candidate": {
-    "commit": "30ae589b3b81a525cc3209dae5d9b61c108303c8",
-    "release_server_binary_sha256": "e4fa45dfb73588ab93448e52ec4425076a1342d099dc7000d6a1d4b796032b5a",
+    "commit": "67c338ca7955faf1021c0951a8f039a915b5a0d0",
+    "release_server_binary_sha256": "8139d7e2b3b8b661a15110e2795b7cd09caa63a2dd5cc6873e309eb54bf3ab6a",
     "stage": 26
   },
   "environment": {
@@ -18,14 +18,10 @@
   "recovery_artifacts": {
     "build_command": "cargo test --features e2e --test e2e_tree_worker_shadow --no-run",
     "execution_command_template": "cargo test --features e2e --test e2e_tree_worker_shadow <test> -- --exact --nocapture",
-    "stage25_e2e_binary": {
-      "path": "target/debug/deps/e2e_tree_worker_shadow-0b7a6c7b84f4b502",
-      "sha256": "74fc0069fdb422454e7a8af36d0c5b771d0d15fbaff144f357cc660a54aa540c"
-    },
-    "stage26_e2e_binary": {
-      "path": "target/debug/deps/e2e_tree_worker_shadow-0b7a6c7b84f4b502",
-      "sha256": "8f81a229e0cb437021ca504f7e806783535e7042cfe67fed06026a7e96c7fe42"
-    }
+    "stage25_debug_server": { "path": "target/debug/kakehashi", "sha256": "d96476057b71c6801ac31bf326b0f51f1f9c07837bb552693a45ae49a921f054" },
+    "stage25_e2e_binary": { "path": "target/debug/deps/e2e_tree_worker_shadow-0b7a6c7b84f4b502", "sha256": "74fc0069fdb422454e7a8af36d0c5b771d0d15fbaff144f357cc660a54aa540c" },
+    "stage26_debug_server": { "path": "target/debug/kakehashi", "sha256": "e9f1ad718b25667006a3d2f39421c1c8e313adc855dd98045d6a94aab664255d" },
+    "stage26_e2e_binary": { "path": "target/debug/deps/e2e_tree_worker_shadow-0b7a6c7b84f4b502", "sha256": "c8f1a4d02f59a4cc0451476751004fe95d801474a553ef0146af868da71a4629" }
   },
   "single_hazard_recovery": {
     "method": {
@@ -38,38 +34,33 @@
       "warmup_runs_per_stage": 1
     },
     "samples_ms": [
-      { "pair": 1, "stage25": 1176, "stage26": 1177 },
-      { "pair": 2, "stage25": 1167, "stage26": 1174 },
-      { "pair": 3, "stage25": 1200, "stage26": 1120 },
-      { "pair": 4, "stage25": 1373, "stage26": 1139 },
-      { "pair": 5, "stage25": 1204, "stage26": 1131 },
-      { "pair": 6, "stage25": 1164, "stage26": 1549 },
-      { "pair": 7, "stage25": 1184, "stage26": 1318 },
-      { "pair": 8, "stage25": 1230, "stage26": 1172 },
-      { "pair": 9, "stage25": 1278, "stage26": 1196 },
-      { "pair": 10, "stage25": 1170, "stage26": 1232 },
-      { "pair": 11, "stage25": 1394, "stage26": 1187 },
-      { "pair": 12, "stage25": 1228, "stage26": 1192 }
+      { "pair": 1, "stage25": 1137, "stage26": 1140 },
+      { "pair": 2, "stage25": 1140, "stage26": 1146 },
+      { "pair": 3, "stage25": 1137, "stage26": 1140 },
+      { "pair": 4, "stage25": 1139, "stage26": 1146 },
+      { "pair": 5, "stage25": 1245, "stage26": 1132 },
+      { "pair": 6, "stage25": 1179, "stage26": 1141 },
+      { "pair": 7, "stage25": 1140, "stage26": 1143 },
+      { "pair": 8, "stage25": 1144, "stage26": 1147 },
+      { "pair": 9, "stage25": 1166, "stage26": 1152 },
+      { "pair": 10, "stage25": 1477, "stage26": 1135 },
+      { "pair": 11, "stage25": 1174, "stage26": 1297 },
+      { "pair": 12, "stage25": 1163, "stage26": 1205 }
     ],
     "summary": {
-      "median_paired_delta_ms": -47,
-      "median_paired_delta_percent": -3.824,
-      "paired_delta_range_ms": [-234, 385],
-      "stage25_mean_ms": 1230.667,
-      "stage25_median_ms": 1202,
-      "stage25_range_ms": [1164, 1394],
-      "stage26_mean_ms": 1215.583,
-      "stage26_median_ms": 1182,
-      "stage26_range_ms": [1120, 1549]
+      "median_paired_delta_ms": 3,
+      "median_paired_delta_percent": 0.264,
+      "paired_delta_range_ms": [-342, 123],
+      "stage25_mean_ms": 1186.750,
+      "stage25_median_ms": 1153.500,
+      "stage25_range_ms": [1137, 1477],
+      "stage26_mean_ms": 1160.333,
+      "stage26_median_ms": 1144.500,
+      "stage26_range_ms": [1132, 1297]
     }
   },
   "two_active_grammars": {
-    "assertions_per_run": {
-      "full_resynced_bytes": 14,
-      "full_resynced_documents": 1,
-      "newly_quarantined_grammars": 2,
-      "restarts": 1
-    },
+    "assertions_per_run": { "full_resynced_bytes": 14, "full_resynced_documents": 1, "newly_quarantined_grammars": 2, "restarts": 1 },
     "method": {
       "build_profile": "test (unoptimized + debuginfo)",
       "measurement": "supervisor recovery_ms from recovery start through replacement spawn and quarantine-aware full resync",
@@ -78,21 +69,11 @@
       "threads": 4,
       "warmup_runs": 1
     },
-    "samples_ms": [978, 962, 961, 967, 954, 962, 957],
-    "summary": {
-      "mean_ms": 963,
-      "median_ms": 962,
-      "range_ms": [954, 978]
-    }
+    "samples_ms": [960, 965, 954, 959, 964, 964, 950],
+    "summary": { "mean_ms": 959.429, "median_ms": 960, "range_ms": [950, 965] }
   },
   "saturated_noncooperative_timeout": {
-    "assertions_per_run": {
-      "committed_hazards": 4,
-      "compute_threads_saturated": 4,
-      "full_resynced_documents": 4,
-      "newly_quarantined_grammars": 0,
-      "restarts": 1
-    },
+    "assertions_per_run": { "committed_hazards": 4, "compute_threads_saturated": 4, "full_resynced_documents": 4, "newly_quarantined_grammars": 0, "restarts": 1 },
     "method": {
       "build_profile": "test (unoptimized + debuginfo)",
       "cancellation_grace_ms": 250,
@@ -103,24 +84,17 @@
       "threads": 4,
       "warmup_runs": 1
     },
-    "samples_ms": [3197, 3204, 3196, 3200, 3204, 3176, 3195],
-    "summary": {
-      "mean_ms": 3196,
-      "median_ms": 3197,
-      "range_ms": [3176, 3204]
-    }
+    "samples_ms": [3200, 3194, 3202, 3181, 3218, 3187, 3185],
+    "summary": { "mean_ms": 3195.286, "median_ms": 3194, "range_ms": [3181, 3218] }
   },
   "steady_state": {
     "artifacts": {
-      "build_commands": [
-        "cargo build --release --locked --bin kakehashi",
-        "cargo bench --locked --bench tree_worker_stage2 --no-run"
-      ],
+      "build_commands": ["cargo build --release --locked --bin kakehashi", "cargo bench --locked --bench tree_worker_stage2 --no-run"],
       "execution_command_template": "target/release/deps/tree_worker_stage2-329ecb03b93d760d --bench --bin target/release/kakehashi --parser deps/test/kakehashi/parser/rust.dylib --requests 500 --threads 4 --lines 200 [--worker-first]",
       "harness_source_path": "benches/tree_worker_stage2.rs",
       "harness_source_sha256": "fe96da0be057f65836e6948334752daeb4d5c0dcd363645e2dbcc0d1a5dbdcab",
       "stage25_harness_binary_sha256": "d9451d0a4e531c4b7fac5bcf81e5be61294ee7b0f0a462ef0e03d478ddcd10a4",
-      "stage26_harness_binary_sha256": "5624184c1ad89e51b25698b86970ce08ad2a5024bdd84897d8cf10405a39ea6f"
+      "stage26_harness_binary_sha256": "8d906956ab5284f3841c2c4cdba4c40b9a05a99c0024a9f4da5fa7227c645e8d"
     },
     "method": {
       "build_profile": "release (optimized)",
@@ -133,32 +107,26 @@
       "worker_direct_order": "odd direct->worker; even worker->direct"
     },
     "pairs": [
-      { "pair": 1, "stage25": [462.209, 521.166, 560.959, 628.834, 6500.936], "stage26": [454.375, 486.084, 564.791, 633.375, 6482.320] },
-      { "pair": 2, "stage25": [441.708, 476.958, 532.417, 635.000, 6931.300], "stage26": [400.000, 471.458, 532.042, 629.834, 6886.238] },
-      { "pair": 3, "stage25": [388.959, 473.792, 565.333, 632.667, 6596.469], "stage26": [426.834, 474.250, 555.041, 635.209, 6622.125] },
-      { "pair": 4, "stage25": [446.000, 475.084, 551.459, 638.708, 6612.179], "stage26": [446.500, 492.375, 542.584, 632.000, 6691.056] },
-      { "pair": 5, "stage25": [387.750, 457.458, 563.875, 628.875, 6511.660], "stage26": [385.500, 457.708, 567.792, 692.125, 6320.616] },
-      { "pair": 6, "stage25": [387.875, 461.209, 550.291, 618.583, 6801.032], "stage26": [406.584, 474.250, 534.166, 630.333, 6896.401] },
-      { "pair": 7, "stage25": [387.750, 462.167, 560.291, 626.125, 6548.370], "stage26": [446.750, 473.958, 559.875, 627.417, 6612.459] },
-      { "pair": 8, "stage25": [385.709, 454.125, 558.292, 636.916, 6673.544], "stage26": [383.042, 450.250, 541.042, 636.709, 6853.446] },
-      { "pair": 9, "stage25": [484.416, 604.459, 563.042, 889.875, 5357.131], "stage26": [518.750, 610.458, 547.083, 675.125, 5591.674] },
-      { "pair": 10, "stage25": [521.500, 612.834, 540.334, 630.417, 6616.083], "stage26": [548.333, 715.959, 545.292, 1116.375, 5767.947] },
-      { "pair": 11, "stage25": [465.416, 528.666, 547.375, 636.833, 6654.559], "stage26": [453.500, 494.542, 560.375, 631.875, 6556.621] },
-      { "pair": 12, "stage25": [383.250, 411.416, 531.042, 632.291, 6924.640], "stage26": [381.541, 414.167, 528.334, 624.166, 6978.314] }
+      { "pair": 1, "stage25": [451.750, 478.709, 558.916, 635.666, 6550.744], "stage26": [450.458, 498.709, 565.750, 635.167, 6489.963] },
+      { "pair": 2, "stage25": [512.625, 624.333, 555.834, 628.500, 6555.521], "stage26": [475.166, 535.000, 561.708, 652.917, 6292.946] },
+      { "pair": 3, "stage25": [455.042, 492.375, 549.875, 617.208, 6689.534], "stage26": [381.958, 406.500, 553.042, 635.083, 6588.028] },
+      { "pair": 4, "stage25": [390.042, 464.708, 535.958, 637.041, 6941.665], "stage26": [380.333, 407.917, 518.625, 655.125, 7018.324] },
+      { "pair": 5, "stage25": [403.250, 471.459, 561.708, 633.542, 6554.508], "stage26": [381.792, 409.041, 558.125, 627.917, 6617.250] },
+      { "pair": 6, "stage25": [392.708, 481.417, 526.834, 635.709, 6900.319], "stage26": [382.958, 412.792, 535.916, 628.834, 6842.426] },
+      { "pair": 7, "stage25": [386.625, 467.458, 563.375, 625.333, 6565.568], "stage26": [383.667, 459.750, 559.458, 629.666, 6588.690] },
+      { "pair": 8, "stage25": [380.792, 408.333, 520.916, 626.333, 7008.556], "stage26": [411.334, 480.708, 539.542, 645.708, 6869.154] },
+      { "pair": 9, "stage25": [383.000, 410.250, 556.833, 629.834, 6602.055], "stage26": [381.167, 406.542, 559.333, 651.709, 6535.923] },
+      { "pair": 10, "stage25": [384.458, 423.542, 522.041, 629.791, 6917.954], "stage26": [385.375, 456.958, 536.292, 633.166, 6894.416] },
+      { "pair": 11, "stage25": [381.833, 402.625, 557.584, 630.375, 6610.656], "stage26": [385.750, 464.833, 554.500, 630.708, 6596.705] },
+      { "pair": 12, "stage25": [391.416, 476.375, 548.375, 635.792, 6676.834], "stage26": [382.583, 408.875, 506.416, 624.958, 7207.263] }
     ],
-    "pair_value_order": [
-      "sequential_parent_p50_us",
-      "sequential_parent_p95_us",
-      "parallel_parent_p50_us",
-      "parallel_parent_p95_us",
-      "parallel_requests_per_second"
-    ],
+    "pair_value_order": ["sequential_parent_p50_us", "sequential_parent_p95_us", "parallel_parent_p50_us", "parallel_parent_p95_us", "parallel_requests_per_second"],
     "summary": {
-      "parallel_parent_p50_us": { "stage25_median": 554.876, "stage26_median": 546.188, "median_paired_delta_percent": -0.292 },
-      "parallel_parent_p95_us": { "stage25_median": 632.479, "stage26_median": 632.688, "median_paired_delta_percent": 0.087 },
-      "parallel_requests_per_second": { "stage25_median": 6614.131, "stage26_median": 6617.292, "median_paired_delta_percent": 0.582 },
-      "sequential_parent_p50_us": { "stage25_median": 415.334, "stage26_median": 436.667, "median_paired_delta_percent": -0.167 },
-      "sequential_parent_p95_us": { "stage25_median": 474.438, "stage26_median": 474.250, "median_paired_delta_percent": 0.383 }
+      "parallel_parent_p50_us": { "stage25_median": 552.855, "stage26_median": 553.771, "median_paired_delta_percent": 0.512 },
+      "parallel_parent_p95_us": { "stage25_median": 630.105, "stage26_median": 634.125, "median_paired_delta_percent": 0.614 },
+      "parallel_requests_per_second": { "stage25_median": 6643.745, "stage26_median": 6606.978, "median_paired_delta_percent": -0.590 },
+      "sequential_parent_p50_us": { "stage25_median": 390.729, "stage26_median": 383.313, "median_paired_delta_percent": -1.511 },
+      "sequential_parent_p95_us": { "stage25_median": 469.459, "stage26_median": 434.875, "median_paired_delta_percent": -6.935 }
     }
   }
 }

--- a/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
+++ b/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
@@ -54,7 +54,7 @@
       "build_profile": "test (unoptimized + debuginfo)",
       "measurement": "supervisor recovery_ms from recovery start through replacement spawn and quarantine-aware full resync",
       "runs": 7,
-      "test": "crash_quarantines_every_unique_committed_grammar_hazard",
+      "test": "windows_and_unix_crash_quarantine_every_unique_committed_grammar_hazard",
       "threads": 4,
       "warmup_runs": 1
     },

--- a/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
+++ b/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
@@ -141,8 +141,16 @@
     },
     "method": {
       "build_profile": "release (optimized)",
+      "build_commands": [
+        "git worktree add --detach /tmp/kakehashi-stage26-measured-67c338ca7 67c338ca7955faf1021c0951a8f039a915b5a0d0",
+        "cargo build --release --locked --bin kakehashi --manifest-path /tmp/kakehashi-stage26-measured-67c338ca7/Cargo.toml --target-dir /tmp/kakehashi-stage26-measured-67c338ca7/target",
+        "cp /tmp/kakehashi-stage26-measured-67c338ca7/target/release/kakehashi /tmp/kakehashi-stage26-semantic-ab/measured-67c338ca7",
+        "cargo build --release --locked --bin kakehashi",
+        "cp target/release/kakehashi /tmp/kakehashi-stage26-semantic-ab/final-36842edc5",
+        "cargo bench --locked --bench semantic_tokens --features e2e --no-run"
+      ],
       "environment": ["KAKEHASHI_TREE_WORKER_MODE=authoritative", "KAKEHASHI_TREE_WORKER_THREADS=4"],
-      "execution_command_template": "KAKEHASHI_BENCH_BIN_A=<A> KAKEHASHI_BENCH_BIN_B=<B> KAKEHASHI_BENCH_ITERS=40 KAKEHASHI_BENCH_WARMUP=10 KAKEHASHI_BENCH_SCENARIOS=rust_large/edit_delta semantic_tokens-08ebd8d8c816111c --bench",
+      "execution_command_template": "KAKEHASHI_TREE_WORKER_MODE=authoritative KAKEHASHI_TREE_WORKER_THREADS=4 KAKEHASHI_BENCH_BIN_A=<A> KAKEHASHI_BENCH_BIN_B=<B> KAKEHASHI_BENCH_ITERS=40 KAKEHASHI_BENCH_WARMUP=10 KAKEHASHI_BENCH_SCENARIOS=rust_large/edit_delta target/release/deps/semantic_tokens-08ebd8d8c816111c --bench",
       "iterations_per_binary_per_pair": 40,
       "pairs": 8,
       "revision_order": "odd measured->review-converged; even review-converged->measured",

--- a/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
+++ b/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
@@ -1,12 +1,12 @@
 {
   "baseline": {
-    "binary_sha256": "66cb417321d9dc694aee35860819050799ed0624398ddebf518125977826b2d1",
     "commit": "f6e0c2125f6f2c93e799ab3b0b4c7b6471691f53",
+    "release_server_binary_sha256": "66cb417321d9dc694aee35860819050799ed0624398ddebf518125977826b2d1",
     "stage": 25
   },
   "candidate": {
-    "binary_sha256": "26480f59d243aaba8dc0b6830c3bf6343f6ced7ebb99e982b491e19becfb3d60",
-    "commit": "33c61b5b660e003dcfcc84e4883e17ad78bd8cfa",
+    "commit": "30ae589b3b81a525cc3209dae5d9b61c108303c8",
+    "release_server_binary_sha256": "e4fa45dfb73588ab93448e52ec4425076a1342d099dc7000d6a1d4b796032b5a",
     "stage": 26
   },
   "environment": {
@@ -15,34 +15,52 @@
     "rustc": "1.95.0 (59807616e 2026-04-14)"
   },
   "measured_at": "2026-07-21",
+  "recovery_artifacts": {
+    "build_command": "cargo test --features e2e --test e2e_tree_worker_shadow --no-run",
+    "execution_command_template": "cargo test --features e2e --test e2e_tree_worker_shadow <test> -- --exact --nocapture",
+    "stage25_e2e_binary": {
+      "path": "target/debug/deps/e2e_tree_worker_shadow-0b7a6c7b84f4b502",
+      "sha256": "74fc0069fdb422454e7a8af36d0c5b771d0d15fbaff144f357cc660a54aa540c"
+    },
+    "stage26_e2e_binary": {
+      "path": "target/debug/deps/e2e_tree_worker_shadow-0b7a6c7b84f4b502",
+      "sha256": "8f81a229e0cb437021ca504f7e806783535e7042cfe67fed06026a7e96c7fe42"
+    }
+  },
   "single_hazard_recovery": {
     "method": {
       "build_profile": "test (unoptimized + debuginfo)",
       "measurement": "supervisor recovery_ms from recovery start through replacement spawn and full resync",
-      "order": "stage25 then stage26 in each pair",
-      "pairs": 7,
+      "pairs": 12,
+      "revision_order": "odd stage25->stage26; even stage26->stage25",
       "test": "crashed_grammar_is_quarantined_only_in_session_and_other_grammar_recovers",
       "threads": 4,
       "warmup_runs_per_stage": 1
     },
     "samples_ms": [
-      { "pair": 1, "stage25": 1146, "stage26": 1133 },
-      { "pair": 2, "stage25": 1170, "stage26": 1151 },
-      { "pair": 3, "stage25": 1159, "stage26": 1184 },
-      { "pair": 4, "stage25": 1236, "stage26": 1150 },
-      { "pair": 5, "stage25": 1183, "stage26": 1172 },
-      { "pair": 6, "stage25": 1168, "stage26": 1184 },
-      { "pair": 7, "stage25": 1243, "stage26": 1204 }
+      { "pair": 1, "stage25": 1176, "stage26": 1177 },
+      { "pair": 2, "stage25": 1167, "stage26": 1174 },
+      { "pair": 3, "stage25": 1200, "stage26": 1120 },
+      { "pair": 4, "stage25": 1373, "stage26": 1139 },
+      { "pair": 5, "stage25": 1204, "stage26": 1131 },
+      { "pair": 6, "stage25": 1164, "stage26": 1549 },
+      { "pair": 7, "stage25": 1184, "stage26": 1318 },
+      { "pair": 8, "stage25": 1230, "stage26": 1172 },
+      { "pair": 9, "stage25": 1278, "stage26": 1196 },
+      { "pair": 10, "stage25": 1170, "stage26": 1232 },
+      { "pair": 11, "stage25": 1394, "stage26": 1187 },
+      { "pair": 12, "stage25": 1228, "stage26": 1192 }
     ],
     "summary": {
-      "median_paired_delta_ms": -13,
-      "median_paired_delta_percent": -1.111,
-      "stage25_mean_ms": 1186.429,
-      "stage25_median_ms": 1170,
-      "stage25_range_ms": [1146, 1243],
-      "stage26_mean_ms": 1168.286,
-      "stage26_median_ms": 1172,
-      "stage26_range_ms": [1133, 1204]
+      "median_paired_delta_ms": -47,
+      "median_paired_delta_percent": -3.824,
+      "paired_delta_range_ms": [-234, 385],
+      "stage25_mean_ms": 1230.667,
+      "stage25_median_ms": 1202,
+      "stage25_range_ms": [1164, 1394],
+      "stage26_mean_ms": 1215.583,
+      "stage26_median_ms": 1182,
+      "stage26_range_ms": [1120, 1549]
     }
   },
   "two_active_grammars": {
@@ -60,11 +78,11 @@
       "threads": 4,
       "warmup_runs": 1
     },
-    "samples_ms": [957, 957, 957, 936, 932, 954, 967],
+    "samples_ms": [978, 962, 961, 967, 954, 962, 957],
     "summary": {
-      "mean_ms": 951.429,
-      "median_ms": 957,
-      "range_ms": [932, 967]
+      "mean_ms": 963,
+      "median_ms": 962,
+      "range_ms": [954, 978]
     }
   },
   "saturated_noncooperative_timeout": {
@@ -85,42 +103,48 @@
       "threads": 4,
       "warmup_runs": 1
     },
-    "samples_ms": [3211, 3205, 3198, 3187, 3206, 3209, 3201],
+    "samples_ms": [3197, 3204, 3196, 3200, 3204, 3176, 3195],
     "summary": {
-      "mean_ms": 3202.429,
-      "median_ms": 3205,
-      "range_ms": [3187, 3211]
+      "mean_ms": 3196,
+      "median_ms": 3197,
+      "range_ms": [3176, 3204]
     }
   },
   "steady_state": {
     "artifacts": {
+      "build_commands": [
+        "cargo build --release --locked --bin kakehashi",
+        "cargo bench --locked --bench tree_worker_stage2 --no-run"
+      ],
+      "execution_command_template": "target/release/deps/tree_worker_stage2-329ecb03b93d760d --bench --bin target/release/kakehashi --parser deps/test/kakehashi/parser/rust.dylib --requests 500 --threads 4 --lines 200 [--worker-first]",
+      "harness_source_path": "benches/tree_worker_stage2.rs",
       "harness_source_sha256": "fe96da0be057f65836e6948334752daeb4d5c0dcd363645e2dbcc0d1a5dbdcab",
       "stage25_harness_binary_sha256": "d9451d0a4e531c4b7fac5bcf81e5be61294ee7b0f0a462ef0e03d478ddcd10a4",
-      "stage26_harness_binary_sha256": "58d1335409085da3ff59c2aa54a0c707482c5f66357d8c64b903f15f76eab5ef"
+      "stage26_harness_binary_sha256": "5624184c1ad89e51b25698b86970ce08ad2a5024bdd84897d8cf10405a39ea6f"
     },
     "method": {
       "build_profile": "release (optimized)",
       "lines": 200,
       "pairs": 12,
       "requests_per_run": 500,
-      "revision_order": "alternating stage25/stage26",
+      "revision_order": "odd stage25->stage26; even stage26->stage25",
       "threads": 4,
       "warmup_runs_per_stage": 1,
-      "worker_direct_order": "alternating"
+      "worker_direct_order": "odd direct->worker; even worker->direct"
     },
     "pairs": [
-      { "pair": 1, "stage25": [475.250, 545.375, 576.375, 651.834, 6368.433], "stage26": [453.333, 495.166, 558.208, 675.375, 6443.960] },
-      { "pair": 2, "stage25": [476.583, 540.000, 566.042, 638.042, 6494.290], "stage26": [530.084, 623.792, 550.000, 642.250, 6569.356] },
-      { "pair": 3, "stage25": [453.833, 482.166, 559.083, 622.417, 6602.349], "stage26": [452.333, 498.750, 556.000, 623.500, 6601.277] },
-      { "pair": 4, "stage25": [438.708, 468.334, 546.834, 628.667, 6789.677], "stage26": [450.458, 477.833, 536.042, 631.250, 6885.657] },
-      { "pair": 5, "stage25": [452.959, 494.458, 560.416, 626.291, 6562.598], "stage26": [455.959, 513.791, 562.292, 621.166, 6599.527] },
-      { "pair": 6, "stage25": [453.375, 497.583, 545.875, 625.500, 6810.887], "stage26": [443.500, 477.417, 549.417, 646.875, 6763.943] },
-      { "pair": 7, "stage25": [450.666, 479.917, 554.125, 629.958, 6620.748], "stage26": [451.167, 484.916, 563.708, 636.666, 6477.443] },
-      { "pair": 8, "stage25": [452.959, 484.875, 544.959, 629.417, 6815.471], "stage26": [449.541, 478.375, 534.167, 642.875, 6878.194] },
-      { "pair": 9, "stage25": [408.458, 467.417, 563.208, 638.667, 6520.509], "stage26": [409.875, 470.833, 559.375, 628.791, 6586.708] },
-      { "pair": 10, "stage25": [455.834, 496.209, 529.500, 633.083, 6954.643], "stage26": [454.667, 495.417, 559.459, 639.583, 6528.353] },
-      { "pair": 11, "stage25": [447.625, 475.875, 558.417, 632.250, 6594.403], "stage26": [453.209, 494.792, 561.250, 626.333, 6538.505] },
-      { "pair": 12, "stage25": [478.000, 542.958, 558.834, 628.375, 6555.425], "stage26": [477.375, 542.250, 540.625, 765.000, 5941.930] }
+      { "pair": 1, "stage25": [462.209, 521.166, 560.959, 628.834, 6500.936], "stage26": [454.375, 486.084, 564.791, 633.375, 6482.320] },
+      { "pair": 2, "stage25": [441.708, 476.958, 532.417, 635.000, 6931.300], "stage26": [400.000, 471.458, 532.042, 629.834, 6886.238] },
+      { "pair": 3, "stage25": [388.959, 473.792, 565.333, 632.667, 6596.469], "stage26": [426.834, 474.250, 555.041, 635.209, 6622.125] },
+      { "pair": 4, "stage25": [446.000, 475.084, 551.459, 638.708, 6612.179], "stage26": [446.500, 492.375, 542.584, 632.000, 6691.056] },
+      { "pair": 5, "stage25": [387.750, 457.458, 563.875, 628.875, 6511.660], "stage26": [385.500, 457.708, 567.792, 692.125, 6320.616] },
+      { "pair": 6, "stage25": [387.875, 461.209, 550.291, 618.583, 6801.032], "stage26": [406.584, 474.250, 534.166, 630.333, 6896.401] },
+      { "pair": 7, "stage25": [387.750, 462.167, 560.291, 626.125, 6548.370], "stage26": [446.750, 473.958, 559.875, 627.417, 6612.459] },
+      { "pair": 8, "stage25": [385.709, 454.125, 558.292, 636.916, 6673.544], "stage26": [383.042, 450.250, 541.042, 636.709, 6853.446] },
+      { "pair": 9, "stage25": [484.416, 604.459, 563.042, 889.875, 5357.131], "stage26": [518.750, 610.458, 547.083, 675.125, 5591.674] },
+      { "pair": 10, "stage25": [521.500, 612.834, 540.334, 630.417, 6616.083], "stage26": [548.333, 715.959, 545.292, 1116.375, 5767.947] },
+      { "pair": 11, "stage25": [465.416, 528.666, 547.375, 636.833, 6654.559], "stage26": [453.500, 494.542, 560.375, 631.875, 6556.621] },
+      { "pair": 12, "stage25": [383.250, 411.416, 531.042, 632.291, 6924.640], "stage26": [381.541, 414.167, 528.334, 624.166, 6978.314] }
     ],
     "pair_value_order": [
       "sequential_parent_p50_us",
@@ -130,11 +154,11 @@
       "parallel_requests_per_second"
     ],
     "summary": {
-      "parallel_parent_p50_us": { "stage25_median": 558.626, "stage26_median": 557.104, "median_paired_delta_percent": -0.616 },
-      "parallel_parent_p95_us": { "stage25_median": 629.688, "stage26_median": 638.125, "median_paired_delta_percent": 0.843 },
-      "parallel_requests_per_second": { "stage25_median": 6598.376, "stage26_median": 6578.032, "median_paired_delta_percent": 0.273 },
-      "sequential_parent_p50_us": { "stage25_median": 453.167, "stage26_median": 452.771, "median_paired_delta_percent": -0.010 },
-      "sequential_parent_p95_us": { "stage25_median": 489.667, "stage26_median": 494.979, "median_paired_delta_percent": 0.886 }
+      "parallel_parent_p50_us": { "stage25_median": 554.876, "stage26_median": 546.188, "median_paired_delta_percent": -0.292 },
+      "parallel_parent_p95_us": { "stage25_median": 632.479, "stage26_median": 632.688, "median_paired_delta_percent": 0.087 },
+      "parallel_requests_per_second": { "stage25_median": 6614.131, "stage26_median": 6617.292, "median_paired_delta_percent": 0.582 },
+      "sequential_parent_p50_us": { "stage25_median": 415.334, "stage26_median": 436.667, "median_paired_delta_percent": -0.167 },
+      "sequential_parent_p95_us": { "stage25_median": 474.438, "stage26_median": 474.250, "median_paired_delta_percent": 0.383 }
     }
   }
 }

--- a/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
+++ b/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
@@ -93,6 +93,13 @@
       "execution_command_template": "target/release/deps/tree_worker_stage2-329ecb03b93d760d --bench --bin target/release/kakehashi --parser deps/test/kakehashi/parser/rust.dylib --requests 500 --threads 4 --lines 200 [--worker-first]",
       "harness_source_path": "benches/tree_worker_stage2.rs",
       "harness_source_sha256": "fe96da0be057f65836e6948334752daeb4d5c0dcd363645e2dbcc0d1a5dbdcab",
+      "parser_artifact": {
+        "path": "deps/test/kakehashi/parser/rust.dylib",
+        "sha256": "5134481a8ce8dfa395ad8c43a67f4623adc25551f03ec339309ca1b51420ea91",
+        "catalog_source": "https://github.com/tree-sitter/tree-sitter-rust",
+        "catalog_revision": "77a3747266f4d621d0757825e6b11edcbf991ca5",
+        "provenance_scope": "source URL and revision come from the mutable deps/test/kakehashi/cache/parsers.lua snapshot; the dylib build toolchain itself was not attested"
+      },
       "stage25_harness_binary_sha256": "d9451d0a4e531c4b7fac5bcf81e5be61294ee7b0f0a462ef0e03d478ddcd10a4",
       "stage26_harness_binary_sha256": "8d906956ab5284f3841c2c4cdba4c40b9a05a99c0024a9f4da5fa7227c645e8d"
     },
@@ -156,10 +163,12 @@
       "environment": ["KAKEHASHI_TREE_WORKER_MODE=authoritative", "KAKEHASHI_TREE_WORKER_THREADS=4"],
       "execution_command_template": "KAKEHASHI_TREE_WORKER_MODE=authoritative KAKEHASHI_TREE_WORKER_THREADS=4 KAKEHASHI_BENCH_BIN_A=<A> KAKEHASHI_BENCH_BIN_B=<B> KAKEHASHI_BENCH_ITERS=40 KAKEHASHI_BENCH_WARMUP=10 KAKEHASHI_BENCH_SCENARIOS=rust_large/edit_delta /tmp/kakehashi-stage26-review-36842edc5/target/release/deps/semantic_tokens-08ebd8d8c816111c --bench",
       "iterations_per_binary_per_pair": 40,
+      "pair_value_statistic": "median_ms",
       "pairs": 8,
       "revision_order": "odd measured->review-converged; even review-converged->measured",
       "scenario": "rust_large/edit_delta",
-      "warmup_iterations_per_binary_per_pair": 10
+      "warmup_iterations_per_binary_per_pair": 10,
+      "sample_retention": "the harness emitted one median per binary per pair; per-iteration samples and p25/p75 were not retained"
     },
     "pilot_ms": {
       "measured_candidate": 45.413,

--- a/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
+++ b/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
@@ -128,5 +128,49 @@
       "sequential_parent_p50_us": { "stage25_median": 390.729, "stage26_median": 383.313, "median_paired_delta_percent": -1.511 },
       "sequential_parent_p95_us": { "stage25_median": 469.459, "stage26_median": 434.875, "median_paired_delta_percent": -6.935 }
     }
+  },
+  "post_review_semantic_scheduling": {
+    "artifacts": {
+      "measured_candidate_commit": "67c338ca7955faf1021c0951a8f039a915b5a0d0",
+      "measured_candidate_server_sha256": "8139d7e2b3b8b661a15110e2795b7cd09caa63a2dd5cc6873e309eb54bf3ab6a",
+      "review_converged_commit": "36842edc5fc2c13864d9d39cecc77a78a9ed56fa",
+      "review_converged_server_sha256": "a3cdaa3de70efba44ec0a3d6835689c6939d9b924185b45ae4cd41e6f770e870",
+      "harness_source_path": "benches/semantic_tokens.rs",
+      "harness_source_sha256": "018cbd1750758496421073bdd3fbaf6588702a52d8986db5be5384f2faebd8bf",
+      "harness_binary_sha256": "4c279d229e422afed5d00ab5636f6704cc51e7507b31dbbfb13a571b6a7d6378"
+    },
+    "method": {
+      "build_profile": "release (optimized)",
+      "environment": ["KAKEHASHI_TREE_WORKER_MODE=authoritative", "KAKEHASHI_TREE_WORKER_THREADS=4"],
+      "execution_command_template": "KAKEHASHI_BENCH_BIN_A=<A> KAKEHASHI_BENCH_BIN_B=<B> KAKEHASHI_BENCH_ITERS=40 KAKEHASHI_BENCH_WARMUP=10 KAKEHASHI_BENCH_SCENARIOS=rust_large/edit_delta semantic_tokens-08ebd8d8c816111c --bench",
+      "iterations_per_binary_per_pair": 40,
+      "pairs": 8,
+      "revision_order": "odd measured->review-converged; even review-converged->measured",
+      "scenario": "rust_large/edit_delta",
+      "warmup_iterations_per_binary_per_pair": 10
+    },
+    "pilot_ms": {
+      "measured_candidate": 45.413,
+      "review_converged": 51.564,
+      "role": "unpaired pre-series pilot; excluded from the paired summary"
+    },
+    "pairs_ms": [
+      { "pair": 1, "measured_candidate": 38.953, "review_converged": 38.887 },
+      { "pair": 2, "measured_candidate": 39.055, "review_converged": 39.117 },
+      { "pair": 3, "measured_candidate": 38.784, "review_converged": 39.014 },
+      { "pair": 4, "measured_candidate": 38.971, "review_converged": 38.845 },
+      { "pair": 5, "measured_candidate": 38.694, "review_converged": 39.027 },
+      { "pair": 6, "measured_candidate": 39.520, "review_converged": 38.998 },
+      { "pair": 7, "measured_candidate": 40.700, "review_converged": 46.566 },
+      { "pair": 8, "measured_candidate": 41.564, "review_converged": 46.342 }
+    ],
+    "summary": {
+      "measured_candidate_median_ms": 39.013,
+      "review_converged_median_ms": 39.021,
+      "median_paired_delta_ms": 0.146,
+      "median_paired_delta_percent": 0.374,
+      "paired_delta_range_ms": [-0.522, 5.866],
+      "interpretation": "central latency was indistinguishable; two late pairs widened the positive tail, so this run does not establish tail equivalence"
+    }
   }
 }

--- a/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
+++ b/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
@@ -1,10 +1,12 @@
 {
   "baseline": {
+    "binary_sha256": "66cb417321d9dc694aee35860819050799ed0624398ddebf518125977826b2d1",
     "commit": "f6e0c2125f6f2c93e799ab3b0b4c7b6471691f53",
     "stage": 25
   },
   "candidate": {
-    "commit": "370d13d2cdcdd7bf6e1b8927e768319116fe8a97",
+    "binary_sha256": "26480f59d243aaba8dc0b6830c3bf6343f6ced7ebb99e982b491e19becfb3d60",
+    "commit": "33c61b5b660e003dcfcc84e4883e17ad78bd8cfa",
     "stage": 26
   },
   "environment": {
@@ -24,23 +26,23 @@
       "warmup_runs_per_stage": 1
     },
     "samples_ms": [
-      { "pair": 1, "stage25": 1275, "stage26": 1251 },
-      { "pair": 2, "stage25": 1266, "stage26": 1277 },
-      { "pair": 3, "stage25": 1299, "stage26": 1283 },
-      { "pair": 4, "stage25": 1254, "stage26": 1571 },
-      { "pair": 5, "stage25": 1264, "stage26": 1281 },
-      { "pair": 6, "stage25": 1250, "stage26": 1450 },
-      { "pair": 7, "stage25": 1279, "stage26": 1278 }
+      { "pair": 1, "stage25": 1146, "stage26": 1133 },
+      { "pair": 2, "stage25": 1170, "stage26": 1151 },
+      { "pair": 3, "stage25": 1159, "stage26": 1184 },
+      { "pair": 4, "stage25": 1236, "stage26": 1150 },
+      { "pair": 5, "stage25": 1183, "stage26": 1172 },
+      { "pair": 6, "stage25": 1168, "stage26": 1184 },
+      { "pair": 7, "stage25": 1243, "stage26": 1204 }
     ],
     "summary": {
-      "median_paired_delta_ms": 11,
-      "median_paired_delta_percent": 0.869,
-      "stage25_mean_ms": 1269.571,
-      "stage25_median_ms": 1266,
-      "stage25_range_ms": [1250, 1299],
-      "stage26_mean_ms": 1341.571,
-      "stage26_median_ms": 1281,
-      "stage26_range_ms": [1251, 1571]
+      "median_paired_delta_ms": -13,
+      "median_paired_delta_percent": -1.111,
+      "stage25_mean_ms": 1186.429,
+      "stage25_median_ms": 1170,
+      "stage25_range_ms": [1146, 1243],
+      "stage26_mean_ms": 1168.286,
+      "stage26_median_ms": 1172,
+      "stage26_range_ms": [1133, 1204]
     }
   },
   "two_active_grammars": {
@@ -58,11 +60,81 @@
       "threads": 4,
       "warmup_runs": 1
     },
-    "samples_ms": [959, 971, 974, 971, 1126, 981, 990],
+    "samples_ms": [957, 957, 957, 936, 932, 954, 967],
     "summary": {
-      "mean_ms": 996,
-      "median_ms": 974,
-      "range_ms": [959, 1126]
+      "mean_ms": 951.429,
+      "median_ms": 957,
+      "range_ms": [932, 967]
+    }
+  },
+  "saturated_noncooperative_timeout": {
+    "assertions_per_run": {
+      "committed_hazards": 4,
+      "compute_threads_saturated": 4,
+      "full_resynced_documents": 4,
+      "newly_quarantined_grammars": 0,
+      "restarts": 1
+    },
+    "method": {
+      "build_profile": "test (unoptimized + debuginfo)",
+      "cancellation_grace_ms": 250,
+      "measurement": "request issue through replacement readiness after all four compute threads park",
+      "request_deadline_ms": 2000,
+      "runs": 7,
+      "test": "noncooperative_jobs_saturating_all_compute_threads_recover_as_one_generation",
+      "threads": 4,
+      "warmup_runs": 1
+    },
+    "samples_ms": [3211, 3205, 3198, 3187, 3206, 3209, 3201],
+    "summary": {
+      "mean_ms": 3202.429,
+      "median_ms": 3205,
+      "range_ms": [3187, 3211]
+    }
+  },
+  "steady_state": {
+    "artifacts": {
+      "harness_source_sha256": "fe96da0be057f65836e6948334752daeb4d5c0dcd363645e2dbcc0d1a5dbdcab",
+      "stage25_harness_binary_sha256": "d9451d0a4e531c4b7fac5bcf81e5be61294ee7b0f0a462ef0e03d478ddcd10a4",
+      "stage26_harness_binary_sha256": "58d1335409085da3ff59c2aa54a0c707482c5f66357d8c64b903f15f76eab5ef"
+    },
+    "method": {
+      "build_profile": "release (optimized)",
+      "lines": 200,
+      "pairs": 12,
+      "requests_per_run": 500,
+      "revision_order": "alternating stage25/stage26",
+      "threads": 4,
+      "warmup_runs_per_stage": 1,
+      "worker_direct_order": "alternating"
+    },
+    "pairs": [
+      { "pair": 1, "stage25": [475.250, 545.375, 576.375, 651.834, 6368.433], "stage26": [453.333, 495.166, 558.208, 675.375, 6443.960] },
+      { "pair": 2, "stage25": [476.583, 540.000, 566.042, 638.042, 6494.290], "stage26": [530.084, 623.792, 550.000, 642.250, 6569.356] },
+      { "pair": 3, "stage25": [453.833, 482.166, 559.083, 622.417, 6602.349], "stage26": [452.333, 498.750, 556.000, 623.500, 6601.277] },
+      { "pair": 4, "stage25": [438.708, 468.334, 546.834, 628.667, 6789.677], "stage26": [450.458, 477.833, 536.042, 631.250, 6885.657] },
+      { "pair": 5, "stage25": [452.959, 494.458, 560.416, 626.291, 6562.598], "stage26": [455.959, 513.791, 562.292, 621.166, 6599.527] },
+      { "pair": 6, "stage25": [453.375, 497.583, 545.875, 625.500, 6810.887], "stage26": [443.500, 477.417, 549.417, 646.875, 6763.943] },
+      { "pair": 7, "stage25": [450.666, 479.917, 554.125, 629.958, 6620.748], "stage26": [451.167, 484.916, 563.708, 636.666, 6477.443] },
+      { "pair": 8, "stage25": [452.959, 484.875, 544.959, 629.417, 6815.471], "stage26": [449.541, 478.375, 534.167, 642.875, 6878.194] },
+      { "pair": 9, "stage25": [408.458, 467.417, 563.208, 638.667, 6520.509], "stage26": [409.875, 470.833, 559.375, 628.791, 6586.708] },
+      { "pair": 10, "stage25": [455.834, 496.209, 529.500, 633.083, 6954.643], "stage26": [454.667, 495.417, 559.459, 639.583, 6528.353] },
+      { "pair": 11, "stage25": [447.625, 475.875, 558.417, 632.250, 6594.403], "stage26": [453.209, 494.792, 561.250, 626.333, 6538.505] },
+      { "pair": 12, "stage25": [478.000, 542.958, 558.834, 628.375, 6555.425], "stage26": [477.375, 542.250, 540.625, 765.000, 5941.930] }
+    ],
+    "pair_value_order": [
+      "sequential_parent_p50_us",
+      "sequential_parent_p95_us",
+      "parallel_parent_p50_us",
+      "parallel_parent_p95_us",
+      "parallel_requests_per_second"
+    ],
+    "summary": {
+      "parallel_parent_p50_us": { "stage25_median": 558.626, "stage26_median": 557.104, "median_paired_delta_percent": -0.616 },
+      "parallel_parent_p95_us": { "stage25_median": 629.688, "stage26_median": 638.125, "median_paired_delta_percent": 0.843 },
+      "parallel_requests_per_second": { "stage25_median": 6598.376, "stage26_median": 6578.032, "median_paired_delta_percent": 0.273 },
+      "sequential_parent_p50_us": { "stage25_median": 453.167, "stage26_median": 452.771, "median_paired_delta_percent": -0.010 },
+      "sequential_parent_p95_us": { "stage25_median": 489.667, "stage26_median": 494.979, "median_paired_delta_percent": 0.886 }
     }
   }
 }

--- a/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
+++ b/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
@@ -137,7 +137,9 @@
       "review_converged_server_sha256": "a3cdaa3de70efba44ec0a3d6835689c6939d9b924185b45ae4cd41e6f770e870",
       "harness_source_path": "benches/semantic_tokens.rs",
       "harness_source_sha256": "018cbd1750758496421073bdd3fbaf6588702a52d8986db5be5384f2faebd8bf",
-      "harness_binary_sha256": "4c279d229e422afed5d00ab5636f6704cc51e7507b31dbbfb13a571b6a7d6378"
+      "harness_binary_sha256": "4c279d229e422afed5d00ab5636f6704cc51e7507b31dbbfb13a571b6a7d6378",
+      "harness_binary_sha256_role": "attests the binary executed from the original checkout; it is not a bit-reproducible rebuild target because CARGO_MANIFEST_DIR is embedded",
+      "rebuild_scope": "the detached-worktree commands reproduce source, revision, features, and benchmark behavior, but intentionally use a different embedded fixture-data path"
     },
     "method": {
       "build_profile": "release (optimized)",

--- a/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
+++ b/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
@@ -194,5 +194,55 @@
       "paired_delta_range_ms": [-0.522, 5.866],
       "interpretation": "central latency was indistinguishable; two late pairs widened the positive tail, so this run does not establish tail equivalence"
     }
+  },
+  "final_head_semantic_scheduling": {
+    "artifacts": {
+      "review_converged_commit": "36842edc5fc2c13864d9d39cecc77a78a9ed56fa",
+      "review_converged_server_sha256": "a3cdaa3de70efba44ec0a3d6835689c6939d9b924185b45ae4cd41e6f770e870",
+      "final_head_commit": "72f58a8b491f5270b796dd6ed61f70f43c0ac17b",
+      "final_head_server_sha256": "d6c0e512cef8250bcd6750685e5898c36635f08ca5c86cb2de72c8e36fa2b7c7",
+      "harness_source_path": "benches/semantic_tokens.rs",
+      "harness_source_sha256": "018cbd1750758496421073bdd3fbaf6588702a52d8986db5be5384f2faebd8bf",
+      "harness_binary_sha256": "c9338da3fd92ad4150ed6db3630223ef19f3f5e5f70165d836272fa6c3dd0081",
+      "harness_binary_sha256_role": "attests the binary executed from the final-head worktree; CARGO_MANIFEST_DIR embeds that checkout path",
+      "rebuild_scope": "source, revision, and features are reproducible; the mutable parser/query fixture tree remains unattested, so a fresh installation is not claimed behavior-equivalent"
+    },
+    "method": {
+      "build_profile": "release (optimized)",
+      "build_commands": [
+        "cargo build --release --locked --bin kakehashi",
+        "cp target/release/kakehashi /tmp/kakehashi-stage26-semantic-ab/final-72f58a8b4",
+        "cargo bench --locked --bench semantic_tokens --features e2e --no-run"
+      ],
+      "environment": ["KAKEHASHI_TREE_WORKER_MODE=authoritative", "KAKEHASHI_TREE_WORKER_THREADS=4"],
+      "execution_command_template": "KAKEHASHI_TREE_WORKER_MODE=authoritative KAKEHASHI_TREE_WORKER_THREADS=4 KAKEHASHI_BENCH_BIN_A=<A> KAKEHASHI_BENCH_BIN_B=<B> KAKEHASHI_BENCH_ITERS=40 KAKEHASHI_BENCH_WARMUP=10 KAKEHASHI_BENCH_SCENARIOS=rust_large/edit_delta target/release/deps/semantic_tokens-08ebd8d8c816111c --bench",
+      "iterations_per_binary_per_pair": 40,
+      "pair_value_statistic": "median_ms",
+      "pairs": 8,
+      "revision_order": "odd review-converged->final-head; even final-head->review-converged",
+      "scenario": "rust_large/edit_delta",
+      "warmup_iterations_per_binary_per_pair": 10,
+      "sample_retention": "the harness emitted one median per binary per pair; per-iteration samples and p25/p75 were not retained"
+    },
+    "pairs_ms": [
+      { "pair": 1, "review_converged": 24.582, "final_head": 26.809 },
+      { "pair": 2, "review_converged": 26.788, "final_head": 28.910 },
+      { "pair": 3, "review_converged": 29.460, "final_head": 26.900 },
+      { "pair": 4, "review_converged": 26.830, "final_head": 26.707 },
+      { "pair": 5, "review_converged": 26.744, "final_head": 26.716 },
+      { "pair": 6, "review_converged": 26.826, "final_head": 26.954 },
+      { "pair": 7, "review_converged": 26.739, "final_head": 26.684 },
+      { "pair": 8, "review_converged": 26.687, "final_head": 26.825 }
+    ],
+    "summary": {
+      "review_converged_median_ms": 26.766,
+      "final_head_median_ms": 26.817,
+      "median_paired_delta_ms": 0.050,
+      "median_paired_delta_percent": 0.186,
+      "median_paired_delta_percent_calculation": "median((final_head - review_converged) / review_converged * 100 for each pair)",
+      "paired_delta_range_ms": [-2.560, 2.227],
+      "paired_delta_percent_range": [-8.690, 9.059],
+      "interpretation": "central latency remained indistinguishable after the final hot-path review fixes; the wide early-pair range means this run does not establish tail equivalence"
+    }
   }
 }

--- a/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
+++ b/benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json
@@ -139,7 +139,7 @@
       "harness_source_sha256": "018cbd1750758496421073bdd3fbaf6588702a52d8986db5be5384f2faebd8bf",
       "harness_binary_sha256": "4c279d229e422afed5d00ab5636f6704cc51e7507b31dbbfb13a571b6a7d6378",
       "harness_binary_sha256_role": "attests the binary executed from the original checkout; it is not a bit-reproducible rebuild target because CARGO_MANIFEST_DIR is embedded",
-      "rebuild_scope": "the detached-worktree commands reproduce source, revision, features, and benchmark behavior, but intentionally use a different embedded fixture-data path"
+      "rebuild_scope": "the detached-worktree commands reproduce source, revision, and features only; the original mutable parser/query fixture tree was not attested, so a fresh install is not claimed behavior-equivalent"
     },
     "method": {
       "build_profile": "release (optimized)",

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -43,41 +43,41 @@ active Rust set, restarts once, and serves the healthy Lua document. A
 transport error received during cancellation grace is propagated instead of
 being overwritten as a generic timeout.
 
-The focused 64 worker and 40 supervisor tests, the single-crash, protocol-
+The focused 65 worker and 40 supervisor tests, the single-crash, protocol-
 failure, multi-hazard, single-timeout, and four-thread saturation E2Es,
 all-target Check, warning-denying Clippy, and formatting checks pass locally.
 
 ## Recovery measurement
 
 The final-HEAD measurement compares immutable Stage 25 (`f6e0c2125`) and Stage
-26 (`30ae589b3`) with the same single-hazard E2E on macOS 26.5.1 (`Darwin
+26 (`67c338ca7`) with the same single-hazard E2E on macOS 26.5.1 (`Darwin
 25.5.0`, Apple M4). After one warmup per stage, 12 pairs alternate revision
 order. The supervisor's `recovery_ms` covers failure recovery through
 replacement spawn and full resync; it is not end-to-end request latency.
 
 | Metric | Stage 25 | Stage 26 | Difference |
 | --- | ---: | ---: | ---: |
-| Median recovery | 1202 ms | 1182 ms | -20 ms (-1.7%) |
-| Mean recovery | 1231 ms | 1216 ms | -15 ms (-1.2%) |
-| Range | 1164–1394 ms | 1120–1549 ms | — |
-| Median paired delta | — | — | -47 ms (-3.8%) |
+| Median recovery | 1153.5 ms | 1144.5 ms | -9 ms (-0.8%) |
+| Mean recovery | 1186.8 ms | 1160.3 ms | -26.4 ms (-2.2%) |
+| Range | 1137–1477 ms | 1132–1297 ms | — |
+| Median paired delta | — | — | +3 ms (+0.26%) |
 
-The medians show no regression, but paired differences span -234 to +385 ms.
+The medians show no regression, but paired differences span -342 to +123 ms.
 The debug E2E combines process spawn, hashing, backoff, and resync, so this run
-does not isolate hazard-set construction and cannot support a claimed 3.8%
-improvement.
+does not isolate hazard-set construction. The +3 ms paired median is
+noise-scale and does not establish a regression.
 
 The two-active-grammar E2E also ran seven times. Every run quarantined two
 grammars, restarted once, and resynchronized one healthy document (14 bytes).
-Recovery was 954–978 ms, with a 962 ms median and 963 ms mean. This fixture has
+Recovery was 950–965 ms, with a 960 ms median and 959 ms mean. This fixture has
 a different failure trigger and document set, so its absolute time is not
 directly comparable with the single-hazard fixture. It establishes that two
 attributions remain one recovery action rather than two restarts.
 
 The four-thread saturation E2E ran seven times after one warmup. Its configured
 2,000 ms request deadline and 250 ms cancellation grace are included in the
-measurement. Replacement readiness was 3176–3204 ms after request issue, with a
-3197 ms median and 3196 ms mean. The narrow 28 ms range shows that four leaked
+measurement. Replacement readiness was 3181–3218 ms after request issue, with a
+3194 ms median and 3195 ms mean. The narrow 37 ms range shows that four leaked
 native jobs are reclaimed by one bounded process restart rather than four
 serial per-thread recoveries.
 
@@ -91,18 +91,17 @@ Rust source lines and four worker threads.
 
 | Metric | Stage 25 median | Stage 26 median | Median paired delta |
 | --- | ---: | ---: | ---: |
-| Sequential parent p50 | 415.334 us | 436.667 us | -0.167% |
-| Sequential parent p95 | 474.438 us | 474.250 us | +0.383% |
-| Four-way parallel parent p50 | 554.876 us | 546.188 us | -0.292% |
-| Four-way parallel parent p95 | 632.479 us | 632.688 us | +0.087% |
-| Four-way parallel throughput | 6614 req/s | 6617 req/s | +0.582% |
+| Sequential parent p50 | 390.729 us | 383.313 us | -1.511% |
+| Sequential parent p95 | 469.459 us | 434.875 us | -6.935% |
+| Four-way parallel parent p50 | 552.855 us | 553.771 us | +0.512% |
+| Four-way parallel parent p95 | 630.105 us | 634.125 us | +0.614% |
+| Four-way parallel throughput | 6644 req/s | 6607 req/s | -0.590% |
 
-Directions are mixed and every paired median is below 1%. Absolute p50 medians
-also move differently from their paired medians because the alternating
-worker/direct order makes these small samples bimodal. The atomic admission
-check therefore has no distinguishable steady-state cost in this fixture. One
-Stage 26 parallel p95 sample reached 1116 us (+77% paired), while another pair
-favored Stage 26 by 24%; this small run cannot establish a tail-latency bound.
+Sequential medians move in the faster direction, while all three parallel
+paired medians move by less than 1%. Run-to-run ranges overlap and sequential
+p95 paired deltas span -17.4% to +17.7%, so the fixture does not distinguish a
+causal speedup. It does show no measurable parallel regression from the atomic
+admission check. This small run cannot establish a tail-latency bound.
 
 Raw samples, artifact roles and hashes, stable source paths, exact build/run
 commands, metric ordering, and commit identities are in

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -65,7 +65,7 @@ planned replacement continues. The regression E2E holds native work beyond the
 full five-second window and proves one replacement, no quarantine, and no
 configuration-gated breaker.
 
-The focused 67 worker and 43 supervisor tests, the single-crash, protocol-
+The focused 68 worker and 43 supervisor tests, the single-crash, protocol-
 failure, multi-hazard, single-timeout, four-thread saturation, planned-restart,
 delayed-restart-response, cancellation-delivery, and reserved-lifecycle
 saturation E2Es,

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -75,12 +75,12 @@ macOS 26.5.1 (`Darwin
 order. The supervisor's `recovery_ms` covers failure recovery through
 replacement spawn and full resync; it is not end-to-end request latency.
 
-Review convergence subsequently changed only deadline/restart branches and test
-assertions. Those commits add no operation to the measured admitted-request hot
-path, so the table remains evidence for the combined Stage 26 admission-path
-cost; its binary
+Review convergence subsequently changed deadline/restart branches, test
+assertions, and semantic request scheduling. The original table remains
+evidence for the combined Stage 26 direct-client admission path; its binary
 hashes and raw samples intentionally continue to identify `67c338ca7` rather
-than being relabeled as a final-HEAD run.
+than being relabeled as a final-HEAD run. The later end-to-end semantic
+scheduling change is measured separately below.
 
 | Metric | Stage 25 | Stage 26 | Difference |
 | --- | ---: | ---: | ---: |
@@ -136,6 +136,25 @@ bound.
 Raw samples, artifact roles and hashes, stable source paths, exact build/run
 commands, metric ordering, and commit identities are in
 `benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json`.
+
+## Post-review semantic scheduling measurement
+
+Review convergence moved semantic route registration and frame enqueue onto the
+async owner before it arms cancellation and delegates only response waiting to
+`spawn_blocking`. Because the direct-client harness above does not exercise that
+LSP scheduling boundary, the measured candidate (`67c338ca7`) and the
+review-converged binary (`36842edc5`) were compared with the end-to-end
+`rust_large/edit_delta` semantic fixture in authoritative-worker mode.
+
+Eight pairs alternated revision order. Each binary ran 10 warmups and 40
+measured edit/reparse/retokenize/delta cycles per pair with four worker threads.
+The measured-candidate median was 39.013 ms and the review-converged median was
+39.021 ms. The paired median delta was +0.146 ms (+0.374%), so central latency
+was indistinguishable. Paired differences ranged from -0.522 to +5.866 ms; two
+late pairs put the review-converged binary about five milliseconds behind, so
+this run does not establish tail equivalence. The raw pairs, one excluded
+pre-series pilot, commands, source hash, harness hash, and both release binary
+hashes are recorded in the JSON artifact.
 
 ## Decision
 

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -165,8 +165,9 @@ pre-series pilot, commands, source hash, harness hash, and both release binary
 hashes are recorded in the JSON artifact. The harness hash attests the binary
 that was executed from the original checkout; it is not a bit-reproducible
 target because `CARGO_MANIFEST_DIR` embeds that checkout path. The detached-
-worktree recipe reproduces the exact source revisions, features, and benchmark
-behavior with its own embedded fixture-data path.
+worktree recipe reproduces the exact source revisions and features with its own
+embedded fixture-data path. The original mutable parser/query fixture tree was
+not attested, so a fresh installation is not claimed behavior-equivalent.
 
 ## Decision
 

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -144,6 +144,9 @@ bound.
 Raw samples, artifact roles and hashes, stable source paths, exact build/run
 commands, metric ordering, and commit identities are in
 `benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json`.
+The steady-state Rust parser dylib is attested there as SHA-256 `5134481a…`;
+its mutable catalog snapshot names `tree-sitter-rust@77a3747…`, but the dylib
+build toolchain itself was not attested.
 
 ## Post-review semantic scheduling measurement
 
@@ -155,7 +158,9 @@ review-converged binary (`36842edc5`) were compared with the end-to-end
 `rust_large/edit_delta` semantic fixture in authoritative-worker mode.
 
 Eight pairs alternated revision order. Each binary ran 10 warmups and 40
-measured edit/reparse/retokenize/delta cycles per pair with four worker threads.
+measured edit/reparse/retokenize/delta cycles per pair with four worker threads;
+each recorded pair value is the median of those 40 cycles. Per-iteration
+samples and p25/p75 were not retained.
 The measured-candidate median was 39.013 ms and the review-converged median was
 39.021 ms. The paired median delta was +0.146 ms (+0.374%), so central latency
 was indistinguishable. Paired differences ranged from -0.522 to +5.866 ms; two

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -171,7 +171,7 @@ measured edit/reparse/retokenize/delta cycles per pair with four worker threads;
 each recorded pair value is the median of those 40 cycles. Per-iteration
 samples and p25/p75 were not retained.
 The measured-candidate median was 39.013 ms and the review-converged median was
-39.021 ms. The paired median delta was +0.146 ms (+0.374%), so central latency
+39.021 ms. The paired median delta was +0.146 ms (+0.376%), so central latency
 was indistinguishable. Paired differences ranged from -0.522 to +5.866 ms; two
 late pairs put the review-converged binary about five milliseconds behind, so
 this run does not establish tail equivalence. The raw pairs, one excluded

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -65,7 +65,7 @@ planned replacement continues. The regression E2E holds native work beyond the
 full five-second window and proves one replacement, no quarantine, and no
 configuration-gated breaker.
 
-The focused 68 worker and 43 supervisor tests, the single-crash, protocol-
+The focused 69 worker and 43 supervisor tests, the single-crash, protocol-
 failure, multi-hazard, single-timeout, four-thread saturation, planned-restart,
 delayed-restart-response, cancellation-delivery, and reserved-lifecycle
 saturation E2Es,

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -1,0 +1,76 @@
+# Single Tree Worker Stage 26 Hazard-Set Measurement
+
+## Scope
+
+Stage 26 makes worker-loss attribution set-valued. After a worker loss, the parent
+waits for that generation's response reader to drain every complete committed
+arm/release frame. It then snapshots the exact active leases, sorts and
+deduplicates their `(grammar_symbol, artifact_digest)` identities, installs the
+complete quarantine set, and performs one restart and quarantine-aware resync.
+Queued commands are not evidence and cannot invent a quarantine.
+
+The ledger remains generation-local. A replacement cannot inherit releases or
+leases from its predecessor, and a grammar already quarantined in the same
+session escalates a repeated native-evidenced failure to systemic breaker
+accounting.
+
+## Correctness result
+
+The RED E2E warmed Rust, Lua, and YAML replicas, held a committed Rust lease,
+then aborted the worker with a committed Lua lease. Before Stage 26, the idle
+worker-loss path observed no implicated grammar and produced zero quarantines.
+
+The GREEN E2E observes both complete arm frames before EOF, quarantines exactly
+Rust and Lua, restarts once, and full-resynchronizes only the healthy YAML
+document. A second server session serves Rust and Lua again, proving the
+quarantine is session-local. A separate hard-deadline E2E hangs only after its
+Rust arm frame is committed; it quarantines Rust from the ledger rather than
+inferring it from the timed-out command.
+
+The focused 61 worker and 34 supervisor tests, the single-crash, multi-hazard,
+and hard-deadline E2Es, all-target Check, and warning-denying Clippy pass
+locally.
+
+## Recovery measurement
+
+The first measurement compares immutable Stage 25 (`f6e0c2125`) and Stage 26
+(`370d13d2c`) with the same single-hazard E2E on macOS 26.5.1
+(`Darwin 25.5.0`, Apple M4). After one warmup per stage, seven pairs run Stage
+25 then Stage 26. The supervisor's `recovery_ms` covers failure recovery through
+replacement spawn and full resync; it is not end-to-end request latency.
+
+| Metric | Stage 25 | Stage 26 | Difference |
+| --- | ---: | ---: | ---: |
+| Median recovery | 1266 ms | 1281 ms | +15 ms (+1.2%) |
+| Mean recovery | 1270 ms | 1342 ms | +72 ms (+5.7%) |
+| Range | 1250–1299 ms | 1251–1571 ms | — |
+| Median paired delta | — | — | +11 ms (+0.9%) |
+
+Stage 26 has two slow samples, 1450 and 1571 ms, so seven runs are insufficient
+to claim a tail-latency bound. The robust center shows that waiting for reader
+drain and building the complete set adds about 11–15 ms in the ordinary case.
+
+The second measurement runs the two-active-grammar E2E seven times. Every run
+quarantines two grammars, restarts once, and resyncs one healthy document
+(14 bytes). Recovery is 959–1126 ms, with a 974 ms median and 996 ms mean. This
+fixture has a different failure trigger and document set, so its absolute time
+must not be compared directly with the single-hazard fixture; it establishes
+that two attributions remain one recovery action rather than two restarts.
+
+Raw samples are in
+`benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json`.
+
+## Decision
+
+Keep complete-set quarantine and the reader-drain barrier. The failure-path
+cost is bounded by active leases and avoids both under-quarantine and command
+inference. The production request hot path adds no per-request synchronization;
+the new condition variable is signaled only when a worker reader terminates,
+and quarantine work runs only during recovery. Stage 25's steady-state
+throughput result therefore remains the current scheduling baseline.
+
+Do not claim a tail-recovery or complete performance-gate pass from seven debug
+E2E samples. Runtime injection identities, independently bounded control
+transport, native segment deadlines, explicit workload-aware admission,
+protocol/compatibility gates, and legacy-path removal remain open. The ADR
+remains `proposed`.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -32,7 +32,9 @@ A generic request deadline remains insufficient parser-fault evidence. The
 client sends cancellation at the deadline, waits 250 ms for a terminal
 response, and systemically terminates the generation if native work does not
 cooperate. Parent deadline termination has its own cause and cannot quarantine
-an active grammar. A nominally nonfatal timeout may continue only when
+an active grammar. Its deadline and transport cause markers come from the same
+single pre-kill child-state observation, so a native exit cannot fall between
+two contradictory classifications. A nominally nonfatal timeout may continue only when
 `try_wait` confirms the worker transport is still live; an already-exited or
 unknown child state enters recovery instead of leaving a dead client published.
 Such a timeout-triggered recovery is systemic unless the preserved child exit

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -162,7 +162,11 @@ was indistinguishable. Paired differences ranged from -0.522 to +5.866 ms; two
 late pairs put the review-converged binary about five milliseconds behind, so
 this run does not establish tail equivalence. The raw pairs, one excluded
 pre-series pilot, commands, source hash, harness hash, and both release binary
-hashes are recorded in the JSON artifact.
+hashes are recorded in the JSON artifact. The harness hash attests the binary
+that was executed from the original checkout; it is not a bit-reproducible
+target because `CARGO_MANIFEST_DIR` embeds that checkout path. The detached-
+worktree recipe reproduces the exact source revisions, features, and benchmark
+behavior with its own embedded fixture-data path.
 
 ## Decision
 

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -82,7 +82,8 @@ then serves a healthy follow-up without restarting the generation.
 
 The worker scheduler's pending bound includes the same one lifecycle slot that
 the client reserves above its ordinary `4*T` route limit. A saturation E2E fills
-all 16 ordinary routes, schedules the 17th lifecycle request, and proves later
+all 16 ordinary routes, using one worker scheduling marker per request as the
+admission barrier, schedules the 17th lifecycle request, and proves later
 FIFO cancellation frames still reach the worker control fast path. With the old
 16-request bound the same test deterministically times out waiting for the
 cancel marker; with the aligned bound it recovers once without quarantine.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -46,10 +46,12 @@ jobs on all four compute threads, then proves that one generation restart
 releases every route, quarantines nothing, full-resynchronizes four documents,
 and keeps LSP service available.
 
-Reader and writer cleanup do not use the deadline cause. A protocol-failure E2E
-commits a Rust hazard and then sends an invalid release frame. The reader
-classifies the failure as systemic, preserves and quarantines the complete
-active Rust set, restarts once, and serves the healthy Lua document. A
+Reader and writer cleanup do not use the deadline cause. A protocol-abort E2E
+commits a Rust hazard, sends an invalid release frame, and queues another arm
+behind it. The reader marks its hazard snapshot incomplete, conservatively
+quarantines the Rust key already observed, disables the tree tier instead of
+restarting from a partial set, and leaves the healthy Lua request served by the
+legacy path. A
 transport error received during cancellation grace is propagated instead of
 being overwritten as a generic timeout. A `WorkerRestartRequired` response
 received after the deadline but inside that grace likewise remains authoritative

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -193,21 +193,21 @@ not attested, so a fresh installation is not claimed behavior-equivalent.
 Later review fixes added grammar-route authentication, current-artifact query
 refresh, and response-variant authentication on the semantic request path. To
 cover those changes, the earlier review-converged binary (`36842edc5`) was
-compared with the final code HEAD (`72f58a8b4`) using the same authoritative
+compared with the final code HEAD (`9b5605abd`) using the same authoritative
 four-thread `rust_large/edit_delta` method: eight alternating pairs, with 10
 warmups and 40 measured cycles per binary and pair.
 
-The earlier binary's median was 26.766 ms and final HEAD's median was 26.817 ms.
-The paired median delta was +0.050 ms (+0.186%), so this run found no measurable
-central-latency regression. Paired differences ranged from -2.560 to +2.227 ms
-(-8.690% to +9.059%), and therefore do not establish tail equivalence. These
+The earlier binary's median was 29.765 ms and final HEAD's median was 29.845 ms.
+The paired median delta was +0.077 ms (+0.259%), so this run found no measurable
+central-latency regression. Paired differences ranged from -4.010 to +3.673 ms
+(-11.859% to +12.314%), and therefore do not establish tail equivalence. These
 absolute values must not be compared with the preceding 39 ms series: the
 harness was rebuilt later against mutable fixture and machine state. Only the
 paired comparison within each series is meaningful.
 
 The JSON artifact records the exact source revisions, release binary hashes,
 harness source and binary hashes, method, and all pair medians. Commit
-`72f58a8b4` is the measured code revision; the subsequent documentation-only
+`9b5605abd` is the measured code revision; the subsequent documentation-only
 commit that records this result does not alter the measured binary.
 
 ## Decision
@@ -216,7 +216,7 @@ Keep complete-set quarantine, the reader-drain barrier, bounded systemic
 cancellation recovery, the termination-cause split, and the request-admission
 fence. Recovery work is bounded by active leases, while the measured request-
 path change is noise-scale in both sequential and four-way workloads. The
-final-HEAD semantic remeasurement likewise found a +0.186% paired median change
+final-HEAD semantic remeasurement likewise found a +0.259% paired median change
 without a distinguishable central regression.
 
 Do not claim a tail-recovery or complete performance-gate pass from these

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -23,12 +23,13 @@ worker-loss path observed no implicated grammar and produced zero quarantines.
 The GREEN E2E observes both complete arm frames before EOF, quarantines exactly
 Rust and Lua, restarts once, and full-resynchronizes only the healthy YAML
 document. A second server session serves Rust and Lua again, proving the
-quarantine is session-local. A separate hard-deadline E2E hangs only after its
-Rust arm frame is committed; it quarantines Rust from the ledger rather than
-inferring it from the timed-out command.
+quarantine is session-local. A separate request-timeout E2E hangs only after a
+Rust arm frame is committed but does not quarantine it: without the ADR's
+future `NativeSegmentEntered` deadline, a generic response deadline is systemic
+rather than sufficient parser-fault evidence.
 
 The focused 61 worker and 34 supervisor tests, the single-crash, multi-hazard,
-and hard-deadline E2Es, all-target Check, and warning-denying Clippy pass
+and request-timeout E2Es, all-target Check, and warning-denying Clippy pass
 locally.
 
 ## Recovery measurement

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -47,8 +47,10 @@ replacement spawn and full resync; it is not end-to-end request latency.
 | Median paired delta | — | — | +11 ms (+0.9%) |
 
 Stage 26 has two slow samples, 1450 and 1571 ms, so seven runs are insufficient
-to claim a tail-latency bound. The robust center shows that waiting for reader
-drain and building the complete set adds about 11–15 ms in the ordinary case.
+to claim a tail-latency bound. Its median is 15 ms higher and the median paired
+difference is 11 ms, but the fixed Stage-25-first order and the combined
+spawn/backoff/resync timer do not isolate reader drain or set construction.
+Treat the delta as inconclusive rather than as their causal cost.
 
 The second measurement runs the two-active-grammar E2E seven times. Every run
 quarantines two grammars, restarts once, and resyncs one healthy document

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -28,49 +28,56 @@ document. A second server session serves Rust and Lua again, proving the
 quarantine is session-local.
 
 A generic request deadline remains insufficient parser-fault evidence. The
-client now sends cancellation at the deadline, waits 250 ms for a terminal
+client sends cancellation at the deadline, waits 250 ms for a terminal
 response, and systemically terminates the generation if native work does not
-cooperate. Parent-initiated termination cannot quarantine an active grammar.
-The saturation E2E parks four distinct committed grammar jobs on all four
-compute threads, then proves that one generation restart releases every route,
-quarantines nothing, full-resynchronizes four documents, and keeps LSP service
-available.
+cooperate. Parent deadline termination has its own cause and cannot quarantine
+an active grammar. The saturation E2E parks four distinct committed grammar
+jobs on all four compute threads, then proves that one generation restart
+releases every route, quarantines nothing, full-resynchronizes four documents,
+and keeps LSP service available.
 
-The focused 63 worker and 40 supervisor tests, the single-crash, multi-hazard,
-single-timeout, and four-thread saturation E2Es, all-target Check, warning-
-denying Clippy, and formatting checks pass locally.
+Reader and writer cleanup do not use the deadline cause. A protocol-failure E2E
+commits a Rust hazard and then sends an invalid release frame. The reader
+classifies the failure as systemic, preserves and quarantines the complete
+active Rust set, restarts once, and serves the healthy Lua document. A
+transport error received during cancellation grace is propagated instead of
+being overwritten as a generic timeout.
+
+The focused 64 worker and 40 supervisor tests, the single-crash, protocol-
+failure, multi-hazard, single-timeout, and four-thread saturation E2Es,
+all-target Check, warning-denying Clippy, and formatting checks pass locally.
 
 ## Recovery measurement
 
-The first final-HEAD measurement compares immutable Stage 25 (`f6e0c2125`) and
-Stage 26 (`33c61b5b6`) with the same single-hazard E2E on macOS 26.5.1
-(`Darwin 25.5.0`, Apple M4). After one warmup per stage, seven pairs run Stage
-25 then Stage 26. The supervisor's `recovery_ms` covers failure recovery through
+The final-HEAD measurement compares immutable Stage 25 (`f6e0c2125`) and Stage
+26 (`30ae589b3`) with the same single-hazard E2E on macOS 26.5.1 (`Darwin
+25.5.0`, Apple M4). After one warmup per stage, 12 pairs alternate revision
+order. The supervisor's `recovery_ms` covers failure recovery through
 replacement spawn and full resync; it is not end-to-end request latency.
 
 | Metric | Stage 25 | Stage 26 | Difference |
 | --- | ---: | ---: | ---: |
-| Median recovery | 1170 ms | 1172 ms | +2 ms (+0.2%) |
-| Mean recovery | 1186 ms | 1168 ms | -18 ms (-1.5%) |
-| Range | 1146–1243 ms | 1133–1204 ms | — |
-| Median paired delta | — | — | -13 ms (-1.1%) |
+| Median recovery | 1202 ms | 1182 ms | -20 ms (-1.7%) |
+| Mean recovery | 1231 ms | 1216 ms | -15 ms (-1.2%) |
+| Range | 1164–1394 ms | 1120–1549 ms | — |
+| Median paired delta | — | — | -47 ms (-3.8%) |
 
-The absolute median and paired median have opposite signs. Seven debug E2E
-pairs therefore provide no evidence of a recovery regression or improvement;
-the difference is noise-scale and the fixed Stage-25-first order remains a
-confounder.
+The medians show no regression, but paired differences span -234 to +385 ms.
+The debug E2E combines process spawn, hashing, backoff, and resync, so this run
+does not isolate hazard-set construction and cannot support a claimed 3.8%
+improvement.
 
 The two-active-grammar E2E also ran seven times. Every run quarantined two
 grammars, restarted once, and resynchronized one healthy document (14 bytes).
-Recovery was 932–967 ms, with a 957 ms median and 951 ms mean. This fixture has
+Recovery was 954–978 ms, with a 962 ms median and 963 ms mean. This fixture has
 a different failure trigger and document set, so its absolute time is not
 directly comparable with the single-hazard fixture. It establishes that two
 attributions remain one recovery action rather than two restarts.
 
 The four-thread saturation E2E ran seven times after one warmup. Its configured
 2,000 ms request deadline and 250 ms cancellation grace are included in the
-measurement. Replacement readiness was 3187–3211 ms after request issue, with a
-3205 ms median and 3202 ms mean. The narrow 24 ms range shows that four leaked
+measurement. Replacement readiness was 3176–3204 ms after request issue, with a
+3197 ms median and 3196 ms mean. The narrow 28 ms range shows that four leaked
 native jobs are reclaimed by one bounded process restart rather than four
 serial per-thread recoveries.
 
@@ -84,26 +91,29 @@ Rust source lines and four worker threads.
 
 | Metric | Stage 25 median | Stage 26 median | Median paired delta |
 | --- | ---: | ---: | ---: |
-| Sequential parent p50 | 453.167 us | 452.771 us | -0.010% |
-| Sequential parent p95 | 489.667 us | 494.979 us | +0.886% |
-| Four-way parallel parent p50 | 558.626 us | 557.104 us | -0.616% |
-| Four-way parallel parent p95 | 629.688 us | 638.125 us | +0.843% |
-| Four-way parallel throughput | 6598 req/s | 6578 req/s | +0.273% |
+| Sequential parent p50 | 415.334 us | 436.667 us | -0.167% |
+| Sequential parent p95 | 474.438 us | 474.250 us | +0.383% |
+| Four-way parallel parent p50 | 554.876 us | 546.188 us | -0.292% |
+| Four-way parallel parent p95 | 632.479 us | 632.688 us | +0.087% |
+| Four-way parallel throughput | 6614 req/s | 6617 req/s | +0.582% |
 
-Directions are mixed and every paired median is below 1%. The atomic admission
-check has no distinguishable steady-state cost in this fixture. One Stage 26
-parallel p95 sample reached 765 us (+21.7% paired) while its throughput fell to
-5942 req/s, so this small run still cannot establish a tail-latency bound.
+Directions are mixed and every paired median is below 1%. Absolute p50 medians
+also move differently from their paired medians because the alternating
+worker/direct order makes these small samples bimodal. The atomic admission
+check therefore has no distinguishable steady-state cost in this fixture. One
+Stage 26 parallel p95 sample reached 1116 us (+77% paired), while another pair
+favored Stage 26 by 24%; this small run cannot establish a tail-latency bound.
 
-Raw samples, artifact hashes, metric ordering, and exact commit identities are
-in `benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json`.
+Raw samples, artifact roles and hashes, stable source paths, exact build/run
+commands, metric ordering, and commit identities are in
+`benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json`.
 
 ## Decision
 
 Keep complete-set quarantine, the reader-drain barrier, bounded systemic
-cancellation recovery, and the request-admission fence. The recovery work is
-bounded by active leases, while the measured request-path change is noise-scale
-in both sequential and four-way workloads.
+cancellation recovery, the termination-cause split, and the request-admission
+fence. Recovery work is bounded by active leases, while the measured request-
+path change is noise-scale in both sequential and four-way workloads.
 
 Do not claim a tail-recovery or complete performance-gate pass from these
 samples. Runtime injection identities, independently bounded control transport,

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -188,16 +188,17 @@ worktree recipe reproduces the exact source revisions and features with its own
 embedded fixture-data path. The original mutable parser/query fixture tree was
 not attested, so a fresh installation is not claimed behavior-equivalent.
 
-## Final-HEAD semantic remeasurement
+## Final worker-path semantic remeasurement
 
 Later review fixes added grammar-route authentication, current-artifact query
 refresh, and response-variant authentication on the semantic request path. To
 cover those changes, the earlier review-converged binary (`36842edc5`) was
-compared with the final code HEAD (`9b5605abd`) using the same authoritative
-four-thread `rust_large/edit_delta` method: eight alternating pairs, with 10
-warmups and 40 measured cycles per binary and pair.
+compared with the final worker-path revision (`9b5605abd`) using the same
+authoritative four-thread `rust_large/edit_delta` method: eight alternating
+pairs, with 10 warmups and 40 measured cycles per binary and pair.
 
-The earlier binary's median was 29.765 ms and final HEAD's median was 29.845 ms.
+The earlier binary's median was 29.765 ms and the final worker-path revision's
+median was 29.845 ms.
 The paired median delta was +0.077 ms (+0.259%), so this run found no measurable
 central-latency regression. Paired differences ranged from -4.010 to +3.673 ms
 (-11.859% to +12.314%), and therefore do not establish tail equivalence. These
@@ -207,8 +208,9 @@ paired comparison within each series is meaningful.
 
 The JSON artifact records the exact source revisions, release binary hashes,
 harness source and binary hashes, method, and all pair medians. Commit
-`9b5605abd` is the measured code revision; the subsequent documentation-only
-commit that records this result does not alter the measured binary.
+`9b5605abd` is the measured worker-path revision. Subsequent documentation and
+Windows parser-install path compatibility commits do not execute on this
+benchmark path.
 
 ## Decision
 
@@ -216,8 +218,8 @@ Keep complete-set quarantine, the reader-drain barrier, bounded systemic
 cancellation recovery, the termination-cause split, and the request-admission
 fence. Recovery work is bounded by active leases, while the measured request-
 path change is noise-scale in both sequential and four-way workloads. The
-final-HEAD semantic remeasurement likewise found a +0.259% paired median change
-without a distinguishable central regression.
+final worker-path semantic remeasurement likewise found a +0.259% paired median
+change without a distinguishable central regression.
 
 Do not claim a tail-recovery or complete performance-gate pass from these
 samples. Runtime injection identities, independently bounded control transport,

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -35,6 +35,9 @@ cooperate. Parent deadline termination has its own cause and cannot quarantine
 an active grammar. A nominally nonfatal timeout may continue only when
 `try_wait` confirms the worker transport is still live; an already-exited or
 unknown child state enters recovery instead of leaving a dead client published.
+Such a timeout-triggered recovery is systemic unless the preserved child exit
+status independently proves a native crash; the `TimedOut` error kind alone
+never supplies parser-fault evidence.
 The saturation E2E parks four distinct committed grammar
 jobs on all four compute threads, then proves that one generation restart
 releases every route, quarantines nothing, full-resynchronizes four documents,
@@ -57,7 +60,7 @@ planned replacement continues. The regression E2E holds native work beyond the
 full five-second window and proves one replacement, no quarantine, and no
 configuration-gated breaker.
 
-The focused 67 worker and 41 supervisor tests, the single-crash, protocol-
+The focused 67 worker and 42 supervisor tests, the single-crash, protocol-
 failure, multi-hazard, single-timeout, four-thread saturation, planned-restart,
 delayed-restart-response, cancellation-delivery, and reserved-lifecycle
 saturation E2Es,

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -37,7 +37,9 @@ an active grammar. A nominally nonfatal timeout may continue only when
 unknown child state enters recovery instead of leaving a dead client published.
 Such a timeout-triggered recovery is systemic unless the preserved child exit
 status independently proves a native crash; the `TimedOut` error kind alone
-never supplies parser-fault evidence.
+never supplies parser-fault evidence. Unix native evidence is limited to
+ABRT/BUS/FPE/ILL/SEGV, excluding external TERM/KILL; Windows uses an explicit
+exception/fail-fast code allowlist rather than every negative exit code.
 The saturation E2E parks four distinct committed grammar
 jobs on all four compute threads, then proves that one generation restart
 releases every route, quarantines nothing, full-resynchronizes four documents,
@@ -60,7 +62,7 @@ planned replacement continues. The regression E2E holds native work beyond the
 full five-second window and proves one replacement, no quarantine, and no
 configuration-gated breaker.
 
-The focused 67 worker and 42 supervisor tests, the single-crash, protocol-
+The focused 67 worker and 43 supervisor tests, the single-crash, protocol-
 failure, multi-hazard, single-timeout, four-thread saturation, planned-restart,
 delayed-restart-response, cancellation-delivery, and reserved-lifecycle
 saturation E2Es,

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -56,7 +56,8 @@ configuration-gated breaker.
 
 The focused 67 worker and 40 supervisor tests, the single-crash, protocol-
 failure, multi-hazard, single-timeout, four-thread saturation, planned-restart,
-and delayed-restart-response E2Es,
+delayed-restart-response, cancellation-delivery, and reserved-lifecycle
+saturation E2Es,
 all-target Check, warning-denying Clippy, and formatting checks pass locally.
 
 Cancellation delivery is also ordered without an unbounded unknown-ID
@@ -65,6 +66,13 @@ arming its cancellation guard, while the worker stores tokens only for admitted
 work. An E2E delays creation of the blocking response waiter, cancels during
 that window, observes the cancel on the already-admitted worker request, and
 then serves a healthy follow-up without restarting the generation.
+
+The worker scheduler's pending bound includes the same one lifecycle slot that
+the client reserves above its ordinary `4*T` route limit. A saturation E2E fills
+all 16 ordinary routes, schedules the 17th lifecycle request, and proves later
+FIFO cancellation frames still reach the worker control fast path. With the old
+16-request bound the same test deterministically times out waiting for the
+cancel marker; with the aligned bound it recovers once without quarantine.
 
 ## Recovery measurement
 

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -188,12 +188,36 @@ worktree recipe reproduces the exact source revisions and features with its own
 embedded fixture-data path. The original mutable parser/query fixture tree was
 not attested, so a fresh installation is not claimed behavior-equivalent.
 
+## Final-HEAD semantic remeasurement
+
+Later review fixes added grammar-route authentication, current-artifact query
+refresh, and response-variant authentication on the semantic request path. To
+cover those changes, the earlier review-converged binary (`36842edc5`) was
+compared with the final code HEAD (`72f58a8b4`) using the same authoritative
+four-thread `rust_large/edit_delta` method: eight alternating pairs, with 10
+warmups and 40 measured cycles per binary and pair.
+
+The earlier binary's median was 26.766 ms and final HEAD's median was 26.817 ms.
+The paired median delta was +0.050 ms (+0.186%), so this run found no measurable
+central-latency regression. Paired differences ranged from -2.560 to +2.227 ms
+(-8.690% to +9.059%), and therefore do not establish tail equivalence. These
+absolute values must not be compared with the preceding 39 ms series: the
+harness was rebuilt later against mutable fixture and machine state. Only the
+paired comparison within each series is meaningful.
+
+The JSON artifact records the exact source revisions, release binary hashes,
+harness source and binary hashes, method, and all pair medians. Commit
+`72f58a8b4` is the measured code revision; the subsequent documentation-only
+commit that records this result does not alter the measured binary.
+
 ## Decision
 
 Keep complete-set quarantine, the reader-drain barrier, bounded systemic
 cancellation recovery, the termination-cause split, and the request-admission
 fence. Recovery work is bounded by active leases, while the measured request-
-path change is noise-scale in both sequential and four-way workloads.
+path change is noise-scale in both sequential and four-way workloads. The
+final-HEAD semantic remeasurement likewise found a +0.186% paired median change
+without a distinguishable central regression.
 
 Do not claim a tail-recovery or complete performance-gate pass from these
 samples. Runtime injection identities, independently bounded control transport,

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -32,7 +32,10 @@ A generic request deadline remains insufficient parser-fault evidence. The
 client sends cancellation at the deadline, waits 250 ms for a terminal
 response, and systemically terminates the generation if native work does not
 cooperate. Parent deadline termination has its own cause and cannot quarantine
-an active grammar. The saturation E2E parks four distinct committed grammar
+an active grammar. A nominally nonfatal timeout may continue only when
+`try_wait` confirms the worker transport is still live; an already-exited or
+unknown child state enters recovery instead of leaving a dead client published.
+The saturation E2E parks four distinct committed grammar
 jobs on all four compute threads, then proves that one generation restart
 releases every route, quarantines nothing, full-resynchronizes four documents,
 and keeps LSP service available.
@@ -54,7 +57,7 @@ planned replacement continues. The regression E2E holds native work beyond the
 full five-second window and proves one replacement, no quarantine, and no
 configuration-gated breaker.
 
-The focused 67 worker and 40 supervisor tests, the single-crash, protocol-
+The focused 67 worker and 41 supervisor tests, the single-crash, protocol-
 failure, multi-hazard, single-timeout, four-thread saturation, planned-restart,
 delayed-restart-response, cancellation-delivery, and reserved-lifecycle
 saturation E2Es,

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -24,8 +24,9 @@ quarantines.
 
 The GREEN E2E observes both complete arm frames before EOF, quarantines exactly
 Rust and Lua, restarts once, and full-resynchronizes only the healthy YAML
-document. A second server session serves Rust and Lua again, proving the
-quarantine is session-local.
+document. A second server session resolves non-null Rust and Lua nodes through
+`kakehashi/node`, proving both grammars parse again and the quarantine is
+session-local; an empty semantic-token result is not accepted as evidence.
 
 A generic request deadline remains insufficient parser-fault evidence. The
 client sends cancellation at the deadline, waits 250 ms for a terminal
@@ -41,19 +42,37 @@ commits a Rust hazard and then sends an invalid release frame. The reader
 classifies the failure as systemic, preserves and quarantines the complete
 active Rust set, restarts once, and serves the healthy Lua document. A
 transport error received during cancellation grace is propagated instead of
-being overwritten as a generic timeout.
+being overwritten as a generic timeout. A `WorkerRestartRequired` response
+received after the deadline but inside that grace likewise remains authoritative
+and replaces the invalid generation rather than being overwritten as a generic
+timeout.
 
-The focused 65 worker and 40 supervisor tests, the single-crash, protocol-
-failure, multi-hazard, single-timeout, and four-thread saturation E2Es,
+A planned configuration transition first fences request admission and waits five
+seconds for cooperative quiescence. If a healthy or non-cooperative published
+request outlives that window, the old generation is forcibly retired and the
+planned replacement continues. The regression E2E holds native work beyond the
+full five-second window and proves one replacement, no quarantine, and no
+configuration-gated breaker.
+
+The focused 66 worker and 40 supervisor tests, the single-crash, protocol-
+failure, multi-hazard, single-timeout, four-thread saturation, planned-restart,
+and delayed-restart-response E2Es,
 all-target Check, warning-denying Clippy, and formatting checks pass locally.
 
 ## Recovery measurement
 
-The final-HEAD measurement compares immutable Stage 25 (`f6e0c2125`) and Stage
-26 (`67c338ca7`) with the same single-hazard E2E on macOS 26.5.1 (`Darwin
+The performance measurement compares immutable Stage 25 (`f6e0c2125`) and the
+measured Stage 26 candidate (`67c338ca7`) with the same single-hazard E2E on
+macOS 26.5.1 (`Darwin
 25.5.0`, Apple M4). After one warmup per stage, 12 pairs alternate revision
 order. The supervisor's `recovery_ms` covers failure recovery through
 replacement spawn and full resync; it is not end-to-end request latency.
+
+Review convergence subsequently changed only deadline/restart branches and test
+assertions. Those commits add no operation to the measured admitted-request hot
+path, so the table remains evidence for the admission-fence cost; its binary
+hashes and raw samples intentionally continue to identify `67c338ca7` rather
+than being relabeled as a final-HEAD run.
 
 | Metric | Stage 25 | Stage 26 | Difference |
 | --- | ---: | ---: | ---: |

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -59,6 +59,13 @@ failure, multi-hazard, single-timeout, four-thread saturation, planned-restart,
 and delayed-restart-response E2Es,
 all-target Check, warning-denying Clippy, and formatting checks pass locally.
 
+Cancellation delivery is also ordered without an unbounded unknown-ID
+tombstone set. The parent registers and enqueues a semantic request before
+arming its cancellation guard, while the worker stores tokens only for admitted
+work. An E2E delays creation of the blocking response waiter, cancels during
+that window, observes the cancel on the already-admitted worker request, and
+then serves a healthy follow-up without restarting the generation.
+
 ## Recovery measurement
 
 The performance measurement compares immutable Stage 25 (`f6e0c2125`) and the

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -36,9 +36,10 @@ an active grammar. A nominally nonfatal timeout may continue only when
 `try_wait` confirms the worker transport is still live; an already-exited or
 unknown child state enters recovery instead of leaving a dead client published.
 Such a timeout-triggered recovery is systemic unless the preserved child exit
-status independently proves a native crash; the `TimedOut` error kind alone
-never supplies parser-fault evidence. Unix native evidence is limited to
-ABRT/BUS/FPE/ILL/SEGV, excluding external TERM/KILL; Windows uses an explicit
+status matches the conservative native-crash evidence allowlist; the `TimedOut`
+error kind alone never supplies parser-fault evidence. Unix native evidence is
+limited to ABRT/BUS/FPE/ILL/SEGV, excluding external TERM/KILL; Windows uses an
+explicit
 exception/fail-fast code allowlist rather than every negative exit code.
 The saturation E2E parks four distinct committed grammar
 jobs on all four compute threads, then proves that one generation restart

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -2,78 +2,111 @@
 
 ## Scope
 
-Stage 26 makes worker-loss attribution set-valued. After a worker loss, the parent
-waits for that generation's response reader to drain every complete committed
-arm/release frame. It then snapshots the exact active leases, sorts and
-deduplicates their `(grammar_symbol, artifact_digest)` identities, installs the
-complete quarantine set, and performs one restart and quarantine-aware resync.
-Queued commands are not evidence and cannot invent a quarantine.
+Stage 26 makes worker-loss attribution set-valued. After a worker loss, the
+parent waits for that generation's response reader to drain every complete
+committed arm/release frame. It then snapshots the exact active leases, sorts
+and deduplicates their `(grammar_symbol, artifact_digest)` identities, installs
+the complete quarantine set, and performs one restart and quarantine-aware
+resync. Queued commands are not evidence and cannot invent a quarantine.
 
 The ledger remains generation-local. A replacement cannot inherit releases or
 leases from its predecessor, and a grammar already quarantined in the same
 session escalates a repeated native-evidenced failure to systemic breaker
-accounting.
+accounting. A request-admission fence prevents a quiescing generation from
+accepting a new route after the supervisor observes it as idle.
 
 ## Correctness result
 
-The RED E2E warmed Rust, Lua, and YAML replicas, held a committed Rust lease,
-then aborted the worker with a committed Lua lease. Before Stage 26, the idle
-worker-loss path observed no implicated grammar and produced zero quarantines.
+The multi-hazard RED E2E warmed Rust, Lua, and YAML replicas, held a committed
+Rust lease, then aborted the worker with a committed Lua lease. Before Stage 26,
+the idle worker-loss path observed no implicated grammar and produced zero
+quarantines.
 
 The GREEN E2E observes both complete arm frames before EOF, quarantines exactly
 Rust and Lua, restarts once, and full-resynchronizes only the healthy YAML
 document. A second server session serves Rust and Lua again, proving the
-quarantine is session-local. A separate request-timeout E2E hangs only after a
-Rust arm frame is committed but does not quarantine it: without the ADR's
-future `NativeSegmentEntered` deadline, a generic response deadline is systemic
-rather than sufficient parser-fault evidence.
+quarantine is session-local.
 
-The focused 61 worker and 34 supervisor tests, the single-crash, multi-hazard,
-and request-timeout E2Es, all-target Check, and warning-denying Clippy pass
-locally.
+A generic request deadline remains insufficient parser-fault evidence. The
+client now sends cancellation at the deadline, waits 250 ms for a terminal
+response, and systemically terminates the generation if native work does not
+cooperate. Parent-initiated termination cannot quarantine an active grammar.
+The saturation E2E parks four distinct committed grammar jobs on all four
+compute threads, then proves that one generation restart releases every route,
+quarantines nothing, full-resynchronizes four documents, and keeps LSP service
+available.
+
+The focused 63 worker and 40 supervisor tests, the single-crash, multi-hazard,
+single-timeout, and four-thread saturation E2Es, all-target Check, warning-
+denying Clippy, and formatting checks pass locally.
 
 ## Recovery measurement
 
-The first measurement compares immutable Stage 25 (`f6e0c2125`) and Stage 26
-(`370d13d2c`) with the same single-hazard E2E on macOS 26.5.1
+The first final-HEAD measurement compares immutable Stage 25 (`f6e0c2125`) and
+Stage 26 (`33c61b5b6`) with the same single-hazard E2E on macOS 26.5.1
 (`Darwin 25.5.0`, Apple M4). After one warmup per stage, seven pairs run Stage
 25 then Stage 26. The supervisor's `recovery_ms` covers failure recovery through
 replacement spawn and full resync; it is not end-to-end request latency.
 
 | Metric | Stage 25 | Stage 26 | Difference |
 | --- | ---: | ---: | ---: |
-| Median recovery | 1266 ms | 1281 ms | +15 ms (+1.2%) |
-| Mean recovery | 1270 ms | 1342 ms | +72 ms (+5.7%) |
-| Range | 1250–1299 ms | 1251–1571 ms | — |
-| Median paired delta | — | — | +11 ms (+0.9%) |
+| Median recovery | 1170 ms | 1172 ms | +2 ms (+0.2%) |
+| Mean recovery | 1186 ms | 1168 ms | -18 ms (-1.5%) |
+| Range | 1146–1243 ms | 1133–1204 ms | — |
+| Median paired delta | — | — | -13 ms (-1.1%) |
 
-Stage 26 has two slow samples, 1450 and 1571 ms, so seven runs are insufficient
-to claim a tail-latency bound. Its median is 15 ms higher and the median paired
-difference is 11 ms, but the fixed Stage-25-first order and the combined
-spawn/backoff/resync timer do not isolate reader drain or set construction.
-Treat the delta as inconclusive rather than as their causal cost.
+The absolute median and paired median have opposite signs. Seven debug E2E
+pairs therefore provide no evidence of a recovery regression or improvement;
+the difference is noise-scale and the fixed Stage-25-first order remains a
+confounder.
 
-The second measurement runs the two-active-grammar E2E seven times. Every run
-quarantines two grammars, restarts once, and resyncs one healthy document
-(14 bytes). Recovery is 959–1126 ms, with a 974 ms median and 996 ms mean. This
-fixture has a different failure trigger and document set, so its absolute time
-must not be compared directly with the single-hazard fixture; it establishes
-that two attributions remain one recovery action rather than two restarts.
+The two-active-grammar E2E also ran seven times. Every run quarantined two
+grammars, restarted once, and resynchronized one healthy document (14 bytes).
+Recovery was 932–967 ms, with a 957 ms median and 951 ms mean. This fixture has
+a different failure trigger and document set, so its absolute time is not
+directly comparable with the single-hazard fixture. It establishes that two
+attributions remain one recovery action rather than two restarts.
 
-Raw samples are in
-`benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json`.
+The four-thread saturation E2E ran seven times after one warmup. Its configured
+2,000 ms request deadline and 250 ms cancellation grace are included in the
+measurement. Replacement readiness was 3187–3211 ms after request issue, with a
+3205 ms median and 3202 ms mean. The narrow 24 ms range shows that four leaked
+native jobs are reclaimed by one bounded process restart rather than four
+serial per-thread recoveries.
+
+## Steady-state measurement
+
+The admission fence adds one atomic load while the request route mutex is
+already held. To measure that hot-path change, the unchanged Stage 25/26 release
+harness ran 12 measured pairs after one warmup per stage. Revision order and
+worker/direct order alternated. Each run used 500 incremental requests over 200
+Rust source lines and four worker threads.
+
+| Metric | Stage 25 median | Stage 26 median | Median paired delta |
+| --- | ---: | ---: | ---: |
+| Sequential parent p50 | 453.167 us | 452.771 us | -0.010% |
+| Sequential parent p95 | 489.667 us | 494.979 us | +0.886% |
+| Four-way parallel parent p50 | 558.626 us | 557.104 us | -0.616% |
+| Four-way parallel parent p95 | 629.688 us | 638.125 us | +0.843% |
+| Four-way parallel throughput | 6598 req/s | 6578 req/s | +0.273% |
+
+Directions are mixed and every paired median is below 1%. The atomic admission
+check has no distinguishable steady-state cost in this fixture. One Stage 26
+parallel p95 sample reached 765 us (+21.7% paired) while its throughput fell to
+5942 req/s, so this small run still cannot establish a tail-latency bound.
+
+Raw samples, artifact hashes, metric ordering, and exact commit identities are
+in `benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json`.
 
 ## Decision
 
-Keep complete-set quarantine and the reader-drain barrier. The failure-path
-cost is bounded by active leases and avoids both under-quarantine and command
-inference. The production request hot path adds no per-request synchronization;
-the new condition variable is signaled only when a worker reader terminates,
-and quarantine work runs only during recovery. Stage 25's steady-state
-throughput result therefore remains the current scheduling baseline.
+Keep complete-set quarantine, the reader-drain barrier, bounded systemic
+cancellation recovery, and the request-admission fence. The recovery work is
+bounded by active leases, while the measured request-path change is noise-scale
+in both sequential and four-way workloads.
 
-Do not claim a tail-recovery or complete performance-gate pass from seven debug
-E2E samples. Runtime injection identities, independently bounded control
-transport, native segment deadlines, explicit workload-aware admission,
-protocol/compatibility gates, and legacy-path removal remain open. The ADR
-remains `proposed`.
+Do not claim a tail-recovery or complete performance-gate pass from these
+samples. Runtime injection identities, independently bounded control transport,
+native segment deadlines, explicit workload-aware admission, protocol and
+compatibility gates, and legacy-path removal remain open. The ADR remains
+`proposed`.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -54,7 +54,7 @@ planned replacement continues. The regression E2E holds native work beyond the
 full five-second window and proves one replacement, no quarantine, and no
 configuration-gated breaker.
 
-The focused 66 worker and 40 supervisor tests, the single-crash, protocol-
+The focused 67 worker and 40 supervisor tests, the single-crash, protocol-
 failure, multi-hazard, single-timeout, four-thread saturation, planned-restart,
 and delayed-restart-response E2Es,
 all-target Check, warning-denying Clippy, and formatting checks pass locally.
@@ -70,7 +70,8 @@ replacement spawn and full resync; it is not end-to-end request latency.
 
 Review convergence subsequently changed only deadline/restart branches and test
 assertions. Those commits add no operation to the measured admitted-request hot
-path, so the table remains evidence for the admission-fence cost; its binary
+path, so the table remains evidence for the combined Stage 26 admission-path
+cost; its binary
 hashes and raw samples intentionally continue to identify `67c338ca7` rather
 than being relabeled as a final-HEAD run.
 
@@ -102,11 +103,13 @@ serial per-thread recoveries.
 
 ## Steady-state measurement
 
-The admission fence adds one atomic load while the request route mutex is
-already held. To measure that hot-path change, the unchanged Stage 25/26 release
-harness ran 12 measured pairs after one warmup per stage. Revision order and
-worker/direct order alternated. Each run used 500 incremental requests over 200
-Rust source lines and four worker threads.
+The Stage 26 admission path adds one atomic fence load while the request route
+mutex is already held, classifies whether a request may use the supervisor
+reserve, and applies the corresponding admission arithmetic. To measure these
+combined hot-path changes, the unchanged Stage 25/26 release harness ran 12
+measured pairs after one warmup per stage. Revision order and worker/direct
+order alternated. Each run used 500 incremental requests over 200 Rust source
+lines and four worker threads.
 
 | Metric | Stage 25 median | Stage 26 median | Median paired delta |
 | --- | ---: | ---: | ---: |
@@ -119,8 +122,9 @@ Rust source lines and four worker threads.
 Sequential medians move in the faster direction, while all three parallel
 paired medians move by less than 1%. Run-to-run ranges overlap and sequential
 p95 paired deltas span -17.4% to +17.7%, so the fixture does not distinguish a
-causal speedup. It does show no measurable parallel regression from the atomic
-admission check. This small run cannot establish a tail-latency bound.
+causal speedup. It does show no measurable parallel regression from the combined
+Stage 26 admission-path changes. This small run cannot establish a tail-latency
+bound.
 
 Raw samples, artifact roles and hashes, stable source paths, exact build/run
 commands, metric ordering, and commit identities are in

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker-stage26-measurement.md
@@ -67,7 +67,7 @@ planned replacement continues. The regression E2E holds native work beyond the
 full five-second window and proves one replacement, no quarantine, and no
 configuration-gated breaker.
 
-The focused 69 worker and 43 supervisor tests, the single-crash, protocol-
+The focused 70 worker and 43 supervisor tests, the single-crash, protocol-
 failure, multi-hazard, single-timeout, four-thread saturation, planned-restart,
 delayed-restart-response, cancellation-delivery, and reserved-lifecycle
 saturation E2Es,

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -558,8 +558,12 @@ installed replacement. The external source itself is never modified.
 For an installer-managed replacement, the parent stages the immutable candidate,
 drains or cancels public tree requests, terminates and reaps the old worker, and
 starts the sole worker in non-serving `Validation` mode with the exact digest
-without changing the manifest. Only after loading, exported-symbol lookup, and
-initial query validation succeed does the parent CAS-commit the expected target
+without changing the manifest. Once admission is fenced, expiry of the bounded
+cooperative drain forcibly retires that old generation and continues this
+planned transition; it does not open a configuration-gated breaker merely
+because healthy work outlived the drain window. Only after loading, exported-
+symbol lookup, and initial query validation succeed does the parent CAS-commit
+the expected target
 manifest revision. It then constructs a promotion snapshot containing that new
 revision plus the unchanged revisions for every other configured grammar and
 applies the post-load fence below. On an exact match it advances configuration,
@@ -753,8 +757,10 @@ therefore retries every installed parser.
 
 An end-to-end request deadline starts at request admission. At expiry, the
 parent requests cooperative cancellation and waits a bounded grace period. A
-terminal response releases the client without a restart. If native work does
-not cooperate, the parent publishes the systemic deadline-termination cause,
+terminal response releases the client without a restart, except that
+`WorkerRestartRequired` remains authoritative and replaces the invalid
+generation even when it arrives during grace. If native work does not cooperate,
+the parent publishes the systemic deadline-termination cause,
 kills and restarts the complete generation, and does not quarantine any active
 grammar. A separate hard native-segment deadline starts with the handoff
 allowance when the parent receives
@@ -1327,14 +1333,18 @@ extends crash attribution from the first observed lease to the complete exact
 set. The parent drains the dead generation's response reader before snapshot,
 deduplicates every committed active grammar identity, installs the full set,
 and then restarts once. The two-grammar E2E consistently quarantined Rust and
-Lua while resyncing only healthy YAML; seven final-HEAD runs recovered in a
-median 960 ms. Against Stage 25 on the same single-hazard fixture, alternating
+Lua while resyncing only healthy YAML; seven measured-candidate runs recovered
+in a median 960 ms, and a fresh server then resolved non-null nodes with both
+grammars. Against Stage 25 on the same single-hazard fixture, alternating
 12-pair medians changed from 1153.5 to 1144.5 ms and the median paired delta was
 +3 ms (+0.26%); the wide -342 to +123 ms paired range does not establish a
 regression. The request-admission fence adds one atomic load under the existing
 route mutex. Paired release measurements moved sequential p50/p95 in the faster
 direction, while parallel p50/p95 and throughput changed by less than 1%, so no
-parallel cost was distinguishable in this fixture.
+parallel cost was distinguishable in this fixture. Review convergence later
+changed only deadline/restart failure branches and stronger E2E assertions; the
+recorded performance binary remains the explicitly identified measured
+candidate rather than being relabeled as final HEAD.
 Keep the failure-path barrier. Runtime
 injection identities, independently bounded control transport, native segment
 deadlines, explicit workload-aware admission, protocol and compatibility

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1389,8 +1389,8 @@ between that candidate and the review-converged scheduling path measured
 paired delta. Two late pairs widened the paired range to -0.522–+5.866 ms, so
 central latency was indistinguishable but tail equivalence was not established.
 Because later review fixes also touched grammar-route and response
-authentication, final code HEAD `9b5605abd` was remeasured against the earlier
-review-converged binary. Across eight alternating pairs, semantic edit/delta
+authentication, final worker-path revision `9b5605abd` was remeasured against
+the earlier review-converged binary. Across eight alternating pairs, semantic edit/delta
 latency changed by a median +0.077 ms (+0.259%); no central regression was
 distinguishable, while the -4.010–+3.673 ms range still does not establish tail
 equivalence. Keep the failure-path barrier. Runtime

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -773,7 +773,8 @@ an already-exited or unknown transport state enters worker-loss recovery rather
 than leaving the dead generation published. That recovery is systemic unless
 the preserved child status matches the conservative native-crash evidence
 allowlist; `TimedOut` alone is not parser-fault evidence. Unix evidence is
-restricted to synchronous crash signals rather than external TERM/KILL, and
+restricted to a conservative ABRT/BUS/FPE/ILL/SEGV crash-signal allowlist that
+excludes TERM/KILL, and
 Windows uses an explicit exception/fail-fast allowlist rather than all negative
 codes. A separate hard native-segment deadline starts with the handoff
 allowance when the parent receives
@@ -1362,7 +1363,7 @@ before the blocking response waiter. The original performance binary remains
 the explicitly identified measured candidate rather than being relabeled as
 final HEAD. A separate eight-pair authoritative semantic edit/delta comparison
 between that candidate and the review-converged scheduling path measured
-39.013 ms versus 39.021 ms median latency, with a +0.146 ms (+0.374%) median
+39.013 ms versus 39.021 ms median latency, with a +0.146 ms (+0.376%) median
 paired delta. Two late pairs widened the paired range to -0.522–+5.866 ms, so
 central latency was indistinguishable but tail equivalence was not established.
 Keep the failure-path barrier. Runtime

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1388,7 +1388,12 @@ between that candidate and the review-converged scheduling path measured
 39.013 ms versus 39.021 ms median latency, with a +0.146 ms (+0.376%) median
 paired delta. Two late pairs widened the paired range to -0.522–+5.866 ms, so
 central latency was indistinguishable but tail equivalence was not established.
-Keep the failure-path barrier. Runtime
+Because later review fixes also touched grammar-route and response
+authentication, final code HEAD `72f58a8b4` was remeasured against the earlier
+review-converged binary. Across eight alternating pairs, semantic edit/delta
+latency changed by a median +0.050 ms (+0.186%); no central regression was
+distinguishable, while the -2.560–+2.227 ms range still does not establish tail
+equivalence. Keep the failure-path barrier. Runtime
 injection identities, independently bounded control transport, native segment
 deadlines, explicit workload-aware admission, protocol and compatibility
 gates, and legacy-path removal remain open.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -461,6 +461,9 @@ identity exactly match an active response route. Direct requests bind that
 identity from their payload; document requests inherit it from an acknowledged
 sync or an active same-document sync route. The reader publishes sync and close
 updates to this identity registry atomically with routing their acknowledgments.
+The worker resolves a document request's runtime identity only after that job
+reaches the head of its document lane, so a preceding queued sync cannot leave
+the arm bound to the prior replica.
 An unknown or mismatched route is an incomplete protocol abort, not quarantine
 evidence. Each grammar
 encountered by a fused host/injection operation is leased separately and remains

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -250,9 +250,8 @@ ResolveNode(context, selector)
 NavigateNode(context, opaque_node_id, operation)
 RunCaptures(context, query, range)
 CancelRequest(request_id, worker_generation)
-GrammarHazardStarting(lease_id, request_id, grammar_key)
-GrammarHazardArmed(lease_id, worker_generation)
-GrammarHazardReleased(lease_id)
+GrammarHazardArmed(lease_id, request_context, grammar_key)
+GrammarHazardReleased(lease_id, worker_generation)
 NativeSegmentStarting(segment_id, lease_id)
 NativeSegmentArmed(segment_id, worker_generation)
 NativeSegmentEntered(segment_id, worker_generation)
@@ -407,8 +406,9 @@ if the matching cancellable reader request arrives later; a non-cancellable
 lifecycle request with that ID discards the token. Canceling a prior generation
 remains a no-op, and duplicate terminal and cancel frames remain harmless.
 
-Cancellation during a handshake has explicit cleanup. A hazard that was armed
-but never entered its grammar-backed scope is released; a native segment that
+Cancellation during hazard commit has explicit cleanup. A hazard whose arm
+frame was committed but whose grammar-backed scope was never entered is
+released; a native segment that
 was started or armed but never entered emits `NativeSegmentAborted`; an entered
 segment must exit before its hazard can be released. `RequestHazardsReleased` is sent
 only after every lease and segment owned by that request is released, exited, or
@@ -443,10 +443,13 @@ whose raw pointers ultimately depend on the grammar mapping. It is intentionally
 broader than the lexical call into `Parser::parse`: native corruption may become
 observable only during a later tree walk.
 
-Before the first such dereference, the worker sends `GrammarHazardStarting` with
-the actual runtime grammar identity and waits. The parent records the lease in
-its session-local active set before replying with `GrammarHazardArmed`; the
-worker must not enter the hazard scope without that reply. Each grammar
+Before the first such dereference, the worker sends `GrammarHazardArmed` with
+the actual runtime grammar identity through its single response writer and
+waits for a worker-local completion receipt. The writer issues that receipt only
+after the complete frame has been committed to the OS pipe. The worker must not
+enter the hazard scope without the receipt; if it later dies, the parent reader
+must decode the complete arm before a later release or EOF. The parent records
+the lease in its session-local active set. Each grammar
 encountered by a fused host/injection operation is leased separately and remains
 active until the complete high-level operation has stopped consuming every
 value backed by that grammar. Only then does `GrammarHazardReleased` remove it
@@ -655,13 +658,14 @@ It logs:
 * the session quarantine action.
 
 With internal parallelism, an externally observed process crash may leave more
-than one acknowledged grammar hazard lease active. The initial safe policy
-quarantines the complete set of active `grammar_key` values recorded by the parent. This can
-conservatively disable an innocent concurrently active grammar, but only for the
-current session. Exact cross-platform identification of the faulting thread
-would require a separate crash-reporting design and is not assumed by this
-decision. A worker failure with no acknowledged grammar hazard lease is treated as a
-worker/protocol failure and does not invent a parser quarantine.
+than one committed grammar hazard lease active. The initial safe policy
+quarantines the complete set of active `grammar_key` values recorded by the
+parent. This can conservatively disable an innocent concurrently active
+grammar, but only for the current session. Exact cross-platform identification
+of the faulting thread would require a separate crash-reporting design and is
+not assumed by this decision. A worker failure with no committed grammar hazard
+lease is treated as a worker/protocol failure and does not invent a parser
+quarantine.
 
 After recording attribution and updating quarantine, the parent clears every
 hazard lease and native-segment record belonging to the dead `worker_gen` before
@@ -1307,9 +1311,22 @@ green. Across twenty-four order-reversed pairs, sequential p50 improved by
 acted as accidental admission pacing: four-way throughput fell 3.151% and p95
 rose 9.200%. Keep crash ordering independent of scheduling, and recover any
 valuable pacing through an explicit workload-aware admission policy. Runtime
-injection identities, multiple-hazard quarantine, independently bounded control
+injection identities, independently bounded control
 transport, native segment deadlines, protocol and compatibility gates, and
 legacy-path removal remain open.
+
+The [Stage 26 hazard-set measurement](single-resident-multithreaded-tree-worker-stage26-measurement.md)
+extends crash attribution from the first observed lease to the complete exact
+set. The parent drains the dead generation's response reader before snapshot,
+deduplicates every committed active grammar identity, installs the full set,
+and then restarts once. The two-grammar E2E consistently quarantined Rust and
+Lua while resyncing only healthy YAML; seven runs recovered in a median 974 ms.
+Against Stage 25 on the same single-hazard fixture, median recovery changed from
+1266 to 1281 ms and the median paired delta was +11 ms (+0.9%). Keep the
+failure-path barrier; no production request hot path was added. Runtime
+injection identities, independently bounded control transport, native segment
+deadlines, explicit workload-aware admission, protocol and compatibility
+gates, and legacy-path removal remain open.
 
 The implementation should proceed in measured stages:
 

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1018,8 +1018,10 @@ Implementation is accepted only when all of the following hold:
   install deduplication, cache invalidation, latest-version re-derivation, and
   refusal to load the same quarantined artifact. Same-path parser replacement,
   including migration from the current fixed destination and the loaded-DLL
-  case on Windows, proves a fresh worker executes the content-addressed new
-  artifact rather than acknowledging a new key while retaining old code.
+  case on Windows, refreshes every affected open document from its language's
+  current catalog descriptor, including query sources, and proves a fresh
+  worker executes the content-addressed new artifact rather than acknowledging
+  a new key while retaining old code.
   Concurrent first-start migration proves exactly one revision-1 manifest wins,
   losers follow it, the legacy file remains intact through every failure point,
   and failed validation leaves no selectable partial migration. Late legacy

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -677,7 +677,10 @@ the versioned quarantine set before enabling document derivation, and full-syncs
 all open documents. Restarts are also governed by a per-session systemic-failure
 circuit breaker. Quarantine and breaker accounting are separate decisions. Any
 active hazard leases at worker loss are conservatively quarantined, but that
-fact alone does not classify the cause as native or exempt the restart.
+fact alone does not classify the cause as native or exempt the restart. The
+exception is a generation that the parent itself selected for generic request-
+deadline termination: that loss is systemic and suppresses parser attribution
+because the deadline is not evidence that an active grammar caused the hang.
 
 Classification precedence is explicit. A supervisor-observed startup,
 handshake, framing/protocol, failed bounded resynchronization, parent-liveness,
@@ -748,9 +751,13 @@ has a new key and may be tried. The parent does not persist a `failed_parsers`
 set or an active-parse marker across server sessions. A fresh kakehashi process
 therefore retries every installed parser.
 
-An end-to-end request deadline starts at request admission and can release the
-client without killing the worker. A separate hard native-segment deadline
-starts with the handoff allowance when the parent receives
+An end-to-end request deadline starts at request admission. At expiry, the
+parent requests cooperative cancellation and waits a bounded grace period. A
+terminal response releases the client without a restart. If native work does
+not cooperate, the parent publishes the systemic deadline-termination cause,
+kills and restarts the complete generation, and does not quarantine any active
+grammar. A separate hard native-segment deadline starts with the handoff
+allowance when the parent receives
 `NativeSegmentEntered`; only after that allowance does it consume the native
 budget, and it ends at `NativeSegmentExited`. It does not run while an arm frame
 is queued or in transit, nor does it run for the lifetime of the surrounding
@@ -1320,10 +1327,14 @@ extends crash attribution from the first observed lease to the complete exact
 set. The parent drains the dead generation's response reader before snapshot,
 deduplicates every committed active grammar identity, installs the full set,
 and then restarts once. The two-grammar E2E consistently quarantined Rust and
-Lua while resyncing only healthy YAML; seven runs recovered in a median 974 ms.
-Against Stage 25 on the same single-hazard fixture, median recovery changed from
-1266 to 1281 ms and the median paired delta was +11 ms (+0.9%). Keep the
-failure-path barrier; no production request hot path was added. Runtime
+Lua while resyncing only healthy YAML; seven final-HEAD runs recovered in a
+median 962 ms. Against Stage 25 on the same single-hazard fixture, alternating
+12-pair medians changed from 1202 to 1182 ms and the median paired delta was
+-47 ms (-3.8%), but the wide -234 to +385 ms paired range does not establish an
+improvement. The request-admission fence adds one atomic load under the existing
+route mutex; paired release measurements put every sequential and four-way
+median delta below 1%, so its cost was not distinguishable in this fixture.
+Keep the failure-path barrier. Runtime
 injection identities, independently bounded control transport, native segment
 deadlines, explicit workload-aware admission, protocol and compatibility
 gates, and legacy-path removal remain open.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -456,9 +456,13 @@ after the complete frame has been committed to the OS pipe. The worker must not
 enter the hazard scope without the receipt; if it later dies, the parent reader
 must decode the complete arm before a later release or EOF. The parent records
 the lease in its session-local active set only when the generation and unique
-lease ID are valid and the arm's complete request context exactly matches an
-active response route. An unknown or mismatched route is an incomplete protocol
-abort, not quarantine evidence. Each grammar
+lease ID are valid and both the arm's complete request context and grammar
+identity exactly match an active response route. Direct requests bind that
+identity from their payload; document requests inherit it from an acknowledged
+sync or an active same-document sync route. The reader publishes sync and close
+updates to this identity registry atomically with routing their acknowledgments.
+An unknown or mismatched route is an incomplete protocol abort, not quarantine
+evidence. Each grammar
 encountered by a fused host/injection operation is leased separately and remains
 active until the complete high-level operation has stopped consuming every
 value backed by that grammar. Only then does `GrammarHazardReleased` remove it
@@ -1001,11 +1005,12 @@ Implementation is accepted only when all of the following hold:
   degraded state instead of resyncing forever.
 * A protocol-corruption fixture followed by another hazard-arm frame proves the
   reader marks its ledger incomplete and disables the tree tier rather than
-  restarting from the observed subset. Unknown-route and context-mismatched arm
-  fixtures prove forged attribution never enters the ledger. A reported
-  Rust-panic fixture while a grammar lease is active may conservatively
-  quarantine that key but still consumes the systemic budget; a signaled native
-  crash with the same lease follows the native-evidence exemption instead.
+  restarting from the observed subset. Unknown-route, context-mismatched, and
+  grammar-mismatched arm fixtures prove forged attribution never enters the
+  ledger. A reported Rust-panic fixture while a grammar lease is active may
+  conservatively quarantine that key but still consumes the systemic budget; a
+  signaled native crash with the same lease follows the native-evidence exemption
+  instead.
 * Install/reload tests cover missing host and injected grammars, concurrent
   install deduplication, cache invalidation, latest-version re-derivation, and
   refusal to load the same quarantined artifact. Same-path parser replacement,

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -760,7 +760,7 @@ control-protocol progress use the supervisor's bounded handshake/liveness
 timeout rather than consuming a grammar's native execution budget. A
 cooperative timeout that returns control from Tree-sitter does not require a
 worker restart. If an entered segment exceeds the hard deadline, the parent
-kills and restarts the worker and quarantines the complete acknowledged active
+kills and restarts the worker and quarantines the complete committed active
 grammar set. This remains correct when one
 `DeriveSnapshot` reaches several injected grammars or when unrelated documents
 parse concurrently.
@@ -892,7 +892,7 @@ runtime reload crosses into the worker.
 Implementation is accepted only when all of the following hold:
 
 * A child grammar fixture that calls `abort` proves that the LSP process stays
-  alive, emits an attributable crash log, quarantines the acknowledged active
+  alive, emits an attributable crash log, quarantines the committed active
   grammar set for the session, restarts the worker, and successfully reparses an
   open document in another language.
 * Failure injection immediately after `GrammarHazardArmed` proves that the parent

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -406,6 +406,12 @@ admitted cancellable work; canceling an unknown, completed, or prior-generation
 request remains a no-op, and duplicate terminal and cancel frames remain
 harmless.
 
+The client admits at most `4*T` ordinary routes plus one supervisor lifecycle
+route. The worker scheduler mirrors that `4*T+1` pending bound so it never stops
+after decoding the reserved lifecycle frame while later FIFO cancellation
+frames wait unread. Control frames remain independently processable at full
+ordinary admission.
+
 Cancellation during hazard commit has explicit cleanup. A hazard whose arm
 frame was committed but whose grammar-backed scope was never entered is
 released; a native segment that

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1328,12 +1328,13 @@ set. The parent drains the dead generation's response reader before snapshot,
 deduplicates every committed active grammar identity, installs the full set,
 and then restarts once. The two-grammar E2E consistently quarantined Rust and
 Lua while resyncing only healthy YAML; seven final-HEAD runs recovered in a
-median 962 ms. Against Stage 25 on the same single-hazard fixture, alternating
-12-pair medians changed from 1202 to 1182 ms and the median paired delta was
--47 ms (-3.8%), but the wide -234 to +385 ms paired range does not establish an
-improvement. The request-admission fence adds one atomic load under the existing
-route mutex; paired release measurements put every sequential and four-way
-median delta below 1%, so its cost was not distinguishable in this fixture.
+median 960 ms. Against Stage 25 on the same single-hazard fixture, alternating
+12-pair medians changed from 1153.5 to 1144.5 ms and the median paired delta was
++3 ms (+0.26%); the wide -342 to +123 ms paired range does not establish a
+regression. The request-admission fence adds one atomic load under the existing
+route mutex. Paired release measurements moved sequential p50/p95 in the faster
+direction, while parallel p50/p95 and throughput changed by less than 1%, so no
+parallel cost was distinguishable in this fixture.
 Keep the failure-path barrier. Runtime
 injection identities, independently bounded control transport, native segment
 deadlines, explicit workload-aware admission, protocol and compatibility

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1338,10 +1338,12 @@ in a median 960 ms, and a fresh server then resolved non-null nodes with both
 grammars. Against Stage 25 on the same single-hazard fixture, alternating
 12-pair medians changed from 1153.5 to 1144.5 ms and the median paired delta was
 +3 ms (+0.26%); the wide -342 to +123 ms paired range does not establish a
-regression. The request-admission fence adds one atomic load under the existing
-route mutex. Paired release measurements moved sequential p50/p95 in the faster
-direction, while parallel p50/p95 and throughput changed by less than 1%, so no
-parallel cost was distinguishable in this fixture. Review convergence later
+regression. The Stage 26 admission path adds one atomic fence load under the
+existing route mutex together with supervisor-reserve classification and
+admission arithmetic. Paired release measurements moved sequential p50/p95 in
+the faster direction, while parallel p50/p95 and throughput changed by less
+than 1%, so no cost from those combined changes was distinguishable in this
+fixture. Review convergence later
 changed only deadline/restart failure branches and stronger E2E assertions; the
 recorded performance binary remains the explicitly identified measured
 candidate rather than being relabeled as final HEAD.

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1028,10 +1028,10 @@ Implementation is accepted only when all of the following hold:
 * Cancellation tests cover queued and running work for client cancellation,
   supersession, handler drop, and `didClose`, including completion races and the
   rule that canceled work publishes and caches nothing.
-* Cancellation tests also cover cancellation before request delivery and at
-  every hazard/segment handshake phase, proving that no later request executes
-  after an overtaking cancel and no lease or timer survives
-  `RequestHazardsReleased`.
+* Cancellation tests also cover enqueue-before-guard ordering and every
+  hazard/segment handshake phase. A delayed response waiter proves cancellation
+  still reaches already-admitted work without an overtaking unknown-ID
+  tombstone, and no lease or timer survives `RequestHazardsReleased`.
 * A saturated worker-to-parent bulk stream proves hazard cleanup may overtake a
   successful response without removing its router, losing the payload, or
   leaving the public request unresolved.
@@ -1343,10 +1343,15 @@ existing route mutex together with supervisor-reserve classification and
 admission arithmetic. Paired release measurements moved sequential p50/p95 in
 the faster direction, while parallel p50/p95 and throughput changed by less
 than 1%, so no cost from those combined changes was distinguishable in this
-fixture. Review convergence later
-changed only deadline/restart failure branches and stronger E2E assertions; the
-recorded performance binary remains the explicitly identified measured
-candidate rather than being relabeled as final HEAD.
+fixture. Review convergence later changed deadline/restart failure branches,
+strengthened E2E assertions, and moved semantic request registration/enqueue
+before the blocking response waiter. The original performance binary remains
+the explicitly identified measured candidate rather than being relabeled as
+final HEAD. A separate eight-pair authoritative semantic edit/delta comparison
+between that candidate and the review-converged scheduling path measured
+39.013 ms versus 39.021 ms median latency, with a +0.146 ms (+0.374%) median
+paired delta. Two late pairs widened the paired range to -0.522–+5.866 ms, so
+central latency was indistinguishable but tail equivalence was not established.
 Keep the failure-path barrier. Runtime
 injection identities, independently bounded control transport, native segment
 deadlines, explicit workload-aware admission, protocol and compatibility

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -768,7 +768,10 @@ terminal response releases the client without a restart, except that
 generation even when it arrives during grace. If native work does not cooperate,
 the parent publishes the systemic deadline-termination cause,
 kills and restarts the complete generation, and does not quarantine any active
-grammar. A separate hard native-segment deadline starts with the handoff
+grammar. A timeout can remain nonfatal only when the child is confirmed live;
+an already-exited or unknown transport state enters worker-loss recovery rather
+than leaving the dead generation published. A separate hard native-segment
+deadline starts with the handoff
 allowance when the parent receives
 `NativeSegmentEntered`; only after that allowance does it consume the native
 budget, and it ends at `NativeSegmentExited`. It does not run while an arm frame

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -455,7 +455,10 @@ waits for a worker-local completion receipt. The writer issues that receipt only
 after the complete frame has been committed to the OS pipe. The worker must not
 enter the hazard scope without the receipt; if it later dies, the parent reader
 must decode the complete arm before a later release or EOF. The parent records
-the lease in its session-local active set. Each grammar
+the lease in its session-local active set only when the generation and unique
+lease ID are valid and the arm's complete request context exactly matches an
+active response route. An unknown or mismatched route is an incomplete protocol
+abort, not quarantine evidence. Each grammar
 encountered by a fused host/injection operation is leased separately and remains
 active until the complete high-level operation has stopped consuming every
 value backed by that grammar. Only then does `GrammarHazardReleased` remove it
@@ -998,10 +1001,11 @@ Implementation is accepted only when all of the following hold:
   degraded state instead of resyncing forever.
 * A protocol-corruption fixture followed by another hazard-arm frame proves the
   reader marks its ledger incomplete and disables the tree tier rather than
-  restarting from the observed subset. A reported Rust-panic fixture while a
-  grammar lease is active may conservatively quarantine that key but still
-  consumes the systemic budget; a signaled native crash with the same lease
-  follows the native-evidence exemption instead.
+  restarting from the observed subset. Unknown-route and context-mismatched arm
+  fixtures prove forged attribution never enters the ledger. A reported
+  Rust-panic fixture while a grammar lease is active may conservatively
+  quarantine that key but still consumes the systemic budget; a signaled native
+  crash with the same lease follows the native-evidence exemption instead.
 * Install/reload tests cover missing host and injected grammars, concurrent
   install deduplication, cache invalidation, latest-version re-derivation, and
   refusal to load the same quarantined artifact. Same-path parser replacement,

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -770,7 +770,9 @@ the parent publishes the systemic deadline-termination cause,
 kills and restarts the complete generation, and does not quarantine any active
 grammar. A timeout can remain nonfatal only when the child is confirmed live;
 an already-exited or unknown transport state enters worker-loss recovery rather
-than leaving the dead generation published. A separate hard native-segment
+than leaving the dead generation published. That recovery is systemic unless
+the preserved child status independently proves a native crash; `TimedOut`
+alone is not parser-fault evidence. A separate hard native-segment
 deadline starts with the handoff
 allowance when the parent receives
 `NativeSegmentEntered`; only after that allowance does it consume the native

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -1389,10 +1389,10 @@ between that candidate and the review-converged scheduling path measured
 paired delta. Two late pairs widened the paired range to -0.522–+5.866 ms, so
 central latency was indistinguishable but tail equivalence was not established.
 Because later review fixes also touched grammar-route and response
-authentication, final code HEAD `72f58a8b4` was remeasured against the earlier
+authentication, final code HEAD `9b5605abd` was remeasured against the earlier
 review-converged binary. Across eight alternating pairs, semantic edit/delta
-latency changed by a median +0.050 ms (+0.186%); no central regression was
-distinguishable, while the -2.560–+2.227 ms range still does not establish tail
+latency changed by a median +0.077 ms (+0.259%); no central regression was
+distinguishable, while the -4.010–+3.673 ms range still does not establish tail
 equivalence. Keep the failure-path barrier. Runtime
 injection identities, independently bounded control transport, native segment
 deadlines, explicit workload-aware admission, protocol and compatibility

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -465,7 +465,9 @@ The worker resolves a document request's runtime identity only after that job
 reaches the head of its document lane, so a preceding queued sync cannot leave
 the arm bound to the prior replica.
 An unknown or mismatched route is an incomplete protocol abort, not quarantine
-evidence. Each grammar
+evidence. Terminal responses are likewise accepted only when their variant is
+valid for that request type; a matching ID and context cannot turn the wrong
+payload into a registry update. Each grammar
 encountered by a fused host/injection operation is leased separately and remains
 active until the complete high-level operation has stopped consuming every
 value backed by that grammar. Only then does `GrammarHazardReleased` remove it

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -393,18 +393,18 @@ flips the same cancellation token polled by its tree walks and nested fan-out.
 Cancellation racing a terminal response may observe either terminal outcome,
 but a canceled or stale result cannot populate a cache, mint node state, or be
 published in the parent. Canceling a completed or prior-generation request is a
-no-op; a same-generation unknown ID is retained for the request-delivery race
-described below. A non-cooperative native call remains governed by its hard
-native-call deadline; cancellation alone does not kill the whole worker.
+no-op; an unknown same-generation ID is also a no-op and creates no tombstone.
+A non-cooperative native call remains governed by its hard native-call deadline;
+cancellation alone does not kill the whole worker.
 
 High-level request admission and cancellation share the parent-to-worker control
-writer, but parent task scheduling does not guarantee that a blocking request
-sender runs before the async owner is dropped. Cancellation may therefore
-overtake first observation of the request. The worker retains an idempotent
-same-generation cancellation token for that unknown request ID and consumes it
-if the matching cancellable reader request arrives later; a non-cancellable
-lifecycle request with that ID discards the token. Canceling a prior generation
-remains a no-op, and duplicate terminal and cancel frames remain harmless.
+writer. The async owner synchronously registers the response route and enqueues
+the request frame before it arms cancellation or delegates the response wait to
+a blocking task. Parent scheduling may delay that waiter, but cancellation
+cannot overtake request delivery. The worker therefore keeps tokens only for
+admitted cancellable work; canceling an unknown, completed, or prior-generation
+request remains a no-op, and duplicate terminal and cancel frames remain
+harmless.
 
 Cancellation during hazard commit has explicit cleanup. A hazard whose arm
 frame was committed but whose grammar-backed scope was never entered is

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -702,8 +702,10 @@ normally exiting failure is systemic. A native-evidenced failure that newly
 quarantines one or more previously allowed grammar keys does not consume the
 global budget: quarantine has removed a concrete cause. Its restart remains
 rate limited by backoff and the independent native-storm budget below. A
-protocol failure may still conservatively quarantine active keys, but it always
-consumes the systemic budget.
+protocol abort may still conservatively quarantine the active keys observed
+before the invalid frame, but it cannot prove that the hazard ledger is
+complete. The parent therefore marks that snapshot incomplete and disables the
+tree tier instead of restarting from a potentially partial quarantine set.
 
 Three systemic worker-generation failures without an intervening 60 seconds of
 healthy service exhaust the budget for the current configuration generation.
@@ -994,10 +996,12 @@ Implementation is accepted only when all of the following hold:
   prove every restart consumes the long-horizon bucket, exponential backoff does
   not reset at the 60-second fast threshold, and the session converges to the
   degraded state instead of resyncing forever.
-* A protocol-corruption or reported Rust-panic fixture while a grammar lease is
-  active may conservatively quarantine that key but still consumes the systemic
-  budget; a signaled native crash with the same lease follows the native-evidence
-  exemption instead.
+* A protocol-corruption fixture followed by another hazard-arm frame proves the
+  reader marks its ledger incomplete and disables the tree tier rather than
+  restarting from the observed subset. A reported Rust-panic fixture while a
+  grammar lease is active may conservatively quarantine that key but still
+  consumes the systemic budget; a signaled native crash with the same lease
+  follows the native-evidence exemption instead.
 * Install/reload tests cover missing host and injected grammars, concurrent
   install deduplication, cache invalidation, latest-version re-derivation, and
   refusal to load the same quarantined artifact. Same-path parser replacement,

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -772,7 +772,9 @@ grammar. A timeout can remain nonfatal only when the child is confirmed live;
 an already-exited or unknown transport state enters worker-loss recovery rather
 than leaving the dead generation published. That recovery is systemic unless
 the preserved child status independently proves a native crash; `TimedOut`
-alone is not parser-fault evidence. A separate hard native-segment
+alone is not parser-fault evidence. Unix evidence is restricted to synchronous
+crash signals rather than external TERM/KILL, and Windows uses an explicit
+exception/fail-fast allowlist rather than all negative codes. A separate hard native-segment
 deadline starts with the handoff
 allowance when the parent receives
 `NativeSegmentEntered`; only after that allowance does it consume the native

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -771,11 +771,11 @@ kills and restarts the complete generation, and does not quarantine any active
 grammar. A timeout can remain nonfatal only when the child is confirmed live;
 an already-exited or unknown transport state enters worker-loss recovery rather
 than leaving the dead generation published. That recovery is systemic unless
-the preserved child status independently proves a native crash; `TimedOut`
-alone is not parser-fault evidence. Unix evidence is restricted to synchronous
-crash signals rather than external TERM/KILL, and Windows uses an explicit
-exception/fail-fast allowlist rather than all negative codes. A separate hard native-segment
-deadline starts with the handoff
+the preserved child status matches the conservative native-crash evidence
+allowlist; `TimedOut` alone is not parser-fault evidence. Unix evidence is
+restricted to synchronous crash signals rather than external TERM/KILL, and
+Windows uses an explicit exception/fail-fast allowlist rather than all negative
+codes. A separate hard native-segment deadline starts with the handoff
 allowance when the parent receives
 `NativeSegmentEntered`; only after that allowance does it consume the native
 budget, and it ends at `NativeSegmentExited`. It does not run while an arm frame

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -701,6 +701,8 @@ fact alone does not classify the cause as native or exempt the restart. The
 exception is a generation that the parent itself selected for generic request-
 deadline termination: that loss is systemic and suppresses parser attribution
 because the deadline is not evidence that an active grammar caused the hang.
+The deadline and transport cause markers are derived from one pre-kill process
+state observation before the parent immediately terminates the process group.
 
 Classification precedence is explicit. A supervisor-observed startup,
 handshake, framing/protocol, failed bounded resynchronization, parent-liveness,

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -853,7 +853,9 @@ fn parser_source_dir(
     location: Option<&str>,
 ) -> Result<PathBuf, ParserInstallError> {
     let Some(location) = location else {
-        return Ok(clone_dir.canonicalize()?);
+        return Ok(compiler_compatible_canonical_path(
+            clone_dir.canonicalize()?,
+        ));
     };
     if location.is_empty()
         || Path::new(location)
@@ -887,7 +889,22 @@ fn parser_source_dir(
         )));
     }
 
-    Ok(source_dir)
+    Ok(compiler_compatible_canonical_path(source_dir))
+}
+
+#[cfg(any(windows, test))]
+fn strip_windows_verbatim_prefix(path: &str) -> Option<String> {
+    path.strip_prefix(r"\\?\UNC\")
+        .map(|path| format!(r"\\{path}"))
+        .or_else(|| path.strip_prefix(r"\\?\").map(str::to_owned))
+}
+
+fn compiler_compatible_canonical_path(path: PathBuf) -> PathBuf {
+    #[cfg(windows)]
+    if let Some(path) = strip_windows_verbatim_prefix(&path.to_string_lossy()) {
+        return PathBuf::from(path);
+    }
+    path
 }
 
 fn reject_parser_source_symlinks(path: &Path) -> Result<(), ParserInstallError> {
@@ -941,6 +958,19 @@ mod tests {
 
     const TREE_SITTER_JSON_URL: &str =
         "https://github.com/tree-sitter/tree-sitter-json/archive/v0.24.8.tar.gz";
+
+    #[test]
+    fn compiler_path_strips_windows_verbatim_prefixes() {
+        assert_eq!(
+            strip_windows_verbatim_prefix(r"\\?\C:\runner\parser"),
+            Some(r"C:\runner\parser".into())
+        );
+        assert_eq!(
+            strip_windows_verbatim_prefix(r"\\?\UNC\server\share\parser"),
+            Some(r"\\server\share\parser".into())
+        );
+        assert_eq!(strip_windows_verbatim_prefix(r"C:\runner\parser"), None);
+    }
 
     #[test]
     fn install_parser_rejects_unsafe_language_name() {

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -893,16 +893,37 @@ fn parser_source_dir(
 }
 
 #[cfg(any(windows, test))]
-fn strip_windows_verbatim_prefix(path: &str) -> Option<String> {
-    path.strip_prefix(r"\\?\UNC\")
-        .map(|path| format!(r"\\{path}"))
-        .or_else(|| path.strip_prefix(r"\\?\").map(str::to_owned))
+fn strip_windows_verbatim_prefix_units(path: &[u16]) -> Option<Vec<u16>> {
+    const VERBATIM: &[u16] = &[b'\\' as u16, b'\\' as u16, b'?' as u16, b'\\' as u16];
+    const VERBATIM_UNC: &[u16] = &[
+        b'\\' as u16,
+        b'\\' as u16,
+        b'?' as u16,
+        b'\\' as u16,
+        b'U' as u16,
+        b'N' as u16,
+        b'C' as u16,
+        b'\\' as u16,
+    ];
+    if let Some(path) = path.strip_prefix(VERBATIM_UNC) {
+        let mut normalized = vec![b'\\' as u16, b'\\' as u16];
+        normalized.extend_from_slice(path);
+        Some(normalized)
+    } else {
+        path.strip_prefix(VERBATIM).map(<[u16]>::to_vec)
+    }
 }
 
 fn compiler_compatible_canonical_path(path: PathBuf) -> PathBuf {
     #[cfg(windows)]
-    if let Some(path) = strip_windows_verbatim_prefix(&path.to_string_lossy()) {
-        return PathBuf::from(path);
+    {
+        use std::ffi::OsString;
+        use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+        let units = path.as_os_str().encode_wide().collect::<Vec<_>>();
+        if let Some(path) = strip_windows_verbatim_prefix_units(&units) {
+            return PathBuf::from(OsString::from_wide(&path));
+        }
     }
     path
 }
@@ -960,16 +981,24 @@ mod tests {
         "https://github.com/tree-sitter/tree-sitter-json/archive/v0.24.8.tar.gz";
 
     #[test]
-    fn compiler_path_strips_windows_verbatim_prefixes() {
+    fn compiler_path_strips_windows_verbatim_prefixes_losslessly() {
+        let units = |path: &str| path.encode_utf16().collect::<Vec<_>>();
         assert_eq!(
-            strip_windows_verbatim_prefix(r"\\?\C:\runner\parser"),
-            Some(r"C:\runner\parser".into())
+            strip_windows_verbatim_prefix_units(&units(r"\\?\C:\runner\parser")),
+            Some(units(r"C:\runner\parser"))
         );
         assert_eq!(
-            strip_windows_verbatim_prefix(r"\\?\UNC\server\share\parser"),
-            Some(r"\\server\share\parser".into())
+            strip_windows_verbatim_prefix_units(&units(r"\\?\UNC\server\share\parser")),
+            Some(units(r"\\server\share\parser"))
         );
-        assert_eq!(strip_windows_verbatim_prefix(r"C:\runner\parser"), None);
+        assert_eq!(
+            strip_windows_verbatim_prefix_units(&units(r"C:\runner\parser")),
+            None
+        );
+        let mut unpaired_surrogate = units(r"\\?\C:\runner\");
+        unpaired_surrogate.push(0xd800);
+        let stripped = strip_windows_verbatim_prefix_units(&unpaired_surrogate).unwrap();
+        assert_eq!(stripped.last(), Some(&0xd800));
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -3424,13 +3424,15 @@ fn quarantine_grammars(
         }
     }
     if !newly_quarantined.is_empty() {
-        let newly_quarantined_set = newly_quarantined.iter().cloned().collect::<HashSet<_>>();
         let open_documents = state
             .open_documents
             .lock()
             .recover_poison("quarantine_grammars(open documents)");
         for request in open_documents.current.values() {
-            if newly_quarantined_set.contains(&GrammarIdentity::from_sync(request)) {
+            if newly_quarantined
+                .binary_search(&GrammarIdentity::from_sync(request))
+                .is_ok()
+            {
                 comparisons.mark_closed(&request.context.uri, request.context.incarnation);
             }
         }

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -3303,11 +3303,15 @@ fn quarantine_grammars(
         }
         drop(open_documents);
     }
+    if !should_log_quarantine_summary(&batch) {
+        return batch;
+    }
+    let effective_class = effective_failure_class(class, &batch);
     for grammar in &newly_quarantined {
         log::error!(
             target: "kakehashi::tree_worker_shadow",
             "quarantined grammar conservatively for this session after {:?} worker loss: symbol={} artifact_digest={}",
-            class,
+            effective_class,
             grammar.grammar_symbol,
             grammar.artifact_digest,
         );
@@ -3319,9 +3323,13 @@ fn quarantine_grammars(
         batch.newly_quarantined + batch.already_quarantined,
         batch.newly_quarantined,
         batch.already_quarantined,
-        class,
+        effective_class,
     );
     batch
+}
+
+fn should_log_quarantine_summary(quarantine: &QuarantineBatch) -> bool {
+    quarantine.newly_quarantined + quarantine.already_quarantined > 0
 }
 
 fn effective_failure_class(class: FailureClass, quarantine: &QuarantineBatch) -> FailureClass {
@@ -3964,6 +3972,15 @@ mod tests {
             ),
             FailureClass::NativeEvidenced,
         );
+    }
+
+    #[test]
+    fn quarantine_summary_is_emitted_only_for_nonempty_evidence() {
+        assert!(!should_log_quarantine_summary(&QuarantineBatch::default()));
+        assert!(should_log_quarantine_summary(&QuarantineBatch {
+            newly_quarantined: 0,
+            already_quarantined: 1,
+        }));
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -3784,7 +3784,19 @@ fn classify_transport_observation(
 fn process_status_is_native_crash(status: &std::process::ExitStatus) -> bool {
     use std::os::unix::process::ExitStatusExt;
 
-    status.signal().is_some()
+    status.signal().is_some_and(unix_signal_is_native_crash)
+}
+
+#[cfg(unix)]
+fn unix_signal_is_native_crash(signal: i32) -> bool {
+    matches!(
+        signal,
+        nix::libc::SIGABRT
+            | nix::libc::SIGBUS
+            | nix::libc::SIGFPE
+            | nix::libc::SIGILL
+            | nix::libc::SIGSEGV
+    )
 }
 
 #[cfg(windows)]
@@ -3799,7 +3811,19 @@ fn process_status_is_native_crash(_status: &std::process::ExitStatus) -> bool {
 
 #[cfg(any(test, windows))]
 fn windows_exit_code_is_exception(code: i32) -> bool {
-    code.is_negative()
+    matches!(
+        code as u32,
+        0xc000_0005 // access violation
+            | 0xc000_001d // illegal instruction
+            | 0xc000_008e // floating-point divide by zero
+            | 0xc000_0090 // floating-point invalid operation
+            | 0xc000_0094 // integer divide by zero
+            | 0xc000_0095 // integer overflow
+            | 0xc000_00fd // stack overflow
+            | 0xc000_0374 // heap corruption
+            | 0xc000_0409 // stack buffer overrun / fail fast
+            | 0xc000_0602 // fail-fast exception
+    )
 }
 
 fn command_uri(command: &ShadowCommand) -> Option<&str> {
@@ -4241,6 +4265,16 @@ mod tests {
     fn windows_exception_status_is_native_crash_evidence() {
         assert!(windows_exit_code_is_exception(0xc000_0409_u32 as i32));
         assert!(!windows_exit_code_is_exception(86));
+        assert!(!windows_exit_code_is_exception(-1));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn external_unix_termination_is_not_native_crash_evidence() {
+        assert!(unix_signal_is_native_crash(nix::libc::SIGABRT));
+        assert!(unix_signal_is_native_crash(nix::libc::SIGSEGV));
+        assert!(!unix_signal_is_native_crash(nix::libc::SIGTERM));
+        assert!(!unix_signal_is_native_crash(nix::libc::SIGKILL));
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -2653,16 +2653,23 @@ fn run_actor(
                     }
                 };
                 let failure = worker_loss_evidence(client, &loss_error);
-                if matches!(state.breaker, BreakerState::HalfOpen { .. })
-                    || !recover_worker(
+                if matches!(state.breaker, BreakerState::HalfOpen { .. }) {
+                    let _ = apply_worker_loss_evidence(&mut state, failure, &comparisons);
+                    mark_tree_tier_unavailable(
                         &mut state,
-                        &executable,
-                        compute_threads,
-                        failure,
-                        &comparisons,
-                        RecoveryMode::Normal,
-                    )
-                {
+                        &disabled,
+                        &pending_configuration_generation,
+                    );
+                    continue;
+                }
+                if !recover_worker(
+                    &mut state,
+                    &executable,
+                    compute_threads,
+                    failure,
+                    &comparisons,
+                    RecoveryMode::Normal,
+                ) {
                     mark_tree_tier_unavailable(
                         &mut state,
                         &disabled,
@@ -2868,16 +2875,23 @@ fn run_actor(
                     "worker generation {} transport failed: {error}",
                     state.worker_generation,
                 );
-                if matches!(state.breaker, BreakerState::HalfOpen { .. })
-                    || !recover_worker(
+                if matches!(state.breaker, BreakerState::HalfOpen { .. }) {
+                    let _ = apply_worker_loss_evidence(&mut state, failure, &comparisons);
+                    mark_tree_tier_unavailable(
                         &mut state,
-                        &executable,
-                        compute_threads,
-                        failure,
-                        &comparisons,
-                        RecoveryMode::Normal,
-                    )
-                {
+                        &disabled,
+                        &pending_configuration_generation,
+                    );
+                    continue;
+                }
+                if !recover_worker(
+                    &mut state,
+                    &executable,
+                    compute_threads,
+                    failure,
+                    &comparisons,
+                    RecoveryMode::Normal,
+                ) {
                     mark_tree_tier_unavailable(
                         &mut state,
                         &disabled,
@@ -3121,27 +3135,14 @@ fn recover_worker(
     state: &mut SupervisorState,
     executable: &std::path::Path,
     compute_threads: usize,
-    mut failure: WorkerLossEvidence,
+    failure: WorkerLossEvidence,
     comparisons: &ComparisonStore,
     mode: RecoveryMode,
 ) -> bool {
     let recovery_started = Instant::now();
-    let initial_quarantine = quarantine_grammars(
-        state,
-        std::mem::take(&mut failure.active_grammars),
-        failure.class,
-        comparisons,
-        failure.active_lease_count,
-    );
-    if !failure.allows_restart() {
-        log::error!(
-            target: "kakehashi::tree_worker_shadow",
-            "disabled tree tier because the dead worker hazard snapshot was incomplete",
-        );
+    let Some(mut class) = apply_worker_loss_evidence(state, failure, comparisons) else {
         return false;
-    }
-    failure.class = effective_failure_class(failure.class, &initial_quarantine);
-    let mut class = failure.class;
+    };
 
     let mut first_attempt = true;
     loop {
@@ -3246,6 +3247,28 @@ fn recover_worker(
             }
         }
     }
+}
+
+fn apply_worker_loss_evidence(
+    state: &mut SupervisorState,
+    mut failure: WorkerLossEvidence,
+    comparisons: &ComparisonStore,
+) -> Option<FailureClass> {
+    let quarantine = quarantine_grammars(
+        state,
+        std::mem::take(&mut failure.active_grammars),
+        failure.class,
+        comparisons,
+        failure.active_lease_count,
+    );
+    if !failure.allows_restart() {
+        log::error!(
+            target: "kakehashi::tree_worker_shadow",
+            "disabled tree tier because the dead worker hazard snapshot was incomplete",
+        );
+        return None;
+    }
+    Some(effective_failure_class(failure.class, &quarantine))
 }
 
 fn quarantine_grammars(
@@ -4539,6 +4562,47 @@ mod tests {
             state.restart_budget.backoff(state.restart_policy),
             INITIAL_RESTART_BACKOFF
         );
+    }
+
+    #[test]
+    fn half_open_worker_loss_applies_hazard_evidence_before_refusing_restart() {
+        let started = Instant::now();
+        let grammar = GrammarIdentity {
+            grammar_symbol: "rust".into(),
+            artifact_digest: "digest-rust".into(),
+        };
+        let mut state = SupervisorState {
+            client: None,
+            read_client: Arc::new(ArcSwapOption::empty()),
+            worker_nodes: Arc::new(dashmap::DashMap::new()),
+            worker_generation: 7,
+            replicas: HashMap::new(),
+            open_documents: Arc::new(Mutex::new(OpenDocuments::default())),
+            quarantined: HashSet::new(),
+            restart_budget: RestartBudget::default(),
+            restart_policy: RestartPolicy::default(),
+            breaker: BreakerState::HalfOpen {
+                probe_generation: 7,
+                synchronized_epoch: 0,
+                reconcile_after: started,
+            },
+            healthy_since: Some(started),
+            long_healthy_since: Some(started),
+        };
+
+        let class = apply_worker_loss_evidence(
+            &mut state,
+            WorkerLossEvidence {
+                class: FailureClass::NativeEvidenced,
+                active_grammars: vec![grammar.clone()],
+                active_lease_count: 1,
+                snapshot_complete: true,
+            },
+            &ComparisonStore::default(),
+        );
+
+        assert_eq!(class, Some(FailureClass::NativeEvidenced));
+        assert!(state.quarantined.contains(&grammar));
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -2922,11 +2922,18 @@ fn run_actor(
             }
             Ok(_) => {}
             Err(error) => {
-                let worker_was_terminated = state
+                let client = state
                     .client
                     .as_ref()
-                    .is_some_and(|client| client.was_terminated_for_request_deadline());
-                if is_nonfatal_client_error(&error) && !worker_was_terminated {
+                    .expect("failed request retains its worker client");
+                let worker_was_terminated = client.was_terminated_for_request_deadline();
+                let worker_transport_is_live =
+                    client.try_wait().is_ok_and(|status| status.is_none());
+                if may_continue_after_client_error(
+                    &error,
+                    worker_was_terminated,
+                    worker_transport_is_live,
+                ) {
                     log::warn!(
                         target: "kakehashi::tree_worker_shadow",
                         "worker request did not complete without transport loss: {error}",
@@ -3695,6 +3702,14 @@ fn is_nonfatal_client_error(error: &std::io::Error) -> bool {
     )
 }
 
+fn may_continue_after_client_error(
+    error: &std::io::Error,
+    terminated_for_request_deadline: bool,
+    worker_transport_is_live: bool,
+) -> bool {
+    is_nonfatal_client_error(error) && !terminated_for_request_deadline && worker_transport_is_live
+}
+
 fn unique_active_grammars(
     active_hazards: &[crate::tree_worker::GrammarHazardArmed],
 ) -> Vec<GrammarIdentity> {
@@ -4158,6 +4173,20 @@ mod tests {
                 "retryable",
             )));
         }
+    }
+
+    #[test]
+    fn nonfatal_timeout_requires_a_confirmed_live_worker() {
+        let timeout = std::io::Error::new(std::io::ErrorKind::TimedOut, "deadline");
+
+        assert!(may_continue_after_client_error(&timeout, false, true));
+        assert!(!may_continue_after_client_error(&timeout, true, true));
+        assert!(!may_continue_after_client_error(&timeout, false, false));
+        assert!(!may_continue_after_client_error(
+            &std::io::Error::new(std::io::ErrorKind::BrokenPipe, "transport"),
+            false,
+            true,
+        ));
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -345,6 +345,7 @@ struct WorkerLossEvidence {
     class: FailureClass,
     active_grammars: Vec<GrammarIdentity>,
     active_lease_count: usize,
+    snapshot_complete: bool,
 }
 
 impl WorkerLossEvidence {
@@ -353,7 +354,21 @@ impl WorkerLossEvidence {
             class: FailureClass::Systemic,
             active_grammars: Vec::new(),
             active_lease_count: 0,
+            snapshot_complete: true,
         }
+    }
+
+    fn incomplete(active_grammars: Vec<GrammarIdentity>, active_lease_count: usize) -> Self {
+        Self {
+            class: FailureClass::Systemic,
+            active_lease_count,
+            active_grammars,
+            snapshot_complete: false,
+        }
+    }
+
+    fn allows_restart(&self) -> bool {
+        self.snapshot_complete
     }
 }
 
@@ -3103,6 +3118,13 @@ fn recover_worker(
         comparisons,
         failure.active_lease_count,
     );
+    if !failure.allows_restart() {
+        log::error!(
+            target: "kakehashi::tree_worker_shadow",
+            "disabled tree tier because the dead worker hazard snapshot was incomplete",
+        );
+        return false;
+    }
     failure.class = effective_failure_class(failure.class, &initial_quarantine);
     let mut class = failure.class;
 
@@ -3446,15 +3468,15 @@ fn retag_command(command: &mut ShadowCommand, generation: u64) {
 
 fn worker_loss_evidence(client: &Client, error: &std::io::Error) -> WorkerLossEvidence {
     if let Err(drain_error) = client.wait_for_reader_drain(SHADOW_SHUTDOWN_TIMEOUT) {
+        let active_hazards = client.active_grammar_hazards();
+        let active_lease_count = active_hazards.len();
+        let active_grammars = unique_active_grammars(&active_hazards);
         log::error!(
             target: "kakehashi::tree_worker_shadow",
-            "could not obtain a complete worker failure snapshot: {drain_error}",
+            "could not obtain a complete worker failure snapshot; disabling the tree tier with {} currently known grammar(s): {drain_error}",
+            active_grammars.len(),
         );
-        return WorkerLossEvidence {
-            class: FailureClass::Systemic,
-            active_grammars: Vec::new(),
-            active_lease_count: 0,
-        };
+        return WorkerLossEvidence::incomplete(active_grammars, active_lease_count);
     }
     let mut active_hazards = client.active_grammar_hazards();
     active_hazards.sort_unstable_by(|left, right| {
@@ -3500,6 +3522,7 @@ fn worker_loss_evidence(client: &Client, error: &std::io::Error) -> WorkerLossEv
         class,
         active_grammars,
         active_lease_count,
+        snapshot_complete: true,
     }
 }
 
@@ -3894,6 +3917,22 @@ mod tests {
             ),
             FailureClass::NativeEvidenced,
         );
+    }
+
+    #[test]
+    fn incomplete_worker_loss_snapshot_cannot_restart_the_tree_tier() {
+        let evidence = WorkerLossEvidence::incomplete(
+            vec![GrammarIdentity {
+                grammar_symbol: "rust".into(),
+                artifact_digest: "digest-rust".into(),
+            }],
+            2,
+        );
+
+        assert!(!evidence.allows_restart());
+        assert_eq!(evidence.class, FailureClass::Systemic);
+        assert_eq!(evidence.active_grammars.len(), 1);
+        assert_eq!(evidence.active_lease_count, 2);
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -3661,21 +3661,38 @@ fn classify_transport_failure(
     if error.kind() == std::io::ErrorKind::TimedOut {
         return FailureClass::NativeEvidenced;
     }
-    #[cfg(unix)]
+    if !client.was_terminated_by_transport()
+        && client
+            .try_wait()
+            .ok()
+            .flatten()
+            .is_some_and(|status| process_status_is_native_crash(&status))
     {
-        use std::os::unix::process::ExitStatusExt;
-
-        if !client.was_terminated_by_transport()
-            && client
-                .try_wait()
-                .ok()
-                .flatten()
-                .is_some_and(|status| status.signal().is_some())
-        {
-            return FailureClass::NativeEvidenced;
-        }
+        return FailureClass::NativeEvidenced;
     }
     FailureClass::Systemic
+}
+
+#[cfg(unix)]
+fn process_status_is_native_crash(status: &std::process::ExitStatus) -> bool {
+    use std::os::unix::process::ExitStatusExt;
+
+    status.signal().is_some()
+}
+
+#[cfg(windows)]
+fn process_status_is_native_crash(status: &std::process::ExitStatus) -> bool {
+    status.code().is_some_and(windows_exit_code_is_exception)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn process_status_is_native_crash(_status: &std::process::ExitStatus) -> bool {
+    false
+}
+
+#[cfg(any(test, windows))]
+fn windows_exit_code_is_exception(code: i32) -> bool {
+    code.is_negative()
 }
 
 fn command_uri(command: &ShadowCommand) -> Option<&str> {
@@ -4071,6 +4088,12 @@ mod tests {
                 "retryable",
             )));
         }
+    }
+
+    #[test]
+    fn windows_exception_status_is_native_crash_evidence() {
+        assert!(windows_exit_code_is_exception(0xc000_0409_u32 as i32));
+        assert!(!windows_exit_code_is_exception(86));
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -2927,8 +2927,10 @@ fn run_actor(
                     .as_ref()
                     .expect("failed request retains its worker client");
                 let worker_was_terminated = client.was_terminated_for_request_deadline();
-                let worker_transport_is_live =
-                    client.try_wait().is_ok_and(|status| status.is_none());
+                let observed_status = client.try_wait();
+                let worker_transport_is_live = observed_status
+                    .as_ref()
+                    .is_ok_and(|status| status.is_none());
                 if may_continue_after_client_error(
                     &error,
                     worker_was_terminated,
@@ -2958,12 +2960,15 @@ fn run_actor(
                     );
                     continue;
                 }
-                let failure = worker_loss_evidence(
-                    state
-                        .client
-                        .as_ref()
-                        .expect("failed request retains its worker client"),
+                let observed_native_crash = match observed_status.as_ref() {
+                    Ok(Some(status)) => Some(process_status_is_native_crash(status)),
+                    Err(_) => Some(false),
+                    Ok(None) => None,
+                };
+                let failure = worker_loss_evidence_with_observed_status(
+                    client,
                     &error,
+                    observed_native_crash,
                 );
                 log::error!(
                     target: "kakehashi::tree_worker_shadow",
@@ -3622,6 +3627,14 @@ fn retag_command(command: &mut ShadowCommand, generation: u64) {
 }
 
 fn worker_loss_evidence(client: &Client, error: &std::io::Error) -> WorkerLossEvidence {
+    worker_loss_evidence_with_observed_status(client, error, None)
+}
+
+fn worker_loss_evidence_with_observed_status(
+    client: &Client,
+    error: &std::io::Error,
+    observed_native_crash: Option<bool>,
+) -> WorkerLossEvidence {
     if client.was_terminated_for_request_deadline() {
         log::error!(
             target: "kakehashi::tree_worker_shadow",
@@ -3679,7 +3692,12 @@ fn worker_loss_evidence(client: &Client, error: &std::io::Error) -> WorkerLossEv
             leases,
         );
     }
-    let class = classify_transport_failure(client, error, !active_grammars.is_empty());
+    let class = classify_transport_failure(
+        client,
+        error,
+        !active_grammars.is_empty(),
+        observed_native_crash,
+    );
     WorkerLossEvidence {
         class,
         active_grammars,
@@ -3729,19 +3747,33 @@ fn classify_transport_failure(
     client: &Client,
     error: &std::io::Error,
     has_active_hazards: bool,
+    observed_native_crash: Option<bool>,
 ) -> FailureClass {
-    if !has_active_hazards || error.kind() == std::io::ErrorKind::InvalidData {
-        return FailureClass::Systemic;
-    }
-    if error.kind() == std::io::ErrorKind::TimedOut {
-        return FailureClass::NativeEvidenced;
-    }
-    if !client.was_terminated_by_transport()
-        && client
+    let native_crash = observed_native_crash.unwrap_or_else(|| {
+        client
             .try_wait()
             .ok()
             .flatten()
             .is_some_and(|status| process_status_is_native_crash(&status))
+    });
+    classify_transport_observation(
+        error.kind(),
+        has_active_hazards,
+        client.was_terminated_by_transport(),
+        native_crash,
+    )
+}
+
+fn classify_transport_observation(
+    error_kind: std::io::ErrorKind,
+    has_active_hazards: bool,
+    terminated_by_transport: bool,
+    observed_native_crash: bool,
+) -> FailureClass {
+    if has_active_hazards
+        && error_kind != std::io::ErrorKind::InvalidData
+        && !terminated_by_transport
+        && observed_native_crash
     {
         return FailureClass::NativeEvidenced;
     }
@@ -4187,6 +4219,22 @@ mod tests {
             false,
             true,
         ));
+    }
+
+    #[test]
+    fn timeout_exit_is_native_only_with_independent_crash_evidence() {
+        assert_eq!(
+            classify_transport_observation(std::io::ErrorKind::TimedOut, true, false, false,),
+            FailureClass::Systemic,
+        );
+        assert_eq!(
+            classify_transport_observation(std::io::ErrorKind::TimedOut, true, false, true,),
+            FailureClass::NativeEvidenced,
+        );
+        assert_eq!(
+            classify_transport_observation(std::io::ErrorKind::TimedOut, true, true, true,),
+            FailureClass::Systemic,
+        );
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -2906,7 +2906,7 @@ fn run_actor(
                 let worker_was_terminated = state
                     .client
                     .as_ref()
-                    .is_some_and(|client| client.was_terminated_by_transport());
+                    .is_some_and(|client| client.was_terminated_for_request_deadline());
                 if is_nonfatal_client_error(&error) && !worker_was_terminated {
                     log::warn!(
                         target: "kakehashi::tree_worker_shadow",
@@ -3589,6 +3589,13 @@ fn retag_command(command: &mut ShadowCommand, generation: u64) {
 }
 
 fn worker_loss_evidence(client: &Client, error: &std::io::Error) -> WorkerLossEvidence {
+    if client.was_terminated_for_request_deadline() {
+        log::error!(
+            target: "kakehashi::tree_worker_shadow",
+            "worker generation was terminated for a request deadline; treating its loss as systemic",
+        );
+        return WorkerLossEvidence::systemic();
+    }
     if let Err(drain_error) = client.wait_for_reader_drain(SHADOW_SHUTDOWN_TIMEOUT) {
         let active_hazards = client.active_grammar_hazards();
         let active_lease_count = active_hazards.len();
@@ -3599,13 +3606,6 @@ fn worker_loss_evidence(client: &Client, error: &std::io::Error) -> WorkerLossEv
             active_grammars.len(),
         );
         return WorkerLossEvidence::incomplete(active_grammars, active_lease_count);
-    }
-    if client.was_terminated_by_transport() {
-        log::error!(
-            target: "kakehashi::tree_worker_shadow",
-            "worker generation was terminated by the supervisor; treating its loss as systemic",
-        );
-        return WorkerLossEvidence::systemic();
     }
     let mut active_hazards = client.active_grammar_hazards();
     active_hazards.sort_unstable_by(|left, right| {

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -2848,6 +2848,16 @@ fn run_actor(
             }
             Ok(_) => {}
             Err(error) => {
+                if is_nonfatal_client_error(&error) {
+                    log::warn!(
+                        target: "kakehashi::tree_worker_shadow",
+                        "worker request did not complete without transport loss: {error}",
+                    );
+                    if let Some((uri, incarnation)) = command_document {
+                        comparisons.mark_closed(&uri, incarnation);
+                    }
+                    continue;
+                }
                 if is_local_client_error(&error) {
                     log::error!(
                         target: "kakehashi::tree_worker_shadow",
@@ -3575,9 +3585,14 @@ fn worker_loss_evidence(client: &Client, error: &std::io::Error) -> WorkerLossEv
 fn is_local_client_error(error: &std::io::Error) -> bool {
     matches!(
         error.kind(),
-        std::io::ErrorKind::InvalidInput
-            | std::io::ErrorKind::AlreadyExists
-            | std::io::ErrorKind::WouldBlock
+        std::io::ErrorKind::InvalidInput | std::io::ErrorKind::AlreadyExists
+    )
+}
+
+fn is_nonfatal_client_error(error: &std::io::Error) -> bool {
+    matches!(
+        error.kind(),
+        std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
     )
 }
 
@@ -4004,7 +4019,6 @@ mod tests {
         for kind in [
             std::io::ErrorKind::InvalidInput,
             std::io::ErrorKind::AlreadyExists,
-            std::io::ErrorKind::WouldBlock,
         ] {
             assert!(is_local_client_error(&std::io::Error::new(kind, "local")));
         }
@@ -4012,6 +4026,12 @@ mod tests {
             std::io::ErrorKind::BrokenPipe,
             "transport",
         )));
+        for kind in [std::io::ErrorKind::TimedOut, std::io::ErrorKind::WouldBlock] {
+            assert!(is_nonfatal_client_error(&std::io::Error::new(
+                kind,
+                "retryable",
+            )));
+        }
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -497,12 +497,25 @@ impl OpenDocuments {
         });
         if artifact_replaced {
             let incoming = incoming.expect("replacement requires an incoming document");
+            let catalog = self
+                .catalog
+                .as_ref()
+                .filter(|(generation, _)| *generation == incoming.context.configuration_generation)
+                .map(|(_, catalog)| catalog);
             for current in self.current.values_mut() {
-                if current.source_path == incoming.source_path {
-                    current.parser_path.clone_from(&incoming.parser_path);
-                    current
-                        .artifact_digest
-                        .clone_from(&incoming.artifact_digest);
+                if current.source_path == incoming.source_path
+                    && let Some(asset) = catalog.and_then(|catalog| {
+                        catalog.assets.iter().find(|asset| {
+                            asset.language == current.language
+                                && asset.source_path == current.source_path
+                        })
+                    })
+                {
+                    current.grammar_symbol.clone_from(&asset.grammar_symbol);
+                    current.source_path.clone_from(&asset.source_path);
+                    current.parser_path.clone_from(&asset.parser_path);
+                    current.artifact_digest.clone_from(&asset.artifact_digest);
+                    current.queries.clone_from(&asset.queries);
                     current.context.configuration_generation =
                         incoming.context.configuration_generation;
                 }
@@ -4528,10 +4541,30 @@ mod tests {
             }
         );
 
+        let replacement_queries = crate::tree_worker::WorkerQuerySources {
+            highlights: Some("(identifier) @variable".into()),
+            bindings: Some("(identifier) @reference".into()),
+            injections: None,
+        };
+        documents.catalog = Some((
+            4,
+            WorkerLanguageCatalog {
+                assets: vec![crate::tree_worker::WorkerLanguageAsset {
+                    language: "rust".into(),
+                    grammar_symbol: "rust".into(),
+                    source_path: "/parser/rust.so".into(),
+                    parser_path: "/private/sha256-rust-v2.so".into(),
+                    artifact_digest: "sha256:rust-v2".into(),
+                    queries: replacement_queries.clone(),
+                }],
+                ..WorkerLanguageCatalog::default()
+            },
+        ));
         let mut replacement = sync("file:///b.rs", 1, 2, 7);
         replacement.parser_path = "/private/sha256-rust-v2.so".into();
         let replacement_path = replacement.parser_path.clone();
         replacement.artifact_digest = "sha256:rust-v2".into();
+        replacement.queries = replacement_queries.clone();
         replacement.context.configuration_generation = 4;
         assert_eq!(
             documents.observe(&ShadowCommand::Sync(replacement)),
@@ -4544,6 +4577,7 @@ mod tests {
             assert_eq!(document.artifact_digest, "sha256:rust-v2");
             assert_eq!(document.parser_path, replacement_path);
             assert_eq!(document.context.configuration_generation, 4);
+            assert_eq!(document.queries, replacement_queries);
         }
 
         let mut alias = sync("file:///c.rs", 1, 1, 7);

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -339,6 +339,19 @@ struct ResyncFailure {
     class: FailureClass,
     active_grammars: Vec<GrammarIdentity>,
     active_lease_count: usize,
+    snapshot_complete: bool,
+}
+
+impl ResyncFailure {
+    fn from_worker_loss(error: std::io::Error, failure: WorkerLossEvidence) -> Self {
+        Self {
+            error,
+            class: failure.class,
+            active_grammars: failure.active_grammars,
+            active_lease_count: failure.active_lease_count,
+            snapshot_complete: failure.snapshot_complete,
+        }
+    }
 }
 
 struct WorkerLossEvidence {
@@ -3276,18 +3289,22 @@ fn recover_worker(
             }
             Err(failure) => {
                 state.client = Some(Arc::new(replacement));
-                let quarantine = quarantine_grammars(
-                    state,
-                    failure.active_grammars,
-                    failure.class,
-                    comparisons,
-                    failure.active_lease_count,
-                );
-                class = effective_failure_class(failure.class, &quarantine);
+                let error = failure.error;
+                let evidence = WorkerLossEvidence {
+                    class: failure.class,
+                    active_grammars: failure.active_grammars,
+                    active_lease_count: failure.active_lease_count,
+                    snapshot_complete: failure.snapshot_complete,
+                };
+                let Some(next_class) = apply_worker_loss_evidence(state, evidence, comparisons)
+                else {
+                    return false;
+                };
+                class = next_class;
                 log::error!(
                     target: "kakehashi::tree_worker_shadow",
                     "worker generation {generation} full resync failed: {}",
-                    failure.error,
+                    error,
                 );
                 if mode == RecoveryMode::HalfOpen {
                     return false;
@@ -3442,16 +3459,12 @@ fn resync_open_documents(
                     class: FailureClass::Systemic,
                     active_grammars: Vec::new(),
                     active_lease_count: 0,
+                    snapshot_complete: true,
                 });
             }
             Err(error) => {
                 let failure = worker_loss_evidence(client, &error);
-                return Err(ResyncFailure {
-                    error,
-                    class: failure.class,
-                    active_grammars: failure.active_grammars,
-                    active_lease_count: failure.active_lease_count,
-                });
+                return Err(ResyncFailure::from_worker_loss(error, failure));
             }
         }
     }
@@ -3501,6 +3514,7 @@ fn resync_open_documents(
                     class: FailureClass::Systemic,
                     active_grammars: Vec::new(),
                     active_lease_count: 0,
+                    snapshot_complete: true,
                 });
             }
             Ok(Response::Error(error)) => {
@@ -3519,16 +3533,12 @@ fn resync_open_documents(
                     class: FailureClass::Systemic,
                     active_grammars: Vec::new(),
                     active_lease_count: 0,
+                    snapshot_complete: true,
                 });
             }
             Err(error) => {
                 let failure = worker_loss_evidence(client, &error);
-                return Err(ResyncFailure {
-                    error,
-                    class: failure.class,
-                    active_grammars: failure.active_grammars,
-                    active_lease_count: failure.active_lease_count,
-                });
+                return Err(ResyncFailure::from_worker_loss(error, failure));
             }
         }
     }
@@ -4068,6 +4078,16 @@ mod tests {
         assert_eq!(evidence.class, FailureClass::Systemic);
         assert_eq!(evidence.active_grammars.len(), 1);
         assert_eq!(evidence.active_lease_count, 2);
+    }
+
+    #[test]
+    fn resync_failure_preserves_incomplete_worker_snapshot() {
+        let failure = ResyncFailure::from_worker_loss(
+            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "lost"),
+            WorkerLossEvidence::incomplete(Vec::new(), 0),
+        );
+
+        assert!(!failure.snapshot_complete);
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -1087,14 +1087,33 @@ impl TreeWorkerShadow {
             .await?;
         let expected = context.clone();
         let started = Instant::now();
-        let mut cancellation =
-            WorkerRequestCancellation::new(Arc::clone(&client), context.request_id);
-        let response = tokio::task::spawn_blocking(move || {
-            client.derive_semantic_tokens(DeriveSemanticTokens {
+        let pending = client
+            .begin_derive_semantic_tokens(DeriveSemanticTokens {
                 context,
                 supports_multiline,
             })
-        });
+            .ok()?;
+        let mut cancellation =
+            WorkerRequestCancellation::new(Arc::clone(&client), expected.request_id);
+        #[cfg(feature = "e2e")]
+        if std::env::var("KAKEHASHI_TREE_WORKER_RESPONSE_WAITER_DELAY_URI_SUFFIX")
+            .ok()
+            .is_some_and(|suffix| expected.uri.ends_with(&suffix))
+        {
+            if let Ok(path) =
+                std::env::var("KAKEHASHI_TREE_WORKER_RESPONSE_WAITER_DELAY_STARTED_FILE")
+            {
+                let _ = std::fs::write(path, b"started");
+            }
+            if let Ok(milliseconds) =
+                std::env::var("KAKEHASHI_TREE_WORKER_RESPONSE_WAITER_DELAY_MS")
+                    .unwrap_or_default()
+                    .parse::<u64>()
+            {
+                tokio::time::sleep(Duration::from_millis(milliseconds)).await;
+            }
+        }
+        let response = tokio::task::spawn_blocking(move || client.wait_for_response(pending));
         let response = if let Some(supersede) = supersede {
             tokio::select! {
                 biased;

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -512,7 +512,6 @@ impl OpenDocuments {
                     })
                 {
                     current.grammar_symbol.clone_from(&asset.grammar_symbol);
-                    current.source_path.clone_from(&asset.source_path);
                     current.parser_path.clone_from(&asset.parser_path);
                     current.artifact_digest.clone_from(&asset.artifact_digest);
                     current.queries.clone_from(&asset.queries);

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -3086,7 +3086,14 @@ fn quiesce_published_client(state: &mut SupervisorState) -> std::io::Result<()> 
         .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotConnected, "worker is absent"))?;
     client.close_request_admission()?;
     state.read_client.store(None);
-    client.wait_for_idle_generation(SHADOW_SHUTDOWN_TIMEOUT)
+    if let Err(error) = client.wait_for_idle_generation(SHADOW_SHUTDOWN_TIMEOUT) {
+        log::warn!(
+            target: "kakehashi::tree_worker_shadow",
+            "forcibly retiring non-quiescent worker generation during restart: {error}",
+        );
+        client.terminate_shared(SHADOW_SHUTDOWN_TIMEOUT);
+    }
+    Ok(())
 }
 
 fn mark_tree_tier_unavailable(

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -2730,6 +2730,18 @@ fn run_actor(
                 );
                 continue;
             }
+            if let Err(error) = quiesce_published_client(&mut state) {
+                log::error!(
+                    target: "kakehashi::tree_worker_shadow",
+                    "disabled tree tier because planned restart could not quiesce: {error}",
+                );
+                mark_tree_tier_unavailable(
+                    &mut state,
+                    &disabled,
+                    &pending_configuration_generation,
+                );
+                continue;
+            }
             if !recover_worker(
                 &mut state,
                 &executable,
@@ -2818,16 +2830,34 @@ fn run_actor(
                     state.worker_generation,
                     required.reason
                 );
-                if matches!(state.breaker, BreakerState::HalfOpen { .. })
-                    || !recover_worker(
+                if matches!(state.breaker, BreakerState::HalfOpen { .. }) {
+                    mark_tree_tier_unavailable(
                         &mut state,
-                        &executable,
-                        compute_threads,
-                        WorkerLossEvidence::systemic(),
-                        &comparisons,
-                        RecoveryMode::Normal,
-                    )
-                {
+                        &disabled,
+                        &pending_configuration_generation,
+                    );
+                    continue;
+                }
+                if let Err(error) = quiesce_published_client(&mut state) {
+                    log::error!(
+                        target: "kakehashi::tree_worker_shadow",
+                        "disabled tree tier because worker-requested restart could not quiesce: {error}",
+                    );
+                    mark_tree_tier_unavailable(
+                        &mut state,
+                        &disabled,
+                        &pending_configuration_generation,
+                    );
+                    continue;
+                }
+                if !recover_worker(
+                    &mut state,
+                    &executable,
+                    compute_threads,
+                    WorkerLossEvidence::systemic(),
+                    &comparisons,
+                    RecoveryMode::Normal,
+                ) {
                     mark_tree_tier_unavailable(
                         &mut state,
                         &disabled,
@@ -3018,6 +3048,15 @@ fn retire_client(state: &mut SupervisorState) -> std::io::Result<()> {
             Ok(())
         }
     }
+}
+
+fn quiesce_published_client(state: &mut SupervisorState) -> std::io::Result<()> {
+    state.read_client.store(None);
+    state
+        .client
+        .as_ref()
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotConnected, "worker is absent"))?
+        .wait_for_idle_generation(SHADOW_SHUTDOWN_TIMEOUT)
 }
 
 fn mark_tree_tier_unavailable(

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -2736,6 +2736,12 @@ fn run_actor(
                 "performing planned worker restart for parser artifact replacement",
             );
             if matches!(state.breaker, BreakerState::HalfOpen { .. }) {
+                if let Err(error) = quiesce_published_client(&mut state) {
+                    log::error!(
+                        target: "kakehashi::tree_worker_shadow",
+                        "half-open planned restart could not quiesce before disabling: {error}",
+                    );
+                }
                 mark_tree_tier_unavailable(
                     &mut state,
                     &disabled,
@@ -2844,6 +2850,12 @@ fn run_actor(
                     required.reason
                 );
                 if matches!(state.breaker, BreakerState::HalfOpen { .. }) {
+                    if let Err(error) = quiesce_published_client(&mut state) {
+                        log::error!(
+                            target: "kakehashi::tree_worker_shadow",
+                            "half-open worker-requested restart could not quiesce before disabling: {error}",
+                        );
+                    }
                     mark_tree_tier_unavailable(
                         &mut state,
                         &disabled,
@@ -3064,12 +3076,13 @@ fn retire_client(state: &mut SupervisorState) -> std::io::Result<()> {
 }
 
 fn quiesce_published_client(state: &mut SupervisorState) -> std::io::Result<()> {
-    state.read_client.store(None);
-    state
+    let client = state
         .client
         .as_ref()
-        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotConnected, "worker is absent"))?
-        .wait_for_idle_generation(SHADOW_SHUTDOWN_TIMEOUT)
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotConnected, "worker is absent"))?;
+    client.close_request_admission()?;
+    state.read_client.store(None);
+    client.wait_for_idle_generation(SHADOW_SHUTDOWN_TIMEOUT)
 }
 
 fn mark_tree_tier_unavailable(

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -123,7 +123,7 @@ impl ReplicaIdentity {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct GrammarIdentity {
     grammar_symbol: String,
     artifact_digest: String,
@@ -337,7 +337,30 @@ struct ResyncStats {
 struct ResyncFailure {
     error: std::io::Error,
     class: FailureClass,
-    implicated_grammar: Option<GrammarIdentity>,
+    active_grammars: Vec<GrammarIdentity>,
+    active_lease_count: usize,
+}
+
+struct WorkerLossEvidence {
+    class: FailureClass,
+    active_grammars: Vec<GrammarIdentity>,
+    active_lease_count: usize,
+}
+
+impl WorkerLossEvidence {
+    fn systemic() -> Self {
+        Self {
+            class: FailureClass::Systemic,
+            active_grammars: Vec::new(),
+            active_lease_count: 0,
+        }
+    }
+}
+
+#[derive(Default)]
+struct QuarantineBatch {
+    newly_quarantined: usize,
+    already_quarantined: usize,
 }
 
 impl OpenDocuments {
@@ -2514,8 +2537,7 @@ fn run_actor(
             &mut state,
             &executable,
             compute_threads,
-            FailureClass::Systemic,
-            None,
+            WorkerLossEvidence::systemic(),
             &comparisons,
             RecoveryMode::Normal,
         )
@@ -2541,8 +2563,7 @@ fn run_actor(
                     &mut state,
                     &executable,
                     compute_threads,
-                    FailureClass::Systemic,
-                    None,
+                    WorkerLossEvidence::systemic(),
                     &comparisons,
                     RecoveryMode::HalfOpen,
                 ) {
@@ -2589,31 +2610,40 @@ fn run_actor(
                     continue;
                 };
                 let status = client.try_wait();
-                match status {
+                let loss_error = match status {
                     Ok(None) => {
                         if !disabled.load(Ordering::Acquire) {
                             observe_healthy_service(&mut state, Instant::now());
                         }
                         continue;
                     }
-                    Ok(Some(status)) => log::error!(
-                        target: "kakehashi::tree_worker_shadow",
-                        "worker generation {} exited while idle: {status}",
-                        state.worker_generation,
-                    ),
-                    Err(error) => log::error!(
-                        target: "kakehashi::tree_worker_shadow",
-                        "worker generation {} liveness check failed: {error}",
-                        state.worker_generation,
-                    ),
-                }
+                    Ok(Some(status)) => {
+                        log::error!(
+                            target: "kakehashi::tree_worker_shadow",
+                            "worker generation {} exited while idle: {status}",
+                            state.worker_generation,
+                        );
+                        std::io::Error::new(
+                            std::io::ErrorKind::UnexpectedEof,
+                            format!("tree worker exited while idle: {status}"),
+                        )
+                    }
+                    Err(error) => {
+                        log::error!(
+                            target: "kakehashi::tree_worker_shadow",
+                            "worker generation {} liveness check failed: {error}",
+                            state.worker_generation,
+                        );
+                        error
+                    }
+                };
+                let failure = worker_loss_evidence(client, &loss_error);
                 if matches!(state.breaker, BreakerState::HalfOpen { .. })
                     || !recover_worker(
                         &mut state,
                         &executable,
                         compute_threads,
-                        FailureClass::Systemic,
-                        None,
+                        failure,
                         &comparisons,
                         RecoveryMode::Normal,
                     )
@@ -2682,8 +2712,7 @@ fn run_actor(
                 &mut state,
                 &executable,
                 compute_threads,
-                FailureClass::Systemic,
-                None,
+                WorkerLossEvidence::systemic(),
                 &comparisons,
                 RecoveryMode::Planned,
             ) {
@@ -2772,8 +2801,7 @@ fn run_actor(
                         &mut state,
                         &executable,
                         compute_threads,
-                        FailureClass::Systemic,
-                        None,
+                        WorkerLossEvidence::systemic(),
                         &comparisons,
                         RecoveryMode::Normal,
                     )
@@ -2798,43 +2826,12 @@ fn run_actor(
             }
             Ok(_) => {}
             Err(error) => {
-                let acknowledged_hazards = state
-                    .client
-                    .as_ref()
-                    .expect("failed request retains its worker client")
-                    .active_grammar_hazards();
-                if !acknowledged_hazards.is_empty() {
-                    log::error!(
-                        target: "kakehashi::tree_worker_shadow",
-                        "worker generation {} failed with {} acknowledged active grammar hazard(s): {}",
-                        state.worker_generation,
-                        acknowledged_hazards.len(),
-                        acknowledged_hazards
-                            .iter()
-                            .map(|hazard| format!(
-                                "lease={} request={} symbol={} artifact_digest={}",
-                                hazard.lease_id,
-                                hazard.context.request_id,
-                                hazard.grammar.grammar_symbol,
-                                hazard.grammar.artifact_digest,
-                            ))
-                            .collect::<Vec<_>>()
-                            .join(", "),
-                    );
-                }
-                let acknowledged_grammar =
-                    acknowledged_hazards.first().map(|hazard| GrammarIdentity {
-                        grammar_symbol: hazard.grammar.grammar_symbol.clone(),
-                        artifact_digest: hazard.grammar.artifact_digest.clone(),
-                    });
-                let implicated_grammar = acknowledged_grammar.or(implicated_grammar);
-                let class = classify_transport_failure(
+                let failure = worker_loss_evidence(
                     state
                         .client
                         .as_ref()
                         .expect("failed request retains its worker client"),
                     &error,
-                    implicated_grammar.as_ref(),
                 );
                 log::error!(
                     target: "kakehashi::tree_worker_shadow",
@@ -2846,8 +2843,7 @@ fn run_actor(
                         &mut state,
                         &executable,
                         compute_threads,
-                        class,
-                        implicated_grammar,
+                        failure,
                         &comparisons,
                         RecoveryMode::Normal,
                     )
@@ -2921,9 +2917,13 @@ fn finish_half_open_recovery(
         comparisons,
     );
     if let Err(failure) = result {
-        if let Some(grammar) = failure.implicated_grammar {
-            quarantine_grammar(state, grammar, failure.class, comparisons);
-        }
+        let _ = quarantine_grammars(
+            state,
+            failure.active_grammars,
+            failure.class,
+            comparisons,
+            failure.active_lease_count,
+        );
         log::error!(
             target: "kakehashi::tree_worker_shadow",
             "half-open registry reconciliation failed: {}",
@@ -3091,15 +3091,20 @@ fn recover_worker(
     state: &mut SupervisorState,
     executable: &std::path::Path,
     compute_threads: usize,
-    mut class: FailureClass,
-    implicated_grammar: Option<GrammarIdentity>,
+    mut failure: WorkerLossEvidence,
     comparisons: &ComparisonStore,
     mode: RecoveryMode,
 ) -> bool {
     let recovery_started = Instant::now();
-    if let Some(grammar) = implicated_grammar {
-        quarantine_grammar(state, grammar, class, comparisons);
-    }
+    let initial_quarantine = quarantine_grammars(
+        state,
+        std::mem::take(&mut failure.active_grammars),
+        failure.class,
+        comparisons,
+        failure.active_lease_count,
+    );
+    failure.class = effective_failure_class(failure.class, &initial_quarantine);
+    let mut class = failure.class;
 
     let mut first_attempt = true;
     loop {
@@ -3176,19 +3181,27 @@ fn recover_worker(
                     resynced.bytes,
                     recovery_started.elapsed().as_millis(),
                 );
+                #[cfg(feature = "e2e")]
+                if let Ok(path) = std::env::var("KAKEHASHI_TREE_WORKER_RECOVERY_READY_FILE") {
+                    let _ = std::fs::write(path, b"ready");
+                }
                 return true;
             }
             Err(failure) => {
                 state.client = Some(Arc::new(replacement));
-                if let Some(grammar) = failure.implicated_grammar {
-                    quarantine_grammar(state, grammar, failure.class, comparisons);
-                }
+                let quarantine = quarantine_grammars(
+                    state,
+                    failure.active_grammars,
+                    failure.class,
+                    comparisons,
+                    failure.active_lease_count,
+                );
+                class = effective_failure_class(failure.class, &quarantine);
                 log::error!(
                     target: "kakehashi::tree_worker_shadow",
                     "worker generation {generation} full resync failed: {}",
                     failure.error,
                 );
-                class = failure.class;
                 if mode == RecoveryMode::HalfOpen {
                     return false;
                 }
@@ -3198,31 +3211,65 @@ fn recover_worker(
     }
 }
 
-fn quarantine_grammar(
+fn quarantine_grammars(
     state: &mut SupervisorState,
-    grammar: GrammarIdentity,
+    mut grammars: Vec<GrammarIdentity>,
     class: FailureClass,
     comparisons: &ComparisonStore,
-) {
-    if !state.quarantined.insert(grammar.clone()) {
-        return;
-    }
-    let open_documents = state
-        .open_documents
-        .lock()
-        .recover_poison("quarantine_grammar(open documents)");
-    for request in open_documents.current.values() {
-        if GrammarIdentity::from_sync(request) == grammar {
-            comparisons.mark_closed(&request.context.uri, request.context.incarnation);
+    active_lease_count: usize,
+) -> QuarantineBatch {
+    grammars.sort_unstable();
+    grammars.dedup();
+    let mut batch = QuarantineBatch::default();
+    let mut newly_quarantined = Vec::new();
+    for grammar in grammars {
+        if state.quarantined.insert(grammar.clone()) {
+            newly_quarantined.push(grammar);
+            batch.newly_quarantined += 1;
+        } else {
+            batch.already_quarantined += 1;
         }
+    }
+    if !newly_quarantined.is_empty() {
+        let newly_quarantined_set = newly_quarantined.iter().cloned().collect::<HashSet<_>>();
+        let open_documents = state
+            .open_documents
+            .lock()
+            .recover_poison("quarantine_grammars(open documents)");
+        for request in open_documents.current.values() {
+            if newly_quarantined_set.contains(&GrammarIdentity::from_sync(request)) {
+                comparisons.mark_closed(&request.context.uri, request.context.incarnation);
+            }
+        }
+        drop(open_documents);
+    }
+    for grammar in &newly_quarantined {
+        log::error!(
+            target: "kakehashi::tree_worker_shadow",
+            "quarantined grammar conservatively for this session after {:?} worker loss: symbol={} artifact_digest={}",
+            class,
+            grammar.grammar_symbol,
+            grammar.artifact_digest,
+        );
     }
     log::error!(
         target: "kakehashi::tree_worker_shadow",
-        "quarantined grammar conservatively for this session after {:?} worker loss: symbol={} artifact_digest={}",
+        "worker loss quarantine summary active_leases={} unique_grammars={} newly_quarantined={} already_quarantined={} class={:?}",
+        active_lease_count,
+        batch.newly_quarantined + batch.already_quarantined,
+        batch.newly_quarantined,
+        batch.already_quarantined,
         class,
-        grammar.grammar_symbol,
-        grammar.artifact_digest,
     );
+    batch
+}
+
+fn effective_failure_class(class: FailureClass, quarantine: &QuarantineBatch) -> FailureClass {
+    if quarantine.already_quarantined > 0 {
+        FailureClass::Systemic
+    } else {
+        class
+    }
 }
 
 fn resync_open_documents(
@@ -3276,17 +3323,17 @@ fn resync_open_documents(
                         "unexpected reconciliation close response: {response:?}"
                     )),
                     class: FailureClass::Systemic,
-                    implicated_grammar: None,
+                    active_grammars: Vec::new(),
+                    active_lease_count: 0,
                 });
             }
             Err(error) => {
+                let failure = worker_loss_evidence(client, &error);
                 return Err(ResyncFailure {
                     error,
-                    class: FailureClass::Systemic,
-                    implicated_grammar: Some(GrammarIdentity {
-                        grammar_symbol: identity.grammar_symbol,
-                        artifact_digest: identity.artifact_digest,
-                    }),
+                    class: failure.class,
+                    active_grammars: failure.active_grammars,
+                    active_lease_count: failure.active_lease_count,
                 });
             }
         }
@@ -3335,7 +3382,8 @@ fn resync_open_documents(
                 return Err(ResyncFailure {
                     error: std::io::Error::other(required.reason),
                     class: FailureClass::Systemic,
-                    implicated_grammar: None,
+                    active_grammars: Vec::new(),
+                    active_lease_count: 0,
                 });
             }
             Ok(Response::Error(error)) => {
@@ -3352,15 +3400,17 @@ fn resync_open_documents(
                         "unexpected resync response: {response:?}"
                     )),
                     class: FailureClass::Systemic,
-                    implicated_grammar: None,
+                    active_grammars: Vec::new(),
+                    active_lease_count: 0,
                 });
             }
             Err(error) => {
-                let class = classify_transport_failure(client, &error, Some(&grammar));
+                let failure = worker_loss_evidence(client, &error);
                 return Err(ResyncFailure {
                     error,
-                    class,
-                    implicated_grammar: Some(grammar),
+                    class: failure.class,
+                    active_grammars: failure.active_grammars,
+                    active_lease_count: failure.active_lease_count,
                 });
             }
         }
@@ -3394,12 +3444,86 @@ fn retag_command(command: &mut ShadowCommand, generation: u64) {
     }
 }
 
+fn worker_loss_evidence(client: &Client, error: &std::io::Error) -> WorkerLossEvidence {
+    if let Err(drain_error) = client.wait_for_reader_drain(SHADOW_SHUTDOWN_TIMEOUT) {
+        log::error!(
+            target: "kakehashi::tree_worker_shadow",
+            "could not obtain a complete worker failure snapshot: {drain_error}",
+        );
+        return WorkerLossEvidence {
+            class: FailureClass::Systemic,
+            active_grammars: Vec::new(),
+            active_lease_count: 0,
+        };
+    }
+    let mut active_hazards = client.active_grammar_hazards();
+    active_hazards.sort_unstable_by(|left, right| {
+        (
+            &left.grammar.grammar_symbol,
+            &left.grammar.artifact_digest,
+            left.lease_id,
+            left.context.request_id,
+        )
+            .cmp(&(
+                &right.grammar.grammar_symbol,
+                &right.grammar.artifact_digest,
+                right.lease_id,
+                right.context.request_id,
+            ))
+    });
+    let active_lease_count = active_hazards.len();
+    let active_grammars = unique_active_grammars(&active_hazards);
+    if !active_hazards.is_empty() {
+        let leases = active_hazards
+            .iter()
+            .map(|hazard| {
+                format!(
+                    "{}@{}:lease={}:request={}",
+                    hazard.grammar.grammar_symbol,
+                    hazard.grammar.artifact_digest,
+                    hazard.lease_id,
+                    hazard.context.request_id,
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        log::error!(
+            target: "kakehashi::tree_worker_shadow",
+            "worker loss snapshot committed active grammar hazard(s): active_leases={} unique_grammars={} leases=[{}]",
+            active_lease_count,
+            active_grammars.len(),
+            leases,
+        );
+    }
+    let class = classify_transport_failure(client, error, !active_grammars.is_empty());
+    WorkerLossEvidence {
+        class,
+        active_grammars,
+        active_lease_count,
+    }
+}
+
+fn unique_active_grammars(
+    active_hazards: &[crate::tree_worker::GrammarHazardArmed],
+) -> Vec<GrammarIdentity> {
+    let mut active_grammars = active_hazards
+        .iter()
+        .map(|hazard| GrammarIdentity {
+            grammar_symbol: hazard.grammar.grammar_symbol.clone(),
+            artifact_digest: hazard.grammar.artifact_digest.clone(),
+        })
+        .collect::<Vec<_>>();
+    active_grammars.sort_unstable();
+    active_grammars.dedup();
+    active_grammars
+}
+
 fn classify_transport_failure(
     client: &Client,
     error: &std::io::Error,
-    implicated_grammar: Option<&GrammarIdentity>,
+    has_active_hazards: bool,
 ) -> FailureClass {
-    if implicated_grammar.is_none() {
+    if !has_active_hazards || error.kind() == std::io::ErrorKind::InvalidData {
         return FailureClass::Systemic;
     }
     if error.kind() == std::io::ErrorKind::TimedOut {
@@ -3663,6 +3787,29 @@ fn sync_and_derive(client: &Client, request: SyncDocument) -> std::io::Result<Re
 mod tests {
     use super::*;
 
+    fn active_hazard(
+        lease_id: u64,
+        request_id: u64,
+        grammar_symbol: &str,
+        artifact_digest: &str,
+    ) -> crate::tree_worker::GrammarHazardArmed {
+        crate::tree_worker::GrammarHazardArmed {
+            lease_id,
+            context: RequestContext {
+                request_id,
+                worker_generation: 7,
+                uri: format!("file:///{grammar_symbol}-{request_id}"),
+                incarnation: 1,
+                content_version: 1,
+                configuration_generation: 1,
+            },
+            grammar: crate::tree_worker::WorkerGrammarIdentity {
+                grammar_symbol: grammar_symbol.into(),
+                artifact_digest: artifact_digest.into(),
+            },
+        }
+    }
+
     fn shadow(sender: mpsc::SyncSender<ShadowCommand>) -> TreeWorkerShadow {
         TreeWorkerShadow {
             mode: TreeWorkerMode::Shadow,
@@ -3699,6 +3846,54 @@ mod tests {
         );
         assert!(should_derive_edit_snapshot(TreeWorkerMode::Shadow));
         assert!(!should_derive_edit_snapshot(TreeWorkerMode::Authoritative));
+    }
+
+    #[test]
+    fn active_hazard_snapshot_is_a_sorted_unique_grammar_set() {
+        let hazards = vec![
+            active_hazard(3, 30, "rust", "digest-b"),
+            active_hazard(1, 10, "lua", "digest-a"),
+            active_hazard(2, 20, "rust", "digest-b"),
+        ];
+
+        assert_eq!(
+            unique_active_grammars(&hazards),
+            vec![
+                GrammarIdentity {
+                    grammar_symbol: "lua".into(),
+                    artifact_digest: "digest-a".into(),
+                },
+                GrammarIdentity {
+                    grammar_symbol: "rust".into(),
+                    artifact_digest: "digest-b".into(),
+                },
+            ]
+        );
+        assert!(unique_active_grammars(&[]).is_empty());
+    }
+
+    #[test]
+    fn already_quarantined_hazard_escalates_worker_loss_to_systemic() {
+        assert_eq!(
+            effective_failure_class(
+                FailureClass::NativeEvidenced,
+                &QuarantineBatch {
+                    newly_quarantined: 0,
+                    already_quarantined: 1,
+                },
+            ),
+            FailureClass::Systemic,
+        );
+        assert_eq!(
+            effective_failure_class(
+                FailureClass::NativeEvidenced,
+                &QuarantineBatch {
+                    newly_quarantined: 2,
+                    already_quarantined: 0,
+                },
+            ),
+            FailureClass::NativeEvidenced,
+        );
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -3768,24 +3768,17 @@ fn classify_transport_failure(
             .flatten()
             .is_some_and(|status| process_status_is_native_crash(&status))
     });
-    classify_transport_observation(
-        error.kind(),
-        has_active_hazards,
-        client.was_terminated_by_transport(),
-        native_crash,
-    )
+    // Cleanup uses SIGKILL or exit code 1, neither of which is classified as a
+    // native crash, so a positive status remains independent crash evidence.
+    classify_transport_observation(error.kind(), has_active_hazards, native_crash)
 }
 
 fn classify_transport_observation(
     error_kind: std::io::ErrorKind,
     has_active_hazards: bool,
-    terminated_by_transport: bool,
     observed_native_crash: bool,
 ) -> FailureClass {
-    if has_active_hazards
-        && error_kind != std::io::ErrorKind::InvalidData
-        && !terminated_by_transport
-        && observed_native_crash
+    if has_active_hazards && error_kind != std::io::ErrorKind::InvalidData && observed_native_crash
     {
         return FailureClass::NativeEvidenced;
     }
@@ -4258,17 +4251,21 @@ mod tests {
     }
 
     #[test]
-    fn timeout_exit_is_native_only_with_independent_crash_evidence() {
+    fn native_crash_status_is_independent_evidence() {
         assert_eq!(
-            classify_transport_observation(std::io::ErrorKind::TimedOut, true, false, false,),
+            classify_transport_observation(std::io::ErrorKind::TimedOut, true, false,),
             FailureClass::Systemic,
         );
         assert_eq!(
-            classify_transport_observation(std::io::ErrorKind::TimedOut, true, false, true,),
+            classify_transport_observation(std::io::ErrorKind::TimedOut, true, true,),
             FailureClass::NativeEvidenced,
         );
         assert_eq!(
-            classify_transport_observation(std::io::ErrorKind::TimedOut, true, true, true,),
+            classify_transport_observation(std::io::ErrorKind::InvalidData, true, true,),
+            FailureClass::Systemic,
+        );
+        assert_eq!(
+            classify_transport_observation(std::io::ErrorKind::TimedOut, false, true,),
             FailureClass::Systemic,
         );
     }

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -2841,6 +2841,21 @@ fn run_actor(
             }
             Ok(_) => {}
             Err(error) => {
+                if is_local_client_error(&error) {
+                    log::error!(
+                        target: "kakehashi::tree_worker_shadow",
+                        "disabled tree tier after local worker request admission failure: {error}",
+                    );
+                    if let Some((uri, incarnation)) = command_document {
+                        comparisons.mark_closed(&uri, incarnation);
+                    }
+                    mark_tree_tier_unavailable(
+                        &mut state,
+                        &disabled,
+                        &pending_configuration_generation,
+                    );
+                    continue;
+                }
                 let failure = worker_loss_evidence(
                     state
                         .client
@@ -3526,6 +3541,15 @@ fn worker_loss_evidence(client: &Client, error: &std::io::Error) -> WorkerLossEv
     }
 }
 
+fn is_local_client_error(error: &std::io::Error) -> bool {
+    matches!(
+        error.kind(),
+        std::io::ErrorKind::InvalidInput
+            | std::io::ErrorKind::AlreadyExists
+            | std::io::ErrorKind::WouldBlock
+    )
+}
+
 fn unique_active_grammars(
     active_hazards: &[crate::tree_worker::GrammarHazardArmed],
 ) -> Vec<GrammarIdentity> {
@@ -3933,6 +3957,21 @@ mod tests {
         assert_eq!(evidence.class, FailureClass::Systemic);
         assert_eq!(evidence.active_grammars.len(), 1);
         assert_eq!(evidence.active_lease_count, 2);
+    }
+
+    #[test]
+    fn local_admission_errors_are_not_worker_loss() {
+        for kind in [
+            std::io::ErrorKind::InvalidInput,
+            std::io::ErrorKind::AlreadyExists,
+            std::io::ErrorKind::WouldBlock,
+        ] {
+            assert!(is_local_client_error(&std::io::Error::new(kind, "local")));
+        }
+        assert!(!is_local_client_error(&std::io::Error::new(
+            std::io::ErrorKind::BrokenPipe,
+            "transport",
+        )));
     }
 
     #[test]

--- a/src/lsp/lsp_impl/tree_worker_shadow.rs
+++ b/src/lsp/lsp_impl/tree_worker_shadow.rs
@@ -2903,7 +2903,11 @@ fn run_actor(
             }
             Ok(_) => {}
             Err(error) => {
-                if is_nonfatal_client_error(&error) {
+                let worker_was_terminated = state
+                    .client
+                    .as_ref()
+                    .is_some_and(|client| client.was_terminated_by_transport());
+                if is_nonfatal_client_error(&error) && !worker_was_terminated {
                     log::warn!(
                         target: "kakehashi::tree_worker_shadow",
                         "worker request did not complete without transport loss: {error}",
@@ -3595,6 +3599,13 @@ fn worker_loss_evidence(client: &Client, error: &std::io::Error) -> WorkerLossEv
             active_grammars.len(),
         );
         return WorkerLossEvidence::incomplete(active_grammars, active_lease_count);
+    }
+    if client.was_terminated_by_transport() {
+        log::error!(
+            target: "kakehashi::tree_worker_shadow",
+            "worker generation was terminated by the supervisor; treating its loss as systemic",
+        );
+        return WorkerLossEvidence::systemic();
     }
     let mut active_hazards = client.active_grammar_hazards();
     active_hazards.sort_unstable_by(|left, right| {

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -5338,6 +5338,34 @@ impl Client {
         }
     }
 
+    pub fn wait_for_idle_generation(&self, timeout: Duration) -> io::Result<()> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let active_routes = self
+                .routes
+                .lock()
+                .map_err(|_| io::Error::other("worker response router is poisoned"))?
+                .len();
+            let active_hazards = self
+                .active_grammar_hazards
+                .lock()
+                .map_err(|_| io::Error::other("worker grammar hazard ledger is poisoned"))?
+                .len();
+            if client_generation_is_idle(active_routes, active_hazards) {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!(
+                        "worker generation did not quiesce (routes={active_routes} hazards={active_hazards})"
+                    ),
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(1));
+        }
+    }
+
     /// Idempotently cancel queued or cooperatively running work in this worker
     /// generation. The original request route remains until its terminal
     /// response arrives.
@@ -5623,6 +5651,10 @@ fn route_is_admissible(active: usize, max_inflight: usize, uses_supervisor_reser
     active < max_inflight.saturating_add(usize::from(uses_supervisor_reserve))
 }
 
+fn client_generation_is_idle(active_routes: usize, active_hazards: usize) -> bool {
+    active_routes == 0 && active_hazards == 0
+}
+
 fn failed_spawn(
     child: Arc<Mutex<OwnedChild>>,
     stdin: ChildStdin,
@@ -5814,8 +5846,8 @@ mod tests {
         ResolveNode, Response, Route, RunCaptures, RunNodeScalar, RunnableDocuments,
         SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES, SyncDocument, WireByteRange, WirePosition,
         WireRange, WireSemanticToken, WorkPriority, WorkerError, WorkerGrammarIdentity,
-        WorkerQuerySources, cache_eviction_plan, close_document, decode_frame,
-        derive_snapshot_with_language, encode_frame, enforce_derived_memory_budget,
+        WorkerQuerySources, cache_eviction_plan, client_generation_is_idle, close_document,
+        decode_frame, derive_snapshot_with_language, encode_frame, enforce_derived_memory_budget,
         named_node_count, parse_request_timeout, pressure_checkpoint_required,
         replace_retained_bytes, replace_retained_estimated_bytes, request_may_grow_derived_state,
         request_priority, reserve_retained_growth, route_is_admissible, route_response, run,
@@ -6140,6 +6172,13 @@ mod tests {
         assert!(!route_is_admissible(16, 16, false));
         assert!(route_is_admissible(16, 16, true));
         assert!(!route_is_admissible(17, 16, true));
+    }
+
+    #[test]
+    fn cooperative_restart_requires_routes_and_hazards_to_drain() {
+        assert!(client_generation_is_idle(0, 0));
+        assert!(!client_generation_is_idle(1, 0));
+        assert!(!client_generation_is_idle(0, 1));
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -5556,10 +5556,7 @@ impl Client {
         let response = match response_rx.recv_timeout(remaining) {
             Ok(response) => response?,
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                self.remove_route(request_id);
-                if let Ok(mut child) = self.child.lock() {
-                    terminate(&mut child, Duration::from_secs(1));
-                }
+                let _ = self.cancel_request(request_id);
                 return Err(io::Error::new(
                     io::ErrorKind::TimedOut,
                     format!("tree worker request {request_id} timed out"),

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -3956,7 +3956,13 @@ where
     let mut pending = injected_hung_compute;
     while let Some(request) = decode_frame::<_, Request>(&mut reader)? {
         if let Request::Cancel(cancel) = request {
-            cancel_active_request(&cancellations, &cancel, worker_generation);
+            let cancelled = cancel_active_request(&cancellations, &cancel, worker_generation);
+            #[cfg(feature = "e2e")]
+            if cancelled
+                && let Ok(path) = std::env::var("KAKEHASHI_TREE_WORKER_CANCEL_OBSERVED_FILE")
+            {
+                let _ = std::fs::write(path, cancel.request_id.to_string());
+            }
             continue;
         }
         let Some(context) = request_context(&request) else {
@@ -5115,6 +5121,13 @@ struct Route {
     sender: mpsc::Sender<io::Result<Response>>,
 }
 
+pub struct PendingResponse {
+    request_id: u64,
+    response_rx: mpsc::Receiver<io::Result<Response>>,
+    started: Instant,
+    timeout: Duration,
+}
+
 impl Client {
     pub fn spawn(
         executable: &std::path::Path,
@@ -5605,9 +5618,17 @@ impl Client {
     }
 
     pub fn derive_semantic_tokens(&self, request: DeriveSemanticTokens) -> io::Result<Response> {
+        let pending = self.begin_derive_semantic_tokens(request)?;
+        self.wait_for_response(pending)
+    }
+
+    pub fn begin_derive_semantic_tokens(
+        &self,
+        request: DeriveSemanticTokens,
+    ) -> io::Result<PendingResponse> {
         let context = request.context.clone();
         let timeout = request_timeout(&context.uri);
-        self.request_with_timeout(Request::DeriveSemanticTokens(request), context, timeout)
+        self.begin_request(Request::DeriveSemanticTokens(request), context, timeout)
     }
 
     pub fn run_captures(&self, request: RunCaptures) -> io::Result<Response> {
@@ -5647,6 +5668,16 @@ impl Client {
         expected: RequestContext,
         timeout: Duration,
     ) -> io::Result<Response> {
+        let pending = self.begin_request(request, expected, timeout)?;
+        self.wait_for_response(pending)
+    }
+
+    fn begin_request(
+        &self,
+        request: Request,
+        expected: RequestContext,
+        timeout: Duration,
+    ) -> io::Result<PendingResponse> {
         let started = Instant::now();
         let uses_supervisor_reserve = request_uses_supervisor_route_reserve(&request);
         if expected.worker_generation != self.ready.worker_generation {
@@ -5708,6 +5739,21 @@ impl Client {
                 ));
             }
         }
+        Ok(PendingResponse {
+            request_id,
+            response_rx,
+            started,
+            timeout,
+        })
+    }
+
+    pub fn wait_for_response(&self, pending: PendingResponse) -> io::Result<Response> {
+        let PendingResponse {
+            request_id,
+            response_rx,
+            started,
+            timeout,
+        } = pending;
         let remaining = timeout.saturating_sub(started.elapsed());
         let response = match response_rx.recv_timeout(remaining) {
             Ok(response) => response?,

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -12,7 +12,7 @@ use std::{
     cell::RefCell,
     collections::{HashMap, VecDeque},
     sync::{
-        Arc, Mutex, Weak,
+        Arc, Condvar, Mutex, Weak,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
@@ -4087,6 +4087,55 @@ where
                     Ok(()) => {
                         #[cfg(feature = "e2e")]
                         if let Ok(marker) =
+                            std::env::var("KAKEHASHI_TREE_WORKER_HANG_AFTER_HAZARD_ARMED_FILE")
+                            && std::env::var(
+                                "KAKEHASHI_TREE_WORKER_HANG_AFTER_HAZARD_ARMED_URI_SUFFIX",
+                            )
+                            .ok()
+                            .is_none_or(|suffix| context.uri.ends_with(&suffix))
+                            && std::fs::OpenOptions::new()
+                                .write(true)
+                                .create_new(true)
+                                .open(marker)
+                                .is_ok()
+                        {
+                            loop {
+                                std::thread::park();
+                            }
+                        }
+                        #[cfg(feature = "e2e")]
+                        if std::env::var_os("KAKEHASHI_TREE_WORKER_MULTI_HAZARD_TRIGGER_FILE")
+                            .is_some_and(|path| std::path::Path::new(&path).exists())
+                        {
+                            if std::env::var(
+                                "KAKEHASHI_TREE_WORKER_HOLD_COMMITTED_HAZARD_URI_SUFFIX",
+                            )
+                            .ok()
+                            .is_some_and(|suffix| context.uri.ends_with(&suffix))
+                                && let Ok(marker) = std::env::var(
+                                    "KAKEHASHI_TREE_WORKER_HOLD_COMMITTED_HAZARD_MARKER",
+                                )
+                                && std::fs::write(marker, b"committed").is_ok()
+                            {
+                                loop {
+                                    std::thread::park();
+                                }
+                            }
+                            if std::env::var(
+                                "KAKEHASHI_TREE_WORKER_CRASH_COMMITTED_HAZARD_URI_SUFFIX",
+                            )
+                            .ok()
+                            .is_some_and(|suffix| context.uri.ends_with(&suffix))
+                                && let Ok(marker) = std::env::var(
+                                    "KAKEHASHI_TREE_WORKER_CRASH_COMMITTED_HAZARD_MARKER",
+                                )
+                                && std::fs::write(marker, b"committed").is_ok()
+                            {
+                                std::process::abort();
+                            }
+                        }
+                        #[cfg(feature = "e2e")]
+                        if let Ok(marker) =
                             std::env::var("KAKEHASHI_TREE_WORKER_CRASH_AFTER_HAZARD_ARMED_FILE")
                             && std::fs::OpenOptions::new()
                                 .write(true)
@@ -4921,6 +4970,7 @@ pub struct Client {
     terminated_by_transport: Arc<AtomicBool>,
     outbound: Mutex<Option<mpsc::Sender<Request>>>,
     active_grammar_hazards: Arc<Mutex<HashMap<u64, GrammarHazardArmed>>>,
+    reader_drained: Arc<(Mutex<bool>, Condvar)>,
     routes: Arc<Mutex<HashMap<u64, Route>>>,
     reader: Option<std::thread::JoinHandle<()>>,
     writer: Option<std::thread::JoinHandle<()>>,
@@ -5038,8 +5088,10 @@ impl Client {
         let routes = Arc::new(Mutex::new(HashMap::<u64, Route>::new()));
         let active_grammar_hazards =
             Arc::new(Mutex::new(HashMap::<u64, GrammarHazardArmed>::new()));
+        let reader_drained = Arc::new((Mutex::new(false), Condvar::new()));
         let reader_routes = Arc::clone(&routes);
         let reader_hazards = Arc::clone(&active_grammar_hazards);
+        let reader_drain_signal = Arc::clone(&reader_drained);
         let reader_child = Arc::clone(&child);
         let reader_terminated_by_transport = Arc::clone(&terminated_by_transport);
         let (handshake_tx, handshake_rx) = mpsc::channel();
@@ -5119,6 +5171,11 @@ impl Client {
                     }
                 }
             }
+            let (drained, ready) = &*reader_drain_signal;
+            *drained
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = true;
+            ready.notify_all();
             if let Ok(mut child) = reader_child.lock() {
                 terminate_by_transport(
                     &mut child,
@@ -5210,6 +5267,7 @@ impl Client {
             terminated_by_transport,
             outbound: Mutex::new(Some(outbound)),
             active_grammar_hazards,
+            reader_drained,
             routes,
             reader: Some(reader),
             writer: Some(writer),
@@ -5244,6 +5302,24 @@ impl Client {
             .values()
             .cloned()
             .collect()
+    }
+
+    pub fn wait_for_reader_drain(&self, timeout: Duration) -> io::Result<()> {
+        let (drained, ready) = &*self.reader_drained;
+        let drained = drained
+            .lock()
+            .map_err(|_| io::Error::other("worker reader drain lock is poisoned"))?;
+        let (drained, _) = ready
+            .wait_timeout_while(drained, timeout, |drained| !*drained)
+            .map_err(|_| io::Error::other("worker reader drain lock is poisoned"))?;
+        if *drained {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "worker response reader did not drain after worker loss",
+            ))
+        }
     }
 
     /// Idempotently cancel queued or cooperatively running work in this worker

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4118,6 +4118,39 @@ where
                             }
                         }
                         #[cfg(feature = "e2e")]
+                        if let Ok(trigger) = std::env::var(
+                            "KAKEHASHI_TREE_WORKER_HANG_ALL_COMMITTED_HAZARDS_TRIGGER_FILE",
+                        ) && std::path::Path::new(&trigger).exists()
+                            && std::env::var(
+                                "KAKEHASHI_TREE_WORKER_HANG_ALL_COMMITTED_HAZARDS_URI_PREFIX",
+                            )
+                            .ok()
+                            .is_some_and(|prefix| context.uri.starts_with(&prefix))
+                            && let Ok(directory) = std::env::var(
+                                "KAKEHASHI_TREE_WORKER_HANG_ALL_COMMITTED_HAZARDS_MARKER_DIR",
+                            )
+                        {
+                            let _ = std::fs::write(
+                                std::path::Path::new(&directory)
+                                    .join(context.request_id.to_string()),
+                                b"hung",
+                            );
+                            let expected = std::env::var(
+                                "KAKEHASHI_TREE_WORKER_HANG_ALL_COMMITTED_HAZARDS_COUNT",
+                            )
+                            .ok()
+                            .and_then(|value| value.parse::<usize>().ok())
+                            .unwrap_or(4);
+                            if std::fs::read_dir(&directory)
+                                .is_ok_and(|entries| entries.count() >= expected)
+                            {
+                                let _ = std::fs::remove_file(trigger);
+                            }
+                            loop {
+                                std::thread::park();
+                            }
+                        }
+                        #[cfg(feature = "e2e")]
                         if std::env::var_os("KAKEHASHI_TREE_WORKER_MULTI_HAZARD_TRIGGER_FILE")
                             .is_some_and(|path| std::path::Path::new(&path).exists())
                             && !std::env::var_os("KAKEHASHI_TREE_WORKER_RECOVERY_READY_FILE")
@@ -5010,6 +5043,11 @@ fn parse_request_timeout(value: Option<&str>) -> Duration {
 fn request_timeout(_uri: &str) -> Duration {
     #[cfg(feature = "e2e")]
     {
+        if std::env::var_os("KAKEHASHI_TREE_WORKER_REQUEST_TIMEOUT_TRIGGER_FILE")
+            .is_some_and(|path| !std::path::Path::new(&path).exists())
+        {
+            return DEFAULT_REQUEST_TIMEOUT;
+        }
         if std::env::var("KAKEHASHI_TREE_WORKER_REQUEST_TIMEOUT_URI_SUFFIX")
             .ok()
             .is_some_and(|suffix| !_uri.ends_with(&suffix))

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4070,8 +4070,6 @@ where
             let hazard_error = grammar_hazard.and_then(|grammar: WorkerGrammarIdentity| {
                 #[cfg(feature = "e2e")]
                 let e2e_grammar_symbol = grammar.grammar_symbol.clone();
-                #[cfg(feature = "e2e")]
-                let e2e_grammar = grammar.clone();
                 let lease_id = job_next_hazard_lease.fetch_add(1, Ordering::Relaxed);
                 let (committed_tx, committed_rx) = mpsc::channel();
                 if responses
@@ -4134,7 +4132,10 @@ where
                                 Response::GrammarHazardArmed(GrammarHazardArmed {
                                     lease_id: late_lease_id,
                                     context: context.clone(),
-                                    grammar: e2e_grammar,
+                                    grammar: WorkerGrammarIdentity {
+                                        grammar_symbol: "e2e-late".into(),
+                                        artifact_digest: "e2e-late-after-protocol-abort".into(),
+                                    },
                                 }),
                                 None,
                                 None,

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4070,6 +4070,8 @@ where
             let hazard_error = grammar_hazard.and_then(|grammar: WorkerGrammarIdentity| {
                 #[cfg(feature = "e2e")]
                 let e2e_grammar_symbol = grammar.grammar_symbol.clone();
+                #[cfg(feature = "e2e")]
+                let e2e_grammar = grammar.clone();
                 let lease_id = job_next_hazard_lease.fetch_add(1, Ordering::Relaxed);
                 let (committed_tx, committed_rx) = mpsc::channel();
                 if responses
@@ -4122,6 +4124,17 @@ where
                                 Response::GrammarHazardReleased(GrammarHazardReleased {
                                     lease_id: u64::MAX,
                                     worker_generation,
+                                }),
+                                None,
+                                None,
+                            ));
+                            let late_lease_id =
+                                job_next_hazard_lease.fetch_add(1, Ordering::Relaxed);
+                            let _ = responses.send((
+                                Response::GrammarHazardArmed(GrammarHazardArmed {
+                                    lease_id: late_lease_id,
+                                    context: context.clone(),
+                                    grammar: e2e_grammar,
                                 }),
                                 None,
                                 None,
@@ -5073,12 +5086,19 @@ pub struct Client {
     outbound: Mutex<Option<mpsc::Sender<Request>>>,
     accepting_requests: AtomicBool,
     active_grammar_hazards: Arc<Mutex<HashMap<u64, GrammarHazardArmed>>>,
-    reader_drained: Arc<(Mutex<bool>, Condvar)>,
+    reader_drain_state: Arc<(Mutex<ReaderDrainState>, Condvar)>,
     routes: Arc<Mutex<HashMap<u64, Route>>>,
     reader: Option<std::thread::JoinHandle<()>>,
     writer: Option<std::thread::JoinHandle<()>>,
     ready: HandshakeReady,
     max_inflight: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReaderDrainState {
+    Reading,
+    Complete,
+    Incomplete,
 }
 
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
@@ -5204,16 +5224,16 @@ impl Client {
         let routes = Arc::new(Mutex::new(HashMap::<u64, Route>::new()));
         let active_grammar_hazards =
             Arc::new(Mutex::new(HashMap::<u64, GrammarHazardArmed>::new()));
-        let reader_drained = Arc::new((Mutex::new(false), Condvar::new()));
+        let reader_drain_state = Arc::new((Mutex::new(ReaderDrainState::Reading), Condvar::new()));
         let reader_routes = Arc::clone(&routes);
         let reader_hazards = Arc::clone(&active_grammar_hazards);
-        let reader_drain_signal = Arc::clone(&reader_drained);
+        let reader_drain_signal = Arc::clone(&reader_drain_state);
         let reader_child = Arc::clone(&child);
         let reader_terminated_by_transport = Arc::clone(&terminated_by_transport);
         let (handshake_tx, handshake_rx) = mpsc::channel();
         let reader = std::thread::spawn(move || {
             let mut handshake_tx = Some(handshake_tx);
-            loop {
+            let drain_state = loop {
                 match decode_frame::<_, Response>(&mut stdout) {
                     Ok(Some(response)) => {
                         if let Some(handshake) = handshake_tx.take() {
@@ -5234,7 +5254,7 @@ impl Client {
                                         io::ErrorKind::InvalidData,
                                         "invalid grammar hazard arm",
                                     );
-                                    break;
+                                    break ReaderDrainState::Incomplete;
                                 }
                                 reader_hazards
                                     .lock()
@@ -5256,7 +5276,7 @@ impl Client {
                                         io::ErrorKind::InvalidData,
                                         "invalid grammar hazard release",
                                     );
-                                    break;
+                                    break ReaderDrainState::Incomplete;
                                 }
                                 continue;
                             }
@@ -5265,7 +5285,7 @@ impl Client {
                                     let kind = error.kind();
                                     let message = error.to_string();
                                     fail_routes(None, &reader_routes, kind, &message);
-                                    break;
+                                    break ReaderDrainState::Incomplete;
                                 }
                             }
                         }
@@ -5277,20 +5297,20 @@ impl Client {
                             io::ErrorKind::UnexpectedEof,
                             "tree worker closed its response stream",
                         );
-                        break;
+                        break ReaderDrainState::Complete;
                     }
                     Err(error) => {
                         let kind = error.kind();
                         let message = error.to_string();
                         fail_routes(handshake_tx.take(), &reader_routes, kind, &message);
-                        break;
+                        break ReaderDrainState::Incomplete;
                     }
                 }
-            }
-            let (drained, ready) = &*reader_drain_signal;
-            *drained
+            };
+            let (state, ready) = &*reader_drain_signal;
+            *state
                 .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner) = true;
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = drain_state;
             ready.notify_all();
             if let Ok(mut child) = reader_child.lock() {
                 terminate_by_transport(
@@ -5385,7 +5405,7 @@ impl Client {
             outbound: Mutex::new(Some(outbound)),
             accepting_requests: AtomicBool::new(true),
             active_grammar_hazards,
-            reader_drained,
+            reader_drain_state,
             routes,
             reader: Some(reader),
             writer: Some(writer),
@@ -5427,20 +5447,23 @@ impl Client {
     }
 
     pub fn wait_for_reader_drain(&self, timeout: Duration) -> io::Result<()> {
-        let (drained, ready) = &*self.reader_drained;
-        let drained = drained
+        let (state, ready) = &*self.reader_drain_state;
+        let state = state
             .lock()
             .map_err(|_| io::Error::other("worker reader drain lock is poisoned"))?;
-        let (drained, _) = ready
-            .wait_timeout_while(drained, timeout, |drained| !*drained)
+        let (state, _) = ready
+            .wait_timeout_while(state, timeout, |state| *state == ReaderDrainState::Reading)
             .map_err(|_| io::Error::other("worker reader drain lock is poisoned"))?;
-        if *drained {
-            Ok(())
-        } else {
-            Err(io::Error::new(
+        match *state {
+            ReaderDrainState::Complete => Ok(()),
+            ReaderDrainState::Incomplete => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "worker response reader aborted before obtaining a complete failure snapshot",
+            )),
+            ReaderDrainState::Reading => Err(io::Error::new(
                 io::ErrorKind::TimedOut,
                 "worker response reader did not drain after worker loss",
-            ))
+            )),
         }
     }
 

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -2309,7 +2309,6 @@ struct GrammarKey {
 }
 
 impl GrammarKey {
-    #[cfg(not(test))]
     fn identity(&self) -> WorkerGrammarIdentity {
         WorkerGrammarIdentity {
             grammar_symbol: self.grammar_symbol.clone(),
@@ -3106,7 +3105,6 @@ fn document_key(request: &Request) -> Option<DocumentKey> {
     }
 }
 
-#[cfg(not(test))]
 fn request_grammar_identity(
     request: &Request,
     documents: &DocumentStore,
@@ -4008,10 +4006,6 @@ where
         }
         pending += 1;
         let enqueued = Instant::now();
-        #[cfg(not(test))]
-        let grammar_hazard = request_grammar_identity(&request, &documents);
-        #[cfg(test)]
-        let grammar_hazard = None;
         let responses = responses.clone();
         let permits = permits.clone();
         let permit_rx = Arc::clone(&permit_rx);
@@ -4066,6 +4060,10 @@ where
                 .recv()
                 .expect("worker admission queue stopped before its jobs");
             let permit = AdmissionPermit(permits);
+            #[cfg(not(test))]
+            let grammar_hazard = request_grammar_identity(&request, &documents);
+            #[cfg(test)]
+            let grammar_hazard = None;
             let mut announced_lease = None;
             let hazard_error = grammar_hazard.and_then(|grammar: WorkerGrammarIdentity| {
                 #[cfg(feature = "e2e")]
@@ -6237,10 +6235,10 @@ mod tests {
         derive_snapshot_with_language, encode_frame, enforce_derived_memory_budget,
         named_node_count, parse_request_timeout, pressure_checkpoint_required,
         record_grammar_hazard_arm, replace_retained_bytes, replace_retained_estimated_bytes,
-        request_may_grow_derived_state, request_priority, reserve_retained_growth,
-        route_is_admissible, route_response, run, submit_document_job, sync_document, terminate,
-        terminate_by_transport, terminate_by_transport_for_request_deadline,
-        validate_document_size,
+        request_grammar_identity, request_may_grow_derived_state, request_priority,
+        reserve_retained_growth, route_is_admissible, route_response, run, submit_document_job,
+        sync_document, terminate, terminate_by_transport,
+        terminate_by_transport_for_request_deadline, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -6884,6 +6882,68 @@ mod tests {
 
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
         assert!(hazards.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn grammar_hazard_identity_uses_the_lane_current_replica() {
+        let documents = Arc::new(dashmap::DashMap::new());
+        let context = RequestContext {
+            request_id: 7,
+            worker_generation: 3,
+            uri: "file:///pipelined.rs".into(),
+            incarnation: 1,
+            content_version: 1,
+            configuration_generation: 2,
+        };
+        let make_replica = |context: RequestContext, digest: &str| {
+            let mut parser = tree_sitter::Parser::new();
+            parser
+                .set_language(&tree_sitter_rust::LANGUAGE.into())
+                .unwrap();
+            DocumentReplica::sync(
+                SyncDocument {
+                    context,
+                    language: "rust".into(),
+                    grammar_symbol: "rust".into(),
+                    source_path: "/unused/rust".into(),
+                    parser_path: "/unused/rust".into(),
+                    artifact_digest: digest.into(),
+                    queries: WorkerQuerySources::default(),
+                    text: "fn pipelined() {}\n".into(),
+                },
+                &mut parser,
+            )
+            .unwrap()
+            .0
+        };
+        documents.insert(
+            DocumentKey::from(&context),
+            Arc::new(Mutex::new(make_replica(context.clone(), "sha256:v1"))),
+        );
+        let request = Request::DeriveSemanticTokens(DeriveSemanticTokens {
+            context: context.clone(),
+            supports_multiline: true,
+        });
+        assert_eq!(
+            request_grammar_identity(&request, &documents)
+                .unwrap()
+                .artifact_digest,
+            "sha256:v1"
+        );
+
+        let mut replacement = context;
+        replacement.content_version = 2;
+        documents.insert(
+            DocumentKey::from(&replacement),
+            Arc::new(Mutex::new(make_replica(replacement, "sha256:v2"))),
+        );
+
+        assert_eq!(
+            request_grammar_identity(&request, &documents)
+                .unwrap()
+                .artifact_digest,
+            "sha256:v2"
+        );
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -3935,7 +3935,7 @@ where
     // The client permits at most four requests per compute thread. Decode one
     // frame beyond this pending window so cancellation stays observable under
     // saturation, but wait before scheduling any excess ordinary work.
-    let max_pending = compute_threads.saturating_mul(4).max(1);
+    let max_pending = compute_threads.saturating_mul(4).max(1).saturating_add(1);
     let (completion_tx, completion_rx) = mpsc::channel::<()>();
     #[cfg(feature = "e2e")]
     let injected_hung_compute =

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4985,6 +4985,7 @@ pub struct Client {
     child: Arc<Mutex<OwnedChild>>,
     terminated_by_transport: Arc<AtomicBool>,
     outbound: Mutex<Option<mpsc::Sender<Request>>>,
+    accepting_requests: AtomicBool,
     active_grammar_hazards: Arc<Mutex<HashMap<u64, GrammarHazardArmed>>>,
     reader_drained: Arc<(Mutex<bool>, Condvar)>,
     routes: Arc<Mutex<HashMap<u64, Route>>>,
@@ -5282,6 +5283,7 @@ impl Client {
             child,
             terminated_by_transport,
             outbound: Mutex::new(Some(outbound)),
+            accepting_requests: AtomicBool::new(true),
             active_grammar_hazards,
             reader_drained,
             routes,
@@ -5364,6 +5366,15 @@ impl Client {
             }
             std::thread::sleep(Duration::from_millis(1));
         }
+    }
+
+    pub fn close_request_admission(&self) -> io::Result<()> {
+        let _routes = self
+            .routes
+            .lock()
+            .map_err(|_| io::Error::other("worker response router is poisoned"))?;
+        self.accepting_requests.store(false, Ordering::Release);
+        Ok(())
     }
 
     /// Idempotently cancel queued or cooperatively running work in this worker
@@ -5550,10 +5561,20 @@ impl Client {
                     format!("tree worker request {request_id} is already active"),
                 ));
             }
-            if !route_is_admissible(routes.len(), self.max_inflight, uses_supervisor_reserve) {
+            let accepting_requests = self.accepting_requests.load(Ordering::Acquire);
+            if !route_is_admissible(
+                routes.len(),
+                self.max_inflight,
+                uses_supervisor_reserve,
+                accepting_requests,
+            ) {
                 return Err(io::Error::new(
-                    io::ErrorKind::WouldBlock,
-                    "tree worker in-flight limit reached",
+                    if accepting_requests {
+                        io::ErrorKind::WouldBlock
+                    } else {
+                        io::ErrorKind::NotConnected
+                    },
+                    "tree worker request admission is unavailable",
                 ));
             }
             routes.insert(
@@ -5647,8 +5668,13 @@ fn request_uses_supervisor_route_reserve(request: &Request) -> bool {
     )
 }
 
-fn route_is_admissible(active: usize, max_inflight: usize, uses_supervisor_reserve: bool) -> bool {
-    active < max_inflight.saturating_add(usize::from(uses_supervisor_reserve))
+fn route_is_admissible(
+    active: usize,
+    max_inflight: usize,
+    uses_supervisor_reserve: bool,
+    accepting_requests: bool,
+) -> bool {
+    accepting_requests && active < max_inflight.saturating_add(usize::from(uses_supervisor_reserve))
 }
 
 fn client_generation_is_idle(active_routes: usize, active_hazards: usize) -> bool {
@@ -6169,9 +6195,10 @@ mod tests {
 
     #[test]
     fn supervisor_lifecycle_request_has_one_reserved_route() {
-        assert!(!route_is_admissible(16, 16, false));
-        assert!(route_is_admissible(16, 16, true));
-        assert!(!route_is_admissible(17, 16, true));
+        assert!(!route_is_admissible(16, 16, false, true));
+        assert!(route_is_admissible(16, 16, true, true));
+        assert!(!route_is_admissible(17, 16, true, true));
+        assert!(!route_is_admissible(0, 16, true, false));
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -3956,9 +3956,7 @@ where
     let mut pending = injected_hung_compute;
     while let Some(request) = decode_frame::<_, Request>(&mut reader)? {
         if let Request::Cancel(cancel) = request {
-            if cancel.worker_generation == worker_generation {
-                cancellations.entry(cancel.request_id).or_default().cancel();
-            }
+            cancel_active_request(&cancellations, &cancel, worker_generation);
             continue;
         }
         let Some(context) = request_context(&request) else {
@@ -4359,6 +4357,21 @@ where
     }
     drop(responses);
     join_writer(writer_thread)
+}
+
+fn cancel_active_request(
+    cancellations: &dashmap::DashMap<u64, crate::cancel::CancelToken>,
+    cancel: &CancelRequest,
+    worker_generation: u64,
+) -> bool {
+    if cancel.worker_generation != worker_generation {
+        return false;
+    }
+    let Some(token) = cancellations.get(&cancel.request_id) else {
+        return false;
+    };
+    token.cancel();
+    true
 }
 
 #[cfg(feature = "e2e")]
@@ -5998,11 +6011,11 @@ mod tests {
         LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
         MAX_RETAINED_DOCUMENT_BYTES, MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES, NavigateNode,
         NodeLayerSelector, NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId,
-        OwnedChild, PROTOCOL_VERSION, ParentLiveness, Request, RequestCancelled, RequestContext,
-        ResolveNode, Response, Route, RunCaptures, RunNodeScalar, RunnableDocuments,
+        OwnedChild, PROTOCOL_VERSION, ParentLiveness, Request, RequestContext, ResolveNode,
+        Response, Route, RunCaptures, RunNodeScalar, RunnableDocuments,
         SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES, SyncDocument, WireByteRange, WirePosition,
         WireRange, WireSemanticToken, WorkPriority, WorkerError, WorkerGrammarIdentity,
-        WorkerQuerySources, WorkerRestartRequired, cache_eviction_plan,
+        WorkerQuerySources, WorkerRestartRequired, cache_eviction_plan, cancel_active_request,
         cancellation_grace_response, client_generation_is_idle, close_document, decode_frame,
         derive_snapshot_with_language, encode_frame, enforce_derived_memory_budget,
         named_node_count, parse_request_timeout, pressure_checkpoint_required,
@@ -6601,7 +6614,7 @@ mod tests {
     }
 
     #[test]
-    fn worker_honors_cancellation_that_arrives_before_reader_work() {
+    fn worker_ignores_cancellation_that_precedes_request_admission() {
         let output = SharedWriter::default();
         let captured = output.clone();
         let cancel = Request::Cancel(CancelRequest {
@@ -6623,11 +6636,27 @@ mod tests {
             Some(Response::HandshakeReady(_))
         ));
         let response = decode_frame::<_, Response>(&mut bytes).unwrap().unwrap();
-        assert!(matches!(
-            response,
-            Response::RequestCancelled(RequestCancelled { context })
-                if context.request_id == 7
-        ));
+        assert!(
+            matches!(response, Response::Error(WorkerError { context, .. }) if
+            context.as_ref().is_some_and(|context| context.request_id == 7))
+        );
+    }
+
+    #[test]
+    fn late_cancellation_does_not_recreate_completed_request_state() {
+        let cancellations = dashmap::DashMap::new();
+        let token = crate::cancel::CancelToken::default();
+        cancellations.insert(7, token.clone());
+        let cancel = CancelRequest {
+            request_id: 7,
+            worker_generation: 3,
+        };
+
+        assert!(cancel_active_request(&cancellations, &cancel, 3));
+        assert!(token.is_cancelled());
+        cancellations.remove(&7);
+        assert!(!cancel_active_request(&cancellations, &cancel, 3));
+        assert!(cancellations.is_empty());
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -6181,9 +6181,13 @@ fn wait_until(child: &mut OwnedChild, timeout: Duration) -> io::Result<std::proc
 }
 
 fn terminate(child: &mut OwnedChild, timeout: Duration) {
-    let exited = child.try_wait().ok().flatten().is_some();
+    let running = child.try_wait().ok().flatten().is_none();
+    terminate_after_observation(child, running, timeout);
+}
+
+fn terminate_after_observation(child: &mut OwnedChild, running: bool, timeout: Duration) {
     child.kill_all();
-    if !exited {
+    if running {
         let _ = wait_until(child, timeout);
     }
 }
@@ -6193,7 +6197,7 @@ fn terminate_by_transport(child: &mut OwnedChild, marker: &AtomicBool, timeout: 
     if terminated {
         marker.store(true, Ordering::Release);
     }
-    terminate(child, timeout);
+    terminate_after_observation(child, terminated, timeout);
     terminated
 }
 
@@ -6203,10 +6207,12 @@ fn terminate_by_transport_for_request_deadline(
     request_deadline_marker: &AtomicBool,
     timeout: Duration,
 ) {
-    if child.try_wait().ok().flatten().is_none() {
+    let terminated = child.try_wait().ok().flatten().is_none();
+    if terminated {
+        transport_marker.store(true, Ordering::Release);
         request_deadline_marker.store(true, Ordering::Release);
     }
-    terminate_by_transport(child, transport_marker, timeout);
+    terminate_after_observation(child, terminated, timeout);
 }
 
 #[cfg(test)]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -6741,9 +6741,10 @@ mod tests {
             request.context.request_id = request_id;
             requests.push(Request::DeriveSnapshot(request));
         }
-        // One handshake, five pending requests (four ordinary plus the
-        // lifecycle reserve), two completed responses buffered behind the
-        // stalled writer, and one cancellation lookahead frame.
+        // One handshake, five scheduler-pending ordinary requests, one
+        // completed response held by the stalled writer, one completed
+        // response buffered in its channel, and one decoded ordinary
+        // lookahead frame.
         let admitted_prefix_bytes = framed(&requests[..9]).len();
         let framed_requests = framed(&requests);
         let progress = Arc::new((AtomicUsize::new(0), Condvar::new(), Mutex::new(())));

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -5486,6 +5486,7 @@ impl Client {
         timeout: Duration,
     ) -> io::Result<Response> {
         let started = Instant::now();
+        let uses_supervisor_reserve = request_uses_supervisor_route_reserve(&request);
         if expected.worker_generation != self.ready.worker_generation {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -5505,7 +5506,7 @@ impl Client {
                     format!("tree worker request {request_id} is already active"),
                 ));
             }
-            if routes.len() >= self.max_inflight {
+            if !route_is_admissible(routes.len(), self.max_inflight, uses_supervisor_reserve) {
                 return Err(io::Error::new(
                     io::ErrorKind::WouldBlock,
                     "tree worker in-flight limit reached",
@@ -5592,6 +5593,21 @@ impl Client {
             )))
         }
     }
+}
+
+fn request_uses_supervisor_route_reserve(request: &Request) -> bool {
+    matches!(
+        request,
+        Request::SyncDocument(_)
+            | Request::ApplyDocumentEdits(_)
+            | Request::ApplyDocumentEditsAndDerive(_)
+            | Request::DeriveDocumentSnapshot(_)
+            | Request::CloseDocument(_)
+    )
+}
+
+fn route_is_admissible(active: usize, max_inflight: usize, uses_supervisor_reserve: bool) -> bool {
+    active < max_inflight.saturating_add(usize::from(uses_supervisor_reserve))
 }
 
 fn failed_spawn(
@@ -5789,8 +5805,9 @@ mod tests {
         derive_snapshot_with_language, encode_frame, enforce_derived_memory_budget,
         named_node_count, parse_request_timeout, pressure_checkpoint_required,
         replace_retained_bytes, replace_retained_estimated_bytes, request_may_grow_derived_state,
-        request_priority, reserve_retained_growth, route_response, run, submit_document_job,
-        sync_document, terminate, terminate_by_transport, validate_document_size,
+        request_priority, reserve_retained_growth, route_is_admissible, route_response, run,
+        submit_document_job, sync_document, terminate, terminate_by_transport,
+        validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -6103,6 +6120,13 @@ mod tests {
             Duration::from_secs(60)
         );
         assert_eq!(parse_request_timeout(None), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn supervisor_lifecycle_request_has_one_reserved_route() {
+        assert!(!route_is_admissible(16, 16, false));
+        assert!(route_is_admissible(16, 16, true));
+        assert!(!route_is_admissible(17, 16, true));
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -3956,9 +3956,9 @@ where
     let mut pending = injected_hung_compute;
     while let Some(request) = decode_frame::<_, Request>(&mut reader)? {
         if let Request::Cancel(cancel) = request {
-            let cancelled = cancel_active_request(&cancellations, &cancel, worker_generation);
+            let _cancelled = cancel_active_request(&cancellations, &cancel, worker_generation);
             #[cfg(feature = "e2e")]
-            if cancelled
+            if _cancelled
                 && let Ok(path) = std::env::var("KAKEHASHI_TREE_WORKER_CANCEL_OBSERVED_FILE")
             {
                 let _ = std::fs::write(path, cancel.request_id.to_string());

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -5153,6 +5153,7 @@ fn request_timeout(_uri: &str) -> Duration {
 struct Route {
     expected: RequestContext,
     enqueue_order: u64,
+    inherited_grammar_uri: Option<String>,
     response_contract: ResponseContract,
     expected_grammar: Option<Arc<WorkerGrammarIdentity>>,
     document_grammar_update: Option<DocumentGrammarUpdate>,
@@ -5890,6 +5891,7 @@ impl Client {
                 Route {
                     expected,
                     enqueue_order,
+                    inherited_grammar_uri: inherited_grammar_uri.map(str::to_owned),
                     response_contract: response_contract(&request),
                     expected_grammar,
                     document_grammar_update,
@@ -6242,6 +6244,28 @@ fn route_response(
                 .remove(uri);
         }
         _ => {}
+    }
+    if let Some(DocumentGrammarUpdate::Set(uri, grammar)) = &route.document_grammar_update {
+        let grammar = if matches!(response, Response::DocumentAck(_)) {
+            Some(Arc::clone(grammar))
+        } else {
+            document_grammars
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .get(uri)
+                .cloned()
+        };
+        for dependent in routes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .values_mut()
+            .filter(|dependent| {
+                dependent.enqueue_order > route.enqueue_order
+                    && dependent.inherited_grammar_uri.as_deref() == Some(uri)
+            })
+        {
+            dependent.expected_grammar = grammar.clone();
+        }
     }
     let _ = route.sender.send(Ok(response));
     Ok(())
@@ -6901,6 +6925,7 @@ mod tests {
             Route {
                 expected: expected.clone(),
                 enqueue_order: 0,
+                inherited_grammar_uri: None,
                 response_contract: ResponseContract {
                     success: SuccessResponseKind::DocumentAck,
                     cancellable: false,
@@ -6943,6 +6968,7 @@ mod tests {
             Route {
                 expected: expected.clone(),
                 enqueue_order: 0,
+                inherited_grammar_uri: None,
                 response_contract: ResponseContract {
                     success: SuccessResponseKind::DocumentAck,
                     cancellable: false,
@@ -6988,6 +7014,7 @@ mod tests {
                     configuration_generation: 1,
                 },
                 enqueue_order,
+                inherited_grammar_uri: None,
                 response_contract: ResponseContract {
                     success: SuccessResponseKind::DocumentAck,
                     cancellable: false,
@@ -7010,6 +7037,84 @@ mod tests {
     }
 
     #[test]
+    fn failed_pending_sync_restores_inherited_route_grammar() {
+        let uri = "file:///pipelined.rs";
+        let grammar = |symbol: &str| {
+            Arc::new(WorkerGrammarIdentity {
+                grammar_symbol: symbol.into(),
+                artifact_digest: format!("sha256:{symbol}"),
+            })
+        };
+        let old_grammar = grammar("rust");
+        let rejected_grammar = grammar("lua");
+        let sync_context = RequestContext {
+            request_id: 90,
+            worker_generation: 3,
+            uri: uri.into(),
+            incarnation: 1,
+            content_version: 2,
+            configuration_generation: 1,
+        };
+        let query_context = RequestContext {
+            request_id: 7,
+            content_version: 1,
+            ..sync_context.clone()
+        };
+        let (sync_sender, _sync_receiver) = std::sync::mpsc::channel();
+        let (query_sender, _query_receiver) = std::sync::mpsc::channel();
+        let routes = Mutex::new(HashMap::from([
+            (
+                90,
+                Route {
+                    expected: sync_context.clone(),
+                    enqueue_order: 1,
+                    inherited_grammar_uri: None,
+                    response_contract: ResponseContract {
+                        success: SuccessResponseKind::DocumentAck,
+                        cancellable: false,
+                    },
+                    expected_grammar: Some(Arc::clone(&rejected_grammar)),
+                    document_grammar_update: Some(DocumentGrammarUpdate::Set(
+                        uri.into(),
+                        rejected_grammar,
+                    )),
+                    sender: sync_sender,
+                },
+            ),
+            (
+                7,
+                Route {
+                    expected: query_context,
+                    enqueue_order: 2,
+                    inherited_grammar_uri: Some(uri.into()),
+                    response_contract: ResponseContract {
+                        success: SuccessResponseKind::Snapshot,
+                        cancellable: true,
+                    },
+                    expected_grammar: Some(grammar("lua")),
+                    document_grammar_update: None,
+                    sender: query_sender,
+                },
+            ),
+        ]));
+        let document_grammars = Mutex::new(HashMap::from([(uri.into(), Arc::clone(&old_grammar))]));
+
+        route_response(
+            &routes,
+            &document_grammars,
+            Response::Error(WorkerError {
+                context: Some(sync_context),
+                message: "injected document rejection".into(),
+            }),
+        )
+        .unwrap();
+
+        let routes = routes.lock().unwrap();
+        let selected = routes.get(&7).unwrap().expected_grammar.as_ref().unwrap();
+        assert!(Arc::ptr_eq(selected, &old_grammar));
+    }
+
+    #[test]
     fn grammar_hazard_arm_requires_the_exact_request_route() {
         let expected = RequestContext {
             request_id: 7,
@@ -7025,6 +7130,7 @@ mod tests {
             Route {
                 expected: expected.clone(),
                 enqueue_order: 0,
+                inherited_grammar_uri: None,
                 response_contract: ResponseContract {
                     success: SuccessResponseKind::DocumentAck,
                     cancellable: false,

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -5089,6 +5089,7 @@ pub struct Client {
     active_grammar_hazards: Arc<Mutex<HashMap<u64, GrammarHazardArmed>>>,
     reader_drain_state: Arc<(Mutex<ReaderDrainState>, Condvar)>,
     routes: Arc<Mutex<HashMap<u64, Route>>>,
+    document_grammars: Arc<Mutex<HashMap<String, Arc<WorkerGrammarIdentity>>>>,
     reader: Option<std::thread::JoinHandle<()>>,
     writer: Option<std::thread::JoinHandle<()>>,
     ready: HandshakeReady,
@@ -5140,6 +5141,8 @@ fn request_timeout(_uri: &str) -> Duration {
 
 struct Route {
     expected: RequestContext,
+    expected_grammar: Option<Arc<WorkerGrammarIdentity>>,
+    document_grammar_update: Option<DocumentGrammarUpdate>,
     sender: mpsc::Sender<io::Result<Response>>,
 }
 
@@ -5153,7 +5156,10 @@ fn record_grammar_hazard_arm(
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .get(&armed.context.request_id)
-        .is_some_and(|route| route.expected == armed.context);
+        .is_some_and(|route| {
+            route.expected == armed.context
+                && route.expected_grammar.as_deref() == Some(&armed.grammar)
+        });
     let mut hazards = hazards
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -5175,6 +5181,11 @@ pub struct PendingResponse {
     response_rx: mpsc::Receiver<io::Result<Response>>,
     started: Instant,
     timeout: Duration,
+}
+
+enum DocumentGrammarUpdate {
+    Set(String, Arc<WorkerGrammarIdentity>),
+    Remove(String),
 }
 
 impl Client {
@@ -5250,10 +5261,12 @@ impl Client {
         let child = Arc::new(Mutex::new(child));
         let terminated_by_transport = Arc::new(AtomicBool::new(false));
         let routes = Arc::new(Mutex::new(HashMap::<u64, Route>::new()));
+        let document_grammars = Arc::new(Mutex::new(HashMap::new()));
         let active_grammar_hazards =
             Arc::new(Mutex::new(HashMap::<u64, GrammarHazardArmed>::new()));
         let reader_drain_state = Arc::new((Mutex::new(ReaderDrainState::Reading), Condvar::new()));
         let reader_routes = Arc::clone(&routes);
+        let reader_document_grammars = Arc::clone(&document_grammars);
         let reader_hazards = Arc::clone(&active_grammar_hazards);
         let reader_drain_signal = Arc::clone(&reader_drain_state);
         let reader_child = Arc::clone(&child);
@@ -5307,7 +5320,11 @@ impl Client {
                                 continue;
                             }
                             response => {
-                                if let Err(error) = route_response(&reader_routes, response) {
+                                if let Err(error) = route_response(
+                                    &reader_routes,
+                                    &reader_document_grammars,
+                                    response,
+                                ) {
                                     let kind = error.kind();
                                     let message = error.to_string();
                                     fail_routes(None, &reader_routes, kind, &message);
@@ -5433,6 +5450,7 @@ impl Client {
             active_grammar_hazards,
             reader_drain_state,
             routes,
+            document_grammars,
             reader: Some(reader),
             writer: Some(writer),
             ready,
@@ -5736,8 +5754,37 @@ impl Client {
                 "request targets a stale worker generation",
             ));
         }
+        let outbound = self
+            .outbound
+            .lock()
+            .map_err(|_| io::Error::other("worker outbound lock is poisoned"))?;
+        let outbound = outbound
+            .as_ref()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker is shut down"))?;
         let request_id = expected.request_id;
         let (response_tx, response_rx) = mpsc::channel();
+        let direct_grammar = direct_request_grammar_identity(&request);
+        let inherited_grammar_uri =
+            inherited_request_grammar_context(&request).map(|context| context.uri.as_str());
+        let committed_grammar = if let Some(uri) = inherited_grammar_uri {
+            self.document_grammars
+                .lock()
+                .map_err(|_| io::Error::other("worker document grammar lock is poisoned"))?
+                .get(uri)
+                .cloned()
+        } else {
+            None
+        };
+        let document_grammar_update = match (&request, &direct_grammar) {
+            (Request::SyncDocument(request), Some(grammar)) => Some(DocumentGrammarUpdate::Set(
+                request.context.uri.clone(),
+                Arc::clone(grammar),
+            )),
+            (Request::CloseDocument(request), _) => {
+                Some(DocumentGrammarUpdate::Remove(request.context.uri.clone()))
+            }
+            _ => None,
+        };
         {
             let mut routes = self
                 .routes
@@ -5747,6 +5794,31 @@ impl Client {
                 return Err(io::Error::new(
                     io::ErrorKind::AlreadyExists,
                     format!("tree worker request {request_id} is already active"),
+                ));
+            }
+            let active_sync_grammar = inherited_grammar_uri.and_then(|uri| {
+                routes
+                    .values()
+                    .filter(|route| {
+                        matches!(
+                            &route.document_grammar_update,
+                            Some(DocumentGrammarUpdate::Set(route_uri, _)) if route_uri == uri
+                        )
+                    })
+                    .max_by_key(|route| route.expected.request_id)
+                    .and_then(|route| route.expected_grammar.clone())
+            });
+            let expected_grammar = direct_grammar
+                .clone()
+                .or(active_sync_grammar)
+                .or(committed_grammar);
+            if inherited_grammar_uri.is_some() && expected_grammar.is_none() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "document grammar is unavailable for {}",
+                        inherited_grammar_uri.unwrap_or_default()
+                    ),
                 ));
             }
             let accepting_requests = self.accepting_requests.load(Ordering::Acquire);
@@ -5769,25 +5841,18 @@ impl Client {
                 request_id,
                 Route {
                     expected,
+                    expected_grammar,
+                    document_grammar_update,
                     sender: response_tx,
                 },
             );
         }
-        {
-            let outbound = self
-                .outbound
-                .lock()
-                .map_err(|_| io::Error::other("worker outbound lock is poisoned"))?;
-            let outbound = outbound
-                .as_ref()
-                .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker is shut down"))?;
-            if outbound.send(request).is_err() {
-                self.remove_route(request_id);
-                return Err(io::Error::new(
-                    io::ErrorKind::BrokenPipe,
-                    "tree worker writer stopped",
-                ));
-            }
+        if outbound.send(request).is_err() {
+            self.remove_route(request_id);
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "tree worker writer stopped",
+            ));
         }
         Ok(PendingResponse {
             request_id,
@@ -5879,6 +5944,43 @@ fn cancellation_grace_response(
         Ok(Ok(response)) => Ok(Some(response)),
         Ok(Err(error)) => Err(error),
         Err(mpsc::RecvTimeoutError::Timeout | mpsc::RecvTimeoutError::Disconnected) => Ok(None),
+    }
+}
+
+fn direct_request_grammar_identity(request: &Request) -> Option<Arc<WorkerGrammarIdentity>> {
+    match request {
+        Request::DeriveSnapshot(request) => Some(Arc::new(WorkerGrammarIdentity {
+            grammar_symbol: request.grammar_symbol.clone(),
+            artifact_digest: request.artifact_digest.clone(),
+        })),
+        Request::SyncDocument(request) => Some(Arc::new(WorkerGrammarIdentity {
+            grammar_symbol: request.grammar_symbol.clone(),
+            artifact_digest: request.artifact_digest.clone(),
+        })),
+        _ => None,
+    }
+}
+
+fn inherited_request_grammar_context(request: &Request) -> Option<&RequestContext> {
+    match request {
+        Request::ApplyDocumentEdits(request) => Some(&request.context),
+        Request::ApplyDocumentEditsAndDerive(request) => Some(&request.context),
+        Request::DeriveDocumentSnapshot(request) => Some(&request.context),
+        Request::ResolveNode(request) => Some(&request.context),
+        Request::NavigateNode(request) => Some(&request.context),
+        Request::RunNodeScalar(request) => Some(&request.context),
+        Request::DeriveSelectionRanges(request) => Some(&request.context),
+        Request::DeriveInjectionRegions(request) => Some(&request.context),
+        Request::DeriveSemanticTokens(request) => Some(&request.context),
+        Request::RunCaptures(request) => Some(&request.context),
+        Request::DeriveNativeBindings(request) => Some(&request.context),
+        Request::Handshake(_)
+        | Request::Cancel(_)
+        | Request::DeriveSnapshot(_)
+        | Request::ConfigureLanguages(_)
+        | Request::SyncDocument(_)
+        | Request::InspectDocumentMemory(_)
+        | Request::CloseDocument(_) => None,
     }
 }
 
@@ -5983,7 +6085,11 @@ fn response_context(response: &Response) -> Option<&RequestContext> {
     }
 }
 
-fn route_response(routes: &Mutex<HashMap<u64, Route>>, response: Response) -> io::Result<()> {
+fn route_response(
+    routes: &Mutex<HashMap<u64, Route>>,
+    document_grammars: &Mutex<HashMap<String, Arc<WorkerGrammarIdentity>>>,
+    response: Response,
+) -> io::Result<()> {
     let Some(request_id) = response_request_id(&response) else {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -6009,6 +6115,21 @@ fn route_response(routes: &Mutex<HashMap<u64, Route>>, response: Response) -> io
             .sender
             .send(Err(io::Error::new(error.kind(), error.to_string())));
         return Err(error);
+    }
+    match (&route.document_grammar_update, &response) {
+        (Some(DocumentGrammarUpdate::Set(uri, grammar)), Response::DocumentAck(_)) => {
+            document_grammars
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .insert(uri.clone(), Arc::clone(grammar));
+        }
+        (Some(DocumentGrammarUpdate::Remove(uri)), Response::DocumentClosed(_)) => {
+            document_grammars
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .remove(uri);
+        }
+        _ => {}
     }
     let _ = route.sender.send(Ok(response));
     Ok(())
@@ -6625,6 +6746,7 @@ mod tests {
     #[test]
     fn response_router_rejects_unknown_request_id() {
         let routes = Mutex::new(HashMap::new());
+        let document_grammars = Mutex::new(HashMap::new());
         let response = Response::Error(WorkerError {
             context: Some(RequestContext {
                 request_id: 99,
@@ -6637,7 +6759,7 @@ mod tests {
             message: "unexpected".into(),
         });
 
-        let error = route_response(&routes, response).unwrap_err();
+        let error = route_response(&routes, &document_grammars, response).unwrap_err();
 
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
         assert!(error.to_string().contains("unknown request id 99"));
@@ -6658,6 +6780,8 @@ mod tests {
             7,
             Route {
                 expected: expected.clone(),
+                expected_grammar: None,
+                document_grammar_update: None,
                 sender,
             },
         )]));
@@ -6666,6 +6790,7 @@ mod tests {
 
         let error = route_response(
             &routes,
+            &Mutex::new(HashMap::new()),
             Response::Error(WorkerError {
                 context: Some(stale),
                 message: "stale".into(),
@@ -6692,6 +6817,11 @@ mod tests {
             7,
             Route {
                 expected: expected.clone(),
+                expected_grammar: Some(Arc::new(WorkerGrammarIdentity {
+                    grammar_symbol: "rust".into(),
+                    artifact_digest: "sha256:expected".into(),
+                })),
+                document_grammar_update: None,
                 sender,
             },
         )]));
@@ -6717,13 +6847,31 @@ mod tests {
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
         assert!(hazards.lock().unwrap().is_empty());
 
+        let error = record_grammar_hazard_arm(
+            &routes,
+            &hazards,
+            GrammarHazardArmed {
+                lease_id: 10,
+                context: expected.clone(),
+                grammar: WorkerGrammarIdentity {
+                    grammar_symbol: "lua".into(),
+                    artifact_digest: "sha256:forged".into(),
+                },
+            },
+            3,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(hazards.lock().unwrap().is_empty());
+
         let mut unknown = expected;
         unknown.request_id = 99;
         let error = record_grammar_hazard_arm(
             &routes,
             &hazards,
             GrammarHazardArmed {
-                lease_id: 10,
+                lease_id: 11,
                 context: unknown,
                 grammar: WorkerGrammarIdentity {
                     grammar_symbol: "lua".into(),

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -5139,9 +5139,32 @@ fn request_timeout(_uri: &str) -> Duration {
 
 struct Route {
     expected: RequestContext,
+    response_contract: ResponseContract,
     expected_grammar: Option<Arc<WorkerGrammarIdentity>>,
     document_grammar_update: Option<DocumentGrammarUpdate>,
     sender: mpsc::Sender<io::Result<Response>>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SuccessResponseKind {
+    DocumentAck,
+    DocumentClosed,
+    Snapshot,
+    Nodes,
+    NodeScalar,
+    SelectionRanges,
+    InjectionRegions,
+    SemanticTokens,
+    Captures,
+    NativeBindings,
+    LanguageCatalogAck,
+    DocumentMemory,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ResponseContract {
+    success: SuccessResponseKind,
+    cancellable: bool,
 }
 
 fn record_grammar_hazard_arm(
@@ -5839,6 +5862,7 @@ impl Client {
                 request_id,
                 Route {
                     expected,
+                    response_contract: response_contract(&request),
                     expected_grammar,
                     document_grammar_update,
                     sender: response_tx,
@@ -5982,6 +6006,34 @@ fn inherited_request_grammar_context(request: &Request) -> Option<&RequestContex
     }
 }
 
+fn response_contract(request: &Request) -> ResponseContract {
+    let success = match request {
+        Request::DeriveSnapshot(_)
+        | Request::ApplyDocumentEditsAndDerive(_)
+        | Request::DeriveDocumentSnapshot(_) => SuccessResponseKind::Snapshot,
+        Request::SyncDocument(_) | Request::ApplyDocumentEdits(_) => {
+            SuccessResponseKind::DocumentAck
+        }
+        Request::ResolveNode(_) | Request::NavigateNode(_) => SuccessResponseKind::Nodes,
+        Request::RunNodeScalar(_) => SuccessResponseKind::NodeScalar,
+        Request::DeriveSelectionRanges(_) => SuccessResponseKind::SelectionRanges,
+        Request::DeriveInjectionRegions(_) => SuccessResponseKind::InjectionRegions,
+        Request::DeriveSemanticTokens(_) => SuccessResponseKind::SemanticTokens,
+        Request::RunCaptures(_) => SuccessResponseKind::Captures,
+        Request::DeriveNativeBindings(_) => SuccessResponseKind::NativeBindings,
+        Request::ConfigureLanguages(_) => SuccessResponseKind::LanguageCatalogAck,
+        Request::InspectDocumentMemory(_) => SuccessResponseKind::DocumentMemory,
+        Request::CloseDocument(_) => SuccessResponseKind::DocumentClosed,
+        Request::Handshake(_) | Request::Cancel(_) => {
+            unreachable!("control requests do not create response routes")
+        }
+    };
+    ResponseContract {
+        success,
+        cancellable: is_cancellable_reader_request(request),
+    }
+}
+
 fn request_uses_supervisor_route_reserve(request: &Request) -> bool {
     matches!(
         request,
@@ -6083,6 +6135,30 @@ fn response_context(response: &Response) -> Option<&RequestContext> {
     }
 }
 
+fn response_matches_contract(response: &Response, contract: ResponseContract) -> bool {
+    match response {
+        Response::Error(_) | Response::WorkerRestartRequired(_) => true,
+        Response::RequestCancelled(_) => contract.cancellable,
+        Response::DocumentAck(_) => contract.success == SuccessResponseKind::DocumentAck,
+        Response::DocumentClosed(_) => contract.success == SuccessResponseKind::DocumentClosed,
+        Response::Snapshot(_) => contract.success == SuccessResponseKind::Snapshot,
+        Response::Nodes(_) => contract.success == SuccessResponseKind::Nodes,
+        Response::NodeScalar(_) => contract.success == SuccessResponseKind::NodeScalar,
+        Response::SelectionRanges(_) => contract.success == SuccessResponseKind::SelectionRanges,
+        Response::InjectionRegions(_) => contract.success == SuccessResponseKind::InjectionRegions,
+        Response::SemanticTokens(_) => contract.success == SuccessResponseKind::SemanticTokens,
+        Response::Captures(_) => contract.success == SuccessResponseKind::Captures,
+        Response::NativeBindings(_) => contract.success == SuccessResponseKind::NativeBindings,
+        Response::LanguageCatalogAck(_) => {
+            contract.success == SuccessResponseKind::LanguageCatalogAck
+        }
+        Response::DocumentMemory(_) => contract.success == SuccessResponseKind::DocumentMemory,
+        Response::HandshakeReady(_)
+        | Response::GrammarHazardArmed(_)
+        | Response::GrammarHazardReleased(_) => false,
+    }
+}
+
 fn route_response(
     routes: &Mutex<HashMap<u64, Route>>,
     document_grammars: &Mutex<HashMap<String, Arc<WorkerGrammarIdentity>>>,
@@ -6108,6 +6184,16 @@ fn route_response(
         let error = io::Error::new(
             io::ErrorKind::InvalidData,
             format!("response context mismatch for request {request_id}"),
+        );
+        let _ = route
+            .sender
+            .send(Err(io::Error::new(error.kind(), error.to_string())));
+        return Err(error);
+    }
+    if !response_matches_contract(&response, route.response_contract) {
+        let error = io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("response variant mismatch for request {request_id}"),
         );
         let _ = route
             .sender
@@ -6229,21 +6315,21 @@ mod tests {
         DeriveNativeBindings, DeriveSelectionRanges, DeriveSemanticTokens, DeriveSnapshot,
         DocumentCompetition, DocumentKey, DocumentLane, DocumentMemoryAdmission, DocumentReplica,
         GrammarHazardArmed, GrammarHazardReleased, GrammarKey, Handshake, HandshakeReady,
-        LaneAction, LaneRegistry, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
+        LaneAction, LaneRegistry, LanguageCatalogAck, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
         MAX_RETAINED_DOCUMENT_BYTES, MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES, NavigateNode,
         NodeLayerSelector, NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId,
         OwnedChild, PROTOCOL_VERSION, ParentLiveness, Request, RequestContext, ResolveNode,
-        Response, Route, RunCaptures, RunNodeScalar, RunnableDocuments,
-        SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES, SyncDocument, WireByteRange, WirePosition,
-        WireRange, WireSemanticToken, WorkPriority, WorkerError, WorkerGrammarIdentity,
-        WorkerQuerySources, WorkerRestartRequired, cache_eviction_plan, cancel_active_request,
-        cancellation_grace_response, client_generation_is_idle, close_document, decode_frame,
-        derive_snapshot_with_language, encode_frame, enforce_derived_memory_budget,
-        named_node_count, parse_request_timeout, pressure_checkpoint_required,
-        record_grammar_hazard_arm, replace_retained_bytes, replace_retained_estimated_bytes,
-        request_grammar_identity, request_may_grow_derived_state, request_priority,
-        reserve_retained_growth, route_is_admissible, route_response, run, submit_document_job,
-        sync_document, terminate, terminate_by_transport,
+        Response, ResponseContract, Route, RunCaptures, RunNodeScalar, RunnableDocuments,
+        SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES, SuccessResponseKind, SyncDocument,
+        WireByteRange, WirePosition, WireRange, WireSemanticToken, WorkPriority, WorkerError,
+        WorkerGrammarIdentity, WorkerQuerySources, WorkerRestartRequired, cache_eviction_plan,
+        cancel_active_request, cancellation_grace_response, client_generation_is_idle,
+        close_document, decode_frame, derive_snapshot_with_language, encode_frame,
+        enforce_derived_memory_budget, named_node_count, parse_request_timeout,
+        pressure_checkpoint_required, record_grammar_hazard_arm, replace_retained_bytes,
+        replace_retained_estimated_bytes, request_grammar_identity, request_may_grow_derived_state,
+        request_priority, reserve_retained_growth, route_is_admissible, route_response, run,
+        submit_document_job, sync_document, terminate, terminate_by_transport,
         terminate_by_transport_for_request_deadline, validate_document_size,
     };
 
@@ -6784,6 +6870,10 @@ mod tests {
             7,
             Route {
                 expected: expected.clone(),
+                response_contract: ResponseContract {
+                    success: SuccessResponseKind::DocumentAck,
+                    cancellable: false,
+                },
                 expected_grammar: None,
                 document_grammar_update: None,
                 sender,
@@ -6807,6 +6897,45 @@ mod tests {
     }
 
     #[test]
+    fn response_router_rejects_a_wrong_terminal_variant() {
+        let expected = RequestContext {
+            request_id: 7,
+            worker_generation: 3,
+            uri: "file:///sync.rs".into(),
+            incarnation: 11,
+            content_version: 5,
+            configuration_generation: 2,
+        };
+        let (sender, _receiver) = std::sync::mpsc::channel();
+        let routes = Mutex::new(HashMap::from([(
+            7,
+            Route {
+                expected: expected.clone(),
+                response_contract: ResponseContract {
+                    success: SuccessResponseKind::DocumentAck,
+                    cancellable: false,
+                },
+                expected_grammar: None,
+                document_grammar_update: None,
+                sender,
+            },
+        )]));
+
+        let error = route_response(
+            &routes,
+            &Mutex::new(HashMap::new()),
+            Response::LanguageCatalogAck(LanguageCatalogAck {
+                context: expected,
+                languages: 1,
+            }),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("variant mismatch"));
+    }
+
+    #[test]
     fn grammar_hazard_arm_requires_the_exact_request_route() {
         let expected = RequestContext {
             request_id: 7,
@@ -6821,6 +6950,10 @@ mod tests {
             7,
             Route {
                 expected: expected.clone(),
+                response_contract: ResponseContract {
+                    success: SuccessResponseKind::DocumentAck,
+                    cancellable: false,
+                },
                 expected_grammar: Some(Arc::new(WorkerGrammarIdentity {
                     grammar_symbol: "rust".into(),
                     artifact_digest: "sha256:expected".into(),

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4361,6 +4361,18 @@ where
         }
         #[cfg(feature = "e2e")]
         if scheduled_key.as_ref().is_some_and(|key| {
+            std::env::var("KAKEHASHI_TREE_WORKER_SCHEDULED_MARKER_URI_PREFIX")
+                .ok()
+                .is_some_and(|prefix| key.uri.starts_with(&prefix))
+        }) && let Ok(directory) = std::env::var("KAKEHASHI_TREE_WORKER_SCHEDULED_MARKER_DIR")
+        {
+            let _ = std::fs::write(
+                std::path::Path::new(&directory).join(request_id.to_string()),
+                b"scheduled",
+            );
+        }
+        #[cfg(feature = "e2e")]
+        if scheduled_key.as_ref().is_some_and(|key| {
             std::env::var("KAKEHASHI_TREE_WORKER_SCHEDULED_URI_SUFFIX")
                 .ok()
                 .is_some_and(|suffix| key.uri.ends_with(&suffix))

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4420,6 +4420,12 @@ fn inject_worker_failure_once(request: &Request) -> Option<Response> {
             .open(marker)
             .is_ok()
     {
+        if let Ok(milliseconds) = std::env::var("KAKEHASHI_TREE_WORKER_RESTART_RESPONSE_DELAY_MS")
+            .unwrap_or_default()
+            .parse::<u64>()
+        {
+            std::thread::sleep(Duration::from_millis(milliseconds));
+        }
         return Some(Response::WorkerRestartRequired(WorkerRestartRequired {
             context: sync.context.clone(),
             reason: "injected systemic restart".into(),
@@ -5693,11 +5699,17 @@ impl Client {
         let response = match response_rx.recv_timeout(remaining) {
             Ok(response) => response?,
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                let cancellation_completed = self.cancel_request(request_id).is_ok()
-                    && cancellation_grace_completed(
+                let cancellation_response = if self.cancel_request(request_id).is_ok() {
+                    cancellation_grace_response(
                         response_rx.recv_timeout(REQUEST_CANCELLATION_GRACE),
-                    )?;
-                if !cancellation_completed {
+                    )?
+                } else {
+                    None
+                };
+                if let Some(Response::WorkerRestartRequired(required)) = cancellation_response {
+                    return Ok(Response::WorkerRestartRequired(required));
+                }
+                if cancellation_response.is_none() {
                     self.terminate_for_request_deadline(Duration::from_secs(1));
                 }
                 return Err(io::Error::new(
@@ -5751,13 +5763,13 @@ impl Client {
     }
 }
 
-fn cancellation_grace_completed(
+fn cancellation_grace_response(
     result: Result<io::Result<Response>, mpsc::RecvTimeoutError>,
-) -> io::Result<bool> {
+) -> io::Result<Option<Response>> {
     match result {
-        Ok(Ok(_)) => Ok(true),
+        Ok(Ok(response)) => Ok(Some(response)),
         Ok(Err(error)) => Err(error),
-        Err(mpsc::RecvTimeoutError::Timeout | mpsc::RecvTimeoutError::Disconnected) => Ok(false),
+        Err(mpsc::RecvTimeoutError::Timeout | mpsc::RecvTimeoutError::Disconnected) => Ok(None),
     }
 }
 
@@ -5990,14 +6002,14 @@ mod tests {
         ResolveNode, Response, Route, RunCaptures, RunNodeScalar, RunnableDocuments,
         SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES, SyncDocument, WireByteRange, WirePosition,
         WireRange, WireSemanticToken, WorkPriority, WorkerError, WorkerGrammarIdentity,
-        WorkerQuerySources, cache_eviction_plan, cancellation_grace_completed,
-        client_generation_is_idle, close_document, decode_frame, derive_snapshot_with_language,
-        encode_frame, enforce_derived_memory_budget, named_node_count, parse_request_timeout,
-        pressure_checkpoint_required, replace_retained_bytes, replace_retained_estimated_bytes,
-        request_may_grow_derived_state, request_priority, reserve_retained_growth,
-        route_is_admissible, route_response, run, submit_document_job, sync_document, terminate,
-        terminate_by_transport, terminate_by_transport_for_request_deadline,
-        validate_document_size,
+        WorkerQuerySources, WorkerRestartRequired, cache_eviction_plan,
+        cancellation_grace_response, client_generation_is_idle, close_document, decode_frame,
+        derive_snapshot_with_language, encode_frame, enforce_derived_memory_budget,
+        named_node_count, parse_request_timeout, pressure_checkpoint_required,
+        replace_retained_bytes, replace_retained_estimated_bytes, request_may_grow_derived_state,
+        request_priority, reserve_retained_growth, route_is_admissible, route_response, run,
+        submit_document_job, sync_document, terminate, terminate_by_transport,
+        terminate_by_transport_for_request_deadline, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -6353,9 +6365,30 @@ mod tests {
                 "worker lost during cancellation grace",
             )));
 
-        let error = cancellation_grace_completed(result).unwrap_err();
+        let error = cancellation_grace_response(result).unwrap_err();
 
         assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
+    }
+
+    #[test]
+    fn cancellation_grace_preserves_worker_restart_requirement() {
+        let required = WorkerRestartRequired {
+            context: RequestContext {
+                request_id: 42,
+                worker_generation: 7,
+                uri: "file:///pressure.rs".into(),
+                incarnation: 3,
+                content_version: 5,
+                configuration_generation: 11,
+            },
+            reason: "post-compute pressure checkpoint failed".into(),
+        };
+
+        let response =
+            cancellation_grace_response(Ok(Ok(Response::WorkerRestartRequired(required.clone()))))
+                .unwrap();
+
+        assert_eq!(response, Some(Response::WorkerRestartRequired(required)));
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4062,7 +4062,9 @@ where
                 .expect("worker admission queue stopped before its jobs");
             let permit = AdmissionPermit(permits);
             let mut announced_lease = None;
-            let hazard_error = grammar_hazard.and_then(|grammar| {
+            let hazard_error = grammar_hazard.and_then(|grammar: WorkerGrammarIdentity| {
+                #[cfg(feature = "e2e")]
+                let e2e_grammar_symbol = grammar.grammar_symbol.clone();
                 let lease_id = job_next_hazard_lease.fetch_add(1, Ordering::Relaxed);
                 let (committed_tx, committed_rx) = mpsc::channel();
                 if responses
@@ -4086,6 +4088,18 @@ where
                 match committed_rx.recv_timeout(Duration::from_secs(5)) {
                     Ok(()) => {
                         #[cfg(feature = "e2e")]
+                        if std::env::var_os("KAKEHASHI_TREE_WORKER_RECOVERY_READY_FILE")
+                            .is_some_and(|path| std::path::Path::new(&path).exists())
+                            && let Ok(path) =
+                                std::env::var("KAKEHASHI_TREE_WORKER_POST_RECOVERY_HAZARD_LOG")
+                            && let Ok(mut log) = std::fs::OpenOptions::new()
+                                .create(true)
+                                .append(true)
+                                .open(path)
+                        {
+                            let _ = writeln!(log, "{e2e_grammar_symbol}");
+                        }
+                        #[cfg(feature = "e2e")]
                         if let Ok(marker) =
                             std::env::var("KAKEHASHI_TREE_WORKER_HANG_AFTER_HAZARD_ARMED_FILE")
                             && std::env::var(
@@ -4106,6 +4120,8 @@ where
                         #[cfg(feature = "e2e")]
                         if std::env::var_os("KAKEHASHI_TREE_WORKER_MULTI_HAZARD_TRIGGER_FILE")
                             .is_some_and(|path| std::path::Path::new(&path).exists())
+                            && !std::env::var_os("KAKEHASHI_TREE_WORKER_RECOVERY_READY_FILE")
+                                .is_some_and(|path| std::path::Path::new(&path).exists())
                         {
                             if std::env::var(
                                 "KAKEHASHI_TREE_WORKER_HOLD_COMMITTED_HAZARD_URI_SUFFIX",

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -5143,6 +5143,33 @@ struct Route {
     sender: mpsc::Sender<io::Result<Response>>,
 }
 
+fn record_grammar_hazard_arm(
+    routes: &Mutex<HashMap<u64, Route>>,
+    hazards: &Mutex<HashMap<u64, GrammarHazardArmed>>,
+    armed: GrammarHazardArmed,
+    worker_generation: u64,
+) -> io::Result<()> {
+    let has_matching_route = routes
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(&armed.context.request_id)
+        .is_some_and(|route| route.expected == armed.context);
+    let mut hazards = hazards
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if armed.context.worker_generation != worker_generation
+        || !has_matching_route
+        || hazards.contains_key(&armed.lease_id)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid grammar hazard arm",
+        ));
+    }
+    hazards.insert(armed.lease_id, armed);
+    Ok(())
+}
+
 pub struct PendingResponse {
     request_id: u64,
     response_rx: mpsc::Receiver<io::Result<Response>>,
@@ -5243,12 +5270,14 @@ impl Client {
                         }
                         match response {
                             Response::GrammarHazardArmed(armed) => {
-                                let valid = armed.context.worker_generation == worker_generation
-                                    && !reader_hazards
-                                        .lock()
-                                        .unwrap_or_else(std::sync::PoisonError::into_inner)
-                                        .contains_key(&armed.lease_id);
-                                if !valid {
+                                if record_grammar_hazard_arm(
+                                    &reader_routes,
+                                    &reader_hazards,
+                                    armed,
+                                    worker_generation,
+                                )
+                                .is_err()
+                                {
                                     fail_routes(
                                         None,
                                         &reader_routes,
@@ -5257,10 +5286,6 @@ impl Client {
                                     );
                                     break ReaderDrainState::Incomplete;
                                 }
-                                reader_hazards
-                                    .lock()
-                                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                                    .insert(armed.lease_id, armed);
                                 continue;
                             }
                             Response::GrammarHazardReleased(released) => {
@@ -6090,10 +6115,11 @@ mod tests {
         cancellation_grace_response, client_generation_is_idle, close_document, decode_frame,
         derive_snapshot_with_language, encode_frame, enforce_derived_memory_budget,
         named_node_count, parse_request_timeout, pressure_checkpoint_required,
-        replace_retained_bytes, replace_retained_estimated_bytes, request_may_grow_derived_state,
-        request_priority, reserve_retained_growth, route_is_admissible, route_response, run,
-        submit_document_job, sync_document, terminate, terminate_by_transport,
-        terminate_by_transport_for_request_deadline, validate_document_size,
+        record_grammar_hazard_arm, replace_retained_bytes, replace_retained_estimated_bytes,
+        request_may_grow_derived_state, request_priority, reserve_retained_growth,
+        route_is_admissible, route_response, run, submit_document_job, sync_document, terminate,
+        terminate_by_transport, terminate_by_transport_for_request_deadline,
+        validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -6649,6 +6675,67 @@ mod tests {
 
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
         assert!(error.to_string().contains("context mismatch"));
+    }
+
+    #[test]
+    fn grammar_hazard_arm_requires_the_exact_request_route() {
+        let expected = RequestContext {
+            request_id: 7,
+            worker_generation: 3,
+            uri: "file:///expected.rs".into(),
+            incarnation: 11,
+            content_version: 5,
+            configuration_generation: 2,
+        };
+        let (sender, _receiver) = std::sync::mpsc::channel();
+        let routes = Mutex::new(HashMap::from([(
+            7,
+            Route {
+                expected: expected.clone(),
+                sender,
+            },
+        )]));
+        let hazards = Mutex::new(HashMap::new());
+        let mut mismatched = expected.clone();
+        mismatched.uri = "file:///forged.rs".into();
+
+        let error = record_grammar_hazard_arm(
+            &routes,
+            &hazards,
+            GrammarHazardArmed {
+                lease_id: 9,
+                context: mismatched,
+                grammar: WorkerGrammarIdentity {
+                    grammar_symbol: "rust".into(),
+                    artifact_digest: "sha256:forged".into(),
+                },
+            },
+            3,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(hazards.lock().unwrap().is_empty());
+
+        let mut unknown = expected;
+        unknown.request_id = 99;
+        let error = record_grammar_hazard_arm(
+            &routes,
+            &hazards,
+            GrammarHazardArmed {
+                lease_id: 10,
+                context: unknown,
+                grammar: WorkerGrammarIdentity {
+                    grammar_symbol: "lua".into(),
+                    artifact_digest: "sha256:unknown".into(),
+                },
+            },
+            3,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(hazards.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4996,6 +4996,7 @@ pub struct Client {
 }
 
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+const REQUEST_CANCELLATION_GRACE: Duration = Duration::from_millis(250);
 
 #[cfg(any(test, feature = "e2e"))]
 fn parse_request_timeout(value: Option<&str>) -> Duration {
@@ -5605,7 +5606,11 @@ impl Client {
         let response = match response_rx.recv_timeout(remaining) {
             Ok(response) => response?,
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                let _ = self.cancel_request(request_id);
+                let cancellation_completed = self.cancel_request(request_id).is_ok()
+                    && response_rx.recv_timeout(REQUEST_CANCELLATION_GRACE).is_ok();
+                if !cancellation_completed {
+                    self.terminate_shared(Duration::from_secs(1));
+                }
                 return Err(io::Error::new(
                     io::ErrorKind::TimedOut,
                     format!("tree worker request {request_id} timed out"),

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -13,7 +13,7 @@ use std::{
     collections::{HashMap, VecDeque},
     sync::{
         Arc, Condvar, Mutex, Weak,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     },
 };
 
@@ -5095,6 +5095,7 @@ pub struct Client {
     terminated_by_transport: Arc<AtomicBool>,
     terminated_for_request_deadline: AtomicBool,
     outbound: Mutex<Option<mpsc::Sender<Request>>>,
+    next_enqueue_order: AtomicU64,
     accepting_requests: AtomicBool,
     active_grammar_hazards: Arc<Mutex<HashMap<u64, GrammarHazardArmed>>>,
     reader_drain_state: Arc<(Mutex<ReaderDrainState>, Condvar)>,
@@ -5151,10 +5152,27 @@ fn request_timeout(_uri: &str) -> Duration {
 
 struct Route {
     expected: RequestContext,
+    enqueue_order: u64,
     response_contract: ResponseContract,
     expected_grammar: Option<Arc<WorkerGrammarIdentity>>,
     document_grammar_update: Option<DocumentGrammarUpdate>,
     sender: mpsc::Sender<io::Result<Response>>,
+}
+
+fn latest_pending_sync_grammar(
+    routes: &HashMap<u64, Route>,
+    uri: &str,
+) -> Option<Arc<WorkerGrammarIdentity>> {
+    routes
+        .values()
+        .filter_map(|route| match &route.document_grammar_update {
+            Some(DocumentGrammarUpdate::Set(route_uri, grammar)) if route_uri == uri => {
+                Some((route.enqueue_order, Arc::clone(grammar)))
+            }
+            _ => None,
+        })
+        .max_by_key(|(enqueue_order, _)| *enqueue_order)
+        .map(|(_, grammar)| grammar)
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -5479,6 +5497,7 @@ impl Client {
             terminated_by_transport,
             terminated_for_request_deadline: AtomicBool::new(false),
             outbound: Mutex::new(Some(outbound)),
+            next_enqueue_order: AtomicU64::new(0),
             accepting_requests: AtomicBool::new(true),
             active_grammar_hazards,
             reader_drain_state,
@@ -5794,6 +5813,12 @@ impl Client {
         let outbound = outbound
             .as_ref()
             .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "worker is shut down"))?;
+        let enqueue_order = self
+            .next_enqueue_order
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |order| {
+                order.checked_add(1)
+            })
+            .map_err(|_| io::Error::other("worker enqueue order is exhausted"))?;
         let request_id = expected.request_id;
         let (response_tx, response_rx) = mpsc::channel();
         let direct_grammar = direct_request_grammar_identity(&request);
@@ -5829,18 +5854,8 @@ impl Client {
                     format!("tree worker request {request_id} is already active"),
                 ));
             }
-            let active_sync_grammar = inherited_grammar_uri.and_then(|uri| {
-                routes
-                    .values()
-                    .filter(|route| {
-                        matches!(
-                            &route.document_grammar_update,
-                            Some(DocumentGrammarUpdate::Set(route_uri, _)) if route_uri == uri
-                        )
-                    })
-                    .max_by_key(|route| route.expected.request_id)
-                    .and_then(|route| route.expected_grammar.clone())
-            });
+            let active_sync_grammar =
+                inherited_grammar_uri.and_then(|uri| latest_pending_sync_grammar(&routes, uri));
             let expected_grammar = direct_grammar
                 .clone()
                 .or(active_sync_grammar)
@@ -5874,6 +5889,7 @@ impl Client {
                 request_id,
                 Route {
                     expected,
+                    enqueue_order,
                     response_contract: response_contract(&request),
                     expected_grammar,
                     document_grammar_update,
@@ -6325,24 +6341,26 @@ mod tests {
         ApplyDocumentEdits, BUILD_ID, ByteEdit, CacheEviction, CacheEvictionCandidate,
         CachedInjectionLayer, CancelRequest, CapturesResult, CloseDocument, DeriveInjectionRegions,
         DeriveNativeBindings, DeriveSelectionRanges, DeriveSemanticTokens, DeriveSnapshot,
-        DocumentCompetition, DocumentKey, DocumentLane, DocumentMemoryAdmission, DocumentReplica,
-        GrammarHazardArmed, GrammarHazardReleased, GrammarKey, Handshake, HandshakeReady,
-        LaneAction, LaneRegistry, LanguageCatalogAck, MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS,
-        MAX_RETAINED_DOCUMENT_BYTES, MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES, NavigateNode,
-        NodeLayerSelector, NodeNavigation, NodeScalarOperation, NodeScalarValue, OpaqueNodeId,
-        OwnedChild, PROTOCOL_VERSION, ParentLiveness, Request, RequestContext, ResolveNode,
-        Response, ResponseContract, Route, RunCaptures, RunNodeScalar, RunnableDocuments,
+        DocumentCompetition, DocumentGrammarUpdate, DocumentKey, DocumentLane,
+        DocumentMemoryAdmission, DocumentReplica, GrammarHazardArmed, GrammarHazardReleased,
+        GrammarKey, Handshake, HandshakeReady, LaneAction, LaneRegistry, LanguageCatalogAck,
+        MAX_DOCUMENT_BYTES, MAX_DOCUMENT_REPLICAS, MAX_RETAINED_DOCUMENT_BYTES,
+        MAX_RETAINED_ESTIMATED_DOCUMENT_BYTES, NavigateNode, NodeLayerSelector, NodeNavigation,
+        NodeScalarOperation, NodeScalarValue, OpaqueNodeId, OwnedChild, PROTOCOL_VERSION,
+        ParentLiveness, Request, RequestContext, ResolveNode, Response, ResponseContract, Route,
+        RunCaptures, RunNodeScalar, RunnableDocuments,
         SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES, SuccessResponseKind, SyncDocument,
         WireByteRange, WirePosition, WireRange, WireSemanticToken, WorkPriority, WorkerError,
         WorkerGrammarIdentity, WorkerQuerySources, WorkerRestartRequired, cache_eviction_plan,
         cancel_active_request, cancellation_grace_response, client_generation_is_idle,
         close_document, decode_frame, derive_snapshot_with_language, encode_frame,
-        enforce_derived_memory_budget, named_node_count, parse_request_timeout,
-        pressure_checkpoint_required, record_grammar_hazard_arm, replace_retained_bytes,
-        replace_retained_estimated_bytes, request_grammar_identity, request_may_grow_derived_state,
-        request_priority, reserve_retained_growth, route_is_admissible, route_response, run,
-        submit_document_job, sync_document, terminate, terminate_by_transport,
-        terminate_by_transport_for_request_deadline, validate_document_size,
+        enforce_derived_memory_budget, latest_pending_sync_grammar, named_node_count,
+        parse_request_timeout, pressure_checkpoint_required, record_grammar_hazard_arm,
+        replace_retained_bytes, replace_retained_estimated_bytes, request_grammar_identity,
+        request_may_grow_derived_state, request_priority, reserve_retained_growth,
+        route_is_admissible, route_response, run, submit_document_job, sync_document, terminate,
+        terminate_by_transport, terminate_by_transport_for_request_deadline,
+        validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -6882,6 +6900,7 @@ mod tests {
             7,
             Route {
                 expected: expected.clone(),
+                enqueue_order: 0,
                 response_contract: ResponseContract {
                     success: SuccessResponseKind::DocumentAck,
                     cancellable: false,
@@ -6923,6 +6942,7 @@ mod tests {
             7,
             Route {
                 expected: expected.clone(),
+                enqueue_order: 0,
                 response_contract: ResponseContract {
                     success: SuccessResponseKind::DocumentAck,
                     cancellable: false,
@@ -6948,6 +6968,48 @@ mod tests {
     }
 
     #[test]
+    fn pending_sync_grammar_follows_enqueue_order_not_request_id() {
+        let uri = "file:///pipelined.rs";
+        let grammar = |symbol: &str| {
+            Arc::new(WorkerGrammarIdentity {
+                grammar_symbol: symbol.into(),
+                artifact_digest: format!("sha256:{symbol}"),
+            })
+        };
+        let route = |request_id, enqueue_order, grammar: Arc<WorkerGrammarIdentity>| {
+            let (sender, _receiver) = std::sync::mpsc::channel();
+            Route {
+                expected: RequestContext {
+                    request_id,
+                    worker_generation: 3,
+                    uri: uri.into(),
+                    incarnation: 1,
+                    content_version: enqueue_order,
+                    configuration_generation: 1,
+                },
+                enqueue_order,
+                response_contract: ResponseContract {
+                    success: SuccessResponseKind::DocumentAck,
+                    cancellable: false,
+                },
+                expected_grammar: Some(Arc::clone(&grammar)),
+                document_grammar_update: Some(DocumentGrammarUpdate::Set(uri.into(), grammar)),
+                sender,
+            }
+        };
+        let earlier_high_id = grammar("rust");
+        let later_low_id = grammar("lua");
+        let routes = HashMap::from([
+            (90, route(90, 1, earlier_high_id)),
+            (7, route(7, 2, Arc::clone(&later_low_id))),
+        ]);
+
+        let selected = latest_pending_sync_grammar(&routes, uri).unwrap();
+
+        assert!(Arc::ptr_eq(&selected, &later_low_id));
+    }
+
+    #[test]
     fn grammar_hazard_arm_requires_the_exact_request_route() {
         let expected = RequestContext {
             request_id: 7,
@@ -6962,6 +7024,7 @@ mod tests {
             7,
             Route {
                 expected: expected.clone(),
+                enqueue_order: 0,
                 response_contract: ResponseContract {
                     success: SuccessResponseKind::DocumentAck,
                     cancellable: false,

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -4100,6 +4100,32 @@ where
                             let _ = writeln!(log, "{e2e_grammar_symbol}");
                         }
                         #[cfg(feature = "e2e")]
+                        if let Ok(marker) = std::env::var(
+                            "KAKEHASHI_TREE_WORKER_INVALID_RELEASE_AFTER_HAZARD_ARMED_FILE",
+                        ) && std::env::var(
+                            "KAKEHASHI_TREE_WORKER_INVALID_RELEASE_AFTER_HAZARD_ARMED_URI_SUFFIX",
+                        )
+                        .ok()
+                        .is_none_or(|suffix| context.uri.ends_with(&suffix))
+                            && std::fs::OpenOptions::new()
+                                .write(true)
+                                .create_new(true)
+                                .open(marker)
+                                .is_ok()
+                        {
+                            let _ = responses.send((
+                                Response::GrammarHazardReleased(GrammarHazardReleased {
+                                    lease_id: u64::MAX,
+                                    worker_generation,
+                                }),
+                                None,
+                                None,
+                            ));
+                            loop {
+                                std::thread::park();
+                            }
+                        }
+                        #[cfg(feature = "e2e")]
                         if let Ok(marker) =
                             std::env::var("KAKEHASHI_TREE_WORKER_HANG_AFTER_HAZARD_ARMED_FILE")
                             && std::env::var(
@@ -5017,6 +5043,7 @@ impl std::ops::DerefMut for OwnedChild {
 pub struct Client {
     child: Arc<Mutex<OwnedChild>>,
     terminated_by_transport: Arc<AtomicBool>,
+    terminated_for_request_deadline: AtomicBool,
     outbound: Mutex<Option<mpsc::Sender<Request>>>,
     accepting_requests: AtomicBool,
     active_grammar_hazards: Arc<Mutex<HashMap<u64, GrammarHazardArmed>>>,
@@ -5321,6 +5348,7 @@ impl Client {
         Ok(Self {
             child,
             terminated_by_transport,
+            terminated_for_request_deadline: AtomicBool::new(false),
             outbound: Mutex::new(Some(outbound)),
             accepting_requests: AtomicBool::new(true),
             active_grammar_hazards,
@@ -5342,6 +5370,10 @@ impl Client {
 
     pub fn was_terminated_by_transport(&self) -> bool {
         self.terminated_by_transport.load(Ordering::Acquire)
+    }
+
+    pub fn was_terminated_for_request_deadline(&self) -> bool {
+        self.terminated_for_request_deadline.load(Ordering::Acquire)
     }
 
     pub fn compute_threads(&self) -> usize {
@@ -5441,12 +5473,25 @@ impl Client {
     /// read router. In-flight requests then observe transport failure while a
     /// replacement generation can be published independently.
     pub fn terminate_shared(&self, timeout: Duration) {
+        self.terminate_shared_with_cause(timeout, false);
+    }
+
+    fn terminate_for_request_deadline(&self, timeout: Duration) {
+        self.terminate_shared_with_cause(timeout, true);
+    }
+
+    fn terminate_shared_with_cause(&self, timeout: Duration, request_deadline: bool) {
         self.outbound
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .take();
         if let Ok(mut child) = self.child.lock() {
-            terminate_by_transport(&mut child, &self.terminated_by_transport, timeout);
+            let terminated =
+                terminate_by_transport(&mut child, &self.terminated_by_transport, timeout);
+            if request_deadline && terminated {
+                self.terminated_for_request_deadline
+                    .store(true, Ordering::Release);
+            }
         }
     }
 
@@ -5645,9 +5690,11 @@ impl Client {
             Ok(response) => response?,
             Err(mpsc::RecvTimeoutError::Timeout) => {
                 let cancellation_completed = self.cancel_request(request_id).is_ok()
-                    && response_rx.recv_timeout(REQUEST_CANCELLATION_GRACE).is_ok();
+                    && cancellation_grace_completed(
+                        response_rx.recv_timeout(REQUEST_CANCELLATION_GRACE),
+                    )?;
                 if !cancellation_completed {
-                    self.terminate_shared(Duration::from_secs(1));
+                    self.terminate_for_request_deadline(Duration::from_secs(1));
                 }
                 return Err(io::Error::new(
                     io::ErrorKind::TimedOut,
@@ -5697,6 +5744,16 @@ impl Client {
                 "tree worker exited with {status}"
             )))
         }
+    }
+}
+
+fn cancellation_grace_completed(
+    result: Result<io::Result<Response>, mpsc::RecvTimeoutError>,
+) -> io::Result<bool> {
+    match result {
+        Ok(Ok(_)) => Ok(true),
+        Ok(Err(error)) => Err(error),
+        Err(mpsc::RecvTimeoutError::Timeout | mpsc::RecvTimeoutError::Disconnected) => Ok(false),
     }
 }
 
@@ -5887,11 +5944,13 @@ fn terminate(child: &mut OwnedChild, timeout: Duration) {
     }
 }
 
-fn terminate_by_transport(child: &mut OwnedChild, marker: &AtomicBool, timeout: Duration) {
-    if child.try_wait().ok().flatten().is_none() {
+fn terminate_by_transport(child: &mut OwnedChild, marker: &AtomicBool, timeout: Duration) -> bool {
+    let terminated = child.try_wait().ok().flatten().is_none();
+    if terminated {
         marker.store(true, Ordering::Release);
     }
     terminate(child, timeout);
+    terminated
 }
 
 #[cfg(test)]
@@ -5915,13 +5974,13 @@ mod tests {
         ResolveNode, Response, Route, RunCaptures, RunNodeScalar, RunnableDocuments,
         SEMANTIC_CACHE_AUXILIARY_TRIM_THRESHOLD_BYTES, SyncDocument, WireByteRange, WirePosition,
         WireRange, WireSemanticToken, WorkPriority, WorkerError, WorkerGrammarIdentity,
-        WorkerQuerySources, cache_eviction_plan, client_generation_is_idle, close_document,
-        decode_frame, derive_snapshot_with_language, encode_frame, enforce_derived_memory_budget,
-        named_node_count, parse_request_timeout, pressure_checkpoint_required,
-        replace_retained_bytes, replace_retained_estimated_bytes, request_may_grow_derived_state,
-        request_priority, reserve_retained_growth, route_is_admissible, route_response, run,
-        submit_document_job, sync_document, terminate, terminate_by_transport,
-        validate_document_size,
+        WorkerQuerySources, cache_eviction_plan, cancellation_grace_completed,
+        client_generation_is_idle, close_document, decode_frame, derive_snapshot_with_language,
+        encode_frame, enforce_derived_memory_budget, named_node_count, parse_request_timeout,
+        pressure_checkpoint_required, replace_retained_bytes, replace_retained_estimated_bytes,
+        request_may_grow_derived_state, request_priority, reserve_retained_growth,
+        route_is_admissible, route_response, run, submit_document_job, sync_document, terminate,
+        terminate_by_transport, validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -6234,6 +6293,19 @@ mod tests {
             Duration::from_secs(60)
         );
         assert_eq!(parse_request_timeout(None), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn cancellation_grace_preserves_worker_transport_failure() {
+        let result: Result<std::io::Result<Response>, std::sync::mpsc::RecvTimeoutError> =
+            Ok(Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "worker lost during cancellation grace",
+            )));
+
+        let error = cancellation_grace_completed(result).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
     }
 
     #[test]

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -3932,9 +3932,10 @@ where
     let runnable_documents = Arc::new(RunnableDocuments::default());
     let cancellations = Arc::new(dashmap::DashMap::<u64, crate::cancel::CancelToken>::new());
     let next_hazard_lease = Arc::new(std::sync::atomic::AtomicU64::new(1));
-    // The client permits at most four requests per compute thread. Decode one
-    // frame beyond this pending window so cancellation stays observable under
-    // saturation, but wait before scheduling any excess ordinary work.
+    // Match the client's four ordinary admissions per compute thread plus its
+    // reserved lifecycle slot. Decode one frame beyond this pending window so
+    // cancellation stays observable under saturation, but wait before
+    // scheduling any excess ordinary work.
     let max_pending = compute_threads.saturating_mul(4).max(1).saturating_add(1);
     let (completion_tx, completion_rx) = mpsc::channel::<()>();
     #[cfg(feature = "e2e")]
@@ -6717,7 +6718,10 @@ mod tests {
             request.context.request_id = request_id;
             requests.push(Request::DeriveSnapshot(request));
         }
-        let admitted_prefix_bytes = framed(&requests[..8]).len();
+        // One handshake, five pending requests (four ordinary plus the
+        // lifecycle reserve), two completed responses buffered behind the
+        // stalled writer, and one cancellation lookahead frame.
+        let admitted_prefix_bytes = framed(&requests[..9]).len();
         let framed_requests = framed(&requests);
         let progress = Arc::new((AtomicUsize::new(0), Condvar::new(), Mutex::new(())));
         let reader = CountingReader {

--- a/src/tree_worker.rs
+++ b/src/tree_worker.rs
@@ -5486,11 +5486,15 @@ impl Client {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .take();
         if let Ok(mut child) = self.child.lock() {
-            let terminated =
+            if request_deadline {
+                terminate_by_transport_for_request_deadline(
+                    &mut child,
+                    &self.terminated_by_transport,
+                    &self.terminated_for_request_deadline,
+                    timeout,
+                );
+            } else {
                 terminate_by_transport(&mut child, &self.terminated_by_transport, timeout);
-            if request_deadline && terminated {
-                self.terminated_for_request_deadline
-                    .store(true, Ordering::Release);
             }
         }
     }
@@ -5953,6 +5957,18 @@ fn terminate_by_transport(child: &mut OwnedChild, marker: &AtomicBool, timeout: 
     terminated
 }
 
+fn terminate_by_transport_for_request_deadline(
+    child: &mut OwnedChild,
+    transport_marker: &AtomicBool,
+    request_deadline_marker: &AtomicBool,
+    timeout: Duration,
+) {
+    if child.try_wait().ok().flatten().is_none() {
+        request_deadline_marker.store(true, Ordering::Release);
+    }
+    terminate_by_transport(child, transport_marker, timeout);
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -5980,7 +5996,8 @@ mod tests {
         pressure_checkpoint_required, replace_retained_bytes, replace_retained_estimated_bytes,
         request_may_grow_derived_state, request_priority, reserve_retained_growth,
         route_is_admissible, route_response, run, submit_document_job, sync_document, terminate,
-        terminate_by_transport, validate_document_size,
+        terminate_by_transport, terminate_by_transport_for_request_deadline,
+        validate_document_size,
     };
 
     #[derive(Clone, Default)]
@@ -6081,6 +6098,39 @@ mod tests {
         exited.wait().unwrap();
         terminate_by_transport(&mut exited, &marker, Duration::from_secs(1));
         assert!(!marker.load(Ordering::Acquire));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn request_deadline_cause_selects_only_a_running_worker() {
+        let transport_marker = AtomicBool::new(false);
+        let deadline_marker = AtomicBool::new(false);
+        let mut running_command = std::process::Command::new("sh");
+        running_command.args(["-c", "sleep 10"]);
+        let mut running = OwnedChild::spawn(running_command).unwrap();
+        terminate_by_transport_for_request_deadline(
+            &mut running,
+            &transport_marker,
+            &deadline_marker,
+            Duration::from_secs(1),
+        );
+        assert!(transport_marker.load(Ordering::Acquire));
+        assert!(deadline_marker.load(Ordering::Acquire));
+
+        let transport_marker = AtomicBool::new(false);
+        let deadline_marker = AtomicBool::new(false);
+        let mut exited_command = std::process::Command::new("sh");
+        exited_command.args(["-c", "exit 0"]);
+        let mut exited = OwnedChild::spawn(exited_command).unwrap();
+        exited.wait().unwrap();
+        terminate_by_transport_for_request_deadline(
+            &mut exited,
+            &transport_marker,
+            &deadline_marker,
+            Duration::from_secs(1),
+        );
+        assert!(!transport_marker.load(Ordering::Acquire));
+        assert!(!deadline_marker.load(Ordering::Acquire));
     }
 
     #[derive(Clone, Default)]

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1330,7 +1330,7 @@ fn crash_quarantines_every_unique_committed_grammar_hazard() {
 }
 
 #[test]
-fn hung_grammar_hits_hard_deadline_and_other_grammar_recovers() {
+fn request_timeout_without_native_segment_does_not_quarantine_grammar() {
     let directory = tempfile::tempdir().unwrap();
     let marker = directory.path().join("hang-once");
     let mut client = LspClient::builder()
@@ -1396,26 +1396,11 @@ fn hung_grammar_hits_hard_deadline_and_other_grammar_recovers() {
     let stderr = shutdown_and_stderr(client);
     assert!(marker.exists(), "failure injection did not run: {stderr}");
     assert!(stderr.contains("timed out"), "{stderr}");
-    assert!(
-        stderr.contains("quarantined grammar conservatively for this session"),
-        "{stderr}"
-    );
-    assert!(stderr.contains("symbol=rust"), "{stderr}");
-    assert!(stderr.contains("restarted worker generation"), "{stderr}");
-    assert!(
-        stderr.contains("full-resynced 1 open documents"),
-        "{stderr}"
-    );
+    assert!(!stderr.contains("quarantined grammar"), "{stderr}");
+    assert!(!stderr.contains("restarted worker generation"), "{stderr}");
     assert_eq!(shadow_metric(&stderr, "matched"), 1, "{stderr}");
     assert!(stderr.contains("pending=0"), "{stderr}");
     assert!(!stderr.contains("disabled shadow tree tier"), "{stderr}");
-    eprintln!(
-        "hard-deadline recovery measurement: {}",
-        stderr
-            .lines()
-            .find(|line| line.contains("restarted worker generation"))
-            .expect("restart measurement log must be present")
-    );
 }
 
 #[test]

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1482,6 +1482,113 @@ fn request_timeout_without_native_segment_does_not_quarantine_grammar() {
 }
 
 #[test]
+fn planned_restart_retires_a_noncooperative_published_request() {
+    let directory = tempfile::tempdir().unwrap();
+    let hang_marker = directory.path().join("hung-request");
+    let recovery_ready = directory.path().join("recovery-ready");
+    std::fs::write(&hang_marker, b"suppress initial hang").unwrap();
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_MODE", "authoritative")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "2")
+        .env(
+            "KAKEHASHI_TREE_WORKER_HANG_AFTER_HAZARD_ARMED_FILE",
+            hang_marker.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_HANG_AFTER_HAZARD_ARMED_URI_SUFFIX",
+            "/planned-restart.rs",
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_RECOVERY_READY_FILE",
+            recovery_ready.to_string_lossy(),
+        )
+        .env("RUST_LOG", "kakehashi::tree_worker_shadow=info")
+        .build();
+    initialize(&mut client);
+
+    let uri = "file:///planned-restart.rs";
+    open_rust_and_request_tokens(&mut client, uri, "fn planned_restart() {}\n");
+    std::fs::remove_file(&hang_marker).unwrap();
+    let hung_request = client.send_request_async(
+        "kakehashi/node",
+        json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": 0, "character": 4 }
+        }),
+    );
+    wait_for_file(
+        &hang_marker,
+        "published request did not enter noncooperative native work",
+    );
+
+    let started = std::time::Instant::now();
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "autoInstall": false,
+                "searchPaths": ["/definitely/missing-kakehashi-parsers"]
+            }
+        }),
+    );
+    let recovery_deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while !recovery_ready.exists() && std::time::Instant::now() < recovery_deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    if !recovery_ready.exists() {
+        client.force_kill_and_wait();
+        let stderr = client.drain_stderr();
+        panic!("planned restart did not replace the noncooperative generation: {stderr}");
+    }
+    assert!(
+        started.elapsed() >= Duration::from_secs(5),
+        "request did not outlive the cooperative quiescence window"
+    );
+    let hung_response = client.receive_response_for_id_public(hung_request);
+    assert!(hung_response.get("result").is_some(), "{hung_response:?}");
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "autoInstall": false,
+                "searchPaths": ["${KAKEHASHI_DATA_DIR}"]
+            }
+        }),
+    );
+
+    let healthy_uri = "file:///after-planned-restart.lua";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": healthy_uri,
+                "languageId": "lua",
+                "version": 1,
+                "text": "local after_planned_restart = true\n"
+            }
+        }),
+    );
+    let healthy = client.send_request(
+        "kakehashi/node",
+        json!({
+            "textDocument": { "uri": healthy_uri },
+            "position": { "line": 0, "character": 6 }
+        }),
+    );
+    assert!(healthy.get("result").is_some(), "{healthy:?}");
+
+    let stderr = shutdown_and_stderr(client);
+    assert_eq!(
+        stderr.matches("restarted worker generation").count(),
+        1,
+        "{stderr}"
+    );
+    assert!(!stderr.contains("quarantined grammar"), "{stderr}");
+    assert!(!stderr.contains("disabled tree tier"), "{stderr}");
+}
+
+#[test]
 fn noncooperative_jobs_saturating_all_compute_threads_recover_as_one_generation() {
     let directory = tempfile::tempdir().unwrap();
     let trigger = directory.path().join("trigger");

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1407,6 +1407,135 @@ fn request_timeout_without_native_segment_does_not_quarantine_grammar() {
 }
 
 #[test]
+fn noncooperative_jobs_saturating_all_compute_threads_recover_as_one_generation() {
+    let directory = tempfile::tempdir().unwrap();
+    let trigger = directory.path().join("trigger");
+    let markers = directory.path().join("hung-jobs");
+    let recovery_ready = directory.path().join("recovery-ready");
+    std::fs::create_dir(&markers).unwrap();
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_MODE", "authoritative")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env("KAKEHASHI_TREE_WORKER_REQUEST_TIMEOUT_MS", "2000")
+        .env(
+            "KAKEHASHI_TREE_WORKER_REQUEST_TIMEOUT_TRIGGER_FILE",
+            trigger.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_HANG_ALL_COMMITTED_HAZARDS_URI_PREFIX",
+            "file:///saturated-",
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_HANG_ALL_COMMITTED_HAZARDS_TRIGGER_FILE",
+            trigger.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_HANG_ALL_COMMITTED_HAZARDS_MARKER_DIR",
+            markers.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_RECOVERY_READY_FILE",
+            recovery_ready.to_string_lossy(),
+        )
+        .env("RUST_LOG", "kakehashi::tree_worker_shadow=info")
+        .build();
+    initialize(&mut client);
+
+    let documents = (0..4)
+        .map(|index| {
+            (
+                format!("file:///saturated-{index}.rs"),
+                format!("fn saturated_{index}() {{}}\n"),
+            )
+        })
+        .collect::<Vec<_>>();
+    for (uri, text) in &documents {
+        client.send_notification(
+            "textDocument/didOpen",
+            json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "rust",
+                    "version": 1,
+                    "text": text
+                }
+            }),
+        );
+        let response = client.send_request(
+            "textDocument/semanticTokens/full",
+            json!({ "textDocument": { "uri": uri } }),
+        );
+        assert!(response.get("result").is_some(), "{response:?}");
+    }
+
+    std::fs::write(&trigger, b"trigger").unwrap();
+    let started = std::time::Instant::now();
+    let request_ids = documents
+        .iter()
+        .map(|(uri, _)| {
+            client.send_request_async(
+                "kakehashi/node",
+                json!({
+                    "textDocument": { "uri": uri },
+                    "position": { "line": 0, "character": 4 }
+                }),
+            )
+        })
+        .collect::<std::collections::HashSet<_>>();
+    let marker_deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::fs::read_dir(&markers).unwrap().count() < 4
+        && std::time::Instant::now() < marker_deadline
+    {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert_eq!(
+        std::fs::read_dir(&markers).unwrap().count(),
+        4,
+        "all compute threads must enter noncooperative jobs"
+    );
+
+    let mut completed = std::collections::HashSet::new();
+    for _ in 0..4 {
+        let response = client.receive_next_response_public();
+        assert!(response.get("result").is_some(), "{response:?}");
+        completed.insert(response.get("id").and_then(|id| id.as_i64()).unwrap());
+    }
+    assert_eq!(completed, request_ids);
+    wait_for_file(
+        &recovery_ready,
+        "saturated worker did not recover as a replacement generation",
+    );
+    let recovery_elapsed = started.elapsed();
+    eprintln!(
+        "saturated_noncooperative_recovery_ms={}",
+        recovery_elapsed.as_millis()
+    );
+
+    let healthy = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": &documents[0].0 } }),
+    );
+    assert!(healthy.get("result").is_some(), "{healthy:?}");
+
+    let stderr = shutdown_and_stderr(client);
+    assert!(
+        recovery_elapsed < Duration::from_secs(6),
+        "{recovery_elapsed:?}\n{stderr}"
+    );
+    assert_eq!(
+        stderr.matches("restarted worker generation").count(),
+        1,
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("full-resynced 4 open documents"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("quarantined grammar"), "{stderr}");
+    assert!(!stderr.contains("disabled tree tier"), "{stderr}");
+}
+
+#[test]
 fn competing_document_finishes_while_injection_fanout_is_running() {
     let force_nested = std::env::var_os("KAKEHASHI_E2E_FORCE_NESTED_PARALLELISM").is_some();
     let mut builder = LspClient::builder()

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1095,7 +1095,7 @@ fn crashed_grammar_is_quarantined_only_in_session_and_other_grammar_recovers() {
     let stderr = shutdown_and_stderr(client);
     assert!(marker.exists(), "failure injection did not run: {stderr}");
     assert!(
-        stderr.contains("acknowledged active grammar hazard(s)"),
+        stderr.contains("committed active grammar hazard(s)"),
         "{stderr}"
     );
     assert!(
@@ -1116,6 +1116,189 @@ fn crashed_grammar_is_quarantined_only_in_session_and_other_grammar_recovers() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn crash_quarantines_every_unique_committed_grammar_hazard() {
+    let directory = tempfile::tempdir().unwrap();
+    let trigger = directory.path().join("trigger");
+    let rust_committed = directory.path().join("rust-committed");
+    let lua_committed = directory.path().join("lua-committed");
+    let recovery_ready = directory.path().join("recovery-ready");
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_SHADOW", "true")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env(
+            "KAKEHASHI_TREE_WORKER_MULTI_HAZARD_TRIGGER_FILE",
+            trigger.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_HOLD_COMMITTED_HAZARD_URI_SUFFIX",
+            "/active-rust.rs",
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_HOLD_COMMITTED_HAZARD_MARKER",
+            rust_committed.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_CRASH_COMMITTED_HAZARD_URI_SUFFIX",
+            "/active-lua.lua",
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_CRASH_COMMITTED_HAZARD_MARKER",
+            lua_committed.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_RECOVERY_READY_FILE",
+            recovery_ready.to_string_lossy(),
+        )
+        .env(
+            "RUST_LOG",
+            "kakehashi::tree_worker_shadow=info,kakehashi::tree_worker_shadow_metrics=info",
+        )
+        .build();
+    initialize(&mut client);
+
+    let documents = [
+        ("file:///active-rust.rs", "rust", "fn active_rust() {}\n"),
+        ("file:///active-lua.lua", "lua", "local active_lua = true\n"),
+        ("file:///healthy.yaml", "yaml", "healthy: true\n"),
+    ];
+    for (uri, language_id, text) in documents {
+        client.send_notification(
+            "textDocument/didOpen",
+            json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": language_id,
+                    "version": 1,
+                    "text": text
+                }
+            }),
+        );
+        let response = client.send_request(
+            "textDocument/semanticTokens/full",
+            json!({ "textDocument": { "uri": uri } }),
+        );
+        assert!(response.get("result").is_some(), "{response:?}");
+    }
+
+    std::fs::write(&trigger, b"trigger").unwrap();
+    let rust_request = client.send_request_async(
+        "kakehashi/node",
+        json!({
+            "textDocument": { "uri": "file:///active-rust.rs" },
+            "position": { "line": 0, "character": 4 }
+        }),
+    );
+    wait_for_file(
+        &rust_committed,
+        "Rust hazard was not committed before the second request",
+    );
+    let lua_request = client.send_request_async(
+        "kakehashi/node",
+        json!({
+            "textDocument": { "uri": "file:///active-lua.lua" },
+            "position": { "line": 0, "character": 6 }
+        }),
+    );
+    wait_for_file(&lua_committed, "Lua hazard did not commit before abort");
+
+    let mut completed = std::collections::HashSet::new();
+    for _ in 0..2 {
+        let response = client.receive_next_response_public();
+        completed.insert(response.get("id").and_then(|id| id.as_i64()).unwrap());
+    }
+    assert_eq!(
+        completed,
+        std::collections::HashSet::from([rust_request, lua_request])
+    );
+    wait_for_file(
+        &recovery_ready,
+        "replacement worker did not complete quarantine-aware resync",
+    );
+
+    let healthy = client.send_request(
+        "kakehashi/node",
+        json!({
+            "textDocument": { "uri": "file:///healthy.yaml" },
+            "position": { "line": 0, "character": 1 }
+        }),
+    );
+    assert!(healthy.get("result").is_some(), "{healthy:?}");
+
+    let stderr = shutdown_and_stderr(client);
+    let quarantine = stderr
+        .lines()
+        .filter(|line| line.contains("quarantined grammar conservatively for this session"))
+        .collect::<Vec<_>>();
+    assert_eq!(quarantine.len(), 2, "{stderr}");
+    assert!(
+        quarantine.iter().any(|line| line.contains("symbol=rust")),
+        "{stderr}"
+    );
+    assert!(
+        quarantine.iter().any(|line| line.contains("symbol=lua")),
+        "{stderr}"
+    );
+    assert!(
+        !quarantine.iter().any(|line| line.contains("symbol=yaml")),
+        "{stderr}"
+    );
+    assert_eq!(
+        stderr
+            .lines()
+            .filter(|line| line.contains("restarted worker generation"))
+            .count(),
+        1,
+        "{stderr}",
+    );
+    assert!(
+        stderr.contains("full-resynced 1 open documents"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains(
+            "worker loss quarantine summary active_leases=2 unique_grammars=2 newly_quarantined=2 already_quarantined=0 class=NativeEvidenced"
+        ),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("disabled shadow tree tier"), "{stderr}");
+    eprintln!(
+        "multi-hazard recovery measurement: {}",
+        stderr
+            .lines()
+            .find(|line| line.contains("restarted worker generation"))
+            .expect("restart measurement log must be present")
+    );
+
+    let mut next_session = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_MODE", "authoritative")
+        .build();
+    initialize(&mut next_session);
+    open_rust_and_request_tokens(
+        &mut next_session,
+        "file:///next-session.rs",
+        "fn next_session() {}\n",
+    );
+    next_session.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": "file:///next-session.lua",
+                "languageId": "lua",
+                "version": 1,
+                "text": "local next_session = true\n"
+            }
+        }),
+    );
+    let lua = next_session.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": "file:///next-session.lua" } }),
+    );
+    assert!(lua.get("result").is_some(), "{lua:?}");
+    let _stderr = shutdown_and_stderr(next_session);
+}
+
 #[test]
 fn hung_grammar_hits_hard_deadline_and_other_grammar_recovers() {
     let directory = tempfile::tempdir().unwrap();
@@ -1129,10 +1312,13 @@ fn hung_grammar_hits_hard_deadline_and_other_grammar_recovers() {
             "/hung.rs",
         )
         .env(
-            "KAKEHASHI_TREE_WORKER_HANG_ONCE_FILE",
+            "KAKEHASHI_TREE_WORKER_HANG_AFTER_HAZARD_ARMED_FILE",
             marker.to_string_lossy().into_owned(),
         )
-        .env("KAKEHASHI_TREE_WORKER_HANG_URI_SUFFIX", "/hung.rs")
+        .env(
+            "KAKEHASHI_TREE_WORKER_HANG_AFTER_HAZARD_ARMED_URI_SUFFIX",
+            "/hung.rs",
+        )
         .env(
             "RUST_LOG",
             "kakehashi::tree_worker_shadow=info,kakehashi::tree_worker_shadow_metrics=info",

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1117,7 +1117,7 @@ fn crashed_grammar_is_quarantined_only_in_session_and_other_grammar_recovers() {
 }
 
 #[test]
-fn protocol_failure_preserves_complete_active_hazard_set() {
+fn protocol_abort_marks_the_active_hazard_snapshot_incomplete() {
     let directory = tempfile::tempdir().unwrap();
     let marker = directory.path().join("invalid-release-once");
     let mut client = LspClient::builder()
@@ -1174,21 +1174,11 @@ fn protocol_failure_preserves_complete_active_hazard_set() {
         "{stderr}"
     );
     assert!(
-        stderr.contains("committed active grammar hazard(s)"),
+        stderr.contains("could not obtain a complete worker failure snapshot"),
         "{stderr}"
     );
-    assert!(stderr.contains("symbol=rust"), "{stderr}");
-    assert!(stderr.contains("class=Systemic"), "{stderr}");
-    assert_eq!(
-        stderr.matches("restarted worker generation").count(),
-        1,
-        "{stderr}"
-    );
-    assert!(
-        stderr.contains("full-resynced 1 open documents"),
-        "{stderr}"
-    );
-    assert!(!stderr.contains("disabled shadow tree tier"), "{stderr}");
+    assert!(stderr.contains("disabled tree tier"), "{stderr}");
+    assert!(!stderr.contains("restarted worker generation"), "{stderr}");
 }
 
 #[test]

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1672,6 +1672,78 @@ fn deadline_grace_preserves_a_delayed_worker_restart_requirement() {
 }
 
 #[test]
+fn cancellation_waits_for_request_delivery_before_sending_cancel() {
+    let directory = tempfile::tempdir().unwrap();
+    let waiter_started = directory.path().join("waiter-started");
+    let cancel_observed = directory.path().join("cancel-observed");
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_MODE", "authoritative")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "2")
+        .env(
+            "KAKEHASHI_TREE_WORKER_ADMISSION_DELAY_URI_SUFFIX",
+            "/cancel-before-wait.rs",
+        )
+        .env("KAKEHASHI_TREE_WORKER_ADMISSION_DELAY_MS", "1000")
+        .env(
+            "KAKEHASHI_TREE_WORKER_RESPONSE_WAITER_DELAY_URI_SUFFIX",
+            "/cancel-before-wait.rs",
+        )
+        .env("KAKEHASHI_TREE_WORKER_RESPONSE_WAITER_DELAY_MS", "500")
+        .env(
+            "KAKEHASHI_TREE_WORKER_RESPONSE_WAITER_DELAY_STARTED_FILE",
+            waiter_started.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_CANCEL_OBSERVED_FILE",
+            cancel_observed.to_string_lossy(),
+        )
+        .env("RUST_LOG", "kakehashi::tree_worker_shadow=info")
+        .build();
+    initialize(&mut client);
+
+    let uri = "file:///cancel-before-wait.rs";
+    open_rust_and_request_tokens(&mut client, uri, "fn cancel_before_wait() {}\n");
+    std::fs::remove_file(&waiter_started).unwrap();
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": uri, "version": 2 },
+            "contentChanges": [{ "text": "fn cancel_before_wait_v2() {}\n" }]
+        }),
+    );
+    let request_id = client.send_request_async(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+    wait_for_file(
+        &waiter_started,
+        "semantic request was not delivered before the blocking waiter delay",
+    );
+    client.send_notification("$/cancelRequest", json!({ "id": request_id }));
+    let cancelled = client.receive_response_for_id_public(request_id);
+    assert!(cancelled.get("error").is_some(), "{cancelled:?}");
+    wait_for_file(
+        &cancel_observed,
+        "worker did not observe cancellation for the already-delivered request",
+    );
+    assert!(
+        std::fs::read_to_string(&cancel_observed)
+            .unwrap()
+            .parse::<u64>()
+            .is_ok(),
+        "worker did not record the cancelled internal request ID"
+    );
+
+    let healthy = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+    assert!(healthy.get("result").is_some(), "{healthy:?}");
+    let stderr = shutdown_and_stderr(client);
+    assert!(!stderr.contains("restarted worker generation"), "{stderr}");
+}
+
+#[test]
 fn noncooperative_jobs_saturating_all_compute_threads_recover_as_one_generation() {
     let directory = tempfile::tempdir().unwrap();
     let trigger = directory.path().join("trigger");

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1873,6 +1873,158 @@ fn noncooperative_jobs_saturating_all_compute_threads_recover_as_one_generation(
 }
 
 #[test]
+fn reserved_lifecycle_slot_does_not_block_cancellation_under_full_admission() {
+    let directory = tempfile::tempdir().unwrap();
+    let trigger = directory.path().join("trigger");
+    let markers = directory.path().join("hung-jobs");
+    let lifecycle_scheduled = directory.path().join("lifecycle-scheduled");
+    let cancel_observed = directory.path().join("cancel-observed");
+    let recovery_ready = directory.path().join("recovery-ready");
+    std::fs::create_dir(&markers).unwrap();
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_MODE", "authoritative")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env("KAKEHASHI_TREE_WORKER_REQUEST_TIMEOUT_MS", "2000")
+        .env(
+            "KAKEHASHI_TREE_WORKER_REQUEST_TIMEOUT_TRIGGER_FILE",
+            trigger.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_HANG_ALL_COMMITTED_HAZARDS_URI_PREFIX",
+            "file:///reserve-saturated-",
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_HANG_ALL_COMMITTED_HAZARDS_TRIGGER_FILE",
+            trigger.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_HANG_ALL_COMMITTED_HAZARDS_MARKER_DIR",
+            markers.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_HANG_ALL_COMMITTED_HAZARDS_COUNT",
+            "4",
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_SCHEDULED_URI_SUFFIX",
+            "/reserve-lifecycle.lua",
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_SCHEDULED_FILE",
+            lifecycle_scheduled.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_CANCEL_OBSERVED_FILE",
+            cancel_observed.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_RECOVERY_READY_FILE",
+            recovery_ready.to_string_lossy(),
+        )
+        .env("RUST_LOG", "kakehashi::tree_worker_shadow=info")
+        .build();
+    initialize(&mut client);
+
+    let documents = (0..4)
+        .map(|index| {
+            (
+                format!("file:///reserve-saturated-{index}.rs"),
+                format!("fn reserve_saturated_{index}() {{}}\n"),
+            )
+        })
+        .collect::<Vec<_>>();
+    for (uri, text) in &documents {
+        open_rust_and_request_tokens(&mut client, uri, text);
+    }
+    let lifecycle_uri = "file:///reserve-lifecycle.lua";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": lifecycle_uri,
+                "languageId": "lua",
+                "version": 1,
+                "text": "local reserve_lifecycle = 1\n"
+            }
+        }),
+    );
+    let lifecycle_ready = client.send_request(
+        "kakehashi/node",
+        json!({
+            "textDocument": { "uri": lifecycle_uri },
+            "position": { "line": 0, "character": 6 }
+        }),
+    );
+    assert!(
+        lifecycle_ready.get("result").is_some(),
+        "{lifecycle_ready:?}"
+    );
+    std::fs::remove_file(&lifecycle_scheduled).unwrap();
+
+    std::fs::write(&trigger, b"trigger").unwrap();
+    let request_ids = (0..16)
+        .map(|index| {
+            let (uri, _) = &documents[index % documents.len()];
+            client.send_request_async(
+                "kakehashi/node",
+                json!({
+                    "textDocument": { "uri": uri },
+                    "position": { "line": 0, "character": 4 }
+                }),
+            )
+        })
+        .collect::<std::collections::HashSet<_>>();
+    let marker_deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::fs::read_dir(&markers).unwrap().count() < 4
+        && std::time::Instant::now() < marker_deadline
+    {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert_eq!(std::fs::read_dir(&markers).unwrap().count(), 4);
+
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": lifecycle_uri, "version": 2 },
+            "contentChanges": [{ "text": "local reserve_lifecycle = 2\n" }]
+        }),
+    );
+    wait_for_file(
+        &lifecycle_scheduled,
+        "reserved lifecycle request was not scheduled at full ordinary admission",
+    );
+    wait_for_file(
+        &cancel_observed,
+        "cancellation frame was blocked behind the reserved lifecycle request",
+    );
+
+    let mut completed = std::collections::HashSet::new();
+    for _ in 0..16 {
+        let response = client.receive_next_response_public();
+        assert!(response.get("result").is_some(), "{response:?}");
+        completed.insert(response.get("id").and_then(|id| id.as_i64()).unwrap());
+    }
+    assert_eq!(completed, request_ids);
+    wait_for_file(
+        &recovery_ready,
+        "fully saturated worker did not recover after cancellation remained observable",
+    );
+
+    let stderr = shutdown_and_stderr(client);
+    assert_eq!(
+        stderr.matches("restarted worker generation").count(),
+        1,
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("full-resynced 5 open documents"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("quarantined grammar"), "{stderr}");
+    assert!(!stderr.contains("disabled tree tier"), "{stderr}");
+}
+
+#[test]
 fn competing_document_finishes_while_injection_fanout_is_running() {
     let force_nested = std::env::var_os("KAKEHASHI_E2E_FORCE_NESTED_PARALLELISM").is_some();
     let mut builder = LspClient::builder()

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1177,6 +1177,12 @@ fn protocol_abort_marks_the_active_hazard_snapshot_incomplete() {
         stderr.contains("could not obtain a complete worker failure snapshot"),
         "{stderr}"
     );
+    assert!(
+        stderr.contains("quarantined grammar conservatively for this session"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("symbol=rust"), "{stderr}");
+    assert!(!stderr.contains("symbol=e2e-late"), "{stderr}");
     assert!(stderr.contains("disabled tree tier"), "{stderr}");
     assert!(!stderr.contains("restarted worker generation"), "{stderr}");
 }

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1124,6 +1124,7 @@ fn crash_quarantines_every_unique_committed_grammar_hazard() {
     let rust_committed = directory.path().join("rust-committed");
     let lua_committed = directory.path().join("lua-committed");
     let recovery_ready = directory.path().join("recovery-ready");
+    let post_recovery_hazards = directory.path().join("post-recovery-hazards");
     let mut client = LspClient::builder()
         .env("KAKEHASHI_TREE_WORKER_SHADOW", "true")
         .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
@@ -1150,6 +1151,10 @@ fn crash_quarantines_every_unique_committed_grammar_hazard() {
         .env(
             "KAKEHASHI_TREE_WORKER_RECOVERY_READY_FILE",
             recovery_ready.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_POST_RECOVERY_HAZARD_LOG",
+            post_recovery_hazards.to_string_lossy(),
         )
         .env(
             "RUST_LOG",
@@ -1215,6 +1220,31 @@ fn crash_quarantines_every_unique_committed_grammar_hazard() {
     wait_for_file(
         &recovery_ready,
         "replacement worker did not complete quarantine-aware resync",
+    );
+
+    for (uri, text) in [
+        ("file:///active-rust.rs", "fn active_rust_v2() {}\n"),
+        ("file:///active-lua.lua", "local active_lua_v2 = true\n"),
+        ("file:///healthy.yaml", "healthy: still\n"),
+    ] {
+        client.send_notification(
+            "textDocument/didChange",
+            json!({
+                "textDocument": { "uri": uri, "version": 2 },
+                "contentChanges": [{ "text": text }]
+            }),
+        );
+    }
+    wait_for_file(
+        &post_recovery_hazards,
+        "healthy YAML did not cross the post-recovery actor barrier",
+    );
+    let post_recovery_hazards = std::fs::read_to_string(&post_recovery_hazards).unwrap();
+    assert!(
+        post_recovery_hazards
+            .lines()
+            .all(|grammar| grammar == "yaml"),
+        "quarantined grammar was rearmed in the same session: {post_recovery_hazards}"
     );
 
     let healthy = client.send_request(

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1873,10 +1873,12 @@ fn reserved_lifecycle_slot_does_not_block_cancellation_under_full_admission() {
     let directory = tempfile::tempdir().unwrap();
     let trigger = directory.path().join("trigger");
     let markers = directory.path().join("hung-jobs");
+    let scheduled_routes = directory.path().join("scheduled-routes");
     let lifecycle_scheduled = directory.path().join("lifecycle-scheduled");
     let cancel_observed = directory.path().join("cancel-observed");
     let recovery_ready = directory.path().join("recovery-ready");
     std::fs::create_dir(&markers).unwrap();
+    std::fs::create_dir(&scheduled_routes).unwrap();
     let mut client = LspClient::builder()
         .env("KAKEHASHI_TREE_WORKER_MODE", "authoritative")
         .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
@@ -1900,6 +1902,14 @@ fn reserved_lifecycle_slot_does_not_block_cancellation_under_full_admission() {
         .env(
             "KAKEHASHI_TREE_WORKER_HANG_ALL_COMMITTED_HAZARDS_COUNT",
             "4",
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_SCHEDULED_MARKER_URI_PREFIX",
+            "file:///reserve-saturated-",
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_SCHEDULED_MARKER_DIR",
+            scheduled_routes.to_string_lossy(),
         )
         .env(
             "KAKEHASHI_TREE_WORKER_SCHEDULED_URI_SUFFIX",
@@ -1931,6 +1941,9 @@ fn reserved_lifecycle_slot_does_not_block_cancellation_under_full_admission() {
         .collect::<Vec<_>>();
     for (uri, text) in &documents {
         open_rust_and_request_tokens(&mut client, uri, text);
+    }
+    for marker in std::fs::read_dir(&scheduled_routes).unwrap() {
+        std::fs::remove_file(marker.unwrap().path()).unwrap();
     }
     let lifecycle_uri = "file:///reserve-lifecycle.lua";
     client.send_notification(
@@ -1970,6 +1983,13 @@ fn reserved_lifecycle_slot_does_not_block_cancellation_under_full_admission() {
             )
         })
         .collect::<std::collections::HashSet<_>>();
+    let admission_deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::fs::read_dir(&scheduled_routes).unwrap().count() < 16
+        && std::time::Instant::now() < admission_deadline
+    {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert_eq!(std::fs::read_dir(&scheduled_routes).unwrap().count(), 16);
     let marker_deadline = std::time::Instant::now() + Duration::from_secs(5);
     while std::fs::read_dir(&markers).unwrap().count() < 4
         && std::time::Instant::now() < marker_deadline

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1116,9 +1116,8 @@ fn crashed_grammar_is_quarantined_only_in_session_and_other_grammar_recovers() {
     );
 }
 
-#[cfg(unix)]
 #[test]
-fn crash_quarantines_every_unique_committed_grammar_hazard() {
+fn windows_and_unix_crash_quarantine_every_unique_committed_grammar_hazard() {
     let directory = tempfile::tempdir().unwrap();
     let trigger = directory.path().join("trigger");
     let rust_committed = directory.path().join("rust-committed");

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1614,7 +1614,7 @@ fn deadline_grace_preserves_a_delayed_worker_restart_requirement() {
     let mut client = LspClient::builder()
         .env("KAKEHASHI_TREE_WORKER_MODE", "authoritative")
         .env("KAKEHASHI_TREE_WORKER_THREADS", "2")
-        .env("KAKEHASHI_TREE_WORKER_REQUEST_TIMEOUT_MS", "500")
+        .env("KAKEHASHI_TREE_WORKER_REQUEST_TIMEOUT_MS", "2000")
         .env(
             "KAKEHASHI_TREE_WORKER_REQUEST_TIMEOUT_URI_SUFFIX",
             "/grace-restart.rs",
@@ -1627,7 +1627,7 @@ fn deadline_grace_preserves_a_delayed_worker_restart_requirement() {
             "KAKEHASHI_TREE_WORKER_RESTART_URI_SUFFIX",
             "/grace-restart.rs",
         )
-        .env("KAKEHASHI_TREE_WORKER_RESTART_RESPONSE_DELAY_MS", "600")
+        .env("KAKEHASHI_TREE_WORKER_RESTART_RESPONSE_DELAY_MS", "2100")
         .env(
             "KAKEHASHI_TREE_WORKER_RECOVERY_READY_FILE",
             recovery_ready.to_string_lossy(),

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1117,6 +1117,81 @@ fn crashed_grammar_is_quarantined_only_in_session_and_other_grammar_recovers() {
 }
 
 #[test]
+fn protocol_failure_preserves_complete_active_hazard_set() {
+    let directory = tempfile::tempdir().unwrap();
+    let marker = directory.path().join("invalid-release-once");
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_SHADOW", "true")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "4")
+        .env(
+            "KAKEHASHI_TREE_WORKER_INVALID_RELEASE_AFTER_HAZARD_ARMED_FILE",
+            marker.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_INVALID_RELEASE_AFTER_HAZARD_ARMED_URI_SUFFIX",
+            "/protocol.rs",
+        )
+        .env(
+            "RUST_LOG",
+            "kakehashi::tree_worker_shadow=info,kakehashi::tree_worker_shadow_metrics=info",
+        )
+        .build();
+    initialize(&mut client);
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": "file:///protocol.rs",
+                "languageId": "rust",
+                "version": 1,
+                "text": "fn corrupt_protocol() {}\n"
+            }
+        }),
+    );
+    wait_for_file(&marker, "invalid release injection did not run");
+
+    let healthy_uri = "file:///protocol-survivor.lua";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": healthy_uri,
+                "languageId": "lua",
+                "version": 1,
+                "text": "local protocol_survivor = true\n"
+            }
+        }),
+    );
+    let healthy = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": healthy_uri } }),
+    );
+    assert!(healthy.get("result").is_some(), "{healthy:?}");
+
+    let stderr = shutdown_and_stderr(client);
+    assert!(
+        stderr.contains("invalid grammar hazard release"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("committed active grammar hazard(s)"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("symbol=rust"), "{stderr}");
+    assert!(stderr.contains("class=Systemic"), "{stderr}");
+    assert_eq!(
+        stderr.matches("restarted worker generation").count(),
+        1,
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("full-resynced 1 open documents"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("disabled shadow tree tier"), "{stderr}");
+}
+
+#[test]
 fn windows_and_unix_crash_quarantine_every_unique_committed_grammar_hazard() {
     let directory = tempfile::tempdir().unwrap();
     let trigger = directory.path().join("trigger");

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1384,6 +1384,17 @@ fn windows_and_unix_crash_quarantine_every_unique_committed_grammar_hazard() {
         "file:///next-session.rs",
         "fn next_session() {}\n",
     );
+    let rust = next_session.send_request(
+        "kakehashi/node",
+        json!({
+            "textDocument": { "uri": "file:///next-session.rs" },
+            "position": { "line": 0, "character": 4 }
+        }),
+    );
+    assert!(
+        rust.get("result").is_some_and(|result| !result.is_null()),
+        "next session did not parse Rust: {rust:?}"
+    );
     next_session.send_notification(
         "textDocument/didOpen",
         json!({
@@ -1396,10 +1407,16 @@ fn windows_and_unix_crash_quarantine_every_unique_committed_grammar_hazard() {
         }),
     );
     let lua = next_session.send_request(
-        "textDocument/semanticTokens/full",
-        json!({ "textDocument": { "uri": "file:///next-session.lua" } }),
+        "kakehashi/node",
+        json!({
+            "textDocument": { "uri": "file:///next-session.lua" },
+            "position": { "line": 0, "character": 6 }
+        }),
     );
-    assert!(lua.get("result").is_some(), "{lua:?}");
+    assert!(
+        lua.get("result").is_some_and(|result| !result.is_null()),
+        "next session did not parse Lua: {lua:?}"
+    );
     let _stderr = shutdown_and_stderr(next_session);
 }
 

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1396,8 +1396,12 @@ fn request_timeout_without_native_segment_does_not_quarantine_grammar() {
     assert!(marker.exists(), "failure injection did not run: {stderr}");
     assert!(stderr.contains("timed out"), "{stderr}");
     assert!(!stderr.contains("quarantined grammar"), "{stderr}");
-    assert!(!stderr.contains("restarted worker generation"), "{stderr}");
-    assert_eq!(shadow_metric(&stderr, "matched"), 1, "{stderr}");
+    assert!(stderr.contains("restarted worker generation"), "{stderr}");
+    assert!(
+        stderr.contains("full-resynced 2 open documents"),
+        "{stderr}"
+    );
+    assert_eq!(shadow_metric(&stderr, "matched"), 2, "{stderr}");
     assert!(stderr.contains("pending=0"), "{stderr}");
     assert!(!stderr.contains("disabled shadow tree tier"), "{stderr}");
 }

--- a/tests/e2e_tree_worker_shadow.rs
+++ b/tests/e2e_tree_worker_shadow.rs
@@ -1589,6 +1589,72 @@ fn planned_restart_retires_a_noncooperative_published_request() {
 }
 
 #[test]
+fn deadline_grace_preserves_a_delayed_worker_restart_requirement() {
+    let directory = tempfile::tempdir().unwrap();
+    let restart_once = directory.path().join("restart-once");
+    let recovery_ready = directory.path().join("recovery-ready");
+    std::fs::write(&restart_once, b"suppress initial restart").unwrap();
+    let mut client = LspClient::builder()
+        .env("KAKEHASHI_TREE_WORKER_MODE", "authoritative")
+        .env("KAKEHASHI_TREE_WORKER_THREADS", "2")
+        .env("KAKEHASHI_TREE_WORKER_REQUEST_TIMEOUT_MS", "500")
+        .env(
+            "KAKEHASHI_TREE_WORKER_REQUEST_TIMEOUT_URI_SUFFIX",
+            "/grace-restart.rs",
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_RESTART_ONCE_FILE",
+            restart_once.to_string_lossy(),
+        )
+        .env(
+            "KAKEHASHI_TREE_WORKER_RESTART_URI_SUFFIX",
+            "/grace-restart.rs",
+        )
+        .env("KAKEHASHI_TREE_WORKER_RESTART_RESPONSE_DELAY_MS", "600")
+        .env(
+            "KAKEHASHI_TREE_WORKER_RECOVERY_READY_FILE",
+            recovery_ready.to_string_lossy(),
+        )
+        .env("RUST_LOG", "kakehashi::tree_worker_shadow=info")
+        .build();
+    initialize(&mut client);
+
+    let uri = "file:///grace-restart.rs";
+    open_rust_and_request_tokens(&mut client, uri, "fn grace_restart() {}\n");
+    std::fs::remove_file(&restart_once).unwrap();
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": { "autoInstall": false } }),
+    );
+    wait_for_file(
+        &recovery_ready,
+        "restart requirement returned during cancellation grace was discarded",
+    );
+
+    let healthy = client.send_request(
+        "kakehashi/node",
+        json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": 0, "character": 4 }
+        }),
+    );
+    assert!(healthy.get("result").is_some(), "{healthy:?}");
+
+    let stderr = shutdown_and_stderr(client);
+    assert!(
+        stderr.contains("requested restart: injected systemic restart"),
+        "{stderr}"
+    );
+    assert_eq!(
+        stderr.matches("restarted worker generation").count(),
+        1,
+        "{stderr}"
+    );
+    assert!(!stderr.contains("timed out"), "{stderr}");
+    assert!(!stderr.contains("quarantined grammar"), "{stderr}");
+}
+
+#[test]
 fn noncooperative_jobs_saturating_all_compute_threads_recover_as_one_generation() {
     let directory = tempfile::tempdir().unwrap();
     let trigger = directory.path().join("trigger");


### PR DESCRIPTION
## Summary

- drain the dead generation's response reader before snapshotting the complete exact set of committed grammar hazards
- authenticate hazard arms against the exact request context, grammar route, enqueue order, and terminal response contract
- reconcile queued inherited routes with the grammar actually committed when a pending sync succeeds or fails
- reserve lifecycle admission, bound deadline/cancellation recovery, and mark protocol-aborted snapshots incomplete instead of restarting from partial evidence
- quarantine every sorted unique active grammar identity for the current session, restart once, and full-resync only healthy documents
- preserve canonical parser-source containment while normalizing Windows verbatim drive/UNC paths losslessly for MSVC
- preserve observed native-crash status when Windows EOF cleanup races process exit

## Stack

- base: #888
- this PR: Stage 26 complete hazard-set quarantine

## Measurement

- single-hazard recovery, 12 alternating pairs: Stage 25 median 1153.5 ms; Stage 26 median 1144.5 ms; paired median +3 ms (+0.264%), range -342 to +123 ms
- two active grammars: median 960 ms; every run quarantined both grammars, restarted once, and resynced only the healthy document
- four-thread saturation recovery: median 3194 ms
- direct steady state: sequential p50 -1.511%, sequential p95 -6.935%, parallel p50 +0.512%, parallel p95 +0.614%, throughput -0.590%; no causal speedup or tail bound claimed
- final semantic worker path, 8 alternating pairs against review-converged `36842edc5`: paired median +0.077 ms (+0.259%), range -4.010 to +3.673 ms; no distinguishable central regression, tail equivalence not established

The raw pairs, commands, source revisions, and artifact hashes are recorded in `benches/profile/results/single_worker_stage26_hazard_set_2026-07-21.json`. The later Windows parser-install and crash-classification compatibility fixes do not execute on the measured worker request path.

## Validation

- 72 `tree_worker` unit tests
- 43 `tree_worker_shadow` unit tests
- 39 parser-install unit tests, including lossless Windows drive/UNC prefix normalization
- 9 focused crash, protocol-abort, timeout, restart, cancellation, and saturation E2Es (run individually to avoid failure-injection environment collisions)
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Codex review converged to CLEAN in the finding session and a fresh final session

The ADR remains proposed. Runtime injection identities, independently bounded control transport, native-segment deadlines, explicit workload-aware admission, compatibility gates, and legacy-path removal remain open.

