### PR TITLE
feat(config): unify empty-means-clear across map and list settings

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -394,6 +394,22 @@ Use `base` when one language should reuse another language's parser, queries, an
 }
 ```
 
+### Omitted, empty, and non-empty
+
+Every map and list setting reads the same three ways, whichever layer it comes
+from:
+
+| | omitted | empty (`{}` / `[]`) | non-empty |
+|---|---|---|---|
+| map | inherit the layer below | **clear** it | merge per key |
+| list | inherit the layer below | **clear** it | replace wholesale |
+
+So `queries = []`, `bridge = {}`, `languageServers = {}`, `cmd = []`, and
+`captureMappings = {}` all mean "none", while leaving the key out means "I have
+nothing to say about this — keep what the layer below decided". Removing a key
+never removes a value: to override one, write the value you want (see the
+`workspace/didChangeConfiguration` notes above).
+
 For `rmd`, kakehashi will try `rmd`-specific parser/query settings first and fall back through `markdown` and then `_`. Fields set on the derived language override inherited fields. Omitted fields inherit from the base chain; `queries: []` and `bridge: {}` explicitly clear inherited query and bridge settings.
 
 Set `base` to the same language name to make a self-contained language that does not inherit from `_`:
@@ -557,12 +573,15 @@ config *files*: layers collapse before the `_` entry is resolved, so a `_`
 wildcard in your user config widens servers declared in any project's config
 too — servers you never saw when you wrote it.
 
-Opting a single server back out is `enabled = false`, not an empty
-`languages`: `[]` means "not specified here", so it resolves to whatever the
-next source supplies — that same server's list from a lower config layer if it
-has one, and otherwise the `_` wildcard, i.e. right back to `["*"]`. A concrete
-server's own non-empty `languages` does override the wildcard, so listing real
-languages narrows it as expected.
+Opting a single server back out is `enabled = false` or an empty `languages`:
+`[]` says the server handles nothing, and — unlike omitting the key, which
+inherits the next source's list and ultimately the `_` wildcard's `["*"]` — it
+does not fall back. A concrete server's own non-empty `languages` overrides the
+wildcard, so listing real languages narrows it as expected.
+
+> **Changed:** `[]` used to mean "not specified here" and inherited. Configs
+> written against that rule still parse, so kakehashi names the affected
+> servers in a warning when it loads them.
 
 **Bridge Language Configuration:**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -396,8 +396,8 @@ Use `base` when one language should reuse another language's parser, queries, an
 
 ### Omitted, empty, and non-empty
 
-Every map and list setting reads the same three ways, whichever layer it comes
-from:
+Every map- or list-**valued** setting reads the same three ways, whichever layer
+it comes from:
 
 | | omitted | empty (`{}` / `[]`) | non-empty |
 |---|---|---|---|
@@ -409,6 +409,14 @@ So `queries = []`, `bridge = {}`, `languageServers = {}`, `cmd = []`, and
 nothing to say about this — keep what the layer below decided". Removing a key
 never removes a value: to override one, write the value you want (see the
 `workspace/didChangeConfiguration` notes above).
+
+An *entry* is not a container: `[captureMappings.rust]` or `[languageServers.foo]`
+with no keys under it sets no field, so it inherits rather than clears. Clear a
+field, not the table — `[captureMappings.rust] highlights = {}`.
+
+Two settings stand outside this: the top-level `languages` map still ignores
+`{}` (it has no clear spelling yet), and `captureMappings` is additive per
+capture name rather than per language — see below.
 
 For `rmd`, kakehashi will try `rmd`-specific parser/query settings first and fall back through `markdown` and then `_`. Fields set on the derived language override inherited fields. Omitted fields inherit from the base chain; `queries: []` and `bridge: {}` explicitly clear inherited query and bridge settings.
 
@@ -528,11 +536,11 @@ languages = ["*"]
 ```
 
 `"*"` is a list element for the same reason `priorities` uses one: `_` keys
-carry field-level inheritance, list elements do not. Note that an **empty or
-omitted** `languages` does *not* mean "any" — it means "not specified here", so
-it falls through to the same server's entry in a lower config layer and, only
-if no layer specified one, to the `_` entry (wildcard-config-inheritance).
-Either way it can only ever *defer*, which is why widening needs its own
+carry field-level inheritance, list elements do not. Note that neither spelling
+of "nothing" means "any": an **omitted** `languages` falls through to the same
+server's entry in a lower config layer and, only if no layer specified one, to
+the `_` entry (wildcard-config-inheritance), while an **empty** one says the
+server handles nothing and defers to no one. Widening therefore needs its own
 marker. Keeping it in the list also leaves room for future set algebra such as
 an `"!markdown"` exclusion.
 

--- a/docs/architecture-decisions/any-language-server-wildcard.md
+++ b/docs/architecture-decisions/any-language-server-wildcard.md
@@ -80,13 +80,17 @@ languages = ["*"]
 | omitted | **not specified at this layer** (unchanged) — see below |
 | `[]` | **handles nothing** — states it, does not defer |
 
-An empty or omitted `languages` is more precisely "absent at this layer" than
+An *omitted* `languages` is more precisely "absent at this layer" than
 "inherit from `_`". Config layers (defaults < user < project <
 `initializationOptions`) collapse *before* the `_` entry is resolved, and the
-same emptiness rule drives both steps — so `checker.languages = []` in a
+same rule drives both steps — so a `checker` entry that omits `languages` in a
 project config first takes the user config's `checker.languages`, and only
 falls through to `languageServers._` when no layer specified it. A lower
 layer's concrete list therefore beats a higher layer's `_` wildcard.
+
+An *empty* one is absent at no layer: `checker.languages = []` in the project
+config states that the server handles nothing, and neither the user config nor
+`_` is consulted.
 
 - Resolved at **match time** (`handles_language`), not expanded during config
   merging. "Every language" is an open set with no static enumeration.

--- a/docs/architecture-decisions/any-language-server-wildcard.md
+++ b/docs/architecture-decisions/any-language-server-wildcard.md
@@ -31,19 +31,22 @@ appears in a document.
 
 The obvious spellings for "any" are already taken:
 
-- **`languages = []`** — `merge_bridge_server_configs`
-  (`src/config/merge.rs`) treats an empty overlay list as "not specified here",
-  which resolves to the same server's entry in a lower config layer, or failing
-  that to the `_` entry (wildcard-config-inheritance).
-- **`languages` omitted** — `#[serde(default)]` on `Vec<String>` produces that
-  same empty vec, so it lands on the identical inherit path. (`null` is not a
-  third spelling: TOML has no `null`, and an explicit JSON `null` from
-  `initializationOptions` fails to deserialize into `Vec<String>` rather than
-  defaulting — the field is neither `Option` nor `default_on_null`.)
+- **`languages` omitted** — resolves to the same server's entry in a lower
+  config layer, or failing that to the `_` entry
+  (wildcard-config-inheritance). (`null` is a synonym for omission: the field is
+  `Option`, so an explicit JSON `null` from `initializationOptions`
+  deserializes to `None`. TOML has no `null`.)
+- **`languages = []`** — states that the server handles nothing, and defers to
+  no one.
 
-Both therefore mean *defer*. A concrete server has no way to **widen** past an
-inherited narrow list — only to accept it. That is precisely the gap a
-language-agnostic server needs to fill.
+Neither can *widen*: omitting accepts whatever was inherited, and an empty list
+narrows to nothing. A concrete server has no way to widen past an inherited
+narrow list. That is precisely the gap a language-agnostic server needs to fill.
+
+> Originally both spellings meant *defer*, because the field was a bare `Vec`
+> that could not distinguish them. Splitting them (#949) did not change this
+> decision — it removed one of the two candidate spellings for "any" rather
+> than freeing it.
 
 ## Decision Drivers
 
@@ -74,7 +77,8 @@ languages = ["*"]
 | `["rust"]` | matches rust only |
 | `["*"]` | matches every language |
 | `["rust", "*"]` | matches every language — membership has no ordering, so the named entry is redundant, not restrictive |
-| `[]` / omitted | **not specified at this layer** (unchanged) — see below |
+| omitted | **not specified at this layer** (unchanged) — see below |
+| `[]` | **handles nothing** — states it, does not defer |
 
 An empty or omitted `languages` is more precisely "absent at this layer" than
 "inherit from `_`". Config layers (defaults < user < project <
@@ -191,11 +195,12 @@ the other is harder to document than the `_self` gate that already exists.
   resolved at match time, so a `_` wildcard in the user config also widens
   servers declared in a project's config. Documented with a recommendation to
   declare `"*"` on concrete servers instead.
-- **Opting a single server back out is not spellable in `languages`.** `[]`
-  means "not specified here", so it lands on the same server's list from a
-  lower config layer, or on the `_` wildcard when no layer supplied one —
-  either way not "nothing". The escape hatch is `enabled = false` (which the
-  selection sites check first, via `is_spawnable`). Narrowing to a real language list does work — a concrete
+- **Opting a single server back out is `enabled = false` or `languages = []`.**
+  Both say "nothing"; the first also stops the server from being spawned at all,
+  and the selection sites check it first via `is_spawnable`. Omitting
+  `languages` is the one spelling that does *not* opt out — it lands on the same
+  server's list from a lower config layer, or on the `_` wildcard when no layer
+  supplied one. Narrowing to a real language list works too: a concrete
   non-empty `languages` overrides the wildcard.
 - **Cost scales with injection *regions*, not with languages — and that is a
   much bigger number than it sounds.** The process count does not grow at all:
@@ -266,12 +271,10 @@ the other is harder to document than the `_self` gate that already exists.
 
 ### A. `languages = []` means "any"
 
-**Rejected because**: already means "not specified at this layer"
-(`merge_bridge_server_configs`), which resolves to a lower layer's list for the
-same server, or to the `_` entry. Redefining it would silently convert every
-server that currently defers — to either source — into an attach-to-everything
-server. Secondary: a multi-line list whose entries are all commented out
-collapses to `[]`, so the intent would be unrecoverable from the text.
+**Rejected because**: a multi-line list whose entries are all commented out
+collapses to `[]`, so "any" would be unrecoverable from the text — the reading
+most likely to be reached by accident would be the widest one. `[]` has since
+been given the opposite meaning ("handles nothing", #949), which settles it.
 
 ### B. `languages` omitted means "any"
 

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -100,6 +100,15 @@ exhaustively, so a new field on either fails to compile until it is classified;
 a new *top-level* path field is not covered, since `searchPaths` reaches the
 walk as a parameter.
 
+Omitted, empty, and non-empty are three distinct statements, uniformly across
+every map and list setting: omitted inherits the layer below, an explicit empty
+container clears it, and a non-empty one merges per key (maps) or replaces
+wholesale (lists). Expressing that requires the field to be `Option`-typed —
+`#[serde(default)]` on a bare `HashMap`/`Vec` cannot tell an omitted key from an
+empty one — so every such field carries `Option` and `skip_serializing_if`, the
+latter so settings written back out do not gain an empty container that reads as
+a clear on the next load.
+
 Bases per layer: a config file uses its own directory (each `--config-file`
 layer its own), `initializationOptions` and `didChangeConfiguration` use the
 workspace root, and the programmed defaults have no base. That root is not

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -100,14 +100,23 @@ exhaustively, so a new field on either fails to compile until it is classified;
 a new *top-level* path field is not covered, since `searchPaths` reaches the
 walk as a parameter.
 
-Omitted, empty, and non-empty are three distinct statements, uniformly across
-every map and list setting: omitted inherits the layer below, an explicit empty
+Omitted, empty, and non-empty are three distinct statements for a map- or
+list-valued setting: omitted inherits the layer below, an explicit empty
 container clears it, and a non-empty one merges per key (maps) or replaces
 wholesale (lists). Expressing that requires the field to be `Option`-typed —
 `#[serde(default)]` on a bare `HashMap`/`Vec` cannot tell an omitted key from an
-empty one — so every such field carries `Option` and `skip_serializing_if`, the
-latter so settings written back out do not gain an empty container that reads as
-a clear on the next load.
+empty one.
+
+Two consequences worth stating. A *serializing* field also needs
+`skip_serializing_if`, so a config written back out does not gain an empty
+container that reads as a clear when it is loaded again — the template `config
+init` emits is the case that matters. And an *entry* is not a container: a table
+with no fields set inherits field by field, so clearing means writing an empty
+value for the field, not an empty table.
+
+The top-level `languages` map is the one map-valued setting still outside this;
+it has no clear spelling, which is bound up with the separate question of
+disabling a language outright.
 
 Bases per layer: a config file uses its own directory (each `--config-file`
 layer its own), `initializationOptions` and `didChangeConfiguration` use the
@@ -385,7 +394,7 @@ fn load_settings(root, override_settings, home, env_fn, explicit) -> SettingsLoa
 
 - **Complexity increase**: Four config sources to understand and debug
 - **Arrays replace, not merge**: `queries` arrays are replaced entirely, not concatenated; overriding one query type requires repeating all
-- **No "unset" mechanism**: Cannot explicitly remove a field inherited from earlier layers (would need `null` support)
+- **No "unset" mechanism for scalars**: a later layer can override a scalar but not return it to unset. Map- and list-valued settings do have one — an explicit empty container clears the layer below (see the merge algorithm above).
 - **File I/O at startup**: Reading the config files adds latency (minimal in practice) — two implicit files, or however many `--config-file` arguments were given
 - **Relative paths changed meaning**: a relative value in an existing config file now resolves against that file's directory rather than wherever the server happened to be launched. Intended (it is the point of the change), but it silently relocates a user config written to be per-project — most visibly a `searchPaths` entry, whose misses are logged at debug level rather than as an error
 - **Infrastructure-integration gap**: Phases 1-3 (Sprints 118-120) built infrastructure (schema, merging, user config loading) but delivered ZERO user value until Sprint 124 wired APIs into application. Lesson: infrastructure sprints must be followed by integration sprints within 1-2 sprints to realize value.

--- a/docs/architecture-decisions/language-server-bridge.md
+++ b/docs/architecture-decisions/language-server-bridge.md
@@ -179,7 +179,7 @@ The bridge requires knowing which server to use for each language. Language serv
 |-------|----------|-------------|
 | `languageServers` | Yes | Server configurations keyed by server name (at root level) |
 | `languageServers.*.cmd` | Yes | Command array: first element is program, rest are arguments |
-| `languageServers.*.languages` | No (inherits from `_`) | Languages this server handles. The element `"*"` matches every language, for servers not tied to one (any-language-server-wildcard). An empty or omitted list is *not* "any": it inherits from the `_` entry (wildcard-config-inheritance) |
+| `languageServers.*.languages` | No (inherits from `_`) | Languages this server handles. The element `"*"` matches every language, for servers not tied to one (any-language-server-wildcard). An omitted list is *not* "any": it inherits from the `_` entry, and an empty one says the server handles nothing (wildcard-config-inheritance) |
 | `languageServers.*.initializationOptions` | No | Passed to server's `initialize` request |
 | `languageServers.*.onTypeFormattingTriggers` | No | Trigger characters for bridged `textDocument/onTypeFormatting`; the sorted union is advertised at initialize, and requests are forwarded only when the downstream also declares the typed character (#354) |
 | `languageServers.*.enabled` | No | Whether this server is eligible to spawn/use at all. Default `true`; inheritable via the `_` wildcard, so `_.enabled: false` disables every server by default while individual servers opt back in with `enabled: true` |

--- a/docs/architecture-decisions/wildcard-config-inheritance.md
+++ b/docs/architecture-decisions/wildcard-config-inheritance.md
@@ -123,29 +123,27 @@ enabled = false
 # "comment" = ""  # overridden (empty string suppresses the token)
 ```
 
-### Bare `Vec` fields: empty means "inherit", so it cannot mean anything else
+### List fields: omitted inherits, empty states
 
-For the **bare** `Vec` fields of `languageServers` (`cmd`, `languages`),
-`merge_bridge_server_configs` treats an **empty overlay list as absent** and
-takes the base value. That is what lets a concrete server omit `cmd` or
-`languages` and pick them up from the wildcard entry.
+For the list fields of `languageServers` (`cmd`, `languages`, `workspaceMarkers`,
+`onTypeFormattingTriggers`), `merge_bridge_server_configs` takes the overlay's
+list whenever the overlay wrote one — empty or not — and the base's only when
+the overlay omitted the key. The same rule resolves the `_` wildcard at read
+time (`is_spawnable_with_wildcard`, `effective_languages_with_wildcard`), so a
+concrete server that omits `cmd` picks the wildcard's up, and one that writes
+`cmd = []` states that it has none and does not.
 
 Note that "the base" is not always `_`. The same function also merges a
 same-named server across config *layers*, which happens before wildcard
-resolution — so an empty list means "not specified at this layer" and reaches
+resolution — so an omitted list means "not specified at this layer" and reaches
 `_` only when no layer specified one. A lower layer's concrete list beats a
 higher layer's `_` wildcard.
 
-The consequence is that a concrete server can only ever *defer* on those fields
-— to a lower layer's value for the same server, or to `_`. It can narrow by
-listing fewer entries, but it has no spelling for "wider than what I
-inherited", because the widest spelling (`[]`) is the defer sentinel. Where widening must be expressible, it needs a marker
-*inside* the list: see any-language-server-wildcard for `languages = ["*"]`.
-
-The `Option<Vec>` fields (`workspaceMarkers`, `onTypeFormattingTriggers`) do
-**not** follow this rule — overlay wins whenever it is `Some`, so an explicit
-`[]` there is preserved and carries its own meaning ("disable the marker
-search"), while `None` is the inherit sentinel.
+A concrete server can therefore narrow (list fewer entries), clear (`[]`), or
+defer (omit the key) — but it still has no spelling for "wider than what I
+inherited", because clearing is not widening. Where widening must be
+expressible, it needs a marker *inside* the list: see
+any-language-server-wildcard for `languages = ["*"]`.
 
 ## Consequences
 

--- a/src/analysis/semantic/legend.rs
+++ b/src/analysis/semantic/legend.rs
@@ -80,14 +80,14 @@ pub(super) fn resolve_capture(
         // Try filetype-specific mapping first
         if let Some(ft) = filetype
             && let Some(lang_mappings) = mappings.get(ft)
-            && let Some(mapped) = lang_mappings.highlights.get(capture_name)
+            && let Some(mapped) = lang_mappings.highlights().get(capture_name)
         {
             return resolve_user_mapping(mapped);
         }
 
         // Try wildcard mapping
         if let Some(wildcard_mappings) = mappings.get(WILDCARD_KEY)
-            && let Some(mapped) = wildcard_mappings.highlights.get(capture_name)
+            && let Some(mapped) = wildcard_mappings.highlights().get(capture_name)
         {
             return resolve_user_mapping(mapped);
         }
@@ -193,8 +193,8 @@ mod tests {
         mappings.insert(
             WILDCARD_KEY.to_string(),
             QueryTypeMappings {
-                highlights: wildcard_highlights,
-                folds: HashMap::new(),
+                highlights: Some(wildcard_highlights),
+                folds: None,
             },
         );
 
@@ -208,8 +208,8 @@ mod tests {
         mappings.insert(
             "rust".to_string(),
             QueryTypeMappings {
-                highlights: rust_highlights,
-                folds: HashMap::new(),
+                highlights: Some(rust_highlights),
+                folds: None,
             },
         );
 
@@ -247,8 +247,8 @@ mod tests {
         mappings.insert(
             "rust".to_string(),
             QueryTypeMappings {
-                highlights,
-                folds: HashMap::new(),
+                highlights: Some(highlights),
+                folds: None,
             },
         );
         assert_eq!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -853,8 +853,8 @@ mod tests {
         use crate::config::settings::BridgeServerConfig;
 
         let server = |cmd: Vec<&str>| BridgeServerConfig {
-            cmd: cmd.into_iter().map(String::from).collect(),
-            languages: vec![],
+            cmd: Some(cmd.into_iter().map(String::from).collect()),
+            languages: None,
             initialization_options: None,
             workspace_markers: None,
             on_type_formatting_triggers: None,
@@ -889,8 +889,8 @@ mod tests {
         use crate::config::settings::BridgeServerConfig;
 
         let server = |cmd: Vec<&str>, enabled: Option<bool>| BridgeServerConfig {
-            cmd: cmd.into_iter().map(String::from).collect(),
-            languages: vec![],
+            cmd: Some(cmd.into_iter().map(String::from).collect()),
+            languages: None,
             initialization_options: None,
             workspace_markers: None,
             on_type_formatting_triggers: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,11 @@ pub(crate) use merge::{
     merge_bridge_server_configs, merge_layer_aggregation_configs, merge_workspace_settings,
     resolve_with_wildcard,
 };
-pub(crate) use settings::{CaptureMappings, DEFAULT_DEBOUNCE_MS, QueryTypeMappings};
+pub(crate) use settings::{CaptureMapping, CaptureMappings, DEFAULT_DEBOUNCE_MS};
+// Raw and effective settings share this type, so converting between them no
+// longer names it; only the tests that build fixtures do.
+#[cfg(test)]
+pub(crate) use settings::QueryTypeMappings;
 pub use settings::{LanguageSettings, RawWorkspaceSettings, WorkspaceSettings, json_schema};
 pub(crate) use user::load_user_config;
 
@@ -45,19 +49,9 @@ fn default_search_paths() -> Vec<String> {
 /// internally by `try_from_settings`.
 fn base_convert(settings: &RawWorkspaceSettings) -> WorkspaceSettings {
     let languages = settings.languages.clone();
-    let capture_mappings = settings
-        .capture_mappings
-        .iter()
-        .map(|(lang, mappings)| {
-            (
-                lang.clone(),
-                QueryTypeMappings {
-                    highlights: mappings.highlights.clone(),
-                    folds: mappings.folds.clone(),
-                },
-            )
-        })
-        .collect();
+    // The raw and effective sides share `QueryTypeMappings`, so the layer's map
+    // carries over as-is; a raw layer that named none contributes nothing.
+    let capture_mappings = settings.capture_mappings.clone().unwrap_or_default();
 
     // Use explicit search_paths if provided, otherwise use platform defaults
     let search_paths = settings
@@ -456,19 +450,7 @@ impl WorkspaceSettings {
 impl From<&WorkspaceSettings> for RawWorkspaceSettings {
     fn from(settings: &WorkspaceSettings) -> Self {
         let languages = strip_inherited_languages(&settings.languages);
-        let capture_mappings = settings
-            .capture_mappings
-            .iter()
-            .map(|(lang, mappings)| {
-                (
-                    lang.clone(),
-                    QueryTypeMappings {
-                        highlights: mappings.highlights.clone(),
-                        folds: mappings.folds.clone(),
-                    },
-                )
-            })
-            .collect();
+        let capture_mappings = Some(settings.capture_mappings.clone());
 
         let search_paths = Some(settings.search_paths.clone());
 
@@ -973,8 +955,8 @@ mod tests {
         );
 
         let query_type_mappings = QueryTypeMappings {
-            highlights,
-            folds: HashMap::new(),
+            highlights: Some(highlights),
+            folds: None,
         };
 
         capture_mappings.insert(WILDCARD_KEY.to_string(), query_type_mappings);
@@ -983,11 +965,11 @@ mod tests {
         assert!(capture_mappings.contains_key(WILDCARD_KEY));
         let wildcard_mappings = capture_mappings.get(WILDCARD_KEY).unwrap();
         assert_eq!(
-            wildcard_mappings.highlights.get("@module"),
+            wildcard_mappings.highlights().get("@module"),
             Some(&"@namespace".to_string())
         );
         assert_eq!(
-            wildcard_mappings.highlights.get("@module.builtin"),
+            wildcard_mappings.highlights().get("@module.builtin"),
             Some(&"@namespace.defaultLibrary".to_string())
         );
     }
@@ -999,7 +981,7 @@ mod tests {
         let settings = RawWorkspaceSettings {
             search_paths: None,
             languages: HashMap::new(),
-            capture_mappings: HashMap::new(),
+            capture_mappings: None,
             auto_install: None,
             diagnostics_debounce_ms: None,
             features: None,
@@ -1029,7 +1011,7 @@ mod tests {
         let settings = RawWorkspaceSettings {
             search_paths: Some(vec!["/custom/path".to_string()]),
             languages: HashMap::new(),
-            capture_mappings: HashMap::new(),
+            capture_mappings: None,
             auto_install: None,
             diagnostics_debounce_ms: None,
             features: None,
@@ -1052,7 +1034,7 @@ mod tests {
         let settings = RawWorkspaceSettings {
             search_paths: Some(paths.clone()),
             languages: HashMap::new(),
-            capture_mappings: HashMap::new(),
+            capture_mappings: None,
             auto_install: None,
             diagnostics_debounce_ms: None,
             features: None,
@@ -1079,7 +1061,7 @@ mod tests {
         let settings = RawWorkspaceSettings {
             search_paths: None,
             languages: HashMap::new(),
-            capture_mappings: HashMap::new(),
+            capture_mappings: None,
             auto_install,
             diagnostics_debounce_ms: None,
             features: None,
@@ -1099,7 +1081,7 @@ mod tests {
         let settings = RawWorkspaceSettings {
             search_paths: None,
             languages: HashMap::new(),
-            capture_mappings: HashMap::new(),
+            capture_mappings: None,
             auto_install: None,
             diagnostics_debounce_ms: raw,
             features: None,
@@ -1511,7 +1493,7 @@ mod try_from_settings_tests {
         let settings = RawWorkspaceSettings {
             search_paths: Some(vec!["$TEST_VAR/parsers".to_string()]),
             languages: HashMap::new(),
-            capture_mappings: HashMap::new(),
+            capture_mappings: None,
             auto_install: None,
             diagnostics_debounce_ms: None,
             features: None,
@@ -1535,7 +1517,7 @@ mod try_from_settings_tests {
         let settings = RawWorkspaceSettings {
             search_paths: None,
             languages,
-            capture_mappings: HashMap::new(),
+            capture_mappings: None,
             auto_install: None,
             diagnostics_debounce_ms: None,
             features: None,
@@ -1565,7 +1547,7 @@ mod try_from_settings_tests {
         let settings = RawWorkspaceSettings {
             search_paths: None,
             languages,
-            capture_mappings: HashMap::new(),
+            capture_mappings: None,
             auto_install: None,
             diagnostics_debounce_ms: None,
             features: None,
@@ -1601,7 +1583,7 @@ mod try_from_settings_tests {
         let settings = RawWorkspaceSettings {
             search_paths: None,
             languages,
-            capture_mappings: HashMap::new(),
+            capture_mappings: None,
             auto_install: None,
             diagnostics_debounce_ms: None,
             features: None,
@@ -1623,7 +1605,7 @@ mod try_from_settings_tests {
         let settings = RawWorkspaceSettings {
             search_paths: Some(vec!["$UNDEFINED/path".to_string()]),
             languages: HashMap::new(),
-            capture_mappings: HashMap::new(),
+            capture_mappings: None,
             auto_install: None,
             diagnostics_debounce_ms: None,
             features: None,
@@ -1653,7 +1635,7 @@ mod try_from_settings_tests {
         let settings = RawWorkspaceSettings {
             search_paths: Some(vec!["$MISSING_ONE/parsers".to_string()]),
             languages,
-            capture_mappings: HashMap::new(),
+            capture_mappings: None,
             auto_install: None,
             diagnostics_debounce_ms: None,
             features: None,
@@ -1673,7 +1655,7 @@ mod try_from_settings_tests {
         let settings = RawWorkspaceSettings {
             search_paths: Some(vec!["~/parsers".to_string()]),
             languages: HashMap::new(),
-            capture_mappings: HashMap::new(),
+            capture_mappings: None,
             auto_install: None,
             diagnostics_debounce_ms: None,
             features: None,

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -83,8 +83,8 @@ fn default_language_servers() -> HashMap<String, BridgeServerConfig> {
     HashMap::from([(
         WILDCARD_KEY.to_string(),
         BridgeServerConfig {
-            cmd: vec![],
-            languages: vec![],
+            cmd: None,
+            languages: None,
             initialization_options: None,
             workspace_markers: Some(vec![RootMarker::Single(".git".to_string())]),
             on_type_formatting_triggers: None,
@@ -502,7 +502,7 @@ mod tests {
             Some(vec![RootMarker::Single(".git".to_string())])
         );
         assert!(
-            wildcard.cmd.is_empty() && wildcard.languages.is_empty(),
+            wildcard.cmd().is_empty() && wildcard.languages().is_empty(),
             "the wildcard entry is defaults-only, not a spawnable server"
         );
 

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -21,7 +21,7 @@ pub fn default_settings() -> RawWorkspaceSettings {
     RawWorkspaceSettings {
         search_paths: Some(vec!["${KAKEHASHI_DATA_DIR}".to_string()]),
         languages: default_languages(),
-        capture_mappings: default_capture_mappings(),
+        capture_mappings: Some(default_capture_mappings()),
         // Safe to carry here even though the key is deprecated: this struct is
         // also merge layer 1, and a user's own top-level value overlays THE
         // SAME key, so it wins. `languages._.autoInstall` is the one that must
@@ -228,8 +228,10 @@ pub fn default_capture_mappings() -> CaptureMappings {
 
     let highlights = default_highlight_mappings();
     let wildcard = QueryTypeMappings {
-        highlights,
-        folds: CaptureMapping::new(),
+        highlights: Some(highlights),
+        // Omitted rather than empty: the defaults layer names no folds, and an
+        // empty map would clear whatever a user layer supplies.
+        folds: None,
     };
 
     mappings.insert(WILDCARD_KEY.to_string(), wildcard);
@@ -542,7 +544,7 @@ mod tests {
 
         // "variable" should map to "variable" (identity mapping)
         assert_eq!(
-            wildcard.highlights.get("variable"),
+            wildcard.highlights().get("variable"),
             Some(&"variable".to_string()),
             "should map 'variable' capture to 'variable' token type"
         );
@@ -706,13 +708,20 @@ mod tests {
 
         // Should have capture mappings populated
         assert!(
-            !settings.capture_mappings.is_empty(),
+            settings
+                .capture_mappings
+                .as_ref()
+                .is_some_and(|m| !m.is_empty()),
             "capture_mappings should not be empty"
         );
 
         // Should contain the wildcard "_" key
         assert!(
-            settings.capture_mappings.contains_key(WILDCARD_KEY),
+            settings
+                .capture_mappings
+                .as_ref()
+                .unwrap()
+                .contains_key(WILDCARD_KEY),
             "capture_mappings should contain wildcard '_' key"
         );
     }
@@ -807,7 +816,7 @@ mod tests {
         );
         let wildcard = ws_settings.capture_mappings.get(WILDCARD_KEY).unwrap();
         assert_eq!(
-            wildcard.highlights.get("markup.strong"),
+            wildcard.highlights().get("markup.strong"),
             Some(&String::new()),
             "WorkspaceSettings should map markup.strong to empty string"
         );
@@ -824,7 +833,7 @@ mod tests {
         );
         let coord_wildcard = mappings.get(WILDCARD_KEY).unwrap();
         assert_eq!(
-            coord_wildcard.highlights.get("markup.strong"),
+            coord_wildcard.highlights().get("markup.strong"),
             Some(&String::new()),
             "Coordinator should map markup.strong to empty string after loading settings"
         );

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -85,7 +85,7 @@ pub(crate) fn merge_bridge_language_configs(
 }
 
 /// Field-level merge of two BridgeServerConfig values.
-/// Vec fields: use overlay if non-empty, else base.
+/// Vec fields: the overlay's list wins when it wrote one, empty or not.
 /// JSON Option fields: deep merge (configuration-merging-strategy).
 /// Option fields: overlay wins when present.
 pub(crate) fn merge_bridge_server_configs(
@@ -93,16 +93,10 @@ pub(crate) fn merge_bridge_server_configs(
     overlay: &BridgeServerConfig,
 ) -> BridgeServerConfig {
     BridgeServerConfig {
-        cmd: if overlay.cmd.is_empty() {
-            base.cmd.clone()
-        } else {
-            overlay.cmd.clone()
-        },
-        languages: if overlay.languages.is_empty() {
-            base.languages.clone()
-        } else {
-            overlay.languages.clone()
-        },
+        // Omitted inherits, written wins — including when what it wrote is
+        // empty, which is how a server says it has none of these.
+        cmd: overlay.cmd.clone().or_else(|| base.cmd.clone()),
+        languages: overlay.languages.clone().or_else(|| base.languages.clone()),
         initialization_options: match (
             &base.initialization_options,
             &overlay.initialization_options,
@@ -722,8 +716,8 @@ mod tests {
                 (
                     "rust-analyzer".to_string(),
                     BridgeServerConfig {
-                        cmd: vec!["rust-analyzer".to_string()],
-                        languages: vec!["rust".to_string()],
+                        cmd: Some(vec!["rust-analyzer".to_string()]),
+                        languages: Some(vec!["rust".to_string()]),
                         initialization_options: Some(json!({"checkOnSave": true})),
                         workspace_markers: None,
                         on_type_formatting_triggers: None,
@@ -735,8 +729,8 @@ mod tests {
                 (
                     "lua-language-server".to_string(),
                     BridgeServerConfig {
-                        cmd: vec!["lua-language-server".to_string()],
-                        languages: vec!["lua".to_string()],
+                        cmd: Some(vec!["lua-language-server".to_string()]),
+                        languages: Some(vec!["lua".to_string()]),
                         initialization_options: None,
                         workspace_markers: None,
                         on_type_formatting_triggers: None,
@@ -805,8 +799,8 @@ mod tests {
                     // shared key: rust-analyzer — overlay adds initOptions, inherits cmd/languages
                     "rust-analyzer".to_string(),
                     BridgeServerConfig {
-                        cmd: vec![],
-                        languages: vec![],
+                        cmd: None,
+                        languages: None,
                         initialization_options: Some(json!({"linkedProjects": ["./Cargo.toml"]})),
                         workspace_markers: None,
                         on_type_formatting_triggers: None,
@@ -819,8 +813,11 @@ mod tests {
                     // new key: pyright — added by overlay
                     "pyright".to_string(),
                     BridgeServerConfig {
-                        cmd: vec!["pyright-langserver".to_string(), "--stdio".to_string()],
-                        languages: vec!["python".to_string()],
+                        cmd: Some(vec![
+                            "pyright-langserver".to_string(),
+                            "--stdio".to_string(),
+                        ]),
+                        languages: Some(vec!["python".to_string()]),
                         initialization_options: None,
                         workspace_markers: None,
                         on_type_formatting_triggers: None,
@@ -884,8 +881,8 @@ mod tests {
             language_servers: Some(HashMap::from([(
                 "rust-analyzer".to_string(),
                 BridgeServerConfig {
-                    cmd: vec!["rust-analyzer".to_string()],
-                    languages: vec!["rust".to_string()],
+                    cmd: Some(vec!["rust-analyzer".to_string()]),
+                    languages: Some(vec!["rust".to_string()]),
                     initialization_options: None,
                     workspace_markers: None,
                     on_type_formatting_triggers: None,
@@ -1275,8 +1272,8 @@ mod tests {
         let servers = HashMap::from([(
             "_".to_string(),
             BridgeServerConfig {
-                cmd: vec!["default-lsp".to_string()],
-                languages: vec!["any".to_string()],
+                cmd: Some(vec!["default-lsp".to_string()]),
+                languages: Some(vec!["any".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -1286,15 +1283,15 @@ mod tests {
             },
         )]);
         let resolved = resolve_with_wildcard(&servers, "ra", merge_bridge_server_configs).unwrap();
-        assert_eq!(resolved.cmd, vec!["default-lsp".to_string()]);
-        assert_eq!(resolved.languages, vec!["any".to_string()]);
+        assert_eq!(resolved.cmd(), ["default-lsp".to_string()]);
+        assert_eq!(resolved.languages(), ["any".to_string()]);
 
         // Specific only → cloned
         let servers = HashMap::from([(
             "ra".to_string(),
             BridgeServerConfig {
-                cmd: vec!["rust-analyzer".to_string()],
-                languages: vec!["rust".to_string()],
+                cmd: Some(vec!["rust-analyzer".to_string()]),
+                languages: Some(vec!["rust".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -1304,16 +1301,16 @@ mod tests {
             },
         )]);
         let resolved = resolve_with_wildcard(&servers, "ra", merge_bridge_server_configs).unwrap();
-        assert_eq!(resolved.cmd, vec!["rust-analyzer".to_string()]);
-        assert_eq!(resolved.languages, vec!["rust".to_string()]);
+        assert_eq!(resolved.cmd(), ["rust-analyzer".to_string()]);
+        assert_eq!(resolved.languages(), ["rust".to_string()]);
 
         // Both → merged (specific cmd wins, empty languages inherits, initOptions deep-merged)
         let servers = HashMap::from([
             (
                 "_".to_string(),
                 BridgeServerConfig {
-                    cmd: vec!["default-lsp".to_string()],
-                    languages: vec!["any".to_string()],
+                    cmd: Some(vec!["default-lsp".to_string()]),
+                    languages: Some(vec!["any".to_string()]),
                     initialization_options: Some(json!({"defaultOption": true})),
                     workspace_markers: None,
                     on_type_formatting_triggers: None,
@@ -1325,8 +1322,8 @@ mod tests {
             (
                 "ra".to_string(),
                 BridgeServerConfig {
-                    cmd: vec!["rust-analyzer".to_string()],
-                    languages: vec![],
+                    cmd: Some(vec!["rust-analyzer".to_string()]),
+                    languages: None,
                     initialization_options: Some(json!({"linkedProjects": ["./Cargo.toml"]})),
                     workspace_markers: None,
                     on_type_formatting_triggers: None,
@@ -1337,8 +1334,8 @@ mod tests {
             ),
         ]);
         let resolved = resolve_with_wildcard(&servers, "ra", merge_bridge_server_configs).unwrap();
-        assert_eq!(resolved.cmd, vec!["rust-analyzer".to_string()]);
-        assert_eq!(resolved.languages, vec!["any".to_string()]);
+        assert_eq!(resolved.cmd(), ["rust-analyzer".to_string()]);
+        assert_eq!(resolved.languages(), ["any".to_string()]);
         let init_opts = resolved.initialization_options.unwrap();
         assert_eq!(init_opts.get("defaultOption"), Some(&json!(true)));
         assert_eq!(
@@ -1356,8 +1353,8 @@ mod tests {
         use settings::{BridgeServerConfig, RootMarker};
 
         let base = BridgeServerConfig {
-            cmd: vec![],
-            languages: vec![],
+            cmd: None,
+            languages: None,
             initialization_options: None,
             workspace_markers: Some(vec![RootMarker::Single(".git".to_string())]),
             on_type_formatting_triggers: None,
@@ -1368,8 +1365,8 @@ mod tests {
 
         // Unset overlay inherits from base (wildcard default applies)
         let inheriting = BridgeServerConfig {
-            cmd: vec!["rust-analyzer".to_string()],
-            languages: vec!["rust".to_string()],
+            cmd: Some(vec!["rust-analyzer".to_string()]),
+            languages: Some(vec!["rust".to_string()]),
             initialization_options: None,
             workspace_markers: None,
             on_type_formatting_triggers: None,
@@ -1413,8 +1410,8 @@ mod tests {
         use settings::BridgeServerConfig;
 
         let server = |prefer: Option<bool>| BridgeServerConfig {
-            cmd: vec![],
-            languages: vec![],
+            cmd: None,
+            languages: None,
             initialization_options: None,
             workspace_markers: None,
             on_type_formatting_triggers: None,
@@ -1455,8 +1452,8 @@ mod tests {
         use settings::BridgeServerConfig;
 
         let server = |enabled: Option<bool>| BridgeServerConfig {
-            cmd: vec![],
-            languages: vec![],
+            cmd: None,
+            languages: None,
             initialization_options: None,
             workspace_markers: None,
             on_type_formatting_triggers: None,
@@ -1500,8 +1497,8 @@ mod tests {
         use settings::BridgeServerConfig;
 
         let base = BridgeServerConfig {
-            cmd: vec!["default-lsp".to_string()],
-            languages: vec![],
+            cmd: Some(vec!["default-lsp".to_string()]),
+            languages: None,
             initialization_options: Some(json!({
                 "feature1": true,
                 "shared_opt": "base",
@@ -1514,8 +1511,8 @@ mod tests {
             settings: None,
         };
         let overlay = BridgeServerConfig {
-            cmd: vec!["rust-analyzer".to_string()],
-            languages: vec!["rust".to_string()],
+            cmd: Some(vec!["rust-analyzer".to_string()]),
+            languages: Some(vec!["rust".to_string()]),
             initialization_options: Some(json!({
                 "feature2": true,
                 "shared_opt": "overlay",
@@ -1607,8 +1604,8 @@ mod tests {
         use settings::BridgeServerConfig;
 
         let server = |triggers: Option<Vec<&str>>| BridgeServerConfig {
-            cmd: vec![],
-            languages: vec![],
+            cmd: None,
+            languages: None,
             initialization_options: None,
             workspace_markers: None,
             on_type_formatting_triggers: triggers
@@ -1761,8 +1758,8 @@ mod tests {
             (
                 "_".to_string(),
                 BridgeServerConfig {
-                    cmd: vec![],
-                    languages: vec![],
+                    cmd: None,
+                    languages: None,
                     initialization_options: Some(json!({ "checkOnSave": true })),
                     workspace_markers: None,
                     on_type_formatting_triggers: None,
@@ -1775,8 +1772,8 @@ mod tests {
             (
                 "rust-analyzer".to_string(),
                 BridgeServerConfig {
-                    cmd: vec!["rust-analyzer".to_string()],
-                    languages: vec!["rust".to_string()],
+                    cmd: Some(vec!["rust-analyzer".to_string()]),
+                    languages: Some(vec!["rust".to_string()]),
                     initialization_options: None, // Should inherit from wildcard
                     workspace_markers: None,
                     on_type_formatting_triggers: None,
@@ -1792,9 +1789,9 @@ mod tests {
             resolve_with_wildcard(&servers, "rust-analyzer", merge_bridge_server_configs).unwrap();
 
         // cmd from specific
-        assert_eq!(ra.cmd, vec!["rust-analyzer".to_string()]);
+        assert_eq!(ra.cmd(), ["rust-analyzer".to_string()]);
         // languages from specific
-        assert_eq!(ra.languages, vec!["rust".to_string()]);
+        assert_eq!(ra.languages(), ["rust".to_string()]);
         // initialization_options inherited from wildcard
         assert!(ra.initialization_options.is_some());
         let opts = ra.initialization_options.as_ref().unwrap();
@@ -1816,8 +1813,8 @@ mod tests {
             (
                 "_".to_string(),
                 BridgeServerConfig {
-                    cmd: vec!["default-lsp".to_string()],
-                    languages: vec!["rust".to_string(), "python".to_string()],
+                    cmd: Some(vec!["default-lsp".to_string()]),
+                    languages: Some(vec!["rust".to_string(), "python".to_string()]),
                     initialization_options: None,
                     workspace_markers: None,
                     on_type_formatting_triggers: None,
@@ -1830,8 +1827,8 @@ mod tests {
             (
                 "rust-analyzer".to_string(),
                 BridgeServerConfig {
-                    cmd: vec!["rust-analyzer".to_string()],
-                    languages: vec![], // Empty - should inherit from wildcard
+                    cmd: Some(vec!["rust-analyzer".to_string()]),
+                    languages: None, // Empty - should inherit from wildcard
                     initialization_options: None,
                     workspace_markers: None,
                     on_type_formatting_triggers: None,
@@ -1869,11 +1866,11 @@ mod tests {
         let server = found_server.unwrap();
         assert_eq!(
             server.cmd,
-            vec!["rust-analyzer".to_string()],
+            Some(vec!["rust-analyzer".to_string()]),
             "Should find rust-analyzer server"
         );
         assert!(
-            server.languages.contains(&"rust".to_string()),
+            server.languages().contains(&"rust".to_string()),
             "Resolved server should have 'rust' in languages (inherited from wildcard)"
         );
     }
@@ -2173,9 +2170,9 @@ mod tests {
     /// independently), not just the trivial no-inheritance case.
     #[test]
     fn test_is_server_spawnable_matches_full_resolution() {
-        let server = |cmd: Vec<&str>, enabled: Option<bool>| settings::BridgeServerConfig {
-            cmd: cmd.into_iter().map(String::from).collect(),
-            languages: vec![],
+        let server = |cmd: Option<Vec<&str>>, enabled: Option<bool>| settings::BridgeServerConfig {
+            cmd: cmd.map(|cmd| cmd.into_iter().map(String::from).collect()),
+            languages: None,
             initialization_options: None,
             workspace_markers: None,
             on_type_formatting_triggers: None,
@@ -2191,17 +2188,17 @@ mod tests {
         };
 
         // Case 1: server has its own cmd and enabled — no inheritance needed.
-        let servers = HashMap::from([("a".to_string(), server(vec!["x"], Some(true)))]);
+        let servers = HashMap::from([("a".to_string(), server(Some(vec!["x"]), Some(true)))]);
         assert!(is_server_spawnable(&servers, "a"));
         assert_eq!(
             is_server_spawnable(&servers, "a"),
             full_resolution(&servers, "a")
         );
 
-        // Case 2: server's own cmd is empty, inherits a non-empty cmd from `_`.
+        // Case 2: server omits its own cmd, inheriting a non-empty one from `_`.
         let servers = HashMap::from([
-            ("_".to_string(), server(vec!["shared-ls"], None)),
-            ("a".to_string(), server(vec![], None)),
+            ("_".to_string(), server(Some(vec!["shared-ls"]), None)),
+            ("a".to_string(), server(None, None)),
         ]);
         assert!(
             is_server_spawnable(&servers, "a"),
@@ -2215,8 +2212,8 @@ mod tests {
         // Case 3: server has its own cmd but the wildcard disables everything
         // by default; server doesn't override enabled — inherits disabled.
         let servers = HashMap::from([
-            ("_".to_string(), server(vec![], Some(false))),
-            ("a".to_string(), server(vec!["x"], None)),
+            ("_".to_string(), server(None, Some(false))),
+            ("a".to_string(), server(Some(vec!["x"]), None)),
         ]);
         assert!(!is_server_spawnable(&servers, "a"));
         assert_eq!(
@@ -2226,8 +2223,8 @@ mod tests {
 
         // Case 4: server re-enables itself over a disabled wildcard.
         let servers = HashMap::from([
-            ("_".to_string(), server(vec![], Some(false))),
-            ("a".to_string(), server(vec!["x"], Some(true))),
+            ("_".to_string(), server(None, Some(false))),
+            ("a".to_string(), server(Some(vec!["x"]), Some(true))),
         ]);
         assert!(is_server_spawnable(&servers, "a"));
         assert_eq!(
@@ -2237,13 +2234,13 @@ mod tests {
 
         // Case 5: name not present in the map at all — false, not a fallback
         // to the wildcard's own config.
-        let servers = HashMap::from([("_".to_string(), server(vec!["x"], Some(true)))]);
+        let servers = HashMap::from([("_".to_string(), server(Some(vec!["x"]), Some(true)))]);
         assert!(!is_server_spawnable(&servers, "missing"));
 
         // Case 6: called with the wildcard key itself — false, per the
         // documented contract (the wildcard is a template, never a server in
         // its own right), even when it has a non-empty cmd and enabled: true.
-        let servers = HashMap::from([("_".to_string(), server(vec!["x"], Some(true)))]);
+        let servers = HashMap::from([("_".to_string(), server(Some(vec!["x"]), Some(true)))]);
         assert!(
             !is_server_spawnable(&servers, WILDCARD_KEY),
             "the wildcard key itself must never report as spawnable"

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -1929,6 +1929,78 @@ mod tests {
         );
     }
 
+    /// An explicit empty map clears the layer below, the same spelling
+    /// `languageServers`, `bridge`, and `layers.aggregation` already answer to.
+    /// Omitting the key still inherits.
+    #[test]
+    fn capture_mappings_empty_map_clears_the_lower_layer() {
+        use crate::config::defaults::default_settings;
+
+        let cleared: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [captureMappings._]
+            highlights = {}
+        "#,
+        )
+        .expect("should parse");
+
+        let merged = merge_workspace_settings(Some(default_settings()), Some(cleared))
+            .expect("two settings merge");
+
+        assert!(
+            merged.capture_mappings[WILDCARD_KEY].highlights.is_empty(),
+            "an explicit empty highlights map should clear the defaults"
+        );
+    }
+
+    /// Clearing one query kind must not disturb the other: `folds` is
+    /// `#[serde(default)]`, so a layer that writes only `highlights` says
+    /// nothing about folds and must leave them alone.
+    #[test]
+    fn capture_mappings_written_highlights_leave_folds_alone() {
+        let base: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [captureMappings._.folds]
+            "comment" = "comment"
+        "#,
+        )
+        .expect("should parse");
+        let overlay: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [captureMappings._.highlights]
+            "keyword" = "keyword"
+        "#,
+        )
+        .expect("should parse");
+
+        let merged =
+            merge_workspace_settings(Some(base), Some(overlay)).expect("two settings merge");
+        let wildcard = &merged.capture_mappings[WILDCARD_KEY];
+
+        assert_eq!(
+            wildcard.folds["comment"], "comment",
+            "writing highlights must not clear folds"
+        );
+        assert_eq!(wildcard.highlights["keyword"], "keyword");
+    }
+
+    /// The whole map clears too, so a layer can drop every language's mappings.
+    #[test]
+    fn capture_mappings_empty_root_clears_every_language() {
+        use crate::config::defaults::default_settings;
+
+        let cleared: RawWorkspaceSettings =
+            toml::from_str("captureMappings = {}\n").expect("should parse");
+
+        let merged = merge_workspace_settings(Some(default_settings()), Some(cleared))
+            .expect("two settings merge");
+
+        assert!(
+            merged.capture_mappings.is_empty(),
+            "an explicit empty captureMappings should clear every language entry"
+        );
+    }
+
     #[test]
     fn test_resolve_with_wildcard_bridge_language_merges_fields() {
         // Wildcard provides aggregation defaults; specific provides enabled override

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -1980,6 +1980,74 @@ mod tests {
         );
     }
 
+    /// An explicit empty `cmd` says "this server has no command", not "inherit
+    /// the wildcard's". Same for `languages`: a list the layer wrote is the
+    /// list, empty or not. Omitting the key is what inherits.
+    #[test]
+    fn bridge_server_empty_lists_clear_rather_than_inherit() {
+        let base: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [languageServers._]
+            cmd = ["shared-server"]
+            languages = ["*"]
+        "#,
+        )
+        .expect("should parse");
+        let overlay: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [languageServers.quiet]
+            cmd = []
+            languages = []
+        "#,
+        )
+        .expect("should parse");
+
+        let merged =
+            merge_workspace_settings(Some(base), Some(overlay)).expect("two settings merge");
+        let servers = merged.language_servers.expect("servers survive the merge");
+        let wildcard = servers.get(WILDCARD_KEY);
+        let quiet = servers.get("quiet").expect("the overlay's server");
+
+        assert!(
+            !quiet.is_spawnable_with_wildcard(wildcard),
+            "an explicitly empty cmd must not inherit the wildcard's command"
+        );
+        assert!(
+            quiet.effective_languages_with_wildcard(wildcard).is_empty(),
+            "an explicitly empty languages list must not inherit the wildcard's"
+        );
+    }
+
+    /// Omitting the keys still inherits, which is what makes the empty spelling
+    /// mean something.
+    #[test]
+    fn bridge_server_omitted_lists_still_inherit() {
+        let base: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [languageServers._]
+            cmd = ["shared-server"]
+            languages = ["*"]
+        "#,
+        )
+        .expect("should parse");
+        let overlay: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [languageServers.loud]
+            enabled = true
+        "#,
+        )
+        .expect("should parse");
+
+        let merged =
+            merge_workspace_settings(Some(base), Some(overlay)).expect("two settings merge");
+        let servers = merged.language_servers.expect("servers survive the merge");
+        let wildcard = servers.get(WILDCARD_KEY);
+        let loud = servers.get("loud").expect("the overlay's server");
+
+        assert!(loud.is_spawnable_with_wildcard(wildcard));
+        assert_eq!(loud.effective_languages_with_wildcard(wildcard), ["*"]);
+    }
+
     /// An explicit empty map clears the layer below, the same spelling
     /// `languageServers`, `bridge`, and `layers.aggregation` already answer to.
     /// Omitting the key still inherits.

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -1,9 +1,9 @@
 use super::settings::{
     AggregationConfig, BridgeLanguageConfig, BridgeServerConfig, DebounceFeatureSettings,
     FeatureSettings, LanguageSettings, LayerAggregationConfig, LayersConfig,
-    LogMessageFeatureSettings,
+    LogMessageFeatureSettings, QueryTypeMappings,
 };
-use super::{CaptureMappings, RawWorkspaceSettings, WILDCARD_KEY};
+use super::{CaptureMapping, CaptureMappings, RawWorkspaceSettings, WILDCARD_KEY};
 use std::collections::{HashMap, HashSet};
 
 /// Resolve a key from a map with wildcard fallback and merging.
@@ -495,14 +495,62 @@ fn merge_language_servers(
     }
 }
 
-fn merge_capture_mappings(mut base: CaptureMappings, overlay: CaptureMappings) -> CaptureMappings {
-    // Deep merge: overlay values override base values for the same key
-    for (lang, overlay_mappings) in overlay {
-        let base_mappings = base.entry(lang).or_default();
-        base_mappings.highlights.extend(overlay_mappings.highlights);
-        base_mappings.folds.extend(overlay_mappings.folds);
+/// Deep merge two optional capture-mapping maps.
+///
+/// Mirrors [`merge_bridge_maps`]: an empty overlay map (`Some({})`) clears the
+/// base (empty-means-clear); otherwise per-language entries merge field by
+/// field via [`merge_query_type_mappings`].
+fn merge_capture_mappings(
+    base: Option<CaptureMappings>,
+    overlay: Option<CaptureMappings>,
+) -> Option<CaptureMappings> {
+    match (base, overlay) {
+        (None, None) => None,
+        (Some(mappings), None) | (None, Some(mappings)) => Some(mappings),
+        (Some(_), Some(overlay)) if overlay.is_empty() => Some(CaptureMappings::new()),
+        (Some(mut base), Some(overlay)) => {
+            for (lang, overlay_mappings) in overlay {
+                base.entry(lang)
+                    .and_modify(|base_mappings| {
+                        *base_mappings =
+                            merge_query_type_mappings(base_mappings, &overlay_mappings);
+                    })
+                    .or_insert(overlay_mappings);
+            }
+            Some(base)
+        }
     }
-    base
+}
+
+/// Field-level merge of one language's capture mappings. The two query kinds
+/// are independent: writing `highlights` says nothing about `folds`.
+fn merge_query_type_mappings(
+    base: &QueryTypeMappings,
+    overlay: &QueryTypeMappings,
+) -> QueryTypeMappings {
+    QueryTypeMappings {
+        highlights: merge_capture_mapping(base.highlights.as_ref(), overlay.highlights.as_ref()),
+        folds: merge_capture_mapping(base.folds.as_ref(), overlay.folds.as_ref()),
+    }
+}
+
+/// Deep merge one query kind's capture names. Empty-means-clear, then
+/// per-capture override — the value is a plain string, so an entry the overlay
+/// names wins outright.
+fn merge_capture_mapping(
+    base: Option<&CaptureMapping>,
+    overlay: Option<&CaptureMapping>,
+) -> Option<CaptureMapping> {
+    match (base, overlay) {
+        (None, None) => None,
+        (Some(mapping), None) | (None, Some(mapping)) => Some(mapping.clone()),
+        (Some(_), Some(overlay)) if overlay.is_empty() => Some(CaptureMapping::new()),
+        (Some(base), Some(overlay)) => {
+            let mut merged = base.clone();
+            merged.extend(overlay.iter().map(|(k, v)| (k.clone(), v.clone())));
+            Some(merged)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -698,31 +746,31 @@ mod tests {
                     },
                 ),
             ])),
-            capture_mappings: HashMap::from([
+            capture_mappings: Some(HashMap::from([
                 (
                     "_".to_string(),
                     QueryTypeMappings {
-                        highlights: HashMap::from([
+                        highlights: Some(HashMap::from([
                             ("variable.builtin".to_string(), "base.variable".to_string()),
                             ("function.builtin".to_string(), "base.function".to_string()),
-                        ]),
-                        folds: HashMap::from([(
+                        ])),
+                        folds: Some(HashMap::from([(
                             "fold.comment".to_string(),
                             "base.comment".to_string(),
-                        )]),
+                        )])),
                     },
                 ),
                 (
                     "lua".to_string(),
                     QueryTypeMappings {
-                        highlights: HashMap::from([(
+                        highlights: Some(HashMap::from([(
                             "keyword".to_string(),
                             "base.keyword".to_string(),
-                        )]),
+                        )])),
                         ..Default::default()
                     },
                 ),
-            ]),
+            ])),
         };
 
         // ── overlay ───────────────────────────────────────────────────
@@ -782,37 +830,37 @@ mod tests {
                     },
                 ),
             ])),
-            capture_mappings: HashMap::from([
+            capture_mappings: Some(HashMap::from([
                 (
                     // shared key: _ — overlay overrides variable.builtin, adds type.builtin;
                     //   adds folds fold.function
                     "_".to_string(),
                     QueryTypeMappings {
-                        highlights: HashMap::from([
+                        highlights: Some(HashMap::from([
                             (
                                 "variable.builtin".to_string(),
                                 "overlay.variable".to_string(),
                             ),
                             ("type.builtin".to_string(), "overlay.type".to_string()),
-                        ]),
-                        folds: HashMap::from([(
+                        ])),
+                        folds: Some(HashMap::from([(
                             "fold.function".to_string(),
                             "overlay.function".to_string(),
-                        )]),
+                        )])),
                     },
                 ),
                 (
                     // new key: rust — added by overlay
                     "rust".to_string(),
                     QueryTypeMappings {
-                        highlights: HashMap::from([(
+                        highlights: Some(HashMap::from([(
                             "type.builtin".to_string(),
                             "rust.type".to_string(),
-                        )]),
+                        )])),
                         ..Default::default()
                     },
                 ),
-            ]),
+            ])),
         };
 
         // ── merge & snapshot ──────────────────────────────────────────
@@ -1900,7 +1948,8 @@ mod tests {
 
         // Verify defaults have empty string for markup.strong
         assert_eq!(
-            defaults.capture_mappings[WILDCARD_KEY].highlights["markup.strong"], "",
+            defaults.capture_mappings.as_ref().unwrap()[WILDCARD_KEY].highlights()["markup.strong"],
+            "",
             "Defaults should suppress markup.strong with empty string"
         );
 
@@ -1911,19 +1960,21 @@ mod tests {
 
         // After merge, user's "keyword" should override default's ""
         assert_eq!(
-            merged.capture_mappings[WILDCARD_KEY].highlights["markup.strong"], "keyword",
+            merged.capture_mappings.as_ref().unwrap()[WILDCARD_KEY].highlights()["markup.strong"],
+            "keyword",
             "User's markup.strong = 'keyword' should override default's ''"
         );
 
         // Also verify other user mappings are present
         assert_eq!(
-            merged.capture_mappings[WILDCARD_KEY].highlights["markup.heading.1"], "class",
+            merged.capture_mappings.as_ref().unwrap()[WILDCARD_KEY].highlights()["markup.heading.1"],
+            "class",
             "User's markup.heading.1 mapping should be present"
         );
 
         // Verify other defaults are still present
         assert_eq!(
-            merged.capture_mappings[WILDCARD_KEY].highlights["variable.builtin"],
+            merged.capture_mappings.as_ref().unwrap()[WILDCARD_KEY].highlights()["variable.builtin"],
             "variable.defaultLibrary",
             "Default variable.builtin mapping should be inherited"
         );
@@ -1948,7 +1999,9 @@ mod tests {
             .expect("two settings merge");
 
         assert!(
-            merged.capture_mappings[WILDCARD_KEY].highlights.is_empty(),
+            merged.capture_mappings.as_ref().unwrap()[WILDCARD_KEY]
+                .highlights()
+                .is_empty(),
             "an explicit empty highlights map should clear the defaults"
         );
     }
@@ -1975,13 +2028,14 @@ mod tests {
 
         let merged =
             merge_workspace_settings(Some(base), Some(overlay)).expect("two settings merge");
-        let wildcard = &merged.capture_mappings[WILDCARD_KEY];
+        let wildcard = &merged.capture_mappings.as_ref().unwrap()[WILDCARD_KEY];
 
         assert_eq!(
-            wildcard.folds["comment"], "comment",
+            wildcard.folds.as_ref().unwrap()["comment"],
+            "comment",
             "writing highlights must not clear folds"
         );
-        assert_eq!(wildcard.highlights["keyword"], "keyword");
+        assert_eq!(wildcard.highlights()["keyword"], "keyword");
     }
 
     /// The whole map clears too, so a layer can drop every language's mappings.
@@ -1996,7 +2050,7 @@ mod tests {
             .expect("two settings merge");
 
         assert!(
-            merged.capture_mappings.is_empty(),
+            merged.capture_mappings.as_ref().unwrap().is_empty(),
             "an explicit empty captureMappings should clear every language entry"
         );
     }

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -85,7 +85,8 @@ pub(crate) fn merge_bridge_language_configs(
 }
 
 /// Field-level merge of two BridgeServerConfig values.
-/// Vec fields: the overlay's list wins when it wrote one, empty or not.
+/// List fields (`Option<Vec<_>>`): the overlay's list wins when it wrote one,
+/// empty or not; omitting the key is what inherits.
 /// JSON Option fields: deep merge (configuration-merging-strategy).
 /// Option fields: overlay wins when present.
 pub(crate) fn merge_bridge_server_configs(

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -582,15 +582,31 @@ pub(crate) fn on_type_formatting_trigger_union(
 }
 
 /// Custom mappings from Tree-sitter capture names to semantic token types, per query kind.
+///
+/// Both fields are optional so that omitting one and writing an empty one say
+/// different things: omit to inherit the layer below, write `{}` to clear it.
+/// A layer that configures only `highlights` must not silently drop the folds
+/// a lower layer supplied, which a non-optional field could not express.
 #[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq, Eq, JsonSchema)]
 pub struct QueryTypeMappings {
-    /// Capture mappings for highlights queries.
-    #[serde(default)]
-    pub highlights: CaptureMapping,
-    /// Capture mappings for folds queries.
+    /// Capture mappings for highlights queries. Omit to inherit; `{}` clears.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub highlights: Option<CaptureMapping>,
+    /// Capture mappings for folds queries. Omit to inherit; `{}` clears.
     /// Reserved for future folding range support — populated and merged but not yet consumed by analysis.
-    #[serde(default)]
-    pub folds: CaptureMapping,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub folds: Option<CaptureMapping>,
+}
+
+/// The empty map an unset [`QueryTypeMappings`] field reads as.
+static NO_CAPTURE_MAPPING: std::sync::LazyLock<CaptureMapping> =
+    std::sync::LazyLock::new(CaptureMapping::new);
+
+impl QueryTypeMappings {
+    /// The highlights mappings in effect — empty when this entry names none.
+    pub(crate) fn highlights(&self) -> &CaptureMapping {
+        self.highlights.as_ref().unwrap_or(&NO_CAPTURE_MAPPING)
+    }
 }
 
 pub type CaptureMappings = HashMap<String, QueryTypeMappings>;
@@ -692,8 +708,9 @@ pub struct RawWorkspaceSettings {
     #[serde(default)]
     pub languages: HashMap<String, LanguageSettings>,
     /// Custom mappings from Tree-sitter capture names to semantic token types.
-    #[serde(default)]
-    pub capture_mappings: CaptureMappings,
+    /// Omit to inherit the layer below; `{}` clears every language's entry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capture_mappings: Option<CaptureMappings>,
     /// Deprecated: use `languages._.autoInstall` (and per-language
     /// `languages.<lang>.autoInstall`) instead. Whether to automatically
     /// install missing parsers and queries. Still honored when no per-language
@@ -1324,7 +1341,7 @@ mod tests {
         assert!(settings.languages.is_empty());
         assert!(settings.search_paths.is_none());
         assert!(settings.auto_install.is_none());
-        assert!(settings.capture_mappings.is_empty());
+        assert!(settings.capture_mappings.is_none());
     }
 
     #[test]
@@ -1486,7 +1503,7 @@ mod tests {
         let mut config = RawWorkspaceSettings {
             search_paths: None,
             languages: HashMap::new(),
-            capture_mappings: HashMap::new(),
+            capture_mappings: None,
             auto_install: None,
             diagnostics_debounce_ms: None,
             features: None,

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -369,21 +369,21 @@ impl RootMarker {
 pub struct BridgeServerConfig {
     /// Command array: first element is the program, rest are arguments
     /// e.g., ["rust-analyzer"] or ["pyright-langserver", "--stdio"].
-    /// Optional so a wildcard `_` entry can carry defaults only; a concrete
-    /// server whose resolved cmd is still empty is skipped at lookup.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub cmd: Vec<String>,
+    /// Omit to inherit the `_` wildcard's command; write `[]` to say this
+    /// server has none, which skips it at lookup.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cmd: Option<Vec<String>>,
     /// Languages this server handles (e.g., ["rust"], ["python"]). The element
     /// `"*"` matches every language, for servers not tied to one.
-    /// Optional for the same wildcard-defaults reason as `cmd`; a server
-    /// with no languages never matches a lookup.
+    /// Omit to inherit the `_` wildcard's list; write `[]` to say this server
+    /// handles none, which never matches a lookup.
     // Doc comments on this struct are user-facing: they become the `config
     // schema` output an editor shows on hover. Keep them free of rustdoc
     // intra-doc links and implementor notes — match through
     // `handles_language`, never by comparing elements directly, so that `"*"`
     // is honored everywhere.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub languages: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub languages: Option<Vec<String>>,
     /// Optional initialization options to pass to the server during initialize
     pub initialization_options: Option<Value>,
     /// Optional workspace settings for the server, propagated *after*
@@ -483,9 +483,22 @@ impl BridgeServerConfig {
     /// candidates. On the host axis a candidate is still not consent — that
     /// path stays gated on the explicit `bridge._self.enabled = true` opt-in.
     pub(crate) fn handles_language(&self, language: &str) -> bool {
-        self.languages
+        self.languages()
             .iter()
             .any(|l| l == language || l == LANGUAGES_WILDCARD)
+    }
+
+    /// The command this config names — empty when it names none, whether by
+    /// omitting the key or by writing `[]`. Callers that need to tell those
+    /// apart resolve wildcard inheritance first; see
+    /// [`Self::is_spawnable_with_wildcard`].
+    pub(crate) fn cmd(&self) -> &[String] {
+        self.cmd.as_deref().unwrap_or_default()
+    }
+
+    /// The languages this config names, on the same terms as [`Self::cmd`].
+    pub(crate) fn languages(&self) -> &[String] {
+        self.languages.as_deref().unwrap_or_default()
     }
 
     /// A resolved config is a real, usable server: it has a command to run
@@ -493,20 +506,22 @@ impl BridgeServerConfig {
     /// (spawn-resolution, capability advertisement, resolve-dispatch) should
     /// share this single predicate rather than re-deriving it.
     pub(crate) fn is_spawnable(&self) -> bool {
-        !self.cmd.is_empty() && self.is_enabled()
+        !self.cmd().is_empty() && self.is_enabled()
     }
 
     /// The `languages` list that actually applies, resolving `_` inheritance
     /// against an already-looked-up `wildcard`.
     ///
-    /// `languages` is `#[serde(default)]`, so a server that omits the key
-    /// inherits the `_` template's list (wildcard-config-inheritance) — its own
-    /// list reads as EMPTY until that merge happens. A caller that reads
-    /// `languages` directly to decide "which languages can this server serve"
-    /// therefore sees nothing for a server that may serve everything.
-    /// Merging the whole config to find out costs a clone per server, so this
-    /// mirrors [`Self::is_spawnable_with_wildcard`]: resolve just this field,
-    /// and let a loop hoist the `_` lookup.
+    /// A server that OMITS `languages` inherits the `_` template's list
+    /// (wildcard-config-inheritance) — its own list reads as absent until that
+    /// merge happens. A caller that reads the field directly to decide "which
+    /// languages can this server serve" therefore sees nothing for a server
+    /// that may serve everything. Merging the whole config to find out costs a
+    /// clone per server, so this mirrors [`Self::is_spawnable_with_wildcard`]:
+    /// resolve just this field, and let a loop hoist the `_` lookup.
+    ///
+    /// A server that WRITES an empty list has said it handles nothing, and
+    /// does not inherit — the same empty-means-clear rule the merge applies.
     ///
     /// Replace-not-union, matching `merge_bridge_server_configs`: a server that
     /// declares its own list has overridden the template.
@@ -514,10 +529,9 @@ impl BridgeServerConfig {
         &'a self,
         wildcard: Option<&'a Self>,
     ) -> &'a [String] {
-        if self.languages.is_empty() {
-            wildcard.map(|w| w.languages.as_slice()).unwrap_or_default()
-        } else {
-            self.languages.as_slice()
+        match self.languages.as_deref() {
+            Some(languages) => languages,
+            None => wildcard.map(Self::languages).unwrap_or_default(),
         }
     }
 
@@ -527,7 +541,12 @@ impl BridgeServerConfig {
     /// and loops over every configured server) that can hoist the wildcard
     /// lookup out of a loop instead of repeating it per server.
     pub(crate) fn is_spawnable_with_wildcard(&self, wildcard: Option<&Self>) -> bool {
-        let cmd_non_empty = !self.cmd.is_empty() || wildcard.is_some_and(|w| !w.cmd.is_empty());
+        // An omitted cmd inherits the wildcard's; an explicitly empty one does
+        // not, so the server stays unspawnable however the template is set.
+        let cmd_non_empty = match self.cmd.as_deref() {
+            Some(cmd) => !cmd.is_empty(),
+            None => wildcard.is_some_and(|w| !w.cmd().is_empty()),
+        };
         let enabled = self
             .enabled
             .or(wildcard.and_then(|w| w.enabled))
@@ -1597,8 +1616,8 @@ mod tests {
         // Empty is already spoken for ("inherit from `_`"), so the wildcard
         // element is the only shape that can *widen* an inherited list.
         let server = BridgeServerConfig {
-            cmd: vec!["harper-ls".to_string()],
-            languages: vec![LANGUAGES_WILDCARD.to_string()],
+            cmd: Some(vec!["harper-ls".to_string()]),
+            languages: Some(vec![LANGUAGES_WILDCARD.to_string()]),
             ..Default::default()
         };
 
@@ -1612,8 +1631,8 @@ mod tests {
         // Membership has no ordering, so a named entry alongside `"*"` is
         // redundant rather than restrictive.
         let server = BridgeServerConfig {
-            cmd: vec!["harper-ls".to_string()],
-            languages: vec!["rust".to_string(), LANGUAGES_WILDCARD.to_string()],
+            cmd: Some(vec!["harper-ls".to_string()]),
+            languages: Some(vec!["rust".to_string(), LANGUAGES_WILDCARD.to_string()]),
             ..Default::default()
         };
 
@@ -1624,8 +1643,8 @@ mod tests {
     #[test]
     fn explicit_languages_list_matches_only_listed_languages() {
         let server = BridgeServerConfig {
-            cmd: vec!["rust-analyzer".to_string()],
-            languages: vec!["rust".to_string()],
+            cmd: Some(vec!["rust-analyzer".to_string()]),
+            languages: Some(vec!["rust".to_string()]),
             ..Default::default()
         };
 
@@ -1639,8 +1658,8 @@ mod tests {
         // A `.contains('*')`-style implementation would pass every other test
         // in this file, so pin the narrower contract explicitly.
         let server = BridgeServerConfig {
-            cmd: vec!["tsgo".to_string()],
-            languages: vec!["ts*".to_string()],
+            cmd: Some(vec!["tsgo".to_string()]),
+            languages: Some(vec!["ts*".to_string()]),
             ..Default::default()
         };
 
@@ -1656,8 +1675,8 @@ mod tests {
     fn empty_languages_matches_nothing() {
         // An unresolved (still-inheriting) config must not become "any".
         let server = BridgeServerConfig {
-            cmd: vec!["rust-analyzer".to_string()],
-            languages: vec![],
+            cmd: Some(vec!["rust-analyzer".to_string()]),
+            languages: None,
             ..Default::default()
         };
 
@@ -1679,14 +1698,14 @@ mod tests {
         let config: BridgeServerConfig = serde_json::from_str(config_json).unwrap();
 
         assert_eq!(
-            config.cmd,
-            vec![
+            config.cmd(),
+            [
                 "rust-analyzer".to_string(),
                 "--log-file".to_string(),
                 "/tmp/ra.log".to_string()
             ]
         );
-        assert_eq!(config.languages, vec!["rust".to_string()]);
+        assert_eq!(config.languages(), ["rust".to_string()]);
         assert!(config.initialization_options.is_some());
         let init_opts = config.initialization_options.unwrap();
         assert!(init_opts.get("linkedProjects").is_some());
@@ -1702,8 +1721,8 @@ mod tests {
 
         let config: BridgeServerConfig = serde_json::from_str(config_json).unwrap();
 
-        assert_eq!(config.cmd, vec!["pyright".to_string()]);
-        assert_eq!(config.languages, vec!["python".to_string()]);
+        assert_eq!(config.cmd(), ["pyright".to_string()]);
+        assert_eq!(config.languages(), ["python".to_string()]);
         assert!(config.initialization_options.is_none());
     }
 
@@ -1866,9 +1885,9 @@ mod tests {
 
     #[test]
     fn is_spawnable_with_wildcard_resolves_cmd_and_enabled_inheritance() {
-        let server = |cmd: Vec<&str>, enabled: Option<bool>| BridgeServerConfig {
-            cmd: cmd.into_iter().map(String::from).collect(),
-            languages: vec![],
+        let server = |cmd: Option<Vec<&str>>, enabled: Option<bool>| BridgeServerConfig {
+            cmd: cmd.map(|cmd| cmd.into_iter().map(String::from).collect()),
+            languages: None,
             initialization_options: None,
             workspace_markers: None,
             on_type_formatting_triggers: None,
@@ -1878,19 +1897,26 @@ mod tests {
         };
 
         // Own cmd and enabled, no wildcard needed.
-        assert!(server(vec!["x"], Some(true)).is_spawnable_with_wildcard(None));
+        assert!(server(Some(vec!["x"]), Some(true)).is_spawnable_with_wildcard(None));
 
-        // cmd inherited from the wildcard.
-        let wildcard = server(vec!["shared-ls"], None);
-        assert!(server(vec![], None).is_spawnable_with_wildcard(Some(&wildcard)));
+        // cmd inherited from the wildcard by OMITTING it.
+        let wildcard = server(Some(vec!["shared-ls"]), None);
+        assert!(server(None, None).is_spawnable_with_wildcard(Some(&wildcard)));
+
+        // An explicitly empty cmd is a statement, not an omission: it does not
+        // inherit, so the wildcard's command cannot make the server spawnable.
+        assert!(!server(Some(vec![]), None).is_spawnable_with_wildcard(Some(&wildcard)));
 
         // enabled inherited (disabled) from the wildcard.
-        let disabling_wildcard = server(vec![], Some(false));
-        assert!(!server(vec!["x"], None).is_spawnable_with_wildcard(Some(&disabling_wildcard)));
+        let disabling_wildcard = server(None, Some(false));
+        assert!(
+            !server(Some(vec!["x"]), None).is_spawnable_with_wildcard(Some(&disabling_wildcard))
+        );
 
         // Own enabled: true overrides a disabling wildcard.
         assert!(
-            server(vec!["x"], Some(true)).is_spawnable_with_wildcard(Some(&disabling_wildcard))
+            server(Some(vec!["x"]), Some(true))
+                .is_spawnable_with_wildcard(Some(&disabling_wildcard))
         );
     }
 
@@ -1984,8 +2010,8 @@ mod tests {
     #[test]
     fn on_type_formatting_trigger_union_is_sorted_and_deduped() {
         let server = |triggers: Option<Vec<&str>>| BridgeServerConfig {
-            cmd: vec!["x".to_string()],
-            languages: vec![],
+            cmd: Some(vec!["x".to_string()]),
+            languages: None,
             initialization_options: None,
             workspace_markers: None,
             on_type_formatting_triggers: triggers
@@ -2023,8 +2049,8 @@ mod tests {
     #[test]
     fn on_type_formatting_trigger_union_excludes_disabled_server() {
         let server = |triggers: Option<Vec<&str>>, enabled: Option<bool>| BridgeServerConfig {
-            cmd: vec!["x".to_string()],
-            languages: vec![],
+            cmd: Some(vec!["x".to_string()]),
+            languages: None,
             initialization_options: None,
             workspace_markers: None,
             on_type_formatting_triggers: triggers
@@ -2108,8 +2134,8 @@ mod tests {
         let servers = HashMap::from([(
             "tsgo".to_string(),
             BridgeServerConfig {
-                cmd: vec![],
-                languages: vec![],
+                cmd: None,
+                languages: None,
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: Some(vec![";".to_string()]),
@@ -2131,8 +2157,8 @@ mod tests {
         let servers = HashMap::from([(
             "a".to_string(),
             BridgeServerConfig {
-                cmd: vec!["x".to_string()],
-                languages: vec![],
+                cmd: Some(vec!["x".to_string()]),
+                languages: None,
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: Some(vec![String::new()]),
@@ -2174,8 +2200,8 @@ mod tests {
         let settings: RawWorkspaceSettings = toml::from_str(toml_str).unwrap();
         let servers = settings.language_servers.unwrap();
         let wildcard = &servers["_"];
-        assert!(wildcard.cmd.is_empty());
-        assert!(wildcard.languages.is_empty());
+        assert!(wildcard.cmd().is_empty());
+        assert!(wildcard.languages().is_empty());
         assert_eq!(
             wildcard.workspace_markers,
             Some(vec![RootMarker::Single(".git".to_string())])
@@ -2306,8 +2332,8 @@ mod tests {
         // via serde_json, so a Group must round-trip: array for a group, bare
         // string for a single, with entry order preserved.
         let config = BridgeServerConfig {
-            cmd: vec![],
-            languages: vec![],
+            cmd: None,
+            languages: None,
             initialization_options: None,
             workspace_markers: Some(vec![
                 RootMarker::Group(vec!["stylua.toml".to_string(), ".luarc.json".to_string()]),

--- a/src/config/snapshots/kakehashi__config__merge__tests__merge_workspace_settings_all_fields.snap
+++ b/src/config/snapshots/kakehashi__config__merge__tests__merge_workspace_settings_all_fields.snap
@@ -1,5 +1,6 @@
 ---
 source: src/config/merge.rs
+assertion_line: 871
 expression: result
 ---
 {
@@ -62,14 +63,12 @@ expression: result
     "lua": {
       "highlights": {
         "keyword": "base.keyword"
-      },
-      "folds": {}
+      }
     },
     "rust": {
       "highlights": {
         "type.builtin": "rust.type"
-      },
-      "folds": {}
+      }
     }
   },
   "autoInstall": false,

--- a/src/config/snapshots/kakehashi__config__settings__tests__should_parse_capture_mappings.snap
+++ b/src/config/snapshots/kakehashi__config__settings__tests__should_parse_capture_mappings.snap
@@ -1,5 +1,6 @@
 ---
 source: src/config/settings.rs
+assertion_line: 1471
 expression: settings.capture_mappings
 ---
 {
@@ -7,13 +8,11 @@ expression: settings.capture_mappings
     "highlights": {
       "function.builtin": "function.defaultLibrary",
       "variable.builtin": "variable.defaultLibrary"
-    },
-    "folds": {}
+    }
   },
   "rust": {
     "highlights": {
       "type.builtin": "type.defaultLibrary"
-    },
-    "folds": {}
+    }
   }
 }

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -261,8 +261,8 @@ mod tests {
         ResolvedServerConfig {
             server_name: name.to_string(),
             config: Arc::new(BridgeServerConfig {
-                cmd: vec![name.to_string()],
-                languages: vec![],
+                cmd: Some(vec![name.to_string()]),
+                languages: None,
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,

--- a/src/lsp/aggregation/server/fan_out.rs
+++ b/src/lsp/aggregation/server/fan_out.rs
@@ -137,8 +137,8 @@ mod tests {
         ResolvedServerConfig {
             server_name: name.to_string(),
             config: Arc::new(BridgeServerConfig {
-                cmd: vec![name.to_string()],
-                languages: vec![],
+                cmd: Some(vec![name.to_string()]),
+                languages: None,
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,

--- a/src/lsp/aggregation/server/priority.rs
+++ b/src/lsp/aggregation/server/priority.rs
@@ -150,8 +150,8 @@ mod tests {
         ResolvedServerConfig {
             server_name: name.to_string(),
             config: Arc::new(BridgeServerConfig {
-                cmd: vec![name.to_string()],
-                languages: vec![],
+                cmd: Some(vec![name.to_string()]),
+                languages: None,
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1412,7 +1412,7 @@ mod tests {
         settings.language_servers.insert(
             crate::config::WILDCARD_KEY.to_string(),
             BridgeServerConfig {
-                cmd: vec!["shared-server".into()],
+                cmd: Some(vec!["shared-server".into()]),
                 ..Default::default()
             },
         );
@@ -1522,8 +1522,8 @@ mod tests {
         servers.insert(
             "rust-analyzer".to_string(),
             BridgeServerConfig {
-                cmd: vec!["rust-analyzer".to_string()],
-                languages: vec!["rust".to_string()],
+                cmd: Some(vec!["rust-analyzer".to_string()]),
+                languages: Some(vec!["rust".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -1554,8 +1554,8 @@ mod tests {
     fn host_language_can_reach_server_screens_on_configuration_alone() {
         let coordinator = BridgeCoordinator::new();
         let server = |language: &str| BridgeServerConfig {
-            cmd: vec!["x".to_string()],
-            languages: vec![language.to_string()],
+            cmd: Some(vec!["x".to_string()]),
+            languages: Some(vec![language.to_string()]),
             initialization_options: None,
             workspace_markers: None,
             on_type_formatting_triggers: None,
@@ -1605,8 +1605,8 @@ mod tests {
         servers.insert(
             crate::config::WILDCARD_KEY.to_string(),
             BridgeServerConfig {
-                cmd: Vec::new(),
-                languages: vec!["*".to_string()],
+                cmd: None,
+                languages: Some(vec!["*".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -1618,9 +1618,9 @@ mod tests {
         servers.insert(
             "harper-ls".to_string(),
             BridgeServerConfig {
-                cmd: vec!["harper-ls".to_string()],
+                cmd: Some(vec!["harper-ls".to_string()]),
                 // Deliberately omitted in TOML → empty here, inherited from `_`.
-                languages: Vec::new(),
+                languages: None,
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -1677,8 +1677,8 @@ mod tests {
         servers.insert(
             "ruff".to_string(),
             BridgeServerConfig {
-                cmd: vec!["ruff".to_string()],
-                languages: vec!["python".to_string()],
+                cmd: Some(vec!["ruff".to_string()]),
+                languages: Some(vec!["python".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -1725,8 +1725,8 @@ mod tests {
             },
         );
         let server = |cmd: &str| BridgeServerConfig {
-            cmd: vec![cmd.to_string()],
-            languages: vec!["python".to_string()],
+            cmd: Some(vec![cmd.to_string()]),
+            languages: Some(vec!["python".to_string()]),
             initialization_options: None,
             workspace_markers: None,
             on_type_formatting_triggers: None,
@@ -1756,7 +1756,7 @@ mod tests {
             assert_eq!(kept.len(), 1, "{name} must self-heal its python injection");
             assert_eq!(
                 config.expect("config for matched server").cmd,
-                vec![cmd.to_string()]
+                Some(vec![cmd.to_string()])
             );
         }
 
@@ -1890,8 +1890,8 @@ mod tests {
         servers.insert(
             "rust-analyzer".to_string(),
             BridgeServerConfig {
-                cmd: vec!["rust-analyzer".to_string()],
-                languages: vec!["rust".to_string()],
+                cmd: Some(vec!["rust-analyzer".to_string()]),
+                languages: Some(vec!["rust".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -1916,7 +1916,7 @@ mod tests {
             "rust should be allowed when no filter is set"
         );
         assert_eq!(result[0].server_name, "rust-analyzer");
-        assert_eq!(result[0].config.cmd, vec!["rust-analyzer".to_string()]);
+        assert_eq!(result[0].config.cmd(), ["rust-analyzer".to_string()]);
     }
 
     #[test]
@@ -1930,8 +1930,8 @@ mod tests {
         servers.insert(
             "_".to_string(),
             BridgeServerConfig {
-                cmd: vec![],
-                languages: vec!["rust".to_string()],
+                cmd: None,
+                languages: Some(vec!["rust".to_string()]),
                 initialization_options: None,
                 workspace_markers: Some(vec![crate::config::settings::RootMarker::Single(
                     ".git".to_string(),
@@ -1945,8 +1945,8 @@ mod tests {
         servers.insert(
             "broken".to_string(),
             BridgeServerConfig {
-                cmd: vec![],
-                languages: vec!["rust".to_string()],
+                cmd: None,
+                languages: Some(vec!["rust".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -2005,8 +2005,8 @@ mod tests {
         servers.insert(
             "_".to_string(),
             BridgeServerConfig {
-                cmd: vec![],
-                languages: vec![],
+                cmd: None,
+                languages: None,
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -2018,8 +2018,8 @@ mod tests {
         servers.insert(
             "rust-analyzer".to_string(),
             BridgeServerConfig {
-                cmd: vec!["rust-analyzer".to_string()],
-                languages: vec!["rust".to_string()],
+                cmd: Some(vec!["rust-analyzer".to_string()]),
+                languages: Some(vec!["rust".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -2075,8 +2075,8 @@ mod tests {
         servers.insert(
             "_".to_string(),
             BridgeServerConfig {
-                cmd: vec![],
-                languages: vec![],
+                cmd: None,
+                languages: None,
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -2088,8 +2088,8 @@ mod tests {
         servers.insert(
             "rust-analyzer".to_string(),
             BridgeServerConfig {
-                cmd: vec!["rust-analyzer".to_string()],
-                languages: vec!["rust".to_string()],
+                cmd: Some(vec!["rust-analyzer".to_string()]),
+                languages: Some(vec!["rust".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -2125,8 +2125,8 @@ mod tests {
         servers.insert(
             "pyright".to_string(),
             BridgeServerConfig {
-                cmd: vec!["pyright-langserver".to_string()],
-                languages: vec!["python".to_string()],
+                cmd: Some(vec!["pyright-langserver".to_string()]),
+                languages: Some(vec!["python".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -2138,8 +2138,8 @@ mod tests {
         servers.insert(
             "ruff".to_string(),
             BridgeServerConfig {
-                cmd: vec!["ruff".to_string(), "server".to_string()],
-                languages: vec!["python".to_string()],
+                cmd: Some(vec!["ruff".to_string(), "server".to_string()]),
+                languages: Some(vec!["python".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -2172,16 +2172,16 @@ mod tests {
             (
                 "harper-ls".to_string(),
                 BridgeServerConfig {
-                    cmd: vec!["harper-ls".to_string()],
-                    languages: vec![LANGUAGES_WILDCARD.to_string()],
+                    cmd: Some(vec!["harper-ls".to_string()]),
+                    languages: Some(vec![LANGUAGES_WILDCARD.to_string()]),
                     ..Default::default()
                 },
             ),
             (
                 "rust-analyzer".to_string(),
                 BridgeServerConfig {
-                    cmd: vec!["rust-analyzer".to_string()],
-                    languages: vec!["rust".to_string()],
+                    cmd: Some(vec!["rust-analyzer".to_string()]),
+                    languages: Some(vec!["rust".to_string()]),
                     ..Default::default()
                 },
             ),
@@ -2272,7 +2272,7 @@ mod tests {
         let coordinator = BridgeCoordinator::new();
         let mut settings = settings_with_any_language_server();
         for config in settings.language_servers.values_mut() {
-            config.cmd = vec!["/nonexistent/kakehashi-test-server".to_string()];
+            config.cmd = Some(vec!["/nonexistent/kakehashi-test-server".to_string()]);
         }
         let host_uri = Url::parse("file:///test.md").unwrap();
 
@@ -2432,14 +2432,14 @@ mod tests {
             (
                 "_".to_string(),
                 BridgeServerConfig {
-                    languages: vec![LANGUAGES_WILDCARD.to_string()],
+                    languages: Some(vec![LANGUAGES_WILDCARD.to_string()]),
                     ..Default::default()
                 },
             ),
             (
                 "harper-ls".to_string(),
                 BridgeServerConfig {
-                    cmd: vec!["harper-ls".to_string()],
+                    cmd: Some(vec!["harper-ls".to_string()]),
                     ..Default::default()
                 },
             ),
@@ -2451,8 +2451,8 @@ mod tests {
             (
                 "rust-analyzer".to_string(),
                 BridgeServerConfig {
-                    cmd: vec!["rust-analyzer".to_string()],
-                    languages: vec!["rust".to_string()],
+                    cmd: Some(vec!["rust-analyzer".to_string()]),
+                    languages: Some(vec!["rust".to_string()]),
                     ..Default::default()
                 },
             ),
@@ -2513,8 +2513,8 @@ mod tests {
         servers.insert(
             "rust-analyzer".to_string(),
             BridgeServerConfig {
-                cmd: vec!["rust-analyzer".to_string()],
-                languages: vec!["rust".to_string()],
+                cmd: Some(vec!["rust-analyzer".to_string()]),
+                languages: Some(vec!["rust".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -2551,8 +2551,8 @@ mod tests {
         servers.insert(
             "rust-analyzer".to_string(),
             BridgeServerConfig {
-                cmd: vec!["rust-analyzer".to_string()],
-                languages: vec!["rust".to_string()],
+                cmd: Some(vec!["rust-analyzer".to_string()]),
+                languages: Some(vec!["rust".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -2670,8 +2670,8 @@ mod tests {
         servers.insert(
             "rust-analyzer".to_string(),
             BridgeServerConfig {
-                cmd: vec!["rust-analyzer".to_string()],
-                languages: vec!["rust".to_string()],
+                cmd: Some(vec!["rust-analyzer".to_string()]),
+                languages: Some(vec!["rust".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -2896,8 +2896,8 @@ mod tests {
         servers.insert(
             "lua-language-server".to_string(),
             BridgeServerConfig {
-                cmd: vec!["lua-language-server".to_string()],
-                languages: vec!["lua".to_string()],
+                cmd: Some(vec!["lua-language-server".to_string()]),
+                languages: Some(vec!["lua".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -2491,7 +2491,7 @@ impl LanguageServerPool {
         }
 
         // Spawn new connection (while holding lock to prevent concurrent spawns)
-        let mut conn = AsyncBridgeConnection::spawn(server_config.cmd.clone()).await?;
+        let mut conn = AsyncBridgeConnection::spawn(server_config.cmd().to_vec()).await?;
 
         // Split connection immediately
         let (writer, reader) = conn.split();
@@ -4213,12 +4213,12 @@ mod tests {
 
         // First attempt with unresponsive server - should timeout
         let unresponsive_config = BridgeServerConfig {
-            cmd: vec![
+            cmd: Some(vec![
                 "sh".to_string(),
                 "-c".to_string(),
                 "cat > /dev/null".to_string(),
-            ],
-            languages: vec!["lua".to_string()],
+            ]),
+            languages: Some(vec!["lua".to_string()]),
             initialization_options: None,
             workspace_markers: None,
             on_type_formatting_triggers: None,
@@ -5015,7 +5015,7 @@ mod tests {
         // Changed `cmd`: the live process was spawned from a superseded config,
         // so the fast path must miss and let the caller respawn.
         let mut changed = config.clone();
-        changed.cmd = vec!["sh".to_string(), "-c".to_string(), "true".to_string()];
+        changed.cmd = Some(vec!["sh".to_string(), "-c".to_string(), "true".to_string()]);
         assert!(
             pool.ready_connection_by_key_for_config(&key, Some(&changed))
                 .await
@@ -7722,8 +7722,8 @@ mod tests {
 
         pool.propagate_settings(|_| {
             Some(crate::config::settings::BridgeServerConfig {
-                cmd: vec!["ruff".to_string()],
-                languages: vec!["*".to_string()],
+                cmd: Some(vec!["ruff".to_string()]),
+                languages: Some(vec!["*".to_string()]),
                 enabled: Some(false),
                 ..Default::default()
             })
@@ -7761,8 +7761,8 @@ mod tests {
         // correctly retire, and the test would pass for the wrong reason.
         pool.propagate_settings(|_| {
             Some(crate::config::settings::BridgeServerConfig {
-                cmd: vec!["ruff".to_string()],
-                languages: vec!["*".to_string()],
+                cmd: Some(vec!["ruff".to_string()]),
+                languages: Some(vec!["*".to_string()]),
                 ..Default::default()
             })
         })
@@ -7788,15 +7788,15 @@ mod tests {
         let unchanged = create_handle_with_key(ConnectionState::Ready, unchanged_key.clone()).await;
 
         let old_changed = BridgeServerConfig {
-            cmd: vec!["old-server".into()],
+            cmd: Some(vec!["old-server".into()]),
             ..Default::default()
         };
         let old_removed = BridgeServerConfig {
-            cmd: vec!["removed-server".into()],
+            cmd: Some(vec!["removed-server".into()]),
             ..Default::default()
         };
         let stable = BridgeServerConfig {
-            cmd: vec!["stable-server".into()],
+            cmd: Some(vec!["stable-server".into()]),
             ..Default::default()
         };
         changed.record_launch_config(&old_changed);
@@ -7812,7 +7812,7 @@ mod tests {
         let stable_for_resolve = stable.clone();
         pool.propagate_settings(move |name| match name {
             "changed" => Some(BridgeServerConfig {
-                cmd: vec!["new-server".into()],
+                cmd: Some(vec!["new-server".into()]),
                 ..Default::default()
             }),
             "removed" => None,

--- a/src/lsp/bridge/pool/test_helpers.rs
+++ b/src/lsp/bridge/pool/test_helpers.rs
@@ -48,8 +48,8 @@ pub(in crate::lsp::bridge) fn is_lua_ls_available() -> bool {
 /// Create a BridgeServerConfig for lua-language-server.
 pub(in crate::lsp::bridge) fn lua_ls_config() -> BridgeServerConfig {
     BridgeServerConfig {
-        cmd: vec!["lua-language-server".to_string()],
-        languages: vec!["lua".to_string()],
+        cmd: Some(vec!["lua-language-server".to_string()]),
+        languages: Some(vec!["lua".to_string()]),
         initialization_options: None,
         workspace_markers: None,
         on_type_formatting_triggers: None,
@@ -68,12 +68,12 @@ pub(in crate::lsp::bridge) fn devnull_config() -> BridgeServerConfig {
 /// Create a BridgeServerConfig for a mock server with a specific language.
 pub(in crate::lsp::bridge) fn devnull_config_for_language(language: &str) -> BridgeServerConfig {
     BridgeServerConfig {
-        cmd: vec![
+        cmd: Some(vec![
             "sh".to_string(),
             "-c".to_string(),
             "cat > /dev/null".to_string(),
-        ],
-        languages: vec![language.to_string()],
+        ]),
+        languages: Some(vec![language.to_string()]),
         initialization_options: None,
         workspace_markers: None,
         on_type_formatting_triggers: None,

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -731,7 +731,7 @@ mod tests {
         settings.language_servers.insert(
             "lua-ls".to_string(),
             BridgeServerConfig {
-                cmd: vec!["lua-language-server".to_string()],
+                cmd: Some(vec!["lua-language-server".to_string()]),
                 enabled: Some(false),
                 ..Default::default()
             },
@@ -771,7 +771,7 @@ mod tests {
         settings.language_servers.insert(
             "lua-ls".to_string(),
             BridgeServerConfig {
-                cmd: vec!["lua-language-server".to_string()],
+                cmd: Some(vec!["lua-language-server".to_string()]),
                 ..Default::default()
             },
         );

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -585,7 +585,7 @@ mod tests {
         settings.language_servers.insert(
             "lua-ls".to_string(),
             BridgeServerConfig {
-                cmd: vec!["lua-language-server".to_string()],
+                cmd: Some(vec!["lua-language-server".to_string()]),
                 enabled: Some(false),
                 ..Default::default()
             },
@@ -619,7 +619,7 @@ mod tests {
         settings.language_servers.insert(
             "lua-ls".to_string(),
             BridgeServerConfig {
-                cmd: vec!["lua-language-server".to_string()],
+                cmd: Some(vec!["lua-language-server".to_string()]),
                 ..Default::default()
             },
         );

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -687,8 +687,8 @@ mod tests {
         cmd: &str,
     ) {
         let config = crate::config::settings::BridgeServerConfig {
-            cmd: vec![cmd.to_string()],
-            languages: vec!["*".to_string()],
+            cmd: Some(vec![cmd.to_string()]),
+            languages: Some(vec!["*".to_string()]),
             ..Default::default()
         };
         pool.insert_connection(
@@ -957,8 +957,8 @@ mod tests {
             settings.language_servers.insert(
                 (*name).to_string(),
                 crate::config::settings::BridgeServerConfig {
-                    cmd: vec!["true".to_string()],
-                    languages: vec!["*".to_string()],
+                    cmd: Some(vec!["true".to_string()]),
+                    languages: Some(vec!["*".to_string()]),
                     ..Default::default()
                 },
             );

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -557,15 +557,14 @@ pub(crate) fn concatenated_formatting_pairs(settings: &WorkspaceSettings) -> Vec
 pub(crate) fn unspawnable_language_servers(settings: &WorkspaceSettings) -> Vec<String> {
     let servers = &settings.language_servers;
     let mut names: Vec<String> = servers
-        .keys()
-        .filter(|name| *name != crate::config::WILDCARD_KEY)
-        .filter(|name| {
+        .iter()
+        .filter(|(name, _)| name.as_str() != crate::config::WILDCARD_KEY)
+        .filter(|(_, config)| {
             // Written as `cmd = []`: the entry says it has none, which is a
             // statement, not the omission this warning exists to surface.
-            !servers
-                .get(*name)
-                .is_some_and(|config| config.cmd.as_ref().is_some_and(Vec::is_empty))
+            !config.cmd.as_ref().is_some_and(Vec::is_empty)
         })
+        .map(|(name, _)| name)
         .filter(|name| {
             crate::config::resolve_with_wildcard(
                 servers,

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -549,12 +549,23 @@ pub(crate) fn concatenated_formatting_pairs(settings: &WorkspaceSettings) -> Vec
 ///
 /// A server that resolves to `enabled: false` is excluded even if its `cmd`
 /// is also empty: disabling a server is a deliberate choice, not the
-/// misconfiguration this warning exists to surface.
+/// misconfiguration this warning exists to surface. A server that WRITES
+/// `cmd = []` is excluded for the same reason — that spelling now says the
+/// entry has none, so it is a statement rather than an omission. What remains
+/// worth naming is a server that said nothing about `cmd` and found nothing to
+/// inherit.
 pub(crate) fn unspawnable_language_servers(settings: &WorkspaceSettings) -> Vec<String> {
     let servers = &settings.language_servers;
     let mut names: Vec<String> = servers
         .keys()
         .filter(|name| *name != crate::config::WILDCARD_KEY)
+        .filter(|name| {
+            // Written as `cmd = []`: the entry says it has none, which is a
+            // statement, not the omission this warning exists to surface.
+            !servers
+                .get(*name)
+                .is_some_and(|config| config.cmd.as_ref().is_some_and(Vec::is_empty))
+        })
         .filter(|name| {
             crate::config::resolve_with_wildcard(
                 servers,
@@ -1621,6 +1632,15 @@ mod tests {
         }
     }
 
+    /// A server that says nothing about `cmd` — the spelling that inherits, and
+    /// the only one this warning is about.
+    fn cmd_unspecified() -> crate::config::settings::BridgeServerConfig {
+        crate::config::settings::BridgeServerConfig {
+            cmd: None,
+            ..server(&[])
+        }
+    }
+
     /// A server that writes `cmd` explicitly — an empty slice means "this
     /// server has no command", which no longer inherits the wildcard's.
     fn server(cmd: &[&str]) -> crate::config::settings::BridgeServerConfig {
@@ -1640,10 +1660,10 @@ mod tests {
     fn unspawnable_language_servers_flags_empty_cmd_but_not_wildcard() {
         let mut settings = settings_with(HashMap::new());
         settings.language_servers = HashMap::from([
-            ("_".to_string(), server(&[])), // defaults-only entry: never flagged
+            ("_".to_string(), cmd_unspecified()), // defaults-only entry: never flagged
             ("good".to_string(), server(&["lua-language-server"])),
-            ("broken".to_string(), server(&[])),
-            ("also-broken".to_string(), server(&[])),
+            ("broken".to_string(), cmd_unspecified()),
+            ("also-broken".to_string(), cmd_unspecified()),
         ]);
 
         assert_eq!(
@@ -1670,17 +1690,17 @@ mod tests {
     }
 
     #[test]
-    fn unspawnable_language_servers_flags_an_explicitly_empty_cmd() {
+    fn unspawnable_language_servers_excludes_an_explicitly_empty_cmd() {
         let mut settings = settings_with(HashMap::new());
         settings.language_servers = HashMap::from([
             ("_".to_string(), server(&["shared-ls", "--stdio"])),
             ("declines".to_string(), server(&[])),
         ]);
 
-        assert_eq!(
-            unspawnable_language_servers(&settings),
-            vec!["declines".to_string()],
-            "an explicitly empty cmd must not inherit the wildcard's"
+        assert!(
+            unspawnable_language_servers(&settings).is_empty(),
+            "`cmd = []` states that the entry has none — a deliberate choice, \
+             like `enabled = false`, not the omission this warning surfaces"
         );
     }
 
@@ -1693,9 +1713,9 @@ mod tests {
         let mut disabled = server(&["lua-language-server"]);
         disabled.enabled = Some(false);
         settings.language_servers = HashMap::from([
-            ("_".to_string(), server(&[])),
+            ("_".to_string(), cmd_unspecified()),
             ("disabled".to_string(), disabled),
-            ("broken".to_string(), server(&[])),
+            ("broken".to_string(), cmd_unspecified()),
         ]);
 
         assert_eq!(
@@ -1711,12 +1731,12 @@ mod tests {
         // a placeholder entry the user hasn't filled in yet, or one they
         // turned off without deleting). Must not be flagged either.
         let mut settings = settings_with(HashMap::new());
-        let mut disabled = server(&[]);
+        let mut disabled = cmd_unspecified();
         disabled.enabled = Some(false);
         settings.language_servers = HashMap::from([
-            ("_".to_string(), server(&[])),
+            ("_".to_string(), cmd_unspecified()),
             ("disabled".to_string(), disabled),
-            ("broken".to_string(), server(&[])),
+            ("broken".to_string(), cmd_unspecified()),
         ]);
 
         assert_eq!(

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -563,7 +563,7 @@ pub(crate) fn unspawnable_language_servers(settings: &WorkspaceSettings) -> Vec<
             )
             // A deliberately disabled server is not a misconfiguration —
             // don't warn about its missing cmd.
-            .is_none_or(|config| config.cmd.is_empty() && config.is_enabled())
+            .is_none_or(|config| config.cmd().is_empty() && config.is_enabled())
         })
         .cloned()
         .collect();
@@ -1621,10 +1621,12 @@ mod tests {
         }
     }
 
+    /// A server that writes `cmd` explicitly — an empty slice means "this
+    /// server has no command", which no longer inherits the wildcard's.
     fn server(cmd: &[&str]) -> crate::config::settings::BridgeServerConfig {
         crate::config::settings::BridgeServerConfig {
-            cmd: cmd.iter().map(|s| s.to_string()).collect(),
-            languages: vec!["lua".to_string()],
+            cmd: Some(cmd.iter().map(|s| s.to_string()).collect()),
+            languages: Some(vec!["lua".to_string()]),
             initialization_options: None,
             workspace_markers: None,
             on_type_formatting_triggers: None,
@@ -1653,14 +1655,32 @@ mod tests {
     #[test]
     fn unspawnable_language_servers_honors_cmd_inherited_from_wildcard() {
         let mut settings = settings_with(HashMap::new());
+        let mut inherits_cmd = server(&[]);
+        // Omitted, not empty: that is what inherits.
+        inherits_cmd.cmd = None;
         settings.language_servers = HashMap::from([
             ("_".to_string(), server(&["shared-ls", "--stdio"])),
-            ("inherits-cmd".to_string(), server(&[])),
+            ("inherits-cmd".to_string(), inherits_cmd),
         ]);
 
         assert!(
             unspawnable_language_servers(&settings).is_empty(),
             "cmd supplied by the '_' wildcard makes the entry spawnable"
+        );
+    }
+
+    #[test]
+    fn unspawnable_language_servers_flags_an_explicitly_empty_cmd() {
+        let mut settings = settings_with(HashMap::new());
+        settings.language_servers = HashMap::from([
+            ("_".to_string(), server(&["shared-ls", "--stdio"])),
+            ("declines".to_string(), server(&[])),
+        ]);
+
+        assert_eq!(
+            unspawnable_language_servers(&settings),
+            vec!["declines".to_string()],
+            "an explicitly empty cmd must not inherit the wildcard's"
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1637,8 +1637,8 @@ mod tests {
         (
             "rust_ls".to_string(),
             BridgeServerConfig {
-                cmd: vec!["true".to_string()],
-                languages: vec!["rust".to_string()],
+                cmd: Some(vec!["true".to_string()]),
+                languages: Some(vec!["rust".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -1748,7 +1748,7 @@ mod tests {
         settings.language_servers.insert(
             "sql_ls".to_string(),
             BridgeServerConfig {
-                cmd: vec!["sql-ls".to_string()],
+                cmd: Some(vec!["sql-ls".to_string()]),
                 enabled: Some(false),
                 ..Default::default()
             },
@@ -2479,7 +2479,7 @@ mod tests {
         settings.language_servers.insert(
             "lua_ls".to_string(),
             BridgeServerConfig {
-                cmd: vec!["lua-language-server".to_string()],
+                cmd: Some(vec!["lua-language-server".to_string()]),
                 ..Default::default()
             },
         );

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -414,6 +414,16 @@ impl Kakehashi {
                 .show_warning(crate::config::deprecation::AUTO_INSTALL_DEPRECATION_NOTICE)
                 .await;
         }
+        // Same shape for the empty-container rule change: what the layers said
+        // still parses, and now means something else.
+        if let Some(notice) =
+            crate::lsp::settings::emptied_container_notice(settings_outcome.raw_settings.as_ref())
+            && self
+                .settings_manager
+                .claim_empty_container_migration_warning()
+        {
+            self.notifier().show_warning(notice).await;
+        }
 
         // Always apply settings (use defaults if none were loaded)
         // This ensures auto_install=true, default capture_mappings, and other defaults are active

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -551,12 +551,12 @@ mod tests {
         language_servers.insert(
             "rust-bridge".to_string(),
             BridgeServerConfig {
-                cmd: vec![
+                cmd: Some(vec![
                     "sh".to_string(),
                     "-c".to_string(),
                     "cat > /dev/null".to_string(),
-                ],
-                languages: vec!["rust".to_string()],
+                ]),
+                languages: Some(vec!["rust".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,
@@ -645,12 +645,12 @@ print("hello")
             BridgeServerConfig {
                 // Inert: the caller pre-inserts a Ready handle via
                 // `insert_ready_test_connection`, so this cmd is never spawned.
-                cmd: vec![
+                cmd: Some(vec![
                     "sh".to_string(),
                     "-c".to_string(),
                     "cat > /dev/null".to_string(),
-                ],
-                languages: vec!["rust".to_string()],
+                ]),
+                languages: Some(vec!["rust".to_string()]),
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -1927,8 +1927,8 @@ mod tests {
         ResolvedServerConfig {
             server_name: name.to_string(),
             config: Arc::new(crate::config::settings::BridgeServerConfig {
-                cmd: vec![name.to_string()],
-                languages: vec![],
+                cmd: Some(vec![name.to_string()]),
+                languages: None,
                 initialization_options: None,
                 workspace_markers: None,
                 on_type_formatting_triggers: None,

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -249,8 +249,8 @@ mod tests {
             configs: vec![ResolvedServerConfig {
                 server_name: server.to_string(),
                 config: Arc::new(BridgeServerConfig {
-                    cmd: vec![server.to_string()],
-                    languages: vec![],
+                    cmd: Some(vec![server.to_string()]),
+                    languages: None,
                     initialization_options: None,
                     workspace_markers: None,
                     on_type_formatting_triggers: None,

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -183,6 +183,17 @@ impl Kakehashi {
         let _ =
             crate::config::paths::anchor_settings_paths(&mut parsed, root_path.as_ref().as_deref());
 
+        // Checked on the pushed layer, not the merge below: an empty container
+        // inherited from a file layer would otherwise be re-announced on every
+        // push. Latched session-wide, like the deprecated-key notices.
+        if let Some(notice) = crate::lsp::settings::emptied_container_notice(Some(&parsed))
+            && self
+                .settings_manager
+                .claim_empty_container_migration_warning()
+        {
+            self.notifier().show_warning(notice).await;
+        }
+
         // Merge onto current effective settings (not from scratch).
         // The current settings already reflect defaults < user < project < initializationOptions,
         // so merging preserves languages and other fields set during initialize.

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -412,6 +412,9 @@ pub fn load_settings(
         .reduce(merge_workspace_settings)
         .flatten();
     let raw_settings = merged.clone();
+    if let Some(message) = emptied_bridge_list_notice(raw_settings.as_ref()) {
+        events.push(SettingsEvent::warning(message));
+    }
     let settings = expand_merged_settings(merged, home, &env_fn, &mut events);
 
     SettingsLoadOutcome {
@@ -420,6 +423,34 @@ pub fn load_settings(
         events,
         deprecated_keys,
     }
+}
+
+/// Report `languageServers` entries whose `cmd` or `languages` is written as an
+/// empty list.
+///
+/// An empty list used to mean "inherit the `_` wildcard's"; it now means "this
+/// server has none", and omitting the key is what inherits. A configuration
+/// written against the old rule keeps parsing and silently changes meaning, so
+/// say so once per load rather than leaving the server mysteriously unused.
+fn emptied_bridge_list_notice(settings: Option<&RawWorkspaceSettings>) -> Option<String> {
+    let servers = settings?.language_servers.as_ref()?;
+    let mut named: Vec<&str> = servers
+        .iter()
+        .filter(|(_, config)| {
+            config.cmd.as_ref().is_some_and(Vec::is_empty)
+                || config.languages.as_ref().is_some_and(Vec::is_empty)
+        })
+        .map(|(name, _)| name.as_str())
+        .collect();
+    if named.is_empty() {
+        return None;
+    }
+    named.sort_unstable();
+    Some(format!(
+        "kakehashi: an empty `cmd` or `languages` list now means the server has none, \
+         not that it inherits the `_` wildcard's — omit the key to inherit. Affected: {}",
+        named.join(", ")
+    ))
 }
 
 /// Expand and validate the fully merged configuration, `initializationOptions`
@@ -837,6 +868,40 @@ mod tests {
     /// directory, and one with no parent at all is an error rather than a base
     /// of "nowhere" — otherwise an unanchored layer would be indistinguishable
     /// from a successfully anchored one.
+    #[test]
+    fn emptied_bridge_lists_are_reported_once_per_load() {
+        let settings: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [languageServers.declines]
+            cmd = []
+
+            [languageServers.silent]
+            languages = []
+
+            [languageServers.fine]
+            cmd = ["real-server"]
+        "#,
+        )
+        .expect("should parse");
+
+        let message = emptied_bridge_list_notice(Some(&settings)).expect("a notice");
+        assert!(message.contains("declines"), "{message}");
+        assert!(message.contains("silent"), "{message}");
+        assert!(!message.contains("fine"), "{message}");
+
+        let inheriting: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [languageServers.inherits]
+            enabled = true
+        "#,
+        )
+        .expect("should parse");
+        assert!(
+            emptied_bridge_list_notice(Some(&inheriting)).is_none(),
+            "omitting the keys is the inheriting spelling and must stay quiet"
+        );
+    }
+
     #[test]
     fn config_file_base_resolves_a_bare_filename_and_rejects_a_parentless_path() {
         let cwd = std::env::current_dir().expect("a working directory");

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -412,9 +412,6 @@ pub fn load_settings(
         .reduce(merge_workspace_settings)
         .flatten();
     let raw_settings = merged.clone();
-    if let Some(message) = emptied_bridge_list_notice(raw_settings.as_ref()) {
-        events.push(SettingsEvent::warning(message));
-    }
     let settings = expand_merged_settings(merged, home, &env_fn, &mut events);
 
     SettingsLoadOutcome {
@@ -425,30 +422,63 @@ pub fn load_settings(
     }
 }
 
-/// Report `languageServers` entries whose `cmd` or `languages` is written as an
-/// empty list.
+/// Report settings written as an explicitly empty container, where that used to
+/// mean something else.
 ///
-/// An empty list used to mean "inherit the `_` wildcard's"; it now means "this
-/// server has none", and omitting the key is what inherits. A configuration
-/// written against the old rule keeps parsing and silently changes meaning, so
-/// say so once per load rather than leaving the server mysteriously unused.
-fn emptied_bridge_list_notice(settings: Option<&RawWorkspaceSettings>) -> Option<String> {
-    let servers = settings?.language_servers.as_ref()?;
-    let mut named: Vec<&str> = servers
-        .iter()
-        .filter(|(_, config)| {
-            config.cmd.as_ref().is_some_and(Vec::is_empty)
-                || config.languages.as_ref().is_some_and(Vec::is_empty)
-        })
-        .map(|(name, _)| name.as_str())
-        .collect();
+/// Two spellings changed meaning at once:
+///
+/// - an empty `cmd` or `languages` used to defer to the `_` wildcard's list;
+///   it now says the entry has none, and omitting the key is what inherits;
+/// - an empty `captureMappings`, `highlights`, or `folds` used to be a no-op —
+///   the merge only extended — and now clears the layer below, which for a
+///   top-level `captureMappings = {}` means every built-in mapping.
+///
+/// A configuration written against either old rule still parses and silently
+/// changes behavior, so name what is affected rather than leaving the user to
+/// discover it through missing highlights or an unused server.
+///
+/// The `_` entry is reported like any other: an empty list there clears a lower
+/// layer's wildcard, which is exactly the kind of change worth naming.
+///
+/// Callers pass the layer the user just wrote, not the merged result — an
+/// inherited `[]` would otherwise be re-announced on every configuration push.
+/// The notice is shown once per session (see
+/// `SettingsManager::claim_empty_container_migration_warning`), because the
+/// spelling it names is also the one the documentation now recommends for
+/// "this entry has none": worth explaining once, not worth nagging about.
+pub(crate) fn emptied_container_notice(settings: Option<&RawWorkspaceSettings>) -> Option<String> {
+    let settings = settings?;
+    let mut named: Vec<String> = Vec::new();
+
+    if let Some(servers) = settings.language_servers.as_ref() {
+        named.extend(
+            servers
+                .iter()
+                .filter(|(_, config)| {
+                    config.cmd.as_ref().is_some_and(Vec::is_empty)
+                        || config.languages.as_ref().is_some_and(Vec::is_empty)
+                })
+                .map(|(name, _)| format!("languageServers.{name}")),
+        );
+    }
+
+    match settings.capture_mappings.as_ref() {
+        Some(mappings) if mappings.is_empty() => named.push("captureMappings".to_string()),
+        Some(mappings) => named.extend(mappings.iter().filter_map(|(lang, entry)| {
+            let cleared = entry.highlights.as_ref().is_some_and(|m| m.is_empty())
+                || entry.folds.as_ref().is_some_and(|m| m.is_empty());
+            cleared.then(|| format!("captureMappings.{lang}"))
+        })),
+        None => {}
+    }
+
     if named.is_empty() {
         return None;
     }
     named.sort_unstable();
     Some(format!(
-        "kakehashi: an empty `cmd` or `languages` list now means the server has none, \
-         not that it inherits the `_` wildcard's — omit the key to inherit. Affected: {}",
+        "kakehashi: an empty list or map now clears the layer below rather than \
+         deferring to it — omit the key to inherit. Affected: {}",
         named.join(", ")
     ))
 }
@@ -869,7 +899,7 @@ mod tests {
     /// of "nowhere" — otherwise an unanchored layer would be indistinguishable
     /// from a successfully anchored one.
     #[test]
-    fn emptied_bridge_lists_are_reported_once_per_load() {
+    fn emptied_containers_are_named_in_the_migration_notice() {
         let settings: RawWorkspaceSettings = toml::from_str(
             r#"
             [languageServers.declines]
@@ -884,7 +914,7 @@ mod tests {
         )
         .expect("should parse");
 
-        let message = emptied_bridge_list_notice(Some(&settings)).expect("a notice");
+        let message = emptied_container_notice(Some(&settings)).expect("a notice");
         assert!(message.contains("declines"), "{message}");
         assert!(message.contains("silent"), "{message}");
         assert!(!message.contains("fine"), "{message}");
@@ -897,7 +927,7 @@ mod tests {
         )
         .expect("should parse");
         assert!(
-            emptied_bridge_list_notice(Some(&inheriting)).is_none(),
+            emptied_container_notice(Some(&inheriting)).is_none(),
             "omitting the keys is the inheriting spelling and must stay quiet"
         );
     }

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -70,6 +70,10 @@ pub(crate) struct SettingsManager {
     /// payload has been warned about. Unlike `rootMarkers`, this applies only to
     /// client-pushed runtime settings, not initializationOptions or TOML files.
     unwrapped_didchange_deprecation_warned: AtomicBool,
+    /// Latches once the empty-container migration notice has been shown. The
+    /// spelling it explains is legitimate under the current rule, so it is
+    /// announced once and then left alone.
+    empty_container_migration_warned: AtomicBool,
 }
 
 impl std::fmt::Debug for SettingsManager {
@@ -118,6 +122,7 @@ impl SettingsManager {
             root_markers_deprecation_warned: AtomicBool::new(false),
             auto_install_deprecation_warned: AtomicBool::new(false),
             unwrapped_didchange_deprecation_warned: AtomicBool::new(false),
+            empty_container_migration_warned: AtomicBool::new(false),
         }
     }
 
@@ -146,6 +151,13 @@ impl SettingsManager {
     pub(crate) fn claim_unwrapped_didchange_deprecation_warning(&self) -> bool {
         !self
             .unwrapped_didchange_deprecation_warned
+            .swap(true, Ordering::Relaxed)
+    }
+
+    /// Claim the one-per-session slot for the empty-container migration notice.
+    pub(crate) fn claim_empty_container_migration_warning(&self) -> bool {
+        !self
+            .empty_container_migration_warned
             .swap(true, Ordering::Relaxed)
     }
 

--- a/tests/e2e_config_file.rs
+++ b/tests/e2e_config_file.rs
@@ -802,17 +802,15 @@ fn test_config_file_language_servers_with_init_options_partial_override() {
         .env_remove("KAKEHASHI_DATA_DIR")
         .build();
 
-    // Note: BridgeServerConfig requires that both `cmd` and `languages` be present in the
-    // JSON for deserialization (they are not `Option` and have no `#[serde(default)]`).
-    // We pass `languages: []` so deserialization succeeds; the merge logic then keeps the
-    // config file's non-empty `languages` because the overlay's is empty.
+    // Omitting `languages` is what inherits the config file's list. Writing
+    // `[]` would say this server handles nothing, which the sibling test below
+    // pins.
     let settings = get_effective_settings_with_init_options(
         &mut client,
         json!({
             "languageServers": {
                 "myserver": {
-                    "cmd": ["new-cmd"],
-                    "languages": []
+                    "cmd": ["new-cmd"]
                 }
             }
         }),
@@ -828,7 +826,44 @@ fn test_config_file_language_servers_with_init_options_partial_override() {
     assert_eq!(
         myserver["languages"],
         json!(["rust"]),
-        "languages should be inherited from config file (overlay was empty)"
+        "languages should be inherited from the config file (the overlay omitted it)"
+    );
+}
+
+/// The other half of the rule the test above relies on: an overlay that writes
+/// an empty `languages` has said the server handles nothing, so the config
+/// file's list is replaced rather than inherited.
+#[test]
+fn test_config_file_language_servers_empty_languages_overrides_rather_than_inherits() {
+    let dir = TempDir::new().unwrap();
+    let config = dir.path().join("kakehashi.toml");
+    std::fs::write(
+        &config,
+        "[languageServers.myserver]\ncmd = [\"old-cmd\"]\nlanguages = [\"rust\"]\n",
+    )
+    .unwrap();
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config.to_str().unwrap())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let settings = get_effective_settings_with_init_options(
+        &mut client,
+        json!({
+            "languageServers": {
+                "myserver": {
+                    "languages": []
+                }
+            }
+        }),
+    );
+
+    assert_eq!(
+        settings["languageServers"]["myserver"]["languages"],
+        json!([]),
+        "an explicitly empty languages list must not fall back to the config file's"
     );
 }
 


### PR DESCRIPTION
> Stacked on #954. Review only the commits from `test(config): pin empty-means-clear for capture mappings` onward; retarget to `main` once #954 merges.

## Summary

Omitted, empty, and non-empty are three distinct statements everywhere in the configuration — except where the field's type could not express them.

| | omitted | empty (`{}` / `[]`) | non-empty |
|---|---|---|---|
| map | inherit the layer below | **clear** it | merge per key |
| list | inherit the layer below | **clear** it | replace wholesale |

`languageServers`, `bridge`, `layers.aggregation`, and `queries` already read that way because they are `Option`-typed. `captureMappings`, `QueryTypeMappings.highlights`/`folds`, and `BridgeServerConfig.cmd`/`languages` did not — they are bare `HashMap`/`Vec` with `#[serde(default)]`, which cannot tell an omitted key from an empty one. That is the whole reason the two groups behaved differently; it was never a design choice.

All five fields are now `Option`-typed and follow the table.

## Behavior changes

- `captureMappings = {}` and `highlights = {}` clear instead of being silently ignored. A default capture mapping could not be dropped before.
- **`cmd = []` and `languages = []` now mean "this server has none" instead of "inherit the `_` wildcard's".** A config written against the old rule keeps parsing and changes meaning, so kakehashi names the affected servers in a warning when it loads them.

The merge function was only half of the second one: `is_spawnable_with_wildcard` and `effective_languages_with_wildcard` resolve the same inheritance at *read* time, independently. Fixing only `merge_bridge_server_configs` would have left `cmd = []` spawning the wildcard's command.

## Why `skip_serializing_if` is load-bearing

Settings written back out must not gain an empty container. `folds` was serializing as `{}` whenever unset, and under the new rule that reads as a clear on the next load — so a round trip through `kakehashi config` would have started deleting mappings. Two snapshots record the corrected shape.

Same reason the defaults layer leaves `folds` unset rather than empty: an empty map there would clear whatever a user layer supplies.

## Tests

Each behavior gained a pair — the empty spelling clears, the omitted spelling still inherits. Existing tests that expressed "inherits" as an empty list now express it as an omission and gained the discriminating case; one e2e test carried a comment recommending `languages: []` as a workaround for a deserialization requirement that did not exist, which is exactly the spelling this PR repurposes.

Closes #949
