### PR TITLE
refactor(config): extract the layer fold, and say why its order binds

### DIFF
--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -78,11 +78,17 @@ pub struct SettingsLoadOutcome {
 /// Extracted rather than inlined because the order is load-bearing beyond
 /// "later wins": [`merge_workspace_settings`] is **not associative** once an
 /// empty container clears the layer below — `merge(merge({x}, {}), {y})` is
-/// `{y}`, while `merge({x}, merge({}, {y}))` is `{x, y}`. Any future caller
-/// that recomposes from retained layers has to fold them strictly
-/// left-to-right, in the order they were received, and must not fold a suffix
-/// on its own and replay it over a rebuilt base.
-pub(crate) fn fold_layers(
+/// `{y}`, while `merge({x}, merge({}, {y}))` is `{x, y}`.
+///
+/// Precisely: because this is a left fold, any *prefix* may be collapsed into
+/// one value and resumed from — that is what a checkpoint is — but no proper
+/// *suffix* may be folded on its own and replayed over a rebuilt base, since
+/// the clear it carried would be lost.
+///
+/// The sibling hazard for anything retaining layers: a layer whose only
+/// content is an empty container looks contentless and is not. It must not be
+/// pruned or deduplicated away.
+fn fold_layers(
     layers: impl IntoIterator<Item = Option<RawWorkspaceSettings>>,
 ) -> Option<RawWorkspaceSettings> {
     layers
@@ -159,11 +165,7 @@ fn unknown_config_keys(contents: &str) -> Vec<String> {
 /// the same defaults, so a lone `debounceMs` is still judged against the
 /// default `maxWaitMs`.
 fn merge_explicit_layers(layers: &[Option<RawWorkspaceSettings>]) -> Option<RawWorkspaceSettings> {
-    layers
-        .iter()
-        .cloned()
-        .reduce(merge_workspace_settings)
-        .flatten()
+    fold_layers(layers.iter().cloned())
 }
 
 /// The directory a config file lives in, as an absolute path.
@@ -1000,8 +1002,40 @@ mod tests {
         assert_eq!(
             names(&replayed),
             ["a", "b"],
-            "folding the suffix on its own loses the clear — this is why the \
-             order and the whole prefix have to be kept"
+            "folding the suffix on its own loses the clear — this characterizes \
+             today's hazard, and is why the order and the whole prefix have to \
+             be kept"
+        );
+    }
+
+    /// An absent layer and a layer that clears are not the same thing, and the
+    /// fold has to keep them apart: `None` contributes nothing, while
+    /// `Some({})` says "none of this". Every future caller that recomposes
+    /// from retained layers depends on the distinction.
+    #[test]
+    fn fold_layers_keeps_an_absent_layer_distinct_from_a_clearing_one() {
+        let with_server: RawWorkspaceSettings =
+            toml::from_str("[languageServers.a]\ncmd = [\"a\"]\n").expect("parses");
+        let cleared: RawWorkspaceSettings =
+            toml::from_str("languageServers = {}\n").expect("parses");
+
+        let absent = fold_layers([None, Some(with_server.clone()), None]).expect("one real layer");
+        assert!(
+            absent
+                .language_servers
+                .as_ref()
+                .is_some_and(|servers| servers.contains_key("a")),
+            "an absent layer must contribute nothing, not clear"
+        );
+
+        let clearing = fold_layers([Some(with_server), Some(cleared)]).expect("two layers fold");
+        assert_eq!(
+            clearing
+                .language_servers
+                .as_ref()
+                .map(std::collections::HashMap::len),
+            Some(0),
+            "a clearing layer must empty what the layer below supplied"
         );
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -72,6 +72,25 @@ pub struct SettingsLoadOutcome {
     pub(crate) deprecated_keys: DeprecatedKeysSeen,
 }
 
+/// Fold configuration layers into the settings they describe, lowest
+/// precedence first.
+///
+/// Extracted rather than inlined because the order is load-bearing beyond
+/// "later wins": [`merge_workspace_settings`] is **not associative** once an
+/// empty container clears the layer below — `merge(merge({x}, {}), {y})` is
+/// `{y}`, while `merge({x}, merge({}, {y}))` is `{x, y}`. Any future caller
+/// that recomposes from retained layers has to fold them strictly
+/// left-to-right, in the order they were received, and must not fold a suffix
+/// on its own and replay it over a rebuilt base.
+pub(crate) fn fold_layers(
+    layers: impl IntoIterator<Item = Option<RawWorkspaceSettings>>,
+) -> Option<RawWorkspaceSettings> {
+    layers
+        .into_iter()
+        .reduce(merge_workspace_settings)
+        .flatten()
+}
+
 /// Ceiling on a single config file read.
 ///
 /// A kakehashi configuration is a hand-written TOML file; megabytes of one is a
@@ -407,10 +426,7 @@ pub fn load_settings(
     let mut layers = vec![defaults];
     layers.extend(config_layers);
     layers.push(override_settings);
-    let merged = layers
-        .into_iter()
-        .reduce(merge_workspace_settings)
-        .flatten();
+    let merged = fold_layers(layers);
     let raw_settings = merged.clone();
     let settings = expand_merged_settings(merged, home, &env_fn, &mut events);
 
@@ -944,6 +960,48 @@ mod tests {
                 .expect_err("a filesystem root has no parent")
                 .kind(),
             std::io::ErrorKind::InvalidInput
+        );
+    }
+
+    /// Folding is left-to-right over the layers as received, and that is not a
+    /// stylistic choice: an empty container clears the layer below, so folding
+    /// a suffix on its own loses the clear and replaying it over a rebuilt base
+    /// resurrects what it was meant to remove.
+    #[test]
+    fn fold_layers_is_left_to_right_because_a_clear_is_not_associative() {
+        let with_server: RawWorkspaceSettings =
+            toml::from_str("[languageServers.a]\ncmd = [\"a\"]\n").expect("parses");
+        let cleared: RawWorkspaceSettings =
+            toml::from_str("languageServers = {}\n").expect("parses");
+        let other_server: RawWorkspaceSettings =
+            toml::from_str("[languageServers.b]\ncmd = [\"b\"]\n").expect("parses");
+
+        let sequential = fold_layers([
+            Some(with_server.clone()),
+            Some(cleared.clone()),
+            Some(other_server.clone()),
+        ])
+        .expect("three layers fold");
+        let names = |settings: &RawWorkspaceSettings| {
+            let mut names: Vec<String> = settings
+                .language_servers
+                .as_ref()
+                .expect("servers")
+                .keys()
+                .cloned()
+                .collect();
+            names.sort();
+            names
+        };
+        assert_eq!(names(&sequential), ["b"], "the clear must survive the fold");
+
+        let suffix = fold_layers([Some(cleared), Some(other_server)]).expect("two layers fold");
+        let replayed = fold_layers([Some(with_server), Some(suffix)]).expect("two layers fold");
+        assert_eq!(
+            names(&replayed),
+            ["a", "b"],
+            "folding the suffix on its own loses the clear — this is why the \
+             order and the whole prefix have to be kept"
         );
     }
 


### PR DESCRIPTION
> **First slice of #948.** Stacked on #957 → #954. Review only `git diff fix/issue-949-empty-means-clear...HEAD`.

## What this slice does

`load_settings` and `merge_explicit_layers` each folded their layers with an inline `reduce`, which reads as an implementation detail. It is not.

`merge_workspace_settings` stopped being associative once an explicit empty container came to clear the layer below (#949). So "later wins" does **not** authorize folding a suffix on its own and replaying it:

```
A = { languageServers.a }
B = { languageServers = {} }     # clear
C = { languageServers.b }

fold([A, B, C])          → { b }        the clear survives
fold([A, fold([B, C])])  → { a, b }     the clear is lost
```

Both sites now go through one `fold_layers`, whose doc states the constraint precisely:

- because this is a left fold, any **prefix** may be collapsed into one value and resumed from — that is what a checkpoint is;
- no proper **suffix** may be folded on its own and replayed over a rebuilt base;
- and a layer whose only content is an empty container **looks contentless and is not**, so anything retaining layers must not prune or deduplicate it away.

Tests pin the hazard and the distinction it rests on: an absent layer (`None`) contributes nothing, while a clearing one (`Some({})`) empties what is below. Every remaining slice of #948 depends on those staying apart.

Structural: same layers, same order, same result.

## What remains (see #948 for the full design)

1. **Retain the layers with their anchors** — no base for the programmed defaults, its own directory for each config file (including each `--config-file` entry separately), the workspace root for client-supplied layers.
2. **Store them unanchored and anchor at recompose time.** This is the fix for Defect 1: anchoring is idempotent and yields absolute paths, so a client layer anchored at push time can never be rebased — a runtime `./queries` pushed under `/old` stays `/old/queries` forever. Anchoring is by origin, not against one root: only client-supplied layers follow the workspace root, and the project layer is *re-read* rather than re-anchored when the root moves.
3. **Recompose from the retained layers** at every publication point, replacing `client_settings_override`.
4. **Split ingress from recomposition** — wire-shape checks, unknown-key rejection, deprecation detection, and notification logging run once at receipt; only anchoring, folding, validation, and publication repeat. Final validation must repeat, because cross-field constraints and base-language chains span layers.
5. **Installed parser dirs as an additive set** below every user-authored `searchPaths`.
6. **Bound the accumulated layers** — a folded prefix is a cache tied to an exact generation of its constituents, never a general compaction, for the reason this slice's test demonstrates.

The layer and anchor types were written for this slice and then removed: nothing reads them until (3), and this project rejects unwired code (`make check` bans `#[allow(dead_code)]`). They belong with the recomposition that consumes them.

Part of #948
