### PR TITLE
feat(bridge): retire palette commands no configured server can serve

### DIFF
--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -202,6 +202,13 @@ pub(crate) enum UpstreamRequest {
     /// and fires them by raw name (#628 palette-fired commands). Fire-and-forget:
     /// no reply/cancel (the editor's ack is ignored; routing fails soft anyway).
     RegisterCommands { commands: Vec<String> },
+    /// Retire palette command names the editor should stop offering, via
+    /// `client/unregisterCapability` (#823 follow-up). Sent only when a settings
+    /// change leaves a name with no configured server that could advertise it —
+    /// NOT when a connection dies, since every removal site expects the same key
+    /// back and retiring there would churn the palette on each respawn.
+    /// Fire-and-forget for the same reason as its sibling.
+    UnregisterCommands { commands: Vec<String> },
     /// Bring `key`'s virtual documents up to date: its previous connection was
     /// purged and has now been replaced by a `Ready` process
     /// (respawn-reopen-derives-its-targets).

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -545,6 +545,18 @@ impl LanguageServerPool {
         &self.command_origins
     }
 
+    /// Whether the editor will accept a dynamic `workspace/executeCommand`
+    /// registration — it does only if it advertised `dynamicRegistration` (LSP
+    /// spec). Both registering and RETIRING a palette command must ask, or a
+    /// retirement names ids the editor was never given.
+    fn client_supports_dynamic_command_registration(&self) -> bool {
+        self.client_capabilities()
+            .and_then(|caps| caps.workspace)
+            .and_then(|ws| ws.execute_command)
+            .and_then(|ec| ec.dynamic_registration)
+            .unwrap_or(false)
+    }
+
     /// Tell the USER, not just the log, that a request they invoked could not be
     /// served — as a `window/logMessage` at WARNING.
     ///
@@ -924,6 +936,37 @@ impl LanguageServerPool {
         drop(connections);
         for (key, handle) in stale_handles {
             shutdown_invalidated_connection(key, handle);
+        }
+        // A settings change is the ONLY event that can retire a palette command
+        // name. Connection removal cannot: every removal site above arms a
+        // re-open for the same key, so the connection is expected back, and
+        // retiring there would churn the editor's palette on each respawn.
+        //
+        // "Gone" is SPAWNABILITY, not mere presence in the config. A server left
+        // in `languageServers` with `enabled = false` or an empty `cmd` will
+        // never advertise anything again, so its commands are exactly as dead as
+        // a deleted server's — and asking only whether the entry resolves would
+        // leave them registered and inert for the rest of the session.
+        //
+        // Deliberately a different question from the invalidation loop above,
+        // which asks whether a LIVE process still matches its config. This one
+        // asks whether a process could ever exist.
+        let retired = self.command_origins.retire_unadvertisable(|server| {
+            resolve(server).is_some_and(|config| config.is_spawnable_with_wildcard(None))
+        });
+        // Gated exactly like registration: a client that cannot accept a dynamic
+        // registration was never sent one, so unregistering would name ids it
+        // never held.
+        if !retired.is_empty()
+            && self.client_supports_dynamic_command_registration()
+            && let Err(e) = self
+                .upstream_request_tx
+                .send(UpstreamRequest::UnregisterCommands { commands: retired })
+        {
+            log::warn!(
+                target: "kakehashi::bridge",
+                "Failed to queue palette-command retirement (forwarding loop gone): {e}"
+            );
         }
         pushed
     }
@@ -2582,12 +2625,8 @@ impl LanguageServerPool {
         let pending_reopen = Arc::clone(&self.pending_reopen);
         // The editor accepts a dynamic `workspace/executeCommand` registration
         // only if it advertised `dynamicRegistration` (LSP spec). Compute once.
-        let supports_dynamic_command_registration = self
-            .client_capabilities()
-            .and_then(|caps| caps.workspace)
-            .and_then(|ws| ws.execute_command)
-            .and_then(|ec| ec.dynamic_registration)
-            .unwrap_or(false);
+        let supports_dynamic_command_registration =
+            self.client_supports_dynamic_command_registration();
         let handshake_task = tokio::spawn(async move {
             let init_result = tokio::time::timeout(
                 timeout,
@@ -2673,22 +2712,61 @@ impl LanguageServerPool {
                     // back to a Ready connection (#628). Dedup is by name across
                     // the whole session, so a respawn / second root re-registers
                     // nothing new.
-                    if let Some(commands) = palette_commands {
-                        let added = command_origins.register(&command_registration_key, commands);
-                        // Advertise the NEWLY-added names upstream so the editor's
-                        // palette lists them. Fire-and-forget; skipped when the
-                        // client can't accept a dynamic registration.
-                        if !added.is_empty()
-                            && supports_dynamic_command_registration
-                            && let Err(e) = upstream_request_tx
-                                .send(UpstreamRequest::RegisterCommands { commands: added })
-                        {
-                            log::warn!(
-                                target: "kakehashi::bridge",
-                                "Failed to queue palette-command registration \
-                                 (forwarding loop gone): {e}"
-                            );
+                    //
+                    // ALWAYS with the list this handshake actually advertised —
+                    // including the empty list when the server has no
+                    // `executeCommandProvider` at all. That is the shape a
+                    // server takes after an upgrade that dropped the feature,
+                    // and skipping it would leave the previous incarnation's
+                    // entries standing as candidates nothing can serve.
+                    let outcome = command_origins.register(
+                        &command_registration_key,
+                        palette_commands.unwrap_or_default(),
+                    );
+                    // Advertise the NEWLY-added names upstream so the editor's
+                    // palette lists them. Fire-and-forget; skipped when the
+                    // client can't accept a dynamic registration — in which case
+                    // the registry is told, so it never believes the editor holds
+                    // something that was never sent.
+                    if !outcome.newly_advertised.is_empty() {
+                        if supports_dynamic_command_registration {
+                            if let Err(e) =
+                                upstream_request_tx.send(UpstreamRequest::RegisterCommands {
+                                    commands: outcome.newly_advertised.clone(),
+                                })
+                            {
+                                log::warn!(
+                                    target: "kakehashi::bridge",
+                                    "Failed to queue palette-command registration \
+                                     (forwarding loop gone): {e}"
+                                );
+                                command_origins.forget_registration(&outcome.newly_advertised);
+                            }
+                        } else {
+                            command_origins.forget_registration(&outcome.newly_advertised);
                         }
+                    }
+                    // A name whose every advertiser has stopped offering it is
+                    // dead even though its server is still configured — the
+                    // in-place-upgrade shape, which the config-driven sweep
+                    // cannot see.
+                    // Gated like every other send on this path. It is currently
+                    // redundant — with no capability nothing was announced, so
+                    // nothing can be orphaned — but that is an invariant two
+                    // steps away, and a retirement that stops asking would name
+                    // ids the editor never held.
+                    if !outcome.orphaned.is_empty()
+                        && supports_dynamic_command_registration
+                        && let Err(e) =
+                            upstream_request_tx.send(UpstreamRequest::UnregisterCommands {
+                                commands: outcome.orphaned,
+                            })
+                    {
+                        log::warn!(
+                            target: "kakehashi::bridge",
+                            "Failed to queue palette-command retirement \
+                             (forwarding loop gone): {e}"
+                        );
                     }
                     // Ask upstream to bring this connection up to date. Sent
                     // after Ready so the didOpen queues behind the settings
@@ -7555,6 +7633,106 @@ mod tests {
             ..Default::default()
         };
         assert!(same_launch_config(&inherited, &explicit));
+    }
+
+    #[tokio::test]
+    async fn removing_the_last_advertiser_retires_its_palette_commands() {
+        let pool = pool_with_dynamic_command_registration();
+        let mut rx = pool.take_upstream_request_rx().expect("receiver");
+        pool.command_origins().register(
+            &ConnectionKey::for_server("ruff"),
+            vec!["ruff.fix".to_string()],
+        );
+
+        // A reload in which `ruff` no longer resolves: it is gone from config,
+        // so nothing can ever advertise `ruff.fix` again.
+        pool.propagate_settings(|_| None).await;
+
+        match rx.try_recv() {
+            Ok(super::UpstreamRequest::UnregisterCommands { commands }) => {
+                assert_eq!(commands, vec!["ruff.fix".to_string()]);
+            }
+            Ok(_) => panic!("expected an UnregisterCommands request"),
+            Err(e) => panic!("expected an UnregisterCommands request, got {e:?}"),
+        }
+    }
+
+    /// A pool whose editor accepts dynamic `workspace/executeCommand`
+    /// registrations. Without this the palette paths are correctly inert, so a
+    /// test that forgets it observes nothing and passes for the wrong reason.
+    fn pool_with_dynamic_command_registration() -> LanguageServerPool {
+        let pool = LanguageServerPool::new();
+        pool.set_client_capabilities(tower_lsp_server::ls_types::ClientCapabilities {
+            workspace: Some(tower_lsp_server::ls_types::WorkspaceClientCapabilities {
+                execute_command: Some(
+                    tower_lsp_server::ls_types::DynamicRegistrationClientCapabilities {
+                        dynamic_registration: Some(true),
+                    },
+                ),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        pool
+    }
+
+    #[tokio::test]
+    async fn disabling_the_last_advertiser_retires_its_commands() {
+        // A server left in `languageServers` with `enabled = false` will never
+        // advertise anything again, so its commands are as dead as a deleted
+        // server's — asking only whether the entry resolves leaves them
+        // registered and inert for the rest of the session.
+        let pool = pool_with_dynamic_command_registration();
+        let mut rx = pool.take_upstream_request_rx().expect("receiver");
+        pool.command_origins().register(
+            &ConnectionKey::for_server("ruff"),
+            vec!["ruff.fix".to_string()],
+        );
+
+        pool.propagate_settings(|_| {
+            Some(crate::config::settings::BridgeServerConfig {
+                cmd: vec!["ruff".to_string()],
+                languages: vec!["*".to_string()],
+                enabled: Some(false),
+                ..Default::default()
+            })
+        })
+        .await;
+
+        match rx.try_recv() {
+            Ok(super::UpstreamRequest::UnregisterCommands { commands }) => {
+                assert_eq!(commands, vec!["ruff.fix".to_string()]);
+            }
+            Ok(_) => panic!("expected an UnregisterCommands request"),
+            Err(e) => panic!("expected an UnregisterCommands request, got {e:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_reload_that_keeps_the_server_retires_nothing() {
+        let pool = pool_with_dynamic_command_registration();
+        let mut rx = pool.take_upstream_request_rx().expect("receiver");
+        pool.command_origins().register(
+            &ConnectionKey::for_server("ruff"),
+            vec!["ruff.fix".to_string()],
+        );
+
+        // A SPAWNABLE config: `BridgeServerConfig::default()` has an empty `cmd`,
+        // which is a server that can never advertise again — so it would
+        // correctly retire, and the test would pass for the wrong reason.
+        pool.propagate_settings(|_| {
+            Some(crate::config::settings::BridgeServerConfig {
+                cmd: vec!["ruff".to_string()],
+                languages: vec!["*".to_string()],
+                ..Default::default()
+            })
+        })
+        .await;
+
+        assert!(
+            rx.try_recv().is_err(),
+            "an ordinary reload must not churn the editor's palette"
+        );
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/pool/command_origin_registry.rs
+++ b/src/lsp/bridge/pool/command_origin_registry.rs
@@ -25,59 +25,196 @@
 //! dispatcher scans the connections map for handles whose exact advertised list
 //! contains the name, which is the only view that cannot lag a handshake.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Mutex;
 
 use super::ConnectionKey;
 use crate::error::LockResultExt;
 
+/// What is known about one advertised raw command name.
+#[derive(Default)]
+struct CommandOrigins {
+    /// Every server that has advertised this name. Server names, not connection
+    /// keys, because the question they answer is "could ANY currently-configured
+    /// server still produce this command?" — which survives respawns, re-roots,
+    /// and the loss of every connection.
+    servers: BTreeSet<String>,
+    /// The client-fallback connections that advertised it, in first-advertisement
+    /// order. Only these, because only these can be revived from the name alone.
+    reconnectable: Vec<ConnectionKey>,
+    /// Whether the editor currently holds a registration for this name.
+    ///
+    /// Distinct from the entry existing. The entry outlives the registration:
+    /// once retired, the name must still be recognised by the decode gate (a
+    /// client can fire a name it cached or a user bound), and must be
+    /// re-registered rather than skipped if a server advertises it again.
+    registered_upstream: bool,
+}
+
 #[derive(Default)]
 pub(crate) struct CommandOriginRegistry {
-    /// Command name → the client-fallback connections that advertised it, in
-    /// first-advertisement order. An EMPTY vec is meaningful: the name is known
-    /// to the editor, but every advertiser was marker-rooted or shared and so
-    /// cannot be reconnected from the name alone.
-    origins: Mutex<HashMap<String, Vec<ConnectionKey>>>,
+    origins: Mutex<HashMap<String, CommandOrigins>>,
+}
+
+/// What a handshake's advertisement changed.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct RegistrationOutcome {
+    /// Names the editor should now be told about.
+    pub(crate) newly_advertised: Vec<String>,
+    /// Names this handshake left with no advertiser at all, so the editor should
+    /// stop offering them.
+    pub(crate) orphaned: Vec<String>,
 }
 
 impl CommandOriginRegistry {
-    /// Record `commands` as advertised by the connection `key`, returning the
-    /// subset that is NEWLY seen (never registered before).
+    /// Reconcile `key`'s advertisement against what it used to advertise, and
+    /// record the result.
     ///
-    /// Only genuinely new command names are returned: the name is already
-    /// registered with the editor after its first advertisement, so
-    /// re-advertising it — by the same connection, a respawn, or a second
-    /// server — must not produce a duplicate registration.
-    pub(crate) fn register(&self, key: &ConnectionKey, commands: Vec<String>) -> Vec<String> {
+    /// `commands` is the WHOLE list this handshake advertised, empty included: a
+    /// server that came back without `executeCommandProvider` has stopped
+    /// offering everything, and treating "no list" as "no news" would leave the
+    /// previous incarnation's claims standing.
+    ///
+    /// Re-advertising a name the editor already knows returns nothing, so no
+    /// duplicate registration is produced. A name whose registration was RETIRED
+    /// does come back, because a server advertising it again is exactly the
+    /// event that makes it real once more.
+    pub(crate) fn register(
+        &self,
+        key: &ConnectionKey,
+        commands: Vec<String>,
+    ) -> RegistrationOutcome {
         let mut origins = self
             .origins
             .lock()
             .recover_poison("CommandOriginRegistry::register");
-        let mut added = Vec::new();
+        // Reconcile BEFORE recording: this handshake is the current truth about
+        // what `key` serves.
+        let orphaned = Self::reconcile(&mut origins, key, &commands);
+        let mut newly_advertised = Vec::new();
         for command in commands {
+            let entry = origins.entry(command.clone()).or_default();
+            entry.servers.insert(key.server().to_string());
             // Recording a non-reconnectable key would only ever subtract: it
             // cannot be revived, but it could make the reconnectable set look
             // ambiguous and veto the key that works.
-            let candidate = key.is_client_fallback();
-            match origins.get_mut(&command) {
-                Some(existing) => {
-                    if candidate && !existing.contains(key) {
-                        existing.push(key.clone());
-                    }
-                }
-                None => {
-                    let seed = if candidate {
-                        vec![key.clone()]
-                    } else {
-                        Vec::new()
-                    };
-                    // Clone only for the map key; move the name itself into `added`.
-                    origins.insert(command.clone(), seed);
-                    added.push(command);
+            if key.is_client_fallback() && !entry.reconnectable.contains(key) {
+                entry.reconnectable.push(key.clone());
+            }
+            if !entry.registered_upstream {
+                entry.registered_upstream = true;
+                newly_advertised.push(command);
+            }
+        }
+        RegistrationOutcome {
+            newly_advertised,
+            orphaned,
+        }
+    }
+
+    /// Undo the registration bookkeeping for names whose request was never sent.
+    ///
+    /// The flag means "the editor was asked to hold this", so it must not be set
+    /// when nothing went out — a client that cannot accept dynamic registration,
+    /// or a forwarding loop that has gone away. Otherwise the registry would
+    /// later try to retire an id the editor never held, and would refuse to
+    /// re-offer the name if the client's capability arrived by another route.
+    pub(crate) fn forget_registration(&self, commands: &[String]) {
+        let mut origins = self
+            .origins
+            .lock()
+            .recover_poison("CommandOriginRegistry::forget_registration");
+        for command in commands {
+            if let Some(entry) = origins.get_mut(command) {
+                entry.registered_upstream = false;
+            }
+        }
+    }
+
+    /// Drop `key`'s claims on every name NOT in `commands`, returning the names
+    /// that lost their LAST advertiser as a result.
+    ///
+    /// A recorded origin is a claim that this connection serves the name, and a
+    /// handshake is the only moment that claim is checked against reality. A
+    /// server that comes back after an upgrade without a command falsifies it.
+    /// Left in place the stale candidate cannot be reached — the exact-name check
+    /// rejects it — but it still COUNTS, so it can make an otherwise-revivable
+    /// name look ambiguous and refuse it for the rest of the session.
+    ///
+    /// The SERVER is dropped too, not just the connection key, which is what
+    /// lets an in-place upgrade retire a name: every instance of one server runs
+    /// the same binary and so advertises the same list, and the config-driven
+    /// sweep cannot see a name disappear while its server stays configured.
+    fn reconcile(
+        origins: &mut HashMap<String, CommandOrigins>,
+        key: &ConnectionKey,
+        commands: &[String],
+    ) -> Vec<String> {
+        // One set, not a linear scan per known name: this runs under the lock on
+        // every handshake, against a map that keeps every name for the session.
+        let advertised: std::collections::HashSet<&str> =
+            commands.iter().map(String::as_str).collect();
+        let mut orphaned = Vec::new();
+        for (command, entry) in origins.iter_mut() {
+            if advertised.contains(command.as_str()) {
+                continue;
+            }
+            entry.reconnectable.retain(|recorded| recorded != key);
+            entry.servers.remove(key.server());
+            if entry.registered_upstream && entry.servers.is_empty() {
+                entry.registered_upstream = false;
+                orphaned.push(command.clone());
+            }
+        }
+        orphaned
+    }
+
+    /// The names whose every advertiser is gone from `is_spawnable`, marking them
+    /// unregistered so a later advertisement re-registers them.
+    ///
+    /// Called on a settings change, which is the only event that can retire a
+    /// name. Connection purges cannot: every removal site in the pool arms a
+    /// re-open for the same key, so the connection is expected back and
+    /// unregistering there would churn the editor's palette on each respawn.
+    ///
+    /// A name with NO recorded server is left alone rather than retired — that
+    /// is a shape `register` cannot produce, and guessing at it would drop a
+    /// registration the editor still holds.
+    pub(crate) fn retire_unadvertisable(&self, is_spawnable: impl Fn(&str) -> bool) -> Vec<String> {
+        let mut origins = self
+            .origins
+            .lock()
+            .recover_poison("CommandOriginRegistry::retire_unadvertisable");
+        // Ask about each distinct SERVER once, before touching any entry. The
+        // caller answers from a full wildcard merge of the config, and one
+        // server typically advertises many commands — asking per (name, server)
+        // pair would pay for that merge once per command on every reload.
+        let mut spawnable: HashMap<&str, bool> = HashMap::new();
+        for entry in origins.values() {
+            for server in &entry.servers {
+                if !spawnable.contains_key(server.as_str()) {
+                    spawnable.insert(server.as_str(), is_spawnable(server));
                 }
             }
         }
-        added
+        let retired: Vec<String> = origins
+            .iter()
+            .filter(|(_, entry)| {
+                entry.registered_upstream
+                    && !entry.servers.is_empty()
+                    && !entry
+                        .servers
+                        .iter()
+                        .any(|server| spawnable[server.as_str()])
+            })
+            .map(|(command, _)| command.clone())
+            .collect();
+        for command in &retired {
+            if let Some(entry) = origins.get_mut(command) {
+                entry.registered_upstream = false;
+            }
+        }
+        retired
     }
 
     /// The connections that advertised `command` AND can be reconnected from the
@@ -91,15 +228,16 @@ impl CommandOriginRegistry {
             .lock()
             .recover_poison("CommandOriginRegistry::reconnectable_origins")
             .get(command)
-            .cloned()
+            .map(|entry| entry.reconnectable.clone())
             .unwrap_or_default()
     }
 
     /// Whether `command` is a raw name some downstream advertised.
     ///
-    /// Separate from [`Self::reconnectable_origins`] because this runs on EVERY
-    /// `workspace/executeCommand` as the decode gate, and because a name with no
-    /// reconnectable origin is still a name the editor knows.
+    /// Deliberately entry PRESENCE, not `registered_upstream`: this is the decode
+    /// gate, and its job is to stop a downstream id shaped like a routing token
+    /// from being decoded and misrouted. A retired name is still such an id, and
+    /// a client can still fire one from a keybind or a stale cache.
     pub(crate) fn is_registered(&self, command: &str) -> bool {
         self.origins
             .lock()
@@ -126,14 +264,19 @@ mod tests {
         let ruff = fallback("ruff");
 
         assert_eq!(
-            reg.register(&ruff, vec!["ruff.fix".to_string(), "ruff.sort".to_string()]),
+            reg.register(&ruff, vec!["ruff.fix".to_string(), "ruff.sort".to_string()])
+                .newly_advertised,
             vec!["ruff.fix".to_string(), "ruff.sort".to_string()]
         );
         assert_eq!(reg.reconnectable_origins("ruff.fix"), vec![ruff.clone()]);
 
         // The same connection advertising again neither duplicates the editor
         // registration nor makes its route ambiguous.
-        assert!(reg.register(&ruff, vec!["ruff.fix".to_string()]).is_empty());
+        assert!(
+            reg.register(&ruff, vec!["ruff.fix".to_string()])
+                .newly_advertised
+                .is_empty()
+        );
         assert_eq!(reg.reconnectable_origins("ruff.fix"), vec![ruff]);
     }
 
@@ -151,11 +294,13 @@ mod tests {
         let eslint = fallback("eslint");
 
         assert_eq!(
-            reg.register(&ruff, vec!["source.fixAll".to_string()]),
+            reg.register(&ruff, vec!["source.fixAll".to_string()])
+                .newly_advertised,
             vec!["source.fixAll"]
         );
         assert!(
             reg.register(&eslint, vec!["source.fixAll".to_string()])
+                .newly_advertised
                 .is_empty(),
             "the editor command name is registered only once"
         );
@@ -175,6 +320,7 @@ mod tests {
 
         assert!(
             reg.register(&ruff, vec!["source.fixAll".to_string()])
+                .newly_advertised
                 .is_empty()
         );
 
@@ -186,12 +332,203 @@ mod tests {
     }
 
     #[test]
+    fn a_name_is_registered_once_until_it_is_retired() {
+        let reg = CommandOriginRegistry::default();
+        let ruff = fallback("ruff");
+        assert_eq!(
+            reg.register(&ruff, vec!["ruff.fix".to_string()])
+                .newly_advertised,
+            vec!["ruff.fix"]
+        );
+        assert!(
+            reg.register(&ruff, vec!["ruff.fix".to_string()])
+                .newly_advertised
+                .is_empty()
+        );
+
+        // Config drops ruff: nothing can advertise the name any more.
+        assert_eq!(reg.retire_unadvertisable(|_| false), vec!["ruff.fix"]);
+        assert!(
+            reg.is_registered("ruff.fix"),
+            "the decode gate must keep recognising a retired name — a client can \
+             still fire one from a keybind or a stale cache"
+        );
+        assert!(
+            reg.retire_unadvertisable(|_| false).is_empty(),
+            "retiring twice would unregister an id the editor no longer holds"
+        );
+
+        // ruff comes back, so the name becomes real again and must be re-offered.
+        assert_eq!(
+            reg.register(&ruff, vec!["ruff.fix".to_string()])
+                .newly_advertised,
+            vec!["ruff.fix"],
+            "a retired name must be re-registered, not skipped as already known"
+        );
+    }
+
+    #[test]
+    fn a_server_that_came_back_with_no_provider_at_all_is_reconciled() {
+        // The shape an upgrade takes when it drops `executeCommandProvider`
+        // entirely. Treating "no list" as "no news" would leave the previous
+        // incarnation's claims standing forever.
+        let reg = CommandOriginRegistry::default();
+        let ruff = fallback("ruff");
+        reg.register(&ruff, vec!["ruff.fix".to_string()]);
+
+        let outcome = reg.register(&ruff, Vec::new());
+
+        assert_eq!(
+            outcome.orphaned,
+            vec!["ruff.fix".to_string()],
+            "its last advertiser stopped offering it, so the editor must stop too"
+        );
+        assert!(reg.reconnectable_origins("ruff.fix").is_empty());
+        assert!(
+            reg.is_registered("ruff.fix"),
+            "the decode gate keeps recognising it; only the registration is gone"
+        );
+    }
+
+    #[test]
+    fn an_in_place_upgrade_retires_a_command_its_server_no_longer_has() {
+        // The config-driven sweep cannot see this: the server is still perfectly
+        // well configured, it just stopped offering the command.
+        let reg = CommandOriginRegistry::default();
+        let ruff = fallback("ruff");
+        reg.register(&ruff, vec!["old.fix".to_string(), "ruff.fix".to_string()]);
+        assert!(
+            reg.retire_unadvertisable(|_| true).is_empty(),
+            "while the server is configured, nothing config-driven can retire it"
+        );
+
+        let outcome = reg.register(&ruff, vec!["ruff.fix".to_string()]);
+
+        assert_eq!(outcome.orphaned, vec!["old.fix".to_string()]);
+        assert!(
+            outcome.newly_advertised.is_empty(),
+            "ruff.fix was already registered and must not be re-announced"
+        );
+    }
+
+    #[test]
+    fn one_server_dropping_a_command_another_still_has_retires_nothing() {
+        let reg = CommandOriginRegistry::default();
+        let ruff = fallback("ruff");
+        reg.register(&ruff, vec!["source.fixAll".to_string()]);
+        reg.register(&fallback("eslint"), vec!["source.fixAll".to_string()]);
+
+        let outcome = reg.register(&ruff, Vec::new());
+
+        assert!(
+            outcome.orphaned.is_empty(),
+            "eslint still advertises it, so the palette entry is still real"
+        );
+        assert!(reg.is_registered("source.fixAll"));
+    }
+
+    #[test]
+    fn a_registration_that_was_never_sent_is_not_remembered_as_sent() {
+        // The client cannot accept dynamic registration, or the forwarding loop
+        // is gone: nothing went out, so the editor holds nothing. Believing
+        // otherwise would later retire an id it never had, and would refuse to
+        // offer the name if the capability arrived by another route.
+        let reg = CommandOriginRegistry::default();
+        let ruff = fallback("ruff");
+        let outcome = reg.register(&ruff, vec!["ruff.fix".to_string()]);
+        assert_eq!(outcome.newly_advertised, vec!["ruff.fix".to_string()]);
+
+        reg.forget_registration(&outcome.newly_advertised);
+
+        assert_eq!(
+            reg.register(&ruff, vec!["ruff.fix".to_string()])
+                .newly_advertised,
+            vec!["ruff.fix".to_string()],
+            "a name that was never announced must be announceable again"
+        );
+    }
+
+    #[test]
+    fn each_server_is_asked_about_once_per_reload() {
+        // The answer comes from a full wildcard merge, so asking per
+        // (name, server) pair makes a reload cost O(commands) merges per server.
+        let reg = CommandOriginRegistry::default();
+        let ruff = fallback("ruff");
+        reg.register(
+            &ruff,
+            vec![
+                "ruff.fix".to_string(),
+                "ruff.sort".to_string(),
+                "ruff.format".to_string(),
+            ],
+        );
+        reg.register(&fallback("eslint"), vec!["eslint.fix".to_string()]);
+
+        let asked = std::cell::RefCell::new(Vec::new());
+        reg.retire_unadvertisable(|server| {
+            asked.borrow_mut().push(server.to_string());
+            false
+        });
+
+        let mut asked = asked.into_inner();
+        asked.sort();
+        assert_eq!(asked, vec!["eslint".to_string(), "ruff".to_string()]);
+    }
+
+    #[test]
+    fn a_name_one_surviving_server_still_advertises_is_not_retired() {
+        let reg = CommandOriginRegistry::default();
+        reg.register(&fallback("ruff"), vec!["source.fixAll".to_string()]);
+        reg.register(&fallback("eslint"), vec!["source.fixAll".to_string()]);
+
+        assert!(
+            reg.retire_unadvertisable(|server| server == "eslint")
+                .is_empty(),
+            "deleting one of two advertisers leaves the name real"
+        );
+        assert!(
+            reg.retire_unadvertisable(|_| false)
+                .contains(&"source.fixAll".to_string())
+        );
+    }
+
+    #[test]
+    fn a_respawn_that_dropped_a_command_stops_being_a_candidate_for_it() {
+        // The false-ambiguity shape: two fallback servers advertise a name, one
+        // comes back after an upgrade without it, the other dies. The name has
+        // exactly one revivable origin left and must not read as ambiguous.
+        let reg = CommandOriginRegistry::default();
+        let ruff = fallback("ruff");
+        let eslint = fallback("eslint");
+        reg.register(&ruff, vec!["source.fixAll".to_string()]);
+        reg.register(&eslint, vec!["source.fixAll".to_string()]);
+        assert_eq!(
+            reg.reconnectable_origins("source.fixAll"),
+            vec![ruff.clone(), eslint.clone()]
+        );
+
+        // eslint re-handshakes advertising something else entirely.
+        reg.register(&eslint, vec!["eslint.restart".to_string()]);
+
+        assert_eq!(
+            reg.reconnectable_origins("source.fixAll"),
+            vec![ruff],
+            "a server that no longer advertises the name must not keep a vote on it"
+        );
+        assert!(
+            reg.is_registered("source.fixAll"),
+            "the name stays registered — another server may still advertise it"
+        );
+    }
+
+    #[test]
     fn a_marker_rooted_advertiser_registers_the_name_without_becoming_a_candidate() {
         let reg = CommandOriginRegistry::default();
         let marker_rooted = marker("ruff", "file:///w/a");
 
         assert_eq!(
-            reg.register(&marker_rooted, vec!["ruff.fix".to_string()]),
+            reg.register(&marker_rooted, vec!["ruff.fix".to_string()])
+                .newly_advertised,
             vec!["ruff.fix"],
             "the editor is still told about the name"
         );

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1357,6 +1357,31 @@ async fn e2e_stall_reopen() {
     tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
 }
 
+/// The `client/registerCapability` id kakehashi uses for one palette command.
+///
+/// Derived from the name rather than allocated and stored: one registration per
+/// name means the id can be recomputed when the name is retired, so the mapping
+/// needs no state to survive between the two events. Ids only have to be unique
+/// among ACTIVE registrations, and a name is registered at most once at a time.
+fn palette_registration_id(command: &str) -> String {
+    format!("kakehashi/executeCommand/{command}")
+}
+
+/// Serializes palette registration against palette RETIREMENT.
+///
+/// The two carry the same derived id — that is the point of deriving it — so
+/// their order is load-bearing: a settings reload that removes a server and a
+/// handshake that re-adds it produce an unregister and a register for the same
+/// id, and the wrong order leaves the editor either holding a dead entry or
+/// missing a live one.
+///
+/// The channel delivers them in order, but each message is dispatched into its
+/// own task, so nothing downstream of the channel preserves it. One lock held
+/// across the round trip does. Only these two message kinds contend for it, and
+/// only at handshake and settings-reload rate.
+static PALETTE_REGISTRATION_ORDER: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+
 fn spawn_upstream_request(
     inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry,
     translators: Option<Arc<UpstreamRequestTranslators>>,
@@ -1374,21 +1399,25 @@ fn spawn_upstream_request(
         match request {
             UpstreamRequest::RegisterCommands { commands } => {
                 use tower_lsp_server::ls_types::Registration;
-                // Fire-and-forget dynamic registration of palette command names.
-                // A unique registration id (we never unregister — a disconnected
-                // server's command simply routes fail-soft). Register-options
-                // carry the `commands` for `workspace/executeCommand`.
-                let id = format!("kakehashi/executeCommand/{}", client.next_request_id());
-                let registration = Registration {
-                    id,
-                    method: "workspace/executeCommand".to_string(),
-                    register_options: Some(serde_json::json!({ "commands": commands })),
-                };
+                let _order = PALETTE_REGISTRATION_ORDER.lock().await;
+                // ONE registration per command name, batched into one request.
+                // Batching them under a single id would be fewer objects but
+                // would make the set un-retirable: `client/unregisterCapability`
+                // names a registration, so dropping one command from a shared id
+                // means unregistering the batch and re-registering the rest.
+                let registrations: Vec<_> = commands
+                    .iter()
+                    .map(|command| Registration {
+                        id: palette_registration_id(command),
+                        method: "workspace/executeCommand".to_string(),
+                        register_options: Some(serde_json::json!({ "commands": [command] })),
+                    })
+                    .collect();
                 // Bound the await: a non-responsive editor must not leak a task
                 // pending forever on the registration request.
                 match tokio::time::timeout(
                     std::time::Duration::from_secs(10),
-                    client.register_capability(vec![registration]),
+                    client.register_capability(registrations),
                 )
                 .await
                 {
@@ -1400,6 +1429,35 @@ fn spawn_upstream_request(
                     Err(_) => log::warn!(
                         target: "kakehashi::bridge",
                         "Timed out registering palette commands upstream"
+                    ),
+                }
+            }
+            UpstreamRequest::UnregisterCommands { commands } => {
+                use tower_lsp_server::ls_types::Unregistration;
+                let _order = PALETTE_REGISTRATION_ORDER.lock().await;
+                // The id is DERIVED from the name, so nothing has to be
+                // remembered between registering and retiring it.
+                let unregistrations: Vec<_> = commands
+                    .iter()
+                    .map(|command| Unregistration {
+                        id: palette_registration_id(command),
+                        method: "workspace/executeCommand".to_string(),
+                    })
+                    .collect();
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(10),
+                    client.unregister_capability(unregistrations),
+                )
+                .await
+                {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => log::warn!(
+                        target: "kakehashi::bridge",
+                        "Failed to unregister palette commands upstream: {e}"
+                    ),
+                    Err(_) => log::warn!(
+                        target: "kakehashi::bridge",
+                        "Timed out unregistering palette commands upstream"
                     ),
                 }
             }


### PR DESCRIPTION
Stacked on #827 — review that first; this PR's diff is only the three commits above it.

## Summary

A raw palette command name is registered with the editor on first advertisement and
was never taken back. A server removed from `languageServers` therefore left its
commands in the palette for the rest of the session: permanently inert, and after
#827 permanently silent about why.

This makes the registration reversible, and closes the gap #827's PR comment records.

## The hard part is WHEN, not how

Every connection-removal site in the pool — the workspace-folder change, the settings
reload, and the acquire-time invalidation — calls `pending_reopen.arm(&key)`. A purge
means *"this connection is coming back"*, not *"this name is gone"*. Retiring there
would churn the editor's palette on every settings reload and every respawn.

A settings change is the only event that can actually retire a name, and only when NO
server that ever advertised it resolves any more. That is the same notion of "gone"
the invalidation loop beside it already uses, so the two cannot drift into disagreeing
about whether a server still exists.

## Three pieces

**The registry learns which SERVERS advertised each name.** Server names rather than
connection keys, because the question is whether any currently-configured server could
still produce the command — which survives respawns, re-roots, and the loss of every
connection. (#827 narrowed the recorded *keys* to the client-fallback ones the
reconnect branch can revive, which deliberately does not answer this.)

**Registration identity is derived from the command name**, not allocated and stored,
so nothing has to be remembered between registering a name and retiring it. That costs
one `Registration` per name instead of one per batch — they still travel in a single
request — and buys individual retirement: `client/unregisterCapability` names a
registration, so a shared id would mean unregistering the batch and re-registering the
remainder.

**Whether the editor holds a registration is tracked separately from whether the entry
exists.** The entry outlives the registration on purpose. A retired name must still be
recognised by the decode gate — a client can fire one from a keybind or a stale cache,
and a name shaped like a routing token would otherwise be decoded and misrouted — and
it must be *re-registered* rather than skipped when a server advertises it again.

## Also closes the gap recorded on #827

A fresh codex review of #827 found that a recorded reconnect candidate is a claim
never checked against reality: servers A and B both advertise `source.fixAll`, B comes
back after an upgrade without it, A crashes, and the name is refused as ambiguous
although only A was ever a real candidate. The stale entry cannot be *reached* — the
exact-name check rejects it — but it still **counts**.

A handshake is the moment that claim can be checked, so `register` now reconciles: a
name the connection no longer advertises drops that key as a candidate. Only the
candidate list is reconciled; the server stays recorded and the name stays registered,
because another server may still advertise it and retirement is a config decision, not
one connection's capabilities.

## What codex review changed

A fresh codex pass found three cases where a name could die **without the config
changing at all** — the sweep above only asks whether a SERVER still resolves.

- **A server that came back with no `executeCommandProvider` was skipped entirely.**
  The recording site only ran when the handshake produced a command list, so the shape
  an upgrade takes when it drops the feature — no list at all — left the previous
  incarnation's claims standing. It now always reconciles, empty list included,
  because "no list" is news rather than the absence of news.
- **A configured server that merely stopped offering one command kept it forever.**
  After an in-place upgrade the server still resolves; only the command is gone. So
  reconciliation drops the SERVER from the name as well as the connection key — every
  instance of one server runs the same binary and advertises the same list — and a
  name that loses its last advertiser that way is retired on the spot.
- **`registered_upstream` was set even when nothing was sent.** A client that cannot
  accept dynamic registration, or a forwarding loop that has gone away, means the
  editor holds nothing; believing otherwise would later try to retire an id it never
  had. The flag now means "the editor was asked to hold this".

Deliberately not changed, recorded so it is not re-derived: the flag flips on ENQUEUE,
not on the editor's acknowledgement. Every user of this channel is fire-and-forget by
design, and both failure directions self-heal — a rejected registration is re-offered
the next time a server advertises the name, and a failed retirement is overwritten by
the next registration of the same derived id.

Codex also confirmed the derived ids cannot collide (concatenating the exact command
name is injective, and the prefix has no other use in the repo).

## What bot review changed

- **Retirement was not gated on the client capability** — registration is skipped when
  the editor did not advertise `workspace.executeCommand.dynamicRegistration`, so
  unregistering named ids it was never given. Both sides now ask through one accessor.
- **"Gone" was resolvability, not spawnability** — a server left in `languageServers`
  with `enabled = false` or an empty `cmd` will never advertise again, so its commands
  are as dead as a deleted server's; `resolve(server).is_some()` kept them registered
  and inert for the session.
- **Register and retire of the same derived id could race** — the channel delivers in
  order but each message is dispatched into its own task. One lock across the round
  trip, taken only by these two message kinds.

Refuted with the rationale already in the tree: "no retry on unregister failure". The
flag flips on enqueue rather than on the editor's acknowledgement because every user of
this channel is fire-and-forget, and both directions self-heal.

Two existing tests were passing for the wrong reason and are fixed: they drove
`propagate_settings` with `BridgeServerConfig::default()`, whose empty `cmd` makes it
UNspawnable, and with a pool whose editor never accepted dynamic registration at all.

## Validation

- `cargo test --lib` — **3285 passed, 0 failed**
- e2e: `e2e_code_action` 45/0, `e2e_host_bridge` 44/0, `e2e_organize_imports` 27/0.
  One suite run of four reported `concatenated_default_merges_actions_from_both_servers`
  failing; it passes alone 3/3 and the full suite passes 2/2 on re-run, and the test is
  a code-action merge unrelated to this diff. Recorded rather than dropped — this repo's
  e2e is known to fail under parallel load with a different set each time.
- `cargo clippy --lib -- -D warnings` clean; `--lib --tests` shows only the 12 errors
  pre-existing on `origin/main`
- `cargo fmt --check` clean

Mutation-verified — each of these passed the suite before its test existed:

| mutation | caught by |
|---|---|
| handshake reconciliation removed | `a_respawn_that_dropped_a_command_stops_being_a_candidate_for_it` |
| retirement never fires | 3 tests |
| retirement fires when *some* advertiser survives, not none | `a_name_one_surviving_server_still_advertises_is_not_retired` |
| a retired name is not re-registered when re-advertised | 6 tests |

Plus a pool-level pair: removing the last advertiser emits `UnregisterCommands`, and
an ordinary reload emits nothing — the churn this design exists to avoid.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Palette commands are automatically registered and retired as language server capabilities and settings change.
  * Commands are removed when servers disconnect, are disabled, deleted, or stop advertising them.
  * Registration remains consistent across reconnects and configuration updates.

* **Bug Fixes**
  * Prevented orphaned or duplicate editor commands.
  * Improved reliability when registering or removing multiple commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->