### PR TITLE
chore(deps): drop fs4 in favor of std's File::lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,16 +541,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs4"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
-dependencies = [
- "rustix 1.1.4",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "futures"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,7 +977,6 @@ dependencies = [
  "env_logger",
  "filetime",
  "flate2",
- "fs4 1.1.0",
  "futures",
  "ignore",
  "indexmap",
@@ -2341,7 +2330,7 @@ checksum = "8ac98a906517ad790c8eb896d4ad170479bb72f6081971658ab94f71528a34cf"
 dependencies = [
  "cc",
  "etcetera",
- "fs4 0.12.0",
+ "fs4",
  "indoc",
  "libloading",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "kakehashi"
 version = "0.9.0"
 edition = "2024"
+# std's inherent `File::lock` (src/install/queries.rs) is stable from 1.89; the
+# 2024 edition alone would only require 1.85. Declared so an older toolchain
+# fails with a clear MSRV message instead of a missing-method error.
+rust-version = "1.89"
 default-run = "kakehashi"
 
 [[bin]]
@@ -78,7 +82,6 @@ serde_json = "1"
 shellexpand = "3"
 similar = "3"
 flate2 = "1"
-fs4 = "1"
 # Gitignore-respecting file walker for `kakehashi format <paths...>`; also
 # provides the gitignore-style Override matcher backing --excludes.
 ignore = "0.4"

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -6,8 +6,6 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use fs4::FileExt;
-
 use super::http::agent_with_timeout;
 #[cfg(test)]
 use super::http::agent_with_timeout_allowing_http;
@@ -948,12 +946,7 @@ impl QueryReplaceLockGuard {
             .write(true)
             .truncate(false)
             .open(path)?;
-        // Spelled as UFCS, not `file.lock()`: std stabilized an inherent
-        // `File::lock` in 1.89 which would silently win method resolution and
-        // leave the fs4 import unused. Both are blocking flock(LOCK_EX), so the
-        // behavior is the same either way — this just keeps the source of the
-        // lock explicit. fs4 1.x renamed `lock_exclusive` to `lock`.
-        FileExt::lock(&file)?;
+        file.lock()?;
         Ok(Self { _file: file })
     }
 }


### PR DESCRIPTION
## Why

The follow-up flagged in #922. `fs4`'s only remaining use in the tree was the query-replace lock in `src/install/queries.rs`, and std stabilized an inherent `File::lock` in 1.89 that performs the same blocking `flock(LOCK_EX)`. The dependency bought us nothing but a name.

It also cost us a duplicate build: `tree-sitter-loader 0.26.11` pins `fs4 0.12`, so our direct `1.1` dependency meant **both versions compiled**. After this change only the transitive `0.12` remains, and `cargo tree -d` no longer lists fs4 at all.

Removing it additionally erases the awkward UFCS call site #922 had to introduce — `FileExt::lock(&file)` with a five-line comment explaining that `file.lock()` would silently resolve to std's method and leave the import unused. It is now just `file.lock()`.

## What

- `src/install/queries.rs`: drop `use fs4::FileExt;`, replace `FileExt::lock(&file)?` with `file.lock()?`, remove the explanatory comment that is no longer needed.
- `Cargo.toml`: remove `fs4` from `[dependencies]`.
- `Cargo.toml`: declare `rust-version = "1.89"`. `File::lock` is what requires it — the 2024 edition alone would only ask for 1.85 — so an older toolchain now fails with a clear MSRV message instead of a confusing missing-method error. CI tracks latest stable and previously pinned nothing, so this documents the floor rather than changing it.

## Verification

- `make check` — pass
- `make test` — 3105 passed, 0 failed
- `make test_e2e` — 57 binaries, 1696 tests passed, 0 failing binaries, **clean on the first pass with no serial-retry needed**
- `cargo tree -d` — fs4 no longer duplicated; `cargo tree -i fs4` shows only `tree-sitter-loader -> fs4 0.12`
- `Cargo.lock` diff is the fs4 1.1.0 entry and nothing else — adding `rust-version` shifted no dependency versions
- The 23 `install::queries` unit tests cover this code path; the lock guard is acquired on all four install paths

Note on the test count: `make test` reports 3105 here versus the 3119 in #922, because main has since merged #921, which removed the crash-quarantine module and its tests. I measured pristine main on this machine to confirm — it also reports 3105, so this change is test-count-neutral and nothing was silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * The project now requires Rust 1.89 or newer to build.

* **Reliability**
  * Improved file-locking behavior during language replacement operations, helping prevent conflicting updates and maintain safer concurrent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->