### PR TITLE
refactor(semantic): introduce immutable artifact seam

### DIFF
--- a/benches/results/semantic-artifact-seam-2026-07-23/README.md
+++ b/benches/results/semantic-artifact-seam-2026-07-23/README.md
@@ -1,0 +1,40 @@
+# Semantic artifact seam benchmark
+
+This run checks that introducing the immutable semantic-artifact boundary does
+not regress the freshly computed semantic-token paths. It does not claim a
+performance improvement.
+
+## Contract
+
+- A: `refactor/semantic-sync-core` at
+  `265d38b0ac95822b17e5cec19c5e226d3d034bb9`
+- B: `benchmark/semantic-artifact-seam-2026-07-23` at
+  `1805e61907b6f2b6ce4718b5145d131a174c4a2e`
+- Harness: `benchmark/semantic-lazy-content-lines-harness-2026-07-23` at
+  `553b901bbf421e3851886c2a3e94b16adca6c34a`
+- Four alternating AB/BA pairs
+- Six warm-up and 30 retained iterations per scenario
+- Lower is better; percentages are paired B-versus-A median deltas
+
+The fixture manifest records the installed language assets used by the run.
+Parser libraries and query files are not archived in this evidence directory.
+
+## Result
+
+The primary freshly computed paths showed no repeatable regression:
+
+| Scenario | Paired median | Faster/slower pairs |
+| --- | ---: | ---: |
+| Rust typing delta | -0.20% | 2 / 2 |
+| Rust typing burst | +0.26% | 2 / 2 |
+| Rust cancellation burst | -1.82% | 2 / 2 |
+| Markdown typing delta | +3.01% | 1 / 3 |
+| Markdown typing burst | +0.38% | 2 / 2 |
+
+The Markdown delta result had mixed signs and a wide -6.15% to +6.55% range.
+Cache-hit controls were likewise noisy even though they do not traverse the new
+artifact construction path. The result therefore supports non-regression, not
+a speedup claim.
+
+`manifest.json` attests the exact commits, harness sources, binaries, fixture
+manifest, raw pair files, stdout captures, and aggregate summary.

--- a/benches/results/semantic-artifact-seam-2026-07-23/README.md
+++ b/benches/results/semantic-artifact-seam-2026-07-23/README.md
@@ -9,7 +9,7 @@ performance improvement.
 - A: `refactor/semantic-sync-core` at
   `265d38b0ac95822b17e5cec19c5e226d3d034bb9`
 - B: `benchmark/semantic-artifact-seam-2026-07-23` at
-  `1805e61907b6f2b6ce4718b5145d131a174c4a2e`
+  `518c1868e7c955d5241b3a5acaadf5d0617981b9`
 - Harness: `benchmark/semantic-lazy-content-lines-harness-2026-07-23` at
   `553b901bbf421e3851886c2a3e94b16adca6c34a`
 - Four alternating AB/BA pairs
@@ -21,20 +21,20 @@ Parser libraries and query files are not archived in this evidence directory.
 
 ## Result
 
-The primary freshly computed paths showed no repeatable regression:
-
 | Scenario | Paired median | Faster/slower pairs |
 | --- | ---: | ---: |
-| Rust typing delta | -0.20% | 2 / 2 |
-| Rust typing burst | +0.26% | 2 / 2 |
-| Rust cancellation burst | -1.82% | 2 / 2 |
-| Markdown typing delta | +3.01% | 1 / 3 |
-| Markdown typing burst | +0.38% | 2 / 2 |
+| Rust typing delta | -4.26% | 4 / 0 |
+| Rust typing burst | -8.30% | 4 / 0 |
+| Rust cancellation burst | +4.04% | 1 / 3 |
+| Markdown typing delta | +7.05% | 1 / 3 |
+| Markdown typing burst | -1.28% | 3 / 1 |
 
-The Markdown delta result had mixed signs and a wide -6.15% to +6.55% range.
-Cache-hit controls were likewise noisy even though they do not traverse the new
-artifact construction path. The result therefore supports non-regression, not
-a speedup claim.
+The run had substantial pair-to-pair noise. Cancellation ranged from -4.05% to
++70.72%, Markdown delta ranged from -10.89% to +17.07%, and cache-hit controls
+that do not traverse artifact construction also moved by a paired median of up
+to +4.88%. The Rust improvements are therefore not claimed as a speedup, while
+the mixed signs and noisy controls provide no repeatable primary-path regression
+signal attributable to the seam.
 
 `manifest.json` attests the exact commits, harness sources, binaries, fixture
 manifest, raw pair files, stdout captures, and aggregate summary.

--- a/benches/results/semantic-artifact-seam-2026-07-23/README.md
+++ b/benches/results/semantic-artifact-seam-2026-07-23/README.md
@@ -8,8 +8,8 @@ performance improvement.
 
 - A: `refactor/semantic-sync-core` at
   `265d38b0ac95822b17e5cec19c5e226d3d034bb9`
-- B: `benchmark/semantic-artifact-seam-final-2026-07-23` at
-  `518c1868e7c955d5241b3a5acaadf5d0617981b9`
+- B: `benchmark/semantic-artifact-seam-converged-2026-07-23` at
+  `8b966d16f5a3a56c985a71d16b91e2e1fe5ae53f`
 - Harness: `benchmark/semantic-lazy-content-lines-harness-2026-07-23` at
   `553b901bbf421e3851886c2a3e94b16adca6c34a`
 - Four alternating AB/BA pairs
@@ -23,18 +23,17 @@ Parser libraries and query files are not archived in this evidence directory.
 
 | Scenario | Paired median | Faster/slower pairs |
 | --- | ---: | ---: |
-| Rust typing delta | -4.26% | 4 / 0 |
-| Rust typing burst | -8.30% | 4 / 0 |
-| Rust cancellation burst | +4.04% | 1 / 3 |
-| Markdown typing delta | +7.05% | 1 / 3 |
-| Markdown typing burst | -1.28% | 3 / 1 |
+| Rust typing delta | +1.13% | 2 / 2 |
+| Rust typing burst | +0.15% | 2 / 2 |
+| Rust cancellation burst | +0.54% | 2 / 2 |
+| Markdown typing delta | -0.61% | 2 / 2 |
+| Markdown typing burst | +3.49% | 2 / 2 |
 
-The run had substantial pair-to-pair noise. Cancellation ranged from -4.05% to
-+70.72%, Markdown delta ranged from -10.89% to +17.07%, and cache-hit controls
-that do not traverse artifact construction also moved by a paired median of up
-to +4.88%. The Rust improvements are therefore not claimed as a speedup, while
-the mixed signs and noisy controls provide no repeatable primary-path regression
-signal attributable to the seam.
+Every primary scenario had mixed pair signs. Controls that do not traverse
+artifact construction were noisier: Markdown large cache hit had a +23.80%
+paired median with a -38.74% to +62.22% range, while Unicode cache hit ranged
+from -0.77% to +46.36%. The result therefore supports non-regression only, not a
+speedup claim.
 
 `manifest.json` attests the exact commits, harness sources, binaries, fixture
 manifest, raw pair files, stdout captures, and aggregate summary.

--- a/benches/results/semantic-artifact-seam-2026-07-23/README.md
+++ b/benches/results/semantic-artifact-seam-2026-07-23/README.md
@@ -8,7 +8,7 @@ performance improvement.
 
 - A: `refactor/semantic-sync-core` at
   `265d38b0ac95822b17e5cec19c5e226d3d034bb9`
-- B: `benchmark/semantic-artifact-seam-2026-07-23` at
+- B: `benchmark/semantic-artifact-seam-final-2026-07-23` at
   `518c1868e7c955d5241b3a5acaadf5d0617981b9`
 - Harness: `benchmark/semantic-lazy-content-lines-harness-2026-07-23` at
   `553b901bbf421e3851886c2a3e94b16adca6c34a`

--- a/benches/results/semantic-artifact-seam-2026-07-23/fixture-manifest.json
+++ b/benches/results/semantic-artifact-seam-2026-07-23/fixture-manifest.json
@@ -1,0 +1,194 @@
+[
+  {
+    "path": ".installed",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "cache/parsers.lua",
+    "sha256": "8a3014b92e4087c85288ee8c247764ac6ee0d1036eeee3c8127a63ab7a90207f",
+    "size": 73934,
+    "type": "file"
+  },
+  {
+    "path": "parser/lua.dylib",
+    "sha256": "bfd6dbf07a32100f8642c1a53bc72cff5f077c99acf2d4c614b77fa2e9722112",
+    "size": 84600,
+    "type": "file"
+  },
+  {
+    "path": "parser/markdown.dylib",
+    "sha256": "f10fa4ab2c085e3ff28f805b46df90bcb82929dfb358848064f0c012daac1d0c",
+    "size": 418088,
+    "type": "file"
+  },
+  {
+    "path": "parser/markdown_inline.dylib",
+    "sha256": "7bb8d9cd0258a7c1fb88492ce2338ea02def97e47e8318d6cbcf5c0f8f2f9269",
+    "size": 416816,
+    "type": "file"
+  },
+  {
+    "path": "parser/python.dylib",
+    "sha256": "004a9d79c5fa535e1c93253313e049f5c0d88855629bb9a45b05bd170ba31aff",
+    "size": 480920,
+    "type": "file"
+  },
+  {
+    "path": "parser/rust.dylib",
+    "sha256": "eb627a0ff57c1c5eeec059f12e785bb137f7e65c2e62b2c8b1fdceaf6607b813",
+    "size": 1142360,
+    "type": "file"
+  },
+  {
+    "path": "parser/yaml.dylib",
+    "sha256": "967f9e0729e1d7cfe3661a83bcd96284862097d53c8f9b1d65838ba5cb6b53be",
+    "size": 217176,
+    "type": "file"
+  },
+  {
+    "path": "queries/.lua.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.markdown.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.markdown_inline.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.python.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.rust.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.yaml.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/highlights.scm",
+    "sha256": "ac7dfa89d16ba817c3681aa47c22bdb4441a78a89ed827a757efa755992de67f",
+    "size": 4336,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/injections.scm",
+    "sha256": "a2ee92c2f00f39ebeeb1d0cc06302dba58c4f1dda77a2f0c9e5d7d7beab0b1ff",
+    "size": 5168,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/highlights.scm",
+    "sha256": "7b71d4994cf3968e16d033ac59d28bb034427dd41be6a057b7a2985e2dfbe5b8",
+    "size": 2654,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/injections.scm",
+    "sha256": "34090de78df99b5ea84c2fbb9324f2b7c32e602043595286e83f1a1ac126073c",
+    "size": 659,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/highlights.scm",
+    "sha256": "7db9147da61de7491ede9155e554dc033d6a1b86ecd1b21f6849c018be9ac875",
+    "size": 2259,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/injections.scm",
+    "sha256": "051f44218e0fe25cd949dfccad80699d5456ee379c7c4cfa18a5165776ecab0e",
+    "size": 207,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/highlights.scm",
+    "sha256": "ab8b66cbe6a7382e0ed7693c194101f1900c39f9ec0085a1749a8817e3e6895c",
+    "size": 9263,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/injections.scm",
+    "sha256": "8558299709200b21d496890e4799153dc069bf302ce1545d23f70a0869c8b65d",
+    "size": 812,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/highlights.scm",
+    "sha256": "4e0f5994f30ee545fc63435054a0b029c7d0222632c5c787c4e9c249dc0ef20f",
+    "size": 8638,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/injections.scm",
+    "sha256": "7dde97bbdabd208f984e13627bd4daae0f73012c41faafab39d670b607710f4e",
+    "size": 2418,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/highlights.scm",
+    "sha256": "13352b80d2ce28c3328ccb2f321e5144c3365ff6055078e00e7cff118d1488b5",
+    "size": 1700,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/injections.scm",
+    "sha256": "8349bd07691e2e610decdfc7b898bb5b01b226aae8745217bc811427f7af6742",
+    "size": 2373,
+    "type": "file"
+  }
+]

--- a/benches/results/semantic-artifact-seam-2026-07-23/fixture-manifest.json
+++ b/benches/results/semantic-artifact-seam-2026-07-23/fixture-manifest.json
@@ -13,37 +13,37 @@
   },
   {
     "path": "parser/lua.dylib",
-    "sha256": "bfd6dbf07a32100f8642c1a53bc72cff5f077c99acf2d4c614b77fa2e9722112",
+    "sha256": "61d726dc2e7c05d603d3bf1d958c9a4624f4f6a0a5f3cd88534ea4a4f4aaa49c",
     "size": 84600,
     "type": "file"
   },
   {
     "path": "parser/markdown.dylib",
-    "sha256": "f10fa4ab2c085e3ff28f805b46df90bcb82929dfb358848064f0c012daac1d0c",
+    "sha256": "29661e9c1762700b6640be2a0c83d427d88ad599176f3f5f5ef94183828dc582",
     "size": 418088,
     "type": "file"
   },
   {
     "path": "parser/markdown_inline.dylib",
-    "sha256": "7bb8d9cd0258a7c1fb88492ce2338ea02def97e47e8318d6cbcf5c0f8f2f9269",
+    "sha256": "750a7e3f5e67535d41d8e70a2f411ff8c6512fed184c78c752bec80c56c512b6",
     "size": 416816,
     "type": "file"
   },
   {
     "path": "parser/python.dylib",
-    "sha256": "004a9d79c5fa535e1c93253313e049f5c0d88855629bb9a45b05bd170ba31aff",
+    "sha256": "3c6439188b1d23312d0d843895e67d34df7d1e336a4a4f6fba44ff6a7379c1cc",
     "size": 480920,
     "type": "file"
   },
   {
     "path": "parser/rust.dylib",
-    "sha256": "eb627a0ff57c1c5eeec059f12e785bb137f7e65c2e62b2c8b1fdceaf6607b813",
+    "sha256": "b36c1ca607a7cdfb39295fb2ea840b52bf0612b431fb0454afe6a89bc6debdd1",
     "size": 1142360,
     "type": "file"
   },
   {
     "path": "parser/yaml.dylib",
-    "sha256": "967f9e0729e1d7cfe3661a83bcd96284862097d53c8f9b1d65838ba5cb6b53be",
+    "sha256": "4f181f9a4f465ecb525a4b6ee0f1e3c2b69bd13e0b92fdf3579c73d927ca539d",
     "size": 217176,
     "type": "file"
   },

--- a/benches/results/semantic-artifact-seam-2026-07-23/fixture-manifest.json
+++ b/benches/results/semantic-artifact-seam-2026-07-23/fixture-manifest.json
@@ -13,37 +13,37 @@
   },
   {
     "path": "parser/lua.dylib",
-    "sha256": "61d726dc2e7c05d603d3bf1d958c9a4624f4f6a0a5f3cd88534ea4a4f4aaa49c",
+    "sha256": "680dafb6ebb9dcd045e6e596a3aa1bdf01daba697d2595f705b64a6b5c230491",
     "size": 84600,
     "type": "file"
   },
   {
     "path": "parser/markdown.dylib",
-    "sha256": "29661e9c1762700b6640be2a0c83d427d88ad599176f3f5f5ef94183828dc582",
+    "sha256": "f719e14fb1311faed4a155267471c2c6d99b2aec99dcb35a244d3cae3b3c6275",
     "size": 418088,
     "type": "file"
   },
   {
     "path": "parser/markdown_inline.dylib",
-    "sha256": "750a7e3f5e67535d41d8e70a2f411ff8c6512fed184c78c752bec80c56c512b6",
+    "sha256": "0b01998efd903f8698ef4ddb098c6ee77040bc8bc6b8c6e1f571dc3e9fe5c85b",
     "size": 416816,
     "type": "file"
   },
   {
     "path": "parser/python.dylib",
-    "sha256": "3c6439188b1d23312d0d843895e67d34df7d1e336a4a4f6fba44ff6a7379c1cc",
+    "sha256": "327e02d0a7b47d576c4bb0740315f7eabe0306e02ffc5ec99196c44e950712e0",
     "size": 480920,
     "type": "file"
   },
   {
     "path": "parser/rust.dylib",
-    "sha256": "b36c1ca607a7cdfb39295fb2ea840b52bf0612b431fb0454afe6a89bc6debdd1",
+    "sha256": "563f22f771943c71f8dd707c2eebff7134062004c772c112a570828a83b99f9d",
     "size": 1142360,
     "type": "file"
   },
   {
     "path": "parser/yaml.dylib",
-    "sha256": "4f181f9a4f465ecb525a4b6ee0f1e3c2b69bd13e0b92fdf3579c73d927ca539d",
+    "sha256": "3cad3bf282a307944a81cd8b5497d57444e49a34bbb16d684513b0f8f3fad89f",
     "size": 217176,
     "type": "file"
   },

--- a/benches/results/semantic-artifact-seam-2026-07-23/manifest.json
+++ b/benches/results/semantic-artifact-seam-2026-07-23/manifest.json
@@ -1,9 +1,9 @@
 {
   "attestations": {
-    "binary_a": "409527ff7fab3534402e8264c316cdb0486435ff31a866644b53761e7f5aa678",
-    "binary_b": "cfead73fe8c6e1a0f0540a8ad66a9f85a368e4d988c841dbd181edb7d839bcf1",
-    "fixture": "aac17aae51200a368f5ab41217b7594a25313cb2a5b3498f25922fc5d9d2ab60",
-    "harness": "848e82e5e3cec662904cdc0f223c5a34bb645440064939f3abace02b5bb2046c"
+    "binary_a": "0a5789c1bfc3d8b4444e52a996e71a2e8af25c7e3c17ab3282487e77cff9f438",
+    "binary_b": "c8b768899d8c5a54aa7994cf6674bf0222ccc3abe9d6f90b3e6b664a26e4e6f7",
+    "fixture": "bda0c04c0a7ebb817c2d6d126ecda9a8ec6fd0307a8eb1548a08c08f61f83dd4",
+    "harness": "4e125ada66252c4f81fc344e6642727315d7746e5cd9b0307c6ff657158f5b2e"
   },
   "configuration": {
     "iterations": 30,
@@ -83,46 +83,46 @@
     }
   },
   "fixture_manifest": "fixture-manifest.json",
-  "fixture_manifest_sha256": "2015cbfd05c9bf7e62cbb0c5be9a136be7ef0b640b9a47ee89e3812edaa9e403",
+  "fixture_manifest_sha256": "5445a436cfd050112a4491dc20dcc456a8274028fc23de904ad8f7c8e2345c52",
   "raw_files": [
     {
       "order": "AB",
       "pair_index": 1,
       "samples": "pair-1.json",
-      "samples_sha256": "eea10a141bbe14edcec99b49c901e49cfea706f0d27bf1d593e9017fc34cf4f4",
+      "samples_sha256": "c8d48eda81863dca16a4ccfc4c47a3273677a3c81bd2cfc62c52014e821380c5",
       "stdout": "pair-1.txt",
-      "stdout_sha256": "48885cc9ce2e97b7fba2956056221a6811ba794245f4d8831c2a7b3c2d8b4800"
+      "stdout_sha256": "c973e5e14d105b8df531e2e232bb7cd56775617990e2a41231b23d84563a67f4"
     },
     {
       "order": "BA",
       "pair_index": 2,
       "samples": "pair-2.json",
-      "samples_sha256": "25669ad010ba4fa304a51fa9dc8520f061762b88a7341b35130a8ceeda3a5f96",
+      "samples_sha256": "63f47a64e56c53eb58715733533d11d19caf9c28f181edde7ab4445c66c1122f",
       "stdout": "pair-2.txt",
-      "stdout_sha256": "4ad84a80faa27c9bcdca80e3bf1c8a24911aa97b7867cafa891576eaf9e60543"
+      "stdout_sha256": "47d5d1c2d8b7ad87067263f8b9f826a20a03b079bfe5a2b1b29f1751d362b0a9"
     },
     {
       "order": "AB",
       "pair_index": 3,
       "samples": "pair-3.json",
-      "samples_sha256": "c706938b456e3e495b97884cfc8c2ead08c531936e6dd7e547a39de2b166035e",
+      "samples_sha256": "bb87a62714a911875af5bdc981b86628f454db4dc4dbdc4779cd904213f89aba",
       "stdout": "pair-3.txt",
-      "stdout_sha256": "4cbf359d44b831761adccb43edb3dc0ac72f7032cc73ed7d2aee7cea6237017b"
+      "stdout_sha256": "7e1575ceeee4a9986ab8e3dd4f2c463e22304b6f3dd3a4e8c622bf331cb50fdc"
     },
     {
       "order": "BA",
       "pair_index": 4,
       "samples": "pair-4.json",
-      "samples_sha256": "5e38e88bb5e77b2c99be8ce49bf1c9d16c4a0bafe7a08b976c7ea25303c0af45",
+      "samples_sha256": "0bf48f2af39def74bc654f36e640fee7b6b08408e5fe084218762fb3faf96259",
       "stdout": "pair-4.txt",
-      "stdout_sha256": "409af599467275d3c4beba7c3d8e8a0c23ffe502b970c1c4345c9ca1850e4ad5"
+      "stdout_sha256": "21d95161c90b28071e1de56af31de8b3a050786308091f8cb39046ff8505c7b7"
     }
   ],
   "schema_version": 1,
   "source": {
     "a_commit": "265d38b0ac95822b17e5cec19c5e226d3d034bb9",
     "a_ref": "refactor/semantic-sync-core",
-    "b_commit": "1805e61907b6f2b6ce4718b5145d131a174c4a2e",
+    "b_commit": "518c1868e7c955d5241b3a5acaadf5d0617981b9",
     "b_ref": "benchmark/semantic-artifact-seam-2026-07-23",
     "harness_commit": "553b901bbf421e3851886c2a3e94b16adca6c34a",
     "harness_ref": "benchmark/semantic-lazy-content-lines-harness-2026-07-23",
@@ -134,5 +134,5 @@
     }
   },
   "summary": "summary.json",
-  "summary_sha256": "04af807227b26851ea797797a419dff0b2fa2faa63729fd30ead4a56bff9fec2"
+  "summary_sha256": "ba158f2adb981eb40ef61ec43d9b879c4b239d0e8423b163e8664b8f22033a59"
 }

--- a/benches/results/semantic-artifact-seam-2026-07-23/manifest.json
+++ b/benches/results/semantic-artifact-seam-2026-07-23/manifest.json
@@ -1,0 +1,138 @@
+{
+  "attestations": {
+    "binary_a": "409527ff7fab3534402e8264c316cdb0486435ff31a866644b53761e7f5aa678",
+    "binary_b": "cfead73fe8c6e1a0f0540a8ad66a9f85a368e4d988c841dbd181edb7d839bcf1",
+    "fixture": "aac17aae51200a368f5ab41217b7594a25313cb2a5b3498f25922fc5d9d2ab60",
+    "harness": "848e82e5e3cec662904cdc0f223c5a34bb645440064939f3abace02b5bb2046c"
+  },
+  "configuration": {
+    "iterations": 30,
+    "pairs": 4,
+    "run_timeout_seconds": 900,
+    "scenario_filters": [
+      "rust_large/full_cache_hit",
+      "rust_large/typing_delta",
+      "rust_sparse_32k_minus/typing_delta",
+      "rust_sparse_32k_exact/typing_delta",
+      "rust_sparse_32k_plus/typing_delta",
+      "rust_sparse_64k/typing_delta",
+      "rust_large/typing_burst",
+      "rust_xlarge/cancel_burst",
+      "markdown_injections_large/full_cache_hit",
+      "markdown_injections/typing_delta",
+      "markdown_injections/typing_burst",
+      "unicode_rust/full_cache_hit"
+    ],
+    "scenarios": [
+      "markdown_injections/typing_burst",
+      "markdown_injections/typing_delta",
+      "markdown_injections_large/full_cache_hit",
+      "rust_large/full_cache_hit",
+      "rust_large/typing_burst",
+      "rust_large/typing_delta",
+      "rust_sparse_32k_exact/typing_delta",
+      "rust_sparse_32k_minus/typing_delta",
+      "rust_sparse_32k_plus/typing_delta",
+      "rust_sparse_64k/typing_delta",
+      "rust_xlarge/cancel_burst",
+      "unicode_rust/full_cache_hit"
+    ],
+    "server_env": {},
+    "warmup_iterations": 6
+  },
+  "environment": {
+    "build": {
+      "CARGO_HOME": "<TEMP>/cargo-home",
+      "CARGO_TERM_COLOR": "never",
+      "HOME": "<TEMP>/home",
+      "LANG": "C",
+      "LC_ALL": "C",
+      "PATH": "<USER_HOME_PATH>:<USER_HOME_PATH>:<USER_HOME_PATH>:/opt/homebrew/bin:/opt/homebrew/sbin:/nix/var/nix/profiles/default/bin:<USER_HOME_PATH>:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:<USER_HOME_PATH>",
+      "RUSTUP_HOME": "<USER_HOME>/.rustup",
+      "TMPDIR": "<TEMP>/tmp"
+    },
+    "cc": "Apple clang version 21.0.0 (clang-2100.1.1.101)\nTarget: arm64-apple-darwin25.5.0\nThread model: posix\nInstalledDir: /Library/Developer/CommandLineTools/usr/bin",
+    "clang": "Apple clang version 21.0.0 (clang-2100.1.1.101)\nTarget: arm64-apple-darwin25.5.0\nThread model: posix\nInstalledDir: /Library/Developer/CommandLineTools/usr/bin",
+    "machine": "arm64",
+    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "processor": "arm",
+    "runtime": {
+      "CARGO_HOME": "<TEMP>/cargo-home",
+      "CARGO_TERM_COLOR": "never",
+      "HOME": "<TEMP>/home",
+      "LANG": "C",
+      "LC_ALL": "C",
+      "PATH": "<USER_HOME_PATH>:<USER_HOME_PATH>:<USER_HOME_PATH>:/opt/homebrew/bin:/opt/homebrew/sbin:/nix/var/nix/profiles/default/bin:<USER_HOME_PATH>:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:<USER_HOME_PATH>",
+      "RUSTUP_HOME": "<USER_HOME>/.rustup",
+      "TMPDIR": "<TEMP>/tmp"
+    },
+    "sdk": "26.5",
+    "toolchains": {
+      "a": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      },
+      "b": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      },
+      "harness": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      }
+    }
+  },
+  "fixture_manifest": "fixture-manifest.json",
+  "fixture_manifest_sha256": "2015cbfd05c9bf7e62cbb0c5be9a136be7ef0b640b9a47ee89e3812edaa9e403",
+  "raw_files": [
+    {
+      "order": "AB",
+      "pair_index": 1,
+      "samples": "pair-1.json",
+      "samples_sha256": "eea10a141bbe14edcec99b49c901e49cfea706f0d27bf1d593e9017fc34cf4f4",
+      "stdout": "pair-1.txt",
+      "stdout_sha256": "48885cc9ce2e97b7fba2956056221a6811ba794245f4d8831c2a7b3c2d8b4800"
+    },
+    {
+      "order": "BA",
+      "pair_index": 2,
+      "samples": "pair-2.json",
+      "samples_sha256": "25669ad010ba4fa304a51fa9dc8520f061762b88a7341b35130a8ceeda3a5f96",
+      "stdout": "pair-2.txt",
+      "stdout_sha256": "4ad84a80faa27c9bcdca80e3bf1c8a24911aa97b7867cafa891576eaf9e60543"
+    },
+    {
+      "order": "AB",
+      "pair_index": 3,
+      "samples": "pair-3.json",
+      "samples_sha256": "c706938b456e3e495b97884cfc8c2ead08c531936e6dd7e547a39de2b166035e",
+      "stdout": "pair-3.txt",
+      "stdout_sha256": "4cbf359d44b831761adccb43edb3dc0ac72f7032cc73ed7d2aee7cea6237017b"
+    },
+    {
+      "order": "BA",
+      "pair_index": 4,
+      "samples": "pair-4.json",
+      "samples_sha256": "5e38e88bb5e77b2c99be8ce49bf1c9d16c4a0bafe7a08b976c7ea25303c0af45",
+      "stdout": "pair-4.txt",
+      "stdout_sha256": "409af599467275d3c4beba7c3d8e8a0c23ffe502b970c1c4345c9ca1850e4ad5"
+    }
+  ],
+  "schema_version": 1,
+  "source": {
+    "a_commit": "265d38b0ac95822b17e5cec19c5e226d3d034bb9",
+    "a_ref": "refactor/semantic-sync-core",
+    "b_commit": "1805e61907b6f2b6ce4718b5145d131a174c4a2e",
+    "b_ref": "benchmark/semantic-artifact-seam-2026-07-23",
+    "harness_commit": "553b901bbf421e3851886c2a3e94b16adca6c34a",
+    "harness_ref": "benchmark/semantic-lazy-content-lines-harness-2026-07-23",
+    "harness_sources_sha256": {
+      "benches/collect_semantic_pairs.py": "7ce0d8628d2f28ac331d15ccf470e7b1b4fb596d5a475588cfa25689746de798",
+      "benches/semantic_summary.py": "8aab3d2622ec7bfface33f29fee8fd695297b31eb2007fc5b2b20d8be2e3d1d0",
+      "benches/semantic_tokens.rs": "2d35487ff38a5b7b72540f55c5fb43ae6ca5190b9b579264ae0323e6fd927139",
+      "benches/support/semantic_baseline.rs": "4ab35bab7a05b32d652262c61c4cd4c720a21bfe3d1730694ea9dda5b306410c"
+    }
+  },
+  "summary": "summary.json",
+  "summary_sha256": "04af807227b26851ea797797a419dff0b2fa2faa63729fd30ead4a56bff9fec2"
+}

--- a/benches/results/semantic-artifact-seam-2026-07-23/manifest.json
+++ b/benches/results/semantic-artifact-seam-2026-07-23/manifest.json
@@ -123,7 +123,7 @@
     "a_commit": "265d38b0ac95822b17e5cec19c5e226d3d034bb9",
     "a_ref": "refactor/semantic-sync-core",
     "b_commit": "518c1868e7c955d5241b3a5acaadf5d0617981b9",
-    "b_ref": "benchmark/semantic-artifact-seam-2026-07-23",
+    "b_ref": "benchmark/semantic-artifact-seam-final-2026-07-23",
     "harness_commit": "553b901bbf421e3851886c2a3e94b16adca6c34a",
     "harness_ref": "benchmark/semantic-lazy-content-lines-harness-2026-07-23",
     "harness_sources_sha256": {

--- a/benches/results/semantic-artifact-seam-2026-07-23/manifest.json
+++ b/benches/results/semantic-artifact-seam-2026-07-23/manifest.json
@@ -1,9 +1,9 @@
 {
   "attestations": {
-    "binary_a": "0a5789c1bfc3d8b4444e52a996e71a2e8af25c7e3c17ab3282487e77cff9f438",
-    "binary_b": "c8b768899d8c5a54aa7994cf6674bf0222ccc3abe9d6f90b3e6b664a26e4e6f7",
-    "fixture": "bda0c04c0a7ebb817c2d6d126ecda9a8ec6fd0307a8eb1548a08c08f61f83dd4",
-    "harness": "4e125ada66252c4f81fc344e6642727315d7746e5cd9b0307c6ff657158f5b2e"
+    "binary_a": "ad264e5cc3a677c7df398fbca1073ea2a101ecdb4722c94800fa058d22418be4",
+    "binary_b": "eccd06df47988207ca33bb5bbfa3206baf714160225a6e58a62affccda6378f9",
+    "fixture": "d97670d5e11f0b424195495369ced287660e7754a8934a199000150913a61c2b",
+    "harness": "af5926283f2cc3ed4f50d4437aae71a2a3d2387345511b26e58486a747033995"
   },
   "configuration": {
     "iterations": 30,
@@ -83,47 +83,47 @@
     }
   },
   "fixture_manifest": "fixture-manifest.json",
-  "fixture_manifest_sha256": "5445a436cfd050112a4491dc20dcc456a8274028fc23de904ad8f7c8e2345c52",
+  "fixture_manifest_sha256": "b3bd436e9472cc133f52f1d472cbb065b401aba5e3746aaf0bca81ee0b493e09",
   "raw_files": [
     {
       "order": "AB",
       "pair_index": 1,
       "samples": "pair-1.json",
-      "samples_sha256": "c8d48eda81863dca16a4ccfc4c47a3273677a3c81bd2cfc62c52014e821380c5",
+      "samples_sha256": "a0734791110ab1632cbe8040beaf408130992cc860533e355936dbe899d562fd",
       "stdout": "pair-1.txt",
-      "stdout_sha256": "c973e5e14d105b8df531e2e232bb7cd56775617990e2a41231b23d84563a67f4"
+      "stdout_sha256": "69b6ca0869946d31f587419d5c6fabd39b7581636a84b6cf497cc71603d75ad8"
     },
     {
       "order": "BA",
       "pair_index": 2,
       "samples": "pair-2.json",
-      "samples_sha256": "63f47a64e56c53eb58715733533d11d19caf9c28f181edde7ab4445c66c1122f",
+      "samples_sha256": "8072ac84646234d6a6915e878b877041fd22ae27b1d2237052c26803447f0b3f",
       "stdout": "pair-2.txt",
-      "stdout_sha256": "47d5d1c2d8b7ad87067263f8b9f826a20a03b079bfe5a2b1b29f1751d362b0a9"
+      "stdout_sha256": "60bcf307f4ab221c8e2810ded76a4636509a4feb1a5c77204088ea1ef9e21f2d"
     },
     {
       "order": "AB",
       "pair_index": 3,
       "samples": "pair-3.json",
-      "samples_sha256": "bb87a62714a911875af5bdc981b86628f454db4dc4dbdc4779cd904213f89aba",
+      "samples_sha256": "945abe56e736e31c3f0b9ac8ede7b796b95b3f99bbf9a30bf4f828601cb757f1",
       "stdout": "pair-3.txt",
-      "stdout_sha256": "7e1575ceeee4a9986ab8e3dd4f2c463e22304b6f3dd3a4e8c622bf331cb50fdc"
+      "stdout_sha256": "59696afb4c718c8139108a0b330d955a6c2d66ad0d4ceb1dda0f16beacd3deff"
     },
     {
       "order": "BA",
       "pair_index": 4,
       "samples": "pair-4.json",
-      "samples_sha256": "0bf48f2af39def74bc654f36e640fee7b6b08408e5fe084218762fb3faf96259",
+      "samples_sha256": "247a85efe59a893ab3d5c977a6eaf6592792d60b80791f60a9c6166579b2ce1f",
       "stdout": "pair-4.txt",
-      "stdout_sha256": "21d95161c90b28071e1de56af31de8b3a050786308091f8cb39046ff8505c7b7"
+      "stdout_sha256": "b4ad582a90743f7cbbd38b311da11a4d195b3cbb0019aed845d50be3c2b67c8a"
     }
   ],
   "schema_version": 1,
   "source": {
     "a_commit": "265d38b0ac95822b17e5cec19c5e226d3d034bb9",
     "a_ref": "refactor/semantic-sync-core",
-    "b_commit": "518c1868e7c955d5241b3a5acaadf5d0617981b9",
-    "b_ref": "benchmark/semantic-artifact-seam-final-2026-07-23",
+    "b_commit": "8b966d16f5a3a56c985a71d16b91e2e1fe5ae53f",
+    "b_ref": "benchmark/semantic-artifact-seam-converged-2026-07-23",
     "harness_commit": "553b901bbf421e3851886c2a3e94b16adca6c34a",
     "harness_ref": "benchmark/semantic-lazy-content-lines-harness-2026-07-23",
     "harness_sources_sha256": {
@@ -134,5 +134,5 @@
     }
   },
   "summary": "summary.json",
-  "summary_sha256": "ba158f2adb981eb40ef61ec43d9b879c4b239d0e8423b163e8664b8f22033a59"
+  "summary_sha256": "94b5d916e67e7f776ffed59196e6eeaf4f77c90b3f94f3b54c49e6b6971ff7ec"
 }

--- a/benches/results/semantic-artifact-seam-2026-07-23/pair-1.txt
+++ b/benches/results/semantic-artifact-seam-2026-07-23/pair-1.txt
@@ -1,0 +1,43 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               1.749ms      1.763ms        +0.8%
+    p95:      1.878ms      2.029ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.659ms      0.790ms        +19.9%
+    p95:      0.772ms      1.040ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.729ms      0.677ms         -7.2%
+    p95:      0.882ms      0.905ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/typing_delta                15.379ms     15.380ms        +0.0%
+    p95:     16.377ms     15.871ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta      5.693ms      5.706ms        +0.2%
+    p95:      5.956ms      6.215ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta      5.860ms      5.730ms         -2.2%
+    p95:      6.278ms      6.082ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta       5.731ms      5.805ms        +1.3%
+    p95:      6.113ms      6.319ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           11.457ms     11.186ms         -2.4%
+    p95:     12.594ms     11.809ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                15.921ms     16.156ms        +1.5%
+    p95:     17.409ms     17.154ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+rust_xlarge/cancel_burst              111.187ms    111.454ms        +0.2%
+    p95:    142.122ms    129.941ms
+    └ targets: current-token latency after four explicitly cancelled edit states
+markdown_injections/typing_delta        4.468ms      4.193ms         -6.1%
+    p95:      5.261ms      4.959ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        4.153ms      4.220ms        +1.6%
+    p95:      5.103ms      5.204ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-artifact-seam-2026-07-23/pair-1.txt
+++ b/benches/results/semantic-artifact-seam-2026-07-23/pair-1.txt
@@ -5,39 +5,39 @@ semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
 
 scenario                                A (med)      B (med) Δ (B vs A)
 ------------------------------------------------------------------------
-rust_large/full_cache_hit               1.749ms      1.763ms        +0.8%
-    p95:      1.878ms      2.029ms
+rust_large/full_cache_hit               1.749ms      1.819ms        +4.0%
+    p95:      1.876ms      2.142ms
     └ targets: large exact-snapshot semantic cache-hit control
-markdown_injections_large/full_cache_hit      0.659ms      0.790ms        +19.9%
-    p95:      0.772ms      1.040ms
+markdown_injections_large/full_cache_hit      0.685ms      0.873ms        +27.5%
+    p95:      0.781ms      1.251ms
     └ targets: large injection document exact-snapshot semantic cache-hit control
-unicode_rust/full_cache_hit             0.729ms      0.677ms         -7.2%
-    p95:      0.882ms      0.905ms
+unicode_rust/full_cache_hit             0.671ms      0.667ms         -0.7%
+    p95:      0.795ms      0.776ms
     └ targets: Unicode document exact-snapshot semantic cache-hit control
-rust_large/typing_delta                15.379ms     15.380ms        +0.0%
-    p95:     16.377ms     15.871ms
+rust_large/typing_delta                15.619ms     15.448ms         -1.1%
+    p95:     16.640ms     16.518ms
     └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
-rust_sparse_32k_minus/typing_delta      5.693ms      5.706ms        +0.2%
-    p95:      5.956ms      6.215ms
+rust_sparse_32k_minus/typing_delta      5.708ms      5.693ms         -0.3%
+    p95:      6.461ms      6.358ms
     └ targets: sparse low-match control just below 32 KiB
-rust_sparse_32k_exact/typing_delta      5.860ms      5.730ms         -2.2%
-    p95:      6.278ms      6.082ms
+rust_sparse_32k_exact/typing_delta      5.684ms      5.671ms         -0.2%
+    p95:      5.999ms      6.004ms
     └ targets: sparse low-match control at 32 KiB
-rust_sparse_32k_plus/typing_delta       5.731ms      5.805ms        +1.3%
-    p95:      6.113ms      6.319ms
+rust_sparse_32k_plus/typing_delta       5.813ms      5.818ms        +0.1%
+    p95:      6.162ms      6.408ms
     └ targets: sparse low-match control just above 32 KiB
-rust_sparse_64k/typing_delta           11.457ms     11.186ms         -2.4%
-    p95:     12.594ms     11.809ms
+rust_sparse_64k/typing_delta           11.234ms     11.221ms         -0.1%
+    p95:     11.757ms     12.291ms
     └ targets: sparse low-match query walk at 64 KiB
-rust_large/typing_burst                15.921ms     16.156ms        +1.5%
-    p95:     17.409ms     17.154ms
+rust_large/typing_burst                17.140ms     15.845ms         -7.6%
+    p95:     19.070ms     16.466ms
     └ targets: eight queued unique edits→current delta; latest-state follow latency
-rust_xlarge/cancel_burst              111.187ms    111.454ms        +0.2%
-    p95:    142.122ms    129.941ms
+rust_xlarge/cancel_burst               81.402ms    138.972ms        +70.7%
+    p95:     87.767ms    161.334ms
     └ targets: current-token latency after four explicitly cancelled edit states
-markdown_injections/typing_delta        4.468ms      4.193ms         -6.1%
-    p95:      5.261ms      4.959ms
+markdown_injections/typing_delta        5.331ms      4.751ms         -10.9%
+    p95:      5.983ms      5.251ms
     └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
-markdown_injections/typing_burst        4.153ms      4.220ms        +1.6%
-    p95:      5.103ms      5.204ms
+markdown_injections/typing_burst        4.465ms      4.799ms        +7.5%
+    p95:      4.778ms      5.183ms
     └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-artifact-seam-2026-07-23/pair-1.txt
+++ b/benches/results/semantic-artifact-seam-2026-07-23/pair-1.txt
@@ -5,39 +5,39 @@ semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
 
 scenario                                A (med)      B (med) Δ (B vs A)
 ------------------------------------------------------------------------
-rust_large/full_cache_hit               1.749ms      1.819ms        +4.0%
-    p95:      1.876ms      2.142ms
+rust_large/full_cache_hit               1.747ms      1.820ms        +4.2%
+    p95:      1.881ms      2.028ms
     └ targets: large exact-snapshot semantic cache-hit control
-markdown_injections_large/full_cache_hit      0.685ms      0.873ms        +27.5%
-    p95:      0.781ms      1.251ms
+markdown_injections_large/full_cache_hit      0.637ms      0.865ms        +35.8%
+    p95:      0.791ms      1.297ms
     └ targets: large injection document exact-snapshot semantic cache-hit control
-unicode_rust/full_cache_hit             0.671ms      0.667ms         -0.7%
-    p95:      0.795ms      0.776ms
+unicode_rust/full_cache_hit             0.470ms      0.687ms        +46.4%
+    p95:      0.513ms      0.891ms
     └ targets: Unicode document exact-snapshot semantic cache-hit control
-rust_large/typing_delta                15.619ms     15.448ms         -1.1%
-    p95:     16.640ms     16.518ms
+rust_large/typing_delta                15.705ms     16.085ms        +2.4%
+    p95:     17.334ms     18.718ms
     └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
-rust_sparse_32k_minus/typing_delta      5.708ms      5.693ms         -0.3%
-    p95:      6.461ms      6.358ms
+rust_sparse_32k_minus/typing_delta      5.778ms      5.872ms        +1.6%
+    p95:      6.102ms      6.189ms
     └ targets: sparse low-match control just below 32 KiB
-rust_sparse_32k_exact/typing_delta      5.684ms      5.671ms         -0.2%
-    p95:      5.999ms      6.004ms
+rust_sparse_32k_exact/typing_delta      5.741ms      5.728ms         -0.2%
+    p95:      6.262ms      6.173ms
     └ targets: sparse low-match control at 32 KiB
-rust_sparse_32k_plus/typing_delta       5.813ms      5.818ms        +0.1%
-    p95:      6.162ms      6.408ms
+rust_sparse_32k_plus/typing_delta       5.817ms      5.770ms         -0.8%
+    p95:      6.344ms      6.052ms
     └ targets: sparse low-match control just above 32 KiB
-rust_sparse_64k/typing_delta           11.234ms     11.221ms         -0.1%
-    p95:     11.757ms     12.291ms
+rust_sparse_64k/typing_delta           11.279ms     11.249ms         -0.3%
+    p95:     12.194ms     12.155ms
     └ targets: sparse low-match query walk at 64 KiB
-rust_large/typing_burst                17.140ms     15.845ms         -7.6%
-    p95:     19.070ms     16.466ms
+rust_large/typing_burst                16.015ms     15.930ms         -0.5%
+    p95:     18.475ms     17.374ms
     └ targets: eight queued unique edits→current delta; latest-state follow latency
-rust_xlarge/cancel_burst               81.402ms    138.972ms        +70.7%
-    p95:     87.767ms    161.334ms
+rust_xlarge/cancel_burst              103.605ms    127.585ms        +23.1%
+    p95:    133.178ms    150.842ms
     └ targets: current-token latency after four explicitly cancelled edit states
-markdown_injections/typing_delta        5.331ms      4.751ms         -10.9%
-    p95:      5.983ms      5.251ms
+markdown_injections/typing_delta        4.564ms      4.130ms         -9.5%
+    p95:      5.043ms      5.148ms
     └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
-markdown_injections/typing_burst        4.465ms      4.799ms        +7.5%
-    p95:      4.778ms      5.183ms
+markdown_injections/typing_burst        4.189ms      4.123ms         -1.6%
+    p95:      5.269ms      5.138ms
     └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-artifact-seam-2026-07-23/pair-2.txt
+++ b/benches/results/semantic-artifact-seam-2026-07-23/pair-2.txt
@@ -5,39 +5,39 @@ semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
 
 scenario                                B (med)      A (med) Δ (A vs B)
 ------------------------------------------------------------------------
-rust_large/full_cache_hit               2.079ms      1.951ms         -6.2%
-    p95:      2.139ms      2.068ms
+rust_large/full_cache_hit               1.839ms      1.794ms         -2.4%
+    p95:      2.217ms      2.213ms
     └ targets: large exact-snapshot semantic cache-hit control
-markdown_injections_large/full_cache_hit      0.496ms      0.867ms        +74.8%
-    p95:      0.540ms      1.253ms
+markdown_injections_large/full_cache_hit      0.999ms      0.616ms         -38.4%
+    p95:      1.214ms      0.710ms
     └ targets: large injection document exact-snapshot semantic cache-hit control
-unicode_rust/full_cache_hit             0.630ms      0.412ms         -34.7%
-    p95:      0.767ms      0.435ms
+unicode_rust/full_cache_hit             0.749ms      0.728ms         -2.8%
+    p95:      0.886ms      0.902ms
     └ targets: Unicode document exact-snapshot semantic cache-hit control
-rust_large/typing_delta                15.921ms     18.456ms        +15.9%
-    p95:     17.162ms     23.350ms
+rust_large/typing_delta                15.320ms     15.343ms        +0.2%
+    p95:     15.799ms     16.502ms
     └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
-rust_sparse_32k_minus/typing_delta      9.367ms      8.704ms         -7.1%
-    p95:     10.007ms      9.892ms
+rust_sparse_32k_minus/typing_delta      5.858ms      5.662ms         -3.4%
+    p95:      6.379ms      6.410ms
     └ targets: sparse low-match control just below 32 KiB
-rust_sparse_32k_exact/typing_delta      8.463ms      8.195ms         -3.2%
-    p95:      8.997ms      8.775ms
+rust_sparse_32k_exact/typing_delta      5.617ms      5.741ms        +2.2%
+    p95:      7.086ms      6.471ms
     └ targets: sparse low-match control at 32 KiB
-rust_sparse_32k_plus/typing_delta       7.181ms      6.533ms         -9.0%
-    p95:      7.613ms      6.989ms
+rust_sparse_32k_plus/typing_delta       5.770ms      5.844ms        +1.3%
+    p95:      6.570ms      6.242ms
     └ targets: sparse low-match control just above 32 KiB
-rust_sparse_64k/typing_delta           13.424ms     14.035ms        +4.6%
-    p95:     14.599ms     15.562ms
+rust_sparse_64k/typing_delta           12.553ms     14.624ms        +16.5%
+    p95:     14.128ms     17.091ms
     └ targets: sparse low-match query walk at 64 KiB
-rust_large/typing_burst                26.676ms     29.682ms        +11.3%
-    p95:     30.511ms     32.734ms
+rust_large/typing_burst                28.552ms     28.319ms         -0.8%
+    p95:     34.047ms     31.581ms
     └ targets: eight queued unique edits→current delta; latest-state follow latency
-rust_xlarge/cancel_burst              137.546ms    143.359ms        +4.2%
-    p95:    147.322ms    159.309ms
+rust_xlarge/cancel_burst              138.657ms    141.984ms        +2.4%
+    p95:    146.308ms    191.214ms
     └ targets: current-token latency after four explicitly cancelled edit states
-markdown_injections/typing_delta        4.383ms      4.179ms         -4.6%
-    p95:      4.857ms      4.944ms
+markdown_injections/typing_delta        7.812ms      7.100ms         -9.1%
+    p95:      9.771ms      7.750ms
     └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
-markdown_injections/typing_burst        4.197ms      4.225ms        +0.7%
-    p95:      5.403ms      5.960ms
+markdown_injections/typing_burst        6.792ms      6.290ms         -7.4%
+    p95:      7.180ms      6.641ms
     └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-artifact-seam-2026-07-23/pair-2.txt
+++ b/benches/results/semantic-artifact-seam-2026-07-23/pair-2.txt
@@ -1,0 +1,43 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               1.768ms      1.833ms        +3.7%
+    p95:      2.026ms      2.199ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.821ms      0.877ms        +6.8%
+    p95:      1.122ms      1.333ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.675ms      0.682ms        +1.1%
+    p95:      0.896ms      0.907ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/typing_delta                15.452ms     15.566ms        +0.7%
+    p95:     16.400ms     16.365ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta      5.793ms      5.819ms        +0.4%
+    p95:      6.307ms      6.038ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta      5.728ms      5.760ms        +0.6%
+    p95:      6.189ms      6.431ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta       5.788ms      5.817ms        +0.5%
+    p95:      5.995ms      6.060ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           11.165ms     11.121ms         -0.4%
+    p95:     12.011ms     11.509ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                16.003ms     16.158ms        +1.0%
+    p95:     16.624ms     16.845ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+rust_xlarge/cancel_burst               97.655ms    109.351ms        +12.0%
+    p95:    125.671ms    112.257ms
+    └ targets: current-token latency after four explicitly cancelled edit states
+markdown_injections/typing_delta        4.484ms      4.208ms         -6.1%
+    p95:      4.670ms      4.979ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        4.176ms      4.210ms        +0.8%
+    p95:      4.413ms      4.791ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-artifact-seam-2026-07-23/pair-2.txt
+++ b/benches/results/semantic-artifact-seam-2026-07-23/pair-2.txt
@@ -5,39 +5,39 @@ semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
 
 scenario                                B (med)      A (med) Δ (A vs B)
 ------------------------------------------------------------------------
-rust_large/full_cache_hit               1.768ms      1.833ms        +3.7%
-    p95:      2.026ms      2.199ms
+rust_large/full_cache_hit               2.079ms      1.951ms         -6.2%
+    p95:      2.139ms      2.068ms
     └ targets: large exact-snapshot semantic cache-hit control
-markdown_injections_large/full_cache_hit      0.821ms      0.877ms        +6.8%
-    p95:      1.122ms      1.333ms
+markdown_injections_large/full_cache_hit      0.496ms      0.867ms        +74.8%
+    p95:      0.540ms      1.253ms
     └ targets: large injection document exact-snapshot semantic cache-hit control
-unicode_rust/full_cache_hit             0.675ms      0.682ms        +1.1%
-    p95:      0.896ms      0.907ms
+unicode_rust/full_cache_hit             0.630ms      0.412ms         -34.7%
+    p95:      0.767ms      0.435ms
     └ targets: Unicode document exact-snapshot semantic cache-hit control
-rust_large/typing_delta                15.452ms     15.566ms        +0.7%
-    p95:     16.400ms     16.365ms
+rust_large/typing_delta                15.921ms     18.456ms        +15.9%
+    p95:     17.162ms     23.350ms
     └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
-rust_sparse_32k_minus/typing_delta      5.793ms      5.819ms        +0.4%
-    p95:      6.307ms      6.038ms
+rust_sparse_32k_minus/typing_delta      9.367ms      8.704ms         -7.1%
+    p95:     10.007ms      9.892ms
     └ targets: sparse low-match control just below 32 KiB
-rust_sparse_32k_exact/typing_delta      5.728ms      5.760ms        +0.6%
-    p95:      6.189ms      6.431ms
+rust_sparse_32k_exact/typing_delta      8.463ms      8.195ms         -3.2%
+    p95:      8.997ms      8.775ms
     └ targets: sparse low-match control at 32 KiB
-rust_sparse_32k_plus/typing_delta       5.788ms      5.817ms        +0.5%
-    p95:      5.995ms      6.060ms
+rust_sparse_32k_plus/typing_delta       7.181ms      6.533ms         -9.0%
+    p95:      7.613ms      6.989ms
     └ targets: sparse low-match control just above 32 KiB
-rust_sparse_64k/typing_delta           11.165ms     11.121ms         -0.4%
-    p95:     12.011ms     11.509ms
+rust_sparse_64k/typing_delta           13.424ms     14.035ms        +4.6%
+    p95:     14.599ms     15.562ms
     └ targets: sparse low-match query walk at 64 KiB
-rust_large/typing_burst                16.003ms     16.158ms        +1.0%
-    p95:     16.624ms     16.845ms
+rust_large/typing_burst                26.676ms     29.682ms        +11.3%
+    p95:     30.511ms     32.734ms
     └ targets: eight queued unique edits→current delta; latest-state follow latency
-rust_xlarge/cancel_burst               97.655ms    109.351ms        +12.0%
-    p95:    125.671ms    112.257ms
+rust_xlarge/cancel_burst              137.546ms    143.359ms        +4.2%
+    p95:    147.322ms    159.309ms
     └ targets: current-token latency after four explicitly cancelled edit states
-markdown_injections/typing_delta        4.484ms      4.208ms         -6.1%
-    p95:      4.670ms      4.979ms
+markdown_injections/typing_delta        4.383ms      4.179ms         -4.6%
+    p95:      4.857ms      4.944ms
     └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
-markdown_injections/typing_burst        4.176ms      4.210ms        +0.8%
-    p95:      4.413ms      4.791ms
+markdown_injections/typing_burst        4.197ms      4.225ms        +0.7%
+    p95:      5.403ms      5.960ms
     └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-artifact-seam-2026-07-23/pair-3.txt
+++ b/benches/results/semantic-artifact-seam-2026-07-23/pair-3.txt
@@ -5,39 +5,39 @@ semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
 
 scenario                                A (med)      B (med) Δ (B vs A)
 ------------------------------------------------------------------------
-rust_large/full_cache_hit               1.775ms      1.823ms        +2.7%
-    p95:      2.222ms      2.133ms
+rust_large/full_cache_hit               1.956ms      1.769ms         -9.6%
+    p95:      2.063ms      2.066ms
     └ targets: large exact-snapshot semantic cache-hit control
-markdown_injections_large/full_cache_hit      0.469ms      0.474ms        +1.1%
-    p95:      0.501ms      0.552ms
+markdown_injections_large/full_cache_hit      0.860ms      0.962ms        +11.8%
+    p95:      1.067ms      1.214ms
     └ targets: large injection document exact-snapshot semantic cache-hit control
-unicode_rust/full_cache_hit             0.682ms      0.447ms         -34.5%
-    p95:      0.785ms      0.456ms
+unicode_rust/full_cache_hit             0.671ms      0.665ms         -0.8%
+    p95:      0.800ms      0.772ms
     └ targets: Unicode document exact-snapshot semantic cache-hit control
-rust_large/typing_delta                25.937ms     25.647ms         -1.1%
-    p95:     27.124ms     26.013ms
+rust_large/typing_delta                15.426ms     16.857ms        +9.3%
+    p95:     16.203ms     17.498ms
     └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
-rust_sparse_32k_minus/typing_delta      7.784ms      6.675ms         -14.2%
-    p95:      8.054ms      7.383ms
+rust_sparse_32k_minus/typing_delta      6.226ms      6.146ms         -1.3%
+    p95:      6.713ms      6.661ms
     └ targets: sparse low-match control just below 32 KiB
-rust_sparse_32k_exact/typing_delta      6.489ms      6.276ms         -3.3%
-    p95:      7.068ms      6.656ms
+rust_sparse_32k_exact/typing_delta      6.185ms      6.185ms         -0.0%
+    p95:      6.670ms      6.681ms
     └ targets: sparse low-match control at 32 KiB
-rust_sparse_32k_plus/typing_delta       6.190ms      5.997ms         -3.1%
-    p95:      6.586ms      6.588ms
+rust_sparse_32k_plus/typing_delta       6.342ms      6.248ms         -1.5%
+    p95:      6.668ms      6.699ms
     └ targets: sparse low-match control just above 32 KiB
-rust_sparse_64k/typing_delta           12.681ms     13.364ms        +5.4%
-    p95:     15.070ms     15.485ms
+rust_sparse_64k/typing_delta           14.428ms     15.039ms        +4.2%
+    p95:     16.951ms     20.660ms
     └ targets: sparse low-match query walk at 64 KiB
-rust_large/typing_burst                26.524ms     24.125ms         -9.0%
-    p95:     30.296ms     26.609ms
+rust_large/typing_burst                29.387ms     26.787ms         -8.8%
+    p95:     35.816ms     27.714ms
     └ targets: eight queued unique edits→current delta; latest-state follow latency
-rust_xlarge/cancel_burst              118.055ms    121.341ms        +2.8%
-    p95:    123.641ms    136.228ms
+rust_xlarge/cancel_burst              142.576ms    131.483ms         -7.8%
+    p95:    186.564ms    148.792ms
     └ targets: current-token latency after four explicitly cancelled edit states
-markdown_injections/typing_delta        4.877ms      5.327ms        +9.2%
-    p95:      5.262ms      5.707ms
+markdown_injections/typing_delta        6.373ms      5.436ms         -14.7%
+    p95:      6.913ms      6.311ms
     └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
-markdown_injections/typing_burst        4.516ms      4.238ms         -6.2%
-    p95:      4.794ms      4.916ms
+markdown_injections/typing_burst        6.072ms      6.882ms        +13.3%
+    p95:      7.719ms      8.085ms
     └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-artifact-seam-2026-07-23/pair-3.txt
+++ b/benches/results/semantic-artifact-seam-2026-07-23/pair-3.txt
@@ -1,0 +1,43 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               1.748ms      1.833ms        +4.8%
+    p95:      1.802ms      2.004ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.866ms      0.855ms         -1.3%
+    p95:      1.042ms      1.224ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.413ms      0.682ms        +65.3%
+    p95:      0.429ms      0.924ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/typing_delta                15.542ms     15.574ms        +0.2%
+    p95:     16.739ms     16.711ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta      5.707ms      5.758ms        +0.9%
+    p95:      5.898ms      6.148ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta      5.810ms      5.824ms        +0.2%
+    p95:      5.997ms      6.208ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta       5.707ms      5.806ms        +1.7%
+    p95:      6.106ms      6.135ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           11.260ms     11.443ms        +1.6%
+    p95:     11.704ms     12.274ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                16.213ms     17.433ms        +7.5%
+    p95:     16.757ms     18.622ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+rust_xlarge/cancel_burst              115.878ms    111.392ms         -3.9%
+    p95:    130.930ms    125.052ms
+    └ targets: current-token latency after four explicitly cancelled edit states
+markdown_injections/typing_delta        4.215ms      4.290ms        +1.8%
+    p95:      4.836ms      5.432ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        4.209ms      4.108ms         -2.4%
+    p95:      4.512ms      4.898ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-artifact-seam-2026-07-23/pair-3.txt
+++ b/benches/results/semantic-artifact-seam-2026-07-23/pair-3.txt
@@ -5,39 +5,39 @@ semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
 
 scenario                                A (med)      B (med) Δ (B vs A)
 ------------------------------------------------------------------------
-rust_large/full_cache_hit               1.748ms      1.833ms        +4.8%
-    p95:      1.802ms      2.004ms
+rust_large/full_cache_hit               1.775ms      1.823ms        +2.7%
+    p95:      2.222ms      2.133ms
     └ targets: large exact-snapshot semantic cache-hit control
-markdown_injections_large/full_cache_hit      0.866ms      0.855ms         -1.3%
-    p95:      1.042ms      1.224ms
+markdown_injections_large/full_cache_hit      0.469ms      0.474ms        +1.1%
+    p95:      0.501ms      0.552ms
     └ targets: large injection document exact-snapshot semantic cache-hit control
-unicode_rust/full_cache_hit             0.413ms      0.682ms        +65.3%
-    p95:      0.429ms      0.924ms
+unicode_rust/full_cache_hit             0.682ms      0.447ms         -34.5%
+    p95:      0.785ms      0.456ms
     └ targets: Unicode document exact-snapshot semantic cache-hit control
-rust_large/typing_delta                15.542ms     15.574ms        +0.2%
-    p95:     16.739ms     16.711ms
+rust_large/typing_delta                25.937ms     25.647ms         -1.1%
+    p95:     27.124ms     26.013ms
     └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
-rust_sparse_32k_minus/typing_delta      5.707ms      5.758ms        +0.9%
-    p95:      5.898ms      6.148ms
+rust_sparse_32k_minus/typing_delta      7.784ms      6.675ms         -14.2%
+    p95:      8.054ms      7.383ms
     └ targets: sparse low-match control just below 32 KiB
-rust_sparse_32k_exact/typing_delta      5.810ms      5.824ms        +0.2%
-    p95:      5.997ms      6.208ms
+rust_sparse_32k_exact/typing_delta      6.489ms      6.276ms         -3.3%
+    p95:      7.068ms      6.656ms
     └ targets: sparse low-match control at 32 KiB
-rust_sparse_32k_plus/typing_delta       5.707ms      5.806ms        +1.7%
-    p95:      6.106ms      6.135ms
+rust_sparse_32k_plus/typing_delta       6.190ms      5.997ms         -3.1%
+    p95:      6.586ms      6.588ms
     └ targets: sparse low-match control just above 32 KiB
-rust_sparse_64k/typing_delta           11.260ms     11.443ms        +1.6%
-    p95:     11.704ms     12.274ms
+rust_sparse_64k/typing_delta           12.681ms     13.364ms        +5.4%
+    p95:     15.070ms     15.485ms
     └ targets: sparse low-match query walk at 64 KiB
-rust_large/typing_burst                16.213ms     17.433ms        +7.5%
-    p95:     16.757ms     18.622ms
+rust_large/typing_burst                26.524ms     24.125ms         -9.0%
+    p95:     30.296ms     26.609ms
     └ targets: eight queued unique edits→current delta; latest-state follow latency
-rust_xlarge/cancel_burst              115.878ms    111.392ms         -3.9%
-    p95:    130.930ms    125.052ms
+rust_xlarge/cancel_burst              118.055ms    121.341ms        +2.8%
+    p95:    123.641ms    136.228ms
     └ targets: current-token latency after four explicitly cancelled edit states
-markdown_injections/typing_delta        4.215ms      4.290ms        +1.8%
-    p95:      4.836ms      5.432ms
+markdown_injections/typing_delta        4.877ms      5.327ms        +9.2%
+    p95:      5.262ms      5.707ms
     └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
-markdown_injections/typing_burst        4.209ms      4.108ms         -2.4%
-    p95:      4.512ms      4.898ms
+markdown_injections/typing_burst        4.516ms      4.238ms         -6.2%
+    p95:      4.794ms      4.916ms
     └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-artifact-seam-2026-07-23/pair-4.txt
+++ b/benches/results/semantic-artifact-seam-2026-07-23/pair-4.txt
@@ -5,39 +5,39 @@ semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
 
 scenario                                B (med)      A (med) Δ (A vs B)
 ------------------------------------------------------------------------
-rust_large/full_cache_hit               1.789ms      1.836ms        +2.7%
-    p95:      1.989ms      2.208ms
+rust_large/full_cache_hit               2.279ms      2.005ms         -12.0%
+    p95:      2.374ms      2.236ms
     └ targets: large exact-snapshot semantic cache-hit control
-markdown_injections_large/full_cache_hit      0.853ms      0.785ms         -8.0%
-    p95:      1.026ms      1.047ms
+markdown_injections_large/full_cache_hit      0.532ms      0.868ms        +63.2%
+    p95:      1.090ms      1.441ms
     └ targets: large injection document exact-snapshot semantic cache-hit control
-unicode_rust/full_cache_hit             0.683ms      0.675ms         -1.1%
-    p95:      0.860ms      0.795ms
+unicode_rust/full_cache_hit             0.455ms      0.433ms         -4.8%
+    p95:      0.667ms      0.465ms
     └ targets: Unicode document exact-snapshot semantic cache-hit control
-rust_large/typing_delta                15.420ms     16.652ms        +8.0%
-    p95:     16.300ms     17.483ms
+rust_large/typing_delta                17.692ms     23.010ms        +30.1%
+    p95:     19.620ms     26.831ms
     └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
-rust_sparse_32k_minus/typing_delta      5.734ms      5.648ms         -1.5%
-    p95:      6.299ms      6.620ms
+rust_sparse_32k_minus/typing_delta      8.352ms      7.559ms         -9.5%
+    p95:      9.096ms      8.047ms
     └ targets: sparse low-match control just below 32 KiB
-rust_sparse_32k_exact/typing_delta      5.743ms      5.763ms        +0.4%
-    p95:      6.166ms      6.225ms
+rust_sparse_32k_exact/typing_delta      7.659ms      6.832ms         -10.8%
+    p95:      8.212ms      7.597ms
     └ targets: sparse low-match control at 32 KiB
-rust_sparse_32k_plus/typing_delta       5.735ms      5.862ms        +2.2%
-    p95:      6.026ms      6.286ms
+rust_sparse_32k_plus/typing_delta       7.168ms      6.343ms         -11.5%
+    p95:      7.583ms      6.911ms
     └ targets: sparse low-match control just above 32 KiB
-rust_sparse_64k/typing_delta           12.662ms     18.870ms        +49.0%
-    p95:     15.328ms     19.426ms
+rust_sparse_64k/typing_delta           14.033ms     14.209ms        +1.3%
+    p95:     15.758ms     16.452ms
     └ targets: sparse low-match query walk at 64 KiB
-rust_large/typing_burst                26.279ms     26.602ms        +1.2%
-    p95:     27.334ms     30.125ms
+rust_large/typing_burst                25.506ms     23.741ms         -6.9%
+    p95:     28.105ms     26.403ms
     └ targets: eight queued unique edits→current delta; latest-state follow latency
-rust_xlarge/cancel_burst              140.019ms    132.982ms         -5.0%
-    p95:    168.000ms    161.768ms
+rust_xlarge/cancel_burst              131.036ms    126.703ms         -3.3%
+    p95:    141.751ms    137.823ms
     └ targets: current-token latency after four explicitly cancelled edit states
-markdown_injections/typing_delta        5.141ms      4.392ms         -14.6%
-    p95:      5.291ms      4.993ms
+markdown_injections/typing_delta        4.858ms      4.486ms         -7.7%
+    p95:      5.277ms      5.313ms
     └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
-markdown_injections/typing_burst        4.172ms      4.253ms        +1.9%
-    p95:      5.134ms     12.992ms
+markdown_injections/typing_burst        4.181ms      4.223ms        +1.0%
+    p95:      5.112ms      5.166ms
     └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-artifact-seam-2026-07-23/pair-4.txt
+++ b/benches/results/semantic-artifact-seam-2026-07-23/pair-4.txt
@@ -1,0 +1,43 @@
+
+semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               1.783ms      1.791ms        +0.4%
+    p95:      1.907ms      1.968ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.596ms      0.896ms        +50.4%
+    p95:      1.092ms      1.225ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+unicode_rust/full_cache_hit             0.610ms      0.524ms         -14.0%
+    p95:      0.700ms      0.569ms
+    └ targets: Unicode document exact-snapshot semantic cache-hit control
+rust_large/typing_delta                15.491ms     15.556ms        +0.4%
+    p95:     16.726ms     16.228ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+rust_sparse_32k_minus/typing_delta      5.743ms      6.178ms        +7.6%
+    p95:      5.954ms      6.784ms
+    └ targets: sparse low-match control just below 32 KiB
+rust_sparse_32k_exact/typing_delta      5.820ms      5.773ms         -0.8%
+    p95:      6.238ms      6.283ms
+    └ targets: sparse low-match control at 32 KiB
+rust_sparse_32k_plus/typing_delta       5.707ms      5.840ms        +2.3%
+    p95:      5.952ms      6.188ms
+    └ targets: sparse low-match control just above 32 KiB
+rust_sparse_64k/typing_delta           11.206ms     12.057ms        +7.6%
+    p95:     12.452ms     12.509ms
+    └ targets: sparse low-match query walk at 64 KiB
+rust_large/typing_burst                18.523ms     20.322ms        +9.7%
+    p95:     20.205ms     22.456ms
+    └ targets: eight queued unique edits→current delta; latest-state follow latency
+rust_xlarge/cancel_burst              112.151ms    109.208ms         -2.6%
+    p95:    120.854ms    113.066ms
+    └ targets: current-token latency after four explicitly cancelled edit states
+markdown_injections/typing_delta        4.382ms      4.204ms         -4.1%
+    p95:      4.822ms      4.465ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
+markdown_injections/typing_burst        4.165ms      4.100ms         -1.6%
+    p95:      5.036ms      4.683ms
+    └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-artifact-seam-2026-07-23/pair-4.txt
+++ b/benches/results/semantic-artifact-seam-2026-07-23/pair-4.txt
@@ -5,39 +5,39 @@ semantic-tokens benchmark  (iters=30, warmup=6, lower is better)
 
 scenario                                B (med)      A (med) Δ (A vs B)
 ------------------------------------------------------------------------
-rust_large/full_cache_hit               1.783ms      1.791ms        +0.4%
-    p95:      1.907ms      1.968ms
+rust_large/full_cache_hit               1.789ms      1.836ms        +2.7%
+    p95:      1.989ms      2.208ms
     └ targets: large exact-snapshot semantic cache-hit control
-markdown_injections_large/full_cache_hit      0.596ms      0.896ms        +50.4%
-    p95:      1.092ms      1.225ms
+markdown_injections_large/full_cache_hit      0.853ms      0.785ms         -8.0%
+    p95:      1.026ms      1.047ms
     └ targets: large injection document exact-snapshot semantic cache-hit control
-unicode_rust/full_cache_hit             0.610ms      0.524ms         -14.0%
-    p95:      0.700ms      0.569ms
+unicode_rust/full_cache_hit             0.683ms      0.675ms         -1.1%
+    p95:      0.860ms      0.795ms
     └ targets: Unicode document exact-snapshot semantic cache-hit control
-rust_large/typing_delta                15.491ms     15.556ms        +0.4%
-    p95:     16.726ms     16.228ms
+rust_large/typing_delta                15.420ms     16.652ms        +8.0%
+    p95:     16.300ms     17.483ms
     └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
-rust_sparse_32k_minus/typing_delta      5.743ms      6.178ms        +7.6%
-    p95:      5.954ms      6.784ms
+rust_sparse_32k_minus/typing_delta      5.734ms      5.648ms         -1.5%
+    p95:      6.299ms      6.620ms
     └ targets: sparse low-match control just below 32 KiB
-rust_sparse_32k_exact/typing_delta      5.820ms      5.773ms         -0.8%
-    p95:      6.238ms      6.283ms
+rust_sparse_32k_exact/typing_delta      5.743ms      5.763ms        +0.4%
+    p95:      6.166ms      6.225ms
     └ targets: sparse low-match control at 32 KiB
-rust_sparse_32k_plus/typing_delta       5.707ms      5.840ms        +2.3%
-    p95:      5.952ms      6.188ms
+rust_sparse_32k_plus/typing_delta       5.735ms      5.862ms        +2.2%
+    p95:      6.026ms      6.286ms
     └ targets: sparse low-match control just above 32 KiB
-rust_sparse_64k/typing_delta           11.206ms     12.057ms        +7.6%
-    p95:     12.452ms     12.509ms
+rust_sparse_64k/typing_delta           12.662ms     18.870ms        +49.0%
+    p95:     15.328ms     19.426ms
     └ targets: sparse low-match query walk at 64 KiB
-rust_large/typing_burst                18.523ms     20.322ms        +9.7%
-    p95:     20.205ms     22.456ms
+rust_large/typing_burst                26.279ms     26.602ms        +1.2%
+    p95:     27.334ms     30.125ms
     └ targets: eight queued unique edits→current delta; latest-state follow latency
-rust_xlarge/cancel_burst              112.151ms    109.208ms         -2.6%
-    p95:    120.854ms    113.066ms
+rust_xlarge/cancel_burst              140.019ms    132.982ms         -5.0%
+    p95:    168.000ms    161.768ms
     └ targets: current-token latency after four explicitly cancelled edit states
-markdown_injections/typing_delta        4.382ms      4.204ms         -4.1%
-    p95:      4.822ms      4.465ms
+markdown_injections/typing_delta        5.141ms      4.392ms         -14.6%
+    p95:      5.291ms      4.993ms
     └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns
-markdown_injections/typing_burst        4.165ms      4.100ms         -1.6%
-    p95:      5.036ms      4.683ms
+markdown_injections/typing_burst        4.172ms      4.253ms        +1.9%
+    p95:      5.134ms     12.992ms
     └ targets: eight queued unique edits→current injection delta; latest-state follow latency

--- a/benches/results/semantic-artifact-seam-2026-07-23/summary.json
+++ b/benches/results/semantic-artifact-seam-2026-07-23/summary.json
@@ -1,40 +1,40 @@
 {
   "scenarios": [
     {
-      "a_median_ns": 4180853.75,
-      "b_median_ns": 4170573.0,
+      "a_median_ns": 4358917.0,
+      "b_median_ns": 4217531.25,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 1.6148532741813222,
-        "median": 0.3848900152771806,
-        "min": -2.4017107998816285
+        "max": 7.48936575260012,
+        "median": -1.2811811800602229,
+        "min": -6.171084020428868
       },
       "pairs": [
         {
-          "a_median_ns": 4152916.0,
-          "b_median_ns": 4219979.5,
-          "delta_percent": 1.6148532741813222,
+          "a_median_ns": 4464937.5,
+          "b_median_ns": 4799333.0,
+          "delta_percent": 7.48936575260012,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 4210417.0,
-          "b_median_ns": 4176271.0,
-          "delta_percent": -0.8109885552903668,
+          "a_median_ns": 4225250.0,
+          "b_median_ns": 4197416.5,
+          "delta_percent": -0.6587420862670847,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 4208791.5,
-          "b_median_ns": 4107708.5,
-          "delta_percent": -2.4017107998816285,
+          "a_median_ns": 4516354.0,
+          "b_median_ns": 4237646.0,
+          "delta_percent": -6.171084020428868,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 4100062.5,
-          "b_median_ns": 4164875.0,
-          "delta_percent": 1.580768585844728,
+          "a_median_ns": 4252896.5,
+          "b_median_ns": 4171937.5,
+          "delta_percent": -1.9036202738533607,
           "order": "BA",
           "pair_index": 4
         }
@@ -42,40 +42,40 @@
       "scenario": "markdown_injections/typing_burst"
     },
     {
-      "a_median_ns": 4211406.25,
-      "b_median_ns": 4335708.0,
+      "a_median_ns": 4634395.75,
+      "b_median_ns": 4945854.0,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 6.551606339210124,
-        "median": 3.0064499287508974,
-        "min": -6.148641768079452
+        "max": 17.06657558420858,
+        "median": 7.052212604339318,
+        "min": -10.886537311682982
       },
       "pairs": [
         {
-          "a_median_ns": 4468125.0,
-          "b_median_ns": 4193396.0,
-          "delta_percent": -6.148641768079452,
+          "a_median_ns": 5330937.5,
+          "b_median_ns": 4750583.0,
+          "delta_percent": -10.886537311682982,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 4207937.5,
-          "b_median_ns": 4483625.0,
-          "delta_percent": 6.551606339210124,
+          "a_median_ns": 4179375.0,
+          "b_median_ns": 4383020.5,
+          "delta_percent": 4.872630477045012,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 4214875.0,
-          "b_median_ns": 4289812.5,
-          "delta_percent": 1.7779293573356267,
+          "a_median_ns": 4877166.5,
+          "b_median_ns": 5327416.5,
+          "delta_percent": 9.231794731633624,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 4203583.0,
-          "b_median_ns": 4381603.5,
-          "delta_percent": 4.234970500166168,
+          "a_median_ns": 4391625.0,
+          "b_median_ns": 5141125.0,
+          "delta_percent": 17.06657558420858,
           "order": "BA",
           "pair_index": 4
         }
@@ -83,40 +83,40 @@
       "scenario": "markdown_injections/typing_delta"
     },
     {
-      "a_median_ns": 871510.25,
-      "b_median_ns": 805771.0,
+      "a_median_ns": 734896.0,
+      "b_median_ns": 674750.0,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 19.944951175670422,
-        "median": -3.824615435122488,
-        "min": -33.5154989595186
+        "max": 27.537620478276303,
+        "median": 4.881292269239333,
+        "min": -42.79466669126077
       },
       "pairs": [
         {
-          "a_median_ns": 658688.0,
-          "b_median_ns": 790063.0,
-          "delta_percent": 19.944951175670422,
+          "a_median_ns": 684667.0,
+          "b_median_ns": 873208.0,
+          "delta_percent": 27.537620478276303,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 877312.0,
-          "b_median_ns": 821479.0,
-          "delta_percent": -6.364098519112926,
+          "a_median_ns": 867416.5,
+          "b_median_ns": 496208.5,
+          "delta_percent": -42.79466669126077,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 865708.5,
-          "b_median_ns": 854583.0,
-          "delta_percent": -1.2851323511320496,
+          "a_median_ns": 468604.0,
+          "b_median_ns": 473666.5,
+          "delta_percent": 1.0803364888050464,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 895979.5,
-          "b_median_ns": 595687.5,
-          "delta_percent": -33.5154989595186,
+          "a_median_ns": 785125.0,
+          "b_median_ns": 853291.5,
+          "delta_percent": 8.68224804967362,
           "order": "BA",
           "pair_index": 4
         }
@@ -124,40 +124,40 @@
       "scenario": "markdown_injections_large/full_cache_hit"
     },
     {
-      "a_median_ns": 1769823.0,
-      "b_median_ns": 1775375.0,
+      "a_median_ns": 1805416.5,
+      "b_median_ns": 1821000.0,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 4.814157257227313,
-        "median": 0.18788900895324215,
-        "min": -3.583855320423124
+        "max": 6.572101631568519,
+        "median": 3.3689199205947906,
+        "min": -2.58564776114201
       },
       "pairs": [
         {
-          "a_median_ns": 1749041.5,
-          "b_median_ns": 1763042.0,
-          "delta_percent": 0.8004669986389688,
+          "a_median_ns": 1748896.0,
+          "b_median_ns": 1818750.0,
+          "delta_percent": 3.9941768978830074,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 1833458.5,
-          "b_median_ns": 1767750.0,
-          "delta_percent": -3.583855320423124,
+          "a_median_ns": 1950791.5,
+          "b_median_ns": 2078999.5,
+          "delta_percent": 6.572101631568519,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 1748333.0,
-          "b_median_ns": 1832500.5,
-          "delta_percent": 4.814157257227313,
+          "a_median_ns": 1774562.0,
+          "b_median_ns": 1823250.0,
+          "delta_percent": 2.743662943306574,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 1790604.5,
-          "b_median_ns": 1783000.0,
-          "delta_percent": -0.42468898073248446,
+          "a_median_ns": 1836271.0,
+          "b_median_ns": 1788791.5,
+          "delta_percent": -2.58564776114201,
           "order": "BA",
           "pair_index": 4
         }
@@ -165,40 +165,40 @@
       "scenario": "rust_large/full_cache_hit"
     },
     {
-      "a_median_ns": 16185187.5,
-      "b_median_ns": 16794843.5,
+      "a_median_ns": 26562864.5,
+      "b_median_ns": 25202041.5,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 7.530056553203539,
-        "median": 0.25832354163963805,
-        "min": -8.853026643938096
+        "max": -1.213872900815735,
+        "median": -8.299635500472379,
+        "min": -10.12705762670363
       },
       "pairs": [
         {
-          "a_median_ns": 15921041.5,
-          "b_median_ns": 16156354.0,
-          "delta_percent": 1.4779969011449408,
+          "a_median_ns": 17140125.0,
+          "b_median_ns": 15845104.5,
+          "delta_percent": -7.555490406283502,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 16157854.0,
-          "b_median_ns": 16002520.5,
-          "delta_percent": -0.9613498178656646,
+          "a_median_ns": 29682437.0,
+          "b_median_ns": 26676479.5,
+          "delta_percent": -10.12705762670363,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 16212521.0,
-          "b_median_ns": 17433333.0,
-          "delta_percent": 7.530056553203539,
+          "a_median_ns": 26523520.5,
+          "b_median_ns": 24124791.5,
+          "delta_percent": -9.043780594661255,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 20322146.0,
-          "b_median_ns": 18523021.0,
-          "delta_percent": -8.853026643938096,
+          "a_median_ns": 26602208.5,
+          "b_median_ns": 26279291.5,
+          "delta_percent": -1.213872900815735,
           "order": "BA",
           "pair_index": 4
         }
@@ -206,40 +206,40 @@
       "scenario": "rust_large/typing_burst"
     },
     {
-      "a_median_ns": 15548750.25,
-      "b_median_ns": 15471437.5,
+      "a_median_ns": 17554062.5,
+      "b_median_ns": 15684229.0,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 0.21139416070440958,
-        "median": -0.20499547445757557,
-        "min": -0.7342285124035165
+        "max": -1.096276614900743,
+        "median": -4.258497445632622,
+        "min": -13.73807975726051
       },
       "pairs": [
         {
-          "a_median_ns": 15378875.0,
-          "b_median_ns": 15380104.0,
-          "delta_percent": 0.007991481821654706,
+          "a_median_ns": 15619187.5,
+          "b_median_ns": 15447958.0,
+          "delta_percent": -1.096276614900743,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 15566271.0,
-          "b_median_ns": 15451979.0,
-          "delta_percent": -0.7342285124035165,
+          "a_median_ns": 18456000.0,
+          "b_median_ns": 15920500.0,
+          "delta_percent": -13.73807975726051,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 15541583.5,
-          "b_median_ns": 15574437.5,
-          "delta_percent": 0.21139416070440958,
+          "a_median_ns": 25936625.0,
+          "b_median_ns": 25646999.5,
+          "delta_percent": -1.1166661043987025,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 15555917.0,
-          "b_median_ns": 15490896.0,
-          "delta_percent": -0.41798243073680585,
+          "a_median_ns": 16652125.0,
+          "b_median_ns": 15419813.0,
+          "delta_percent": -7.400328786866541,
           "order": "BA",
           "pair_index": 4
         }
@@ -247,40 +247,40 @@
       "scenario": "rust_large/typing_delta"
     },
     {
-      "a_median_ns": 5791500.0,
-      "b_median_ns": 5775104.25,
+      "a_median_ns": 6125771.0,
+      "b_median_ns": 6009125.0,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 0.8152056002654386,
-        "median": -0.15585620167918535,
-        "min": -2.2236288442609182
+        "max": 3.267865792160868,
+        "median": -0.29276463026467836,
+        "min": -3.279504085817738
       },
       "pairs": [
         {
-          "a_median_ns": 5860375.5,
-          "b_median_ns": 5730062.5,
-          "delta_percent": -2.2236288442609182,
+          "a_median_ns": 5684000.0,
+          "b_median_ns": 5670937.5,
+          "delta_percent": -0.22981175228712175,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 5760271.0,
-          "b_median_ns": 5728104.5,
-          "delta_percent": -0.5584199076744827,
+          "a_median_ns": 8195333.5,
+          "b_median_ns": 8463146.0,
+          "delta_percent": 3.267865792160868,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 5809916.5,
-          "b_median_ns": 5824250.0,
-          "delta_percent": 0.24670750431611196,
+          "a_median_ns": 6488542.0,
+          "b_median_ns": 6275750.0,
+          "delta_percent": -3.279504085817738,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 5773083.5,
-          "b_median_ns": 5820146.0,
-          "delta_percent": 0.8152056002654386,
+          "a_median_ns": 5763000.0,
+          "b_median_ns": 5742500.0,
+          "delta_percent": -0.3557175082422349,
           "order": "BA",
           "pair_index": 4
         }
@@ -288,40 +288,40 @@
       "scenario": "rust_sparse_32k_exact/typing_delta"
     },
     {
-      "a_median_ns": 5763021.0,
-      "b_median_ns": 5750187.25,
+      "a_median_ns": 6745740.0,
+      "b_median_ns": 6204489.5,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 0.8811613156323127,
-        "median": -0.11199882546671518,
-        "min": -7.042686465258822
+        "max": 7.61955882229604,
+        "median": 0.6328019365454594,
+        "min": -14.244653430914026
       },
       "pairs": [
         {
-          "a_median_ns": 5692979.0,
-          "b_median_ns": 5705604.0,
-          "delta_percent": 0.2217643873269162,
+          "a_median_ns": 5707563.0,
+          "b_median_ns": 5693188.0,
+          "delta_percent": -0.25185880558830454,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 5818687.5,
-          "b_median_ns": 5792750.0,
-          "delta_percent": -0.44576203826034655,
+          "a_median_ns": 8704021.0,
+          "b_median_ns": 9367229.0,
+          "delta_percent": 7.61955882229604,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 5707354.5,
-          "b_median_ns": 5757645.5,
-          "delta_percent": 0.8811613156323127,
+          "a_median_ns": 7783917.0,
+          "b_median_ns": 6675125.0,
+          "delta_percent": -14.244653430914026,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 6177813.0,
-          "b_median_ns": 5742729.0,
-          "delta_percent": -7.042686465258822,
+          "a_median_ns": 5648145.5,
+          "b_median_ns": 5733854.0,
+          "delta_percent": 1.5174626786792231,
           "order": "BA",
           "pair_index": 4
         }
@@ -329,40 +329,40 @@
       "scenario": "rust_sparse_32k_minus/typing_delta"
     },
     {
-      "a_median_ns": 5774239.5,
-      "b_median_ns": 5796792.0,
+      "a_median_ns": 6026104.5,
+      "b_median_ns": 5907666.75,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 1.7302049009389802,
-        "median": 0.3971480651155779,
-        "min": -2.2686459816124924
+        "max": 9.921584753465982,
+        "median": -1.0407258667327632,
+        "min": -3.119320419687564
       },
       "pairs": [
         {
-          "a_median_ns": 5731479.0,
-          "b_median_ns": 5805146.0,
-          "delta_percent": 1.2853052414568735,
+          "a_median_ns": 5813458.5,
+          "b_median_ns": 5818479.5,
+          "delta_percent": 0.08636855324588624,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 5817000.0,
-          "b_median_ns": 5788438.0,
-          "delta_percent": -0.4910091112257178,
+          "a_median_ns": 6533104.5,
+          "b_median_ns": 7181292.0,
+          "delta_percent": 9.921584753465982,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 5707416.5,
-          "b_median_ns": 5806166.5,
-          "delta_percent": 1.7302049009389802,
+          "a_median_ns": 6189938.0,
+          "b_median_ns": 5996854.0,
+          "delta_percent": -3.119320419687564,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 5839562.5,
-          "b_median_ns": 5707083.5,
-          "delta_percent": -2.2686459816124924,
+          "a_median_ns": 5862271.0,
+          "b_median_ns": 5735187.5,
+          "delta_percent": -2.1678202867114127,
           "order": "BA",
           "pair_index": 4
         }
@@ -370,40 +370,40 @@
       "scenario": "rust_sparse_32k_plus/typing_delta"
     },
     {
-      "a_median_ns": 11358458.5,
-      "b_median_ns": 11195864.75,
+      "a_median_ns": 13358229.25,
+      "b_median_ns": 13013260.5,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 1.62911806645461,
-        "median": -0.9819536688635856,
-        "min": -7.058509619615437
+        "max": 5.384084893876937,
+        "median": -2.2343516034247664,
+        "min": -32.894947533214065
       },
       "pairs": [
         {
-          "a_median_ns": 11457021.0,
-          "b_median_ns": 11186083.5,
-          "delta_percent": -2.364816299106024,
+          "a_median_ns": 11234271.0,
+          "b_median_ns": 11221396.0,
+          "delta_percent": -0.11460467706360297,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 11120604.5,
-          "b_median_ns": 11165188.0,
-          "delta_percent": 0.40090896137885307,
+          "a_median_ns": 14035167.0,
+          "b_median_ns": 13424062.0,
+          "delta_percent": -4.354098529785929,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 11259896.0,
-          "b_median_ns": 11443333.0,
-          "delta_percent": 1.62911806645461,
+          "a_median_ns": 12681291.5,
+          "b_median_ns": 13364063.0,
+          "delta_percent": 5.384084893876937,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 12056667.0,
-          "b_median_ns": 11205646.0,
-          "delta_percent": -7.058509619615437,
+          "a_median_ns": 18869604.5,
+          "b_median_ns": 12662458.0,
+          "delta_percent": -32.894947533214065,
           "order": "BA",
           "pair_index": 4
         }
@@ -411,40 +411,40 @@
       "scenario": "rust_sparse_64k/typing_delta"
     },
     {
-      "a_median_ns": 110269031.25,
-      "b_median_ns": 111422833.25,
+      "a_median_ns": 125518739.5,
+      "b_median_ns": 138258718.5,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 2.694672189691373,
-        "median": -1.8156001053189013,
-        "min": -10.695445688970787
+        "max": 70.7217455239578,
+        "median": 4.037477054309031,
+        "min": -4.054718113112459
       },
       "pairs": [
         {
-          "a_median_ns": 111187000.0,
-          "b_median_ns": 111453667.0,
-          "delta_percent": 0.23983649167618518,
+          "a_median_ns": 81402354.5,
+          "b_median_ns": 138971520.5,
+          "delta_percent": 70.7217455239578,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 109351062.5,
-          "b_median_ns": 97655479.0,
-          "delta_percent": -10.695445688970787,
+          "a_median_ns": 143358708.0,
+          "b_median_ns": 137545916.5,
+          "delta_percent": -4.054718113112459,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 115877666.5,
-          "b_median_ns": 111391999.5,
-          "delta_percent": -3.8710367023139876,
+          "a_median_ns": 118055354.0,
+          "b_median_ns": 121341333.0,
+          "delta_percent": 2.783422258002801,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 109207792.0,
-          "b_median_ns": 112150584.0,
-          "delta_percent": 2.694672189691373,
+          "a_median_ns": 132982125.0,
+          "b_median_ns": 140018916.5,
+          "delta_percent": 5.291531850615262,
           "order": "BA",
           "pair_index": 4
         }
@@ -452,40 +452,40 @@
       "scenario": "rust_xlarge/cancel_burst"
     },
     {
-      "a_median_ns": 603468.75,
-      "b_median_ns": 675978.75,
+      "a_median_ns": 673364.25,
+      "b_median_ns": 648406.25,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 65.31891564440406,
-        "median": 7.622112738784861,
-        "min": -7.195610787109052
+        "max": 53.03121212047601,
+        "median": 0.21865105541352864,
+        "min": -34.52632149848617
       },
       "pairs": [
         {
-          "a_median_ns": 729333.5,
-          "b_median_ns": 676853.5,
-          "delta_percent": -7.195610787109052,
+          "a_median_ns": 671395.5,
+          "b_median_ns": 666833.5,
+          "delta_percent": -0.6794802765285141,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 682458.0,
-          "b_median_ns": 675104.0,
-          "delta_percent": -1.0775754698457634,
+          "a_median_ns": 411667.0,
+          "b_median_ns": 629979.0,
+          "delta_percent": 53.03121212047601,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 412687.5,
-          "b_median_ns": 682250.5,
-          "delta_percent": 65.31891564440406,
+          "a_median_ns": 682208.5,
+          "b_median_ns": 446667.0,
+          "delta_percent": -34.52632149848617,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 524479.5,
-          "b_median_ns": 610084.0,
-          "delta_percent": 16.321800947415486,
+          "a_median_ns": 675333.0,
+          "b_median_ns": 682875.0,
+          "delta_percent": 1.1167823873555713,
           "order": "BA",
           "pair_index": 4
         }

--- a/benches/results/semantic-artifact-seam-2026-07-23/summary.json
+++ b/benches/results/semantic-artifact-seam-2026-07-23/summary.json
@@ -1,0 +1,497 @@
+{
+  "scenarios": [
+    {
+      "a_median_ns": 4180853.75,
+      "b_median_ns": 4170573.0,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 1.6148532741813222,
+        "median": 0.3848900152771806,
+        "min": -2.4017107998816285
+      },
+      "pairs": [
+        {
+          "a_median_ns": 4152916.0,
+          "b_median_ns": 4219979.5,
+          "delta_percent": 1.6148532741813222,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 4210417.0,
+          "b_median_ns": 4176271.0,
+          "delta_percent": -0.8109885552903668,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 4208791.5,
+          "b_median_ns": 4107708.5,
+          "delta_percent": -2.4017107998816285,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 4100062.5,
+          "b_median_ns": 4164875.0,
+          "delta_percent": 1.580768585844728,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "markdown_injections/typing_burst"
+    },
+    {
+      "a_median_ns": 4211406.25,
+      "b_median_ns": 4335708.0,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 6.551606339210124,
+        "median": 3.0064499287508974,
+        "min": -6.148641768079452
+      },
+      "pairs": [
+        {
+          "a_median_ns": 4468125.0,
+          "b_median_ns": 4193396.0,
+          "delta_percent": -6.148641768079452,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 4207937.5,
+          "b_median_ns": 4483625.0,
+          "delta_percent": 6.551606339210124,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 4214875.0,
+          "b_median_ns": 4289812.5,
+          "delta_percent": 1.7779293573356267,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 4203583.0,
+          "b_median_ns": 4381603.5,
+          "delta_percent": 4.234970500166168,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "markdown_injections/typing_delta"
+    },
+    {
+      "a_median_ns": 871510.25,
+      "b_median_ns": 805771.0,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 19.944951175670422,
+        "median": -3.824615435122488,
+        "min": -33.5154989595186
+      },
+      "pairs": [
+        {
+          "a_median_ns": 658688.0,
+          "b_median_ns": 790063.0,
+          "delta_percent": 19.944951175670422,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 877312.0,
+          "b_median_ns": 821479.0,
+          "delta_percent": -6.364098519112926,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 865708.5,
+          "b_median_ns": 854583.0,
+          "delta_percent": -1.2851323511320496,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 895979.5,
+          "b_median_ns": 595687.5,
+          "delta_percent": -33.5154989595186,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "markdown_injections_large/full_cache_hit"
+    },
+    {
+      "a_median_ns": 1769823.0,
+      "b_median_ns": 1775375.0,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 4.814157257227313,
+        "median": 0.18788900895324215,
+        "min": -3.583855320423124
+      },
+      "pairs": [
+        {
+          "a_median_ns": 1749041.5,
+          "b_median_ns": 1763042.0,
+          "delta_percent": 0.8004669986389688,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 1833458.5,
+          "b_median_ns": 1767750.0,
+          "delta_percent": -3.583855320423124,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 1748333.0,
+          "b_median_ns": 1832500.5,
+          "delta_percent": 4.814157257227313,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 1790604.5,
+          "b_median_ns": 1783000.0,
+          "delta_percent": -0.42468898073248446,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_large/full_cache_hit"
+    },
+    {
+      "a_median_ns": 16185187.5,
+      "b_median_ns": 16794843.5,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 7.530056553203539,
+        "median": 0.25832354163963805,
+        "min": -8.853026643938096
+      },
+      "pairs": [
+        {
+          "a_median_ns": 15921041.5,
+          "b_median_ns": 16156354.0,
+          "delta_percent": 1.4779969011449408,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 16157854.0,
+          "b_median_ns": 16002520.5,
+          "delta_percent": -0.9613498178656646,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 16212521.0,
+          "b_median_ns": 17433333.0,
+          "delta_percent": 7.530056553203539,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 20322146.0,
+          "b_median_ns": 18523021.0,
+          "delta_percent": -8.853026643938096,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_large/typing_burst"
+    },
+    {
+      "a_median_ns": 15548750.25,
+      "b_median_ns": 15471437.5,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 0.21139416070440958,
+        "median": -0.20499547445757557,
+        "min": -0.7342285124035165
+      },
+      "pairs": [
+        {
+          "a_median_ns": 15378875.0,
+          "b_median_ns": 15380104.0,
+          "delta_percent": 0.007991481821654706,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 15566271.0,
+          "b_median_ns": 15451979.0,
+          "delta_percent": -0.7342285124035165,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 15541583.5,
+          "b_median_ns": 15574437.5,
+          "delta_percent": 0.21139416070440958,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 15555917.0,
+          "b_median_ns": 15490896.0,
+          "delta_percent": -0.41798243073680585,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_large/typing_delta"
+    },
+    {
+      "a_median_ns": 5791500.0,
+      "b_median_ns": 5775104.25,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 0.8152056002654386,
+        "median": -0.15585620167918535,
+        "min": -2.2236288442609182
+      },
+      "pairs": [
+        {
+          "a_median_ns": 5860375.5,
+          "b_median_ns": 5730062.5,
+          "delta_percent": -2.2236288442609182,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 5760271.0,
+          "b_median_ns": 5728104.5,
+          "delta_percent": -0.5584199076744827,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 5809916.5,
+          "b_median_ns": 5824250.0,
+          "delta_percent": 0.24670750431611196,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 5773083.5,
+          "b_median_ns": 5820146.0,
+          "delta_percent": 0.8152056002654386,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_sparse_32k_exact/typing_delta"
+    },
+    {
+      "a_median_ns": 5763021.0,
+      "b_median_ns": 5750187.25,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 0.8811613156323127,
+        "median": -0.11199882546671518,
+        "min": -7.042686465258822
+      },
+      "pairs": [
+        {
+          "a_median_ns": 5692979.0,
+          "b_median_ns": 5705604.0,
+          "delta_percent": 0.2217643873269162,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 5818687.5,
+          "b_median_ns": 5792750.0,
+          "delta_percent": -0.44576203826034655,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 5707354.5,
+          "b_median_ns": 5757645.5,
+          "delta_percent": 0.8811613156323127,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 6177813.0,
+          "b_median_ns": 5742729.0,
+          "delta_percent": -7.042686465258822,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_sparse_32k_minus/typing_delta"
+    },
+    {
+      "a_median_ns": 5774239.5,
+      "b_median_ns": 5796792.0,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 1.7302049009389802,
+        "median": 0.3971480651155779,
+        "min": -2.2686459816124924
+      },
+      "pairs": [
+        {
+          "a_median_ns": 5731479.0,
+          "b_median_ns": 5805146.0,
+          "delta_percent": 1.2853052414568735,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 5817000.0,
+          "b_median_ns": 5788438.0,
+          "delta_percent": -0.4910091112257178,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 5707416.5,
+          "b_median_ns": 5806166.5,
+          "delta_percent": 1.7302049009389802,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 5839562.5,
+          "b_median_ns": 5707083.5,
+          "delta_percent": -2.2686459816124924,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_sparse_32k_plus/typing_delta"
+    },
+    {
+      "a_median_ns": 11358458.5,
+      "b_median_ns": 11195864.75,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 1.62911806645461,
+        "median": -0.9819536688635856,
+        "min": -7.058509619615437
+      },
+      "pairs": [
+        {
+          "a_median_ns": 11457021.0,
+          "b_median_ns": 11186083.5,
+          "delta_percent": -2.364816299106024,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 11120604.5,
+          "b_median_ns": 11165188.0,
+          "delta_percent": 0.40090896137885307,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 11259896.0,
+          "b_median_ns": 11443333.0,
+          "delta_percent": 1.62911806645461,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 12056667.0,
+          "b_median_ns": 11205646.0,
+          "delta_percent": -7.058509619615437,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_sparse_64k/typing_delta"
+    },
+    {
+      "a_median_ns": 110269031.25,
+      "b_median_ns": 111422833.25,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 2.694672189691373,
+        "median": -1.8156001053189013,
+        "min": -10.695445688970787
+      },
+      "pairs": [
+        {
+          "a_median_ns": 111187000.0,
+          "b_median_ns": 111453667.0,
+          "delta_percent": 0.23983649167618518,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 109351062.5,
+          "b_median_ns": 97655479.0,
+          "delta_percent": -10.695445688970787,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 115877666.5,
+          "b_median_ns": 111391999.5,
+          "delta_percent": -3.8710367023139876,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 109207792.0,
+          "b_median_ns": 112150584.0,
+          "delta_percent": 2.694672189691373,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "rust_xlarge/cancel_burst"
+    },
+    {
+      "a_median_ns": 603468.75,
+      "b_median_ns": 675978.75,
+      "pair_count": 4,
+      "paired_delta_percent": {
+        "max": 65.31891564440406,
+        "median": 7.622112738784861,
+        "min": -7.195610787109052
+      },
+      "pairs": [
+        {
+          "a_median_ns": 729333.5,
+          "b_median_ns": 676853.5,
+          "delta_percent": -7.195610787109052,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 682458.0,
+          "b_median_ns": 675104.0,
+          "delta_percent": -1.0775754698457634,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 412687.5,
+          "b_median_ns": 682250.5,
+          "delta_percent": 65.31891564440406,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 524479.5,
+          "b_median_ns": 610084.0,
+          "delta_percent": 16.321800947415486,
+          "order": "BA",
+          "pair_index": 4
+        }
+      ],
+      "scenario": "unicode_rust/full_cache_hit"
+    }
+  ],
+  "schema_version": 1
+}

--- a/benches/results/semantic-artifact-seam-2026-07-23/summary.json
+++ b/benches/results/semantic-artifact-seam-2026-07-23/summary.json
@@ -1,40 +1,40 @@
 {
   "scenarios": [
     {
-      "a_median_ns": 4358917.0,
-      "b_median_ns": 4217531.25,
+      "a_median_ns": 5147468.75,
+      "b_median_ns": 5486552.0,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 7.48936575260012,
-        "median": -1.2811811800602229,
-        "min": -6.171084020428868
+        "max": 13.33598310142922,
+        "median": 3.4935486169251537,
+        "min": -1.5736872003790172
       },
       "pairs": [
         {
-          "a_median_ns": 4464937.5,
-          "b_median_ns": 4799333.0,
-          "delta_percent": 7.48936575260012,
+          "a_median_ns": 4188729.5,
+          "b_median_ns": 4122812.0,
+          "delta_percent": -1.5736872003790172,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 4225250.0,
-          "b_median_ns": 4197416.5,
-          "delta_percent": -0.6587420862670847,
+          "a_median_ns": 6290396.0,
+          "b_median_ns": 6792229.0,
+          "delta_percent": 7.977764833883272,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 4516354.0,
-          "b_median_ns": 4237646.0,
-          "delta_percent": -6.171084020428868,
+          "a_median_ns": 6072229.5,
+          "b_median_ns": 6882021.0,
+          "delta_percent": 13.33598310142922,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 4252896.5,
-          "b_median_ns": 4171937.5,
-          "delta_percent": -1.9036202738533607,
+          "a_median_ns": 4222708.0,
+          "b_median_ns": 4180875.0,
+          "delta_percent": -0.9906676000329646,
           "order": "BA",
           "pair_index": 4
         }
@@ -42,40 +42,40 @@
       "scenario": "markdown_injections/typing_burst"
     },
     {
-      "a_median_ns": 4634395.75,
-      "b_median_ns": 4945854.0,
+      "a_median_ns": 5468031.25,
+      "b_median_ns": 5147260.5,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 17.06657558420858,
-        "median": 7.052212604339318,
-        "min": -10.886537311682982
+        "max": 10.0174308713809,
+        "median": -0.609821296928291,
+        "min": -14.69161087456237
       },
       "pairs": [
         {
-          "a_median_ns": 5330937.5,
-          "b_median_ns": 4750583.0,
-          "delta_percent": -10.886537311682982,
+          "a_median_ns": 4563521.0,
+          "b_median_ns": 4129749.5,
+          "delta_percent": -9.505193467938462,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 4179375.0,
-          "b_median_ns": 4383020.5,
-          "delta_percent": 4.872630477045012,
+          "a_median_ns": 7100333.5,
+          "b_median_ns": 7811604.5,
+          "delta_percent": 10.0174308713809,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 4877166.5,
-          "b_median_ns": 5327416.5,
-          "delta_percent": 9.231794731633624,
+          "a_median_ns": 6372541.5,
+          "b_median_ns": 5436312.5,
+          "delta_percent": -14.69161087456237,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 4391625.0,
-          "b_median_ns": 5141125.0,
-          "delta_percent": 17.06657558420858,
+          "a_median_ns": 4486479.0,
+          "b_median_ns": 4858208.5,
+          "delta_percent": 8.28555087408188,
           "order": "BA",
           "pair_index": 4
         }
@@ -83,40 +83,40 @@
       "scenario": "markdown_injections/typing_delta"
     },
     {
-      "a_median_ns": 734896.0,
-      "b_median_ns": 674750.0,
+      "a_median_ns": 748729.25,
+      "b_median_ns": 913531.25,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 27.537620478276303,
-        "median": 4.881292269239333,
-        "min": -42.79466669126077
+        "max": 62.216250980545006,
+        "median": 23.801268646103253,
+        "min": -38.7402401900881
       },
       "pairs": [
         {
-          "a_median_ns": 684667.0,
-          "b_median_ns": 873208.0,
-          "delta_percent": 27.537620478276303,
+          "a_median_ns": 637021.0,
+          "b_median_ns": 865083.0,
+          "delta_percent": 35.801331510264184,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 867416.5,
-          "b_median_ns": 496208.5,
-          "delta_percent": -42.79466669126077,
+          "a_median_ns": 615729.0,
+          "b_median_ns": 998812.5,
+          "delta_percent": 62.216250980545006,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 468604.0,
-          "b_median_ns": 473666.5,
-          "delta_percent": 1.0803364888050464,
+          "a_median_ns": 860437.5,
+          "b_median_ns": 961979.5,
+          "delta_percent": 11.801205781942326,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 785125.0,
-          "b_median_ns": 853291.5,
-          "delta_percent": 8.68224804967362,
+          "a_median_ns": 868229.0,
+          "b_median_ns": 531875.0,
+          "delta_percent": -38.7402401900881,
           "order": "BA",
           "pair_index": 4
         }
@@ -124,40 +124,40 @@
       "scenario": "markdown_injections_large/full_cache_hit"
     },
     {
-      "a_median_ns": 1805416.5,
-      "b_median_ns": 1821000.0,
+      "a_median_ns": 1875302.25,
+      "b_median_ns": 1829156.5,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 6.572101631568519,
-        "median": 3.3689199205947906,
-        "min": -2.58564776114201
+        "max": 13.67317848791894,
+        "median": 3.324841847346164,
+        "min": -9.568001570234246
       },
       "pairs": [
         {
-          "a_median_ns": 1748896.0,
-          "b_median_ns": 1818750.0,
-          "delta_percent": 3.9941768978830074,
+          "a_median_ns": 1746771.0,
+          "b_median_ns": 1819521.0,
+          "delta_percent": 4.164827558964513,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 1950791.5,
-          "b_median_ns": 2078999.5,
-          "delta_percent": 6.572101631568519,
+          "a_median_ns": 1794208.5,
+          "b_median_ns": 1838792.0,
+          "delta_percent": 2.4848561357278154,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 1774562.0,
-          "b_median_ns": 1823250.0,
-          "delta_percent": 2.743662943306574,
+          "a_median_ns": 1956396.0,
+          "b_median_ns": 1769208.0,
+          "delta_percent": -9.568001570234246,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 1836271.0,
-          "b_median_ns": 1788791.5,
-          "delta_percent": -2.58564776114201,
+          "a_median_ns": 2004687.5,
+          "b_median_ns": 2278792.0,
+          "delta_percent": 13.67317848791894,
           "order": "BA",
           "pair_index": 4
         }
@@ -165,40 +165,40 @@
       "scenario": "rust_large/full_cache_hit"
     },
     {
-      "a_median_ns": 26562864.5,
-      "b_median_ns": 25202041.5,
+      "a_median_ns": 26029874.75,
+      "b_median_ns": 26146906.25,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": -1.213872900815735,
-        "median": -8.299635500472379,
-        "min": -10.12705762670363
+        "max": 7.4367466835849605,
+        "median": 0.1458494278878465,
+        "min": -8.845163265753358
       },
       "pairs": [
         {
-          "a_median_ns": 17140125.0,
-          "b_median_ns": 15845104.5,
-          "delta_percent": -7.555490406283502,
+          "a_median_ns": 16014562.5,
+          "b_median_ns": 15929666.5,
+          "delta_percent": -0.5301175102348253,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 29682437.0,
-          "b_median_ns": 26676479.5,
-          "delta_percent": -10.12705762670363,
+          "a_median_ns": 28318978.5,
+          "b_median_ns": 28551708.5,
+          "delta_percent": 0.8218163660105183,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 26523520.5,
-          "b_median_ns": 24124791.5,
-          "delta_percent": -9.043780594661255,
+          "a_median_ns": 29386812.0,
+          "b_median_ns": 26787500.5,
+          "delta_percent": -8.845163265753358,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 26602208.5,
-          "b_median_ns": 26279291.5,
-          "delta_percent": -1.213872900815735,
+          "a_median_ns": 23740771.0,
+          "b_median_ns": 25506312.0,
+          "delta_percent": 7.4367466835849605,
           "order": "BA",
           "pair_index": 4
         }
@@ -206,40 +206,40 @@
       "scenario": "rust_large/typing_burst"
     },
     {
-      "a_median_ns": 17554062.5,
-      "b_median_ns": 15684229.0,
+      "a_median_ns": 15565302.0,
+      "b_median_ns": 16471052.25,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": -1.096276614900743,
-        "median": -4.258497445632622,
-        "min": -13.73807975726051
+        "max": 9.27936726929543,
+        "median": 1.1343717209912898,
+        "min": -23.11194682127469
       },
       "pairs": [
         {
-          "a_median_ns": 15619187.5,
-          "b_median_ns": 15447958.0,
-          "delta_percent": -1.096276614900743,
+          "a_median_ns": 15705021.0,
+          "b_median_ns": 16085125.0,
+          "delta_percent": 2.4202705618795415,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 18456000.0,
-          "b_median_ns": 15920500.0,
-          "delta_percent": -13.73807975726051,
+          "a_median_ns": 15343458.0,
+          "b_median_ns": 15320208.5,
+          "delta_percent": -0.15152711989696196,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 25936625.0,
-          "b_median_ns": 25646999.5,
-          "delta_percent": -1.1166661043987025,
+          "a_median_ns": 15425583.0,
+          "b_median_ns": 16856979.5,
+          "delta_percent": 9.27936726929543,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 16652125.0,
-          "b_median_ns": 15419813.0,
-          "delta_percent": -7.400328786866541,
+          "a_median_ns": 23010104.0,
+          "b_median_ns": 17692021.0,
+          "delta_percent": -23.11194682127469,
           "order": "BA",
           "pair_index": 4
         }
@@ -247,40 +247,40 @@
       "scenario": "rust_large/typing_delta"
     },
     {
-      "a_median_ns": 6125771.0,
-      "b_median_ns": 6009125.0,
+      "a_median_ns": 5963208.0,
+      "b_median_ns": 5956281.25,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 3.267865792160868,
-        "median": -0.29276463026467836,
-        "min": -3.279504085817738
+        "max": 12.112710712678963,
+        "median": -0.12048948258952301,
+        "min": -2.1548789173975273
       },
       "pairs": [
         {
-          "a_median_ns": 5684000.0,
-          "b_median_ns": 5670937.5,
-          "delta_percent": -0.22981175228712175,
+          "a_median_ns": 5741416.5,
+          "b_median_ns": 5727812.5,
+          "delta_percent": -0.2369450117405696,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 8195333.5,
-          "b_median_ns": 8463146.0,
-          "delta_percent": 3.267865792160868,
+          "a_median_ns": 5740833.0,
+          "b_median_ns": 5617125.0,
+          "delta_percent": -2.1548789173975273,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 6488542.0,
-          "b_median_ns": 6275750.0,
-          "delta_percent": -3.279504085817738,
+          "a_median_ns": 6184999.5,
+          "b_median_ns": 6184750.0,
+          "delta_percent": -0.0040339534384764295,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 5763000.0,
-          "b_median_ns": 5742500.0,
-          "delta_percent": -0.3557175082422349,
+          "a_median_ns": 6831666.5,
+          "b_median_ns": 7659166.5,
+          "delta_percent": 12.112710712678963,
           "order": "BA",
           "pair_index": 4
         }
@@ -288,40 +288,40 @@
       "scenario": "rust_sparse_32k_exact/typing_delta"
     },
     {
-      "a_median_ns": 6745740.0,
-      "b_median_ns": 6204489.5,
+      "a_median_ns": 6002187.25,
+      "b_median_ns": 6009000.0,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 7.61955882229604,
-        "median": 0.6328019365454594,
-        "min": -14.244653430914026
+        "max": 10.4831510734912,
+        "median": 2.550412075704092,
+        "min": -1.2978851307738277
       },
       "pairs": [
         {
-          "a_median_ns": 5707563.0,
-          "b_median_ns": 5693188.0,
-          "delta_percent": -0.25185880558830454,
+          "a_median_ns": 5777937.5,
+          "b_median_ns": 5872375.0,
+          "delta_percent": 1.6344500091944574,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 8704021.0,
-          "b_median_ns": 9367229.0,
-          "delta_percent": 7.61955882229604,
+          "a_median_ns": 5661521.0,
+          "b_median_ns": 5857770.5,
+          "delta_percent": 3.4663741422137266,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 7783917.0,
-          "b_median_ns": 6675125.0,
-          "delta_percent": -14.244653430914026,
+          "a_median_ns": 6226437.0,
+          "b_median_ns": 6145625.0,
+          "delta_percent": -1.2978851307738277,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 5648145.5,
-          "b_median_ns": 5733854.0,
-          "delta_percent": 1.5174626786792231,
+          "a_median_ns": 7559354.0,
+          "b_median_ns": 8351812.5,
+          "delta_percent": 10.4831510734912,
           "order": "BA",
           "pair_index": 4
         }
@@ -329,40 +329,40 @@
       "scenario": "rust_sparse_32k_minus/typing_delta"
     },
     {
-      "a_median_ns": 6026104.5,
-      "b_median_ns": 5907666.75,
+      "a_median_ns": 6092666.75,
+      "b_median_ns": 6009135.5,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 9.921584753465982,
-        "median": -1.0407258667327632,
-        "min": -3.119320419687564
+        "max": 13.006528235380637,
+        "median": -1.0355401757738865,
+        "min": -1.4812532482932268
       },
       "pairs": [
         {
-          "a_median_ns": 5813458.5,
-          "b_median_ns": 5818479.5,
-          "delta_percent": 0.08636855324588624,
+          "a_median_ns": 5817313.0,
+          "b_median_ns": 5770417.0,
+          "delta_percent": -0.8061453801780993,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 6533104.5,
-          "b_median_ns": 7181292.0,
-          "delta_percent": 9.921584753465982,
+          "a_median_ns": 5843541.5,
+          "b_median_ns": 5769624.5,
+          "delta_percent": -1.2649349713696736,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 6189938.0,
-          "b_median_ns": 5996854.0,
-          "delta_percent": -3.119320419687564,
+          "a_median_ns": 6341792.0,
+          "b_median_ns": 6247854.0,
+          "delta_percent": -1.4812532482932268,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 5862271.0,
-          "b_median_ns": 5735187.5,
-          "delta_percent": -2.1678202867114127,
+          "a_median_ns": 6343291.5,
+          "b_median_ns": 7168333.5,
+          "delta_percent": 13.006528235380637,
           "order": "BA",
           "pair_index": 4
         }
@@ -370,40 +370,40 @@
       "scenario": "rust_sparse_32k_plus/typing_delta"
     },
     {
-      "a_median_ns": 13358229.25,
-      "b_median_ns": 13013260.5,
+      "a_median_ns": 14318604.25,
+      "b_median_ns": 13293031.0,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 5.384084893876937,
-        "median": -2.2343516034247664,
-        "min": -32.894947533214065
+        "max": 4.235609228896134,
+        "median": -0.7539322830760733,
+        "min": -14.161062675564398
       },
       "pairs": [
         {
-          "a_median_ns": 11234271.0,
-          "b_median_ns": 11221396.0,
-          "delta_percent": -0.11460467706360297,
+          "a_median_ns": 11279124.5,
+          "b_median_ns": 11248937.5,
+          "delta_percent": -0.2676360208631441,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 14035167.0,
-          "b_median_ns": 13424062.0,
-          "delta_percent": -4.354098529785929,
+          "a_median_ns": 14623729.5,
+          "b_median_ns": 12552854.0,
+          "delta_percent": -14.161062675564398,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 12681291.5,
-          "b_median_ns": 13364063.0,
-          "delta_percent": 5.384084893876937,
+          "a_median_ns": 14427771.0,
+          "b_median_ns": 15038875.0,
+          "delta_percent": 4.235609228896134,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 18869604.5,
-          "b_median_ns": 12662458.0,
-          "delta_percent": -32.894947533214065,
+          "a_median_ns": 14209437.5,
+          "b_median_ns": 14033208.0,
+          "delta_percent": -1.2402285452890025,
           "order": "BA",
           "pair_index": 4
         }
@@ -411,40 +411,40 @@
       "scenario": "rust_sparse_64k/typing_delta"
     },
     {
-      "a_median_ns": 125518739.5,
-      "b_median_ns": 138258718.5,
+      "a_median_ns": 134343312.25,
+      "b_median_ns": 131259344.0,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 70.7217455239578,
-        "median": 4.037477054309031,
-        "min": -4.054718113112459
+        "max": 23.14631307311401,
+        "median": 0.5381780998961261,
+        "min": -7.780199549426422
       },
       "pairs": [
         {
-          "a_median_ns": 81402354.5,
-          "b_median_ns": 138971520.5,
-          "delta_percent": 70.7217455239578,
+          "a_median_ns": 103604604.0,
+          "b_median_ns": 127585250.0,
+          "delta_percent": 23.14631307311401,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 143358708.0,
-          "b_median_ns": 137545916.5,
-          "delta_percent": -4.054718113112459,
+          "a_median_ns": 141983520.5,
+          "b_median_ns": 138656604.5,
+          "delta_percent": -2.3431705230889803,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 118055354.0,
-          "b_median_ns": 121341333.0,
-          "delta_percent": 2.783422258002801,
+          "a_median_ns": 142575604.0,
+          "b_median_ns": 131482937.5,
+          "delta_percent": -7.780199549426422,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 132982125.0,
-          "b_median_ns": 140018916.5,
-          "delta_percent": 5.291531850615262,
+          "a_median_ns": 126703104.0,
+          "b_median_ns": 131035750.5,
+          "delta_percent": 3.4195267228812325,
           "order": "BA",
           "pair_index": 4
         }
@@ -452,40 +452,40 @@
       "scenario": "rust_xlarge/cancel_burst"
     },
     {
-      "a_median_ns": 673364.25,
-      "b_median_ns": 648406.25,
+      "a_median_ns": 570167.0,
+      "b_median_ns": 676427.0,
       "pair_count": 4,
       "paired_delta_percent": {
-        "max": 53.03121212047601,
-        "median": 0.21865105541352864,
-        "min": -34.52632149848617
+        "max": 46.35561001732154,
+        "median": 3.960446808519401,
+        "min": -0.7734600689590905
       },
       "pairs": [
         {
-          "a_median_ns": 671395.5,
-          "b_median_ns": 666833.5,
-          "delta_percent": -0.6794802765285141,
+          "a_median_ns": 469646.5,
+          "b_median_ns": 687354.0,
+          "delta_percent": 46.35561001732154,
           "order": "AB",
           "pair_index": 1
         },
         {
-          "a_median_ns": 411667.0,
-          "b_median_ns": 629979.0,
-          "delta_percent": 53.03121212047601,
+          "a_median_ns": 728146.0,
+          "b_median_ns": 749104.0,
+          "delta_percent": 2.878268918595996,
           "order": "BA",
           "pair_index": 2
         },
         {
-          "a_median_ns": 682208.5,
-          "b_median_ns": 446667.0,
-          "delta_percent": -34.52632149848617,
+          "a_median_ns": 670687.5,
+          "b_median_ns": 665500.0,
+          "delta_percent": -0.7734600689590905,
           "order": "AB",
           "pair_index": 3
         },
         {
-          "a_median_ns": 675333.0,
-          "b_median_ns": 682875.0,
-          "delta_percent": 1.1167823873555713,
+          "a_median_ns": 433375.5,
+          "b_median_ns": 455229.0,
+          "delta_percent": 5.042624698442806,
           "order": "BA",
           "pair_index": 4
         }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -15,4 +15,7 @@ pub(crate) use semantic_cache::{
 };
 
 // Re-export crate-internal functions used by LSP layer
-pub(crate) use semantic::{filter_semantic_tokens_by_range, handle_semantic_tokens_full};
+pub(crate) use semantic::{
+    SemanticArtifact, SemanticArtifactIdentity, filter_semantic_tokens_by_range,
+    handle_semantic_tokens_full,
+};

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -5,6 +5,7 @@ mod legend;
 mod parallel;
 pub(crate) use parallel::invalidate_thread_local_parser_caches;
 mod range;
+mod semantic_artifact;
 mod token_collector;
 
 use crate::config::CaptureMappings;
@@ -18,6 +19,7 @@ pub(crate) use legend::{LEGEND_MODIFIERS, LEGEND_TYPES};
 pub(crate) use parallel::DISCOVERY_REUSE_HITS;
 pub(crate) use parallel::build_document_discovery;
 pub(crate) use range::filter_semantic_tokens_by_range;
+pub(crate) use semantic_artifact::{SemanticArtifact, SemanticArtifactIdentity};
 
 // Re-export for parallel processing
 use parallel::{INJECTION_CACHE_MIN_REGIONS, InjectionCacheCtx, collect_injection_tokens_parallel};

--- a/src/analysis/semantic/semantic_artifact.rs
+++ b/src/analysis/semantic/semantic_artifact.rs
@@ -275,6 +275,16 @@ mod tests {
         ];
 
         for mismatch in mismatches {
+            let shared_artifact = SemanticArtifact::from_full_result(
+                identity(),
+                SemanticTokensResult::Tokens(SemanticTokens {
+                    result_id: None,
+                    data: vec![],
+                }),
+            )
+            .expect("complete result");
+            assert!(shared_artifact.materialize_full(mismatch, None).is_none());
+
             let artifact = SemanticArtifact::from_full_result(
                 identity(),
                 SemanticTokensResult::Tokens(SemanticTokens {

--- a/src/analysis/semantic/semantic_artifact.rs
+++ b/src/analysis/semantic/semantic_artifact.rs
@@ -107,7 +107,7 @@ impl SemanticArtifact {
         Some(Self { identity, tokens })
     }
 
-    pub(crate) fn materialize_full(
+    pub(crate) fn into_full(
         mut self,
         expected_identity: SemanticArtifactIdentityRef<'_>,
         result_id: Option<String>,
@@ -117,6 +117,29 @@ impl SemanticArtifact {
         }
         self.tokens.result_id = result_id;
         Some(self.tokens)
+    }
+
+    /// Materialize one request response while retaining the artifact for other
+    /// consumers of the same snapshot slot.
+    ///
+    /// Stage 2 has only unique local artifacts and uses [`Self::into_full`] to
+    /// move the payload without cloning. Stage 3 shared-slot consumers use this
+    /// borrowed form and pay the wire-payload clone required for each response.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "shared snapshot slots are introduced in Stage 3")
+    )]
+    pub(crate) fn materialize_full(
+        &self,
+        expected_identity: SemanticArtifactIdentityRef<'_>,
+        result_id: Option<String>,
+    ) -> Option<SemanticTokens> {
+        if !self.identity.matches(expected_identity) {
+            return None;
+        }
+        let mut tokens = self.tokens.clone();
+        tokens.result_id = result_id;
+        Some(tokens)
     }
 }
 
@@ -173,7 +196,7 @@ mod tests {
         .expect("complete result");
 
         let materialized = artifact
-            .materialize_full(identity().as_ref(), None)
+            .into_full(identity().as_ref(), None)
             .expect("matching identity");
         assert_eq!(materialized.result_id, None);
         assert_eq!(materialized.data, vec![token]);
@@ -191,7 +214,7 @@ mod tests {
         .expect("complete result");
 
         let materialized = artifact
-            .materialize_full(identity().as_ref(), Some("request-42".into()))
+            .into_full(identity().as_ref(), Some("request-42".into()))
             .expect("matching identity");
         assert_eq!(materialized.result_id.as_deref(), Some("request-42"));
     }
@@ -261,8 +284,30 @@ mod tests {
             )
             .expect("complete result");
 
-            assert!(artifact.materialize_full(mismatch, None).is_none());
+            assert!(artifact.into_full(mismatch, None).is_none());
         }
+    }
+
+    #[test]
+    fn shared_artifact_materializes_independent_responses() {
+        let artifact = SemanticArtifact::from_full_result(
+            identity(),
+            SemanticTokensResult::Tokens(SemanticTokens {
+                result_id: None,
+                data: vec![],
+            }),
+        )
+        .expect("complete result");
+
+        let first = artifact
+            .materialize_full(identity().as_ref(), Some("request-1".into()))
+            .expect("matching identity");
+        let second = artifact
+            .materialize_full(identity().as_ref(), Some("request-2".into()))
+            .expect("artifact remains available");
+
+        assert_eq!(first.result_id.as_deref(), Some("request-1"));
+        assert_eq!(second.result_id.as_deref(), Some("request-2"));
     }
 
     #[test]

--- a/src/analysis/semantic/semantic_artifact.rs
+++ b/src/analysis/semantic/semantic_artifact.rs
@@ -155,7 +155,7 @@ mod tests {
     }
 
     #[test]
-    fn artifact_owns_complete_tokens_without_request_result_id() {
+    fn artifact_discards_compute_local_result_id() {
         let token = SemanticToken {
             delta_line: 1,
             delta_start: 2,
@@ -173,10 +173,27 @@ mod tests {
         .expect("complete result");
 
         let materialized = artifact
+            .materialize_full(identity().as_ref(), None)
+            .expect("matching identity");
+        assert_eq!(materialized.result_id, None);
+        assert_eq!(materialized.data, vec![token]);
+    }
+
+    #[test]
+    fn materialization_assigns_request_result_id() {
+        let artifact = SemanticArtifact::from_full_result(
+            identity(),
+            SemanticTokensResult::Tokens(SemanticTokens {
+                result_id: None,
+                data: vec![],
+            }),
+        )
+        .expect("complete result");
+
+        let materialized = artifact
             .materialize_full(identity().as_ref(), Some("request-42".into()))
             .expect("matching identity");
         assert_eq!(materialized.result_id.as_deref(), Some("request-42"));
-        assert_eq!(materialized.data, vec![token]);
     }
 
     #[test]

--- a/src/analysis/semantic/semantic_artifact.rs
+++ b/src/analysis/semantic/semantic_artifact.rs
@@ -1,5 +1,4 @@
 use crate::analysis::SemanticSnapshotIdentity;
-use std::sync::Arc;
 use tower_lsp_server::ls_types::{SemanticTokens, SemanticTokensResult};
 use url::Url;
 
@@ -7,7 +6,7 @@ use url::Url;
 ///
 /// The artifact remains scoped to one immutable parse snapshot. Response-local
 /// state such as an LSP `resultId` is deliberately not part of this identity.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub(crate) struct SemanticArtifactIdentity {
     uri: Url,
     language: String,
@@ -29,6 +28,62 @@ impl SemanticArtifactIdentity {
             supports_multiline,
         }
     }
+
+    pub(crate) fn expected<'a>(
+        uri: &'a Url,
+        language: &'a str,
+        snapshot: SemanticSnapshotIdentity,
+        supports_multiline: bool,
+    ) -> SemanticArtifactIdentityRef<'a> {
+        SemanticArtifactIdentityRef {
+            uri,
+            language,
+            snapshot,
+            supports_multiline,
+        }
+    }
+
+    #[cfg(test)]
+    fn as_ref(&self) -> SemanticArtifactIdentityRef<'_> {
+        Self::expected(
+            &self.uri,
+            &self.language,
+            self.snapshot,
+            self.supports_multiline,
+        )
+    }
+
+    fn matches(&self, expected: SemanticArtifactIdentityRef<'_>) -> bool {
+        self.uri == *expected.uri
+            && self.language == expected.language
+            && self.snapshot == expected.snapshot
+            && self.supports_multiline == expected.supports_multiline
+    }
+}
+
+/// Allocation-free request view used to validate a reusable artifact.
+///
+/// Stage 2 constructs the artifact locally, so this comparison is expected to
+/// succeed. Keeping the authoritative request inputs separate makes the same
+/// check non-tautological when Stage 3 retrieves an artifact from a snapshot
+/// slot, without cloning its URI or language for every lookup.
+#[derive(Clone, Copy)]
+pub(crate) struct SemanticArtifactIdentityRef<'a> {
+    uri: &'a Url,
+    language: &'a str,
+    snapshot: SemanticSnapshotIdentity,
+    supports_multiline: bool,
+}
+
+impl SemanticArtifactIdentityRef<'_> {
+    pub(crate) fn to_owned(self) -> SemanticArtifactIdentity {
+        SemanticArtifactIdentity::new(
+            self.uri.clone(),
+            self.language.to_owned(),
+            self.snapshot,
+            self.supports_multiline,
+        )
+    }
 }
 
 /// Complete immutable semantic output for one [`SemanticArtifactIdentity`].
@@ -36,13 +91,13 @@ impl SemanticArtifactIdentity {
 /// Construction accepts only a complete full result. The data stays private
 /// until a request materializes it and supplies its own LSP `resultId`.
 pub(crate) struct SemanticArtifact {
-    identity: Arc<SemanticArtifactIdentity>,
+    identity: SemanticArtifactIdentity,
     tokens: SemanticTokens,
 }
 
 impl SemanticArtifact {
     pub(crate) fn from_full_result(
-        identity: Arc<SemanticArtifactIdentity>,
+        identity: SemanticArtifactIdentity,
         result: SemanticTokensResult,
     ) -> Option<Self> {
         let SemanticTokensResult::Tokens(mut tokens) = result else {
@@ -54,10 +109,10 @@ impl SemanticArtifact {
 
     pub(crate) fn materialize_full(
         mut self,
-        expected_identity: &SemanticArtifactIdentity,
+        expected_identity: SemanticArtifactIdentityRef<'_>,
         result_id: Option<String>,
     ) -> Option<SemanticTokens> {
-        if self.identity.as_ref() != expected_identity {
+        if !self.identity.matches(expected_identity) {
             return None;
         }
         self.tokens.result_id = result_id;
@@ -69,7 +124,6 @@ impl SemanticArtifact {
 mod tests {
     use super::{SemanticArtifact, SemanticArtifactIdentity};
     use crate::analysis::SemanticSnapshotIdentity;
-    use std::sync::Arc;
     use tower_lsp_server::ls_types::{
         SemanticToken, SemanticTokens, SemanticTokensPartialResult, SemanticTokensResult,
     };
@@ -110,7 +164,7 @@ mod tests {
             token_modifiers_bitset: 5,
         };
         let artifact = SemanticArtifact::from_full_result(
-            Arc::new(identity()),
+            identity(),
             SemanticTokensResult::Tokens(SemanticTokens {
                 result_id: Some("compute-local".into()),
                 data: vec![token],
@@ -119,7 +173,7 @@ mod tests {
         .expect("complete result");
 
         let materialized = artifact
-            .materialize_full(&identity(), Some("request-42".into()))
+            .materialize_full(identity().as_ref(), Some("request-42".into()))
             .expect("matching identity");
         assert_eq!(materialized.result_id.as_deref(), Some("request-42"));
         assert_eq!(materialized.data, vec![token]);
@@ -128,7 +182,7 @@ mod tests {
     #[test]
     fn mismatched_identity_cannot_materialize_artifact() {
         let artifact = SemanticArtifact::from_full_result(
-            Arc::new(identity()),
+            identity(),
             SemanticTokensResult::Tokens(SemanticTokens {
                 result_id: None,
                 data: vec![],
@@ -138,13 +192,17 @@ mod tests {
         let mut different = identity();
         different.snapshot.generation += 1;
 
-        assert!(artifact.materialize_full(&different, None).is_none());
+        assert!(
+            artifact
+                .materialize_full(different.as_ref(), None)
+                .is_none()
+        );
     }
 
     #[test]
     fn partial_result_cannot_become_visible_artifact() {
         let artifact = SemanticArtifact::from_full_result(
-            Arc::new(identity()),
+            identity(),
             SemanticTokensResult::Partial(SemanticTokensPartialResult { data: vec![] }),
         );
 

--- a/src/analysis/semantic/semantic_artifact.rs
+++ b/src/analysis/semantic/semantic_artifact.rs
@@ -180,23 +180,72 @@ mod tests {
     }
 
     #[test]
-    fn mismatched_identity_cannot_materialize_artifact() {
-        let artifact = SemanticArtifact::from_full_result(
-            identity(),
-            SemanticTokensResult::Tokens(SemanticTokens {
-                result_id: None,
-                data: vec![],
-            }),
-        )
-        .expect("complete result");
-        let mut different = identity();
-        different.snapshot.generation += 1;
+    fn every_identity_component_discriminates_materialization() {
+        let base = identity();
+        let other_uri = Url::parse("file:///workspace/other.rs").unwrap();
+        let different_parsed_version = SemanticSnapshotIdentity {
+            parsed_version: base.snapshot.parsed_version + 1,
+            ..base.snapshot
+        };
+        let different_incarnation = SemanticSnapshotIdentity {
+            incarnation: base.snapshot.incarnation + 1,
+            ..base.snapshot
+        };
+        let different_generation = SemanticSnapshotIdentity {
+            generation: base.snapshot.generation + 1,
+            ..base.snapshot
+        };
+        let mismatches = [
+            SemanticArtifactIdentity::expected(
+                &other_uri,
+                &base.language,
+                base.snapshot,
+                base.supports_multiline,
+            ),
+            SemanticArtifactIdentity::expected(
+                &base.uri,
+                "python",
+                base.snapshot,
+                base.supports_multiline,
+            ),
+            SemanticArtifactIdentity::expected(
+                &base.uri,
+                &base.language,
+                different_parsed_version,
+                base.supports_multiline,
+            ),
+            SemanticArtifactIdentity::expected(
+                &base.uri,
+                &base.language,
+                different_incarnation,
+                base.supports_multiline,
+            ),
+            SemanticArtifactIdentity::expected(
+                &base.uri,
+                &base.language,
+                different_generation,
+                base.supports_multiline,
+            ),
+            SemanticArtifactIdentity::expected(
+                &base.uri,
+                &base.language,
+                base.snapshot,
+                !base.supports_multiline,
+            ),
+        ];
 
-        assert!(
-            artifact
-                .materialize_full(different.as_ref(), None)
-                .is_none()
-        );
+        for mismatch in mismatches {
+            let artifact = SemanticArtifact::from_full_result(
+                identity(),
+                SemanticTokensResult::Tokens(SemanticTokens {
+                    result_id: None,
+                    data: vec![],
+                }),
+            )
+            .expect("complete result");
+
+            assert!(artifact.materialize_full(mismatch, None).is_none());
+        }
     }
 
     #[test]

--- a/src/analysis/semantic/semantic_artifact.rs
+++ b/src/analysis/semantic/semantic_artifact.rs
@@ -1,4 +1,5 @@
 use crate::analysis::SemanticSnapshotIdentity;
+use std::sync::Arc;
 use tower_lsp_server::ls_types::{SemanticTokens, SemanticTokensResult};
 use url::Url;
 
@@ -35,13 +36,13 @@ impl SemanticArtifactIdentity {
 /// Construction accepts only a complete full result. The data stays private
 /// until a request materializes it and supplies its own LSP `resultId`.
 pub(crate) struct SemanticArtifact {
-    identity: SemanticArtifactIdentity,
+    identity: Arc<SemanticArtifactIdentity>,
     tokens: SemanticTokens,
 }
 
 impl SemanticArtifact {
     pub(crate) fn from_full_result(
-        identity: SemanticArtifactIdentity,
+        identity: Arc<SemanticArtifactIdentity>,
         result: SemanticTokensResult,
     ) -> Option<Self> {
         let SemanticTokensResult::Tokens(mut tokens) = result else {
@@ -56,7 +57,7 @@ impl SemanticArtifact {
         expected_identity: &SemanticArtifactIdentity,
         result_id: Option<String>,
     ) -> Option<SemanticTokens> {
-        if &self.identity != expected_identity {
+        if self.identity.as_ref() != expected_identity {
             return None;
         }
         self.tokens.result_id = result_id;
@@ -68,6 +69,7 @@ impl SemanticArtifact {
 mod tests {
     use super::{SemanticArtifact, SemanticArtifactIdentity};
     use crate::analysis::SemanticSnapshotIdentity;
+    use std::sync::Arc;
     use tower_lsp_server::ls_types::{
         SemanticToken, SemanticTokens, SemanticTokensPartialResult, SemanticTokensResult,
     };
@@ -108,7 +110,7 @@ mod tests {
             token_modifiers_bitset: 5,
         };
         let artifact = SemanticArtifact::from_full_result(
-            identity(),
+            Arc::new(identity()),
             SemanticTokensResult::Tokens(SemanticTokens {
                 result_id: Some("compute-local".into()),
                 data: vec![token],
@@ -126,7 +128,7 @@ mod tests {
     #[test]
     fn mismatched_identity_cannot_materialize_artifact() {
         let artifact = SemanticArtifact::from_full_result(
-            identity(),
+            Arc::new(identity()),
             SemanticTokensResult::Tokens(SemanticTokens {
                 result_id: None,
                 data: vec![],
@@ -142,7 +144,7 @@ mod tests {
     #[test]
     fn partial_result_cannot_become_visible_artifact() {
         let artifact = SemanticArtifact::from_full_result(
-            identity(),
+            Arc::new(identity()),
             SemanticTokensResult::Partial(SemanticTokensPartialResult { data: vec![] }),
         );
 

--- a/src/analysis/semantic/semantic_artifact.rs
+++ b/src/analysis/semantic/semantic_artifact.rs
@@ -1,0 +1,151 @@
+use crate::analysis::SemanticSnapshotIdentity;
+use tower_lsp_server::ls_types::{SemanticTokens, SemanticTokensResult};
+use url::Url;
+
+/// All request-independent inputs that identify one semantic-token artifact.
+///
+/// The artifact remains scoped to one immutable parse snapshot. Response-local
+/// state such as an LSP `resultId` is deliberately not part of this identity.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SemanticArtifactIdentity {
+    uri: Url,
+    language: String,
+    snapshot: SemanticSnapshotIdentity,
+    supports_multiline: bool,
+}
+
+impl SemanticArtifactIdentity {
+    pub(crate) fn new(
+        uri: Url,
+        language: String,
+        snapshot: SemanticSnapshotIdentity,
+        supports_multiline: bool,
+    ) -> Self {
+        Self {
+            uri,
+            language,
+            snapshot,
+            supports_multiline,
+        }
+    }
+}
+
+/// Complete immutable semantic output for one [`SemanticArtifactIdentity`].
+///
+/// Construction accepts only a complete full result. The data stays private
+/// until a request materializes it and supplies its own LSP `resultId`.
+pub(crate) struct SemanticArtifact {
+    identity: SemanticArtifactIdentity,
+    tokens: SemanticTokens,
+}
+
+impl SemanticArtifact {
+    pub(crate) fn from_full_result(
+        identity: SemanticArtifactIdentity,
+        result: SemanticTokensResult,
+    ) -> Option<Self> {
+        let SemanticTokensResult::Tokens(mut tokens) = result else {
+            return None;
+        };
+        tokens.result_id = None;
+        Some(Self { identity, tokens })
+    }
+
+    pub(crate) fn materialize_full(
+        mut self,
+        expected_identity: &SemanticArtifactIdentity,
+        result_id: Option<String>,
+    ) -> Option<SemanticTokens> {
+        if &self.identity != expected_identity {
+            return None;
+        }
+        self.tokens.result_id = result_id;
+        Some(self.tokens)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SemanticArtifact, SemanticArtifactIdentity};
+    use crate::analysis::SemanticSnapshotIdentity;
+    use tower_lsp_server::ls_types::{
+        SemanticToken, SemanticTokens, SemanticTokensPartialResult, SemanticTokensResult,
+    };
+    use url::Url;
+
+    fn identity() -> SemanticArtifactIdentity {
+        SemanticArtifactIdentity::new(
+            Url::parse("file:///workspace/main.rs").unwrap(),
+            "rust".into(),
+            SemanticSnapshotIdentity {
+                parsed_version: 7,
+                incarnation: 3,
+                generation: 11,
+            },
+            true,
+        )
+    }
+
+    #[test]
+    fn artifact_identity_includes_every_output_input() {
+        let identity = identity();
+
+        assert_eq!(identity.uri.as_str(), "file:///workspace/main.rs");
+        assert_eq!(identity.language, "rust");
+        assert_eq!(identity.snapshot.parsed_version, 7);
+        assert_eq!(identity.snapshot.incarnation, 3);
+        assert_eq!(identity.snapshot.generation, 11);
+        assert!(identity.supports_multiline);
+    }
+
+    #[test]
+    fn artifact_owns_complete_tokens_without_request_result_id() {
+        let token = SemanticToken {
+            delta_line: 1,
+            delta_start: 2,
+            length: 3,
+            token_type: 4,
+            token_modifiers_bitset: 5,
+        };
+        let artifact = SemanticArtifact::from_full_result(
+            identity(),
+            SemanticTokensResult::Tokens(SemanticTokens {
+                result_id: Some("compute-local".into()),
+                data: vec![token],
+            }),
+        )
+        .expect("complete result");
+
+        let materialized = artifact
+            .materialize_full(&identity(), Some("request-42".into()))
+            .expect("matching identity");
+        assert_eq!(materialized.result_id.as_deref(), Some("request-42"));
+        assert_eq!(materialized.data, vec![token]);
+    }
+
+    #[test]
+    fn mismatched_identity_cannot_materialize_artifact() {
+        let artifact = SemanticArtifact::from_full_result(
+            identity(),
+            SemanticTokensResult::Tokens(SemanticTokens {
+                result_id: None,
+                data: vec![],
+            }),
+        )
+        .expect("complete result");
+        let mut different = identity();
+        different.snapshot.generation += 1;
+
+        assert!(artifact.materialize_full(&different, None).is_none());
+    }
+
+    #[test]
+    fn partial_result_cannot_become_visible_artifact() {
+        let artifact = SemanticArtifact::from_full_result(
+            identity(),
+            SemanticTokensResult::Partial(SemanticTokensPartialResult { data: vec![] }),
+        );
+
+        assert!(artifact.is_none());
+    }
+}

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -73,16 +73,6 @@ enum CurrentTokens {
 }
 
 impl CurrentTokens {
-    fn from_result(result: SemanticTokensResult) -> Self {
-        match result {
-            SemanticTokensResult::Tokens(tokens) => Self::Owned(tokens),
-            SemanticTokensResult::Partial(_) => Self::Owned(SemanticTokens {
-                result_id: None,
-                data: Vec::new(),
-            }),
-        }
-    }
-
     fn as_ref(&self) -> &SemanticTokens {
         match self {
             Self::Cached(arc) => arc,
@@ -878,6 +868,12 @@ impl Kakehashi {
                     // The snapshot's own discovery (ADR §3, don't-discover-twice).
                     discovery: snapshot.injection_regions.clone(),
                 });
+                let artifact_identity = SemanticArtifactIdentity::new(
+                    uri.clone(),
+                    language_name.clone(),
+                    snapshot_identity,
+                    supports_multiline,
+                );
 
                 // Compute tokens, racing against cancel notification if provided
                 let compute_future = handle_semantic_tokens_full(
@@ -921,7 +917,12 @@ impl Kakehashi {
                     // No cancel support - just await the computation
                     compute_future.await
                 };
-                computed.map(CurrentTokens::from_result)
+                computed
+                    .and_then(|result| {
+                        SemanticArtifact::from_full_result(artifact_identity.clone(), result)
+                    })
+                    .and_then(|artifact| artifact.materialize_full(&artifact_identity, None))
+                    .map(CurrentTokens::Owned)
             }
         };
 
@@ -1222,6 +1223,12 @@ impl Kakehashi {
         // Use Rayon-based parallel injection processing
         let supports_multiline = self.settings_manager.supports_multiline_tokens();
         let coordinator = std::sync::Arc::clone(&self.language);
+        let artifact_identity = SemanticArtifactIdentity::new(
+            uri.clone(),
+            language_name.clone(),
+            snapshot_identity,
+            supports_multiline,
+        );
 
         let result = handle_semantic_tokens_full(
             &self.compute_pool,
@@ -1239,19 +1246,19 @@ impl Kakehashi {
 
         // Shape immutable payloads before taking the edit lock. Only the final
         // live-snapshot validation and cache commits need to exclude edits.
-        let (domain_range_result, tokens_to_store) = match result {
-            Some(tower_lsp_server::ls_types::SemanticTokensResult::Tokens(mut full_tokens)) => {
-                full_tokens.result_id = Some(next_result_id());
+        let artifact = result.and_then(|result| {
+            SemanticArtifact::from_full_result(artifact_identity.clone(), result)
+        });
+        let (domain_range_result, tokens_to_store) = match artifact.and_then(|artifact| {
+            artifact.materialize_full(&artifact_identity, Some(next_result_id()))
+        }) {
+            Some(full_tokens) => {
                 let range_tokens = filter_semantic_tokens_by_range(&full_tokens, &domain_range);
                 let response = tower_lsp_server::ls_types::SemanticTokensRangeResult::from(
                     range_tokens.clone(),
                 );
                 (response, Some((full_tokens, range_tokens)))
             }
-            Some(tower_lsp_server::ls_types::SemanticTokensResult::Partial(partial)) => (
-                tower_lsp_server::ls_types::SemanticTokensRangeResult::from(partial),
-                None,
-            ),
             None => (
                 tower_lsp_server::ls_types::SemanticTokensRangeResult::Tokens(
                     tower_lsp_server::ls_types::SemanticTokens {

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -910,6 +910,27 @@ impl Kakehashi {
                     // No cancel support - just await the computation
                     compute_future.await
                 };
+                // Do not allocate artifact identity or shape a payload for work
+                // already made obsolete while the compute was in flight. The
+                // outer checks remain necessary for cache hits and for a
+                // cancellation racing with materialization itself.
+                if cancel_token.is_cancelled() {
+                    self.cache.finish_request(&uri, request_id);
+                    log::debug!(
+                        target: "kakehashi::semantic",
+                        "[SEMANTIC_TOKENS_DELTA] CANCELLED uri={} req={} (before artifact)",
+                        uri, request_id
+                    );
+                    return Ok(None);
+                }
+                if !self.cache.is_request_active(&uri, request_id) {
+                    log::debug!(
+                        target: "kakehashi::semantic",
+                        "[SEMANTIC_TOKENS_DELTA] CANCELLED uri={} req={} (before artifact)",
+                        uri, request_id
+                    );
+                    return Ok(None);
+                }
                 computed
                     .and_then(|result| {
                         let expected_artifact_identity = SemanticArtifactIdentity::expected(

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -870,13 +870,6 @@ impl Kakehashi {
                     // The snapshot's own discovery (ADR §3, don't-discover-twice).
                     discovery: snapshot.injection_regions.clone(),
                 });
-                let expected_artifact_identity = SemanticArtifactIdentity::expected(
-                    &uri,
-                    &language_name,
-                    snapshot_identity,
-                    supports_multiline,
-                );
-
                 // Compute tokens, racing against cancel notification if provided
                 let compute_future = handle_semantic_tokens_full(
                     &self.compute_pool,
@@ -921,13 +914,19 @@ impl Kakehashi {
                 };
                 computed
                     .and_then(|result| {
+                        let expected_artifact_identity = SemanticArtifactIdentity::expected(
+                            &uri,
+                            &language_name,
+                            snapshot_identity,
+                            supports_multiline,
+                        );
                         SemanticArtifact::from_full_result(
                             expected_artifact_identity.to_owned(),
                             result,
                         )
-                    })
-                    .and_then(|artifact| {
-                        artifact.materialize_full(expected_artifact_identity, None)
+                        .and_then(|artifact| {
+                            artifact.materialize_full(expected_artifact_identity, None)
+                        })
                     })
                     .map(CurrentTokens::Owned)
             }
@@ -1230,13 +1229,6 @@ impl Kakehashi {
         // Use Rayon-based parallel injection processing
         let supports_multiline = self.settings_manager.supports_multiline_tokens();
         let coordinator = std::sync::Arc::clone(&self.language);
-        let expected_artifact_identity = SemanticArtifactIdentity::expected(
-            &uri,
-            &language_name,
-            snapshot_identity,
-            supports_multiline,
-        );
-
         let result = handle_semantic_tokens_full(
             &self.compute_pool,
             text,
@@ -1253,12 +1245,19 @@ impl Kakehashi {
 
         // Shape immutable payloads before taking the edit lock. Only the final
         // live-snapshot validation and cache commits need to exclude edits.
-        let artifact = result.and_then(|result| {
+        let full_tokens = result.and_then(|result| {
+            let expected_artifact_identity = SemanticArtifactIdentity::expected(
+                &uri,
+                &language_name,
+                snapshot_identity,
+                supports_multiline,
+            );
             SemanticArtifact::from_full_result(expected_artifact_identity.to_owned(), result)
+                .and_then(|artifact| {
+                    artifact.materialize_full(expected_artifact_identity, Some(next_result_id()))
+                })
         });
-        let (domain_range_result, tokens_to_store) = match artifact.and_then(|artifact| {
-            artifact.materialize_full(expected_artifact_identity, Some(next_result_id()))
-        }) {
+        let (domain_range_result, tokens_to_store) = match full_tokens {
             Some(full_tokens) => {
                 let range_tokens = filter_semantic_tokens_by_range(&full_tokens, &domain_range);
                 let response = tower_lsp_server::ls_types::SemanticTokensRangeResult::from(

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -557,9 +557,7 @@ impl Kakehashi {
         // complete identity before assigning this request's result ID.
         let result_id = Some(next_result_id());
         let tokens_with_id = artifact
-            .and_then(|artifact| {
-                artifact.materialize_full(expected_artifact_identity, result_id.clone())
-            })
+            .and_then(|artifact| artifact.into_full(expected_artifact_identity, result_id.clone()))
             .unwrap_or_else(|| SemanticTokens {
                 result_id,
                 data: Vec::new(),
@@ -924,9 +922,7 @@ impl Kakehashi {
                             expected_artifact_identity.to_owned(),
                             result,
                         )
-                        .and_then(|artifact| {
-                            artifact.materialize_full(expected_artifact_identity, None)
-                        })
+                        .and_then(|artifact| artifact.into_full(expected_artifact_identity, None))
                     })
                     .map(CurrentTokens::Owned)
             }
@@ -1254,7 +1250,7 @@ impl Kakehashi {
             );
             SemanticArtifact::from_full_result(expected_artifact_identity.to_owned(), result)
                 .and_then(|artifact| {
-                    artifact.materialize_full(expected_artifact_identity, Some(next_result_id()))
+                    artifact.into_full(expected_artifact_identity, Some(next_result_id()))
                 })
         });
         let (domain_range_result, tokens_to_store) = match full_tokens {

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -544,21 +544,21 @@ impl Kakehashi {
             );
             return Ok(None);
         }
-        let artifact_identity = std::sync::Arc::new(SemanticArtifactIdentity::new(
-            uri.clone(),
-            language_name.clone(),
+        let expected_artifact_identity = SemanticArtifactIdentity::expected(
+            &uri,
+            &language_name,
             snapshot_identity,
             supports_multiline,
-        ));
+        );
         let artifact = result.and_then(|result| {
-            SemanticArtifact::from_full_result(std::sync::Arc::clone(&artifact_identity), result)
+            SemanticArtifact::from_full_result(expected_artifact_identity.to_owned(), result)
         });
         // The artifact contains no request lineage. Materialization checks the
         // complete identity before assigning this request's result ID.
         let result_id = Some(next_result_id());
         let tokens_with_id = artifact
             .and_then(|artifact| {
-                artifact.materialize_full(artifact_identity.as_ref(), result_id.clone())
+                artifact.materialize_full(expected_artifact_identity, result_id.clone())
             })
             .unwrap_or_else(|| SemanticTokens {
                 result_id,
@@ -870,12 +870,12 @@ impl Kakehashi {
                     // The snapshot's own discovery (ADR §3, don't-discover-twice).
                     discovery: snapshot.injection_regions.clone(),
                 });
-                let artifact_identity = std::sync::Arc::new(SemanticArtifactIdentity::new(
-                    uri.clone(),
-                    language_name.clone(),
+                let expected_artifact_identity = SemanticArtifactIdentity::expected(
+                    &uri,
+                    &language_name,
                     snapshot_identity,
                     supports_multiline,
-                ));
+                );
 
                 // Compute tokens, racing against cancel notification if provided
                 let compute_future = handle_semantic_tokens_full(
@@ -922,12 +922,12 @@ impl Kakehashi {
                 computed
                     .and_then(|result| {
                         SemanticArtifact::from_full_result(
-                            std::sync::Arc::clone(&artifact_identity),
+                            expected_artifact_identity.to_owned(),
                             result,
                         )
                     })
                     .and_then(|artifact| {
-                        artifact.materialize_full(artifact_identity.as_ref(), None)
+                        artifact.materialize_full(expected_artifact_identity, None)
                     })
                     .map(CurrentTokens::Owned)
             }
@@ -1230,12 +1230,12 @@ impl Kakehashi {
         // Use Rayon-based parallel injection processing
         let supports_multiline = self.settings_manager.supports_multiline_tokens();
         let coordinator = std::sync::Arc::clone(&self.language);
-        let artifact_identity = std::sync::Arc::new(SemanticArtifactIdentity::new(
-            uri.clone(),
-            language_name.clone(),
+        let expected_artifact_identity = SemanticArtifactIdentity::expected(
+            &uri,
+            &language_name,
             snapshot_identity,
             supports_multiline,
-        ));
+        );
 
         let result = handle_semantic_tokens_full(
             &self.compute_pool,
@@ -1254,10 +1254,10 @@ impl Kakehashi {
         // Shape immutable payloads before taking the edit lock. Only the final
         // live-snapshot validation and cache commits need to exclude edits.
         let artifact = result.and_then(|result| {
-            SemanticArtifact::from_full_result(std::sync::Arc::clone(&artifact_identity), result)
+            SemanticArtifact::from_full_result(expected_artifact_identity.to_owned(), result)
         });
         let (domain_range_result, tokens_to_store) = match artifact.and_then(|artifact| {
-            artifact.materialize_full(artifact_identity.as_ref(), Some(next_result_id()))
+            artifact.materialize_full(expected_artifact_identity, Some(next_result_id()))
         }) {
             Some(full_tokens) => {
                 let range_tokens = filter_semantic_tokens_by_range(&full_tokens, &domain_range);

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -29,8 +29,8 @@ use tower_lsp_server::ls_types::{
 };
 
 use crate::analysis::{
-    SemanticSnapshotIdentity, calculate_delta_or_full, filter_semantic_tokens_by_range,
-    handle_semantic_tokens_full, next_result_id,
+    SemanticArtifact, SemanticArtifactIdentity, SemanticSnapshotIdentity, calculate_delta_or_full,
+    filter_semantic_tokens_by_range, handle_semantic_tokens_full, next_result_id,
 };
 use crate::lsp::current_upstream_id;
 
@@ -554,24 +554,24 @@ impl Kakehashi {
             );
             return Ok(None);
         }
-        let mut tokens_with_id = match result.unwrap_or_else(|| {
-            tower_lsp_server::ls_types::SemanticTokensResult::Tokens(
-                tower_lsp_server::ls_types::SemanticTokens {
-                    result_id: None,
-                    data: Vec::new(),
-                },
-            )
-        }) {
-            tower_lsp_server::ls_types::SemanticTokensResult::Tokens(tokens) => tokens,
-            tower_lsp_server::ls_types::SemanticTokensResult::Partial(_) => {
-                tower_lsp_server::ls_types::SemanticTokens {
-                    result_id: None,
-                    data: Vec::new(),
-                }
-            }
-        };
-        // Use atomic sequential ID for efficient cache validation
-        tokens_with_id.result_id = Some(next_result_id());
+        let artifact_identity = SemanticArtifactIdentity::new(
+            uri.clone(),
+            language_name.clone(),
+            snapshot_identity,
+            supports_multiline,
+        );
+        let artifact = result.and_then(|result| {
+            SemanticArtifact::from_full_result(artifact_identity.clone(), result)
+        });
+        // The artifact contains no request lineage. Materialization checks the
+        // complete identity before assigning this request's result ID.
+        let result_id = Some(next_result_id());
+        let tokens_with_id = artifact
+            .and_then(|artifact| artifact.materialize_full(&artifact_identity, result_id.clone()))
+            .unwrap_or_else(|| SemanticTokens {
+                result_id,
+                data: Vec::new(),
+            });
         let stored_tokens = tokens_with_id.clone();
         let lsp_tokens = tokens_with_id;
         let edit_lock = self.documents.edit_lock(&uri);

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -544,20 +544,22 @@ impl Kakehashi {
             );
             return Ok(None);
         }
-        let artifact_identity = SemanticArtifactIdentity::new(
+        let artifact_identity = std::sync::Arc::new(SemanticArtifactIdentity::new(
             uri.clone(),
             language_name.clone(),
             snapshot_identity,
             supports_multiline,
-        );
+        ));
         let artifact = result.and_then(|result| {
-            SemanticArtifact::from_full_result(artifact_identity.clone(), result)
+            SemanticArtifact::from_full_result(std::sync::Arc::clone(&artifact_identity), result)
         });
         // The artifact contains no request lineage. Materialization checks the
         // complete identity before assigning this request's result ID.
         let result_id = Some(next_result_id());
         let tokens_with_id = artifact
-            .and_then(|artifact| artifact.materialize_full(&artifact_identity, result_id.clone()))
+            .and_then(|artifact| {
+                artifact.materialize_full(artifact_identity.as_ref(), result_id.clone())
+            })
             .unwrap_or_else(|| SemanticTokens {
                 result_id,
                 data: Vec::new(),
@@ -868,12 +870,12 @@ impl Kakehashi {
                     // The snapshot's own discovery (ADR §3, don't-discover-twice).
                     discovery: snapshot.injection_regions.clone(),
                 });
-                let artifact_identity = SemanticArtifactIdentity::new(
+                let artifact_identity = std::sync::Arc::new(SemanticArtifactIdentity::new(
                     uri.clone(),
                     language_name.clone(),
                     snapshot_identity,
                     supports_multiline,
-                );
+                ));
 
                 // Compute tokens, racing against cancel notification if provided
                 let compute_future = handle_semantic_tokens_full(
@@ -919,9 +921,14 @@ impl Kakehashi {
                 };
                 computed
                     .and_then(|result| {
-                        SemanticArtifact::from_full_result(artifact_identity.clone(), result)
+                        SemanticArtifact::from_full_result(
+                            std::sync::Arc::clone(&artifact_identity),
+                            result,
+                        )
                     })
-                    .and_then(|artifact| artifact.materialize_full(&artifact_identity, None))
+                    .and_then(|artifact| {
+                        artifact.materialize_full(artifact_identity.as_ref(), None)
+                    })
                     .map(CurrentTokens::Owned)
             }
         };
@@ -1223,12 +1230,12 @@ impl Kakehashi {
         // Use Rayon-based parallel injection processing
         let supports_multiline = self.settings_manager.supports_multiline_tokens();
         let coordinator = std::sync::Arc::clone(&self.language);
-        let artifact_identity = SemanticArtifactIdentity::new(
+        let artifact_identity = std::sync::Arc::new(SemanticArtifactIdentity::new(
             uri.clone(),
             language_name.clone(),
             snapshot_identity,
             supports_multiline,
-        );
+        ));
 
         let result = handle_semantic_tokens_full(
             &self.compute_pool,
@@ -1247,10 +1254,10 @@ impl Kakehashi {
         // Shape immutable payloads before taking the edit lock. Only the final
         // live-snapshot validation and cache commits need to exclude edits.
         let artifact = result.and_then(|result| {
-            SemanticArtifact::from_full_result(artifact_identity.clone(), result)
+            SemanticArtifact::from_full_result(std::sync::Arc::clone(&artifact_identity), result)
         });
         let (domain_range_result, tokens_to_store) = match artifact.and_then(|artifact| {
-            artifact.materialize_full(&artifact_identity, Some(next_result_id()))
+            artifact.materialize_full(artifact_identity.as_ref(), Some(next_result_id()))
         }) {
             Some(full_tokens) => {
                 let range_tokens = filter_semantic_tokens_by_range(&full_tokens, &domain_range);

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -555,11 +555,12 @@ impl Kakehashi {
         });
         // The artifact contains no request lineage. Materialization checks the
         // complete identity before assigning this request's result ID.
-        let result_id = Some(next_result_id());
         let tokens_with_id = artifact
-            .and_then(|artifact| artifact.into_full(expected_artifact_identity, result_id.clone()))
+            .and_then(|artifact| {
+                artifact.into_full(expected_artifact_identity, Some(next_result_id()))
+            })
             .unwrap_or_else(|| SemanticTokens {
-                result_id,
+                result_id: Some(next_result_id()),
                 data: Vec::new(),
             });
         let stored_tokens = tokens_with_id.clone();

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -913,18 +913,12 @@ impl Kakehashi {
                 };
                 // Do not allocate artifact identity or shape a payload for work
                 // already made obsolete while the compute was in flight. The
-                // outer checks remain necessary for cache hits and for a
-                // cancellation racing with materialization itself.
+                // outer cancellation check remains necessary for cache hits and
+                // for a cancellation racing with materialization itself; the
+                // existing activity check immediately after materialization
+                // avoids adding a second DashMap lookup to every computed delta.
                 if cancel_token.is_cancelled() {
                     self.cache.finish_request(&uri, request_id);
-                    log::debug!(
-                        target: "kakehashi::semantic",
-                        "[SEMANTIC_TOKENS_DELTA] CANCELLED uri={} req={} (before artifact)",
-                        uri, request_id
-                    );
-                    return Ok(None);
-                }
-                if !self.cache.is_request_active(&uri, request_id) {
                     log::debug!(
                         target: "kakehashi::semantic",
                         "[SEMANTIC_TOKENS_DELTA] CANCELLED uri={} req={} (before artifact)",


### PR DESCRIPTION
## 概要

#896 / #904 の段階 2 として、既存の whole-document semantic token 計算を挙動変更なしで包む immutable `SemanticArtifact` 境界を導入します。

- artifact identity に URI、language、parse snapshot identity、multiline capability を保持
- complete な full result だけを artifact として構築し、partial result は公開しない
- LSP `resultId` は artifact に保持せず、request ごとの materialization 時に付与
- freshly computed な full / delta / range を同じ境界へ通す
- owned artifact identity と allocation-free な borrowed expected view を分離
- unique artifact は token payload を move、将来の shared slot は borrowed materialization で独立 response を生成
- cancelled delta は artifact identity 所有化・materialization より前に除外

この PR では same-revision sharing、single-flight、prefetch、chunk 化、部分再計算はまだ行いません。既存 cache-hit と delta baseline の経路も変更しません。

## 目的

後続 PR で snapshot-scoped slot を導入する前に、「request lineage を持たない完全な semantic output」と「request ごとの response shaping / currency validation」の境界を小さく固定します。Stage 2 の identity comparison はローカル構築なので成功する前提ですが、Stage 3 で slot から取得する artifact と authoritative request input を allocation なしで照合できる API にしています。semantic freshness、cancellation、latest-edit validation は既存のままです。

## 依存関係と merge 順

- #899: exact benchmark contract
- #900: synchronous stateless semantic core（この PR の base）
- #904: revision-scoped artifact ADR

merge 順は `#899 -> #900 -> この PR` です。#904 もこの PR より先に merge します。依存 PR の merge 後に `main` へ retarget して CI を確認するため、それまでは draft にします。

## ベンチマーク

比較は #900 exact head `265d38b0a` と runtime-converged exact tag `benchmark/semantic-artifact-seam-converged-2026-07-23` (`8b966d16f`) です。

- 4 alternating AB/BA pairs
- 6 warmups
- 30 retained iterations
- stdout / SHA attestation を保存
- parser library / query file は保存せず、インストール済み言語資産の fixture manifest のみ保持

主要 freshly-computed path の paired median:

- Rust typing delta: +1.13%（2 faster / 2 slower）
- Rust typing burst: +0.15%（2 / 2）
- Rust cancel burst: +0.54%（2 / 2）
- Markdown typing delta: -0.61%（2 / 2）
- Markdown typing burst: +3.49%（2 / 2）

primary は全 scenario で符号が混在しています。artifact construction を通らない control はさらに noisy で、Markdown large cache hit は paired median +23.80%、range -38.74%..+62.22%、Unicode cache hit は -0.77%..+46.36% でした。そのため speedup は主張せず、primary path の非回帰のみを結論にします。証拠は `benches/results/semantic-artifact-seam-2026-07-23/` にあります。

## revise で修正した点

- 同一 `Arc` 由来で恒真だった identity guard を owned identity / borrowed expected view に分離 (`cbf398083`)
- cancelled delta / range で不要になる identity ownership を complete result 後へ遅延 (`44b4185ec`)
- identity 各成分と resultId lineage の識別テストを追加 (`3744bb9df`, `518c1868e`)
- shared slot 用 borrowed materialization と独立 response テストを追加 (`85fcc733e`)
- obsolete delta を artifact shaping 前に除外し、二重 DashMap lookup は回避 (`3f14104e0`, `8b966d16f`)
- full miss の正常系 resultId clone を除去 (`79afe97a6`)
- shared materialization の全 identity mismatch を検証 (`725bcd4f1`)
- runtime-converged exact binary で全 evidence を再収集 (`9d776be71`)

## 検証

- semantic unit: 241 passed
- semantic handler 関連: 31 passed
- `e2e_semantic`: 32 passed
- `e2e_semantic_blockquote`: 42 passed
- `e2e_semantic_tokens_refresh`: 28 passed
- `cargo fmt --all -- --check`
- `cargo clippy --locked --lib -- -D warnings`
- benchmark manifest / raw samples / stdout / summary / fixture SHA を再検証
- repository 内への parser library / query file の追加なし
- revise Stage 1 最終3視点: actionable finding なし
- revise Stage 2 Codex MCP: 同一 thread 収束後、fresh session 初回も `no comments to provide`

Part of #896

---

**注記 (2026-08-11): 生サンプルの削除**

リポジトリに raw benchmark data を残さないため、`benches/results/*/pair-*.json`（各pairの生サンプル配列）をこのスタックの全PRから削除しました。evidence ディレクトリは残っており、中身は次の通りです。

- `summary.json` — pairごとの median / delta / min / max と集計値
- `pair-*.txt` — シナリオ別の A/B 比較表（p95 付き）
- `manifest.json` / `fixture-manifest.json` — commit・tag・binary/harness/fixture の SHA-256

**本文に記載した数値はすべてこれらから再構成できます。** 失われたのは各シナリオ 30 本の生サンプル配列のみです。`manifest.json` の `raw_files` / `samples_sha256` は、削除したファイルの記録として意図的に残しています。

なお本文中の「raw samples を検証／再検証した」という記述は当時実施した検証の記録であり、現在のリポジトリからは再実行できません。今後の再混入を防ぐため `.gitignore` に `benches/results/*/pair-*.json` を追加しています。
