### PR TITLE
perf(semantic): promote stable delta snapshots

### DIFF
--- a/benches/collect_semantic_pairs.py
+++ b/benches/collect_semantic_pairs.py
@@ -24,6 +24,7 @@ from semantic_summary import summarize_pairs, validate_collection
 DEFAULT_SCENARIOS = ",".join(
     [
         "rust_large/full_cache_hit",
+        "rust_large/stable_edit_followup_delta",
         "rust_large/typing_delta",
         "rust_sparse_32k_minus/typing_delta",
         "rust_sparse_32k_exact/typing_delta",
@@ -32,6 +33,7 @@ DEFAULT_SCENARIOS = ",".join(
         "rust_large/typing_burst",
         "rust_xlarge/cancel_burst",
         "markdown_injections_large/full_cache_hit",
+        "markdown_injections/stable_edit_followup_delta",
         "markdown_injections/typing_delta",
         "markdown_injections/typing_burst",
         "unicode_rust/full_cache_hit",

--- a/benches/results/semantic-empty-delta-cache-2026-07-24/README.md
+++ b/benches/results/semantic-empty-delta-cache-2026-07-24/README.md
@@ -1,0 +1,35 @@
+# Stable empty-delta snapshot promotion
+
+This run compares baseline `265d38b0ac95822b17e5cec19c5e226d3d034bb9`
+with candidate `e77599ec2e937216bf9c028d330ae6dc4983cac3`.
+Lower paired delta is better. It used eight alternating A/B pairs, 12 warmups,
+and 30 retained samples per scenario.
+
+## Result
+
+| Scenario | Paired median | Pair range |
+| --- | ---: | ---: |
+| Rust stable-edit follow-up delta | -45.30% | -52.75% .. -24.83% |
+| Markdown stable-edit follow-up delta | -11.24% | -27.73% .. +11.15% |
+| Rust typing delta control | -6.34% | -13.07% .. -1.29% |
+| Markdown typing delta control | +0.25% | -1.04% .. +33.56% |
+| Rust full-cache-hit control | +4.98% | -10.37% .. +39.09% |
+| Markdown full-cache-hit control | +7.10% | -7.93% .. +20.73% |
+
+The candidate establishes a repeatable improvement only for the Rust
+stable-edit follow-up path: all eight pairs improved. The Markdown target
+improved in six of eight pairs but crossed zero, so it is directional evidence
+rather than a repeatable-win claim.
+
+The full-cache-hit controls have sub-millisecond-to-low-millisecond absolute
+latency and wide, sign-changing ranges. They do not support either a regression
+or a non-regression claim. Markdown typing is likewise inconclusive. Rust typing
+improved in every pair, but it is a control rather than the changed cache path,
+so the performance claim remains limited to the intended stable-edit follow-up
+path.
+
+Every stable-edit sample validates that both the first response after the
+unique edit and the same-snapshot follow-up are empty deltas preserving the
+client's result ID. Focused handler tests separately pin that the first response
+promotes the baseline to the edited snapshot identity after the final
+generation, snapshot, and request-currency checks.

--- a/benches/results/semantic-empty-delta-cache-2026-07-24/fixture-manifest.json
+++ b/benches/results/semantic-empty-delta-cache-2026-07-24/fixture-manifest.json
@@ -1,0 +1,194 @@
+[
+  {
+    "path": ".installed",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "cache/parsers.lua",
+    "sha256": "f168a9d0ba25240053b12ccd71e8b987f9a7203482b8612ee8a4937434716730",
+    "size": 73934,
+    "type": "file"
+  },
+  {
+    "path": "parser/lua.dylib",
+    "sha256": "5d5eec4f59e413c4e774258a764e99695f1c5d8656b437e9db4df5a6131eaac1",
+    "size": 84600,
+    "type": "file"
+  },
+  {
+    "path": "parser/markdown.dylib",
+    "sha256": "1260bce8b8264e0bf42188b81b92fece22cc0f712b76259d5a0c173fceaeb248",
+    "size": 418088,
+    "type": "file"
+  },
+  {
+    "path": "parser/markdown_inline.dylib",
+    "sha256": "6f7ed918105a74d181b925461fda8dc83ebad2e1a4e63d95826d27234d4b8b24",
+    "size": 416816,
+    "type": "file"
+  },
+  {
+    "path": "parser/python.dylib",
+    "sha256": "9e33dfaec966ef1e480681104ec352f9ebd47fab4776a146c7623b5a33426433",
+    "size": 480920,
+    "type": "file"
+  },
+  {
+    "path": "parser/rust.dylib",
+    "sha256": "f1639ad7ebe9779d14b4b80e82cef686ed66588a904378736a91c4dbe218cda8",
+    "size": 1142360,
+    "type": "file"
+  },
+  {
+    "path": "parser/yaml.dylib",
+    "sha256": "c770298648d69eb8c46587f5276a2fb70b31ad7f1ccdebfcbeb68da98e0c93fd",
+    "size": 217176,
+    "type": "file"
+  },
+  {
+    "path": "queries/.lua.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.markdown.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.markdown_inline.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.python.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.rust.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/.yaml.replace.lock",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/highlights.scm",
+    "sha256": "ac7dfa89d16ba817c3681aa47c22bdb4441a78a89ed827a757efa755992de67f",
+    "size": 4336,
+    "type": "file"
+  },
+  {
+    "path": "queries/lua/injections.scm",
+    "sha256": "a2ee92c2f00f39ebeeb1d0cc06302dba58c4f1dda77a2f0c9e5d7d7beab0b1ff",
+    "size": 5168,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/highlights.scm",
+    "sha256": "7b71d4994cf3968e16d033ac59d28bb034427dd41be6a057b7a2985e2dfbe5b8",
+    "size": 2654,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown/injections.scm",
+    "sha256": "34090de78df99b5ea84c2fbb9324f2b7c32e602043595286e83f1a1ac126073c",
+    "size": 659,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/highlights.scm",
+    "sha256": "7db9147da61de7491ede9155e554dc033d6a1b86ecd1b21f6849c018be9ac875",
+    "size": 2259,
+    "type": "file"
+  },
+  {
+    "path": "queries/markdown_inline/injections.scm",
+    "sha256": "051f44218e0fe25cd949dfccad80699d5456ee379c7c4cfa18a5165776ecab0e",
+    "size": 207,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/highlights.scm",
+    "sha256": "ab8b66cbe6a7382e0ed7693c194101f1900c39f9ec0085a1749a8817e3e6895c",
+    "size": 9263,
+    "type": "file"
+  },
+  {
+    "path": "queries/python/injections.scm",
+    "sha256": "8558299709200b21d496890e4799153dc069bf302ce1545d23f70a0869c8b65d",
+    "size": 812,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/highlights.scm",
+    "sha256": "4e0f5994f30ee545fc63435054a0b029c7d0222632c5c787c4e9c249dc0ef20f",
+    "size": 8638,
+    "type": "file"
+  },
+  {
+    "path": "queries/rust/injections.scm",
+    "sha256": "7dde97bbdabd208f984e13627bd4daae0f73012c41faafab39d670b607710f4e",
+    "size": 2418,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/.kakehashi-install-complete",
+    "sha256": "dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+    "size": 3,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/highlights.scm",
+    "sha256": "13352b80d2ce28c3328ccb2f321e5144c3365ff6055078e00e7cff118d1488b5",
+    "size": 1700,
+    "type": "file"
+  },
+  {
+    "path": "queries/yaml/injections.scm",
+    "sha256": "8349bd07691e2e610decdfc7b898bb5b01b226aae8745217bc811427f7af6742",
+    "size": 2373,
+    "type": "file"
+  }
+]

--- a/benches/results/semantic-empty-delta-cache-2026-07-24/manifest.json
+++ b/benches/results/semantic-empty-delta-cache-2026-07-24/manifest.json
@@ -145,6 +145,7 @@
     "b_commit": "e77599ec2e937216bf9c028d330ae6dc4983cac3",
     "b_ref": "benchmark/semantic-empty-delta-cache-candidate-2026-07-24",
     "harness_commit": "e77599ec2e937216bf9c028d330ae6dc4983cac3",
+    "harness_ref": "benchmark/semantic-empty-delta-cache-candidate-2026-07-24",
     "harness_sources_sha256": {
       "benches/collect_semantic_pairs.py": "7ce0d8628d2f28ac331d15ccf470e7b1b4fb596d5a475588cfa25689746de798",
       "benches/semantic_summary.py": "8aab3d2622ec7bfface33f29fee8fd695297b31eb2007fc5b2b20d8be2e3d1d0",

--- a/benches/results/semantic-empty-delta-cache-2026-07-24/manifest.json
+++ b/benches/results/semantic-empty-delta-cache-2026-07-24/manifest.json
@@ -1,0 +1,157 @@
+{
+  "attestations": {
+    "binary_a": "5417ebe966bc538c9aa3d876e987fb48ccd647ad367a0bee3d42f649b5c3fb16",
+    "binary_b": "f33067abf7b3701a32f81fad32289a3eebf12320c52576d744d3de5ba5a0f4cb",
+    "fixture": "f029bd1e2b5a8730cd9a4c1f407c1da28618a4f29d0bf4ff67f65c85ffad5d3c",
+    "harness": "90249569268f0bd12fab7555cc1fc407c5870b75d061ac55092c2065967f41e0"
+  },
+  "configuration": {
+    "iterations": 30,
+    "pairs": 8,
+    "run_timeout_seconds": 900,
+    "scenario_filters": [
+      "rust_large/stable_edit_followup_delta",
+      "markdown_injections/stable_edit_followup_delta",
+      "rust_large/typing_delta",
+      "markdown_injections/typing_delta",
+      "rust_large/full_cache_hit",
+      "markdown_injections_large/full_cache_hit"
+    ],
+    "scenarios": [
+      "markdown_injections/stable_edit_followup_delta",
+      "markdown_injections/typing_delta",
+      "markdown_injections_large/full_cache_hit",
+      "rust_large/full_cache_hit",
+      "rust_large/stable_edit_followup_delta",
+      "rust_large/typing_delta"
+    ],
+    "server_env": {},
+    "warmup_iterations": 12
+  },
+  "environment": {
+    "build": {
+      "CARGO_HOME": "<TEMP>/cargo-home",
+      "CARGO_TERM_COLOR": "never",
+      "HOME": "<TEMP>/home",
+      "LANG": "C",
+      "LC_ALL": "C",
+      "PATH": "<USER_HOME_PATH>:<USER_HOME_PATH>:<USER_HOME_PATH>:/opt/homebrew/bin:/opt/homebrew/sbin:/nix/var/nix/profiles/default/bin:<USER_HOME_PATH>:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:<USER_HOME_PATH>",
+      "RUSTUP_HOME": "<USER_HOME>/.rustup",
+      "TMPDIR": "<TEMP>/tmp"
+    },
+    "cc": "Apple clang version 21.0.0 (clang-2100.1.1.101)\nTarget: arm64-apple-darwin25.5.0\nThread model: posix\nInstalledDir: /Library/Developer/CommandLineTools/usr/bin",
+    "clang": "Apple clang version 21.0.0 (clang-2100.1.1.101)\nTarget: arm64-apple-darwin25.5.0\nThread model: posix\nInstalledDir: /Library/Developer/CommandLineTools/usr/bin",
+    "machine": "arm64",
+    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "processor": "arm",
+    "runtime": {
+      "CARGO_HOME": "<TEMP>/cargo-home",
+      "CARGO_TERM_COLOR": "never",
+      "HOME": "<TEMP>/home",
+      "LANG": "C",
+      "LC_ALL": "C",
+      "PATH": "<USER_HOME_PATH>:<USER_HOME_PATH>:<USER_HOME_PATH>:/opt/homebrew/bin:/opt/homebrew/sbin:/nix/var/nix/profiles/default/bin:<USER_HOME_PATH>:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:<USER_HOME_PATH>",
+      "RUSTUP_HOME": "<USER_HOME>/.rustup",
+      "TMPDIR": "<TEMP>/tmp"
+    },
+    "sdk": "26.5",
+    "toolchains": {
+      "a": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      },
+      "b": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      },
+      "harness": {
+        "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)\nrelease: 1.95.0\ncommit-hash: f2d3ce0bd7f24a49f8f72d9000448f8838c4e850\ncommit-date: 2026-03-21\nhost: aarch64-apple-darwin\nlibgit2: 1.9.2 (sys:0.20.4 vendored)\nlibcurl: 8.20.0 (sys:0.4.83+curl-8.15.0 system ssl:OpenSSL/3.6.2)\nos: Mac OS 26.5.1 [64-bit]",
+        "rustc": "rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)\nbinary: rustc\ncommit-hash: 59807616e1fa2540724bfbac14d7976d7e4a3860\ncommit-date: 2026-04-14\nhost: aarch64-apple-darwin\nrelease: 1.95.0\nLLVM version: 21.1.8"
+      }
+    }
+  },
+  "fixture_manifest": "fixture-manifest.json",
+  "fixture_manifest_sha256": "06be7b69447efb7182915f7b3aa5ae5325dbf9cfbebcc9bbee69e5df8ac3ff8d",
+  "raw_files": [
+    {
+      "order": "AB",
+      "pair_index": 1,
+      "samples": "pair-1.json",
+      "samples_sha256": "c93f682d3d43a8600889a5ddbb070d3770da5612a7745e1a71cf1fff5bb55a54",
+      "stdout": "pair-1.txt",
+      "stdout_sha256": "b9290fc92701f6b458ee857815a45fa89d33cdd096b77f323f74166898056402"
+    },
+    {
+      "order": "BA",
+      "pair_index": 2,
+      "samples": "pair-2.json",
+      "samples_sha256": "d8a5a8b3f1bca09ea3709da09f7e694a0ef0223b0f1654917b1b5d03997db0da",
+      "stdout": "pair-2.txt",
+      "stdout_sha256": "60691e4f3a2215f7c2d8b3a7decd96ae04bfb6cc58e396be8d290108adbdc2b6"
+    },
+    {
+      "order": "AB",
+      "pair_index": 3,
+      "samples": "pair-3.json",
+      "samples_sha256": "46dffef7fb2dea30de21c130e849aebf12488faf0c24dad58a99aa3622c874a7",
+      "stdout": "pair-3.txt",
+      "stdout_sha256": "be707a8c19f43b707cfbc7f0c6522768fedde1c3c603f14b8dd1418d45b28012"
+    },
+    {
+      "order": "BA",
+      "pair_index": 4,
+      "samples": "pair-4.json",
+      "samples_sha256": "a1b0b1e2083140023a1ada13d2882c1d17438d06e2a4d2dce81106cbcbddbf10",
+      "stdout": "pair-4.txt",
+      "stdout_sha256": "e423cd00ca01ab542eaba63277401589d51c11dea582e1690d08f2131e2312e5"
+    },
+    {
+      "order": "AB",
+      "pair_index": 5,
+      "samples": "pair-5.json",
+      "samples_sha256": "ce1056ae2c54c6476dd2c1168581202b1f43bd3ae309b66c4c5d1feb84bd535f",
+      "stdout": "pair-5.txt",
+      "stdout_sha256": "aa04c93b5697c2f5d0377c8bf15e973f84245f2bf297c2d4fa06f3b2bf1f0bfd"
+    },
+    {
+      "order": "BA",
+      "pair_index": 6,
+      "samples": "pair-6.json",
+      "samples_sha256": "65b6c9ffb813296e118c23ead860871bde6bfa180171f4f140a108b6f0ecda93",
+      "stdout": "pair-6.txt",
+      "stdout_sha256": "db9e0de5d5f0660f228cd04792702c06c8fd3411da30d84f44b135f73301d49d"
+    },
+    {
+      "order": "AB",
+      "pair_index": 7,
+      "samples": "pair-7.json",
+      "samples_sha256": "a0513a2e34efbee5ab064bfeffaadf1e8e3e905187ec3c13fe850dabfddfce11",
+      "stdout": "pair-7.txt",
+      "stdout_sha256": "d0fc620e9157a8f3abbbb7d6ca9e7566fe79449e8e9c8274158b54065a18beba"
+    },
+    {
+      "order": "BA",
+      "pair_index": 8,
+      "samples": "pair-8.json",
+      "samples_sha256": "17756301a482afcbaa9f397301a6758d01bc9cb6a3c8a680f40b9c1aabff4c9b",
+      "stdout": "pair-8.txt",
+      "stdout_sha256": "42a126f38d5835f90c39f4db791185c5e383ec94377309911efba05576a74577"
+    }
+  ],
+  "schema_version": 1,
+  "source": {
+    "a_commit": "265d38b0ac95822b17e5cec19c5e226d3d034bb9",
+    "a_ref": "benchmark/semantic-empty-delta-cache-baseline-2026-07-24",
+    "b_commit": "e77599ec2e937216bf9c028d330ae6dc4983cac3",
+    "b_ref": "benchmark/semantic-empty-delta-cache-candidate-2026-07-24",
+    "harness_commit": "e77599ec2e937216bf9c028d330ae6dc4983cac3",
+    "harness_sources_sha256": {
+      "benches/collect_semantic_pairs.py": "7ce0d8628d2f28ac331d15ccf470e7b1b4fb596d5a475588cfa25689746de798",
+      "benches/semantic_summary.py": "8aab3d2622ec7bfface33f29fee8fd695297b31eb2007fc5b2b20d8be2e3d1d0",
+      "benches/semantic_tokens.rs": "1a86ca99ed7b4a18f448308711fba91d3d59f13dc7b53b7bd6ad870e08d93fe2",
+      "benches/support/semantic_baseline.rs": "4ab35bab7a05b32d652262c61c4cd4c720a21bfe3d1730694ea9dda5b306410c"
+    }
+  },
+  "summary": "summary.json",
+  "summary_sha256": "5eb6340926dca9fbf37e9fd6d6bfda30529aaa35a6446ebffbe28817f667f2be"
+}

--- a/benches/results/semantic-empty-delta-cache-2026-07-24/pair-1.txt
+++ b/benches/results/semantic-empty-delta-cache-2026-07-24/pair-1.txt
@@ -1,0 +1,25 @@
+
+semantic-tokens benchmark  (iters=30, warmup=12, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               1.899ms      2.641ms        +39.1%
+    p95:      1.941ms      2.725ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.691ms      0.770ms        +11.5%
+    p95:      0.698ms      0.991ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+rust_large/stable_edit_followup_delta     56.798ms     33.257ms         -41.4%
+    p95:     59.214ms     34.191ms
+    └ targets: unique token-stable edit→empty delta→same-snapshot follow-up
+rust_large/typing_delta                33.268ms     31.243ms         -6.1%
+    p95:     34.944ms     34.214ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+markdown_injections/stable_edit_followup_delta      7.646ms      6.187ms         -19.1%
+    p95:      8.003ms      7.041ms
+    └ targets: unique token-stable injection edit→empty delta→same-snapshot follow-up
+markdown_injections/typing_delta        6.733ms      6.740ms        +0.1%
+    p95:      6.880ms      7.537ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns

--- a/benches/results/semantic-empty-delta-cache-2026-07-24/pair-2.txt
+++ b/benches/results/semantic-empty-delta-cache-2026-07-24/pair-2.txt
@@ -1,0 +1,25 @@
+
+semantic-tokens benchmark  (iters=30, warmup=12, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               2.336ms      2.407ms        +3.0%
+    p95:      2.368ms      2.471ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.626ms      0.592ms         -5.5%
+    p95:      0.641ms      0.597ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+rust_large/stable_edit_followup_delta     26.598ms     55.126ms        +107.3%
+    p95:     33.819ms     58.979ms
+    └ targets: unique token-stable edit→empty delta→same-snapshot follow-up
+rust_large/typing_delta                30.941ms     33.123ms        +7.1%
+    p95:     33.608ms     34.032ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+markdown_injections/stable_edit_followup_delta      6.592ms      7.027ms        +6.6%
+    p95:      6.842ms      8.558ms
+    └ targets: unique token-stable injection edit→empty delta→same-snapshot follow-up
+markdown_injections/typing_delta        6.226ms      5.315ms         -14.6%
+    p95:      6.794ms      5.710ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns

--- a/benches/results/semantic-empty-delta-cache-2026-07-24/pair-3.txt
+++ b/benches/results/semantic-empty-delta-cache-2026-07-24/pair-3.txt
@@ -1,0 +1,25 @@
+
+semantic-tokens benchmark  (iters=30, warmup=12, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               2.576ms      2.634ms        +2.3%
+    p95:      2.637ms      2.667ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.761ms      0.820ms        +7.7%
+    p95:      0.868ms      1.058ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+rust_large/stable_edit_followup_delta     52.923ms     39.781ms         -24.8%
+    p95:     59.320ms     43.882ms
+    └ targets: unique token-stable edit→empty delta→same-snapshot follow-up
+rust_large/typing_delta                33.645ms     31.195ms         -7.3%
+    p95:     41.060ms     35.491ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+markdown_injections/stable_edit_followup_delta      6.777ms      5.951ms         -12.2%
+    p95:      7.166ms      6.471ms
+    └ targets: unique token-stable injection edit→empty delta→same-snapshot follow-up
+markdown_injections/typing_delta        6.314ms      6.284ms         -0.5%
+    p95:      6.889ms      6.725ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns

--- a/benches/results/semantic-empty-delta-cache-2026-07-24/pair-4.txt
+++ b/benches/results/semantic-empty-delta-cache-2026-07-24/pair-4.txt
@@ -1,0 +1,25 @@
+
+semantic-tokens benchmark  (iters=30, warmup=12, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               2.346ms      2.605ms        +11.0%
+    p95:      2.543ms      2.663ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.633ms      0.594ms         -6.1%
+    p95:      0.650ms      0.615ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+rust_large/stable_edit_followup_delta     28.828ms     56.686ms        +96.6%
+    p95:     34.349ms     63.559ms
+    └ targets: unique token-stable edit→empty delta→same-snapshot follow-up
+rust_large/typing_delta                28.563ms     29.034ms        +1.6%
+    p95:     33.572ms     32.241ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+markdown_injections/stable_edit_followup_delta      7.481ms      7.260ms         -2.9%
+    p95:      7.825ms      7.752ms
+    └ targets: unique token-stable injection edit→empty delta→same-snapshot follow-up
+markdown_injections/typing_delta        5.450ms      5.507ms        +1.1%
+    p95:      5.646ms      6.106ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns

--- a/benches/results/semantic-empty-delta-cache-2026-07-24/pair-5.txt
+++ b/benches/results/semantic-empty-delta-cache-2026-07-24/pair-5.txt
@@ -1,0 +1,25 @@
+
+semantic-tokens benchmark  (iters=30, warmup=12, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               2.550ms      2.787ms        +9.3%
+    p95:      2.582ms      2.967ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.770ms      0.847ms        +10.0%
+    p95:      1.002ms      1.023ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+rust_large/stable_edit_followup_delta     48.903ms     33.315ms         -31.9%
+    p95:     57.491ms     34.002ms
+    └ targets: unique token-stable edit→empty delta→same-snapshot follow-up
+rust_large/typing_delta                33.295ms     28.942ms         -13.1%
+    p95:     36.682ms     33.748ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+markdown_injections/stable_edit_followup_delta      7.581ms      5.478ms         -27.7%
+    p95:      7.876ms      5.705ms
+    └ targets: unique token-stable injection edit→empty delta→same-snapshot follow-up
+markdown_injections/typing_delta        5.991ms      5.936ms         -0.9%
+    p95:      6.225ms      6.462ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns

--- a/benches/results/semantic-empty-delta-cache-2026-07-24/pair-6.txt
+++ b/benches/results/semantic-empty-delta-cache-2026-07-24/pair-6.txt
@@ -1,0 +1,25 @@
+
+semantic-tokens benchmark  (iters=30, warmup=12, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               2.323ms      2.111ms         -9.1%
+    p95:      2.392ms      2.244ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.558ms      0.590ms        +5.7%
+    p95:      0.569ms      0.974ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+rust_large/stable_edit_followup_delta     25.655ms     51.510ms        +100.8%
+    p95:     29.804ms     57.870ms
+    └ targets: unique token-stable edit→empty delta→same-snapshot follow-up
+rust_large/typing_delta                28.791ms     32.246ms        +12.0%
+    p95:     33.421ms     34.011ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+markdown_injections/stable_edit_followup_delta      5.926ms      6.747ms        +13.8%
+    p95:      6.567ms      7.135ms
+    └ targets: unique token-stable injection edit→empty delta→same-snapshot follow-up
+markdown_injections/typing_delta        6.585ms      4.930ms         -25.1%
+    p95:      6.817ms      5.190ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns

--- a/benches/results/semantic-empty-delta-cache-2026-07-24/pair-7.txt
+++ b/benches/results/semantic-empty-delta-cache-2026-07-24/pair-7.txt
@@ -1,0 +1,25 @@
+
+semantic-tokens benchmark  (iters=30, warmup=12, lower is better)
+  A = <TEMP>/target-a/release/kakehashi
+  B = <TEMP>/target-b/release/kakehashi
+
+scenario                                A (med)      B (med) Δ (B vs A)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               2.211ms      2.381ms        +7.7%
+    p95:      2.381ms      2.621ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.632ms      0.764ms        +20.7%
+    p95:      0.642ms      0.990ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+rust_large/stable_edit_followup_delta     49.601ms     33.302ms         -32.9%
+    p95:     57.427ms     36.649ms
+    └ targets: unique token-stable edit→empty delta→same-snapshot follow-up
+rust_large/typing_delta                29.601ms     28.758ms         -2.8%
+    p95:     34.063ms     32.910ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+markdown_injections/stable_edit_followup_delta      7.476ms      6.705ms         -10.3%
+    p95:      7.954ms      7.006ms
+    └ targets: unique token-stable injection edit→empty delta→same-snapshot follow-up
+markdown_injections/typing_delta        5.206ms      5.226ms        +0.4%
+    p95:      5.621ms      5.608ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns

--- a/benches/results/semantic-empty-delta-cache-2026-07-24/pair-8.txt
+++ b/benches/results/semantic-empty-delta-cache-2026-07-24/pair-8.txt
@@ -1,0 +1,25 @@
+
+semantic-tokens benchmark  (iters=30, warmup=12, lower is better)
+  B = <TEMP>/target-b/release/kakehashi
+  A = <TEMP>/target-a/release/kakehashi
+
+scenario                                B (med)      A (med) Δ (A vs B)
+------------------------------------------------------------------------
+rust_large/full_cache_hit               2.338ms      2.609ms        +11.6%
+    p95:      2.364ms      2.661ms
+    └ targets: large exact-snapshot semantic cache-hit control
+markdown_injections_large/full_cache_hit      0.802ms      0.872ms        +8.6%
+    p95:      1.016ms      1.213ms
+    └ targets: large injection document exact-snapshot semantic cache-hit control
+rust_large/stable_edit_followup_delta     26.233ms     55.517ms        +111.6%
+    p95:     34.070ms     59.422ms
+    └ targets: unique token-stable edit→empty delta→same-snapshot follow-up
+rust_large/typing_delta                33.442ms     33.878ms        +1.3%
+    p95:     38.902ms     40.195ms
+    └ targets: unique edit states→reparse→retokenize→delta; excludes A/B cache returns
+markdown_injections/stable_edit_followup_delta      7.471ms      6.721ms         -10.0%
+    p95:      8.929ms      7.030ms
+    └ targets: unique token-stable injection edit→empty delta→same-snapshot follow-up
+markdown_injections/typing_delta        6.661ms      6.387ms         -4.1%
+    p95:      6.839ms      6.823ms
+    └ targets: unique edit states→injection reuse→delta; excludes A/B cache returns

--- a/benches/results/semantic-empty-delta-cache-2026-07-24/summary.json
+++ b/benches/results/semantic-empty-delta-cache-2026-07-24/summary.json
@@ -1,0 +1,419 @@
+{
+  "scenarios": [
+    {
+      "a_median_ns": 7143416.75,
+      "b_median_ns": 6389250.25,
+      "pair_count": 8,
+      "paired_delta_percent": {
+        "max": 11.148792602013033,
+        "median": -11.235919987051705,
+        "min": -27.732172624657835
+      },
+      "pairs": [
+        {
+          "a_median_ns": 7645604.5,
+          "b_median_ns": 6186625.0,
+          "delta_percent": -19.082591834301656,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 7026541.5,
+          "b_median_ns": 6591875.5,
+          "delta_percent": -6.186058959446834,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 6777437.5,
+          "b_median_ns": 5951270.5,
+          "delta_percent": -12.189961176329549,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 7260292.0,
+          "b_median_ns": 7480687.5,
+          "delta_percent": 3.0356285945523953,
+          "order": "BA",
+          "pair_index": 4
+        },
+        {
+          "a_median_ns": 7580771.0,
+          "b_median_ns": 5478458.5,
+          "delta_percent": -27.732172624657835,
+          "order": "AB",
+          "pair_index": 5
+        },
+        {
+          "a_median_ns": 6746521.0,
+          "b_median_ns": 5926291.5,
+          "delta_percent": -12.157814375735287,
+          "order": "BA",
+          "pair_index": 6
+        },
+        {
+          "a_median_ns": 7476062.5,
+          "b_median_ns": 6704979.5,
+          "delta_percent": -10.314025598368124,
+          "order": "AB",
+          "pair_index": 7
+        },
+        {
+          "a_median_ns": 6721396.0,
+          "b_median_ns": 7470750.5,
+          "delta_percent": 11.148792602013033,
+          "order": "BA",
+          "pair_index": 8
+        }
+      ],
+      "scenario": "markdown_injections/stable_edit_followup_delta"
+    },
+    {
+      "a_median_ns": 5749052.0,
+      "b_median_ns": 6254791.75,
+      "pair_count": 8,
+      "paired_delta_percent": {
+        "max": 33.559264658188404,
+        "median": 0.2456349409897998,
+        "min": -1.039589945776078
+      },
+      "pairs": [
+        {
+          "a_median_ns": 6732792.0,
+          "b_median_ns": 6740083.5,
+          "delta_percent": 0.10829831071567338,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 5315375.0,
+          "b_median_ns": 6225708.5,
+          "delta_percent": 17.126420995696446,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 6313603.5,
+          "b_median_ns": 6283875.0,
+          "delta_percent": -0.47086422199303457,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 5506979.0,
+          "b_median_ns": 5449729.0,
+          "delta_percent": -1.039589945776078,
+          "order": "BA",
+          "pair_index": 4
+        },
+        {
+          "a_median_ns": 5991125.0,
+          "b_median_ns": 5936312.0,
+          "delta_percent": -0.9149032944563835,
+          "order": "AB",
+          "pair_index": 5
+        },
+        {
+          "a_median_ns": 4930333.0,
+          "b_median_ns": 6584916.5,
+          "delta_percent": 33.559264658188404,
+          "order": "BA",
+          "pair_index": 6
+        },
+        {
+          "a_median_ns": 5206000.0,
+          "b_median_ns": 5225937.5,
+          "delta_percent": 0.3829715712639262,
+          "order": "AB",
+          "pair_index": 7
+        },
+        {
+          "a_median_ns": 6387479.0,
+          "b_median_ns": 6661417.0,
+          "delta_percent": 4.288671633988934,
+          "order": "BA",
+          "pair_index": 8
+        }
+      ],
+      "scenario": "markdown_injections/typing_delta"
+    },
+    {
+      "a_median_ns": 661583.25,
+      "b_median_ns": 766948.0,
+      "pair_count": 8,
+      "paired_delta_percent": {
+        "max": 20.725944864366593,
+        "median": 7.102020918670126,
+        "min": -7.934968284906965
+      },
+      "pairs": [
+        {
+          "a_median_ns": 690708.0,
+          "b_median_ns": 770354.5,
+          "delta_percent": 11.531139063106261,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 591895.5,
+          "b_median_ns": 626416.5,
+          "delta_percent": 5.832279515556378,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 761104.0,
+          "b_median_ns": 820020.5,
+          "delta_percent": 7.74092633858185,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 594396.0,
+          "b_median_ns": 632812.5,
+          "delta_percent": 6.463115498758404,
+          "order": "BA",
+          "pair_index": 4
+        },
+        {
+          "a_median_ns": 770145.5,
+          "b_median_ns": 847104.0,
+          "delta_percent": 9.992722154450036,
+          "order": "AB",
+          "pair_index": 5
+        },
+        {
+          "a_median_ns": 589854.0,
+          "b_median_ns": 557791.5,
+          "delta_percent": -5.435667131188396,
+          "order": "BA",
+          "pair_index": 6
+        },
+        {
+          "a_median_ns": 632458.5,
+          "b_median_ns": 763541.5,
+          "delta_percent": 20.725944864366593,
+          "order": "AB",
+          "pair_index": 7
+        },
+        {
+          "a_median_ns": 871667.0,
+          "b_median_ns": 802500.5,
+          "delta_percent": -7.934968284906965,
+          "order": "BA",
+          "pair_index": 8
+        }
+      ],
+      "scenario": "markdown_injections_large/full_cache_hit"
+    },
+    {
+      "a_median_ns": 2478698.0,
+      "b_median_ns": 2363520.75,
+      "pair_count": 8,
+      "paired_delta_percent": {
+        "max": 39.08570742353133,
+        "median": 4.976595570118067,
+        "min": -10.36595744680851
+      },
+      "pairs": [
+        {
+          "a_median_ns": 1898604.5,
+          "b_median_ns": 2640687.5,
+          "delta_percent": 39.08570742353133,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 2406895.5,
+          "b_median_ns": 2336145.5,
+          "delta_percent": -2.939471198479535,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 2575667.0,
+          "b_median_ns": 2634041.5,
+          "delta_percent": 2.2663838143673076,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 2605146.0,
+          "b_median_ns": 2346041.5,
+          "delta_percent": -9.94587251539837,
+          "order": "BA",
+          "pair_index": 4
+        },
+        {
+          "a_median_ns": 2550500.5,
+          "b_median_ns": 2787312.5,
+          "delta_percent": 9.284922704386844,
+          "order": "AB",
+          "pair_index": 5
+        },
+        {
+          "a_median_ns": 2110541.5,
+          "b_median_ns": 2322562.5,
+          "delta_percent": 10.045810518295898,
+          "order": "BA",
+          "pair_index": 6
+        },
+        {
+          "a_median_ns": 2211041.5,
+          "b_median_ns": 2381000.0,
+          "delta_percent": 7.686807325868827,
+          "order": "AB",
+          "pair_index": 7
+        },
+        {
+          "a_median_ns": 2608500.0,
+          "b_median_ns": 2338104.0,
+          "delta_percent": -10.36595744680851,
+          "order": "BA",
+          "pair_index": 8
+        }
+      ],
+      "scenario": "rust_large/full_cache_hit"
+    },
+    {
+      "a_median_ns": 54024916.5,
+      "b_median_ns": 31042333.25,
+      "pair_count": 8,
+      "paired_delta_percent": {
+        "max": -24.833710962180035,
+        "median": -45.29576323792854,
+        "min": -52.74712782777935
+      },
+      "pairs": [
+        {
+          "a_median_ns": 56797604.0,
+          "b_median_ns": 33256791.5,
+          "delta_percent": -41.44684078574864,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 55126395.5,
+          "b_median_ns": 26597958.0,
+          "delta_percent": -51.75095748823265,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 52923437.5,
+          "b_median_ns": 39780584.0,
+          "delta_percent": -24.833710962180035,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 56686062.0,
+          "b_median_ns": 28827875.0,
+          "delta_percent": -49.14468569010844,
+          "order": "BA",
+          "pair_index": 4
+        },
+        {
+          "a_median_ns": 48902979.0,
+          "b_median_ns": 33315292.0,
+          "delta_percent": -31.874718716011145,
+          "order": "AB",
+          "pair_index": 5
+        },
+        {
+          "a_median_ns": 51510479.0,
+          "b_median_ns": 25654708.0,
+          "delta_percent": -50.1951670843519,
+          "order": "BA",
+          "pair_index": 6
+        },
+        {
+          "a_median_ns": 49601208.0,
+          "b_median_ns": 33301854.0,
+          "delta_percent": -32.86080048695588,
+          "order": "AB",
+          "pair_index": 7
+        },
+        {
+          "a_median_ns": 55517083.5,
+          "b_median_ns": 26233416.5,
+          "delta_percent": -52.74712782777935,
+          "order": "BA",
+          "pair_index": 8
+        }
+      ],
+      "scenario": "rust_large/stable_edit_followup_delta"
+    },
+    {
+      "a_median_ns": 33195437.75,
+      "b_median_ns": 29941333.75,
+      "pair_count": 8,
+      "paired_delta_percent": {
+        "max": -1.2867110970582005,
+        "median": -6.3368565483973756,
+        "min": -13.07457798319539
+      },
+      "pairs": [
+        {
+          "a_median_ns": 33268271.0,
+          "b_median_ns": 31243479.0,
+          "delta_percent": -6.086255579678307,
+          "order": "AB",
+          "pair_index": 1
+        },
+        {
+          "a_median_ns": 33122604.5,
+          "b_median_ns": 30940667.0,
+          "delta_percent": -6.5874575171164444,
+          "order": "BA",
+          "pair_index": 2
+        },
+        {
+          "a_median_ns": 33644645.5,
+          "b_median_ns": 31194896.0,
+          "delta_percent": -7.281246283305317,
+          "order": "AB",
+          "pair_index": 3
+        },
+        {
+          "a_median_ns": 29033874.5,
+          "b_median_ns": 28562833.5,
+          "delta_percent": -1.622384225708491,
+          "order": "BA",
+          "pair_index": 4
+        },
+        {
+          "a_median_ns": 33295208.5,
+          "b_median_ns": 28942000.5,
+          "delta_percent": -13.07457798319539,
+          "order": "AB",
+          "pair_index": 5
+        },
+        {
+          "a_median_ns": 32245958.0,
+          "b_median_ns": 28790937.5,
+          "delta_percent": -10.714584755087754,
+          "order": "BA",
+          "pair_index": 6
+        },
+        {
+          "a_median_ns": 29600979.0,
+          "b_median_ns": 28757833.0,
+          "delta_percent": -2.8483720082366193,
+          "order": "AB",
+          "pair_index": 7
+        },
+        {
+          "a_median_ns": 33878312.0,
+          "b_median_ns": 33442396.0,
+          "delta_percent": -1.2867110970582005,
+          "order": "BA",
+          "pair_index": 8
+        }
+      ],
+      "scenario": "rust_large/typing_delta"
+    }
+  ],
+  "schema_version": 1
+}

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -880,14 +880,18 @@ fn run_once(
             server.did_change_append_newline(scn.uri, edit.version, edit.append_line);
             edit.append_line += 1;
             let baseline = baseline.as_mut().expect("delta baseline");
+            let result_id = baseline.result_id().to_string();
             let edited = server.semantic_delta(scn.uri, baseline.result_id());
+            validate_empty_delta_response(scn, &edited, &result_id, "stable edit");
             baseline.apply_response(&edited).unwrap_or_else(|error| {
                 panic!(
                     "invalid semantic response after stable edit for {}: {error:?}",
                     scn.name
                 )
             });
+            let result_id = baseline.result_id().to_string();
             let follow_up = server.semantic_delta(scn.uri, baseline.result_id());
+            validate_empty_delta_response(scn, &follow_up, &result_id, "same-snapshot follow-up");
             baseline.apply_response(&follow_up).unwrap_or_else(|error| {
                 panic!(
                     "invalid same-snapshot follow-up response for {}: {error:?}",
@@ -957,6 +961,28 @@ fn run_once(
             });
         }
     }
+}
+
+fn validate_empty_delta_response(
+    scn: &Scenario,
+    response: &Value,
+    expected_result_id: &str,
+    phase: &str,
+) {
+    assert_eq!(
+        response.get("resultId").and_then(Value::as_str),
+        Some(expected_result_id),
+        "{phase} must preserve the semantic baseline id for {}: {response}",
+        scn.name
+    );
+    assert!(
+        response
+            .get("edits")
+            .and_then(Value::as_array)
+            .is_some_and(Vec::is_empty),
+        "{phase} must return an empty delta for {}: {response}",
+        scn.name
+    );
 }
 
 fn validate_full_response_generators() {

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -222,6 +222,22 @@ impl Server {
         );
     }
 
+    fn did_change_append_newline(&mut self, uri: &str, version: i64, line: u32) {
+        self.notify(
+            "textDocument/didChange",
+            json!({
+                "textDocument": { "uri": uri, "version": version },
+                "contentChanges": [{
+                    "range": {
+                        "start": { "line": line, "character": 0 },
+                        "end": { "line": line, "character": 0 },
+                    },
+                    "text": "\n",
+                }],
+            }),
+        );
+    }
+
     fn did_change_replace_prefix(&mut self, uri: &str, version: i64, line: u32, text: &str) {
         self.notify(
             "textDocument/didChange",
@@ -544,6 +560,9 @@ enum Kind {
     },
     /// `semanticTokens/full/delta` with no edit between requests.
     DeltaNoop,
+    /// Append a newline that leaves the token payload unchanged, consume its
+    /// empty delta, then issue a follow-up delta for the same current snapshot.
+    StableEditFollowupDelta,
     /// Realistic editing: a toggle `didChange` then `semanticTokens/full/delta`,
     /// so each measured request pays incremental reparse + cache invalidation +
     /// delta diff on top of the (full) token recompute.
@@ -576,6 +595,7 @@ struct EditState {
     line: u32,
     range_next: u32,
     fixed_width_next: usize,
+    append_line: u32,
 }
 
 struct Scenario {
@@ -636,6 +656,8 @@ fn measure(
         line: baseline.as_ref().map_or(0, SemanticBaseline::tracked_line),
         range_next: 0,
         fixed_width_next: 0,
+        append_line: u32::try_from(scn.content.lines().count())
+            .expect("benchmark line count fits u32"),
     };
 
     for _ in 0..warmup {
@@ -801,6 +823,7 @@ fn seed_baseline(server: &mut Server, scn: &Scenario) -> Option<SemanticBaseline
     match scn.kind {
         Kind::Full | Kind::Range { .. } | Kind::OpenFirstToken | Kind::CancelBurst { .. } => None,
         Kind::DeltaNoop
+        | Kind::StableEditFollowupDelta
         | Kind::EditDelta
         | Kind::TypingDelta
         | Kind::FixedWidthTypingDelta
@@ -850,6 +873,26 @@ fn run_once(
             let result = server.semantic_delta(scn.uri, baseline.result_id());
             baseline.apply_response(&result).unwrap_or_else(|error| {
                 panic!("invalid semantic response for {}: {error:?}", scn.name)
+            });
+        }
+        Kind::StableEditFollowupDelta => {
+            edit.version += 1;
+            server.did_change_append_newline(scn.uri, edit.version, edit.append_line);
+            edit.append_line += 1;
+            let baseline = baseline.as_mut().expect("delta baseline");
+            let edited = server.semantic_delta(scn.uri, baseline.result_id());
+            baseline.apply_response(&edited).unwrap_or_else(|error| {
+                panic!(
+                    "invalid semantic response after stable edit for {}: {error:?}",
+                    scn.name
+                )
+            });
+            let follow_up = server.semantic_delta(scn.uri, baseline.result_id());
+            baseline.apply_response(&follow_up).unwrap_or_else(|error| {
+                panic!(
+                    "invalid same-snapshot follow-up response for {}: {error:?}",
+                    scn.name
+                )
             });
         }
         Kind::EditDelta => {
@@ -1016,6 +1059,14 @@ fn main() {
             targets: "no-op delta result_id reuse",
         },
         Scenario {
+            name: "rust_large/stable_edit_followup_delta",
+            language_id: "rust",
+            uri: "file:///bench/large_stable_edit.rs",
+            content: gen_rust(150),
+            kind: Kind::StableEditFollowupDelta,
+            targets: "unique token-stable edit→empty delta→same-snapshot follow-up",
+        },
+        Scenario {
             name: "rust_large/edit_delta",
             language_id: "rust",
             uri: "file:///bench/large_edit.rs",
@@ -1086,6 +1137,14 @@ fn main() {
             content: gen_markdown_injections(60),
             kind: Kind::EditDelta,
             targets: "edit→reparse→injection re-detect→cache invalidation→delta (typing)",
+        },
+        Scenario {
+            name: "markdown_injections/stable_edit_followup_delta",
+            language_id: "markdown",
+            uri: "file:///bench/injections_stable_edit.md",
+            content: gen_markdown_injections(60),
+            kind: Kind::StableEditFollowupDelta,
+            targets: "unique token-stable injection edit→empty delta→same-snapshot follow-up",
         },
         Scenario {
             name: "markdown_injections/typing_delta",

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -721,6 +721,59 @@ mod tests {
         );
     }
 
+    #[test]
+    fn promote_current_reuses_baseline_for_a_new_snapshot_identity() {
+        let cache = SemanticTokenCache::new();
+        let uri = Url::parse("file:///unchanged_tokens.rs").unwrap();
+        let tokens = SemanticTokens {
+            result_id: Some("stable".to_string()),
+            data: vec![SemanticToken {
+                delta_line: 0,
+                delta_start: 0,
+                length: 5,
+                token_type: 0,
+                token_modifiers_bitset: 0,
+            }],
+        };
+        let old_snapshot = snapshot(1, 7, 3);
+        let new_snapshot = snapshot(2, 7, 3);
+        cache.store(
+            uri.clone(),
+            tokens,
+            "rust".to_string(),
+            11,
+            old_snapshot,
+        );
+        let baseline = cache
+            .get_if_valid(&uri, "stable")
+            .expect("stored result must remain a delta baseline");
+
+        cache.promote_current(
+            uri.clone(),
+            Arc::clone(&baseline),
+            "rust".to_string(),
+            12,
+            new_snapshot,
+        );
+
+        let promoted = cache
+            .get_if_same_snapshot(&uri, "rust", new_snapshot)
+            .expect("unchanged tokens must become current for the new snapshot");
+        assert!(
+            Arc::ptr_eq(&baseline, &promoted),
+            "promotion must reuse the existing token allocation"
+        );
+        assert!(
+            cache.get_if_same_snapshot(&uri, "rust", old_snapshot)
+                .is_none(),
+            "the old snapshot must no longer be the current identity"
+        );
+        assert!(
+            cache.get_if_valid(&uri, "stable").is_some(),
+            "promotion must preserve the client-visible delta baseline"
+        );
+    }
+
     /// Pins the named worst-case from #576: a delta-baseline read must not
     /// perform an extra `Arc::clone` (refcount bump) to feed the
     /// comparison — `&Arc<T>` deref-coerces to `&T` at the call, so

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -108,6 +108,36 @@ impl SemanticTokenCache {
         }
     }
 
+    /// Make an existing baseline the current result for a newer snapshot whose
+    /// semantic tokens were proven byte-identical.
+    ///
+    /// This updates only the cache identity and reuses the existing token
+    /// allocation and client-visible result ID.
+    pub fn promote_current(
+        &self,
+        uri: Url,
+        tokens: Arc<SemanticTokens>,
+        language: String,
+        cache_key: u64,
+        snapshot: SemanticSnapshotIdentity,
+    ) {
+        let result_id = tokens.result_id.clone();
+        let mut document = self.documents.entry(uri).or_default();
+        document.current = Some(CachedSemanticTokens {
+            tokens: Arc::clone(&tokens),
+            language,
+            snapshot,
+            cache_key,
+        });
+        if let Some(result_id) = result_id {
+            if document.baselines.contains_key(&result_id) {
+                Self::touch_baseline(&mut document, &result_id);
+            } else {
+                Self::store_baseline(&mut document, result_id, tokens);
+            }
+        }
+    }
+
     fn store_baseline(
         document: &mut SemanticDocumentCache,
         result_id: String,
@@ -737,13 +767,7 @@ mod tests {
         };
         let old_snapshot = snapshot(1, 7, 3);
         let new_snapshot = snapshot(2, 7, 3);
-        cache.store(
-            uri.clone(),
-            tokens,
-            "rust".to_string(),
-            11,
-            old_snapshot,
-        );
+        cache.store(uri.clone(), tokens, "rust".to_string(), 11, old_snapshot);
         let baseline = cache
             .get_if_valid(&uri, "stable")
             .expect("stored result must remain a delta baseline");
@@ -764,7 +788,8 @@ mod tests {
             "promotion must reuse the existing token allocation"
         );
         assert!(
-            cache.get_if_same_snapshot(&uri, "rust", old_snapshot)
+            cache
+                .get_if_same_snapshot(&uri, "rust", old_snapshot)
                 .is_none(),
             "the old snapshot must no longer be the current identity"
         );

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -561,6 +561,20 @@ impl CacheCoordinator {
             .store(uri, tokens, language, cache_key, snapshot);
     }
 
+    /// Promote an existing delta baseline to the current snapshot identity
+    /// after a fresh computation proved that the token payload is unchanged.
+    pub(crate) fn promote_current_tokens(
+        &self,
+        uri: Url,
+        tokens: std::sync::Arc<SemanticTokens>,
+        language: String,
+        cache_key: u64,
+        snapshot: SemanticSnapshotIdentity,
+    ) {
+        self.semantic_cache
+            .promote_current(uri, tokens, language, cache_key, snapshot);
+    }
+
     /// Store the most-recent `semanticTokens/range` result for a document (#535),
     /// tagged with the viewport `range` and the `cache_key` it was computed under.
     pub(crate) fn store_range_tokens(

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -967,7 +967,8 @@ impl Kakehashi {
         // `try_unwrap` when the Arc is uniquely owned) instead of routing
         // through `delta_result`'s `Tokens` arm, which would clone it once
         // to build the intermediate value and again for the cache store.
-        let (final_result, tokens_to_store) = if let Some(prev) = previous_tokens {
+        let (final_result, tokens_to_store, tokens_to_promote) = if let Some(prev) = previous_tokens
+        {
             // Calculate delta or return full tokens outside the document edit
             // lock. Only the final currency check and cache commit need to be
             // serialized with didChange/didClose.
@@ -978,11 +979,19 @@ impl Kakehashi {
                 SemanticTokensFullDeltaResult::Tokens(mut tokens) => {
                     tokens.result_id = Some(next_result_id());
                     let stored = tokens.clone();
-                    (SemanticTokensFullDeltaResult::Tokens(tokens), Some(stored))
+                    (
+                        SemanticTokensFullDeltaResult::Tokens(tokens),
+                        Some(stored),
+                        None,
+                    )
                 }
                 SemanticTokensFullDeltaResult::TokensDelta(mut delta) if delta.edits.is_empty() => {
                     delta.result_id = Some(previous_result_id.clone());
-                    (SemanticTokensFullDeltaResult::TokensDelta(delta), None)
+                    (
+                        SemanticTokensFullDeltaResult::TokensDelta(delta),
+                        None,
+                        Some(prev),
+                    )
                 }
                 SemanticTokensFullDeltaResult::TokensDelta(mut delta) => {
                     let mut stored = current_tokens.into_owned();
@@ -991,6 +1000,7 @@ impl Kakehashi {
                     (
                         SemanticTokensFullDeltaResult::TokensDelta(delta),
                         Some(stored),
+                        None,
                     )
                 }
                 SemanticTokensFullDeltaResult::PartialTokensDelta { .. } => {
@@ -1002,14 +1012,22 @@ impl Kakehashi {
                     let mut tokens = current_tokens.into_owned();
                     tokens.result_id = Some(next_result_id());
                     let stored = tokens.clone();
-                    (SemanticTokensFullDeltaResult::Tokens(tokens), Some(stored))
+                    (
+                        SemanticTokensFullDeltaResult::Tokens(tokens),
+                        Some(stored),
+                        None,
+                    )
                 }
             }
         } else {
             let mut tokens = current_tokens.into_owned();
             tokens.result_id = Some(next_result_id());
             let stored = tokens.clone();
-            (SemanticTokensFullDeltaResult::Tokens(tokens), Some(stored))
+            (
+                SemanticTokensFullDeltaResult::Tokens(tokens),
+                Some(stored),
+                None,
+            )
         };
 
         let edit_lock = self.documents.edit_lock(&uri);
@@ -1027,6 +1045,14 @@ impl Kakehashi {
         }
         if let Some(tokens) = tokens_to_store {
             self.cache.store_tokens(
+                uri.clone(),
+                tokens,
+                language_name,
+                cache_key,
+                snapshot_identity,
+            );
+        } else if let Some(tokens) = tokens_to_promote {
+            self.cache.promote_current_tokens(
                 uri.clone(),
                 tokens,
                 language_name,
@@ -2112,6 +2138,103 @@ mod tests {
                 .get_tokens_if_valid(&uri, &initial_result_id)
                 .is_some(),
             "cache should still hold tokens under the reused result_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn unchanged_edit_delta_promotes_tokens_to_the_new_snapshot() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///stable_edit_delta.lua").expect("should construct test uri");
+
+        server.documents.insert(
+            uri.clone(),
+            "local x = 1".to_string(),
+            Some("lua".to_string()),
+            None,
+        );
+        let settings = crate::config::WorkspaceSettings {
+            search_paths: vec![
+                std::env::var("TREE_SITTER_GRAMMARS")
+                    .unwrap_or_else(|_| "deps/tree-sitter".to_string()),
+            ],
+            ..Default::default()
+        };
+        let _ = server.language.load_settings(&settings);
+        let load_result = server.language.ensure_language_loaded("lua");
+        if !load_result.success || server.language.highlight_query("lua").is_none() {
+            eprintln!("Skipping: lua language parser or highlight query not available");
+            return;
+        }
+
+        server
+            .parse_coordinator()
+            .parse_document(uri.clone(), Some("lua"), None)
+            .await;
+        let document = TextDocumentIdentifier {
+            uri: crate::lsp::lsp_impl::url_to_uri(&uri).expect("test URI should convert"),
+        };
+        let full = server
+            .semantic_tokens_full_impl(SemanticTokensParams {
+                text_document: document.clone(),
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            })
+            .await
+            .expect("full request should succeed")
+            .expect("full request should return tokens");
+        let baseline_id = match full {
+            SemanticTokensResult::Tokens(tokens) => {
+                tokens.result_id.expect("full result should have an id")
+            }
+            other => panic!("expected full tokens, got {other:?}"),
+        };
+
+        server
+            .documents
+            .update_document(uri.clone(), "local x = 1\n".to_string(), None);
+        server
+            .parse_coordinator()
+            .parse_document(uri.clone(), Some("lua"), None)
+            .await;
+        let snapshot = server
+            .current_snapshot(&uri)
+            .await
+            .expect("edited document should publish a snapshot");
+        let snapshot_identity = SemanticSnapshotIdentity {
+            parsed_version: snapshot.parsed_version,
+            incarnation: snapshot.incarnation,
+            generation: server.cache.semantic_token_generation(),
+        };
+
+        let delta = server
+            .semantic_tokens_full_delta_impl(SemanticTokensDeltaParams {
+                text_document: document,
+                previous_result_id: baseline_id.clone(),
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            })
+            .await
+            .expect("delta request should succeed")
+            .expect("delta request should return a result");
+        assert!(
+            matches!(
+                delta,
+                SemanticTokensFullDeltaResult::TokensDelta(ref delta)
+                    if delta.edits.is_empty()
+                        && delta.result_id.as_deref() == Some(baseline_id.as_str())
+            ),
+            "a semantically unchanged edit should reuse the baseline id"
+        );
+
+        let promoted = server
+            .cache
+            .get_current_tokens_for_snapshot(&uri, "lua", snapshot_identity)
+            .expect("the empty delta must promote the baseline to the edited snapshot");
+        assert_eq!(
+            promoted.result_id.as_deref(),
+            Some(baseline_id.as_str()),
+            "snapshot promotion must preserve the client-visible result id"
         );
     }
 


### PR DESCRIPTION
## Dependencies

Depends on #900. Merge #900 first, then retarget this PR to `main` and run the full CI checks before making it ready for merge.

## Summary

意味が変わらない編集で `semanticTokens/full/delta` が空deltaを返したとき、既存baselineのtoken allocationと`resultId`を保ったまま、cacheのcurrent identityだけを最新parse snapshotへ昇格します。

これまでは空deltaを返してもcache identityが編集前snapshotのままだったため、同じ最新snapshotへの次のdeltaがtoken計算を繰り返していました。promotionは次の条件を満たした後だけ行います。

- 新旧のencoded semantic token payloadが完全一致し、delta editsが空
- didChange/didCloseと共有するedit lockを取得
- incarnation、parsed/content version、settings generationがcurrent
- requestがまだlatest active request

新しいresult ID、追加token vector、worker/process stateは導入しません。semantic-token freshness契約も変更しません。

## Benchmark

Baseline: #900 head `265d38b0ac95822b17e5cec19c5e226d3d034bb9`

Candidate/harness: `e77599ec2e937216bf9c028d330ae6dc4983cac3`

8つのAB/BA交互ペア、各12 warmups + 30 retained samples。lower is betterです。stable-edit scenarioは、末尾改行というunique editの直後の空deltaと、同一current snapshotへのfollow-up空deltaを両方検証します。

| scenario | paired median | pair range |
| --- | ---: | ---: |
| Rust stable-edit follow-up delta | **-45.30%** | **-52.75% .. -24.83%** |
| Markdown stable-edit follow-up delta | -11.24% | -27.73% .. +11.15% |
| Rust typing delta control | -6.34% | -13.07% .. -1.29% |
| Markdown typing delta control | +0.25% | -1.04% .. +33.56% |
| Rust full-cache-hit control | +4.98% | -10.37% .. +39.09% |
| Markdown full-cache-hit control | +7.10% | -7.93% .. +20.73% |

再現可能な性能主張は8/8ペアで改善したRust stable-edit follow-upに限定します。Markdown targetは6/8改善ですが0を跨ぐためdirectional evidenceです。full-cache controlsとMarkdown typingも符号が揺れるため、回帰/非回帰の結論には使いません。

Summary、environment、binary/harness/fixture hashesは `benches/results/semantic-empty-delta-cache-2026-07-24/` に保存しています。baseline/candidate/harnessのdurable tagsもoriginへpush済みです。

## Validation

- `cargo test --locked --lib` — 3041 passed, 2 ignored
- `cargo clippy --locked --lib --bins -- -D warnings`
- `cargo clippy --locked --features e2e --bench semantic_tokens -- -D warnings`
- `PYTHONPATH=benches python3 -m unittest benches/test_semantic_summary.py benches/test_collect_semantic_pairs.py` — 19 passed
- artifact hashes、summary再生成、durable refsを検証
- local multi-perspective review: clean after 3 findings fixed as separate commits
- two fresh local Codex review sessions: no actionable regression
- parser libraries/query files are not committed; the benchmark uses the installer-built temporary fixture and retains only its manifest

Contributes to #895.

---

**注記 (2026-08-11): 生サンプルの削除**

リポジトリに raw benchmark data を残さないため、`benches/results/*/pair-*.json`（各pairの生サンプル配列）をこのスタックの全PRから削除しました。evidence ディレクトリは残っており、中身は次の通りです。

- `summary.json` — pairごとの median / delta / min / max と集計値
- `pair-*.txt` — シナリオ別の A/B 比較表（p95 付き）
- `manifest.json` / `fixture-manifest.json` — commit・tag・binary/harness/fixture の SHA-256

**本文に記載した数値はすべてこれらから再構成できます。** 失われたのは各シナリオ 30 本の生サンプル配列のみです。`manifest.json` の `raw_files` / `samples_sha256` は、削除したファイルの記録として意図的に残しています。

なお本文中の「raw samples を検証／再検証した」という記述は当時実施した検証の記録であり、現在のリポジトリからは再実行できません。今後の再混入を防ぐため `.gitignore` に `benches/results/*/pair-*.json` を追加しています。
