### PR TITLE
test(semantic): add dirty footprint benchmarks

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -47,3 +47,9 @@ keeps every source commit named by archived evidence fetchable after temporary
 development branches are deleted. Before merging archived evidence, also retain
 the recorded harness commit with a durable tag and add that tag as
 `source.harness_ref` in the published manifest.
+
+The retained scenario set includes dense Rust documents with contiguous 1%,
+10%, and 50% dirty syntax footprints. A footprint replaces that fraction of
+100 generated function units with a unique, line-stable state before requesting
+`semanticTokens/full/delta`. The tracked marker moves within the replaced block,
+so the harness rejects a stale response rather than accepting latency alone.

--- a/benches/collect_semantic_pairs.py
+++ b/benches/collect_semantic_pairs.py
@@ -25,6 +25,9 @@ DEFAULT_SCENARIOS = ",".join(
     [
         "rust_large/full_cache_hit",
         "rust_large/typing_delta",
+        "rust_dirty_01pct/typing_delta",
+        "rust_dirty_10pct/typing_delta",
+        "rust_dirty_50pct/typing_delta",
         "rust_sparse_32k_minus/typing_delta",
         "rust_sparse_32k_exact/typing_delta",
         "rust_sparse_32k_plus/typing_delta",
@@ -36,6 +39,14 @@ DEFAULT_SCENARIOS = ",".join(
         "markdown_injections/typing_burst",
         "unicode_rust/full_cache_hit",
     ]
+)
+
+HARNESS_SOURCE_FILES = (
+    "benches/semantic_tokens.rs",
+    "benches/support/semantic_baseline.rs",
+    "benches/support/dirty_footprint.rs",
+    "benches/collect_semantic_pairs.py",
+    "benches/semantic_summary.py",
 )
 
 ISOLATED_ENVIRONMENT_KEYS = {
@@ -547,12 +558,6 @@ def main() -> None:
             (artifact_dir / "summary.json").write_text(
                 json.dumps(summary, indent=2, sort_keys=True) + "\n"
             )
-            source_files = [
-                "benches/semantic_tokens.rs",
-                "benches/support/semantic_baseline.rs",
-                "benches/collect_semantic_pairs.py",
-                "benches/semantic_summary.py",
-            ]
             manifest = {
                 "schema_version": 1,
                 "source": {
@@ -563,7 +568,7 @@ def main() -> None:
                     "harness_commit": harness_commit,
                     "harness_sources_sha256": {
                         path: file_sha256(worktrees["harness-src"] / path)
-                        for path in source_files
+                        for path in HARNESS_SOURCE_FILES
                     },
                 },
                 "attestations": attestations,

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -45,7 +45,7 @@ mod dirty_footprint;
 #[path = "support/semantic_baseline.rs"]
 mod semantic_baseline;
 
-use dirty_footprint::{DIRTY_STATE_COUNT, gen_dirty_rust, gen_dirty_rust_block};
+use dirty_footprint::{DIRTY_STATE_COUNT, gen_dirty_rust, gen_dirty_rust_replacements};
 use semantic_baseline::{
     SemanticBaseline, TRACKED_MARKER, tracked_marker_line, validate_token_payload,
 };
@@ -610,6 +610,8 @@ struct EditState {
     line: u32,
     range_next: u32,
     fixed_width_next: usize,
+    dirty_state_next: usize,
+    dirty_replacements: Vec<String>,
 }
 
 struct Scenario {
@@ -670,6 +672,12 @@ fn measure(
     // Delta scenarios retain and validate the complete client-side baseline,
     // rather than treating a fresh resultId as proof of a current response.
     let mut baseline = seed_baseline(&mut server, scn);
+    let dirty_replacements = match scn.kind {
+        Kind::DirtyFootprintTypingDelta { dirty_units, .. } => {
+            gen_dirty_rust_replacements(dirty_units, warmup + iters)
+        }
+        _ => Vec::new(),
+    };
     let mut edit = EditState {
         version: 1,
         // First edit must insert (the document opens with no extra space).
@@ -677,6 +685,8 @@ fn measure(
         line: baseline.as_ref().map_or(0, SemanticBaseline::tracked_line),
         range_next: 0,
         fixed_width_next: 0,
+        dirty_state_next: 0,
+        dirty_replacements,
     };
 
     for _ in 0..warmup {
@@ -948,15 +958,15 @@ fn run_once(
             total_units,
         } => {
             edit.version += 1;
-            edit.fixed_width_next += 1;
-            let state = edit.fixed_width_next;
-            let replacement = gen_dirty_rust_block(dirty_units, state);
+            edit.dirty_state_next += 1;
+            let state = edit.dirty_state_next;
+            let replacement = &edit.dirty_replacements[state - 1];
             server.did_change_replace_lines(
                 scn.uri,
                 edit.version,
                 edit_start_line,
                 edit_end_line,
-                &replacement,
+                replacement,
             );
             let baseline = baseline.as_mut().expect("dirty-footprint baseline");
             baseline.expect_tracked_start(u32::try_from(state).expect("dirty state fits u32"));

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -40,9 +40,12 @@
 //! comparisons should use `benches/collect_semantic_pairs.py`, which supplies
 //! the fixture and binary attestations required by raw output.
 
+#[path = "support/dirty_footprint.rs"]
+mod dirty_footprint;
 #[path = "support/semantic_baseline.rs"]
 mod semantic_baseline;
 
+use dirty_footprint::{DIRTY_STATE_COUNT, gen_dirty_rust, gen_dirty_rust_block};
 use semantic_baseline::{
     SemanticBaseline, TRACKED_MARKER, tracked_marker_line, validate_token_payload,
 };
@@ -231,6 +234,29 @@ impl Server {
                     "range": {
                         "start": { "line": line, "character": 0 },
                         "end": { "line": line, "character": FIXED_WIDTH_STATE_COUNT },
+                    },
+                    "text": text,
+                }],
+            }),
+        );
+    }
+
+    fn did_change_replace_lines(
+        &mut self,
+        uri: &str,
+        version: i64,
+        start_line: u32,
+        end_line: u32,
+        text: &str,
+    ) {
+        self.notify(
+            "textDocument/didChange",
+            json!({
+                "textDocument": { "uri": uri, "version": version },
+                "contentChanges": [{
+                    "range": {
+                        "start": { "line": start_line, "character": 0 },
+                        "end": { "line": end_line, "character": 0 },
                     },
                     "text": text,
                 }],
@@ -553,6 +579,14 @@ enum Kind {
     TypingDelta,
     /// Unique same-width edit states, preserving the scenario's exact byte size.
     FixedWidthTypingDelta,
+    /// Replace a contiguous percentage of dense Rust syntax units while keeping
+    /// line count stable and exposing freshness through the tracked token.
+    DirtyFootprintTypingDelta {
+        edit_start_line: u32,
+        edit_end_line: u32,
+        dirty_units: usize,
+        total_units: usize,
+    },
     /// Several edits arrive before the one semantic-token request whose result
     /// is still useful to an editor.
     TypingBurst { edits: usize },
@@ -612,6 +646,13 @@ fn measure(
         assert!(
             warmup + iters <= FIXED_WIDTH_STATE_COUNT,
             "{} requires at most {FIXED_WIDTH_STATE_COUNT} total fixed-width states",
+            scn.name
+        );
+    }
+    if matches!(scn.kind, Kind::DirtyFootprintTypingDelta { .. }) {
+        assert!(
+            warmup + iters < DIRTY_STATE_COUNT,
+            "{} requires fewer than {DIRTY_STATE_COUNT} total dirty states",
             scn.name
         );
     }
@@ -804,6 +845,7 @@ fn seed_baseline(server: &mut Server, scn: &Scenario) -> Option<SemanticBaseline
         | Kind::EditDelta
         | Kind::TypingDelta
         | Kind::FixedWidthTypingDelta
+        | Kind::DirtyFootprintTypingDelta { .. }
         | Kind::TypingBurst { .. } => {
             let tracked_line = tracked_marker_line(&scn.content).unwrap_or_else(|error| {
                 panic!("invalid tracked marker for {}: {error:?}", scn.name)
@@ -899,6 +941,33 @@ fn run_once(
                 panic!("invalid semantic response for {}: {error:?}", scn.name)
             });
         }
+        Kind::DirtyFootprintTypingDelta {
+            edit_start_line,
+            edit_end_line,
+            dirty_units,
+            total_units,
+        } => {
+            edit.version += 1;
+            edit.fixed_width_next += 1;
+            let state = edit.fixed_width_next;
+            let replacement = gen_dirty_rust_block(dirty_units, state);
+            server.did_change_replace_lines(
+                scn.uri,
+                edit.version,
+                edit_start_line,
+                edit_end_line,
+                &replacement,
+            );
+            let baseline = baseline.as_mut().expect("dirty-footprint baseline");
+            baseline.expect_tracked_start(u32::try_from(state).expect("dirty state fits u32"));
+            let result = server.semantic_delta(scn.uri, baseline.result_id());
+            baseline.apply_response(&result).unwrap_or_else(|error| {
+                panic!(
+                    "invalid semantic response for {} ({dirty_units}/{total_units} dirty units): {error:?}",
+                    scn.name
+                )
+            });
+        }
         Kind::TypingBurst { edits } => {
             for _ in 0..edits {
                 edit.version += 1;
@@ -924,6 +993,29 @@ fn validate_full_response_generators() {
         gen_unicode_rust(1),
     ] {
         tracked_marker_line(&content).expect("full-response generator has one fixed marker");
+    }
+}
+
+fn dirty_footprint_scenario(
+    name: &'static str,
+    uri: &'static str,
+    dirty_units: usize,
+    targets: &'static str,
+) -> Scenario {
+    let document = gen_dirty_rust(100, dirty_units);
+    let kind = Kind::DirtyFootprintTypingDelta {
+        edit_start_line: document.edit_start_line,
+        edit_end_line: document.edit_end_line,
+        dirty_units: document.dirty_units,
+        total_units: document.total_units,
+    };
+    Scenario {
+        name,
+        language_id: "rust",
+        uri,
+        content: document.content,
+        kind,
+        targets,
     }
 }
 
@@ -1031,6 +1123,24 @@ fn main() {
             kind: Kind::TypingDelta,
             targets: "unique edit states→reparse→retokenize→delta; excludes A/B cache returns",
         },
+        dirty_footprint_scenario(
+            "rust_dirty_01pct/typing_delta",
+            "file:///bench/dirty_01pct.rs",
+            1,
+            "1/100 dense syntax units replaced; incremental lower-bound target",
+        ),
+        dirty_footprint_scenario(
+            "rust_dirty_10pct/typing_delta",
+            "file:///bench/dirty_10pct.rs",
+            10,
+            "10/100 dense syntax units replaced; partial-reuse crossover target",
+        ),
+        dirty_footprint_scenario(
+            "rust_dirty_50pct/typing_delta",
+            "file:///bench/dirty_50pct.rs",
+            50,
+            "50/100 dense syntax units replaced; full-fallback crossover control",
+        ),
         Scenario {
             name: "rust_sparse_32k_minus/typing_delta",
             language_id: "rust",

--- a/benches/support/dirty_footprint.rs
+++ b/benches/support/dirty_footprint.rs
@@ -1,0 +1,68 @@
+use crate::semantic_baseline::TRACKED_MARKER;
+
+pub const DIRTY_STATE_COUNT: usize = 128;
+
+pub struct DirtyRustDocument {
+    pub content: String,
+    pub edit_start_line: u32,
+    pub edit_end_line: u32,
+    pub dirty_units: usize,
+    pub total_units: usize,
+}
+
+fn gen_rust_unit(unit: usize, state: usize) -> String {
+    assert!(state < 1_000, "state must fit the fixed three-digit field");
+    format!(
+        "/// Dirty unit {unit:04}, state {state:03}.\n\
+         pub fn dirty_unit_{unit:04}_state_{state:03}(input: usize) -> usize {{\n\
+        \x20   let value_state_{state:03} = input + {state:03};\n\
+        \x20   let label_state_{state:03} = \"state_{state:03}\";\n\
+        \x20   if value_state_{state:03} % 2 == 0 {{\n\
+        \x20       value_state_{state:03} + label_state_{state:03}.len()\n\
+        \x20   }} else {{\n\
+        \x20       value_state_{state:03}\n\
+        \x20   }}\n\
+         }}\n\n"
+    )
+}
+
+/// Generate the contiguous replacement for `dirty_units` syntax units.
+///
+/// The marker's leading column equals `state`, allowing the client-side token
+/// baseline to reject a stale response even though every replacement preserves
+/// the number of lines and the Rust grammar remains valid.
+pub fn gen_dirty_rust_block(dirty_units: usize, state: usize) -> String {
+    assert!(dirty_units > 0);
+    assert!(state < DIRTY_STATE_COUNT);
+    let mut block = format!("{}{TRACKED_MARKER}\n", " ".repeat(state));
+    for unit in 0..dirty_units {
+        block.push_str(&gen_rust_unit(unit, state));
+    }
+    block
+}
+
+/// Generate a dense Rust document whose first `dirty_units` out of
+/// `total_units` form one replaceable syntax footprint.
+pub fn gen_dirty_rust(total_units: usize, dirty_units: usize) -> DirtyRustDocument {
+    assert!(total_units > 0);
+    assert!((1..=total_units).contains(&dirty_units));
+
+    let prefix = "use std::collections::HashMap;\n\n";
+    let edit_start_line = u32::try_from(prefix.lines().count()).expect("line count fits u32");
+    let initial_block = gen_dirty_rust_block(dirty_units, 0);
+    let block_lines = u32::try_from(initial_block.lines().count()).expect("line count fits u32");
+    let mut content = String::with_capacity(total_units * 500);
+    content.push_str(prefix);
+    content.push_str(&initial_block);
+    for unit in dirty_units..total_units {
+        content.push_str(&gen_rust_unit(unit, 0));
+    }
+
+    DirtyRustDocument {
+        content,
+        edit_start_line,
+        edit_end_line: edit_start_line + block_lines,
+        dirty_units,
+        total_units,
+    }
+}

--- a/benches/support/dirty_footprint.rs
+++ b/benches/support/dirty_footprint.rs
@@ -41,6 +41,14 @@ pub fn gen_dirty_rust_block(dirty_units: usize, state: usize) -> String {
     block
 }
 
+/// Precompute every unique replacement before the timed request loop.
+pub fn gen_dirty_rust_replacements(dirty_units: usize, states: usize) -> Vec<String> {
+    assert!(states < DIRTY_STATE_COUNT);
+    (1..=states)
+        .map(|state| gen_dirty_rust_block(dirty_units, state))
+        .collect()
+}
+
 /// Generate a dense Rust document whose first `dirty_units` out of
 /// `total_units` form one replaceable syntax footprint.
 pub fn gen_dirty_rust(total_units: usize, dirty_units: usize) -> DirtyRustDocument {

--- a/benches/test_collect_semantic_pairs.py
+++ b/benches/test_collect_semantic_pairs.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 from collect_semantic_pairs import (
     DEFAULT_SCENARIOS,
+    HARNESS_SOURCE_FILES,
     manifest_sha256,
     normalize_captured_stdout,
     parse_server_env,
@@ -20,6 +21,17 @@ from collect_semantic_pairs import (
 
 
 class CollectSemanticPairsTest(unittest.TestCase):
+    def test_dirty_footprints_are_default_attested_scenarios(self):
+        defaults = set(DEFAULT_SCENARIOS.split(","))
+        self.assertTrue(
+            {
+                "rust_dirty_01pct/typing_delta",
+                "rust_dirty_10pct/typing_delta",
+                "rust_dirty_50pct/typing_delta",
+            }.issubset(defaults)
+        )
+        self.assertIn("benches/support/dirty_footprint.rs", HARNESS_SOURCE_FILES)
+
     def test_scenario_filters_are_normalized_for_execution_and_manifest(self):
         self.assertEqual(
             scenario_filter_terms(" rust, , markdown "),
@@ -75,7 +87,7 @@ class CollectSemanticPairsTest(unittest.TestCase):
         harness = (Path(__file__).parent / "semantic_tokens.rs").read_text()
         for scenario in DEFAULT_SCENARIOS.split(","):
             with self.subTest(scenario=scenario):
-                self.assertIn(f'name: "{scenario}"', harness)
+                self.assertIn(f'"{scenario}"', harness)
 
     def test_captured_stdout_has_exactly_one_terminal_newline(self):
         self.assertEqual(normalize_captured_stdout("result\n\n"), "result\n")

--- a/tests/semantic_benchmark_contract.rs
+++ b/tests/semantic_benchmark_contract.rs
@@ -1,6 +1,9 @@
+#[path = "../benches/support/dirty_footprint.rs"]
+mod dirty_footprint;
 #[path = "../benches/support/semantic_baseline.rs"]
 mod semantic_baseline;
 
+use dirty_footprint::{gen_dirty_rust, gen_dirty_rust_block};
 use semantic_baseline::{
     SemanticBaseline, TRACKED_MARKER, ValidationError, tracked_marker_line, validate_token_payload,
 };
@@ -185,5 +188,39 @@ fn validates_range_token_payload_shape() {
     assert_eq!(
         validate_token_payload(&serde_json::Value::Null),
         Err(ValidationError::MissingTokenPayload)
+    );
+}
+
+#[test]
+fn dirty_rust_documents_define_exact_syntax_unit_footprints() {
+    for dirty_units in [1, 10, 50] {
+        let document = gen_dirty_rust(100, dirty_units);
+        assert_eq!(
+            document.dirty_units * 100 / document.total_units,
+            dirty_units
+        );
+        assert_eq!(
+            tracked_marker_line(&document.content),
+            Ok(document.edit_start_line)
+        );
+        assert_eq!(
+            document.edit_end_line - document.edit_start_line,
+            u32::try_from(gen_dirty_rust_block(dirty_units, 0).lines().count()).unwrap()
+        );
+    }
+}
+
+#[test]
+fn dirty_rust_replacements_are_unique_line_stable_and_freshness_visible() {
+    let initial = gen_dirty_rust_block(10, 0);
+    let next = gen_dirty_rust_block(10, 1);
+    assert_ne!(initial, next);
+    assert_eq!(initial.lines().count(), next.lines().count());
+    assert!(initial.lines().next().unwrap().starts_with(TRACKED_MARKER));
+    assert!(
+        next.lines()
+            .next()
+            .unwrap()
+            .starts_with(&format!(" {TRACKED_MARKER}"))
     );
 }

--- a/tests/semantic_benchmark_contract.rs
+++ b/tests/semantic_benchmark_contract.rs
@@ -3,7 +3,7 @@ mod dirty_footprint;
 #[path = "../benches/support/semantic_baseline.rs"]
 mod semantic_baseline;
 
-use dirty_footprint::{gen_dirty_rust, gen_dirty_rust_block};
+use dirty_footprint::{gen_dirty_rust, gen_dirty_rust_block, gen_dirty_rust_replacements};
 use semantic_baseline::{
     SemanticBaseline, TRACKED_MARKER, ValidationError, tracked_marker_line, validate_token_payload,
 };
@@ -223,4 +223,13 @@ fn dirty_rust_replacements_are_unique_line_stable_and_freshness_visible() {
             .unwrap()
             .starts_with(&format!(" {TRACKED_MARKER}"))
     );
+}
+
+#[test]
+fn dirty_rust_replacements_can_be_precomputed_before_timing() {
+    let replacements = gen_dirty_rust_replacements(10, 3);
+    assert_eq!(replacements.len(), 3);
+    for (index, replacement) in replacements.iter().enumerate() {
+        assert!(replacement.starts_with(&" ".repeat(index + 1)));
+    }
 }


### PR DESCRIPTION
## 概要

#896 のmeasurement sliceとして、large dense Rust文書に1% / 10% / 50%のdirty syntax footprintを作るsemantic token benchmarkを追加します。

このPRはbenchmark契約 #899 (`test/nonworker-semantic-perf-baseline`) の直上に置く兄弟PRで、#905のstackは深くしません。production codeは変更しません。

## 計測契約

- 100個の生成関数単位のうち1 / 10 / 50個を、contiguousなLSP rangeとして毎回unique stateへ置換
- 行数を一定に保ち、後続syntaxのline positionを変えない
- 置換block内のtracked semantic token位置をstateごとに変え、stale responseを拒否
- warmup + retained sample分の置換文字列をtimed loop前にprecomputeし、fixture生成コストをsampleから除外
- 3ケースをpaired collectorのdefault scenarioへ追加
- generator sourceを`harness_sources_sha256`へ追加してmanifestでattest

## 検証

- TDD: generator未実装、precompute未実装、collector attestation未実装のREDを確認
- `cargo test --test semantic_benchmark_contract`（12 passed）
- `python3 benches/test_collect_semantic_pairs.py`（12 passed）
- `python3 benches/test_semantic_summary.py`（7 passed）
- `KAKEHASHI_BENCH_VALIDATE_SCENARIOS=1 cargo test --bench semantic_tokens --features e2e`
- `cargo clippy --bench semantic_tokens --features e2e -- -D warnings`
- `make check`
- 3 scenarioをrelease serverへ実送信し、delta freshness検証を含めて完走
- ローカルCodex reviewを3巡し、timed fixture generation、collector defaults、source attestationの指摘を修正後、actionable findingなし

## 性能証跡について

これはproduction性能を変える実装PRではなく、後続PRをexact A/Bで判定するためのharness PRです。そのためこのPR自体からspeedupは主張しません。後続のperformance implementation PRでは、4 alternating AB/BA pairs、6 warmups、30 retained samplesでこの3ケースを含むevidenceを保持します。

Part of #896.

---

**注記 (2026-08-11): 生サンプルの削除**

リポジトリに raw benchmark data を残さないため、`benches/results/*/pair-*.json`（各pairの生サンプル配列）をこのスタックの全PRから削除しました。evidence ディレクトリは残っており、中身は次の通りです。

- `summary.json` — pairごとの median / delta / min / max と集計値
- `pair-*.txt` — シナリオ別の A/B 比較表（p95 付き）
- `manifest.json` / `fixture-manifest.json` — commit・tag・binary/harness/fixture の SHA-256

**本文に記載した数値はすべてこれらから再構成できます。** 失われたのは各シナリオ 30 本の生サンプル配列のみです。`manifest.json` の `raw_files` / `samples_sha256` は、削除したファイルの記録として意図的に残しています。

なお本文中の「raw samples を検証／再検証した」という記述は当時実施した検証の記録であり、現在のリポジトリからは再実行できません。今後の再混入を防ぐため `.gitignore` に `benches/results/*/pair-*.json` を追加しています。
