### PR TITLE
feat(config): make autoInstall per-language

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ To let kakehashi auto-install the parsers it needs, make sure a **C compiler** i
 ```lua
 vim.lsp.config.kakehashi = {
     cmd = { "kakehashi" },
-    init_options = { autoInstall = true },
     on_attach = function(_, bufnr)
         -- Let kakehashi own highlighting (avoids double-highlighting)
         vim.api.nvim_create_autocmd("LspTokenUpdate", {

--- a/docs/README.md
+++ b/docs/README.md
@@ -240,7 +240,7 @@ Per-language configuration. Usually not needed as kakehashi auto-detects languag
 
 | Field | Description |
 |-------|-------------|
-| `base` | Inherit parser, queries, and bridge configuration from another language |
+| `base` | Inherit parser, queries, bridge, and `autoInstall` configuration from another language |
 | `parser` | Explicit path to the parser library (`.so`, `.dylib`, `.dll`) |
 | `queries` | Array of query configurations with `path` and `kind` (highlights, bindings, injections) |
 | `bridge` | Per-injection-language bridge filter and aggregation settings |
@@ -252,10 +252,19 @@ Per-language configuration. Usually not needed as kakehashi auto-detects languag
 Whether kakehashi may download and install a missing parser/queries for this
 language when a file is opened.
 
-Resolved most-specific-wins: the language's own value, then the `"_"` wildcard's,
-then the deprecated top-level `autoInstall`, defaulting to `true`. Unset is the
-default at every level, so a language inherits `"_"` exactly like the other
-fields.
+Resolved most-specific-wins: the language's own value, then each entry in its
+`base` chain, then the `"_"` wildcard's, then the deprecated top-level
+`autoInstall`, defaulting to `true`. Unset is the default at every level, so a
+language inherits through `base` and `"_"` exactly like the other fields — for
+example `[languages.rmd] base = "markdown"` picks up markdown's `autoInstall`
+before `"_"` is consulted.
+
+**Which name to use.** The key names the language kakehashi would *install*, not
+the token in your document. A host document uses the `languageId` your editor
+sends; an injected region uses its resolved language, so a ```` ```py ```` fence
+is governed by `languages.python.autoInstall` and an `rmd` region whose own
+parser is absent is governed by whatever its `base` resolves to. Set the key on
+the resolved name.
 
 Enable everywhere except one language:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -154,8 +154,10 @@ default `info` forwards Error, Warning, and Info while suppressing LSP `Log` and
 ```json
 {
   "searchPaths": ["$HOME/.local/share/kakehashi", "/another/path"],
-  "autoInstall": true,
   "languages": {
+    "_": {
+      "autoInstall": true
+    },
     "typescript": {
       "base": "ecma",
       "queries": [
@@ -222,10 +224,15 @@ Array of base directories to search for parsers and queries. If not specified, u
 Parsers are searched as `{searchPath}/parser/{language}.{so,dylib,dll}`.
 Queries are searched as `{searchPath}/queries/{language}/{query_type}.scm`.
 
-#### `autoInstall`
+#### `autoInstall` (deprecated)
 
-- `true` (default): Automatically download and install missing parsers/queries when a file is opened
-- `false`: Require manual installation via CLI
+**Deprecated:** use [`languages[*].autoInstall`](#languagesautoinstall) instead.
+The top-level key still works — it answers whenever no per-language value is
+set — but kakehashi shows a one-time migration notice when it is present, and
+it may be removed in a future release.
+
+Move `autoInstall = true` to `[languages._] autoInstall = true` for identical
+behavior, then override per language as needed.
 
 #### `languages`
 
@@ -237,7 +244,43 @@ Per-language configuration. Usually not needed as kakehashi auto-detects languag
 | `parser` | Explicit path to the parser library (`.so`, `.dylib`, `.dll`) |
 | `queries` | Array of query configurations with `path` and `kind` (highlights, bindings, injections) |
 | `bridge` | Per-injection-language bridge filter and aggregation settings |
+| `autoInstall` | Whether missing parsers/queries for this language may be auto-installed |
 | `aliases` | Deprecated alternative language IDs. Prefer `base` on the derived language instead. |
+
+##### `languages[*].autoInstall`
+
+Whether kakehashi may download and install a missing parser/queries for this
+language when a file is opened.
+
+Resolved most-specific-wins: the language's own value, then the `"_"` wildcard's,
+then the deprecated top-level `autoInstall`, defaulting to `true`. Unset is the
+default at every level, so a language inherits `"_"` exactly like the other
+fields.
+
+Enable everywhere except one language:
+
+```toml
+[languages._]
+autoInstall = true
+
+[languages.python]
+autoInstall = false   # never auto-install the python parser
+```
+
+Or the reverse — off by default, with opt-in exceptions:
+
+```toml
+[languages._]
+autoInstall = false
+
+[languages.lua]
+autoInstall = true
+```
+
+When auto-install is off for a language and its parser is missing, kakehashi
+logs which key turned it off (for example ``` `languages.python.autoInstall` is
+false ```) alongside the manual `kakehashi language install` hint, so the
+setting responsible is never ambiguous.
 
 ##### `languages[*].base`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -261,10 +261,12 @@ before `"_"` is consulted.
 
 **Which name to use.** The key names the language kakehashi would *install*, not
 the token in your document. A host document uses the `languageId` your editor
-sends; an injected region uses its resolved language, so a ```` ```py ```` fence
-is governed by `languages.python.autoInstall` and an `rmd` region whose own
-parser is absent is governed by whatever its `base` resolves to. Set the key on
-the resolved name.
+sends — except `plaintext`, where the language is inferred from the path and
+content instead, so a `.rs` file opened as `plaintext` is governed by
+`languages.rust.autoInstall`. An injected region uses its resolved language, so a
+```` ```py ```` fence is governed by `languages.python.autoInstall`, and an `rmd`
+region whose own parser is absent by whatever its `base` resolves to. Set the key
+on the resolved name.
 
 Enable everywhere except one language:
 
@@ -294,10 +296,13 @@ does have an entry it names the overriding key and the places the value may have
 come from, since `base`-chain and `_` inheritance are folded together by then.
 
 **Migration caveat:** moving the top-level key to `[languages._]` is
-equivalence-preserving for every language *except* one that opts out of wildcard
-inheritance with a self-referential `base` (`[languages.foo] base = "foo"`, or a
-circular chain). Such a language inherits nothing from `_` — by design, for every
-field — so it falls through to the top-level default instead. Give those
+equivalence-preserving for every language *except* one whose `base` chain
+terminates before reaching `"_"` — a self-referential `base`
+(`[languages.foo] base = "foo"`) or a cycle that never visits `"_"`. Such a
+language inherits nothing from `"_"` — by design, for every field — so it falls
+through to the top-level default instead. (A chain that *does* reach `"_"`,
+including one that gets there via an explicit `[languages._] base`, inherits
+normally.) Give those
 languages an explicit `autoInstall` when migrating.
 
 **Precedence note:** a `languages.*.autoInstall` value outranks the top-level

--- a/docs/README.md
+++ b/docs/README.md
@@ -231,8 +231,10 @@ The top-level key still works — it answers whenever no per-language value is
 set — but kakehashi shows a one-time migration notice when it is present, and
 it may be removed in a future release.
 
-Move `autoInstall = true` to `[languages._] autoInstall = true` for identical
-behavior, then override per language as needed.
+Move `autoInstall = true` to `[languages._] autoInstall = true` — equivalent in
+every case but one, see the migration caveat under
+[`languages[*].autoInstall`](#languagesautoinstall) — then override per language
+as needed.
 
 #### `languages`
 
@@ -291,7 +293,7 @@ autoInstall = true
 When auto-install is off for a language and its parser is missing, kakehashi
 says so in the log alongside the manual `kakehashi language install` hint, and
 points at the config that decided it. For a language with no entry of its own it
-names the exact key (``` `languages._.autoInstall` is false ```); for one that
+names the exact key (`` `languages._.autoInstall` is false ``); for one that
 does have an entry it names the overriding key and the places the value may have
 come from, since `base`-chain and `_` inheritance are folded together by then.
 
@@ -874,7 +876,6 @@ Using Neovim's built-in LSP client (0.11+):
 vim.lsp.config.kakehashi = {
   cmd = { "kakehashi" },
   init_options = {
-    languages = { _ = { autoInstall = true } },
     -- LSP Bridge configuration (optional)
     languageServers = {
       pyright = {
@@ -887,6 +888,7 @@ vim.lsp.config.kakehashi = {
       },
     },
     languages = {
+      _ = { autoInstall = true },
       markdown = {
         bridge = {
           python = {

--- a/docs/README.md
+++ b/docs/README.md
@@ -284,6 +284,13 @@ names the exact key (``` `languages._.autoInstall` is false ```); for one that
 does have an entry it names the overriding key and the places the value may have
 come from, since `base`-chain and `_` inheritance are folded together by then.
 
+**Migration caveat:** moving the top-level key to `[languages._]` is
+equivalence-preserving for every language *except* one that opts out of wildcard
+inheritance with a self-referential `base` (`[languages.foo] base = "foo"`, or a
+circular chain). Such a language inherits nothing from `_` — by design, for every
+field — so it falls through to the top-level default instead. Give those
+languages an explicit `autoInstall` when migrating.
+
 **Precedence note:** a `languages.*.autoInstall` value outranks the top-level
 `autoInstall` even when the top-level one is set at a higher-precedence source.
 That is deliberate — the top-level key is only a fallback for an unset

--- a/docs/README.md
+++ b/docs/README.md
@@ -278,9 +278,18 @@ autoInstall = true
 ```
 
 When auto-install is off for a language and its parser is missing, kakehashi
-logs which key turned it off (for example ``` `languages.python.autoInstall` is
-false ```) alongside the manual `kakehashi language install` hint, so the
-setting responsible is never ambiguous.
+says so in the log alongside the manual `kakehashi language install` hint, and
+points at the config that decided it. For a language with no entry of its own it
+names the exact key (``` `languages._.autoInstall` is false ```); for one that
+does have an entry it names the overriding key and the places the value may have
+come from, since `base`-chain and `_` inheritance are folded together by then.
+
+**Precedence note:** a `languages.*.autoInstall` value outranks the top-level
+`autoInstall` even when the top-level one is set at a higher-precedence source.
+That is deliberate — the top-level key is only a fallback for an unset
+per-language value — but it means moving the key to `[languages._]` in a
+low-precedence file will shadow a top-level `autoInstall` pushed via
+`initializationOptions`. Prefer setting one or the other, not both.
 
 ##### `languages[*].base`
 
@@ -844,7 +853,7 @@ Using Neovim's built-in LSP client (0.11+):
 vim.lsp.config.kakehashi = {
   cmd = { "kakehashi" },
   init_options = {
-    autoInstall = true,
+    languages = { _ = { autoInstall = true } },
     -- LSP Bridge configuration (optional)
     languageServers = {
       pyright = {
@@ -889,7 +898,7 @@ With nvim-lspconfig:
 ```lua
 require("lspconfig").kakehashi.setup({
   init_options = {
-    autoInstall = true,
+    languages = { _ = { autoInstall = true } },
   },
 })
 ```

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -99,6 +99,17 @@ final_config = [defaults, user_config, project_config, InitializationOptions]
 - Later sources completely replace earlier values (via `overlay.or(base)`)
 - Example: `autoInstall: false` in InitializationOptions overrides `autoInstall: true` from project config
 
+**Exception — key specificity can outrank source order.** The top-level
+`autoInstall` is deprecated in favour of `languages.<lang>.autoInstall` (and
+`languages._.autoInstall`), and `WorkspaceSettings::auto_install_for` consults the
+per-language keys first *regardless of which source supplied them*. So a
+`[languages._] autoInstall = true` in project config wins over an
+`autoInstall: false` from InitializationOptions — the merge above still runs
+normally per key, but the two keys are then read in specificity order, not source
+order. This is why `default_settings()` (merge layer 1) and the `config init`
+template both leave `languages._.autoInstall` unset: a built-in value there would
+silently shadow every user-supplied top-level opt-out.
+
 **Languages HashMap** (`languages`):
 - **Deep merge at language level**: Keys from later sources override same keys from earlier sources
 - **Deep merge within each language**: Individual fields (`parser`, `queries`, `bridge`, etc.) are merged

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -672,9 +672,9 @@ fn write_content_to_output(
 
 /// Run the config init command
 fn run_config_init(output: Option<PathBuf>, force: bool) -> Result<(), ExitCode> {
-    use kakehashi::config::defaults::default_settings;
+    use kakehashi::config::defaults::config_init_settings;
 
-    let settings = default_settings();
+    let settings = config_init_settings();
     let config_toml = toml::to_string_pretty(&settings).map_err(|e| {
         eprintln!("Failed to serialize configuration: {}", e);
         ExitCode::FAILURE

--- a/src/config.rs
+++ b/src/config.rs
@@ -367,44 +367,61 @@ impl WorkspaceSettings {
         self.auto_install_decision(language).1
     }
 
-    /// The config key that turns auto-install OFF for `language`, or `None`
-    /// when it is enabled — so a user-facing message can name the key to edit
-    /// rather than just saying "disabled".
+    /// Why auto-install is OFF for `language`, or `None` when it is enabled —
+    /// so a user-facing message can point at config rather than just saying
+    /// "disabled".
+    ///
+    /// Deliberately vague on the language arm. `resolve_base_configs` copies
+    /// the whole `base` chain (and `"_"`) into every present entry, so a folded
+    /// `Some(false)` does not tell us whether the user wrote it on the language,
+    /// on its base, or on the wildcard. Naming `languages.<lang>.autoInstall`
+    /// outright would misdirect someone hunting for the global switch; the
+    /// phrasing here names the key that overrides it, which is true either way.
     ///
     /// Formats lazily: [`Self::auto_install_for`] shares the same decision
     /// without allocating, since the gate runs per `didOpen` and per injected
     /// language while this runs only on the disabled path.
-    pub(crate) fn auto_install_disabled_key(&self, language: &str) -> Option<String> {
+    pub(crate) fn auto_install_disabled_reason(&self, language: &str) -> Option<String> {
         let (source, enabled) = self.auto_install_decision(language);
         if enabled {
             return None;
         }
         Some(match source {
-            AutoInstallSource::Language => format!("languages.{language}.autoInstall"),
-            AutoInstallSource::Wildcard => format!("languages.{WILDCARD_KEY}.autoInstall"),
-            AutoInstallSource::TopLevel => "autoInstall".to_string(),
+            AutoInstallSource::Language => format!(
+                "`languages.{language}.autoInstall` resolves to false                  (set on the language, its `base` chain, or `languages._`)"
+            ),
+            AutoInstallSource::Wildcard => {
+                format!("`languages.{WILDCARD_KEY}.autoInstall` is false")
+            }
+            AutoInstallSource::TopLevel => "`autoInstall` is false".to_string(),
         })
     }
 
     /// Which level answers auto-install for `language`, and what it says.
-    /// Single source of the precedence order so the boolean and the
-    /// key-naming can never disagree.
+    /// Single source of the precedence order so the boolean and the message
+    /// can never disagree.
+    ///
+    /// A PRESENT entry owns the answer outright: `resolve_base_configs` has
+    /// already folded `"_"` and the `base` chain into it, so `None` there means
+    /// nothing in the chain set the key — including the case where the language
+    /// deliberately escaped wildcard inheritance with a self-referential `base`
+    /// (`merge::build_base_chain`), where re-consulting `"_"` here would apply a
+    /// wildcard value every other field on that language ignores.
+    ///
+    /// The `"_"` lookup is for languages with NO entry: the fold maps over
+    /// `languages.keys()`, so it never ran for them.
     fn auto_install_decision(&self, language: &str) -> (AutoInstallSource, bool) {
-        if let Some(enabled) = self
-            .languages
-            .get(language)
-            .and_then(|settings| settings.auto_install)
-        {
-            return (AutoInstallSource::Language, enabled);
-        }
-        if let Some(enabled) = self
-            .languages
-            .get(WILDCARD_KEY)
-            .and_then(|wildcard| wildcard.auto_install)
-        {
-            return (AutoInstallSource::Wildcard, enabled);
-        }
-        (AutoInstallSource::TopLevel, self.auto_install)
+        let resolved = match self.languages.get(language) {
+            Some(settings) => settings
+                .auto_install
+                .map(|enabled| (AutoInstallSource::Language, enabled)),
+            None => self
+                .languages
+                .get(WILDCARD_KEY)
+                .and_then(|wildcard| wildcard.auto_install)
+                .map(|enabled| (AutoInstallSource::Wildcard, enabled)),
+        };
+        resolved.unwrap_or((AutoInstallSource::TopLevel, self.auto_install))
     }
 
     /// True if any configured language opts into host bridging
@@ -554,6 +571,29 @@ mod tests {
     }
 
     #[test]
+    fn stripping_keeps_an_auto_install_that_differs_from_the_inherited_value() {
+        use crate::config::settings::LanguageSettings;
+        let inherited = LanguageSettings {
+            auto_install: Some(true),
+            ..Default::default()
+        };
+        // Differs → kept, so the effective-config dump shows the override.
+        let differing = LanguageSettings {
+            auto_install: Some(false),
+            ..Default::default()
+        };
+        assert_eq!(
+            strip_inherited_language_settings(&inherited, &differing).auto_install,
+            Some(false)
+        );
+        // Equal → stripped as redundant, like every neighbouring field.
+        assert_eq!(
+            strip_inherited_language_settings(&inherited, &inherited).auto_install,
+            None
+        );
+    }
+
+    #[test]
     fn auto_install_for_honors_the_language_entry() {
         let settings = settings_with_auto_install(&[("python", Some(false))], true);
         assert!(!settings.auto_install_for("python"));
@@ -562,12 +602,18 @@ mod tests {
     }
 
     #[test]
-    fn auto_install_for_falls_back_to_the_wildcard_when_the_entry_omits_it() {
-        // `resolve_base_configs` normally folds `_` into every present entry;
-        // this pins the behavior for an entry that reached us unfolded.
+    fn auto_install_for_lets_a_present_entry_own_the_answer() {
+        // A present entry has already been through `resolve_base_configs`, which
+        // folds `_` and the whole `base` chain into it. `None` there therefore
+        // means nothing in the chain set the key — notably including a language
+        // that escaped wildcard inheritance via a self-referential `base`, where
+        // re-applying `_` would contradict every other field on that language.
         let settings =
             settings_with_auto_install(&[(WILDCARD_KEY, Some(false)), ("python", None)], true);
-        assert!(!settings.auto_install_for("python"));
+        assert!(
+            settings.auto_install_for("python"),
+            "an entry the fold left unset must not pick `_` up again at lookup time"
+        );
     }
 
     #[test]
@@ -610,39 +656,130 @@ mod tests {
     }
 
     #[test]
-    fn auto_install_disabled_key_names_the_level_that_decided() {
-        let language = settings_with_auto_install(&[("python", Some(false))], true);
-        assert_eq!(
-            language.auto_install_disabled_key("python").as_deref(),
-            Some("languages.python.autoInstall")
-        );
+    fn auto_install_inherits_through_the_base_chain() {
+        // Discriminating on purpose: with NO `"_"` entry, only
+        // `merge_language_settings`'s `auto_install` arm can carry markdown's
+        // value onto `rmd`. A `"_"`-based fixture would pass even without the
+        // arm, because the lookup-time wildcard fallback answers identically.
+        let raw = crate::config::RawWorkspaceSettings {
+            languages: HashMap::from([
+                (
+                    "markdown".to_string(),
+                    LanguageSettings {
+                        auto_install: Some(false),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "rmd".to_string(),
+                    LanguageSettings {
+                        base: Some("markdown".to_string()),
+                        ..Default::default()
+                    },
+                ),
+            ]),
+            ..Default::default()
+        };
+        let settings =
+            WorkspaceSettings::try_from_settings(&raw, None, |_| None).expect("settings expand");
 
-        let wildcard = settings_with_auto_install(&[(WILDCARD_KEY, Some(false))], true);
-        assert_eq!(
-            wildcard.auto_install_disabled_key("python").as_deref(),
-            Some("languages._.autoInstall")
-        );
-
-        let top_level = settings_with_auto_install(&[], false);
-        assert_eq!(
-            top_level.auto_install_disabled_key("python").as_deref(),
-            Some("autoInstall")
+        assert!(
+            !settings.auto_install_for("rmd"),
+            "rmd must inherit markdown's autoInstall through the base chain"
         );
     }
 
     #[test]
-    fn auto_install_disabled_key_is_none_when_enabled() {
+    fn auto_install_respects_a_self_referential_base_through_the_real_fold() {
+        // Built through `try_from_settings` so `resolve_base_configs` actually
+        // runs: `base = "foo"` is the supported escape from wildcard
+        // inheritance, and `autoInstall` must honor it like every other field.
+        let raw = crate::config::RawWorkspaceSettings {
+            languages: HashMap::from([
+                (
+                    WILDCARD_KEY.to_string(),
+                    LanguageSettings {
+                        auto_install: Some(false),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "foo".to_string(),
+                    LanguageSettings {
+                        base: Some("foo".to_string()),
+                        ..Default::default()
+                    },
+                ),
+                ("bar".to_string(), LanguageSettings::default()),
+            ]),
+            ..Default::default()
+        };
+        let settings =
+            WorkspaceSettings::try_from_settings(&raw, None, |_| None).expect("settings expand");
+
+        assert!(
+            settings.auto_install_for("foo"),
+            "a self-referential base opts out of wildcard inheritance entirely"
+        );
+        assert!(
+            !settings.auto_install_for("bar"),
+            "an ordinary entry still inherits the wildcard through the fold"
+        );
+        assert!(
+            !settings.auto_install_for("unconfigured"),
+            "a language with no entry falls back to the wildcard at lookup time"
+        );
+    }
+
+    #[test]
+    fn auto_install_disabled_reason_points_at_the_config() {
+        // Language arm: the fold makes "who set it" unknowable, so the message
+        // names the overriding key and says where it may have come from rather
+        // than asserting the user wrote it on the language.
+        let language = settings_with_auto_install(&[("python", Some(false))], true);
+        let reason = language
+            .auto_install_disabled_reason("python")
+            .expect("disabled");
+        assert!(reason.contains("languages.python.autoInstall"), "{reason}");
+        assert!(reason.contains("base"), "{reason}");
+        assert!(reason.contains("languages._"), "{reason}");
+
+        // Wildcard and top-level arms ARE reliable, so they name the key flatly.
+        let wildcard = settings_with_auto_install(&[(WILDCARD_KEY, Some(false))], true);
         assert_eq!(
-            WorkspaceSettings::default().auto_install_disabled_key("python"),
+            wildcard.auto_install_disabled_reason("python").as_deref(),
+            Some("`languages._.autoInstall` is false")
+        );
+
+        let top_level = settings_with_auto_install(&[], false);
+        assert_eq!(
+            top_level.auto_install_disabled_reason("python").as_deref(),
+            Some("`autoInstall` is false")
+        );
+
+        // Discriminates the ORDER, not just each arm in isolation: with the
+        // arms swapped, the wildcard's `false` would win and this would report
+        // a reason instead of `None`.
+        let overridden = settings_with_auto_install(
+            &[(WILDCARD_KEY, Some(false)), ("python", Some(true))],
+            true,
+        );
+        assert_eq!(overridden.auto_install_disabled_reason("python"), None);
+    }
+
+    #[test]
+    fn auto_install_disabled_reason_is_none_when_enabled() {
+        assert_eq!(
+            WorkspaceSettings::default().auto_install_disabled_reason("python"),
             None
         );
         // Re-enabled per-language over a global off: nothing is disabling it,
-        // so there is no key to report even though the top level says false.
+        // so there is nothing to report even though the top level says false.
         let exception = settings_with_auto_install(&[("python", Some(true))], false);
-        assert_eq!(exception.auto_install_disabled_key("python"), None);
+        assert_eq!(exception.auto_install_disabled_reason("python"), None);
         assert_eq!(
-            exception.auto_install_disabled_key("rust").as_deref(),
-            Some("autoInstall")
+            exception.auto_install_disabled_reason("rust").as_deref(),
+            Some("`autoInstall` is false")
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -693,6 +693,11 @@ mod tests {
                 (
                     "markdown".to_string(),
                     LanguageSettings {
+                        // Self-based so it escapes the wildcard: otherwise the
+                        // reversed-arm mutation would let `_`'s `false` override
+                        // markdown's `true`, and `rmd` would land on `false` for
+                        // the wrong reason — passing this test by accident.
+                        base: Some("markdown".to_string()),
                         auto_install: Some(true),
                         ..Default::default()
                     },

--- a/src/config.rs
+++ b/src/config.rs
@@ -352,17 +352,16 @@ impl WorkspaceSettings {
             .or_else(|| self.languages.get(WILDCARD_KEY))
     }
 
-    /// Whether missing parsers/queries for `language` may be auto-installed,
-    /// most-specific-wins: the language's own `autoInstall`, else the `"_"`
-    /// wildcard's, else the deprecated top-level `autoInstall` (which itself
-    /// defaults to enabled).
+    /// Whether missing parsers/queries for `language` may be auto-installed.
     ///
-    /// The wildcard arm is not redundant with [`merge::resolve_base_configs`]:
-    /// that fold only covers languages that HAVE an entry, and an unconfigured
-    /// document has none. It also cannot be replaced by
-    /// [`Self::resolve_host_language_settings`], whose fallback is wholesale —
-    /// a language entry that sets only `parser` must still inherit the
-    /// wildcard's `autoInstall`, not shadow it with `None`.
+    /// Per-ENTRY fallback, not per-key: the language's resolved entry answers if
+    /// it has a value, else the `"_"` entry, else the deprecated top-level
+    /// `autoInstall` (which itself defaults to enabled). Because
+    /// [`merge::resolve_base_configs`] has already folded `"_"` and the whole
+    /// `base` chain into every present entry, "the entry has no value" means
+    /// nothing in that chain set one — including a language that deliberately
+    /// escaped wildcard inheritance with a self-referential `base`. See
+    /// [`Self::auto_install_decision`] for why that is the right reading.
     pub(crate) fn auto_install_for(&self, language: &str) -> bool {
         self.auto_install_decision(language).1
     }
@@ -388,7 +387,8 @@ impl WorkspaceSettings {
         }
         Some(match source {
             AutoInstallSource::Language => format!(
-                "`languages.{language}.autoInstall` resolves to false                  (set on the language, its `base` chain, or `languages._`)"
+                "`languages.{language}.autoInstall` resolves to false (set on \
+                 the language, its `base` chain, or `languages._`)"
             ),
             AutoInstallSource::Wildcard => {
                 format!("`languages.{WILDCARD_KEY}.autoInstall` is false")
@@ -657,10 +657,10 @@ mod tests {
 
     #[test]
     fn auto_install_inherits_through_the_base_chain() {
-        // Discriminating on purpose: with NO `"_"` entry, only
-        // `merge_language_settings`'s `auto_install` arm can carry markdown's
-        // value onto `rmd`. A `"_"`-based fixture would pass even without the
-        // arm, because the lookup-time wildcard fallback answers identically.
+        // Discriminating on purpose: only `merge_language_settings`'s
+        // `auto_install` arm can carry markdown's value onto `rmd`. Without it
+        // `rmd`'s entry stays unset and, since a present entry owns the answer,
+        // resolution falls straight through to the top-level default.
         let raw = crate::config::RawWorkspaceSettings {
             languages: HashMap::from([
                 (
@@ -737,12 +737,16 @@ mod tests {
         // names the overriding key and says where it may have come from rather
         // than asserting the user wrote it on the language.
         let language = settings_with_auto_install(&[("python", Some(false))], true);
-        let reason = language
-            .auto_install_disabled_reason("python")
-            .expect("disabled");
-        assert!(reason.contains("languages.python.autoInstall"), "{reason}");
-        assert!(reason.contains("base"), "{reason}");
-        assert!(reason.contains("languages._"), "{reason}");
+        // Exact, not `contains`: this string reaches the client verbatim inside
+        // `notify_parser_missing`'s sentence, and a `contains` triple let a
+        // line-continuation slip that shipped 18 literal spaces mid-message.
+        assert_eq!(
+            language.auto_install_disabled_reason("python").as_deref(),
+            Some(
+                "`languages.python.autoInstall` resolves to false \
+                 (set on the language, its `base` chain, or `languages._`)"
+            )
+        );
 
         // Wildcard and top-level arms ARE reliable, so they name the key flatly.
         let wildcard = settings_with_auto_install(&[(WILDCARD_KEY, Some(false))], true);

--- a/src/config.rs
+++ b/src/config.rs
@@ -140,6 +140,9 @@ fn strip_inherited_language_settings(
         aliases: (current.aliases != inherited.aliases)
             .then(|| current.aliases.clone())
             .flatten(),
+        auto_install: (current.auto_install != inherited.auto_install)
+            .then_some(current.auto_install)
+            .flatten(),
     }
 }
 
@@ -240,6 +243,17 @@ fn strip_inherited_aggregation_config(
     }
 }
 
+/// Which configuration level decided `autoInstall` for a language.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AutoInstallSource {
+    /// `[languages.<lang>] autoInstall`
+    Language,
+    /// `[languages._] autoInstall`
+    Wildcard,
+    /// The deprecated top-level `autoInstall`.
+    TopLevel,
+}
+
 impl WorkspaceSettings {
     /// Convert `RawWorkspaceSettings` to `WorkspaceSettings`, expanding environment
     /// variables (`$VAR`, `${VAR}`) and tilde (`~`) in path fields.
@@ -336,6 +350,61 @@ impl WorkspaceSettings {
         self.languages
             .get(host_language)
             .or_else(|| self.languages.get(WILDCARD_KEY))
+    }
+
+    /// Whether missing parsers/queries for `language` may be auto-installed,
+    /// most-specific-wins: the language's own `autoInstall`, else the `"_"`
+    /// wildcard's, else the deprecated top-level `autoInstall` (which itself
+    /// defaults to enabled).
+    ///
+    /// The wildcard arm is not redundant with [`merge::resolve_base_configs`]:
+    /// that fold only covers languages that HAVE an entry, and an unconfigured
+    /// document has none. It also cannot be replaced by
+    /// [`Self::resolve_host_language_settings`], whose fallback is wholesale —
+    /// a language entry that sets only `parser` must still inherit the
+    /// wildcard's `autoInstall`, not shadow it with `None`.
+    pub(crate) fn auto_install_for(&self, language: &str) -> bool {
+        self.auto_install_decision(language).1
+    }
+
+    /// The config key that turns auto-install OFF for `language`, or `None`
+    /// when it is enabled — so a user-facing message can name the key to edit
+    /// rather than just saying "disabled".
+    ///
+    /// Formats lazily: [`Self::auto_install_for`] shares the same decision
+    /// without allocating, since the gate runs per `didOpen` and per injected
+    /// language while this runs only on the disabled path.
+    pub(crate) fn auto_install_disabled_key(&self, language: &str) -> Option<String> {
+        let (source, enabled) = self.auto_install_decision(language);
+        if enabled {
+            return None;
+        }
+        Some(match source {
+            AutoInstallSource::Language => format!("languages.{language}.autoInstall"),
+            AutoInstallSource::Wildcard => format!("languages.{WILDCARD_KEY}.autoInstall"),
+            AutoInstallSource::TopLevel => "autoInstall".to_string(),
+        })
+    }
+
+    /// Which level answers auto-install for `language`, and what it says.
+    /// Single source of the precedence order so the boolean and the
+    /// key-naming can never disagree.
+    fn auto_install_decision(&self, language: &str) -> (AutoInstallSource, bool) {
+        if let Some(enabled) = self
+            .languages
+            .get(language)
+            .and_then(|settings| settings.auto_install)
+        {
+            return (AutoInstallSource::Language, enabled);
+        }
+        if let Some(enabled) = self
+            .languages
+            .get(WILDCARD_KEY)
+            .and_then(|wildcard| wildcard.auto_install)
+        {
+            return (AutoInstallSource::Wildcard, enabled);
+        }
+        (AutoInstallSource::TopLevel, self.auto_install)
     }
 
     /// True if any configured language opts into host bridging
@@ -456,6 +525,125 @@ mod tests {
             languages: HashMap::from([(key.to_string(), lang)]),
             ..Default::default()
         }
+    }
+
+    /// Build a [`WorkspaceSettings`] with the given per-language `autoInstall`
+    /// values and top-level (deprecated) value, WITHOUT running
+    /// `resolve_base_configs` — so each case exercises the lookup-time
+    /// precedence in isolation from the base-chain fold.
+    fn settings_with_auto_install(
+        entries: &[(&str, Option<bool>)],
+        top_level: bool,
+    ) -> WorkspaceSettings {
+        WorkspaceSettings {
+            languages: entries
+                .iter()
+                .map(|(key, auto_install)| {
+                    (
+                        key.to_string(),
+                        LanguageSettings {
+                            auto_install: *auto_install,
+                            ..Default::default()
+                        },
+                    )
+                })
+                .collect(),
+            auto_install: top_level,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn auto_install_for_honors_the_language_entry() {
+        let settings = settings_with_auto_install(&[("python", Some(false))], true);
+        assert!(!settings.auto_install_for("python"));
+        // A sibling language is unaffected by python's exception.
+        assert!(settings.auto_install_for("rust"));
+    }
+
+    #[test]
+    fn auto_install_for_falls_back_to_the_wildcard_when_the_entry_omits_it() {
+        // `resolve_base_configs` normally folds `_` into every present entry;
+        // this pins the behavior for an entry that reached us unfolded.
+        let settings =
+            settings_with_auto_install(&[(WILDCARD_KEY, Some(false)), ("python", None)], true);
+        assert!(!settings.auto_install_for("python"));
+    }
+
+    #[test]
+    fn auto_install_for_falls_back_to_the_wildcard_with_no_language_entry() {
+        // The case the base-chain fold does NOT cover: no entry for the
+        // language at all, so only a lookup-time `_` fallback can answer.
+        let settings = settings_with_auto_install(&[(WILDCARD_KEY, Some(false))], true);
+        assert!(!settings.auto_install_for("python"));
+    }
+
+    #[test]
+    fn auto_install_for_falls_back_to_the_deprecated_top_level_key() {
+        let settings = settings_with_auto_install(&[], false);
+        assert!(!settings.auto_install_for("python"));
+    }
+
+    #[test]
+    fn auto_install_for_defaults_to_enabled() {
+        // Nothing configured anywhere: the zero-config default.
+        assert!(WorkspaceSettings::default().auto_install_for("python"));
+    }
+
+    #[test]
+    fn auto_install_for_lets_a_language_opt_back_in_over_a_global_off() {
+        // The point of the feature: `autoInstall = false` globally, with a
+        // per-language exception that re-enables it.
+        let settings = settings_with_auto_install(&[("python", Some(true))], false);
+        assert!(settings.auto_install_for("python"));
+        assert!(!settings.auto_install_for("rust"));
+    }
+
+    #[test]
+    fn auto_install_for_prefers_the_language_entry_over_the_wildcard() {
+        let settings = settings_with_auto_install(
+            &[(WILDCARD_KEY, Some(false)), ("python", Some(true))],
+            false,
+        );
+        assert!(settings.auto_install_for("python"));
+        assert!(!settings.auto_install_for("rust"));
+    }
+
+    #[test]
+    fn auto_install_disabled_key_names_the_level_that_decided() {
+        let language = settings_with_auto_install(&[("python", Some(false))], true);
+        assert_eq!(
+            language.auto_install_disabled_key("python").as_deref(),
+            Some("languages.python.autoInstall")
+        );
+
+        let wildcard = settings_with_auto_install(&[(WILDCARD_KEY, Some(false))], true);
+        assert_eq!(
+            wildcard.auto_install_disabled_key("python").as_deref(),
+            Some("languages._.autoInstall")
+        );
+
+        let top_level = settings_with_auto_install(&[], false);
+        assert_eq!(
+            top_level.auto_install_disabled_key("python").as_deref(),
+            Some("autoInstall")
+        );
+    }
+
+    #[test]
+    fn auto_install_disabled_key_is_none_when_enabled() {
+        assert_eq!(
+            WorkspaceSettings::default().auto_install_disabled_key("python"),
+            None
+        );
+        // Re-enabled per-language over a global off: nothing is disabling it,
+        // so there is no key to report even though the top level says false.
+        let exception = settings_with_auto_install(&[("python", Some(true))], false);
+        assert_eq!(exception.auto_install_disabled_key("python"), None);
+        assert_eq!(
+            exception.auto_install_disabled_key("rust").as_deref(),
+            Some("autoInstall")
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,6 +117,17 @@ fn inherited_language_settings<'a>(
         })
 }
 
+/// Drop fields whose value equals the one they would inherit, so a
+/// reconstructed raw config shows only genuine overrides.
+///
+/// Not behavior-preserving for a CIRCULAR `base` chain: both nodes resolve to
+/// the same folded value, so each looks inherited from the other and the
+/// cycle's single explicit value is stripped from both — re-resolving then
+/// falls through to the top-level default. Unreachable today (every production
+/// path carries the original raw settings; only the `None` arm in
+/// `apply_shared_settings` would land here, and no production caller passes
+/// `None`), and fixing it properly needs cycle-aware stripping. Recorded so a
+/// future caller of that arm knows what it inherits.
 fn strip_inherited_language_settings(
     inherited: &LanguageSettings,
     current: &LanguageSettings,
@@ -653,6 +664,62 @@ mod tests {
         );
         assert!(settings.auto_install_for("python"));
         assert!(!settings.auto_install_for("rust"));
+    }
+
+    #[test]
+    fn auto_install_precedence_holds_through_the_real_merge() {
+        // The synthetic `settings_with_auto_install` fixtures construct an
+        // ALREADY-resolved map, so they cannot catch a reversed
+        // `merge_language_settings` arm (`base.or(overlay)`): the wildcard's
+        // value would win in production while those tests stayed green. This
+        // runs the real fold with every level in conflict.
+        let raw = crate::config::RawWorkspaceSettings {
+            auto_install: Some(true),
+            languages: HashMap::from([
+                (
+                    WILDCARD_KEY.to_string(),
+                    LanguageSettings {
+                        auto_install: Some(false),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "python".to_string(),
+                    LanguageSettings {
+                        auto_install: Some(true),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "markdown".to_string(),
+                    LanguageSettings {
+                        auto_install: Some(true),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "rmd".to_string(),
+                    LanguageSettings {
+                        base: Some("markdown".to_string()),
+                        auto_install: Some(false),
+                        ..Default::default()
+                    },
+                ),
+                ("lua".to_string(), LanguageSettings::default()),
+            ]),
+            ..Default::default()
+        };
+        let settings =
+            WorkspaceSettings::try_from_settings(&raw, None, |_| None).expect("settings expand");
+
+        // Own value beats the wildcard...
+        assert!(settings.auto_install_for("python"));
+        // ...and beats an inherited base value.
+        assert!(!settings.auto_install_for("rmd"));
+        // An entry with nothing of its own takes the wildcard through the fold.
+        assert!(!settings.auto_install_for("lua"));
+        // No entry at all: the wildcard answers at lookup time.
+        assert!(!settings.auto_install_for("unconfigured"));
     }
 
     #[test]

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -47,24 +47,28 @@ pub fn default_settings() -> RawWorkspaceSettings {
     }
 }
 
-/// The `kakehashi config init` template: [`default_settings`] plus the
-/// defaults that are resolved at lookup time rather than carried in layer 1.
+/// The `kakehashi config init` template: [`default_settings`] minus the one key
+/// that cannot be spelled out inertly.
 ///
-/// Exists because `default_settings` is both the template source AND merge
-/// layer 1, and `autoInstall` cannot be in layer 1 (see the comment there).
-/// The template still spells the default out — per
-/// config-init-template-convention, deleting any generated line must not
-/// change behavior — but spells the CANONICAL key, `[languages._]`, so a
-/// generated file never trips the top-level deprecation notice.
+/// `autoInstall` is the sole documented exception to
+/// config-init-template-convention, which otherwise requires every built-in
+/// default to appear in the generated file. Neither spelling can be emitted
+/// safely:
+///
+/// - The top-level key is deprecated, so a generated file would trip the very
+///   migration notice we show users.
+/// - `[languages._] autoInstall` is worse than deprecated — it INVERTS layer
+///   precedence. `auto_install_for` checks `_` before the top-level key and is
+///   layer-unaware, so a `_` sitting in a generated user config (layer 2) would
+///   silently outrank a top-level `autoInstall = false` pushed by the editor at
+///   layer 4. That is not a spelled-out default; it is a behavior change.
+///   Pinned by `a_generated_template_does_not_shadow_a_higher_layer_optout`.
+///
+/// So the default lives in `auto_install_for`'s fallback and in the docs, not in
+/// the template. `default_settings` still carries the top-level value for merge
+/// layer 1, where it is safe.
 pub fn config_init_settings() -> RawWorkspaceSettings {
     let mut settings = default_settings();
-    // Spell the default on the CANONICAL key so a generated file never trips
-    // the top-level deprecation notice, and drop the deprecated spelling for
-    // the same reason. Layer 1 still carries the top-level value, so deleting
-    // the generated line changes nothing — the convention's requirement.
-    if let Some(wildcard) = settings.languages.get_mut(WILDCARD_KEY) {
-        wildcard.auto_install = Some(true);
-    }
     settings.auto_install = None;
     settings
 }
@@ -586,38 +590,61 @@ mod tests {
         assert!(!resolved.auto_install_for("python"));
     }
 
+    fn resolve(raw: &RawWorkspaceSettings) -> crate::config::WorkspaceSettings {
+        crate::config::WorkspaceSettings::try_from_settings(
+            raw,
+            None,
+            crate::config::expand::with_kakehashi_defaults(|_| None),
+        )
+        .expect("settings expand")
+    }
+
     #[test]
-    fn config_init_template_spells_out_the_canonical_auto_install_default() {
+    fn config_init_template_emits_no_auto_install_at_all() {
         let template = config_init_settings();
 
-        // Spelled out per config-init-template-convention, and on the
-        // canonical key so a generated file never trips the deprecation
-        // notice for the top-level spelling.
+        // The documented exception to config-init-template-convention: neither
+        // spelling is safe to generate. See `config_init_settings`.
+        assert_eq!(
+            template.auto_install, None,
+            "the template must not emit the deprecated top-level key"
+        );
         assert_eq!(
             template
                 .languages
                 .get(WILDCARD_KEY)
                 .and_then(|wildcard| wildcard.auto_install),
-            Some(true)
-        );
-        assert_eq!(
-            template.auto_install, None,
-            "the template must not emit the deprecated top-level key"
+            None,
+            "the template must not emit `languages._.autoInstall` either — it \
+             would invert layer precedence, see the regression test below"
         );
 
-        // Deleting the generated line must not change behavior: the resolved
-        // value with it, and without it, agree.
-        let resolved = |raw: &RawWorkspaceSettings| {
-            crate::config::WorkspaceSettings::try_from_settings(
-                raw,
-                None,
-                crate::config::expand::with_kakehashi_defaults(|_| None),
-            )
-            .expect("template expands")
-            .auto_install_for("python")
-        };
-        assert!(resolved(&template));
-        assert!(resolved(&default_settings()));
+        // The generated file still resolves to the zero-config default.
+        assert!(resolve(&template).auto_install_for("python"));
+    }
+
+    #[test]
+    fn a_generated_template_does_not_shadow_a_higher_layer_optout() {
+        // The regression: `auto_install_for` checks `_` before the top-level
+        // key and is layer-unaware, so a `_` written into a generated user
+        // config (layer 2) would silently outrank the editor's top-level
+        // `autoInstall = false` at layer 4.
+        let merged = crate::config::merge::merge_workspace_settings(
+            crate::config::merge::merge_workspace_settings(
+                Some(default_settings()),
+                Some(config_init_settings()),
+            ),
+            Some(RawWorkspaceSettings {
+                auto_install: Some(false),
+                ..Default::default()
+            }),
+        )
+        .expect("layers present");
+
+        assert!(
+            !resolve(&merged).auto_install_for("python"),
+            "a higher layer's top-level opt-out must win over the template"
+        );
     }
 
     #[test]
@@ -699,10 +726,16 @@ mod tests {
         let toml_string =
             toml::to_string_pretty(&settings).expect("should serialize to TOML without error");
 
-        // Should contain autoInstall setting
+        // `autoInstall` is deliberately absent (see `config_init_settings`), so
+        // anchor on a key the template does spell out.
         assert!(
-            toml_string.contains("autoInstall = true"),
-            "TOML should contain 'autoInstall = true'. Got:\n{}",
+            toml_string.contains("searchPaths = "),
+            "TOML should contain 'searchPaths'. Got:\n{}",
+            toml_string
+        );
+        assert!(
+            !toml_string.contains("autoInstall"),
+            "template must emit no autoInstall at either level. Got:\n{}",
             toml_string
         );
 

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -22,6 +22,12 @@ pub fn default_settings() -> RawWorkspaceSettings {
         search_paths: Some(vec!["${KAKEHASHI_DATA_DIR}".to_string()]),
         languages: default_languages(),
         capture_mappings: default_capture_mappings(),
+        // Safe to carry here even though the key is deprecated: this struct is
+        // also merge layer 1, and a user's own top-level value overlays THE
+        // SAME key, so it wins. `languages._.autoInstall` is the one that must
+        // stay unset in layer 1 — it outranks the top-level key in
+        // `auto_install_for`, so a defaults-supplied `_` would shadow a user's
+        // `autoInstall = false` and silently ignore it.
         auto_install: Some(true),
         diagnostics_debounce_ms: Some(DEFAULT_DEBOUNCE_MS),
         features: Some(FeatureSettings {
@@ -39,6 +45,28 @@ pub fn default_settings() -> RawWorkspaceSettings {
         }),
         language_servers: Some(default_language_servers()),
     }
+}
+
+/// The `kakehashi config init` template: [`default_settings`] plus the
+/// defaults that are resolved at lookup time rather than carried in layer 1.
+///
+/// Exists because `default_settings` is both the template source AND merge
+/// layer 1, and `autoInstall` cannot be in layer 1 (see the comment there).
+/// The template still spells the default out — per
+/// config-init-template-convention, deleting any generated line must not
+/// change behavior — but spells the CANONICAL key, `[languages._]`, so a
+/// generated file never trips the top-level deprecation notice.
+pub fn config_init_settings() -> RawWorkspaceSettings {
+    let mut settings = default_settings();
+    // Spell the default on the CANONICAL key so a generated file never trips
+    // the top-level deprecation notice, and drop the deprecated spelling for
+    // the same reason. Layer 1 still carries the top-level value, so deleting
+    // the generated line changes nothing — the convention's requirement.
+    if let Some(wildcard) = settings.languages.get_mut(WILDCARD_KEY) {
+        wildcard.auto_install = Some(true);
+    }
+    settings.auto_install = None;
+    settings
 }
 
 /// Returns the default languageServers map: a defaults-only `_` wildcard
@@ -517,15 +545,79 @@ mod tests {
     }
 
     #[test]
-    fn default_settings_has_auto_install_true() {
+    fn layer_one_leaves_the_wildcard_auto_install_unset() {
         let settings = default_settings();
 
-        // autoInstall should default to true for zero-config experience
+        // `_` outranks the top-level key, so a defaults-supplied value here
+        // would shadow a user's `autoInstall = false` and silently ignore it.
         assert_eq!(
-            settings.auto_install,
-            Some(true),
-            "autoInstall should be Some(true) by default"
+            settings
+                .languages
+                .get(WILDCARD_KEY)
+                .and_then(|wildcard| wildcard.auto_install),
+            None,
+            "layer 1 must not set languages._.autoInstall"
         );
+        // The top-level key IS safe in layer 1: a user's own top-level value
+        // overlays the same key and wins. Keeping it preserves what
+        // `effective_configuration` reports before any config is applied.
+        assert_eq!(settings.auto_install, Some(true));
+    }
+
+    #[test]
+    fn a_user_top_level_auto_install_survives_the_layer_one_default() {
+        // The regression this guards: if layer 1 supplied `languages._`, the
+        // merge would hand `auto_install_for` a wildcard `Some(true)` that
+        // outranks the user's key, silently ignoring their opt-out.
+        let user = RawWorkspaceSettings {
+            auto_install: Some(false),
+            ..Default::default()
+        };
+        let merged =
+            crate::config::merge::merge_workspace_settings(Some(default_settings()), Some(user))
+                .expect("both layers present");
+        let resolved = crate::config::WorkspaceSettings::try_from_settings(
+            &merged,
+            None,
+            crate::config::expand::with_kakehashi_defaults(|_| None),
+        )
+        .expect("merged settings expand");
+
+        assert!(!resolved.auto_install_for("python"));
+    }
+
+    #[test]
+    fn config_init_template_spells_out_the_canonical_auto_install_default() {
+        let template = config_init_settings();
+
+        // Spelled out per config-init-template-convention, and on the
+        // canonical key so a generated file never trips the deprecation
+        // notice for the top-level spelling.
+        assert_eq!(
+            template
+                .languages
+                .get(WILDCARD_KEY)
+                .and_then(|wildcard| wildcard.auto_install),
+            Some(true)
+        );
+        assert_eq!(
+            template.auto_install, None,
+            "the template must not emit the deprecated top-level key"
+        );
+
+        // Deleting the generated line must not change behavior: the resolved
+        // value with it, and without it, agree.
+        let resolved = |raw: &RawWorkspaceSettings| {
+            crate::config::WorkspaceSettings::try_from_settings(
+                raw,
+                None,
+                crate::config::expand::with_kakehashi_defaults(|_| None),
+            )
+            .expect("template expands")
+            .auto_install_for("python")
+        };
+        assert!(resolved(&template));
+        assert!(resolved(&default_settings()));
     }
 
     #[test]
@@ -599,8 +691,9 @@ mod tests {
     }
 
     #[test]
-    fn default_settings_serializes_to_valid_toml() {
-        let settings = default_settings();
+    fn config_init_template_serializes_to_valid_toml() {
+        // The template, not layer 1: this asserts what `config init` writes.
+        let settings = config_init_settings();
 
         // Should serialize to valid TOML
         let toml_string =

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -11,6 +11,33 @@
 
 use serde_json::Value as JsonValue;
 
+/// Which deprecated config keys any loaded layer actually spelled.
+///
+/// Serde collapses deprecated and canonical spellings (via `alias`, or by the
+/// key simply still being accepted), so the parsed settings carry no trace of
+/// what the user wrote — each flag is detected from the raw config value
+/// before that collapse. Kept OUT of `events` because many callers re-load
+/// settings and would re-warn; the `initialize` and `didChangeConfiguration`
+/// handlers instead surface each one once per session via `SettingsManager`'s
+/// claim guards.
+///
+/// An aggregate rather than one `&mut bool` per key: every loader has to
+/// thread all of them, and the count grows with each deprecation.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DeprecatedKeysSeen {
+    /// `[languageServers.*] rootMarkers`, superseded by `workspaceMarkers`.
+    pub(crate) root_markers: bool,
+    /// Top-level `autoInstall`, superseded by `[languages.*] autoInstall`.
+    pub(crate) auto_install: bool,
+}
+
+impl DeprecatedKeysSeen {
+    pub(crate) fn merge(&mut self, other: Self) {
+        self.root_markers |= other.root_markers;
+        self.auto_install |= other.auto_install;
+    }
+}
+
 /// User-facing text for the one-per-session `rootMarkers` deprecation notice,
 /// shared by every path that can surface it (initialize, didChangeConfiguration).
 pub(crate) const ROOT_MARKERS_DEPRECATION_NOTICE: &str = "kakehashi: the `rootMarkers` config key is deprecated; rename it to \
@@ -23,39 +50,59 @@ pub(crate) const UNWRAPPED_DIDCHANGE_CONFIGURATION_NOTICE: &str = "kakehashi: un
      send runtime settings in the notification's `settings.kakehashi` object. \
      Flat didChange settings still work for now but may be removed in a future release.";
 
-/// True if any `[languageServers.*]` entry declares the deprecated `rootMarkers`
-/// key (superseded by `workspaceMarkers`), scanning raw TOML text.
+/// User-facing text for the one-per-session top-level `autoInstall` notice.
+pub(crate) const AUTO_INSTALL_DEPRECATION_NOTICE: &str = "kakehashi: the top-level `autoInstall` config key is deprecated; move it to \
+     `[languages._] autoInstall` (and override per language with \
+     `[languages.<lang>] autoInstall`). The top-level key still works for now \
+     but may be removed in a future release.";
+
+/// Which deprecated keys the raw TOML text spells.
 ///
-/// Returns `false` for unparseable input: this is a best-effort migration nudge,
-/// and a genuine parse error is surfaced through the normal load-error path.
-pub(crate) fn toml_uses_deprecated_root_markers(contents: &str) -> bool {
-    toml::from_str::<toml::Value>(contents)
-        .ok()
-        .as_ref()
-        .and_then(|value| value.get("languageServers"))
-        .and_then(|servers| servers.as_table())
-        .is_some_and(|servers| {
-            servers.values().any(|config| {
-                config
-                    .as_table()
-                    .is_some_and(|table| table.contains_key("rootMarkers"))
-            })
-        })
+/// Returns all-false for unparseable input: this is a best-effort migration
+/// nudge, and a genuine parse error is surfaced through the normal load-error
+/// path.
+pub(crate) fn toml_deprecated_keys(contents: &str) -> DeprecatedKeysSeen {
+    let Ok(value) = toml::from_str::<toml::Value>(contents) else {
+        return DeprecatedKeysSeen::default();
+    };
+    DeprecatedKeysSeen {
+        root_markers: value
+            .get("languageServers")
+            .and_then(|servers| servers.as_table())
+            .is_some_and(|servers| {
+                servers.values().any(|config| {
+                    config
+                        .as_table()
+                        .is_some_and(|table| table.contains_key("rootMarkers"))
+                })
+            }),
+        // Only the TOP-LEVEL spelling is deprecated. A `[languages.*]` table
+        // carries the canonical key of the same name, so scanning by name alone
+        // would warn about the very config we are telling people to write.
+        auto_install: value
+            .as_table()
+            .is_some_and(|table| table.contains_key("autoInstall")),
+    }
 }
 
-/// True if any `languageServers.*` entry declares the deprecated `rootMarkers`
-/// key, scanning a raw JSON value (the `initializationOptions` override path).
-pub(crate) fn json_uses_deprecated_root_markers(value: &JsonValue) -> bool {
-    value
-        .get("languageServers")
-        .and_then(|servers| servers.as_object())
-        .is_some_and(|servers| {
-            servers.values().any(|config| {
-                config
-                    .as_object()
-                    .is_some_and(|object| object.contains_key("rootMarkers"))
-            })
-        })
+/// Which deprecated keys a raw JSON value spells (the `initializationOptions`
+/// and `didChangeConfiguration` override paths).
+pub(crate) fn json_deprecated_keys(value: &JsonValue) -> DeprecatedKeysSeen {
+    DeprecatedKeysSeen {
+        root_markers: value
+            .get("languageServers")
+            .and_then(|servers| servers.as_object())
+            .is_some_and(|servers| {
+                servers.values().any(|config| {
+                    config
+                        .as_object()
+                        .is_some_and(|object| object.contains_key("rootMarkers"))
+                })
+            }),
+        auto_install: value
+            .as_object()
+            .is_some_and(|object| object.contains_key("autoInstall")),
+    }
 }
 
 #[cfg(test)]
@@ -63,12 +110,66 @@ mod tests {
     use super::*;
 
     #[test]
+    fn toml_detects_the_deprecated_top_level_auto_install() {
+        assert!(toml_deprecated_keys("autoInstall = true").auto_install);
+        assert!(toml_deprecated_keys("autoInstall = false").auto_install);
+    }
+
+    #[test]
+    fn toml_does_not_flag_the_canonical_per_language_auto_install() {
+        // The regression this guards: scanning by key name alone would warn
+        // about the exact config the notice tells people to write.
+        let canonical = r#"
+[languages._]
+autoInstall = true
+
+[languages.python]
+autoInstall = false
+"#;
+        assert!(!toml_deprecated_keys(canonical).auto_install);
+    }
+
+    #[test]
+    fn toml_flags_both_keys_independently() {
+        let both = r#"
+autoInstall = false
+
+[languageServers.rust-analyzer]
+rootMarkers = [".git"]
+"#;
+        let seen = toml_deprecated_keys(both);
+        assert!(seen.auto_install);
+        assert!(seen.root_markers);
+
+        let neither = toml_deprecated_keys("[languages._]\nautoInstall = true\n");
+        assert!(!neither.auto_install);
+        assert!(!neither.root_markers);
+    }
+
+    #[test]
+    fn json_detects_the_deprecated_top_level_auto_install() {
+        let deprecated = serde_json::json!({ "autoInstall": false });
+        assert!(json_deprecated_keys(&deprecated).auto_install);
+
+        let canonical = serde_json::json!({
+            "languages": { "_": { "autoInstall": true } }
+        });
+        assert!(!json_deprecated_keys(&canonical).auto_install);
+    }
+
+    #[test]
+    fn unparseable_toml_flags_nothing() {
+        let seen = toml_deprecated_keys("this is not = = toml");
+        assert_eq!(seen, DeprecatedKeysSeen::default());
+    }
+
+    #[test]
     fn toml_detects_deprecated_key() {
         let contents = r#"
             [languageServers.rust-analyzer]
             rootMarkers = [".git"]
         "#;
-        assert!(toml_uses_deprecated_root_markers(contents));
+        assert!(toml_deprecated_keys(contents).root_markers);
     }
 
     #[test]
@@ -77,15 +178,13 @@ mod tests {
             [languageServers.rust-analyzer]
             workspaceMarkers = [".git"]
         "#;
-        assert!(!toml_uses_deprecated_root_markers(contents));
+        assert!(!toml_deprecated_keys(contents).root_markers);
     }
 
     #[test]
     fn toml_ignores_absent_key_and_unparseable_input() {
-        assert!(!toml_uses_deprecated_root_markers("autoInstall = false"));
-        assert!(!toml_uses_deprecated_root_markers(
-            "this is not [valid toml"
-        ));
+        assert!(!toml_deprecated_keys("autoInstall = false").root_markers);
+        assert!(!toml_deprecated_keys("this is not [valid toml").root_markers);
     }
 
     #[test]
@@ -96,7 +195,7 @@ mod tests {
             [languageServers.rust-analyzer]
             workspaceMarkers = ["rootMarkers"]
         "#;
-        assert!(!toml_uses_deprecated_root_markers(contents));
+        assert!(!toml_deprecated_keys(contents).root_markers);
     }
 
     #[test]
@@ -104,7 +203,7 @@ mod tests {
         let value = serde_json::json!({
             "languageServers": { "rust-analyzer": { "rootMarkers": [".git"] } }
         });
-        assert!(json_uses_deprecated_root_markers(&value));
+        assert!(json_deprecated_keys(&value).root_markers);
     }
 
     #[test]
@@ -112,8 +211,8 @@ mod tests {
         let canonical = serde_json::json!({
             "languageServers": { "rust-analyzer": { "workspaceMarkers": [".git"] } }
         });
-        assert!(!json_uses_deprecated_root_markers(&canonical));
-        assert!(!json_uses_deprecated_root_markers(&serde_json::json!({})));
+        assert!(!json_deprecated_keys(&canonical).root_markers);
+        assert!(!json_deprecated_keys(&serde_json::json!({})).root_markers);
     }
 
     #[test]
@@ -122,44 +221,48 @@ mod tests {
         // level, an unrelated table, or a server's opaque passthrough blob) must
         // not trip the deprecation warning. This pins that scope against a
         // future change that broadens the walk and starts false-warning.
-        assert!(!toml_uses_deprecated_root_markers(
-            "rootMarkers = [\".git\"]"
-        ));
-        assert!(!toml_uses_deprecated_root_markers(
-            "[other]\nrootMarkers = [\".git\"]"
-        ));
-        assert!(!json_uses_deprecated_root_markers(&serde_json::json!({
-            "rootMarkers": [".git"],
-            "other": { "rootMarkers": [".git"] }
-        })));
+        assert!(!toml_deprecated_keys("rootMarkers = [\".git\"]").root_markers);
+        assert!(!toml_deprecated_keys("[other]\nrootMarkers = [\".git\"]").root_markers);
+        assert!(
+            !json_deprecated_keys(&serde_json::json!({
+                "rootMarkers": [".git"],
+                "other": { "rootMarkers": [".git"] }
+            }))
+            .root_markers
+        );
         // A downstream server's opaque `initializationOptions` blob may itself
         // carry an unrelated `rootMarkers` key — must not be walked into.
-        assert!(!json_uses_deprecated_root_markers(&serde_json::json!({
-            "languageServers": {
-                "x": { "initializationOptions": { "rootMarkers": [".git"] } }
-            }
-        })));
+        assert!(
+            !json_deprecated_keys(&serde_json::json!({
+                "languageServers": {
+                    "x": { "initializationOptions": { "rootMarkers": [".git"] } }
+                }
+            }))
+            .root_markers
+        );
     }
 
     #[test]
     fn non_table_languageservers_is_ignored() {
-        assert!(!toml_uses_deprecated_root_markers(
-            "languageServers = \"oops\""
-        ));
-        assert!(!json_uses_deprecated_root_markers(&serde_json::json!({
-            "languageServers": ["oops"]
-        })));
+        assert!(!toml_deprecated_keys("languageServers = \"oops\"").root_markers);
+        assert!(
+            !json_deprecated_keys(&serde_json::json!({
+                "languageServers": ["oops"]
+            }))
+            .root_markers
+        );
     }
 
     #[test]
     fn deprecated_key_is_flagged_regardless_of_value_shape() {
         // Empty array and a both-keys table (which serde later rejects as a
         // duplicate field) still count as "the deprecated key was written".
-        assert!(toml_uses_deprecated_root_markers(
-            "[languageServers.x]\nrootMarkers = []"
-        ));
-        assert!(toml_uses_deprecated_root_markers(
-            "[languageServers.x]\nrootMarkers = [\".git\"]\nworkspaceMarkers = [\".git\"]"
-        ));
+        assert!(toml_deprecated_keys("[languageServers.x]\nrootMarkers = []").root_markers);
+        assert!(
+            toml_deprecated_keys(
+                "[languageServers.x]\nrootMarkers = [\".git\"]\nworkspaceMarkers = [\".git\"]"
+            )
+            .root_markers
+        );
     }
 }

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -53,8 +53,9 @@ pub(crate) const UNWRAPPED_DIDCHANGE_CONFIGURATION_NOTICE: &str = "kakehashi: un
 /// User-facing text for the one-per-session top-level `autoInstall` notice.
 pub(crate) const AUTO_INSTALL_DEPRECATION_NOTICE: &str = "kakehashi: the top-level `autoInstall` config key is deprecated; move it to \
      `[languages._] autoInstall` (and override per language with \
-     `[languages.<lang>] autoInstall`). The top-level key still works for now \
-     but may be removed in a future release.";
+     `[languages.<lang>] autoInstall`). A language with a self-referential \
+     `base` inherits nothing from `_`, so give those an explicit value. The \
+     top-level key still works for now but may be removed in a future release.";
 
 /// Which deprecated keys the raw TOML text spells.
 ///

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -51,9 +51,13 @@ pub(crate) const UNWRAPPED_DIDCHANGE_CONFIGURATION_NOTICE: &str = "kakehashi: un
      Flat didChange settings still work for now but may be removed in a future release.";
 
 /// User-facing text for the one-per-session top-level `autoInstall` notice.
+///
+/// Dotted key paths, not TOML table syntax: this notice also fires for JSON
+/// runtime settings (`initializationOptions`, `didChangeConfiguration`), where
+/// `[languages._]` would name a shape the user cannot write.
 pub(crate) const AUTO_INSTALL_DEPRECATION_NOTICE: &str = "kakehashi: the top-level `autoInstall` config key is deprecated; move it to \
-     `[languages._] autoInstall` (and override per language with \
-     `[languages.<lang>] autoInstall`). A language with a self-referential \
+     `languages._.autoInstall` (and override per language with \
+     `languages.<lang>.autoInstall`). A language with a self-referential \
      `base` inherits nothing from `_`, so give those an explicit value. The \
      top-level key still works for now but may be removed in a future release.";
 

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -110,6 +110,30 @@ mod tests {
     use super::*;
 
     #[test]
+    fn merge_ors_flags_so_a_clean_later_layer_cannot_clear_them() {
+        // The regression: `=` instead of `|=` would let a clean higher layer
+        // (e.g. `initializationOptions: {}`, which every session runs through
+        // `parse_override_settings`) clobber a flag a config FILE set, and the
+        // notice would never fire for file-config users.
+        let mut seen = DeprecatedKeysSeen {
+            root_markers: true,
+            auto_install: true,
+        };
+        seen.merge(DeprecatedKeysSeen::default());
+        assert!(seen.root_markers, "a later clean layer must not clear this");
+        assert!(seen.auto_install, "a later clean layer must not clear this");
+
+        // And it must still pick flags UP from a later layer.
+        let mut none = DeprecatedKeysSeen::default();
+        none.merge(DeprecatedKeysSeen {
+            root_markers: false,
+            auto_install: true,
+        });
+        assert!(none.auto_install);
+        assert!(!none.root_markers);
+    }
+
+    #[test]
     fn toml_detects_the_deprecated_top_level_auto_install() {
         assert!(toml_deprecated_keys("autoInstall = true").auto_install);
         assert!(toml_deprecated_keys("autoInstall = false").auto_install);

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -153,6 +153,7 @@ pub(crate) fn merge_language_settings(
         bridge: merge_bridge_maps(base.bridge.as_ref(), overlay.bridge.as_ref()),
         layers: merge_layers_configs(base.layers.as_ref(), overlay.layers.as_ref()),
         aliases: overlay.aliases.clone().or_else(|| base.aliases.clone()),
+        auto_install: overlay.auto_install.or(base.auto_install),
     }
 }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -845,7 +845,12 @@ pub fn json_schema() -> schemars::Schema {
 // via RawWorkspaceSettings.
 
 /// Per-language Tree-sitter configuration.
+///
+/// `rename_all` is load-bearing now that a field is multi-word: the config
+/// surface is camelCase throughout (see the `snake_case leak` assertions), and
+/// `KNOWN_LANGUAGE_SETTING_KEYS` is checked against the generated schema.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct LanguageSettings {
     /// Base language to inherit unfilled fields from (most-specific-wins).
     /// E.g., `base = "markdown"` on `rmd` means rmd inherits markdown's
@@ -865,6 +870,13 @@ pub struct LanguageSettings {
     /// Deprecated: use `base` on the derived language instead.
     /// Alternative languageId values that should use this parser.
     pub aliases: Option<Vec<String>>,
+    /// Whether missing parsers/queries for this language may be auto-installed.
+    ///
+    /// Omit to inherit from the `base` chain and ultimately the `"_"` wildcard;
+    /// when unset everywhere, the deprecated top-level `autoInstall` answers,
+    /// which itself defaults to enabled. Set `false` on `"_"` and `true` on a
+    /// language (or the reverse) to carve out per-language exceptions.
+    pub auto_install: Option<bool>,
 }
 
 impl LanguageSettings {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -664,7 +664,10 @@ pub struct RawWorkspaceSettings {
     /// Custom mappings from Tree-sitter capture names to semantic token types.
     #[serde(default)]
     pub capture_mappings: CaptureMappings,
-    /// Whether to automatically install missing parsers and queries.
+    /// Deprecated: use `languages._.autoInstall` (and per-language
+    /// `languages.<lang>.autoInstall`) instead. Whether to automatically
+    /// install missing parsers and queries. Still honored when no per-language
+    /// value is set, but setting it shows a one-time migration notice.
     pub auto_install: Option<bool>,
     /// Debounce delay, in milliseconds, between a `didChange` and the diagnostic
     /// pull it triggers. Higher values cut refresh/pull volume during rapid typing
@@ -847,8 +850,11 @@ pub fn json_schema() -> schemars::Schema {
 /// Per-language Tree-sitter configuration.
 ///
 /// `rename_all` is load-bearing now that a field is multi-word: the config
-/// surface is camelCase throughout (see the `snake_case leak` assertions), and
-/// `KNOWN_LANGUAGE_SETTING_KEYS` is checked against the generated schema.
+/// surface is camelCase throughout, and dropping it fails
+/// `known_language_setting_keys_match_schema_properties`, which compares the
+/// camelCase `KNOWN_LANGUAGE_SETTING_KEYS` against this struct's generated
+/// schema property names. (The `snake_case leak` assertions nearby only cover
+/// `RawWorkspaceSettings`' own top-level keys, not this type's.)
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct LanguageSettings {

--- a/src/config/snapshots/kakehashi__config__merge__tests__merge_workspace_settings_all_fields.snap
+++ b/src/config/snapshots/kakehashi__config__merge__tests__merge_workspace_settings_all_fields.snap
@@ -13,7 +13,8 @@ expression: result
       "queries": null,
       "bridge": null,
       "layers": null,
-      "aliases": null
+      "aliases": null,
+      "autoInstall": null
     },
     "python": {
       "base": null,
@@ -33,7 +34,8 @@ expression: result
       "layers": null,
       "aliases": [
         "py3"
-      ]
+      ],
+      "autoInstall": null
     },
     "rust": {
       "base": null,
@@ -41,7 +43,8 @@ expression: result
       "queries": null,
       "bridge": null,
       "layers": null,
-      "aliases": null
+      "aliases": null,
+      "autoInstall": null
     }
   },
   "captureMappings": {

--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -60,14 +60,14 @@ impl std::error::Error for UserConfigError {
 
 /// User configuration plus metadata gathered from the same read.
 ///
-/// `uses_deprecated_root_markers` is detected from the very bytes that were
-/// parsed (not a second read), so it cannot disagree with `settings` under a
-/// concurrent file edit. Serde's alias erases which spelling was written, so
-/// this flag is the only way to know the deprecated key was used.
+/// `deprecated_keys` is detected from the very bytes that were parsed (not a
+/// second read), so it cannot disagree with `settings` under a concurrent file
+/// edit. Parsing collapses deprecated and canonical spellings, so these flags
+/// are the only way to know a deprecated key was used.
 #[derive(Debug)]
 pub(crate) struct UserConfig {
     pub(crate) settings: RawWorkspaceSettings,
-    pub(crate) uses_deprecated_root_markers: bool,
+    pub(crate) deprecated_keys: crate::config::deprecation::DeprecatedKeysSeen,
 }
 
 /// Loads user configuration from the XDG config directory.
@@ -93,14 +93,13 @@ pub fn load_user_config() -> UserConfigResult<Option<UserConfig>> {
         source: e,
     })?;
 
-    let uses_deprecated_root_markers =
-        crate::config::deprecation::toml_uses_deprecated_root_markers(&contents);
+    let deprecated_keys = crate::config::deprecation::toml_deprecated_keys(&contents);
     let settings = toml::from_str::<RawWorkspaceSettings>(&contents)
         .map_err(|e| UserConfigError::ParseError { path, source: e })?;
 
     Ok(Some(UserConfig {
         settings,
-        uses_deprecated_root_markers,
+        deprecated_keys,
     }))
 }
 
@@ -327,7 +326,7 @@ mod tests {
 
         let config = settings.unwrap();
         assert!(
-            !config.uses_deprecated_root_markers,
+            !config.deprecated_keys.root_markers,
             "no rootMarkers in this fixture"
         );
         let settings = config.settings;
@@ -374,7 +373,7 @@ mod tests {
 
         let config = result.unwrap().expect("config exists");
         assert!(
-            config.uses_deprecated_root_markers,
+            config.deprecated_keys.root_markers,
             "rootMarkers in the user config should be flagged"
         );
     }

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -321,13 +321,6 @@ impl InjectionCoordinator {
         }
         after_incarnation_check.await;
         let install = self.install_coordinator();
-        let auto_install_enabled = self.settings_manager.is_auto_install_enabled();
-
-        let reason = if auto_install_enabled {
-            String::new()
-        } else {
-            install.auto_install_disabled_reason()
-        };
 
         // Events emitted while loading an injected-language parser that was on disk
         // but not yet loaded — a one-time `Log` plus (when the language has queries)
@@ -380,7 +373,17 @@ impl InjectionCoordinator {
                 continue;
             }
 
-            if !auto_install_enabled {
+            // Resolved per language, not hoisted: `autoInstall` is now
+            // per-language (`[languages.<lang>]`, falling back to `"_"` then the
+            // deprecated top-level key), so one injected language being opted
+            // out must not decide for its siblings in the same document. Keyed
+            // on `resolved_lang` — the language actually installed — so an
+            // opt-out on the normalized name (`python`, not `py`) applies.
+            if !self
+                .settings_manager
+                .is_auto_install_enabled(&resolved_lang)
+            {
+                let reason = install.auto_install_disabled_reason(&resolved_lang);
                 install.notify_parser_missing(&resolved_lang, &reason).await;
                 continue;
             }

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -114,11 +114,15 @@ impl InstallCoordinator {
         }
     }
 
-    /// Build a human-readable reason why auto-install is disabled.
-    pub(crate) fn auto_install_disabled_reason(&self) -> String {
+    /// Build a human-readable reason why auto-install is disabled for
+    /// `language`.
+    ///
+    /// Names the exact key that turned it off — with per-language overrides the
+    /// answer to "why is this off?" is no longer a single global setting.
+    pub(crate) fn auto_install_disabled_reason(&self, language: &str) -> String {
         let settings = self.settings_manager.load_settings();
-        if !settings.auto_install {
-            return "autoInstall is disabled".to_string();
+        if let Some(key) = settings.auto_install_disabled_key(language) {
+            return format!("`{key}` is false");
         }
         if !self
             .settings_manager

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -121,8 +121,8 @@ impl InstallCoordinator {
     /// answer to "why is this off?" is no longer a single global setting.
     pub(crate) fn auto_install_disabled_reason(&self, language: &str) -> String {
         let settings = self.settings_manager.load_settings();
-        if let Some(key) = settings.auto_install_disabled_key(language) {
-            return format!("`{key}` is false");
+        if let Some(reason) = settings.auto_install_disabled_reason(language) {
+            return reason;
         }
         if !self
             .settings_manager

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -117,8 +117,10 @@ impl InstallCoordinator {
     /// Build a human-readable reason why auto-install is disabled for
     /// `language`.
     ///
-    /// Names the exact key that turned it off — with per-language overrides the
-    /// answer to "why is this off?" is no longer a single global setting.
+    /// Points at the config that decided it: exactly for the wildcard and
+    /// top-level cases, hedged for a per-language entry, where the base-chain
+    /// fold makes the original spelling unknowable. See
+    /// [`crate::config::WorkspaceSettings::auto_install_disabled_reason`].
     pub(crate) fn auto_install_disabled_reason(&self, language: &str) -> String {
         let settings = self.settings_manager.load_settings();
         if let Some(reason) = settings.auto_install_disabled_reason(language) {

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -192,16 +192,26 @@ impl Kakehashi {
         let settings_events = settings_outcome.events;
         let mut default_settings_warning = None;
 
-        // Nudge users off the deprecated `rootMarkers` config key. The claim
-        // guard latches session-wide so a later didChangeConfiguration carrying
-        // `rootMarkers` does not warn a second time (and vice versa).
-        if settings_outcome.used_deprecated_root_markers
+        // Nudge users off deprecated config keys. Each claim guard latches
+        // session-wide so a later didChangeConfiguration carrying the same key
+        // does not warn a second time (and vice versa). The two keys claim
+        // independently: seeing one must not suppress the other.
+        if settings_outcome.deprecated_keys.root_markers
             && self
                 .settings_manager
                 .claim_root_markers_deprecation_warning()
         {
             self.notifier()
                 .show_warning(crate::config::deprecation::ROOT_MARKERS_DEPRECATION_NOTICE)
+                .await;
+        }
+        if settings_outcome.deprecated_keys.auto_install
+            && self
+                .settings_manager
+                .claim_auto_install_deprecation_warning()
+        {
+            self.notifier()
+                .show_warning(crate::config::deprecation::AUTO_INSTALL_DEPRECATION_NOTICE)
                 .await;
         }
 

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -119,7 +119,7 @@ impl Kakehashi {
             }
 
             if !load_result.success {
-                if self.settings_manager.is_auto_install_enabled() {
+                if self.settings_manager.is_auto_install_enabled(lang) {
                     // Language failed to load and auto-install is enabled.
                     //
                     // Move auto-install OFF the ingress writer ticket (#480
@@ -201,7 +201,9 @@ impl Kakehashi {
                     skip_parse = true;
                 } else {
                     // Notify user that parser is missing and needs manual installation
-                    let reason = self.install_coordinator().auto_install_disabled_reason();
+                    let reason = self
+                        .install_coordinator()
+                        .auto_install_disabled_reason(lang);
                     self.install_coordinator()
                         .notify_parser_missing(lang, &reason)
                         .await;

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -47,8 +47,15 @@ const KNOWN_BRIDGE_SERVER_SETTING_KEYS: &[&str] = &[
 
 const KNOWN_CAPTURE_MAPPINGS_SETTING_KEYS: &[&str] = &["folds", "highlights"];
 
-const KNOWN_LANGUAGE_SETTING_KEYS: &[&str] =
-    &["aliases", "base", "bridge", "layers", "parser", "queries"];
+const KNOWN_LANGUAGE_SETTING_KEYS: &[&str] = &[
+    "aliases",
+    "autoInstall",
+    "base",
+    "bridge",
+    "layers",
+    "parser",
+    "queries",
+];
 
 const KNOWN_LAYER_AGGREGATION_SETTING_KEYS: &[&str] = &["priorities", "strategy"];
 

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -371,17 +371,28 @@ impl Kakehashi {
             uses_deprecated_unwrapped_didchange_shape(&params.settings);
         let (settings_value, unknown_keys) = settings_payload(params.settings);
 
-        // Nudge users off the deprecated `rootMarkers` key if this push carries
-        // it. Detect from the raw value before serde's alias erases which key
-        // was used; the claim guard shares the once-per-session slot with the
+        // Nudge users off any deprecated key this push carries. Detected from
+        // the raw value before parsing collapses the deprecated and canonical
+        // spellings; each claim guard shares its once-per-session slot with the
         // initialize path.
-        if crate::config::deprecation::json_uses_deprecated_root_markers(&settings_value)
+        let pushed_deprecated_keys =
+            crate::config::deprecation::json_deprecated_keys(&settings_value);
+        if pushed_deprecated_keys.root_markers
             && self
                 .settings_manager
                 .claim_root_markers_deprecation_warning()
         {
             self.notifier()
                 .show_warning(crate::config::deprecation::ROOT_MARKERS_DEPRECATION_NOTICE)
+                .await;
+        }
+        if pushed_deprecated_keys.auto_install
+            && self
+                .settings_manager
+                .claim_auto_install_deprecation_warning()
+        {
+            self.notifier()
+                .show_warning(crate::config::deprecation::AUTO_INSTALL_DEPRECATION_NOTICE)
                 .await;
         }
 
@@ -715,6 +726,15 @@ mod tests {
                 ..Default::default()
             },
         );
+
+        // This payload uses the deprecated top-level `autoInstall` on purpose
+        // (the merge behavior under test is about that key). Consume the notice
+        // slot first: the warning would otherwise `show_warning` into a socket
+        // this test never drains, parking the future for a reason unrelated to
+        // the settings-reload lock it is meant to park on.
+        server
+            .settings_manager
+            .claim_auto_install_deprecation_warning();
 
         let reload_guard = crate::lsp::lsp_impl::lock_settings_reload().await;
         let mut update = Box::pin(server.did_change_configuration_impl(

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -1,3 +1,4 @@
+use crate::config::deprecation::DeprecatedKeysSeen;
 use crate::config::{
     RawWorkspaceSettings, WorkspaceSettings, defaults::default_settings, load_user_config,
     merge_workspace_settings,
@@ -61,14 +62,9 @@ pub struct SettingsLoadOutcome {
     pub settings: Option<WorkspaceSettings>,
     pub raw_settings: Option<RawWorkspaceSettings>,
     pub events: Vec<SettingsEvent>,
-    /// True if any loaded config layer used the deprecated `rootMarkers` key
-    /// (superseded by `workspaceMarkers`). Serde's alias erases which spelling
-    /// was written, so this is detected from the raw config value. The
-    /// `initialize` handler reads this field and surfaces a one-per-session
-    /// deprecation notice (gated by `SettingsManager`'s claim guard, shared
-    /// with the didChangeConfiguration path); it is intentionally kept out of
-    /// `events` so the many callers that re-load settings do not re-warn.
-    pub used_deprecated_root_markers: bool,
+    /// Which deprecated keys the loaded layers spelled — see
+    /// [`DeprecatedKeysSeen`] for why this is not an `events` entry.
+    pub(crate) deprecated_keys: DeprecatedKeysSeen,
 }
 
 pub fn load_settings(
@@ -79,7 +75,7 @@ pub fn load_settings(
 ) -> SettingsLoadOutcome {
     let env_fn = crate::config::expand::with_kakehashi_defaults(env_fn);
     let mut events = Vec::new();
-    let mut used_deprecated_root_markers = false;
+    let mut deprecated_keys = DeprecatedKeysSeen::default();
 
     // Layer 1: Programmed defaults (configuration-merging-strategy: lowest precedence)
     let defaults = Some(default_settings());
@@ -93,25 +89,20 @@ pub fn load_settings(
             )));
             files
                 .iter()
-                .map(|p| load_toml_file(p, &mut events, &mut used_deprecated_root_markers))
+                .map(|p| load_toml_file(p, &mut events, &mut deprecated_keys))
                 .collect()
         } else {
             vec![
                 // Layer 2: User config from XDG_CONFIG_HOME (~/.config/kakehashi/kakehashi.toml)
-                load_user_config_with_events(&mut events, &mut used_deprecated_root_markers),
+                load_user_config_with_events(&mut events, &mut deprecated_keys),
                 // Layer 3: Project config from root_path/kakehashi.toml
-                load_toml_settings(root_path, &mut events, &mut used_deprecated_root_markers),
+                load_toml_settings(root_path, &mut events, &mut deprecated_keys),
             ]
         };
 
     // Layer 4: Override settings from initialization options or client configuration
     let override_settings = override_settings.and_then(|(source, value)| {
-        parse_override_settings(
-            source,
-            value,
-            &mut events,
-            &mut used_deprecated_root_markers,
-        )
+        parse_override_settings(source, value, &mut events, &mut deprecated_keys)
     });
 
     // Merge all layers: defaults < config_layers < override (later layers override earlier)
@@ -142,21 +133,21 @@ pub fn load_settings(
         settings,
         raw_settings,
         events,
-        used_deprecated_root_markers,
+        deprecated_keys,
     }
 }
 
 /// Load user config and add appropriate events to the events vector.
 fn load_user_config_with_events(
     events: &mut Vec<SettingsEvent>,
-    used_deprecated_root_markers: &mut bool,
+    deprecated_keys: &mut DeprecatedKeysSeen,
 ) -> Option<RawWorkspaceSettings> {
     match load_user_config() {
         Ok(Some(config)) => {
             events.push(SettingsEvent::info(
                 "Loaded user config from XDG_CONFIG_HOME",
             ));
-            *used_deprecated_root_markers |= config.uses_deprecated_root_markers;
+            deprecated_keys.merge(config.deprecated_keys);
             Some(config.settings)
         }
         Ok(None) => {
@@ -180,7 +171,7 @@ fn load_user_config_with_events(
 fn load_toml_file(
     path: &Path,
     events: &mut Vec<SettingsEvent>,
-    used_deprecated_root_markers: &mut bool,
+    deprecated_keys: &mut DeprecatedKeysSeen,
 ) -> Option<RawWorkspaceSettings> {
     if !path.exists() {
         events.push(SettingsEvent::error(format!(
@@ -197,8 +188,7 @@ fn load_toml_file(
 
     match fs::read_to_string(path) {
         Ok(contents) => {
-            *used_deprecated_root_markers |=
-                crate::config::deprecation::toml_uses_deprecated_root_markers(&contents);
+            deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
             match toml::from_str::<RawWorkspaceSettings>(&contents) {
                 Ok(settings) => {
                     events.push(SettingsEvent::info(format!(
@@ -231,7 +221,7 @@ fn load_toml_file(
 fn load_toml_settings(
     root_path: Option<&Path>,
     events: &mut Vec<SettingsEvent>,
-    used_deprecated_root_markers: &mut bool,
+    deprecated_keys: &mut DeprecatedKeysSeen,
 ) -> Option<RawWorkspaceSettings> {
     let root = root_path?;
     let config_path = root.join("kakehashi.toml");
@@ -246,8 +236,7 @@ fn load_toml_settings(
 
     match fs::read_to_string(&config_path) {
         Ok(contents) => {
-            *used_deprecated_root_markers |=
-                crate::config::deprecation::toml_uses_deprecated_root_markers(&contents);
+            deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
             match toml::from_str::<RawWorkspaceSettings>(&contents) {
                 Ok(settings) => {
                     events.push(SettingsEvent::info("Successfully loaded kakehashi.toml"));
@@ -276,10 +265,9 @@ fn parse_override_settings(
     source: SettingsSource,
     value: Value,
     events: &mut Vec<SettingsEvent>,
-    used_deprecated_root_markers: &mut bool,
+    deprecated_keys: &mut DeprecatedKeysSeen,
 ) -> Option<RawWorkspaceSettings> {
-    *used_deprecated_root_markers |=
-        crate::config::deprecation::json_uses_deprecated_root_markers(&value);
+    deprecated_keys.merge(crate::config::deprecation::json_deprecated_keys(&value));
     match serde_json::from_value::<RawWorkspaceSettings>(value) {
         Ok(settings) => {
             events.push(SettingsEvent::info(format!(
@@ -596,7 +584,8 @@ mod tests {
             None,
             make_env(&[]),
         )
-        .used_deprecated_root_markers;
+        .deprecated_keys
+        .root_markers;
 
         let canonical = serde_json::json!({
             "languageServers": { "rust-analyzer": { "workspaceMarkers": [".git"] } }
@@ -607,7 +596,8 @@ mod tests {
             None,
             make_env(&[]),
         )
-        .used_deprecated_root_markers;
+        .deprecated_keys
+        .root_markers;
 
         // SAFETY: #[serial(xdg_env)] prevents concurrent modification.
         unsafe {
@@ -635,7 +625,7 @@ mod tests {
         std::fs::write(&path, "autoInstall = false\n").unwrap();
 
         let mut events = Vec::new();
-        let mut ignored_deprecation = false;
+        let mut ignored_deprecation = DeprecatedKeysSeen::default();
         let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
 
         assert!(result.is_some(), "valid TOML should parse");
@@ -653,7 +643,7 @@ mod tests {
     #[test]
     fn test_load_toml_file_missing() {
         let mut events = Vec::new();
-        let mut ignored_deprecation = false;
+        let mut ignored_deprecation = DeprecatedKeysSeen::default();
         let result = load_toml_file(
             Path::new("/nonexistent/config.toml"),
             &mut events,
@@ -677,7 +667,7 @@ mod tests {
         std::fs::write(&path, "this is not [valid toml").unwrap();
 
         let mut events = Vec::new();
-        let mut ignored_deprecation = false;
+        let mut ignored_deprecation = DeprecatedKeysSeen::default();
         let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
 
         assert!(result.is_none(), "invalid TOML should return None");
@@ -699,11 +689,14 @@ mod tests {
         std::fs::write(&path, "[languageServers.x]\nrootMarkers = [\".git\"]\n").unwrap();
 
         let mut events = Vec::new();
-        let mut used_deprecated = false;
+        let mut used_deprecated = DeprecatedKeysSeen::default();
         let result = load_toml_file(&path, &mut events, &mut used_deprecated);
 
         assert!(result.is_some(), "valid TOML should parse");
-        assert!(used_deprecated, "rootMarkers should set the flag");
+        assert!(
+            used_deprecated.root_markers,
+            "rootMarkers should set the flag"
+        );
     }
 
     /// load_toml_settings (the project kakehashi.toml layer) sets the flag when
@@ -718,10 +711,13 @@ mod tests {
         .unwrap();
 
         let mut events = Vec::new();
-        let mut used_deprecated = false;
+        let mut used_deprecated = DeprecatedKeysSeen::default();
         let result = load_toml_settings(Some(dir.path()), &mut events, &mut used_deprecated);
 
         assert!(result.is_some(), "valid project config should parse");
-        assert!(used_deprecated, "rootMarkers should set the flag");
+        assert!(
+            used_deprecated.root_markers,
+            "rootMarkers should set the flag"
+        );
     }
 }

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -33,6 +33,7 @@ pub(crate) struct SettingsManager {
     /// about, so the notice is shown at most once per session regardless of
     /// which path (initialize or didChangeConfiguration) first sees it.
     root_markers_deprecation_warned: AtomicBool,
+    auto_install_deprecation_warned: AtomicBool,
     /// Latches once an unwrapped runtime `workspace/didChangeConfiguration`
     /// payload has been warned about. Unlike `rootMarkers`, this applies only to
     /// client-pushed runtime settings, not initializationOptions or TOML files.
@@ -81,6 +82,7 @@ impl SettingsManager {
             })),
             client_capabilities: OnceLock::new(),
             root_markers_deprecation_warned: AtomicBool::new(false),
+            auto_install_deprecation_warned: AtomicBool::new(false),
             unwrapped_didchange_deprecation_warned: AtomicBool::new(false),
         }
     }
@@ -93,6 +95,15 @@ impl SettingsManager {
     pub(crate) fn claim_root_markers_deprecation_warning(&self) -> bool {
         !self
             .root_markers_deprecation_warned
+            .swap(true, Ordering::Relaxed)
+    }
+
+    /// Claim the one-per-session slot for the deprecated top-level
+    /// `autoInstall` key. Independent of the other slots: seeing one deprecated
+    /// key must not suppress the notice for another.
+    pub(crate) fn claim_auto_install_deprecation_warning(&self) -> bool {
+        !self
+            .auto_install_deprecation_warned
             .swap(true, Ordering::Relaxed)
     }
 
@@ -669,6 +680,32 @@ mod tests {
             "subsequent claims must not re-warn"
         );
         assert!(!manager.claim_root_markers_deprecation_warning());
+    }
+
+    #[test]
+    fn claim_auto_install_deprecation_warning_is_true_exactly_once() {
+        let manager = SettingsManager::new();
+        assert!(
+            manager.claim_auto_install_deprecation_warning(),
+            "first claim should win the once-per-session slot"
+        );
+        assert!(
+            !manager.claim_auto_install_deprecation_warning(),
+            "subsequent claims must not re-warn"
+        );
+    }
+
+    #[test]
+    fn deprecation_claim_slots_are_independent() {
+        // A config carrying both deprecated keys must warn about both; one
+        // shared latch would silently drop the second notice.
+        let manager = SettingsManager::new();
+        assert!(manager.claim_root_markers_deprecation_warning());
+        assert!(
+            manager.claim_auto_install_deprecation_warning(),
+            "claiming rootMarkers must not consume the autoInstall slot"
+        );
+        assert!(manager.claim_unwrapped_didchange_deprecation_warning());
     }
 
     #[test]

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -222,11 +222,12 @@ impl SettingsManager {
     /// - `autoInstall` is explicitly set to `false` in settings
     /// - `searchPaths` doesn't include the default data directory (auto-install
     ///   would install to a location that isn't being searched)
-    pub(crate) fn is_auto_install_enabled(&self) -> bool {
+    pub(crate) fn is_auto_install_enabled(&self, language: &str) -> bool {
         let settings = self.load_settings();
 
-        // If explicitly disabled, return false
-        if !settings.auto_install {
+        // Per-language first: `[languages.<lang>] autoInstall`, else `"_"`,
+        // else the deprecated top-level key.
+        if !settings.auto_install_for(language) {
             return false;
         }
 

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -230,7 +230,8 @@ impl SettingsManager {
     /// Check if auto-install is enabled.
     ///
     /// Returns `false` if:
-    /// - `autoInstall` is explicitly set to `false` in settings
+    /// - auto-install is off for `language` — its own `autoInstall`, else
+    ///   `languages._`'s, else the deprecated top-level key
     /// - `searchPaths` doesn't include the default data directory (auto-install
     ///   would install to a location that isn't being searched)
     pub(crate) fn is_auto_install_enabled(&self, language: &str) -> bool {

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -230,8 +230,10 @@ impl SettingsManager {
     /// Check if auto-install is enabled.
     ///
     /// Returns `false` if:
-    /// - auto-install is off for `language` — its own `autoInstall`, else
-    ///   `languages._`'s, else the deprecated top-level key
+    /// - auto-install is off for `language` — its resolved entry's
+    ///   `autoInstall` (which the base-chain fold may have inherited from
+    ///   `languages._`), else `languages._`'s when the language has no entry
+    ///   at all, else the deprecated top-level key
     /// - `searchPaths` doesn't include the default data directory (auto-install
     ///   would install to a location that isn't being searched)
     pub(crate) fn is_auto_install_enabled(&self, language: &str) -> bool {

--- a/tests/e2e_deprecation_warning.rs
+++ b/tests/e2e_deprecation_warning.rs
@@ -2,12 +2,18 @@
 //! (`rootMarkers`, the top-level `autoInstall`, and the unwrapped
 //! `didChangeConfiguration` shape).
 //!
-//! Each notice is surfaced by `initialize` and `workspace/didChangeConfiguration`
-//! sharing a single session-scoped claim guard, so it fires at most once even
-//! when config keeps carrying the deprecated key. Most tests drive it through
-//! didChangeConfiguration, whose notifications the ordinary synchronous request
-//! helper does not discard; the one initialize-path test sends `initialize`
-//! asynchronously so the notifications preceding its response are retained too.
+//! The `rootMarkers` and `autoInstall` notices can each be surfaced by
+//! `initialize` OR by `workspace/didChangeConfiguration`, sharing one
+//! session-scoped claim guard so each fires at most once however often config
+//! keeps carrying the key. The unwrapped-shape notice is didChange-only — there
+//! is no initialize payload with that shape.
+//!
+//! Most tests therefore send a notification and then wait on the notification
+//! stream explicitly, because the synchronous request helper discards
+//! notifications that arrive while it awaits a response. The one initialize-path
+//! test cannot do that, so it sends `initialize` asynchronously and keeps the
+//! notifications that precede the response.
+//!
 //! The guard and detectors are also covered in isolation by unit tests.
 
 #![cfg(feature = "e2e")]
@@ -435,9 +441,16 @@ fn e2e_auto_install_deprecation_warns_at_initialize_and_not_again_on_didchange()
     );
     let (_response, watched) = client
         .receive_response_for_id_watching_notifications(initialize_id, &["window/showMessage"]);
-    let mut notice = watched
+    let mut matching: Vec<_> = watched
         .into_iter()
-        .find(|(_, params)| is_auto_install_deprecation_notice(params));
+        .filter(|(_, params)| is_auto_install_deprecation_notice(params))
+        .collect();
+    assert!(
+        matching.len() <= 1,
+        "initialize must warn at most once; got {} notices: {matching:?}",
+        matching.len()
+    );
+    let mut notice = matching.pop();
 
     // The warning is enqueued before the initialize handler returns, but the
     // server merges its response and its client-notification streams without an

--- a/tests/e2e_deprecation_warning.rs
+++ b/tests/e2e_deprecation_warning.rs
@@ -373,9 +373,17 @@ fn e2e_auto_install_deprecation_warns_once_and_spares_the_canonical_key() {
         Some(2),
         "deprecation notice should be MessageType::WARNING"
     );
-    client
-        .wait_for_notification_where(&["window/logMessage"], TIMEOUT, is_config_updated)
+    // Watch BOTH methods: waiting only for `logMessage` would let a second
+    // identical popup for this same update be discarded by the predicate filter.
+    let (method, params) = client
+        .wait_for_notification_where(&["window/showMessage", "window/logMessage"], TIMEOUT, |p| {
+            is_auto_install_deprecation_notice(p) || is_config_updated(p)
+        })
         .expect("first top-level reconfig should log a config-updated message");
+    assert_eq!(
+        method, "window/logMessage",
+        "one update must not emit the notice twice; got: {params:?}"
+    );
 
     // Still carrying it → the guard has latched, so no second popup precedes
     // the config-updated log.
@@ -398,7 +406,7 @@ fn e2e_auto_install_deprecation_warns_once_and_spares_the_canonical_key() {
 }
 
 #[test]
-fn e2e_auto_install_deprecation_claimed_at_initialize_suppresses_the_didchange_notice() {
+fn e2e_auto_install_deprecation_warns_at_initialize_and_not_again_on_didchange() {
     // The other autoInstall test starts from a CLEAN initialize, so it proves
     // only the didChangeConfiguration half. This one starts from a config FILE
     // carrying the deprecated key, exercising initialize-time DETECTION of it.
@@ -411,7 +419,11 @@ fn e2e_auto_install_deprecation_claimed_at_initialize_suppresses_the_didchange_n
         .arg(config_path.to_str().expect("utf-8 temp path"))
         .build();
 
-    client.send_request(
+    // Send `initialize` ASYNCHRONOUSLY and collect the notifications that arrive
+    // before its response. The synchronous helper discards them, which is why an
+    // earlier version of this test could not see the initialize-time popup at
+    // all — and therefore passed even with `show_warning` deleted.
+    let initialize_id = client.send_request_async(
         "initialize",
         json!({
             "processId": std::process::id(),
@@ -421,19 +433,28 @@ fn e2e_auto_install_deprecation_claimed_at_initialize_suppresses_the_didchange_n
             "initializationOptions": {}
         }),
     );
+    let (_response, watched) = client
+        .receive_response_for_id_watching_notifications(initialize_id, &["window/showMessage"]);
+    let notices: Vec<_> = watched
+        .iter()
+        .filter(|(_, params)| is_auto_install_deprecation_notice(params))
+        .collect();
+    assert_eq!(
+        notices.len(),
+        1,
+        "a config file carrying top-level autoInstall must warn exactly once at \
+         initialize; got: {watched:?}"
+    );
+    assert_eq!(
+        notices[0].1["type"].as_i64(),
+        Some(2),
+        "deprecation notice should be MessageType::WARNING"
+    );
     client.send_notification("initialized", json!({}));
 
-    // The initialize-time popup is not observable by this client (it is emitted
-    // inside the `initialize` request, before its response — see the module
-    // doc), so prove it by its EFFECT: it consumed the session's only slot.
-    // Pushing the same deprecated key now yields the config-updated log with no
-    // popup ahead of it. Scope, precisely: this pins that initialize DETECTED
-    // the file's key and claimed the slot — delete the whole `if` block at
-    // `lifecycle.rs` and the popup appears here (verified). It does NOT pin the
-    // `show_warning` call: dropping only that line leaves the claim, and this
-    // test still passes, because `initialize`'s own notifications are discarded
-    // while the client awaits the response. The sibling test pins the popup
-    // itself, on the didChange path.
+    // And the claim it consumed is shared with the didChange path: pushing the
+    // same deprecated key now yields the config-updated log with no popup ahead
+    // of it.
     client.send_notification(
         "workspace/didChangeConfiguration",
         wrapped_didchange_config(false),

--- a/tests/e2e_deprecation_warning.rs
+++ b/tests/e2e_deprecation_warning.rs
@@ -401,7 +401,7 @@ fn e2e_auto_install_deprecation_warns_once_and_spares_the_canonical_key() {
 fn e2e_auto_install_deprecation_claimed_at_initialize_suppresses_the_didchange_notice() {
     // The other autoInstall test starts from a CLEAN initialize, so it proves
     // only the didChangeConfiguration half. This one starts from a config FILE
-    // carrying the deprecated key, exercising the initialize emission path.
+    // carrying the deprecated key, exercising initialize-time DETECTION of it.
     let config_dir = tempfile::TempDir::new().expect("temp config dir");
     let config_path = config_dir.path().join("kakehashi.toml");
     std::fs::write(&config_path, "autoInstall = false\n").expect("write config");
@@ -429,10 +429,11 @@ fn e2e_auto_install_deprecation_claimed_at_initialize_suppresses_the_didchange_n
     // Pushing the same deprecated key now yields the config-updated log with no
     // popup ahead of it. Scope, precisely: this pins that initialize DETECTED
     // the file's key and claimed the slot — delete the whole `if` block at
-    // `lifecycle.rs` and the popup appears here (verified). It does not pin the
-    // `show_warning` call itself, since `initialize`'s own notifications are
-    // dropped while the client awaits the response; the sibling test covers the
-    // popup text on the didChange path.
+    // `lifecycle.rs` and the popup appears here (verified). It does NOT pin the
+    // `show_warning` call: dropping only that line leaves the claim, and this
+    // test still passes, because `initialize`'s own notifications are discarded
+    // while the client awaits the response. The sibling test pins the popup
+    // itself, on the didChange path.
     client.send_notification(
         "workspace/didChangeConfiguration",
         wrapped_didchange_config(false),
@@ -444,7 +445,7 @@ fn e2e_auto_install_deprecation_claimed_at_initialize_suppresses_the_didchange_n
         .expect("reconfig should log a config-updated message");
     assert_eq!(
         method, "window/logMessage",
-        "the initialize warning must consume the session's only slot; got: {params:?}"
+        "initialize must have claimed the session's only slot; got: {params:?}"
     );
 
     let _ = client.send_request("shutdown", json!(null));

--- a/tests/e2e_deprecation_warning.rs
+++ b/tests/e2e_deprecation_warning.rs
@@ -2,13 +2,13 @@
 //! (`rootMarkers`, the top-level `autoInstall`, and the unwrapped
 //! `didChangeConfiguration` shape).
 //!
-//! The notice is surfaced by `initialize` and `workspace/didChangeConfiguration`
+//! Each notice is surfaced by `initialize` and `workspace/didChangeConfiguration`
 //! sharing a single session-scoped claim guard, so it fires at most once even
-//! when config keeps carrying the deprecated key. This drives it through
-//! didChangeConfiguration (whose notifications, unlike a warning emitted during
-//! the `initialize` request, are observable by the test client) to prove the
-//! warn-path works and the guard suppresses the repeat. The guard and detectors
-//! are also covered in isolation by unit tests.
+//! when config keeps carrying the deprecated key. Most tests drive it through
+//! didChangeConfiguration, whose notifications the ordinary synchronous request
+//! helper does not discard; the one initialize-path test sends `initialize`
+//! asynchronously so the notifications preceding its response are retained too.
+//! The guard and detectors are also covered in isolation by unit tests.
 
 #![cfg(feature = "e2e")]
 
@@ -435,22 +435,31 @@ fn e2e_auto_install_deprecation_warns_at_initialize_and_not_again_on_didchange()
     );
     let (_response, watched) = client
         .receive_response_for_id_watching_notifications(initialize_id, &["window/showMessage"]);
-    let notices: Vec<_> = watched
-        .iter()
-        .filter(|(_, params)| is_auto_install_deprecation_notice(params))
-        .collect();
+    let mut notice = watched
+        .into_iter()
+        .find(|(_, params)| is_auto_install_deprecation_notice(params));
+
+    // The warning is enqueued before the initialize handler returns, but the
+    // server merges its response and its client-notification streams without an
+    // ordering guarantee, so the response can reach stdout first. Position is
+    // therefore not asserted — presence is: if the notice was not in the
+    // pre-response batch it is still in the stream, so wait for it. Delete
+    // `show_warning` and neither place has it, and this times out.
+    client.send_notification("initialized", json!({}));
+    if notice.is_none() {
+        notice = client.wait_for_notification_where(
+            &["window/showMessage"],
+            TIMEOUT,
+            is_auto_install_deprecation_notice,
+        );
+    }
+    let (_, notice_params) =
+        notice.expect("a config file carrying top-level autoInstall must warn at initialize");
     assert_eq!(
-        notices.len(),
-        1,
-        "a config file carrying top-level autoInstall must warn exactly once at \
-         initialize; got: {watched:?}"
-    );
-    assert_eq!(
-        notices[0].1["type"].as_i64(),
+        notice_params["type"].as_i64(),
         Some(2),
         "deprecation notice should be MessageType::WARNING"
     );
-    client.send_notification("initialized", json!({}));
 
     // And the claim it consumed is shared with the didChange path: pushing the
     // same deprecated key now yields the config-updated log with no popup ahead

--- a/tests/e2e_deprecation_warning.rs
+++ b/tests/e2e_deprecation_warning.rs
@@ -427,9 +427,12 @@ fn e2e_auto_install_deprecation_claimed_at_initialize_suppresses_the_didchange_n
     // inside the `initialize` request, before its response — see the module
     // doc), so prove it by its EFFECT: it consumed the session's only slot.
     // Pushing the same deprecated key now yields the config-updated log with no
-    // popup ahead of it. Delete the initialize emission or its claim and the
-    // popup appears here, failing the assertion — coverage the sibling test
-    // cannot provide, since that one starts from a clean initialize.
+    // popup ahead of it. Scope, precisely: this pins that initialize DETECTED
+    // the file's key and claimed the slot — delete the whole `if` block at
+    // `lifecycle.rs` and the popup appears here (verified). It does not pin the
+    // `show_warning` call itself, since `initialize`'s own notifications are
+    // dropped while the client awaits the response; the sibling test covers the
+    // popup text on the didChange path.
     client.send_notification(
         "workspace/didChangeConfiguration",
         wrapped_didchange_config(false),

--- a/tests/e2e_deprecation_warning.rs
+++ b/tests/e2e_deprecation_warning.rs
@@ -64,6 +64,24 @@ fn section_wrapped_config_with_root_markers() -> Value {
     })
 }
 
+/// The top-level-`autoInstall` notice, distinct from the `rootMarkers` one.
+fn is_auto_install_deprecation_notice(params: &Value) -> bool {
+    params["message"]
+        .as_str()
+        .is_some_and(|m| m.contains("autoInstall") && m.contains("deprecated"))
+}
+
+/// The canonical replacement spelling, which must NOT warn.
+fn canonical_per_language_auto_install(auto_install: bool) -> Value {
+    json!({
+        "settings": {
+            "kakehashi": {
+                "languages": { "_": { "autoInstall": auto_install } }
+            }
+        }
+    })
+}
+
 fn flat_didchange_config(auto_install: bool) -> Value {
     json!({ "settings": { "autoInstall": auto_install } })
 }
@@ -282,6 +300,95 @@ fn e2e_unwrapped_didchange_deprecation_warns_once_and_ignores_unrelated_settings
         query_effective_settings(&mut client)["autoInstall"],
         json!(false),
         "second flat didChange config should still update the effective runtime settings"
+    );
+
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn e2e_auto_install_deprecation_warns_once_and_spares_the_canonical_key() {
+    let config_dir = tempfile::TempDir::new().expect("temp config dir");
+    let config_path = config_dir.path().join("kakehashi.toml");
+    std::fs::write(&config_path, "").expect("write empty config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("utf-8 temp path"))
+        .build();
+
+    // Clean initialize (no `autoInstall` anywhere) leaves the slot free.
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    // The canonical per-language spelling must NOT warn — it is what the notice
+    // tells people to write, so a name-only detector would warn about its own
+    // migration target. Positive proof: the config-updated log arrives with no
+    // popup ahead of it.
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        canonical_per_language_auto_install(false),
+    );
+    let (method, params) = client
+        .wait_for_notification_where(&["window/showMessage", "window/logMessage"], TIMEOUT, |p| {
+            is_auto_install_deprecation_notice(p) || is_config_updated(p)
+        })
+        .expect("canonical reconfig should log a config-updated message");
+    assert_eq!(
+        method, "window/logMessage",
+        "`[languages._] autoInstall` must not trigger the deprecation popup; got: {params:?}"
+    );
+    assert_eq!(
+        query_effective_settings(&mut client)["languages"]["_"]["autoInstall"],
+        json!(false),
+        "canonical key should still reach the effective runtime settings"
+    );
+
+    // The deprecated top-level spelling → the popup fires.
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        wrapped_didchange_config(true),
+    );
+    let (method, params) = client
+        .wait_for_notification_where(
+            &["window/showMessage"],
+            TIMEOUT,
+            is_auto_install_deprecation_notice,
+        )
+        .expect("top-level autoInstall should surface the deprecation popup");
+    assert_eq!(method, "window/showMessage");
+    assert_eq!(
+        params["type"].as_i64(),
+        Some(2),
+        "deprecation notice should be MessageType::WARNING"
+    );
+    client
+        .wait_for_notification_where(&["window/logMessage"], TIMEOUT, is_config_updated)
+        .expect("first top-level reconfig should log a config-updated message");
+
+    // Still carrying it → the guard has latched, so no second popup precedes
+    // the config-updated log.
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        wrapped_didchange_config(false),
+    );
+    let (method, params) = client
+        .wait_for_notification_where(&["window/showMessage", "window/logMessage"], TIMEOUT, |p| {
+            is_auto_install_deprecation_notice(p) || is_config_updated(p)
+        })
+        .expect("second reconfig should log a config-updated message");
+    assert_eq!(
+        method, "window/logMessage",
+        "no second autoInstall deprecation popup should fire; got: {params:?}"
     );
 
     let _ = client.send_request("shutdown", json!(null));

--- a/tests/e2e_deprecation_warning.rs
+++ b/tests/e2e_deprecation_warning.rs
@@ -1,4 +1,6 @@
-//! E2E tests for the one-per-session `rootMarkers` deprecation notice.
+//! E2E tests for the one-per-session config deprecation notices
+//! (`rootMarkers`, the top-level `autoInstall`, and the unwrapped
+//! `didChangeConfiguration` shape).
 //!
 //! The notice is surfaced by `initialize` and `workspace/didChangeConfiguration`
 //! sharing a single session-scoped claim guard, so it fires at most once even

--- a/tests/e2e_deprecation_warning.rs
+++ b/tests/e2e_deprecation_warning.rs
@@ -14,7 +14,9 @@
 //! test cannot do that, so it sends `initialize` asynchronously and keeps the
 //! notifications that precede the response.
 //!
-//! The guard and detectors are also covered in isolation by unit tests.
+//! The claim guards and the config-key detectors are also covered in isolation
+//! by unit tests; the wrapped/unwrapped shape classification is covered only
+//! here.
 
 #![cfg(feature = "e2e")]
 

--- a/tests/e2e_deprecation_warning.rs
+++ b/tests/e2e_deprecation_warning.rs
@@ -396,3 +396,54 @@ fn e2e_auto_install_deprecation_warns_once_and_spares_the_canonical_key() {
     let _ = client.send_request("shutdown", json!(null));
     client.send_notification("exit", json!(null));
 }
+
+#[test]
+fn e2e_auto_install_deprecation_claimed_at_initialize_suppresses_the_didchange_notice() {
+    // The other autoInstall test starts from a CLEAN initialize, so it proves
+    // only the didChangeConfiguration half. This one starts from a config FILE
+    // carrying the deprecated key, exercising the initialize emission path.
+    let config_dir = tempfile::TempDir::new().expect("temp config dir");
+    let config_path = config_dir.path().join("kakehashi.toml");
+    std::fs::write(&config_path, "autoInstall = false\n").expect("write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("utf-8 temp path"))
+        .build();
+
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    // The initialize-time popup is not observable by this client (it is emitted
+    // inside the `initialize` request, before its response — see the module
+    // doc), so prove it by its EFFECT: it consumed the session's only slot.
+    // Pushing the same deprecated key now yields the config-updated log with no
+    // popup ahead of it. Delete the initialize emission or its claim and the
+    // popup appears here, failing the assertion — coverage the sibling test
+    // cannot provide, since that one starts from a clean initialize.
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        wrapped_didchange_config(false),
+    );
+    let (method, params) = client
+        .wait_for_notification_where(&["window/showMessage", "window/logMessage"], TIMEOUT, |p| {
+            is_auto_install_deprecation_notice(p) || is_config_updated(p)
+        })
+        .expect("reconfig should log a config-updated message");
+    assert_eq!(
+        method, "window/logMessage",
+        "the initialize warning must consume the session's only slot; got: {params:?}"
+    );
+
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -236,9 +236,42 @@ fn test_config_init_outputs_to_stdout() {
     // Stdout should contain the config template
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("autoInstall"),
+        stdout.contains("searchPaths"),
         "Stdout should contain config template. Got: {}",
         stdout
+    );
+}
+
+/// `config init` output must round-trip: valid TOML that emits neither spelling
+/// of `autoInstall`.
+///
+/// The deprecated top-level key would make kakehashi warn about a file it wrote
+/// itself; `[languages._] autoInstall` would silently outrank a top-level
+/// `autoInstall = false` set at a higher-precedence source. Pointing
+/// `run_config_init` back at `default_settings()` reintroduces the first, and no
+/// other assertion in this file notices.
+#[test]
+fn test_config_init_emits_no_auto_install_spelling() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args(["config", "init"])
+        .output()
+        .expect("Failed to run config init");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: toml::Value = toml::from_str(&stdout).expect("config init must emit valid TOML");
+
+    assert!(
+        parsed.get("autoInstall").is_none(),
+        "must not emit the deprecated top-level key. Got:\n{stdout}"
+    );
+    assert!(
+        parsed
+            .get("languages")
+            .and_then(|languages| languages.get("_"))
+            .and_then(|wildcard| wildcard.get("autoInstall"))
+            .is_none(),
+        "must not emit `languages._.autoInstall` either. Got:\n{stdout}"
     );
 }
 
@@ -382,7 +415,7 @@ fn test_config_init_output_creates_file() {
     // File should contain expected options
     let content = fs::read_to_string(&config_path).expect("Failed to read config");
     assert!(
-        content.contains("autoInstall"),
+        content.contains("searchPaths"),
         "Config should contain expected options. Got: {}",
         content
     );
@@ -444,7 +477,7 @@ fn test_config_init_output_force_overwrites() {
         "Content should be overwritten"
     );
     assert!(
-        content.contains("autoInstall"),
+        content.contains("searchPaths"),
         "New content should be present"
     );
 }
@@ -474,7 +507,7 @@ fn test_config_init_force_without_output_warns() {
     // Should still output to stdout
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("autoInstall"),
+        stdout.contains("searchPaths"),
         "Should still output config to stdout. Got: {}",
         stdout
     );
@@ -498,7 +531,7 @@ fn test_config_init_output_dash_outputs_to_stdout() {
     // Stdout should contain the config template
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("autoInstall"),
+        stdout.contains("searchPaths"),
         "Stdout should contain config template. Got: {}",
         stdout
     );


### PR DESCRIPTION
## Summary

`autoInstall` was global-only, so one crashing or unwanted grammar forced the whole
feature off. This adds `[languages.<lang>].autoInstall`:

```toml
[languages._]
autoInstall = true    # canonical spelling of the old global switch

[languages.python]
autoInstall = false   # never auto-install this one
```

The reverse works too — `_ = false` with per-language opt-ins. Precedence is the
language's own value → the `"_"` wildcard's → the deprecated top-level
`autoInstall` → `true`. Unset is the default at every level, so a language inherits
`_` and its `base` chain exactly like the other `LanguageSettings` fields.

Top-level `autoInstall` still answers when nothing per-language is set, and now gets
the same one-per-session migration notice `rootMarkers` has.

## The design constraint that shaped this

**`languages.*.autoInstall` outranks the top-level key regardless of which config
source supplied it.** That follows from the spec — the top-level key is only a
fallback for an unset per-language value — but it means key specificity can beat
*source* precedence, which the merge strategy otherwise guarantees. Two consequences,
both now enforced:

- `default_settings()` (merge layer 1) must not carry `languages._.autoInstall`. A
  built-in value there would silently shadow every user-supplied top-level opt-out.
  Its top-level value *is* safe — a user overlays the same key and wins.
- The `config init` template must emit **neither** spelling. The top-level one would
  make kakehashi warn about a file it wrote itself; `[languages._]` would let a
  generated user config (layer 2) outrank an `autoInstall = false` pushed via
  `initializationOptions` (layer 4). `autoInstall` is therefore the documented
  exception to config-init-template-convention: the default lives in the resolver and
  the docs, not the generated file.

The second point was a regression in the first version of this branch, caught by
review and fixed in `be826d174`. It is now pinned by
`a_generated_template_does_not_shadow_a_higher_layer_optout` and, through the real
binary, `test_config_init_emits_no_auto_install_spelling`. `docs/README.md` and the
merge-strategy ADR both record the precedence exception.

## Other things reviewers should know

- **The deprecation detector checks only the top level.** `[languages.*]` carries the
  canonical key of the same name, so a name-only scan would warn about exactly the
  config the notice tells people to write. Pinned by
  `toml_does_not_flag_the_canonical_per_language_auto_install` and the e2e
  `..._spares_the_canonical_key`.
- **A present language entry owns the answer.** `resolve_base_configs` folds `"_"` and
  the `base` chain into every present entry, so `auto_install_decision` consults `"_"`
  only for languages the fold never ran for. Otherwise a language that escaped
  wildcard inheritance with a self-referential `base` would still pick `"_"` up for
  this one field.
- **The disabled-reason message deliberately hedges on the language arm.** After the
  fold, a `Some(false)` on the entry could have come from the language, its base, or
  `"_"`, so naming `languages.<lang>.autoInstall` as the culprit would misdirect
  someone hunting the global switch. It names the overriding key and the possible
  sources; the wildcard and top-level arms stay exact.
- **`injection.rs` hoisted the gate above its per-language loop.** It now resolves
  inside, keyed on `resolved_lang` (the language actually installed), so one injected
  language's opt-out cannot decide for its siblings.
- `rename_all = "camelCase"` on `LanguageSettings` renames nothing — every
  pre-existing field is one word — but is load-bearing now, and
  `known_language_setting_keys_match_schema_properties` pins it.
- The Neovim quickstart snippets set `autoInstall` in kakehashi's own `init_options`
  (merge layer 4), so they would have popped the new warning every session. Updated to
  the canonical key.
- One pre-existing test needed adjusting:
  `did_change_configuration_merges_into_settings_published_while_waiting` pushes
  top-level `autoInstall` on purpose and never drains its socket, so the new
  `show_warning` parked the future for a reason unrelated to the lock it is meant to
  park on. It consumes the notice slot up front.

## Test rigor

Review ran mutation experiments and found three one-line edits that left the whole
suite green. All three now fail:

| Mutation | Now caught by |
|---|---|
| drop `merge_language_settings`'s `auto_install` arm | `auto_install_inherits_through_the_base_chain` (uses a `base` chain, not `_`, so it actually discriminates) |
| `DeprecatedKeysSeen::merge` overwrites instead of OR-ing | `merge_ors_flags_so_a_clean_later_layer_cannot_clear_them` — an empty `initializationOptions` runs every session and would have cleared a file-detected flag, so the notice would never fire |
| `run_config_init` → `default_settings()` | `test_config_init_emits_no_auto_install_spelling` |

Verified by re-applying each mutation in a scratch worktree.

## Validation

- `cargo test --lib`: 3128 passed, 0 failed
- Full e2e sweep: 57 binaries, 1698 tests, 0 failures
- `cargo clippy --lib --features e2e -- -D warnings`, `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-language `autoInstall` control with wildcard defaults, including language-specific behavior for missing parsers/queries.
  * When auto-install is disabled, users now get clearer, language-specific disable explanations.
  * Added session-scoped deprecation warnings for the legacy top-level `autoInstall` setting.

* **Documentation**
  * Updated migration guidance for moving from top-level `autoInstall` to `languages._.autoInstall`.
  * Refreshed Neovim and `config init` examples to avoid generating deprecated `autoInstall` keys.

* **Bug Fixes**
  * Fixed auto-install evaluation for injected languages to be independent.
  * Corrected precedence and inheritance behavior, including removing redundant inherited overrides and preserving user opt-outs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->