### PR TITLE
docs(bench): retain rejected semantic hot-path trials

### DIFF
--- a/benches/results/semantic-capture-role-table-2026-07-23/fixture-manifest.json
+++ b/benches/results/semantic-capture-role-table-2026-07-23/fixture-manifest.json
@@ -1,0 +1,194 @@
+[
+  {
+    "path": ".installed",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "cache/parsers.lua",
+    "sha256": "8a3014b92e4087c85288ee8c247764ac6ee0d1036eeee3c8127a63ab7a90207f",
+    "size": 73934,
+    "type": "file"
+  },
+  {
+    "path": "parser/lua.dylib",
+    "sha256": "3627531efe8ba26db42ffededd23de30e554e1c30ac8ad1a7d4127653b7d333f",
+    "size": 84600,
+    "type": "file"
+  },
+  {
+    "path": "parser/markdown.dylib",
+    "sha256": "2d814ac6471460a7ee6efdca136f03539e0467543d8c670fa6ca0006baefeae2",
+    "size": 418088,
+    "type": "file"
+  },
+  {
+    "path": "parser/markdown_inline.dylib",
+    "sha256": "52712e77a59008811da5f6b252f9d4bf4b4468e06a24aab9085d630227d3fb55",
+    "size": 416816,
+    "type": "file"
+  },
+  {
+    "path": "parser/python.dylib",
+    "sha256": "54dafefe808b21443b2929ba73b70ff73bc4816b3909efa4565c2e9f4025e375",
+    "size": 480920,
+    "type": "file"
+  },
+  {
+    "path": "parser/rust.dylib",
+    "sha256": "58f9f096964df352f3802ee7522d46a3ab0bcf73f81350cb4d83fb4038c7604f",
+    "size": 1142360,
+    "type": "file"
+  },
+  {
+    "path": "parser/yaml.dylib",
+    "sha256": "1baf5e6aea2f11e78adb4a5f96963c8c98da1c16b56032138a2e8e92b7dc4bc4",
+    "size": 217176,
+    "type": "file"
+  },
+  {
+    "path": "queries/.lua.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.markdown.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.markdown_inline.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.python.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.rust.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.yaml.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/highlights.scm",
+    "sha256": "ac7dfa89d16ba817c3681aa47c22bdb4441a78a89ed827a757efa755992de67f",
+    "size": 4336,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/injections.scm",
+    "sha256": "a2ee92c2f00f39ebeeb1d0cc06302dba58c4f1dda77a2f0c9e5d7d7beab0b1ff",
+    "size": 5168,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/highlights.scm",
+    "sha256": "7b71d4994cf3968e16d033ac59d28bb034427dd41be6a057b7a2985e2dfbe5b8",
+    "size": 2654,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/injections.scm",
+    "sha256": "34090de78df99b5ea84c2fbb9324f2b7c32e602043595286e83f1a1ac126073c",
+    "size": 659,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/highlights.scm",
+    "sha256": "7db9147da61de7491ede9155e554dc033d6a1b86ecd1b21f6849c018be9ac875",
+    "size": 2259,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/injections.scm",
+    "sha256": "051f44218e0fe25cd949dfccad80699d5456ee379c7c4cfa18a5165776ecab0e",
+    "size": 207,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/highlights.scm",
+    "sha256": "ab8b66cbe6a7382e0ed7693c194101f1900c39f9ec0085a1749a8817e3e6895c",
+    "size": 9263,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/injections.scm",
+    "sha256": "8558299709200b21d496890e4799153dc069bf302ce1545d23f70a0869c8b65d",
+    "size": 812,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/highlights.scm",
+    "sha256": "4e0f5994f30ee545fc63435054a0b029c7d0222632c5c787c4e9c249dc0ef20f",
+    "size": 8638,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/injections.scm",
+    "sha256": "7dde97bbdabd208f984e13627bd4daae0f73012c41faafab39d670b607710f4e",
+    "size": 2418,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/highlights.scm",
+    "sha256": "13352b80d2ce28c3328ccb2f321e5144c3365ff6055078e00e7cff118d1488b5",
+    "size": 1700,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/injections.scm",
+    "sha256": "8349bd07691e2e610decdfc7b898bb5b01b226aae8745217bc811427f7af6742",
+    "size": 2373,
+    "type": "file"
+  }
+]

--- a/benches/results/semantic-capture-role-table-2026-07-23/manifest.json
+++ b/benches/results/semantic-capture-role-table-2026-07-23/manifest.json
@@ -125,6 +125,7 @@
     "b_commit": "0b8626b40950074f6d935a00bed7b0bd05ec2ecb",
     "b_ref": "benchmark/semantic-capture-role-table-2026-07-23",
     "harness_commit": "553b901bbf421e3851886c2a3e94b16adca6c34a",
+    "harness_ref": "benchmark/semantic-lazy-content-lines-harness-2026-07-23",
     "harness_sources_sha256": {
       "benches/collect_semantic_pairs.py": "7ce0d8628d2f28ac331d15ccf470e7b1b4fb596d5a475588cfa25689746de798",
       "benches/semantic_summary.py": "8aab3d2622ec7bfface33f29fee8fd695297b31eb2007fc5b2b20d8be2e3d1d0",

--- a/benches/results/semantic-capture-role-table-2026-07-23/manifest.json
+++ b/benches/results/semantic-capture-role-table-2026-07-23/manifest.json
@@ -1,0 +1,137 @@
+{
+  "attestations": {
+    "binary_a": "03454758496ad4f6501a5e21dc2427e85e26b9202a0b00be13d528412f686957",
+    "binary_b": "235bcbe6bbb920129b18b67dba62d8b5377bdcf4078d2878fe2a3a3b66702147",
+    "fixture": "4bd6d43c37d67e416dfe6a1d84623f4c533bd30a43dc7c696890724723ea5d2c",
+    "harness": "29d69d323afe93abe36f94f67be10cb815b2c8c51867b832bf60d9448c51c9f7"
+  },
+  "configuration": {
+    "iterations": 30,
+    "pairs": 4,
+    "run_timeout_seconds": 900,
+    "scenario_filters": [
+      "rust_large/full_cache_hit",
+      "rust_large/typing_delta",
+      "rust_sparse_32k_minus/typing_delta",
+      "rust_sparse_32k_exact/typing_delta",
+      "rust_sparse_32k_plus/typing_delta",
+      "rust_sparse_64k/typing_delta",
+      "rust_large/typing_burst",
+      "rust_xlarge/cancel_burst",
+      "markdown_injections_large/full_cache_hit",
+      "markdown_injections/typing_delta",
+      "markdown_injections/typing_burst",
+      "unicode_rust/full_cache_hit"
+    ],
+    "scenarios": [
+      "markdown_injections/typing_burst",
+      "markdown_injections/typing_delta",
+      "markdown_injections_large/full_cache_hit",
+      "rust_large/full_cache_hit",
+      "rust_large/typing_burst",
+      "rust_large/typing_delta",
+      "rust_sparse_32k_exact/typing_delta",
+      "rust_sparse_32k_minus/typing_delta",
+      "rust_sparse_32k_plus/typing_delta",
+      "rust_sparse_64k/typing_delta",
+      "rust_xlarge/cancel_burst",
+      "unicode_rust/full_cache_hit"
+    ],
+    "server_env": {},
+    "warmup_iterations": 6
+  },
+  "environment": {
+    "build": {
+      "CARGO_HOME": "<TEMP>/cargo-home",
+      "CARGO_TERM_COLOR": "never",
+      "HOME": "<TEMP>/home",
+      "LANG": "C",
+      "LC_ALL": "C",
+      "PATH": "<USER_HOME_PATH>:<USER_HOME_PATH>:<USER_HOME_PATH>:/opt/homebrew/bin:/opt/homebrew/sbin:/nix/var/nix/profiles/default/bin:<USER_HOME_PATH>:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:<USER_HOME_PATH>",
+      "RUSTUP_HOME": "<USER_HOME>/.rustup",
+      "TMPDIR": "<TEMP>/tmp"
+    },
+    "cc": "Apple clang version 21.0.0 (clang-2100.1.1.101)\nTarget: arm64-apple-darwin25.5.0\nThread model: posix\nInstalledDir: /Library/Developer/CommandLineTools/usr/bin",
+    "clang": "Apple clang version 21.0.0 (clang-2100.1.1.101)\nTarget: arm64-apple-darwin25.5.0\nThread model: posix\nInstalledDir: /Library/Developer/CommandLineTools/usr/bin",
+    "machine": "arm64",
+    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "processor": "arm",
+    "runtime": {
+      "CARGO_HOME": "<TEMP>/cargo-home",
+      "CARGO_TERM_COLOR": "never",
+      "HOME": "<TEMP>/home",
+      "LANG": "C",
+      "LC_ALL": "C",
+      "PATH": "<USER_HOME_PATH>:<USER_HOME_PATH>:<USER_HOME_PATH>:/opt/homebrew/bin:/opt/homebrew/sbin:/nix/var/nix/profiles/default/bin:<USER_HOME_PATH>:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:<USER_HOME_PATH>",
+      "RUSTUP_HOME": "<USER_HOME>/.rustup",
+      "TMPDIR": "<TEMP>/tmp"
+    },
+    "sdk": "26.5",
+    "toolchains": {
+      "a": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      },
+      "b": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      },
+      "harness": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      }
+    }
+  },
+  "fixture_manifest": "fixture-manifest.json",
+  "fixture_manifest_sha256": "cab3dc82bb3a780f9fccf8c3d7eab4cef0fd9ed5c853c9940e3f96b3f8362b4f",
+  "raw_files": [
+    {
+      "order": "AB",
+      "pair_index": 1,
+      "samples": "pair-1.json",
+      "samples_sha256": "a6f82ac8187a1b5227c85bcfe5a9bc0623d6f6e35633490390ec12f1d2b854ee",
+      "stdout": "pair-1.txt",
+      "stdout_sha256": "4967fb91bce4eb29b2e06aad6bd09004a0dcb7530bf91e6d1097ff47dd778c63"
+    },
+    {
+      "order": "BA",
+      "pair_index": 2,
+      "samples": "pair-2.json",
+      "samples_sha256": "bc6903cb341c5b44379dcc73236aba9b92c555d518ccd831a5f64afb196eff37",
+      "stdout": "pair-2.txt",
+      "stdout_sha256": "b1ed106854180a356910bc251cbf48aa1f12f357a641d0d1ceae10b7c0079fd4"
+    },
+    {
+      "order": "AB",
+      "pair_index": 3,
+      "samples": "pair-3.json",
+      "samples_sha256": "9e8967051b30253441e1fc43bb034c02759a72ea4d4fea2ce3d1735bff3f79d1",
+      "stdout": "pair-3.txt",
+      "stdout_sha256": "77ea466a9be1adf8cc7985c7fc54c1578b5e11e452bdaa1f951e7597973045f2"
+    },
+    {
+      "order": "BA",
+      "pair_index": 4,
+      "samples": "pair-4.json",
+      "samples_sha256": "32bd4517bc468f6dd643e933cd11c75f59b4d530869dd681176e74b88fe5853c",
+      "stdout": "pair-4.txt",
+      "stdout_sha256": "d8f0773a0642453cca8c11b1fcc8359c2bfdae34d0e1a7c4270c3a647fc8c429"
+    }
+  ],
+  "schema_version": 1,
+  "source": {
+    "a_commit": "a1278be5fdff24d109d9e03134c6bdb880577f64",
+    "a_ref": "origin/main",
+    "b_commit": "0b8626b40950074f6d935a00bed7b0bd05ec2ecb",
+    "b_ref": "benchmark/semantic-capture-role-table-2026-07-23",
+    "harness_commit": "553b901bbf421e3851886c2a3e94b16adca6c34a",
+    "harness_sources_sha256": {
+      "benches/collect_semantic_pairs.py": "7ce0d8628d2f28ac331d15ccf470e7b1b4fb596d5a475588cfa25689746de798",
+      "benches/semantic_summary.py": "8aab3d2622ec7bfface33f29fee8fd695297b31eb2007fc5b2b20d8be2e3d1d0",
+      "benches/semantic_tokens.rs": "2d35487ff38a5b7b72540f55c5fb43ae6ca5190b9b579264ae0323e6fd927139",
+      "benches/support/semantic_baseline.rs": "4ab35bab7a05b32d652262c61c4cd4c720a21bfe3d1730694ea9dda5b306410c"
+    }
+  },
+  "summary": "summary.json",
+  "summary_sha256": "cf09b4fae4edbcb46b211c2cf81f6158cfe5d73eec8121a349840774ba288347"
+}

--- a/benches/results/semantic-capture-role-table-2026-07-23/pair-1.txt
+++ b/benches/results/semantic-capture-role-table-2026-07-23/pair-1.txt
@@ -1,0 +1,43 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               3.878ms      3.781ms         -2.5%
+    p95:      4.739ms      4.117ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      1.040ms      0.856ms         -17.7%
+    p95:      1.072ms      0.873ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.760ms      0.762ms        +0.2%
+    p95:      0.784ms      0.795ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/typing_delta                34.312ms     35.386ms        +3.1%
+    p95:     38.079ms     39.362ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     12.699ms     14.136ms        +11.3%
+    p95:     15.266ms     16.400ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta     14.082ms     13.657ms         -3.0%
+    p95:     15.667ms     15.275ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta      12.535ms     13.038ms        +4.0%
+    p95:     14.223ms     16.691ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           28.982ms     28.261ms         -2.5%
+    p95:     35.830ms     32.984ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                38.149ms     40.832ms        +7.0%
+    p95:     44.607ms     45.036ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+rust_xlarge/cancel_burst              191.615ms    164.155ms         -14.3%
+    p95:    230.702ms    186.966ms
+    └ targets: current-token latency after four explicitly cancelled edit states
+markdown_injections/typing_delta        9.009ms      7.617ms         -15.5%
+    p95:      9.972ms      7.973ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        8.024ms      9.262ms        +15.4%
+    p95:     10.495ms     10.192ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-capture-role-table-2026-07-23/pair-2.txt
+++ b/benches/results/semantic-capture-role-table-2026-07-23/pair-2.txt
@@ -1,0 +1,43 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               3.779ms      3.824ms        +1.2%
+    p95:      3.910ms      5.040ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.862ms      0.763ms         -11.5%
+    p95:      0.916ms      0.776ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.999ms      0.682ms         -31.7%
+    p95:      1.073ms      0.726ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/typing_delta                30.999ms     36.569ms        +18.0%
+    p95:     36.751ms     45.533ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     14.438ms     12.794ms         -11.4%
+    p95:     17.794ms     15.523ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta     12.083ms     11.197ms         -7.3%
+    p95:     14.202ms     13.837ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta      10.988ms     13.821ms        +25.8%
+    p95:     14.838ms     15.746ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           25.896ms     25.515ms         -1.5%
+    p95:     28.005ms     29.460ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                36.129ms     40.532ms        +12.2%
+    p95:     45.459ms     48.507ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+rust_xlarge/cancel_burst              158.125ms    157.069ms         -0.7%
+    p95:    186.669ms    191.052ms
+    └ targets: current-token latency after four explicitly cancelled edit states
+markdown_injections/typing_delta        7.615ms      7.385ms         -3.0%
+    p95:      8.087ms     10.721ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        6.969ms      7.735ms        +11.0%
+    p95:      7.673ms      8.896ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-capture-role-table-2026-07-23/pair-3.txt
+++ b/benches/results/semantic-capture-role-table-2026-07-23/pair-3.txt
@@ -1,0 +1,43 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               3.478ms      3.510ms        +0.9%
+    p95:      3.755ms      3.853ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.863ms      0.763ms         -11.6%
+    p95:      0.872ms      0.772ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.678ms      0.676ms         -0.2%
+    p95:      0.701ms      0.689ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/typing_delta                32.458ms     35.230ms        +8.5%
+    p95:     36.126ms     41.917ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     12.914ms     12.946ms        +0.3%
+    p95:     16.186ms     15.064ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta     10.661ms     10.704ms        +0.4%
+    p95:     13.248ms     12.664ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta      11.010ms     10.886ms         -1.1%
+    p95:     13.182ms     13.178ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           23.728ms     25.454ms        +7.3%
+    p95:     27.910ms     28.162ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                37.050ms     31.437ms         -15.2%
+    p95:     40.565ms     36.191ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+rust_xlarge/cancel_burst              162.192ms    140.717ms         -13.2%
+    p95:    188.434ms    157.546ms
+    └ targets: current-token latency after four explicitly cancelled edit states
+markdown_injections/typing_delta        8.647ms      8.180ms         -5.4%
+    p95:      9.072ms      9.239ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        7.560ms      7.861ms        +4.0%
+    p95:      8.006ms      9.006ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-capture-role-table-2026-07-23/pair-4.txt
+++ b/benches/results/semantic-capture-role-table-2026-07-23/pair-4.txt
@@ -1,0 +1,43 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               3.206ms      3.247ms        +1.3%
+    p95:      3.249ms      3.337ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.862ms      0.773ms         -10.3%
+    p95:      0.871ms      0.787ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.679ms      0.683ms        +0.6%
+    p95:      0.713ms      0.739ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/typing_delta                32.913ms     35.429ms        +7.6%
+    p95:     38.516ms     40.998ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     11.844ms     11.145ms         -5.9%
+    p95:     13.695ms     13.378ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta     10.852ms     13.908ms        +28.2%
+    p95:     15.018ms     16.466ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta      13.867ms     12.569ms         -9.4%
+    p95:     16.093ms     16.298ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           24.364ms     23.753ms         -2.5%
+    p95:     37.675ms     27.513ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                38.328ms     36.483ms         -4.8%
+    p95:     41.885ms     43.133ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+rust_xlarge/cancel_burst              156.919ms    152.794ms         -2.6%
+    p95:    194.358ms    168.456ms
+    └ targets: current-token latency after four explicitly cancelled edit states
+markdown_injections/typing_delta        7.963ms      9.254ms        +16.2%
+    p95:      9.012ms     10.839ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        8.826ms      8.989ms        +1.8%
+    p95:      9.415ms     11.849ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-capture-role-table-2026-07-23/summary.json
+++ b/benches/results/semantic-capture-role-table-2026-07-23/summary.json
@@ -1,0 +1,497 @@
+{
+  "scenarios": [
+    {
+      "a_median_ns": 7879229.25,
+      "b_median_ns": 8343760.5,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 15.43694355185361,
+        "median": 1.0855683160037695,
+        "min": -9.902093652781705
+      },
+      "pairs": [
+        {
+          "a_median_ns": 8023771.0,
+          "b_median_ns": 9262396.0,
+          "delta_percent": 15.43694355185361,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 7734687.5,
+          "b_median_ns": 6968791.5,
+          "delta_percent": -9.902093652781705,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 7560104.5,
+          "b_median_ns": 7861104.0,
+          "delta_percent": 3.9814198335485975,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 8989146.0,
+          "b_median_ns": 8826417.0,
+          "delta_percent": -1.8102832015410586,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "markdown_injections/typing_burst"
+    },
+    {
+      "a_median_ns": 8828010.25,
+      "b_median_ns": 7790302.25,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 3.1222404269687907,
+        "median": -9.67169409498947,
+        "min": -15.452983535257742
+      },
+      "pairs": [
+        {
+          "a_median_ns": 9009312.0,
+          "b_median_ns": 7617104.5,
+          "delta_percent": -15.452983535257742,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 7384521.0,
+          "b_median_ns": 7615083.5,
+          "delta_percent": 3.1222404269687907,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 8646708.5,
+          "b_median_ns": 8180020.5,
+          "delta_percent": -5.397290772552353,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 9254083.5,
+          "b_median_ns": 7963500.0,
+          "delta_percent": -13.946097417426587,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "markdown_injections/typing_delta"
+    },
+    {
+      "a_median_ns": 818114.75,
+      "b_median_ns": 858604.25,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 13.012389631089953,
+        "median": -0.08232982299712255,
+        "min": -17.689701196416763
+      },
+      "pairs": [
+        {
+          "a_median_ns": 1039562.5,
+          "b_median_ns": 855667.0,
+          "delta_percent": -17.689701196416763,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 762896.0,
+          "b_median_ns": 862167.0,
+          "delta_percent": 13.012389631089953,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 863271.0,
+          "b_median_ns": 762916.5,
+          "delta_percent": -11.624912686746109,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 772958.5,
+          "b_median_ns": 861541.5,
+          "delta_percent": 11.460253040751864,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "markdown_injections_large/full_cache_hit"
+    },
+    {
+      "a_median_ns": 3650843.75,
+      "b_median_ns": 3644854.25,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 0.9380639701862169,
+        "median": -1.2152740500845265,
+        "min": -2.5012080514761434
+      },
+      "pairs": [
+        {
+          "a_median_ns": 3878146.0,
+          "b_median_ns": 3781145.5,
+          "delta_percent": -2.5012080514761434,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 3823833.0,
+          "b_median_ns": 3779229.5,
+          "delta_percent": -1.1664604599625559,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 3477854.5,
+          "b_median_ns": 3510479.0,
+          "delta_percent": 0.9380639701862169,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 3246729.0,
+          "b_median_ns": 3205687.5,
+          "delta_percent": -1.264087640206497,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_large/full_cache_hit"
+    },
+    {
+      "a_median_ns": 37599656.0,
+      "b_median_ns": 37228552.25,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 7.031722381643535,
+        "median": -2.9033222936060206,
+        "min": -15.150580130162384
+      },
+      "pairs": [
+        {
+          "a_median_ns": 38149437.0,
+          "b_median_ns": 40831999.5,
+          "delta_percent": 7.031722381643535,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 40532417.0,
+          "b_median_ns": 36128646.0,
+          "delta_percent": -10.86481223165152,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 37049875.0,
+          "b_median_ns": 31436604.0,
+          "delta_percent": -15.150580130162384,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 36483083.0,
+          "b_median_ns": 38328458.5,
+          "delta_percent": 5.058167644439479,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_large/typing_burst"
+    },
+    {
+      "a_median_ns": 34870083.5,
+      "b_median_ns": 34071500.0,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 8.540008494977995,
+        "median": -1.9839342463892715,
+        "min": -15.229558283019568
+      },
+      "pairs": [
+        {
+          "a_median_ns": 34311562.5,
+          "b_median_ns": 35386333.0,
+          "delta_percent": 3.132385766459921,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 36568687.0,
+          "b_median_ns": 30999437.5,
+          "delta_percent": -15.229558283019568,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 32458000.5,
+          "b_median_ns": 35229916.5,
+          "delta_percent": 8.540008494977995,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 35428604.5,
+          "b_median_ns": 32913083.5,
+          "delta_percent": -7.100254259238464,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_large/typing_delta"
+    },
+    {
+      "a_median_ns": 12552468.75,
+      "b_median_ns": 11467552.25,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 7.910818277607186,
+        "median": -1.307461157892765,
+        "min": -21.970150301127493
+      },
+      "pairs": [
+        {
+          "a_median_ns": 14081729.5,
+          "b_median_ns": 13656791.5,
+          "delta_percent": -3.017654898143016,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 11196958.0,
+          "b_median_ns": 12082729.0,
+          "delta_percent": 7.910818277607186,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 10661417.0,
+          "b_median_ns": 10704354.0,
+          "delta_percent": 0.4027325823574858,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 13907979.5,
+          "b_median_ns": 10852375.5,
+          "delta_percent": -21.970150301127493,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_sparse_32k_exact/typing_delta"
+    },
+    {
+      "a_median_ns": 12746364.75,
+      "b_median_ns": 13541041.75,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 12.852079862824315,
+        "median": 8.795092817449408,
+        "min": 0.25102296290571796
+      },
+      "pairs": [
+        {
+          "a_median_ns": 12698917.0,
+          "b_median_ns": 14135708.5,
+          "delta_percent": 11.314283729864522,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 12793812.5,
+          "b_median_ns": 14438083.5,
+          "delta_percent": 12.852079862824315,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 12913958.0,
+          "b_median_ns": 12946375.0,
+          "delta_percent": 0.25102296290571796,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 11144812.5,
+          "b_median_ns": 11844250.0,
+          "delta_percent": 6.275901905034292,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_sparse_32k_minus/typing_delta"
+    },
+    {
+      "a_median_ns": 12551885.25,
+      "b_median_ns": 12013000.0,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 10.325695739292877,
+        "median": 1.4439222947545451,
+        "min": -20.502301084007073
+      },
+      "pairs": [
+        {
+          "a_median_ns": 12535000.0,
+          "b_median_ns": 13038375.0,
+          "delta_percent": 4.0157558835261264,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 13821312.0,
+          "b_median_ns": 10987625.0,
+          "delta_percent": -20.502301084007073,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 11010396.0,
+          "b_median_ns": 10886208.5,
+          "delta_percent": -1.1279112940170362,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 12568770.5,
+          "b_median_ns": 13866583.5,
+          "delta_percent": 10.325695739292877,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_sparse_32k_plus/typing_delta"
+    },
+    {
+      "a_median_ns": 24634197.75,
+      "b_median_ns": 25674979.5,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 7.2741703062805,
+        "median": 2.0323248485774292,
+        "min": -2.4872364524007295
+      },
+      "pairs": [
+        {
+          "a_median_ns": 28982146.0,
+          "b_median_ns": 28261291.5,
+          "delta_percent": -2.4872364524007295,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 25515208.0,
+          "b_median_ns": 25896167.0,
+          "delta_percent": 1.4930664096487083,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 23727792.0,
+          "b_median_ns": 25453792.0,
+          "delta_percent": 7.2741703062805,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 23753187.5,
+          "b_median_ns": 24364020.5,
+          "delta_percent": 2.5715832875061504,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_sparse_64k/typing_delta"
+    },
+    {
+      "a_median_ns": 159630625.25,
+      "b_median_ns": 157521864.5,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 2.6996311589967252,
+        "median": -6.284228923153341,
+        "min": -14.331029236973572
+      },
+      "pairs": [
+        {
+          "a_median_ns": 191615250.0,
+          "b_median_ns": 164154812.5,
+          "delta_percent": -14.331029236973572,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 157068771.0,
+          "b_median_ns": 158124833.0,
+          "delta_percent": 0.6723564418798438,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 162192479.5,
+          "b_median_ns": 140716874.5,
+          "delta_percent": -13.240814288186526,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 152794021.0,
+          "b_median_ns": 156918896.0,
+          "delta_percent": 2.6996311589967252,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_xlarge/cancel_burst"
+    },
+    {
+      "a_median_ns": 682927.25,
+      "b_median_ns": 720573.0,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 46.431467815774496,
+        "median": -0.006156041729205863,
+        "min": -0.5822019041375334
+      },
+      "pairs": [
+        {
+          "a_median_ns": 760437.5,
+          "b_median_ns": 761770.5,
+          "delta_percent": 0.17529382756636805,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 682500.5,
+          "b_median_ns": 999395.5,
+          "delta_percent": 46.431467815774496,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 677750.5,
+          "b_median_ns": 676479.0,
+          "delta_percent": -0.18760591102477978,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 683354.0,
+          "b_median_ns": 679375.5,
+          "delta_percent": -0.5822019041375334,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "unicode_rust/full_cache_hit"
+    }
+  ],
+  "schema_version": 1
+}

--- a/benches/results/semantic-lazy-content-lines-2026-07-23/fixture-manifest.json
+++ b/benches/results/semantic-lazy-content-lines-2026-07-23/fixture-manifest.json
@@ -1,0 +1,194 @@
+[
+  {
+    "path": ".installed",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "cache/parsers.lua",
+    "sha256": "8a3014b92e4087c85288ee8c247764ac6ee0d1036eeee3c8127a63ab7a90207f",
+    "size": 73934,
+    "type": "file"
+  },
+  {
+    "path": "parser/lua.dylib",
+    "sha256": "a7b45ecff855c3b1e4c05c4ddaec5ec1efd9b5290b12a2a01a003d2f4de796cd",
+    "size": 84600,
+    "type": "file"
+  },
+  {
+    "path": "parser/markdown.dylib",
+    "sha256": "ebdcacdfe499262943162065809eb93a9a978b1fdf326d2c56550f0858d3627e",
+    "size": 418088,
+    "type": "file"
+  },
+  {
+    "path": "parser/markdown_inline.dylib",
+    "sha256": "d60c067a9bc4229035a19739b2a8f8d0ec6f75fbe069750e0e6077ff2c49bf9b",
+    "size": 416816,
+    "type": "file"
+  },
+  {
+    "path": "parser/python.dylib",
+    "sha256": "9158a3e161550b5eb3d0ecb0fe5fb20e138bf02059fa0052128cb2f2da075b00",
+    "size": 480920,
+    "type": "file"
+  },
+  {
+    "path": "parser/rust.dylib",
+    "sha256": "c82cc4d16ec2b1a788a0fd3d3b8b6237ff9694aa8b19056741cc3477ef6de5e1",
+    "size": 1142360,
+    "type": "file"
+  },
+  {
+    "path": "parser/yaml.dylib",
+    "sha256": "7bcae755df23cbef4dbcdef2fd0b5019d32e7e1bcc021bc6fa44809779230556",
+    "size": 217176,
+    "type": "file"
+  },
+  {
+    "path": "queries/.lua.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.markdown.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.markdown_inline.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.python.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.rust.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.yaml.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/highlights.scm",
+    "sha256": "ac7dfa89d16ba817c3681aa47c22bdb4441a78a89ed827a757efa755992de67f",
+    "size": 4336,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/injections.scm",
+    "sha256": "a2ee92c2f00f39ebeeb1d0cc06302dba58c4f1dda77a2f0c9e5d7d7beab0b1ff",
+    "size": 5168,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/highlights.scm",
+    "sha256": "7b71d4994cf3968e16d033ac59d28bb034427dd41be6a057b7a2985e2dfbe5b8",
+    "size": 2654,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/injections.scm",
+    "sha256": "34090de78df99b5ea84c2fbb9324f2b7c32e602043595286e83f1a1ac126073c",
+    "size": 659,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/highlights.scm",
+    "sha256": "7db9147da61de7491ede9155e554dc033d6a1b86ecd1b21f6849c018be9ac875",
+    "size": 2259,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/injections.scm",
+    "sha256": "051f44218e0fe25cd949dfccad80699d5456ee379c7c4cfa18a5165776ecab0e",
+    "size": 207,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/highlights.scm",
+    "sha256": "ab8b66cbe6a7382e0ed7693c194101f1900c39f9ec0085a1749a8817e3e6895c",
+    "size": 9263,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/injections.scm",
+    "sha256": "8558299709200b21d496890e4799153dc069bf302ce1545d23f70a0869c8b65d",
+    "size": 812,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/highlights.scm",
+    "sha256": "4e0f5994f30ee545fc63435054a0b029c7d0222632c5c787c4e9c249dc0ef20f",
+    "size": 8638,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/injections.scm",
+    "sha256": "7dde97bbdabd208f984e13627bd4daae0f73012c41faafab39d670b607710f4e",
+    "size": 2418,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/highlights.scm",
+    "sha256": "13352b80d2ce28c3328ccb2f321e5144c3365ff6055078e00e7cff118d1488b5",
+    "size": 1700,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/injections.scm",
+    "sha256": "8349bd07691e2e610decdfc7b898bb5b01b226aae8745217bc811427f7af6742",
+    "size": 2373,
+    "type": "file"
+  }
+]

--- a/benches/results/semantic-lazy-content-lines-2026-07-23/manifest.json
+++ b/benches/results/semantic-lazy-content-lines-2026-07-23/manifest.json
@@ -1,0 +1,137 @@
+{
+  "attestations": {
+    "binary_a": "12df5cf0a54e3229564a7192974b57b7547277869adc51b29c328c260956d0a4",
+    "binary_b": "d1427f0be6d622c24a20eeb75727db5f4bbeb4e3f6196c05ff63f9cbb3e85154",
+    "fixture": "553810642638c33d8d85403641b014cc5fa9a9f557484bd4174267b01c21f3e3",
+    "harness": "4c930e754a3deda26f738f67246f88fd4e8ff3f2aa90725fd5429cb2d3de585b"
+  },
+  "configuration": {
+    "iterations": 30,
+    "pairs": 4,
+    "run_timeout_seconds": 900,
+    "scenario_filters": [
+      "rust_large/full_cache_hit",
+      "rust_large/typing_delta",
+      "rust_sparse_32k_minus/typing_delta",
+      "rust_sparse_32k_exact/typing_delta",
+      "rust_sparse_32k_plus/typing_delta",
+      "rust_sparse_64k/typing_delta",
+      "rust_large/typing_burst",
+      "rust_xlarge/cancel_burst",
+      "markdown_injections_large/full_cache_hit",
+      "markdown_injections/typing_delta",
+      "markdown_injections/typing_burst",
+      "unicode_rust/full_cache_hit"
+    ],
+    "scenarios": [
+      "markdown_injections/typing_burst",
+      "markdown_injections/typing_delta",
+      "markdown_injections_large/full_cache_hit",
+      "rust_large/full_cache_hit",
+      "rust_large/typing_burst",
+      "rust_large/typing_delta",
+      "rust_sparse_32k_exact/typing_delta",
+      "rust_sparse_32k_minus/typing_delta",
+      "rust_sparse_32k_plus/typing_delta",
+      "rust_sparse_64k/typing_delta",
+      "rust_xlarge/cancel_burst",
+      "unicode_rust/full_cache_hit"
+    ],
+    "server_env": {},
+    "warmup_iterations": 6
+  },
+  "environment": {
+    "build": {
+      "CARGO_HOME": "<TEMP>/cargo-home",
+      "CARGO_TERM_COLOR": "never",
+      "HOME": "<TEMP>/home",
+      "LANG": "C",
+      "LC_ALL": "C",
+      "PATH": "<USER_HOME_PATH>:<USER_HOME_PATH>:<USER_HOME_PATH>:/opt/homebrew/bin:/opt/homebrew/sbin:/nix/var/nix/profiles/default/bin:<USER_HOME_PATH>:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:<USER_HOME_PATH>",
+      "RUSTUP_HOME": "<USER_HOME>/.rustup",
+      "TMPDIR": "<TEMP>/tmp"
+    },
+    "cc": "Apple clang version 21.0.0 (clang-2100.1.1.101)\nTarget: arm64-apple-darwin25.5.0\nThread model: posix\nInstalledDir: /Library/Developer/CommandLineTools/usr/bin",
+    "clang": "Apple clang version 21.0.0 (clang-2100.1.1.101)\nTarget: arm64-apple-darwin25.5.0\nThread model: posix\nInstalledDir: /Library/Developer/CommandLineTools/usr/bin",
+    "machine": "arm64",
+    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "processor": "arm",
+    "runtime": {
+      "CARGO_HOME": "<TEMP>/cargo-home",
+      "CARGO_TERM_COLOR": "never",
+      "HOME": "<TEMP>/home",
+      "LANG": "C",
+      "LC_ALL": "C",
+      "PATH": "<USER_HOME_PATH>:<USER_HOME_PATH>:<USER_HOME_PATH>:/opt/homebrew/bin:/opt/homebrew/sbin:/nix/var/nix/profiles/default/bin:<USER_HOME_PATH>:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:<USER_HOME_PATH>",
+      "RUSTUP_HOME": "<USER_HOME>/.rustup",
+      "TMPDIR": "<TEMP>/tmp"
+    },
+    "sdk": "26.5",
+    "toolchains": {
+      "a": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      },
+      "b": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      },
+      "harness": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      }
+    }
+  },
+  "fixture_manifest": "fixture-manifest.json",
+  "fixture_manifest_sha256": "51f71936153a0a314b239598d3ea45e619a8d5c9c1eb26a975590d28c9b05574",
+  "raw_files": [
+    {
+      "order": "AB",
+      "pair_index": 1,
+      "samples": "pair-1.json",
+      "samples_sha256": "de2af019be4d8455a98a4561b33316f92081743578c72cdf12e4540a0ee3b28e",
+      "stdout": "pair-1.txt",
+      "stdout_sha256": "0f252dffda6936a4320d2ee4dd0d73a30be5db72eb39269662c1749c77c793b7"
+    },
+    {
+      "order": "BA",
+      "pair_index": 2,
+      "samples": "pair-2.json",
+      "samples_sha256": "fe2862f198b0499a2a546b983a164aeb9f9ae1d00b3f95f3369b011d9cabe2fa",
+      "stdout": "pair-2.txt",
+      "stdout_sha256": "ec7ca3e9c761dc83b1035b301a774d838914d88bfb05d434811c77040c7c68af"
+    },
+    {
+      "order": "AB",
+      "pair_index": 3,
+      "samples": "pair-3.json",
+      "samples_sha256": "fd3eb79b08ab4c31b45eab3bf17799cb1c856b6fce60a3c64c32c6c906f42fed",
+      "stdout": "pair-3.txt",
+      "stdout_sha256": "3603f1a23a9f90bc47d05a822c985d81b80022fe7610e3975430ba5b9f973682"
+    },
+    {
+      "order": "BA",
+      "pair_index": 4,
+      "samples": "pair-4.json",
+      "samples_sha256": "0c7c45db621577536aba51e4bd9aa2a1b4dd92270f8684a530add820d4123144",
+      "stdout": "pair-4.txt",
+      "stdout_sha256": "95a6eb7493574c6ed945b97ec5e4d29e08c2bec4d4fd6928b8ab2d6e1d8cd391"
+    }
+  ],
+  "schema_version": 1,
+  "source": {
+    "a_commit": "a1278be5fdff24d109d9e03134c6bdb880577f64",
+    "a_ref": "origin/main",
+    "b_commit": "5e2375c08b58dafae961a24b92f112bcb4f84a03",
+    "b_ref": "benchmark/semantic-lazy-content-lines-2026-07-23",
+    "harness_commit": "553b901bbf421e3851886c2a3e94b16adca6c34a",
+    "harness_sources_sha256": {
+      "benches/collect_semantic_pairs.py": "7ce0d8628d2f28ac331d15ccf470e7b1b4fb596d5a475588cfa25689746de798",
+      "benches/semantic_summary.py": "8aab3d2622ec7bfface33f29fee8fd695297b31eb2007fc5b2b20d8be2e3d1d0",
+      "benches/semantic_tokens.rs": "2d35487ff38a5b7b72540f55c5fb43ae6ca5190b9b579264ae0323e6fd927139",
+      "benches/support/semantic_baseline.rs": "4ab35bab7a05b32d652262c61c4cd4c720a21bfe3d1730694ea9dda5b306410c"
+    }
+  },
+  "summary": "summary.json",
+  "summary_sha256": "45f36be28fab96950020039aa9b0b3d02d23035d25aa8c66ebf28b0c54d14c77"
+}

--- a/benches/results/semantic-lazy-content-lines-2026-07-23/manifest.json
+++ b/benches/results/semantic-lazy-content-lines-2026-07-23/manifest.json
@@ -125,6 +125,7 @@
     "b_commit": "5e2375c08b58dafae961a24b92f112bcb4f84a03",
     "b_ref": "benchmark/semantic-lazy-content-lines-2026-07-23",
     "harness_commit": "553b901bbf421e3851886c2a3e94b16adca6c34a",
+    "harness_ref": "benchmark/semantic-lazy-content-lines-harness-2026-07-23",
     "harness_sources_sha256": {
       "benches/collect_semantic_pairs.py": "7ce0d8628d2f28ac331d15ccf470e7b1b4fb596d5a475588cfa25689746de798",
       "benches/semantic_summary.py": "8aab3d2622ec7bfface33f29fee8fd695297b31eb2007fc5b2b20d8be2e3d1d0",

--- a/benches/results/semantic-lazy-content-lines-2026-07-23/pair-1.txt
+++ b/benches/results/semantic-lazy-content-lines-2026-07-23/pair-1.txt
@@ -1,0 +1,43 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               3.203ms      2.887ms         -9.9%
+    p95:      3.264ms      2.992ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.800ms      0.810ms        +1.3%
+    p95:      0.900ms      0.831ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.734ms      0.680ms         -7.3%
+    p95:      0.795ms      0.689ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/typing_delta                29.039ms     30.606ms        +5.4%
+    p95:     32.912ms     34.485ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     10.543ms     10.890ms        +3.3%
+    p95:     12.692ms     13.132ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta     11.455ms     11.106ms         -3.0%
+    p95:     13.898ms     12.605ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta      11.408ms     10.970ms         -3.8%
+    p95:     14.041ms     12.765ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           21.845ms     24.078ms        +10.2%
+    p95:     24.629ms     27.122ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                33.505ms     30.373ms         -9.3%
+    p95:     38.818ms     34.782ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+rust_xlarge/cancel_burst              162.317ms    153.868ms         -5.2%
+    p95:    179.092ms    177.746ms
+    └ targets: current-token latency after four explicitly cancelled edit states
+markdown_injections/typing_delta        7.872ms      6.776ms         -13.9%
+    p95:      9.677ms      6.999ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        6.884ms      6.634ms         -3.6%
+    p95:      9.264ms      7.440ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-lazy-content-lines-2026-07-23/pair-2.txt
+++ b/benches/results/semantic-lazy-content-lines-2026-07-23/pair-2.txt
@@ -1,0 +1,43 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               2.842ms      2.860ms        +0.6%
+    p95:      2.913ms      2.929ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.701ms      0.712ms        +1.6%
+    p95:      1.106ms      0.735ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.703ms      1.033ms        +47.1%
+    p95:      0.714ms      1.097ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/typing_delta                28.922ms     29.106ms        +0.6%
+    p95:     34.059ms     31.925ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     10.106ms     10.585ms        +4.7%
+    p95:     12.974ms     13.275ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta     11.069ms     10.733ms         -3.0%
+    p95:     15.105ms     12.416ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta      10.661ms      9.711ms         -8.9%
+    p95:     13.209ms      9.968ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           20.044ms     20.267ms        +1.1%
+    p95:     24.479ms     24.475ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                36.276ms     30.359ms         -16.3%
+    p95:     41.085ms     33.377ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+rust_xlarge/cancel_burst              155.535ms    155.573ms        +0.0%
+    p95:    168.852ms    172.013ms
+    └ targets: current-token latency after four explicitly cancelled edit states
+markdown_injections/typing_delta        8.277ms      8.505ms        +2.8%
+    p95:      9.898ms      8.803ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        6.855ms      6.310ms         -8.0%
+    p95:      9.419ms      6.825ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-lazy-content-lines-2026-07-23/pair-3.txt
+++ b/benches/results/semantic-lazy-content-lines-2026-07-23/pair-3.txt
@@ -1,0 +1,43 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               2.573ms      2.692ms        +4.6%
+    p95:      2.598ms      2.962ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.690ms      0.631ms         -8.5%
+    p95:      0.707ms      0.640ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.554ms      0.705ms        +27.1%
+    p95:      0.574ms      0.714ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/typing_delta                29.485ms     29.332ms         -0.5%
+    p95:     35.691ms     33.754ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     11.205ms     10.991ms         -1.9%
+    p95:     13.337ms     13.029ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta     10.811ms     10.222ms         -5.5%
+    p95:     15.281ms     12.677ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta      10.953ms     10.732ms         -2.0%
+    p95:     14.034ms     13.175ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           21.280ms     20.168ms         -5.2%
+    p95:     24.744ms     24.523ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                30.277ms     31.415ms        +3.8%
+    p95:     35.482ms     36.729ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+rust_xlarge/cancel_burst              158.556ms    165.822ms        +4.6%
+    p95:    172.864ms    181.666ms
+    └ targets: current-token latency after four explicitly cancelled edit states
+markdown_injections/typing_delta        8.417ms      9.398ms        +11.7%
+    p95:     10.466ms     11.874ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        9.189ms      7.513ms         -18.2%
+    p95:     11.009ms      7.950ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-lazy-content-lines-2026-07-23/pair-4.txt
+++ b/benches/results/semantic-lazy-content-lines-2026-07-23/pair-4.txt
@@ -1,0 +1,43 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               2.839ms      2.861ms        +0.8%
+    p95:      2.925ms      2.922ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.779ms      0.687ms         -11.9%
+    p95:      0.799ms      0.704ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.607ms      0.607ms        +0.0%
+    p95:      0.614ms      0.618ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/typing_delta                33.171ms     31.427ms         -5.3%
+    p95:     40.692ms     35.925ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     10.656ms      9.722ms         -8.8%
+    p95:     13.801ms     13.447ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta     10.048ms     13.288ms        +32.3%
+    p95:     15.558ms     16.032ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta      12.325ms     10.287ms         -16.5%
+    p95:     14.410ms     13.257ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           20.236ms     19.538ms         -3.5%
+    p95:     23.902ms     24.150ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                36.532ms     33.058ms         -9.5%
+    p95:     41.158ms     37.868ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+rust_xlarge/cancel_burst              164.980ms    159.204ms         -3.5%
+    p95:    182.588ms    177.220ms
+    └ targets: current-token latency after four explicitly cancelled edit states
+markdown_injections/typing_delta        8.415ms      8.200ms         -2.6%
+    p95:      8.984ms      8.676ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        6.906ms      6.366ms         -7.8%
+    p95:      7.212ms      7.486ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-lazy-content-lines-2026-07-23/summary.json
+++ b/benches/results/semantic-lazy-content-lines-2026-07-23/summary.json
@@ -1,0 +1,497 @@
+{
+  "scenarios": [
+    {
+      "a_median_ns": 6624885.25,
+      "b_median_ns": 6880364.75,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 8.639987321334825,
+        "median": 2.423748819136408,
+        "min": -18.237657616497803
+      },
+      "pairs": [
+        {
+          "a_median_ns": 6883666.5,
+          "b_median_ns": 6633833.0,
+          "delta_percent": -3.6293667045026075,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 6309812.5,
+          "b_median_ns": 6854979.5,
+          "delta_percent": 8.639987321334825,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 9188521.0,
+          "b_median_ns": 7512750.0,
+          "delta_percent": -18.237657616497803,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 6366104.0,
+          "b_median_ns": 6905750.0,
+          "delta_percent": 8.476864342775423,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "markdown_injections/typing_burst"
+    },
+    {
+      "a_median_ns": 8308344.0,
+      "b_median_ns": 8345854.25,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 11.656862577368189,
+        "median": -0.029104774815363887,
+        "min": -13.923974816002795
+      },
+      "pairs": [
+        {
+          "a_median_ns": 7872062.5,
+          "b_median_ns": 6775958.5,
+          "delta_percent": -13.923974816002795,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 8504875.0,
+          "b_median_ns": 8276687.5,
+          "delta_percent": -2.6830200326283453,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 8416896.0,
+          "b_median_ns": 9398042.0,
+          "delta_percent": 11.656862577368189,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 8199792.0,
+          "b_median_ns": 8415021.0,
+          "delta_percent": 2.6248104829976175,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "markdown_injections/typing_delta"
+    },
+    {
+      "a_median_ns": 700823.25,
+      "b_median_ns": 739791.75,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 13.459201290913578,
+        "median": -0.16813672243653732,
+        "min": -8.488516921934789
+      },
+      "pairs": [
+        {
+          "a_median_ns": 800125.5,
+          "b_median_ns": 810312.0,
+          "delta_percent": 1.2731127804325697,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 711979.5,
+          "b_median_ns": 700521.0,
+          "delta_percent": -1.6093862253056443,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 689667.0,
+          "b_median_ns": 631124.5,
+          "delta_percent": -8.488516921934789,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 686645.5,
+          "b_median_ns": 779062.5,
+          "delta_percent": 13.459201290913578,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "markdown_injections_large/full_cache_hit"
+    },
+    {
+      "a_median_ns": 2860395.5,
+      "b_median_ns": 2840250.5,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 4.617419554545629,
+        "median": -0.7042677691209378,
+        "min": -9.886506727039071
+      },
+      "pairs": [
+        {
+          "a_median_ns": 3203229.5,
+          "b_median_ns": 2886542.0,
+          "delta_percent": -9.886506727039071,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 2860145.5,
+          "b_median_ns": 2841792.0,
+          "delta_percent": -0.6416981233996661,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 2573125.5,
+          "b_median_ns": 2691937.5,
+          "delta_percent": 4.617419554545629,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 2860645.5,
+          "b_median_ns": 2838709.0,
+          "delta_percent": -0.7668374148422096,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_large/full_cache_hit"
+    },
+    {
+      "a_median_ns": 31708458.25,
+      "b_median_ns": 33845489.75,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 19.492280435649633,
+        "median": 7.132321198948568,
+        "min": -9.347843936303
+      },
+      "pairs": [
+        {
+          "a_median_ns": 33505063.0,
+          "b_median_ns": 30373062.0,
+          "delta_percent": -9.347843936303,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 30358708.0,
+          "b_median_ns": 36276312.5,
+          "delta_percent": 19.492280435649633,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 30276958.5,
+          "b_median_ns": 31414667.0,
+          "delta_percent": 3.7576710355500205,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 33058208.5,
+          "b_median_ns": 36531625.0,
+          "delta_percent": 10.506971362347116,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_large/typing_burst"
+    },
+    {
+      "a_median_ns": 29295562.25,
+      "b_median_ns": 29969073.0,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 5.548844925071355,
+        "median": 2.439040311216324,
+        "min": -0.631382125125431
+      },
+      "pairs": [
+        {
+          "a_median_ns": 29038937.5,
+          "b_median_ns": 30606083.5,
+          "delta_percent": 5.396705716247366,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 29106145.5,
+          "b_median_ns": 28922374.5,
+          "delta_percent": -0.631382125125431,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 29484979.0,
+          "b_median_ns": 29332062.5,
+          "delta_percent": -0.5186250938147183,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 31427333.5,
+          "b_median_ns": 33171187.5,
+          "delta_percent": 5.548844925071355,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_large/typing_delta"
+    },
+    {
+      "a_median_ns": 11132750.25,
+      "b_median_ns": 10645541.5,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 3.130601373262587,
+        "median": -4.247589596247276,
+        "min": -24.38758883427792
+      },
+      "pairs": [
+        {
+          "a_median_ns": 11454521.0,
+          "b_median_ns": 11105854.0,
+          "delta_percent": -3.0439247525060193,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 10733417.0,
+          "b_median_ns": 11069437.5,
+          "delta_percent": 3.130601373262587,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 10810979.5,
+          "b_median_ns": 10221645.5,
+          "delta_percent": -5.451254439988532,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 13288437.5,
+          "b_median_ns": 10047708.0,
+          "delta_percent": -24.38758883427792,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_sparse_32k_exact/typing_delta"
+    },
+    {
+      "a_median_ns": 10564260.75,
+      "b_median_ns": 10772906.25,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 9.611526345211132,
+        "median": 0.6902937217943772,
+        "min": -4.523636235154433
+      },
+      "pairs": [
+        {
+          "a_median_ns": 10543375.5,
+          "b_median_ns": 10889791.5,
+          "delta_percent": 3.2856270745550136,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 10585146.0,
+          "b_median_ns": 10106312.5,
+          "delta_percent": -4.523636235154433,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 11204937.5,
+          "b_median_ns": 10991479.0,
+          "delta_percent": -1.9050396309662592,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 9721624.5,
+          "b_median_ns": 10656021.0,
+          "delta_percent": 9.611526345211132,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_sparse_32k_minus/typing_delta"
+    },
+    {
+      "a_median_ns": 10620031.25,
+      "b_median_ns": 10850822.75,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 19.810564176093905,
+        "median": 3.8843154259107164,
+        "min": -3.8414944654274
+      },
+      "pairs": [
+        {
+          "a_median_ns": 11408333.5,
+          "b_median_ns": 10970083.0,
+          "delta_percent": -3.8414944654274,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 9710812.5,
+          "b_median_ns": 10661479.5,
+          "delta_percent": 9.78977814678226,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 10952937.5,
+          "b_median_ns": 10731562.5,
+          "delta_percent": -2.021147294960827,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 10287125.0,
+          "b_median_ns": 12325062.5,
+          "delta_percent": 19.810564176093905,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_sparse_32k_plus/typing_delta"
+    },
+    {
+      "a_median_ns": 20773437.5,
+      "b_median_ns": 20201750.0,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 10.22462298186937,
+        "median": 1.2362722279999656,
+        "min": -5.226119186010311
+      },
+      "pairs": [
+        {
+          "a_median_ns": 21844937.5,
+          "b_median_ns": 24078500.0,
+          "delta_percent": 10.22462298186937,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 20267146.0,
+          "b_median_ns": 20043937.5,
+          "delta_percent": -1.1013316823197503,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 21279729.0,
+          "b_median_ns": 20167625.0,
+          "delta_percent": -5.226119186010311,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 19537624.5,
+          "b_median_ns": 20235875.0,
+          "delta_percent": 3.5738761383196813,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_sparse_64k/typing_delta"
+    },
+    {
+      "a_median_ns": 158880166.75,
+      "b_median_ns": 160257562.25,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 4.582242435852863,
+        "median": 1.801940336160496,
+        "min": -5.205004195541281
+      },
+      "pairs": [
+        {
+          "a_median_ns": 162316958.5,
+          "b_median_ns": 153868354.0,
+          "delta_percent": -5.205004195541281,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 155572771.0,
+          "b_median_ns": 155535312.5,
+          "delta_percent": -0.02407779957843651,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 158556375.0,
+          "b_median_ns": 165821812.5,
+          "delta_percent": 4.582242435852863,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 159203958.5,
+          "b_median_ns": 164979812.0,
+          "delta_percent": 3.6279584718994284,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_xlarge/cancel_burst"
+    },
+    {
+      "a_median_ns": 670375.25,
+      "b_median_ns": 691354.25,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 27.138899759954842,
+        "median": -3.6701464139154494,
+        "min": -32.01410773966004
+      },
+      "pairs": [
+        {
+          "a_median_ns": 733771.0,
+          "b_median_ns": 680187.5,
+          "delta_percent": -7.30248265467019,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 1033333.5,
+          "b_median_ns": 702521.0,
+          "delta_percent": -32.01410773966004,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 554479.0,
+          "b_median_ns": 704958.5,
+          "delta_percent": 27.138899759954842,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 606979.5,
+          "b_median_ns": 606750.0,
+          "delta_percent": -0.03781017316070806,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "unicode_rust/full_cache_hit"
+    }
+  ],
+  "schema_version": 1
+}

--- a/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/fixture-manifest.json
+++ b/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/fixture-manifest.json
@@ -1,0 +1,194 @@
+[
+  {
+    "path": ".installed",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "cache/parsers.lua",
+    "sha256": "8a3014b92e4087c85288ee8c247764ac6ee0d1036eeee3c8127a63ab7a90207f",
+    "size": 73934,
+    "type": "file"
+  },
+  {
+    "path": "parser/lua.dylib",
+    "sha256": "9e8439b598f7618969b47a34a9c998d19faefe7b2e03bd508c4147c742bff2ad",
+    "size": 84600,
+    "type": "file"
+  },
+  {
+    "path": "parser/markdown.dylib",
+    "sha256": "faaa1af5b7043d878b73334a5357b954a39504c5761134fcde37de67c9331050",
+    "size": 418088,
+    "type": "file"
+  },
+  {
+    "path": "parser/markdown_inline.dylib",
+    "sha256": "933cafcdaa8174fc212d9fc4e105cf7af259925a51c54972afd6f0b493618a0d",
+    "size": 416816,
+    "type": "file"
+  },
+  {
+    "path": "parser/python.dylib",
+    "sha256": "4d59fef6477e92df0339db158f5eaffb5c89a37cc3009650dd98f6c0c7f6b1fb",
+    "size": 480920,
+    "type": "file"
+  },
+  {
+    "path": "parser/rust.dylib",
+    "sha256": "3682706b9573f1ad902fa84613a200c7eb0252f29f688d4a3dcb6b9106b416ad",
+    "size": 1142360,
+    "type": "file"
+  },
+  {
+    "path": "parser/yaml.dylib",
+    "sha256": "bfdd727d339d2a46afbcb97c482fa575ba23c4520190bbec1d75b4cf1b460d17",
+    "size": 217176,
+    "type": "file"
+  },
+  {
+    "path": "queries/.lua.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.markdown.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.markdown_inline.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.python.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.rust.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.yaml.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/highlights.scm",
+    "sha256": "ac7dfa89d16ba817c3681aa47c22bdb4441a78a89ed827a757efa755992de67f",
+    "size": 4336,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/injections.scm",
+    "sha256": "a2ee92c2f00f39ebeeb1d0cc06302dba58c4f1dda77a2f0c9e5d7d7beab0b1ff",
+    "size": 5168,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/highlights.scm",
+    "sha256": "7b71d4994cf3968e16d033ac59d28bb034427dd41be6a057b7a2985e2dfbe5b8",
+    "size": 2654,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/injections.scm",
+    "sha256": "34090de78df99b5ea84c2fbb9324f2b7c32e602043595286e83f1a1ac126073c",
+    "size": 659,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/highlights.scm",
+    "sha256": "7db9147da61de7491ede9155e554dc033d6a1b86ecd1b21f6849c018be9ac875",
+    "size": 2259,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/injections.scm",
+    "sha256": "051f44218e0fe25cd949dfccad80699d5456ee379c7c4cfa18a5165776ecab0e",
+    "size": 207,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/highlights.scm",
+    "sha256": "ab8b66cbe6a7382e0ed7693c194101f1900c39f9ec0085a1749a8817e3e6895c",
+    "size": 9263,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/injections.scm",
+    "sha256": "8558299709200b21d496890e4799153dc069bf302ce1545d23f70a0869c8b65d",
+    "size": 812,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/highlights.scm",
+    "sha256": "4e0f5994f30ee545fc63435054a0b029c7d0222632c5c787c4e9c249dc0ef20f",
+    "size": 8638,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/injections.scm",
+    "sha256": "7dde97bbdabd208f984e13627bd4daae0f73012c41faafab39d670b607710f4e",
+    "size": 2418,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/highlights.scm",
+    "sha256": "13352b80d2ce28c3328ccb2f321e5144c3365ff6055078e00e7cff118d1488b5",
+    "size": 1700,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/injections.scm",
+    "sha256": "8349bd07691e2e610decdfc7b898bb5b01b226aae8745217bc811427f7af6742",
+    "size": 2373,
+    "type": "file"
+  }
+]

--- a/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/manifest.json
+++ b/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/manifest.json
@@ -149,6 +149,7 @@
     "b_commit": "5e2375c08b58dafae961a24b92f112bcb4f84a03",
     "b_ref": "benchmark/semantic-lazy-content-lines-2026-07-23",
     "harness_commit": "553b901bbf421e3851886c2a3e94b16adca6c34a",
+    "harness_ref": "benchmark/semantic-lazy-content-lines-harness-2026-07-23",
     "harness_sources_sha256": {
       "benches/collect_semantic_pairs.py": "7ce0d8628d2f28ac331d15ccf470e7b1b4fb596d5a475588cfa25689746de798",
       "benches/semantic_summary.py": "8aab3d2622ec7bfface33f29fee8fd695297b31eb2007fc5b2b20d8be2e3d1d0",

--- a/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/manifest.json
+++ b/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/manifest.json
@@ -1,0 +1,161 @@
+{
+  "attestations": {
+    "binary_a": "a077411e3d268c36fcb9fe4d153d682fb732b2cbf0226739371b642225a30a88",
+    "binary_b": "ef36d2c20e18dd44fe137853a7fe4d917c0ed6d902bfb615feba907836e40f3a",
+    "fixture": "91935a29cb6f44c30e4b357b917a3fbfc09596119c8b9cbe4b91924fc193c4f0",
+    "harness": "0b3273ee7c9163463805955583609b14d9312474fb5a370f3d995c43755241e4"
+  },
+  "configuration": {
+    "iterations": 30,
+    "pairs": 8,
+    "run_timeout_seconds": 900,
+    "scenario_filters": [
+      "rust_large/typing_delta",
+      "rust_large/typing_burst",
+      "rust_sparse_32k_minus/typing_delta",
+      "rust_sparse_32k_exact/typing_delta",
+      "rust_sparse_32k_plus/typing_delta",
+      "rust_sparse_64k/typing_delta",
+      "markdown_injections/typing_delta",
+      "markdown_injections/typing_burst"
+    ],
+    "scenarios": [
+      "markdown_injections/typing_burst",
+      "markdown_injections/typing_delta",
+      "rust_large/typing_burst",
+      "rust_large/typing_delta",
+      "rust_sparse_32k_exact/typing_delta",
+      "rust_sparse_32k_minus/typing_delta",
+      "rust_sparse_32k_plus/typing_delta",
+      "rust_sparse_64k/typing_delta"
+    ],
+    "server_env": {},
+    "warmup_iterations": 12
+  },
+  "environment": {
+    "build": {
+      "CARGO_HOME": "<TEMP>/cargo-home",
+      "CARGO_TERM_COLOR": "never",
+      "HOME": "<TEMP>/home",
+      "LANG": "C",
+      "LC_ALL": "C",
+      "PATH": "<USER_HOME_PATH>:<USER_HOME_PATH>:<USER_HOME_PATH>:/opt/homebrew/bin:/opt/homebrew/sbin:/nix/var/nix/profiles/default/bin:<USER_HOME_PATH>:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:<USER_HOME_PATH>",
+      "RUSTUP_HOME": "<USER_HOME>/.rustup",
+      "TMPDIR": "<TEMP>/tmp"
+    },
+    "cc": "Apple clang version 21.0.0 (clang-2100.1.1.101)\nTarget: arm64-apple-darwin25.5.0\nThread model: posix\nInstalledDir: /Library/Developer/CommandLineTools/usr/bin",
+    "clang": "Apple clang version 21.0.0 (clang-2100.1.1.101)\nTarget: arm64-apple-darwin25.5.0\nThread model: posix\nInstalledDir: /Library/Developer/CommandLineTools/usr/bin",
+    "machine": "arm64",
+    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "processor": "arm",
+    "runtime": {
+      "CARGO_HOME": "<TEMP>/cargo-home",
+      "CARGO_TERM_COLOR": "never",
+      "HOME": "<TEMP>/home",
+      "LANG": "C",
+      "LC_ALL": "C",
+      "PATH": "<USER_HOME_PATH>:<USER_HOME_PATH>:<USER_HOME_PATH>:/opt/homebrew/bin:/opt/homebrew/sbin:/nix/var/nix/profiles/default/bin:<USER_HOME_PATH>:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:<USER_HOME_PATH>",
+      "RUSTUP_HOME": "<USER_HOME>/.rustup",
+      "TMPDIR": "<TEMP>/tmp"
+    },
+    "sdk": "26.5",
+    "toolchains": {
+      "a": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      },
+      "b": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      },
+      "harness": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      }
+    }
+  },
+  "fixture_manifest": "fixture-manifest.json",
+  "fixture_manifest_sha256": "5ea809517e58a6c51059e2d5f9168680839d68e767d98b80f6a0c2511a0c05a5",
+  "raw_files": [
+    {
+      "order": "AB",
+      "pair_index": 1,
+      "samples": "pair-1.json",
+      "samples_sha256": "3275824daedc23a57856911c569e99da99e547d195ea81899f77a8827a7c4f12",
+      "stdout": "pair-1.txt",
+      "stdout_sha256": "d37ad9f48993d814174cbaafdc0726b777334be9aa34792e785b96f1b807718b"
+    },
+    {
+      "order": "BA",
+      "pair_index": 2,
+      "samples": "pair-2.json",
+      "samples_sha256": "22c647e3061a26e2ef2e71c4a3d32d1ab214716584e23e2fd48e72e7575939b4",
+      "stdout": "pair-2.txt",
+      "stdout_sha256": "771d8e9ee5e0995a50334641a1edc4a09d5a378b0f6404c210970400cc5ce629"
+    },
+    {
+      "order": "AB",
+      "pair_index": 3,
+      "samples": "pair-3.json",
+      "samples_sha256": "8a2fef784bf0903316925aa2beab432c368e76b558f3b2868e561dda651327bc",
+      "stdout": "pair-3.txt",
+      "stdout_sha256": "1e8eb69101ac789ef6fa246c93c511d0385d39e5a188e36b9c2d9d079f1abdd3"
+    },
+    {
+      "order": "BA",
+      "pair_index": 4,
+      "samples": "pair-4.json",
+      "samples_sha256": "d004b42fcd89d34c7bf10c650b2182039b3db307ac017bc95b96aa7109746797",
+      "stdout": "pair-4.txt",
+      "stdout_sha256": "d88454e64b340e6e50496aca5e8f55983ceabd2265c7e69cf01f793d46321c53"
+    },
+    {
+      "order": "AB",
+      "pair_index": 5,
+      "samples": "pair-5.json",
+      "samples_sha256": "53b281571b69c631eac1e680e3f151e6f8c15069460a2fccd32fe2be87db92eb",
+      "stdout": "pair-5.txt",
+      "stdout_sha256": "68ad5bcfa76c74b9f94e76c5d30fa1bbaaabf6fedeed8fbf022787b27e2867c2"
+    },
+    {
+      "order": "BA",
+      "pair_index": 6,
+      "samples": "pair-6.json",
+      "samples_sha256": "980d97b4ab3b560c6442bc8efbe493a3e0d00df4737cea55811c91a8c60b6253",
+      "stdout": "pair-6.txt",
+      "stdout_sha256": "6be81aa707c8a135afcb4c0b398c0d1ca015ec06ee8a6cdd2322dfa579b03f47"
+    },
+    {
+      "order": "AB",
+      "pair_index": 7,
+      "samples": "pair-7.json",
+      "samples_sha256": "4893cad781f46c320f23baa178c711e73831d5052f7876c362df65a75746e33e",
+      "stdout": "pair-7.txt",
+      "stdout_sha256": "eac490c5cc77455a7691789a4f9882b75e1faaf3d8855573322894cb0940064e"
+    },
+    {
+      "order": "BA",
+      "pair_index": 8,
+      "samples": "pair-8.json",
+      "samples_sha256": "5bfb98d71679bf8400ae244a308bc8332c40178d51b5d3630d0d17aa5f3af937",
+      "stdout": "pair-8.txt",
+      "stdout_sha256": "494f8d415c59ac457cddc0a62c54e3934eab3307f0689f7dd5c227868a54ef73"
+    }
+  ],
+  "schema_version": 1,
+  "source": {
+    "a_commit": "a1278be5fdff24d109d9e03134c6bdb880577f64",
+    "a_ref": "origin/main",
+    "b_commit": "5e2375c08b58dafae961a24b92f112bcb4f84a03",
+    "b_ref": "benchmark/semantic-lazy-content-lines-2026-07-23",
+    "harness_commit": "553b901bbf421e3851886c2a3e94b16adca6c34a",
+    "harness_sources_sha256": {
+      "benches/collect_semantic_pairs.py": "7ce0d8628d2f28ac331d15ccf470e7b1b4fb596d5a475588cfa25689746de798",
+      "benches/semantic_summary.py": "8aab3d2622ec7bfface33f29fee8fd695297b31eb2007fc5b2b20d8be2e3d1d0",
+      "benches/semantic_tokens.rs": "2d35487ff38a5b7b72540f55c5fb43ae6ca5190b9b579264ae0323e6fd927139",
+      "benches/support/semantic_baseline.rs": "4ab35bab7a05b32d652262c61c4cd4c720a21bfe3d1730694ea9dda5b306410c"
+    }
+  },
+  "summary": "summary.json",
+  "summary_sha256": "f09101bda7a5ecc479290a502102f4d7a4645fd85ccc280f4aae75ba9a263b42"
+}

--- a/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/pair-1.txt
+++ b/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/pair-1.txt
@@ -1,0 +1,31 @@
+
+semantic-tokens benchmark  (iters=30, warmup=12, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/typing_delta                32.480ms     32.409ms         -0.2%
+    p95:     35.932ms     37.109ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     11.193ms     11.334ms        +1.3%
+    p95:     13.595ms     13.500ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta     11.460ms     10.907ms         -4.8%
+    p95:     12.831ms     14.056ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta      11.073ms     12.151ms        +9.7%
+    p95:     13.827ms     14.143ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           21.801ms     21.502ms         -1.4%
+    p95:     25.723ms     24.816ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                36.023ms     36.564ms        +1.5%
+    p95:     42.304ms     41.331ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+markdown_injections/typing_delta        6.722ms      6.659ms         -0.9%
+    p95:      6.916ms      6.865ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        7.000ms      6.975ms         -0.4%
+    p95:      7.780ms      8.225ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/pair-2.txt
+++ b/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/pair-2.txt
@@ -1,0 +1,31 @@
+
+semantic-tokens benchmark  (iters=30, warmup=12, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/typing_delta                33.307ms     31.138ms         -6.5%
+    p95:     36.023ms     34.563ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     10.837ms     12.138ms        +12.0%
+    p95:     14.720ms     14.022ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta     11.937ms     12.367ms        +3.6%
+    p95:     16.118ms     15.046ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta      11.003ms     10.731ms         -2.5%
+    p95:     12.906ms     13.266ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           20.743ms     21.081ms        +1.6%
+    p95:     24.474ms     25.069ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                33.334ms     34.064ms        +2.2%
+    p95:     39.605ms     37.602ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+markdown_injections/typing_delta        6.714ms      6.698ms         -0.2%
+    p95:      6.929ms      6.915ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        6.763ms      6.848ms        +1.2%
+    p95:      7.370ms      7.249ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/pair-3.txt
+++ b/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/pair-3.txt
@@ -1,0 +1,31 @@
+
+semantic-tokens benchmark  (iters=30, warmup=12, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/typing_delta                33.050ms     34.054ms        +3.0%
+    p95:     37.715ms     39.940ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     10.975ms      9.657ms         -12.0%
+    p95:     12.776ms     12.480ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta     10.361ms     12.262ms        +18.3%
+    p95:     14.720ms     13.970ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta      10.496ms     11.091ms        +5.7%
+    p95:     12.645ms     13.506ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           22.217ms     21.465ms         -3.4%
+    p95:     28.194ms     24.398ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                31.784ms     30.122ms         -5.2%
+    p95:     35.967ms     33.013ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+markdown_injections/typing_delta        6.863ms      7.712ms        +12.4%
+    p95:      8.277ms     10.010ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        8.260ms      7.346ms         -11.1%
+    p95:      8.682ms      7.941ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/pair-4.txt
+++ b/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/pair-4.txt
@@ -1,0 +1,31 @@
+
+semantic-tokens benchmark  (iters=30, warmup=12, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/typing_delta                32.157ms     30.807ms         -4.2%
+    p95:     36.061ms     35.593ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     11.931ms     11.397ms         -4.5%
+    p95:     15.526ms     13.661ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta     10.884ms     10.014ms         -8.0%
+    p95:     13.100ms     12.341ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta       9.974ms      9.830ms         -1.4%
+    p95:     12.723ms     12.592ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           20.925ms     22.093ms        +5.6%
+    p95:     24.095ms     25.685ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                31.201ms     30.176ms         -3.3%
+    p95:     37.347ms     33.208ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+markdown_injections/typing_delta        6.869ms      6.473ms         -5.8%
+    p95:      7.063ms      6.875ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        7.729ms      6.786ms         -12.2%
+    p95:     10.533ms      7.044ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/pair-5.txt
+++ b/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/pair-5.txt
@@ -1,0 +1,31 @@
+
+semantic-tokens benchmark  (iters=30, warmup=12, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/typing_delta                29.240ms     29.013ms         -0.8%
+    p95:     33.043ms     32.530ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     10.008ms     10.950ms        +9.4%
+    p95:     12.790ms     13.502ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta     11.068ms     11.010ms         -0.5%
+    p95:     13.085ms     14.059ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta      10.987ms      9.650ms         -12.2%
+    p95:     13.853ms     12.149ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           20.060ms     21.815ms        +8.8%
+    p95:     24.454ms     26.059ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                33.686ms     31.506ms         -6.5%
+    p95:     37.500ms     37.186ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+markdown_injections/typing_delta        7.689ms      8.395ms        +9.2%
+    p95:      8.081ms      9.703ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        6.786ms      6.568ms         -3.2%
+    p95:      7.138ms      9.256ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/pair-6.txt
+++ b/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/pair-6.txt
@@ -1,0 +1,31 @@
+
+semantic-tokens benchmark  (iters=30, warmup=12, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/typing_delta                28.741ms     30.688ms        +6.8%
+    p95:     35.916ms     32.754ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta      9.479ms     10.966ms        +15.7%
+    p95:     12.555ms     13.068ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta     11.218ms     11.481ms        +2.3%
+    p95:     13.552ms     13.579ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta       9.700ms      9.659ms         -0.4%
+    p95:     12.505ms     11.746ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           18.777ms     24.341ms        +29.6%
+    p95:     22.778ms     27.416ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                30.959ms     30.320ms         -2.1%
+    p95:     34.452ms     34.940ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+markdown_injections/typing_delta        6.825ms      6.844ms        +0.3%
+    p95:      7.452ms      9.697ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        6.819ms      7.731ms        +13.4%
+    p95:      7.719ms      8.205ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/pair-7.txt
+++ b/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/pair-7.txt
@@ -1,0 +1,31 @@
+
+semantic-tokens benchmark  (iters=30, warmup=12, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/typing_delta                29.467ms     30.664ms        +4.1%
+    p95:     35.942ms     33.532ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     10.731ms      9.735ms         -9.3%
+    p95:     13.312ms     12.529ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta      9.743ms     10.492ms        +7.7%
+    p95:     11.533ms     12.831ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta      10.457ms     10.114ms         -3.3%
+    p95:     11.466ms     12.896ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           22.002ms     21.703ms         -1.4%
+    p95:     24.931ms     24.306ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                29.363ms     30.132ms        +2.6%
+    p95:     33.380ms     37.586ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+markdown_injections/typing_delta        7.276ms      7.641ms        +5.0%
+    p95:      9.180ms      8.118ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        7.722ms      6.665ms         -13.7%
+    p95:      8.086ms      6.968ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/pair-8.txt
+++ b/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/pair-8.txt
@@ -1,0 +1,31 @@
+
+semantic-tokens benchmark  (iters=30, warmup=12, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/typing_delta                29.256ms     29.930ms        +2.3%
+    p95:     36.383ms     33.350ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     12.161ms     11.124ms         -8.5%
+    p95:     13.805ms     13.446ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta      9.939ms     11.460ms        +15.3%
+    p95:     12.524ms     12.639ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta      10.859ms     11.103ms        +2.3%
+    p95:     13.336ms     15.085ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           24.101ms     20.174ms         -16.3%
+    p95:     25.815ms     24.640ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                29.507ms     30.883ms        +4.7%
+    p95:     33.067ms     36.824ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+markdown_injections/typing_delta        7.831ms      6.654ms         -15.0%
+    p95:      8.798ms      6.815ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        6.791ms      6.376ms         -6.1%
+    p95:      6.948ms      6.905ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/summary.json
+++ b/benches/results/semantic-lazy-content-lines-confirmation-2026-07-23/summary.json
@@ -1,0 +1,557 @@
+{
+  "scenarios": [
+    {
+      "a_median_ns": 6924031.25,
+      "b_median_ns": 6805020.75,
+      "pair_count": 8,
+      "paired_delta_percent": {
+        "max": 13.902647747942778,
+        "median": -2.2215165730863857,
+        "min": -13.689614644477258
+      },
+      "pairs": [
+        {
+          "a_median_ns": 7000312.5,
+          "b_median_ns": 6975458.5,
+          "delta_percent": -0.3550412927994286,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 6847750.0,
+          "b_median_ns": 6763333.0,
+          "delta_percent": -1.2327698879193896,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 8260437.5,
+          "b_median_ns": 7345874.5,
+          "delta_percent": -11.07160486354385,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 6785729.0,
+          "b_median_ns": 7729125.0,
+          "delta_percent": 13.902647747942778,
+          "order": "BA",
+          "pair_index": 4
+        },
+        {
+          "a_median_ns": 6786188.0,
+          "b_median_ns": 6568333.5,
+          "delta_percent": -3.2102632582533817,
+          "order": "AB",
+          "pair_index": 5
+        },
+        {
+          "a_median_ns": 7730542.0,
+          "b_median_ns": 6819041.5,
+          "delta_percent": -11.79090030168648,
+          "order": "BA",
+          "pair_index": 6
+        },
+        {
+          "a_median_ns": 7721791.5,
+          "b_median_ns": 6664708.0,
+          "delta_percent": -13.689614644477258,
+          "order": "AB",
+          "pair_index": 7
+        },
+        {
+          "a_median_ns": 6375687.5,
+          "b_median_ns": 6791000.0,
+          "delta_percent": 6.514003391791082,
+          "order": "BA",
+          "pair_index": 8
+        }
+      ],
+      "scenario": "markdown_injections/typing_burst"
+    },
+    {
+      "a_median_ns": 6782760.5,
+      "b_median_ns": 7255489.75,
+      "pair_count": 8,
+      "paired_delta_percent": {
+        "max": 17.692107284772295,
+        "median": 5.566858780854659,
+        "min": -0.9301285233611826
+      },
+      "pairs": [
+        {
+          "a_median_ns": 6721813.0,
+          "b_median_ns": 6659291.5,
+          "delta_percent": -0.9301285233611826,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 6697666.5,
+          "b_median_ns": 6713708.0,
+          "delta_percent": 0.23950879011369108,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 6862563.0,
+          "b_median_ns": 7712270.5,
+          "delta_percent": 12.381780684563479,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 6473479.5,
+          "b_median_ns": 6869479.5,
+          "delta_percent": 6.117266610638065,
+          "order": "BA",
+          "pair_index": 4
+        },
+        {
+          "a_median_ns": 7688812.0,
+          "b_median_ns": 8394645.5,
+          "delta_percent": 9.180007262500371,
+          "order": "AB",
+          "pair_index": 5
+        },
+        {
+          "a_median_ns": 6843708.0,
+          "b_median_ns": 6825125.0,
+          "delta_percent": -0.2715340864922934,
+          "order": "BA",
+          "pair_index": 6
+        },
+        {
+          "a_median_ns": 7276479.0,
+          "b_median_ns": 7641500.0,
+          "delta_percent": 5.016450951071253,
+          "order": "AB",
+          "pair_index": 7
+        },
+        {
+          "a_median_ns": 6653749.5,
+          "b_median_ns": 7830938.0,
+          "delta_percent": 17.692107284772295,
+          "order": "BA",
+          "pair_index": 8
+        }
+      ],
+      "scenario": "markdown_injections/typing_delta"
+    },
+    {
+      "a_median_ns": 31333187.75,
+      "b_median_ns": 31080260.5,
+      "pair_count": 8,
+      "paired_delta_percent": {
+        "max": 3.396366998070451,
+        "median": -0.3203528186353204,
+        "min": -6.471098444999823
+      },
+      "pairs": [
+        {
+          "a_median_ns": 36023271.0,
+          "b_median_ns": 36564354.0,
+          "delta_percent": 1.5020373913296212,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 34063604.0,
+          "b_median_ns": 33333708.5,
+          "delta_percent": -2.142743028600262,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 31783729.5,
+          "b_median_ns": 30121958.5,
+          "delta_percent": -5.228370069031704,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 30176229.5,
+          "b_median_ns": 31201125.0,
+          "delta_percent": 3.396366998070451,
+          "order": "BA",
+          "pair_index": 4
+        },
+        {
+          "a_median_ns": 33685687.5,
+          "b_median_ns": 31505853.5,
+          "delta_percent": -6.471098444999823,
+          "order": "AB",
+          "pair_index": 5
+        },
+        {
+          "a_median_ns": 30319520.5,
+          "b_median_ns": 30959396.0,
+          "delta_percent": 2.1104406977676313,
+          "order": "BA",
+          "pair_index": 6
+        },
+        {
+          "a_median_ns": 29362895.5,
+          "b_median_ns": 30132271.5,
+          "delta_percent": 2.6202320544307356,
+          "order": "AB",
+          "pair_index": 7
+        },
+        {
+          "a_median_ns": 30882646.0,
+          "b_median_ns": 29507250.0,
+          "delta_percent": -4.453620975352954,
+          "order": "BA",
+          "pair_index": 8
+        }
+      ],
+      "scenario": "rust_large/typing_burst"
+    },
+    {
+      "a_median_ns": 30747094.0,
+      "b_median_ns": 31410281.5,
+      "pair_count": 8,
+      "paired_delta_percent": {
+        "max": 6.966236654536403,
+        "median": 1.4079185131163334,
+        "min": -6.342631912170423
+      },
+      "pairs": [
+        {
+          "a_median_ns": 32480083.5,
+          "b_median_ns": 32408708.5,
+          "delta_percent": -0.2197500508273016,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 31137687.5,
+          "b_median_ns": 33306812.5,
+          "delta_percent": 6.966236654536403,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 33050312.0,
+          "b_median_ns": 34053583.0,
+          "delta_percent": 3.0355870770599687,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 30806667.0,
+          "b_median_ns": 32156562.5,
+          "delta_percent": 4.381829102122603,
+          "order": "BA",
+          "pair_index": 4
+        },
+        {
+          "a_median_ns": 29240395.5,
+          "b_median_ns": 29012771.0,
+          "delta_percent": -0.7784590328130138,
+          "order": "AB",
+          "pair_index": 5
+        },
+        {
+          "a_median_ns": 30687521.0,
+          "b_median_ns": 28741124.5,
+          "delta_percent": -6.342631912170423,
+          "order": "BA",
+          "pair_index": 6
+        },
+        {
+          "a_median_ns": 29467291.5,
+          "b_median_ns": 30664000.5,
+          "delta_percent": 4.0611435224713475,
+          "order": "AB",
+          "pair_index": 7
+        },
+        {
+          "a_median_ns": 29930333.0,
+          "b_median_ns": 29256270.5,
+          "delta_percent": -2.252104913099363,
+          "order": "BA",
+          "pair_index": 8
+        }
+      ],
+      "scenario": "rust_large/typing_delta"
+    },
+    {
+      "a_median_ns": 11263968.75,
+      "b_median_ns": 10958448.0,
+      "pair_count": 8,
+      "paired_delta_percent": {
+        "max": 18.346161392748055,
+        "median": -1.4065008978864,
+        "min": -13.278322898715125
+      },
+      "pairs": [
+        {
+          "a_median_ns": 11460125.0,
+          "b_median_ns": 10906896.0,
+          "delta_percent": -4.827425529826245,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 12366750.0,
+          "b_median_ns": 11937229.5,
+          "delta_percent": -3.473188186063436,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 10361271.0,
+          "b_median_ns": 12262166.5,
+          "delta_percent": 18.346161392748055,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 10014416.5,
+          "b_median_ns": 10884499.5,
+          "delta_percent": 8.6883045058092,
+          "order": "BA",
+          "pair_index": 4
+        },
+        {
+          "a_median_ns": 11067812.5,
+          "b_median_ns": 11010000.0,
+          "delta_percent": -0.5223480249597651,
+          "order": "AB",
+          "pair_index": 5
+        },
+        {
+          "a_median_ns": 11481416.5,
+          "b_median_ns": 11218417.0,
+          "delta_percent": -2.290653770813035,
+          "order": "BA",
+          "pair_index": 6
+        },
+        {
+          "a_median_ns": 9743229.5,
+          "b_median_ns": 10491812.5,
+          "delta_percent": 7.683109589074136,
+          "order": "AB",
+          "pair_index": 7
+        },
+        {
+          "a_median_ns": 11460250.0,
+          "b_median_ns": 9938521.0,
+          "delta_percent": -13.278322898715125,
+          "order": "BA",
+          "pair_index": 8
+        }
+      ],
+      "scenario": "rust_sparse_32k_exact/typing_delta"
+    },
+    {
+      "a_median_ns": 11049281.25,
+      "b_median_ns": 10893260.5,
+      "pair_count": 8,
+      "paired_delta_percent": {
+        "max": 9.415886537224509,
+        "median": -4.009646102462734,
+        "min": -13.56279407307001
+      },
+      "pairs": [
+        {
+          "a_median_ns": 11192875.0,
+          "b_median_ns": 11334458.0,
+          "delta_percent": 1.264938632835621,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 12137958.0,
+          "b_median_ns": 10836521.0,
+          "delta_percent": -10.722042373189955,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 10974916.5,
+          "b_median_ns": 9657500.0,
+          "delta_percent": -12.003886316583822,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 11396937.5,
+          "b_median_ns": 11931458.5,
+          "delta_percent": 4.690040635916446,
+          "order": "BA",
+          "pair_index": 4
+        },
+        {
+          "a_median_ns": 10007687.5,
+          "b_median_ns": 10950000.0,
+          "delta_percent": 9.415886537224509,
+          "order": "AB",
+          "pair_index": 5
+        },
+        {
+          "a_median_ns": 10965812.0,
+          "b_median_ns": 9478541.5,
+          "delta_percent": -13.56279407307001,
+          "order": "BA",
+          "pair_index": 6
+        },
+        {
+          "a_median_ns": 10730792.0,
+          "b_median_ns": 9734520.5,
+          "delta_percent": -9.28423083776109,
+          "order": "AB",
+          "pair_index": 7
+        },
+        {
+          "a_median_ns": 11123646.0,
+          "b_median_ns": 12161291.5,
+          "delta_percent": 9.32828588755881,
+          "order": "BA",
+          "pair_index": 8
+        }
+      ],
+      "scenario": "rust_sparse_32k_minus/typing_delta"
+    },
+    {
+      "a_median_ns": 10613739.75,
+      "b_median_ns": 10486156.25,
+      "pair_count": 8,
+      "paired_delta_percent": {
+        "max": 9.738842980580456,
+        "median": 0.9461791147379033,
+        "min": -12.163418703096697
+      },
+      "pairs": [
+        {
+          "a_median_ns": 11072917.0,
+          "b_median_ns": 12151291.0,
+          "delta_percent": 9.738842980580456,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 10731333.5,
+          "b_median_ns": 11002958.0,
+          "delta_percent": 2.531134644170736,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 10496146.0,
+          "b_median_ns": 11090604.0,
+          "delta_percent": 5.663583566768221,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 9830479.0,
+          "b_median_ns": 9974312.5,
+          "delta_percent": 1.4631382662024912,
+          "order": "BA",
+          "pair_index": 4
+        },
+        {
+          "a_median_ns": 10986833.0,
+          "b_median_ns": 9650458.5,
+          "delta_percent": -12.163418703096697,
+          "order": "AB",
+          "pair_index": 5
+        },
+        {
+          "a_median_ns": 9658917.0,
+          "b_median_ns": 9700375.0,
+          "delta_percent": 0.42921996327331524,
+          "order": "BA",
+          "pair_index": 6
+        },
+        {
+          "a_median_ns": 10456896.0,
+          "b_median_ns": 10113604.0,
+          "delta_percent": -3.28292449308093,
+          "order": "AB",
+          "pair_index": 7
+        },
+        {
+          "a_median_ns": 11103291.5,
+          "b_median_ns": 10858708.5,
+          "delta_percent": -2.2027972516077776,
+          "order": "BA",
+          "pair_index": 8
+        }
+      ],
+      "scenario": "rust_sparse_32k_plus/typing_delta"
+    },
+    {
+      "a_median_ns": 21901635.75,
+      "b_median_ns": 21483604.0,
+      "pair_count": 8,
+      "paired_delta_percent": {
+        "max": 19.464683151016235,
+        "median": -1.4861680161496285,
+        "min": -22.858836449096685
+      },
+      "pairs": [
+        {
+          "a_median_ns": 21800979.5,
+          "b_median_ns": 21502479.0,
+          "delta_percent": -1.3692068285280485,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 21081145.5,
+          "b_median_ns": 20743187.5,
+          "delta_percent": -1.6031292037712086,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 22217187.5,
+          "b_median_ns": 21464729.0,
+          "delta_percent": -3.38683057880301,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 22092708.0,
+          "b_median_ns": 20925083.5,
+          "delta_percent": -5.285112626301855,
+          "order": "BA",
+          "pair_index": 4
+        },
+        {
+          "a_median_ns": 20059771.0,
+          "b_median_ns": 21815333.5,
+          "delta_percent": 8.751657733281203,
+          "order": "AB",
+          "pair_index": 5
+        },
+        {
+          "a_median_ns": 24341333.0,
+          "b_median_ns": 18777187.5,
+          "delta_percent": -22.858836449096685,
+          "order": "BA",
+          "pair_index": 6
+        },
+        {
+          "a_median_ns": 22002292.0,
+          "b_median_ns": 21702875.0,
+          "delta_percent": -1.3608445883728841,
+          "order": "AB",
+          "pair_index": 7
+        },
+        {
+          "a_median_ns": 20174145.5,
+          "b_median_ns": 24100979.0,
+          "delta_percent": 19.464683151016235,
+          "order": "BA",
+          "pair_index": 8
+        }
+      ],
+      "scenario": "rust_sparse_64k/typing_delta"
+    }
+  ],
+  "schema_version": 1
+}

--- a/benches/results/semantic-pattern-priority-table-2026-07-23/fixture-manifest.json
+++ b/benches/results/semantic-pattern-priority-table-2026-07-23/fixture-manifest.json
@@ -1,0 +1,194 @@
+[
+  {
+    "path": ".installed",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "cache/parsers.lua",
+    "sha256": "8a3014b92e4087c85288ee8c247764ac6ee0d1036eeee3c8127a63ab7a90207f",
+    "size": 73934,
+    "type": "file"
+  },
+  {
+    "path": "parser/lua.dylib",
+    "sha256": "1e633c2ca77d9825abf3a82e2665962aaf24050046efccd48cc435aaf674dce4",
+    "size": 84600,
+    "type": "file"
+  },
+  {
+    "path": "parser/markdown.dylib",
+    "sha256": "6624fbdbb257b73660ffa16de6da621236c444312249e7ebc3e0e04447518a75",
+    "size": 418088,
+    "type": "file"
+  },
+  {
+    "path": "parser/markdown_inline.dylib",
+    "sha256": "fa27783f356118788679b089d54a7ce92b8bdc8d2f31b4741d81f52d513c3a61",
+    "size": 416816,
+    "type": "file"
+  },
+  {
+    "path": "parser/python.dylib",
+    "sha256": "43a74dd77e8ac0c2b215cf9b7a451fd6d9cf21aad429d04cfc3f9bb7e3dfd08c",
+    "size": 480920,
+    "type": "file"
+  },
+  {
+    "path": "parser/rust.dylib",
+    "sha256": "b9ee219c99c43d38ef4daadac6415b452d0ac783196e06a831378b1ceb16581e",
+    "size": 1142360,
+    "type": "file"
+  },
+  {
+    "path": "parser/yaml.dylib",
+    "sha256": "92971c854535dd5852adb5dfef8deba67de96eff45c112e8bf5ffc8154fb9b76",
+    "size": 217176,
+    "type": "file"
+  },
+  {
+    "path": "queries/.lua.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.markdown.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.markdown_inline.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.python.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.rust.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.yaml.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/highlights.scm",
+    "sha256": "ac7dfa89d16ba817c3681aa47c22bdb4441a78a89ed827a757efa755992de67f",
+    "size": 4336,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/injections.scm",
+    "sha256": "a2ee92c2f00f39ebeeb1d0cc06302dba58c4f1dda77a2f0c9e5d7d7beab0b1ff",
+    "size": 5168,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/highlights.scm",
+    "sha256": "7b71d4994cf3968e16d033ac59d28bb034427dd41be6a057b7a2985e2dfbe5b8",
+    "size": 2654,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/injections.scm",
+    "sha256": "34090de78df99b5ea84c2fbb9324f2b7c32e602043595286e83f1a1ac126073c",
+    "size": 659,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/highlights.scm",
+    "sha256": "7db9147da61de7491ede9155e554dc033d6a1b86ecd1b21f6849c018be9ac875",
+    "size": 2259,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/injections.scm",
+    "sha256": "051f44218e0fe25cd949dfccad80699d5456ee379c7c4cfa18a5165776ecab0e",
+    "size": 207,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/highlights.scm",
+    "sha256": "ab8b66cbe6a7382e0ed7693c194101f1900c39f9ec0085a1749a8817e3e6895c",
+    "size": 9263,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/injections.scm",
+    "sha256": "8558299709200b21d496890e4799153dc069bf302ce1545d23f70a0869c8b65d",
+    "size": 812,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/highlights.scm",
+    "sha256": "4e0f5994f30ee545fc63435054a0b029c7d0222632c5c787c4e9c249dc0ef20f",
+    "size": 8638,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/injections.scm",
+    "sha256": "7dde97bbdabd208f984e13627bd4daae0f73012c41faafab39d670b607710f4e",
+    "size": 2418,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/highlights.scm",
+    "sha256": "13352b80d2ce28c3328ccb2f321e5144c3365ff6055078e00e7cff118d1488b5",
+    "size": 1700,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/injections.scm",
+    "sha256": "8349bd07691e2e610decdfc7b898bb5b01b226aae8745217bc811427f7af6742",
+    "size": 2373,
+    "type": "file"
+  }
+]

--- a/benches/results/semantic-pattern-priority-table-2026-07-23/manifest.json
+++ b/benches/results/semantic-pattern-priority-table-2026-07-23/manifest.json
@@ -125,6 +125,7 @@
     "b_commit": "5681ae5fff701b9f5570fe4a169aca76ebd8b47a",
     "b_ref": "benchmark/semantic-pattern-priority-table-2026-07-23",
     "harness_commit": "553b901bbf421e3851886c2a3e94b16adca6c34a",
+    "harness_ref": "benchmark/semantic-lazy-content-lines-harness-2026-07-23",
     "harness_sources_sha256": {
       "benches/collect_semantic_pairs.py": "7ce0d8628d2f28ac331d15ccf470e7b1b4fb596d5a475588cfa25689746de798",
       "benches/semantic_summary.py": "8aab3d2622ec7bfface33f29fee8fd695297b31eb2007fc5b2b20d8be2e3d1d0",

--- a/benches/results/semantic-pattern-priority-table-2026-07-23/manifest.json
+++ b/benches/results/semantic-pattern-priority-table-2026-07-23/manifest.json
@@ -1,0 +1,137 @@
+{
+  "attestations": {
+    "binary_a": "5dafac1e313d9c93e3e641d4f0e3433d6a48d56eeec4658def0b8a14ef9e525d",
+    "binary_b": "64d263b9f476e73bb819f54b0b1b32c7720176816b85148c2055b6e1eec6e4a6",
+    "fixture": "e0254347e2a628ed7dc0595d25ba4e628141ebf151cdd38b16eaf4289f5e858b",
+    "harness": "6f57424b2c8652b3c6b1b42a733d37f850dea6310e58a9a4fe82813533981d2e"
+  },
+  "configuration": {
+    "iterations": 30,
+    "pairs": 4,
+    "run_timeout_seconds": 900,
+    "scenario_filters": [
+      "rust_large/full_cache_hit",
+      "rust_large/typing_delta",
+      "rust_sparse_32k_minus/typing_delta",
+      "rust_sparse_32k_exact/typing_delta",
+      "rust_sparse_32k_plus/typing_delta",
+      "rust_sparse_64k/typing_delta",
+      "rust_large/typing_burst",
+      "rust_xlarge/cancel_burst",
+      "markdown_injections_large/full_cache_hit",
+      "markdown_injections/typing_delta",
+      "markdown_injections/typing_burst",
+      "unicode_rust/full_cache_hit"
+    ],
+    "scenarios": [
+      "markdown_injections/typing_burst",
+      "markdown_injections/typing_delta",
+      "markdown_injections_large/full_cache_hit",
+      "rust_large/full_cache_hit",
+      "rust_large/typing_burst",
+      "rust_large/typing_delta",
+      "rust_sparse_32k_exact/typing_delta",
+      "rust_sparse_32k_minus/typing_delta",
+      "rust_sparse_32k_plus/typing_delta",
+      "rust_sparse_64k/typing_delta",
+      "rust_xlarge/cancel_burst",
+      "unicode_rust/full_cache_hit"
+    ],
+    "server_env": {},
+    "warmup_iterations": 6
+  },
+  "environment": {
+    "build": {
+      "CARGO_HOME": "<TEMP>/cargo-home",
+      "CARGO_TERM_COLOR": "never",
+      "HOME": "<TEMP>/home",
+      "LANG": "C",
+      "LC_ALL": "C",
+      "PATH": "<USER_HOME_PATH>:<USER_HOME_PATH>:<USER_HOME_PATH>:/opt/homebrew/bin:/opt/homebrew/sbin:/nix/var/nix/profiles/default/bin:<USER_HOME_PATH>:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:<USER_HOME_PATH>",
+      "RUSTUP_HOME": "<USER_HOME>/.rustup",
+      "TMPDIR": "<TEMP>/tmp"
+    },
+    "cc": "Apple clang version 21.0.0 (clang-2100.1.1.101)\nTarget: arm64-apple-darwin25.5.0\nThread model: posix\nInstalledDir: /Library/Developer/CommandLineTools/usr/bin",
+    "clang": "Apple clang version 21.0.0 (clang-2100.1.1.101)\nTarget: arm64-apple-darwin25.5.0\nThread model: posix\nInstalledDir: /Library/Developer/CommandLineTools/usr/bin",
+    "machine": "arm64",
+    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "processor": "arm",
+    "runtime": {
+      "CARGO_HOME": "<TEMP>/cargo-home",
+      "CARGO_TERM_COLOR": "never",
+      "HOME": "<TEMP>/home",
+      "LANG": "C",
+      "LC_ALL": "C",
+      "PATH": "<USER_HOME_PATH>:<USER_HOME_PATH>:<USER_HOME_PATH>:/opt/homebrew/bin:/opt/homebrew/sbin:/nix/var/nix/profiles/default/bin:<USER_HOME_PATH>:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:<USER_HOME_PATH>",
+      "RUSTUP_HOME": "<USER_HOME>/.rustup",
+      "TMPDIR": "<TEMP>/tmp"
+    },
+    "sdk": "26.5",
+    "toolchains": {
+      "a": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      },
+      "b": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      },
+      "harness": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      }
+    }
+  },
+  "fixture_manifest": "fixture-manifest.json",
+  "fixture_manifest_sha256": "c2dbea7a5e7613456a6967fe65b5f32b8d6a3abda749801a3952ed6a13d6f72e",
+  "raw_files": [
+    {
+      "order": "AB",
+      "pair_index": 1,
+      "samples": "pair-1.json",
+      "samples_sha256": "d46c31439a4c29ee348ec43ef777fbee9ff67e78aee98230eb4db47b394372f5",
+      "stdout": "pair-1.txt",
+      "stdout_sha256": "e4dfd8b0626a6764818fc8923f0c79a198d0c73f7483544f6935754671955b01"
+    },
+    {
+      "order": "BA",
+      "pair_index": 2,
+      "samples": "pair-2.json",
+      "samples_sha256": "6ec6fd2f53a80c43ccc170da2e62f4ca9f871d212d7f73222f2bd9f36cf8ef3e",
+      "stdout": "pair-2.txt",
+      "stdout_sha256": "4b473f64a5122f0aa3545548bb4f72dd94b69c205e14f04ea0634d6a24413bdc"
+    },
+    {
+      "order": "AB",
+      "pair_index": 3,
+      "samples": "pair-3.json",
+      "samples_sha256": "97a84535c79a7addf33405d7c1cbfa25efe1c61260c47d63c0cb2662db3668d1",
+      "stdout": "pair-3.txt",
+      "stdout_sha256": "5e152da3d577497ac195a6f5694db14bd0d76cc5674d2ccf06290d8fe04cff80"
+    },
+    {
+      "order": "BA",
+      "pair_index": 4,
+      "samples": "pair-4.json",
+      "samples_sha256": "0e2391a6133d7c8411b8376a2eaafb1d3c1d7a3af68f19e377d509dc82e49d5c",
+      "stdout": "pair-4.txt",
+      "stdout_sha256": "17bd7340c6c01f03f0ae2860b197b2ec92d4e36cd92610f5093b5e81d96f9d7a"
+    }
+  ],
+  "schema_version": 1,
+  "source": {
+    "a_commit": "a1278be5fdff24d109d9e03134c6bdb880577f64",
+    "a_ref": "origin/main",
+    "b_commit": "5681ae5fff701b9f5570fe4a169aca76ebd8b47a",
+    "b_ref": "benchmark/semantic-pattern-priority-table-2026-07-23",
+    "harness_commit": "553b901bbf421e3851886c2a3e94b16adca6c34a",
+    "harness_sources_sha256": {
+      "benches/collect_semantic_pairs.py": "7ce0d8628d2f28ac331d15ccf470e7b1b4fb596d5a475588cfa25689746de798",
+      "benches/semantic_summary.py": "8aab3d2622ec7bfface33f29fee8fd695297b31eb2007fc5b2b20d8be2e3d1d0",
+      "benches/semantic_tokens.rs": "2d35487ff38a5b7b72540f55c5fb43ae6ca5190b9b579264ae0323e6fd927139",
+      "benches/support/semantic_baseline.rs": "4ab35bab7a05b32d652262c61c4cd4c720a21bfe3d1730694ea9dda5b306410c"
+    }
+  },
+  "summary": "summary.json",
+  "summary_sha256": "3de22a71cecad258001ebcdd989b2a69fbc1ef4ded79bd625d84bc4062533cc3"
+}

--- a/benches/results/semantic-pattern-priority-table-2026-07-23/pair-1.txt
+++ b/benches/results/semantic-pattern-priority-table-2026-07-23/pair-1.txt
@@ -1,0 +1,43 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               3.127ms      2.853ms         -8.8%
+    p95:      3.271ms      2.919ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.689ms      0.690ms        +0.1%
+    p95:      0.703ms      0.720ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.611ms      0.614ms        +0.6%
+    p95:      0.625ms      0.626ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/typing_delta                30.914ms     33.047ms        +6.9%
+    p95:     37.622ms     54.553ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     10.882ms     10.950ms        +0.6%
+    p95:     12.377ms     13.545ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta     10.837ms     10.739ms         -0.9%
+    p95:     13.649ms     12.944ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta      10.749ms     10.240ms         -4.7%
+    p95:     12.785ms     13.309ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           23.128ms     21.472ms         -7.2%
+    p95:     25.779ms     24.691ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                32.110ms     30.965ms         -3.6%
+    p95:     34.889ms     33.386ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+rust_xlarge/cancel_burst              148.593ms    148.484ms         -0.1%
+    p95:    166.705ms    167.037ms
+    └ targets: current-token latency after four explicitly cancelled edit states
+markdown_injections/typing_delta        6.900ms      6.830ms         -1.0%
+    p95:      7.043ms      7.142ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        6.884ms      6.848ms         -0.5%
+    p95:      7.261ms      7.204ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-pattern-priority-table-2026-07-23/pair-2.txt
+++ b/benches/results/semantic-pattern-priority-table-2026-07-23/pair-2.txt
@@ -1,0 +1,43 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               2.863ms      2.842ms         -0.7%
+    p95:      3.901ms      2.946ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.697ms      0.771ms        +10.6%
+    p95:      0.739ms      0.806ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.610ms      0.615ms        +0.9%
+    p95:      0.627ms      0.635ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/typing_delta                29.300ms     30.934ms        +5.6%
+    p95:     32.469ms     35.152ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     10.602ms     11.318ms        +6.8%
+    p95:     13.140ms     14.275ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta     11.833ms     12.518ms        +5.8%
+    p95:     13.865ms     15.211ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta      11.452ms     10.076ms         -12.0%
+    p95:     15.536ms     11.934ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           22.086ms     21.377ms         -3.2%
+    p95:     24.291ms     24.517ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                31.348ms     35.508ms        +13.3%
+    p95:     35.737ms     39.600ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+rust_xlarge/cancel_burst              146.710ms    144.136ms         -1.8%
+    p95:    178.609ms    164.136ms
+    └ targets: current-token latency after four explicitly cancelled edit states
+markdown_injections/typing_delta        6.934ms      6.736ms         -2.9%
+    p95:      7.447ms      6.978ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        6.711ms      6.612ms         -1.5%
+    p95:      6.962ms      7.244ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-pattern-priority-table-2026-07-23/pair-3.txt
+++ b/benches/results/semantic-pattern-priority-table-2026-07-23/pair-3.txt
@@ -1,0 +1,43 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               2.839ms      2.588ms         -8.8%
+    p95:      2.923ms      2.890ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.694ms      0.636ms         -8.5%
+    p95:      0.704ms      0.687ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.602ms      0.608ms        +1.1%
+    p95:      0.612ms      0.624ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/typing_delta                32.601ms     32.911ms        +0.9%
+    p95:     37.582ms     36.685ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     10.730ms     10.764ms        +0.3%
+    p95:     12.343ms     15.324ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta     10.255ms     10.000ms         -2.5%
+    p95:     13.036ms     14.717ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta       9.996ms      9.806ms         -1.9%
+    p95:     13.127ms     12.583ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           20.982ms     20.415ms         -2.7%
+    p95:     24.117ms     25.656ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                30.879ms     32.810ms        +6.3%
+    p95:     36.642ms     36.527ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+rust_xlarge/cancel_burst              150.500ms    156.171ms        +3.8%
+    p95:    171.415ms    176.956ms
+    └ targets: current-token latency after four explicitly cancelled edit states
+markdown_injections/typing_delta        6.925ms      6.840ms         -1.2%
+    p95:      8.188ms      7.432ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        6.889ms      6.281ms         -8.8%
+    p95:      7.317ms      6.985ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-pattern-priority-table-2026-07-23/pair-4.txt
+++ b/benches/results/semantic-pattern-priority-table-2026-07-23/pair-4.txt
@@ -1,0 +1,43 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               2.840ms      2.845ms        +0.2%
+    p95:      2.880ms      2.934ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.688ms      0.647ms         -5.9%
+    p95:      0.710ms      0.704ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.610ms      0.607ms         -0.5%
+    p95:      0.622ms      0.615ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/typing_delta                29.384ms     29.577ms        +0.7%
+    p95:     33.936ms     33.832ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta     10.985ms     10.165ms         -7.5%
+    p95:     13.962ms     12.170ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta      9.934ms      9.953ms        +0.2%
+    p95:     12.563ms     12.688ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta      10.149ms      9.645ms         -5.0%
+    p95:     12.642ms     13.136ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           20.734ms     20.343ms         -1.9%
+    p95:     24.421ms     23.655ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                33.364ms     34.437ms        +3.2%
+    p95:     39.997ms     40.804ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+rust_xlarge/cancel_burst              151.204ms    148.947ms         -1.5%
+    p95:    175.073ms    176.181ms
+    └ targets: current-token latency after four explicitly cancelled edit states
+markdown_injections/typing_delta        7.016ms      6.847ms         -2.4%
+    p95:      7.642ms      7.342ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        6.747ms      6.584ms         -2.4%
+    p95:      7.004ms      6.854ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-pattern-priority-table-2026-07-23/summary.json
+++ b/benches/results/semantic-pattern-priority-table-2026-07-23/summary.json
@@ -1,0 +1,497 @@
+{
+  "scenarios": [
+    {
+      "a_median_ns": 6748021.25,
+      "b_median_ns": 6729385.25,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 2.482327913637847,
+        "median": 0.487575522484124,
+        "min": -8.828733137854602
+      },
+      "pairs": [
+        {
+          "a_median_ns": 6884438.0,
+          "b_median_ns": 6847771.0,
+          "delta_percent": -0.5326070189026323,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 6611604.5,
+          "b_median_ns": 6711291.5,
+          "delta_percent": 1.5077580638708803,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 6888729.0,
+          "b_median_ns": 6280541.5,
+          "delta_percent": -8.828733137854602,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 6584041.5,
+          "b_median_ns": 6747479.0,
+          "delta_percent": 2.482327913637847,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "markdown_injections/typing_burst"
+    },
+    {
+      "a_median_ns": 6873489.5,
+      "b_median_ns": 6887271.0,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 2.942507108960062,
+        "median": 0.7326746593737037,
+        "min": -1.2294602326567816
+      },
+      "pairs": [
+        {
+          "a_median_ns": 6900125.0,
+          "b_median_ns": 6830396.0,
+          "delta_percent": -1.0105469103820583,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 6736041.5,
+          "b_median_ns": 6934250.0,
+          "delta_percent": 2.942507108960062,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 6925437.5,
+          "b_median_ns": 6840292.0,
+          "delta_percent": -1.2294602326567816,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 6846854.0,
+          "b_median_ns": 7016375.0,
+          "delta_percent": 2.4758962291294657,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "markdown_injections/typing_delta"
+    },
+    {
+      "a_median_ns": 691843.5,
+      "b_median_ns": 689041.75,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 6.257160094893709,
+        "median": -4.159912546974645,
+        "min": -9.606741208880246
+      },
+      "pairs": [
+        {
+          "a_median_ns": 689395.5,
+          "b_median_ns": 690333.5,
+          "delta_percent": 0.13606123045479698,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 771375.0,
+          "b_median_ns": 697271.0,
+          "delta_percent": -9.606741208880246,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 694291.5,
+          "b_median_ns": 635583.0,
+          "delta_percent": -8.455886324404087,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 647250.5,
+          "b_median_ns": 687750.0,
+          "delta_percent": 6.257160094893709,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "markdown_injections_large/full_cache_hit"
+    },
+    {
+      "a_median_ns": 2843354.0,
+      "b_median_ns": 2846208.25,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 0.7535780177734913,
+        "median": -4.471262639908865,
+        "min": -8.829346454288292
+      },
+      "pairs": [
+        {
+          "a_median_ns": 3126896.0,
+          "b_median_ns": 2852562.5,
+          "delta_percent": -8.77334903367429,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 2842041.5,
+          "b_median_ns": 2863458.5,
+          "delta_percent": 0.7535780177734913,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 2839021.0,
+          "b_median_ns": 2588354.0,
+          "delta_percent": -8.829346454288292,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 2844666.5,
+          "b_median_ns": 2839854.0,
+          "delta_percent": -0.16917624614344073,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_large/full_cache_hit"
+    },
+    {
+      "a_median_ns": 33273333.5,
+      "b_median_ns": 32078937.5,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 6.252134510997253,
+        "median": -3.3405813213223223,
+        "min": -11.717388518424169
+      },
+      "pairs": [
+        {
+          "a_median_ns": 32109729.5,
+          "b_median_ns": 30964875.0,
+          "delta_percent": -3.5654442370808512,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 35508479.5,
+          "b_median_ns": 31347813.0,
+          "delta_percent": -11.717388518424169,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 30879438.0,
+          "b_median_ns": 32810062.0,
+          "delta_percent": 6.252134510997253,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 34436937.5,
+          "b_median_ns": 33363979.5,
+          "delta_percent": -3.1157184055637934,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_large/typing_burst"
+    },
+    {
+      "a_median_ns": 30924010.5,
+      "b_median_ns": 31147229.0,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 6.899383301419292,
+        "median": 0.1486631008454487,
+        "min": -5.281587615899784
+      },
+      "pairs": [
+        {
+          "a_median_ns": 30914292.0,
+          "b_median_ns": 33047187.5,
+          "delta_percent": 6.899383301419292,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 30933729.0,
+          "b_median_ns": 29299937.0,
+          "delta_percent": -5.281587615899784,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 32601250.0,
+          "b_median_ns": 32910666.5,
+          "delta_percent": 0.9490939764579579,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 29576562.0,
+          "b_median_ns": 29383791.5,
+          "delta_percent": -0.6517677747670605,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_large/typing_delta"
+    },
+    {
+      "a_median_ns": 10546031.5,
+      "b_median_ns": 10369104.0,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": -0.19403195991319,
+        "median": -1.6995890784318006,
+        "min": -5.477158147478993
+      },
+      "pairs": [
+        {
+          "a_median_ns": 10836583.5,
+          "b_median_ns": 10738624.5,
+          "delta_percent": -0.9039657194539219,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 12518271.0,
+          "b_median_ns": 11832625.5,
+          "delta_percent": -5.477158147478993,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 10255479.5,
+          "b_median_ns": 9999583.5,
+          "delta_percent": -2.4952124374096796,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 9952999.5,
+          "b_median_ns": 9933687.5,
+          "delta_percent": -0.19403195991319,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_sparse_32k_exact/typing_delta"
+    },
+    {
+      "a_median_ns": 10806010.75,
+      "b_median_ns": 10856614.75,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 8.06861030289821,
+        "median": 0.4672194031202731,
+        "min": -6.327687983522279
+      },
+      "pairs": [
+        {
+          "a_median_ns": 10882229.5,
+          "b_median_ns": 10949667.0,
+          "delta_percent": 0.6197029753875343,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 11318312.5,
+          "b_median_ns": 10602125.0,
+          "delta_percent": -6.327687983522279,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 10729792.0,
+          "b_median_ns": 10763562.5,
+          "delta_percent": 0.3147358308530119,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 10164916.5,
+          "b_median_ns": 10985084.0,
+          "delta_percent": 8.06861030289821,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_sparse_32k_minus/typing_delta"
+    },
+    {
+      "a_median_ns": 10036166.5,
+      "b_median_ns": 10194479.0,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 13.661033521576806,
+        "median": 1.6586202733898032,
+        "min": -4.7403828429235855
+      },
+      "pairs": [
+        {
+          "a_median_ns": 10749395.5,
+          "b_median_ns": 10239833.0,
+          "delta_percent": -4.7403828429235855,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 10075958.0,
+          "b_median_ns": 11452438.0,
+          "delta_percent": 13.661033521576806,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 9996375.0,
+          "b_median_ns": 9805625.0,
+          "delta_percent": -1.9081917194983182,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 9645125.5,
+          "b_median_ns": 10149125.0,
+          "delta_percent": 5.225432266277925,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_sparse_32k_plus/typing_delta"
+    },
+    {
+      "a_median_ns": 21179250.0,
+      "b_median_ns": 21102854.0,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 3.3152030117001083,
+        "median": -0.39090964278105955,
+        "min": -7.159987213582762
+      },
+      "pairs": [
+        {
+          "a_median_ns": 23127667.0,
+          "b_median_ns": 21471729.0,
+          "delta_percent": -7.159987213582762,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 21376896.0,
+          "b_median_ns": 22085583.5,
+          "delta_percent": 3.3152030117001083,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 20981604.0,
+          "b_median_ns": 20414729.5,
+          "delta_percent": -2.701769130710884,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 20343396.0,
+          "b_median_ns": 20733979.0,
+          "delta_percent": 1.9199498451487649,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_sparse_64k/typing_delta"
+    },
+    {
+      "a_median_ns": 148770021.25,
+      "b_median_ns": 149843906.5,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 3.7683903553872993,
+        "median": 1.6504752183981166,
+        "min": -0.07364918304658427
+      },
+      "pairs": [
+        {
+          "a_median_ns": 148592958.5,
+          "b_median_ns": 148483521.0,
+          "delta_percent": -0.07364918304658427,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 144136187.5,
+          "b_median_ns": 146709750.0,
+          "delta_percent": 1.7855075429964458,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 150499708.5,
+          "b_median_ns": 156171125.0,
+          "delta_percent": 3.7683903553872993,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 148947084.0,
+          "b_median_ns": 151204292.0,
+          "delta_percent": 1.5154428937997872,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_xlarge/cancel_burst"
+    },
+    {
+      "a_median_ns": 608666.25,
+      "b_median_ns": 609833.5,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 1.0526228316194037,
+        "median": 0.5664193521802943,
+        "min": -0.8568177199756147
+      },
+      "pairs": [
+        {
+          "a_median_ns": 610687.0,
+          "b_median_ns": 614417.0,
+          "delta_percent": 0.6107875229045321,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 615125.0,
+          "b_median_ns": 609854.5,
+          "delta_percent": -0.8568177199756147,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 601687.5,
+          "b_median_ns": 608021.0,
+          "delta_percent": 1.0526228316194037,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 606645.5,
+          "b_median_ns": 609812.5,
+          "delta_percent": 0.5220511814560563,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "unicode_rust/full_cache_hit"
+    }
+  ],
+  "schema_version": 1
+}

--- a/benches/results/semantic-rejected-hot-path-trials-2026-07-23.md
+++ b/benches/results/semantic-rejected-hot-path-trials-2026-07-23.md
@@ -1,4 +1,4 @@
-# Rejected semantic hot-path trials (2026-07-23)
+# Rejected semantic hot-path trials (2026-07-23 to 2026-07-24)
 
 These measurements preserve four implementation trials that did not provide
 enough end-to-end evidence to ship. Lower paired delta is better. Every default

--- a/benches/results/semantic-rejected-hot-path-trials-2026-07-23.md
+++ b/benches/results/semantic-rejected-hot-path-trials-2026-07-23.md
@@ -1,6 +1,6 @@
 # Rejected semantic hot-path trials (2026-07-23)
 
-These measurements preserve three implementation trials that did not provide
+These measurements preserve four implementation trials that did not provide
 enough end-to-end evidence to ship. Lower paired delta is better. Every default
 run used four alternating A/B pairs, six warmups, and 30 retained samples per
 scenario. The lazy-line-table confirmation used eight pairs, 12 warmups, and 30
@@ -47,6 +47,22 @@ general end-to-end benefit.
 
 Evidence: `semantic-pattern-priority-table-2026-07-23/`
 
+## Exact-snapshot cache before language preparation
+
+Candidate `0dad66b49356483ae42a91bdde8632d219e7b3c9` moved the existing
+full/delta exact-snapshot cache lookup before language loading and highlight
+query preparation.
+
+The change did not establish an end-to-end cache-hit win. Paired medians were
+-0.69% for the Rust full cache hit, +3.97% for the Markdown injection full
+cache hit, -2.88% for the Unicode full cache hit, and +0.72% for the Rust
+no-op delta. Every target scenario changed sign across the four pairs. Primary
+typing controls stayed near neutral (Rust +0.29%, Markdown -1.44%), so there
+was no compensating throughput benefit. The earlier lookup is rejected because
+the preparation it skips is already cheap after initial language load.
+
+Evidence: `semantic-snapshot-cache-first-2026-07-24/`
+
 ## Consequence
 
 Do not transplant these collection-local forms. These measurements do not rule
@@ -55,3 +71,7 @@ capture roles or pattern properties are revisited, prefer constructing an
 immutable query plan when a query or settings generation is loaded, then
 measure the complete LSP path again. This keeps immutable work out of repeated
 requests without weakening semantic-token freshness.
+
+Also keep the exact-snapshot lookup after language preparation. Revisit that
+ordering only if attribution shows language/query preparation has become
+material on cache-hit requests.

--- a/benches/results/semantic-rejected-hot-path-trials-2026-07-23.md
+++ b/benches/results/semantic-rejected-hot-path-trials-2026-07-23.md
@@ -1,0 +1,56 @@
+# Rejected semantic hot-path trials (2026-07-23)
+
+These measurements preserve three implementation trials that did not provide
+enough end-to-end evidence to ship. Lower paired delta is better. Every default
+run used four alternating A/B pairs, six warmups, and 30 retained samples per
+scenario. The lazy-line-table confirmation used eight pairs, 12 warmups, and 30
+retained samples.
+
+## Lazy content line table
+
+Candidate `5e2375c08b58dafae961a24b92f112bcb4f84a03` deferred collecting
+`text.lines()` until the first multiline capture.
+
+The default run was inconclusive. The confirmation still crossed zero in every
+scenario: Rust sparse medians ranged from -4.01% to +0.95%, Rust large delta was
++1.41%, and Markdown delta was +5.57%. The change is rejected because it did
+not produce a repeatable sparse-document win and retained a Markdown delta
+regression signal.
+
+Evidence:
+
+- `semantic-lazy-content-lines-2026-07-23/`
+- `semantic-lazy-content-lines-confirmation-2026-07-23/`
+
+## Request-local capture role table
+
+Candidate `0b8626b40950074f6d935a00bed7b0bd05ec2ecb` resolved capture roles
+once per request rather than once per matched capture.
+
+Markdown typing delta improved by a median -9.67%, but
+`rust_sparse_32k_minus/typing_delta` regressed in all four pairs with a +8.80%
+median. Other primary scenarios changed sign across pairs. The mixed result is
+not safe to ship as a general hot-path optimization.
+
+Evidence: `semantic-capture-role-table-2026-07-23/`
+
+## Request-local pattern priority table
+
+Candidate `5681ae5fff701b9f5570fe4a169aca76ebd8b47a` parsed query priorities
+once per request rather than once per match.
+
+Only `rust_sparse_32k_exact/typing_delta` improved in all four pairs (-1.70%
+median). Markdown typing delta and burst had +0.73% and +0.49% medians,
+respectively, while Rust large delta was effectively unchanged (+0.15%).
+Request-local precomputation therefore adds fixed work without demonstrating a
+general end-to-end benefit.
+
+Evidence: `semantic-pattern-priority-table-2026-07-23/`
+
+## Consequence
+
+Do not transplant these request-local forms. If capture roles or pattern
+properties are revisited, construct an immutable query plan when a query or
+settings generation is loaded, then measure the complete LSP path again. This
+keeps immutable work out of repeated requests without weakening semantic-token
+freshness.

--- a/benches/results/semantic-rejected-hot-path-trials-2026-07-23.md
+++ b/benches/results/semantic-rejected-hot-path-trials-2026-07-23.md
@@ -59,7 +59,7 @@ cache hit, -2.88% for the Unicode full cache hit, and +0.72% for the Rust
 no-op delta. Every target scenario changed sign across the four pairs. Primary
 typing controls stayed near neutral (Rust +0.29%, Markdown -1.44%), so there
 was no compensating throughput benefit. The earlier lookup is rejected because
-the preparation it skips is already cheap after initial language load.
+it did not demonstrate a repeatable end-to-end improvement.
 
 Evidence: `semantic-snapshot-cache-first-2026-07-24/`
 

--- a/benches/results/semantic-rejected-hot-path-trials-2026-07-23.md
+++ b/benches/results/semantic-rejected-hot-path-trials-2026-07-23.md
@@ -42,7 +42,7 @@ once per host or injection collection rather than once per match.
 Only `rust_sparse_32k_exact/typing_delta` improved in all four pairs (-1.70%
 median). Markdown typing delta and burst had +0.73% and +0.49% medians,
 respectively, while Rust large delta was effectively unchanged (+0.15%).
-Request-local precomputation therefore adds fixed work without demonstrating a
+Collection-local precomputation therefore adds fixed work without demonstrating a
 general end-to-end benefit.
 
 Evidence: `semantic-pattern-priority-table-2026-07-23/`

--- a/benches/results/semantic-rejected-hot-path-trials-2026-07-23.md
+++ b/benches/results/semantic-rejected-hot-path-trials-2026-07-23.md
@@ -22,10 +22,10 @@ Evidence:
 - `semantic-lazy-content-lines-2026-07-23/`
 - `semantic-lazy-content-lines-confirmation-2026-07-23/`
 
-## Request-local capture role table
+## Collection-local capture role table
 
 Candidate `0b8626b40950074f6d935a00bed7b0bd05ec2ecb` resolved capture roles
-once per request rather than once per matched capture.
+once per host or injection collection rather than once per matched capture.
 
 Markdown typing delta improved by a median -9.67%, but
 `rust_sparse_32k_minus/typing_delta` regressed in all four pairs with a +8.80%
@@ -34,10 +34,10 @@ not safe to ship as a general hot-path optimization.
 
 Evidence: `semantic-capture-role-table-2026-07-23/`
 
-## Request-local pattern priority table
+## Collection-local pattern priority table
 
 Candidate `5681ae5fff701b9f5570fe4a169aca76ebd8b47a` parsed query priorities
-once per request rather than once per match.
+once per host or injection collection rather than once per match.
 
 Only `rust_sparse_32k_exact/typing_delta` improved in all four pairs (-1.70%
 median). Markdown typing delta and burst had +0.73% and +0.49% medians,
@@ -49,8 +49,9 @@ Evidence: `semantic-pattern-priority-table-2026-07-23/`
 
 ## Consequence
 
-Do not transplant these request-local forms. If capture roles or pattern
-properties are revisited, construct an immutable query plan when a query or
-settings generation is loaded, then measure the complete LSP path again. This
-keeps immutable work out of repeated requests without weakening semantic-token
-freshness.
+Do not transplant these collection-local forms. These measurements do not rule
+out a table shared across all host and injection collections in one request. If
+capture roles or pattern properties are revisited, prefer constructing an
+immutable query plan when a query or settings generation is loaded, then
+measure the complete LSP path again. This keeps immutable work out of repeated
+requests without weakening semantic-token freshness.

--- a/benches/results/semantic-rejected-hot-path-trials-2026-07-23.md
+++ b/benches/results/semantic-rejected-hot-path-trials-2026-07-23.md
@@ -6,6 +6,11 @@ run used four alternating A/B pairs, six warmups, and 30 retained samples per
 scenario. The lazy-line-table confirmation used eight pairs, 12 warmups, and 30
 retained samples.
 
+Every candidate commit is preserved by the pushed `benchmark/...` tag recorded
+as `source.b_ref` in its manifest. The exact-snapshot trial also records a
+pushed baseline tag as `source.a_ref`; the other trials use the preserved
+`origin/main` commit recorded in their manifests.
+
 ## Lazy content line table
 
 Candidate `5e2375c08b58dafae961a24b92f112bcb4f84a03` deferred collecting

--- a/benches/results/semantic-snapshot-cache-first-2026-07-24/fixture-manifest.json
+++ b/benches/results/semantic-snapshot-cache-first-2026-07-24/fixture-manifest.json
@@ -1,0 +1,194 @@
+[
+  {
+    "path": ".installed",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "cache/parsers.lua",
+    "sha256": "8a3014b92e4087c85288ee8c247764ac6ee0d1036eeee3c8127a63ab7a90207f",
+    "size": 73934,
+    "type": "file"
+  },
+  {
+    "path": "parser/lua.dylib",
+    "sha256": "37506a28b2d7cbe9fdcbff9c4a925ad6032c2de7c9b9eaf1b2678cf4f20d9e1d",
+    "size": 84600,
+    "type": "file"
+  },
+  {
+    "path": "parser/markdown.dylib",
+    "sha256": "cff76ce5d1bb4ab3fabe636952f9bb11da4b5f03d730a97833689b91b499a583",
+    "size": 418088,
+    "type": "file"
+  },
+  {
+    "path": "parser/markdown_inline.dylib",
+    "sha256": "610a2764676a72ef85dcba5c40ff736bc8b4b7ccf997170b213c144d722bdac3",
+    "size": 416816,
+    "type": "file"
+  },
+  {
+    "path": "parser/python.dylib",
+    "sha256": "45d78fa59e4165ed81bc05a2c2069a25d595640d64934987701cea55805c7ca1",
+    "size": 480920,
+    "type": "file"
+  },
+  {
+    "path": "parser/rust.dylib",
+    "sha256": "cfdbbe333f7a080ce8c83ebbb34e5d4f5c3c176f3de0478c26a7f8d170f4443c",
+    "size": 1142360,
+    "type": "file"
+  },
+  {
+    "path": "parser/yaml.dylib",
+    "sha256": "bd048cb3061dc9a051cbea8874f43a50d9a10fabd86f35454c11d68088f00227",
+    "size": 217176,
+    "type": "file"
+  },
+  {
+    "path": "queries/.lua.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.markdown.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.markdown_inline.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.python.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.rust.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.yaml.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/highlights.scm",
+    "sha256": "ac7dfa89d16ba817c3681aa47c22bdb4441a78a89ed827a757efa755992de67f",
+    "size": 4336,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/injections.scm",
+    "sha256": "a2ee92c2f00f39ebeeb1d0cc06302dba58c4f1dda77a2f0c9e5d7d7beab0b1ff",
+    "size": 5168,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/highlights.scm",
+    "sha256": "7b71d4994cf3968e16d033ac59d28bb034427dd41be6a057b7a2985e2dfbe5b8",
+    "size": 2654,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/injections.scm",
+    "sha256": "34090de78df99b5ea84c2fbb9324f2b7c32e602043595286e83f1a1ac126073c",
+    "size": 659,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/highlights.scm",
+    "sha256": "7db9147da61de7491ede9155e554dc033d6a1b86ecd1b21f6849c018be9ac875",
+    "size": 2259,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/injections.scm",
+    "sha256": "051f44218e0fe25cd949dfccad80699d5456ee379c7c4cfa18a5165776ecab0e",
+    "size": 207,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/highlights.scm",
+    "sha256": "ab8b66cbe6a7382e0ed7693c194101f1900c39f9ec0085a1749a8817e3e6895c",
+    "size": 9263,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/injections.scm",
+    "sha256": "8558299709200b21d496890e4799153dc069bf302ce1545d23f70a0869c8b65d",
+    "size": 812,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/highlights.scm",
+    "sha256": "4e0f5994f30ee545fc63435054a0b029c7d0222632c5c787c4e9c249dc0ef20f",
+    "size": 8638,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/injections.scm",
+    "sha256": "7dde97bbdabd208f984e13627bd4daae0f73012c41faafab39d670b607710f4e",
+    "size": 2418,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/highlights.scm",
+    "sha256": "13352b80d2ce28c3328ccb2f321e5144c3365ff6055078e00e7cff118d1488b5",
+    "size": 1700,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/injections.scm",
+    "sha256": "8349bd07691e2e610decdfc7b898bb5b01b226aae8745217bc811427f7af6742",
+    "size": 2373,
+    "type": "file"
+  }
+]

--- a/benches/results/semantic-snapshot-cache-first-2026-07-24/manifest.json
+++ b/benches/results/semantic-snapshot-cache-first-2026-07-24/manifest.json
@@ -1,0 +1,126 @@
+{
+  "attestations": {
+    "binary_a": "715e188bf30f95036c8e5b9683c5c26a58850c7e0a24261b6a091fd156263f3a",
+    "binary_b": "74a825b599854111a3551e7c37843c1def562e9e1ab5641e7ac28177ebf199e1",
+    "fixture": "b358f3c8de0c77defffe1ce75af5755e3457c8509b5b6134d7c43327a969e61c",
+    "harness": "95851f99ddd4b33ac28384dace47a919547302d10e5c04e5e0a0e64bdfc42bce"
+  },
+  "configuration": {
+    "iterations": 30,
+    "pairs": 4,
+    "run_timeout_seconds": 900,
+    "scenario_filters": [
+      "rust_large/full_cache_hit",
+      "rust_large/delta_noop",
+      "markdown_injections_large/full_cache_hit",
+      "unicode_rust/full_cache_hit",
+      "rust_large/typing_delta",
+      "markdown_injections/typing_delta"
+    ],
+    "scenarios": [
+      "markdown_injections/typing_delta",
+      "markdown_injections_large/full_cache_hit",
+      "rust_large/delta_noop",
+      "rust_large/full_cache_hit",
+      "rust_large/typing_delta",
+      "unicode_rust/full_cache_hit"
+    ],
+    "server_env": {},
+    "warmup_iterations": 6
+  },
+  "environment": {
+    "build": {
+      "CARGO_HOME": "<TEMP>/cargo-home",
+      "CARGO_TERM_COLOR": "never",
+      "HOME": "<TEMP>/home",
+      "LANG": "C",
+      "LC_ALL": "C",
+      "PATH": "<USER_HOME_PATH>:<USER_HOME_PATH>:<USER_HOME_PATH>:/opt/homebrew/bin:/opt/homebrew/sbin:/nix/var/nix/profiles/default/bin:<USER_HOME_PATH>:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:<USER_HOME_PATH>",
+      "RUSTUP_HOME": "<USER_HOME>/.rustup",
+      "TMPDIR": "<TEMP>/tmp"
+    },
+    "cc": "Apple clang version 21.0.0 (clang-2100.1.1.101)\nTarget: arm64-apple-darwin25.5.0\nThread model: posix\nInstalledDir: /Library/Developer/CommandLineTools/usr/bin",
+    "clang": "Apple clang version 21.0.0 (clang-2100.1.1.101)\nTarget: arm64-apple-darwin25.5.0\nThread model: posix\nInstalledDir: /Library/Developer/CommandLineTools/usr/bin",
+    "machine": "arm64",
+    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "processor": "arm",
+    "runtime": {
+      "CARGO_HOME": "<TEMP>/cargo-home",
+      "CARGO_TERM_COLOR": "never",
+      "HOME": "<TEMP>/home",
+      "LANG": "C",
+      "LC_ALL": "C",
+      "PATH": "<USER_HOME_PATH>:<USER_HOME_PATH>:<USER_HOME_PATH>:/opt/homebrew/bin:/opt/homebrew/sbin:/nix/var/nix/profiles/default/bin:<USER_HOME_PATH>:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:<USER_HOME_PATH>",
+      "RUSTUP_HOME": "<USER_HOME>/.rustup",
+      "TMPDIR": "<TEMP>/tmp"
+    },
+    "sdk": "26.5",
+    "toolchains": {
+      "a": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      },
+      "b": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      },
+      "harness": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      }
+    }
+  },
+  "fixture_manifest": "fixture-manifest.json",
+  "fixture_manifest_sha256": "1833be51e136df5e39e4226d86172211831e5e3d38e78fca3ab62259441204bf",
+  "raw_files": [
+    {
+      "order": "AB",
+      "pair_index": 1,
+      "samples": "pair-1.json",
+      "samples_sha256": "2770c6235e42aaf459bec5033addea4157aba0c58314b427653a1cb04c89d84e",
+      "stdout": "pair-1.txt",
+      "stdout_sha256": "0d538a7f864a59e720f6ce6a93139d705e3269e95ff4ab5a84aacc4cdc3abb02"
+    },
+    {
+      "order": "BA",
+      "pair_index": 2,
+      "samples": "pair-2.json",
+      "samples_sha256": "addd3af009c3efe8e2603563e31d13c54043f8227f23ddddfddf05354bd8ceaf",
+      "stdout": "pair-2.txt",
+      "stdout_sha256": "81ef3e7ce60792d07cfbd96c0f2b2be6fc0d4b51fc83c8a4865a28dd87ff9613"
+    },
+    {
+      "order": "AB",
+      "pair_index": 3,
+      "samples": "pair-3.json",
+      "samples_sha256": "b4d224f329054fb5b1ec97335ead4ece9ac841a67f1df34651056cbab0c390dc",
+      "stdout": "pair-3.txt",
+      "stdout_sha256": "bee5f7dcee40cd70ac47aeb6684d0be7847cc01bc97ac88774b144b71e790595"
+    },
+    {
+      "order": "BA",
+      "pair_index": 4,
+      "samples": "pair-4.json",
+      "samples_sha256": "ec6620017633287879bd68e290aa589ddd3fdeb422f53d76dae3840737c945d9",
+      "stdout": "pair-4.txt",
+      "stdout_sha256": "6bae5632fd9db540e4c1d859a3deabaeb10c51e282ca89df418fe9455c73acf2"
+    }
+  ],
+  "schema_version": 1,
+  "source": {
+    "a_commit": "265d38b0ac95822b17e5cec19c5e226d3d034bb9",
+    "a_ref": "benchmark/semantic-snapshot-cache-first-baseline-2026-07-24",
+    "b_commit": "0dad66b49356483ae42a91bdde8632d219e7b3c9",
+    "b_ref": "benchmark/semantic-snapshot-cache-first-candidate-2026-07-24",
+    "harness_commit": "0dad66b49356483ae42a91bdde8632d219e7b3c9",
+    "harness_ref": "benchmark/semantic-snapshot-cache-first-candidate-2026-07-24",
+    "harness_sources_sha256": {
+      "benches/collect_semantic_pairs.py": "7ce0d8628d2f28ac331d15ccf470e7b1b4fb596d5a475588cfa25689746de798",
+      "benches/semantic_summary.py": "8aab3d2622ec7bfface33f29fee8fd695297b31eb2007fc5b2b20d8be2e3d1d0",
+      "benches/semantic_tokens.rs": "2d35487ff38a5b7b72540f55c5fb43ae6ca5190b9b579264ae0323e6fd927139",
+      "benches/support/semantic_baseline.rs": "4ab35bab7a05b32d652262c61c4cd4c720a21bfe3d1730694ea9dda5b306410c"
+    }
+  },
+  "summary": "summary.json",
+  "summary_sha256": "f19508ec63ccb7dd643feaa8184b4bfd8546fcf2e7c4f36c9b0080080a9f7cf7"
+}

--- a/benches/results/semantic-snapshot-cache-first-2026-07-24/pair-1.txt
+++ b/benches/results/semantic-snapshot-cache-first-2026-07-24/pair-1.txt
@@ -1,0 +1,25 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               1.707ms      1.777ms        +4.1%
+    p95:      1.740ms      2.017ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.684ms      1.000ms        +46.3%
+    p95:      0.775ms      1.230ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.600ms      0.752ms        +25.2%
+    p95:      0.691ms      0.901ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/delta_noop                   0.052ms      0.052ms         -0.7%
+    p95:      0.068ms      0.067ms
+    └ targets: no-op delta result_id reuse
+rust_large/typing_delta                15.324ms     15.548ms        +1.5%
+    p95:     15.807ms     15.847ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+markdown_injections/typing_delta        4.184ms      4.089ms         -2.3%
+    p95:      4.320ms      4.814ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns

--- a/benches/results/semantic-snapshot-cache-first-2026-07-24/pair-2.txt
+++ b/benches/results/semantic-snapshot-cache-first-2026-07-24/pair-2.txt
@@ -1,0 +1,25 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               1.732ms      1.790ms        +3.3%
+    p95:      1.784ms      2.065ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.993ms      1.003ms        +1.0%
+    p95:      1.213ms      1.327ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.687ms      0.729ms        +6.1%
+    p95:      0.914ms      0.905ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/delta_noop                   0.048ms      0.047ms         -2.1%
+    p95:      0.059ms      0.056ms
+    └ targets: no-op delta result_id reuse
+rust_large/typing_delta                15.319ms     15.407ms        +0.6%
+    p95:     15.825ms     17.014ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+markdown_injections/typing_delta        4.104ms      4.187ms        +2.0%
+    p95:      5.335ms      4.947ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns

--- a/benches/results/semantic-snapshot-cache-first-2026-07-24/pair-3.txt
+++ b/benches/results/semantic-snapshot-cache-first-2026-07-24/pair-3.txt
@@ -1,0 +1,25 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               1.765ms      1.782ms        +1.0%
+    p95:      2.129ms      2.078ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      1.012ms      0.986ms         -2.6%
+    p95:      1.380ms      1.242ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.719ms      0.673ms         -6.4%
+    p95:      0.907ms      0.781ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/delta_noop                   0.050ms      0.053ms        +5.2%
+    p95:      0.071ms      0.064ms
+    └ targets: no-op delta result_id reuse
+rust_large/typing_delta                15.375ms     15.502ms        +0.8%
+    p95:     16.049ms     15.959ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+markdown_injections/typing_delta        4.134ms      4.144ms        +0.2%
+    p95:      5.250ms      5.171ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns

--- a/benches/results/semantic-snapshot-cache-first-2026-07-24/pair-4.txt
+++ b/benches/results/semantic-snapshot-cache-first-2026-07-24/pair-4.txt
@@ -1,0 +1,25 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               1.760ms      1.803ms        +2.5%
+    p95:      2.072ms      2.275ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      1.020ms      0.936ms         -8.2%
+    p95:      1.286ms      1.203ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.761ms      0.761ms        +0.0%
+    p95:      0.904ms      0.902ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/delta_noop                   0.050ms      0.058ms        +15.1%
+    p95:      0.058ms      0.076ms
+    └ targets: no-op delta result_id reuse
+rust_large/typing_delta                15.399ms     15.438ms        +0.3%
+    p95:     16.088ms     16.581ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+markdown_injections/typing_delta        4.096ms      4.132ms        +0.9%
+    p95:      4.274ms      5.176ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns

--- a/benches/results/semantic-snapshot-cache-first-2026-07-24/summary.json
+++ b/benches/results/semantic-snapshot-cache-first-2026-07-24/summary.json
@@ -1,0 +1,251 @@
+{
+  "scenarios": [
+    {
+      "a_median_ns": 4159343.75,
+      "b_median_ns": 4099646.0,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 0.22475549193019662,
+        "median": -1.436667023183856,
+        "min": -2.2693483942924426
+      },
+      "pairs": [
+        {
+          "a_median_ns": 4184417.0,
+          "b_median_ns": 4089458.0,
+          "delta_percent": -2.2693483942924426,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 4187479.5,
+          "b_median_ns": 4103667.0,
+          "delta_percent": -2.001502335712927,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 4134270.5,
+          "b_median_ns": 4143562.5,
+          "delta_percent": 0.22475549193019662,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 4131646.0,
+          "b_median_ns": 4095625.0,
+          "delta_percent": -0.871831710654785,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "markdown_injections/typing_delta"
+    },
+    {
+      "a_median_ns": 969708.5,
+      "b_median_ns": 996750.25,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 46.26402266288952,
+        "median": 3.970567943697732,
+        "min": -2.6283616468346196
+      },
+      "pairs": [
+        {
+          "a_median_ns": 683937.5,
+          "b_median_ns": 1000354.5,
+          "delta_percent": 46.26402266288952,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 1003000.0,
+          "b_median_ns": 993146.0,
+          "delta_percent": -0.9824526420737787,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 1012208.5,
+          "b_median_ns": 985604.0,
+          "delta_percent": -2.6283616468346196,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 936417.0,
+          "b_median_ns": 1019979.0,
+          "delta_percent": 8.923588529469242,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "markdown_injections_large/full_cache_hit"
+    },
+    {
+      "a_median_ns": 51458.5,
+      "b_median_ns": 51073.0,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 5.159634554787055,
+        "median": 0.7168091053995704,
+        "min": -13.09197277966808
+      },
+      "pairs": [
+        {
+          "a_median_ns": 52458.0,
+          "b_median_ns": 52083.5,
+          "delta_percent": -0.7139044568988524,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 46542.0,
+          "b_median_ns": 47541.5,
+          "delta_percent": 2.1475226676979933,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 50459.0,
+          "b_median_ns": 53062.5,
+          "delta_percent": 5.159634554787055,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 57604.0,
+          "b_median_ns": 50062.5,
+          "delta_percent": -13.09197277966808,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_large/delta_noop"
+    },
+    {
+      "a_median_ns": 1777270.75,
+      "b_median_ns": 1768541.75,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 4.082887145364395,
+        "median": -0.6892341239618445,
+        "min": -3.212328189325126
+      },
+      "pairs": [
+        {
+          "a_median_ns": 1707333.5,
+          "b_median_ns": 1777042.0,
+          "delta_percent": 4.082887145364395,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 1789979.0,
+          "b_median_ns": 1732479.0,
+          "delta_percent": -3.212328189325126,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 1764562.5,
+          "b_median_ns": 1782500.0,
+          "delta_percent": 1.0165409272836752,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 1803229.0,
+          "b_median_ns": 1760041.5,
+          "delta_percent": -2.395009175207364,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_large/full_cache_hit"
+    },
+    {
+      "a_median_ns": 15391020.5,
+      "b_median_ns": 15450593.5,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 1.4593188311901881,
+        "median": 0.2883286299557264,
+        "min": -0.5756163047778873
+      },
+      "pairs": [
+        {
+          "a_median_ns": 15323896.0,
+          "b_median_ns": 15547520.5,
+          "delta_percent": 1.4593188311901881,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 15407312.0,
+          "b_median_ns": 15318625.0,
+          "delta_percent": -0.5756163047778873,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 15374729.0,
+          "b_median_ns": 15502291.5,
+          "delta_percent": 0.8296894208671906,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 15437958.5,
+          "b_median_ns": 15398895.5,
+          "delta_percent": -0.2530321609557378,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_large/typing_delta"
+    },
+    {
+      "a_median_ns": 723927.25,
+      "b_median_ns": 719416.75,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 25.184711423793633,
+        "median": -2.8812753762780168,
+        "min": -6.39100045632116
+      },
+      "pairs": [
+        {
+          "a_median_ns": 600396.0,
+          "b_median_ns": 751604.0,
+          "delta_percent": 25.184711423793633,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 729062.5,
+          "b_median_ns": 687229.5,
+          "delta_percent": -5.737916845263609,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 718792.0,
+          "b_median_ns": 672854.0,
+          "delta_percent": -6.39100045632116,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 761146.0,
+          "b_median_ns": 760958.5,
+          "delta_percent": -0.024633907292424845,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "unicode_rust/full_cache_hit"
+    }
+  ],
+  "schema_version": 1
+}


### PR DESCRIPTION
## Dependencies

Depends on #899. Merge #899 first, then retarget this PR to `main` and run the full CI checks before making it ready for merge.

## Summary

#895 の実装候補から、end-to-endで安全かつ再現可能な改善を示せず棄却した4案の計測記録を保存します。

- content line tableの遅延構築
- collection-local capture role table
- collection-local pattern priority table
- exact-snapshot cacheをlanguage/query preparationより前に確認

実装コードは含めません。最初の3案は `origin/main` と #899 harness、4案目は #900 の同期coreを含むbaselineとcandidateを比較しました。各manifestが正確なcommit、pushed benchmark tag、fixture/harness/binary hashを固定しています。また、パーサーライブラリやqueryファイルは保存せず、installerで構築したfixtureの `fixture-manifest.json` だけを保持します。

## Exact-snapshot cache trial

4つのAB/BA交互ペア、各6 warmups + 30 retained samplesで測定しました。lower is betterです。

| scenario | median B vs A | pair range |
| --- | ---: | ---: |
| Rust full cache hit | -0.69% | -3.21% .. +4.08% |
| Markdown injection full cache hit | +3.97% | -2.63% .. +46.26% |
| Unicode full cache hit | -2.88% | -6.39% .. +25.18% |
| Rust no-op delta | +0.72% | -13.09% .. +5.16% |
| Rust typing delta control | +0.29% | -0.58% .. +1.46% |
| Markdown typing delta control | -1.44% | -2.27% .. +0.22% |

対象scenarioがすべて0を跨いだため、cache lookupの並べ替え単独には再現可能な改善を認めませんでした。

## Decision

collection-localな事前計算は採用しません。この測定は1 request内の全host/injection collectionで共有する表まで棄却するものではありません。capture roleやpattern propertyを再検討する場合は、query/settings generationのload時にimmutable query planを構築して、完全なLSP経路を再測定します。

exact-snapshot lookupは現状の順序を維持します。language/query preparationのattributionがcache-hitで支配的になった場合だけ再検討します。semantic-token freshnessは変更しません。

Closes no issue; contributes negative evidence to #895.

## Validation

- `PYTHONPATH=benches python3 -m unittest benches/test_semantic_summary.py benches/test_collect_semantic_pairs.py` (19 passed)
- all summary, fixture-manifest, raw sample, and stdout SHA-256 values match their manifests
- all candidate, baseline, and harness refs resolve to published durable tags/commits
- no archived parser libraries or query files
- two fresh local Codex review sessions found no actionable correctness issue after the final provenance clarification

---

**注記 (2026-08-11): 生サンプルの削除**

リポジトリに raw benchmark data を残さないため、`benches/results/*/pair-*.json`（各pairの生サンプル配列）をこのスタックの全PRから削除しました。evidence ディレクトリは残っており、中身は次の通りです。

- `summary.json` — pairごとの median / delta / min / max と集計値
- `pair-*.txt` — シナリオ別の A/B 比較表（p95 付き）
- `manifest.json` / `fixture-manifest.json` — commit・tag・binary/harness/fixture の SHA-256

**本文に記載した数値はすべてこれらから再構成できます。** 失われたのは各シナリオ 30 本の生サンプル配列のみです。`manifest.json` の `raw_files` / `samples_sha256` は、削除したファイルの記録として意図的に残しています。

なお本文中の「raw samples を検証／再検証した」という記述は当時実施した検証の記録であり、現在のリポジトリからは再実行できません。今後の再混入を防ぐため `.gitignore` に `benches/results/*/pair-*.json` を追加しています。
