### PR TITLE
test(bench): measure same-snapshot semantic fan-out

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - run: cargo check
+      - run: cargo check --features semantic-bench-instrumentation
       - run: cargo check --bench semantic_tokens --features e2e
       - run: KAKEHASHI_BENCH_VALIDATE_SCENARIOS=1 cargo test --bench semantic_tokens --features e2e
 
@@ -44,6 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - run: cargo clippy -- -D warnings
+      - run: cargo clippy --features semantic-bench-instrumentation -- -D warnings
       - run: cargo clippy --bench semantic_tokens --features e2e -- -D warnings
 
   audit:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ nix = { version = "0.31", features = ["signal", "process", "fs"] }
 
 [features]
 e2e = []
+semantic-bench-instrumentation = []
 
 # Unix-only dev dependencies: pipe() for deterministic broken-pipe tests,
 # Signal::SIGPIPE for asserting the termination signal.

--- a/benches/README.md
+++ b/benches/README.md
@@ -32,6 +32,13 @@ attestation, and raw-contract check succeeds. A failed run removes its staging
 artifacts and reports any exact worktree cleanup failure, so the same output
 path can be retried.
 
+The `rust_xlarge/same_snapshot_fanout` scenario synchronizes delta and range
+consumers after both miss the completed-artifact cache. The collector compiles
+measured servers with the opt-in `semantic-bench-instrumentation` feature only
+when this scenario is selected; normal builds contain no synchronization hook.
+Both compared refs must therefore include that feature. Select a scenario list
+without `same_snapshot_fanout` when comparing an older ref.
+
 The collector uses kakehashi's installer to create a temporary parser/query
 data directory, freezes it for the timed runs, and removes it afterward. The
 resulting `manifest.json` binds source commits, binary and harness hashes, the

--- a/benches/README.md
+++ b/benches/README.md
@@ -33,11 +33,20 @@ artifacts and reports any exact worktree cleanup failure, so the same output
 path can be retried.
 
 The `rust_xlarge/same_snapshot_fanout` scenario synchronizes delta and range
-consumers after both miss the completed-artifact cache. The collector compiles
-measured servers with the opt-in `semantic-bench-instrumentation` feature only
-when this scenario is selected; normal builds contain no synchronization hook.
-Both compared refs must therefore include that feature. Select a scenario list
-without `same_snapshot_fanout` when comparing an older ref.
+consumers after both miss the completed-artifact cache. Collect it separately:
+
+```sh
+python3 benches/collect_semantic_pairs.py \
+  baseline-ref candidate-ref benches/results/same-snapshot-fanout \
+  --scenarios rust_xlarge/same_snapshot_fanout
+```
+
+The collector compiles these measured servers with the opt-in
+`semantic-bench-instrumentation` feature and records that feature in the
+manifest. Instrumented fan-out collection cannot be mixed with production
+scenarios, and the default scenario set remains feature-free. Both refs in a
+fan-out comparison must include the feature; select other scenarios when
+comparing an older ref.
 
 The collector uses kakehashi's installer to create a temporary parser/query
 data directory, freezes it for the timed runs, and removes it afterward. The

--- a/benches/collect_semantic_pairs.py
+++ b/benches/collect_semantic_pairs.py
@@ -21,6 +21,7 @@ from typing import Any
 from semantic_summary import summarize_pairs, validate_collection
 
 
+SAME_SNAPSHOT_FANOUT_SCENARIO = "rust_xlarge/same_snapshot_fanout"
 DEFAULT_SCENARIOS = ",".join(
     [
         "rust_large/full_cache_hit",
@@ -31,6 +32,7 @@ DEFAULT_SCENARIOS = ",".join(
         "rust_sparse_64k/typing_delta",
         "rust_large/typing_burst",
         "rust_xlarge/cancel_burst",
+        SAME_SNAPSHOT_FANOUT_SCENARIO,
         "markdown_injections_large/full_cache_hit",
         "markdown_injections/typing_delta",
         "markdown_injections/typing_burst",
@@ -49,6 +51,23 @@ ISOLATED_ENVIRONMENT_KEYS = {
     "RUSTUP_HOME",
 }
 ALLOWED_SERVER_ENVIRONMENT_KEYS = {"KAKEHASHI_TREE_WORKER_MODE"}
+
+
+def requires_semantic_bench_instrumentation(scenarios: str) -> bool:
+    return any(
+        term in SAME_SNAPSHOT_FANOUT_SCENARIO
+        for term in scenario_filter_terms(scenarios)
+    )
+
+
+def require_semantic_bench_instrumentation(source: Path) -> None:
+    manifest = (source / "Cargo.toml").read_text()
+    if "semantic-bench-instrumentation = []" not in manifest:
+        raise RuntimeError(
+            f"{source} cannot run {SAME_SNAPSHOT_FANOUT_SCENARIO}: "
+            "the ref predates semantic benchmark instrumentation; select other "
+            "scenarios or compare refs that include the benchmark contract"
+        )
 
 
 def terminate_process_group(process: subprocess.Popen[str]) -> None:
@@ -400,12 +419,26 @@ def main() -> None:
             add_worktree(repo, worktrees["b-src"], b_commit)
             add_worktree(repo, worktrees["harness-src"], harness_commit)
 
+            instrument_fanout = requires_semantic_bench_instrumentation(args.scenarios)
             binaries = {}
             for label, source in (("A", worktrees["a-src"]), ("B", worktrees["b-src"])):
                 target = temp / f"target-{label.lower()}"
                 env = base_environment | {"CARGO_TARGET_DIR": str(target)}
+                build_command = [
+                    "cargo",
+                    "build",
+                    "--release",
+                    "--locked",
+                    "--bin",
+                    "kakehashi",
+                ]
+                if instrument_fanout:
+                    require_semantic_bench_instrumentation(source)
+                    build_command.extend(
+                        ["--features", "semantic-bench-instrumentation"]
+                    )
                 run(
-                    ["cargo", "build", "--release", "--locked", "--bin", "kakehashi"],
+                    build_command,
                     cwd=source,
                     env=env,
                 )

--- a/benches/collect_semantic_pairs.py
+++ b/benches/collect_semantic_pairs.py
@@ -32,7 +32,6 @@ DEFAULT_SCENARIOS = ",".join(
         "rust_sparse_64k/typing_delta",
         "rust_large/typing_burst",
         "rust_xlarge/cancel_burst",
-        SAME_SNAPSHOT_FANOUT_SCENARIO,
         "markdown_injections_large/full_cache_hit",
         "markdown_injections/typing_delta",
         "markdown_injections/typing_burst",
@@ -58,6 +57,20 @@ def requires_semantic_bench_instrumentation(scenarios: str) -> bool:
         term in SAME_SNAPSHOT_FANOUT_SCENARIO
         for term in scenario_filter_terms(scenarios)
     )
+
+
+def validate_instrumented_scenario_selection(scenarios: str) -> None:
+    terms = scenario_filter_terms(scenarios)
+    if not terms:
+        raise ValueError("scenario filters must contain at least one non-empty term")
+    if requires_semantic_bench_instrumentation(scenarios) and not (
+        len(terms) == 1
+        and terms[0] in {SAME_SNAPSHOT_FANOUT_SCENARIO, "same_snapshot_fanout"}
+    ):
+        raise ValueError(
+            f"{SAME_SNAPSHOT_FANOUT_SCENARIO} must be collected alone so "
+            "benchmark-instrumented binaries never contaminate production scenarios"
+        )
 
 
 def require_semantic_bench_instrumentation(source: Path) -> None:
@@ -387,6 +400,7 @@ def main() -> None:
     args = parser.parse_args()
     if args.pairs < 1 or args.iters < 1 or args.warmup < 0:
         parser.error("pairs and iters must be positive; warmup must be non-negative")
+    validate_instrumented_scenario_selection(args.scenarios)
 
     repo = Path(output(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd()))
     ensure_clean(repo)
@@ -607,6 +621,11 @@ def main() -> None:
                     "scenario_filters": scenario_filter_terms(args.scenarios),
                     "scenarios": sorted(measured_scenarios),
                     "server_env": server_env,
+                    "server_build_features": (
+                        ["semantic-bench-instrumentation"]
+                        if instrument_fanout
+                        else []
+                    ),
                     "run_timeout_seconds": args.run_timeout,
                 },
                 "environment": {

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -33,6 +33,11 @@
 //!   cargo bench --bench semantic_tokens --features e2e
 //! ```
 //!
+//! `rust_xlarge/same_snapshot_fanout` is a separately collected instrumented
+//! scenario. Build both measured servers with
+//! `--features semantic-bench-instrumentation`; the harness deliberately fails
+//! rather than retaining an unsynchronized sample when that feature is absent.
+//!
 //! Tunables (env): `KAKEHASHI_BENCH_ITERS` (default 80),
 //! `KAKEHASHI_BENCH_WARMUP` (default 10), `KAKEHASHI_BENCH_SCENARIOS`
 //! (optional comma-separated scenario-name substrings), and

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -45,7 +45,6 @@ mod semantic_baseline;
 
 use semantic_baseline::{
     SemanticBaseline, TRACKED_MARKER, tracked_marker_line, validate_token_payload,
-    validate_tracked_token,
 };
 use serde_json::{Value, json};
 use std::collections::HashMap;
@@ -74,8 +73,16 @@ struct Server {
 impl Server {
     /// Spawn `bin`, run the LSP handshake, and return a ready server.
     fn start(bin: &str, data_dir: &str) -> Server {
-        let mut child = Command::new(bin)
-            .env("KAKEHASHI_DATA_DIR", data_dir)
+        Self::start_with_fanout_barrier(bin, data_dir, false)
+    }
+
+    fn start_with_fanout_barrier(bin: &str, data_dir: &str, fanout_barrier: bool) -> Server {
+        let mut command = Command::new(bin);
+        command.env("KAKEHASHI_DATA_DIR", data_dir);
+        if fanout_barrier {
+            command.env("KAKEHASHI_BENCH_SEMANTIC_FANOUT_PARTIES", "2");
+        }
+        let mut child = command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -104,7 +111,7 @@ impl Server {
             buffered_responses: HashMap::new(),
         };
 
-        server.request(
+        let initialize = server.request(
             "initialize",
             json!({
                 "processId": std::process::id(),
@@ -113,7 +120,10 @@ impl Server {
                     "textDocument": {
                         "semanticTokens": {
                             "dynamicRegistration": false,
-                            "requests": { "full": { "delta": true } },
+                            "requests": {
+                                "range": true,
+                                "full": { "delta": true }
+                            },
                             "tokenTypes": [],
                             "tokenModifiers": [],
                             "formats": ["relative"]
@@ -121,6 +131,11 @@ impl Server {
                     }
                 }
             }),
+        );
+        assert_eq!(
+            initialize.pointer("/capabilities/semanticTokensProvider/range"),
+            Some(&Value::Bool(true)),
+            "benchmarked server must advertise semanticTokens/range"
         );
         server.notify("initialized", json!({}));
         server
@@ -173,14 +188,28 @@ impl Server {
         )
     }
 
-    /// Wait until the edit's parse is current without populating the semantic
-    /// token cache. Rust has no injection query in the benchmark fixture, so
-    /// this request stops after `ensure_document_parsed`.
-    fn wait_until_parsed(&mut self, uri: &str) {
-        self.request(
-            "textDocument/documentSymbol",
-            json!({ "textDocument": { "uri": uri } }),
-        );
+    /// Positively observe the edited version's current parse without touching
+    /// semantic-token caches. `kakehashi/node` is ingress-ordered behind the
+    /// preceding didChange and returns null when its bounded current-snapshot
+    /// wait expires, so retrying until a node arrives is a real parse barrier.
+    fn wait_until_parsed(&mut self, uri: &str, line: u32, character: u32) {
+        let deadline = Instant::now() + Duration::from_secs(60);
+        loop {
+            let result = self.request(
+                "kakehashi/node",
+                json!({
+                    "textDocument": { "uri": uri },
+                    "position": { "line": line, "character": character },
+                }),
+            );
+            if !result.is_null() {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "current parse did not become observable for {uri}"
+            );
+        }
     }
 
     /// Incremental `didChange` that toggles a single space at the start of
@@ -687,7 +716,7 @@ fn measure_same_snapshot_fanout(
     start_line: u32,
     end_line: u32,
 ) -> Measurement {
-    let mut server = Server::start(&bin.path, data_dir);
+    let mut server = Server::start_with_fanout_barrier(&bin.path, data_dir, true);
     server.did_open(scn.uri, scn.language_id, &scn.content);
     std::thread::sleep(Duration::from_millis(300));
 
@@ -713,7 +742,7 @@ fn measure_same_snapshot_fanout(
         // Keep parse latency outside this measurement. The measured work is
         // specifically the duplicate whole-document semantic computation and
         // request-local delta/range shaping for one immutable snapshot.
-        server.wait_until_parsed(scn.uri);
+        server.wait_until_parsed(scn.uri, tracked_line, 0);
 
         let started = Instant::now();
         let delta_id = server.send_request(
@@ -743,7 +772,8 @@ fn measure_same_snapshot_fanout(
         baseline
             .apply_response(delta_result)
             .unwrap_or_else(|error| panic!("invalid delta response for {}: {error:?}", scn.name));
-        validate_tracked_token(range_result, tracked_line, baseline.expected_start())
+        baseline
+            .validate_line_range(range_result, start_line, end_line)
             .unwrap_or_else(|error| {
                 panic!(
                     "stale or invalid range response for {}: {error:?}",

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -45,6 +45,7 @@ mod semantic_baseline;
 
 use semantic_baseline::{
     SemanticBaseline, TRACKED_MARKER, tracked_marker_line, validate_token_payload,
+    validate_tracked_token,
 };
 use serde_json::{Value, json};
 use std::collections::HashMap;
@@ -170,6 +171,16 @@ impl Server {
                 }
             }),
         )
+    }
+
+    /// Wait until the edit's parse is current without populating the semantic
+    /// token cache. Rust has no injection query in the benchmark fixture, so
+    /// this request stops after `ensure_document_parsed`.
+    fn wait_until_parsed(&mut self, uri: &str) {
+        self.request(
+            "textDocument/documentSymbol",
+            json!({ "textDocument": { "uri": uri } }),
+        );
     }
 
     /// Incremental `didChange` that toggles a single space at the start of
@@ -559,6 +570,10 @@ enum Kind {
     /// Several full requests become obsolete and are explicitly cancelled
     /// before the one response an editor can still use.
     CancelBurst { obsolete: usize },
+    /// A delta and viewport request for one freshly parsed snapshot are sent
+    /// back-to-back. Both need the same whole-document semantic artifact but
+    /// shape independent LSP responses.
+    SameSnapshotFanout { start_line: u32, end_line: u32 },
     /// Cold-open latency: each iteration opens a FRESH document and times
     /// `didOpen` → first `semanticTokens/full` response — the editor-visible
     /// "open the file, see highlights" latency. The one scenario that captures
@@ -618,6 +633,15 @@ fn measure(
     if let Kind::CancelBurst { obsolete } = scn.kind {
         return measure_cancel_burst(bin, scn, data_dir, iters, warmup, obsolete);
     }
+    if let Kind::SameSnapshotFanout {
+        start_line,
+        end_line,
+    } = scn.kind
+    {
+        return measure_same_snapshot_fanout(
+            bin, scn, data_dir, iters, warmup, start_line, end_line,
+        );
+    }
     if let Kind::OpenFirstToken = scn.kind {
         return measure_open(bin, scn, data_dir, iters, warmup);
     }
@@ -652,6 +676,99 @@ fn measure(
         samples,
         discarded_attempts: 0,
     }
+}
+
+fn measure_same_snapshot_fanout(
+    bin: &Binary,
+    scn: &Scenario,
+    data_dir: &str,
+    iters: usize,
+    warmup: usize,
+    start_line: u32,
+    end_line: u32,
+) -> Measurement {
+    let mut server = Server::start(&bin.path, data_dir);
+    server.did_open(scn.uri, scn.language_id, &scn.content);
+    std::thread::sleep(Duration::from_millis(300));
+
+    let tracked_line = tracked_marker_line(&scn.content)
+        .unwrap_or_else(|error| panic!("invalid tracked marker for {}: {error:?}", scn.name));
+    assert!(
+        start_line <= tracked_line && tracked_line < end_line,
+        "{} range must contain its tracked marker",
+        scn.name
+    );
+    let mut baseline = SemanticBaseline::from_full(&server.semantic_full(scn.uri), tracked_line)
+        .unwrap_or_else(|error| panic!("invalid semantic baseline for {}: {error:?}", scn.name));
+    let mut version = 1_i64;
+    let mut samples = Vec::with_capacity(iters);
+
+    for iteration in 0..(warmup + iters) {
+        version += 1;
+        server.did_change_insert_space(scn.uri, version, tracked_line);
+        baseline
+            .record_prefix_insert(1)
+            .expect("tracked position remains valid");
+
+        // Keep parse latency outside this measurement. The measured work is
+        // specifically the duplicate whole-document semantic computation and
+        // request-local delta/range shaping for one immutable snapshot.
+        server.wait_until_parsed(scn.uri);
+
+        let started = Instant::now();
+        let delta_id = server.send_request(
+            "textDocument/semanticTokens/full/delta",
+            json!({
+                "textDocument": { "uri": scn.uri },
+                "previousResultId": baseline.result_id(),
+            }),
+        );
+        let range_id = server.send_request(
+            "textDocument/semanticTokens/range",
+            json!({
+                "textDocument": { "uri": scn.uri },
+                "range": {
+                    "start": { "line": start_line, "character": 0 },
+                    "end": { "line": end_line, "character": 0 },
+                }
+            }),
+        );
+
+        let delta_response = server.recv_raw_response(delta_id);
+        let range_response = server.recv_raw_response(range_id);
+        let elapsed = started.elapsed();
+        let delta_result = response_result(delta_id, &delta_response);
+        let range_result = response_result(range_id, &range_response);
+
+        baseline
+            .apply_response(delta_result)
+            .unwrap_or_else(|error| panic!("invalid delta response for {}: {error:?}", scn.name));
+        validate_tracked_token(range_result, tracked_line, baseline.expected_start())
+            .unwrap_or_else(|error| {
+                panic!(
+                    "stale or invalid range response for {}: {error:?}",
+                    scn.name
+                )
+            });
+
+        if iteration >= warmup {
+            samples.push(elapsed);
+        }
+    }
+
+    Measurement {
+        samples,
+        discarded_attempts: 0,
+    }
+}
+
+fn response_result(id: i64, response: &Value) -> &Value {
+    if let Some(error) = response.get("error") {
+        panic!("server returned a JSON-RPC error for request id={id}: {error}");
+    }
+    response
+        .get("result")
+        .unwrap_or_else(|| panic!("server response for request id={id} has no result: {response}"))
 }
 
 fn measure_cancel_burst(
@@ -800,6 +917,7 @@ fn validate_full_response(scn: &Scenario, result: &Value) {
 fn seed_baseline(server: &mut Server, scn: &Scenario) -> Option<SemanticBaseline> {
     match scn.kind {
         Kind::Full | Kind::Range { .. } | Kind::OpenFirstToken | Kind::CancelBurst { .. } => None,
+        Kind::SameSnapshotFanout { .. } => None,
         Kind::DeltaNoop
         | Kind::EditDelta
         | Kind::TypingDelta
@@ -828,6 +946,9 @@ fn run_once(
         // Handled by `measure_open`, which never calls `run_once`.
         Kind::OpenFirstToken => unreachable!("OpenFirstToken uses measure_open"),
         Kind::CancelBurst { .. } => unreachable!("CancelBurst uses measure_cancel_burst"),
+        Kind::SameSnapshotFanout { .. } => {
+            unreachable!("SameSnapshotFanout uses measure_same_snapshot_fanout")
+        }
         Kind::Full => {
             let result = server.semantic_full(scn.uri);
             validate_full_response(scn, &result);
@@ -1078,6 +1199,17 @@ fn main() {
             content: gen_rust(600),
             kind: Kind::CancelBurst { obsolete: 4 },
             targets: "current-token latency after four explicitly cancelled edit states",
+        },
+        Scenario {
+            name: "rust_xlarge/same_snapshot_fanout",
+            language_id: "rust",
+            uri: "file:///bench/same_snapshot_fanout.rs",
+            content: gen_rust(600),
+            kind: Kind::SameSnapshotFanout {
+                start_line: 0,
+                end_line: 80,
+            },
+            targets: "concurrent delta + range consumers of one freshly parsed snapshot; all-consumer latency and freshness",
         },
         Scenario {
             name: "markdown_injections/edit_delta",

--- a/benches/support/semantic_baseline.rs
+++ b/benches/support/semantic_baseline.rs
@@ -24,6 +24,10 @@ pub(crate) enum ValidationError {
         expected_start: u32,
         actual_start: u32,
     },
+    TokenPayloadMismatch {
+        expected_len: usize,
+        actual_len: usize,
+    },
     EditOutOfBounds {
         edit_index: usize,
         start: usize,
@@ -78,10 +82,6 @@ impl SemanticBaseline {
         self.tracked_line
     }
 
-    pub(crate) fn expected_start(&self) -> u32 {
-        self.expected_start
-    }
-
     pub(crate) fn record_prefix_insert(&mut self, count: u32) -> Result<(), ValidationError> {
         self.expected_start = self
             .expected_start
@@ -125,29 +125,29 @@ impl SemanticBaseline {
         self.data = next_data;
         Ok(())
     }
+
+    pub(crate) fn validate_line_range(
+        &self,
+        result: &Value,
+        start_line: u32,
+        end_line: u32,
+    ) -> Result<(), ValidationError> {
+        let actual = full_data(result)?.ok_or(ValidationError::MissingTokenPayload)?;
+        let expected = filter_line_range(&self.data, start_line, end_line)?;
+        if actual != expected {
+            return Err(ValidationError::TokenPayloadMismatch {
+                expected_len: expected.len(),
+                actual_len: actual.len(),
+            });
+        }
+        Ok(())
+    }
 }
 
 pub(crate) fn validate_token_payload(result: &Value) -> Result<(), ValidationError> {
     let data = full_data(result)?.ok_or(ValidationError::MissingTokenPayload)?;
     if !data.len().is_multiple_of(TOKEN_WIDTH) {
         return Err(ValidationError::InvalidTokenDataLength { len: data.len() });
-    }
-    Ok(())
-}
-
-pub(crate) fn validate_tracked_token(
-    result: &Value,
-    tracked_line: u32,
-    expected_start: u32,
-) -> Result<(), ValidationError> {
-    let data = full_data(result)?.ok_or(ValidationError::MissingTokenPayload)?;
-    let actual_start = first_token_start(&data, tracked_line)?;
-    if actual_start != expected_start {
-        return Err(ValidationError::TrackedTokenMismatch {
-            line: tracked_line,
-            expected_start,
-            actual_start,
-        });
     }
     Ok(())
 }
@@ -269,4 +269,52 @@ fn first_token_start(data: &[u32], tracked_line: u32) -> Result<u32, ValidationE
     }
 
     Err(ValidationError::TrackedLineHasNoToken { line: tracked_line })
+}
+
+fn filter_line_range(
+    data: &[u32],
+    start_line: u32,
+    end_line: u32,
+) -> Result<Vec<u32>, ValidationError> {
+    if !data.len().is_multiple_of(TOKEN_WIDTH) {
+        return Err(ValidationError::InvalidTokenDataLength { len: data.len() });
+    }
+
+    let mut line = 0_u32;
+    let mut start = 0_u32;
+    let mut absolute = Vec::new();
+    for token in data.chunks_exact(TOKEN_WIDTH) {
+        line = line
+            .checked_add(token[0])
+            .ok_or(ValidationError::PositionOverflow)?;
+        start = if token[0] == 0 {
+            start
+                .checked_add(token[1])
+                .ok_or(ValidationError::PositionOverflow)?
+        } else {
+            token[1]
+        };
+        if line >= end_line {
+            break;
+        }
+        if line >= start_line {
+            absolute.push((line, start, token[2], token[3], token[4]));
+        }
+    }
+
+    let mut encoded = Vec::with_capacity(absolute.len() * TOKEN_WIDTH);
+    let mut previous_line = 0_u32;
+    let mut previous_start = 0_u32;
+    for (line, start, length, token_type, modifiers) in absolute {
+        let delta_line = line - previous_line;
+        let delta_start = if delta_line == 0 {
+            start - previous_start
+        } else {
+            start
+        };
+        encoded.extend_from_slice(&[delta_line, delta_start, length, token_type, modifiers]);
+        previous_line = line;
+        previous_start = start;
+    }
+    Ok(encoded)
 }

--- a/benches/support/semantic_baseline.rs
+++ b/benches/support/semantic_baseline.rs
@@ -78,6 +78,10 @@ impl SemanticBaseline {
         self.tracked_line
     }
 
+    pub(crate) fn expected_start(&self) -> u32 {
+        self.expected_start
+    }
+
     pub(crate) fn record_prefix_insert(&mut self, count: u32) -> Result<(), ValidationError> {
         self.expected_start = self
             .expected_start
@@ -127,6 +131,23 @@ pub(crate) fn validate_token_payload(result: &Value) -> Result<(), ValidationErr
     let data = full_data(result)?.ok_or(ValidationError::MissingTokenPayload)?;
     if !data.len().is_multiple_of(TOKEN_WIDTH) {
         return Err(ValidationError::InvalidTokenDataLength { len: data.len() });
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_tracked_token(
+    result: &Value,
+    tracked_line: u32,
+    expected_start: u32,
+) -> Result<(), ValidationError> {
+    let data = full_data(result)?.ok_or(ValidationError::MissingTokenPayload)?;
+    let actual_start = first_token_start(&data, tracked_line)?;
+    if actual_start != expected_start {
+        return Err(ValidationError::TrackedTokenMismatch {
+            line: tracked_line,
+            expected_start,
+            actual_start,
+        });
     }
     Ok(())
 }

--- a/benches/test_collect_semantic_pairs.py
+++ b/benches/test_collect_semantic_pairs.py
@@ -8,6 +8,8 @@ from collect_semantic_pairs import (
     manifest_sha256,
     normalize_captured_stdout,
     parse_server_env,
+    require_semantic_bench_instrumentation,
+    requires_semantic_bench_instrumentation,
     redact_temporary_paths,
     recorded_environment,
     scenario_filter_terms,
@@ -20,6 +22,30 @@ from collect_semantic_pairs import (
 
 
 class CollectSemanticPairsTest(unittest.TestCase):
+    def test_only_fanout_scenario_requires_benchmark_instrumentation(self):
+        self.assertTrue(
+            requires_semantic_bench_instrumentation(
+                "rust_xlarge/same_snapshot_fanout"
+            )
+        )
+        self.assertTrue(requires_semantic_bench_instrumentation("fanout"))
+        self.assertFalse(
+            requires_semantic_bench_instrumentation("rust_large/typing_delta")
+        )
+
+    def test_fanout_instrumentation_requires_feature_on_measured_ref(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary)
+            (source / "Cargo.toml").write_text("[features]\ne2e = []\n")
+            with self.assertRaisesRegex(
+                RuntimeError, "predates semantic benchmark instrumentation"
+            ):
+                require_semantic_bench_instrumentation(source)
+            (source / "Cargo.toml").write_text(
+                "[features]\nsemantic-bench-instrumentation = []\n"
+            )
+            require_semantic_bench_instrumentation(source)
+
     def test_scenario_filters_are_normalized_for_execution_and_manifest(self):
         self.assertEqual(
             scenario_filter_terms(" rust, , markdown "),

--- a/benches/test_collect_semantic_pairs.py
+++ b/benches/test_collect_semantic_pairs.py
@@ -16,6 +16,7 @@ from collect_semantic_pairs import (
     set_tree_read_only,
     set_tree_writable,
     tree_manifest,
+    validate_instrumented_scenario_selection,
     validate_requested_scenario_filters,
     write_installed_data_manifest,
 )
@@ -32,6 +33,15 @@ class CollectSemanticPairsTest(unittest.TestCase):
         self.assertFalse(
             requires_semantic_bench_instrumentation("rust_large/typing_delta")
         )
+        validate_instrumented_scenario_selection("same_snapshot_fanout")
+        with self.assertRaisesRegex(ValueError, "must be collected alone"):
+            validate_instrumented_scenario_selection(
+                "same_snapshot_fanout,rust_large/typing_delta"
+            )
+        with self.assertRaisesRegex(ValueError, "must be collected alone"):
+            validate_instrumented_scenario_selection("rust_xlarge")
+        with self.assertRaisesRegex(ValueError, "at least one non-empty term"):
+            validate_instrumented_scenario_selection(" , ")
 
     def test_fanout_instrumentation_requires_feature_on_measured_ref(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -102,6 +112,9 @@ class CollectSemanticPairsTest(unittest.TestCase):
         for scenario in DEFAULT_SCENARIOS.split(","):
             with self.subTest(scenario=scenario):
                 self.assertIn(f'name: "{scenario}"', harness)
+
+    def test_default_scenarios_do_not_enable_benchmark_instrumentation(self):
+        self.assertFalse(requires_semantic_bench_instrumentation(DEFAULT_SCENARIOS))
 
     def test_captured_stdout_has_exactly_one_terminal_newline(self):
         self.assertEqual(normalize_captured_stdout("result\n\n"), "result\n")

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1226,6 +1226,12 @@ async fn serve_lsp() {
     use tokio::io::{stdin, stdout};
     use tower_lsp_server::{LspService, Server};
 
+    #[cfg(not(feature = "semantic-bench-instrumentation"))]
+    assert!(
+        std::env::var_os("KAKEHASHI_BENCH_SEMANTIC_FANOUT_PARTIES").is_none(),
+        "same-snapshot fan-out requires --features semantic-bench-instrumentation"
+    );
+
     // Initialize logging to stderr (CRITICAL: stdout is used for LSP JSON-RPC)
     // Configure via RUST_LOG, e.g.: RUST_LOG=kakehashi=debug
     Builder::from_default_env()

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -36,6 +36,31 @@ use crate::lsp::current_upstream_id;
 
 use super::super::{Kakehashi, uri_to_url};
 
+#[cfg(feature = "semantic-bench-instrumentation")]
+async fn wait_for_same_snapshot_benchmark_peer() {
+    static BARRIER: std::sync::LazyLock<Option<tokio::sync::Barrier>> =
+        std::sync::LazyLock::new(|| {
+            std::env::var("KAKEHASHI_BENCH_SEMANTIC_FANOUT_PARTIES")
+                .ok()
+                .map(|value| {
+                    let parties = value
+                        .parse::<usize>()
+                        .expect("KAKEHASHI_BENCH_SEMANTIC_FANOUT_PARTIES must be an integer");
+                    assert!(
+                        parties >= 2,
+                        "semantic fan-out requires at least two parties"
+                    );
+                    tokio::sync::Barrier::new(parties)
+                })
+        });
+    if let Some(barrier) = BARRIER.as_ref() {
+        barrier.wait().await;
+    }
+}
+
+#[cfg(not(feature = "semantic-bench-instrumentation"))]
+async fn wait_for_same_snapshot_benchmark_peer() {}
+
 /// Outcome of the serve-current snapshot resolution for the whole-document
 /// token handlers (see [`Kakehashi::current_snapshot_for_tokens`]).
 pub(crate) enum TokenSnapshot {
@@ -859,6 +884,13 @@ impl Kakehashi {
                 // never needs ownership at all).
                 Some(CurrentTokens::Cached(cached))
             } else {
+                // Benchmark-only rendezvous after the completed-artifact cache
+                // miss. Stage 3 inserts single-flight resolution after this
+                // point, so both the unshared (two producers) and shared (one
+                // producer + one joiner) binaries start from two admitted
+                // consumers of the same immutable snapshot.
+                wait_for_same_snapshot_benchmark_peer().await;
+
                 // capture_mappings and supports_multiline were read before the await
                 // above (consistent with the query and token_generation). Rayon-based
                 // parallel injection processing (SAME as semanticTokens/full).
@@ -1218,6 +1250,10 @@ impl Kakehashi {
 
         // Get capture mappings for token type resolution
         let capture_mappings = self.language.capture_mappings();
+
+        // See the delta-path note: this is compiled only into benchmark
+        // binaries and runs after both completed-cache lookup paths missed.
+        wait_for_same_snapshot_benchmark_peer().await;
 
         // Use Rayon-based parallel injection processing
         let supports_multiline = self.settings_manager.supports_multiline_tokens();

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -58,14 +58,6 @@ async fn wait_for_same_snapshot_benchmark_peer() {
     }
 }
 
-#[cfg(not(feature = "semantic-bench-instrumentation"))]
-async fn wait_for_same_snapshot_benchmark_peer() {
-    assert!(
-        std::env::var_os("KAKEHASHI_BENCH_SEMANTIC_FANOUT_PARTIES").is_none(),
-        "same-snapshot fan-out requires --features semantic-bench-instrumentation"
-    );
-}
-
 /// Outcome of the serve-current snapshot resolution for the whole-document
 /// token handlers (see [`Kakehashi::current_snapshot_for_tokens`]).
 pub(crate) enum TokenSnapshot {
@@ -894,6 +886,7 @@ impl Kakehashi {
                 // point, so both the unshared (two producers) and shared (one
                 // producer + one joiner) binaries start from two admitted
                 // consumers of the same immutable snapshot.
+                #[cfg(feature = "semantic-bench-instrumentation")]
                 wait_for_same_snapshot_benchmark_peer().await;
 
                 // capture_mappings and supports_multiline were read before the await
@@ -1258,6 +1251,7 @@ impl Kakehashi {
 
         // See the delta-path note: this is compiled only into benchmark
         // binaries and runs after both completed-cache lookup paths missed.
+        #[cfg(feature = "semantic-bench-instrumentation")]
         wait_for_same_snapshot_benchmark_peer().await;
 
         // Use Rayon-based parallel injection processing

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -59,7 +59,12 @@ async fn wait_for_same_snapshot_benchmark_peer() {
 }
 
 #[cfg(not(feature = "semantic-bench-instrumentation"))]
-async fn wait_for_same_snapshot_benchmark_peer() {}
+async fn wait_for_same_snapshot_benchmark_peer() {
+    assert!(
+        std::env::var_os("KAKEHASHI_BENCH_SEMANTIC_FANOUT_PARTIES").is_none(),
+        "same-snapshot fan-out requires --features semantic-bench-instrumentation"
+    );
+}
 
 /// Outcome of the serve-current snapshot resolution for the whole-document
 /// token handlers (see [`Kakehashi::current_snapshot_for_tokens`]).


### PR DESCRIPTION
## Summary

- add a whole-LSP benchmark for concurrent delta and range consumers of one freshly parsed snapshot
- positively observe the edited parse through the ingress-ordered `kakehashi/node` endpoint before timing
- use opt-in benchmark instrumentation to rendezvous after both completed-artifact cache lookups miss
- validate the delta baseline and the complete independently projected range payload

## Why

Issue #896 proposes sharing one immutable semantic artifact across request-local full, delta, and range responses. Existing cache-hit and typing scenarios do not prove that two concurrent consumers reached the same uncached snapshot. The benchmark-only barrier makes the contract deterministic: the current implementation releases two producers, while Stage 3 will release one producer and one in-flight joiner from the same point.

## Benchmark contract

- scenario: `rust_xlarge/same_snapshot_fanout`
- parse latency is outside the timed section
- timed value is all-consumer latency for delta + range
- collect separately with 4 alternating AB/BA pairs, 6 warmups, and 30 retained samples
- collector enables and attests `semantic-bench-instrumentation` only for this isolated scenario
- production default scenarios remain feature-free; mixed or empty filters are rejected
- direct runs fail explicitly if the synchronization feature is absent

## Validation

- `cargo fmt --check`
- `git diff --check`
- `python3 -m unittest test_collect_semantic_pairs.py` (15 passed)
- `cargo clippy --lib --bin kakehashi -- -D warnings`
- `cargo clippy --lib --bin kakehashi --features semantic-bench-instrumentation -- -D warnings`
- `cargo clippy --bench semantic_tokens --features e2e -- -D warnings`
- `KAKEHASHI_BENCH_VALIDATE_SCENARIOS=1 cargo bench --bench semantic_tokens --features e2e --no-run`
- release smoke with instrumentation: 1 warmup + 3 retained samples; all complete delta/range freshness checks passed

A focused unit-test link was attempted, but the machine ran out of disk while linking test artifacts. This was an environment failure after the clippy, benchmark build, Python tests, and release smoke checks above had passed.

## Dependencies

- based on #899 so the measurement contract can precede the later #896 implementation PR
- no parser libraries or query files are committed; fixtures are installed through kakehashi and only their manifest is retained