### PR TITLE
docs: link the known limits to their tracking issue

### DIFF
--- a/docs/architecture-decisions/respawn-reopen-derives-its-targets.md
+++ b/docs/architecture-decisions/respawn-reopen-derives-its-targets.md
@@ -219,7 +219,7 @@ anyway, incorrectly, since it cannot include documents opened since the purge.
 
 ### Known limits of `done`
 
-Four ways the sweep's report can be wrong — mostly by claiming success for a
+Tracked as issue #929. Four ways the sweep's report can be wrong — mostly by claiming success for a
 connection that is not caught up, and in the last case by claiming failure for a
 document nobody is owed. All are narrow, all degrade to the pre-existing lazy
 heal (the next parse's eager open), and none is introduced here — but the
@@ -235,8 +235,8 @@ settings-reload path, which invalidates every parse and purges connections in
 the same pass. Distinguishing a placeholder from a legitimately tree-less parse
 (no parser loaded, parse produced nothing) needs a discriminator the snapshot
 does not currently carry, and rejecting every tree-less snapshot instead would
-wedge the barrier shut while a parser is still being installed. Tracked as the
-same class as the reload-placeholder issue in the parse-snapshot work.
+wedge the barrier shut while a parser is still being installed. Same root cause
+as the reload-placeholder issue (#923).
 
 **An empty resolution can be confirmed against a NEWER version.** If a
 `didChange` clears the tree and its reparse publishes before the currency


### PR DESCRIPTION
Docs-only follow-up to #928.

The ADR's "Known limits of `done`" section described four ways the respawn re-open can misreport, but pointed at no tracking item — the only breadcrumb was a prose reference to "the parse-snapshot work", which names no issue.

Now points at #929, and names #923 as the shared root cause of the first limit (the invalidation placeholder that reads as a current parse) rather than describing it as merely "the same class as" something unnamed.

No code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified known limitations related to completed-item handling.
  * Documented the connection between invalidation placeholders and related issue tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->