### PR TITLE
chore(worker): expose internal debug telemetry

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -363,26 +363,35 @@ fn main() -> ExitCode {
             non_evictable_estimate_hard_bytes,
             parent_liveness_fd,
             expected_parent_pid,
-        }) => kakehashi::tree_worker::WorkerMemoryBudgets::new(
-            derived_cache_soft_bytes,
-            non_evictable_estimate_hard_bytes,
-        )
-        .map_err(|error| {
-            eprintln!("tree worker configuration failed: {error}");
-            ExitCode::FAILURE
-        })
-        .and_then(|memory_budgets| {
-            kakehashi::tree_worker::run_stdio_with_parent_liveness(
-                threads,
-                memory_budgets,
-                parent_liveness_fd,
-                expected_parent_pid,
+        }) => {
+            // The worker owns performance-critical parse/query phases whose
+            // debug telemetry cannot be reconstructed from parent-side round
+            // trip timings. Keep stdout protocol-only and expose those logs on
+            // inherited stderr under the same RUST_LOG contract as LSP mode.
+            let _ = env_logger::Builder::from_default_env()
+                .target(env_logger::Target::Stderr)
+                .try_init();
+            kakehashi::tree_worker::WorkerMemoryBudgets::new(
+                derived_cache_soft_bytes,
+                non_evictable_estimate_hard_bytes,
             )
             .map_err(|error| {
-                eprintln!("tree worker failed: {error}");
+                eprintln!("tree worker configuration failed: {error}");
                 ExitCode::FAILURE
             })
-        }),
+            .and_then(|memory_budgets| {
+                kakehashi::tree_worker::run_stdio_with_parent_liveness(
+                    threads,
+                    memory_budgets,
+                    parent_liveness_fd,
+                    expected_parent_pid,
+                )
+                .map_err(|error| {
+                    eprintln!("tree worker failed: {error}");
+                    ExitCode::FAILURE
+                })
+            })
+        }
         None => {
             // Start LSP server (backward compatible default behavior)
             // Only LSP mode needs a tokio runtime; CLI subcommands are synchronous


### PR DESCRIPTION
## Summary

- initialize the hidden tree worker's logger from `RUST_LOG`
- keep worker diagnostics on inherited stderr; stdout remains protocol-only
- expose existing semantic phase timing from inside the isolation boundary

## Why

Parent metrics report queue and round-trip time but cannot separate host query, injection, and finalization costs owned by the worker. The existing phase logs were unreachable because the hidden worker never initialized a logger. This stage makes performance diagnosis possible without enabling logs or adding hot-path work by default.

## Stack

- base: #890
- this PR: Stage 28 worker telemetry

## Validation

- `cargo clippy --bin kakehashi --all-features -- -D warnings`
- authoritative semantic typing run with `RUST_LOG=kakehashi::semantic=debug,kakehashi::tree_worker_shadow_metrics=debug`
