### PR TITLE
feat(config): pull the editor's configuration when it can answer

### DIFF
--- a/docs/architecture-decisions/downstream-settings-propagation.md
+++ b/docs/architecture-decisions/downstream-settings-propagation.md
@@ -225,6 +225,15 @@ The following are **deferred** and intentionally out of scope:
   identically to a push of the same section (see the accumulate contract in
   configuration-merging-strategy), so nothing about the merge is special-cased
   for having been pulled.
+
+  One consequence worth stating for anyone writing an editor integration: a
+  field the client answers with an empty container **clears** the layer below,
+  exactly as the same spelling would in a config file. LSP carries no
+  provenance that distinguishes a value the user authored from a default the
+  extension registered, so an extension that registers `{}` as the default for
+  a setting would clear it for users who configured nothing. Special-casing it
+  is not an option — it would make an intentional clear unspellable through a
+  pull-model editor — so register defaults as absent rather than empty.
 - **`scopeUri` / multi-root resolution**: on the downstream side
   `ConfigurationItem.scopeUri` is ignored — a single per-server `settings`
   value answers all scopes. Upstream, kakehashi asks without a scope on

--- a/docs/architecture-decisions/downstream-settings-propagation.md
+++ b/docs/architecture-decisions/downstream-settings-propagation.md
@@ -216,14 +216,22 @@ keeps propagation proportional to actual change.
 
 The following are **deferred** and intentionally out of scope:
 
-- **Upstream pull** (kakehashi → editor `workspace/configuration`): needed only
-  to support pull-model editors (e.g. VS Code sends `didChangeConfiguration`
-  with no usable `settings` and expects the server to pull). Editors that push
-  full settings via `initializationOptions` / `didChangeConfiguration` (e.g.
-  Neovim) do not need it. When added, it must be gated on the editor's
-  `capabilities.workspace.configuration`.
-- **`scopeUri` / multi-root resolution**: `ConfigurationItem.scopeUri` is
-  ignored; a single per-server `settings` value answers all scopes.
+- ~~**Upstream pull**~~ (kakehashi → editor `workspace/configuration`):
+  **implemented** (#952 stage 1). Gated on the editor's
+  `capabilities.workspace.configuration`, as this decision required. kakehashi
+  asks once the handshake completes, and again whenever a
+  `didChangeConfiguration` carries no usable payload — which is the shape
+  pull-model editors send. The answer is applied as a configuration layer,
+  identically to a push of the same section (see the accumulate contract in
+  configuration-merging-strategy), so nothing about the merge is special-cased
+  for having been pulled.
+- **`scopeUri` / multi-root resolution**: on the downstream side
+  `ConfigurationItem.scopeUri` is ignored — a single per-server `settings`
+  value answers all scopes. Upstream, kakehashi asks without a scope on
+  purpose: it resolves one effective settings snapshot for the whole process,
+  so naming a scope and applying the answer process-wide would promote one
+  folder's configuration to global. Scoped pull is #952 stage 2 and changes
+  that invariant.
 
 ## Validation
 

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -341,6 +341,9 @@ pub struct Kakehashi {
     /// dropped. Cancelling the token gives deterministic shutdown: `shutdown()`
     /// cancels → task exits immediately → no waiting for channel drainage.
     shutdown_token: tokio_util::sync::CancellationToken,
+    /// Whether a `workspace/configuration` pull is already in flight; see
+    /// `pull_client_configuration`.
+    configuration_pull_in_flight: std::sync::atomic::AtomicBool,
     /// Pre-computed home directory for tilde expansion in config paths.
     /// Computed once at construction — `dirs::home_dir()` is stable for the
     /// process lifetime.
@@ -424,6 +427,7 @@ impl std::fmt::Debug for Kakehashi {
             .field("synthetic_diagnostics", &"SyntheticDiagnosticsManager")
             .field("debounced_diagnostics", &"DebouncedDiagnosticsManager")
             .field("shutdown_token", &"CancellationToken")
+            .field("configuration_pull_in_flight", &"AtomicBool")
             .field("home_dir", &self.home_dir)
             .finish_non_exhaustive()
     }
@@ -475,6 +479,7 @@ impl Kakehashi {
                 crate::lsp::diagnostic_cache::DiagnosticAggregator::new(),
             ),
             shutdown_token: tokio_util::sync::CancellationToken::new(),
+            configuration_pull_in_flight: std::sync::atomic::AtomicBool::new(false),
             home_dir: dirs::home_dir().map(|p| p.to_string_lossy().into_owned()),
             captures_cache: dashmap::DashMap::new(),
             captures_walk_cache: dashmap::DashMap::new(),

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -341,9 +341,11 @@ pub struct Kakehashi {
     /// dropped. Cancelling the token gives deterministic shutdown: `shutdown()`
     /// cancels → task exits immediately → no waiting for channel drainage.
     shutdown_token: tokio_util::sync::CancellationToken,
-    /// Whether a `workspace/configuration` pull is already in flight; see
+    /// Whether a `workspace/configuration` pull is already in flight, and
+    /// whether a trigger arrived while one was; see
     /// `pull_client_configuration`.
     configuration_pull_in_flight: std::sync::atomic::AtomicBool,
+    configuration_pull_pending: std::sync::atomic::AtomicBool,
     /// Pre-computed home directory for tilde expansion in config paths.
     /// Computed once at construction — `dirs::home_dir()` is stable for the
     /// process lifetime.
@@ -428,6 +430,7 @@ impl std::fmt::Debug for Kakehashi {
             .field("debounced_diagnostics", &"DebouncedDiagnosticsManager")
             .field("shutdown_token", &"CancellationToken")
             .field("configuration_pull_in_flight", &"AtomicBool")
+            .field("configuration_pull_pending", &"AtomicBool")
             .field("home_dir", &self.home_dir)
             .finish_non_exhaustive()
     }
@@ -480,6 +483,7 @@ impl Kakehashi {
             ),
             shutdown_token: tokio_util::sync::CancellationToken::new(),
             configuration_pull_in_flight: std::sync::atomic::AtomicBool::new(false),
+            configuration_pull_pending: std::sync::atomic::AtomicBool::new(false),
             home_dir: dirs::home_dir().map(|p| p.to_string_lossy().into_owned()),
             captures_cache: dashmap::DashMap::new(),
             captures_walk_cache: dashmap::DashMap::new(),

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -701,12 +701,6 @@ impl Kakehashi {
     pub(crate) async fn initialized_impl(&self, _: InitializedParams) {
         self.notifier().log_info("server is ready").await;
 
-        // Now that the handshake is complete, ask a pull-capable client for its
-        // configuration. Editors that send `didChangeConfiguration` with no
-        // usable `settings` have no other way to configure kakehashi past
-        // `initializationOptions`.
-        self.pull_client_configuration().await;
-
         // Forward downstream-initiated messages to the upstream editor
         // (workspace/applyEdit is answered locally instead when the editor
         // never declared the capability). The reader tasks feed three
@@ -776,6 +770,17 @@ impl Kakehashi {
                 editor_supports_apply_edit,
             ));
         }
+
+        // Ask a pull-capable client for its configuration now that the
+        // handshake is complete. Editors that send `didChangeConfiguration`
+        // with no usable `settings` have no other way to configure kakehashi
+        // past `initializationOptions`.
+        //
+        // Last, deliberately: this awaits a response from the client, and a
+        // client that is slow to answer — or never does — must not hold up the
+        // forwarding loops above. Nothing follows it, so the only thing such a
+        // client delays is its own configuration.
+        self.pull_client_configuration().await;
     }
 
     /// Arm a Unix-signal watcher that reaps the downstream server pool when

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -701,6 +701,12 @@ impl Kakehashi {
     pub(crate) async fn initialized_impl(&self, _: InitializedParams) {
         self.notifier().log_info("server is ready").await;
 
+        // Now that the handshake is complete, ask a pull-capable client for its
+        // configuration. Editors that send `didChangeConfiguration` with no
+        // usable `settings` have no other way to configure kakehashi past
+        // `initializationOptions`.
+        self.pull_client_configuration().await;
+
         // Forward downstream-initiated messages to the upstream editor
         // (workspace/applyEdit is answered locally instead when the editor
         // never declared the capability). The reader tasks feed three

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -101,6 +101,22 @@ fn is_kakehashi_workspace_entry(key: &str, value: &Value) -> bool {
     is_workspace_setting_key_or_typo(key)
 }
 
+/// Holds the single-flight claim for the duration of one pull, releasing it on
+/// every exit path including the timeout and shutdown arms.
+struct SingleFlightPull<'a>(&'a std::sync::atomic::AtomicBool);
+
+impl<'a> SingleFlightPull<'a> {
+    fn claim(flag: &'a std::sync::atomic::AtomicBool) -> Option<Self> {
+        (!flag.swap(true, std::sync::atomic::Ordering::AcqRel)).then_some(Self(flag))
+    }
+}
+
+impl Drop for SingleFlightPull<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, std::sync::atomic::Ordering::Release);
+    }
+}
+
 /// How long to wait for the client to answer `workspace/configuration`.
 ///
 /// The await lives in a service future the server joins on, so an answer that
@@ -174,6 +190,16 @@ impl Kakehashi {
             return;
         }
 
+        // One pull at a time. Startup pulls, and so does every no-payload
+        // notification, so two can be in flight at once — and since the reload
+        // lock is only taken once an answer arrives, the older answer could
+        // apply last and merge its snapshot over the newer one. A pull already
+        // running will read the client's current state, which is what a second
+        // one would have asked for.
+        let Some(_in_flight) = SingleFlightPull::claim(&self.configuration_pull_in_flight) else {
+            return;
+        };
+
         let items = vec![ConfigurationItem {
             scope_uri: None,
             section: Some("kakehashi".to_string()),
@@ -183,6 +209,10 @@ impl Kakehashi {
         // would keep `serve` from returning after `exit`. The SIGTERM handler
         // rescues that on Unix and nothing does on Windows.
         let answered = match tokio::select! {
+            // Biased, response first: `select!` is unbiased by default, so an
+            // answer that arrives in the same poll as the deadline could be
+            // thrown away. An answer that came is an answer.
+            biased;
             result = self.client.configuration(items) => result,
             () = self.shutdown_token.cancelled() => return,
             () = tokio::time::sleep(CONFIGURATION_PULL_TIMEOUT) => {
@@ -423,6 +453,26 @@ impl Kakehashi {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn single_flight_pull_admits_one_claim_at_a_time() {
+        use std::sync::atomic::AtomicBool;
+
+        let in_flight = AtomicBool::new(false);
+        let first = SingleFlightPull::claim(&in_flight).expect("the first pull runs");
+        assert!(
+            SingleFlightPull::claim(&in_flight).is_none(),
+            "a second pull must stand down: the one already running reads the \
+             same client state it would have asked for"
+        );
+
+        drop(first);
+        assert!(
+            SingleFlightPull::claim(&in_flight).is_some(),
+            "the claim is released on every exit path, including the timeout \
+             and shutdown arms"
+        );
+    }
+
     use super::*;
 
     use std::future::Future;

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -71,6 +71,18 @@ fn kakehashi_targeted_payload(object: serde_json::Map<String, Value>) -> serde_j
     Value::Object(object)
 }
 
+/// Whether a pushed `settings` says nothing at all — `null`, or an object with
+/// no keys. Distinct from a payload that mentions only settings kakehashi does
+/// not own, which is a statement about other servers and still says nothing
+/// about this one, but which the unknown-key path reports on.
+fn carries_no_payload(settings: &Value) -> bool {
+    match settings {
+        Value::Null => true,
+        Value::Object(object) => object.is_empty(),
+        _ => false,
+    }
+}
+
 fn format_rejected_keys(keys: &[String]) -> String {
     keys.iter()
         .map(|key| format!("`{key}`"))
@@ -89,6 +101,45 @@ fn is_kakehashi_workspace_entry(key: &str, value: &Value) -> bool {
     is_workspace_setting_key_or_typo(key)
 }
 
+/// How long to wait for the client to answer `workspace/configuration`.
+///
+/// The await lives in a service future the server joins on, so an answer that
+/// never comes must not be waited for indefinitely. Generous, because the cost
+/// of giving up early is a session running on file settings alone.
+const CONFIGURATION_PULL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// How a client-supplied configuration reached kakehashi.
+///
+/// Only used to describe it back to the user: the two arrive by different
+/// routes, and a message naming the wrong one sends people looking for a
+/// notification they never sent.
+#[derive(Clone, Copy)]
+pub(crate) enum ConfigurationIngress {
+    /// The client pushed `workspace/didChangeConfiguration`.
+    Push,
+    /// kakehashi asked, via `workspace/configuration`.
+    Pull,
+}
+
+impl ConfigurationIngress {
+    fn describe(self) -> &'static str {
+        match self {
+            Self::Push => "workspace/didChangeConfiguration",
+            Self::Pull => "the configuration read from the client",
+        }
+    }
+
+    /// What to say once the layer is in effect. A pull runs at startup for
+    /// every capable client, where "Configuration updated!" would describe an
+    /// event the user did not cause.
+    fn applied_message(self) -> &'static str {
+        match self {
+            Self::Push => "Configuration updated!",
+            Self::Pull => "Applied the configuration read from the client",
+        }
+    }
+}
+
 impl Kakehashi {
     /// Ask the client for its `kakehashi` section and apply what comes back.
     ///
@@ -100,11 +151,24 @@ impl Kakehashi {
     /// supersedes anything: the layer is appended in arrival order like any
     /// other (#734).
     ///
-    /// `scopeUri` is deliberately null. kakehashi resolves one effective
-    /// settings snapshot for the whole process, so asking with a scope and
-    /// applying the answer process-wide would silently promote one folder's
-    /// configuration to global. Asking unscoped asks for exactly what the
-    /// single layer means; scoped pull is the separate half of #952.
+    /// The item carries no `scopeUri`, which asks for the client's global
+    /// settings. kakehashi resolves one effective settings snapshot for the
+    /// whole process, so naming a scope and then applying the answer
+    /// process-wide would silently promote one folder's configuration to
+    /// global. Asking unscoped asks for exactly what the single layer means;
+    /// scoped pull is the separate half of #952.
+    ///
+    /// The answer is trusted as authored: a field written as an empty container
+    /// clears the layer below, exactly as the same spelling would in a config
+    /// file. An editor that materializes `{}` as the default for a setting it
+    /// registers would therefore clear it for a user who configured nothing —
+    /// worth knowing before registering such a default, and the reason a pull
+    /// answer is not merged more leniently than a push.
+    ///
+    /// Those global settings are still anchored against the workspace root, as
+    /// a push is. Relative paths in a client's global configuration therefore
+    /// resolve against whichever workspace is open — accepted, because the
+    /// alternative leaves them resolving against the launch directory.
     pub(crate) async fn pull_client_configuration(&self) {
         if !self.settings_manager.supports_configuration_pull() {
             return;
@@ -114,7 +178,24 @@ impl Kakehashi {
             scope_uri: None,
             section: Some("kakehashi".to_string()),
         }];
-        let answered = match self.client.configuration(items).await {
+        // Bounded by shutdown: this await lives in the `initialized` service
+        // future, which the server joins on, so a client that never answers
+        // would keep `serve` from returning after `exit`. The SIGTERM handler
+        // rescues that on Unix and nothing does on Windows.
+        let answered = match tokio::select! {
+            result = self.client.configuration(items) => result,
+            () = self.shutdown_token.cancelled() => return,
+            () = tokio::time::sleep(CONFIGURATION_PULL_TIMEOUT) => {
+                self.notifier()
+                    .log_warning(
+                        "The client did not answer workspace/configuration in time; \
+                         keeping the settings already in effect"
+                            .to_string(),
+                    )
+                    .await;
+                return;
+            }
+        } {
             Ok(values) => values,
             Err(error) => {
                 // Leave the settings in effect alone: a failed pull is no
@@ -128,20 +209,47 @@ impl Kakehashi {
             }
         };
 
-        // `null` means the client cannot provide a value for this item — also
-        // no answer. An object, empty or not, is one.
-        let Some(section @ Value::Object(_)) = answered.into_iter().next() else {
-            return;
+        // A missing element or `null` is the client saying it cannot provide a
+        // value for this item — no answer, so nothing changes. Anything else is
+        // an answer, including a malformed one: routing it through says so,
+        // where swallowing it would leave the user with a client that is
+        // answering wrongly and a server that looks like it never asked.
+        let section = match answered.into_iter().next() {
+            None | Some(Value::Null) => return,
+            Some(section) => section,
         };
 
-        self.did_change_configuration_impl(DidChangeConfigurationParams {
-            settings: serde_json::json!({ "kakehashi": section }),
-        })
+        self.apply_client_configuration(
+            serde_json::json!({ "kakehashi": section }),
+            ConfigurationIngress::Pull,
+        )
         .await;
     }
 
     /// Handle workspace/didChangeConfiguration notification.
+    ///
+    /// A client that carries no usable payload is telling kakehashi that
+    /// something changed, not what — vscode-languageclient's canonical push is
+    /// `{"settings": null}`. When it can answer a pull, the notification is a
+    /// trigger and the answer is the content; when it cannot, there is nothing
+    /// to apply and nothing worth warning about.
+    ///
+    /// The trigger lives here rather than in `apply_client_configuration`, so
+    /// that applying a pulled answer cannot pull again.
     pub(crate) async fn did_change_configuration_impl(&self, params: DidChangeConfigurationParams) {
+        if carries_no_payload(&params.settings) {
+            if self.settings_manager.supports_configuration_pull() {
+                self.pull_client_configuration().await;
+            }
+            return;
+        }
+        self.apply_client_configuration(params.settings, ConfigurationIngress::Push)
+            .await;
+    }
+
+    /// Apply a client-supplied configuration layer, however it arrived.
+    async fn apply_client_configuration(&self, settings: Value, ingress: ConfigurationIngress) {
+        let params = DidChangeConfigurationParams { settings };
         let uses_deprecated_unwrapped_shape =
             uses_deprecated_unwrapped_didchange_shape(&params.settings);
         let (settings_value, unknown_keys) = settings_payload(params.settings);
@@ -182,13 +290,33 @@ impl Kakehashi {
         }
 
         if !unknown_keys.is_empty() {
-            self.notifier()
-                .log_warning(format!(
-                    "workspace/didChangeConfiguration rejected configuration update containing unknown or mixed-format key(s): {}",
-                    format_rejected_keys(&unknown_keys)
-                ))
-                .await;
-            return;
+            match ingress {
+                ConfigurationIngress::Push => {
+                    self.notifier()
+                        .log_warning(format!(
+                            "{} rejected configuration update containing unknown or mixed-format \
+                             key(s): {}",
+                            ingress.describe(),
+                            format_rejected_keys(&unknown_keys)
+                        ))
+                        .await;
+                    return;
+                }
+                // kakehashi asked for the whole section, so it also gets the
+                // keys the editor keeps there — `trace.server` is
+                // vscode-languageclient's near-universal convention, inside
+                // the very section being pulled. Rejecting the layer over one
+                // of those would make the pull useless for the editors it
+                // exists for; the keys are dropped by parsing instead.
+                ConfigurationIngress::Pull => {
+                    self.notifier()
+                        .log_info(format!(
+                            "Ignoring {} in the configuration read from the client",
+                            format_rejected_keys(&unknown_keys)
+                        ))
+                        .await;
+                }
+            }
         }
 
         if settings_value
@@ -278,7 +406,7 @@ impl Kakehashi {
                     .await;
                 drop(reload);
                 self.warn_on_misconfigured_settings(&warnings).await;
-                self.notifier().log_info("Configuration updated!").await;
+                self.notifier().log_info(ingress.applied_message()).await;
             }
             Err(errs) => {
                 drop(reload);

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -5,7 +5,7 @@ use crate::config::unknown_keys::{
     unknown_workspace_setting_keys,
 };
 use serde_json::Value;
-use tower_lsp_server::ls_types::DidChangeConfigurationParams;
+use tower_lsp_server::ls_types::{ConfigurationItem, DidChangeConfigurationParams};
 
 use crate::config::{RawWorkspaceSettings, WorkspaceSettings, merge_workspace_settings};
 
@@ -90,6 +90,56 @@ fn is_kakehashi_workspace_entry(key: &str, value: &Value) -> bool {
 }
 
 impl Kakehashi {
+    /// Ask the client for its `kakehashi` section and apply what comes back.
+    ///
+    /// Editors that send `didChangeConfiguration` with no usable `settings`
+    /// (VS Code most prominently) expect the server to pull instead. The
+    /// answer is not a delta and not a snapshot of kakehashi's own state — it
+    /// is the client's configuration, which is one layer among the rest, so it
+    /// is applied exactly as a push of the same section would be. Nothing
+    /// supersedes anything: the layer is appended in arrival order like any
+    /// other (#734).
+    ///
+    /// `scopeUri` is deliberately null. kakehashi resolves one effective
+    /// settings snapshot for the whole process, so asking with a scope and
+    /// applying the answer process-wide would silently promote one folder's
+    /// configuration to global. Asking unscoped asks for exactly what the
+    /// single layer means; scoped pull is the separate half of #952.
+    pub(crate) async fn pull_client_configuration(&self) {
+        if !self.settings_manager.supports_configuration_pull() {
+            return;
+        }
+
+        let items = vec![ConfigurationItem {
+            scope_uri: None,
+            section: Some("kakehashi".to_string()),
+        }];
+        let answered = match self.client.configuration(items).await {
+            Ok(values) => values,
+            Err(error) => {
+                // Leave the settings in effect alone: a failed pull is no
+                // answer, not an empty one.
+                self.notifier()
+                    .log_warning(format!(
+                        "Could not read configuration from the client: {error}"
+                    ))
+                    .await;
+                return;
+            }
+        };
+
+        // `null` means the client cannot provide a value for this item — also
+        // no answer. An object, empty or not, is one.
+        let Some(section @ Value::Object(_)) = answered.into_iter().next() else {
+            return;
+        };
+
+        self.did_change_configuration_impl(DidChangeConfigurationParams {
+            settings: serde_json::json!({ "kakehashi": section }),
+        })
+        .await;
+    }
+
     /// Handle workspace/didChangeConfiguration notification.
     pub(crate) async fn did_change_configuration_impl(&self, params: DidChangeConfigurationParams) {
         let uses_deprecated_unwrapped_shape =

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -107,7 +107,10 @@ struct SingleFlightPull<'a>(&'a std::sync::atomic::AtomicBool);
 
 impl<'a> SingleFlightPull<'a> {
     fn claim(flag: &'a std::sync::atomic::AtomicBool) -> Option<Self> {
-        (!flag.swap(true, std::sync::atomic::Ordering::AcqRel)).then_some(Self(flag))
+        // `then`, not `then_some`: the latter builds its argument eagerly, so a
+        // failed claim would construct a guard, drop it, and release the flag
+        // it never held — leaving no single-flight at all.
+        (!flag.swap(true, std::sync::atomic::Ordering::AcqRel)).then(|| Self(flag))
     }
 }
 
@@ -190,16 +193,42 @@ impl Kakehashi {
             return;
         }
 
-        // One pull at a time. Startup pulls, and so does every no-payload
-        // notification, so two can be in flight at once — and since the reload
-        // lock is only taken once an answer arrives, the older answer could
-        // apply last and merge its snapshot over the newer one. A pull already
-        // running will read the client's current state, which is what a second
-        // one would have asked for.
-        let Some(_in_flight) = SingleFlightPull::claim(&self.configuration_pull_in_flight) else {
-            return;
-        };
+        // One pull at a time, with a burst collapsed into at most one trailing
+        // pull. Startup pulls, and so does every no-payload notification, so
+        // two can be in flight at once — and since the reload lock is only
+        // taken once an answer arrives, the older answer could apply last and
+        // merge its snapshot over the newer one.
+        //
+        // Standing down is not enough on its own: the running pull may already
+        // have its answer when the user changes something, and dropping that
+        // trigger would lose the change until the next one. A rejected trigger
+        // is recorded instead, and whoever holds the claim runs one more pull
+        // before letting go.
+        loop {
+            {
+                let Some(_in_flight) = SingleFlightPull::claim(&self.configuration_pull_in_flight)
+                else {
+                    self.configuration_pull_pending
+                        .store(true, std::sync::atomic::Ordering::Release);
+                    return;
+                };
+                // Cleared inside the claim, so a trigger arriving during the
+                // request below is still seen by the trailing check.
+                self.configuration_pull_pending
+                    .store(false, std::sync::atomic::Ordering::Release);
+                self.pull_client_configuration_once().await;
+            }
+            if !self
+                .configuration_pull_pending
+                .swap(false, std::sync::atomic::Ordering::AcqRel)
+            {
+                return;
+            }
+        }
+    }
 
+    /// One round trip: ask, and apply whatever comes back.
+    async fn pull_client_configuration_once(&self) {
         let items = vec![ConfigurationItem {
             scope_uri: None,
             section: Some("kakehashi".to_string()),
@@ -471,6 +500,38 @@ mod tests {
             "the claim is released on every exit path, including the timeout \
              and shutdown arms"
         );
+    }
+
+    /// The trailing-pull handshake: a trigger rejected while a pull is running
+    /// is recorded, and the running pull sees it after releasing — so a burst
+    /// collapses into one follow-up rather than being dropped.
+    #[test]
+    fn a_rejected_trigger_survives_as_one_trailing_pull() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let in_flight = AtomicBool::new(false);
+        let pending = AtomicBool::new(false);
+
+        let claim = SingleFlightPull::claim(&in_flight).expect("the first pull runs");
+        pending.store(false, Ordering::Release);
+
+        // Two triggers arrive while it is running; both stand down, both leave
+        // the same mark.
+        for _ in 0..2 {
+            assert!(SingleFlightPull::claim(&in_flight).is_none());
+            pending.store(true, Ordering::Release);
+        }
+
+        drop(claim);
+        assert!(
+            pending.swap(false, Ordering::AcqRel),
+            "the burst must leave exactly one follow-up behind"
+        );
+        assert!(
+            !pending.swap(false, Ordering::AcqRel),
+            "and only one — the trailing pull is not run per trigger"
+        );
+        assert!(SingleFlightPull::claim(&in_flight).is_some());
     }
 
     use super::*;

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -265,6 +265,19 @@ impl SettingsManager {
             .unwrap_or(false)
     }
 
+    /// Whether the client can answer a `workspace/configuration` request.
+    ///
+    /// Editors that send `didChangeConfiguration` with no usable `settings`
+    /// expect the server to pull instead; without the capability there is
+    /// nothing to pull from and the push is all there is.
+    pub(crate) fn supports_configuration_pull(&self) -> bool {
+        self.client_capabilities
+            .get()
+            .and_then(|caps| caps.workspace.as_ref())
+            .and_then(|workspace| workspace.configuration)
+            .unwrap_or(false)
+    }
+
     /// Returns true if client declared textDocument.semanticTokens.multilineTokenSupport.
     /// Returns false if initialize() hasn't been called yet (OnceLock is empty).
     ///
@@ -395,6 +408,35 @@ mod tests {
         assert!(manager.root_path().is_none());
         assert!(manager.client_capabilities().is_none());
         assert!(!manager.supports_semantic_tokens_refresh());
+    }
+
+    #[test]
+    fn configuration_pull_requires_the_client_capability() {
+        let manager = SettingsManager::new();
+        assert!(
+            !manager.supports_configuration_pull(),
+            "no capabilities yet means nothing to pull from"
+        );
+
+        let manager = SettingsManager::new();
+        manager.set_capabilities(ClientCapabilities {
+            workspace: Some(WorkspaceClientCapabilities {
+                configuration: Some(false),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        assert!(!manager.supports_configuration_pull());
+
+        let manager = SettingsManager::new();
+        manager.set_capabilities(ClientCapabilities {
+            workspace: Some(WorkspaceClientCapabilities {
+                configuration: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        assert!(manager.supports_configuration_pull());
     }
 
     #[test]


### PR DESCRIPTION
> Stacked on #959 → #957 → #954. Review only `git diff fix/issue-948-retain-config-layers...HEAD`.

## Summary

kakehashi never asked the editor for its configuration. Editors that send `workspace/didChangeConfiguration` without usable `settings` — VS Code most prominently — therefore had no way to configure it past `initializationOptions`. Upstream pull was recorded as deferred in `downstream-settings-propagation`, together with the requirement to gate it on `capabilities.workspace.configuration`.

It now asks, gated on that capability:

- once the handshake completes, and
- whenever a `didChangeConfiguration` carries no usable payload — `{"settings": null}` is vscode-languageclient's canonical push, which previously produced a parse warning on every settings change and no way to reconfigure.

The trigger lives in the notification handler, never in the shared apply path, so a pulled answer cannot pull again.

## The answer is a layer, not a snapshot

The response is applied exactly as a push of the same section would be — it is the client's configuration, one layer among the rest, appended in arrival order like any other (#734). Routing it through the push handler makes that literal: deprecation detection, path anchoring, the merge, and publication all happen once, in one place.

Nothing supersedes anything. A pull does not replace the accumulated `didChangeConfiguration` layers; it follows them.

| response | effect |
|---|---|
| a settings object | appended as a layer; omitted keys inherit from the layers below |
| `{}` | an empty layer contributes nothing — no special case needed |
| `null`, or no element | the client cannot provide a value: no answer, settings left alone |
| anything else | routed through, so a malformed answer reaches the parse warning rather than vanishing |
| request error, or no answer within 10s | no answer; the settings in effect are kept |

## Two asymmetries, both deliberate

**Unknown keys.** A pushed unknown key is rejected — the user typed it. A pulled one is dropped by parsing and reported as information, because asking for a section also returns the keys the editor keeps there: `trace.server` is vscode-languageclient's near-universal convention, living inside the very section being pulled. Rejecting the layer over one of those would make the pull useless for the editors it exists for.

**Empty containers.** A pulled answer is trusted as authored: a field written as an empty container clears the layer below, exactly as it would in a config file. An editor that materializes `{}` as a registered default would therefore clear that setting for a user who configured nothing. Documented rather than special-cased — merging a pull more leniently than a push would split the contract in two.

## `scopeUri` is absent on purpose

kakehashi resolves one effective settings snapshot for the whole process — `SETTINGS_RELOAD_LOCK`'s doc comment states it as an invariant. Naming a scope and then applying the answer process-wide would silently promote one folder's configuration to global. Asking unscoped asks for exactly what the single layer means.

## Bounded

The await lives in the `initialized` service future, which `serve` joins on, so a client that declares the capability and never answers would keep `serve` from returning after `exit` — rescued by the SIGTERM handler on Unix and by nothing on Windows. It is bounded by both the shutdown token and a 10s timeout.

## What remains

**Stage 2, scoped pull** (`scopeUri`) — the one thing pull can express that push structurally cannot, since `didChangeConfiguration` carries no scope. It unlocks multi-root and per-folder anchoring, and it breaks the one-snapshot-per-process invariant, so it depends on #948's layer model and changes its premise.

Part of #952


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving workspace configuration from compatible editors during initialization.
  * Configuration updates can now be refreshed when editors send empty change notifications.
  * Retrieved settings are applied consistently, including clearing outdated values when the response is empty.
* **Bug Fixes**
  * Improved handling of repeated configuration changes, errors, timeouts, and shutdowns.
  * Unknown settings from retrieved configuration are safely ignored.
* **Documentation**
  * Documented the current workspace configuration propagation behavior and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->