### PR TITLE
feat(bridge): derive the respawn re-open set from current state

### DIFF
--- a/docs/architecture-decisions/execute-command-routing-token.md
+++ b/docs/architecture-decisions/execute-command-routing-token.md
@@ -131,8 +131,11 @@ not opened. Two things restore the ordering:
   the guarantee can be unmet, and proceeding anyway is the failure the barrier
   exists to prevent. A null the user can re-fire beats a confusing downstream
   error. Dropping the completion signal — a re-open that can never finish —
-  counts as settled, so a dead handler degrades to the old lazy behaviour instead
-  of blocking every command.
+  does NOT count as success: the command observing it is still withheld, because
+  a re-open that died without reporting leaves the connection just as possibly
+  empty. What the dropped sender buys is that the entry is then RETIRED, so the
+  next command proceeds and a dead handler degrades to the old lazy behaviour
+  instead of blocking every command forever.
 
 The claim is reversible: a handshake that dies after claiming re-arms the key,
 so the next replacement still learns it owes a re-open.

--- a/docs/architecture-decisions/execute-command-routing-token.md
+++ b/docs/architecture-decisions/execute-command-routing-token.md
@@ -1,6 +1,7 @@
 # Execute Command Routing Token
 
 **Related Decisions**:
+[respawn-reopen-derives-its-targets](respawn-reopen-derives-its-targets.md),
 [language-server-bridge-request-strategies](language-server-bridge-request-strategies.md),
 [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md),
 [host-document-bridge](host-document-bridge.md),

--- a/docs/architecture-decisions/execute-command-routing-token.md
+++ b/docs/architecture-decisions/execute-command-routing-token.md
@@ -84,11 +84,14 @@ reconnect.
 
 ### 2. State repair belongs to respawn, not to the request path
 
-When a connection is purged the document tracker already computes the virtual
-URIs that connection had open, and holds a host→virtual index besides. Those
-resolve back to host documents. The re-open is therefore driven by the purge
-set and runs when the replacement connection reaches `Ready` — before any
+The re-open runs when the replacement connection reaches `Ready` — before any
 request needs it, and off the user-facing path.
+
+This decision originally also chose *which documents* to re-open, by capturing
+the set the purge dropped. That half is superseded by
+respawn-reopen-derives-its-targets: the set is derived from the documents open
+at the time the re-open runs. Everything below about *when* the repair happens,
+*who* performs it, and how requests synchronize on it still holds.
 
 Re-opening needs document *content*, which only the host document and its
 injection regions can supply, so the work is performed on the server side
@@ -96,13 +99,10 @@ injection regions can supply, so the work is performed on the server side
 the existing pool→editor upward request channel. The pool decides *when*; the
 server side decides *what*.
 
-The pool also states *which connection*. The server side resolves each host
-against current settings, so a config change that re-roots the host between the
-purge and the respawn would otherwise repair a different connection than the one
-the barrier signals for — leaving the claimed one empty while reporting success.
-The claimed key travels with the request and the open is ACQUIRED by it, not
-merely checked against it — resolving from the host would repair whichever
-connection it routes to now. A claimed connection that has since died is
+The pool also states *which connection*, and the open is ACQUIRED by that key
+rather than by whatever a host resolves to — otherwise the repair lands on
+whichever connection the host routes to now, leaving the one the barrier signals
+for empty while reporting success. A claimed connection that has since died is
 reported as unrepaired, and the barrier then withholds the commands waiting on
 it rather than releasing them onto an empty connection.
 
@@ -133,14 +133,13 @@ not opened. Two things restore the ordering:
   counts as settled, so a dead handler degrades to the old lazy behaviour instead
   of blocking every command.
 
-The claim is reversible: a handshake that dies after claiming the set restores
-it, because the purge that recorded it already emptied the tracker and no later
-purge would report those documents again.
+The claim is reversible: a handshake that dies after claiming re-arms the key,
+so the next replacement still learns it owes a re-open.
 
 This is sound across intervening edits because region ids are position-keyed
-and shifted by edits rather than re-minted
-(lazy-node-identity-tracking), so a virtual URI captured at purge
-time still names the same region afterwards.
+and shifted by edits rather than re-minted (lazy-node-identity-tracking), so a
+region keeps its identity across the edits that happen while a connection is
+being replaced.
 
 Repair then benefits every request path, not just `workspace/executeCommand`,
 and the routing token no longer has to name a document.
@@ -183,9 +182,12 @@ a routing mechanism; it remains a legitimate fallback nowhere in this design.
 
 ### Re-open every open host document on respawn
 
-Correct but wasteful: it re-resolves injections for documents the dead
-connection never held. Unnecessary, since the purge already knows the exact
-set. Rejected in favour of the captured set.
+Rejected here as wasteful — the purge appeared to know the exact set already.
+That reasoning did not survive: the captured set is a claim about a state that
+has already stopped being true, and it is empty in exactly the case where a
+replacement most needs repairing. Superseded by
+respawn-reopen-derives-its-targets, which considers every open document and
+narrows by configuration first.
 
 ## Consequences
 
@@ -213,9 +215,9 @@ set. Rejected in favour of the captured set.
   now an explicit barrier. A future request path that depends on repaired
   document state must remember to wait on it; forgetting is silent, and shows
   up only as a downstream error about an unopened document.
-- A respawn re-opens the dead connection's whole document set at once, where
-  the previous design re-opened one document lazily. Large workspaces on a
-  shared instance pay this as a burst.
+- A respawn re-opens a connection's whole document set at once, where the
+  previous design re-opened one document lazily. Large workspaces on a shared
+  instance pay this as a burst.
 - Encoded names minted by an older build no longer decode. Harmless in
   practice — names are minted fresh in each `textDocument/codeAction` response
   and never persisted — but a client that cached an action across a kakehashi

--- a/docs/architecture-decisions/respawn-reopen-derives-its-targets.md
+++ b/docs/architecture-decisions/respawn-reopen-derives-its-targets.md
@@ -136,11 +136,13 @@ whether N remembered hosts had been restored: a per-host property forced into a
 per-connection signal, which is why its granularity never quite fit.
 
 It is a report on the sweep, not a proof of completeness. A host whose tree does
-not settle inside the parse budget resolves no injections and is skipped, and a
-host misjudged as not-applicable is skipped silently by construction — both
-leave `done` reporting success, degrading to the pre-existing lazy heal. That
-asymmetry is the price of the three-way outcome: it buys a barrier that is not
-permanently shut, and it makes every future misclassification invisible.
+not settle inside the budget IS reported — it marks the connection not caught
+up, because an empty resolution from a document with no tree says nothing about
+that document. What stays invisible is a host misjudged as not-applicable:
+skipping is indistinguishable from having nothing to do, by construction. That
+asymmetry is the price of the three-way outcome — it buys a barrier that is not
+permanently shut, and it makes every future misclassification silent. See
+"Known limits of `done`" below for the cases that remain.
 
 ## Considered Options
 
@@ -214,6 +216,48 @@ anyway, incorrectly, since it cannot include documents opened since the purge.
   respawned server. The pre-existing eager path already resolves markers per
   open, so this is not a new kind of work, but it is work the captured-list
   design skipped.
+
+### Known limits of `done`
+
+Two ways the sweep can report success for a connection that is not in fact
+caught up. Both are narrow, both degrade to the pre-existing lazy heal (the next
+parse's eager open), and neither is introduced here — but the barrier's contract
+is stated in terms of `done`, so they belong written down rather than implied.
+
+**An invalidation placeholder reads as a current parse.** `invalidate_parse`
+publishes a tree-less snapshot whose `parsed_version` equals the content
+version, so both the parse wait and the currency re-check classify it as
+settled. The sweep then resolves no injections — because there is no tree, not
+because the host has no regions — and reports success. This matters most on the
+settings-reload path, which invalidates every parse and purges connections in
+the same pass. Distinguishing a placeholder from a legitimately tree-less parse
+(no parser loaded, parse produced nothing) needs a discriminator the snapshot
+does not currently carry, and rejecting every tree-less snapshot instead would
+wedge the barrier shut while a parser is still being installed. Tracked as the
+same class as the reload-placeholder issue in the parse-snapshot work.
+
+**An empty resolution can be confirmed against a NEWER version.** If a
+`didChange` clears the tree and its reparse publishes before the currency
+re-check runs, the check passes on version N+1 while the emptiness came from N.
+The new version's own `process_injections` opens the documents, so the
+connection is repaired — just not by this sweep, and possibly after the barrier
+released.
+
+**A `didOpen` can carry superseded content.** `ensure_document_opened` re-reads
+the latest virtual content immediately before enqueue, but that cache is
+refreshed when a `didChange` is FORWARDED, which happens after the reparse the
+edit scheduled. A sweep that claims the document in between reads the older
+content and enqueues it. The open claim does order the eventual
+`didChange` after this `didOpen`, so the downstream converges — but it does not
+order either of them against the command the barrier is about to release, so a
+command can arrive between them.
+
+**The incarnation checks are not atomic with what they guard.** A close landing
+between the liveness check and the currency re-check still reports failure, and
+a close+reopen can validate an empty result from one lifetime against a snapshot
+from the next. Same shape as the version case above: a two-step check over a
+value that can move between the steps. Closing it properly needs one lookup
+returning gone / exactly-current / changed rather than two booleans.
 
 ### Neutral
 

--- a/docs/architecture-decisions/respawn-reopen-derives-its-targets.md
+++ b/docs/architecture-decisions/respawn-reopen-derives-its-targets.md
@@ -81,8 +81,12 @@ with the work that belongs to the connection.
 
 1. Could a document in this HOST language bridge to this server at all? Pure
    configuration, answered from the per-snapshot memo — no parse, no tree, no
-   pool lookup, no filesystem access. This rejects the great majority of open
-   documents, and it must run before the parse wait and the injection
+   pool lookup, no filesystem access. It rejects hosts whose configured `bridge`
+   filter blocks every language the server declares, and servers no longer
+   configured. How much that narrows depends entirely on the configuration: on
+   the shipped defaults the bridge filter allows everything, so a workspace of
+   same-host-language documents is barely thinned, and the later stages carry
+   the load. It must still run before the parse wait and the injection
    resolution, not merely before the open.
 2. Do its resolved injections actually bridge to this server? Also pure
    configuration, but it needs the injections, so it is paid only by hosts that
@@ -92,10 +96,16 @@ with the work that belongs to the connection.
    belonging to another root cannot bring that root's server up.
 
 Stage 1 is deliberately conservative — a server declaring the `*` wildcard is
-never pre-rejected — and advisory, in that it reads the host language before the
-parse wait while the authoritative language is re-read with the injections.
-Screening on a stale language can only cost an unnecessary stage 2; it cannot
-open anything.
+never pre-rejected, and inheritance from the `_` template is resolved before the
+list is read, because a server that omits `languages` reads as declaring nothing
+until the template is merged in.
+
+It is also advisory, in that it reads the host language before the parse wait
+while the authoritative language is re-read with the injections. That asymmetry
+runs one way only, and the safe direction is the ACCEPTING one: a wrong accept
+costs an unnecessary stage 2, while a wrong reject skips the document and still
+reports success. Any future narrowing of stage 1 has to be judged against the
+reject direction, which no test can observe from the outside.
 
 Only then is the connection acquired, and acquired BY KEY rather than by what
 the host resolves to. Both are needed and they are not the same check. The
@@ -119,11 +129,18 @@ withholds correct results.
 
 ### What the barrier now means
 
-`done` reports whether this connection matches current state, which is a
-per-connection property — matching what the barrier is keyed by and what a
-routing token names. Under the captured-list design it reported whether N
-remembered hosts had been restored: a per-host property forced into a
+`done` reports whether every host this re-open judged applicable was opened on
+this connection — a per-connection property, matching what the barrier is keyed
+by and what a routing token names. Under the captured-list design it reported
+whether N remembered hosts had been restored: a per-host property forced into a
 per-connection signal, which is why its granularity never quite fit.
+
+It is a report on the sweep, not a proof of completeness. A host whose tree does
+not settle inside the parse budget resolves no injections and is skipped, and a
+host misjudged as not-applicable is skipped silently by construction — both
+leave `done` reporting success, degrading to the pre-existing lazy heal. That
+asymmetry is the price of the three-way outcome: it buys a barrier that is not
+permanently shut, and it makes every future misclassification invisible.
 
 ## Considered Options
 
@@ -174,12 +191,18 @@ anyway, incorrectly, since it cannot include documents opened since the purge.
 ### Negative
 
 - A host re-rooted away from the connection being repaired is no longer
-  re-opened onto it. Current settings are the authority, so that connection's
-  correct contents are nothing — but a command already in flight against the
-  old root now fails downstream rather than being served. This is the outcome
-  execute-command-routing-token already accepts for a token naming a root no
-  open document sits under, and it requires a configuration change between the
-  action and its command.
+  re-opened onto it. This is a real regression against what
+  execute-command-routing-token's follow-up deliberately built: it made the
+  re-open acquire the CLAIMED connection precisely so a re-rooted host would
+  still be restored there. Current settings are the authority now, so that
+  connection's correct contents are nothing — but a command already in flight
+  against the
+  old root now fails downstream rather than being served. It needs BOTH a
+  respawn and a re-rooting — a live connection already holds its documents, and
+  the barrier is a no-op for it. Re-rooting is not only a configuration change:
+  marker resolution walks the live filesystem uncached, so creating a marker
+  (`git init` in a subdirectory, a submodule checkout, scaffolding a nested
+  project) re-roots a host with settings untouched.
 - The re-open considers every open document rather than a pre-narrowed set. The
   configuration question is answered first and from a memo, so the cost is a
   map lookup per open document, but it does scale with the workspace rather

--- a/docs/architecture-decisions/respawn-reopen-derives-its-targets.md
+++ b/docs/architecture-decisions/respawn-reopen-derives-its-targets.md
@@ -219,10 +219,12 @@ anyway, incorrectly, since it cannot include documents opened since the purge.
 
 ### Known limits of `done`
 
-Two ways the sweep can report success for a connection that is not in fact
-caught up. Both are narrow, both degrade to the pre-existing lazy heal (the next
-parse's eager open), and neither is introduced here — but the barrier's contract
-is stated in terms of `done`, so they belong written down rather than implied.
+Four ways the sweep's report can be wrong — mostly by claiming success for a
+connection that is not caught up, and in the last case by claiming failure for a
+document nobody is owed. All are narrow, all degrade to the pre-existing lazy
+heal (the next parse's eager open), and none is introduced here — but the
+barrier's contract is stated in terms of `done`, so they belong written down
+rather than implied.
 
 **An invalidation placeholder reads as a current parse.** `invalidate_parse`
 publishes a tree-less snapshot whose `parsed_version` equals the content

--- a/docs/architecture-decisions/respawn-reopen-derives-its-targets.md
+++ b/docs/architecture-decisions/respawn-reopen-derives-its-targets.md
@@ -1,0 +1,184 @@
+# Respawn Re-open Derives Its Targets
+
+**Related Decisions**:
+[execute-command-routing-token](execute-command-routing-token.md),
+[ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md),
+[language-server-bridge-virtual-document-model](language-server-bridge-virtual-document-model.md),
+[host-document-bridge](host-document-bridge.md)
+
+## Context
+
+When a bridged downstream is replaced, the fresh process has nothing open. The
+replacement must be told about the virtual documents it is expected to serve,
+or it answers requests about documents it has never seen.
+
+execute-command-routing-token established *when* that happens (at respawn,
+signalled by a barrier) and *who* does it (the server side, which owns document
+content). It answered *which documents* by capturing them: the purge returned
+the host documents the dead connection had held, and the replacement replayed
+that list.
+
+Capturing seemed forced by the situation — the purge is the moment the
+information is destroyed, so it looked like the last moment it was knowable.
+But a captured list is a claim about a state that has already stopped being
+true, and every way it could drift from the present needed its own repair:
+
+| Drift | Repair it needed |
+|-------|------------------|
+| a document closed after the purge | the claim DRAINS the list |
+| a second purge before any replacement lands | the record UNIONS instead of replacing |
+| the handshake dies after claiming | restore the claimed list |
+| the hand-off send fails | restore the claimed list again |
+| a config change re-roots a host | carry the claimed key and acquire by it |
+
+Four restore-shaped repairs against one cause. And one divergence had no repair
+available at all: a connection that died before opening anything held nothing,
+so its purge captured an empty list, which was skipped — nothing was recorded
+and nothing was scheduled. Its replacement was never repaired by anyone.
+Restoring could not help, because the list had never existed. That case is not
+exotic: it is precisely a connection that fails during startup and is replaced,
+which is when a replacement most needs the repair.
+
+The pattern points at the premise. The question "what did the dead process
+hold?" is not the question that needs answering. The question is "what should
+this connection hold?" — and that has an answer that is true now.
+
+## Decision
+
+**Derive the re-open set from current state; remember only that a connection
+owes one.**
+
+A purge ARMS its key. The replacement's handshake CLAIMS it. The re-open then
+asks, of every currently open document, whether it belongs to this connection,
+and opens the ones that do.
+
+Nothing is remembered about documents, so nothing about them can go stale.
+
+### Arming is unconditional, and that is the load-bearing part
+
+The previous design armed only when the captured list was non-empty, which is
+what left a young connection's replacement unrepaired. Arming records that a
+connection was replaced — a fact about the connection, not about its contents —
+so there is nothing to be empty. A first-ever spawn is still free: no prior
+purge, no armed key, no re-open.
+
+Symmetrically, a handshake that finds an armed key always emits the re-open
+request. Both halves must be unconditional; leaving either gated on a captured
+set would preserve the hole while appearing to fix it.
+
+### Belonging is decided per host, against current settings
+
+Which documents are a connection's is not a property of language alone. A
+connection is a `(server, root)` pair, so a document that bridges to the right
+server but sits under a different root is not its document.
+
+So each candidate host is asked twice, cheap question first:
+
+1. Do any of its injections bridge to this server? Pure configuration, answered
+   from the per-snapshot memo, with no pool lookup and no filesystem access.
+   This rejects the great majority of open documents — most bridge nowhere near
+   any one server — before anything expensive runs.
+2. Does it route to *this* connection? A marker resolution, paid only by hosts
+   that survived the first question. Read-only: it never spawns, so asking
+   about a document belonging to another root cannot bring that root's server
+   up.
+
+Only then is the connection acquired, and acquired BY KEY rather than by what
+the host resolves to. Both are needed and they are not the same check. The
+routing question decides whether this host belongs here; acquiring by key
+decides that the open lands on the connection the barrier signals for. A by-key
+lookup succeeds whichever host asked, so without the routing question a sweep
+over every open document would cross-open one root's documents onto another
+root's process.
+
+### The third outcome is "not applicable", not "wrong"
+
+An open reports one of three things: it happened; it was not this connection's
+document; or it was and it failed.
+
+The middle case is the common one under derivation, and it is not a failure.
+Only an applicable host that failed to open may mark the connection as not
+caught up. Conflating them would report failure on essentially every respawn,
+holding the barrier shut so that every command pays the full wait and then
+fails soft — a correctness mechanism turned into a latency tax that also
+withholds correct results.
+
+### What the barrier now means
+
+`done` reports whether this connection matches current state, which is a
+per-connection property — matching what the barrier is keyed by and what a
+routing token names. Under the captured-list design it reported whether N
+remembered hosts had been restored: a per-host property forced into a
+per-connection signal, which is why its granularity never quite fit.
+
+## Considered Options
+
+### Keep the captured list and add a bounded wait for the Initializing case
+
+The unrepaired-replacement hole can be closed by having the re-open wait for a
+still-initializing replacement instead of giving up on it. It works, and it
+would have been a fifth repair against the same cause — arriving after four
+others, in a mechanism where each one had made the next harder to see. Rejected
+in favour of removing the cause. Under derivation the case dissolves rather
+than being handled: nothing is lost when a re-open gives up, because the next
+one re-derives.
+
+### Derive by language only, without the root check
+
+Simpler, and wrong. Two roots each running the same server would repair each
+other: a respawn under root A would open root B's documents onto A's process.
+
+### Derive, but resolve each host's connection instead of acquiring by key
+
+Resolving from the host is how the pre-#927 design worked and it re-introduces
+that bug: it finds whichever connection the host routes to now, which after a
+re-rooting is not the one the barrier signals for. It also spawns, so a sweep
+would start servers for roots nobody asked about.
+
+### Keep remembering, but recompute the list at claim time
+
+A middle path: capture at purge, then filter against current state before
+replaying. This is derivation with a redundant input — the filter is doing all
+the work, and the captured list only narrows what the filter would have found
+anyway, incorrectly, since it cannot include documents opened since the purge.
+
+## Consequences
+
+### Positive
+
+- A replacement of a connection that died before opening anything is now
+  repaired. Previously it never was, silently.
+- `purge_connection`'s return value, the remembered host map, and the
+  record/take/restore lifecycle are gone, along with the class of bug where a
+  claimed set is dropped on a failure path.
+- The barrier's signal is per-connection in meaning as well as in keying.
+- Documents opened *since* the purge are now included; the captured list could
+  only ever shrink.
+- The re-open no longer touches documents the editor has closed, without
+  needing a drain to arrange it.
+
+### Negative
+
+- A host re-rooted away from the connection being repaired is no longer
+  re-opened onto it. Current settings are the authority, so that connection's
+  correct contents are nothing — but a command already in flight against the
+  old root now fails downstream rather than being served. This is the outcome
+  execute-command-routing-token already accepts for a token naming a root no
+  open document sits under, and it requires a configuration change between the
+  action and its command.
+- The re-open considers every open document rather than a pre-narrowed set. The
+  configuration question is answered first and from a memo, so the cost is a
+  map lookup per open document, but it does scale with the workspace rather
+  than with what one connection held.
+- Marker resolution now runs during the re-open for hosts that bridge to the
+  respawned server. The pre-existing eager path already resolves markers per
+  open, so this is not a new kind of work, but it is work the captured-list
+  design skipped.
+
+### Neutral
+
+- The barrier itself is unchanged: same claim-before-Ready ordering, same
+  bound, same fail-soft-on-unsettled rule. Only what it is a barrier *for*
+  changed.
+- Arming a key whose connection is never replaced leaves one entry until the
+  key is next claimed. Bounded by the number of distinct `(server, root)` pairs.

--- a/docs/architecture-decisions/respawn-reopen-derives-its-targets.md
+++ b/docs/architecture-decisions/respawn-reopen-derives-its-targets.md
@@ -72,16 +72,30 @@ Which documents are a connection's is not a property of language alone. A
 connection is a `(server, root)` pair, so a document that bridges to the right
 server but sits under a different root is not its document.
 
-So each candidate host is asked twice, cheap question first:
+So each candidate host is screened in stages, cheapest first, and the ordering
+is a correctness property rather than a micro-optimization: the re-open runs
+inside a fixed budget that `done` must signal within, so work done per candidate
+is work charged against every command on that connection. Screening after the
+expensive steps would make that budget scale with workspace size instead of
+with the work that belongs to the connection.
 
-1. Do any of its injections bridge to this server? Pure configuration, answered
-   from the per-snapshot memo, with no pool lookup and no filesystem access.
-   This rejects the great majority of open documents — most bridge nowhere near
-   any one server — before anything expensive runs.
-2. Does it route to *this* connection? A marker resolution, paid only by hosts
-   that survived the first question. Read-only: it never spawns, so asking
-   about a document belonging to another root cannot bring that root's server
-   up.
+1. Could a document in this HOST language bridge to this server at all? Pure
+   configuration, answered from the per-snapshot memo — no parse, no tree, no
+   pool lookup, no filesystem access. This rejects the great majority of open
+   documents, and it must run before the parse wait and the injection
+   resolution, not merely before the open.
+2. Do its resolved injections actually bridge to this server? Also pure
+   configuration, but it needs the injections, so it is paid only by hosts that
+   survived (1).
+3. Does it route to *this* connection? A marker resolution, paid only by hosts
+   that survived (2). Read-only: it never spawns, so asking about a document
+   belonging to another root cannot bring that root's server up.
+
+Stage 1 is deliberately conservative — a server declaring the `*` wildcard is
+never pre-rejected — and advisory, in that it reads the host language before the
+parse wait while the authoritative language is re-read with the injections.
+Screening on a stale language can only cost an unnecessary stage 2; it cannot
+open anything.
 
 Only then is the connection acquired, and acquired BY KEY rather than by what
 the host resolves to. Both are needed and they are not the same check. The
@@ -169,7 +183,10 @@ anyway, incorrectly, since it cannot include documents opened since the purge.
 - The re-open considers every open document rather than a pre-narrowed set. The
   configuration question is answered first and from a memo, so the cost is a
   map lookup per open document, but it does scale with the workspace rather
-  than with what one connection held.
+  than with what one connection held. The ordering above is what keeps that
+  cost off the barrier's budget; a future change that moves work ahead of the
+  stage-1 screen re-couples them, and the symptom is every command on a
+  respawned connection failing soft on a large workspace.
 - Marker resolution now runs during the re-open for hosts that bridge to the
   respawned server. The pre-existing eager path already resolves markers per
   open, so this is not a new kind of work, but it is work the captured-list

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -496,6 +496,31 @@ impl BridgeServerConfig {
         !self.cmd.is_empty() && self.is_enabled()
     }
 
+    /// The `languages` list that actually applies, resolving `_` inheritance
+    /// against an already-looked-up `wildcard`.
+    ///
+    /// `languages` is `#[serde(default)]`, so a server that omits the key
+    /// inherits the `_` template's list (wildcard-config-inheritance) — its own
+    /// list reads as EMPTY until that merge happens. A caller that reads
+    /// `languages` directly to decide "which languages can this server serve"
+    /// therefore sees nothing for a server that may serve everything.
+    /// Merging the whole config to find out costs a clone per server, so this
+    /// mirrors [`Self::is_spawnable_with_wildcard`]: resolve just this field,
+    /// and let a loop hoist the `_` lookup.
+    ///
+    /// Replace-not-union, matching `merge_bridge_server_configs`: a server that
+    /// declares its own list has overridden the template.
+    pub(crate) fn effective_languages_with_wildcard<'a>(
+        &'a self,
+        wildcard: Option<&'a Self>,
+    ) -> &'a [String] {
+        if self.languages.is_empty() {
+            wildcard.map(|w| w.languages.as_slice()).unwrap_or_default()
+        } else {
+            self.languages.as_slice()
+        }
+    }
+
     /// Same as [`Self::is_spawnable`], but resolves `cmd`/`enabled`
     /// inheritance against an already-looked-up `wildcard` instead of doing
     /// its own `_` lookup — for callers (like [`crate::config::is_server_spawnable`]

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -202,9 +202,9 @@ pub(crate) enum UpstreamRequest {
     /// and fires them by raw name (#628 palette-fired commands). Fire-and-forget:
     /// no reply/cancel (the editor's ack is ignored; routing fails soft anyway).
     RegisterCommands { commands: Vec<String> },
-    /// Re-open the virtual documents of `hosts` on `server`, whose previous
-    /// connection was purged and has now been replaced by a `Ready` process
-    /// (execute-command-routing-token).
+    /// Bring `key`'s virtual documents up to date: its previous connection was
+    /// purged and has now been replaced by a `Ready` process
+    /// (respawn-reopen-derives-its-targets).
     ///
     /// Routed upward because re-opening needs document *content*, which only the
     /// server side can supply: it owns the document store and injection
@@ -218,13 +218,13 @@ pub(crate) enum UpstreamRequest {
     /// degrades to the pre-existing lazy behaviour (the next parse's
     /// `process_injections` opens the documents again).
     ReopenDocuments {
-        /// The connection the purge recorded this set under. The re-open
-        /// resolves each host's connection from the CURRENT settings, so a
-        /// config change that re-roots the host in between would otherwise open
-        /// a DIFFERENT connection while this one — the one `done` signals for,
-        /// and the one a routed command names — stays empty.
+        /// The connection to bring up to date, and the ONLY input the re-open
+        /// needs: which documents belong to it is derived from the documents
+        /// open when this runs, not from what its dead predecessor held. A list
+        /// captured at purge time is a snapshot of a state that has already
+        /// stopped being true — documents close, hosts re-root, and a
+        /// connection that died young held nothing to capture at all.
         key: ConnectionKey,
-        hosts: Vec<url::Url>,
         done: tokio::sync::watch::Sender<bool>,
     },
 }

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -557,6 +557,42 @@ impl BridgeCoordinator {
         self.cached_configs(settings, host_language, Some(injection_language))
     }
 
+    /// Whether a document whose HOST language is `host_language` could bridge
+    /// any injection to `server_name` at all, under current settings.
+    ///
+    /// Pure configuration, answered from the same per-snapshot memo the open
+    /// path uses: no pool lookup, no marker walk, no tree. It exists so the
+    /// respawn re-open can reject a candidate host before paying for one —
+    /// deriving the target set means asking about EVERY open document, and the
+    /// answer is "no" for most of them. Without this the per-host parse wait
+    /// and injection resolution run first, so the barrier's fixed budget is
+    /// spent in proportion to workspace size rather than to the work that
+    /// belongs to the connection (respawn-reopen-derives-its-targets).
+    ///
+    /// Conservative in the safe direction: a server declaring the `*` wildcard
+    /// could serve any injection language, so it is never pre-rejected.
+    pub(crate) fn host_language_can_reach_server(
+        &self,
+        settings: &Arc<WorkspaceSettings>,
+        host_language: &str,
+        server_name: &str,
+    ) -> bool {
+        let Some(config) = settings.language_servers.get(server_name) else {
+            return false;
+        };
+        config.languages.iter().any(|injection_language| {
+            injection_language == "*"
+                || self
+                    .cached_configs_for_injection_language(
+                        settings,
+                        host_language,
+                        injection_language,
+                    )
+                    .iter()
+                    .any(|resolved| resolved.server_name == server_name)
+        })
+    }
+
     /// Memoized [`Self::get_host_configs_for_language`] for the current
     /// settings snapshot.
     pub(crate) fn cached_host_configs_for_language(
@@ -1499,6 +1535,95 @@ mod tests {
         assert!(
             result.is_empty(),
             "rust should be blocked by markdown's bridge filter"
+        );
+    }
+
+    /// The screen the respawn re-open applies to every open document before
+    /// paying for a parse wait or an injection resolution.
+    #[test]
+    fn host_language_can_reach_server_screens_on_configuration_alone() {
+        let coordinator = BridgeCoordinator::new();
+        let server = |language: &str| BridgeServerConfig {
+            cmd: vec!["x".to_string()],
+            languages: vec![language.to_string()],
+            initialization_options: None,
+            workspace_markers: None,
+            on_type_formatting_triggers: None,
+            prefer_shared_instance: None,
+            enabled: None,
+            settings: None,
+        };
+        let mut servers = HashMap::new();
+        servers.insert("ruff".to_string(), server("python"));
+        servers.insert("anything".to_string(), server("*"));
+        let settings = Arc::new(WorkspaceSettings {
+            languages: HashMap::new(),
+            auto_install: false,
+            language_servers: servers,
+            ..Default::default()
+        });
+
+        assert!(
+            coordinator.host_language_can_reach_server(&settings, "markdown", "ruff"),
+            "markdown can host a python injection, so ruff is reachable"
+        );
+        assert!(
+            !coordinator.host_language_can_reach_server(&settings, "markdown", "gone"),
+            "a server that is not configured at all is unreachable"
+        );
+        assert!(
+            coordinator.host_language_can_reach_server(&settings, "markdown", "anything"),
+            "a wildcard server could serve any injection language, so it must \
+             never be pre-rejected"
+        );
+    }
+
+    /// A host language whose bridge filter blocks the server's only language
+    /// must be screened out — otherwise the re-open pays full price for a
+    /// document that can supply nothing.
+    #[test]
+    fn host_language_can_reach_server_respects_the_hosts_bridge_filter() {
+        let coordinator = BridgeCoordinator::new();
+        let mut bridge_filter = HashMap::new();
+        bridge_filter.insert(
+            "python".to_string(),
+            BridgeLanguageConfig {
+                enabled: Some(false),
+                ..Default::default()
+            },
+        );
+        let mut languages = HashMap::new();
+        languages.insert(
+            "markdown".to_string(),
+            LanguageSettings {
+                bridge: Some(bridge_filter),
+                ..Default::default()
+            },
+        );
+        let mut servers = HashMap::new();
+        servers.insert(
+            "ruff".to_string(),
+            BridgeServerConfig {
+                cmd: vec!["ruff".to_string()],
+                languages: vec!["python".to_string()],
+                initialization_options: None,
+                workspace_markers: None,
+                on_type_formatting_triggers: None,
+                prefer_shared_instance: None,
+                enabled: None,
+                settings: None,
+            },
+        );
+        let settings = Arc::new(WorkspaceSettings {
+            languages,
+            auto_install: false,
+            language_servers: servers,
+            ..Default::default()
+        });
+
+        assert!(
+            !coordinator.host_language_can_reach_server(&settings, "markdown", "ruff"),
+            "markdown blocks python, so ruff can receive nothing from it"
         );
     }
 

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -393,15 +393,12 @@ impl BridgeCoordinator {
         let (for_server, config) =
             self.injections_for_server(settings, host_language, injections, server_name);
         let Some(config) = config else {
-            // No injected region on this host bridges to `server_name`.
-            // With no named connection this is simply nothing to do; but a
-            // caller repairing a NAMED connection asked for documents this host
-            // can no longer supply (server removed from config, or the host's
-            // injections changed), so its repair did NOT happen.
-            return match expect.connection {
-                Some(_) => OpenOutcome::NotOpened,
-                None => OpenOutcome::Opened,
-            };
+            // No injected region on this host bridges to `server_name`, so this
+            // host supplies nothing for that server on any connection. Pure
+            // config — resolved from the memo, before any pool lookup or marker
+            // walk, so the hosts that bridge nowhere near this server cost
+            // nothing to reject.
+            return OpenOutcome::NotApplicable;
         };
         let Ok(host_uri_lsp) = crate::lsp::lsp_impl::url_to_uri(host_uri) else {
             return OpenOutcome::NotOpened;
@@ -1638,9 +1635,9 @@ mod tests {
         .expect("a non-matching server must short-circuit, not attempt a spawn");
         assert_eq!(
             outcome,
-            crate::lsp::bridge::OpenOutcome::Opened,
-            "a caller that named no connection has nothing to repair, so \
-             'this host bridges nowhere' is success, not failure"
+            crate::lsp::bridge::OpenOutcome::NotApplicable,
+            "a host that bridges to no such server supplies nothing for it — \
+             the answer the respawn re-open gets for most open documents"
         );
     }
 

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -580,8 +580,18 @@ impl BridgeCoordinator {
         let Some(config) = settings.language_servers.get(server_name) else {
             return false;
         };
-        config.languages.iter().any(|injection_language| {
-            injection_language == "*"
+        // Resolve `_` inheritance: `languages` is `#[serde(default)]`, so a
+        // server that omits it reads as declaring NOTHING until the wildcard
+        // template is merged in — and the authoritative resolver merges before
+        // matching. Reading the raw list here would answer "reaches nothing"
+        // for a server that reaches everything, and because this screen only
+        // ever SKIPS, that false negative is silent: no didOpen, no failure
+        // reported, and the barrier releases commands onto an empty connection.
+        let effective_languages = config.effective_languages_with_wildcard(
+            settings.language_servers.get(crate::config::WILDCARD_KEY),
+        );
+        effective_languages.iter().any(|injection_language| {
+            injection_language == crate::config::settings::LANGUAGES_WILDCARD
                 || self
                     .cached_configs_for_injection_language(
                         settings,
@@ -1575,6 +1585,69 @@ mod tests {
             coordinator.host_language_can_reach_server(&settings, "markdown", "anything"),
             "a wildcard server could serve any injection language, so it must \
              never be pre-rejected"
+        );
+    }
+
+    /// A server that INHERITS its `languages` from the `_` template must not be
+    /// screened out.
+    ///
+    /// `languages` is `#[serde(default)]`, so omitting the key leaves the raw
+    /// entry's list empty and the authoritative resolver merges the template in
+    /// before matching. A screen that read the raw list would answer "reaches
+    /// nothing" for a server that reaches everything — and because this screen
+    /// only ever SKIPS, the failure is silent: no didOpen is sent, nothing is
+    /// reported as failed, and the barrier releases commands onto a connection
+    /// that holds no documents.
+    #[test]
+    fn host_language_can_reach_server_resolves_inherited_languages() {
+        let coordinator = BridgeCoordinator::new();
+        let mut servers = HashMap::new();
+        servers.insert(
+            crate::config::WILDCARD_KEY.to_string(),
+            BridgeServerConfig {
+                cmd: Vec::new(),
+                languages: vec!["*".to_string()],
+                initialization_options: None,
+                workspace_markers: None,
+                on_type_formatting_triggers: None,
+                prefer_shared_instance: None,
+                enabled: None,
+                settings: None,
+            },
+        );
+        servers.insert(
+            "harper-ls".to_string(),
+            BridgeServerConfig {
+                cmd: vec!["harper-ls".to_string()],
+                // Deliberately omitted in TOML → empty here, inherited from `_`.
+                languages: Vec::new(),
+                initialization_options: None,
+                workspace_markers: None,
+                on_type_formatting_triggers: None,
+                prefer_shared_instance: None,
+                enabled: None,
+                settings: None,
+            },
+        );
+        let settings = Arc::new(WorkspaceSettings {
+            languages: HashMap::new(),
+            auto_install: false,
+            language_servers: servers,
+            ..Default::default()
+        });
+
+        // The authority says this server bridges the language...
+        assert!(
+            coordinator
+                .get_all_configs_for_language(&settings, "markdown", "python")
+                .iter()
+                .any(|r| r.server_name == "harper-ls"),
+            "precondition: the merged config makes harper-ls a candidate"
+        );
+        // ...so the screen must not disagree.
+        assert!(
+            coordinator.host_language_can_reach_server(&settings, "markdown", "harper-ls"),
+            "a server inheriting `languages` from `_` must not be pre-rejected"
         );
     }
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -781,8 +781,10 @@ impl LanguageServerPool {
                 .lock()
                 .await
                 .retain(|(_, connection_key), _| connection_key != &key);
-            let reopen_hosts = self.document_tracker.purge_connection(&key).await;
-            self.pending_reopen.record(&key, reopen_hosts);
+            self.document_tracker.purge_connection(&key).await;
+            // Arm before the replacement can claim: what this connection held
+            // is irrelevant, only that it owes a re-open.
+            self.pending_reopen.arm(&key);
             self.purge_open_transition_locks(&key).await;
             if let Some(handle) = connections.remove(&key) {
                 stale_handles.push((key, handle));
@@ -2024,7 +2026,7 @@ impl LanguageServerPool {
     ///
     /// Briefly locks `connections` for the capability probe; the marker is still
     /// resolved with a single filesystem walk.
-    async fn resolve_acquire(
+    pub(super) async fn resolve_acquire(
         &self,
         server_name: &str,
         server_config: &crate::config::settings::BridgeServerConfig,
@@ -2332,11 +2334,10 @@ impl LanguageServerPool {
                         .lock()
                         .await
                         .retain(|(_, key), _| key != &connection_key);
-                    let reopen_hosts = self
-                        .document_tracker
+                    self.document_tracker
                         .purge_connection(&connection_key)
                         .await;
-                    self.pending_reopen.record(&connection_key, reopen_hosts);
+                    self.pending_reopen.arm(&connection_key);
                     self.invalidate_diagnostic_connections(std::slice::from_ref(&connection_key));
                     self.purge_open_transition_locks(&connection_key).await;
                     // Remove only after every async purge completes. If this
@@ -2558,14 +2559,14 @@ impl LanguageServerPool {
                     // SEE that one is in flight and wait for it — registering
                     // after Ready would leave exactly the window in which a
                     // command overtakes its own didOpen.
-                    let mut pending_reopen_handoff = pending_reopen.take(&command_registration_key);
+                    let mut pending_reopen_handoff =
+                        pending_reopen.claim(&command_registration_key);
                     if !handle_for_handshake.transition_initializing_to_ready() {
-                        // Put the claimed set back: `take` drained it, and the
-                        // purge that recorded it already emptied the document
-                        // tracker, so nothing would re-record it for the next
-                        // replacement.
-                        if let Some((hosts, _done)) = pending_reopen_handoff.take() {
-                            pending_reopen.restore(&command_registration_key, hosts);
+                        // Re-arm: `claim` disarmed the key, and this replacement
+                        // is not going to serve anyone, so the NEXT one must
+                        // still learn that it owes a re-open.
+                        if pending_reopen_handoff.take().is_some() {
+                            pending_reopen.rearm(&command_registration_key);
                         }
                         return Err(io::Error::new(
                             io::ErrorKind::Interrupted,
@@ -2594,15 +2595,19 @@ impl LanguageServerPool {
                             );
                         }
                     }
-                    // Hand the claimed set upstream to be re-opened. Sent after
-                    // Ready so the didOpen queues behind the settings push.
-                    // `done` travels with it and releases waiters when the
+                    // Ask upstream to bring this connection up to date. Sent
+                    // after Ready so the didOpen queues behind the settings
+                    // push. `done` travels with it and releases waiters when the
                     // re-open finishes — or when it is dropped, so a lost
                     // message cannot strand a request for the full bound.
-                    if let Some((hosts, done)) = pending_reopen_handoff
+                    //
+                    // The request carries no document list: upstream derives
+                    // what this connection should hold from the documents open
+                    // at the time it runs, which is the only set that is still
+                    // true by then.
+                    if let Some(done) = pending_reopen_handoff
                         && let Err(e) = upstream_request_tx.send(UpstreamRequest::ReopenDocuments {
                             key: command_registration_key.clone(),
-                            hosts,
                             done,
                         })
                     {
@@ -2611,12 +2616,9 @@ impl LanguageServerPool {
                             "Failed to queue virtual-document re-open after respawn \
                              (forwarding loop gone): {e}"
                         );
-                        // Same reasoning as the Ready-flip failure above: the
-                        // undelivered set is the only record that these documents
-                        // need re-opening.
-                        if let UpstreamRequest::ReopenDocuments { hosts, .. } = e.0 {
-                            pending_reopen.restore(&command_registration_key, hosts);
-                        }
+                        // Same reasoning as the Ready-flip failure above: this
+                        // connection still owes a re-open nobody is going to make.
+                        pending_reopen.rearm(&command_registration_key);
                     }
                     Ok(())
                 }
@@ -4598,18 +4600,15 @@ mod tests {
         .await
         .unwrap();
 
-        // Purge records the host; the handshake claims it before going Ready.
-        let hosts = pool
-            .document_tracker
+        // Purge arms the key; the handshake claims it before going Ready.
+        pool.document_tracker
             .purge_connection(&connection_key)
             .await;
-        assert_eq!(hosts, vec![host_uri.clone()], "purge reports the host");
-        pool.pending_reopen.record(&connection_key, hosts);
-        let (claimed, done) = pool
+        pool.pending_reopen.arm(&connection_key);
+        let done = pool
             .pending_reopen
-            .take(&connection_key)
+            .claim(&connection_key)
             .expect("the handshake claims the pending re-open");
-        assert_eq!(claimed, vec![host_uri]);
 
         let waiter = {
             let pool = Arc::clone(&pool);

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -368,9 +368,9 @@ pub struct LanguageServerPool {
     /// servers via `bridge._self`, with their version and content
     /// fingerprint for lazy full-text re-sync.
     host_documents: Mutex<HashMap<(String, ConnectionKey), HostDocSyncState>>,
-    /// Host documents whose virtual documents a purged connection held, awaiting
-    /// re-open on the replacement connection (execute-command-routing-token).
-    /// `Arc` because the drain runs inside the spawned handshake task.
+    /// Connections whose replacement still owes a virtual-document re-open, and
+    /// the barrier requests wait on (respawn-reopen-derives-its-targets).
+    /// `Arc` because the claim runs inside the spawned handshake task.
     pending_reopen: Arc<PendingReopenRegistry>,
     /// Last full downstream pull report per exact connection/document. Region
     /// diagnostics stay virtual-local and are re-anchored with the request's

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -2565,8 +2565,8 @@ impl LanguageServerPool {
                         // Re-arm: `claim` disarmed the key, and this replacement
                         // is not going to serve anyone, so the NEXT one must
                         // still learn that it owes a re-open.
-                        if pending_reopen_handoff.take().is_some() {
-                            pending_reopen.rearm(&command_registration_key);
+                        if let Some(done) = pending_reopen_handoff.take() {
+                            pending_reopen.rearm(&command_registration_key, &done);
                         }
                         return Err(io::Error::new(
                             io::ErrorKind::Interrupted,
@@ -2618,7 +2618,11 @@ impl LanguageServerPool {
                         );
                         // Same reasoning as the Ready-flip failure above: this
                         // connection still owes a re-open nobody is going to make.
-                        pending_reopen.rearm(&command_registration_key);
+                        // The undelivered message carries the sender back, so the
+                        // retire stays identity-guarded.
+                        if let UpstreamRequest::ReopenDocuments { done, .. } = e.0 {
+                            pending_reopen.rearm(&command_registration_key, &done);
+                        }
                     }
                     Ok(())
                 }
@@ -7338,6 +7342,26 @@ mod tests {
             _ => unreachable!(),
         })
         .await;
+
+        // Every purged connection owes a re-open, and NONE of these handles ever
+        // opened a document. That is the whole point: the predecessor design
+        // armed from the host list the purge returned, so a connection holding
+        // nothing armed nothing and its replacement was never repaired by
+        // anyone. Asserting it here rather than on the registry is deliberate —
+        // the registry cannot express "held nothing", because `arm` takes no
+        // host list at all. Only the production purge site can.
+        assert!(
+            pool.pending_reopen.claim(&changed_key).is_some(),
+            "an invalidated connection owes a re-open even though it held nothing"
+        );
+        assert!(
+            pool.pending_reopen.claim(&removed_key).is_some(),
+            "a connection whose server was removed owes one too"
+        );
+        assert!(
+            pool.pending_reopen.claim(&unchanged_key).is_none(),
+            "a surviving connection must not be armed"
+        );
 
         let connections = pool.connections().await;
         assert!(!connections.contains_key(&changed_key));

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -549,15 +549,7 @@ impl DocumentTracker {
     /// `(server, root)` key, so sibling connections sharing the server name (or
     /// a different root) keep their state; `opened_documents` is decremented
     /// per URI (not cleared), so a URI also open on another connection survives.
-    ///
-    /// Returns the HOST documents whose virtual documents this connection held.
-    /// The purge is the last moment that set is knowable — afterwards nothing
-    /// records what the dead process had open — so the replacement connection's
-    /// re-open is driven from this return value (execute-command-routing-token).
-    /// `#[must_use]`: a purge site that drops this loses the heal with no
-    /// compiler or runtime signal.
-    #[must_use]
-    pub(super) async fn purge_connection(&self, connection_key: &ConnectionKey) -> Vec<Url> {
+    pub(super) async fn purge_connection(&self, connection_key: &ConnectionKey) {
         let mut generation = self
             .connection_generations
             .entry(connection_key.clone())
@@ -586,23 +578,13 @@ impl DocumentTracker {
         }
         // Drop this connection's host→virtual registrations so a later
         // host-close does not try to didClose documents the dead process held.
-        // The same pass collects the affected HOST documents for the caller's
-        // re-open: a host is reported only when this connection actually held
-        // one of its virtual documents, so the re-open never touches documents
-        // the dead process never opened.
-        let hosts: Vec<Url> = {
+        {
             let mut host_map = self.host_to_virtual.lock().await;
-            let mut hosts = Vec::new();
-            for (host_uri, docs) in host_map.iter_mut() {
-                let before = docs.len();
+            for docs in host_map.values_mut() {
                 docs.retain(|doc| &doc.connection_key != connection_key);
-                if docs.len() != before {
-                    hosts.push(host_uri.clone());
-                }
             }
             host_map.retain(|_, docs| !docs.is_empty());
-            hosts
-        };
+        }
         self.open_claims.retain(|(key, _), notify| {
             if key == connection_key {
                 notify.notify_waiters();
@@ -611,7 +593,6 @@ impl DocumentTracker {
                 true
             }
         });
-        hosts
     }
 
     /// Remove a single virtual document from host_to_virtual tracking.
@@ -1992,12 +1973,7 @@ mod tests {
         );
 
         // The dead connection respawns → purge its state.
-        let reopen_hosts = tracker.purge_connection(&dead).await;
-        assert_eq!(
-            reopen_hosts,
-            vec![host_uri.clone()],
-            "purge reports the host whose virtual document the dead connection held"
-        );
+        tracker.purge_connection(&dead).await;
 
         // The document is still open (sibling holds it) but re-claimable on the
         // purged connection, so its respawn will send a fresh didOpen.
@@ -2025,11 +2001,11 @@ mod tests {
         );
     }
 
-    /// The purge's re-open set must be scoped to the dead connection: re-opening
-    /// a host the dead process never held would resolve injections (and send
-    /// didOpen) for documents that were never affected.
+    /// A purge is scoped to its own connection: another connection's
+    /// host→virtual registrations must survive it, or a later close of THAT
+    /// host would fail to didClose the documents it still holds.
     #[tokio::test]
-    async fn purge_reports_only_the_hosts_the_dead_connection_held() {
+    async fn purge_forgets_only_the_dead_connections_registrations() {
         let tracker = DocumentTracker::new();
         let held = Url::parse("file:///test/held.md").unwrap();
         let foreign = Url::parse("file:///test/foreign.md").unwrap();
@@ -2045,27 +2021,31 @@ mod tests {
             .register_opened_document(&foreign, &foreign_vuri, &other)
             .await;
 
-        assert_eq!(
-            tracker.purge_connection(&dead).await,
-            vec![held],
-            "only the dead connection's host is reported"
-        );
-        // And the untouched connection's registration survives, so a later purge
-        // of ITS key still reports its host.
-        assert_eq!(tracker.purge_connection(&other).await, vec![foreign]);
-    }
+        tracker.purge_connection(&dead).await;
 
-    /// A connection that never opened a virtual document has nothing to re-open,
-    /// so the respawn path must stay silent rather than queue an empty heal.
-    #[tokio::test]
-    async fn purge_reports_nothing_for_a_connection_that_held_no_documents() {
-        let tracker = DocumentTracker::new();
+        assert!(
+            !tracker
+                .get_all_connections_for_virtual_uri(&held_vuri)
+                .contains(&dead),
+            "the dead connection's own registration must be gone"
+        );
         assert!(
             tracker
-                .purge_connection(&ConnectionKey::for_server("never-bridged"))
-                .await
-                .is_empty()
+                .get_all_connections_for_virtual_uri(&foreign_vuri)
+                .contains(&other),
+            "an untouched connection's registration must survive the purge"
         );
+    }
+
+    /// Purging a connection that never opened anything is a no-op, not a panic:
+    /// every purge site now arms its key unconditionally, so this runs whenever
+    /// a connection dies before opening its first document.
+    #[tokio::test]
+    async fn purging_a_connection_that_held_no_documents_is_a_noop() {
+        let tracker = DocumentTracker::new();
+        tracker
+            .purge_connection(&ConnectionKey::for_server("never-bridged"))
+            .await;
     }
 
     /// Test that get_all_connections_for_virtual_uri works with process sharing.

--- a/src/lsp/bridge/pool/pending_reopen.rs
+++ b/src/lsp/bridge/pool/pending_reopen.rs
@@ -97,17 +97,36 @@ impl PendingReopenRegistry {
         Some(tx)
     }
 
-    /// Re-arm after a claimed hand-off failed, and retire the barrier it
-    /// registered.
+    /// Re-arm after a claimed hand-off failed, and retire the barrier THAT
+    /// claim registered.
     ///
     /// [`claim`](Self::claim) disarms, so a handshake that claims and then dies
     /// before the re-open is queued would leave the replacement owing a repair
     /// nobody remembers to make.
-    pub(crate) fn rearm(&self, key: &ConnectionKey) {
-        self.in_flight
-            .lock()
-            .recover_poison("PendingReopenRegistry::rearm")
-            .remove(key);
+    ///
+    /// Takes the claim's own `done` so the retire can be identity-guarded, for
+    /// the same reason [`wait_for_reopen`](Self::wait_for_reopen) guards its
+    /// own: claim → publish-Ready → rearm is not atomic against the registry,
+    /// so a LATER respawn can claim this key in between and install a live
+    /// barrier. Removing by key alone would evict that one, and a command
+    /// arriving next finds nothing outstanding, reads the requirement as
+    /// vacuously met, and is enqueued ahead of the didOpens the live re-open
+    /// has not sent yet — the one failure mode this whole mechanism exists to
+    /// prevent, and the one case that does NOT degrade to the lazy heal.
+    pub(crate) fn rearm(&self, key: &ConnectionKey, done: &watch::Sender<bool>) {
+        let probe = done.subscribe();
+        {
+            let mut in_flight = self
+                .in_flight
+                .lock()
+                .recover_poison("PendingReopenRegistry::rearm");
+            if in_flight
+                .get(key)
+                .is_some_and(|current| current.same_channel(&probe))
+            {
+                in_flight.remove(key);
+            }
+        }
         self.arm(key);
     }
 
@@ -239,8 +258,8 @@ mod tests {
         let key = ConnectionKey::for_server("ruff");
         registry.arm(&key);
         let done = registry.claim(&key).expect("armed");
+        registry.rearm(&key, &done);
         drop(done);
-        registry.rearm(&key);
 
         assert!(
             registry.claim(&key).is_some(),
@@ -256,7 +275,7 @@ mod tests {
         let key = ConnectionKey::for_server("ruff");
         registry.arm(&key);
         let done = registry.claim(&key).expect("armed");
-        registry.rearm(&key);
+        registry.rearm(&key, &done);
         drop(done);
 
         assert!(
@@ -265,6 +284,42 @@ mod tests {
                 .expect("a retired barrier must not make the caller wait"),
             "a re-armed key has no re-open in flight to wait for"
         );
+    }
+
+    /// A late `rearm` must not retire a barrier a LATER respawn registered.
+    ///
+    /// claim -> publish-Ready -> rearm is not atomic against this registry, so a
+    /// replacement can claim the same key in between and install a live barrier.
+    /// Retiring by key alone would evict it, and the next command would find
+    /// nothing outstanding, read the ordering requirement as vacuously met, and
+    /// be enqueued ahead of didOpens that have not been sent — the one failure
+    /// this mechanism exists to prevent, and the one that does NOT degrade to
+    /// the lazy heal.
+    #[tokio::test]
+    async fn a_stale_rearm_does_not_retire_a_later_respawns_barrier() {
+        let registry = PendingReopenRegistry::default();
+        let key = ConnectionKey::for_server("ruff");
+
+        // The displaced handshake claims...
+        registry.arm(&key);
+        let stale = registry.claim(&key).expect("armed");
+        // ...is displaced, so its key is armed again and a replacement claims.
+        registry.arm(&key);
+        let live = registry.claim(&key).expect("re-armed");
+
+        // Only NOW does the displaced handshake notice it lost the Ready flip.
+        registry.rearm(&key, &stale);
+        drop(stale);
+
+        // The live re-open is still outstanding, so a command must wait for it.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), registry.wait_for_reopen(&key))
+                .await
+                .is_err(),
+            "the live respawn's barrier must survive a stale rearm"
+        );
+        live.send(true).expect("the registry holds the receiver");
+        assert!(registry.wait_for_reopen(&key).await);
     }
 
     #[test]

--- a/src/lsp/bridge/pool/pending_reopen.rs
+++ b/src/lsp/bridge/pool/pending_reopen.rs
@@ -1,5 +1,5 @@
-//! Host documents awaiting re-open on a respawned connection
-//! (execute-command-routing-token).
+//! Connections owing a virtual-document re-open after a respawn
+//! (respawn-reopen-derives-its-targets).
 //!
 //! When a stale connection is purged, the replacement process has nothing open.
 //! Nothing re-opens it on its own: `process_injections` eagerly opens virtual
@@ -7,21 +7,22 @@
 //! subsequent edit leaves the fresh process receiving requests for documents it
 //! never opened.
 //!
-//! The purge is the last moment the affected set is knowable, since it is the
-//! purge itself that forgets what the dead process held. So `purge_connection`
-//! returns the host documents it dropped and they are recorded here, then drained
-//! when the replacement reaches `Ready`.
+//! What this registry stores is a KEY, not a document set. A purge ARMS its key;
+//! the replacement's handshake CLAIMS it and the re-open then derives what the
+//! connection should hold from the documents that are open now. Remembering the
+//! dead process's set instead made the record a snapshot of a past state that
+//! kept diverging from the present — closed documents, re-rooted hosts, a second
+//! purge reporting nothing — and each divergence needed its own repair.
 //!
 //! Held in an `Arc` on the pool (like the sibling `CommandOriginRegistry`)
-//! because the drain runs inside the spawned handshake task, which cannot reach
+//! because the claim runs inside the spawned handshake task, which cannot reach
 //! `&self`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 use std::time::Duration;
 
 use tokio::sync::watch;
-use url::Url;
 
 use super::ConnectionKey;
 use crate::error::LockResultExt;
@@ -34,7 +35,9 @@ pub(crate) const REOPEN_WAIT: Duration = Duration::from_secs(2);
 
 #[derive(Default)]
 pub(crate) struct PendingReopenRegistry {
-    hosts: Mutex<HashMap<ConnectionKey, Vec<Url>>>,
+    /// Keys whose connection was purged and whose replacement still owes a
+    /// re-open.
+    armed: Mutex<HashSet<ConnectionKey>>,
     /// Re-opens handed off but not yet finished, so a request that must not
     /// overtake its own `didOpen` can wait for one.
     ///
@@ -46,33 +49,28 @@ pub(crate) struct PendingReopenRegistry {
 }
 
 impl PendingReopenRegistry {
-    /// Record the host documents a just-purged connection held.
+    /// Note that `key`'s connection was purged, so its replacement owes a
+    /// re-open.
     ///
-    /// Unions rather than replaces: a respawn that dies before reaching `Ready`
-    /// is purged again, and the second purge reports nothing (the first already
-    /// emptied the tracker), so replacing would forget the set entirely.
-    pub(crate) fn record(&self, key: &ConnectionKey, hosts: Vec<Url>) {
-        if hosts.is_empty() {
-            return;
-        }
-        let mut pending = self
-            .hosts
+    /// UNCONDITIONAL, and that is load-bearing. The predecessor recorded a host
+    /// list and skipped when it was empty — but a connection that dies young
+    /// holds nothing, so the purge that follows it reported nothing, armed
+    /// nothing, and its replacement was never repaired by anyone. Arming on the
+    /// purge itself has no such hole: what the dead connection happened to hold
+    /// is not what the replacement needs.
+    ///
+    /// Idempotent — a key purged twice before any replacement lands is armed
+    /// once, and one re-open brings the replacement fully up to date.
+    pub(crate) fn arm(&self, key: &ConnectionKey) {
+        self.armed
             .lock()
-            .recover_poison("PendingReopenRegistry::record");
-        let entry = pending.entry(key.clone()).or_default();
-        for host in hosts {
-            if !entry.contains(&host) {
-                entry.push(host);
-            }
-        }
+            .recover_poison("PendingReopenRegistry::arm")
+            .insert(key.clone());
     }
 
-    /// Take the host documents awaiting re-open on `key` and mark the re-open
-    /// in flight, returning the hosts and the completion sender.
-    ///
-    /// Draining means one re-open attempt per respawn. That is deliberate: a
-    /// retained set would re-open the same documents on every later respawn of
-    /// the key, including documents the editor has since closed.
+    /// Claim `key`'s outstanding re-open and mark it in flight, returning the
+    /// completion sender. `None` when nothing was armed — a first-ever spawn,
+    /// which has no predecessor's state to restore.
     ///
     /// MUST be called before the connection is published as `Ready`. A request
     /// unblocked by that transition checks [`wait_for_reopen`](Self::wait_for_reopen),
@@ -82,37 +80,35 @@ impl PendingReopenRegistry {
     /// Dropping the returned sender completes the wait, so a handler that dies
     /// or is never serviced releases waiters instead of stranding them until the
     /// timeout.
-    pub(crate) fn take(&self, key: &ConnectionKey) -> Option<(Vec<Url>, watch::Sender<bool>)> {
-        let hosts = self
-            .hosts
+    pub(crate) fn claim(&self, key: &ConnectionKey) -> Option<watch::Sender<bool>> {
+        if !self
+            .armed
             .lock()
-            .recover_poison("PendingReopenRegistry::take")
-            .remove(key)?;
-        if hosts.is_empty() {
+            .recover_poison("PendingReopenRegistry::claim")
+            .remove(key)
+        {
             return None;
         }
         let (tx, rx) = watch::channel(false);
         self.in_flight
             .lock()
-            .recover_poison("PendingReopenRegistry::take")
+            .recover_poison("PendingReopenRegistry::claim")
             .insert(key.clone(), rx);
-        Some((hosts, tx))
+        Some(tx)
     }
 
-    /// Put a claimed host set back after a hand-off failed, and retire the
-    /// barrier it registered.
+    /// Re-arm after a claimed hand-off failed, and retire the barrier it
+    /// registered.
     ///
-    /// [`take`](Self::take) DRAINS, so a handshake that claims the set and then
-    /// dies before the re-open is queued would lose it permanently: the purge
-    /// that recorded it already emptied the document tracker, so the next purge
-    /// of the same key reports nothing to re-record. Restoring leaves it for the
-    /// next replacement to claim.
-    pub(crate) fn restore(&self, key: &ConnectionKey, hosts: Vec<Url>) {
+    /// [`claim`](Self::claim) disarms, so a handshake that claims and then dies
+    /// before the re-open is queued would leave the replacement owing a repair
+    /// nobody remembers to make.
+    pub(crate) fn rearm(&self, key: &ConnectionKey) {
         self.in_flight
             .lock()
-            .recover_poison("PendingReopenRegistry::restore")
+            .recover_poison("PendingReopenRegistry::rearm")
             .remove(key);
-        self.record(key, hosts);
+        self.arm(key);
     }
 
     /// Wait (bounded by [`REOPEN_WAIT`]) for an in-flight re-open on `key`.
@@ -192,64 +188,99 @@ impl PendingReopenRegistry {
 mod tests {
     use super::*;
 
-    fn url(path: &str) -> Url {
-        Url::parse(path).expect("valid test URL")
-    }
+    #[test]
+    fn claim_disarms_what_arm_set() {
+        let registry = PendingReopenRegistry::default();
+        let key = ConnectionKey::for_server("ruff");
+        registry.arm(&key);
 
-    fn hosts_of(taken: Option<(Vec<Url>, watch::Sender<bool>)>) -> Vec<Url> {
-        taken.map(|(hosts, _tx)| hosts).unwrap_or_default()
+        assert!(registry.claim(&key).is_some());
+        // Disarmed, not retained: one respawn owes one re-open. A retained key
+        // would make every later respawn of it re-derive for no reason.
+        assert!(registry.claim(&key).is_none());
     }
 
     #[test]
-    fn take_drains_what_record_stored() {
+    fn a_connection_that_died_holding_nothing_still_arms() {
+        // The hole the remembered-list design could not close. A connection
+        // purged before it opened anything reported an EMPTY set, which armed
+        // nothing — so its replacement was never repaired by anyone, and no
+        // amount of restoring helped because the set had never existed. Arming
+        // on the purge itself does not consult what was held.
         let registry = PendingReopenRegistry::default();
         let key = ConnectionKey::for_server("ruff");
-        registry.record(&key, vec![url("file:///w/a.md")]);
+        registry.arm(&key);
 
-        assert_eq!(hosts_of(registry.take(&key)), vec![url("file:///w/a.md")]);
-        // Drained, not retained: a later respawn must not re-open documents the
-        // editor may have closed in the meantime.
-        assert!(registry.take(&key).is_none());
-    }
-
-    #[test]
-    fn a_second_purge_before_ready_keeps_the_first_set() {
-        // A respawn that dies during the handshake is purged again, and that
-        // second purge reports nothing — the first one already emptied the
-        // tracker. Replacing instead of unioning would lose the documents.
-        let registry = PendingReopenRegistry::default();
-        let key = ConnectionKey::for_server("ruff");
-        registry.record(&key, vec![url("file:///w/a.md")]);
-        registry.record(&key, vec![]);
-
-        assert_eq!(hosts_of(registry.take(&key)), vec![url("file:///w/a.md")]);
-    }
-
-    #[test]
-    fn record_unions_without_duplicating() {
-        let registry = PendingReopenRegistry::default();
-        let key = ConnectionKey::for_server("ruff");
-        registry.record(&key, vec![url("file:///w/a.md")]);
-        registry.record(&key, vec![url("file:///w/a.md"), url("file:///w/b.md")]);
-
-        assert_eq!(
-            hosts_of(registry.take(&key)),
-            vec![url("file:///w/a.md"), url("file:///w/b.md")]
+        assert!(
+            registry.claim(&key).is_some(),
+            "a purge must arm its key regardless of what the dead connection held"
         );
     }
 
     #[test]
-    fn keys_do_not_share_a_pending_set() {
+    fn arming_twice_before_a_claim_owes_one_reopen() {
+        // A respawn that dies during its own handshake is purged again. One
+        // derivation brings the eventual replacement fully up to date, so the
+        // second purge must not queue a second one.
+        let registry = PendingReopenRegistry::default();
+        let key = ConnectionKey::for_server("ruff");
+        registry.arm(&key);
+        registry.arm(&key);
+
+        assert!(registry.claim(&key).is_some());
+        assert!(registry.claim(&key).is_none());
+    }
+
+    #[test]
+    fn rearm_puts_back_a_claim_that_could_not_be_handed_off() {
+        // A handshake that claims and then fails to publish Ready (or to queue
+        // the re-open) leaves the connection still owing one.
+        let registry = PendingReopenRegistry::default();
+        let key = ConnectionKey::for_server("ruff");
+        registry.arm(&key);
+        let done = registry.claim(&key).expect("armed");
+        drop(done);
+        registry.rearm(&key);
+
+        assert!(
+            registry.claim(&key).is_some(),
+            "the next replacement must still learn it owes a re-open"
+        );
+    }
+
+    #[tokio::test]
+    async fn rearm_retires_the_barrier_the_failed_claim_registered() {
+        // The claim registered an in-flight entry; nobody will ever signal it.
+        // Leaving it would block every command on the key for the full budget.
+        let registry = PendingReopenRegistry::default();
+        let key = ConnectionKey::for_server("ruff");
+        registry.arm(&key);
+        let done = registry.claim(&key).expect("armed");
+        registry.rearm(&key);
+        drop(done);
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), registry.wait_for_reopen(&key))
+                .await
+                .expect("a retired barrier must not make the caller wait"),
+            "a re-armed key has no re-open in flight to wait for"
+        );
+    }
+
+    #[test]
+    fn keys_are_armed_independently() {
         // Sibling connections (same server, different root) respawn
-        // independently; one reaching Ready must not consume the other's set.
+        // independently; one reaching Ready must not consume the other's claim.
         let registry = PendingReopenRegistry::default();
         let a = ConnectionKey::new("ruff", Some("file:///w/a".to_string()));
         let b = ConnectionKey::new("ruff", Some("file:///w/b".to_string()));
-        registry.record(&a, vec![url("file:///w/a/doc.md")]);
-        registry.record(&b, vec![url("file:///w/b/doc.md")]);
+        registry.arm(&a);
 
-        assert_eq!(hosts_of(registry.take(&a)), vec![url("file:///w/a/doc.md")]);
-        assert_eq!(hosts_of(registry.take(&b)), vec![url("file:///w/b/doc.md")]);
+        assert!(registry.claim(&a).is_some());
+        assert!(
+            registry.claim(&b).is_none(),
+            "arming one root must not arm its sibling"
+        );
     }
 
     #[tokio::test]
@@ -266,13 +297,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn an_armed_but_unclaimed_key_registers_no_wait() {
+        // Arming records a debt; only the claim puts a re-open in flight. A
+        // request arriving between the two must not wait for a barrier that
+        // nobody is holding.
+        let registry = PendingReopenRegistry::default();
+        let key = ConnectionKey::for_server("ruff");
+        registry.arm(&key);
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), registry.wait_for_reopen(&key))
+                .await
+                .expect("nothing in flight, so no wait"),
+        );
+    }
+
+    #[tokio::test]
     async fn a_request_waits_until_the_reopen_signals_completion() {
         // The ordering guarantee: a command enqueued after Ready must not
         // overtake the didOpen its arguments depend on.
         let registry = std::sync::Arc::new(PendingReopenRegistry::default());
         let key = ConnectionKey::for_server("ruff");
-        registry.record(&key, vec![url("file:///w/a.md")]);
-        let (_hosts, tx) = registry.take(&key).expect("a re-open is pending");
+        registry.arm(&key);
+        let tx = registry.claim(&key).expect("a re-open is pending");
 
         let waiter = {
             let registry = std::sync::Arc::clone(&registry);
@@ -293,8 +340,8 @@ mod tests {
         // request for the full timeout.
         let registry = std::sync::Arc::new(PendingReopenRegistry::default());
         let key = ConnectionKey::for_server("ruff");
-        registry.record(&key, vec![url("file:///w/a.md")]);
-        let (_hosts, tx) = registry.take(&key).expect("a re-open is pending");
+        registry.arm(&key);
+        let tx = registry.claim(&key).expect("a re-open is pending");
         drop(tx);
 
         // Would hang for REOPEN_WAIT if a dropped sender did not count as done.
@@ -316,14 +363,14 @@ mod tests {
 
     #[tokio::test]
     async fn a_reopen_that_reports_failure_does_not_release_the_caller() {
-        // The re-open ran but could not repair THIS connection (its host
-        // re-routed, so the opens were skipped). Releasing the caller would send
-        // a command to a connection that is still empty — the exact outcome the
-        // barrier exists to prevent.
+        // The re-open ran but could not bring THIS connection up to date (a
+        // document that belongs to it would not open). Releasing the caller
+        // would send a command to a connection still missing documents — the
+        // exact outcome the barrier exists to prevent.
         let registry = PendingReopenRegistry::default();
         let key = ConnectionKey::for_server("ruff");
-        registry.record(&key, vec![url("file:///w/a.md")]);
-        let (_hosts, done) = registry.take(&key).expect("a re-open is pending");
+        registry.arm(&key);
+        let done = registry.claim(&key).expect("a re-open is pending");
 
         done.send(false).expect("the registry holds the receiver");
         drop(done);
@@ -343,8 +390,8 @@ mod tests {
         // all — exactly when the re-open is known to be slow.
         let registry = PendingReopenRegistry::default();
         let key = ConnectionKey::for_server("ruff");
-        registry.record(&key, vec![url("file:///w/a.md")]);
-        let (_hosts, done) = registry.take(&key).expect("a re-open is pending");
+        registry.arm(&key);
+        let done = registry.claim(&key).expect("a re-open is pending");
 
         // Auto-advances past REOPEN_WAIT without a real sleep. The wait did NOT
         // settle, so the caller must be told to fail soft rather than send
@@ -366,19 +413,5 @@ mod tests {
             registry.wait_for_reopen(&key).await,
             "a completed re-open reports settled"
         );
-    }
-
-    #[tokio::test]
-    async fn an_empty_pending_set_registers_no_wait() {
-        // `record` ignores an empty set, so `take` must report nothing in flight
-        // rather than register a barrier nobody will ever signal.
-        let registry = PendingReopenRegistry::default();
-        let key = ConnectionKey::for_server("ruff");
-        registry.record(&key, vec![]);
-
-        assert!(registry.take(&key).is_none());
-        tokio::time::timeout(Duration::from_secs(1), registry.wait_for_reopen(&key))
-            .await
-            .expect("nothing in flight, so no wait");
     }
 }

--- a/src/lsp/bridge/pool/pending_reopen.rs
+++ b/src/lsp/bridge/pool/pending_reopen.rs
@@ -135,13 +135,20 @@ impl PendingReopenRegistry {
             .state
             .lock()
             .recover_poison("PendingReopenRegistry::rearm");
-        if state
+        if !state
             .in_flight
             .get(key)
             .is_some_and(|current| current.same_channel(&probe))
         {
-            state.in_flight.remove(key);
+            // Someone else owns the barrier for this key, which can only mean a
+            // purge re-armed it and a LATER replacement claimed it. That
+            // replacement is making the repair, so there is no debt left to
+            // record — and recording one anyway would leave the key armed AND
+            // in flight at once, breaking the invariant that it is exactly one
+            // of the two, and buying a redundant sweep on the next spawn.
+            return;
         }
+        state.in_flight.remove(key);
         state.armed.insert(key.clone());
     }
 
@@ -337,6 +344,32 @@ mod tests {
         );
         live.send(true).expect("the registry holds the receiver");
         assert!(registry.wait_for_reopen(&key).await);
+    }
+
+    /// A key is armed OR in flight, never both. A stale `rearm` that finds a
+    /// later respawn's barrier must record nothing: that respawn is making the
+    /// repair, so there is no outstanding debt to remember.
+    #[tokio::test]
+    async fn a_superseded_rearm_records_no_debt() {
+        let registry = PendingReopenRegistry::default();
+        let key = ConnectionKey::for_server("ruff");
+
+        registry.arm(&key);
+        let stale = registry.claim(&key).expect("armed");
+        registry.arm(&key);
+        let live = registry.claim(&key).expect("re-armed");
+
+        registry.rearm(&key, &stale);
+        drop(stale);
+
+        // Settle the live re-open and let a waiter retire it.
+        live.send(true).expect("the registry holds the receiver");
+        assert!(registry.wait_for_reopen(&key).await);
+
+        assert!(
+            registry.claim(&key).is_none(),
+            "the superseded rearm must not have left a debt behind"
+        );
     }
 
     #[test]

--- a/src/lsp/bridge/pool/pending_reopen.rs
+++ b/src/lsp/bridge/pool/pending_reopen.rs
@@ -33,11 +33,19 @@ use crate::error::LockResultExt;
 /// stuck downstream must not hold a user-facing request open indefinitely.
 pub(crate) const REOPEN_WAIT: Duration = Duration::from_secs(2);
 
+/// The two halves of a key's re-open state, under ONE lock.
+///
+/// They are separate maps but a single invariant: a key is either owing a
+/// re-open, or having one made, never both and never neither-by-accident.
+/// Splitting the lock let `claim` disarm under one mutex and install under the
+/// other, so a second claim could interleave between them and have its live
+/// barrier overwritten by the first — leaving one connection Ready with an
+/// unclaimable debt and the other reporting through a channel nobody holds.
 #[derive(Default)]
-pub(crate) struct PendingReopenRegistry {
+struct ReopenState {
     /// Keys whose connection was purged and whose replacement still owes a
     /// re-open.
-    armed: Mutex<HashSet<ConnectionKey>>,
+    armed: HashSet<ConnectionKey>,
     /// Re-opens handed off but not yet finished, so a request that must not
     /// overtake its own `didOpen` can wait for one.
     ///
@@ -45,7 +53,12 @@ pub(crate) struct PendingReopenRegistry {
     /// server side does the work), so without this a command enqueued right
     /// after `Ready` would reach the downstream BEFORE the didOpen it depends
     /// on — the FIFO ordering the previous inline heal guaranteed by awaiting.
-    in_flight: Mutex<HashMap<ConnectionKey, watch::Receiver<bool>>>,
+    in_flight: HashMap<ConnectionKey, watch::Receiver<bool>>,
+}
+
+#[derive(Default)]
+pub(crate) struct PendingReopenRegistry {
+    state: Mutex<ReopenState>,
 }
 
 impl PendingReopenRegistry {
@@ -62,9 +75,10 @@ impl PendingReopenRegistry {
     /// Idempotent — a key purged twice before any replacement lands is armed
     /// once, and one re-open brings the replacement fully up to date.
     pub(crate) fn arm(&self, key: &ConnectionKey) {
-        self.armed
+        self.state
             .lock()
             .recover_poison("PendingReopenRegistry::arm")
+            .armed
             .insert(key.clone());
     }
 
@@ -81,19 +95,21 @@ impl PendingReopenRegistry {
     /// or is never serviced releases waiters instead of stranding them until the
     /// timeout.
     pub(crate) fn claim(&self, key: &ConnectionKey) -> Option<watch::Sender<bool>> {
-        if !self
-            .armed
+        // Disarm and install under ONE lock. Releasing between them let a second
+        // handshake claim the same key and install its barrier, which this one
+        // would then overwrite: the second connection reaches Ready reporting
+        // through a channel the registry no longer holds, its `done` reads as
+        // closed, and the debt it was supposed to settle stays armed with
+        // nothing left to claim it.
+        let mut state = self
+            .state
             .lock()
-            .recover_poison("PendingReopenRegistry::claim")
-            .remove(key)
-        {
+            .recover_poison("PendingReopenRegistry::claim");
+        if !state.armed.remove(key) {
             return None;
         }
         let (tx, rx) = watch::channel(false);
-        self.in_flight
-            .lock()
-            .recover_poison("PendingReopenRegistry::claim")
-            .insert(key.clone(), rx);
+        state.in_flight.insert(key.clone(), rx);
         Some(tx)
     }
 
@@ -115,19 +131,18 @@ impl PendingReopenRegistry {
     /// prevent, and the one case that does NOT degrade to the lazy heal.
     pub(crate) fn rearm(&self, key: &ConnectionKey, done: &watch::Sender<bool>) {
         let probe = done.subscribe();
+        let mut state = self
+            .state
+            .lock()
+            .recover_poison("PendingReopenRegistry::rearm");
+        if state
+            .in_flight
+            .get(key)
+            .is_some_and(|current| current.same_channel(&probe))
         {
-            let mut in_flight = self
-                .in_flight
-                .lock()
-                .recover_poison("PendingReopenRegistry::rearm");
-            if in_flight
-                .get(key)
-                .is_some_and(|current| current.same_channel(&probe))
-            {
-                in_flight.remove(key);
-            }
+            state.in_flight.remove(key);
         }
-        self.arm(key);
+        state.armed.insert(key.clone());
     }
 
     /// Wait (bounded by [`REOPEN_WAIT`]) for an in-flight re-open on `key`.
@@ -149,9 +164,10 @@ impl PendingReopenRegistry {
     /// downstream error.
     pub(crate) async fn wait_for_reopen(&self, key: &ConnectionKey) -> bool {
         let Some(mut rx) = self
-            .in_flight
+            .state
             .lock()
             .recover_poison("PendingReopenRegistry::wait_for_reopen")
+            .in_flight
             .get(key)
             .cloned()
         else {
@@ -188,15 +204,16 @@ impl PendingReopenRegistry {
         // respawn may have claimed the key in between and registered a genuinely
         // outstanding re-open. Removing by key alone would evict it.
         if retire {
-            let mut in_flight = self
-                .in_flight
+            let mut state = self
+                .state
                 .lock()
                 .recover_poison("PendingReopenRegistry::wait_for_reopen");
-            if in_flight
+            if state
+                .in_flight
                 .get(key)
                 .is_some_and(|current| current.same_channel(&rx))
             {
-                in_flight.remove(key);
+                state.in_flight.remove(key);
             }
         }
         settled

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -169,6 +169,9 @@ impl LanguageServerPool {
         // above, before the lookup.
         let connection_key = handle.key().clone();
         let mut sender = ConnectionHandleSender(&handle);
+        // Every injection's didOpen must actually be enqueued before this counts
+        // as a completed open.
+        let mut enqueued_all = true;
 
         let Some(lifecycle) = self.existing_host_lifecycle_lock(host_uri) else {
             // The host closed underneath us; nothing to open.
@@ -240,9 +243,21 @@ impl LanguageServerPool {
                     server_name,
                     e
                 );
+                // Keep opening the rest — one region failing does not make the
+                // others unopenable — but do NOT report success. A claim that
+                // did not settle, a full outbound queue, or a claim invalidated
+                // mid-enqueue each mean this connection is missing a document it
+                // should have, and a caller repairing it must hear so: that is
+                // exactly the state in which releasing a command produces the
+                // out-of-order delivery the barrier exists to prevent.
+                enqueued_all = false;
             }
         }
-        OpenOutcome::Opened
+        if enqueued_all {
+            OpenOutcome::Opened
+        } else {
+            OpenOutcome::NotOpened
+        }
     }
 
     /// Fire `didOpen` for the real host document on a `_self` host-bridge server

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -26,11 +26,18 @@ pub(crate) enum OpenOutcome {
     /// The open ran on the connection the caller expected (or the caller named
     /// none). Documents it could open are enqueued.
     Opened,
-    /// The host resolved to a DIFFERENT connection than the caller named, so
-    /// nothing was opened. A caller repairing the named connection must report
-    /// failure rather than success: the connection is still empty.
-    WrongConnection,
-    /// The connection could not be reached at all, so nothing was opened.
+    /// This host supplies nothing for the named connection — it routes to a
+    /// different one, or none of its injections bridge to that server.
+    ///
+    /// NOT a failure. The respawn re-open asks this of every open document, and
+    /// for most of them the answer is "not mine": a markdown file with no lua
+    /// fence, or one under a different workspace root. Counting those as failed
+    /// repairs would hold the barrier shut on every respawn.
+    NotApplicable,
+    /// The open was applicable — this host does belong to the named connection
+    /// — but did not happen: the connection is gone, the document moved to a
+    /// new lifetime, or the handle was replaced mid-loop. The caller repairing
+    /// that connection must report failure; it is still missing documents.
     NotOpened,
 }
 
@@ -40,11 +47,17 @@ pub(crate) struct OpenExpectation<'a> {
     pub(crate) incarnation: u64,
     /// The connection this open is FOR, when the caller is repairing a specific
     /// one — the respawn re-open is claimed under a key and its barrier signals
-    /// for that key. The connection is still resolved from `host_uri`, so a
-    /// config change that re-roots the host resolves a DIFFERENT one, and
-    /// opening there would satisfy nobody: the claimed connection stays empty
-    /// while its barrier reports success. `None` opens wherever the host routes
-    /// now, which is what every other caller wants.
+    /// for that key.
+    ///
+    /// Naming it does two things the `None` case does not: the open is ACQUIRED
+    /// by that key rather than by whatever the host routes to (a config change
+    /// that re-roots the host would otherwise repair a different connection
+    /// while the claimed one stays empty and its barrier reports success), and
+    /// the host is first checked to actually belong there, so a caller may ask
+    /// about a host without risking an open on the wrong connection.
+    ///
+    /// `None` opens wherever the host routes now, spawning if needed, which is
+    /// what every other caller wants.
     pub(crate) connection: Option<&'a ConnectionKey>,
 }
 
@@ -90,21 +103,42 @@ impl LanguageServerPool {
         // and never spawning: this repairs a connection that exists, and a named
         // connection that has since died has nothing to restore.
         let handle = match expected_key {
-            Some(key) => match self
-                .ready_connection_by_key_for_config(key, Some(server_config))
-                .await
-            {
-                Some(handle) => handle,
-                None => {
+            Some(key) => {
+                // Does this host belong to the connection being repaired?
+                // Acquiring by key cannot answer that: the lookup succeeds for
+                // the key no matter which host asked, so a caller sweeping
+                // several hosts would open documents rooted elsewhere onto this
+                // connection. Resolve where the host actually routes and
+                // compare. Read-only — unlike the `None` arm below it never
+                // spawns, so asking about a host that belongs to some other
+                // root cannot bring that root's server up.
+                let (_marker, routes_to) = self
+                    .resolve_acquire(server_name, server_config, Some(host_uri))
+                    .await;
+                if &routes_to != key {
                     log::debug!(
                         target: "kakehashi::bridge",
-                        "Eager open: connection {key} is gone; nothing to repair for \
-                         {} injections",
-                        injections.len()
+                        "Eager open: {host_uri} routes to {routes_to}, not the \
+                         requested {key}; it supplies nothing for that connection"
                     );
-                    return OpenOutcome::NotOpened;
+                    return OpenOutcome::NotApplicable;
                 }
-            },
+                match self
+                    .ready_connection_by_key_for_config(key, Some(server_config))
+                    .await
+                {
+                    Some(handle) => handle,
+                    None => {
+                        log::debug!(
+                            target: "kakehashi::bridge",
+                            "Eager open: connection {key} is gone; nothing to repair for \
+                             {} injections",
+                            injections.len()
+                        );
+                        return OpenOutcome::NotOpened;
+                    }
+                }
+            }
             // Open wherever this host routes now, spawning if needed.
             None => match self
                 .get_or_create_connection_wait_ready(
@@ -129,20 +163,11 @@ impl LanguageServerPool {
             },
         };
 
+        // The by-key lookup returns the connection stored under that key, so
+        // comparing `handle.key()` to `expected_key` again could never fail —
+        // the question that CAN fail ("does this host route here?") is asked
+        // above, before the lookup.
         let connection_key = handle.key().clone();
-        // Belt-and-braces: the by-key lookup above already returns the named
-        // connection, so this only fires if that ever stops holding. Report it
-        // rather than open on a connection nobody asked for.
-        if let Some(expected) = expected_key
-            && &connection_key != expected
-        {
-            log::debug!(
-                target: "kakehashi::bridge",
-                "Eager open: resolved {connection_key}, not the requested \
-                 {expected}; skipping this open"
-            );
-            return OpenOutcome::WrongConnection;
-        }
         let mut sender = ConnectionHandleSender(&handle);
 
         let Some(lifecycle) = self.existing_host_lifecycle_lock(host_uri) else {
@@ -371,19 +396,27 @@ mod tests {
         );
     }
 
-    /// A named connection is repaired BY KEY, not by re-resolving the host.
-    /// When a config change re-roots the host between purge and respawn,
-    /// resolving from the host would repair a different connection and leave the
-    /// named one — the one the barrier signals for, and the one a routed command
-    /// carries — empty.
+    /// A host that has been re-rooted away from the connection being repaired
+    /// supplies nothing for it — and the connection is left EMPTY rather than
+    /// propped up with a document that no longer belongs to it.
+    ///
+    /// This is a deliberate consequence of deriving. The remembered-list design
+    /// re-opened such a host on the claimed connection anyway, because the list
+    /// asserted the host had been its document. Derived, current settings are
+    /// the authority: the host now routes elsewhere, so this connection's
+    /// correct contents are nothing, and `done` reporting success for an empty
+    /// connection is accurate rather than a lie. A command still in flight
+    /// against the old root fails downstream instead — the same outcome the
+    /// routing ADR already accepts for a token naming a root no open document
+    /// sits under.
     #[tokio::test]
-    async fn eager_open_repairs_the_named_connection_not_the_hosts_current_one() {
+    async fn a_rerooted_host_is_not_reopened_on_the_connection_it_left() {
         let pool = LanguageServerPool::new();
         let server_name = "lua_ls";
         let config = crate::lsp::bridge::pool::test_helpers::devnull_config_for_language("lua");
 
-        // The connection the purge claimed: rooted somewhere the host no longer
-        // resolves to. Nothing else would ever pick it.
+        // The connection the purge claimed, rooted where the host no longer
+        // resolves to. It is present and Ready, so only routing refuses it.
         let claimed = crate::lsp::bridge::ConnectionKey::new(
             server_name,
             Some("file:///claimed".to_string()),
@@ -396,12 +429,6 @@ mod tests {
         pool.open_host_incarnation(&host_uri, 1).await;
 
         use super::super::super::coordinator::BridgeInjection;
-        let injections = vec![BridgeInjection {
-            language: "lua".to_string(),
-            region_id: TEST_ULID_LUA_0.to_string(),
-            content: "print('hello')".to_string(),
-        }];
-
         let outcome = pool
             .eager_open_virtual_documents(
                 server_name,
@@ -412,18 +439,19 @@ mod tests {
                     incarnation: 1,
                     connection: Some(&claimed),
                 },
-                injections,
+                vec![BridgeInjection {
+                    language: "lua".to_string(),
+                    region_id: TEST_ULID_LUA_0.to_string(),
+                    content: "print('hello')".to_string(),
+                }],
             )
             .await;
 
-        assert_eq!(outcome, OpenOutcome::Opened);
+        assert_eq!(outcome, OpenOutcome::NotApplicable);
         let vuri = VirtualDocumentUri::new(&host_uri_lsp, "lua", TEST_ULID_LUA_0);
-        // The claimed connection is the one that got the document — resolving
-        // from the host would have produced the client-root fallback key, which
-        // is NOT `claimed`.
         assert!(
-            pool.is_document_opened_on_connection(&vuri, &claimed),
-            "the named connection must be the one repaired"
+            !pool.is_document_opened_on_connection(&vuri, &claimed),
+            "a host that routes elsewhere must not be opened here"
         );
     }
 
@@ -446,9 +474,11 @@ mod tests {
             content: "print('hello')".to_string(),
         }];
 
-        // No connection under this key at all.
-        let gone =
-            crate::lsp::bridge::ConnectionKey::new(server_name, Some("file:///gone".to_string()));
+        // The key this host routes to (client-root fallback, no marker above
+        // `/test`), with NO connection under it. Naming a key the host does not
+        // route to would be refused by the routing filter first and never reach
+        // the acquisition this test is about.
+        let gone = crate::lsp::bridge::ConnectionKey::for_server(server_name);
         let outcome = pool
             .eager_open_virtual_documents(
                 server_name,
@@ -473,6 +503,106 @@ mod tests {
             !pool.is_document_opened(&vuri),
             "and must not have opened anything anywhere"
         );
+    }
+
+    /// A named connection is not enough on its own: the host must actually
+    /// route there.
+    ///
+    /// Acquiring by key always succeeds for a key the pool holds, whichever
+    /// host asked — so without this check a caller sweeping candidate hosts
+    /// would open documents belonging to one root onto a connection serving
+    /// another. The connection here is present and `Ready`, so the by-key
+    /// acquisition WOULD hand it over; only the routing question refuses.
+    #[tokio::test]
+    async fn an_open_is_refused_for_a_connection_the_host_does_not_route_to() {
+        let pool = LanguageServerPool::new();
+        let config = devnull_config();
+        let server_name = "test-server";
+
+        // The host sits under no marker root, so it routes to the client
+        // fallback — never to this marker-rooted key.
+        let elsewhere = crate::lsp::bridge::ConnectionKey::new(
+            server_name,
+            Some("file:///elsewhere".to_string()),
+        );
+        let handle = create_handle_with_key(ConnectionState::Ready, elsewhere.clone()).await;
+        pool.insert_connection(handle).await;
+
+        let host_uri = test_host_uri("routes_elsewhere");
+        let host_uri_lsp = url_to_uri(&host_uri);
+        pool.open_host_incarnation(&host_uri, 1).await;
+
+        use super::super::super::coordinator::BridgeInjection;
+        let outcome = pool
+            .eager_open_virtual_documents(
+                server_name,
+                &config,
+                &host_uri,
+                &host_uri_lsp,
+                OpenExpectation {
+                    incarnation: 1,
+                    connection: Some(&elsewhere),
+                },
+                vec![BridgeInjection {
+                    language: "lua".to_string(),
+                    region_id: TEST_ULID_LUA_0.to_string(),
+                    content: "print('hello')".to_string(),
+                }],
+            )
+            .await;
+
+        assert_eq!(outcome, OpenOutcome::NotApplicable);
+        assert!(
+            !pool.is_document_opened(&VirtualDocumentUri::new(
+                &host_uri_lsp,
+                "lua",
+                TEST_ULID_LUA_0
+            )),
+            "nothing may be opened on a connection this host does not route to"
+        );
+    }
+
+    /// The mirror of the above: when the host DOES route to the named
+    /// connection, naming it opens exactly as an unnamed open would.
+    #[tokio::test]
+    async fn an_open_for_the_connection_the_host_routes_to_proceeds() {
+        let pool = LanguageServerPool::new();
+        let config = devnull_config();
+        let server_name = "test-server";
+
+        let routed_key = crate::lsp::bridge::ConnectionKey::for_server(server_name);
+        let handle = create_handle_with_key(ConnectionState::Ready, routed_key.clone()).await;
+        pool.insert_connection(handle).await;
+
+        let host_uri = test_host_uri("routes_here");
+        let host_uri_lsp = url_to_uri(&host_uri);
+        pool.open_host_incarnation(&host_uri, 1).await;
+
+        use super::super::super::coordinator::BridgeInjection;
+        let outcome = pool
+            .eager_open_virtual_documents(
+                server_name,
+                &config,
+                &host_uri,
+                &host_uri_lsp,
+                OpenExpectation {
+                    incarnation: 1,
+                    connection: Some(&routed_key),
+                },
+                vec![BridgeInjection {
+                    language: "lua".to_string(),
+                    region_id: TEST_ULID_LUA_0.to_string(),
+                    content: "print('hello')".to_string(),
+                }],
+            )
+            .await;
+
+        assert_eq!(outcome, OpenOutcome::Opened);
+        assert!(pool.is_document_opened(&VirtualDocumentUri::new(
+            &host_uri_lsp,
+            "lua",
+            TEST_ULID_LUA_0
+        )));
     }
 
     /// Test that eager_open_virtual_documents is idempotent.

--- a/src/lsp/lsp_impl/coordinator.rs
+++ b/src/lsp/lsp_impl/coordinator.rs
@@ -6,6 +6,6 @@ mod parse;
 
 pub(crate) use diagnostic::DiagnosticScheduler;
 pub(crate) use diagnostic_publisher::{DiagnosticPublisher, DiagnosticPush};
-pub(crate) use injection::InjectionCoordinator;
+pub(crate) use injection::{InjectionCoordinator, ParseWait};
 pub(crate) use install::InstallCoordinator;
 pub(crate) use parse::ParseCoordinator;

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -485,8 +485,8 @@ impl InjectionCoordinator {
         Some((host_language, injections))
     }
 
-    /// Wait (bounded) for `uri`'s tree to be current before its injections are
-    /// resolved.
+    /// Wait (bounded by `budget`) for `uri`'s tree to be current before its
+    /// injections are resolved.
     ///
     /// `didChange` clears the tree and reparses off-ingress, so a re-open
     /// landing right after an edit would resolve ZERO injections and silently
@@ -495,11 +495,26 @@ impl InjectionCoordinator {
     /// closing it: the wait is bounded, and on expiry the re-open proceeds and
     /// may still open nothing. Degrading to the pre-existing lazy heal (the next
     /// parse re-opens) is preferred over stalling the barrier.
-    pub(crate) async fn ensure_document_parsed(&self, uri: &Url) {
-        let _ = crate::lsp::lsp_impl::snapshot_read::wait_for_current_snapshot_in(
-            &self.documents,
-            uri,
-            std::time::Duration::from_millis(200),
+    pub(crate) async fn ensure_document_parsed(&self, uri: &Url, budget: std::time::Duration) {
+        // `budget` is enforced HERE rather than passed through, because
+        // `wait_for_current_snapshot_in` honours its `wait` argument only for a
+        // snapshot that TRAILS. A document with no snapshot at all — open, first
+        // parse still queued — parks on `FIRST_PARSE_BACKSTOP` (15s) instead,
+        // which is right for a request that needs an answer and fatal for a
+        // caller sweeping documents inside a 2s barrier budget. The captured-set
+        // design never met that state (it only ever revisited documents the dead
+        // connection had already opened, hence already parsed); deriving the set
+        // means meeting every open document, including one mid-first-parse.
+        //
+        // The caller passes what is LEFT of the shared budget, so a sweep cannot
+        // spend it several times over.
+        let _ = tokio::time::timeout(
+            budget,
+            crate::lsp::lsp_impl::snapshot_read::wait_for_current_snapshot_in(
+                &self.documents,
+                uri,
+                budget,
+            ),
         )
         .await;
     }

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -495,7 +495,15 @@ impl InjectionCoordinator {
     /// closing it: the wait is bounded, and on expiry the re-open proceeds and
     /// may still open nothing. Degrading to the pre-existing lazy heal (the next
     /// parse re-opens) is preferred over stalling the barrier.
-    pub(crate) async fn ensure_document_parsed(&self, uri: &Url, budget: std::time::Duration) {
+    /// Returns whether the tree is CURRENT. `false` means the budget expired
+    /// with the parse still outstanding, so a caller that must not silently
+    /// under-report has to treat whatever it resolves next as unreliable rather
+    /// than as "this document has nothing".
+    pub(crate) async fn ensure_document_parsed(
+        &self,
+        uri: &Url,
+        budget: std::time::Duration,
+    ) -> bool {
         // `budget` is enforced HERE rather than passed through, because
         // `wait_for_current_snapshot_in` honours its `wait` argument only for a
         // snapshot that TRAILS. A document with no snapshot at all — open, first
@@ -508,15 +516,20 @@ impl InjectionCoordinator {
         //
         // The caller passes what is LEFT of the shared budget, so a sweep cannot
         // spend it several times over.
-        let _ = tokio::time::timeout(
-            budget,
-            crate::lsp::lsp_impl::snapshot_read::wait_for_current_snapshot_in(
-                &self.documents,
-                uri,
+        matches!(
+            tokio::time::timeout(
                 budget,
-            ),
+                crate::lsp::lsp_impl::snapshot_read::wait_for_current_snapshot_in(
+                    &self.documents,
+                    uri,
+                    budget,
+                ),
+            )
+            .await,
+            Ok(crate::lsp::lsp_impl::snapshot_read::SnapshotWait::Current(
+                _
+            ))
         )
-        .await;
     }
 
     fn install_coordinator(&self) -> InstallCoordinator {

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -458,6 +458,15 @@ impl InjectionCoordinator {
         self.documents.open_uris()
     }
 
+    /// `uri`'s host language, without parsing or resolving anything.
+    ///
+    /// The cheap half of what [`Self::bridge_injections`] returns, so a caller
+    /// screening many candidate documents can ask the configuration question
+    /// before paying for a parse wait and an injection resolution.
+    pub(crate) fn document_language(&self, uri: &Url) -> Option<String> {
+        self.get_language_for_document(uri)
+    }
+
     /// `uri`'s reopen generation, which scopes a downstream `didOpen` to the
     /// document's current lifetime. `None` once the document is closed.
     pub(crate) fn document_incarnation(&self, uri: &Url) -> Option<u64> {

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -446,6 +446,18 @@ impl InjectionCoordinator {
         &self.bridge
     }
 
+    /// Every host document open right now — the candidate set the respawn
+    /// re-open derives its targets from.
+    ///
+    /// Deliberately unfiltered: which of these belong to the connection being
+    /// repaired depends on the injections each one currently resolves and on
+    /// current settings, neither of which this accessor should decide. A
+    /// snapshot, so a document closed while the re-open runs is caught by the
+    /// per-host incarnation check rather than here.
+    pub(crate) fn open_host_uris(&self) -> Vec<Url> {
+        self.documents.open_uris()
+    }
+
     /// `uri`'s reopen generation, which scopes a downstream `didOpen` to the
     /// document's current lifetime. `None` once the document is closed.
     pub(crate) fn document_incarnation(&self, uri: &Url) -> Option<u64> {

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -37,6 +37,17 @@ pub(crate) struct InjectionCoordinator {
     diagnostics: std::sync::Arc<DiagnosticAggregator>,
 }
 
+/// What a bounded wait for a current tree actually found.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ParseWait {
+    /// The tree matches the document's content.
+    Current,
+    /// The document was closed; there is nothing to wait for.
+    Gone,
+    /// The budget expired with the tree still trailing or absent.
+    Unsettled,
+}
+
 impl InjectionCoordinator {
     pub(crate) fn new(server: &Kakehashi) -> Self {
         Self {
@@ -495,15 +506,16 @@ impl InjectionCoordinator {
     /// closing it: the wait is bounded, and on expiry the re-open proceeds and
     /// may still open nothing. Degrading to the pre-existing lazy heal (the next
     /// parse re-opens) is preferred over stalling the barrier.
-    /// Returns whether the tree is CURRENT. `false` means the budget expired
-    /// with the parse still outstanding, so a caller that must not silently
-    /// under-report has to treat whatever it resolves next as unreliable rather
-    /// than as "this document has nothing".
+    /// Returns which of the three outcomes a caller must distinguish. They are
+    /// not interchangeable: `Gone` is nothing to do, `Unsettled` is something
+    /// this pass could not determine, and collapsing them makes a closed buffer
+    /// look like a failed repair (holding the barrier shut) or an unparsed one
+    /// look like a document with no injections (releasing commands onto it).
     pub(crate) async fn ensure_document_parsed(
         &self,
         uri: &Url,
         budget: std::time::Duration,
-    ) -> bool {
+    ) -> ParseWait {
         // `budget` is enforced HERE rather than passed through, because
         // `wait_for_current_snapshot_in` honours its `wait` argument only for a
         // snapshot that TRAILS. A document with no snapshot at all — open, first
@@ -516,20 +528,39 @@ impl InjectionCoordinator {
         //
         // The caller passes what is LEFT of the shared budget, so a sweep cannot
         // spend it several times over.
-        matches!(
-            tokio::time::timeout(
+        use crate::lsp::lsp_impl::snapshot_read::SnapshotWait;
+        match tokio::time::timeout(
+            budget,
+            crate::lsp::lsp_impl::snapshot_read::wait_for_current_snapshot_in(
+                &self.documents,
+                uri,
                 budget,
-                crate::lsp::lsp_impl::snapshot_read::wait_for_current_snapshot_in(
-                    &self.documents,
-                    uri,
-                    budget,
-                ),
-            )
-            .await,
-            Ok(crate::lsp::lsp_impl::snapshot_read::SnapshotWait::Current(
-                _
-            ))
+            ),
         )
+        .await
+        {
+            Ok(SnapshotWait::Current(_)) => ParseWait::Current,
+            // Closed while this sweep was running. It WAS in the snapshot the
+            // sweep started from, but there is nothing left to repair, and
+            // reporting failure would hold the barrier shut over a buffer the
+            // user simply closed.
+            Ok(SnapshotWait::Gone) => ParseWait::Gone,
+            // Trailing, never parsed, or out of budget: whatever the injection
+            // resolution says next is not evidence about this document.
+            Ok(SnapshotWait::Stale | SnapshotWait::Unparsed) | Err(_) => ParseWait::Unsettled,
+        }
+    }
+
+    /// Whether `uri`'s published snapshot still matches its content — a cheap
+    /// re-check for a caller that resolved something against it and needs to
+    /// know the ground did not move underneath.
+    pub(crate) fn snapshot_is_current(&self, uri: &Url) -> bool {
+        self.documents.latest_snapshot(uri).is_some_and(|view| {
+            view.slot
+                .snapshot
+                .as_ref()
+                .is_some_and(|snapshot| snapshot.parsed_version == view.content_version)
+        })
     }
 
     fn install_coordinator(&self) -> InstallCoordinator {

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1368,6 +1368,34 @@ fn spawn_upstream_request(
                     #[cfg(feature = "e2e")]
                     e2e_stall_reopen().await;
                     for host in hosts {
+                        // Cheapest question first. Deriving means asking about
+                        // every open document, and for most of them the answer
+                        // is "this host bridges nowhere near that server" —
+                        // which is pure configuration, answered from a memo
+                        // with no parse, no tree and no I/O. Paying the parse
+                        // wait and the injection resolution before asking it
+                        // would spend this connection's fixed budget in
+                        // proportion to WORKSPACE SIZE rather than to the work
+                        // that belongs to it, and the budget is what `done`
+                        // must signal inside.
+                        //
+                        // Advisory only, so reading the language before the
+                        // parse wait is safe: the authoritative language is
+                        // re-read with the injections below, keeping the
+                        // incarnation/injections ordering intact. A document
+                        // whose language changes in between is at worst
+                        // screened on its old language, and the re-read decides
+                        // what actually opens.
+                        let Some(candidate_language) = injection.document_language(&host) else {
+                            continue;
+                        };
+                        if !injection.bridge().host_language_can_reach_server(
+                            &settings,
+                            &candidate_language,
+                            &reopen_server,
+                        ) {
+                            continue;
+                        }
                         // Await the tree first: a re-open racing an edit would
                         // otherwise resolve no injections and open nothing.
                         injection.ensure_document_parsed(&host).await;

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1367,7 +1367,29 @@ fn spawn_upstream_request(
                     // release builds do not contain this branch.
                     #[cfg(feature = "e2e")]
                     e2e_stall_reopen().await;
+                    // ONE budget for the whole sweep, not one per host. Each
+                    // surviving host can park waiting for its tree, so a
+                    // per-host bound lets ten of them spend `REOPEN_WAIT` ten
+                    // times over — and the barrier promises to settle inside it
+                    // ONCE. Deriving the set is what makes that reachable: the
+                    // sweep is now sized by the workspace rather than by what
+                    // one dead connection held.
+                    let sweep_deadline = std::time::Instant::now() + REOPEN_WAIT;
                     for host in hosts {
+                        // Stop if nobody can hear the answer. `rearm` and a
+                        // later `claim` both drop the registry's receiver, so a
+                        // closed channel means this re-open has been superseded
+                        // by a newer respawn of the same key — and the sweep is
+                        // now O(open documents), so continuing would spend
+                        // marker walks and parse waits producing a result that
+                        // will be discarded.
+                        if done.is_closed() {
+                            log::debug!(
+                                target: "kakehashi::bridge",
+                                "Re-open of {key} was superseded; stopping the sweep"
+                            );
+                            return;
+                        }
                         // Cheapest question first. Deriving means asking about
                         // every open document, and for most of them the answer
                         // is "this host bridges nowhere near that server" —
@@ -1379,13 +1401,18 @@ fn spawn_upstream_request(
                         // that belongs to it, and the budget is what `done`
                         // must signal inside.
                         //
-                        // Advisory only, so reading the language before the
-                        // parse wait is safe: the authoritative language is
-                        // re-read with the injections below, keeping the
-                        // incarnation/injections ordering intact. A document
-                        // whose language changes in between is at worst
-                        // screened on its old language, and the re-read decides
-                        // what actually opens.
+                        // Reading the language before the parse wait keeps the
+                        // incarnation/injections ordering intact, because the
+                        // authoritative language is re-read with the injections
+                        // below. The screen is one-directional, though, and not
+                        // symmetric: a stale ACCEPT costs only an unnecessary
+                        // resolution, but a stale REJECT skips the document for
+                        // this round while `repaired` still reports success —
+                        // indistinguishable from "nothing to repair". Every
+                        // widening of this screen has to be weighed in that
+                        // direction. (A `languageId` change needs
+                        // didClose+didOpen, which bumps the incarnation, so the
+                        // stale-reject window is narrow rather than absent.)
                         let Some(candidate_language) = injection.document_language(&host) else {
                             continue;
                         };
@@ -1398,7 +1425,25 @@ fn spawn_upstream_request(
                         }
                         // Await the tree first: a re-open racing an edit would
                         // otherwise resolve no injections and open nothing.
-                        injection.ensure_document_parsed(&host).await;
+                        // Bounded by what is LEFT of the sweep's budget.
+                        let remaining = sweep_deadline
+                            .checked_duration_since(std::time::Instant::now())
+                            .unwrap_or_default();
+                        if remaining.is_zero() {
+                            // Out of budget with candidates still unexamined.
+                            // Report the connection as NOT caught up: the
+                            // waiters are about to time out anyway, and telling
+                            // them the sweep finished would release commands
+                            // onto documents this pass never reached.
+                            log::debug!(
+                                target: "kakehashi::bridge",
+                                "Re-open of {key} ran out of budget with candidates \
+                                 left; reporting it incomplete"
+                            );
+                            repaired = false;
+                            break;
+                        }
+                        injection.ensure_document_parsed(&host, remaining).await;
                         // Incarnation BEFORE injections, matching the ordering the
                         // inline heal used: a close+reopen landing between the two
                         // reads then pairs a stale incarnation with fresh

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1413,14 +1413,26 @@ fn spawn_upstream_request(
                         // direction. (A `languageId` change needs
                         // didClose+didOpen, which bumps the incarnation, so the
                         // stale-reject window is narrow rather than absent.)
-                        let Some(candidate_language) = injection.document_language(&host) else {
-                            continue;
-                        };
-                        if !injection.bridge().host_language_can_reach_server(
-                            &settings,
-                            &candidate_language,
-                            &reopen_server,
-                        ) {
+                        let screened_at = injection.document_incarnation(&host);
+                        let reachable =
+                            injection
+                                .document_language(&host)
+                                .is_some_and(|candidate_language| {
+                                    injection.bridge().host_language_can_reach_server(
+                                        &settings,
+                                        &candidate_language,
+                                        &reopen_server,
+                                    )
+                                });
+                        // Only trust a REJECTION if the document did not change
+                        // lifetime underneath it. A close+reopen under a
+                        // different `languageId` between the two reads would
+                        // otherwise reject on the OLD language and skip a
+                        // document the NEW lifetime does bridge — silently,
+                        // since a skip is indistinguishable from "nothing to
+                        // repair". On a mismatch fall through and let the
+                        // authoritative path, which re-reads both, decide.
+                        if !reachable && injection.document_incarnation(&host) == screened_at {
                             continue;
                         }
                         // Await the tree first: a re-open racing an edit would
@@ -1443,7 +1455,26 @@ fn spawn_upstream_request(
                             repaired = false;
                             break;
                         }
-                        injection.ensure_document_parsed(&host, remaining).await;
+                        if !injection.ensure_document_parsed(&host, remaining).await {
+                            // The budget expired with this document's parse
+                            // still outstanding. Resolving injections now yields
+                            // ZERO — not because the host has none, but because
+                            // there is no tree to find them in — and the skip
+                            // below would then read as "nothing to repair here".
+                            // This host passed the configuration screen, so it
+                            // is a plausible member of this connection's set and
+                            // saying otherwise is the one direction that
+                            // releases a command onto a document that was never
+                            // opened. Report the connection as not caught up and
+                            // let the next parse's eager open heal it.
+                            log::debug!(
+                                target: "kakehashi::bridge",
+                                "Re-open of {key}: {host} did not settle within the \
+                                 remaining budget; reporting the connection incomplete"
+                            );
+                            repaired = false;
+                            continue;
+                        }
                         // Incarnation BEFORE injections, matching the ordering the
                         // inline heal used: a close+reopen landing between the two
                         // reads then pairs a stale incarnation with fresh

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -788,7 +788,7 @@ struct UpstreamDeliveryContext {
     diagnostic_publisher: Arc<crate::lsp::lsp_impl::coordinator::DiagnosticPublisher>,
     settings_manager: Arc<crate::lsp::settings_manager::SettingsManager>,
     /// Re-opens a respawned connection's virtual documents
-    /// (execute-command-routing-token). Lives here because the pool cannot
+    /// (respawn-reopen-derives-its-targets). Lives here because the pool cannot
     /// resolve injections itself — the document store and injection query are
     /// server-side — so the pool signals *when* and this supplies *what*.
     injection: crate::lsp::lsp_impl::coordinator::InjectionCoordinator,
@@ -1285,8 +1285,8 @@ fn spawn_upstream_request(
                 // key would be an invariant nobody checks, and a divergence
                 // would make the repair a silent no-op.
                 let server = key.server().to_string();
-                // A respawned connection has nothing open; re-open what its dead
-                // predecessor held (execute-command-routing-token).
+                // A respawned connection has nothing open; bring it up to date
+                // (respawn-reopen-derives-its-targets).
                 //
                 // `ensure_server_documents_open` — NOT `process_injections`.
                 // `process_injections` reaches the open through

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1280,7 +1280,7 @@ fn spawn_upstream_request(
                     ),
                 }
             }
-            UpstreamRequest::ReopenDocuments { key, hosts, done } => {
+            UpstreamRequest::ReopenDocuments { key, done } => {
                 // One source of truth for the server: carrying it alongside the
                 // key would be an invariant nobody checks, and a divergence
                 // would make the repair a silent no-op.
@@ -1302,36 +1302,36 @@ fn spawn_upstream_request(
                     // context), but the fallback must not silently skip a heal.
                     log::warn!(
                         target: "kakehashi::bridge",
-                        "Cannot re-open {} document(s) for respawned {server:?}: \
-                         no delivery context",
-                        hosts.len()
+                        "Cannot re-open documents for respawned {server:?}: \
+                         no delivery context"
                     );
                     return;
                 };
+                // DERIVE the target set rather than replay one captured at purge
+                // time. Every open document is a candidate; which of them belong
+                // to this connection is decided below, per host, against current
+                // settings. A captured list answers the question as it stood
+                // before the respawn — it re-opens documents the editor has since
+                // closed, misses ones opened since, and is simply EMPTY when the
+                // dead connection never got far enough to hold anything, which is
+                // exactly when a replacement most needs the repair.
+                let hosts = context.injection.open_host_uris();
                 log::debug!(
                     target: "kakehashi::bridge",
-                    "Re-opening {} document(s) after {server:?} respawned",
+                    "Bringing {key} up to date after {server:?} respawned: \
+                     {} open document(s) to consider",
                     hosts.len()
                 );
-                use crate::lsp::bridge::REOPEN_WAIT;
+                use crate::lsp::bridge::{OpenOutcome, REOPEN_WAIT};
                 let settings = context.settings_manager.load_settings();
-                // The re-open targets the connection the purge CLAIMED, and the
-                // open is ACQUIRED by that key rather than resolved from the
-                // host. Resolving from the host finds whatever it routes to now,
-                // so a `workspaceMarkers` change between purge and respawn
-                // repairs a different connection while the claimed one — the one
-                // `done` signals for — stays empty.
-                //
-                // A stale-rooted claimed connection IS reachable: a routed
-                // command's token carries the root, and `reconnect_by_key`
-                // rebuilds the workspace from that token rather than from
-                // current markers, spawning a fresh connection that records the
-                // current config and so passes every launch-config check. There
-                // is no guard that rejects it — the root is not a
-                // `BridgeServerConfig` field, so `same_launch_config` cannot see
-                // a stale root at all. Repairing the named connection, and
-                // reporting failure when it is gone, is what makes the barrier
-                // mean what it says.
+                // Naming the connection still matters: the open is ACQUIRED by
+                // this key, never by whatever a host routes to, so the repair
+                // lands on the connection `done` signals for and a routed
+                // command names. What the key now ALSO does is filter — a host
+                // that does not route here supplies nothing for this connection,
+                // and saying so is how the derivation stays scoped to
+                // `(server, root)` instead of cross-opening one root's documents
+                // onto another root's process.
                 // Bound the WAIT, not the work — the shape the inline heal used.
                 // `ensure_server_documents_open` can block up to the init timeout
                 // on a cold downstream, and `done` gates every command on this
@@ -1349,11 +1349,14 @@ fn spawn_upstream_request(
                 // — the failure this barrier exists to prevent. A panic drops the
                 // sender instead, which waiters read as "can never finish".
                 let mut work = tokio::spawn(async move {
-                    // Whether the CLAIMED connection actually ended up with its
-                    // documents. A skip (the host re-routed) or an unreachable
-                    // connection leaves it empty, and the barrier must say so:
-                    // releasing a command onto an empty connection is the
-                    // failure this whole mechanism exists to prevent.
+                    // Whether this connection ended up holding everything current
+                    // state says it should. Only an APPLICABLE host that failed
+                    // to open clears it — a host that supplies nothing for this
+                    // connection is not a failed repair, it is not this
+                    // connection's document. Counting those would report failure
+                    // on essentially every respawn (most open documents bridge
+                    // nowhere near any one server), holding the barrier shut and
+                    // making every command pay the full wait and then fail soft.
                     let mut repaired = true;
                     // e2e-only fault injection: hold the re-open BEFORE any
                     // didOpen goes out, so the ordering e2e can force the window
@@ -1395,16 +1398,21 @@ fn spawn_upstream_request(
                                 &host,
                                 crate::lsp::bridge::OpenExpectation {
                                     incarnation,
-                                    // Repair the connection the purge CLAIMED,
-                                    // not whatever this host routes to now.
+                                    // Both the filter and the target: only hosts
+                                    // that route here are opened, and they are
+                                    // opened HERE.
                                     connection: Some(&key),
                                 },
                                 injections,
                                 &reopen_server,
                             )
                             .await;
-                        if outcome != crate::lsp::bridge::OpenOutcome::Opened {
-                            repaired = false;
+                        match outcome {
+                            OpenOutcome::Opened => {}
+                            // Not this connection's document. Nothing to report.
+                            OpenOutcome::NotApplicable => {}
+                            // It was this connection's and it did not open.
+                            OpenOutcome::NotOpened => repaired = false,
                         }
                     }
                     // Report what actually happened. `true` releases waiters;

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1455,25 +1455,35 @@ fn spawn_upstream_request(
                             repaired = false;
                             break;
                         }
-                        if !injection.ensure_document_parsed(&host, remaining).await {
-                            // The budget expired with this document's parse
-                            // still outstanding. Resolving injections now yields
-                            // ZERO — not because the host has none, but because
-                            // there is no tree to find them in — and the skip
-                            // below would then read as "nothing to repair here".
-                            // This host passed the configuration screen, so it
-                            // is a plausible member of this connection's set and
-                            // saying otherwise is the one direction that
-                            // releases a command onto a document that was never
-                            // opened. Report the connection as not caught up and
-                            // let the next parse's eager open heal it.
-                            log::debug!(
-                                target: "kakehashi::bridge",
-                                "Re-open of {key}: {host} did not settle within the \
-                                 remaining budget; reporting the connection incomplete"
-                            );
-                            repaired = false;
-                            continue;
+                        use crate::lsp::lsp_impl::coordinator::ParseWait;
+                        match injection.ensure_document_parsed(&host, remaining).await {
+                            ParseWait::Current => {}
+                            // Closed underneath the sweep. It was in the
+                            // snapshot this pass started from, but a buffer the
+                            // user closed is not a repair this connection is
+                            // owed, and calling it a failure would hold the
+                            // barrier shut over it.
+                            ParseWait::Gone => continue,
+                            ParseWait::Unsettled => {
+                                // The budget expired with this document's parse
+                                // still outstanding. Resolving injections now yields
+                                // ZERO — not because the host has none, but because
+                                // there is no tree to find them in — and the skip
+                                // below would then read as "nothing to repair here".
+                                // This host passed the configuration screen, so it
+                                // is a plausible member of this connection's set and
+                                // saying otherwise is the one direction that
+                                // releases a command onto a document that was never
+                                // opened. Report the connection as not caught up and
+                                // let the next parse's eager open heal it.
+                                log::debug!(
+                                    target: "kakehashi::bridge",
+                                    "Re-open of {key}: {host} did not settle within the \
+                                     remaining budget; reporting the connection incomplete"
+                                );
+                                repaired = false;
+                                continue;
+                            }
                         }
                         // Incarnation BEFORE injections, matching the ordering the
                         // inline heal used: a close+reopen landing between the two
@@ -1489,6 +1499,17 @@ fn spawn_upstream_request(
                             continue;
                         };
                         if injections.is_empty() {
+                            // Empty means one of two very different things: this
+                            // host genuinely has no region for this server, or
+                            // an edit cleared the tree between the currency
+                            // check above and this resolution — `didChange`
+                            // clears it WITHOUT bumping the incarnation, so
+                            // neither guard above catches that. Re-check rather
+                            // than assume the benign reading, because the benign
+                            // reading is the one that releases commands.
+                            if !injection.snapshot_is_current(&host) {
+                                repaired = false;
+                            }
                             continue;
                         }
                         // Sequential: each host's didOpen goes out on the SAME

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1507,7 +1507,14 @@ fn spawn_upstream_request(
                             // neither guard above catches that. Re-check rather
                             // than assume the benign reading, because the benign
                             // reading is the one that releases commands.
-                            if !injection.snapshot_is_current(&host) {
+                            // ...unless the host is simply gone. A buffer
+                            // closed mid-sweep is not a repair this connection
+                            // is owed, and `document_language` falls back to the
+                            // URI extension, so a closed document can reach here
+                            // and would otherwise wedge the barrier shut.
+                            if injection.document_incarnation(&host).is_some()
+                                && !injection.snapshot_is_current(&host)
+                            {
                                 repaired = false;
                             }
                             continue;
@@ -1536,8 +1543,15 @@ fn spawn_upstream_request(
                             OpenOutcome::Opened => {}
                             // Not this connection's document. Nothing to report.
                             OpenOutcome::NotApplicable => {}
-                            // It was this connection's and it did not open.
-                            OpenOutcome::NotOpened => repaired = false,
+                            // It was this connection's and it did not open —
+                            // unless the reason is that the host closed while
+                            // the open was running, which is the same benign
+                            // case as `ParseWait::Gone` arriving one step later.
+                            OpenOutcome::NotOpened => {
+                                if injection.document_incarnation(&host).is_some() {
+                                    repaired = false;
+                                }
+                            }
                         }
                     }
                     // Report what actually happened. `true` releases waiters;

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -255,6 +255,26 @@ fn init_client_reopen_order(
     (client, config_dir)
 }
 
+/// Directory of the second fenced host, distinct from the first so its virtual
+/// documents are identifiable in the wire log (a virtual URI keeps its host's
+/// directory).
+const SECOND_HOST_DIR: &str = "second_host";
+
+/// A second markdown host with a lua fence, under its own directory.
+fn open_second_host(client: &mut LspClient) {
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": format!("file:///{SECOND_HOST_DIR}/other.md"),
+                "languageId": "markdown",
+                "version": 1,
+                "text": MARKDOWN
+            }
+        }),
+    );
+}
+
 /// Open `count` markdown documents with no injected fence, so they bridge to no
 /// downstream at all. They exist to be *considered* by a derived re-open and
 /// rejected — the workload a re-open sees on a real workspace, where the
@@ -294,7 +314,7 @@ fn dirty_bystanders(client: &mut LspClient, count: usize) {
 ///
 /// Waiting on the observable effect rather than on a duration is what keeps the
 /// caller's assertion about the barrier's RESULT instead of about the clock.
-fn await_replacement_reopen(log: &std::path::Path) {
+fn await_replacement_reopen(log: &std::path::Path, uri_marker: &str) {
     for _ in 0..300 {
         if let Ok(wire) = std::fs::read_to_string(log)
             && wire
@@ -302,16 +322,18 @@ fn await_replacement_reopen(log: &std::path::Path) {
                 .filter(|l| l.split('\t').next() == Some("initialize"))
                 .count()
                 >= 2
-            && replacement_segment(&wire)
-                .iter()
-                .any(|l| l.split('\t').next() == Some("textDocument/didOpen"))
+            && replacement_segment(&wire).iter().any(|l| {
+                let mut parts = l.split('\t');
+                parts.next() == Some("textDocument/didOpen")
+                    && parts.next().is_some_and(|uri| uri.contains(uri_marker))
+            })
         {
             return;
         }
         std::thread::sleep(Duration::from_millis(50));
     }
     let wire = std::fs::read_to_string(log).unwrap_or_default();
-    panic!("the replacement never re-opened a document:\n{wire}");
+    panic!("the replacement never re-opened a {uri_marker} document:\n{wire}");
 }
 
 /// Split the wire log into lines and return the segment belonging to the
@@ -454,6 +476,11 @@ fn a_completed_reopen_releases_the_command_it_was_holding() {
     // wait. The screen only rejects hosts whose language cannot reach the
     // server at all, and no e2e covers that direction.
     open_bystanders(&mut client, 12);
+    // A second fenced host, in its own directory so its virtual URIs are
+    // distinguishable on the wire. Nothing in this test requests anything on
+    // it after the crash, so its presence in the replacement's segment is
+    // positive evidence that the derived sweep — not a request — opened it.
+    open_second_host(&mut client);
 
     let actions = code_action_with_retry(&mut client);
     let routed = actions
@@ -475,7 +502,12 @@ fn a_completed_reopen_releases_the_command_it_was_holding() {
     // barrier, so the re-open runs and settles while nothing has waited on it —
     // and only a wait retires the entry, so its result is still there to read.
     let _ = code_action_with_retry(&mut client);
-    await_replacement_reopen(&log);
+    // Wait for the SECOND host specifically. Only the derived sweep can have
+    // opened it: the codeAction above touches the first host, so the request
+    // path's own lazy open cannot account for a virtual URI under `/second/`.
+    // Waiting on any didOpen would let a re-open that opened NOTHING satisfy
+    // this, because the request path produces one either way.
+    await_replacement_reopen(&log, SECOND_HOST_DIR);
 
     // The barrier now holds a settled result. Releasing the command is the only
     // correct response to one that reports success.

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -386,7 +386,7 @@ fn replacement_segment(wire: &str) -> Vec<&str> {
 /// document its arguments reference (execute-command-routing-token).
 ///
 /// The stall makes the barrier load-bearing instead of raced. While the
-/// re-open is held (2.5 s > REOPEN_WAIT), a correct kakehashi DROPS the
+/// re-open is held (5 s > REOPEN_WAIT), a correct kakehashi DROPS the
 /// command (fail-soft null; nothing on the wire); one that signals early,
 /// ignores the unsettled wait, or never waits sends it ahead of the didOpen —
 /// and the replacement-segment wire order catches every one of those shapes.
@@ -426,7 +426,7 @@ fn a_command_does_not_overtake_the_reopen_of_a_respawned_downstream() {
         "a command whose re-open is still in flight must fail soft, got: {first:?}"
     );
 
-    // Retry until it goes through: the stall ends at ~2.5 s, the barrier
+    // Retry until it goes through: the stall ends at ~5 s, the barrier
     // settles, and a retry then waits it out and sends AFTER the didOpen.
     let mut delivered = false;
     for _ in 0..40 {

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -255,6 +255,40 @@ fn init_client_reopen_order(
     (client, config_dir)
 }
 
+/// Open `count` markdown documents with no injected fence, so they bridge to no
+/// downstream at all. They exist to be *considered* by a derived re-open and
+/// rejected — the workload a re-open sees on a real workspace, where the
+/// documents belonging to any one connection are a small minority.
+fn open_bystanders(client: &mut LspClient, count: usize) {
+    for i in 0..count {
+        client.send_notification(
+            "textDocument/didOpen",
+            json!({
+                "textDocument": {
+                    "uri": format!("file:///bystander_{i}.md"),
+                    "languageId": "markdown",
+                    "version": 1,
+                    "text": "# Prose\n\nNo fenced code here.\n"
+                }
+            }),
+        );
+    }
+}
+
+/// Clear every bystander's tree, so the re-open meets documents whose parses are
+/// pending — the state a settings reload leaves the whole workspace in.
+fn dirty_bystanders(client: &mut LspClient, count: usize) {
+    for i in 0..count {
+        client.send_notification(
+            "textDocument/didChange",
+            json!({
+                "textDocument": { "uri": format!("file:///bystander_{i}.md"), "version": 2 },
+                "contentChanges": [{ "text": "# Prose\n\nStill no fenced code.\n" }]
+            }),
+        );
+    }
+}
+
 /// Block until the replacement incarnation has both initialized AND received a
 /// `didOpen`, i.e. its re-open has actually run.
 ///
@@ -411,6 +445,16 @@ fn a_completed_reopen_releases_the_command_it_was_holding() {
     let (mut client, _config_dir) = init_client_reopen_order(&log, 0);
     open_markdown(&mut client);
 
+    // Bystanders: markdown with no fence, so they bridge to nothing. The
+    // re-open derives its targets from the OPEN DOCUMENTS, so these are all
+    // candidates it must reject — and rejecting them must be cheap. When the
+    // per-host parse wait (200 ms each) ran before the configuration question,
+    // a handful of them exhausted the 2 s budget on documents that supply
+    // nothing, `done` never signalled in time, and the command below failed
+    // soft. Every other e2e opens exactly one document, so nothing else in the
+    // suite can see that.
+    open_bystanders(&mut client, 12);
+
     let actions = code_action_with_retry(&mut client);
     let routed = actions
         .iter()
@@ -419,6 +463,12 @@ fn a_completed_reopen_releases_the_command_it_was_holding() {
         .as_str()
         .expect("a routed command name")
         .to_string();
+
+    // Dirty every bystander so its tree is cleared and a reparse is pending.
+    // This is the settings-reload shape: that path invalidates ALL parses and
+    // purges connections in the same pass, so "every snapshot stale AND a
+    // connection owing a re-open" is the ordinary case, not the tail.
+    dirty_bystanders(&mut client, 12);
 
     // The mock died surfacing that action. Drive the respawn with a SECOND
     // codeAction rather than with the command: codeAction never consults the

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -255,6 +255,31 @@ fn init_client_reopen_order(
     (client, config_dir)
 }
 
+/// Block until the replacement incarnation has both initialized AND received a
+/// `didOpen`, i.e. its re-open has actually run.
+///
+/// Waiting on the observable effect rather than on a duration is what keeps the
+/// caller's assertion about the barrier's RESULT instead of about the clock.
+fn await_replacement_reopen(log: &std::path::Path) {
+    for _ in 0..300 {
+        if let Ok(wire) = std::fs::read_to_string(log)
+            && wire
+                .lines()
+                .filter(|l| l.split('\t').next() == Some("initialize"))
+                .count()
+                >= 2
+            && replacement_segment(&wire)
+                .iter()
+                .any(|l| l.split('\t').next() == Some("textDocument/didOpen"))
+        {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let wire = std::fs::read_to_string(log).unwrap_or_default();
+    panic!("the replacement never re-opened a document:\n{wire}");
+}
+
 /// Split the wire log into lines and return the segment belonging to the
 /// REPLACEMENT incarnation: everything from the last exact `initialize` on.
 /// Segmenting matters — the first incarnation legitimately received a didOpen
@@ -370,9 +395,15 @@ fn a_command_does_not_overtake_the_reopen_of_a_respawned_downstream() {
 /// there distinguishes "waited and was released" from "never released, gave up
 /// waiting".
 ///
-/// So this pins the positive direction: with no stall, the re-open finishes
-/// well inside `REOPEN_WAIT`, and the FIRST command must come back non-null —
-/// having waited, not having skipped the wait, which the wire order proves.
+/// So this pins the positive direction. It does NOT race the barrier to do it:
+/// firing the command while the re-open is still in flight makes the assertion
+/// depend on the re-open beating `REOPEN_WAIT`, which a loaded machine breaks —
+/// and a fail-soft null is the CORRECT answer then, so the test would be
+/// failing on correct behaviour. Instead the re-open is allowed to finish
+/// first, and the command then fires against a barrier whose recorded result is
+/// already `true`. A barrier that reports failure leaves that result `false`
+/// with its sender dropped, which the wait reads as "connection may still be
+/// missing documents" and withholds the command — no timing involved.
 #[test]
 fn a_completed_reopen_releases_the_command_it_was_holding() {
     let log_dir = tempfile::TempDir::new().expect("Failed to create log temp dir");
@@ -389,12 +420,15 @@ fn a_completed_reopen_releases_the_command_it_was_holding() {
         .expect("a routed command name")
         .to_string();
 
-    // The mock died surfacing that action, so this command is the request that
-    // drives the respawn. Its connection is acquired BEFORE the barrier wait,
-    // and the barrier is claimed BEFORE the replacement flips to Ready — so the
-    // wait always observes the in-flight re-open rather than racing it. With no
-    // stall the re-open settles, and a released command is the only correct
-    // outcome.
+    // The mock died surfacing that action. Drive the respawn with a SECOND
+    // codeAction rather than with the command: codeAction never consults the
+    // barrier, so the re-open runs and settles while nothing has waited on it —
+    // and only a wait retires the entry, so its result is still there to read.
+    let _ = code_action_with_retry(&mut client);
+    await_replacement_reopen(&log);
+
+    // The barrier now holds a settled result. Releasing the command is the only
+    // correct response to one that reports success.
     let response = client.send_request(
         "workspace/executeCommand",
         json!({ "command": routed, "arguments": [] }),

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -234,6 +234,7 @@ fn init_client_reopen_order(
             log.to_str().expect("temp path should be UTF-8"),
         )
         .env("KAKEHASHI_E2E_STALL_REOPEN_MS", stall_ms.to_string())
+        // (see the stall_ms doc above for why the withhold case needs slack)
         .build();
 
     client.send_request(
@@ -309,6 +310,35 @@ fn dirty_bystanders(client: &mut LspClient, count: usize) {
     }
 }
 
+/// Block until the FIRST incarnation has opened `uri_marker`'s virtual
+/// document — i.e. before any respawn, so a later appearance of that host can
+/// only have come from the re-open sweep.
+fn await_initial_open(log: &std::path::Path, uri_marker: &str) {
+    for _ in 0..300 {
+        if let Ok(wire) = std::fs::read_to_string(log) {
+            let incarnations = wire
+                .lines()
+                .filter(|l| l.split('\t').next() == Some("initialize"))
+                .count();
+            assert!(
+                incarnations <= 1,
+                "the predecessor died before it opened {uri_marker}; this test \
+                 cannot then attribute a later open to the sweep:\n{wire}"
+            );
+            if wire.lines().any(|l| {
+                let mut parts = l.split('\t');
+                parts.next() == Some("textDocument/didOpen")
+                    && parts.next().is_some_and(|uri| uri.contains(uri_marker))
+            }) {
+                return;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let wire = std::fs::read_to_string(log).unwrap_or_default();
+    panic!("the first incarnation never opened a {uri_marker} document:\n{wire}");
+}
+
 /// Block until the replacement incarnation has both initialized AND received a
 /// `didOpen`, i.e. its re-open has actually run.
 ///
@@ -366,7 +396,11 @@ fn replacement_segment(wire: &str) -> Vec<&str> {
 fn a_command_does_not_overtake_the_reopen_of_a_respawned_downstream() {
     let log_dir = tempfile::TempDir::new().expect("Failed to create log temp dir");
     let log = log_dir.path().join("wire.log");
-    let (mut client, _config_dir) = init_client_reopen_order(&log, 2500);
+    // 5 s, not the 2 s bound plus a hair: the stall starts when the re-open is
+    // SERVICED, while the barrier's 2 s starts when the command begins waiting,
+    // and those are independently scheduled. A 500 ms margin makes a correct
+    // barrier fail this test whenever the command is dispatched late under load.
+    let (mut client, _config_dir) = init_client_reopen_order(&log, 5000);
     open_markdown(&mut client);
 
     // Surface the routed command; the mock then exits once (crash marker), so
@@ -481,6 +515,12 @@ fn a_completed_reopen_releases_the_command_it_was_holding() {
     // it after the crash, so its presence in the replacement's segment is
     // positive evidence that the derived sweep — not a request — opened it.
     open_second_host(&mut client);
+    // Let the FIRST incarnation open it before the crash. `didOpen` schedules
+    // parsing asynchronously and the eager open that follows uses
+    // `connection: None`, so a task still in flight when the predecessor dies
+    // could open this host on the REPLACEMENT without the sweep — which would
+    // silently make the assertion below non-discriminating again.
+    await_initial_open(&log, SECOND_HOST_DIR);
 
     let actions = code_action_with_retry(&mut client);
     let routed = actions

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -208,9 +208,18 @@ fn assert_advertised(init_response: &Value) {
 }
 
 /// Drive the reopen-order mock: an appended wire log shared by every
-/// incarnation, plus a stall (longer than the pool's 2 s `REOPEN_WAIT`) that
-/// holds the respawn re-open before any `didOpen` goes out.
-fn init_client_reopen_order(log: &std::path::Path) -> (LspClient, tempfile::TempDir) {
+/// incarnation, plus a stall that holds the respawn re-open before any
+/// `didOpen` goes out.
+///
+/// `stall_ms` selects which half of the barrier contract is under test.
+/// Longer than the pool's 2 s `REOPEN_WAIT` pins that an UNSETTLED barrier
+/// withholds the command; `0` pins that a SETTLED one releases it. Both
+/// directions are needed — a barrier that always reports failure satisfies
+/// the withhold half perfectly.
+fn init_client_reopen_order(
+    log: &std::path::Path,
+    stall_ms: u32,
+) -> (LspClient, tempfile::TempDir) {
     let bin = mock_formatter_bin();
     let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
     let config_path = config_dir.path().join("code_action.toml");
@@ -224,11 +233,7 @@ fn init_client_reopen_order(log: &std::path::Path) -> (LspClient, tempfile::Temp
             "MOCK_LSP_WIRE_LOG",
             log.to_str().expect("temp path should be UTF-8"),
         )
-        // Longer than REOPEN_WAIT (2 s), so a command fired while the re-open
-        // is in flight can NEVER be saved by winning the race: the barrier's
-        // fail-soft is the only correct outcome, and any code path that sends
-        // anyway is caught by the wire-order assertion below.
-        .env("KAKEHASHI_E2E_STALL_REOPEN_MS", "2500")
+        .env("KAKEHASHI_E2E_STALL_REOPEN_MS", stall_ms.to_string())
         .build();
 
     client.send_request(
@@ -280,7 +285,7 @@ fn replacement_segment(wire: &str) -> Vec<&str> {
 fn a_command_does_not_overtake_the_reopen_of_a_respawned_downstream() {
     let log_dir = tempfile::TempDir::new().expect("Failed to create log temp dir");
     let log = log_dir.path().join("wire.log");
-    let (mut client, _config_dir) = init_client_reopen_order(&log);
+    let (mut client, _config_dir) = init_client_reopen_order(&log, 2500);
     open_markdown(&mut client);
 
     // Surface the routed command; the mock then exits once (crash marker), so
@@ -348,6 +353,77 @@ fn a_command_does_not_overtake_the_reopen_of_a_respawned_downstream() {
     assert!(
         reopen < execute,
         "the replacement got the command BEFORE its re-open didOpen:\n{wire}"
+    );
+
+    shutdown(&mut client);
+}
+
+/// The other half of the barrier contract: a re-open that COMPLETES must
+/// release the command, on the first attempt.
+///
+/// Withholding is only half a guarantee. A barrier that reported failure
+/// unconditionally would satisfy
+/// `a_command_does_not_overtake_the_reopen_of_a_respawned_downstream`
+/// completely — its first command is null either way, and the retry loop
+/// still succeeds because a dropped completion sender retires the entry, so
+/// the second attempt sails through and the didOpen still precedes it. Nothing
+/// there distinguishes "waited and was released" from "never released, gave up
+/// waiting".
+///
+/// So this pins the positive direction: with no stall, the re-open finishes
+/// well inside `REOPEN_WAIT`, and the FIRST command must come back non-null —
+/// having waited, not having skipped the wait, which the wire order proves.
+#[test]
+fn a_completed_reopen_releases_the_command_it_was_holding() {
+    let log_dir = tempfile::TempDir::new().expect("Failed to create log temp dir");
+    let log = log_dir.path().join("wire.log");
+    let (mut client, _config_dir) = init_client_reopen_order(&log, 0);
+    open_markdown(&mut client);
+
+    let actions = code_action_with_retry(&mut client);
+    let routed = actions
+        .iter()
+        .find(|a| a["command"].is_string())
+        .expect("the executable command action")["command"]
+        .as_str()
+        .expect("a routed command name")
+        .to_string();
+
+    // The mock died surfacing that action, so this command is the request that
+    // drives the respawn. Its connection is acquired BEFORE the barrier wait,
+    // and the barrier is claimed BEFORE the replacement flips to Ready — so the
+    // wait always observes the in-flight re-open rather than racing it. With no
+    // stall the re-open settles, and a released command is the only correct
+    // outcome.
+    let response = client.send_request(
+        "workspace/executeCommand",
+        json!({ "command": routed, "arguments": [] }),
+    );
+    assert!(
+        !response["result"].is_null(),
+        "a settled re-open must release the command it was holding, got: {response:?}"
+    );
+
+    let wire = std::fs::read_to_string(&log).expect("the mock wrote a wire log");
+    assert!(
+        std::path::Path::new(&format!("{}.died", log.to_str().expect("utf-8"))).exists(),
+        "the mock must have crashed once, else the respawn path was not exercised"
+    );
+    let segment = replacement_segment(&wire);
+    let execute = segment
+        .iter()
+        .position(|l| l.split('\t').next() == Some("workspace/executeCommand"))
+        .unwrap_or_else(|| panic!("the replacement never received the command:\n{wire}"));
+    let reopen = segment
+        .iter()
+        .position(|l| l.split('\t').next() == Some("textDocument/didOpen"))
+        .unwrap_or_else(|| {
+            panic!("no didOpen reached the replacement before the command:\n{wire}")
+        });
+    // Released, not un-awaited: being answered is not proof the wait happened.
+    assert!(
+        reopen < execute,
+        "the released command still overtook its re-open didOpen:\n{wire}"
     );
 
     shutdown(&mut client);

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -445,14 +445,14 @@ fn a_completed_reopen_releases_the_command_it_was_holding() {
     let (mut client, _config_dir) = init_client_reopen_order(&log, 0);
     open_markdown(&mut client);
 
-    // Bystanders: markdown with no fence, so they bridge to nothing. The
-    // re-open derives its targets from the OPEN DOCUMENTS, so these are all
-    // candidates it must reject — and rejecting them must be cheap. When the
-    // per-host parse wait (200 ms each) ran before the configuration question,
-    // a handful of them exhausted the 2 s budget on documents that supply
-    // nothing, `done` never signalled in time, and the command below failed
-    // soft. Every other e2e opens exactly one document, so nothing else in the
-    // suite can see that.
+    // Bystanders: markdown with no fence, so they resolve no injections and
+    // open nothing. They exist to drive the derived re-open over a realistic
+    // candidate count — every other e2e opens exactly one document.
+    //
+    // Note what they do NOT test: they share the real host's language, so the
+    // configuration screen ACCEPTS them and they still pay the bounded parse
+    // wait. The screen only rejects hosts whose language cannot reach the
+    // server at all, and no e2e covers that direction.
     open_bystanders(&mut client, 12);
 
     let actions = code_action_with_retry(&mut client);


### PR DESCRIPTION
Follow-up to #926 / #927. Splits the "which documents does a respawned connection need?" half out of `execute-command-routing-token` and answers it differently.

## The problem

The re-open replayed a host list captured when the dead connection was purged. Capturing looked forced — the purge is when the information is destroyed, so it seemed like the last moment it was knowable. But a captured list is a claim about a state that has already stopped being true, and every way it could drift needed its own repair:

| Drift | Repair it needed |
|---|---|
| a document closed after the purge | the claim DRAINS the list |
| a second purge before a replacement lands | the record UNIONS instead of replacing |
| the handshake dies after claiming | restore the claimed list |
| the hand-off send fails | restore the claimed list again |
| a config change re-roots a host | carry the claimed key and acquire by it (#927) |

Four restore-shaped repairs against one cause — and one divergence had **no repair available**: a connection that died before opening anything held nothing, so its purge captured an empty list, which was skipped. Nothing armed, nothing scheduled, **its replacement was never repaired by anyone**. Restoring could not help, because the list had never existed. That is precisely a connection that fails during startup and is replaced — when a replacement most needs repairing.

## The change

A purge **arms** its key. The replacement's handshake **claims** it. The re-open then asks, of every currently open document, whether it belongs to this connection.

Nothing is remembered about documents, so nothing about them can go stale.

**Arming is unconditional, and that is the load-bearing part** — not the derivation itself. Arming records a fact about the *connection*, so there is nothing to be empty.

## Notes for review

- **Belonging is per `(server, root)`, not per language.** `eager_open_virtual_documents` now resolves where a host actually routes before acquiring by key. Both checks are needed and they differ: a by-key lookup succeeds whichever host asked, so without the routing question a sweep would cross-open one root's documents onto another root's process.
- **Screening order is a correctness property, not an optimization.** The re-open runs inside a fixed budget that `done` must signal within, so per-candidate work is charged against every command on that connection. The cheap configuration question runs before the parse wait and the injection resolution; commit 5 explains why, and the ADR now records it so a future reorder is visibly a regression.
- **One deliberate behaviour change.** A host re-rooted away from the connection being repaired is no longer re-opened onto it. Current settings are the authority, so that connection's correct contents are nothing, and reporting success is accurate rather than a lie. A command in flight against the old root fails downstream — the outcome `execute-command-routing-token` already accepts for a token naming a root no open document sits under. Pinned by `a_rerooted_host_is_not_reopened_on_the_connection_it_left`.
- **`WrongConnection` → `NotApplicable`.** Under derivation most open documents are not any one connection's; counting them as failed repairs would hold the barrier shut on every respawn, so every command would pay the full wait and then fail soft.

## Testing

- `a_completed_reopen_releases_the_command_it_was_holding` (new) closes a real gap: the existing ordering e2e only pins that an *unsettled* barrier withholds. Hardcoding `done.send(false)` leaves it **green** and fails only the new one — verified both ways.
- That test does not race the barrier. An earlier version fired the command while the re-open was in flight and failed 1-in-8 under CPU saturation, where a fail-soft null is the *correct* answer; it now waits for the re-open and asks about its recorded result. 0/12 failures under the same saturation.
- Gate: `cargo clippy -- -D warnings` clean (CI's exact invocation); `--all-targets --all-features` at the 9 pre-existing `main` errors, no new ones; 3199 lib tests; full e2e 58 binaries / 1745 tests.

### Known limit, deliberately not papered over

The bystander documents in the new e2e exercise the screening path but do **not** fail without commit 5 — small documents reparse in under a millisecond, so the per-host 200 ms wait is a ceiling reached only when parses genuinely queue. The commit removes a coupling rather than trimming a measured cost, and says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document reopening after a language server connection is replaced or repaired.
  * Reopening now includes documents currently open when recovery begins, including newly opened documents.
  * Prevented unrelated documents from reopening on the wrong connection.
  * Improved recovery when handshakes or reopen requests fail.
  * Commands now resume reliably after reopening completes.

* **Tests**
  * Expanded coverage for routing, reconnection failures, filtering, and command behavior during reopening.

* **Documentation**
  * Added and updated architecture decisions describing the revised reopening behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->