### PR TITLE
fix(bridge): re-open the connection the purge claimed

### DIFF
--- a/docs/architecture-decisions/execute-command-routing-token.md
+++ b/docs/architecture-decisions/execute-command-routing-token.md
@@ -96,6 +96,14 @@ injection regions can supply, so the work is performed on the server side
 the existing pool→editor upward request channel. The pool decides *when*; the
 server side decides *what*.
 
+The pool also states *which connection*. The server side resolves each host
+against current settings, so a config change that re-roots the host between the
+purge and the respawn would otherwise repair a different connection than the one
+the barrier signals for — leaving the claimed one empty while reporting success.
+The claimed key travels with the request and the open is pinned to it; a
+re-routed host is skipped rather than opened elsewhere, since its new connection
+opens it through its own request path.
+
 That split makes the repair **asynchronous**, where the inline version was
 awaited — and being awaited was load-bearing, not incidental. The outbound
 queue to a downstream is FIFO, so a request enqueued before the re-open's

--- a/docs/architecture-decisions/execute-command-routing-token.md
+++ b/docs/architecture-decisions/execute-command-routing-token.md
@@ -100,9 +100,17 @@ The pool also states *which connection*. The server side resolves each host
 against current settings, so a config change that re-roots the host between the
 purge and the respawn would otherwise repair a different connection than the one
 the barrier signals for — leaving the claimed one empty while reporting success.
-The claimed key travels with the request and the open is pinned to it; a
-re-routed host is skipped rather than opened elsewhere, since its new connection
-opens it through its own request path.
+The claimed key travels with the request and the open is ACQUIRED by it, not
+merely checked against it — resolving from the host would repair whichever
+connection it routes to now. A claimed connection that has since died is
+reported as unrepaired, and the barrier then withholds the commands waiting on
+it rather than releasing them onto an empty connection.
+
+A stale-rooted claimed connection is reachable rather than hypothetical: a
+routing token carries the root, and reconnection rebuilds the workspace from the
+token rather than from current markers, so it spawns a connection recording the
+current config that no launch-config check can reject. The root is not part of
+the server config, so config comparison cannot detect a stale root at all.
 
 That split makes the repair **asynchronous**, where the inline version was
 awaited — and being awaited was load-bearing, not incidental. The outbound

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -79,13 +79,13 @@ pub(crate) use protocol::translate_virtual_range_to_host;
 pub(crate) use protocol::workspace_edit_has_effect;
 pub(crate) use protocol::workspace_edit_preserves_line_prefixes;
 pub(crate) use protocol::workspace_edit_within_region;
-pub(crate) use text_document::OpenExpectation;
 pub(crate) use text_document::host::{HostDocument, HostTextReader, normalize_host_goto_result};
 pub(crate) use text_document::{
     CodeActionEnvelope, CodeLensEnvelope, UpstreamCodeActionCaps, bridge_code_actions,
     extract_code_action_envelope, extract_code_lens_envelope, parse_code_actions_leniently,
 };
 pub(crate) use text_document::{KakehashiEnvelope, extract_envelope};
+pub(crate) use text_document::{OpenExpectation, OpenOutcome};
 pub(crate) use workspace::WorkspaceFolderSet;
 
 /// Integration tests for the bridge module.

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -79,6 +79,7 @@ pub(crate) use protocol::translate_virtual_range_to_host;
 pub(crate) use protocol::workspace_edit_has_effect;
 pub(crate) use protocol::workspace_edit_preserves_line_prefixes;
 pub(crate) use protocol::workspace_edit_within_region;
+pub(crate) use text_document::OpenExpectation;
 pub(crate) use text_document::host::{HostDocument, HostTextReader, normalize_host_goto_result};
 pub(crate) use text_document::{
     CodeActionEnvelope, CodeLensEnvelope, UpstreamCodeActionCaps, bridge_code_actions,

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -218,6 +218,12 @@ pub(crate) enum UpstreamRequest {
     /// degrades to the pre-existing lazy behaviour (the next parse's
     /// `process_injections` opens the documents again).
     ReopenDocuments {
+        /// The connection the purge recorded this set under. The re-open
+        /// resolves each host's connection from the CURRENT settings, so a
+        /// config change that re-roots the host in between would otherwise open
+        /// a DIFFERENT connection while this one — the one `done` signals for,
+        /// and the one a routed command names — stays empty.
+        key: ConnectionKey,
         server: String,
         hosts: Vec<url::Url>,
         done: tokio::sync::watch::Sender<bool>,

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -224,7 +224,6 @@ pub(crate) enum UpstreamRequest {
         /// a DIFFERENT connection while this one — the one `done` signals for,
         /// and the one a routed command names — stays empty.
         key: ConnectionKey,
-        server: String,
         hosts: Vec<url::Url>,
         done: tokio::sync::watch::Sender<bool>,
     },

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -385,7 +385,7 @@ impl BridgeCoordinator {
         settings: &Arc<WorkspaceSettings>,
         host_language: &str,
         host_uri: &Url,
-        host_incarnation: u64,
+        expect: super::text_document::OpenExpectation<'_>,
         injections: Vec<BridgeInjection>,
         server_name: &str,
     ) {
@@ -403,7 +403,7 @@ impl BridgeCoordinator {
                 &config,
                 host_uri,
                 &host_uri_lsp,
-                host_incarnation,
+                expect,
                 for_server,
             )
             .await;
@@ -931,7 +931,11 @@ impl BridgeCoordinator {
                         &config,
                         &host_uri_owned,
                         &host_uri_lsp,
-                        incarnation,
+                        super::text_document::OpenExpectation {
+                            incarnation,
+                            // The eager batch opens wherever the host routes now.
+                            connection: None,
+                        },
                         group_injections,
                     ) => {}
                 }
@@ -1613,7 +1617,10 @@ mod tests {
                 &settings,
                 "markdown",
                 &host_uri,
-                1,
+                crate::lsp::bridge::OpenExpectation {
+                    incarnation: 1,
+                    connection: None,
+                },
                 injections,
                 "other-server",
             ),

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1620,7 +1620,7 @@ mod tests {
         }];
 
         // `python` bridges to "ruff", not "other-server" → no match → no-op.
-        tokio::time::timeout(
+        let outcome = tokio::time::timeout(
             std::time::Duration::from_secs(2),
             coordinator.ensure_server_documents_open(
                 &settings,
@@ -1636,6 +1636,12 @@ mod tests {
         )
         .await
         .expect("a non-matching server must short-circuit, not attempt a spawn");
+        assert_eq!(
+            outcome,
+            crate::lsp::bridge::OpenOutcome::Opened,
+            "a caller that named no connection has nothing to repair, so \
+             'this host bridges nowhere' is success, not failure"
+        );
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -388,14 +388,17 @@ impl BridgeCoordinator {
         expect: super::text_document::OpenExpectation<'_>,
         injections: Vec<BridgeInjection>,
         server_name: &str,
-    ) {
+    ) -> super::text_document::OpenOutcome {
+        use super::text_document::OpenOutcome;
         let (for_server, config) =
             self.injections_for_server(settings, host_language, injections, server_name);
         let Some(config) = config else {
-            return; // no injected region on this host bridges to `server_name`
+            // No injected region on this host bridges to `server_name`, so there
+            // is nothing for THIS server to open — not a failure to repair it.
+            return OpenOutcome::Opened;
         };
         let Ok(host_uri_lsp) = crate::lsp::lsp_impl::url_to_uri(host_uri) else {
-            return;
+            return OpenOutcome::NotOpened;
         };
         self.pool
             .eager_open_virtual_documents(
@@ -406,7 +409,7 @@ impl BridgeCoordinator {
                 expect,
                 for_server,
             )
-            .await;
+            .await
     }
 
     fn injection_open_on_connection(

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -393,9 +393,15 @@ impl BridgeCoordinator {
         let (for_server, config) =
             self.injections_for_server(settings, host_language, injections, server_name);
         let Some(config) = config else {
-            // No injected region on this host bridges to `server_name`, so there
-            // is nothing for THIS server to open — not a failure to repair it.
-            return OpenOutcome::Opened;
+            // No injected region on this host bridges to `server_name`.
+            // With no named connection this is simply nothing to do; but a
+            // caller repairing a NAMED connection asked for documents this host
+            // can no longer supply (server removed from config, or the host's
+            // injections changed), so its repair did NOT happen.
+            return match expect.connection {
+                Some(_) => OpenOutcome::NotOpened,
+                None => OpenOutcome::Opened,
+            };
         };
         let Ok(host_uri_lsp) = crate::lsp::lsp_impl::url_to_uri(host_uri) else {
             return OpenOutcome::NotOpened;

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -2602,6 +2602,7 @@ impl LanguageServerPool {
                     // message cannot strand a request for the full bound.
                     if let Some((hosts, done)) = pending_reopen_handoff
                         && let Err(e) = upstream_request_tx.send(UpstreamRequest::ReopenDocuments {
+                            key: command_registration_key.clone(),
                             server: reopen_server_name,
                             hosts,
                             done,

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -2484,7 +2484,6 @@ impl LanguageServerPool {
         let command_registration_key = connection_key.clone();
         let upstream_request_tx = self.upstream_request_tx.clone();
         let pending_reopen = Arc::clone(&self.pending_reopen);
-        let reopen_server_name = server_name.to_string();
         // The editor accepts a dynamic `workspace/executeCommand` registration
         // only if it advertised `dynamicRegistration` (LSP spec). Compute once.
         let supports_dynamic_command_registration = self
@@ -2603,7 +2602,6 @@ impl LanguageServerPool {
                     if let Some((hosts, done)) = pending_reopen_handoff
                         && let Err(e) = upstream_request_tx.send(UpstreamRequest::ReopenDocuments {
                             key: command_registration_key.clone(),
-                            server: reopen_server_name,
                             hosts,
                             done,
                         })

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -4249,23 +4249,29 @@ mod tests {
 
         let handle = create_handle_with_key(ConnectionState::Ready, connection_key.clone()).await;
         pool.insert_connection(handle).await;
-        use crate::lsp::bridge::text_document::OpenExpectation;
-        pool.eager_open_virtual_documents(
-            "lua",
-            &devnull_config(),
-            &host_uri,
-            &host_uri_lsp,
-            OpenExpectation {
-                incarnation: 1,
-                connection: None,
-            },
-            vec![super::super::coordinator::BridgeInjection {
-                language: "lua".to_string(),
-                region_id: TEST_ULID_LUA_0.to_string(),
-                content: "print('old lifetime')".to_string(),
-            }],
-        )
-        .await;
+        use crate::lsp::bridge::text_document::{OpenExpectation, OpenOutcome};
+        let outcome = pool
+            .eager_open_virtual_documents(
+                "lua",
+                &devnull_config(),
+                &host_uri,
+                &host_uri_lsp,
+                OpenExpectation {
+                    incarnation: 1,
+                    connection: None,
+                },
+                vec![super::super::coordinator::BridgeInjection {
+                    language: "lua".to_string(),
+                    region_id: TEST_ULID_LUA_0.to_string(),
+                    content: "print('old lifetime')".to_string(),
+                }],
+            )
+            .await;
+        assert_eq!(
+            outcome,
+            OpenOutcome::NotOpened,
+            "the host moved to incarnation 2, so a stale batch opens nothing"
+        );
         assert!(!pool.is_document_opened(&virtual_uri));
         assert!(pool.host_lifecycle_locks.contains_key(&host_uri));
 
@@ -4289,22 +4295,28 @@ mod tests {
         );
 
         pool.close_host_incarnation(&host_uri, 2).await;
-        pool.eager_open_virtual_documents(
-            "lua",
-            &devnull_config(),
-            &host_uri,
-            &host_uri_lsp,
-            OpenExpectation {
-                incarnation: 1,
-                connection: None,
-            },
-            vec![super::super::coordinator::BridgeInjection {
-                language: "lua".to_string(),
-                region_id: TEST_ULID_LUA_0.to_string(),
-                content: "print('old lifetime')".to_string(),
-            }],
-        )
-        .await;
+        let outcome = pool
+            .eager_open_virtual_documents(
+                "lua",
+                &devnull_config(),
+                &host_uri,
+                &host_uri_lsp,
+                OpenExpectation {
+                    incarnation: 1,
+                    connection: None,
+                },
+                vec![super::super::coordinator::BridgeInjection {
+                    language: "lua".to_string(),
+                    region_id: TEST_ULID_LUA_0.to_string(),
+                    content: "print('old lifetime')".to_string(),
+                }],
+            )
+            .await;
+        assert_eq!(
+            outcome,
+            OpenOutcome::NotOpened,
+            "the host is closed, so there is no lifetime to open under"
+        );
         assert!(pool.host_lifecycle_locks.is_empty());
     }
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -4250,12 +4250,16 @@ mod tests {
 
         let handle = create_handle_with_key(ConnectionState::Ready, connection_key.clone()).await;
         pool.insert_connection(handle).await;
+        use crate::lsp::bridge::text_document::OpenExpectation;
         pool.eager_open_virtual_documents(
             "lua",
             &devnull_config(),
             &host_uri,
             &host_uri_lsp,
-            1,
+            OpenExpectation {
+                incarnation: 1,
+                connection: None,
+            },
             vec![super::super::coordinator::BridgeInjection {
                 language: "lua".to_string(),
                 region_id: TEST_ULID_LUA_0.to_string(),
@@ -4291,7 +4295,10 @@ mod tests {
             &devnull_config(),
             &host_uri,
             &host_uri_lsp,
-            1,
+            OpenExpectation {
+                incarnation: 1,
+                connection: None,
+            },
             vec![super::super::coordinator::BridgeInjection {
                 language: "lua".to_string(),
                 region_id: TEST_ULID_LUA_0.to_string(),

--- a/src/lsp/bridge/pool/pending_reopen.rs
+++ b/src/lsp/bridge/pool/pending_reopen.rs
@@ -118,8 +118,13 @@ impl PendingReopenRegistry {
     /// Wait (bounded by [`REOPEN_WAIT`]) for an in-flight re-open on `key`.
     ///
     /// Returns `true` when the ordering requirement is met — either nothing was
-    /// outstanding (the common case) or the re-open finished. Returns `false` on
-    /// timeout, where the re-open is still running.
+    /// outstanding (the common case) or the re-open reported that it repaired
+    /// this connection.
+    ///
+    /// Returns `false` in three cases, all meaning "this connection may still be
+    /// missing documents": the wait timed out and the re-open is still running;
+    /// the re-open reported it could not repair this connection; or its sender
+    /// was dropped before reporting success (a handler that died).
     ///
     /// The caller must NOT proceed on `false`. A bounded wait means the guarantee
     /// can be unmet, and sending anyway is the failure this barrier exists to

--- a/src/lsp/bridge/pool/pending_reopen.rs
+++ b/src/lsp/bridge/pool/pending_reopen.rs
@@ -138,21 +138,36 @@ impl PendingReopenRegistry {
             // Nothing outstanding: the ordering requirement is vacuously met.
             return true;
         };
-        // `Err` (sender dropped) counts as finished: the re-open completed, or
-        // its handler died and will never signal.
-        let settled = tokio::time::timeout(REOPEN_WAIT, rx.wait_for(|done| *done))
-            .await
-            .is_ok();
-        // Retire the entry only when the re-open actually SETTLED, and only when
-        // it is still the one we waited on. Two independent hazards:
-        //
-        // - On timeout the re-open is still running, so forgetting it would let
-        //   the NEXT request sail past with no wait at all — precisely when the
-        //   re-open is known to be slow. Leave it; the sender's drop retires it.
-        // - Two awaits separate the clone above from this retire, so a LATER
-        //   respawn may have claimed the key in between and registered a
-        //   genuinely outstanding re-open. Removing by key alone would evict it.
-        if settled {
+        // Three outcomes, and they are not the same thing:
+        // - observed `true`  → the re-open repaired this connection; go ahead.
+        // - sender dropped   → no further news will come. Trust the last value:
+        //   a re-open that reported failure (or died before reporting) leaves
+        //   the connection empty, so the caller must NOT send. Retire the entry
+        //   regardless — nothing will ever settle it, and keeping it would fail
+        //   every later command on this key forever.
+        // - timed out        → still running. Keep the entry so the next
+        //   command is bounded by the same budget rather than sailing past.
+        // Collapse to a plain discriminant first: `wait_for`'s `Ok` holds a
+        // `Ref` borrowing `rx`, and the sender-gone arm needs to read `rx` again.
+        enum Waited {
+            Repaired,
+            SenderGone,
+            TimedOut,
+        }
+        let waited = match tokio::time::timeout(REOPEN_WAIT, rx.wait_for(|done| *done)).await {
+            Ok(Ok(_)) => Waited::Repaired,
+            Ok(Err(_)) => Waited::SenderGone,
+            Err(_) => Waited::TimedOut,
+        };
+        let (settled, retire) = match waited {
+            Waited::Repaired => (true, true),
+            Waited::SenderGone => (*rx.borrow(), true),
+            Waited::TimedOut => (false, false),
+        };
+        // Two awaits separate the clone above from this retire, so a LATER
+        // respawn may have claimed the key in between and registered a genuinely
+        // outstanding re-open. Removing by key alone would evict it.
+        if retire {
             let mut in_flight = self
                 .in_flight
                 .lock()
@@ -279,11 +294,40 @@ mod tests {
 
         // Would hang for REOPEN_WAIT if a dropped sender did not count as done.
         assert!(
-            tokio::time::timeout(Duration::from_secs(1), registry.wait_for_reopen(&key))
+            !tokio::time::timeout(Duration::from_secs(1), registry.wait_for_reopen(&key))
                 .await
                 .expect("a dropped sender releases the waiter immediately"),
-            "a dropped sender means the re-open will never signal, so waiting \
-             further is pointless — report settled and let the caller proceed"
+            "a re-open that died without reporting success leaves the connection \
+             empty, so the caller must NOT send"
+        );
+        // ...but the entry is retired, so it cannot block every later command.
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), registry.wait_for_reopen(&key))
+                .await
+                .expect("no wait"),
+            "a settled-by-drop entry must be retired, not left blocking forever"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_reopen_that_reports_failure_does_not_release_the_caller() {
+        // The re-open ran but could not repair THIS connection (its host
+        // re-routed, so the opens were skipped). Releasing the caller would send
+        // a command to a connection that is still empty — the exact outcome the
+        // barrier exists to prevent.
+        let registry = PendingReopenRegistry::default();
+        let key = ConnectionKey::for_server("ruff");
+        registry.record(&key, vec![url("file:///w/a.md")]);
+        let (_hosts, done) = registry.take(&key).expect("a re-open is pending");
+
+        done.send(false).expect("the registry holds the receiver");
+        drop(done);
+
+        assert!(
+            !tokio::time::timeout(Duration::from_secs(1), registry.wait_for_reopen(&key))
+                .await
+                .expect("a reported failure must not make the caller wait out the budget"),
+            "a re-open that reported failure must not release the caller"
         );
     }
 

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -23,6 +23,7 @@ mod diagnostic;
 mod did_change;
 mod did_close;
 mod did_open;
+pub(crate) use did_open::OpenExpectation;
 mod document_color;
 mod document_highlight;
 mod document_link;

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -23,7 +23,7 @@ mod diagnostic;
 mod did_change;
 mod did_close;
 mod did_open;
-pub(crate) use did_open::OpenExpectation;
+pub(crate) use did_open::{OpenExpectation, OpenOutcome};
 mod document_color;
 mod document_highlight;
 mod document_link;

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -262,6 +262,76 @@ mod tests {
     ///
     /// Given a ready server and injection data, calling eager_open_virtual_documents
     /// should result in each virtual document being marked as opened in DocumentTracker.
+    /// The re-open must repair the connection it was CLAIMED for. When a config
+    /// change re-roots the host between purge and respawn, this resolves a
+    /// different connection — opening there would leave the claimed one empty
+    /// while its barrier reports success, which is exactly the state a routed
+    /// command then hits.
+    #[tokio::test]
+    async fn eager_open_skips_a_connection_other_than_the_expected_one() {
+        let pool = LanguageServerPool::new();
+        let server_name = "lua_ls";
+        let config = crate::lsp::bridge::pool::test_helpers::devnull_config_for_language("lua");
+
+        // The connection the host actually routes to.
+        let live_key = crate::lsp::bridge::ConnectionKey::for_server(server_name);
+        let handle = create_handle_with_key(ConnectionState::Ready, live_key.clone()).await;
+        pool.insert_connection(handle).await;
+
+        let host_uri = test_host_uri("eager_open_expected_key");
+        let host_uri_lsp = url_to_uri(&host_uri);
+        pool.open_host_incarnation(&host_uri, 1).await;
+
+        use super::super::super::coordinator::BridgeInjection;
+        let injections = vec![BridgeInjection {
+            language: "lua".to_string(),
+            region_id: TEST_ULID_LUA_0.to_string(),
+            content: "print('hello')".to_string(),
+        }];
+
+        // Expect a DIFFERENT connection than the one this host resolves to.
+        let claimed_elsewhere =
+            crate::lsp::bridge::ConnectionKey::new(server_name, Some("file:///other".to_string()));
+        assert_ne!(claimed_elsewhere, live_key);
+        pool.eager_open_virtual_documents(
+            server_name,
+            &config,
+            &host_uri,
+            &host_uri_lsp,
+            OpenExpectation {
+                incarnation: 1,
+                connection: Some(&claimed_elsewhere),
+            },
+            injections.clone(),
+        )
+        .await;
+
+        let vuri = VirtualDocumentUri::new(&host_uri_lsp, "lua", TEST_ULID_LUA_0);
+        assert!(
+            !pool.is_document_opened(&vuri),
+            "an open for a different connection must not land on this one"
+        );
+
+        // The same call naming the live connection DOES open — proving the skip
+        // came from the key check, not from a broken fixture.
+        pool.eager_open_virtual_documents(
+            server_name,
+            &config,
+            &host_uri,
+            &host_uri_lsp,
+            OpenExpectation {
+                incarnation: 1,
+                connection: Some(&live_key),
+            },
+            injections,
+        )
+        .await;
+        assert!(
+            pool.is_document_opened(&vuri),
+            "an open naming the resolved connection must proceed"
+        );
+    }
+
     #[tokio::test]
     async fn eager_open_marks_documents_as_opened() {
         let pool = LanguageServerPool::new();

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -15,6 +15,25 @@ use super::super::protocol::VirtualDocumentUri;
 /// What the caller requires to STILL hold by the time an eager open actually
 /// runs. Both fields are preconditions checked inside the open, not inputs to
 /// it, which is why they travel together.
+/// Whether an eager open did what the caller asked for.
+///
+/// Only a caller that named a `connection` can act on the difference, but the
+/// value is returned unconditionally so the compiler forces every caller to
+/// decide (`let _ =` is an explicit "I open wherever it lands").
+#[derive(Debug, PartialEq, Eq)]
+#[must_use]
+pub(crate) enum OpenOutcome {
+    /// The open ran on the connection the caller expected (or the caller named
+    /// none). Documents it could open are enqueued.
+    Opened,
+    /// The host resolved to a DIFFERENT connection than the caller named, so
+    /// nothing was opened. A caller repairing the named connection must report
+    /// failure rather than success: the connection is still empty.
+    WrongConnection,
+    /// The connection could not be reached at all, so nothing was opened.
+    NotOpened,
+}
+
 pub(crate) struct OpenExpectation<'a> {
     /// The document lifetime the injections were resolved under; a close+reopen
     /// in between invalidates them.
@@ -58,53 +77,77 @@ impl LanguageServerPool {
         host_uri_lsp: &tower_lsp_server::ls_types::Uri,
         expect: OpenExpectation<'_>,
         injections: Vec<crate::lsp::bridge::coordinator::BridgeInjection>,
-    ) {
+    ) -> OpenOutcome {
         let OpenExpectation {
             incarnation: expected_incarnation,
             connection: expected_key,
         } = expect;
-        // Wait for the server to be ready (handshake complete)
-        let handle = match self
-            .get_or_create_connection_wait_ready(
-                server_name,
-                server_config,
-                Some(host_uri),
-                Duration::from_secs(INIT_TIMEOUT_SECS),
-            )
-            .await
-        {
-            Ok(h) => h,
-            Err(e) => {
-                log::debug!(
-                    target: "kakehashi::bridge",
-                    "Eager open: server {} not ready, skipping didOpen for {} injections: {}",
+        // A caller repairing a NAMED connection is acquired BY KEY. Resolving
+        // from `host_uri` would find whatever that host routes to *now*, which
+        // after a re-rooting config change is a different connection — and then
+        // the named one, the one whose barrier is about to be signalled and whose
+        // token a routed command carries, is never repaired at all. Ready-only
+        // and never spawning: this repairs a connection that exists, and a named
+        // connection that has since died has nothing to restore.
+        let handle = match expected_key {
+            Some(key) => match self
+                .ready_connection_by_key_for_config(key, Some(server_config))
+                .await
+            {
+                Some(handle) => handle,
+                None => {
+                    log::debug!(
+                        target: "kakehashi::bridge",
+                        "Eager open: connection {key} is gone; nothing to repair for \
+                         {} injections",
+                        injections.len()
+                    );
+                    return OpenOutcome::NotOpened;
+                }
+            },
+            // Open wherever this host routes now, spawning if needed.
+            None => match self
+                .get_or_create_connection_wait_ready(
                     server_name,
-                    injections.len(),
-                    e
-                );
-                return;
-            }
+                    server_config,
+                    Some(host_uri),
+                    Duration::from_secs(INIT_TIMEOUT_SECS),
+                )
+                .await
+            {
+                Ok(h) => h,
+                Err(e) => {
+                    log::debug!(
+                        target: "kakehashi::bridge",
+                        "Eager open: server {} not ready, skipping didOpen for {} injections: {}",
+                        server_name,
+                        injections.len(),
+                        e
+                    );
+                    return OpenOutcome::NotOpened;
+                }
+            },
         };
 
         let connection_key = handle.key().clone();
-        // The host re-routed since the caller claimed its key: this open is not
-        // the one that was asked for. Skip rather than open on the wrong
-        // connection — the host's new connection opens it through its own
-        // request/parse path, and the caller learns nothing false.
+        // Belt-and-braces: the by-key lookup above already returns the named
+        // connection, so this only fires if that ever stops holding. Report it
+        // rather than open on a connection nobody asked for.
         if let Some(expected) = expected_key
             && &connection_key != expected
         {
             log::debug!(
                 target: "kakehashi::bridge",
-                "Eager open: {host_uri} now routes to {connection_key}, not the \
-                 requested {expected}; skipping this open"
+                "Eager open: resolved {connection_key}, not the requested \
+                 {expected}; skipping this open"
             );
-            return;
+            return OpenOutcome::WrongConnection;
         }
         let mut sender = ConnectionHandleSender(&handle);
 
         let Some(lifecycle) = self.existing_host_lifecycle_lock(host_uri) else {
-            return;
+            // The host closed underneath us; nothing to open.
+            return OpenOutcome::NotOpened;
         };
         let _lifecycle_cleanup = LifecycleCleanup {
             pool: self,
@@ -120,7 +163,9 @@ impl LanguageServerPool {
             let current_incarnation = self.current_host_incarnation(host_uri);
             if current_incarnation != Some(expected_incarnation) {
                 drop(lifecycle_guard);
-                return;
+                // The document was reopened under a new lifetime; these
+                // injections are stale. Nothing further is opened.
+                return OpenOutcome::NotOpened;
             }
             let virtual_uri =
                 VirtualDocumentUri::new(host_uri_lsp, &injection.language, &injection.region_id);
@@ -148,7 +193,9 @@ impl LanguageServerPool {
                     "Eager open: connection {} replaced mid-loop; stopping",
                     connection_key
                 );
-                return;
+                // A respawn replaced the handle; the purge lets the next real
+                // request re-open cleanly, but THIS open did not finish.
+                return OpenOutcome::NotOpened;
             }
 
             if let Err(e) = self
@@ -170,6 +217,7 @@ impl LanguageServerPool {
                 );
             }
         }
+        OpenOutcome::Opened
     }
 
     /// Fire `didOpen` for the real host document on a `_self` host-bridge server
@@ -256,82 +304,16 @@ mod tests {
     use super::super::super::pool::test_helpers::*;
     use super::super::super::pool::{ConnectionState, LanguageServerPool};
     use super::super::super::protocol::VirtualDocumentUri;
-    use super::OpenExpectation;
+    use super::{OpenExpectation, OpenOutcome};
 
     /// Test that eager_open_virtual_documents marks virtual documents as opened.
     ///
     /// Given a ready server and injection data, calling eager_open_virtual_documents
     /// should result in each virtual document being marked as opened in DocumentTracker.
-    /// The re-open must repair the connection it was CLAIMED for. When a config
-    /// change re-roots the host between purge and respawn, this resolves a
-    /// different connection — opening there would leave the claimed one empty
-    /// while its barrier reports success, which is exactly the state a routed
-    /// command then hits.
-    #[tokio::test]
-    async fn eager_open_skips_a_connection_other_than_the_expected_one() {
-        let pool = LanguageServerPool::new();
-        let server_name = "lua_ls";
-        let config = crate::lsp::bridge::pool::test_helpers::devnull_config_for_language("lua");
-
-        // The connection the host actually routes to.
-        let live_key = crate::lsp::bridge::ConnectionKey::for_server(server_name);
-        let handle = create_handle_with_key(ConnectionState::Ready, live_key.clone()).await;
-        pool.insert_connection(handle).await;
-
-        let host_uri = test_host_uri("eager_open_expected_key");
-        let host_uri_lsp = url_to_uri(&host_uri);
-        pool.open_host_incarnation(&host_uri, 1).await;
-
-        use super::super::super::coordinator::BridgeInjection;
-        let injections = vec![BridgeInjection {
-            language: "lua".to_string(),
-            region_id: TEST_ULID_LUA_0.to_string(),
-            content: "print('hello')".to_string(),
-        }];
-
-        // Expect a DIFFERENT connection than the one this host resolves to.
-        let claimed_elsewhere =
-            crate::lsp::bridge::ConnectionKey::new(server_name, Some("file:///other".to_string()));
-        assert_ne!(claimed_elsewhere, live_key);
-        pool.eager_open_virtual_documents(
-            server_name,
-            &config,
-            &host_uri,
-            &host_uri_lsp,
-            OpenExpectation {
-                incarnation: 1,
-                connection: Some(&claimed_elsewhere),
-            },
-            injections.clone(),
-        )
-        .await;
-
-        let vuri = VirtualDocumentUri::new(&host_uri_lsp, "lua", TEST_ULID_LUA_0);
-        assert!(
-            !pool.is_document_opened(&vuri),
-            "an open for a different connection must not land on this one"
-        );
-
-        // The same call naming the live connection DOES open — proving the skip
-        // came from the key check, not from a broken fixture.
-        pool.eager_open_virtual_documents(
-            server_name,
-            &config,
-            &host_uri,
-            &host_uri_lsp,
-            OpenExpectation {
-                incarnation: 1,
-                connection: Some(&live_key),
-            },
-            injections,
-        )
-        .await;
-        assert!(
-            pool.is_document_opened(&vuri),
-            "an open naming the resolved connection must proceed"
-        );
-    }
-
+    /// Test that eager_open_virtual_documents marks virtual documents as opened.
+    ///
+    /// Given a ready server and injection data, calling eager_open_virtual_documents
+    /// should result in each virtual document being marked as opened in DocumentTracker.
     #[tokio::test]
     async fn eager_open_marks_documents_as_opened() {
         let pool = LanguageServerPool::new();
@@ -388,6 +370,110 @@ mod tests {
         assert!(
             pool.is_document_opened(&vuri_1),
             "Second virtual document should be marked as opened"
+        );
+    }
+
+    /// A named connection is repaired BY KEY, not by re-resolving the host.
+    /// When a config change re-roots the host between purge and respawn,
+    /// resolving from the host would repair a different connection and leave the
+    /// named one — the one the barrier signals for, and the one a routed command
+    /// carries — empty.
+    #[tokio::test]
+    async fn eager_open_repairs_the_named_connection_not_the_hosts_current_one() {
+        let pool = LanguageServerPool::new();
+        let server_name = "lua_ls";
+        let config = crate::lsp::bridge::pool::test_helpers::devnull_config_for_language("lua");
+
+        // The connection the purge claimed: rooted somewhere the host no longer
+        // resolves to. Nothing else would ever pick it.
+        let claimed = crate::lsp::bridge::ConnectionKey::new(
+            server_name,
+            Some("file:///claimed".to_string()),
+        );
+        let handle = create_handle_with_key(ConnectionState::Ready, claimed.clone()).await;
+        pool.insert_connection(handle).await;
+
+        let host_uri = test_host_uri("eager_open_named_connection");
+        let host_uri_lsp = url_to_uri(&host_uri);
+        pool.open_host_incarnation(&host_uri, 1).await;
+
+        use super::super::super::coordinator::BridgeInjection;
+        let injections = vec![BridgeInjection {
+            language: "lua".to_string(),
+            region_id: TEST_ULID_LUA_0.to_string(),
+            content: "print('hello')".to_string(),
+        }];
+
+        let outcome = pool
+            .eager_open_virtual_documents(
+                server_name,
+                &config,
+                &host_uri,
+                &host_uri_lsp,
+                OpenExpectation {
+                    incarnation: 1,
+                    connection: Some(&claimed),
+                },
+                injections,
+            )
+            .await;
+
+        assert_eq!(outcome, OpenOutcome::Opened);
+        let vuri = VirtualDocumentUri::new(&host_uri_lsp, "lua", TEST_ULID_LUA_0);
+        // The claimed connection is the one that got the document — resolving
+        // from the host would have produced the client-root fallback key, which
+        // is NOT `claimed`.
+        assert!(
+            pool.is_document_opened_on_connection(&vuri, &claimed),
+            "the named connection must be the one repaired"
+        );
+    }
+
+    /// A named connection that has since died has nothing to restore, and the
+    /// caller must learn that: releasing a command onto it would hit an empty
+    /// process.
+    #[tokio::test]
+    async fn eager_open_reports_not_opened_when_the_named_connection_is_gone() {
+        let pool = LanguageServerPool::new();
+        let server_name = "lua_ls";
+        let config = crate::lsp::bridge::pool::test_helpers::devnull_config_for_language("lua");
+        let host_uri = test_host_uri("eager_open_named_gone");
+        let host_uri_lsp = url_to_uri(&host_uri);
+        pool.open_host_incarnation(&host_uri, 1).await;
+
+        use super::super::super::coordinator::BridgeInjection;
+        let injections = vec![BridgeInjection {
+            language: "lua".to_string(),
+            region_id: TEST_ULID_LUA_0.to_string(),
+            content: "print('hello')".to_string(),
+        }];
+
+        // No connection under this key at all.
+        let gone =
+            crate::lsp::bridge::ConnectionKey::new(server_name, Some("file:///gone".to_string()));
+        let outcome = pool
+            .eager_open_virtual_documents(
+                server_name,
+                &config,
+                &host_uri,
+                &host_uri_lsp,
+                OpenExpectation {
+                    incarnation: 1,
+                    connection: Some(&gone),
+                },
+                injections,
+            )
+            .await;
+
+        assert_eq!(
+            outcome,
+            OpenOutcome::NotOpened,
+            "a gone connection must report failure, not success"
+        );
+        let vuri = VirtualDocumentUri::new(&host_uri_lsp, "lua", TEST_ULID_LUA_0);
+        assert!(
+            !pool.is_document_opened(&vuri),
+            "and must not have opened anything anywhere"
         );
     }
 

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -7,8 +7,27 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use super::super::pool::{ConnectionHandleSender, INIT_TIMEOUT_SECS, LanguageServerPool};
+use super::super::pool::{
+    ConnectionHandleSender, ConnectionKey, INIT_TIMEOUT_SECS, LanguageServerPool,
+};
 use super::super::protocol::VirtualDocumentUri;
+
+/// What the caller requires to STILL hold by the time an eager open actually
+/// runs. Both fields are preconditions checked inside the open, not inputs to
+/// it, which is why they travel together.
+pub(crate) struct OpenExpectation<'a> {
+    /// The document lifetime the injections were resolved under; a close+reopen
+    /// in between invalidates them.
+    pub(crate) incarnation: u64,
+    /// The connection this open is FOR, when the caller is repairing a specific
+    /// one — the respawn re-open is claimed under a key and its barrier signals
+    /// for that key. The connection is still resolved from `host_uri`, so a
+    /// config change that re-roots the host resolves a DIFFERENT one, and
+    /// opening there would satisfy nobody: the claimed connection stays empty
+    /// while its barrier reports success. `None` opens wherever the host routes
+    /// now, which is what every other caller wants.
+    pub(crate) connection: Option<&'a ConnectionKey>,
+}
 
 struct LifecycleCleanup<'a> {
     pool: &'a LanguageServerPool,
@@ -37,9 +56,13 @@ impl LanguageServerPool {
         server_config: &crate::config::settings::BridgeServerConfig,
         host_uri: &url::Url,
         host_uri_lsp: &tower_lsp_server::ls_types::Uri,
-        expected_incarnation: u64,
+        expect: OpenExpectation<'_>,
         injections: Vec<crate::lsp::bridge::coordinator::BridgeInjection>,
     ) {
+        let OpenExpectation {
+            incarnation: expected_incarnation,
+            connection: expected_key,
+        } = expect;
         // Wait for the server to be ready (handshake complete)
         let handle = match self
             .get_or_create_connection_wait_ready(
@@ -64,6 +87,20 @@ impl LanguageServerPool {
         };
 
         let connection_key = handle.key().clone();
+        // The host re-routed since the caller claimed its key: this open is not
+        // the one that was asked for. Skip rather than open on the wrong
+        // connection — the host's new connection opens it through its own
+        // request/parse path, and the caller learns nothing false.
+        if let Some(expected) = expected_key
+            && &connection_key != expected
+        {
+            log::debug!(
+                target: "kakehashi::bridge",
+                "Eager open: {host_uri} now routes to {connection_key}, not the \
+                 requested {expected}; skipping this open"
+            );
+            return;
+        }
         let mut sender = ConnectionHandleSender(&handle);
 
         let Some(lifecycle) = self.existing_host_lifecycle_lock(host_uri) else {
@@ -219,6 +256,7 @@ mod tests {
     use super::super::super::pool::test_helpers::*;
     use super::super::super::pool::{ConnectionState, LanguageServerPool};
     use super::super::super::protocol::VirtualDocumentUri;
+    use super::OpenExpectation;
 
     /// Test that eager_open_virtual_documents marks virtual documents as opened.
     ///
@@ -261,7 +299,10 @@ mod tests {
             &config,
             &host_uri,
             &host_uri_lsp,
-            1,
+            OpenExpectation {
+                incarnation: 1,
+                connection: None,
+            },
             injections,
         )
         .await;
@@ -315,7 +356,10 @@ mod tests {
             &config,
             &host_uri,
             &host_uri_lsp,
-            1,
+            OpenExpectation {
+                incarnation: 1,
+                connection: None,
+            },
             injections.clone(),
         )
         .await;
@@ -332,7 +376,10 @@ mod tests {
             &config,
             &host_uri,
             &host_uri_lsp,
-            1,
+            OpenExpectation {
+                incarnation: 1,
+                connection: None,
+            },
             injections,
         )
         .await;

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -310,10 +310,6 @@ mod tests {
     ///
     /// Given a ready server and injection data, calling eager_open_virtual_documents
     /// should result in each virtual document being marked as opened in DocumentTracker.
-    /// Test that eager_open_virtual_documents marks virtual documents as opened.
-    ///
-    /// Given a ready server and injection data, calling eager_open_virtual_documents
-    /// should result in each virtual document being marked as opened in DocumentTracker.
     #[tokio::test]
     async fn eager_open_marks_documents_as_opened() {
         let pool = LanguageServerPool::new();
@@ -346,18 +342,20 @@ mod tests {
             },
         ];
 
-        pool.eager_open_virtual_documents(
-            server_name,
-            &config,
-            &host_uri,
-            &host_uri_lsp,
-            OpenExpectation {
-                incarnation: 1,
-                connection: None,
-            },
-            injections,
-        )
-        .await;
+        let outcome = pool
+            .eager_open_virtual_documents(
+                server_name,
+                &config,
+                &host_uri,
+                &host_uri_lsp,
+                OpenExpectation {
+                    incarnation: 1,
+                    connection: None,
+                },
+                injections,
+            )
+            .await;
+        assert_eq!(outcome, OpenOutcome::Opened);
 
         // Verify both virtual documents are marked as opened
         let vuri_0 = VirtualDocumentUri::new(&host_uri_lsp, "lua", TEST_ULID_LUA_0);
@@ -507,18 +505,20 @@ mod tests {
         }];
 
         // First call - should open the document
-        pool.eager_open_virtual_documents(
-            server_name,
-            &config,
-            &host_uri,
-            &host_uri_lsp,
-            OpenExpectation {
-                incarnation: 1,
-                connection: None,
-            },
-            injections.clone(),
-        )
-        .await;
+        let outcome = pool
+            .eager_open_virtual_documents(
+                server_name,
+                &config,
+                &host_uri,
+                &host_uri_lsp,
+                OpenExpectation {
+                    incarnation: 1,
+                    connection: None,
+                },
+                injections.clone(),
+            )
+            .await;
+        assert_eq!(outcome, OpenOutcome::Opened);
 
         let vuri = VirtualDocumentUri::new(&host_uri_lsp, "lua", TEST_ULID_LUA_0);
         assert!(
@@ -527,18 +527,24 @@ mod tests {
         );
 
         // Second call - should be a no-op (idempotent)
-        pool.eager_open_virtual_documents(
-            server_name,
-            &config,
-            &host_uri,
-            &host_uri_lsp,
-            OpenExpectation {
-                incarnation: 1,
-                connection: None,
-            },
-            injections,
-        )
-        .await;
+        let outcome = pool
+            .eager_open_virtual_documents(
+                server_name,
+                &config,
+                &host_uri,
+                &host_uri_lsp,
+                OpenExpectation {
+                    incarnation: 1,
+                    connection: None,
+                },
+                injections,
+            )
+            .await;
+        assert_eq!(
+            outcome,
+            OpenOutcome::Opened,
+            "an idempotent re-open still reports the connection as open"
+        );
 
         assert!(
             pool.is_document_opened(&vuri),

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1280,12 +1280,11 @@ fn spawn_upstream_request(
                     ),
                 }
             }
-            UpstreamRequest::ReopenDocuments {
-                key,
-                server,
-                hosts,
-                done,
-            } => {
+            UpstreamRequest::ReopenDocuments { key, hosts, done } => {
+                // One source of truth for the server: carrying it alongside the
+                // key would be an invariant nobody checks, and a divergence
+                // would make the repair a silent no-op.
+                let server = key.server().to_string();
                 // A respawned connection has nothing open; re-open what its dead
                 // predecessor held (execute-command-routing-token).
                 //
@@ -1316,20 +1315,23 @@ fn spawn_upstream_request(
                 );
                 use crate::lsp::bridge::REOPEN_WAIT;
                 let settings = context.settings_manager.load_settings();
-                // The re-open targets the connection the purge CLAIMED. Without
-                // that, it resolves each host from the CURRENT settings, so a
-                // `workspaceMarkers` change between purge and respawn opens a
-                // newly resolved connection while the claimed one — the one
+                // The re-open targets the connection the purge CLAIMED, and the
+                // open is ACQUIRED by that key rather than resolved from the
+                // host. Resolving from the host finds whatever it routes to now,
+                // so a `workspaceMarkers` change between purge and respawn
+                // repairs a different connection while the claimed one — the one
                 // `done` signals for — stays empty.
                 //
-                // No command could reach the claimed connection in that state
-                // anyway (`workspace_markers` is part of `same_launch_config`,
-                // so both by-key routing paths reject it and the command fails
-                // soft). But that made the safety depend on a comparison in a
-                // different module continuing to include markers: drop the
-                // field there and this silently breaks. Pinning the key here
-                // makes the re-open mean what its barrier claims, without the
-                // remote coupling.
+                // A stale-rooted claimed connection IS reachable: a routed
+                // command's token carries the root, and `reconnect_by_key`
+                // rebuilds the workspace from that token rather than from
+                // current markers, spawning a fresh connection that records the
+                // current config and so passes every launch-config check. There
+                // is no guard that rejects it — the root is not a
+                // `BridgeServerConfig` field, so `same_launch_config` cannot see
+                // a stale root at all. Repairing the named connection, and
+                // reporting failure when it is gone, is what makes the barrier
+                // mean what it says.
                 // Bound the WAIT, not the work — the shape the inline heal used.
                 // `ensure_server_documents_open` can block up to the init timeout
                 // on a cold downstream, and `done` gates every command on this
@@ -1347,6 +1349,12 @@ fn spawn_upstream_request(
                 // — the failure this barrier exists to prevent. A panic drops the
                 // sender instead, which waiters read as "can never finish".
                 let mut work = tokio::spawn(async move {
+                    // Whether the CLAIMED connection actually ended up with its
+                    // documents. A skip (the host re-routed) or an unreachable
+                    // connection leaves it empty, and the barrier must say so:
+                    // releasing a command onto an empty connection is the
+                    // failure this whole mechanism exists to prevent.
+                    let mut repaired = true;
                     // e2e-only fault injection: hold the re-open BEFORE any
                     // didOpen goes out, so the ordering e2e can force the window
                     // in which a command could overtake its own didOpen instead
@@ -1379,7 +1387,7 @@ fn spawn_upstream_request(
                         // Sequential: each host's didOpen goes out on the SAME
                         // connection, so fanning out would only contend on the
                         // single-writer outbound queue.
-                        injection
+                        let outcome = injection
                             .bridge()
                             .ensure_server_documents_open(
                                 &settings,
@@ -1395,11 +1403,17 @@ fn spawn_upstream_request(
                                 &reopen_server,
                             )
                             .await;
+                        if outcome != crate::lsp::bridge::OpenOutcome::Opened {
+                            repaired = false;
+                        }
                     }
-                    // Every didOpen is now enqueued; release the waiters. A send
-                    // error means a later respawn's claim superseded this
-                    // barrier, and that respawn owns it now.
-                    let _ = done.send(true);
+                    // Report what actually happened. `true` releases waiters;
+                    // `false` leaves them to time out and fail soft, which is
+                    // correct when the claimed connection is still empty — a
+                    // command sent there would fail downstream anyway, less
+                    // legibly. A send error means a later respawn's claim
+                    // superseded this barrier, and that respawn owns it now.
+                    let _ = done.send(repaired);
                 });
                 // Bound only how long THIS task waits. The work owns the signal,
                 // so exceeding the budget stops us watching without pretending

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1382,7 +1382,11 @@ fn spawn_upstream_request(
                                 &settings,
                                 &host_language,
                                 &host,
-                                incarnation,
+                                crate::lsp::bridge::OpenExpectation {
+                                    incarnation,
+                                    // Threaded in the next commit; unchanged here.
+                                    connection: None,
+                                },
                                 injections,
                                 &reopen_server,
                             )

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1281,6 +1281,7 @@ fn spawn_upstream_request(
                 }
             }
             UpstreamRequest::ReopenDocuments {
+                key,
                 server,
                 hosts,
                 done,
@@ -1315,18 +1316,20 @@ fn spawn_upstream_request(
                 );
                 use crate::lsp::bridge::REOPEN_WAIT;
                 let settings = context.settings_manager.load_settings();
-                // The re-open resolves each host's connection from the CURRENT
-                // settings, so a `workspaceMarkers` change between purge and
-                // respawn can open the document on a newly resolved key rather
-                // than the one the purge recorded. That does not strand a
-                // command on the old key: `workspace_markers` is part of
-                // `same_launch_config`, so both by-key routing paths reject a
-                // connection whose config no longer matches and the command
-                // fails soft instead of executing document-less. Opening at the
-                // new location is the correct outcome for the document itself.
-                // Carrying the claimed key here would let the re-open target the
-                // dead key exactly; it buys nothing while that key is
-                // unreachable anyway.
+                // The re-open targets the connection the purge CLAIMED. Without
+                // that, it resolves each host from the CURRENT settings, so a
+                // `workspaceMarkers` change between purge and respawn opens a
+                // newly resolved connection while the claimed one — the one
+                // `done` signals for — stays empty.
+                //
+                // No command could reach the claimed connection in that state
+                // anyway (`workspace_markers` is part of `same_launch_config`,
+                // so both by-key routing paths reject it and the command fails
+                // soft). But that made the safety depend on a comparison in a
+                // different module continuing to include markers: drop the
+                // field there and this silently breaks. Pinning the key here
+                // makes the re-open mean what its barrier claims, without the
+                // remote coupling.
                 // Bound the WAIT, not the work — the shape the inline heal used.
                 // `ensure_server_documents_open` can block up to the init timeout
                 // on a cold downstream, and `done` gates every command on this
@@ -1384,8 +1387,9 @@ fn spawn_upstream_request(
                                 &host,
                                 crate::lsp::bridge::OpenExpectation {
                                     incarnation,
-                                    // Threaded in the next commit; unchanged here.
-                                    connection: None,
+                                    // Repair the connection the purge CLAIMED,
+                                    // not whatever this host routes to now.
+                                    connection: Some(&key),
                                 },
                                 injections,
                                 &reopen_server,


### PR DESCRIPTION
Follow-up to #926. Raised there three rounds running and each time refuted as harmless rather than closed; this closes it.

## The problem

When a downstream connection is purged, the host documents it held are re-opened on its replacement, and a barrier makes a routed `workspace/executeCommand` wait so it cannot overtake its own `didOpen`.

`ReopenDocuments` carried only the server name, and the open resolved its connection from the **host document**. So a `workspaceMarkers` change between purge and respawn re-rooted the host, the opens landed on a newly resolved connection, and the claimed one — the one the barrier signals for, and the one a routed token names — stayed empty.

The old refutation was that no command could reach the claimed connection anyway, because `workspace_markers` is compared by `same_launch_config`. **That is wrong**, and this PR corrects the comment that stated it: a routing token carries the root, `reconnect_by_key` rebuilds the workspace from the token rather than from current markers, and the connection it spawns records the *current* config — so no launch-config check rejects it. The root is not a config field at all, so config comparison cannot see a stale root.

## The fix

- `ReopenDocuments` carries the claimed `ConnectionKey` (and no longer the server separately — two sources for one fact is an unchecked invariant).
- The open is **acquired by that key**, not merely checked against it. Ready-only and never spawning: it repairs a connection that exists, and a named connection that has since died has nothing to restore.
- The barrier reports the truth. `eager_open_virtual_documents` returns an `OpenOutcome`, the re-open tracks whether the claimed connection actually got its documents, and `done` carries that. `wait_for_reopen` distinguishes "repaired" from "the sender went away without reporting success", so a command is withheld rather than released onto an empty connection — while still retiring the entry, since nothing will ever settle it.

## Review note

The middle commit here did **not** do what its subject claimed — it pinned the check but not the acquisition, turning "repairs the wrong connection" into "repairs nothing". Caught in review; the last commit fixes it and the message says so. Left in history rather than squashed because the distinction is the interesting part.

Gate: `cargo clippy -- -D warnings` (the CI invocation) clean, `--all-targets --all-features` clean, 3168 lib tests, e2e 44/44 twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)