### PR TITLE
test(profile): add exact-PID allocation profiling handshake

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - run: python3 -m unittest benches/profile/test_drive.py -v
       - run: rustup component add rust-analyzer
       - run: make deps/tree-sitter
       - run: cargo test

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -120,6 +120,24 @@ wait_for_driver_marker "$profile_dir/ready" || exit $?
   exit 1
 }
 server_pid="$(cat "$profile_dir/pid")"
+
+profile_target_is_live() {
+  kill -0 "$driver_pid" 2>/dev/null &&
+    [ -s "$profile_dir/pid" ] &&
+    [ "$(cat "$profile_dir/pid")" = "$server_pid" ] &&
+    kill -0 "$server_pid" 2>/dev/null
+}
+
+require_profile_target() {
+  profile_target_is_live && return 0
+  wait "$driver_pid"
+  target_status=$?
+  [ "$target_status" -ne 0 ] || target_status=1
+  printf 'profile target exited or invalidated PID marker\n' >&2
+  return "$target_status"
+}
+
+require_profile_target || exit $?
 printf 'Attach the profiler to kakehashi PID %s\n' "$server_pid"
 ```
 
@@ -128,6 +146,7 @@ attachment, run the second block in the same shell to release only the measured
 semantic-token workload:
 
 ```sh
+require_profile_target || exit $?
 touch "$profile_dir/start" || exit $?
 
 # "$profile_dir/done" marks the end of measured requests. The server remains

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -69,6 +69,7 @@ python3 benches/profile/drive.py \
   --profile-ready-file "$profile_dir/ready" \
   --profile-start-file "$profile_dir/start" \
   --profile-done-file "$profile_dir/done" \
+  --profile-wait-timeout 300 \
   --profile-hold-seconds 5 &
 driver_pid=$!
 
@@ -109,8 +110,9 @@ wait "$driver_pid"
 
 Use a fresh marker directory for each run. `pid`, `ready`, and `done` are
 published atomically. `start` is owned by the profiler controller; if it is not
-published within `--profile-wait-timeout` (30 seconds by default), the driver
-fails and still reaps the server.
+published within `--profile-wait-timeout`, the driver fails and still reaps the
+server. The interactive example allows five minutes for attachment; the CLI
+default is 30 seconds.
 
 The harness drives the server against `deps/test/kakehashi` for parsers/queries.
 If that dir has no installed parsers, the server auto-installs on the first

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -130,11 +130,15 @@ touch "$profile_dir/start"
 # alive during the hold interval so retained-heap tools can inspect it.
 wait_for_driver_marker "$profile_dir/done" || exit $?
 heap -H "$server_pid"
+heap_status=$?
 touch "$profile_dir/stop"
+stop_status=$?
 wait "$driver_pid"
 driver_status=$?
 trap - EXIT HUP INT TERM
 rm -r "$profile_dir"
+[ "$heap_status" -eq 0 ] || exit "$heap_status"
+[ "$stop_status" -eq 0 ] || exit "$stop_status"
 [ "$driver_status" -eq 0 ] || exit "$driver_status"
 ```
 

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -60,6 +60,7 @@ an external profiler can attach to the exact PID after an awaited, unmeasured
 semantic-token warmup and before measured requests begin:
 
 ```sh
+cargo build --profile profiling --bin kakehashi
 profile_dir="$(mktemp -d "${TMPDIR:-/tmp}/kakehashi-profile.XXXXXX")"
 python3 benches/profile/drive.py \
   --bin ./target/profiling/kakehashi \

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -54,6 +54,37 @@ benches/profile/xctrace.sh --lang markdown --size 150 --requests 160 --edits 1
 # -> $TMPDIR/kakehashi-xctrace/semantic-time.trace (+ a target-only summary)
 ```
 
+Allocation and retained-heap profilers need to attach to the spawned server
+rather than the Python driver. The driver exposes an optional file handshake so
+an external profiler can attach to the exact PID after parser/query warmup and
+before measured requests begin:
+
+```sh
+profile_dir="$(mktemp -d "${TMPDIR:-/tmp}/kakehashi-profile.XXXXXX")"
+python3 benches/profile/drive.py \
+  --bin ./target/profiling/kakehashi \
+  --file path/to/input.md --requests 80 --edits 1 \
+  --profile-pid-file "$profile_dir/pid" \
+  --profile-ready-file "$profile_dir/ready" \
+  --profile-start-file "$profile_dir/start" \
+  --profile-done-file "$profile_dir/done" \
+  --profile-hold-seconds 5 &
+driver_pid=$!
+
+# Wait for pid + ready, attach the profiler to "$(cat "$profile_dir/pid")",
+# then release only the semantic-token workload:
+touch "$profile_dir/start"
+
+# "$profile_dir/done" marks the end of measured requests. During the hold
+# interval, retained-heap tools can inspect the still-running server.
+wait "$driver_pid"
+```
+
+Use a fresh marker directory for each run. `pid`, `ready`, and `done` are
+published atomically. `start` is owned by the profiler controller; if it is not
+published within `--profile-wait-timeout` (30 seconds by default), the driver
+fails and still reaps the server.
+
 The harness drives the server against `deps/test/kakehashi` for parsers/queries.
 If that dir has no installed parsers, the server auto-installs on the first
 request (slow, needs network) and the profile is dominated by install work —

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -77,6 +77,7 @@ wait_for_driver_marker() {
     if ! kill -0 "$driver_pid" 2>/dev/null; then
       wait "$driver_pid"
       driver_status=$?
+      [ -f "$marker" ] && return 0
       [ "$driver_status" -ne 0 ] || driver_status=1
       printf 'driver exited before publishing %s\n' "$marker" >&2
       return "$driver_status"

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -60,8 +60,8 @@ an external profiler can attach to the exact PID after an awaited, unmeasured
 semantic-token warmup and before measured requests begin:
 
 ```sh
-cargo build --profile profiling --bin kakehashi
-profile_dir="$(mktemp -d "${TMPDIR:-/tmp}/kakehashi-profile.XXXXXX")"
+cargo build --profile profiling --bin kakehashi || exit $?
+profile_dir="$(mktemp -d "${TMPDIR:-/tmp}/kakehashi-profile.XXXXXX")" || exit $?
 python3 benches/profile/drive.py \
   --bin ./target/profiling/kakehashi \
   --file path/to/input.md --requests 80 --edits 1 \

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -79,10 +79,6 @@ driver_job_is_running() {
 
 cleanup_profile_run() {
   trap - EXIT HUP INT TERM
-  if [ -s "$profile_dir/pid" ]; then
-    cleanup_server_pid="$(cat "$profile_dir/pid")"
-    kill "$cleanup_server_pid" 2>/dev/null || true
-  fi
   cleanup_driver_pid="$driver_pid"
   if driver_job_is_running; then
     kill "$cleanup_driver_pid" 2>/dev/null || true
@@ -90,11 +86,6 @@ cleanup_profile_run() {
   driver_pid=
   [ -z "$cleanup_driver_pid" ] ||
     wait "$cleanup_driver_pid" 2>/dev/null || true
-  # Recheck in case the PID marker appeared while cleanup was starting.
-  if [ -s "$profile_dir/pid" ]; then
-    cleanup_server_pid="$(cat "$profile_dir/pid")"
-    kill "$cleanup_server_pid" 2>/dev/null || true
-  fi
   [ ! -d "$profile_dir" ] || rm -r "$profile_dir"
 }
 trap cleanup_profile_run EXIT
@@ -137,12 +128,24 @@ wait_for_driver_marker "$profile_dir/ready" || exit $?
   exit 1
 }
 server_pid="$(cat "$profile_dir/pid")"
+server_identity="$(
+  ps -o ppid= -o lstart= -p "$server_pid" |
+    awk '{$1 = $1; print}'
+)"
+[ "${server_identity%% *}" = "$driver_pid" ] || {
+  printf 'could not record profile target identity\n' >&2
+  exit 1
+}
 
 profile_target_is_live() {
   kill -0 "$driver_pid" 2>/dev/null &&
     [ -s "$profile_dir/pid" ] &&
     [ "$(cat "$profile_dir/pid")" = "$server_pid" ] &&
-    kill -0 "$server_pid" 2>/dev/null
+    kill -0 "$server_pid" 2>/dev/null &&
+    [ "$(
+      ps -o ppid= -o lstart= -p "$server_pid" |
+        awk '{$1 = $1; print}'
+    )" = "$server_identity" ]
 }
 
 require_profile_target() {

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -69,8 +69,9 @@ python3 benches/profile/drive.py \
   --profile-ready-file "$profile_dir/ready" \
   --profile-start-file "$profile_dir/start" \
   --profile-done-file "$profile_dir/done" \
+  --profile-stop-file "$profile_dir/stop" \
   --profile-wait-timeout 300 \
-  --profile-hold-seconds 5 &
+  --profile-hold-seconds 60 &
 driver_pid=$!
 
 wait_for_driver_marker() {
@@ -109,14 +110,17 @@ touch "$profile_dir/start"
 # alive during the hold interval so retained-heap tools can inspect it.
 wait_for_driver_marker "$profile_dir/done" || exit $?
 heap -H "$server_pid"
+touch "$profile_dir/stop"
 wait "$driver_pid"
 ```
 
 Use a fresh marker directory for each run. `pid`, `ready`, and `done` are
-published atomically. `start` is owned by the profiler controller; if it is not
-published within `--profile-wait-timeout`, the driver fails and still reaps the
-server. The interactive example allows five minutes for attachment; the CLI
-default is 30 seconds.
+published atomically. `start` and `stop` are owned by the profiler controller.
+If `start` is not published within `--profile-wait-timeout`, the driver fails
+and still reaps the server. The interactive example allows five minutes for
+attachment; the CLI default is 30 seconds. After `done`, `stop` releases the
+server as soon as the retained-heap snapshot finishes; `--profile-hold-seconds`
+is a 60-second safety deadline if the controller never publishes it.
 
 The harness drives the server against `deps/test/kakehashi` for parsers/queries.
 If that dir has no installed parsers, the server auto-installs on the first

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -96,14 +96,13 @@ wait_for_driver_marker "$profile_dir/ready" || exit $?
 }
 server_pid="$(cat "$profile_dir/pid")"
 printf 'Attach the profiler to kakehashi PID %s\n' "$server_pid"
+```
 
-# Attach the profiler to "$server_pid". Continue only after it confirms the
-# attachment; this prompt prevents the full block from releasing work early.
-printf 'Press Enter after the profiler confirms attachment: '
-if ! IFS= read -r profile_confirmation; then
-  printf 'no attachment confirmation received\n' >&2
-  exit 1
-fi
+Pause here and attach the profiler to `"$server_pid"`. After it confirms the
+attachment, run the second block in the same shell to release only the measured
+semantic-token workload:
+
+```sh
 touch "$profile_dir/start"
 
 # "$profile_dir/done" marks the end of measured requests. The server remains

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -56,8 +56,8 @@ benches/profile/xctrace.sh --lang markdown --size 150 --requests 160 --edits 1
 
 Allocation and retained-heap profilers need to attach to the spawned server
 rather than the Python driver. The driver exposes an optional file handshake so
-an external profiler can attach to the exact PID after parser/query warmup and
-before measured requests begin:
+an external profiler can attach to the exact PID after an awaited, unmeasured
+semantic-token warmup and before measured requests begin:
 
 ```sh
 profile_dir="$(mktemp -d "${TMPDIR:-/tmp}/kakehashi-profile.XXXXXX")"
@@ -71,12 +71,23 @@ python3 benches/profile/drive.py \
   --profile-hold-seconds 5 &
 driver_pid=$!
 
-# Wait for pid + ready, attach the profiler to "$(cat "$profile_dir/pid")",
-# then release only the semantic-token workload:
+# Wait until the server PID is complete and the semantic warmup has responded.
+while [ ! -s "$profile_dir/pid" ] || [ ! -f "$profile_dir/ready" ]; do
+  sleep 0.05
+done
+server_pid="$(cat "$profile_dir/pid")"
+printf 'Attach the profiler to kakehashi PID %s\n' "$server_pid"
+
+# PAUSE HERE: attach the profiler to "$server_pid" and wait for the profiler to
+# confirm attachment. Only then release the measured semantic-token workload.
 touch "$profile_dir/start"
 
-# "$profile_dir/done" marks the end of measured requests. During the hold
-# interval, retained-heap tools can inspect the still-running server.
+# "$profile_dir/done" marks the end of measured requests. The server remains
+# alive during the hold interval so retained-heap tools can inspect it.
+while [ ! -f "$profile_dir/done" ]; do
+  sleep 0.05
+done
+heap -H "$server_pid"
 wait "$driver_pid"
 ```
 

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -76,10 +76,10 @@ wait_for_driver_marker() {
   while [ ! -f "$marker" ]; do
     if ! kill -0 "$driver_pid" 2>/dev/null; then
       wait "$driver_pid"
-      status=$?
-      [ "$status" -ne 0 ] || status=1
+      driver_status=$?
+      [ "$driver_status" -ne 0 ] || driver_status=1
       printf 'driver exited before publishing %s\n' "$marker" >&2
-      return "$status"
+      return "$driver_status"
     fi
     sleep 0.05
   done

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -139,11 +139,13 @@ touch "$profile_dir/stop"
 stop_status=$?
 wait "$driver_pid"
 driver_status=$?
-trap - EXIT HUP INT TERM
 rm -r "$profile_dir"
+remove_status=$?
+[ "$remove_status" -ne 0 ] || trap - EXIT HUP INT TERM
 [ "$heap_status" -eq 0 ] || exit "$heap_status"
 [ "$stop_status" -eq 0 ] || exit "$stop_status"
 [ "$driver_status" -eq 0 ] || exit "$driver_status"
+[ "$remove_status" -eq 0 ] || exit "$remove_status"
 ```
 
 Use a fresh marker directory for each run. `pid`, `ready`, and `done` are

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -73,9 +73,11 @@ driver_job_is_running() {
   jobs -l > "$jobs_file" 2>/dev/null || return 1
   awk -v pid="$driver_pid" '
     {
-      state = tolower($0)
-      for (field = 1; field <= NF; field++)
-        if ($field == pid && state !~ /(done|exit|terminated)/) found = 1
+      for (field = 1; field < NF; field++)
+        if ($field == pid) {
+          state = tolower($(field + 1))
+          if (state == "running" || state == "suspended") found = 1
+        }
     }
     END { exit !found }
   ' "$jobs_file"

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -124,7 +124,7 @@ attachment, run the second block in the same shell to release only the measured
 semantic-token workload:
 
 ```sh
-touch "$profile_dir/start"
+touch "$profile_dir/start" || exit $?
 
 # "$profile_dir/done" marks the end of measured requests. The server remains
 # alive during the hold interval so retained-heap tools can inspect it.

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -62,6 +62,9 @@ semantic-token warmup and before measured requests begin:
 ```sh
 cargo build --profile profiling --bin kakehashi || exit $?
 profile_dir="$(mktemp -d "${TMPDIR:-/tmp}/kakehashi-profile.XXXXXX")" || exit $?
+profile_wait_seconds=300
+profile_hold_seconds=60
+controller_grace_seconds=12
 driver_pid=
 
 driver_job_is_running() {
@@ -69,7 +72,11 @@ driver_job_is_running() {
   jobs_file="$profile_dir/controller-jobs"
   jobs -l > "$jobs_file" 2>/dev/null || return 1
   awk -v pid="$driver_pid" '
-    { for (field = 1; field <= NF; field++) if ($field == pid) found = 1 }
+    {
+      state = tolower($0)
+      for (field = 1; field <= NF; field++)
+        if ($field == pid && state !~ /(done|exit|terminated)/) found = 1
+    }
     END { exit !found }
   ' "$jobs_file"
   jobs_status=$?
@@ -77,15 +84,34 @@ driver_job_is_running() {
   return "$jobs_status"
 }
 
+wait_for_driver_exit() {
+  timeout_seconds="$1"
+  wait_pid="$driver_pid"
+  [ -n "$wait_pid" ] || return 0
+  deadline=$(( $(date +%s) + timeout_seconds ))
+  while driver_job_is_running; do
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      if driver_job_is_running; then
+        kill -KILL "$wait_pid" 2>/dev/null || true
+      fi
+      wait "$wait_pid" 2>/dev/null || true
+      driver_pid=
+      return 124
+    fi
+    sleep 0.05
+  done
+  wait "$wait_pid"
+  wait_status=$?
+  driver_pid=
+  return "$wait_status"
+}
+
 cleanup_profile_run() {
   trap - EXIT HUP INT TERM
-  cleanup_driver_pid="$driver_pid"
   if driver_job_is_running; then
-    kill "$cleanup_driver_pid" 2>/dev/null || true
+    kill "$driver_pid" 2>/dev/null || true
   fi
-  driver_pid=
-  [ -z "$cleanup_driver_pid" ] ||
-    wait "$cleanup_driver_pid" 2>/dev/null || true
+  wait_for_driver_exit "$controller_grace_seconds" || true
   [ ! -d "$profile_dir" ] || rm -r "$profile_dir"
 }
 trap cleanup_profile_run EXIT
@@ -101,28 +127,33 @@ python3 benches/profile/drive.py \
   --profile-start-file "$profile_dir/start" \
   --profile-done-file "$profile_dir/done" \
   --profile-stop-file "$profile_dir/stop" \
-  --profile-wait-timeout 300 \
-  --profile-hold-seconds 60 &
+  --profile-wait-timeout "$profile_wait_seconds" \
+  --profile-hold-seconds "$profile_hold_seconds" &
 driver_pid=$!
 
 wait_for_driver_marker() {
   marker="$1"
+  timeout_seconds="$2"
+  deadline=$(( $(date +%s) + timeout_seconds ))
   while [ ! -f "$marker" ]; do
-    if ! kill -0 "$driver_pid" 2>/dev/null; then
-      wait "$driver_pid"
+    if ! driver_job_is_running; then
+      wait_for_driver_exit "$controller_grace_seconds"
       driver_status=$?
-      driver_pid=
       [ -f "$marker" ] && return 0
       [ "$driver_status" -ne 0 ] || driver_status=1
       printf 'driver exited before publishing %s\n' "$marker" >&2
       return "$driver_status"
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      printf 'controller timed out waiting for %s\n' "$marker" >&2
+      return 124
     fi
     sleep 0.05
   done
 }
 
 # Wait until the server PID is complete and the semantic warmup has responded.
-wait_for_driver_marker "$profile_dir/ready" || exit $?
+wait_for_driver_marker "$profile_dir/ready" "$profile_wait_seconds" || exit $?
 [ -s "$profile_dir/pid" ] || {
   printf 'driver published ready without a PID\n' >&2
   exit 1
@@ -138,7 +169,7 @@ server_identity="$(
 }
 
 profile_target_is_live() {
-  kill -0 "$driver_pid" 2>/dev/null &&
+  driver_job_is_running &&
     [ -s "$profile_dir/pid" ] &&
     [ "$(cat "$profile_dir/pid")" = "$server_pid" ] &&
     kill -0 "$server_pid" 2>/dev/null &&
@@ -150,12 +181,8 @@ profile_target_is_live() {
 
 require_profile_target() {
   profile_target_is_live && return 0
-  wait "$driver_pid"
-  target_status=$?
-  driver_pid=
-  [ "$target_status" -ne 0 ] || target_status=1
   printf 'profile target exited or invalidated PID marker\n' >&2
-  return "$target_status"
+  return 1
 }
 
 require_profile_target || exit $?
@@ -172,15 +199,23 @@ touch "$profile_dir/start" || exit $?
 
 # "$profile_dir/done" marks the end of measured requests. The server remains
 # alive during the hold interval so retained-heap tools can inspect it.
-wait_for_driver_marker "$profile_dir/done" || exit $?
+wait_for_driver_marker "$profile_dir/done" "$profile_wait_seconds" || exit $?
 require_profile_target || exit $?
-heap -H "$server_pid"
+python3 -c '
+import subprocess
+import sys
+
+try:
+    completed = subprocess.run(sys.argv[2:], timeout=float(sys.argv[1]))
+except subprocess.TimeoutExpired:
+    sys.exit(124)
+sys.exit(completed.returncode)
+' "$profile_hold_seconds" /usr/bin/heap -H "$server_pid"
 heap_status=$?
 touch "$profile_dir/stop"
 stop_status=$?
-wait "$driver_pid"
+wait_for_driver_exit "$controller_grace_seconds"
 driver_status=$?
-driver_pid=
 rm -r "$profile_dir"
 remove_status=$?
 [ "$remove_status" -ne 0 ] || trap - EXIT HUP INT TERM
@@ -198,7 +233,11 @@ attachment; the CLI default is 30 seconds. The same timeout bounds the semantic
 warmup response, while shutdown responses are capped at five seconds. After
 `done`, `stop` releases the server as soon as the retained-heap snapshot
 finishes; `--profile-hold-seconds` is a 60-second safety deadline if the
-controller never publishes it.
+controller never publishes it. Independently, the shell controller caps
+`ready`/`done` polling at `profile_wait_seconds`, the foreground heap command
+at `profile_hold_seconds`, and driver cleanup at `controller_grace_seconds`
+(12 seconds, longer than the driver's bounded shutdown phases). These variables
+can be raised for intentionally longer profiling runs.
 
 The harness drives the server against `deps/test/kakehashi` for parsers/queries.
 If that dir has no installed parsers, the server auto-installs on the first

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -64,16 +64,32 @@ cargo build --profile profiling --bin kakehashi || exit $?
 profile_dir="$(mktemp -d "${TMPDIR:-/tmp}/kakehashi-profile.XXXXXX")" || exit $?
 driver_pid=
 
+driver_job_is_running() {
+  [ -n "$driver_pid" ] || return 1
+  jobs_file="$profile_dir/controller-jobs"
+  jobs -l > "$jobs_file" 2>/dev/null || return 1
+  awk -v pid="$driver_pid" '
+    { for (field = 1; field <= NF; field++) if ($field == pid) found = 1 }
+    END { exit !found }
+  ' "$jobs_file"
+  jobs_status=$?
+  rm -f "$jobs_file"
+  return "$jobs_status"
+}
+
 cleanup_profile_run() {
   trap - EXIT HUP INT TERM
   if [ -s "$profile_dir/pid" ]; then
     cleanup_server_pid="$(cat "$profile_dir/pid")"
     kill "$cleanup_server_pid" 2>/dev/null || true
   fi
-  if [ -n "$driver_pid" ]; then
-    kill "$driver_pid" 2>/dev/null || true
-    wait "$driver_pid" 2>/dev/null || true
+  cleanup_driver_pid="$driver_pid"
+  if driver_job_is_running; then
+    kill "$cleanup_driver_pid" 2>/dev/null || true
   fi
+  driver_pid=
+  [ -z "$cleanup_driver_pid" ] ||
+    wait "$cleanup_driver_pid" 2>/dev/null || true
   # Recheck in case the PID marker appeared while cleanup was starting.
   if [ -s "$profile_dir/pid" ]; then
     cleanup_server_pid="$(cat "$profile_dir/pid")"
@@ -104,6 +120,7 @@ wait_for_driver_marker() {
     if ! kill -0 "$driver_pid" 2>/dev/null; then
       wait "$driver_pid"
       driver_status=$?
+      driver_pid=
       [ -f "$marker" ] && return 0
       [ "$driver_status" -ne 0 ] || driver_status=1
       printf 'driver exited before publishing %s\n' "$marker" >&2
@@ -132,6 +149,7 @@ require_profile_target() {
   profile_target_is_live && return 0
   wait "$driver_pid"
   target_status=$?
+  driver_pid=
   [ "$target_status" -ne 0 ] || target_status=1
   printf 'profile target exited or invalidated PID marker\n' >&2
   return "$target_status"
@@ -152,12 +170,14 @@ touch "$profile_dir/start" || exit $?
 # "$profile_dir/done" marks the end of measured requests. The server remains
 # alive during the hold interval so retained-heap tools can inspect it.
 wait_for_driver_marker "$profile_dir/done" || exit $?
+require_profile_target || exit $?
 heap -H "$server_pid"
 heap_status=$?
 touch "$profile_dir/stop"
 stop_status=$?
 wait "$driver_pid"
 driver_status=$?
+driver_pid=
 rm -r "$profile_dir"
 remove_status=$?
 [ "$remove_status" -ne 0 ] || trap - EXIT HUP INT TERM

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -82,9 +82,9 @@ cleanup_profile_run() {
   [ ! -d "$profile_dir" ] || rm -r "$profile_dir"
 }
 trap cleanup_profile_run EXIT
-trap 'cleanup_profile_run; exit 129' HUP
-trap 'cleanup_profile_run; exit 130' INT
-trap 'cleanup_profile_run; exit 143' TERM
+trap 'trap - EXIT HUP INT TERM; cleanup_profile_run; exit 129' HUP
+trap 'trap - EXIT HUP INT TERM; cleanup_profile_run; exit 130' INT
+trap 'trap - EXIT HUP INT TERM; cleanup_profile_run; exit 143' TERM
 
 python3 benches/profile/drive.py \
   --bin ./target/profiling/kakehashi \

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -97,8 +97,13 @@ wait_for_driver_marker "$profile_dir/ready" || exit $?
 server_pid="$(cat "$profile_dir/pid")"
 printf 'Attach the profiler to kakehashi PID %s\n' "$server_pid"
 
-# PAUSE HERE: attach the profiler to "$server_pid" and wait for the profiler to
-# confirm attachment. Only then release the measured semantic-token workload.
+# Attach the profiler to "$server_pid". Continue only after it confirms the
+# attachment; this prompt prevents the full block from releasing work early.
+printf 'Press Enter after the profiler confirms attachment: '
+if ! IFS= read -r profile_confirmation; then
+  printf 'no attachment confirmation received\n' >&2
+  exit 1
+fi
 touch "$profile_dir/start"
 
 # "$profile_dir/done" marks the end of measured requests. The server remains

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -150,6 +150,6 @@ the kakehashi/tree-sitter/regex frames for the actual CPU cost.
 | `profile.sh` | end-to-end: build → dSYM → samply record → analyze → SVG |
 | `xctrace.sh` | end-to-end: build → Instruments Time Profiler → XML summary |
 | `drive.py` | synchronous/batched LSP driver with per-method latency and wire-volume output |
-| `test_drive.py` | unit tests for driver metric aggregation |
+| `test_drive.py` | unit and fake-LSP integration tests for metrics and profiler-handshake ordering |
 | `gen_session.py` | document generators + a framed-session emitter |
 | `analyze.py` | atos symbolication, self/inclusive report, collapsed stacks |

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -74,6 +74,26 @@ python3 benches/profile/drive.py \
   --profile-hold-seconds 60 &
 driver_pid=$!
 
+cleanup_profile_run() {
+  trap - EXIT HUP INT TERM
+  if [ -s "$profile_dir/pid" ]; then
+    cleanup_server_pid="$(cat "$profile_dir/pid")"
+    kill "$cleanup_server_pid" 2>/dev/null || true
+  fi
+  kill "$driver_pid" 2>/dev/null || true
+  wait "$driver_pid" 2>/dev/null || true
+  # Recheck in case the PID marker appeared while cleanup was starting.
+  if [ -s "$profile_dir/pid" ]; then
+    cleanup_server_pid="$(cat "$profile_dir/pid")"
+    kill "$cleanup_server_pid" 2>/dev/null || true
+  fi
+  [ ! -d "$profile_dir" ] || rm -r "$profile_dir"
+}
+trap cleanup_profile_run EXIT
+trap 'cleanup_profile_run; exit 129' HUP
+trap 'cleanup_profile_run; exit 130' INT
+trap 'cleanup_profile_run; exit 143' TERM
+
 wait_for_driver_marker() {
   marker="$1"
   while [ ! -f "$marker" ]; do
@@ -112,6 +132,10 @@ wait_for_driver_marker "$profile_dir/done" || exit $?
 heap -H "$server_pid"
 touch "$profile_dir/stop"
 wait "$driver_pid"
+driver_status=$?
+trap - EXIT HUP INT TERM
+rm -r "$profile_dir"
+[ "$driver_status" -eq 0 ] || exit "$driver_status"
 ```
 
 Use a fresh marker directory for each run. `pid`, `ready`, and `done` are

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -62,17 +62,7 @@ semantic-token warmup and before measured requests begin:
 ```sh
 cargo build --profile profiling --bin kakehashi || exit $?
 profile_dir="$(mktemp -d "${TMPDIR:-/tmp}/kakehashi-profile.XXXXXX")" || exit $?
-python3 benches/profile/drive.py \
-  --bin ./target/profiling/kakehashi \
-  --file path/to/input.md --requests 80 --edits 1 \
-  --profile-pid-file "$profile_dir/pid" \
-  --profile-ready-file "$profile_dir/ready" \
-  --profile-start-file "$profile_dir/start" \
-  --profile-done-file "$profile_dir/done" \
-  --profile-stop-file "$profile_dir/stop" \
-  --profile-wait-timeout 300 \
-  --profile-hold-seconds 60 &
-driver_pid=$!
+driver_pid=
 
 cleanup_profile_run() {
   trap - EXIT HUP INT TERM
@@ -80,8 +70,10 @@ cleanup_profile_run() {
     cleanup_server_pid="$(cat "$profile_dir/pid")"
     kill "$cleanup_server_pid" 2>/dev/null || true
   fi
-  kill "$driver_pid" 2>/dev/null || true
-  wait "$driver_pid" 2>/dev/null || true
+  if [ -n "$driver_pid" ]; then
+    kill "$driver_pid" 2>/dev/null || true
+    wait "$driver_pid" 2>/dev/null || true
+  fi
   # Recheck in case the PID marker appeared while cleanup was starting.
   if [ -s "$profile_dir/pid" ]; then
     cleanup_server_pid="$(cat "$profile_dir/pid")"
@@ -93,6 +85,18 @@ trap cleanup_profile_run EXIT
 trap 'cleanup_profile_run; exit 129' HUP
 trap 'cleanup_profile_run; exit 130' INT
 trap 'cleanup_profile_run; exit 143' TERM
+
+python3 benches/profile/drive.py \
+  --bin ./target/profiling/kakehashi \
+  --file path/to/input.md --requests 80 --edits 1 \
+  --profile-pid-file "$profile_dir/pid" \
+  --profile-ready-file "$profile_dir/ready" \
+  --profile-start-file "$profile_dir/start" \
+  --profile-done-file "$profile_dir/done" \
+  --profile-stop-file "$profile_dir/stop" \
+  --profile-wait-timeout 300 \
+  --profile-hold-seconds 60 &
+driver_pid=$!
 
 wait_for_driver_marker() {
   marker="$1"

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -63,7 +63,8 @@ semantic-token warmup and before measured requests begin:
 cargo build --profile profiling --bin kakehashi || exit $?
 profile_dir="$(mktemp -d "${TMPDIR:-/tmp}/kakehashi-profile.XXXXXX")" || exit $?
 profile_wait_seconds=300
-profile_hold_seconds=60
+heap_timeout_seconds=60
+profile_hold_seconds=72
 controller_grace_seconds=12
 driver_pid=
 
@@ -212,7 +213,7 @@ try:
 except subprocess.TimeoutExpired:
     sys.exit(124)
 sys.exit(completed.returncode)
-' "$profile_hold_seconds" /usr/bin/heap -H "$server_pid"
+' "$heap_timeout_seconds" /usr/bin/heap -H "$server_pid"
 heap_status=$?
 touch "$profile_dir/stop"
 stop_status=$?
@@ -234,10 +235,12 @@ and still reaps the server. The interactive example allows five minutes for
 attachment; the CLI default is 30 seconds. The same timeout bounds the semantic
 warmup response, while shutdown responses are capped at five seconds. After
 `done`, `stop` releases the server as soon as the retained-heap snapshot
-finishes; `--profile-hold-seconds` is a 60-second safety deadline if the
-controller never publishes it. Independently, the shell controller caps
-`ready`/`done` polling at `profile_wait_seconds`, the foreground heap command
-at `profile_hold_seconds`, and driver cleanup at `controller_grace_seconds`
+finishes; `--profile-hold-seconds` is a 72-second safety deadline if the
+controller never publishes it. This gives the driver-side deadline 12 seconds
+of slack beyond the controller's 60-second `heap_timeout_seconds`
+to cover marker polling, identity validation, and process startup.
+Independently, the shell controller caps `ready`/`done` polling at
+`profile_wait_seconds` and driver cleanup at `controller_grace_seconds`
 (12 seconds, longer than the driver's bounded shutdown phases). These variables
 can be raised for intentionally longer profiling runs.
 

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -71,10 +71,26 @@ python3 benches/profile/drive.py \
   --profile-hold-seconds 5 &
 driver_pid=$!
 
+wait_for_driver_marker() {
+  marker="$1"
+  while [ ! -f "$marker" ]; do
+    if ! kill -0 "$driver_pid" 2>/dev/null; then
+      wait "$driver_pid"
+      status=$?
+      [ "$status" -ne 0 ] || status=1
+      printf 'driver exited before publishing %s\n' "$marker" >&2
+      return "$status"
+    fi
+    sleep 0.05
+  done
+}
+
 # Wait until the server PID is complete and the semantic warmup has responded.
-while [ ! -s "$profile_dir/pid" ] || [ ! -f "$profile_dir/ready" ]; do
-  sleep 0.05
-done
+wait_for_driver_marker "$profile_dir/ready" || exit $?
+[ -s "$profile_dir/pid" ] || {
+  printf 'driver published ready without a PID\n' >&2
+  exit 1
+}
 server_pid="$(cat "$profile_dir/pid")"
 printf 'Attach the profiler to kakehashi PID %s\n' "$server_pid"
 
@@ -84,9 +100,7 @@ touch "$profile_dir/start"
 
 # "$profile_dir/done" marks the end of measured requests. The server remains
 # alive during the hold interval so retained-heap tools can inspect it.
-while [ ! -f "$profile_dir/done" ]; do
-  sleep 0.05
-done
+wait_for_driver_marker "$profile_dir/done" || exit $?
 heap -H "$server_pid"
 wait "$driver_pid"
 ```

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -171,9 +171,11 @@ Use a fresh marker directory for each run. `pid`, `ready`, and `done` are
 published atomically. `start` and `stop` are owned by the profiler controller.
 If `start` is not published within `--profile-wait-timeout`, the driver fails
 and still reaps the server. The interactive example allows five minutes for
-attachment; the CLI default is 30 seconds. After `done`, `stop` releases the
-server as soon as the retained-heap snapshot finishes; `--profile-hold-seconds`
-is a 60-second safety deadline if the controller never publishes it.
+attachment; the CLI default is 30 seconds. The same timeout bounds the semantic
+warmup response, while shutdown responses are capped at five seconds. After
+`done`, `stop` releases the server as soon as the retained-heap snapshot
+finishes; `--profile-hold-seconds` is a 60-second safety deadline if the
+controller never publishes it.
 
 The harness drives the server against `deps/test/kakehashi` for parsers/queries.
 If that dir has no installed parsers, the server auto-installs on the first

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -13,6 +13,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+from collections.abc import Callable
 from collections import Counter, defaultdict
 from dataclasses import dataclass
 import json
@@ -76,12 +77,19 @@ def publish_marker(path: Path | str | None, content: str) -> Path | None:
 
 
 def wait_for_marker(
-    path: Path | str, timeout_seconds: float, poll_seconds: float = 0.01
+    path: Path | str,
+    timeout_seconds: float,
+    poll_seconds: float = 0.01,
+    abort_if: Callable[[], str | None] | None = None,
 ) -> Path:
     """Wait until an external profiler publishes a marker."""
     marker = Path(path)
     deadline = time.monotonic() + timeout_seconds
     while not marker.is_file():
+        if abort_if is not None and (reason := abort_if()) is not None:
+            raise RuntimeError(
+                f"{reason} while waiting for profile marker {marker}"
+            )
         if time.monotonic() >= deadline:
             raise TimeoutError(f"timed out waiting for profile marker {marker}")
         time.sleep(poll_seconds)
@@ -546,7 +554,19 @@ def main() -> None:
 
         publish_marker(args.profile_ready_file, "ready\n")
         if args.profile_start_file:
-            wait_for_marker(args.profile_start_file, args.profile_wait_timeout)
+            def server_exit_reason() -> str | None:
+                status = srv.poll()
+                return (
+                    None
+                    if status is None
+                    else f"server exited with status {status}"
+                )
+
+            wait_for_marker(
+                args.profile_start_file,
+                args.profile_wait_timeout,
+                abort_if=server_exit_reason,
+            )
 
         ok, canceled, superseded, tokens = 0, 0, 0, 0
         version = 1

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -305,7 +305,8 @@ def main() -> None:
         help="keep the server alive after measurement for an external snapshot")
     ap.add_argument(
         "--profile-wait-timeout", type=float, default=30,
-        help="seconds to wait for --profile-start-file")
+        help="seconds to wait for semantic warmup and start; "
+             "shutdown response is capped at 5 seconds")
     args = ap.parse_args()
     if args.requests <= 0:
         ap.error("--requests must be positive")  # avoids divide-by-zero in the summary

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -16,8 +16,10 @@ from dataclasses import dataclass
 import json
 import math
 import os
+from pathlib import Path
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 
@@ -44,6 +46,43 @@ class RequestSummary:
     p90_ms: float
     max_ms: float
     wire_bytes: int
+
+
+def publish_marker(path: Path | str | None, content: str) -> Path | None:
+    """Atomically publish a marker consumed by an external profiler."""
+    if path is None:
+        return None
+    marker = Path(path)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=marker.parent,
+            prefix=f".{marker.name}.",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(content)
+        os.replace(temporary, marker)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+    return marker
+
+
+def wait_for_marker(
+    path: Path | str, timeout_seconds: float, poll_seconds: float = 0.01
+) -> Path:
+    """Wait until an external profiler publishes a marker."""
+    marker = Path(path)
+    deadline = time.monotonic() + timeout_seconds
+    while not marker.exists():
+        if time.monotonic() >= deadline:
+            raise TimeoutError(f"timed out waiting for profile marker {marker}")
+        time.sleep(poll_seconds)
+    return marker
 
 
 def summarize_samples(samples: list[RequestSample]) -> RequestSummary:
@@ -197,6 +236,24 @@ def main() -> None:
         help="parser/query data dir; must already contain installed parsers "
              "(populated by `cargo test --features e2e` or `make deps/tree-sitter`), "
              "else the server auto-installs on first request")
+    ap.add_argument(
+        "--profile-pid-file",
+        help="atomically publish the spawned server PID for profiler attachment")
+    ap.add_argument(
+        "--profile-ready-file",
+        help="publish after initialization and warmup are complete")
+    ap.add_argument(
+        "--profile-start-file",
+        help="wait for this external marker before starting measured requests")
+    ap.add_argument(
+        "--profile-done-file",
+        help="publish after measured requests finish, before the hold interval")
+    ap.add_argument(
+        "--profile-hold-seconds", type=float, default=0,
+        help="keep the server alive after measurement for an external snapshot")
+    ap.add_argument(
+        "--profile-wait-timeout", type=float, default=30,
+        help="seconds to wait for --profile-start-file")
     args = ap.parse_args()
     if args.requests <= 0:
         ap.error("--requests must be positive")  # avoids divide-by-zero in the summary
@@ -206,6 +263,10 @@ def main() -> None:
         ap.error("--burst-edits requires --burst greater than 1")
     if args.burst_delay_ms < 0:
         ap.error("--burst-delay-ms must be non-negative")
+    if args.profile_hold_seconds < 0:
+        ap.error("--profile-hold-seconds must be non-negative")
+    if args.profile_wait_timeout <= 0:
+        ap.error("--profile-wait-timeout must be positive")
     if args.burst > 1 and (args.captures or args.concurrent_captures):
         ap.error("--burst cannot be combined with captures modes")
     if args.concurrent_captures:
@@ -396,6 +457,7 @@ def main() -> None:
     # loop, or a shutdown timeout) still reaps the server instead of leaving a
     # stray process behind.
     try:
+        publish_marker(args.profile_pid_file, f"{srv.pid}\n")
         request("initialize", {"processId": None, "rootUri": None, "capabilities": {
             "textDocument": {"semanticTokens": {"requests": {"full": {"delta": True}},
                                                 "tokenTypes": [], "tokenModifiers": [],
@@ -422,6 +484,10 @@ def main() -> None:
                     "captures warmup did not return a resultId; "
                     "cannot measure a real delta lineage"
                 )
+
+        publish_marker(args.profile_ready_file, "ready\n")
+        if args.profile_start_file:
+            wait_for_marker(args.profile_start_file, args.profile_wait_timeout)
 
         ok, canceled, superseded, tokens = 0, 0, 0, 0
         version = 1
@@ -514,6 +580,10 @@ def main() -> None:
             canceled += cycle_canceled
             superseded += cycle_superseded
         elapsed = time.time() - t0
+
+        publish_marker(args.profile_done_file, "done\n")
+        if args.profile_hold_seconds > 0:
+            time.sleep(args.profile_hold_seconds)
 
         request("shutdown", None)
         notify("exit", {})

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -21,6 +21,7 @@ import math
 import os
 from pathlib import Path
 import queue
+import signal
 import subprocess
 import sys
 import tempfile
@@ -359,8 +360,45 @@ def main() -> None:
     env = dict(os.environ, KAKEHASHI_DATA_DIR=args.data_dir)
     # Let the server's stderr through (it's silent unless RUST_LOG is set) so a
     # crash or panic is visible instead of being swallowed during profiling.
-    srv = subprocess.Popen([args.bin, *args.server_arg], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                           env=env)
+    profile_signals = [signal.SIGINT, signal.SIGTERM]
+    if hasattr(signal, "SIGHUP"):
+        profile_signals.append(signal.SIGHUP)
+    previous_mask = signal.pthread_sigmask(signal.SIG_BLOCK, profile_signals)
+    previous_handlers = {
+        profile_signal: signal.getsignal(profile_signal)
+        for profile_signal in profile_signals
+    }
+    srv = None
+
+    def terminate_server() -> None:
+        if srv is not None and srv.poll() is None:
+            srv.kill()
+            srv.wait()
+
+    def restore_profile_signal_handlers() -> None:
+        for profile_signal, previous in previous_handlers.items():
+            signal.signal(profile_signal, previous)
+
+    def handle_profile_signal(signum, _frame) -> None:
+        terminate_server()
+        raise SystemExit(128 + signum)
+
+    for profile_signal in profile_signals:
+        signal.signal(profile_signal, handle_profile_signal)
+    try:
+        srv = subprocess.Popen(
+            [args.bin, *args.server_arg],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            env=env,
+        )
+        publish_marker(args.profile_pid_file, f"{srv.pid}\n")
+    except BaseException:
+        terminate_server()
+        restore_profile_signal_handlers()
+        raise
+    finally:
+        signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
 
     def server_exit_reason() -> str | None:
         status = srv.poll()
@@ -554,7 +592,6 @@ def main() -> None:
     # loop, or a shutdown timeout) still reaps the server instead of leaving a
     # stray process behind.
     try:
-        publish_marker(args.profile_pid_file, f"{srv.pid}\n")
         request("initialize", {"processId": None, "rootUri": None, "capabilities": {
             "textDocument": {"semanticTokens": {"requests": {"full": {"delta": True}},
                                                 "tokenTypes": [], "tokenModifiers": [],
@@ -716,11 +753,10 @@ def main() -> None:
     except subprocess.TimeoutExpired:
         pass  # graceful shutdown didn't land in time; the finally kills it
     finally:
-        if srv.poll() is None:
-            srv.kill()
-            srv.wait()
+        terminate_server()
         for reader in request_threads:
             reader.join(timeout=1)
+        restore_profile_signal_handlers()
 
     n_bytes = len(text.encode("utf-8"))
     n_lines = len(text.splitlines())

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -241,7 +241,7 @@ def main() -> None:
         help="atomically publish the spawned server PID for profiler attachment")
     ap.add_argument(
         "--profile-ready-file",
-        help="publish after initialization and warmup are complete")
+        help="publish after initialization and an unmeasured semantic warmup")
     ap.add_argument(
         "--profile-start-file",
         help="wait for this external marker before starting measured requests")
@@ -485,6 +485,18 @@ def main() -> None:
                     "cannot measure a real delta lineage"
                 )
 
+        semantic_request = (
+            "textDocument/semanticTokens/full",
+            {"textDocument": {"uri": uri}},
+        )
+        if args.profile_ready_file or args.profile_start_file:
+            warmup, _ = request(*semantic_request)
+            if response_status(warmup) != "ok":
+                raise RuntimeError(
+                    "semantic warmup did not return tokens; "
+                    f"status={response_status(warmup)}"
+                )
+
         publish_marker(args.profile_ready_file, "ready\n")
         if args.profile_start_file:
             wait_for_marker(args.profile_start_file, args.profile_wait_timeout)
@@ -519,10 +531,6 @@ def main() -> None:
             t_req = time.perf_counter()
             semantic_sample_start = len(
                 request_samples["textDocument/semanticTokens/full"]
-            )
-            semantic_request = (
-                "textDocument/semanticTokens/full",
-                {"textDocument": {"uri": uri}},
             )
             captures_requests = [
                 ("kakehashi/captures/full/delta",

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -751,9 +751,21 @@ def main() -> None:
         elif args.profile_hold_seconds > 0:
             time.sleep(args.profile_hold_seconds)
 
-        request("shutdown", None)
-        notify("exit", {})
-        srv.wait(timeout=5)
+        try:
+            request_with_timeout(
+                "shutdown",
+                None,
+                timeout_seconds=min(args.profile_wait_timeout, 5.0),
+                description="shutdown response",
+            )
+        except TimeoutError:
+            sys.stderr.write(
+                "[drive] shutdown response deadline expired; "
+                "killing server\n"
+            )
+        else:
+            notify("exit", {})
+            srv.wait(timeout=5)
     except subprocess.TimeoutExpired:
         pass  # graceful shutdown didn't land in time; the finally kills it
     finally:

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -24,6 +24,7 @@ import sys
 import tempfile
 import threading
 import time
+import unicodedata
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from gen_session import gen_rust, gen_markdown_injections  # noqa: E402
@@ -91,17 +92,20 @@ def validate_profile_marker_paths(
     paths: list[Path | str | None],
 ) -> None:
     """Reject aliases that could satisfy a profiling phase prematurely."""
-    seen: dict[Path, Path | str] = {}
+    seen: dict[str, Path | str] = {}
     for path in paths:
         if path is None:
             continue
         resolved = Path(path).expanduser().resolve()
-        if resolved in seen:
-            previous = seen[resolved]
+        # Marker names are a cross-process protocol, so conservatively reject
+        # case/normalization-only differences even on a case-sensitive volume.
+        key = unicodedata.normalize("NFC", str(resolved)).casefold()
+        if key in seen:
+            previous = seen[key]
             raise ValueError(
                 f"profile marker paths must be distinct: {previous} and {path}"
             )
-        seen[resolved] = path
+        seen[key] = path
 
 
 def summarize_samples(samples: list[RequestSample]) -> RequestSummary:

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -297,6 +297,9 @@ def main() -> None:
         "--profile-done-file",
         help="publish after measured requests finish, before the hold interval")
     ap.add_argument(
+        "--profile-stop-file",
+        help="wait for this controller marker after done, bounded by hold seconds")
+    ap.add_argument(
         "--profile-hold-seconds", type=float, default=0,
         help="keep the server alive after measurement for an external snapshot")
     ap.add_argument(
@@ -319,12 +322,17 @@ def main() -> None:
         ap.error("--profile-wait-timeout must be finite")
     if args.profile_wait_timeout <= 0:
         ap.error("--profile-wait-timeout must be positive")
+    if args.profile_stop_file and args.profile_hold_seconds <= 0:
+        ap.error(
+            "--profile-stop-file requires positive --profile-hold-seconds"
+        )
     try:
         validate_profile_marker_paths([
             args.profile_pid_file,
             args.profile_ready_file,
             args.profile_start_file,
             args.profile_done_file,
+            args.profile_stop_file,
         ])
     except ValueError as error:
         ap.error(str(error))
@@ -353,6 +361,11 @@ def main() -> None:
     # crash or panic is visible instead of being swallowed during profiling.
     srv = subprocess.Popen([args.bin, *args.server_arg], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                            env=env)
+
+    def server_exit_reason() -> str | None:
+        status = srv.poll()
+        return None if status is None else f"server exited with status {status}"
+
     rid = 0
     request_samples = defaultdict(list)
     notification_counts = Counter()
@@ -587,14 +600,6 @@ def main() -> None:
 
         publish_marker(args.profile_ready_file, "ready\n")
         if args.profile_start_file:
-            def server_exit_reason() -> str | None:
-                status = srv.poll()
-                return (
-                    None
-                    if status is None
-                    else f"server exited with status {status}"
-                )
-
             wait_for_marker(
                 args.profile_start_file,
                 args.profile_wait_timeout,
@@ -690,7 +695,19 @@ def main() -> None:
         elapsed = time.time() - t0
 
         publish_marker(args.profile_done_file, "done\n")
-        if args.profile_hold_seconds > 0:
+        if args.profile_stop_file:
+            try:
+                wait_for_marker(
+                    args.profile_stop_file,
+                    args.profile_hold_seconds,
+                    abort_if=server_exit_reason,
+                )
+            except TimeoutError:
+                sys.stderr.write(
+                    "[drive] profile stop marker deadline expired; "
+                    "shutting down server\n"
+                )
+        elif args.profile_hold_seconds > 0:
             time.sleep(args.profile_hold_seconds)
 
         request("shutdown", None)

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -20,6 +20,7 @@ import json
 import math
 import os
 from pathlib import Path
+import queue
 import subprocess
 import sys
 import tempfile
@@ -359,6 +360,7 @@ def main() -> None:
     server_request_counts = Counter()
     server_request_bytes = Counter()
     send_lock = threading.Lock()
+    request_threads = []
 
     def send(obj):
         body = json.dumps(obj).encode()
@@ -375,6 +377,28 @@ def main() -> None:
     def request(method, params):
         request_id = send_request(method, params)
         return read_until(request_id)
+
+    def request_with_timeout(method, params, timeout_seconds, description):
+        result_queue = queue.Queue(maxsize=1)
+
+        def run_request():
+            try:
+                result_queue.put((request(method, params), None))
+            except BaseException as error:
+                result_queue.put((None, error))
+
+        reader = threading.Thread(target=run_request, daemon=True)
+        request_threads.append(reader)
+        reader.start()
+        try:
+            result, error = result_queue.get(timeout=timeout_seconds)
+        except queue.Empty as error:
+            raise TimeoutError(
+                f"timed out waiting for {description}"
+            ) from error
+        if error is not None:
+            raise error
+        return result
 
     def notify(method, params):
         send({"jsonrpc": "2.0", "method": method, "params": params})
@@ -550,7 +574,11 @@ def main() -> None:
             {"textDocument": {"uri": uri}},
         )
         if args.profile_ready_file or args.profile_start_file:
-            warmup, _ = request(*semantic_request)
+            warmup, _ = request_with_timeout(
+                *semantic_request,
+                timeout_seconds=args.profile_wait_timeout,
+                description="semantic warmup response",
+            )
             if response_status(warmup) != "ok":
                 raise RuntimeError(
                     "semantic warmup did not return tokens; "
@@ -674,6 +702,8 @@ def main() -> None:
         if srv.poll() is None:
             srv.kill()
             srv.wait()
+        for reader in request_threads:
+            reader.join(timeout=1)
 
     n_bytes = len(text.encode("utf-8"))
     n_lines = len(text.splitlines())

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -87,6 +87,23 @@ def wait_for_marker(
     return marker
 
 
+def validate_profile_marker_paths(
+    paths: list[Path | str | None],
+) -> None:
+    """Reject aliases that could satisfy a profiling phase prematurely."""
+    seen: dict[Path, Path | str] = {}
+    for path in paths:
+        if path is None:
+            continue
+        resolved = Path(path).expanduser().resolve()
+        if resolved in seen:
+            previous = seen[resolved]
+            raise ValueError(
+                f"profile marker paths must be distinct: {previous} and {path}"
+            )
+        seen[resolved] = path
+
+
 def summarize_samples(samples: list[RequestSample]) -> RequestSummary:
     if not samples:
         raise ValueError("cannot summarize an empty request sample")
@@ -269,6 +286,15 @@ def main() -> None:
         ap.error("--profile-hold-seconds must be non-negative")
     if args.profile_wait_timeout <= 0:
         ap.error("--profile-wait-timeout must be positive")
+    try:
+        validate_profile_marker_paths([
+            args.profile_pid_file,
+            args.profile_ready_file,
+            args.profile_start_file,
+            args.profile_done_file,
+        ])
+    except ValueError as error:
+        ap.error(str(error))
     if args.burst > 1 and (args.captures or args.concurrent_captures):
         ap.error("--burst cannot be combined with captures modes")
     if args.concurrent_captures:

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -81,7 +81,7 @@ def wait_for_marker(
     """Wait until an external profiler publishes a marker."""
     marker = Path(path)
     deadline = time.monotonic() + timeout_seconds
-    while not marker.exists():
+    while not marker.is_file():
         if time.monotonic() >= deadline:
             raise TimeoutError(f"timed out waiting for profile marker {marker}")
         time.sleep(poll_seconds)
@@ -96,6 +96,8 @@ def validate_profile_marker_paths(
     for path in paths:
         if path is None:
             continue
+        if isinstance(path, str) and not path:
+            raise ValueError("profile marker paths must not be empty")
         resolved = Path(path).expanduser().resolve()
         # Marker names are a cross-process protocol, so conservatively reject
         # case/normalization-only differences even on a case-sensitive volume.

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -369,11 +369,16 @@ def main() -> None:
         for profile_signal in profile_signals
     }
     srv = None
+    pid_marker_published = False
 
     def terminate_server() -> None:
+        nonlocal pid_marker_published
         if srv is not None and srv.poll() is None:
             srv.kill()
             srv.wait()
+        if pid_marker_published:
+            Path(args.profile_pid_file).unlink(missing_ok=True)
+            pid_marker_published = False
 
     def restore_profile_signal_handlers() -> None:
         for profile_signal, previous in previous_handlers.items():
@@ -397,6 +402,7 @@ def main() -> None:
             preexec_fn=restore_child_signal_mask,
         )
         publish_marker(args.profile_pid_file, f"{srv.pid}\n")
+        pid_marker_published = args.profile_pid_file is not None
     except BaseException:
         terminate_server()
         restore_profile_signal_handlers()

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -286,8 +286,12 @@ def main() -> None:
         ap.error("--burst-edits requires --burst greater than 1")
     if args.burst_delay_ms < 0:
         ap.error("--burst-delay-ms must be non-negative")
+    if not math.isfinite(args.profile_hold_seconds):
+        ap.error("--profile-hold-seconds must be finite")
     if args.profile_hold_seconds < 0:
         ap.error("--profile-hold-seconds must be non-negative")
+    if not math.isfinite(args.profile_wait_timeout):
+        ap.error("--profile-wait-timeout must be finite")
     if args.profile_wait_timeout <= 0:
         ap.error("--profile-wait-timeout must be positive")
     try:

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -92,20 +92,29 @@ def validate_profile_marker_paths(
     paths: list[Path | str | None],
 ) -> None:
     """Reject aliases that could satisfy a profiling phase prematurely."""
-    seen: dict[str, Path | str] = {}
+    seen: list[tuple[tuple[str, ...], Path | str]] = []
     for path in paths:
         if path is None:
             continue
         resolved = Path(path).expanduser().resolve()
         # Marker names are a cross-process protocol, so conservatively reject
         # case/normalization-only differences even on a case-sensitive volume.
-        key = unicodedata.normalize("NFC", str(resolved)).casefold()
-        if key in seen:
-            previous = seen[key]
-            raise ValueError(
-                f"profile marker paths must be distinct: {previous} and {path}"
-            )
-        seen[key] = path
+        parts = tuple(
+            unicodedata.normalize("NFC", part).casefold()
+            for part in resolved.parts
+        )
+        for previous_parts, previous in seen:
+            if parts == previous_parts:
+                raise ValueError(
+                    f"profile marker paths must be distinct: {previous} and {path}"
+                )
+            shared = min(len(parts), len(previous_parts))
+            if parts[:shared] == previous_parts[:shared]:
+                raise ValueError(
+                    "profile marker paths must not contain one another: "
+                    f"{previous} and {path}"
+                )
+        seen.append((parts, path))
 
 
 def summarize_samples(samples: list[RequestSample]) -> RequestSummary:

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -106,7 +106,12 @@ def validate_profile_marker_paths(
             continue
         if isinstance(path, str) and not path:
             raise ValueError("profile marker paths must not be empty")
-        resolved = Path(path).expanduser().resolve()
+        try:
+            resolved = Path(path).expanduser().resolve()
+        except (OSError, RuntimeError) as error:
+            raise ValueError(
+                f"invalid profile marker path {path}: {error}"
+            ) from error
         # Marker names are a cross-process protocol, so conservatively reject
         # case/normalization-only differences even on a case-sensitive volume.
         parts = tuple(

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -383,6 +383,9 @@ def main() -> None:
         terminate_server()
         raise SystemExit(128 + signum)
 
+    def restore_child_signal_mask() -> None:
+        signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
+
     for profile_signal in profile_signals:
         signal.signal(profile_signal, handle_profile_signal)
     try:
@@ -391,6 +394,7 @@ def main() -> None:
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             env=env,
+            preexec_fn=restore_child_signal_mask,
         )
         publish_marker(args.profile_pid_file, f"{srv.pid}\n")
     except BaseException:

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -10,6 +10,8 @@ the sampled process actually spends its time in the semantic-tokens hot path.
 Usage:
     drive.py --bin ./target/profiling/kakehashi --lang rust --size 150 --requests 300
 """
+from __future__ import annotations
+
 import argparse
 from collections import Counter, defaultdict
 from dataclasses import dataclass

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -146,9 +146,14 @@ class RequestSummaryTest(unittest.TestCase):
                     2,
                 )
             finally:
+                publish_marker(warmup_release, "")
+                publish_marker(start, "")
                 if process.poll() is None:
-                    process.kill()
-                    process.wait()
+                    try:
+                        process.communicate(timeout=1)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait()
 
     def test_profile_markers_are_published_and_waited_for(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -18,6 +18,7 @@ from drive import (
     server_request_result,
     summarize_samples,
     summarize_samples_by_status,
+    validate_profile_marker_paths,
     wait_for_marker,
 )
 
@@ -174,6 +175,15 @@ class RequestSummaryTest(unittest.TestCase):
             marker = pathlib.Path(temporary) / "missing"
             with self.assertRaisesRegex(TimeoutError, "missing"):
                 wait_for_marker(marker, 0.01)
+
+    def test_profile_marker_paths_must_be_distinct(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            marker = directory / "ready"
+            with self.assertRaisesRegex(ValueError, "must be distinct"):
+                validate_profile_marker_paths(
+                    [marker, directory / "nested" / ".." / "ready"]
+                )
 
     def test_summarizes_latency_status_and_wire_bytes(self):
         samples = [

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -175,6 +175,8 @@ class RequestSummaryTest(unittest.TestCase):
             marker = pathlib.Path(temporary) / "missing"
             with self.assertRaisesRegex(TimeoutError, "missing"):
                 wait_for_marker(marker, 0.01)
+            with self.assertRaisesRegex(TimeoutError, temporary):
+                wait_for_marker(pathlib.Path(temporary), 0.01)
 
     def test_profile_marker_paths_must_be_distinct(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -193,6 +195,23 @@ class RequestSummaryTest(unittest.TestCase):
                 with self.subTest(paths=paths):
                     with self.assertRaisesRegex(ValueError, "contain one another"):
                         validate_profile_marker_paths(paths)
+        with self.assertRaisesRegex(ValueError, "must not be empty"):
+            validate_profile_marker_paths([""])
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(pathlib.Path(__file__).parent / "drive.py"),
+                "--bin=not-used-after-validation",
+                "--requests=1",
+                "--profile-start-file=",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn("must not be empty", result.stderr)
 
     def test_profile_timing_options_must_be_finite(self):
         drive = str(pathlib.Path(__file__).parent / "drive.py")

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -31,7 +31,7 @@ FAKE_SERVER_SOURCE = textwrap.dedent(
 
     log_path = pathlib.Path(sys.argv[1])
     warmup_release = pathlib.Path(sys.argv[2])
-    exit_after_warmup = len(sys.argv) > 3 and sys.argv[3] == "exit-after-warmup"
+    behavior = sys.argv[3] if len(sys.argv) > 3 else "normal"
     semantic_requests = 0
 
     def read_message():
@@ -73,11 +73,14 @@ FAKE_SERVER_SOURCE = textwrap.dedent(
             if semantic_requests == 1:
                 while not warmup_release.exists():
                     time.sleep(0.01)
+                if behavior == "hang-warmup":
+                    while True:
+                        time.sleep(1)
             result = {"data": []}
         else:
             result = None
         send({"jsonrpc": "2.0", "id": message["id"], "result": result})
-        if exit_after_warmup and semantic_requests == 1:
+        if behavior == "exit-after-warmup" and semantic_requests == 1:
             break
     """
 )
@@ -197,6 +200,45 @@ class RequestSummaryTest(unittest.TestCase):
                 self.assertTrue(ready.is_file())
                 self.assertIn("server exited", stderr)
                 self.assertIn("waiting for profile marker", stderr)
+            finally:
+                if process.poll() is None:
+                    process.kill()
+                    process.wait()
+
+    def test_profile_warmup_response_has_a_deadline(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            fake_server = directory / "fake_server.py"
+            fake_server.write_text(FAKE_SERVER_SOURCE)
+            log = directory / "methods.log"
+            warmup_release = directory / "warmup-release"
+            publish_marker(warmup_release, "")
+            ready = directory / "ready"
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    str(pathlib.Path(__file__).parent / "drive.py"),
+                    "--bin",
+                    sys.executable,
+                    f"--server-arg={fake_server}",
+                    f"--server-arg={log}",
+                    f"--server-arg={warmup_release}",
+                    "--server-arg=hang-warmup",
+                    "--requests=1",
+                    "--size=1",
+                    "--settle=0",
+                    f"--profile-ready-file={ready}",
+                    "--profile-wait-timeout=0.05",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            try:
+                _, stderr = process.communicate(timeout=3)
+                self.assertNotEqual(process.returncode, 0)
+                self.assertFalse(ready.exists())
+                self.assertIn("semantic warmup response", stderr)
             finally:
                 if process.poll() is None:
                     process.kill()

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -1,7 +1,10 @@
 import pathlib
+import subprocess
 import sys
 import tempfile
+import textwrap
 import threading
+import time
 import unittest
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
@@ -20,6 +23,108 @@ from drive import (
 
 
 class RequestSummaryTest(unittest.TestCase):
+    def test_profile_ready_follows_warmup_and_start_gates_measurement(self):
+        fake_server_source = textwrap.dedent(
+            """\
+            import json
+            import pathlib
+            import sys
+
+            log_path = pathlib.Path(sys.argv[1])
+
+            def read_message():
+                length = None
+                while True:
+                    line = sys.stdin.buffer.readline()
+                    if not line:
+                        raise EOFError
+                    line = line.strip()
+                    if not line:
+                        break
+                    if line.lower().startswith(b"content-length:"):
+                        length = int(line.split(b":", 1)[1])
+                return json.loads(sys.stdin.buffer.read(length))
+
+            def send(message):
+                body = json.dumps(message).encode()
+                sys.stdout.buffer.write(
+                    f"Content-Length: {len(body)}\\r\\n\\r\\n".encode() + body
+                )
+                sys.stdout.buffer.flush()
+
+            while True:
+                try:
+                    message = read_message()
+                except EOFError:
+                    break
+                method = message.get("method")
+                with log_path.open("a") as log:
+                    log.write(f"{method}\\n")
+                if method == "exit":
+                    break
+                if "id" not in message:
+                    continue
+                if method == "initialize":
+                    result = {"capabilities": {}}
+                elif method == "textDocument/semanticTokens/full":
+                    result = {"data": []}
+                else:
+                    result = None
+                send({"jsonrpc": "2.0", "id": message["id"], "result": result})
+            """
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            fake_server = directory / "fake_server.py"
+            fake_server.write_text(fake_server_source)
+            log = directory / "methods.log"
+            ready = directory / "ready"
+            start = directory / "start"
+            done = directory / "done"
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    str(pathlib.Path(__file__).parent / "drive.py"),
+                    "--bin",
+                    sys.executable,
+                    f"--server-arg={fake_server}",
+                    f"--server-arg={log}",
+                    "--requests=1",
+                    "--size=1",
+                    "--settle=0",
+                    f"--profile-ready-file={ready}",
+                    f"--profile-start-file={start}",
+                    f"--profile-done-file={done}",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            try:
+                wait_for_marker(ready, 3)
+                methods_at_ready = log.read_text().splitlines()
+                self.assertEqual(
+                    methods_at_ready.count("textDocument/semanticTokens/full"),
+                    1,
+                )
+                time.sleep(0.05)
+                self.assertEqual(log.read_text().splitlines(), methods_at_ready)
+
+                publish_marker(start, "")
+                wait_for_marker(done, 3)
+                _, stderr = process.communicate(timeout=3)
+                self.assertEqual(process.returncode, 0, stderr)
+                self.assertEqual(
+                    log.read_text()
+                    .splitlines()
+                    .count("textDocument/semanticTokens/full"),
+                    2,
+                )
+            finally:
+                if process.poll() is None:
+                    process.kill()
+                    process.wait()
+
     def test_profile_markers_are_published_and_waited_for(self):
         with tempfile.TemporaryDirectory() as temporary:
             marker = pathlib.Path(temporary) / "nested" / "start"

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -184,6 +184,8 @@ class RequestSummaryTest(unittest.TestCase):
                 validate_profile_marker_paths(
                     [marker, directory / "nested" / ".." / "ready"]
                 )
+            with self.assertRaisesRegex(ValueError, "must be distinct"):
+                validate_profile_marker_paths([marker, directory / "READY"])
 
     def test_summarizes_latency_status_and_wire_bytes(self):
         samples = [

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -309,6 +309,7 @@ class RequestSummaryTest(unittest.TestCase):
                 process.communicate(timeout=3)
                 with self.assertRaises(ProcessLookupError):
                     os.kill(server_pid, 0)
+                self.assertFalse(pid_file.exists())
             finally:
                 try:
                     os.killpg(process.pid, signal.SIGKILL)
@@ -367,6 +368,7 @@ class RequestSummaryTest(unittest.TestCase):
                 process.communicate(timeout=3)
                 with self.assertRaises(ProcessLookupError):
                     os.kill(server_pid, 0)
+                self.assertFalse(pid_file.exists())
             finally:
                 try:
                     os.killpg(process.pid, signal.SIGKILL)

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -187,6 +187,30 @@ class RequestSummaryTest(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "must be distinct"):
                 validate_profile_marker_paths([marker, directory / "READY"])
 
+    def test_profile_timing_options_must_be_finite(self):
+        drive = str(pathlib.Path(__file__).parent / "drive.py")
+        for option, value in (
+            ("--profile-wait-timeout", "nan"),
+            ("--profile-wait-timeout", "inf"),
+            ("--profile-hold-seconds", "nan"),
+            ("--profile-hold-seconds", "inf"),
+        ):
+            with self.subTest(option=option, value=value):
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        drive,
+                        "--bin=not-used-after-validation",
+                        "--requests=1",
+                        f"{option}={value}",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=3,
+                )
+                self.assertEqual(result.returncode, 2, result.stderr)
+                self.assertIn("must be finite", result.stderr)
+
     def test_summarizes_latency_status_and_wire_bytes(self):
         samples = [
             RequestSample(seconds=0.010, wire_bytes=100, status="ok"),

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -97,6 +97,7 @@ class RequestSummaryTest(unittest.TestCase):
             ready = directory / "ready"
             start = directory / "start"
             done = directory / "done"
+            stop = directory / "stop"
             process = subprocess.Popen(
                 [
                     sys.executable,
@@ -112,6 +113,8 @@ class RequestSummaryTest(unittest.TestCase):
                     f"--profile-ready-file={ready}",
                     f"--profile-start-file={start}",
                     f"--profile-done-file={done}",
+                    f"--profile-stop-file={stop}",
+                    "--profile-hold-seconds=3",
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -145,6 +148,9 @@ class RequestSummaryTest(unittest.TestCase):
 
                 publish_marker(start, "")
                 wait_for_marker(done, 3)
+                time.sleep(0.05)
+                self.assertIsNone(process.poll())
+                publish_marker(stop, "")
                 _, stderr = process.communicate(timeout=3)
                 self.assertEqual(process.returncode, 0, stderr)
                 self.assertEqual(
@@ -340,6 +346,20 @@ class RequestSummaryTest(unittest.TestCase):
                 )
                 self.assertEqual(result.returncode, 2, result.stderr)
                 self.assertIn("must be finite", result.stderr)
+        result = subprocess.run(
+            [
+                sys.executable,
+                drive,
+                "--bin=not-used-after-validation",
+                "--requests=1",
+                "--profile-stop-file=stop",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn("requires positive --profile-hold-seconds", result.stderr)
 
     def test_summarizes_latency_status_and_wire_bytes(self):
         samples = [

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -249,8 +249,11 @@ class RequestSummaryTest(unittest.TestCase):
                 self.assertFalse(ready.exists())
                 self.assertIn("semantic warmup response", stderr)
             finally:
-                if process.poll() is None:
+                try:
                     os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                if process.poll() is None:
                     process.wait()
 
     def test_profile_signal_reaps_server(self):

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -289,6 +289,7 @@ class RequestSummaryTest(unittest.TestCase):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                start_new_session=True,
             )
             server_pid = None
             try:
@@ -309,14 +310,12 @@ class RequestSummaryTest(unittest.TestCase):
                 with self.assertRaises(ProcessLookupError):
                     os.kill(server_pid, 0)
             finally:
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
                 if process.poll() is None:
-                    process.kill()
                     process.wait()
-                if server_pid is not None:
-                    try:
-                        os.kill(server_pid, signal.SIGKILL)
-                    except ProcessLookupError:
-                        pass
 
     def test_profile_server_does_not_inherit_blocked_signals(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -348,6 +347,7 @@ class RequestSummaryTest(unittest.TestCase):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                start_new_session=True,
             )
             server_pid = None
             try:
@@ -368,14 +368,12 @@ class RequestSummaryTest(unittest.TestCase):
                 with self.assertRaises(ProcessLookupError):
                     os.kill(server_pid, 0)
             finally:
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
                 if process.poll() is None:
-                    process.kill()
                     process.wait()
-                if server_pid is not None:
-                    try:
-                        os.kill(server_pid, signal.SIGKILL)
-                    except ProcessLookupError:
-                        pass
 
     def test_profile_shutdown_response_has_a_deadline(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -1,4 +1,6 @@
+import os
 import pathlib
+import signal
 import subprocess
 import sys
 import tempfile
@@ -239,6 +241,7 @@ class RequestSummaryTest(unittest.TestCase):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                start_new_session=True,
             )
             try:
                 _, stderr = process.communicate(timeout=3)
@@ -247,7 +250,7 @@ class RequestSummaryTest(unittest.TestCase):
                 self.assertIn("semantic warmup response", stderr)
             finally:
                 if process.poll() is None:
-                    process.kill()
+                    os.killpg(process.pid, signal.SIGKILL)
                     process.wait()
 
     def test_profile_markers_are_published_and_waited_for(self):

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -22,69 +22,73 @@ from drive import (
     wait_for_marker,
 )
 
+FAKE_SERVER_SOURCE = textwrap.dedent(
+    """\
+    import json
+    import pathlib
+    import sys
+    import time
+
+    log_path = pathlib.Path(sys.argv[1])
+    warmup_release = pathlib.Path(sys.argv[2])
+    exit_after_warmup = len(sys.argv) > 3 and sys.argv[3] == "exit-after-warmup"
+    semantic_requests = 0
+
+    def read_message():
+        length = None
+        while True:
+            line = sys.stdin.buffer.readline()
+            if not line:
+                raise EOFError
+            line = line.strip()
+            if not line:
+                break
+            if line.lower().startswith(b"content-length:"):
+                length = int(line.split(b":", 1)[1])
+        return json.loads(sys.stdin.buffer.read(length))
+
+    def send(message):
+        body = json.dumps(message).encode()
+        sys.stdout.buffer.write(
+            f"Content-Length: {len(body)}\\r\\n\\r\\n".encode() + body
+        )
+        sys.stdout.buffer.flush()
+
+    while True:
+        try:
+            message = read_message()
+        except EOFError:
+            break
+        method = message.get("method")
+        with log_path.open("a") as log:
+            log.write(f"{method}\\n")
+        if method == "exit":
+            break
+        if "id" not in message:
+            continue
+        if method == "initialize":
+            result = {"capabilities": {}}
+        elif method == "textDocument/semanticTokens/full":
+            semantic_requests += 1
+            if semantic_requests == 1:
+                while not warmup_release.exists():
+                    time.sleep(0.01)
+            result = {"data": []}
+        else:
+            result = None
+        send({"jsonrpc": "2.0", "id": message["id"], "result": result})
+        if exit_after_warmup and semantic_requests == 1:
+            break
+    """
+)
+
 
 class RequestSummaryTest(unittest.TestCase):
     def test_profile_ready_follows_warmup_and_start_gates_measurement(self):
-        fake_server_source = textwrap.dedent(
-            """\
-            import json
-            import pathlib
-            import sys
-            import time
-
-            log_path = pathlib.Path(sys.argv[1])
-            warmup_release = pathlib.Path(sys.argv[2])
-            semantic_requests = 0
-
-            def read_message():
-                length = None
-                while True:
-                    line = sys.stdin.buffer.readline()
-                    if not line:
-                        raise EOFError
-                    line = line.strip()
-                    if not line:
-                        break
-                    if line.lower().startswith(b"content-length:"):
-                        length = int(line.split(b":", 1)[1])
-                return json.loads(sys.stdin.buffer.read(length))
-
-            def send(message):
-                body = json.dumps(message).encode()
-                sys.stdout.buffer.write(
-                    f"Content-Length: {len(body)}\\r\\n\\r\\n".encode() + body
-                )
-                sys.stdout.buffer.flush()
-
-            while True:
-                try:
-                    message = read_message()
-                except EOFError:
-                    break
-                method = message.get("method")
-                with log_path.open("a") as log:
-                    log.write(f"{method}\\n")
-                if method == "exit":
-                    break
-                if "id" not in message:
-                    continue
-                if method == "initialize":
-                    result = {"capabilities": {}}
-                elif method == "textDocument/semanticTokens/full":
-                    semantic_requests += 1
-                    if semantic_requests == 1:
-                        while not warmup_release.exists():
-                            time.sleep(0.01)
-                    result = {"data": []}
-                else:
-                    result = None
-                send({"jsonrpc": "2.0", "id": message["id"], "result": result})
-            """
-        )
         with tempfile.TemporaryDirectory() as temporary:
             directory = pathlib.Path(temporary)
             fake_server = directory / "fake_server.py"
-            fake_server.write_text(fake_server_source)
+            fake_server.write_text(FAKE_SERVER_SOURCE)
             log = directory / "methods.log"
             warmup_release = directory / "warmup-release"
             ready = directory / "ready"
@@ -155,6 +159,48 @@ class RequestSummaryTest(unittest.TestCase):
                     except subprocess.TimeoutExpired:
                         process.kill()
                         process.wait()
+
+    def test_profile_start_wait_aborts_when_server_exits(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            fake_server = directory / "fake_server.py"
+            fake_server.write_text(FAKE_SERVER_SOURCE)
+            log = directory / "methods.log"
+            warmup_release = directory / "warmup-release"
+            publish_marker(warmup_release, "")
+            ready = directory / "ready"
+            start = directory / "start"
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    str(pathlib.Path(__file__).parent / "drive.py"),
+                    "--bin",
+                    sys.executable,
+                    f"--server-arg={fake_server}",
+                    f"--server-arg={log}",
+                    f"--server-arg={warmup_release}",
+                    "--server-arg=exit-after-warmup",
+                    "--requests=1",
+                    "--size=1",
+                    "--settle=0",
+                    f"--profile-ready-file={ready}",
+                    f"--profile-start-file={start}",
+                    "--profile-wait-timeout=10",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            try:
+                _, stderr = process.communicate(timeout=3)
+                self.assertNotEqual(process.returncode, 0)
+                self.assertTrue(ready.is_file())
+                self.assertIn("server exited", stderr)
+                self.assertIn("waiting for profile marker", stderr)
+            finally:
+                if process.poll() is None:
+                    process.kill()
+                    process.wait()
 
     def test_profile_markers_are_published_and_waited_for(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -1,5 +1,7 @@
 import pathlib
 import sys
+import tempfile
+import threading
 import unittest
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
@@ -8,14 +10,36 @@ from drive import (
     RequestSample,
     count_semantic_outcomes,
     next_toggle_change,
+    publish_marker,
     response_result_id,
     server_request_result,
     summarize_samples,
     summarize_samples_by_status,
+    wait_for_marker,
 )
 
 
 class RequestSummaryTest(unittest.TestCase):
+    def test_profile_markers_are_published_and_waited_for(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            marker = pathlib.Path(temporary) / "nested" / "start"
+            observed = []
+            waiter = threading.Thread(
+                target=lambda: observed.append(wait_for_marker(marker, 1.0))
+            )
+            waiter.start()
+            publish_marker(marker, "ready\n")
+            waiter.join(timeout=2)
+
+            self.assertEqual(observed, [marker])
+            self.assertEqual(marker.read_text(), "ready\n")
+
+    def test_profile_marker_wait_has_a_timeout(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            marker = pathlib.Path(temporary) / "missing"
+            with self.assertRaisesRegex(TimeoutError, "missing"):
+                wait_for_marker(marker, 0.01)
+
     def test_summarizes_latency_status_and_wire_bytes(self):
         samples = [
             RequestSample(seconds=0.010, wire_bytes=100, status="ok"),

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -80,6 +80,9 @@ FAKE_SERVER_SOURCE = textwrap.dedent(
                         time.sleep(1)
             result = {"data": []}
         else:
+            if method == "shutdown" and behavior == "hang-shutdown":
+                while True:
+                    time.sleep(1)
             result = None
         send({"jsonrpc": "2.0", "id": message["id"], "result": result})
         if behavior == "exit-after-warmup" and semantic_requests == 1:
@@ -373,6 +376,46 @@ class RequestSummaryTest(unittest.TestCase):
                         os.kill(server_pid, signal.SIGKILL)
                     except ProcessLookupError:
                         pass
+
+    def test_profile_shutdown_response_has_a_deadline(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            fake_server = directory / "fake_server.py"
+            fake_server.write_text(FAKE_SERVER_SOURCE)
+            log = directory / "methods.log"
+            warmup_release = directory / "warmup-release"
+            publish_marker(warmup_release, "")
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    str(pathlib.Path(__file__).parent / "drive.py"),
+                    "--bin",
+                    sys.executable,
+                    f"--server-arg={fake_server}",
+                    f"--server-arg={log}",
+                    f"--server-arg={warmup_release}",
+                    "--server-arg=hang-shutdown",
+                    "--requests=1",
+                    "--size=1",
+                    "--settle=0",
+                    "--profile-wait-timeout=0.05",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                start_new_session=True,
+            )
+            try:
+                _, stderr = process.communicate(timeout=3)
+                self.assertEqual(process.returncode, 0, stderr)
+                self.assertIn("shutdown response deadline expired", stderr)
+            finally:
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                if process.poll() is None:
+                    process.wait()
 
     def test_profile_markers_are_published_and_waited_for(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -29,8 +29,11 @@ class RequestSummaryTest(unittest.TestCase):
             import json
             import pathlib
             import sys
+            import time
 
             log_path = pathlib.Path(sys.argv[1])
+            warmup_release = pathlib.Path(sys.argv[2])
+            semantic_requests = 0
 
             def read_message():
                 length = None
@@ -67,6 +70,10 @@ class RequestSummaryTest(unittest.TestCase):
                 if method == "initialize":
                     result = {"capabilities": {}}
                 elif method == "textDocument/semanticTokens/full":
+                    semantic_requests += 1
+                    if semantic_requests == 1:
+                        while not warmup_release.exists():
+                            time.sleep(0.01)
                     result = {"data": []}
                 else:
                     result = None
@@ -78,6 +85,7 @@ class RequestSummaryTest(unittest.TestCase):
             fake_server = directory / "fake_server.py"
             fake_server.write_text(fake_server_source)
             log = directory / "methods.log"
+            warmup_release = directory / "warmup-release"
             ready = directory / "ready"
             start = directory / "start"
             done = directory / "done"
@@ -89,6 +97,7 @@ class RequestSummaryTest(unittest.TestCase):
                     sys.executable,
                     f"--server-arg={fake_server}",
                     f"--server-arg={log}",
+                    f"--server-arg={warmup_release}",
                     "--requests=1",
                     "--size=1",
                     "--settle=0",
@@ -101,6 +110,22 @@ class RequestSummaryTest(unittest.TestCase):
                 text=True,
             )
             try:
+                deadline = time.monotonic() + 3
+                while (
+                    not log.exists()
+                    or log.read_text()
+                    .splitlines()
+                    .count("textDocument/semanticTokens/full")
+                    < 1
+                ):
+                    if time.monotonic() >= deadline:
+                        self.fail("fake server did not receive semantic warmup")
+                    time.sleep(0.01)
+                self.assertFalse(ready.exists())
+                time.sleep(0.05)
+                self.assertFalse(ready.exists())
+
+                publish_marker(warmup_release, "")
                 wait_for_marker(ready, 3)
                 methods_at_ready = log.read_text().splitlines()
                 self.assertEqual(

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -186,6 +186,13 @@ class RequestSummaryTest(unittest.TestCase):
                 )
             with self.assertRaisesRegex(ValueError, "must be distinct"):
                 validate_profile_marker_paths([marker, directory / "READY"])
+            for paths in (
+                [directory / "pid", directory],
+                [directory, directory / "start"],
+            ):
+                with self.subTest(paths=paths):
+                    with self.assertRaisesRegex(ValueError, "contain one another"):
+                        validate_profile_marker_paths(paths)
 
     def test_profile_timing_options_must_be_finite(self):
         drive = str(pathlib.Path(__file__).parent / "drive.py")

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -253,6 +253,65 @@ class RequestSummaryTest(unittest.TestCase):
                     os.killpg(process.pid, signal.SIGKILL)
                     process.wait()
 
+    def test_profile_signal_reaps_server(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            fake_server = directory / "fake_server.py"
+            fake_server.write_text(FAKE_SERVER_SOURCE)
+            log = directory / "methods.log"
+            warmup_release = directory / "warmup-release"
+            publish_marker(warmup_release, "")
+            pid_file = directory / "pid"
+            ready = directory / "ready"
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    str(pathlib.Path(__file__).parent / "drive.py"),
+                    "--bin",
+                    sys.executable,
+                    f"--server-arg={fake_server}",
+                    f"--server-arg={log}",
+                    f"--server-arg={warmup_release}",
+                    "--server-arg=hang-warmup",
+                    "--requests=1",
+                    "--size=1",
+                    "--settle=0",
+                    f"--profile-pid-file={pid_file}",
+                    f"--profile-ready-file={ready}",
+                    "--profile-wait-timeout=10",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            server_pid = None
+            try:
+                wait_for_marker(pid_file, 3)
+                server_pid = int(pid_file.read_text())
+                deadline = time.monotonic() + 3
+                while (
+                    not log.exists()
+                    or "textDocument/semanticTokens/full"
+                    not in log.read_text().splitlines()
+                ):
+                    if time.monotonic() >= deadline:
+                        self.fail("fake server did not enter semantic warmup")
+                    time.sleep(0.01)
+
+                process.terminate()
+                process.communicate(timeout=3)
+                with self.assertRaises(ProcessLookupError):
+                    os.kill(server_pid, 0)
+            finally:
+                if process.poll() is None:
+                    process.kill()
+                    process.wait()
+                if server_pid is not None:
+                    try:
+                        os.kill(server_pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+
     def test_profile_markers_are_published_and_waited_for(self):
         with tempfile.TemporaryDirectory() as temporary:
             marker = pathlib.Path(temporary) / "nested" / "start"

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -259,6 +259,22 @@ class RequestSummaryTest(unittest.TestCase):
         self.assertEqual(result.returncode, 2, result.stderr)
         self.assertIn("must not be empty", result.stderr)
 
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(pathlib.Path(__file__).parent / "drive.py"),
+                "--bin=not-used-after-validation",
+                "--requests=1",
+                "--profile-start-file=~kakehashi-profile-no-such-user/start",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn("invalid profile marker path", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
     def test_profile_timing_options_must_be_finite(self):
         drive = str(pathlib.Path(__file__).parent / "drive.py")
         for option, value in (

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -312,6 +312,65 @@ class RequestSummaryTest(unittest.TestCase):
                     except ProcessLookupError:
                         pass
 
+    def test_profile_server_does_not_inherit_blocked_signals(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = pathlib.Path(temporary)
+            fake_server = directory / "fake_server.py"
+            fake_server.write_text(FAKE_SERVER_SOURCE)
+            log = directory / "methods.log"
+            warmup_release = directory / "warmup-release"
+            publish_marker(warmup_release, "")
+            pid_file = directory / "pid"
+            ready = directory / "ready"
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    str(pathlib.Path(__file__).parent / "drive.py"),
+                    "--bin",
+                    sys.executable,
+                    f"--server-arg={fake_server}",
+                    f"--server-arg={log}",
+                    f"--server-arg={warmup_release}",
+                    "--server-arg=hang-warmup",
+                    "--requests=1",
+                    "--size=1",
+                    "--settle=0",
+                    f"--profile-pid-file={pid_file}",
+                    f"--profile-ready-file={ready}",
+                    "--profile-wait-timeout=10",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            server_pid = None
+            try:
+                wait_for_marker(pid_file, 3)
+                server_pid = int(pid_file.read_text())
+                deadline = time.monotonic() + 3
+                while (
+                    not log.exists()
+                    or "textDocument/semanticTokens/full"
+                    not in log.read_text().splitlines()
+                ):
+                    if time.monotonic() >= deadline:
+                        self.fail("fake server did not enter semantic warmup")
+                    time.sleep(0.01)
+
+                os.kill(server_pid, signal.SIGTERM)
+                process.communicate(timeout=3)
+                with self.assertRaises(ProcessLookupError):
+                    os.kill(server_pid, 0)
+            finally:
+                if process.poll() is None:
+                    process.kill()
+                    process.wait()
+                if server_pid is not None:
+                    try:
+                        os.kill(server_pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+
     def test_profile_markers_are_published_and_waited_for(self):
         with tempfile.TemporaryDirectory() as temporary:
             marker = pathlib.Path(temporary) / "nested" / "start"


### PR DESCRIPTION
## Summary

- add an atomic `pid -> ready -> start -> done -> stop` file handshake to the semantic-token profile driver
- await an unmeasured semantic-token warmup before publishing `ready`
- keep the exact server process alive until retained-heap inspection is acknowledged, with bounded fallback deadlines
- harden marker validation, signal handling, child cleanup, and stale-PID invalidation
- cover the protocol with fake-LSP integration tests and run them in CI
- document a copy-paste-safe macOS controller flow for allocation and retained-heap tools

## Why

Allocation profilers must attach to the spawned `kakehashi` server, not the Python driver. Fixed sleeps or all-process recording cannot establish an exact workload boundary and can mix startup/parser allocation with measured semantic-token work. This PR provides an observable boundary without changing production semantic-token behavior.

This is a measurement-only PR and does not claim a runtime speedup. It prepares allocation/retention evidence for #896.

## Protocol

1. publish the exact spawned server PID atomically
2. initialize, open the document, and await one unmeasured semantic-token response
3. publish `ready`
4. wait for the controller's `start` marker
5. run and await all measured requests
6. publish `done`
7. keep the server alive until `stop`, bounded by `--profile-hold-seconds`
8. shut down with bounded response waits, reap the child, and invalidate the PID marker

Marker paths must be nonempty regular-file paths, pairwise distinct, non-nested, and safe across case-insensitive filesystems. Warmup/start waits, server death, signals, malformed paths, and controller failures all have explicit cleanup behavior.

## Validation

- `python3 -m unittest benches/profile/test_drive.py -v` — 15 passed
- `python3 -m py_compile benches/profile/drive.py benches/profile/test_drive.py`
- README shell blocks parse under `/bin/sh` and `/bin/zsh`
- `make check`
- fresh local Codex review: no comments to provide

Real macOS server run using the new handshake:

- generated dense Rust document, size 80
- 10 edit + `semanticTokens/full` cycles
- all 10 responses successful
- semantic latency: p50 7.8 ms, p90 7.9 ms, max 8.1 ms
- `heap -H <exact-server-pid>` succeeded during the acknowledged hold
- driver exited 0 after `stop`
- PID marker was removed after reaping

Refs #896

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional semantic-token profiling coordination using readiness, start, done, and stop markers.
  * Added configurable warmup, start-wait, timeout, and hold controls.
* **Bug Fixes**
  * Improved marker validation, request deadlines, and server cleanup.
  * Added safeguards for invalid timing values and marker paths.
* **Documentation**
  * Added macOS profiling guidance for attaching external profilers to the server.
* **Tests**
  * Added end-to-end coverage for profiling handshakes, deadlines, signals, and process cleanup.
* **Chores**
  * CI now runs the profiling driver’s Python test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->