### PR TITLE
feat(bridge): give every connection its own palette entry

### DIFF
--- a/docs/architecture-decisions/execute-command-routing-token.md
+++ b/docs/architecture-decisions/execute-command-routing-token.md
@@ -245,21 +245,39 @@ narrows by configuration first.
 
 ## Decision–Implementation Gap
 
-**Dynamic registration of encoded names is deferred.** Making the name set
-finite is the precondition, not the feature. Two questions must be settled
-empirically before registering them, and neither can be answered from the
-protocol text:
+**Dynamic registration of encoded names is no longer deferred (#823 stack).**
+Making the name set finite was the precondition. Two questions had to be settled
+empirically first, and neither could be answered from the protocol text:
 
 - Roots are discovered lazily as documents open, so the registerable set grows
-  during a session. The existing palette registration mints a fresh
-  registration id per batch and never unregisters; whether real clients
-  tolerate repeated `workspace/executeCommand` registrations with overlapping
-  command lists is untested.
-- Whether a client that filters on registered ids also expects a
-  human-readable command id, given these are machine-generated.
+  during a session. Whether real clients tolerate repeated
+  `workspace/executeCommand` registrations, with the ids and lists that produces,
+  was untested.
+- Whether a client that filters on registered ids also expects a human-readable
+  command id, given these are machine-generated.
 
-Until that is settled, `executeCommandProvider.commands` stays empty and the
-vscode-languageclient limitation stands.
+**Measured in Neovim** (v0.13 nightly, `scripts/probe_palette_registration.lua`,
+one kakehashi spanning two `.git` roots so one downstream server has two
+connections):
+
+- Registrations DO accumulate — one request per root as it is discovered — and
+  Neovim accepts every one without error. The raw name is announced exactly once;
+  each new root adds only its own encoded entry. No duplicate registration ids,
+  which the derived-id scheme (one id per name, `kakehashi/executeCommand/<name>`)
+  is what guarantees.
+- Neovim keys dynamic registrations by CAPABILITY name, so they land in
+  `client.registrations.executeCommandProvider` — enumerable, and the encoded
+  names are usable as-is: firing one runs the command on exactly its connection,
+  while firing the raw name is refused with a `window/logMessage` naming the
+  connections that collided.
+- **Neovim does not advertise `workspace.executeCommand.dynamicRegistration` at
+  all** (checked against `vim.lsp.protocol.make_client_capabilities()`), so none
+  of this happens there unless the user opts in by setting that capability. The
+  palette-registration feature is inert in a default Neovim.
+
+Answered for Neovim only. The vscode-languageclient limitation is unmeasured, so
+`executeCommandProvider.commands` still stays empty in the initialize result —
+this path is dynamic registration only.
 
 **A DEAD shared-instance connection cannot be re-rooted from the token alone.**
 A `preferSharedInstance` connection is keyed without a root, and announcing a

--- a/scripts/probe_palette_registration.lua
+++ b/scripts/probe_palette_registration.lua
@@ -1,0 +1,209 @@
+-- Manual probe for the palette-command registration gate in
+-- docs/architecture-decisions/execute-command-routing-token.md.
+--
+-- The two questions that ADR deferred can only be answered by a real client:
+--   Q1 does the editor tolerate a `client/registerCapability` for
+--      `workspace/executeCommand` arriving repeatedly, as workspace roots are
+--      discovered lazily through a session?
+--   Q2 is a machine-generated command id usable where the client surfaces it?
+--
+-- Run from the repo root, after `cargo build --features e2e`:
+--
+--   PROBE_ROOT=/path/with/repo-a-and-repo-b \
+--   KAKEHASHI_BIN=target/debug/kakehashi \
+--   MOCK_BIN=target/debug/mock-lsp-formatter \
+--   FORCE_EXEC_DYNREG=1 \
+--     nvim --headless --noplugin -u NONE -l scripts/probe_palette_registration.lua
+--
+-- PROBE_ROOT must hold `repo-a/` and `repo-b/`, each with a `.git` directory
+-- and a `doc.md` containing a lua fence. Two marker roots is the whole point:
+-- per-root pooling is on by default, so ONE kakehashi spawns TWO connections of
+-- one downstream server -- the shape that makes a raw palette name ambiguous
+-- (#823).
+--
+-- FORCE_EXEC_DYNREG exists because Neovim does NOT advertise
+-- `workspace.executeCommand.dynamicRegistration` on its own, so without it
+-- kakehashi registers nothing and the probe measures nothing. That is itself a
+-- finding, recorded in the ADR.
+
+local root = vim.fn.fnamemodify(vim.env.PROBE_ROOT or vim.uv.cwd(), ":p"):gsub("/$", "")
+local kakehashi = vim.env.KAKEHASHI_BIN
+local mock = vim.env.MOCK_BIN
+
+local log = {}
+local function say(fmt, ...)
+  local line = select("#", ...) > 0 and string.format(fmt, ...) or fmt
+  table.insert(log, line)
+end
+
+-- Capture every registerCapability / unregisterCapability the server sends,
+-- then hand off to Neovim's own handler so we also learn whether IT accepts them.
+local registrations = {}
+local unregistrations = {}
+local handler_errors = {}
+
+local orig_register = vim.lsp.handlers["client/registerCapability"]
+vim.lsp.handlers["client/registerCapability"] = function(err, result, ctx, config)
+  local copy = vim.deepcopy(result)
+  copy.__client = ctx and ctx.client_id
+  table.insert(registrations, copy)
+  local ok, res = pcall(orig_register, err, result, ctx, config)
+  if not ok then
+    table.insert(handler_errors, "register: " .. tostring(res))
+    return vim.NIL
+  end
+  return res
+end
+
+local orig_unregister = vim.lsp.handlers["client/unregisterCapability"]
+vim.lsp.handlers["client/unregisterCapability"] = function(err, result, ctx, config)
+  table.insert(unregistrations, vim.deepcopy(result))
+  local ok, res = pcall(orig_unregister, err, result, ctx, config)
+  if not ok then
+    table.insert(handler_errors, "unregister: " .. tostring(res))
+    return vim.NIL
+  end
+  return res
+end
+
+local caps = vim.lsp.protocol.make_client_capabilities()
+if vim.env.FORCE_EXEC_DYNREG == "1" then
+  caps.workspace = caps.workspace or {}
+  caps.workspace.executeCommand = { dynamicRegistration = true }
+end
+
+vim.lsp.config["kakehashi"] = {
+  cmd = { kakehashi },
+  capabilities = caps,
+  filetypes = { "markdown" },
+  -- ONE kakehashi for both repos: its own per-root pooling (workspaceMarkers
+  -- defaults to ) is what spawns a downstream connection per repo. A
+  -- root_dir per file would start two kakehashi processes instead, which is a
+  -- different question entirely.
+  root_dir = function(_, on_dir)
+    on_dir(root)
+  end,
+  init_options = {
+    languages = { markdown = { bridge = { lua = { enabled = true } } } },
+    languageServers = {
+      ["mock-codeaction"] = { cmd = { mock, "code-action" }, languages = { "lua" } },
+    },
+  },
+}
+vim.lsp.enable("kakehashi")
+
+local function wait(ms)
+  vim.wait(ms, function() return false end, 50)
+end
+
+local function open(path)
+  vim.cmd.edit(path)
+  vim.bo.filetype = "markdown"
+  wait(4000)
+end
+
+-- 1st root
+open(root .. "/repo-a/doc.md")
+local after_a = #registrations
+say("== after opening repo-a ==")
+say("registerCapability requests: %d", after_a)
+
+-- 2nd root: the lazily-discovered one Q1 is about
+open(root .. "/repo-b/doc.md")
+say("== after opening repo-b ==")
+say("registerCapability requests: %d (delta %d)", #registrations, #registrations - after_a)
+
+say("")
+say("== every executeCommand registration, in arrival order ==")
+local ids = {}
+local dup_ids = {}
+for i, params in ipairs(registrations) do
+  for _, reg in ipairs(params.registrations or {}) do
+    if reg.method == "workspace/executeCommand" then
+      local cmds = (reg.registerOptions or {}).commands or {}
+      say("  [req %d client %s] id=%s", i, tostring(params.__client), reg.id)
+      if ids[reg.id] then table.insert(dup_ids, reg.id) end
+      ids[reg.id] = true
+    end
+  end
+end
+say("duplicate registration ids across the session: %s",
+  #dup_ids == 0 and "none" or vim.inspect(dup_ids))
+say("unregisterCapability requests: %d", #unregistrations)
+say("handler errors: %s", #handler_errors == 0 and "none" or vim.inspect(handler_errors))
+
+say("")
+say("== what the client exposes (Q2) ==")
+local client = vim.lsp.get_clients({ name = "kakehashi" })[1]
+if not client then
+  say("  NO CLIENT — kakehashi did not attach")
+else
+  say("  kakehashi clients attached: %d", #vim.lsp.get_clients({ name = "kakehashi" }))
+  say("  server_capabilities.executeCommandProvider = %s",
+    vim.inspect(client.server_capabilities.executeCommandProvider):gsub("%s+", " "))
+  -- Neovim keys dynamic registrations by CAPABILITY name, not by method.
+  local regs = (rawget(client, "registrations") or {})["executeCommandProvider"] or {}
+  local offered = {}
+  for _, reg in ipairs(regs) do
+    for _, c in ipairs((reg.registerOptions or {}).commands or {}) do
+      table.insert(offered, c)
+    end
+  end
+  table.sort(offered)
+  say("  commands the client now holds (%d):", #offered)
+  for _, c in ipairs(offered) do
+    say("    %s", (c:gsub(vim.pesc(root), "<root>")))
+  end
+
+  say("")
+  say("== end to end: raw vs routed (Q2's real substance) ==")
+  local messages = {}
+  local orig_log = vim.lsp.handlers["window/logMessage"]
+  vim.lsp.handlers["window/logMessage"] = function(err, result, ctx, cfg)
+    if result and result.message and result.message:match("kakehashi") then
+      table.insert(messages, result.message)
+    end
+    return orig_log and orig_log(err, result, ctx, cfg)
+  end
+
+  local function run(name, label)
+    local before = #messages
+    -- Wait for the CALLBACK, not a fixed interval: `client:request` is async, so
+    -- a timer that expires first would report a half-finished request as if it
+    -- were the result.
+    local settled = false
+    client:request("workspace/executeCommand", { command = name, arguments = {} },
+      function(rerr, rres)
+        say("    %s -> err=%s result=%s", label, vim.inspect(rerr):gsub("%s+", " "),
+          vim.inspect(rres):gsub("%s+", " "))
+        settled = true
+      end)
+    if not vim.wait(2500, function() return settled end, 50) then
+      say("    %s -> request never came back", label)
+    end
+    -- The refusal notification is a separate message and can land just after the
+    -- response. Give it a moment, or it gets attributed to the NEXT command.
+    vim.wait(500, function() return #messages > before end, 20)
+    local said = {}
+    for i = before + 1, #messages do table.insert(said, messages[i]) end
+    say("    %s -> editor was told: %s", label,
+      #said == 0 and "(nothing)" or vim.inspect(said):gsub("%s+", " "):sub(1, 260))
+  end
+
+  run("mock.run", "RAW  mock.run")
+  local routed_b
+  for _, c in ipairs(offered) do
+    if c:match("repo%-b") then routed_b = c end
+  end
+  if routed_b then
+    run(routed_b, "ROUTED repo-b")
+  else
+    say("    ROUTED repo-b -> no routed entry found to try")
+  end
+
+  say("  supports_method('workspace/executeCommand') = %s",
+    tostring(client:supports_method("workspace/executeCommand")))
+end
+
+io.write(table.concat(log, "\n"), "\n")
+vim.cmd("qall!")

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -2723,44 +2723,67 @@ impl LanguageServerPool {
                         &command_registration_key,
                         palette_commands.unwrap_or_default(),
                     );
-                    // Advertise the NEWLY-added names upstream so the editor's
-                    // palette lists them. Fire-and-forget; skipped when the
-                    // client can't accept a dynamic registration — in which case
-                    // the registry is told, so it never believes the editor holds
-                    // something that was never sent.
-                    if !outcome.newly_advertised.is_empty() {
+                    // Advertise the new names upstream so the editor's palette
+                    // lists them — the raw one and this connection's routed one
+                    // in ONE request. Not two: the forwarding loop spawns a task
+                    // per request, so two would race and the editor could see
+                    // them in either order.
+                    //
+                    // Skipped when the client can't accept a dynamic
+                    // registration, in which case the registry is told, so it
+                    // never believes the editor holds something never sent.
+                    // Deduplicated: a downstream advertising both `foo` and the
+                    // literal text of `foo`'s routed name would otherwise put
+                    // two Registrations with the SAME derived id in one request,
+                    // which a client may reject wholesale — taking the unrelated
+                    // names in the batch down with it.
+                    let mut announce: Vec<String> = Vec::new();
+                    for name in outcome
+                        .newly_advertised
+                        .iter()
+                        .cloned()
+                        .chain(outcome.newly_encoded.iter().cloned())
+                    {
+                        if !announce.contains(&name) {
+                            announce.push(name);
+                        }
+                    }
+                    if !announce.is_empty() {
                         if supports_dynamic_command_registration {
-                            if let Err(e) =
-                                upstream_request_tx.send(UpstreamRequest::RegisterCommands {
-                                    commands: outcome.newly_advertised.clone(),
-                                })
+                            if let Err(e) = upstream_request_tx
+                                .send(UpstreamRequest::RegisterCommands { commands: announce })
                             {
                                 log::warn!(
                                     target: "kakehashi::bridge",
                                     "Failed to queue palette-command registration \
                                      (forwarding loop gone): {e}"
                                 );
-                                command_origins.forget_registration(&outcome.newly_advertised);
+                                command_origins.forget_registration(&outcome);
                             }
                         } else {
-                            command_origins.forget_registration(&outcome.newly_advertised);
+                            command_origins.forget_registration(&outcome);
                         }
                     }
                     // A name whose every advertiser has stopped offering it is
                     // dead even though its server is still configured — the
                     // in-place-upgrade shape, which the config-driven sweep
-                    // cannot see.
+                    // cannot see. Encoded entries retire per connection, so one
+                    // server dropping a command takes only its own rows.
+                    //
                     // Gated like every other send on this path. It is currently
                     // redundant — with no capability nothing was announced, so
                     // nothing can be orphaned — but that is an invariant two
                     // steps away, and a retirement that stops asking would name
                     // ids the editor never held.
-                    if !outcome.orphaned.is_empty()
+                    let dead: Vec<String> = outcome
+                        .orphaned
+                        .into_iter()
+                        .chain(outcome.retired_encoded)
+                        .collect();
+                    if !dead.is_empty()
                         && supports_dynamic_command_registration
-                        && let Err(e) =
-                            upstream_request_tx.send(UpstreamRequest::UnregisterCommands {
-                                commands: outcome.orphaned,
-                            })
+                        && let Err(e) = upstream_request_tx
+                            .send(UpstreamRequest::UnregisterCommands { commands: dead })
                     {
                         log::warn!(
                             target: "kakehashi::bridge",
@@ -7649,8 +7672,16 @@ mod tests {
         pool.propagate_settings(|_| None).await;
 
         match rx.try_recv() {
-            Ok(super::UpstreamRequest::UnregisterCommands { commands }) => {
-                assert_eq!(commands, vec!["ruff.fix".to_string()]);
+            Ok(super::UpstreamRequest::UnregisterCommands { mut commands }) => {
+                commands.sort();
+                assert_eq!(
+                    commands,
+                    vec![
+                        "kakehashi|c|ruff||ruff.fix".to_string(),
+                        "ruff.fix".to_string()
+                    ],
+                    "the raw entry AND the routed one that named the gone connection"
+                );
             }
             Ok(_) => panic!("expected an UnregisterCommands request"),
             Err(e) => panic!("expected an UnregisterCommands request, got {e:?}"),
@@ -7700,8 +7731,16 @@ mod tests {
         .await;
 
         match rx.try_recv() {
-            Ok(super::UpstreamRequest::UnregisterCommands { commands }) => {
-                assert_eq!(commands, vec!["ruff.fix".to_string()]);
+            Ok(super::UpstreamRequest::UnregisterCommands { mut commands }) => {
+                commands.sort();
+                assert_eq!(
+                    commands,
+                    vec![
+                        "kakehashi|c|ruff||ruff.fix".to_string(),
+                        "ruff.fix".to_string()
+                    ],
+                    "the raw entry AND the routed one that named the disabled server"
+                );
             }
             Ok(_) => panic!("expected an UnregisterCommands request"),
             Err(e) => panic!("expected an UnregisterCommands request, got {e:?}"),

--- a/src/lsp/bridge/pool/command_origin_registry.rs
+++ b/src/lsp/bridge/pool/command_origin_registry.rs
@@ -25,11 +25,12 @@
 //! dispatcher scans the connections map for handles whose exact advertised list
 //! contains the name, which is the only view that cannot lag a handshake.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Mutex;
 
 use super::ConnectionKey;
 use crate::error::LockResultExt;
+use crate::lsp::bridge::protocol::encode_command;
 
 /// What is known about one advertised raw command name.
 #[derive(Default)]
@@ -42,6 +43,17 @@ struct CommandOrigins {
     /// The client-fallback connections that advertised it, in first-advertisement
     /// order. Only these, because only these can be revived from the name alone.
     reconnectable: Vec<ConnectionKey>,
+    /// The connections whose ENCODED form of this name the editor was asked to
+    /// hold. Per connection, unlike `registered_upstream`: an encoded entry
+    /// names one connection, so each gets its own palette row and its own
+    /// retirement.
+    ///
+    /// "Asked to hold", not "advertises": a connection is added when its
+    /// handshake advertises the name AND the routed entry goes out, removed
+    /// when it stops advertising it, when its server leaves the config, or when
+    /// the request could not be sent at all. So it tracks the editor's side, not
+    /// the downstream's.
+    encoded_registered: HashSet<ConnectionKey>,
     /// Whether the editor currently holds a registration for this name.
     ///
     /// Distinct from the entry existing. The entry outlives the registration:
@@ -59,11 +71,16 @@ pub(crate) struct CommandOriginRegistry {
 /// What a handshake's advertisement changed.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct RegistrationOutcome {
-    /// Names the editor should now be told about.
+    /// Raw names the editor should now be told about.
     pub(crate) newly_advertised: Vec<String>,
-    /// Names this handshake left with no advertiser at all, so the editor should
-    /// stop offering them.
+    /// Raw names this handshake left with no advertiser at all, so the editor
+    /// should stop offering them.
     pub(crate) orphaned: Vec<String>,
+    /// Encoded, connection-specific names the editor should now be told about —
+    /// the unambiguous sibling of every raw entry this connection contributes.
+    pub(crate) newly_encoded: Vec<String>,
+    /// Encoded names this connection no longer backs.
+    pub(crate) retired_encoded: Vec<String>,
 }
 
 impl CommandOriginRegistry {
@@ -90,9 +107,28 @@ impl CommandOriginRegistry {
             .recover_poison("CommandOriginRegistry::register");
         // Reconcile BEFORE recording: this handshake is the current truth about
         // what `key` serves.
-        let orphaned = Self::reconcile(&mut origins, key, &commands);
+        let (orphaned, retired_encoded) = Self::reconcile(&mut origins, key, &commands);
         let mut newly_advertised = Vec::new();
+        let mut newly_encoded = Vec::new();
         for command in commands {
+            // Never ANNOUNCE a name whose text is already claimed by the other
+            // kind — checked against the WHOLE registry, because the two owners
+            // need not come from the same connection or the same handshake.
+            //
+            // The registration id is derived from the final text, so two owners
+            // of one string share one id, and either retiring would unregister
+            // what the other still needs. Nothing usable is lost by withholding:
+            // dispatch refuses that exact text anyway, since it cannot tell which
+            // of the two readings the user picked.
+            let encoded = encode_command(key, &command);
+            let routed_text_is_a_known_raw_name = origins.contains_key(&encoded);
+            let raw_text_is_a_held_routed_name =
+                crate::lsp::bridge::protocol::decode_command(&command).is_some_and(|route| {
+                    origins
+                        .get(route.command)
+                        .is_some_and(|entry| entry.encoded_registered.contains(&route.key))
+                });
+
             let entry = origins.entry(command.clone()).or_default();
             entry.servers.insert(key.server().to_string());
             // Recording a non-reconnectable key would only ever subtract: it
@@ -101,7 +137,10 @@ impl CommandOriginRegistry {
             if key.is_client_fallback() && !entry.reconnectable.contains(key) {
                 entry.reconnectable.push(key.clone());
             }
-            if !entry.registered_upstream {
+            if entry.encoded_registered.insert(key.clone()) && !routed_text_is_a_known_raw_name {
+                newly_encoded.push(encoded);
+            }
+            if !entry.registered_upstream && !raw_text_is_a_held_routed_name {
                 entry.registered_upstream = true;
                 newly_advertised.push(command);
             }
@@ -109,6 +148,8 @@ impl CommandOriginRegistry {
         RegistrationOutcome {
             newly_advertised,
             orphaned,
+            newly_encoded,
+            retired_encoded,
         }
     }
 
@@ -119,14 +160,34 @@ impl CommandOriginRegistry {
     /// or a forwarding loop that has gone away. Otherwise the registry would
     /// later try to retire an id the editor never held, and would refuse to
     /// re-offer the name if the client's capability arrived by another route.
-    pub(crate) fn forget_registration(&self, commands: &[String]) {
+    /// Take back the bookkeeping for an announcement that never reached the
+    /// editor — an unsendable request, or a client that cannot accept one.
+    ///
+    /// The two halves are taken back SEPARATELY because they are independent.
+    /// A second connection advertising a name the first already announced
+    /// contributes a routed entry and NO raw one, so keying the rollback off the
+    /// raw list would silently retain a routed row the editor never received —
+    /// and nothing would ever re-offer it. Conversely a raw name may be shared,
+    /// so clearing it from this connection's failure must not be inferred from a
+    /// routed rollback either.
+    pub(crate) fn forget_registration(&self, outcome: &RegistrationOutcome) {
         let mut origins = self
             .origins
             .lock()
             .recover_poison("CommandOriginRegistry::forget_registration");
-        for command in commands {
+        for command in &outcome.newly_advertised {
             if let Some(entry) = origins.get_mut(command) {
                 entry.registered_upstream = false;
+            }
+        }
+        for encoded in &outcome.newly_encoded {
+            // The routed name carries its own owner, so it needs no separate
+            // key argument: decoding gives back exactly the (connection, command)
+            // pair that minted it.
+            if let Some(route) = crate::lsp::bridge::protocol::decode_command(encoded)
+                && let Some(entry) = origins.get_mut(route.command)
+            {
+                entry.encoded_registered.remove(&route.key);
             }
         }
     }
@@ -149,24 +210,39 @@ impl CommandOriginRegistry {
         origins: &mut HashMap<String, CommandOrigins>,
         key: &ConnectionKey,
         commands: &[String],
-    ) -> Vec<String> {
+    ) -> (Vec<String>, Vec<String>) {
         // One set, not a linear scan per known name: this runs under the lock on
         // every handshake, against a map that keeps every name for the session.
         let advertised: std::collections::HashSet<&str> =
             commands.iter().map(String::as_str).collect();
         let mut orphaned = Vec::new();
+        let mut retired_encoded = Vec::new();
         for (command, entry) in origins.iter_mut() {
             if advertised.contains(command.as_str()) {
                 continue;
             }
             entry.reconnectable.retain(|recorded| recorded != key);
-            entry.servers.remove(key.server());
+            if entry.encoded_registered.remove(key) {
+                retired_encoded.push(encode_command(key, command));
+            }
+            // Drop the SERVER only once none of its connections advertise the
+            // name any more. One connection's handshake speaks for itself, not
+            // for its siblings: the same server rooted at two workspace folders
+            // is two connections, and the first to drop a command must not
+            // retire an entry the second still backs.
+            if !entry
+                .encoded_registered
+                .iter()
+                .any(|live| live.server() == key.server())
+            {
+                entry.servers.remove(key.server());
+            }
             if entry.registered_upstream && entry.servers.is_empty() {
                 entry.registered_upstream = false;
                 orphaned.push(command.clone());
             }
         }
-        orphaned
+        (orphaned, retired_encoded)
     }
 
     /// The names whose every advertiser is gone from `is_spawnable`, marking them
@@ -189,29 +265,45 @@ impl CommandOriginRegistry {
         // caller answers from a full wildcard merge of the config, and one
         // server typically advertises many commands — asking per (name, server)
         // pair would pay for that merge once per command on every reload.
-        let mut spawnable: HashMap<&str, bool> = HashMap::new();
+        let mut spawnable: HashMap<String, bool> = HashMap::new();
         for entry in origins.values() {
-            for server in &entry.servers {
-                if !spawnable.contains_key(server.as_str()) {
-                    spawnable.insert(server.as_str(), is_spawnable(server));
+            let servers = entry
+                .servers
+                .iter()
+                .map(String::as_str)
+                .chain(entry.encoded_registered.iter().map(ConnectionKey::server));
+            for server in servers {
+                if !spawnable.contains_key(server) {
+                    spawnable.insert(server.to_string(), is_spawnable(server));
                 }
             }
         }
-        let retired: Vec<String> = origins
-            .iter()
-            .filter(|(_, entry)| {
-                entry.registered_upstream
-                    && !entry.servers.is_empty()
-                    && !entry
-                        .servers
-                        .iter()
-                        .any(|server| spawnable[server.as_str()])
-            })
-            .map(|(command, _)| command.clone())
-            .collect();
-        for command in &retired {
-            if let Some(entry) = origins.get_mut(command) {
+        let mut retired = Vec::new();
+        for (command, entry) in origins.iter_mut() {
+            // Routed entries name a connection, so each dies with ITS OWN
+            // server. They are retired independently of the raw name, which
+            // survives as long as any advertiser does — otherwise a removed
+            // server's routed row would be left visible and broken whenever a
+            // second server kept the raw name alive.
+            let dead_keys: Vec<_> = entry
+                .encoded_registered
+                .iter()
+                .filter(|key| !spawnable.get(key.server()).copied().unwrap_or(false))
+                .cloned()
+                .collect();
+            for key in dead_keys {
+                entry.encoded_registered.remove(&key);
+                retired.push(encode_command(&key, command));
+            }
+            if entry.registered_upstream
+                && !entry.servers.is_empty()
+                && !entry
+                    .servers
+                    .iter()
+                    .any(|server| spawnable.get(server.as_str()).copied().unwrap_or(false))
+            {
                 entry.registered_upstream = false;
+                retired.push(command.clone());
             }
         }
         retired
@@ -230,6 +322,24 @@ impl CommandOriginRegistry {
             .get(command)
             .map(|entry| entry.reconnectable.clone())
             .unwrap_or_default()
+    }
+
+    /// Whether `name` is a ROUTED entry kakehashi minted and the editor still
+    /// holds — the exact question, not "does this string happen to decode".
+    ///
+    /// A downstream is free to advertise a raw id shaped like a routed name.
+    /// That is only a collision if a routed entry of the same text actually
+    /// exists; otherwise there is one reading and it routes fine, which is what
+    /// happened before these entries were registered.
+    pub(crate) fn holds_encoded(&self, name: &str) -> bool {
+        let Some(route) = crate::lsp::bridge::protocol::decode_command(name) else {
+            return false;
+        };
+        self.origins
+            .lock()
+            .recover_poison("CommandOriginRegistry::holds_encoded")
+            .get(route.command)
+            .is_some_and(|entry| entry.encoded_registered.contains(&route.key))
     }
 
     /// Whether `command` is a raw name some downstream advertised.
@@ -346,8 +456,17 @@ mod tests {
                 .is_empty()
         );
 
-        // Config drops ruff: nothing can advertise the name any more.
-        assert_eq!(reg.retire_unadvertisable(|_| false), vec!["ruff.fix"]);
+        // Config drops ruff: nothing can advertise the name any more, so BOTH
+        // the raw entry and ruff's routed one die.
+        let mut retired = reg.retire_unadvertisable(|_| false);
+        retired.sort();
+        assert_eq!(
+            retired,
+            vec![
+                "kakehashi|c|ruff||ruff.fix".to_string(),
+                "ruff.fix".to_string()
+            ]
+        );
         assert!(
             reg.is_registered("ruff.fix"),
             "the decode gate must keep recognising a retired name — a client can \
@@ -364,6 +483,123 @@ mod tests {
                 .newly_advertised,
             vec!["ruff.fix"],
             "a retired name must be re-registered, not skipped as already known"
+        );
+    }
+
+    #[test]
+    fn every_connection_gets_its_own_encoded_entry() {
+        // The escape hatch a refusal leaves the user without: a raw name shared
+        // by two roots is unresolvable, but each root's encoded entry names its
+        // own connection, so picking one IS the disambiguation.
+        let reg = CommandOriginRegistry::default();
+        let a = marker("ruff", "file:///repo-a");
+        let b = marker("ruff", "file:///repo-b");
+
+        let first = reg.register(&a, vec!["ruff.fix".to_string()]);
+        let second = reg.register(&b, vec!["ruff.fix".to_string()]);
+
+        assert_eq!(first.newly_advertised, vec!["ruff.fix".to_string()]);
+        assert!(
+            second.newly_advertised.is_empty(),
+            "the raw name is still announced exactly once"
+        );
+        assert_eq!(first.newly_encoded.len(), 1);
+        assert_eq!(second.newly_encoded.len(), 1);
+        assert_ne!(
+            first.newly_encoded, second.newly_encoded,
+            "two roots must get two distinguishable entries"
+        );
+        for encoded in first.newly_encoded.iter().chain(&second.newly_encoded) {
+            assert!(encoded.contains("ruff.fix"), "{encoded}");
+        }
+    }
+
+    #[test]
+    fn a_routed_only_announcement_that_was_never_sent_is_taken_back() {
+        // The rollback shape that keying off the RAW list misses entirely: the
+        // second connection contributes a routed entry and no raw one, because
+        // the first already announced the raw name.
+        let reg = CommandOriginRegistry::default();
+        let a = marker("ruff", "file:///repo-a");
+        let b = marker("ruff", "file:///repo-b");
+        reg.register(&a, vec!["ruff.fix".to_string()]);
+
+        let second = reg.register(&b, vec!["ruff.fix".to_string()]);
+        assert!(
+            second.newly_advertised.is_empty(),
+            "the raw name was already announced by repo-a"
+        );
+        assert_eq!(second.newly_encoded.len(), 1);
+
+        reg.forget_registration(&second);
+
+        assert_eq!(
+            reg.register(&b, vec!["ruff.fix".to_string()]).newly_encoded,
+            second.newly_encoded,
+            "a routed entry the editor never received must be offered again"
+        );
+    }
+
+    #[test]
+    fn a_text_two_owners_could_claim_is_announced_by_at_most_one() {
+        // One registration id is derived from the final text, so two owners of
+        // one string would share it and either retiring would unregister what
+        // the other still needs. At most one owner is the property that matters;
+        // WHICH one depends on advertisement order and does not.
+        //
+        // The survivor is unusable either way — dispatch refuses that exact text,
+        // since it cannot tell the two readings apart — so nothing the user could
+        // have run is lost.
+        let reg = CommandOriginRegistry::default();
+        let srv = fallback("srv");
+        let collide = encode_command(&srv, "foo");
+
+        let outcome = reg.register(&srv, vec!["foo".to_string(), collide.clone()]);
+
+        let owners = outcome
+            .newly_advertised
+            .iter()
+            .chain(&outcome.newly_encoded)
+            .filter(|name| **name == collide)
+            .count();
+        assert_eq!(
+            owners, 1,
+            "two owners would share one registration id: {outcome:?}"
+        );
+        assert!(
+            reg.is_registered(&collide),
+            "it is still a name the decode gate has to recognise"
+        );
+    }
+
+    #[test]
+    fn re_advertising_from_the_same_connection_adds_no_second_encoded_entry() {
+        let reg = CommandOriginRegistry::default();
+        let a = marker("ruff", "file:///repo-a");
+        reg.register(&a, vec!["ruff.fix".to_string()]);
+
+        assert!(
+            reg.register(&a, vec!["ruff.fix".to_string()])
+                .newly_encoded
+                .is_empty(),
+            "a respawn under the same key must not duplicate its palette row"
+        );
+    }
+
+    #[test]
+    fn one_connection_dropping_a_command_retires_only_its_own_encoded_entry() {
+        let reg = CommandOriginRegistry::default();
+        let a = marker("ruff", "file:///repo-a");
+        let b = marker("ruff", "file:///repo-b");
+        reg.register(&a, vec!["ruff.fix".to_string()]);
+        let b_entry = reg.register(&b, vec!["ruff.fix".to_string()]).newly_encoded;
+
+        let outcome = reg.register(&b, Vec::new());
+
+        assert_eq!(outcome.retired_encoded, b_entry);
+        assert!(
+            outcome.orphaned.is_empty(),
+            "the raw name survives — repo-a still advertises it"
         );
     }
 
@@ -438,13 +674,17 @@ mod tests {
         let outcome = reg.register(&ruff, vec!["ruff.fix".to_string()]);
         assert_eq!(outcome.newly_advertised, vec!["ruff.fix".to_string()]);
 
-        reg.forget_registration(&outcome.newly_advertised);
+        reg.forget_registration(&outcome);
 
+        let again = reg.register(&ruff, vec!["ruff.fix".to_string()]);
         assert_eq!(
-            reg.register(&ruff, vec!["ruff.fix".to_string()])
-                .newly_advertised,
+            again.newly_advertised,
             vec!["ruff.fix".to_string()],
             "a name that was never announced must be announceable again"
+        );
+        assert_eq!(
+            again.newly_encoded, outcome.newly_encoded,
+            "the routed entry rode the same unsent request, so it must come back too"
         );
     }
 
@@ -481,10 +721,12 @@ mod tests {
         reg.register(&fallback("ruff"), vec!["source.fixAll".to_string()]);
         reg.register(&fallback("eslint"), vec!["source.fixAll".to_string()]);
 
-        assert!(
-            reg.retire_unadvertisable(|server| server == "eslint")
-                .is_empty(),
-            "deleting one of two advertisers leaves the name real"
+        // Deleting ruff leaves the RAW name real — eslint still advertises it —
+        // but ruff's routed entry names a connection that is gone, so it must
+        // not be left visible and broken.
+        assert_eq!(
+            reg.retire_unadvertisable(|server| server == "eslint"),
+            vec!["kakehashi|c|ruff||source.fixAll".to_string()],
         );
         assert!(
             reg.retire_unadvertisable(|_| false)

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -132,10 +132,39 @@ impl LanguageServerPool {
         // PALETTE FIRST. A downstream's advertised command ids are arbitrary
         // strings, so one could in principle be shaped exactly like a routed name
         // (`kakehashi|c|srv||reload`). Decoding first would strip it to `reload`
-        // and send the wrong id. An encoded name can never be in this registry —
-        // it holds RAW advertised names — so an exact hit here is unambiguous
-        // evidence the client meant the palette command.
-        if self.command_origins().is_registered(&params.command) {
+        // and send the wrong id, so a raw-registry hit wins.
+        //
+        // That rule was safe while encoded names were minted per code-action
+        // response and never registered: the client could not be holding one as
+        // a palette entry, so a hit meant the palette command and nothing else.
+        // Registering encoded names breaks the premise. A downstream can now
+        // advertise a raw id byte-identical to an entry kakehashi minted for a
+        // DIFFERENT connection, and the two readings point at different
+        // processes with no way to tell which the user picked. Refuse — the same
+        // answer #823 gives every other unresolvable name.
+        // The test is whether a routed entry of this exact text EXISTS, not
+        // whether the string happens to decode. A downstream is free to
+        // advertise a raw id shaped like a routed name with nothing on the other
+        // side of it; that has one reading and routes fine, as it did before
+        // these entries were registered.
+        let is_raw_name = self.command_origins().is_registered(&params.command);
+        let collides_with_routed_entry = self.command_origins().holds_encoded(&params.command);
+        if collides_with_routed_entry && is_raw_name {
+            warn!(
+                target: "kakehashi::bridge",
+                "executeCommand: {:?} is both a routed name kakehashi minted and a raw id a \
+                 downstream advertised; refusing rather than guessing which was picked",
+                params.command
+            );
+            self.warn_to_editor(format!(
+                "command {:?} was not run: it is both a routed entry kakehashi created and a \
+                 raw command a downstream server advertised, so which one you picked cannot \
+                 be told apart",
+                params.command
+            ));
+            return None;
+        }
+        if is_raw_name {
             return self
                 .dispatch_palette_command(params, settings, upstream_id)
                 .await;
@@ -921,6 +950,22 @@ mod tests {
         assert_reached_downstream(dispatch(&pool, &settings, "source.fixAll")).await;
     }
 
+    /// Settings in which exactly the named servers can be spawned.
+    fn settings_with_servers(names: &[&str]) -> WorkspaceSettings {
+        let mut settings = WorkspaceSettings::default();
+        for name in names {
+            settings.language_servers.insert(
+                (*name).to_string(),
+                crate::config::settings::BridgeServerConfig {
+                    cmd: vec!["true".to_string()],
+                    languages: vec!["*".to_string()],
+                    ..Default::default()
+                },
+            );
+        }
+        settings
+    }
+
     #[tokio::test]
     async fn a_superseded_process_beside_the_current_one_does_not_make_it_ambiguous() {
         // The window's real shape: during settings propagation the OLD process
@@ -986,50 +1031,70 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_registered_raw_name_shaped_like_a_routing_token_stays_a_palette_command() {
-        // Why the palette-first gate exists: a downstream's advertised ids are
-        // arbitrary strings, so one can be shaped exactly like a minted routing
-        // token. Decoding first would strip it to its last segment and send
-        // `reload` to whatever the token's key names.
+    async fn a_raw_name_that_collides_with_a_real_routed_entry_is_refused() {
+        // The genuine collision: `srv` advertises `reload`, so kakehashi minted
+        // and registered `kakehashi|c|srv||reload` for it — and `ruff`
+        // separately advertises that exact text as a raw id of its own. The two
+        // readings name different processes with nothing to separate them.
         let pool = LanguageServerPool::new();
+        let srv = ConnectionKey::new("srv", None);
+        let ruff = ConnectionKey::new("ruff", None);
         let shaped = "kakehashi|c|srv||reload";
         assert!(
-            decode_command(shaped).is_some(),
-            "this test is only meaningful while the name really does decode"
+            pool.command_origins()
+                .register(&srv, vec!["reload".to_string()])
+                .newly_encoded
+                .contains(&shaped.to_string()),
+            "the routed entry this collides with must really have been minted"
         );
-        // `ruff` advertises the awkward name and is its sole live advertiser, so
-        // the palette path has a target. The decode path's target would be
-        // `srv`, which nothing serves — so which path ran is observable.
-        let ruff = ConnectionKey::new("ruff", None);
         pool.command_origins()
             .register(&ruff, vec![shaped.to_string()]);
         seed(&pool, &ruff, ConnectionState::Ready, &[shaped]).await;
 
-        // Treated as the raw palette command it is. Decoding it first would
-        // have stripped it to `reload` and aimed at `srv`, which nothing serves
-        // — so the dispatch would settle instead of parking.
-        assert_reached_downstream(pool.dispatch_execute_command(
+        assert_refused(pool.dispatch_execute_command(
             params(shaped),
-            &settings_with_servers(&["ruff"]),
+            &settings_with_servers(&["ruff", "srv"]),
             None,
         ))
         .await;
     }
 
-    /// Settings in which exactly the named servers can be spawned.
-    fn settings_with_servers(names: &[&str]) -> WorkspaceSettings {
-        let mut settings = WorkspaceSettings::default();
-        for name in names {
-            settings.language_servers.insert(
-                (*name).to_string(),
-                crate::config::settings::BridgeServerConfig {
-                    cmd: vec!["true".to_string()],
-                    languages: vec!["*".to_string()],
-                    ..Default::default()
-                },
-            );
-        }
-        settings
+    #[tokio::test]
+    async fn a_routed_shaped_raw_name_with_no_routed_twin_still_routes() {
+        // Decodability alone is not a collision. Nothing ever minted
+        // `kakehashi|c|srv||reload`, so there is exactly one reading of it and
+        // refusing would break a command that works.
+        let pool = LanguageServerPool::new();
+        let ruff = ConnectionKey::new("ruff", None);
+        let shaped = "kakehashi|c|srv||reload";
+        pool.command_origins()
+            .register(&ruff, vec![shaped.to_string()]);
+        seed(&pool, &ruff, ConnectionState::Ready, &[shaped]).await;
+
+        assert_reached_downstream(pool.dispatch_execute_command(
+            params(shaped),
+            &settings_with_servers(&["ruff", "srv"]),
+            None,
+        ))
+        .await;
+    }
+
+    #[tokio::test]
+    async fn an_ordinary_raw_name_still_takes_the_palette_path() {
+        // The guard must fire only on the genuine collision. A raw name that
+        // does not decode is not ambiguous with anything.
+        let pool = LanguageServerPool::new();
+        let ruff = ConnectionKey::new("ruff", None);
+        pool.command_origins()
+            .register(&ruff, vec!["ruff.fix".to_string()]);
+        seed(&pool, &ruff, ConnectionState::Ready, &["ruff.fix"]).await;
+
+        assert_reached_downstream(pool.dispatch_execute_command(
+            params("ruff.fix"),
+            &settings_with_servers(&["ruff"]),
+            None,
+        ))
+        .await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
Stacked on #950 (which is stacked on #827) — this PR's diff is only the two commits above it.

## Summary

#827 made an ambiguous raw palette name **refuse** rather than guess. That is the only
answer that never runs a command in the wrong workspace, but it leaves the user with no
way to say which workspace they meant — and per-root pooling is on by default, so two
git repositories are enough to lose a server's palette commands for the session.

This is the escape hatch: **every connection gets its own palette entry.**

N connections advertising `ruff.fix` now produce one raw entry plus N routed entries:

```
ruff.fix                                    ← the readable one; refuses when ambiguous
kakehashi|m|ruff|file:///repo-a|ruff.fix    ← unambiguous
kakehashi|m|ruff|file:///repo-b|ruff.fix    ← unambiguous
```

The raw name is all the downstream gives us and it names no workspace. But kakehashi
already mints names that *do* name a connection — for code actions — so it mints them
here too. Picking a routed entry **is** the disambiguation: the choice moves from the
router, which has no information, to the user, who does.

## Both, not either

Registering only routed names would break every user's muscle memory and every keybind
holding a raw id, and would swap a readable palette entry for a machine-generated one
in the ordinary single-connection case where nothing was ambiguous to begin with.
Registering only raw names is where #827 left us. So: both. The readable entry keeps
working when it can, and the routed one is there when it cannot.

## The gate, now measured

`docs/architecture-decisions/execute-command-routing-token.md` deferred exactly this,
pending two questions **only a real client can answer**:

1. Do clients tolerate `workspace/executeCommand` registrations accumulating as roots
   are discovered lazily? (Per-connection naming makes them disjoint rather than
   overlapping, which shrinks the question but does not answer it.)
2. Does a client that filters on registered ids also expect a human-readable id? The
   protocol has no title field — `ExecuteCommandRegistrationOptions` carries only
   `commands` — so the palette label *is* the id.

**Measured in Neovim** (v0.13 nightly), with one kakehashi spanning two `.git` roots
so one downstream server has two connections. `scripts/probe_palette_registration.lua`
is checked in so the claim is re-runnable rather than described:

```
== every executeCommand registration, in arrival order ==
  [req 1] id=kakehashi/executeCommand/mock.run
  [req 1] id=kakehashi/executeCommand/kakehashi|m|mock-codeaction|file://<root>/repo-a|mock.run
  [req 2] id=kakehashi/executeCommand/kakehashi|m|mock-codeaction|file://<root>/repo-b|mock.run
duplicate registration ids across the session: none
handler errors: none

commands the client now holds (3):
  kakehashi|m|mock-codeaction|file://<root>/repo-a|mock.run
  kakehashi|m|mock-codeaction|file://<root>/repo-b|mock.run
  mock.run

RAW  mock.run   -> result=nil, editor told: [kakehashi] command "mock.run" was not run:
                   several live connections [mock-codeaction@…/repo-b,
                   mock-codeaction@…/repo-a] advertise it …
ROUTED repo-b   -> result={ executed = "mock.run" }
```

- **Q1 answered: yes.** Registrations accumulate one per root as it is discovered and
  Neovim accepts every one without error. The raw name is announced exactly once; each
  new root adds only its own routed entry; no duplicate ids — which is precisely what
  the derived-id scheme (#950) buys.
- **Q2 answered: yes, for Neovim.** It keys dynamic registrations by *capability* name,
  so they land in `client.registrations.executeCommandProvider` — enumerable, and the
  machine-generated ids are usable as-is. Firing the raw name is refused *and reported*;
  firing repo-b's routed name runs the command on exactly that connection. That is the
  whole stack demonstrated end to end in a real client.
- **And the finding that reframes the rest:** Neovim does **not** advertise
  `workspace.executeCommand.dynamicRegistration` at all, so none of this happens there
  unless the user sets that capability. The palette registration feature — this PR's and
  #628's alike — is inert in a default Neovim.

vscode-languageclient is still unmeasured. Reverting is one condition in `pool.rs` if a
client rejects them.

## Step 5: the collision registering them creates

The palette-first gate preferred a raw-registry hit over decoding, because an encoded
name could not be a palette entry — so a hit could only mean the palette command.
Registering routed names breaks that premise. A downstream can now advertise a raw id
byte-identical to an entry kakehashi minted for a **different** connection, and the two
readings name different processes with nothing to separate them.

That collision is refused, visibly, like every other unresolvable name. The test that
pinned the old rule is replaced by one that pins the new one, plus a sibling proving an
ordinary raw name still takes the palette path — the guard has to fire only on the real
collision.

## A defect in #950 that this exposed

#950 dropped the whole SERVER from a name during reconciliation, reasoning that every
instance of one server runs the same binary. True of the binary, wrong of the
bookkeeping: one connection's handshake speaks for itself, not for its siblings, so the
first of two roots to drop a command retired an entry the second still backed. Only
per-connection tracking makes that visible, and it is fixed here — the server is
dropped once none of its connections advertise the name.

## What codex review changed

Three findings, all consequences of registering routed names that the first pass did
not follow through:

- **The collision guard fired on decodability, not on a collision.** A downstream may
  advertise a raw id shaped like a routed name; that is only ambiguous if a routed
  entry of the same text actually exists. With nothing on the other side there is one
  reading and it routes fine. The guard now asks whether kakehashi *holds* that routed
  entry. Worth stating plainly: **the test I wrote for this pinned the false positive**
  — it set up a name that merely decoded and asserted a refusal, so it would have kept
  the bug alive. Replaced by one that mints the routed entry first, plus a sibling
  proving the non-collision still routes.
- **Settings retirement never cleared routed rows**, so removing a server left its
  routed entries visible and broken — and if another server still advertised the raw
  name, nothing was returned at all and the dead row leaked silently.
- **The announcement batch was not deduplicated**, so a downstream advertising both
  `foo` and the literal text of `foo`'s routed name would put two Registrations with
  the same derived id in one request, which a client may reject wholesale.

## What bot review changed

Two findings had already been fixed before the bots reported (they reviewed an earlier
commit): the collision guard testing decodability rather than a real routed twin, and
settings retirement leaving routed rows behind. The two that survived:

- **Routed entries were not rolled back when the request was never sent.**
  `forget_registration` took back the raw name but not the routed one that travelled
  with it, so the registry believed the editor held a row it never received.
- **`encoded_registered`'s comment claimed more than it tracks** — "the editor
  currently holds" was true only when every send succeeded.

## Validation

- `cargo test --lib` — **3291 passed, 0 failed**
- e2e — `e2e_code_action` 45/0, `e2e_host_bridge` 44/0, `e2e_organize_imports` 27/0
- clippy `--lib -D warnings` clean; `--lib --tests` only the 12 pre-existing on `main`
- `cargo fmt --check` clean

**The e2e earned its keep.** `downstream_command_names_are_registered_upstream_for_the_palette`
failed on the first attempt: the forwarding loop spawns a task per upstream request, so
sending the raw and routed names as two registrations made which one the editor saw
first a race. Both names were correct, both were sent, and every unit test passed —
only the wire order was wrong, which is the one thing a unit test of the registry
cannot see. They now travel in one request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dynamic routing for encoded palette commands, allowing commands from multiple workspace connections to reach the correct destination.
  - Supports per-connection command registration and cleanup as servers become available or are removed.

- **Bug Fixes**
  - Prevented ambiguous command collisions by rejecting conflicting raw command names.
  - Improved cleanup when command registration fails or dynamic registration is unsupported.

- **Documentation**
  - Documented dynamic registration behavior and client opt-in requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->