### PR TITLE
test(semantic): measure unique typing states

### DIFF
--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -423,8 +423,14 @@ fn summarize(samples: &[Duration]) -> Stats {
     let mut samples = samples.to_vec();
     samples.sort_unstable();
     let pick = |q: f64| samples[((samples.len() as f64 * q) as usize).min(samples.len() - 1)];
+    let middle = samples.len() / 2;
+    let median = if samples.len().is_multiple_of(2) {
+        (samples[middle - 1] + samples[middle]) / 2
+    } else {
+        samples[middle]
+    };
     Stats {
-        median: pick(0.50),
+        median,
         p25: pick(0.25),
         p75: pick(0.75),
         p95: pick(0.95),

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -37,6 +37,8 @@
 //! `KAKEHASHI_BENCH_WARMUP` (default 10), `KAKEHASHI_BENCH_SCENARIOS`
 //! (optional comma-separated scenario-name substrings), and
 //! `KAKEHASHI_BENCH_SAMPLES_FILE` (optional raw-sample JSON output path).
+//! `KAKEHASHI_BENCH_DATA_DIR` can point both servers at an attested fixture
+//! snapshot instead of the checkout-local persistent test directory.
 
 use serde_json::{Value, json};
 use std::collections::HashMap;
@@ -904,7 +906,9 @@ fn result_id_of(result: &Value) -> Option<String> {
 
 fn main() {
     // Ensure parsers/queries exist, and reuse the test data dir both binaries read.
-    let data_dir: PathBuf = kakehashi::install::test_support::test_data_dir_path();
+    let data_dir: PathBuf = std::env::var_os("KAKEHASHI_BENCH_DATA_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(kakehashi::install::test_support::test_data_dir_path);
     std::fs::create_dir_all(&data_dir).expect("create data dir");
     kakehashi::install::test_support::ensure_test_languages_installed(&data_dir)
         .expect("install test languages");

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -453,6 +453,9 @@ enum Kind {
     /// Sustained typing through unique document states. Unlike `EditDelta`, this
     /// never toggles back to a previously cached whole-document snapshot.
     TypingDelta,
+    /// Several unique edits arrive without waiting for intermediate token
+    /// requests, followed by one delta for the only version still usable.
+    TypingBurst { edits: usize },
     /// Rapid edits explicitly cancel several already-issued full requests.
     /// Measures latency from the final edit/request until the only result the
     /// editor can still use, while obsolete computation is reclaimed.
@@ -619,7 +622,7 @@ fn seed_result_id(server: &mut Server, scn: &Scenario) -> String {
             String::new()
         }
         // Delta-based scenarios need an initial result_id to diff against.
-        Kind::DeltaNoop | Kind::EditDelta | Kind::TypingDelta => {
+        Kind::DeltaNoop | Kind::EditDelta | Kind::TypingDelta | Kind::TypingBurst { .. } => {
             result_id_of(&server.semantic_full(scn.uri)).unwrap_or_default()
         }
     }
@@ -689,6 +692,24 @@ fn run_once(
             let id = result_id_of(&result).unwrap_or_else(|| {
                 panic!(
                     "typing_delta returned no usable semantic-token baseline for {}: {result}",
+                    scn.name
+                )
+            });
+            *prev_result_id = id;
+        }
+        Kind::TypingBurst { edits } => {
+            for _ in 0..edits {
+                edit.version += 1;
+                server.did_change_insert_space(scn.uri, edit.version, edit.line);
+            }
+            let result = if prev_result_id.is_empty() {
+                server.semantic_full(scn.uri)
+            } else {
+                server.semantic_delta(scn.uri, prev_result_id)
+            };
+            let id = result_id_of(&result).unwrap_or_else(|| {
+                panic!(
+                    "typing_burst returned no usable semantic-token baseline for {}: {result}",
                     scn.name
                 )
             });
@@ -817,6 +838,14 @@ fn main() {
             targets: "unique edit states→reparse→retokenize→delta; excludes A/B cache returns",
         },
         Scenario {
+            name: "rust_large/typing_burst",
+            language_id: "rust",
+            uri: "file:///bench/large_typing_burst.rs",
+            content: gen_rust(150),
+            kind: Kind::TypingBurst { edits: 8 },
+            targets: "eight queued unique edits→current delta; latest-wins follow latency",
+        },
+        Scenario {
             name: "rust_xlarge/cancel_burst",
             language_id: "rust",
             uri: "file:///bench/large_supersede.rs",
@@ -839,6 +868,14 @@ fn main() {
             content: gen_markdown_injections(60),
             kind: Kind::TypingDelta,
             targets: "unique edit states→injection reuse→delta; excludes A/B cache returns",
+        },
+        Scenario {
+            name: "markdown_injections/typing_burst",
+            language_id: "markdown",
+            uri: "file:///bench/injections_typing_burst.md",
+            content: gen_markdown_injections(60),
+            kind: Kind::TypingBurst { edits: 8 },
+            targets: "eight queued unique edits→current injection delta; latest-wins follow latency",
         },
         // Cold-open latency scenarios for the #6 off-ingress flip. The reader gates
         // on the **host parse** via the watermark (≤200ms budget), then falls back to

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -532,7 +532,7 @@ impl SemanticBaseline {
                     .unwrap_or_else(|| {
                         panic!("semantic delta edit has no deleteCount for {scenario}: {edit}")
                     }) as usize;
-                let end = start.checked_add(delete_count).unwrap_or(usize::MAX);
+                let end = start.saturating_add(delete_count);
                 assert!(
                     end <= self.data.len(),
                     "semantic delta edit is out of bounds for {scenario}: {edit}"
@@ -841,7 +841,7 @@ fn nearest_token_line(data: &[u32], preferred_line: u32) -> Option<u32> {
             continue;
         }
         previous_line = Some(line);
-        if fallback.map_or(true, |current: u32| {
+        if fallback.is_none_or(|current: u32| {
             line.abs_diff(preferred_line) < current.abs_diff(preferred_line)
         }) {
             fallback = Some(line);
@@ -849,7 +849,7 @@ fn nearest_token_line(data: &[u32], preferred_line: u32) -> Option<u32> {
         // Leading-space edits preserve the grammar most reliably on an already
         // indented token line (not headings/fences at column zero in Markdown).
         if start > 0
-            && nearest.map_or(true, |current: u32| {
+            && nearest.is_none_or(|current: u32| {
                 line.abs_diff(preferred_line) < current.abs_diff(preferred_line)
             })
         {

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -478,6 +478,86 @@ struct EditState {
     range_next: u32,
 }
 
+/// Client-side semantic-token state. A fresh `resultId` alone does not prove
+/// that a response represents the latest document version, so typing scenarios
+/// also reconstruct full token data and verify the edited line moved exactly as
+/// far as the inserted/removed prefix.
+struct SemanticBaseline {
+    result_id: String,
+    data: Vec<u32>,
+    tracked_line: u32,
+    initial_start: u32,
+    expected_shift: u32,
+}
+
+impl SemanticBaseline {
+    fn seed(result: &Value, preferred_line: u32, scenario: &str) -> Self {
+        let result_id = result_id_of(result).unwrap_or_else(|| {
+            panic!("initial semantic response has no resultId for {scenario}: {result}")
+        });
+        let data = token_data_of(result).unwrap_or_else(|| {
+            panic!("initial semantic response has no token data for {scenario}: {result}")
+        });
+        let tracked_line = nearest_token_line(&data, preferred_line)
+            .unwrap_or_else(|| panic!("initial semantic response has no tokens for {scenario}"));
+        let initial_start = first_token_start_on_line(&data, tracked_line)
+            .expect("nearest semantic-token line must contain a token");
+        Self {
+            result_id,
+            data,
+            tracked_line,
+            initial_start,
+            expected_shift: 0,
+        }
+    }
+
+    fn apply_and_verify(&mut self, result: &Value, scenario: &str) {
+        if let Some(data) = token_data_of(result) {
+            self.data = data;
+        } else if let Some(edits) = result.get("edits").and_then(Value::as_array) {
+            for edit in edits {
+                let start = edit
+                    .get("start")
+                    .and_then(Value::as_u64)
+                    .unwrap_or_else(|| {
+                        panic!("semantic delta edit has no start for {scenario}: {edit}")
+                    }) as usize;
+                let delete_count = edit
+                    .get("deleteCount")
+                    .and_then(Value::as_u64)
+                    .unwrap_or_else(|| {
+                        panic!("semantic delta edit has no deleteCount for {scenario}: {edit}")
+                    }) as usize;
+                let end = start.checked_add(delete_count).unwrap_or(usize::MAX);
+                assert!(
+                    end <= self.data.len(),
+                    "semantic delta edit is out of bounds for {scenario}: {edit}"
+                );
+                let replacement = edit.get("data").map(parse_token_array).unwrap_or_default();
+                self.data.splice(start..end, replacement);
+            }
+        } else {
+            panic!("semantic response has neither data nor edits for {scenario}: {result}");
+        }
+
+        self.result_id = result_id_of(result).unwrap_or_else(|| {
+            panic!("semantic response has no resultId for {scenario}: {result}")
+        });
+        let actual =
+            first_token_start_on_line(&self.data, self.tracked_line).unwrap_or_else(|| {
+                panic!(
+                    "latest semantic response lost every token on tracked line {} for {scenario}",
+                    self.tracked_line
+                )
+            });
+        assert_eq!(
+            actual,
+            self.initial_start + self.expected_shift,
+            "semantic tokens did not follow the latest edit for {scenario}"
+        );
+    }
+}
+
 struct Scenario {
     name: &'static str,
     language_id: &'static str,
@@ -513,10 +593,6 @@ fn measure(
     // Let the initial parse settle (didOpen parse may be async).
     std::thread::sleep(Duration::from_millis(300));
 
-    // For delta/edit scenarios we need a valid previous result_id; seed it from a
-    // full request, then keep it current (a no-op delta may or may not rotate).
-    let mut prev_result_id = seed_result_id(&mut server, scn);
-
     // did_open used version 1; edits continue from there. Edit a line in the
     // middle of the document (representative of typical cursor position).
     let mut edit = EditState {
@@ -527,14 +603,21 @@ fn measure(
         range_next: 0,
     };
 
+    // Delta/edit scenarios keep a complete client-side baseline. This validates
+    // both the delta protocol and that tokens represent the latest typed state.
+    let mut baseline = seed_baseline(&mut server, scn, edit.line);
+    if let Some(baseline) = &baseline {
+        edit.line = baseline.tracked_line;
+    }
+
     for _ in 0..warmup {
-        run_once(&mut server, scn, &mut prev_result_id, &mut edit);
+        run_once(&mut server, scn, &mut baseline, &mut edit);
     }
 
     let mut samples = Vec::with_capacity(iters);
     for _ in 0..iters {
         let start = Instant::now();
-        run_once(&mut server, scn, &mut prev_result_id, &mut edit);
+        run_once(&mut server, scn, &mut baseline, &mut edit);
         samples.push(start.elapsed());
     }
     samples
@@ -552,12 +635,16 @@ fn measure_cancel_burst(
     server.did_open(scn.uri, scn.language_id, &scn.content);
     std::thread::sleep(Duration::from_millis(300));
     let mut version = 1_i64;
-    let line = (scn.content.lines().count() / 2) as u32;
+    let preferred_line = (scn.content.lines().count() / 2) as u32;
+    let mut baseline =
+        SemanticBaseline::seed(&server.semantic_full(scn.uri), preferred_line, scn.name);
+    let line = baseline.tracked_line;
     let mut samples = Vec::with_capacity(iters);
     for iteration in 0..(warmup + iters) {
         for _ in 0..obsolete {
             version += 1;
             server.did_change_insert_space(scn.uri, version, line);
+            baseline.expected_shift += 1;
             let obsolete_id = server.send_semantic_full(scn.uri);
             // Let the request enter worker compute before explicitly
             // cancelling it; immediate cancellation would only benchmark
@@ -568,13 +655,10 @@ fn measure_cancel_burst(
         version += 1;
         let started = Instant::now();
         server.did_change_insert_space(scn.uri, version, line);
+        baseline.expected_shift += 1;
         let final_id = server.send_semantic_full(scn.uri);
         let result = server.recv_response(final_id);
-        assert!(
-            result_id_of(&result).is_some(),
-            "cancel_burst final request returned no usable semantic-token baseline for {}: {result}",
-            scn.name
-        );
+        baseline.apply_and_verify(&result, scn.name);
         if iteration >= warmup {
             samples.push(started.elapsed());
         }
@@ -616,22 +700,24 @@ fn measure_open(
     samples
 }
 
-fn seed_result_id(server: &mut Server, scn: &Scenario) -> String {
+fn seed_baseline(
+    server: &mut Server,
+    scn: &Scenario,
+    tracked_line: u32,
+) -> Option<SemanticBaseline> {
     match scn.kind {
-        Kind::Full | Kind::Range { .. } | Kind::OpenFirstToken | Kind::CancelBurst { .. } => {
-            String::new()
-        }
+        Kind::Full | Kind::Range { .. } | Kind::OpenFirstToken | Kind::CancelBurst { .. } => None,
         // Delta-based scenarios need an initial result_id to diff against.
-        Kind::DeltaNoop | Kind::EditDelta | Kind::TypingDelta | Kind::TypingBurst { .. } => {
-            result_id_of(&server.semantic_full(scn.uri)).unwrap_or_default()
-        }
+        Kind::DeltaNoop | Kind::EditDelta | Kind::TypingDelta | Kind::TypingBurst { .. } => Some(
+            SemanticBaseline::seed(&server.semantic_full(scn.uri), tracked_line, scn.name),
+        ),
     }
 }
 
 fn run_once(
     server: &mut Server,
     scn: &Scenario,
-    prev_result_id: &mut String,
+    baseline: &mut Option<SemanticBaseline>,
     edit: &mut EditState,
 ) {
     match scn.kind {
@@ -654,11 +740,9 @@ fn run_once(
             let _ = server.semantic_range(scn.uri, start_line + offset, end_line + offset);
         }
         Kind::DeltaNoop => {
-            let result = server.semantic_delta(scn.uri, prev_result_id);
-            // Keep the id valid for the next request whether or not it rotated.
-            if let Some(id) = result_id_of(&result) {
-                *prev_result_id = id;
-            }
+            let baseline = baseline.as_mut().expect("delta baseline");
+            let result = server.semantic_delta(scn.uri, &baseline.result_id);
+            baseline.apply_and_verify(&result, scn.name);
         }
         Kind::EditDelta => {
             // Apply one toggle edit, then request a delta against the prior id.
@@ -666,56 +750,112 @@ fn run_once(
             edit.insert_next = !edit.insert_next;
             edit.version += 1;
             server.did_change_toggle(scn.uri, edit.version, edit.line, insert);
-            // Fall back to a full request if we don't yet have a valid id
-            // (e.g. a prior delta was cancelled and returned no result).
-            let result = if prev_result_id.is_empty() {
-                server.semantic_full(scn.uri)
+            let baseline = baseline.as_mut().expect("edit baseline");
+            if insert {
+                baseline.expected_shift += 1;
             } else {
-                server.semantic_delta(scn.uri, prev_result_id)
-            };
-            let id = result_id_of(&result).unwrap_or_else(|| {
-                panic!(
-                    "edit_delta returned no usable semantic-token baseline for {}: {result}",
-                    scn.name
-                )
-            });
-            *prev_result_id = id;
+                baseline.expected_shift -= 1;
+            }
+            let result = server.semantic_delta(scn.uri, &baseline.result_id);
+            baseline.apply_and_verify(&result, scn.name);
         }
         Kind::TypingDelta => {
             edit.version += 1;
             server.did_change_insert_space(scn.uri, edit.version, edit.line);
-            let result = if prev_result_id.is_empty() {
-                server.semantic_full(scn.uri)
-            } else {
-                server.semantic_delta(scn.uri, prev_result_id)
-            };
-            let id = result_id_of(&result).unwrap_or_else(|| {
-                panic!(
-                    "typing_delta returned no usable semantic-token baseline for {}: {result}",
-                    scn.name
-                )
-            });
-            *prev_result_id = id;
+            let baseline = baseline.as_mut().expect("typing baseline");
+            baseline.expected_shift += 1;
+            let result = server.semantic_delta(scn.uri, &baseline.result_id);
+            baseline.apply_and_verify(&result, scn.name);
         }
         Kind::TypingBurst { edits } => {
             for _ in 0..edits {
                 edit.version += 1;
                 server.did_change_insert_space(scn.uri, edit.version, edit.line);
             }
-            let result = if prev_result_id.is_empty() {
-                server.semantic_full(scn.uri)
-            } else {
-                server.semantic_delta(scn.uri, prev_result_id)
-            };
-            let id = result_id_of(&result).unwrap_or_else(|| {
-                panic!(
-                    "typing_burst returned no usable semantic-token baseline for {}: {result}",
-                    scn.name
-                )
-            });
-            *prev_result_id = id;
+            let baseline = baseline.as_mut().expect("typing baseline");
+            baseline.expected_shift += edits as u32;
+            let result = server.semantic_delta(scn.uri, &baseline.result_id);
+            baseline.apply_and_verify(&result, scn.name);
         }
     }
+}
+
+fn token_data_of(result: &Value) -> Option<Vec<u32>> {
+    result.get("data").map(parse_token_array)
+}
+
+fn parse_token_array(value: &Value) -> Vec<u32> {
+    value
+        .as_array()
+        .unwrap_or_else(|| panic!("semantic token data is not an array: {value}"))
+        .iter()
+        .map(|value| {
+            value
+                .as_u64()
+                .and_then(|value| u32::try_from(value).ok())
+                .unwrap_or_else(|| panic!("semantic token value is not u32: {value}"))
+        })
+        .collect()
+}
+
+fn first_token_start_on_line(data: &[u32], tracked_line: u32) -> Option<u32> {
+    assert_eq!(data.len() % 5, 0, "semantic token data is not 5-tuples");
+    let mut line = 0_u32;
+    let mut start = 0_u32;
+    for token in data.chunks_exact(5) {
+        line += token[0];
+        start = if token[0] == 0 {
+            start + token[1]
+        } else {
+            token[1]
+        };
+        if line == tracked_line {
+            return Some(start);
+        }
+        if line > tracked_line {
+            return None;
+        }
+    }
+    None
+}
+
+fn nearest_token_line(data: &[u32], preferred_line: u32) -> Option<u32> {
+    assert_eq!(data.len() % 5, 0, "semantic token data is not 5-tuples");
+    let mut line = 0_u32;
+    let mut start = 0_u32;
+    let mut nearest = None;
+    let mut fallback = None;
+    let mut previous_line = None;
+    for token in data.chunks_exact(5) {
+        line += token[0];
+        start = if token[0] == 0 {
+            start + token[1]
+        } else {
+            token[1]
+        };
+        if previous_line == Some(line) {
+            continue;
+        }
+        previous_line = Some(line);
+        if fallback.map_or(true, |current: u32| {
+            line.abs_diff(preferred_line) < current.abs_diff(preferred_line)
+        }) {
+            fallback = Some(line);
+        }
+        // Leading-space edits preserve the grammar most reliably on an already
+        // indented token line (not headings/fences at column zero in Markdown).
+        if start > 0
+            && nearest.map_or(true, |current: u32| {
+                line.abs_diff(preferred_line) < current.abs_diff(preferred_line)
+            })
+        {
+            nearest = Some(line);
+        }
+        if line > preferred_line && nearest.is_some() {
+            break;
+        }
+    }
+    nearest.or(fallback)
 }
 
 fn result_id_of(result: &Value) -> Option<String> {

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -549,14 +549,12 @@ fn measure_cancel_burst(
     server.did_open(scn.uri, scn.language_id, &scn.content);
     std::thread::sleep(Duration::from_millis(300));
     let mut version = 1_i64;
-    let mut insert = true;
     let line = (scn.content.lines().count() / 2) as u32;
     let mut samples = Vec::with_capacity(iters);
     for iteration in 0..(warmup + iters) {
         for _ in 0..obsolete {
             version += 1;
-            server.did_change_toggle(scn.uri, version, line, insert);
-            insert = !insert;
+            server.did_change_insert_space(scn.uri, version, line);
             let obsolete_id = server.send_semantic_full(scn.uri);
             // Let the request enter worker compute before explicitly
             // cancelling it; immediate cancellation would only benchmark
@@ -566,10 +564,14 @@ fn measure_cancel_burst(
         }
         version += 1;
         let started = Instant::now();
-        server.did_change_toggle(scn.uri, version, line, insert);
-        insert = !insert;
+        server.did_change_insert_space(scn.uri, version, line);
         let final_id = server.send_semantic_full(scn.uri);
-        let _ = server.recv_response(final_id);
+        let result = server.recv_response(final_id);
+        assert!(
+            result_id_of(&result).is_some(),
+            "cancel_burst final request returned no usable semantic-token baseline for {}: {result}",
+            scn.name
+        );
         if iteration >= warmup {
             samples.push(started.elapsed());
         }
@@ -820,7 +822,7 @@ fn main() {
             uri: "file:///bench/large_supersede.rs",
             content: gen_rust(600),
             kind: Kind::CancelBurst { obsolete: 4 },
-            targets: "latest request latency after four explicitly cancelled computations",
+            targets: "current-token latency after four superseded unique edit states",
         },
         Scenario {
             name: "markdown_injections/edit_delta",

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -189,6 +189,26 @@ impl Server {
         );
     }
 
+    /// A unique typing edit: insert one more space at the cursor without
+    /// toggling back to an earlier whole-document cache key. Real typing grows
+    /// through distinct document states; an A/B toggle would turn every other
+    /// request into an unrealistic whole-document cache hit.
+    fn did_change_insert_space(&mut self, uri: &str, version: i64, line: u32) {
+        self.notify(
+            "textDocument/didChange",
+            json!({
+                "textDocument": { "uri": uri, "version": version },
+                "contentChanges": [{
+                    "range": {
+                        "start": { "line": line, "character": 0 },
+                        "end": { "line": line, "character": 0 },
+                    },
+                    "text": " ",
+                }],
+            }),
+        );
+    }
+
     fn request(&mut self, method: &str, params: Value) -> Value {
         let id = self.send_request(method, params);
         self.recv_response(id)
@@ -430,6 +450,9 @@ enum Kind {
     /// so each measured request pays incremental reparse + cache invalidation +
     /// delta diff on top of the (full) token recompute.
     EditDelta,
+    /// Sustained typing through unique document states. Unlike `EditDelta`, this
+    /// never toggles back to a previously cached whole-document snapshot.
+    TypingDelta,
     /// Rapid edits explicitly cancel several already-issued full requests.
     /// Measures latency from the final edit/request until the only result the
     /// editor can still use, while obsolete computation is reclaimed.
@@ -593,8 +616,8 @@ fn seed_result_id(server: &mut Server, scn: &Scenario) -> String {
         Kind::Full | Kind::Range { .. } | Kind::OpenFirstToken | Kind::CancelBurst { .. } => {
             String::new()
         }
-        // Both delta-based scenarios need an initial result_id to diff against.
-        Kind::DeltaNoop | Kind::EditDelta => {
+        // Delta-based scenarios need an initial result_id to diff against.
+        Kind::DeltaNoop | Kind::EditDelta | Kind::TypingDelta => {
             result_id_of(&server.semantic_full(scn.uri)).unwrap_or_default()
         }
     }
@@ -645,9 +668,29 @@ fn run_once(
             } else {
                 server.semantic_delta(scn.uri, prev_result_id)
             };
-            if let Some(id) = result_id_of(&result) {
-                *prev_result_id = id;
-            }
+            let id = result_id_of(&result).unwrap_or_else(|| {
+                panic!(
+                    "edit_delta returned no usable semantic-token baseline for {}: {result}",
+                    scn.name
+                )
+            });
+            *prev_result_id = id;
+        }
+        Kind::TypingDelta => {
+            edit.version += 1;
+            server.did_change_insert_space(scn.uri, edit.version, edit.line);
+            let result = if prev_result_id.is_empty() {
+                server.semantic_full(scn.uri)
+            } else {
+                server.semantic_delta(scn.uri, prev_result_id)
+            };
+            let id = result_id_of(&result).unwrap_or_else(|| {
+                panic!(
+                    "typing_delta returned no usable semantic-token baseline for {}: {result}",
+                    scn.name
+                )
+            });
+            *prev_result_id = id;
         }
     }
 }
@@ -764,6 +807,14 @@ fn main() {
             targets: "edit→reparse→retokenize→delta diff (host path under typing)",
         },
         Scenario {
+            name: "rust_large/typing_delta",
+            language_id: "rust",
+            uri: "file:///bench/large_typing.rs",
+            content: gen_rust(150),
+            kind: Kind::TypingDelta,
+            targets: "unique edit states→reparse→retokenize→delta; excludes A/B cache returns",
+        },
+        Scenario {
             name: "rust_xlarge/cancel_burst",
             language_id: "rust",
             uri: "file:///bench/large_supersede.rs",
@@ -778,6 +829,14 @@ fn main() {
             content: gen_markdown_injections(60),
             kind: Kind::EditDelta,
             targets: "edit→reparse→injection re-detect→cache invalidation→delta (typing)",
+        },
+        Scenario {
+            name: "markdown_injections/typing_delta",
+            language_id: "markdown",
+            uri: "file:///bench/injections_typing.md",
+            content: gen_markdown_injections(60),
+            kind: Kind::TypingDelta,
+            targets: "unique edit states→injection reuse→delta; excludes A/B cache returns",
         },
         // Cold-open latency scenarios for the #6 off-ingress flip. The reader gates
         // on the **host parse** via the watermark (≤200ms budget), then falls back to

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -39,6 +39,7 @@
 //! `KAKEHASHI_BENCH_SAMPLES_FILE` (optional raw-sample JSON output path).
 
 use serde_json::{Value, json};
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::PathBuf;
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
@@ -55,6 +56,7 @@ struct Server {
     stdin: ChildStdin,
     stdout: BufReader<ChildStdout>,
     next_id: i64,
+    buffered_responses: HashMap<i64, Value>,
 }
 
 impl Server {
@@ -80,6 +82,7 @@ impl Server {
             stdin,
             stdout,
             next_id: 0,
+            buffered_responses: HashMap::new(),
         };
 
         server.request(
@@ -244,6 +247,20 @@ impl Server {
     /// Read messages until the response for `id` arrives, skipping
     /// notifications and server-to-client requests.
     fn recv_response(&mut self, id: i64) -> Value {
+        let msg = self.recv_raw_response(id);
+        // Fail fast on a JSON-RPC error: a misconfigured server (missing
+        // parser/query, bad setup) must not silently produce Null and bogus
+        // timings.
+        if let Some(error) = msg.get("error") {
+            panic!("server returned a JSON-RPC error for request id={id}: {error}");
+        }
+        msg.get("result").cloned().unwrap_or(Value::Null)
+    }
+
+    fn recv_raw_response(&mut self, id: i64) -> Value {
+        if let Some(response) = self.buffered_responses.remove(&id) {
+            return response;
+        }
         let deadline = Instant::now() + Duration::from_secs(60);
         loop {
             if Instant::now() > deadline {
@@ -254,15 +271,13 @@ impl Server {
             if msg.get("method").is_some() {
                 continue;
             }
-            if msg.get("id").and_then(Value::as_i64) == Some(id) {
-                // Fail fast on a JSON-RPC error: a misconfigured server (missing
-                // parser/query, bad setup) must not silently produce Null and
-                // bogus timings.
-                if let Some(error) = msg.get("error") {
-                    panic!("server returned a JSON-RPC error for request id={id}: {error}");
-                }
-                return msg.get("result").cloned().unwrap_or(Value::Null);
+            let Some(response_id) = msg.get("id").and_then(Value::as_i64) else {
+                continue;
+            };
+            if response_id == id {
+                return msg;
             }
+            self.buffered_responses.insert(response_id, msg);
         }
     }
 
@@ -651,6 +666,7 @@ fn measure_cancel_burst(
     let line = baseline.tracked_line;
     let mut samples = Vec::with_capacity(iters);
     for iteration in 0..(warmup + iters) {
+        let mut obsolete_ids = Vec::with_capacity(obsolete);
         for _ in 0..obsolete {
             version += 1;
             server.did_change_insert_space(scn.uri, version, line);
@@ -661,6 +677,7 @@ fn measure_cancel_burst(
             // ingress coalescing.
             std::thread::sleep(Duration::from_millis(20));
             server.notify("$/cancelRequest", json!({ "id": obsolete_id }));
+            obsolete_ids.push(obsolete_id);
         }
         version += 1;
         let started = Instant::now();
@@ -669,8 +686,18 @@ fn measure_cancel_burst(
         let final_id = server.send_semantic_full(scn.uri);
         let result = server.recv_response(final_id);
         baseline.apply_and_verify(&result, scn.name);
+        let elapsed = started.elapsed();
+        for obsolete_id in obsolete_ids {
+            let response = server.recv_raw_response(obsolete_id);
+            assert_eq!(
+                response.pointer("/error/code").and_then(Value::as_i64),
+                Some(-32800),
+                "cancel_burst obsolete request {obsolete_id} did not return RequestCancelled for {}: {response}",
+                scn.name
+            );
+        }
         if iteration >= warmup {
-            samples.push(started.elapsed());
+            samples.push(elapsed);
         }
     }
     samples

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -35,7 +35,8 @@
 //!
 //! Tunables (env): `KAKEHASHI_BENCH_ITERS` (default 80),
 //! `KAKEHASHI_BENCH_WARMUP` (default 10), `KAKEHASHI_BENCH_SCENARIOS`
-//! (optional comma-separated scenario-name substrings).
+//! (optional comma-separated scenario-name substrings), and
+//! `KAKEHASHI_BENCH_SAMPLES_FILE` (optional raw-sample JSON output path).
 
 use serde_json::{Value, json};
 use std::io::{BufRead, BufReader, Read, Write};
@@ -415,15 +416,18 @@ struct Stats {
     median: Duration,
     p25: Duration,
     p75: Duration,
+    p95: Duration,
 }
 
-fn summarize(mut samples: Vec<Duration>) -> Stats {
+fn summarize(samples: &[Duration]) -> Stats {
+    let mut samples = samples.to_vec();
     samples.sort_unstable();
     let pick = |q: f64| samples[((samples.len() as f64 * q) as usize).min(samples.len() - 1)];
     Stats {
         median: pick(0.50),
         p25: pick(0.25),
         p75: pick(0.75),
+        p95: pick(0.95),
     }
 }
 
@@ -1063,23 +1067,60 @@ fn main() {
     }
     println!();
 
+    let mut raw_runs = Vec::new();
+
     if binaries.len() == 2 {
         print_ab_header(&binaries[0].label, &binaries[1].label);
         for scn in &scenarios {
             // Interleave A and B at the scenario level (separate processes); the
             // two runs are back-to-back to minimize machine drift between them.
-            let a = summarize(measure(&binaries[0], scn, &data_dir, iters, warmup));
-            let b = summarize(measure(&binaries[1], scn, &data_dir, iters, warmup));
+            let a_samples = measure(&binaries[0], scn, &data_dir, iters, warmup);
+            let b_samples = measure(&binaries[1], scn, &data_dir, iters, warmup);
+            record_raw_run(&mut raw_runs, &binaries[0], scn, &a_samples);
+            record_raw_run(&mut raw_runs, &binaries[1], scn, &b_samples);
+            let a = summarize(&a_samples);
+            let b = summarize(&b_samples);
             print_ab_row(scn, &a, &b);
         }
     } else {
         print_single_header();
         for scn in &scenarios {
-            let s = summarize(measure(&binaries[0], scn, &data_dir, iters, warmup));
+            let samples = measure(&binaries[0], scn, &data_dir, iters, warmup);
+            record_raw_run(&mut raw_runs, &binaries[0], scn, &samples);
+            let s = summarize(&samples);
             print_single_row(scn, &s);
         }
     }
+    write_raw_samples(iters, warmup, &binaries, raw_runs);
     println!();
+}
+
+fn record_raw_run(raw_runs: &mut Vec<Value>, bin: &Binary, scn: &Scenario, samples: &[Duration]) {
+    raw_runs.push(json!({
+        "binary_label": bin.label,
+        "binary_path": bin.path,
+        "scenario": scn.name,
+        "samples_ns": samples.iter().map(Duration::as_nanos).collect::<Vec<_>>(),
+    }));
+}
+
+fn write_raw_samples(iters: usize, warmup: usize, binaries: &[Binary], raw_runs: Vec<Value>) {
+    let Some(path) = std::env::var_os("KAKEHASHI_BENCH_SAMPLES_FILE") else {
+        return;
+    };
+    let output = json!({
+        "schema_version": 1,
+        "iterations": iters,
+        "warmup_iterations": warmup,
+        "binaries": binaries.iter().map(|bin| json!({
+            "label": bin.label,
+            "path": bin.path,
+        })).collect::<Vec<_>>(),
+        "runs": raw_runs,
+    });
+    let bytes = serde_json::to_vec_pretty(&output).expect("serialize raw benchmark samples");
+    std::fs::write(&path, bytes)
+        .unwrap_or_else(|error| panic!("write raw samples to {:?}: {error}", path));
 }
 
 fn filter_scenarios(scenarios: Vec<Scenario>) -> Vec<Scenario> {
@@ -1109,19 +1150,20 @@ fn filter_scenarios(scenarios: Vec<Scenario>) -> Vec<Scenario> {
 
 fn print_single_header() {
     println!(
-        "{:<34} {:>10} {:>10} {:>10}",
-        "scenario", "median", "p25", "p75"
+        "{:<34} {:>10} {:>10} {:>10} {:>10}",
+        "scenario", "median", "p25", "p75", "p95"
     );
-    println!("{}", "-".repeat(68));
+    println!("{}", "-".repeat(79));
 }
 
 fn print_single_row(scn: &Scenario, s: &Stats) {
     println!(
-        "{:<34} {:>9.3}ms {:>9.3}ms {:>9.3}ms",
+        "{:<34} {:>9.3}ms {:>9.3}ms {:>9.3}ms {:>9.3}ms",
         scn.name,
         ms(s.median),
         ms(s.p25),
-        ms(s.p75)
+        ms(s.p75),
+        ms(s.p95)
     );
     println!("    └ targets: {}", scn.targets);
 }
@@ -1150,6 +1192,7 @@ fn print_ab_row(scn: &Scenario, a: &Stats, b: &Stats) {
         "{:<34} {:>10.3}ms {:>10.3}ms {:>8}{:.1}%",
         scn.name, am, bm, sign, delta_pct
     );
+    println!("    p95: {:>10.3}ms {:>10.3}ms", ms(a.p95), ms(b.p95));
     println!("    └ targets: {}", scn.targets);
 }
 

--- a/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
+++ b/docs/architecture-decisions/single-resident-multithreaded-tree-worker.md
@@ -170,6 +170,16 @@ The internal scheduler provides:
   every compute thread indefinitely; and
 * cooperative cancellation checkpoints within interruptible tree walks.
 
+Latest-wins is an admission policy, not a trailing-only debounce. An edit may
+supersede queued parse or semantic-token work for an older version, but it must
+make the newest version immediately eligible to run. Sustained input therefore
+may skip intermediate token sets that the client can no longer apply, while the
+observable performance contract remains the latency from the latest edit to a
+usable token result for that current version. Measurement must use unique edit
+states and verify that the final response advances a usable semantic-token
+baseline; edit/undo toggles can revisit the whole-document cache and hide
+starvation or tail-latency regressions.
+
 One worker process is not a promise to serialize all documents. Independent
 documents and injection regions may execute on different worker threads within
 the shared budget.


### PR DESCRIPTION
## Summary

- measure semantic-token typing through unique document states and queued/cancelled bursts
- reconstruct full and delta responses client-side instead of trusting `resultId`
- reject a timing sample unless the tracked token position matches the latest edit
- optionally retain raw per-request samples and report p95

## Why

A rotating `resultId` does not prove that token content follows the current document. Likewise, toggling between two document states can hit the whole-document cache and understate real typing work. This stage establishes a latest-edit correctness and latency contract before scheduling changes.

`latest-wins` here is admission, not trailing-edge debounce: the newest version remains immediately eligible, while only work whose result is already unusable may be cancelled.

## Stack

- base: #889
- this PR: Stage 27 typing measurement contract

## Validation

- Rust and Markdown single-edit and eight-edit burst scenarios reconstruct and verify current tokens
- cancellation burst verifies the final full result against every preceding edit
- `cargo clippy --bench semantic_tokens --features e2e -- -D warnings`
- `cargo fmt --all -- --check`
- CI