### PR TITLE
feat(config): let a bridge server declare `languages = ["*"]` for any language

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -390,6 +390,25 @@ from the `_` entry" (wildcard-config-inheritance), which is why the widening
 needs its own marker. Keeping it in the list also leaves room for future set
 algebra such as an `"!markdown"` exclusion.
 
+**Budget it against regions, not languages.** A `"*"` server is one process per
+workspace root — the connection pool has no language dimension — but it gets a
+virtual `didOpen` for every injection *region* it matches, and joins every
+region's fan-out. That number is larger than it looks in markdown: the shipped
+injection query emits a `markdown_inline` region per inline node and per table
+cell, so a prose file yields regions in the hundreds. Nothing bounds it
+(`maxFanOut` caps servers per region, not regions). Use the per-host bridge
+filter to exclude what the server should not see:
+
+```toml
+# harper-ls checks the prose; it does not need the inline sub-regions too.
+[languages.markdown.bridge.markdown_inline]
+enabled = false
+```
+
+Also note that diagnostics and code actions are concatenated without span
+dedup, so a `"*"` server can report the same finding once per matching region —
+and, with `bridge._self.enabled = true`, once more from the host document.
+
 Two things `"*"` does **not** do:
 
 - It does not enable bridging for a language the host blocks. `"*"` widens

--- a/docs/README.md
+++ b/docs/README.md
@@ -350,7 +350,7 @@ Configure language servers for bridging LSP requests in injection regions.
 | Field | Description |
 |-------|-------------|
 | `cmd` | Command and arguments to start the language server |
-| `languages` | Languages this server handles |
+| `languages` | Languages this server handles. The single element `"*"` means **any language**, for servers that are not tied to one (spell/grammar/typo checkers, AI completion) — see below. |
 | `initializationOptions` | Optional initialization options forwarded during the downstream server's `initialize` request |
 | `workspaceMarkers` | Marker files/directories locating the workspace root the server is initialized with, following Neovim's `vim.fs.root` `(string\|string[])[]` shape. (The pre-rename key `rootMarkers` is still accepted as a deprecated alias.) Entries are tried **in list order** (earlier = higher priority): each entry is searched up the triggering document's ancestors nearest-first before the next entry is tried, so a higher-priority marker in a far ancestor outranks a lower-priority one sitting next to the document. A **nested array** is one equal-priority group where the nearest ancestor containing any of its names wins — e.g. `[["stylua.toml", ".luarc.json"], ".git"]` means "nearest of stylua.toml/.luarc.json, otherwise .git". The first matching entry's directory becomes the server's `rootUri` and sole workspace folder. Default: `[".git"]`. No marker hit falls back to the client-supplied root; an explicit `[]` disables the search. The connection pool is keyed by `(server, resolved root)`, so in a multi-root monorepo documents under different marker roots get their own downstream process, each rooted correctly; documents sharing a root (or the no-marker fallback) share one process. Trade-off: process count grows with the number of distinct roots opened, and there is currently no idle-eviction — a long session touching many roots keeps one process per root alive until shutdown. Servers that operate purely on `workspaceFolders` can opt out of this growth with `preferSharedInstance` (below). |
 | `onTypeFormattingTriggers` | Trigger characters for bridged `textDocument/onTypeFormatting` (e.g. `["}", ";"]`). kakehashi advertises the sorted union across all servers at initialize and forwards a request to a downstream server only when that server's own capabilities declare the typed character. Unset everywhere (default) → the capability is not advertised. |
@@ -370,6 +370,39 @@ server's explicit value overrides the wildcard, so `_.preferSharedInstance =
 true` can still be opted out of per server with `preferSharedInstance =
 false`. A wildcard-only entry is never spawned itself, and a concrete server
 whose merged `cmd` is still empty is skipped.
+
+**Servers for any language (`languages = ["*"]`)**
+
+Some servers are not tied to a language at all — grammar and spell checkers,
+typo linters, AI completion. Give them the single element `"*"` instead of an
+enumeration:
+
+```toml
+[languageServers.harper-ls]
+cmd = ["harper-ls", "--stdio"]
+languages = ["*"]
+```
+
+`"*"` is a list element for the same reason `priorities` uses one: `_` keys
+carry field-level inheritance, list elements do not. Note that an **empty or
+omitted** `languages` does *not* mean "any" — it means "inherit `languages`
+from the `_` entry" (wildcard-config-inheritance), which is why the widening
+needs its own marker. Keeping it in the list also leaves room for future set
+algebra such as an `"!markdown"` exclusion.
+
+Two things `"*"` does **not** do:
+
+- It does not enable bridging for a language the host blocks. `"*"` widens
+  *which servers may answer*, not *which injections a host bridges at all* —
+  a `languages.markdown.bridge.rust.enabled = false` filter still applies.
+- It does not opt the server into the host-document bridge. A `"*"` server
+  becomes a host candidate for every language, but the host path remains
+  gated on the explicit `bridge._self.enabled = true` opt-in.
+
+Because `languages` is inheritable, `languageServers._.languages = ["*"]`
+attaches **every** server that omits `languages` to **every** language. That
+is occasionally what you want, but it is rarely what you mean — prefer
+declaring `"*"` on the concrete servers that need it.
 
 **Bridge Language Configuration:**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -391,7 +391,8 @@ needs its own marker. Keeping it in the list also leaves room for future set
 algebra such as an `"!markdown"` exclusion.
 
 **Budget it against regions, not languages.** A `"*"` server is one process per
-workspace root — the connection pool has no language dimension — but it gets a
+workspace root by default — the connection pool has no language dimension, and
+`preferSharedInstance` can collapse the roots too — but it gets a
 virtual `didOpen` for every injection *region* it matches, and joins every
 region's fan-out. That number is larger than it looks in markdown: the shipped
 injection query emits a `markdown_inline` region per inline node and per table

--- a/docs/README.md
+++ b/docs/README.md
@@ -385,10 +385,12 @@ languages = ["*"]
 
 `"*"` is a list element for the same reason `priorities` uses one: `_` keys
 carry field-level inheritance, list elements do not. Note that an **empty or
-omitted** `languages` does *not* mean "any" — it means "inherit `languages`
-from the `_` entry" (wildcard-config-inheritance), which is why the widening
-needs its own marker. Keeping it in the list also leaves room for future set
-algebra such as an `"!markdown"` exclusion.
+omitted** `languages` does *not* mean "any" — it means "not specified here", so
+it falls through to the same server's entry in a lower config layer and, only
+if no layer specified one, to the `_` entry (wildcard-config-inheritance).
+Either way it can only ever *defer*, which is why widening needs its own
+marker. Keeping it in the list also leaves room for future set algebra such as
+an `"!markdown"` exclusion.
 
 **Budget it against regions, not languages.** A `"*"` server is one process per
 workspace root by default — the connection pool has no language dimension, and
@@ -428,9 +430,11 @@ wildcard in your user config widens servers declared in any project's config
 too — servers you never saw when you wrote it.
 
 Opting a single server back out is `enabled = false`, not an empty
-`languages`: `[]` means "inherit", so under a `_` wildcard it resolves right
-back to `["*"]`. A concrete server's own non-empty `languages` does override
-the wildcard, so listing real languages narrows it as expected.
+`languages`: `[]` means "not specified here", so it resolves to whatever the
+next source supplies — that same server's list from a lower config layer if it
+has one, and otherwise the `_` wildcard, i.e. right back to `["*"]`. A concrete
+server's own non-empty `languages` does override the wildcard, so listing real
+languages narrows it as expected.
 
 **Bridge Language Configuration:**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -350,7 +350,7 @@ Configure language servers for bridging LSP requests in injection regions.
 | Field | Description |
 |-------|-------------|
 | `cmd` | Command and arguments to start the language server |
-| `languages` | Languages this server handles. The single element `"*"` means **any language**, for servers that are not tied to one (spell/grammar/typo checkers, AI completion) — see below. |
+| `languages` | Languages this server handles. The element `"*"` means **any language**, for servers that are not tied to one (spell/grammar/typo checkers, AI completion) — see below. |
 | `initializationOptions` | Optional initialization options forwarded during the downstream server's `initialize` request |
 | `workspaceMarkers` | Marker files/directories locating the workspace root the server is initialized with, following Neovim's `vim.fs.root` `(string\|string[])[]` shape. (The pre-rename key `rootMarkers` is still accepted as a deprecated alias.) Entries are tried **in list order** (earlier = higher priority): each entry is searched up the triggering document's ancestors nearest-first before the next entry is tried, so a higher-priority marker in a far ancestor outranks a lower-priority one sitting next to the document. A **nested array** is one equal-priority group where the nearest ancestor containing any of its names wins — e.g. `[["stylua.toml", ".luarc.json"], ".git"]` means "nearest of stylua.toml/.luarc.json, otherwise .git". The first matching entry's directory becomes the server's `rootUri` and sole workspace folder. Default: `[".git"]`. No marker hit falls back to the client-supplied root; an explicit `[]` disables the search. The connection pool is keyed by `(server, resolved root)`, so in a multi-root monorepo documents under different marker roots get their own downstream process, each rooted correctly; documents sharing a root (or the no-marker fallback) share one process. Trade-off: process count grows with the number of distinct roots opened, and there is currently no idle-eviction — a long session touching many roots keeps one process per root alive until shutdown. Servers that operate purely on `workspaceFolders` can opt out of this growth with `preferSharedInstance` (below). |
 | `onTypeFormattingTriggers` | Trigger characters for bridged `textDocument/onTypeFormatting` (e.g. `["}", ";"]`). kakehashi advertises the sorted union across all servers at initialize and forwards a request to a downstream server only when that server's own capabilities declare the typed character. Unset everywhere (default) → the capability is not advertised. |
@@ -402,7 +402,15 @@ Two things `"*"` does **not** do:
 Because `languages` is inheritable, `languageServers._.languages = ["*"]`
 attaches **every** server that omits `languages` to **every** language. That
 is occasionally what you want, but it is rarely what you mean — prefer
-declaring `"*"` on the concrete servers that need it.
+declaring `"*"` on the concrete servers that need it. Note the reach crosses
+config *files*: layers collapse before the `_` entry is resolved, so a `_`
+wildcard in your user config widens servers declared in any project's config
+too — servers you never saw when you wrote it.
+
+Opting a single server back out is `enabled = false`, not an empty
+`languages`: `[]` means "inherit", so under a `_` wildcard it resolves right
+back to `["*"]`. A concrete server's own non-empty `languages` does override
+the wildcard, so listing real languages narrows it as expected.
 
 **Bridge Language Configuration:**
 
@@ -417,7 +425,7 @@ Each entry in the `bridge` map configures bridging for one injection language:
 
 The reserved `_self` key makes the host language its own bridge target: with
 it enabled, requests on the host document are forwarded to servers whose
-`languages` contains the **host** language, with the real URI and no
+`languages` matches the **host** language (including a `"*"` server), with the real URI and no
 coordinate translation. All bridged request methods are wired (exceptions:
 semantic tokens; document color stays injection-only; host completion-item
 and code-lens resolves pass through unrouted); by default the host layer is

--- a/docs/architecture-decisions/any-language-server-wildcard.md
+++ b/docs/architecture-decisions/any-language-server-wildcard.md
@@ -33,9 +33,11 @@ The obvious spellings for "any" are already taken:
 - **`languages = []`** — `merge_bridge_server_configs`
   (`src/config/merge.rs`) treats an empty overlay list as "inherit `languages`
   from the `_` entry" (wildcard-config-inheritance).
-- **`languages` omitted / `null`** — `#[serde(default)]` on `Vec<String>`
-  produces the same empty vec, so it lands on the identical inherit path. TOML
-  has no `null` regardless.
+- **`languages` omitted** — `#[serde(default)]` on `Vec<String>` produces that
+  same empty vec, so it lands on the identical inherit path. (`null` is not a
+  third spelling: TOML has no `null`, and an explicit JSON `null` from
+  `initializationOptions` fails to deserialize into `Vec<String>` rather than
+  defaulting — the field is neither `Option` nor `default_on_null`.)
 
 Both therefore mean *defer*. A concrete server has no way to **widen** past an
 inherited narrow list — only to accept it. That is precisely the gap a
@@ -77,8 +79,33 @@ languages = ["*"]
 - Resolution order is unchanged: wildcard *inheritance* (`_`) is applied first,
   then the resolved `languages` list is tested. `languageServers._.languages =
   ["*"]` is therefore legal and inheritable.
-- `"*"` is unambiguous as a marker: tree-sitter language identifiers never
-  contain `*`.
+- `"*"` is safe as a marker in practice — no real tree-sitter language is named
+  `*` — but that is an observation, not an enforced invariant. Injection
+  language ids are taken verbatim from `#set! injection.language` properties and
+  from `@injection.language` capture *text*, and canonicalization falls through
+  to the raw identifier, so a hand-authored query or a `` ```* `` fence can
+  produce the literal id `*`. The consequence is benign: such a region is
+  matched by exactly the servers that already accept every language.
+
+### Scope: `priorities` Still Excludes an Unlisted Server
+
+A third limit, easy to miss because it lives on a different axis:
+`aggregation.<method>.priorities` is an ordered **allowlist over server names**
+(aggregation-priorities-wildcard), and its `"*"` element means "the configured
+servers not named elsewhere in this list" — a different thing from a `"*"`
+*language*. A `"*"` server passes `handles_language` and reaches the candidate
+set, but is still dropped from any target whose `priorities` enumerates server
+names without a `"*"` element.
+
+```toml
+# harper-ls.languages = ["*"] answers in every fence EXCEPT python,
+# because this list names servers explicitly and omits it.
+[languages.markdown.bridge.python.aggregation."_"]
+priorities = ["pyright", "ruff"]
+```
+
+The default (absent `priorities` ≡ `["*"]`) includes it everywhere, so this
+only bites configs that have already opted into explicit priority lists.
 
 ### Scope: What `"*"` Does Not Widen
 
@@ -107,24 +134,50 @@ the other is harder to document than the `_self` gate that already exists.
   set that cannot be known in advance.
 - **Widening becomes expressible** at all, closing the defer-only gap left by
   the inheritance semantics of the empty list.
-- **No behavior change for existing configs**: `"*"` is opt-in and was
-  previously a language name matching nothing.
+- **No behavior change for existing configs**: `"*"` is opt-in, and no existing
+  config could have used it meaningfully — it was a language name matching
+  nothing.
 
 ### Negative
 
 - **`languageServers._.languages = ["*"]` is a footgun**: it attaches every
   server that omits `languages` to every language, silently and totally. It is
   the same hazard any `_.languages` value carries, but the blast radius is
-  maximal. Documented with a recommendation to declare `"*"` on concrete
-  servers instead.
+  maximal — and it crosses config *files*, since layers collapse before `_` is
+  resolved at match time, so a `_` wildcard in the user config also widens
+  servers declared in a project's config. Documented with a recommendation to
+  declare `"*"` on concrete servers instead.
+- **Opting a single server back out is not spellable in `languages`.** Under a
+  `_` wildcard, `[]` means "inherit" and resolves back to `["*"]`; the escape
+  hatch is `enabled = false` (which the selection sites check first, via
+  `is_spawnable`). Narrowing to a real language list does work — a concrete
+  non-empty `languages` overrides the wildcard.
 - **Fan-out grows** with each `"*"` server, which now participates in every
   injection region — including languages the user never intended it for. The
-  capability prefilter blunts the *steady-state* cost by dropping servers that
-  have advertised no support for the requested method, but it can only do so
-  once the server is `Ready`: a `"*"` server is still spawned and initialized
-  for every injection language it is a candidate for. Cost is therefore
-  proportional to the number of distinct injection languages opened, and the
-  wildcard should be spent on servers that genuinely answer for all of them.
+  *process* count does not grow with languages: the connection pool is keyed by
+  `(server, resolved root)` with no language component, so one `"*"` server is
+  one process per root. What scales is per-region work — the server receives a
+  virtual `didOpen` for every region it is a candidate for and joins every
+  region's fan-out. The capability prefilter blunts the steady-state request
+  cost by dropping servers that advertised no support for the method, but only
+  once the server is `Ready`; the first request in any language still pays the
+  spawn and initialize.
+- **A `"*"` server joins first-win races it would previously have sat out.**
+  Under the default `priorities = ["*"]` every matching server lands in one
+  `Rest` group, and the default `preferred` strategy decides that group by
+  arrival time. For methods where the `"*"` server returns a non-empty result
+  (hover, definition, completion), it can beat the language-specific server
+  nondeterministically. Users who care about the ordering must name servers
+  explicitly in `priorities` — which, per the `priorities` scope note above,
+  then also excludes the `"*"` server unless `"*"` is in that list too.
+- **The single-pick site becomes order-dependent for every language.**
+  `get_config_for_language` returns the first match while iterating a
+  `HashMap`, so its pick is not deterministic when several servers match. That
+  was previously reachable only with a genuinely overlapping config (ruff +
+  pyright for python); a `"*"` server makes *every* language have at least two
+  candidates. The site is used for eager virtual-document opening, so the
+  consequence is which server gets warmed up first, not which answers — request
+  paths use the full candidate set.
 
 ### Neutral
 

--- a/docs/architecture-decisions/any-language-server-wildcard.md
+++ b/docs/architecture-decisions/any-language-server-wildcard.md
@@ -9,10 +9,10 @@
 ## Implementation Status
 
 Implemented. `LANGUAGES_WILDCARD` and the `BridgeServerConfig::handles_language`
-predicate live in `src/config/settings.rs`, alongside `names_language` (exact
-membership, ignoring the wildcard) for the one site that must rank the two
-apart. The three selection sites that consume them (injection single-pick,
-injection fan-out, host fan-out) are in `src/lsp/bridge/coordinator.rs`.
+predicate live in `src/config/settings.rs`; the two selection sites that consume
+it — `get_all_configs_for_language` (injections) and
+`get_host_configs_for_language` (host documents) — are in
+`src/lsp/bridge/coordinator.rs`.
 
 ## Context
 
@@ -192,14 +192,17 @@ the other is harder to document than the `_self` gate that already exists.
   nondeterministically. Users who care about the ordering must name servers
   explicitly in `priorities` — which, per the `priorities` scope note above,
   then also excludes the `"*"` server unless `"*"` is in that list too.
-- **The single-pick site needed a tie-break.** `get_config_for_language` picks
-  one server to drive the eager virtual-document open. It previously returned
-  the first `HashMap` match, which a `"*"` server would win about half the time
-  for *every* language, starving the language's real server of its warm start.
-  It now walks sorted and ranks a server that names the language above one that
-  only accepts everything (`names_language` vs `handles_language`), falling
-  back to the wildcard when nothing names the language. That also settles the
-  pre-existing pyright/ruff coin flip.
+- **The eager open had to stop picking one server per language.** It resolved a
+  single server and gave it the virtual `didOpen`, which was survivable while
+  overlapping servers were a deliberate config. A `"*"` server overlaps
+  *everything*, and the starved case is not merely a slower warm start: a
+  **push-only** server — one that publishes diagnostics instead of answering
+  pulls — issues no request, so nothing opens the document lazily and the pull
+  path returns on its capability check before `ensure_document_opened`. Missing
+  the eager open meant never seeing the region at all, for exactly the
+  grammar/spell-checker shape this wildcard exists to support. The eager open
+  now fans out to every matching server, like every other selection site, and
+  the single-pick resolver is gone.
 
 ### Neutral
 

--- a/docs/architecture-decisions/any-language-server-wildcard.md
+++ b/docs/architecture-decisions/any-language-server-wildcard.md
@@ -1,0 +1,183 @@
+# Any-Language Server Wildcard
+
+**Related Decisions**:
+- [language-server-bridge](language-server-bridge.md) — The `languageServers.<name>.languages` field this decision extends
+- [wildcard-config-inheritance](wildcard-config-inheritance.md) — The `_` key inheritance that occupies the empty/absent spelling
+- [aggregation-priorities-wildcard](aggregation-priorities-wildcard.md) — The sigil discipline (`_` for keys, `"*"` for list elements) this decision follows
+- [host-document-bridge](host-document-bridge.md) — The second axis that selects servers through the same `languages` list
+
+## Implementation Status
+
+Implemented. `LANGUAGES_WILDCARD` and the `BridgeServerConfig::handles_language`
+predicate live in `src/config/settings.rs`; the three selection sites that
+consume it (injection single-pick, injection fan-out, host fan-out) are in
+`src/lsp/bridge/coordinator.rs`.
+
+## Context
+
+`languageServers.<name>.languages` is an enumeration of the languages a
+downstream server answers for. Selection is plain membership: a server is a
+bridge candidate for an injected region when its `languages` contains that
+region's language.
+
+Enumeration fits servers that *are* a language's server — `rust-analyzer` for
+rust, `pyright` for python. It does not fit the cross-cutting ones, which
+language-server-bridge already anticipated as a motivating case: grammar and
+spell checkers (`harper-ls`), typo linters (`typos-lsp`), AI completion. These
+have no finite language list. Enumerating "every language I might ever open" is
+both unwritable in advance and wrong the moment a new injection language
+appears in a document.
+
+The obvious spellings for "any" are already taken:
+
+- **`languages = []`** — `merge_bridge_server_configs`
+  (`src/config/merge.rs`) treats an empty overlay list as "inherit `languages`
+  from the `_` entry" (wildcard-config-inheritance).
+- **`languages` omitted / `null`** — `#[serde(default)]` on `Vec<String>`
+  produces the same empty vec, so it lands on the identical inherit path. TOML
+  has no `null` regardless.
+
+Both therefore mean *defer*. A concrete server has no way to **widen** past an
+inherited narrow list — only to accept it. That is precisely the gap a
+language-agnostic server needs to fill.
+
+## Decision Drivers
+
+- **Widening must be expressible.** The empty/absent spellings can only defer;
+  something must be able to say "more than what I inherited".
+- **Sigil discipline** (aggregation-priorities-wildcard): `_` is for wildcard
+  *keys* carrying field-level inheritance. A list *element* meaning
+  "everything" carries no inheritance and must not reuse that sigil.
+- **Open set.** Injected languages are discovered from documents at runtime;
+  "every language" cannot be enumerated statically at config-merge time.
+- **Room to grow.** Whatever shape is chosen should not foreclose refinement
+  ("any *except* markdown").
+
+## Decision Outcome
+
+**Chosen approach**: a `"*"` element in `languages` matches every language.
+
+```toml
+[languageServers.harper-ls]
+cmd = ["harper-ls", "--stdio"]
+languages = ["*"]
+```
+
+### Resolution Rules
+
+| Configured value | Meaning |
+|---|---|
+| `["rust"]` | matches rust only |
+| `["*"]` | matches every language |
+| `["rust", "*"]` | matches every language — membership has no ordering, so the named entry is redundant, not restrictive |
+| `[]` / omitted | **inherit from `languageServers._`** (unchanged); if nothing is inherited the server matches nothing |
+
+- Resolved at **match time** (`handles_language`), not expanded during config
+  merging. "Every language" is an open set with no static enumeration.
+- Resolution order is unchanged: wildcard *inheritance* (`_`) is applied first,
+  then the resolved `languages` list is tested. `languageServers._.languages =
+  ["*"]` is therefore legal and inheritable.
+- `"*"` is unambiguous as a marker: tree-sitter language identifiers never
+  contain `*`.
+
+### Scope: What `"*"` Does Not Widen
+
+Both bridge axes select servers through this one list, so `"*"` reaches both.
+Two limits keep that from becoming a blanket opt-in:
+
+1. **It does not enable a blocked language.** `"*"` widens *which servers may
+   answer*, not *which injections a host bridges at all*. The host's
+   `languages.<host>.bridge.<lang>.enabled` filter is evaluated before server
+   selection and still applies.
+2. **It does not opt into the host-document bridge.** A `"*"` server becomes a
+   host candidate for every host language, but candidacy is not consent: the
+   host path stays gated on the explicit `bridge._self.enabled = true` opt-in
+   (host-document-bridge).
+
+Restricting `"*"` to the injection axis only was considered and rejected: both
+axes ask the same question ("does this server handle language L?") through the
+same field, and a marker that silently means "any" on one axis and "none" on
+the other is harder to document than the `_self` gate that already exists.
+
+## Consequences
+
+### Positive
+
+- **Cross-cutting servers become configurable** without enumerating a language
+  set that cannot be known in advance.
+- **Widening becomes expressible** at all, closing the defer-only gap left by
+  the inheritance semantics of the empty list.
+- **No behavior change for existing configs**: `"*"` is opt-in and was
+  previously a language name matching nothing.
+
+### Negative
+
+- **`languageServers._.languages = ["*"]` is a footgun**: it attaches every
+  server that omits `languages` to every language, silently and totally. It is
+  the same hazard any `_.languages` value carries, but the blast radius is
+  maximal. Documented with a recommendation to declare `"*"` on concrete
+  servers instead.
+- **Fan-out grows** with each `"*"` server, which now participates in every
+  injection region. Mitigated — not eliminated — by the capability prefilter,
+  which drops servers that have advertised no support for the method.
+
+### Neutral
+
+- `"*"` here means "everything" whereas the `priorities` `"*"` means "the
+  unlisted rest, at this position". On an unordered membership predicate the
+  two collapse to the same thing ("anything not named"), so the sigil stays
+  consistent even though the surrounding list semantics differ.
+
+## Alternatives Considered
+
+### A. `languages = []` means "any"
+
+**Rejected because**: already means "inherit from `_`"
+(`merge_bridge_server_configs`). Redefining it would silently convert every
+server that currently defers to the wildcard entry into an attach-to-everything
+server. Secondary: a multi-line list whose entries are all commented out
+collapses to `[]`, so the intent would be unrecoverable from the text.
+
+### B. `languages = null` / omitted means "any"
+
+**Rejected because**: `#[serde(default)]` maps it onto the same empty vec as A,
+inheriting A's problem exactly. TOML has no `null` literal, so it is not even
+spellable in the primary config format.
+
+### C. A separate boolean, e.g. `anyLanguage = true`
+
+**Rejected because**: it creates a second knob whose interaction with
+`languages` must then be defined (what does `anyLanguage = true` alongside
+`languages = ["rust"]` mean?), and it cannot grow into exclusions without a
+third. Keeping the statement inside the list keeps one field authoritative.
+
+### D. `languages = "*"` as a scalar (untagged string-or-array)
+
+**Rejected because**: two wire shapes for one field, and the scalar form is a
+dead end — `"any except markdown"` has no scalar spelling, so exclusions would
+force a return to the list anyway.
+
+### E. `languages = ["_"]`
+
+**Rejected because**: `_` is reserved for wildcard *keys* carrying field-level
+inheritance (aggregation-priorities-wildcard, alternative C). Reusing it as a
+list element would suggest inheritance where none exists.
+
+### F. Invert the axis — declare it as `languages._.bridge.<server>.enabled = true`
+
+Express "this server applies everywhere" from the language side, reusing the
+`languages._` wildcard that already exists.
+
+**Rejected because**: it does not actually work without a code change. The
+`bridge` map gates *whether a language is bridged*; the server must still pass
+the `languages` membership filter to be selected at all, so an inverted opt-in
+would need the same predicate change plus a second mechanism to reconcile. Given
+a code change either way, the server-side marker is the smaller one and keeps
+"which languages does this server handle" answerable from the server's own
+entry.
+
+### G. Full glob matching (`languages = ["ts*"]`)
+
+**Rejected as premature**: a strict superset of `["*"]` with no current
+requirement behind it. `["*"]` is forward-compatible with adding globs later,
+so nothing is foreclosed.

--- a/docs/architecture-decisions/any-language-server-wildcard.md
+++ b/docs/architecture-decisions/any-language-server-wildcard.md
@@ -9,9 +9,10 @@
 ## Implementation Status
 
 Implemented. `LANGUAGES_WILDCARD` and the `BridgeServerConfig::handles_language`
-predicate live in `src/config/settings.rs`; the three selection sites that
-consume it (injection single-pick, injection fan-out, host fan-out) are in
-`src/lsp/bridge/coordinator.rs`.
+predicate live in `src/config/settings.rs`, alongside `names_language` (exact
+membership, ignoring the wildcard) for the one site that must rank the two
+apart. The three selection sites that consume them (injection single-pick,
+injection fan-out, host fan-out) are in `src/lsp/bridge/coordinator.rs`.
 
 ## Context
 
@@ -152,16 +153,37 @@ the other is harder to document than the `_self` gate that already exists.
   hatch is `enabled = false` (which the selection sites check first, via
   `is_spawnable`). Narrowing to a real language list does work — a concrete
   non-empty `languages` overrides the wildcard.
-- **Fan-out grows** with each `"*"` server, which now participates in every
-  injection region — including languages the user never intended it for. The
-  *process* count does not grow with languages: the connection pool is keyed by
-  `(server, resolved root)` with no language component, so one `"*"` server is
-  one process per root. What scales is per-region work — the server receives a
-  virtual `didOpen` for every region it is a candidate for and joins every
-  region's fan-out. The capability prefilter blunts the steady-state request
-  cost by dropping servers that advertised no support for the method, but only
-  once the server is `Ready`; the first request in any language still pays the
-  spawn and initialize.
+- **Cost scales with injection *regions*, not with languages — and that is a
+  much bigger number than it sounds.** The process count does not grow at all:
+  the connection pool is keyed by `(server, resolved root)` with no language
+  component, so one `"*"` server is one process per root. What grows is
+  per-region work — a virtual `didOpen` per region, a task and a downstream
+  request per region on whole-document methods, a context per region per
+  diagnostics cycle.
+
+  The worst case is the wildcard's own headline use case. The shipped markdown
+  injection query emits a `markdown_inline` region for *every* inline node and
+  every table cell, so a prose document produces regions on the order of
+  hundreds. Before this change nothing matched `markdown_inline` and every
+  consumer dropped those regions at an `is_empty()` check; a `"*"` grammar
+  checker matches all of them. Nothing bounds this: `maxFanOut` caps servers
+  per region, not regions, and the capability prefilter cannot help for methods
+  the server *does* advertise (diagnostics, hover, codeAction — exactly the
+  ones such a server exists to answer). The prefilter also only acts once the
+  server is `Ready`, so the first request in any language still pays the spawn
+  and initialize.
+
+  The mitigation is the per-host bridge filter, which is evaluated before
+  server selection: disable the injection languages the wildcard server should
+  not see, e.g. `languages.markdown.bridge.markdown_inline.enabled = false`.
+- **Results can duplicate rather than merely multiply.** Diagnostics and
+  codeAction default to `concatenated` and neither path dedups by span. Two
+  shapes follow: same-span alternate-language regions each contribute
+  (a `"*"` server is a candidate for every alternate), and — when combined with
+  `bridge._self.enabled = true` — one process holds both the host document and
+  its virtual regions, so a finding inside an injected region is reported once
+  by the host answer and once by the region answer, at the same host
+  coordinates.
 - **A `"*"` server joins first-win races it would previously have sat out.**
   Under the default `priorities = ["*"]` every matching server lands in one
   `Rest` group, and the default `preferred` strategy decides that group by
@@ -170,14 +192,14 @@ the other is harder to document than the `_self` gate that already exists.
   nondeterministically. Users who care about the ordering must name servers
   explicitly in `priorities` — which, per the `priorities` scope note above,
   then also excludes the `"*"` server unless `"*"` is in that list too.
-- **The single-pick site becomes order-dependent for every language.**
-  `get_config_for_language` returns the first match while iterating a
-  `HashMap`, so its pick is not deterministic when several servers match. That
-  was previously reachable only with a genuinely overlapping config (ruff +
-  pyright for python); a `"*"` server makes *every* language have at least two
-  candidates. The site is used for eager virtual-document opening, so the
-  consequence is which server gets warmed up first, not which answers — request
-  paths use the full candidate set.
+- **The single-pick site needed a tie-break.** `get_config_for_language` picks
+  one server to drive the eager virtual-document open. It previously returned
+  the first `HashMap` match, which a `"*"` server would win about half the time
+  for *every* language, starving the language's real server of its warm start.
+  It now walks sorted and ranks a server that names the language above one that
+  only accepts everything (`names_language` vs `handles_language`), falling
+  back to the wildcard when nothing names the language. That also settles the
+  pre-existing pyright/ruff coin flip.
 
 ### Neutral
 

--- a/docs/architecture-decisions/any-language-server-wildcard.md
+++ b/docs/architecture-decisions/any-language-server-wildcard.md
@@ -227,11 +227,16 @@ server that currently defers to the wildcard entry into an attach-to-everything
 server. Secondary: a multi-line list whose entries are all commented out
 collapses to `[]`, so the intent would be unrecoverable from the text.
 
-### B. `languages = null` / omitted means "any"
+### B. `languages` omitted means "any"
 
-**Rejected because**: `#[serde(default)]` maps it onto the same empty vec as A,
-inheriting A's problem exactly. TOML has no `null` literal, so it is not even
-spellable in the primary config format.
+**Rejected because**: `#[serde(default)]` maps omission onto the same empty vec
+as A, inheriting A's problem exactly.
+
+`null` is not a separable variant of this: TOML has no `null` literal, and an
+explicit JSON `null` from `initializationOptions` is a deserialization *error*
+for a bare `Vec<String>` — `serde(default)` covers a missing field, not a null
+one. So it could only mean "any" by first adding null handling that does not
+exist, which is strictly more work than A for the same outcome.
 
 ### C. A separate boolean, e.g. `anyLanguage = true`
 

--- a/docs/architecture-decisions/any-language-server-wildcard.md
+++ b/docs/architecture-decisions/any-language-server-wildcard.md
@@ -73,7 +73,15 @@ languages = ["*"]
 | `["rust"]` | matches rust only |
 | `["*"]` | matches every language |
 | `["rust", "*"]` | matches every language — membership has no ordering, so the named entry is redundant, not restrictive |
-| `[]` / omitted | **inherit from `languageServers._`** (unchanged); if nothing is inherited the server matches nothing |
+| `[]` / omitted | **not specified at this layer** (unchanged) — see below |
+
+An empty or omitted `languages` is more precisely "absent at this layer" than
+"inherit from `_`". Config layers (defaults < user < project <
+`initializationOptions`) collapse *before* the `_` entry is resolved, and the
+same emptiness rule drives both steps — so `checker.languages = []` in a
+project config first takes the user config's `checker.languages`, and only
+falls through to `languageServers._` when no layer specified it. A lower
+layer's concrete list therefore beats a higher layer's `_` wildcard.
 
 - Resolved at **match time** (`handles_language`), not expanded during config
   merging. "Every language" is an open set with no static enumeration.
@@ -85,8 +93,11 @@ languages = ["*"]
   language ids are taken verbatim from `#set! injection.language` properties and
   from `@injection.language` capture *text*, and canonicalization falls through
   to the raw identifier, so a hand-authored query or a `` ```* `` fence can
-  produce the literal id `*`. The consequence is benign: such a region is
-  matched by exactly the servers that already accept every language.
+  produce the literal id `*`. Reserving the element is therefore not quite a
+  no-op for existing configs: a server that declared `languages = ["*"]` to
+  serve *only* such a pseudo-language now serves every language instead. No
+  real configuration is believed to do this — it needs a hand-authored query
+  emitting `*` — but the reservation is a semantic change, not purely additive.
 
 ### Scope: `priorities` Still Excludes an Unlisted Server
 
@@ -107,6 +118,34 @@ priorities = ["pyright", "ruff"]
 
 The default (absent `priorities` ≡ `["*"]`) includes it everywhere, so this
 only bites configs that have already opted into explicit priority lists.
+
+**This exclusion covers requests kakehashi dispatches, not unsolicited pushes.**
+A server excluded by `priorities` is still a *candidate* — `handles_language`
+put it in the set — so the eager open still opens the region on it, and
+`record_region_push` accepts what it publishes after checking only that the
+server is still spawnable. A push-driven server therefore keeps reaching the
+editor for a language whose `priorities` omit it. That gate predates this
+decision (it bites an excluded pyright/ruff pair the same way), but the
+wildcard makes it far easier to hit, since a `"*"` server is a candidate for
+every language by construction. Tracked separately; the reliable exclusion for
+a push-driven server today is `enabled = false`, which the selection sites
+check first.
+
+### Scope: Turning a Language Off at Runtime Does Not Retract It
+
+Disabling a bridged language while a document is open
+(`languages.<host>.bridge.<lang>.enabled = false` via
+`workspace/didChangeConfiguration`) stops *new* selections but does not retract
+regions already open downstream. `close_replaced_docs` closes a virtual
+document when its region changes language, not when its server stops being a
+candidate, and a host-filter edit does not touch any server's launch config, so
+nothing recycles the connection either — a `same_launch_config` mismatch would.
+The server keeps receiving `didChange` for those regions, and keeps publishing,
+until the host document closes or the connection restarts.
+
+Also pre-existing, also amplified for the same reason: with `"*"` there is
+always a server holding the region. Changing the server's own `languages` *does*
+reconcile, because that is part of the launch config.
 
 ### Scope: What `"*"` Does Not Widen
 
@@ -135,9 +174,9 @@ the other is harder to document than the `_self` gate that already exists.
   set that cannot be known in advance.
 - **Widening becomes expressible** at all, closing the defer-only gap left by
   the inheritance semantics of the empty list.
-- **No behavior change for existing configs**: `"*"` is opt-in, and no existing
-  config could have used it meaningfully — it was a language name matching
-  nothing.
+- **Effectively no behavior change for existing configs**: `"*"` is opt-in, and
+  it previously named a language that only a hand-authored injection query
+  could produce (see the reservation caveat above).
 
 ### Negative
 

--- a/docs/architecture-decisions/any-language-server-wildcard.md
+++ b/docs/architecture-decisions/any-language-server-wildcard.md
@@ -188,10 +188,11 @@ the other is harder to document than the `_self` gate that already exists.
   resolved at match time, so a `_` wildcard in the user config also widens
   servers declared in a project's config. Documented with a recommendation to
   declare `"*"` on concrete servers instead.
-- **Opting a single server back out is not spellable in `languages`.** Under a
-  `_` wildcard, `[]` means "inherit" and resolves back to `["*"]`; the escape
-  hatch is `enabled = false` (which the selection sites check first, via
-  `is_spawnable`). Narrowing to a real language list does work — a concrete
+- **Opting a single server back out is not spellable in `languages`.** `[]`
+  means "not specified here", so it lands on the same server's list from a
+  lower config layer, or on the `_` wildcard when no layer supplied one —
+  either way not "nothing". The escape hatch is `enabled = false` (which the
+  selection sites check first, via `is_spawnable`). Narrowing to a real language list does work — a concrete
   non-empty `languages` overrides the wildcard.
 - **Cost scales with injection *regions*, not with languages — and that is a
   much bigger number than it sounds.** The process count does not grow at all:
@@ -262,9 +263,10 @@ the other is harder to document than the `_self` gate that already exists.
 
 ### A. `languages = []` means "any"
 
-**Rejected because**: already means "inherit from `_`"
-(`merge_bridge_server_configs`). Redefining it would silently convert every
-server that currently defers to the wildcard entry into an attach-to-everything
+**Rejected because**: already means "not specified at this layer"
+(`merge_bridge_server_configs`), which resolves to a lower layer's list for the
+same server, or to the `_` entry. Redefining it would silently convert every
+server that currently defers — to either source — into an attach-to-everything
 server. Secondary: a multi-line list whose entries are all commented out
 collapses to `[]`, so the intent would be unrecoverable from the text.
 

--- a/docs/architecture-decisions/any-language-server-wildcard.md
+++ b/docs/architecture-decisions/any-language-server-wildcard.md
@@ -156,7 +156,8 @@ the other is harder to document than the `_self` gate that already exists.
 - **Cost scales with injection *regions*, not with languages — and that is a
   much bigger number than it sounds.** The process count does not grow at all:
   the connection pool is keyed by `(server, resolved root)` with no language
-  component, so one `"*"` server is one process per root. What grows is
+  component, so one `"*"` server is one process per root — fewer still under
+  `preferSharedInstance`, which collapses the roots as well. What grows is
   per-region work — a virtual `didOpen` per region, a task and a downstream
   request per region on whole-document methods, a context per region per
   diagnostics cycle.

--- a/docs/architecture-decisions/any-language-server-wildcard.md
+++ b/docs/architecture-decisions/any-language-server-wildcard.md
@@ -204,6 +204,12 @@ the other is harder to document than the `_self` gate that already exists.
   now fans out to every matching server, like every other selection site, and
   the single-pick resolver is gone.
 
+  This is a behavior change for existing non-wildcard configs too: two servers
+  on one language now both spawn and open at `didOpen` where one did before.
+  Note it does *not* multiply the region worst case above — nothing but the
+  `"*"` server matches `markdown_inline`, so the multiplication lands only on
+  languages that already have a real server, where the server count is small.
+
 ### Neutral
 
 - `"*"` here means "everything" whereas the `priorities` `"*"` means "the

--- a/docs/architecture-decisions/any-language-server-wildcard.md
+++ b/docs/architecture-decisions/any-language-server-wildcard.md
@@ -32,8 +32,9 @@ appears in a document.
 The obvious spellings for "any" are already taken:
 
 - **`languages = []`** — `merge_bridge_server_configs`
-  (`src/config/merge.rs`) treats an empty overlay list as "inherit `languages`
-  from the `_` entry" (wildcard-config-inheritance).
+  (`src/config/merge.rs`) treats an empty overlay list as "not specified here",
+  which resolves to the same server's entry in a lower config layer, or failing
+  that to the `_` entry (wildcard-config-inheritance).
 - **`languages` omitted** — `#[serde(default)]` on `Vec<String>` produces that
   same empty vec, so it lands on the identical inherit path. (`null` is not a
   third spelling: TOML has no `null`, and an explicit JSON `null` from

--- a/docs/architecture-decisions/any-language-server-wildcard.md
+++ b/docs/architecture-decisions/any-language-server-wildcard.md
@@ -175,9 +175,12 @@ the other is harder to document than the `_self` gate that already exists.
   set that cannot be known in advance.
 - **Widening becomes expressible** at all, closing the defer-only gap left by
   the inheritance semantics of the empty list.
-- **Effectively no behavior change for existing configs**: `"*"` is opt-in, and
-  it previously named a language that only a hand-authored injection query
-  could produce (see the reservation caveat above).
+- **Language-matching semantics are unchanged for existing configs**: `"*"` is
+  opt-in, and it previously named a language that only a hand-authored
+  injection query could produce (see the reservation caveat above). This is a
+  narrower claim than "no behavior change" — the eager-open fan-out below *is*
+  observable for any config with several servers on one language, wildcard or
+  not.
 
 ### Negative
 

--- a/docs/architecture-decisions/any-language-server-wildcard.md
+++ b/docs/architecture-decisions/any-language-server-wildcard.md
@@ -118,8 +118,13 @@ the other is harder to document than the `_self` gate that already exists.
   maximal. Documented with a recommendation to declare `"*"` on concrete
   servers instead.
 - **Fan-out grows** with each `"*"` server, which now participates in every
-  injection region. Mitigated — not eliminated — by the capability prefilter,
-  which drops servers that have advertised no support for the method.
+  injection region — including languages the user never intended it for. The
+  capability prefilter blunts the *steady-state* cost by dropping servers that
+  have advertised no support for the requested method, but it can only do so
+  once the server is `Ready`: a `"*"` server is still spawned and initialized
+  for every injection language it is a candidate for. Cost is therefore
+  proportional to the number of distinct injection languages opened, and the
+  wildcard should be spent on servers that genuinely answer for all of them.
 
 ### Neutral
 

--- a/docs/architecture-decisions/any-language-server-wildcard.md
+++ b/docs/architecture-decisions/any-language-server-wildcard.md
@@ -127,9 +127,9 @@ server is still spawnable. A push-driven server therefore keeps reaching the
 editor for a language whose `priorities` omit it. That gate predates this
 decision (it bites an excluded pyright/ruff pair the same way), but the
 wildcard makes it far easier to hit, since a `"*"` server is a candidate for
-every language by construction. Tracked separately; the reliable exclusion for
-a push-driven server today is `enabled = false`, which the selection sites
-check first.
+every language by construction. Tracked as #916; the reliable exclusion for a
+push-driven server today is `enabled = false`, which the selection sites check
+first.
 
 ### Scope: Turning a Language Off at Runtime Does Not Retract It
 
@@ -145,7 +145,7 @@ until the host document closes or the connection restarts.
 
 Also pre-existing, also amplified for the same reason: with `"*"` there is
 always a server holding the region. Changing the server's own `languages` *does*
-reconcile, because that is part of the launch config.
+reconcile, because that is part of the launch config. Tracked as #917.
 
 ### Scope: What `"*"` Does Not Widen
 

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -14,11 +14,11 @@ Partially implemented:
 
 - **Schema & gate**: the `_self` reserved key is live. Opt-in is the explicit
   `bridge._self.enabled = true` (`LanguageSettings::is_host_bridging_enabled`);
-  the built-in `_self.enabled = false` default is implemented as an
-  explicit-only rule — the `_` wildcard's `enabled = true` deliberately does
-  not leak into `_self` (equivalent to the Wildcard Merge Safety reasoning
-  below, without materializing built-in default entries). Aggregation fields
-  DO wildcard-merge (`resolve_host_aggregation`).
+  `enabled` is read with a direct `get(_self)` defaulting to `false`, so the
+  `_` wildcard's `enabled = true` (the virt default) cannot leak into `_self`
+  and the shipped defaults declare no `_self` entry at all. Aggregation fields
+  DO wildcard-merge (`resolve_host_aggregation`). See Wildcard Merge Safety
+  below for why the apparent inconsistency must stay.
 - **Dispatch**: implemented for every bridged request method. Because the
   host path needs no URI synthesis or coordinate translation, all methods
   share one generic forwarder
@@ -115,21 +115,24 @@ Design challenges:
 ## Decision Drivers
 
 - **Minimal schema disruption**: no new types in `BridgeServerConfig`, `BridgeLanguageConfig`, or `AggregationConfig`.
-- **Reuse wildcard machinery**: wildcard-config-inheritance's `resolve_with_wildcard` should apply uniformly across host and virt entries.
+- **Reuse wildcard machinery**: wildcard-config-inheritance's `resolve_with_wildcard` should apply to host entries wherever it can, so host bridging needs as little bespoke resolver logic as possible.
 - **Capability vs. policy separation**: `languageServers.*` declares *what* an LS can do; `languages.*.bridge.*` decides *whether and how* it is used.
 - **Opt-in for new behavior**: host bridging defaults *off* so existing configs are unchanged.
 - **Symmetric mental model**: host and virt are both "bridges" — only the LS-matching rule differs.
 
 ## Decision Outcome
 
-**Chosen approach**: Reserve `_self` as a special key in the `bridge` map. It represents the host language acting as its own bridge target. `BridgeLanguageConfig` is reused unchanged. Defaults are declared explicitly at `languages._.bridge._self` (enabled = false) and `languages._.bridge._` (enabled = true), so the existing wildcard merge naturally yields the right answers without special-case resolver logic.
+**Chosen approach**: Reserve `_self` as a special key in the `bridge` map. It represents the host language acting as its own bridge target. `BridgeLanguageConfig` is reused unchanged.
+
+Aggregation fields under `_self` resolve through the ordinary wildcard merge (`resolve_host_aggregation`). The `enabled` field does **not** — it is read with a direct `get(_self)` and defaults to `false`, so absence is the off state and the shipped defaults declare no `_self` key at all.
 
 ### Schema
 
 ```toml
 # ---- Built-in defaults (declared in code; not user-facing) ----
-[languages._.bridge._self]
-enabled = false              # Host bridging is opt-in.
+# There is deliberately NO [languages._.bridge._self] entry: host bridging is
+# opt-in, and `is_host_bridging_enabled` reads `_self.enabled` directly, so
+# absence already means off.
 
 [languages._.bridge._]
 enabled = true               # Virt bridging stays default-on (wildcard-config-inheritance).
@@ -187,34 +190,24 @@ No new fields on `BridgeServerConfig`. An LS that should not act as host for a g
 
 ### Wildcard Merge Safety
 
-Concern: under wildcard-config-inheritance, `resolve_with_wildcard(map, "_self", merge)` merges the `_` wildcard into the `_self` entry. If `_.enabled = true` and `_self.enabled` were absent, the wildcard would silently turn host bridging on.
+Concern: under wildcard-config-inheritance, `resolve_with_wildcard(map, "_self", merge)` merges the `_` wildcard into the `_self` entry. The shipped `_.enabled = true` is the *virt* default; if it reached `_self`, the wildcard would silently turn host bridging on for every language.
 
-Resolution: built-in defaults at `languages._.bridge._self.enabled = false` and `languages._.bridge._.enabled = true` mean that after the *outer* wildcard merge (language layer), every `bridge` map sees `_self` populated with `Some(false)`. During the *inner* wildcard merge (`_self ⊕ _`), key-specific fields win — `_self.enabled = Some(false)` beats `_.enabled = Some(true)`. No special case is needed.
-
-Trace for an unconfigured language `lua`:
+Resolution: `enabled` is exempted from that merge. `is_host_bridging_enabled` reads `bridge._self.enabled` with a **direct** `get(HOST_BRIDGE_KEY)` and `unwrap_or(false)`; there is no `_self` entry in the built-in defaults for `_` to merge into, and none is wanted.
 
 ```
-1. Outer merge:  languages.lua ⊕ languages._
-                 → lua.bridge = {_self: {enabled: false}, _: {enabled: true}}
-2. Inner merge for bridge._self:
-                 _self.enabled = Some(false)  ⊕  _.enabled = Some(true)
-                 → Some(false) wins  ✓ host bridging stays off
-3. Inner merge for bridge._:
-                 _.enabled = Some(true)
-                 → Some(true)         ✓ virt bridging stays on
+Unconfigured language `lua`:
+    lua.bridge = {_: {enabled: true}}          # after the language-layer merge
+    is_host_bridging_enabled → get("_self") = None → false   ✓ host off
+    is_language_bridgeable("python") → resolves via `_` → true  ✓ virt on
+
+User opts markdown in — languages.markdown.bridge._self.enabled = true:
+    markdown.bridge = {_self: {enabled: true}, _: {enabled: true}}
+    is_host_bridging_enabled → get("_self").enabled = Some(true) → true  ✓ host on
 ```
 
-Trace when user opts markdown in:
+**Do not "simplify" this to `resolve_with_wildcard`.** It looks like an inconsistency worth removing, and removing it enables host bridging globally — including for every `languages = ["*"]` server (any-language-server-wildcard), since the host axis selects servers through the same `languages` list. Two tests hold the line: `host_bridging_not_enabled_by_bridge_wildcard` (the `_` wildcard must not leak in) and `default_settings_has_wildcard_language_with_bridge_defaults` (the defaults must not grow a `_self` key).
 
-```
-User: languages.markdown.bridge._self.enabled = true
-1. Outer merge: markdown.bridge = {_self: {enabled: true}, _: {enabled: true (default)}}
-2. Inner merge for bridge._self:
-                _self.enabled = Some(true) ⊕ _.enabled = Some(true)
-                → Some(true)               ✓ host bridging on
-```
-
-The same reasoning extends to any future `_self`-meaningful field: as long as the field carries an explicit default at `languages._.bridge._self`, the wildcard merge is safe without resolver changes.
+Any *future* `_self`-meaningful field has the same choice to make: inherit from `_` like the aggregation fields, or be read directly like `enabled`. Fields whose virt default would be wrong for the host role belong in the second group.
 
 ### URI and Coordinate Handling
 
@@ -246,8 +239,8 @@ Practical consequences:
 ### Positive
 
 - **Zero new types**: `BridgeServerConfig`, `BridgeLanguageConfig`, `AggregationConfig` all unchanged.
-- **Reuses wildcard machinery**: wildcard-config-inheritance's `resolve_with_wildcard` applies uniformly, no host-specific resolver path.
-- **Backward compatible**: `_self.enabled = false` default keeps existing configs inert.
+- **Reuses wildcard machinery**: wildcard-config-inheritance's `resolve_with_wildcard` covers the aggregation fields; only `enabled` needs a direct read.
+- **Backward compatible**: an absent `_self` reads as disabled, so existing configs are inert.
 - **Granular control**: host bridging is per-host-language; aggregation/priorities are per-method.
 - **Symmetric mental model**: virt and host live in the same `bridge` map, with the only operational difference being LS-match key (injection language vs. host language).
 - **LS catalog stays capability-pure**: no host/virt role flags on `BridgeServerConfig`; one LS entry naturally serves both roles when its `languages` field matches.

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -47,9 +47,11 @@ Partially implemented:
   document state is briefly speculative (it sees the virt-applied text);
   the lazy fingerprint sync restores the editor text on the next request.
 - **Document sync deviation**: instead of forwarding `didChange` params
-  verbatim, sync is *lazy*: `didOpen` with the full host text fires on the
-  first request per `(uri, server)`, and a **full-text** `didChange` fires
-  when the host text's fingerprint changed since the last request. This
+  verbatim, sync sends **full-text** `didChange` with downstream-generated
+  versions whenever the host text's fingerprint changed since the last
+  request. `didOpen` fires eagerly at upstream `didOpen` on every `_self`
+  server (#429, below) and lazily on first request for any server that
+  missed it. This
   matches the virt path's full-content `didChange` forwarding and avoids
   hooking the concurrent upstream `didChange` stream; verbatim forwarding
   remains the target if eager sync proves necessary.
@@ -118,7 +120,7 @@ Design challenges:
 - **Reuse wildcard machinery**: wildcard-config-inheritance's `resolve_with_wildcard` should apply to host entries wherever it can, so host bridging needs as little bespoke resolver logic as possible.
 - **Capability vs. policy separation**: `languageServers.*` declares *what* an LS can do; `languages.*.bridge.*` decides *whether and how* it is used.
 - **Opt-in for new behavior**: host bridging defaults *off* so existing configs are unchanged.
-- **Symmetric mental model**: host and virt are both "bridges" — only the LS-matching rule differs.
+- **Symmetric mental model**: host and virt are both "bridges", differing in the LS-matching key and in how `enabled` resolves.
 
 ## Decision Outcome
 
@@ -217,7 +219,7 @@ Host bridges use the **real URI** as sent by the client. This is the key distinc
 |---|---|---|
 | URI in `textDocument/didOpen` | `vhost://...` synthesized | client URI verbatim |
 | Document text | sub-extracted from host | client text verbatim |
-| `didChange` params | injection-range deltas synthesized | forwarded verbatim |
+| `didChange` params | injection-range deltas synthesized | synthetic full-text, downstream-generated version |
 | Response position/range fixup | required (virt → host coordinates) | identity |
 | `publishDiagnostics` URI | translated to host URI | passed through unchanged |
 
@@ -242,13 +244,13 @@ Practical consequences:
 - **Reuses wildcard machinery**: wildcard-config-inheritance's `resolve_with_wildcard` covers the aggregation fields; only `enabled` needs a direct read.
 - **Backward compatible**: an absent `_self` reads as disabled, so existing configs are inert.
 - **Granular control**: host bridging is per-host-language; aggregation/priorities are per-method.
-- **Symmetric mental model**: virt and host live in the same `bridge` map, with the only operational difference being LS-match key (injection language vs. host language).
+- **Symmetric mental model**: virt and host live in the same `bridge` map, differing operationally in the LS-match key (injection language vs. host language) and in `enabled` resolution (direct vs. wildcard-merged).
 - **LS catalog stays capability-pure**: no host/virt role flags on `BridgeServerConfig`; one LS entry naturally serves both roles when its `languages` field matches.
 - **Real URI for host simplifies coordinate logic**: existing virt position-mapping code remains virt-only and untouched.
 
 ### Negative
 
-- **Two-line opt-in**: users must write both `bridge._self.enabled = true` and per-method `aggregation.<method>.priorities`. Forgetting `enabled = true` produces silent no-response.
+- **Silent no-response when the flag is missed**: `bridge._self.enabled = true` is the whole opt-in — absent `priorities` resolve to `["*"]` (aggregation-priorities-wildcard), so no per-method config is required once a matching server exists. But forgetting `enabled = true` produces no response and no error.
 - **Reserved key cost**: a hypothetical user language literally named `_self` cannot be addressed via `bridge.<lang>`. Acceptable; `_` is already reserved on the same axis, and `_`-prefix names are conventionally reserved.
 
 ### Neutral
@@ -290,7 +292,7 @@ priorities = ["pyright"]
 
 **Rejected because**:
 - Introduces a parallel field with semantically identical structure to `bridge.<key>`. Two resolvers, two wildcard rules, two `enabled` flags to keep in sync — for no expressive gain.
-- Loses the symmetry that host and virt are both "bridges" — only the LS-matching rule differs.
+- Loses the symmetry that host and virt are both "bridges" living in one map.
 
 ### C. Top-level `aggregation` field on `LanguageSettings`
 
@@ -308,7 +310,7 @@ priorities = ["pyright"]
 - Splits bridge configuration into two non-uniform shapes: `bridge.<inj>.aggregation` (nested) vs. `aggregation` (flat). Resolvers diverge.
 - `LanguageSettings.aggregation` requires its own `resolve_aggregation` method, duplicating logic on `BridgeLanguageConfig`.
 - **Less extensibility**: the value type is `AggregationConfig`, so host inherits only fields defined on `AggregationConfig`. Fields on `BridgeLanguageConfig` itself — most notably `enabled` — have no host counterpart, forcing either an ad-hoc parallel field on `LanguageSettings` (e.g., `host_enabled`) or coverage gaps. Any future `BridgeLanguageConfig` field reopens the same asymmetry.
-- Subsumed by treating "host" as just another bridge target (one map, one resolver) per the decision in this decision.
+- Subsumed by treating "host" as just another bridge target in the same `bridge` map per the decision above.
 
 ### D. Role flags on `BridgeServerConfig`
 

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -163,10 +163,12 @@ languages = ["python"]
 | Key | Meaning | Field-level wildcard fallback |
 |---|---|---|
 | `_` | "any injection target" (virt default) | n/a — `_` is itself the wildcard |
-| `_self` | "host language itself" (host target) | falls back into `_` during normal merge, but explicit `languages._.bridge._self` defaults keep `enabled` / role-relevant fields key-specific |
+| `_self` | "host language itself" (host target) | aggregation fields fall back into `_` during normal merge; `enabled` does not — it is read directly, so absence means off |
 | `<language>` | "specific injection target" (virt) | inherits from `_` |
 
-The `_self` ⊕ `_` merge is *not* special-cased in the resolver. It works correctly because, after language-level wildcard merge, `bridge._self.enabled` is always `Some(false)` (from the built-in default), and wildcard-config-inheritance's key-specific-wins rule ensures it overrides the virt default of `Some(true)` when both are present in the same `bridge` map. See "Wildcard Merge Safety" below.
+The opt-in is enforced by `is_host_bridging_enabled`, which reads `bridge._self.enabled` with a **direct** `get(HOST_BRIDGE_KEY)` and no wildcard fallback, defaulting to `false`. The shipped defaults deliberately contain **no** `_self` key at all, so absence is the off state.
+
+This is worth stating precisely because the obvious refactor is wrong: routing this lookup through `resolve_with_wildcard`, like the aggregation fields legitimately are (`resolve_host_aggregation`), would let the shipped `bridge._.enabled = true` virt default flow into `_self` and turn host bridging on for every language — and, since the host axis selects servers through the same `languages` list, for every `languages = ["*"]` server too (any-language-server-wildcard). `default_settings_has_wildcard_language_with_bridge_defaults` asserts the absence so a defaults change fails loudly.
 
 ### LS Dispatch Rules
 

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -172,12 +172,16 @@ The `_self` ⊕ `_` merge is *not* special-cased in the resolver. It works corre
 
 Whether an LS is a candidate for a given request depends entirely on the `languages` field on its `BridgeServerConfig`:
 
-- **Virt path** (`bridge.<inj>` route): select LSes where `languages` contains `<inj>` (the injection language).
-- **Host path** (`bridge._self` route): select LSes where `languages` contains `<host>` (the host language of the document).
+- **Virt path** (`bridge.<inj>` route): select LSes whose `languages` matches `<inj>` (the injection language).
+- **Host path** (`bridge._self` route): select LSes whose `languages` matches `<host>` (the host language of the document).
+
+Matching is list membership, except that the element `"*"` matches every
+language (any-language-server-wildcard) — so a `"*"` LS is a candidate on both
+paths for every language.
 
 The same LS naturally serves both roles when applicable. `pyright` with `languages = ["python"]` is a host candidate for `.py` files *and* a virt candidate for Python injections inside other host languages — both routes flow through one connection (one entry in the pool keyed by its `ConnectionKey`, i.e. `(server_name, resolved root)`).
 
-No new fields on `BridgeServerConfig`. An LS that should not act as host for a given language is excluded by leaving `bridge._self.enabled = false` for that language, or by not listing the language in its `languages` field.
+No new fields on `BridgeServerConfig`. An LS that should not act as host for a given language is excluded by leaving `bridge._self.enabled = false` for that language, or by not listing the language in its `languages` field — the latter being unavailable for a `"*"` LS (any-language-server-wildcard), which only the `_self` gate can exclude.
 
 ### Wildcard Merge Safety
 

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -196,7 +196,7 @@ Concern: under wildcard-config-inheritance, `resolve_with_wildcard(map, "_self",
 
 Resolution: `enabled` is exempted from that merge. `is_host_bridging_enabled` reads `bridge._self.enabled` with a **direct** `get(HOST_BRIDGE_KEY)` and `unwrap_or(false)`; there is no `_self` entry in the built-in defaults for `_` to merge into, and none is wanted.
 
-```
+```text
 Unconfigured language `lua`:
     lua.bridge = {_: {enabled: true}}          # after the language-layer merge
     is_host_bridging_enabled → get("_self") = None → false   ✓ host off

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -48,8 +48,8 @@ Partially implemented:
   the lazy fingerprint sync restores the editor text on the next request.
 - **Document sync deviation**: instead of forwarding `didChange` params
   verbatim, sync sends **full-text** `didChange` with downstream-generated
-  versions whenever the host text's fingerprint changed since the last
-  request. `didOpen` fires eagerly at upstream `didOpen` on every `_self`
+  versions whenever the host text's fingerprint changed since the last sync
+  (which may have been an eager one rather than a request). `didOpen` fires eagerly at upstream `didOpen` on every `_self`
   server (#429, below) and lazily on first request for any server that
   missed it. This
   matches the virt path's full-content `didChange` forwarding and avoids

--- a/docs/architecture-decisions/language-server-bridge.md
+++ b/docs/architecture-decisions/language-server-bridge.md
@@ -179,7 +179,7 @@ The bridge requires knowing which server to use for each language. Language serv
 |-------|----------|-------------|
 | `languageServers` | Yes | Server configurations keyed by server name (at root level) |
 | `languageServers.*.cmd` | Yes | Command array: first element is program, rest are arguments |
-| `languageServers.*.languages` | Yes | Languages this server handles. The element `"*"` matches every language, for servers not tied to one — see [any-language-server-wildcard](any-language-server-wildcard.md). An empty or omitted list is *not* "any": it inherits from the `_` entry ([wildcard-config-inheritance](wildcard-config-inheritance.md)) |
+| `languageServers.*.languages` | No (inherits from `_`) | Languages this server handles. The element `"*"` matches every language, for servers not tied to one (any-language-server-wildcard). An empty or omitted list is *not* "any": it inherits from the `_` entry (wildcard-config-inheritance) |
 | `languageServers.*.initializationOptions` | No | Passed to server's `initialize` request |
 | `languageServers.*.onTypeFormattingTriggers` | No | Trigger characters for bridged `textDocument/onTypeFormatting`; the sorted union is advertised at initialize, and requests are forwarded only when the downstream also declares the typed character (#354) |
 | `languageServers.*.enabled` | No | Whether this server is eligible to spawn/use at all. Default `true`; inheritable via the `_` wildcard, so `_.enabled: false` disables every server by default while individual servers opt back in with `enabled: true` |
@@ -245,7 +245,7 @@ This enables complementary servers: `pyright` for type checking, `ruff` for lint
 | **Example** | Parser paths, query sources, `bridge` filter | `typos-lsp` for markdown + asciidoc |
 
 This separation allows:
-- **Cross-cutting servers**: `typos-lsp` provides diagnostics for multiple languages — or for *any* language via `languages = ["*"]` ([any-language-server-wildcard](any-language-server-wildcard.md))
+- **Cross-cutting servers**: `typos-lsp` provides diagnostics for multiple languages — or for *any* language via `languages = ["*"]` (any-language-server-wildcard)
 - **Multiple servers per language**: `pyright` + `ruff` for Python (both in `languageServers`)
 - **Independent lifecycle**: Tree-sitter config doesn't affect server spawning
 - **Per-host filtering**: Each host language can selectively enable/disable bridging via `bridge` field
@@ -506,3 +506,4 @@ See language-server-bridge-request-strategies for per-method implementation deta
 - [language-detection-fallback-chain](language-detection-fallback-chain.md): Language detection applies to both host documents and injection regions
 - [language-server-bridge-virtual-document-model](language-server-bridge-virtual-document-model.md): How multiple injections are represented as virtual documents
 - [language-server-bridge-request-strategies](language-server-bridge-request-strategies.md): Per-method bridge strategies
+- [any-language-server-wildcard](any-language-server-wildcard.md): The `languages = ["*"]` marker for servers not tied to one language

--- a/docs/architecture-decisions/language-server-bridge.md
+++ b/docs/architecture-decisions/language-server-bridge.md
@@ -179,7 +179,7 @@ The bridge requires knowing which server to use for each language. Language serv
 |-------|----------|-------------|
 | `languageServers` | Yes | Server configurations keyed by server name (at root level) |
 | `languageServers.*.cmd` | Yes | Command array: first element is program, rest are arguments |
-| `languageServers.*.languages` | Yes | Languages this server handles |
+| `languageServers.*.languages` | Yes | Languages this server handles. The element `"*"` matches every language, for servers not tied to one — see [any-language-server-wildcard](any-language-server-wildcard.md). An empty or omitted list is *not* "any": it inherits from the `_` entry ([wildcard-config-inheritance](wildcard-config-inheritance.md)) |
 | `languageServers.*.initializationOptions` | No | Passed to server's `initialize` request |
 | `languageServers.*.onTypeFormattingTriggers` | No | Trigger characters for bridged `textDocument/onTypeFormatting`; the sorted union is advertised at initialize, and requests are forwarded only when the downstream also declares the typed character (#354) |
 | `languageServers.*.enabled` | No | Whether this server is eligible to spawn/use at all. Default `true`; inheritable via the `_` wildcard, so `_.enabled: false` disables every server by default while individual servers opt back in with `enabled: true` |
@@ -245,7 +245,7 @@ This enables complementary servers: `pyright` for type checking, `ruff` for lint
 | **Example** | Parser paths, query sources, `bridge` filter | `typos-lsp` for markdown + asciidoc |
 
 This separation allows:
-- **Cross-cutting servers**: `typos-lsp` provides diagnostics for multiple languages
+- **Cross-cutting servers**: `typos-lsp` provides diagnostics for multiple languages — or for *any* language via `languages = ["*"]` ([any-language-server-wildcard](any-language-server-wildcard.md))
 - **Multiple servers per language**: `pyright` + `ruff` for Python (both in `languageServers`)
 - **Independent lifecycle**: Tree-sitter config doesn't affect server spawning
 - **Per-host filtering**: Each host language can selectively enable/disable bridging via `bridge` field

--- a/docs/architecture-decisions/wildcard-config-inheritance.md
+++ b/docs/architecture-decisions/wildcard-config-inheritance.md
@@ -123,6 +123,21 @@ enabled = false
 # "comment" = ""  # overridden (empty string suppresses the token)
 ```
 
+### Vec fields: empty means "inherit", so it cannot mean anything else
+
+For the `Vec` fields of `languageServers` (`cmd`, `languages`),
+`merge_bridge_server_configs` treats an **empty overlay list as absent** and
+takes the base (`_`) value. That is what lets a concrete server omit `cmd` or
+`languages` and pick them up from the wildcard entry.
+
+The consequence is that a concrete server can only ever *defer* to `_` on those
+fields — it can narrow by listing fewer entries, but it has no spelling for
+"wider than what I inherited", because the widest spelling (`[]`) is the
+inherit sentinel. Where widening must be expressible, it needs a marker
+*inside* the list: see
+[any-language-server-wildcard](any-language-server-wildcard.md) for
+`languages = ["*"]`.
+
 ## Consequences
 
 ### Positive

--- a/docs/architecture-decisions/wildcard-config-inheritance.md
+++ b/docs/architecture-decisions/wildcard-config-inheritance.md
@@ -127,8 +127,14 @@ enabled = false
 
 For the **bare** `Vec` fields of `languageServers` (`cmd`, `languages`),
 `merge_bridge_server_configs` treats an **empty overlay list as absent** and
-takes the base (`_`) value. That is what lets a concrete server omit `cmd` or
+takes the base value. That is what lets a concrete server omit `cmd` or
 `languages` and pick them up from the wildcard entry.
+
+Note that "the base" is not always `_`. The same function also merges a
+same-named server across config *layers*, which happens before wildcard
+resolution — so an empty list means "not specified at this layer" and reaches
+`_` only when no layer specified one. A lower layer's concrete list beats a
+higher layer's `_` wildcard.
 
 The consequence is that a concrete server can only ever *defer* to `_` on those
 fields — it can narrow by listing fewer entries, but it has no spelling for

--- a/docs/architecture-decisions/wildcard-config-inheritance.md
+++ b/docs/architecture-decisions/wildcard-config-inheritance.md
@@ -123,9 +123,9 @@ enabled = false
 # "comment" = ""  # overridden (empty string suppresses the token)
 ```
 
-### Vec fields: empty means "inherit", so it cannot mean anything else
+### Bare `Vec` fields: empty means "inherit", so it cannot mean anything else
 
-For the `Vec` fields of `languageServers` (`cmd`, `languages`),
+For the **bare** `Vec` fields of `languageServers` (`cmd`, `languages`),
 `merge_bridge_server_configs` treats an **empty overlay list as absent** and
 takes the base (`_`) value. That is what lets a concrete server omit `cmd` or
 `languages` and pick them up from the wildcard entry.
@@ -134,9 +134,12 @@ The consequence is that a concrete server can only ever *defer* to `_` on those
 fields — it can narrow by listing fewer entries, but it has no spelling for
 "wider than what I inherited", because the widest spelling (`[]`) is the
 inherit sentinel. Where widening must be expressible, it needs a marker
-*inside* the list: see
-[any-language-server-wildcard](any-language-server-wildcard.md) for
-`languages = ["*"]`.
+*inside* the list: see any-language-server-wildcard for `languages = ["*"]`.
+
+The `Option<Vec>` fields (`workspaceMarkers`, `onTypeFormattingTriggers`) do
+**not** follow this rule — overlay wins whenever it is `Some`, so an explicit
+`[]` there is preserved and carries its own meaning ("disable the marker
+search"), while `None` is the inherit sentinel.
 
 ## Consequences
 
@@ -246,3 +249,4 @@ The existing `resolve_capture()` in `legend.rs` already implements lazy fallback
 ## Related Decisions
 
 - [configuration-merging-strategy](configuration-merging-strategy.md): Cross-layer configuration merging strategy
+- [any-language-server-wildcard](any-language-server-wildcard.md): Why widening past an inherited `languages` list needs an in-list marker

--- a/docs/architecture-decisions/wildcard-config-inheritance.md
+++ b/docs/architecture-decisions/wildcard-config-inheritance.md
@@ -136,10 +136,10 @@ resolution — so an empty list means "not specified at this layer" and reaches
 `_` only when no layer specified one. A lower layer's concrete list beats a
 higher layer's `_` wildcard.
 
-The consequence is that a concrete server can only ever *defer* to `_` on those
-fields — it can narrow by listing fewer entries, but it has no spelling for
-"wider than what I inherited", because the widest spelling (`[]`) is the
-inherit sentinel. Where widening must be expressible, it needs a marker
+The consequence is that a concrete server can only ever *defer* on those fields
+— to a lower layer's value for the same server, or to `_`. It can narrow by
+listing fewer entries, but it has no spelling for "wider than what I
+inherited", because the widest spelling (`[]`) is the defer sentinel. Where widening must be expressible, it needs a marker
 *inside* the list: see any-language-server-wildcard for `languages = ["*"]`.
 
 The `Option<Vec>` fields (`workspaceMarkers`, `onTypeFormattingTriggers`) do

--- a/docs/architecture-decisions/workspace-resolver.md
+++ b/docs/architecture-decisions/workspace-resolver.md
@@ -144,8 +144,10 @@ async-friendliness is achieved at the Rust↔Lua boundary, not inside Lua.
 
 - **Veto (`attach = false`)** is applied as a filter **after** the
   language-based server selection in `src/lsp/bridge/coordinator.rs` (the
-  `c.languages.iter().any(...)` filters). Language match first, resolver
-  refinement second.
+  `c.handles_language(...)` filters). Language match first, resolver
+  refinement second. Match through that predicate rather than testing
+  `languages` membership directly, or the refinement silently drops every
+  `languages = ["*"]` server (any-language-server-wildcard).
 - **The resolved workspace replaces the marker in the existing acquire flow**,
   not signaled separately by the resolver. It is exactly what
   `resolve_marker_and_key` / `resolve_acquire` (`pool.rs`) would otherwise

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -345,6 +345,17 @@ mod tests {
             .expect("should have bridge wildcard '_'");
         assert_eq!(bridge_wildcard.enabled, Some(true));
 
+        // No `_self` key: host bridging stays opt-in (host-document-bridge),
+        // and `is_host_bridging_enabled` reads `_self` directly without a
+        // wildcard fallback, so its absence here IS the default-off.
+        // Two coordinator tests rely on this to exercise the gate rather than
+        // short-circuit before it; adding `_self` to the defaults would make
+        // them silently vacuous, so fail loudly on this side instead.
+        assert!(
+            !bridge.contains_key(crate::config::settings::HOST_BRIDGE_KEY),
+            "shipped defaults must not enable the host bridge"
+        );
+
         // Aggregation strategies
         let agg = bridge_wildcard
             .aggregation

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -1805,10 +1805,7 @@ mod tests {
 
             if let Some(resolved_config) =
                 resolve_with_wildcard(&servers, server_name, merge_bridge_server_configs)
-                && resolved_config
-                    .languages
-                    .iter()
-                    .any(|l| l == injection_language)
+                && resolved_config.handles_language(injection_language)
             {
                 found_server = Some(resolved_config);
                 break;

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -24,15 +24,10 @@ pub(crate) const PRIORITIES_WILDCARD: &str = "*";
 ///
 /// A list element rather than an empty/absent list because both of those
 /// already mean "inherit `languages` from the `_` entry"
-/// ([`crate::config::merge::merge_bridge_server_configs`]). A concrete
-/// server can therefore only *defer* to the wildcard entry, never widen past
-/// it, which is exactly what a language-agnostic server (spell/grammar/typo
-/// checkers, AI completion) needs to say. Keeping it in the list also leaves
-/// room for set algebra (e.g. a future `"!markdown"` exclusion) that a bare
-/// scalar could not express.
-///
-/// Same sigil and same reason as [`PRIORITIES_WILDCARD`]: `_` keys carry
-/// field-level inheritance semantics, list elements do not.
+/// ([`crate::config::merge::merge_bridge_server_configs`]), so a concrete
+/// server could otherwise only *defer* to the wildcard entry, never widen
+/// past it. Same sigil, and same `_`-vs-`*` reasoning, as
+/// [`PRIORITIES_WILDCARD`].
 pub(crate) const LANGUAGES_WILDCARD: &str = "*";
 
 /// The resolved default for an absent `priorities`: `["*"]`, i.e. fan out to
@@ -378,13 +373,15 @@ pub struct BridgeServerConfig {
     /// server whose resolved cmd is still empty is skipped at lookup.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub cmd: Vec<String>,
-    /// Languages this server handles (e.g., ["rust"], ["python"]), or the
-    /// [`LANGUAGES_WILDCARD`] element `"*"` for "any language".
+    /// Languages this server handles (e.g., ["rust"], ["python"]). The element
+    /// `"*"` matches every language, for servers not tied to one.
     /// Optional for the same wildcard-defaults reason as `cmd`; a server
     /// with no languages never matches a lookup.
-    ///
-    /// Test membership through [`Self::handles_language`] rather than
-    /// comparing elements directly, so `"*"` is honored everywhere.
+    // Doc comments on this struct are user-facing: they become the `config
+    // schema` output an editor shows on hover. Keep them free of rustdoc
+    // intra-doc links and implementor notes — match through
+    // `handles_language`, never by comparing elements directly, so that `"*"`
+    // is honored everywhere.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub languages: Vec<String>,
     /// Optional initialization options to pass to the server during initialize

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1484,6 +1484,60 @@ mod tests {
     }
 
     #[test]
+    fn languages_wildcard_matches_every_language() {
+        // `["*"]` = "attach to any language" (any-language-server-wildcard).
+        // Empty is already spoken for ("inherit from `_`"), so the wildcard
+        // element is the only shape that can *widen* an inherited list.
+        let server = BridgeServerConfig {
+            cmd: vec!["harper-ls".to_string()],
+            languages: vec![LANGUAGES_WILDCARD.to_string()],
+            ..Default::default()
+        };
+
+        assert!(server.handles_language("rust"));
+        assert!(server.handles_language("python"));
+        assert!(server.handles_language("a-language-nobody-configured"));
+    }
+
+    #[test]
+    fn languages_wildcard_mixed_with_names_still_matches_every_language() {
+        // Membership has no ordering, so a named entry alongside `"*"` is
+        // redundant rather than restrictive.
+        let server = BridgeServerConfig {
+            cmd: vec!["harper-ls".to_string()],
+            languages: vec!["rust".to_string(), LANGUAGES_WILDCARD.to_string()],
+            ..Default::default()
+        };
+
+        assert!(server.handles_language("rust"));
+        assert!(server.handles_language("python"));
+    }
+
+    #[test]
+    fn explicit_languages_list_matches_only_listed_languages() {
+        let server = BridgeServerConfig {
+            cmd: vec!["rust-analyzer".to_string()],
+            languages: vec!["rust".to_string()],
+            ..Default::default()
+        };
+
+        assert!(server.handles_language("rust"));
+        assert!(!server.handles_language("python"));
+    }
+
+    #[test]
+    fn empty_languages_matches_nothing() {
+        // An unresolved (still-inheriting) config must not become "any".
+        let server = BridgeServerConfig {
+            cmd: vec!["rust-analyzer".to_string()],
+            languages: vec![],
+            ..Default::default()
+        };
+
+        assert!(!server.handles_language("rust"));
+    }
+
+    #[test]
     fn should_parse_bridge_server_config() {
         // Test that BridgeServerConfig can deserialize all fields:
         // cmd (required), languages (required), initialization_options (optional)

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -488,17 +488,6 @@ impl BridgeServerConfig {
             .any(|l| l == language || l == LANGUAGES_WILDCARD)
     }
 
-    /// Whether this server names `language` explicitly, ignoring
-    /// [`LANGUAGES_WILDCARD`].
-    ///
-    /// Only for callers that must rank a server declaring the language above
-    /// one that merely accepts everything — a single-pick site, where handing
-    /// the slot to a wildcard server would starve the language's real server.
-    /// Membership tests want [`Self::handles_language`].
-    pub(crate) fn names_language(&self, language: &str) -> bool {
-        self.languages.iter().any(|l| l == language)
-    }
-
     /// A resolved config is a real, usable server: it has a command to run
     /// AND it hasn't been disabled. Every "is this server usable" call site
     /// (spawn-resolution, capability advertisement, resolve-dispatch) should

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -18,6 +18,23 @@ pub(crate) const HOST_BRIDGE_KEY: &str = "_self";
 /// does not.
 pub(crate) const PRIORITIES_WILDCARD: &str = "*";
 
+/// Reserved `languages` element standing for "every language"
+/// (any-language-server-wildcard): a server declaring it is a bridge
+/// candidate for any injected — and any host — language.
+///
+/// A list element rather than an empty/absent list because both of those
+/// already mean "inherit `languages` from the `_` entry"
+/// ([`crate::config::merge::merge_bridge_server_configs`]). A concrete
+/// server can therefore only *defer* to the wildcard entry, never widen past
+/// it, which is exactly what a language-agnostic server (spell/grammar/typo
+/// checkers, AI completion) needs to say. Keeping it in the list also leaves
+/// room for set algebra (e.g. a future `"!markdown"` exclusion) that a bare
+/// scalar could not express.
+///
+/// Same sigil and same reason as [`PRIORITIES_WILDCARD`]: `_` keys carry
+/// field-level inheritance semantics, list elements do not.
+pub(crate) const LANGUAGES_WILDCARD: &str = "*";
+
 /// The resolved default for an absent `priorities`: `["*"]`, i.e. fan out to
 /// every configured server with no ranking (first-win).
 fn default_priorities() -> Vec<String> {
@@ -361,9 +378,13 @@ pub struct BridgeServerConfig {
     /// server whose resolved cmd is still empty is skipped at lookup.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub cmd: Vec<String>,
-    /// Languages this server handles (e.g., ["rust"], ["python"]).
+    /// Languages this server handles (e.g., ["rust"], ["python"]), or the
+    /// [`LANGUAGES_WILDCARD`] element `"*"` for "any language".
     /// Optional for the same wildcard-defaults reason as `cmd`; a server
     /// with no languages never matches a lookup.
+    ///
+    /// Test membership through [`Self::handles_language`] rather than
+    /// comparing elements directly, so `"*"` is honored everywhere.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub languages: Vec<String>,
     /// Optional initialization options to pass to the server during initialize
@@ -449,6 +470,25 @@ impl BridgeServerConfig {
     /// built-in default `true`.
     pub(crate) fn is_enabled(&self) -> bool {
         self.enabled.unwrap_or(true)
+    }
+
+    /// Whether this server is a bridge candidate for `language`.
+    ///
+    /// Plain membership, except that the [`LANGUAGES_WILDCARD`] element
+    /// matches everything (any-language-server-wildcard). The wildcard is
+    /// resolved here, at match time, rather than expanded during config
+    /// merging: "every language" is an open set that cannot be enumerated
+    /// statically — injected languages are discovered from the document.
+    ///
+    /// Applies to both bridge axes, since both select servers by this same
+    /// list: injection candidates
+    /// ([`crate::lsp::bridge::coordinator`]'s per-region lookups) and host
+    /// candidates. On the host axis a candidate is still not consent — that
+    /// path stays gated on the explicit `bridge._self.enabled = true` opt-in.
+    pub(crate) fn handles_language(&self, language: &str) -> bool {
+        self.languages
+            .iter()
+            .any(|l| l == language || l == LANGUAGES_WILDCARD)
     }
 
     /// A resolved config is a real, usable server: it has a command to run

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1574,6 +1574,25 @@ mod tests {
     }
 
     #[test]
+    fn languages_wildcard_is_an_exact_element_not_a_glob() {
+        // Globs are deferred (any-language-server-wildcard, alternative G).
+        // A `.contains('*')`-style implementation would pass every other test
+        // in this file, so pin the narrower contract explicitly.
+        let server = BridgeServerConfig {
+            cmd: vec!["tsgo".to_string()],
+            languages: vec!["ts*".to_string()],
+            ..Default::default()
+        };
+
+        assert!(!server.handles_language("tsx"));
+        assert!(!server.handles_language("typescript"));
+        assert!(
+            server.handles_language("ts*"),
+            "matched literally, not glob"
+        );
+    }
+
+    #[test]
     fn empty_languages_matches_nothing() {
         // An unresolved (still-inheriting) config must not become "any".
         let server = BridgeServerConfig {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -908,12 +908,16 @@ impl LanguageSettings {
     /// enabled for this language.
     ///
     /// Host bridging is **opt-in**: it requires an explicit
-    /// `bridge._self.enabled = true`. Unlike injection entries, the `enabled`
-    /// field deliberately does NOT inherit from the `_` wildcard entry —
-    /// that implements the ADR's built-in `languages._.bridge._self.enabled
-    /// = false` default, which must beat the wildcard's `enabled = true`
-    /// virt default (key-specific wins). Aggregation fields DO inherit from
-    /// `_` via [`Self::resolve_host_aggregation`].
+    /// `bridge._self.enabled = true`. The lookup is deliberately DIRECT — no
+    /// `resolve_with_wildcard` — so an absent `_self` is the off state, and
+    /// the shipped defaults ship no `_self` key at all
+    /// (`default_settings_has_wildcard_language_with_bridge_defaults` pins
+    /// that). Routing this through the wildcard would let the shipped
+    /// `bridge._.enabled = true` virt default flow in and enable host
+    /// bridging for every language — and for every `languages = ["*"]` server
+    /// with it, since the host axis selects through the same list.
+    /// Aggregation fields DO inherit from `_` via
+    /// [`Self::resolve_host_aggregation`]; only `enabled` is special.
     pub(crate) fn is_host_bridging_enabled(&self) -> bool {
         self.bridge
             .as_ref()

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -2596,8 +2596,11 @@ kind = "locals""#;
     #[test]
     fn host_bridging_not_enabled_by_bridge_wildcard() {
         // The `_` wildcard's enabled = true is the VIRT default; it must not
-        // silently turn host bridging on (host-document-bridge: the built-in
-        // `_self.enabled = false` default is key-specific and wins).
+        // silently turn host bridging on. The fixture deliberately has NO
+        // `_self` entry, because that is the real shipped shape and absence is
+        // what the direct `get` reads as off — adding `_self = false` here
+        // would make this test vacuous against a switch to
+        // `resolve_with_wildcard` (host-document-bridge § Wildcard Merge Safety).
         let settings = LanguageSettings {
             bridge: Some(HashMap::from([(
                 WILDCARD_KEY.to_string(),

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -488,6 +488,17 @@ impl BridgeServerConfig {
             .any(|l| l == language || l == LANGUAGES_WILDCARD)
     }
 
+    /// Whether this server names `language` explicitly, ignoring
+    /// [`LANGUAGES_WILDCARD`].
+    ///
+    /// Only for callers that must rank a server declaring the language above
+    /// one that merely accepts everything — a single-pick site, where handing
+    /// the slot to a wildcard server would starve the language's real server.
+    /// Membership tests want [`Self::handles_language`].
+    pub(crate) fn names_language(&self, language: &str) -> bool {
+        self.languages.iter().any(|l| l == language)
+    }
+
     /// A resolved config is a real, usable server: it has a command to run
     /// AND it hasn't been disabled. Every "is this server usable" call site
     /// (spawn-resolution, capability advertisement, resolve-dispatch) should

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -817,13 +817,25 @@ impl BridgeCoordinator {
                     self.get_all_configs_for_language(settings, host_language, &injection.language)
                 });
 
-            for config in resolved.iter() {
+            // Hand the injection itself to the last server and clone only for
+            // the others, so the overwhelmingly common one-server case stays a
+            // move: `BridgeInjection` owns the region text, and this loop runs
+            // on the tokio runtime over every region in the document.
+            let Some((last, rest)) = resolved.split_last() else {
+                continue;
+            };
+            for config in rest {
                 groups
                     .entry(config.server_name.clone())
                     .or_insert_with(|| (config.config.clone(), Vec::new()))
                     .1
                     .push(injection.clone());
             }
+            groups
+                .entry(last.server_name.clone())
+                .or_insert_with(|| (last.config.clone(), Vec::new()))
+                .1
+                .push(injection);
         }
 
         groups

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -2044,6 +2044,43 @@ mod tests {
         assert_eq!(ra, vec!["r1"]);
     }
 
+    #[tokio::test]
+    async fn eager_open_spawns_a_task_for_every_group_not_just_the_first() {
+        // `eager_open_groups` deciding on two servers is worthless if the
+        // dispatch loop below it only acts on one — the push-only server would
+        // still get no `didOpen`. Pin the loop itself: one registered task per
+        // group. The commands are unspawnable on purpose; the assertion is
+        // about dispatch, and the batch is cancelled before anything runs.
+        let coordinator = BridgeCoordinator::new();
+        let mut settings = settings_with_any_language_server();
+        for config in settings.language_servers.values_mut() {
+            config.cmd = vec!["/nonexistent/kakehashi-test-server".to_string()];
+        }
+        let host_uri = Url::parse("file:///test.md").unwrap();
+
+        coordinator
+            .eager_spawn_and_open_documents(
+                &settings,
+                "markdown",
+                &host_uri,
+                1,
+                vec![injection("rust", "r1")],
+            )
+            .await;
+
+        let handles = coordinator
+            .eager_open_tasks
+            .get(&host_uri)
+            .map(|batch| batch.handles.len());
+        coordinator.cancel_eager_open(&host_uri);
+
+        assert_eq!(
+            handles,
+            Some(2),
+            "both the rust server and the wildcard server must get a task"
+        );
+    }
+
     #[test]
     fn eager_open_groups_are_empty_when_nothing_bridges() {
         // Distinguishes "resolved nothing" from "everything already open" for

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -492,26 +492,39 @@ impl BridgeCoordinator {
         // Look for a server that handles this language
         // wildcard-config-inheritance: Resolve each server with wildcard BEFORE checking languages,
         // because languages list may be inherited from languageServers._
+        //
+        // Sorted, and a server naming the language outranks one that only
+        // accepts everything (any-language-server-wildcard). This site picks a
+        // single server and drives the eager virtual-document open, so an
+        // arbitrary pick would starve the language's real server of its warm
+        // start — and `servers` is a HashMap, so "arbitrary" is reshuffled
+        // every process. The fan-out resolvers below sort for the same reason.
         let servers = &settings.language_servers;
-        for server_name in servers.keys() {
-            // Skip wildcard entry - we use it for inheritance, not direct lookup
-            if server_name == "_" {
-                continue;
-            }
+        let mut names: Vec<&String> = servers.keys().filter(|name| *name != "_").collect();
+        names.sort();
 
-            if let Some(resolved_config) =
+        let mut wildcard_pick: Option<ResolvedServerConfig> = None;
+        for server_name in names {
+            let Some(resolved_config) =
                 resolve_with_wildcard(servers, server_name, merge_bridge_server_configs)
                     .filter(|c| c.is_spawnable())
                     .filter(|c| c.handles_language(injection_language))
-            {
-                return Some(ResolvedServerConfig {
-                    server_name: server_name.clone(),
-                    config: Arc::new(resolved_config),
-                });
+            else {
+                continue;
+            };
+
+            let names_it = resolved_config.names_language(injection_language);
+            let pick = ResolvedServerConfig {
+                server_name: server_name.clone(),
+                config: Arc::new(resolved_config),
+            };
+            if names_it {
+                return Some(pick);
             }
+            wildcard_pick.get_or_insert(pick);
         }
 
-        None
+        wildcard_pick
     }
 
     /// Memo-resolving front for [`Self::get_all_configs_for_language`] /

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -618,8 +618,9 @@ impl BridgeCoordinator {
     /// given host language (host-document-bridge).
     ///
     /// Selection mirrors [`Self::get_all_configs_for_language`] with the
-    /// host-path matching rule: servers whose `languages` contains the
-    /// *host* language itself. Gated on the explicit `bridge._self.enabled =
+    /// host-path matching rule: servers whose `languages` matches the *host*
+    /// language itself, via `handles_language` — so a `"*"` server qualifies
+    /// here too (any-language-server-wildcard). Gated on the explicit `bridge._self.enabled =
     /// true` opt-in ([`LanguageSettings::is_host_bridging_enabled`]) — a
     /// candidate server alone is not consent to use it.
     pub(crate) fn get_host_configs_for_language(

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -2025,6 +2025,35 @@ mod tests {
     }
 
     #[test]
+    fn any_language_server_works_under_the_real_shipped_defaults() {
+        // The hand-built settings above leave `languages` empty, which makes
+        // `resolve_host_language_settings` return None and skips the bridge
+        // filter entirely. Real configs always carry the shipped `languages._`
+        // entry, so the filter branch *is* live — and it is the branch that
+        // decides whether a `"*"` server reaches a language with no
+        // `languages.<lang>` entry of its own. Pin the zero-config path.
+        let coordinator = BridgeCoordinator::new();
+        let mut settings = settings_with_any_language_server();
+        settings.languages = crate::config::defaults::default_settings().languages;
+        assert!(
+            settings.languages.contains_key("_"),
+            "the shipped defaults must carry the wildcard language entry"
+        );
+
+        let names: Vec<String> = coordinator
+            .get_all_configs_for_language(&settings, "markdown", "toml")
+            .into_iter()
+            .map(|r| r.server_name)
+            .collect();
+        assert_eq!(
+            names,
+            vec!["harper-ls".to_string()],
+            "a `\"*\"` server must reach an injection language that no \
+             `languages.<lang>` entry mentions"
+        );
+    }
+
+    #[test]
     fn any_language_server_still_obeys_the_host_bridge_filter() {
         // `"*"` widens the *server* axis (which servers can answer), not the
         // *language* axis (which injections the host bridges at all). A host

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -33,6 +33,10 @@ pub(crate) struct BridgeInjection {
     pub(crate) content: String,
 }
 
+/// One server's share of an eager-open batch: its spawn config plus the
+/// injections to open on it.
+type ServerGroup = (Arc<BridgeServerConfig>, Vec<BridgeInjection>);
+
 /// Resolved server configuration with server name.
 ///
 /// Carries both the server name (for connection lookup) and the config (for
@@ -424,10 +428,10 @@ impl BridgeCoordinator {
     /// The injections whose language bridges to `server_name`, plus that server's
     /// resolved config. A codeAction fans out to ALL servers bridging an
     /// injection language, so the command's origin may be ANY of them — match by
-    /// name against the full set ([`Self::get_all_configs_for_language`]), not
-    /// [`Self::get_config_for_language`]'s single first pick (which would miss
-    /// the origin when e.g. both ruff and pyright bridge python and the command
-    /// came from ruff). Pure; the async open is separate so it is unit-testable.
+    /// name against the full set ([`Self::get_all_configs_for_language`]). A
+    /// single first pick would miss the origin when e.g. both ruff and pyright
+    /// bridge python and the command came from ruff. Pure; the async open is
+    /// separate so it is unit-testable.
     fn injections_for_server(
         &self,
         settings: &Arc<WorkspaceSettings>,
@@ -459,72 +463,6 @@ impl BridgeCoordinator {
             })
             .collect();
         (for_server, config)
-    }
-
-    /// Resolve `bridge.servers` for `injection_language`, returning the
-    /// `ResolvedServerConfig` (server name for pooling + spawn config) or
-    /// `None` when no server matches, or the host's bridge filter excludes
-    /// this injection. Host lookup uses wildcard resolution (wildcard-config-inheritance):
-    /// undefined hosts inherit `languages._`, letting one default filter apply
-    /// to every host.
-    pub(crate) fn get_config_for_language(
-        &self,
-        settings: &WorkspaceSettings,
-        host_language: &str,
-        injection_language: &str,
-    ) -> Option<ResolvedServerConfig> {
-        // Host-language bridge filters are checked first, with an optional
-        // fallback to the wildcard ("_") entry when the host has no explicit
-        // configuration. This allows using languages._ to define shared
-        // defaults, but does not guarantee that every language inherits them.
-        if let Some(host_settings) = settings.resolve_host_language_settings(host_language)
-            && !host_settings.is_language_bridgeable(injection_language)
-        {
-            log::debug!(
-                target: "kakehashi::bridge",
-                "Bridge filter for {} blocks injection language {}",
-                host_language,
-                injection_language
-            );
-            return None;
-        }
-
-        // Look for a server that handles this language
-        // wildcard-config-inheritance: Resolve each server with wildcard BEFORE checking languages,
-        // because languages list may be inherited from languageServers._
-        //
-        // Sorted, and a server naming the language outranks one that only
-        // accepts everything (any-language-server-wildcard). This site picks a
-        // single server and drives the eager virtual-document open, so an
-        // arbitrary pick would starve the language's real server of its warm
-        // start — and `servers` is a HashMap, so "arbitrary" is reshuffled
-        // every process. The fan-out resolvers below sort for the same reason.
-        let servers = &settings.language_servers;
-        let mut names: Vec<&String> = servers.keys().filter(|name| *name != "_").collect();
-        names.sort();
-
-        let mut wildcard_pick: Option<ResolvedServerConfig> = None;
-        for server_name in names {
-            let Some(resolved_config) =
-                resolve_with_wildcard(servers, server_name, merge_bridge_server_configs)
-                    .filter(|c| c.is_spawnable())
-                    .filter(|c| c.handles_language(injection_language))
-            else {
-                continue;
-            };
-
-            let names_it = resolved_config.names_language(injection_language);
-            let pick = ResolvedServerConfig {
-                server_name: server_name.clone(),
-                config: Arc::new(resolved_config),
-            };
-            if names_it {
-                return Some(pick);
-            }
-            wildcard_pick.get_or_insert(pick);
-        }
-
-        wildcard_pick
     }
 
     /// Memo-resolving front for [`Self::get_all_configs_for_language`] /
@@ -625,10 +563,11 @@ impl BridgeCoordinator {
 
     /// Get all bridge server configs for a given injection language from settings.
     ///
-    /// Unlike `get_config_for_language()` which returns the first matching server,
-    /// this method returns **all** servers configured for the injection language.
-    /// This enables diagnostic fan-out to multiple servers (e.g., pyright + ruff
-    /// both handling Python).
+    /// **All** servers configured for the injection language, not a preferred
+    /// one: every consumer needs the full set — diagnostic fan-out to e.g.
+    /// pyright + ruff, codeAction command routing back to whichever server
+    /// produced it, and the eager open, where a push-only server that is
+    /// skipped never receives the region at all.
     ///
     /// Results are sorted by server name for deterministic ordering.
     ///
@@ -641,7 +580,7 @@ impl BridgeCoordinator {
         host_language: &str,
         injection_language: &str,
     ) -> Vec<ResolvedServerConfig> {
-        // Check bridge filter (same logic as get_config_for_language)
+        // Check the host's bridge filter before considering any server
         if let Some(host_settings) = settings.resolve_host_language_settings(host_language)
             && !host_settings.is_language_bridgeable(injection_language)
         {
@@ -841,6 +780,55 @@ impl BridgeCoordinator {
     // Eager spawn + open (warmup with document content)
     // ========================================
 
+    /// Which servers should receive an eager `didOpen`, and for which
+    /// injections. Grouped by server name, since several languages can share
+    /// one server (e.g. ts/tsx → tsgo).
+    ///
+    /// **Every** matching server, not a preferred one: the eager open is the
+    /// only way a push-only server ever receives a region. It issues no
+    /// request, so nothing opens the document lazily, and the pull path
+    /// returns on its capability check before `ensure_document_opened`. Any
+    /// ranking here would silently starve such a server whenever another
+    /// server also matched the language — which, for an any-language server
+    /// (any-language-server-wildcard), is every language that has a real
+    /// server of its own.
+    ///
+    /// Resolves configs once per DISTINCT language rather than per region:
+    /// resolution walks the wildcard+merge chain, and a fence-heavy document
+    /// has hundreds of regions across a handful of languages — per-region
+    /// resolution was a measured tokio-side hotspot (the caller runs on the
+    /// runtime, and starving it delays every handler).
+    ///
+    /// Pure, so the selection is unit-testable; resolving connection keys and
+    /// skipping already-open regions needs `await` and stays in the caller.
+    fn eager_open_groups(
+        &self,
+        settings: &WorkspaceSettings,
+        host_language: &str,
+        injections: Vec<BridgeInjection>,
+    ) -> BTreeMap<String, ServerGroup> {
+        let mut configs_by_lang: HashMap<String, Vec<ResolvedServerConfig>> = HashMap::new();
+        let mut groups: BTreeMap<String, ServerGroup> = BTreeMap::new();
+
+        for injection in injections {
+            let resolved = configs_by_lang
+                .entry(injection.language.clone())
+                .or_insert_with(|| {
+                    self.get_all_configs_for_language(settings, host_language, &injection.language)
+                });
+
+            for config in resolved.iter() {
+                groups
+                    .entry(config.server_name.clone())
+                    .or_insert_with(|| (config.config.clone(), Vec::new()))
+                    .1
+                    .push(injection.clone());
+            }
+        }
+
+        groups
+    }
+
     /// Eagerly spawn language servers and open virtual documents for detected injections.
     ///
     /// Sending `didOpen` up front (not just a handshake) lets downstream servers
@@ -866,62 +854,36 @@ impl BridgeCoordinator {
             }
         };
 
-        // Group injections by server name
-        // Multiple injection languages may map to the same server (e.g., ts/tsx → tsgo)
-        type ServerGroup = (Arc<BridgeServerConfig>, Vec<BridgeInjection>);
-        let mut server_groups: BTreeMap<String, ServerGroup> = BTreeMap::new();
+        // Empty means current settings resolve no server for any injection —
+        // the batch belongs to removed configuration and must stop.
+        let resolved_groups = self.eager_open_groups(settings, host_language, injections);
+        if resolved_groups.is_empty() {
+            self.cancel_eager_open(host_uri);
+            return;
+        }
 
-        // Resolve the server config once per DISTINCT language, not per region:
-        // config resolution walks the wildcard+merge chain, and a fence-heavy
-        // document has hundreds of regions across a handful of languages —
-        // per-region resolution was a measured tokio-side hotspot (this loop
-        // runs on the runtime, and starving it delays every handler).
-        let mut config_by_lang: HashMap<String, Option<ResolvedServerConfig>> = HashMap::new();
-        let mut connection_key_by_lang = HashMap::new();
-        let mut any_resolved = false;
-        for injection in injections {
-            let resolved = config_by_lang
-                .entry(injection.language.clone())
-                .or_insert_with(|| {
-                    self.get_config_for_language(settings, host_language, &injection.language)
-                });
-            if let Some(resolved) = resolved {
-                any_resolved = true;
-                let connection_key = match connection_key_by_lang.get(&injection.language) {
-                    Some(key) => key,
-                    None => {
-                        let key = self
-                            .pool
-                            .resolved_connection_key(
-                                &resolved.server_name,
-                                &resolved.config,
-                                host_uri,
-                            )
-                            .await;
-                        connection_key_by_lang.insert(injection.language.clone(), key);
-                        connection_key_by_lang
-                            .get(&injection.language)
-                            .expect("just inserted")
-                    }
-                };
-                if self.injection_open_on_connection(&host_uri_lsp, connection_key, &injection) {
-                    continue;
-                }
-                server_groups
-                    .entry(resolved.server_name.clone())
-                    .or_insert_with(|| (resolved.config.clone(), Vec::new()))
-                    .1
-                    .push(injection);
+        // Drop the regions already open on each server's connection. The key
+        // is per SERVER (`(server, root)`), so it is resolved once per group
+        // rather than once per region.
+        let mut server_groups: BTreeMap<String, ServerGroup> = BTreeMap::new();
+        for (server_name, (config, group_injections)) in resolved_groups {
+            let connection_key = self
+                .pool
+                .resolved_connection_key(&server_name, &config, host_uri)
+                .await;
+            let pending: Vec<BridgeInjection> = group_injections
+                .into_iter()
+                .filter(|injection| {
+                    !self.injection_open_on_connection(&host_uri_lsp, &connection_key, injection)
+                })
+                .collect();
+            if !pending.is_empty() {
+                server_groups.insert(server_name, (config, pending));
             }
         }
 
-        // Empty means either every resolved injection is already sent/open, or
-        // current settings resolve none. Preserve a batch only in the former
-        // case; in the latter it belongs to removed configuration and must stop.
+        // Every resolved injection is already sent/open — preserve the batch.
         if server_groups.is_empty() {
-            if !any_resolved {
-                self.cancel_eager_open(host_uri);
-            }
             return;
         }
 
@@ -1510,9 +1472,9 @@ mod tests {
         };
 
         // rust should be blocked by markdown's bridge filter
-        let result = coordinator.get_config_for_language(&settings, "markdown", "rust");
+        let result = coordinator.get_all_configs_for_language(&settings, "markdown", "rust");
         assert!(
-            result.is_none(),
+            result.is_empty(),
             "rust should be blocked by markdown's bridge filter"
         );
     }
@@ -1521,8 +1483,8 @@ mod tests {
     fn injections_for_server_matches_any_fan_out_server_not_just_the_first() {
         // python bridges to BOTH ruff and pyright (codeAction fans out to all).
         // A command routed to either must still select the python injection —
-        // get_config_for_language's single first pick would miss whichever the
-        // command did NOT come from.
+        // a single first pick would miss whichever the command did NOT come
+        // from.
         let coordinator = BridgeCoordinator::new();
 
         let mut bridge_filter = HashMap::new();
@@ -1717,14 +1679,14 @@ mod tests {
         };
 
         // rust should be allowed (no filter)
-        let result = coordinator.get_config_for_language(&settings, "markdown", "rust");
-        assert!(
-            result.is_some(),
+        let result = coordinator.get_all_configs_for_language(&settings, "markdown", "rust");
+        assert_eq!(
+            result.len(),
+            1,
             "rust should be allowed when no filter is set"
         );
-        let resolved = result.unwrap();
-        assert_eq!(resolved.server_name, "rust-analyzer");
-        assert_eq!(resolved.config.cmd, vec!["rust-analyzer".to_string()]);
+        assert_eq!(result[0].server_name, "rust-analyzer");
+        assert_eq!(result[0].config.cmd, vec!["rust-analyzer".to_string()]);
     }
 
     #[test]
@@ -1790,15 +1752,9 @@ mod tests {
 
         assert!(
             coordinator
-                .get_config_for_language(&settings, "markdown", "rust")
-                .is_none(),
-            "a server whose resolved cmd is empty must be skipped"
-        );
-        assert!(
-            coordinator
                 .get_all_configs_for_language(&settings, "markdown", "rust")
                 .is_empty(),
-            "fan-out must also skip servers with empty resolved cmd"
+            "a server whose resolved cmd is empty must be skipped"
         );
         assert!(
             coordinator
@@ -1867,15 +1823,9 @@ mod tests {
 
         assert!(
             coordinator
-                .get_config_for_language(&settings, "markdown", "rust")
-                .is_none(),
-            "a server disabled via the wildcard must be skipped"
-        );
-        assert!(
-            coordinator
                 .get_all_configs_for_language(&settings, "markdown", "rust")
                 .is_empty(),
-            "fan-out must also skip servers disabled via the wildcard"
+            "a server disabled via the wildcard must be skipped"
         );
         assert!(
             coordinator
@@ -1926,9 +1876,9 @@ mod tests {
         };
 
         assert!(
-            coordinator
-                .get_config_for_language(&settings, "markdown", "rust")
-                .is_some(),
+            !coordinator
+                .get_all_configs_for_language(&settings, "markdown", "rust")
+                .is_empty(),
             "a server with an explicit enabled: true must override a disabled wildcard"
         );
     }
@@ -2097,74 +2047,6 @@ mod tests {
                 .eager_open_groups(&settings, "markdown", vec![injection("rust", "r1")])
                 .is_empty()
         );
-    }
-
-    #[test]
-    fn single_pick_prefers_a_server_that_names_the_language_over_a_wildcard() {
-        // `get_config_for_language` picks ONE server and feeds the eager
-        // virtual-document open. With a `"*"` server configured, every
-        // language has at least two candidates, so an arbitrary pick would
-        // hand the warm start to the wildcard server roughly half the time
-        // and leave the language's real server to open lazily. Iteration is
-        // over a HashMap, so "arbitrary" means "reshuffled every process".
-        let coordinator = BridgeCoordinator::new();
-        let settings = settings_with_any_language_server();
-
-        let picked = coordinator
-            .get_config_for_language(&settings, "markdown", "rust")
-            .expect("a server must be picked for rust");
-        assert_eq!(
-            picked.server_name, "rust-analyzer",
-            "the server naming rust must win over the `\"*\"` server"
-        );
-
-        // The wildcard server is still the pick when nothing names the
-        // language — otherwise it could never warm anything up.
-        let picked = coordinator
-            .get_config_for_language(&settings, "markdown", "toml")
-            .expect("the wildcard server must be picked for an unnamed language");
-        assert_eq!(picked.server_name, "harper-ls");
-    }
-
-    #[test]
-    fn single_pick_is_deterministic_among_equally_matching_servers() {
-        // Two servers naming the same language: the pick must not depend on
-        // HashMap iteration order. Repeating over freshly built settings
-        // exercises several hash seeds' worth of ordering within one process.
-        let coordinator = BridgeCoordinator::new();
-        for _ in 0..16 {
-            let servers = HashMap::from([
-                (
-                    "pyright".to_string(),
-                    BridgeServerConfig {
-                        cmd: vec!["pyright".to_string()],
-                        languages: vec!["python".to_string()],
-                        ..Default::default()
-                    },
-                ),
-                (
-                    "ruff".to_string(),
-                    BridgeServerConfig {
-                        cmd: vec!["ruff".to_string()],
-                        languages: vec!["python".to_string()],
-                        ..Default::default()
-                    },
-                ),
-            ]);
-            let settings = WorkspaceSettings {
-                auto_install: false,
-                language_servers: servers,
-                ..Default::default()
-            };
-
-            let picked = coordinator
-                .get_config_for_language(&settings, "markdown", "python")
-                .expect("a server must be picked");
-            assert_eq!(
-                picked.server_name, "pyright",
-                "ties must break on server name, not hash order"
-            );
-        }
     }
 
     #[test]
@@ -2540,9 +2422,9 @@ mod tests {
         };
 
         // "quarto" is configured with an empty bridge — should be blocked
-        let result = coordinator.get_config_for_language(&settings, "quarto", "rust");
+        let result = coordinator.get_all_configs_for_language(&settings, "quarto", "rust");
         assert!(
-            result.is_none(),
+            result.is_empty(),
             "quarto with empty bridge map should block all bridging"
         );
     }
@@ -2767,9 +2649,9 @@ mod tests {
 
         // "markdown" is not in settings.languages (auto-discovered at runtime).
         // It should still inherit "_"'s bridge filter that blocks lua.
-        let result = coordinator.get_config_for_language(&settings, "markdown", "lua");
+        let result = coordinator.get_all_configs_for_language(&settings, "markdown", "lua");
         assert!(
-            result.is_none(),
+            result.is_empty(),
             "unconfigured host should inherit '_'s bridge filter — lua should be blocked"
         );
     }

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -502,7 +502,7 @@ impl BridgeCoordinator {
             if let Some(resolved_config) =
                 resolve_with_wildcard(servers, server_name, merge_bridge_server_configs)
                     .filter(|c| c.is_spawnable())
-                    .filter(|c| c.languages.iter().any(|l| l == injection_language))
+                    .filter(|c| c.handles_language(injection_language))
             {
                 return Some(ResolvedServerConfig {
                     server_name: server_name.clone(),
@@ -649,7 +649,7 @@ impl BridgeCoordinator {
             .filter_map(|server_name| {
                 resolve_with_wildcard(servers, server_name, merge_bridge_server_configs)
                     .filter(|c| c.is_spawnable())
-                    .filter(|c| c.languages.iter().any(|l| l == injection_language))
+                    .filter(|c| c.handles_language(injection_language))
                     .map(|config| ResolvedServerConfig {
                         server_name: server_name.clone(),
                         config: Arc::new(config),
@@ -690,7 +690,7 @@ impl BridgeCoordinator {
             .filter_map(|server_name| {
                 resolve_with_wildcard(servers, server_name, merge_bridge_server_configs)
                     .filter(|c| c.is_spawnable())
-                    .filter(|c| c.languages.iter().any(|l| l == host_language))
+                    .filter(|c| c.handles_language(host_language))
                     .map(|config| ResolvedServerConfig {
                         server_name: server_name.clone(),
                         config: Arc::new(config),
@@ -1971,6 +1971,164 @@ mod tests {
             result.iter().map(|r| r.server_name.as_str()).collect();
         assert!(names.contains("pyright"), "should contain pyright");
         assert!(names.contains("ruff"), "should contain ruff");
+    }
+
+    /// A server with `languages = ["*"]` plus one concrete-language server.
+    fn settings_with_any_language_server() -> WorkspaceSettings {
+        let servers = HashMap::from([
+            (
+                "harper-ls".to_string(),
+                BridgeServerConfig {
+                    cmd: vec!["harper-ls".to_string()],
+                    languages: vec!["*".to_string()],
+                    ..Default::default()
+                },
+            ),
+            (
+                "rust-analyzer".to_string(),
+                BridgeServerConfig {
+                    cmd: vec!["rust-analyzer".to_string()],
+                    languages: vec!["rust".to_string()],
+                    ..Default::default()
+                },
+            ),
+        ]);
+
+        WorkspaceSettings {
+            auto_install: false,
+            language_servers: servers,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn any_language_server_is_a_candidate_for_every_injection_language() {
+        let coordinator = BridgeCoordinator::new();
+        let settings = settings_with_any_language_server();
+
+        // Named-language server + wildcard server both match rust...
+        let names: std::collections::HashSet<String> = coordinator
+            .get_all_configs_for_language(&settings, "markdown", "rust")
+            .into_iter()
+            .map(|r| r.server_name)
+            .collect();
+        assert!(names.contains("harper-ls"));
+        assert!(names.contains("rust-analyzer"));
+
+        // ...and the wildcard server alone matches a language no server names.
+        let names: Vec<String> = coordinator
+            .get_all_configs_for_language(&settings, "markdown", "toml")
+            .into_iter()
+            .map(|r| r.server_name)
+            .collect();
+        assert_eq!(names, vec!["harper-ls".to_string()]);
+    }
+
+    #[test]
+    fn any_language_server_still_obeys_the_host_bridge_filter() {
+        // `"*"` widens the *server* axis (which servers can answer), not the
+        // *language* axis (which injections the host bridges at all). A host
+        // that only enables python must not gain rust bridging for free.
+        let coordinator = BridgeCoordinator::new();
+        let mut settings = settings_with_any_language_server();
+        settings.languages.insert(
+            "markdown".to_string(),
+            LanguageSettings {
+                bridge: Some(HashMap::from([(
+                    "python".to_string(),
+                    BridgeLanguageConfig {
+                        enabled: Some(true),
+                        ..Default::default()
+                    },
+                )])),
+                ..Default::default()
+            },
+        );
+
+        assert!(
+            coordinator
+                .get_all_configs_for_language(&settings, "markdown", "rust")
+                .is_empty(),
+            "the host's bridge filter must still block rust"
+        );
+        assert!(
+            !coordinator
+                .get_all_configs_for_language(&settings, "markdown", "python")
+                .is_empty(),
+            "the wildcard server must answer the language the host does enable"
+        );
+    }
+
+    #[test]
+    fn any_language_server_reaches_the_host_axis_only_when_opted_in() {
+        // `handles_language` is shared by both axes, so a `"*"` server is a
+        // host candidate for every language — but candidacy is not consent:
+        // `bridge._self.enabled = true` still gates the host path.
+        let coordinator = BridgeCoordinator::new();
+        let mut settings = settings_with_any_language_server();
+
+        assert!(
+            coordinator
+                .get_host_configs_for_language(&settings, "lua")
+                .is_empty(),
+            "without the _self opt-in the host axis stays empty"
+        );
+
+        settings.languages.insert(
+            "lua".to_string(),
+            LanguageSettings {
+                bridge: Some(HashMap::from([(
+                    "_self".to_string(),
+                    BridgeLanguageConfig {
+                        enabled: Some(true),
+                        ..Default::default()
+                    },
+                )])),
+                ..Default::default()
+            },
+        );
+
+        let names: Vec<String> = coordinator
+            .get_host_configs_for_language(&settings, "lua")
+            .into_iter()
+            .map(|r| r.server_name)
+            .collect();
+        assert_eq!(names, vec!["harper-ls".to_string()]);
+    }
+
+    #[test]
+    fn any_language_is_inheritable_from_the_wildcard_server_entry() {
+        // wildcard-config-inheritance: `languageServers._.languages = ["*"]`
+        // reaches a concrete server that omits `languages` entirely.
+        let coordinator = BridgeCoordinator::new();
+        let servers = HashMap::from([
+            (
+                "_".to_string(),
+                BridgeServerConfig {
+                    languages: vec!["*".to_string()],
+                    ..Default::default()
+                },
+            ),
+            (
+                "harper-ls".to_string(),
+                BridgeServerConfig {
+                    cmd: vec!["harper-ls".to_string()],
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let settings = WorkspaceSettings {
+            auto_install: false,
+            language_servers: servers,
+            ..Default::default()
+        };
+
+        let names: Vec<String> = coordinator
+            .get_all_configs_for_language(&settings, "markdown", "toml")
+            .into_iter()
+            .map(|r| r.server_name)
+            .collect();
+        assert_eq!(names, vec!["harper-ls".to_string()]);
     }
 
     #[test]

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1373,7 +1373,7 @@ mod tests {
 
     use super::*;
     use crate::config::LanguageSettings;
-    use crate::config::settings::BridgeLanguageConfig;
+    use crate::config::settings::{BridgeLanguageConfig, LANGUAGES_WILDCARD};
 
     #[test]
     fn reload_resolution_does_not_resurrect_deleted_server_from_wildcard() {
@@ -1993,7 +1993,7 @@ mod tests {
                 "harper-ls".to_string(),
                 BridgeServerConfig {
                     cmd: vec!["harper-ls".to_string()],
-                    languages: vec!["*".to_string()],
+                    languages: vec![LANGUAGES_WILDCARD.to_string()],
                     ..Default::default()
                 },
             ),
@@ -2176,6 +2176,12 @@ mod tests {
         // `bridge._self.enabled = true` still gates the host path.
         let coordinator = BridgeCoordinator::new();
         let mut settings = settings_with_any_language_server();
+        // The shipped `languages._` carries `bridge._` but no `_self`, so the
+        // gate is genuinely evaluated and genuinely says no. Leaving
+        // `languages` empty would instead make `resolve_host_language_settings`
+        // return None and short-circuit `is_some_and` before the gate runs —
+        // the assertion would then hold even if the gate were deleted.
+        settings.languages = crate::config::defaults::default_settings().languages;
 
         assert!(
             coordinator
@@ -2215,7 +2221,7 @@ mod tests {
             (
                 "_".to_string(),
                 BridgeServerConfig {
-                    languages: vec!["*".to_string()],
+                    languages: vec![LANGUAGES_WILDCARD.to_string()],
                     ..Default::default()
                 },
             ),
@@ -2223,6 +2229,19 @@ mod tests {
                 "harper-ls".to_string(),
                 BridgeServerConfig {
                     cmd: vec!["harper-ls".to_string()],
+                    ..Default::default()
+                },
+            ),
+            // ...but a concrete server that DOES declare `languages` keeps its
+            // own narrower list. This is the containment guarantee for the
+            // documented `_.languages = ["*"]` footgun: the wildcard reaches
+            // only the servers that stayed silent, so listing real languages
+            // is a working opt-out.
+            (
+                "rust-analyzer".to_string(),
+                BridgeServerConfig {
+                    cmd: vec!["rust-analyzer".to_string()],
+                    languages: vec!["rust".to_string()],
                     ..Default::default()
                 },
             ),
@@ -2238,7 +2257,22 @@ mod tests {
             .into_iter()
             .map(|r| r.server_name)
             .collect();
-        assert_eq!(names, vec!["harper-ls".to_string()]);
+        assert_eq!(
+            names,
+            vec!["harper-ls".to_string()],
+            "the wildcard must not leak into a server with its own list"
+        );
+
+        let names: Vec<String> = coordinator
+            .get_all_configs_for_language(&settings, "markdown", "rust")
+            .into_iter()
+            .map(|r| r.server_name)
+            .collect();
+        assert_eq!(
+            names,
+            vec!["harper-ls".to_string(), "rust-analyzer".to_string()],
+            "both answer for rust, in the documented name-sorted order"
+        );
     }
 
     #[test]

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -2037,6 +2037,68 @@ mod tests {
         assert_eq!(names, vec!["harper-ls".to_string()]);
     }
 
+    fn injection(language: &str, region_id: &str) -> BridgeInjection {
+        BridgeInjection {
+            language: language.to_string(),
+            region_id: region_id.to_string(),
+            content: String::new(),
+        }
+    }
+
+    #[test]
+    fn eager_open_reaches_every_server_matching_the_language() {
+        // The eager open is the ONLY way a push-only server (one that
+        // publishes diagnostics rather than answering pulls) ever receives a
+        // region: it issues no request, so nothing opens the document lazily,
+        // and the pull path returns on its capability check before
+        // `ensure_document_opened`. Resolving one server per language starves
+        // it whenever another server also matches — and for a `"*"` server
+        // that is every language that has a real server of its own.
+        let coordinator = BridgeCoordinator::new();
+        let settings = settings_with_any_language_server();
+
+        let groups = coordinator.eager_open_groups(
+            &settings,
+            "markdown",
+            vec![injection("rust", "r1"), injection("toml", "r2")],
+        );
+
+        let names: Vec<&str> = groups.keys().map(String::as_str).collect();
+        assert_eq!(names, vec!["harper-ls", "rust-analyzer"]);
+
+        // The wildcard server takes both regions; the rust server takes only
+        // the one it handles.
+        let harper: Vec<&str> = groups["harper-ls"]
+            .1
+            .iter()
+            .map(|i| i.region_id.as_str())
+            .collect();
+        assert_eq!(harper, vec!["r1", "r2"]);
+        let ra: Vec<&str> = groups["rust-analyzer"]
+            .1
+            .iter()
+            .map(|i| i.region_id.as_str())
+            .collect();
+        assert_eq!(ra, vec!["r1"]);
+    }
+
+    #[test]
+    fn eager_open_groups_are_empty_when_nothing_bridges() {
+        // Distinguishes "resolved nothing" from "everything already open" for
+        // the caller, which cancels a stale batch only in the former case.
+        let coordinator = BridgeCoordinator::new();
+        let settings = WorkspaceSettings {
+            auto_install: false,
+            ..Default::default()
+        };
+
+        assert!(
+            coordinator
+                .eager_open_groups(&settings, "markdown", vec![injection("rust", "r1")])
+                .is_empty()
+        );
+    }
+
     #[test]
     fn single_pick_prefers_a_server_that_names_the_language_over_a_wildcard() {
         // `get_config_for_language` picks ONE server and feeds the eager

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -2025,6 +2025,74 @@ mod tests {
     }
 
     #[test]
+    fn single_pick_prefers_a_server_that_names_the_language_over_a_wildcard() {
+        // `get_config_for_language` picks ONE server and feeds the eager
+        // virtual-document open. With a `"*"` server configured, every
+        // language has at least two candidates, so an arbitrary pick would
+        // hand the warm start to the wildcard server roughly half the time
+        // and leave the language's real server to open lazily. Iteration is
+        // over a HashMap, so "arbitrary" means "reshuffled every process".
+        let coordinator = BridgeCoordinator::new();
+        let settings = settings_with_any_language_server();
+
+        let picked = coordinator
+            .get_config_for_language(&settings, "markdown", "rust")
+            .expect("a server must be picked for rust");
+        assert_eq!(
+            picked.server_name, "rust-analyzer",
+            "the server naming rust must win over the `\"*\"` server"
+        );
+
+        // The wildcard server is still the pick when nothing names the
+        // language — otherwise it could never warm anything up.
+        let picked = coordinator
+            .get_config_for_language(&settings, "markdown", "toml")
+            .expect("the wildcard server must be picked for an unnamed language");
+        assert_eq!(picked.server_name, "harper-ls");
+    }
+
+    #[test]
+    fn single_pick_is_deterministic_among_equally_matching_servers() {
+        // Two servers naming the same language: the pick must not depend on
+        // HashMap iteration order. Repeating over freshly built settings
+        // exercises several hash seeds' worth of ordering within one process.
+        let coordinator = BridgeCoordinator::new();
+        for _ in 0..16 {
+            let servers = HashMap::from([
+                (
+                    "pyright".to_string(),
+                    BridgeServerConfig {
+                        cmd: vec!["pyright".to_string()],
+                        languages: vec!["python".to_string()],
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "ruff".to_string(),
+                    BridgeServerConfig {
+                        cmd: vec!["ruff".to_string()],
+                        languages: vec!["python".to_string()],
+                        ..Default::default()
+                    },
+                ),
+            ]);
+            let settings = WorkspaceSettings {
+                auto_install: false,
+                language_servers: servers,
+                ..Default::default()
+            };
+
+            let picked = coordinator
+                .get_config_for_language(&settings, "markdown", "python")
+                .expect("a server must be picked");
+            assert_eq!(
+                picked.server_name, "pyright",
+                "ties must break on server name, not hash order"
+            );
+        }
+    }
+
+    #[test]
     fn any_language_server_works_under_the_real_shipped_defaults() {
         // The hand-built settings above leave `languages` empty, which makes
         // `resolve_host_language_settings` return None and skips the bridge

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -11,11 +11,12 @@
 //! request/cancel machinery are shared with the virt path; only the document
 //! key and the (absent) translation differ.
 //!
-//! Document sync is lazy: the host document is opened on the first request
-//! per `(uri, connection)` and re-synced with a full-text `didChange` whenever
-//! the host text changed since the last request (fingerprint comparison) —
-//! the same full-content sync the virt path uses for its `didChange`
-//! forwarding.
+//! Document sync: the host document is opened eagerly at upstream `didOpen`
+//! on every `_self` server (#429, so a push-only host server pushes on open),
+//! and lazily on the first request per `(uri, connection)` for anything that
+//! missed that. It is re-synced with a full-text `didChange` whenever the host
+//! text changed since the last request (fingerprint comparison) — the same
+//! full-content sync the virt path uses for its `didChange` forwarding.
 
 use std::collections::hash_map::Entry;
 use std::hash::{Hash, Hasher};

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -15,7 +15,8 @@
 //! on every `_self` server (#429, so a push-only host server pushes on open),
 //! and lazily on the first request per `(uri, connection)` for anything that
 //! missed that. It is re-synced with a full-text `didChange` whenever the host
-//! text changed since the last request (fingerprint comparison) — the same
+//! text changed since the last sync (fingerprint comparison; the sync may have
+//! been an eager one, not a request) — the same
 //! full-content sync the virt path uses for its `didChange` forwarding.
 
 use std::collections::hash_map::Entry;
@@ -65,8 +66,8 @@ pub(crate) type HostTextReader = Arc<dyn Fn() -> Option<Arc<str>> + Send + Sync>
 /// Open or re-sync the host document on a downstream server, mutating the
 /// pool's sync-state map in place.
 ///
-/// - First request for `(uri, connection)`: send `didOpen` with the real URI,
-///   the host language id, and the full host text.
+/// - First sync for `(uri, connection)` — eager or request-driven: send
+///   `didOpen` with the real URI, the host language id, and the full host text.
 /// - Host text changed since the last sync: send a full-text `didChange`
 ///   with an incremented version.
 /// - Unchanged: no-op.

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -152,8 +152,9 @@ pub(crate) struct HostRequestContext {
     pub(crate) language_id: String,
     /// The current host text, shared across per-server tasks.
     pub(crate) text: std::sync::Arc<str>,
-    /// Host-capable server configs (`languages` contains the host language),
-    /// gated on the explicit `bridge._self.enabled = true` opt-in.
+    /// Host-capable server configs (`languages` matches the host language —
+    /// `handles_language`, so a `"*"` server qualifies too), gated on the
+    /// explicit `bridge._self.enabled = true` opt-in.
     pub(crate) configs: Vec<ResolvedServerConfig>,
     /// Ordered allowlist from `bridge._self.aggregation` (wildcard-merged).
     pub(crate) priorities: Vec<String>,


### PR DESCRIPTION
## Why

Cross-cutting language servers — grammar/spell checkers (`harper-ls`), typo linters (`typos-lsp`), AI completion — have no finite language list to enumerate in `languageServers.<name>.languages`. `docs/architecture-decisions/language-server-bridge.md` already names them as a motivating case, but there was no way to configure one.

The two spellings a user would reach for first are both already taken. `merge_bridge_server_configs` (`src/config/merge.rs`) treats an **empty** `languages` as "inherit from the `_` entry", and `#[serde(default)]` on `Vec<String>` maps an omitted field onto that same empty vec. So a concrete server could only ever *defer* to the wildcard entry — it had no way to **widen** past it.

## What

A `"*"` element in `languages` matches every language.

```toml
[languageServers.harper-ls]
cmd = ["harper-ls", "--stdio"]
languages = ["*"]
```

- Follows the sigil discipline already set by `priorities` (aggregation-priorities-wildcard): `_` for map keys that carry field-level inheritance, `"*"` for list elements that do not.
- Resolved at match time in `BridgeServerConfig::handles_language`, not expanded during config merge — injected languages are discovered from documents, so "every language" is an open set with no static enumeration.
- Staying a list element leaves room for set algebra (a future `"!markdown"` exclusion) that a scalar or a separate boolean would foreclose.

### Behavior change beyond the new marker

The eager open (the `didOpen` sent up front so downstream servers start analyzing before the first request) resolved **one** server per injection language. It now fans out to **all** matching servers, and the single-pick resolver `get_config_for_language` is deleted.

This was necessary, not cosmetic: a **push-only** server — one that publishes diagnostics rather than answering pulls — issues no request, so nothing opens the document lazily, and the pull path returns on its capability check before `ensure_document_opened`. A server that missed the eager open therefore never saw the region at all. Grammar and spell checkers, the wildcard's whole reason to exist, are typically push-only and overlap every language that has a real server.

**This changes existing non-wildcard configs too**: a config with `pyright` and `ruff` both on `["python"]` now spawns and opens on *both* at `didOpen`, where before only one (chosen by `HashMap` iteration order) did. That is more startup work, and it is deliberate — the other server was previously silently dead if it was push-only. It does not multiply the region worst case described below, since only the `"*"` server matches `markdown_inline`.

### What `"*"` deliberately does **not** widen

Both bridge axes select servers through this one list, so `"*"` reaches both. Three limits keep that from becoming a blanket opt-in, each documented and the first two pinned by tests:

1. **Not a host-filter bypass** — it widens *which servers may answer*, not *which injections a host bridges at all*. `languages.<host>.bridge.<lang>.enabled = false` still applies, and is evaluated before server selection.
2. **Not a host-bridge opt-in** — a `"*"` server becomes a host candidate for every language, but the host path stays gated on the explicit `bridge._self.enabled = true`.
3. **Not a `priorities` bypass** — `priorities` is an allowlist over server *names*, so a target that enumerates names without a `"*"` element still excludes the wildcard server.

### Cost

Worth reading the ADR's Negative section before configuring one. The process count does not grow with languages (the pool is keyed by `(server, root)`), but per-**region** work does — and the shipped markdown injection query emits a `markdown_inline` region per inline node and per table cell, so a prose file yields regions in the hundreds. Those regions used to be free because nothing matched them. The mitigation is the per-host bridge filter; `docs/README.md` carries the concrete config line.

## Tests

- `src/config/settings.rs` — membership semantics, including that empty still matches nothing, and that `"*"` is an *exact* element (a `.contains('*')` implementation would otherwise pass everything else).
- `src/lsp/bridge/coordinator.rs` — selection for an arbitrary injection language; inheritance from `languageServers._` **and** the containment guarantee that a concrete server's own list survives it; the two non-widening invariants; and that the eager open reaches *every* matching server (the pure `eager_open_groups` seam exists so this is assertable without a pool).
- `any_language_server_works_under_the_real_shipped_defaults` — the hand-built settings in the other tests leave `languages` empty, which makes `resolve_host_language_settings` return `None` and skips the per-host filter entirely. This one uses the real `default_settings().languages`. Without it the feature could have been inert out of the box with every other test green.
- `src/config/defaults.rs` — asserts the shipped defaults carry no `bridge._self`, since two coordinator tests depend on that to exercise the `_self` gate rather than short-circuit before it.

## Docs

- New ADR `docs/architecture-decisions/any-language-server-wildcard.md`, recording the 7 rejected alternatives — the reasoning is not recoverable from the code, since it hinges on a merge rule in a different module.
- `docs/README.md` — usage, the cost model with its mitigation, the non-widening limits, and the `_` blast radius (which crosses config *files*: layers collapse before `_` is resolved).
- `host-document-bridge.md` corrected — it claimed an LS is excluded from the host axis by not listing the language, an escape hatch that does not exist for a `"*"` LS.
- `wildcard-config-inheritance.md` gains a note that empty-means-inherit applies to the *bare* `Vec` fields only, and is *why* widening needs an in-list marker.

## Verification

Rebased onto `origin/main` (1c63ea0f7). `make check` green. `cargo test --lib` 3119 passed. `make test_e2e` 1696 passed, 0 failing binaries.

Two pre-existing gaps that this change makes materially easier to hit are documented in the ADR and tracked rather than fixed here: #916 (`priorities` excludes a server from dispatch but not from unsolicited pushes) and #917 (disabling a bridged language at runtime does not retract already-open virtual documents). Both are gate defects in other subsystems; #918 collects leftover host-bridge doc drift outside this diff's scope.

Two pre-existing conditions on `main`, flagged so they aren't mistaken for regressions here:

- `cargo test --features e2e --test e2e_code_action` fails `concatenated_default_merges_actions_from_both_servers` when run directly. Verified identical on a clean `origin/main` worktree. It passes under `make test_e2e`, which runs the same binary through `scripts/test_e2e_parallel.sh`.
- `cargo clippy --all-targets` has 7 pre-existing errors in unrelated files (`analysis/semantic.rs`, `language/injection/discovery.rs`, `lsp/lsp_impl/kakehashi/node/entry.rs`, `lsp/lsp_impl/text_document/publish_diagnostic.rs`). `make check` passes because it does not pass `--all-targets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Language server configuration now supports `"*"` to match any injected language (while empty/omitted `languages` continues to use wildcard inheritance, not any-language behavior).
  * Requests can be routed to **all** eligible language servers to improve diagnostics and code-action coverage.
  * Host-document bridging for any-language servers is supported **only** when explicitly enabled, with updated document sync behavior (eager opens for opted-in servers; synthetic full-text `didChange` when the host text changes).
* **Documentation**
  * Expanded guidance on wildcard semantics, inheritance rules, routing/aggregation interactions, and host-bridge opt-in safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

