### PR TITLE
chore: bump to v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "kakehashi"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "arc-swap",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kakehashi"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 default-run = "kakehashi"
 


### PR DESCRIPTION
Version bump for the v0.9.0 release.

Mirrors the v0.8.0 release PR (#607): `Cargo.toml` version bump plus the regenerated `kakehashi` entry in `Cargo.lock`. No dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->