### PR TITLE
fix(workspace): keep a configuration root when the folder list empties

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -220,6 +220,8 @@ Each `--config-file` layer uses its own directory, so two files that both say `.
 
 The **workspace root** is the first `workspaceFolders` entry, or the deprecated `rootUri`, or — if the client sends neither, or sends a non-`file:` URI — the server's working directory as a last resort. In that last case a client-supplied relative path is launch-directory-dependent after all; send a workspace folder to avoid it.
 
+The root is re-selected the same way whenever the client sends `workspace/didChangeWorkspaceFolders`, and the project `kakehashi.toml` is re-read at the new root. One rung differs there: a folder change never falls back to the working directory. Removing the last folder falls back to `rootUri`, then the deprecated `rootPath`, and otherwise leaves the session with no project layer — closing a folder must not silently adopt the configuration of whichever directory the server happens to have been launched from. A `--config-file` session keeps its config-file stack regardless, since those files are read exactly once.
+
 Resolution is two steps: a relative value is rebased onto its source directory, and then **every** value — rebased or not — goes through the variable and tilde expansion described above.
 
 A value beginning with `/`, `~`, or `$` skips the *rebasing* step only; it already says where it lives, and it is still expanded afterwards. On Windows a rooted path is likewise not rebased, whether it names a drive (`C:\parsers`) or not (`\parsers`, which means the current drive). This covers three cases worth calling out:

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -102,7 +102,11 @@ walk as a parameter.
 
 Bases per layer: a config file uses its own directory (each `--config-file`
 layer its own), `initializationOptions` and `didChangeConfiguration` use the
-initialized workspace root, and the programmed defaults have no base.
+workspace root, and the programmed defaults have no base. That root is not
+fixed at initialize: `workspace/didChangeWorkspaceFolders` re-selects it from
+the current folder list. A layer anchored earlier keeps the root it was
+anchored to, because anchoring yields absolute paths and is idempotent — see
+#948.
 
 Resolution is therefore two distinct steps, in this order:
 

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -135,7 +135,6 @@ impl ClientRoot<'_> {
 /// suppressing `X` would not leave that root empty: it would fall through to the
 /// process CWD, trading a location the client named for the launch directory
 /// #742 exists to stop depending on.
-#[allow(deprecated)]
 fn client_root(params: &InitializeParams) -> Option<ClientRoot<'_>> {
     if let Some(folder) = params
         .workspace_folders
@@ -144,6 +143,17 @@ fn client_root(params: &InitializeParams) -> Option<ClientRoot<'_>> {
     {
         return Some(ClientRoot::WorkspaceFolder(&folder.uri));
     }
+    client_root_without_folders(params)
+}
+
+/// The rungs of [`client_root`]'s ladder below `workspaceFolders`.
+///
+/// Split out because the folder list is the one input that changes after
+/// `initialize`: when `workspace/didChangeWorkspaceFolders` empties it, the
+/// session's root is whatever it would have been had the client never sent a
+/// folder, and that is exactly this ladder.
+#[allow(deprecated)]
+fn client_root_without_folders(params: &InitializeParams) -> Option<ClientRoot<'_>> {
     if let Some(uri) = params.root_uri.as_ref() {
         return Some(ClientRoot::RootUri(uri));
     }

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -272,7 +272,8 @@ impl Kakehashi {
         params: InitializeParams,
     ) -> Result<InitializeResult> {
         // Reject an unusable `--config-file` before anything from `params` is
-        // latched. Several of the stores below are first-write-wins, and
+        // latched. Several of the stores below are first-write-wins
+        // (`set_capabilities`, `set_folderless_root_path`), and
         // tower-lsp-server resets to `Uninitialized` after an error response,
         // so a client may fix the file and retry: without this, the retry would
         // load the corrected settings while downstream servers kept the failed

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -177,6 +177,23 @@ fn config_root_path(root: Option<ClientRoot<'_>>) -> (Option<std::path::PathBuf>
     }
 }
 
+/// Kakehashi's root for a session whose first workspace folder is now `folder`,
+/// where `folderless` is [`SettingsManager::folderless_root_path`].
+///
+/// This is [`config_root_path`] with the top rung supplied by the *current*
+/// folder list rather than the one `initialize` received, so a folder change
+/// resolves the root the same way the handshake did — including the process-CWD
+/// fallback for a folder URI that names no file path.
+pub(super) fn config_root_for_first_folder(
+    folder: Option<&Uri>,
+    folderless: Option<std::path::PathBuf>,
+) -> Option<std::path::PathBuf> {
+    match folder {
+        Some(uri) => config_root_path(Some(ClientRoot::WorkspaceFolder(uri))).0,
+        None => folderless,
+    }
+}
+
 /// Derive a root URI only from workspace inputs the upstream client supplied,
 /// for downstream initialization. Kakehashi may use its process CWD internally
 /// for config discovery, but forwarding that fallback would turn a
@@ -302,6 +319,12 @@ impl Kakehashi {
         // Resolved here, into owned values, because `params.capabilities` is
         // moved into the pool below and that ends any borrow of `params`.
         let (root_path, source) = config_root_path(client_root(&params));
+        // The root a later `didChangeWorkspaceFolders` falls back to once it
+        // empties the folder list: the same ladder minus its top rung, since a
+        // session that loses its last folder ends up where a session that never
+        // had one starts.
+        self.settings_manager
+            .set_folderless_root_path(config_root_path(client_root_without_folders(&params)).0);
 
         // Forward root_uri and workspace_folders to bridge pool for downstream server initialization
         let workspace_folders_for_bridge =

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -177,19 +177,24 @@ fn config_root_path(root: Option<ClientRoot<'_>>) -> (Option<std::path::PathBuf>
     }
 }
 
-/// Kakehashi's root for a session whose first workspace folder is now `folder`,
-/// where `folderless` is [`SettingsManager::folderless_root_path`].
+/// Kakehashi's root once the client's folder list has changed: the current first
+/// folder, else `folderless` — the rungs `initialize` resolved below
+/// `workspaceFolders`.
 ///
-/// This is [`config_root_path`] with the top rung supplied by the *current*
-/// folder list rather than the one `initialize` received, so a folder change
-/// resolves the root the same way the handshake did — including the process-CWD
-/// fallback for a folder URI that names no file path.
-pub(super) fn config_root_for_first_folder(
+/// Deliberately **not** [`config_root_path`]: this ladder stops at roots the
+/// client named and never reaches the process CWD. That last rung exists so a
+/// session opened with no workspace at all can still find a configuration; it is
+/// a property of how the server was launched, not of the workspace. Migrating an
+/// established session to the launch directory — where an unrelated
+/// `kakehashi.toml` may name parser libraries to load — is not something closing
+/// a folder should do. A client that named no other root gets no project layer,
+/// which is what it had before it opened the folder.
+pub(super) fn config_root_after_folder_change(
     folder: Option<&Uri>,
     folderless: Option<std::path::PathBuf>,
 ) -> Option<std::path::PathBuf> {
     match folder {
-        Some(uri) => config_root_path(Some(ClientRoot::WorkspaceFolder(uri))).0,
+        Some(uri) => ClientRoot::WorkspaceFolder(uri).to_file_path(),
         None => folderless,
     }
 }
@@ -322,9 +327,12 @@ impl Kakehashi {
         // The root a later `didChangeWorkspaceFolders` falls back to once it
         // empties the folder list: the same ladder minus its top rung, since a
         // session that loses its last folder ends up where a session that never
-        // had one starts.
-        self.settings_manager
-            .set_folderless_root_path(config_root_path(client_root_without_folders(&params)).0);
+        // had one starts. Resolved here because `params` does not outlive this
+        // request, and without `config_root_path`'s process-CWD rung — see
+        // `config_root_after_folder_change`.
+        self.settings_manager.set_folderless_root_path(
+            client_root_without_folders(&params).and_then(|root| root.to_file_path()),
+        );
 
         // Forward root_uri and workspace_folders to bridge pool for downstream server initialization
         let workspace_folders_for_bridge =
@@ -2256,6 +2264,57 @@ mod tests {
             object.insert(key.clone(), field.clone());
         }
         serde_json::from_value(value).expect("valid initialize params")
+    }
+
+    /// The folder-change ladder resolves the current first folder, exactly as
+    /// the handshake resolves `workspaceFolders[0]`.
+    #[test]
+    fn config_root_after_folder_change_uses_the_current_first_folder() {
+        use std::path::PathBuf;
+        use std::str::FromStr as _;
+        let uri = Uri::from_str("file:///current").expect("a file URI");
+
+        assert_eq!(
+            config_root_after_folder_change(Some(&uri), Some(PathBuf::from("/folderless"))),
+            Some(PathBuf::from("/current")),
+            "a folder outranks the folderless fallback",
+        );
+    }
+
+    /// An emptied folder list falls back to the rungs `initialize` resolved
+    /// below `workspaceFolders`, and to nothing when the client named none.
+    #[test]
+    fn config_root_after_folder_change_falls_back_when_no_folder_remains() {
+        use std::path::PathBuf;
+
+        assert_eq!(
+            config_root_after_folder_change(None, Some(PathBuf::from("/folderless"))),
+            Some(PathBuf::from("/folderless")),
+        );
+        assert_eq!(
+            config_root_after_folder_change(None, None),
+            None,
+            "a client that named no other root gets no project layer",
+        );
+    }
+
+    /// The launch directory is a handshake-time last resort, not somewhere a
+    /// folder change may migrate an established session: a folder URI naming no
+    /// file path leaves the session rootless rather than reaching the CWD rung
+    /// that `config_root_path` ends with.
+    #[test]
+    fn config_root_after_folder_change_never_reaches_the_process_cwd() {
+        use std::path::PathBuf;
+        use std::str::FromStr as _;
+        let uri = Uri::from_str("untitled:Untitled-1").expect("a non-file URI");
+
+        assert_eq!(config_root_after_folder_change(Some(&uri), None), None);
+        assert_eq!(
+            config_root_after_folder_change(Some(&uri), Some(PathBuf::from("/folderless"))),
+            None,
+            "an unresolvable folder does not fall through to the folderless rungs \
+             either — the handshake ladder stops at its top rung too",
+        );
     }
 
     #[test]

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -326,11 +326,11 @@ impl Kakehashi {
         // moved into the pool below and that ends any borrow of `params`.
         let (root_path, source) = config_root_path(client_root(&params));
         // The root a later `didChangeWorkspaceFolders` falls back to once it
-        // empties the folder list: the same ladder minus its top rung, since a
-        // session that loses its last folder ends up where a session that never
-        // had one starts. Resolved here because `params` does not outlive this
-        // request, and without `config_root_path`'s process-CWD rung — see
-        // `config_root_after_folder_change`.
+        // empties the folder list. Resolved here because `params` does not
+        // outlive this request, and deliberately without `config_root_path`'s
+        // process-CWD rung: a session that started folderless may load the
+        // launch directory's config, while one that lost its last folder gets
+        // no project layer — see `config_root_after_folder_change`.
         self.settings_manager.set_folderless_root_path(
             client_root_without_folders(&params).and_then(|root| root.to_file_path()),
         );

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -159,6 +159,16 @@ impl Kakehashi {
             }
         };
 
+        // Snapshot read, derivation, and publication must share the same reload
+        // transaction as post-install search-path updates, or either path can
+        // overwrite a concurrent update derived from a stale snapshot. The root
+        // read below is part of that: `didChangeWorkspaceFolders` stores a new
+        // root inside this same transaction, and anchoring against a root read
+        // outside it pins this push to a workspace the session may already have
+        // left — permanently, since anchoring yields absolute paths that no
+        // later reload re-bases.
+        let reload = lock_settings_reload().await;
+
         // A pushed path is workspace-local, matching `initializationOptions`:
         // the client knows the workspace it opened, not the directory the server
         // was launched from. Anchored here, while this push is still a layer of
@@ -172,11 +182,6 @@ impl Kakehashi {
         // previous settings in effect rather than taking the session down.
         let _ =
             crate::config::paths::anchor_settings_paths(&mut parsed, root_path.as_ref().as_deref());
-
-        // Snapshot read, derivation, and publication must share the same reload
-        // transaction as post-install search-path updates, or either path can
-        // overwrite a concurrent update derived from a stale snapshot.
-        let reload = lock_settings_reload().await;
 
         // Merge onto current effective settings (not from scratch).
         // The current settings already reflect defaults < user < project < initializationOptions,

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -26,13 +26,18 @@ impl Kakehashi {
         // snapshot the other has already replaced.
         let reload = lock_settings_reload().await;
 
-        let root_path = self
+        // An emptied folder list does not leave the session rootless: it puts it
+        // exactly where a client that never sent a folder starts, so the rungs
+        // below `workspaceFolders` answer, as they did at initialize.
+        let first_folder = self
             .bridge
             .pool()
             .workspace_folders()
-            .and_then(|folders| folders.first().cloned())
-            .and_then(|folder| super::super::uri_to_url(&folder.uri).ok())
-            .and_then(|url| url.to_file_path().ok());
+            .and_then(|folders| folders.first().cloned());
+        let root_path = super::super::lifecycle::config_root_for_first_folder(
+            first_folder.as_ref().map(|folder| &folder.uri),
+            self.settings_manager.folderless_root_path(),
+        );
         self.settings_manager.set_root_path(root_path);
 
         // An explicit `--config-file` replaces the whole config-file stack, so
@@ -41,8 +46,7 @@ impl Kakehashi {
         // exactly once by contract, which leaves this reload nothing to read
         // and only initialize's settings events to re-emit. Refreshing the root
         // — which still anchors relative paths — and stopping there is the whole
-        // of it; #746 covers reloading the project layer for the sessions that
-        // do have one.
+        // of it.
         if crate::config::expand::config_file_override().is_some() {
             return;
         }

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -39,7 +39,6 @@ impl Kakehashi {
             first_folder.as_ref().map(|folder| &folder.uri),
             self.settings_manager.folderless_root_path(),
         );
-        self.settings_manager.set_root_path(root_path);
 
         // An explicit `--config-file` replaces the whole config-file stack, so
         // the project layer at the workspace root is never consulted and no
@@ -49,10 +48,14 @@ impl Kakehashi {
         // — which still anchors relative paths — and stopping there is the whole
         // of it.
         if crate::config::expand::config_file_override().is_some() {
+            self.settings_manager.set_root_path(root_path);
             return;
         }
 
-        let root_path = self.settings_manager.root_path().as_ref().clone();
+        // The root stays local until the settings derived from it are the ones
+        // in effect. Publishing it earlier would leave a rejected reload with
+        // the new root over the old snapshot, so the next pushed layer would
+        // anchor to a workspace the settings in effect know nothing about.
         let client_override = self.client_settings_override.load_full();
         let outcome = load_settings(
             root_path.as_deref(),
@@ -77,6 +80,7 @@ impl Kakehashi {
         ) {
             Ok(settings) => {
                 let warnings = Self::misconfigured_settings_warnings(&settings);
+                self.settings_manager.set_root_path(root_path);
                 self.apply_raw_settings_locked(&reload, raw, settings).await;
                 drop(reload);
                 self.warn_on_misconfigured_settings(&warnings).await;

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -5,7 +5,7 @@ use tower_lsp_server::ls_types::DidChangeWorkspaceFoldersParams;
 use crate::config::WorkspaceSettings;
 use crate::lsp::{SettingsSource, load_settings};
 
-use super::super::{Kakehashi, lock_settings_reload};
+use super::super::{Kakehashi, lifecycle::config_root_after_folder_change, lock_settings_reload};
 
 impl Kakehashi {
     pub(crate) async fn did_change_workspace_folders_impl(
@@ -26,15 +26,16 @@ impl Kakehashi {
         // snapshot the other has already replaced.
         let reload = lock_settings_reload().await;
 
-        // An emptied folder list does not leave the session rootless: it puts it
-        // exactly where a client that never sent a folder starts, so the rungs
-        // below `workspaceFolders` answer, as they did at initialize.
+        // An emptied folder list does not leave the session rootless when the
+        // client named another root: the rungs below `workspaceFolders` answer,
+        // as they did at initialize. A client that named none gets no project
+        // layer rather than the launch directory.
         let first_folder = self
             .bridge
             .pool()
             .workspace_folders()
             .and_then(|folders| folders.first().cloned());
-        let root_path = super::super::lifecycle::config_root_for_first_folder(
+        let root_path = config_root_after_folder_change(
             first_folder.as_ref().map(|folder| &folder.uri),
             self.settings_manager.folderless_root_path(),
         );

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -14,17 +14,25 @@ impl Kakehashi {
     ) {
         let added = params.event.added;
         let removed = params.event.removed;
-        self.bridge
-            .pool()
-            .apply_workspace_folder_change(added, &removed)
-            .await;
 
         // Reading the settings in effect, merging the reloaded root onto them,
         // and publishing the result share the one reload transaction
         // `workspace/didChangeConfiguration` uses. Without it a configuration
         // push racing this notification can publish a merge derived from the
         // snapshot the other has already replaced.
+        //
+        // The pool's folder set moves inside that transaction too: it is what
+        // the configuration root is derived from, so committing it first would
+        // let a push anchor against the old root after the workspace has
+        // already moved. The lock order is reload-then-connections on every
+        // path that takes both, since the settings reload also reaches the
+        // bridge.
         let reload = lock_settings_reload().await;
+
+        self.bridge
+            .pool()
+            .apply_workspace_folder_change(added, &removed)
+            .await;
 
         // An emptied folder list does not leave the session rootless when the
         // client named another root: the rungs below `workspaceFolders` answer,

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -45,9 +45,14 @@ pub(crate) struct SettingsSnapshot {
 pub(crate) struct SettingsManager {
     root_path: ArcSwap<Option<PathBuf>>,
     /// The root to fall back to once the client's workspace-folder list is
-    /// empty: `initialize`'s ladder below `workspaceFolders` (`rootUri`, then
-    /// the deprecated `rootPath`, then the process CWD), resolved during
-    /// `initialize` because the params it reads do not outlive that request.
+    /// empty: the roots `initialize` was given below `workspaceFolders` —
+    /// `rootUri`, then the deprecated `rootPath` — resolved during `initialize`
+    /// because the params it reads do not outlive that request.
+    ///
+    /// Stops there deliberately. `initialize` itself ends at the process
+    /// working directory, but that rung answers for a session opened with no
+    /// workspace at all; a session that had one and lost it gets no project
+    /// layer instead. See `config_root_after_folder_change`.
     ///
     /// A `OnceLock` because no rung below `workspaceFolders` can change after
     /// the handshake — only the folder list does.

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -1,17 +1,25 @@
 //! `SettingsManager`: workspace settings (`ArcSwap`, hot-swappable via
-//! `apply_settings`) plus initialize-only state — `client_capabilities` (a
-//! `OnceLock`) and `root_path`.
+//! `apply_settings`) plus initialize-only state — `client_capabilities` and
+//! `folderless_root_path` (both `OnceLock`) — and `root_path`, which is not
+//! initialize-only; see below.
 //!
 //! `root_path` is an `ArcSwap`, not a `OnceLock`, because `initialize()` is not
 //! its only writer: `didChangeWorkspaceFolders` restores it when the client's
 //! folder list changes. Configuration depends on that value — it is the base
 //! every relative path in a client-supplied layer is resolved against
-//! (`config::paths`) — so two writers would otherwise let a
-//! `didChangeConfiguration` read one root, the handler store another, and the
-//! merge then hold paths anchored to two different workspaces. What keeps that
-//! sound is that the second writer stores the root and re-derives the settings
-//! inside the same settings-reload transaction; any further writer has to do
-//! the same.
+//! (`config::paths`) — so an unsynchronized reader could anchor one layer to a
+//! root the session has already left, and the merge would then hold paths
+//! anchored to two different workspaces. What keeps that sound is that every
+//! writer AND every reader that anchors takes the settings-reload transaction;
+//! any further one has to do the same.
+//!
+//! Two carve-outs the transaction does not cover, both tracked by #948:
+//!
+//! - an explicit `--config-file` session stores the new root and returns
+//!   without re-deriving, since no file layer of its can change with the root;
+//! - a `didChangeConfiguration` layer is anchored when it is pushed and
+//!   accumulated in that form, so a later root change moves the project layer
+//!   and `initializationOptions` (stored raw) but not that layer's paths.
 
 use arc_swap::ArcSwap;
 use path_clean::PathClean;
@@ -64,6 +72,7 @@ impl std::fmt::Debug for SettingsManager {
         f.debug_struct("SettingsManager")
             .field("root_path", &"ArcSwap<Option<PathBuf>>")
             .field("settings_snapshot", &"ArcSwap<SettingsSnapshot>")
+            .field("folderless_root_path", &"OnceLock<Option<PathBuf>>")
             .field("client_capabilities", &"OnceLock<ClientCapabilities>")
             .finish()
     }
@@ -163,9 +172,15 @@ impl SettingsManager {
 
     /// Set the workspace root path.
     ///
-    /// Called during initialize() to store the workspace root derived from
+    /// Called during `initialize()` with the root derived from
     /// `workspace_folders`, `root_uri` (deprecated but supported for backward
-    /// compatibility), or the current working directory.
+    /// compatibility), `root_path` (likewise), or the current working
+    /// directory — and again by `didChangeWorkspaceFolders` when the client's
+    /// folder list changes, where the ladder stops before that last rung.
+    ///
+    /// A writer must hold the settings-reload transaction and re-derive the
+    /// settings under it; see the module doc for why, and for the two
+    /// carve-outs that exist today.
     pub(crate) fn set_root_path(&self, path: Option<PathBuf>) {
         self.root_path.store(Arc::new(path));
     }
@@ -178,6 +193,9 @@ impl SettingsManager {
     /// Record the root a later folder change falls back to once the client's
     /// folder list is empty. Set once, during `initialize`.
     pub(crate) fn set_folderless_root_path(&self, path: Option<PathBuf>) {
+        // First-write-wins, like `set_capabilities`: the LSP handshake runs at
+        // most once per session, and the one initialize path that can fail and
+        // be retried returns before reaching this call.
         let _ = self.folderless_root_path.set(path);
     }
 

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -2,14 +2,16 @@
 //! `apply_settings`) plus initialize-only state — `client_capabilities` (a
 //! `OnceLock`) and `root_path`.
 //!
-//! `root_path` is an `ArcSwap`, not a `OnceLock`, but only `initialize()` calls
-//! [`SettingsManager::set_root_path`], and configuration now depends on that:
-//! it is the base every relative path in a client-supplied layer is resolved
-//! against (`config::paths`). A second writer — a `didChangeWorkspaceFolders`
-//! handler, say — would let a `didChangeConfiguration` read one root, the
-//! handler store another, and the merge then hold paths anchored to two
-//! different workspaces. Anything that makes it genuinely mutable has to make
-//! the read and the merge share the settings-reload transaction.
+//! `root_path` is an `ArcSwap`, not a `OnceLock`, because `initialize()` is not
+//! its only writer: `didChangeWorkspaceFolders` restores it when the client's
+//! folder list changes. Configuration depends on that value — it is the base
+//! every relative path in a client-supplied layer is resolved against
+//! (`config::paths`) — so two writers would otherwise let a
+//! `didChangeConfiguration` read one root, the handler store another, and the
+//! merge then hold paths anchored to two different workspaces. What keeps that
+//! sound is that the second writer stores the root and re-derives the settings
+//! inside the same settings-reload transaction; any further writer has to do
+//! the same.
 
 use arc_swap::ArcSwap;
 use path_clean::PathClean;
@@ -34,6 +36,14 @@ pub(crate) struct SettingsSnapshot {
 
 pub(crate) struct SettingsManager {
     root_path: ArcSwap<Option<PathBuf>>,
+    /// The root to fall back to once the client's workspace-folder list is
+    /// empty: `initialize`'s ladder below `workspaceFolders` (`rootUri`, then
+    /// the deprecated `rootPath`, then the process CWD), resolved during
+    /// `initialize` because the params it reads do not outlive that request.
+    ///
+    /// A `OnceLock` because no rung below `workspaceFolders` can change after
+    /// the handshake — only the folder list does.
+    folderless_root_path: OnceLock<Option<PathBuf>>,
     settings_snapshot: ArcSwap<SettingsSnapshot>,
     /// Client capabilities from initialize() - immutable after initialization.
     /// Uses OnceLock to enforce "set once, read many" semantics per LSP protocol.
@@ -85,6 +95,7 @@ impl SettingsManager {
 
         Self {
             root_path: ArcSwap::new(Arc::new(None)),
+            folderless_root_path: OnceLock::new(),
             settings_snapshot: ArcSwap::new(Arc::new(SettingsSnapshot {
                 raw_settings: Arc::new(raw_settings),
                 settings: Arc::new(settings),
@@ -162,6 +173,18 @@ impl SettingsManager {
     /// Get the current workspace root path.
     pub(crate) fn root_path(&self) -> Arc<Option<PathBuf>> {
         self.root_path.load_full()
+    }
+
+    /// Record the root a later folder change falls back to once the client's
+    /// folder list is empty. Set once, during `initialize`.
+    pub(crate) fn set_folderless_root_path(&self, path: Option<PathBuf>) {
+        let _ = self.folderless_root_path.set(path);
+    }
+
+    /// The root for a session with no workspace folders — `None` before
+    /// `initialize` resolves one, and also when no rung of its ladder answered.
+    pub(crate) fn folderless_root_path(&self) -> Option<PathBuf> {
+        self.folderless_root_path.get().cloned().flatten()
     }
 
     /// Load the current workspace settings.

--- a/tests/e2e_workspace_folder_config.rs
+++ b/tests/e2e_workspace_folder_config.rs
@@ -1,0 +1,116 @@
+//! End-to-end tests for the configuration reload driven by
+//! `workspace/didChangeWorkspaceFolders`.
+//!
+//! The handler picks kakehashi's own configuration root from the current folder
+//! list, so a folder change re-reads the project `kakehashi.toml` at the new
+//! root. These tests pin which root it picks — including when the client removes
+//! the last folder, where the root has to come from the same ladder
+//! `initialize` uses.
+//!
+//! Run with: `cargo test --test e2e_workspace_folder_config --features e2e`
+
+#![cfg(feature = "e2e")]
+
+mod helpers;
+
+use helpers::lsp_client::LspClient;
+use serde_json::json;
+use std::time::Duration;
+use tempfile::TempDir;
+
+/// A directory holding a project config whose `searchPaths` names it.
+fn project_dir(marker: &str) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(
+        dir.path().join("kakehashi.toml"),
+        format!("searchPaths = [\"/{marker}\"]\n"),
+    )
+    .unwrap();
+    dir
+}
+
+fn uri_of(dir: &TempDir) -> String {
+    format!("file://{}", dir.path().display())
+}
+
+fn folder(dir: &TempDir, name: &str) -> serde_json::Value {
+    json!({ "uri": uri_of(dir), "name": name })
+}
+
+fn query_effective_settings(client: &mut LspClient) -> serde_json::Value {
+    client
+        .send_request("kakehashi/internal/effectiveConfiguration", json!({}))
+        .get("result")
+        .expect("should have result")
+        .get("settings")
+        .expect("should have settings")
+        .clone()
+}
+
+/// Poll until `searchPaths` matches `expected`, then return the settings.
+fn poll_search_paths(client: &mut LspClient, expected: &str, msg: &str) -> serde_json::Value {
+    for _ in 0..20 {
+        let settings = query_effective_settings(client);
+        if settings["searchPaths"] == json!([expected]) {
+            return settings;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    let settings = query_effective_settings(client);
+    assert_eq!(
+        settings["searchPaths"],
+        json!([expected]),
+        "{msg}: {settings}"
+    );
+    settings
+}
+
+/// Removing the last workspace folder must not leave the session rootless.
+///
+/// `initialize` walks `workspaceFolders` → `rootUri` → `rootPath` → process CWD
+/// to choose the configuration root. Emptying the folder list puts the session
+/// in exactly the state a client that never sent a folder starts in, so the same
+/// ladder has to answer — otherwise the project layer silently disappears and
+/// relative paths in the client layers lose the base they were anchored to.
+#[test]
+fn test_removing_the_last_folder_falls_back_to_root_uri() {
+    let folder_dir = project_dir("from-folder");
+    let root_uri_dir = project_dir("from-root-uri");
+
+    let mut client = LspClient::builder()
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": uri_of(&root_uri_dir),
+            "workspaceFolders": [folder(&folder_dir, "folder")],
+            "capabilities": {}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    let settings = query_effective_settings(&mut client);
+    assert_eq!(
+        settings["searchPaths"],
+        json!(["/from-folder"]),
+        "precondition: the first workspace folder outranks rootUri: {settings}"
+    );
+
+    client.send_notification(
+        "workspace/didChangeWorkspaceFolders",
+        json!({
+            "event": {
+                "added": [],
+                "removed": [folder(&folder_dir, "folder")],
+            }
+        }),
+    );
+
+    poll_search_paths(
+        &mut client,
+        "/from-root-uri",
+        "removing the last folder should fall back to the rootUri project config",
+    );
+}

--- a/tests/e2e_workspace_folder_config.rs
+++ b/tests/e2e_workspace_folder_config.rs
@@ -114,3 +114,166 @@ fn test_removing_the_last_folder_falls_back_to_root_uri() {
         "removing the last folder should fall back to the rootUri project config",
     );
 }
+
+/// The primary root follows the client's folder order, not the change event:
+/// removing a folder that is not first leaves the configuration root alone.
+#[test]
+fn test_removing_a_non_primary_folder_keeps_the_root() {
+    let primary = project_dir("from-primary");
+    let secondary = project_dir("from-secondary");
+
+    let mut client = LspClient::builder()
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "workspaceFolders": [
+                folder(&primary, "primary"),
+                folder(&secondary, "secondary"),
+            ],
+            "capabilities": {}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    let settings = query_effective_settings(&mut client);
+    assert_eq!(
+        settings["searchPaths"],
+        json!(["/from-primary"]),
+        "precondition: the first folder is the configuration root: {settings}"
+    );
+
+    client.send_notification(
+        "workspace/didChangeWorkspaceFolders",
+        json!({
+            "event": {
+                "added": [],
+                "removed": [folder(&secondary, "secondary")],
+            }
+        }),
+    );
+
+    // Nothing should change, so poll for the *stable* value rather than a
+    // transition: a wrong root would show up as `/from-secondary` or the
+    // programmed defaults.
+    let settings = poll_search_paths(
+        &mut client,
+        "/from-primary",
+        "removing a non-primary folder must not move the configuration root",
+    );
+    assert_eq!(settings["searchPaths"], json!(["/from-primary"]));
+}
+
+/// Removing the primary folder promotes the next one in client order.
+#[test]
+fn test_removing_the_primary_folder_promotes_the_next() {
+    let primary = project_dir("from-primary");
+    let secondary = project_dir("from-secondary");
+
+    let mut client = LspClient::builder()
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "workspaceFolders": [
+                folder(&primary, "primary"),
+                folder(&secondary, "secondary"),
+            ],
+            "capabilities": {}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+    let settings = query_effective_settings(&mut client);
+    assert_eq!(
+        settings["searchPaths"],
+        json!(["/from-primary"]),
+        "precondition"
+    );
+
+    client.send_notification(
+        "workspace/didChangeWorkspaceFolders",
+        json!({
+            "event": {
+                "added": [],
+                "removed": [folder(&primary, "primary")],
+            }
+        }),
+    );
+
+    poll_search_paths(
+        &mut client,
+        "/from-secondary",
+        "removing the primary folder should promote the next one",
+    );
+}
+
+/// A folder change replaces the project-file layer only. The layers the client
+/// supplied — `initializationOptions` and everything pushed since — outrank it
+/// and must survive the reload.
+#[test]
+fn test_folder_change_preserves_client_layers() {
+    let primary = project_dir("from-primary");
+    let secondary = project_dir("from-secondary");
+
+    let mut client = LspClient::builder()
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "workspaceFolders": [
+                folder(&primary, "primary"),
+                folder(&secondary, "secondary"),
+            ],
+            "initializationOptions": { "diagnosticsDebounceMs": 111 },
+            "capabilities": {}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": { "kakehashi": { "diagnosticsDebounceMs": 222 } } }),
+    );
+    for _ in 0..20 {
+        if query_effective_settings(&mut client)["diagnosticsDebounceMs"] == json!(222) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    let settings = query_effective_settings(&mut client);
+    assert_eq!(
+        settings["diagnosticsDebounceMs"],
+        json!(222),
+        "precondition: the runtime layer outranks initializationOptions: {settings}"
+    );
+
+    client.send_notification(
+        "workspace/didChangeWorkspaceFolders",
+        json!({
+            "event": {
+                "added": [],
+                "removed": [folder(&primary, "primary")],
+            }
+        }),
+    );
+
+    let settings = poll_search_paths(
+        &mut client,
+        "/from-secondary",
+        "the project layer should follow the new root",
+    );
+    assert_eq!(
+        settings["diagnosticsDebounceMs"],
+        json!(222),
+        "the client layers must survive a project-layer reload: {settings}"
+    );
+}

--- a/tests/e2e_workspace_folder_config.rs
+++ b/tests/e2e_workspace_folder_config.rs
@@ -4,8 +4,9 @@
 //! The handler picks kakehashi's own configuration root from the current folder
 //! list, so a folder change re-reads the project `kakehashi.toml` at the new
 //! root. These tests pin which root it picks — including when the client removes
-//! the last folder, where the root has to come from the same ladder
-//! `initialize` uses.
+//! the last folder, where the root comes from the rungs `initialize` resolved
+//! below `workspaceFolders`, and where the ladder deliberately stops before the
+//! process working directory.
 //!
 //! Run with: `cargo test --test e2e_workspace_folder_config --features e2e`
 
@@ -14,23 +15,35 @@
 mod helpers;
 
 use helpers::lsp_client::LspClient;
+use helpers::lsp_polling::poll_until;
 use serde_json::json;
-use std::time::Duration;
 use tempfile::TempDir;
 
 /// A directory holding a project config whose `searchPaths` names it.
 fn project_dir(marker: &str) -> TempDir {
     let dir = TempDir::new().unwrap();
+    write_marker(&dir, marker);
+    dir
+}
+
+/// Repoint a project config at a new marker, so the only way to observe it is a
+/// reload that reads that directory again.
+fn write_marker(dir: &TempDir, marker: &str) {
     std::fs::write(
         dir.path().join("kakehashi.toml"),
         format!("searchPaths = [\"/{marker}\"]\n"),
     )
     .unwrap();
-    dir
 }
 
+/// A canonical `file://` URI. Built via `Url::from_file_path` rather than string
+/// formatting so the URI is RFC-canonical and percent-encoded — a `TMPDIR`
+/// containing a space would otherwise produce something kakehashi's
+/// `url::Url::parse` rejects.
 fn uri_of(dir: &TempDir) -> String {
-    format!("file://{}", dir.path().display())
+    url::Url::from_file_path(dir.path())
+        .expect("valid file URI")
+        .to_string()
 }
 
 fn folder(dir: &TempDir, name: &str) -> serde_json::Value {
@@ -47,31 +60,31 @@ fn query_effective_settings(client: &mut LspClient) -> serde_json::Value {
         .clone()
 }
 
-/// Poll until `searchPaths` matches `expected`, then return the settings.
-fn poll_search_paths(client: &mut LspClient, expected: &str, msg: &str) -> serde_json::Value {
-    for _ in 0..20 {
+/// Poll until `searchPaths` equals `expected`.
+///
+/// Every caller polls for a value that differs from the one in effect when the
+/// notification was sent, so this is a barrier on the reload rather than a
+/// sample that can pass before the handler has run.
+fn poll_search_paths(client: &mut LspClient, expected: serde_json::Value, msg: &str) {
+    let settled = poll_until(20, 100, || {
         let settings = query_effective_settings(client);
-        if settings["searchPaths"] == json!([expected]) {
-            return settings;
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
-    let settings = query_effective_settings(client);
-    assert_eq!(
-        settings["searchPaths"],
-        json!([expected]),
-        "{msg}: {settings}"
+        (settings["searchPaths"] == expected).then_some(settings)
+    });
+    assert!(
+        settled.is_some(),
+        "{msg}; last seen: {}",
+        query_effective_settings(client)["searchPaths"]
     );
-    settings
 }
 
-/// Removing the last workspace folder must not leave the session rootless.
+/// Removing the last workspace folder must not leave the session rootless when
+/// the client named another root.
 ///
-/// `initialize` walks `workspaceFolders` → `rootUri` → `rootPath` → process CWD
-/// to choose the configuration root. Emptying the folder list puts the session
-/// in exactly the state a client that never sent a folder starts in, so the same
-/// ladder has to answer — otherwise the project layer silently disappears and
-/// relative paths in the client layers lose the base they were anchored to.
+/// `initialize` walks `workspaceFolders` → `rootUri` → `rootPath`, and an empty
+/// folder list deliberately does not suppress those deprecated fields
+/// (`client_root`). Emptying the list through a notification reaches the same
+/// state, so the same rungs answer — otherwise the project layer silently
+/// disappears and relative paths in the client layers lose their base.
 #[test]
 fn test_removing_the_last_folder_falls_back_to_root_uri() {
     let folder_dir = project_dir("from-folder");
@@ -110,8 +123,111 @@ fn test_removing_the_last_folder_falls_back_to_root_uri() {
 
     poll_search_paths(
         &mut client,
-        "/from-root-uri",
+        json!(["/from-root-uri"]),
         "removing the last folder should fall back to the rootUri project config",
+    );
+}
+
+/// The common client shape: `rootUri` names the same directory as the only
+/// workspace folder (Neovim and single-folder VS Code both send this).
+///
+/// Removing that folder restores the root to the directory the client just
+/// closed, so its `kakehashi.toml` stays in effect. That follows from the rung
+/// order rather than being chosen for this case, and it matches `client_root`'s
+/// existing refusal to let an empty folder list suppress `rootUri` — pinned here
+/// because this shape is the one real clients produce.
+#[test]
+fn test_removing_the_last_folder_keeps_a_root_uri_that_names_it() {
+    let dir = project_dir("from-shared-root");
+
+    let mut client = LspClient::builder()
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": uri_of(&dir),
+            "workspaceFolders": [folder(&dir, "root")],
+            "capabilities": {}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+    assert_eq!(
+        query_effective_settings(&mut client)["searchPaths"],
+        json!(["/from-shared-root"]),
+        "precondition"
+    );
+
+    // Repoint the config so the assertion below can only be satisfied by a
+    // reload that read this directory again, not by the settings already in
+    // effect.
+    write_marker(&dir, "from-shared-root-reloaded");
+    client.send_notification(
+        "workspace/didChangeWorkspaceFolders",
+        json!({
+            "event": {
+                "added": [],
+                "removed": [folder(&dir, "root")],
+            }
+        }),
+    );
+
+    poll_search_paths(
+        &mut client,
+        json!(["/from-shared-root-reloaded"]),
+        "a rootUri naming the removed folder keeps that directory as the root",
+    );
+}
+
+/// A client that named no root besides its folders gets no project layer when
+/// the last one goes — never the directory the server was launched from.
+///
+/// The working directory is `initialize`'s last resort so a session opened with
+/// no workspace can still find a configuration. Reaching it from a folder change
+/// would migrate an established session to whatever `kakehashi.toml` sits in the
+/// launch directory, which may name parser libraries to load.
+#[test]
+fn test_removing_the_last_folder_without_a_named_root_drops_the_project_layer() {
+    let folder_dir = project_dir("from-folder");
+    let launch_dir = project_dir("from-launch-dir");
+
+    let mut client = LspClient::builder()
+        .current_dir(launch_dir.path())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "workspaceFolders": [folder(&folder_dir, "folder")],
+            "capabilities": {}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+    assert_eq!(
+        query_effective_settings(&mut client)["searchPaths"],
+        json!(["/from-folder"]),
+        "precondition: the folder outranks the launch directory"
+    );
+
+    client.send_notification(
+        "workspace/didChangeWorkspaceFolders",
+        json!({
+            "event": {
+                "added": [],
+                "removed": [folder(&folder_dir, "folder")],
+            }
+        }),
+    );
+
+    // Back to the programmed default, which the launch directory's config would
+    // have replaced had the ladder reached it.
+    poll_search_paths(
+        &mut client,
+        json!(["${KAKEHASHI_DATA_DIR}"]),
+        "an unrooted session must not adopt the launch directory's config",
     );
 }
 
@@ -146,6 +262,11 @@ fn test_removing_a_non_primary_folder_keeps_the_root() {
         "precondition: the first folder is the configuration root: {settings}"
     );
 
+    // Repoint the primary's config before the change. Polling for the value
+    // already in effect would return on the first sample — passing even if the
+    // notification were dropped — so the reload has to produce a value that did
+    // not exist when it was sent.
+    write_marker(&primary, "from-primary-reloaded");
     client.send_notification(
         "workspace/didChangeWorkspaceFolders",
         json!({
@@ -156,15 +277,11 @@ fn test_removing_a_non_primary_folder_keeps_the_root() {
         }),
     );
 
-    // Nothing should change, so poll for the *stable* value rather than a
-    // transition: a wrong root would show up as `/from-secondary` or the
-    // programmed defaults.
-    let settings = poll_search_paths(
+    poll_search_paths(
         &mut client,
-        "/from-primary",
-        "removing a non-primary folder must not move the configuration root",
+        json!(["/from-primary-reloaded"]),
+        "removing a non-primary folder must reload from the unchanged primary root",
     );
-    assert_eq!(settings["searchPaths"], json!(["/from-primary"]));
 }
 
 /// Removing the primary folder promotes the next one in client order.
@@ -189,9 +306,8 @@ fn test_removing_the_primary_folder_promotes_the_next() {
         }),
     );
     client.send_notification("initialized", json!({}));
-    let settings = query_effective_settings(&mut client);
     assert_eq!(
-        settings["searchPaths"],
+        query_effective_settings(&mut client)["searchPaths"],
         json!(["/from-primary"]),
         "precondition"
     );
@@ -208,7 +324,7 @@ fn test_removing_the_primary_folder_promotes_the_next() {
 
     poll_search_paths(
         &mut client,
-        "/from-secondary",
+        json!(["/from-secondary"]),
         "removing the primary folder should promote the next one",
     );
 }
@@ -243,17 +359,13 @@ fn test_folder_change_preserves_client_layers() {
         "workspace/didChangeConfiguration",
         json!({ "settings": { "kakehashi": { "diagnosticsDebounceMs": 222 } } }),
     );
-    for _ in 0..20 {
-        if query_effective_settings(&mut client)["diagnosticsDebounceMs"] == json!(222) {
-            break;
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
-    let settings = query_effective_settings(&mut client);
-    assert_eq!(
-        settings["diagnosticsDebounceMs"],
-        json!(222),
-        "precondition: the runtime layer outranks initializationOptions: {settings}"
+    let pushed = poll_until(20, 100, || {
+        let settings = query_effective_settings(&mut client);
+        (settings["diagnosticsDebounceMs"] == json!(222)).then_some(settings)
+    });
+    assert!(
+        pushed.is_some(),
+        "precondition: the runtime layer outranks initializationOptions"
     );
 
     client.send_notification(
@@ -266,11 +378,12 @@ fn test_folder_change_preserves_client_layers() {
         }),
     );
 
-    let settings = poll_search_paths(
+    poll_search_paths(
         &mut client,
-        "/from-secondary",
+        json!(["/from-secondary"]),
         "the project layer should follow the new root",
     );
+    let settings = query_effective_settings(&mut client);
     assert_eq!(
         settings["diagnosticsDebounceMs"],
         json!(222),


### PR DESCRIPTION
## Summary

Removing the last workspace folder left the session without a configuration root, so the project `kakehashi.toml` silently stopped applying and relative paths in the client layers lost the base they were anchored to.

`initialize` picks kakehashi's own root by walking `workspaceFolders` → `rootUri` → the deprecated `rootPath` → the process working directory (`client_root` / `config_root_path`). `didChangeWorkspaceFolders` consulted only the first entry of the current folder list, so emptying that list produced `None` — a state `initialize` can never produce.

An emptied folder list puts the session where a client that never sent a folder starts, so the same rungs now answer — with one deliberate exception.

## The fallback decision (#746 asked for it explicitly)

The ladder used on a folder change stops at roots **the client named**: current first folder → `rootUri` → `rootPath`, and otherwise no project layer.

It does **not** reach `config_root_path`'s working-directory rung. That rung exists so a session opened with no workspace at all can still find a configuration; it describes how the server was launched, not the workspace. Reaching it from a folder change would migrate an established session to whatever `kakehashi.toml` sits in the launch directory — a file that can name parser libraries to `dlopen` and `searchPaths` to auto-install into. A client that named no other root gets what it had before it opened the folder: no project layer.

One consequence is worth stating plainly, because it is what most clients will see: Neovim and single-folder VS Code send `rootUri` equal to `workspaceFolders[0]`, so removing that folder keeps the directory as the configuration root. That follows from the rung order rather than being chosen for the case, and it matches `client_root`'s existing refusal to let an empty `workspaceFolders` suppress `rootUri`. Both shapes are now pinned by tests.

## What changed

- `client_root` is split so its rungs below `workspaceFolders` are reachable on their own (structural, no behavior change).
- `initialize` resolves that lower ladder once and stores it as `SettingsManager::folderless_root_path` — the params it reads do not outlive the request.
- The folder-change handler resolves the root through `config_root_after_folder_change`.
- `didChangeConfiguration` now reads the root and anchors its pushed layer **inside** the settings-reload transaction. It previously anchored before taking the lock, so a push could pin itself to a root the session had already left — permanently, since the anchored layer is what accumulates into `client_settings_override`, anchoring is idempotent, and it yields absolute paths that no later reload re-bases.

## Tests

`tests/e2e_workspace_folder_config.rs` is new: the folder-change configuration reload had **no** test before this, unit or e2e. Six cases cover the fallback rungs, client folder ordering, client-layer survival, and the two decisions above.

CI runs a bare `cargo test`, which compiles every `e2e`-gated file to nothing, so `config_root_after_folder_change` also has unit tests covering its three arms.

## Scope

This is the remaining half of #746. The other half — "preserve initializationOptions and runtime configuration layers while replacing only the project-file layer" — is implemented on main but incorrectly: those layers are preserved in already-anchored form, so a relative client path pushed under the old root can never rebind. That is Defect 1 in #948 and is deliberately not patched here; the two carve-outs it leaves are now named in the `settings_manager` module doc.

Review also turned up a pre-existing race in the bridge pool's own root URI, filed separately as #955.

Fixes #746


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace-folder changes now select the correct project root and preserve appropriate fallback roots.
  - Removing folders no longer falls back unexpectedly to the process working directory.
  - Configuration reloads now prevent stale or invalid roots from being applied.
  - Explicit configuration-file settings remain preserved during workspace changes.

- **Documentation**
  - Documented workspace-root selection and configuration path anchoring behavior.

- **Tests**
  - Added end-to-end coverage for workspace-folder additions, removals, root promotion, fallback behavior, and configuration preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->