### PR TITLE
docs(adr): workspace-scoped symbol search

### DIFF
--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -1005,7 +1005,7 @@ normalization**: set `deprecated = Some(true)` when the normalized tags contain
 it was meant to preserve. It is bounded: the modern type is used everywhere
 else.
 
-### 6. Latency is bounded by the pool's timeouts and our own phase budgets
+### 6. Every wait is bounded; the synchronous work between them is not
 
 Every target is awaited, so latency is max-over-targets. The bounds are:
 
@@ -1105,8 +1105,8 @@ one region's offset is known. Workspace symbol search holds every region's
 geometry for the hosts it touches, so each entry is translated by its own
 region's offset rather than by a single borrowed one.
 
-Shipping this obliges edits in **both** user-facing docs, in three separate
-respects each. They are listed here because more than one review round found the
+Shipping this obliges edits in **both** user-facing docs, in four separate
+respects. They are listed here because more than one review round found the
 inventory incomplete.
 
 *The no-cross-block rule is stated as a blanket claim and must be amended, not
@@ -1264,11 +1264,12 @@ Including it would defeat dedup on a field carrying no identity.
   silent connection death). The same query answers differently at different
   points in a session. LSP permits partial `workspace/symbol` results, but a
   user expecting an indexed whole-project search will find this surprising.
-- Latency is max-over-live-targets, bounded by the pool's existing 30s request
-  timeout and liveness timeout, plus three-second budgets on selection's and
-  each send's `connections` **lock acquisition** — the synchronous filtering
-  that follows is outside them — and the reopen barrier's two seconds; forwarded cancellation is best-effort because a downstream may
-  ignore it.
+- Latency is max-over-live-targets, and every *wait* is bounded: the pool's 30s
+  request timeout and liveness timeout, three-second budgets on selection's and
+  each send's `connections` lock **acquisition**, and the reopen barrier's two
+  seconds. Total latency is not bounded, because the synchronous filtering
+  between those waits cannot be preempted. Forwarded cancellation is
+  best-effort, since a downstream may ignore it.
 - One request per keystroke, un-coalesced (point 9).
 - Fan-in can wait on a parse: the distinct host documents a result addresses are
   ensured before translation. Because they are ensured concurrently the pass

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -373,12 +373,10 @@ name across roots, recreating the leak point 3 exists to prevent. The
 `(host_language, _self, ConnectionKey)` triples come from `host_documents`
 directly.
 
-That is a second async map, so selection acquires three locks in all — the
-tracker snapshot, `host_documents`, then `connections` — and each falls under
-point 6's budget rather than the "one acquisition then synchronous work" shape
-an earlier draft assumed. The first two are snapshots taken and released before
-`connections` is held, so the only nesting is `connections` → tracker, which is
-the pool's own order.
+That is a second async map, read **under** `connections` by the batch validator
+below rather than snapshotted separately, so selection's acquisitions are the
+tracker snapshot and then `connections`, each falling under point 6's budget —
+not the "one acquisition then synchronous work" shape an earlier draft assumed.
 
 The two snapshots also have to be **joined safely**. Host language comes from
 the document store, while the exact keys come from pool tracking read later, and
@@ -427,33 +425,48 @@ existing configuration from becoming a silent no-op here.
 **No candidate is waited for; the only waits are lock acquisitions and the
 final barrier.** The order is fixed:
 
-1. **Snapshot the tracker's host→virtual map, then `host_documents`**, each
-   under its own lock and each **released before the next**. Nothing is held
-   across them, so no ordering question arises between the two.
-2. **Take `connections` once** and hold it across every per-handle check below,
-   with no `.await` inside. Consulting the tracker's live reverse index while
-   holding it is the pool's own `connections` → tracker order, which the
-   respawn purge also takes.
-3. Under that lock, per candidate: keep only `Ready` handles (`connections()`
-   returns the raw map, and `ConnectionState` also has `Initializing`,
-   `Failed`, `Closing`, `Closed`); drop handles lacking `workspace/symbol`;
-   drop handles whose recorded launch configuration no longer matches the
-   `BridgeServerConfig` that admitted them; and confirm the
-   `(virtual_uri, connection)` pair is still in the live reverse index.
-4. Release the lock, then apply the per-pair `priorities` allowlist and
-   `max_fan_out` cap — pure computation over what survived.
-5. Dedup the survivors by **connection key** `(server, root)`.
-6. Await `wait_for_pending_reopen` for the survivors, **concurrently**, then
+1. **Snapshot the tracker's host→virtual map** under its own lock and release
+   it. This only *enumerates* candidates; every entry is re-validated in step 2
+   before it can contribute.
+2. Hand the candidate set to a **pool-owned batch validator**, which takes
+   `connections` **once** and, without awaiting inside, per candidate: keeps
+   only `Ready` handles (`connections()` returns the raw map, and
+   `ConnectionState` also has `Initializing`, `Failed`, `Closing`, `Closed`);
+   drops handles lacking `workspace/symbol`; drops handles whose recorded launch
+   configuration no longer matches the `BridgeServerConfig` that admitted them;
+   and confirms current membership — the live reverse index for a virtual
+   candidate, `host_documents` for a `_self` one.
+3. Apply the per-pair `priorities` allowlist and `max_fan_out` cap to the
+   survivors — pure computation, after the lock is released.
+4. Dedup by **connection key** `(server, root)`.
+5. Await `wait_for_pending_reopen` for the survivors, **concurrently**, then
    send.
 
-Every filter in step 3 precedes the cap in step 4, and that ordering is
+The validator is **pool-owned** for two reasons. It is the only way to do all of
+this under one acquisition — `launch_config` and its comparator are private to
+the pool, and the exposed comparison helper takes `connections` itself, so a
+caller in `bridge/workspace/symbol.rs` doing these checks piecemeal would
+re-lock between them and validate against a map that had already moved. And it
+is what lets `host_documents` be read **while `connections` is held** rather
+than snapshotted first: a `_self` candidate has no reverse-index check to fall
+back on, `HostDocSyncState` records neither connection generation nor handle
+identity, and a respawn can purge the entry and install a fresh `Ready` handle
+under the same `ConnectionKey` — so a released snapshot would let a connection
+that never opened the host document pass every other check. The language and
+incarnation recheck does not catch that, because the host lifetime never
+changed; only the connection did.
+
+The resulting order is `connections` → {tracker, `host_documents`}, which is the
+pool's own nesting and the one the respawn purge takes.
+
+Every filter in step 2 precedes the cap in step 3, and that ordering is
 load-bearing for each of them: with `priorities = [A, B]` and
 `max_fan_out = 1`, an A that is incapable, stale-configured, or no longer
 holding its documents would otherwise take the only slot and then be dropped,
 leaving the query to consult nobody. Filtering on what is already knowable
 before allocating slots costs nothing and removes all three cases at once.
 
-Step 6 exists because a connection reaches `Ready` *before* its virtual
+Step 5 exists because a connection reaches `Ready` *before* its virtual
 documents are replayed after a respawn, so a query landing in that window would
 under-report that server's embedded symbols indistinguishably from "no matches".
 The barrier is **bounded to two seconds** and enforced with a timeout, and
@@ -600,10 +613,10 @@ with its own name and semantics rather than smuggled into this one.
                           ▼
         ┌──────────────────────────────────────┐
         │ SELECTION (3s per lock ACQUIRE, §6)  │
-        │ under `connections`, all before the  │
-        │ cap: keep Ready only, drop incapable,│
-        │ drop stale-config, confirm still     │
-        │ open on that connection              │
+        │ pool-owned batch validator, one lock:│
+        │ Ready only, drop incapable, drop     │
+        │ stale-config, confirm still open on  │
+        │ that exact connection                │
         │ then: allowlist + per-pair maxFanOut │
         │ NEVER spawns a connection            │
         └──────────────────┬───────────────────┘
@@ -1132,9 +1145,10 @@ send re-acquires `connections` before enqueue, and translation takes each host's
 `edit_lock` across downstream close, change, and eager-spawn awaits, so a query
 arriving mid-processing would otherwise wait on unrelated work with no bound.
 
-- **Selection** (`connections`, then `host_documents`, then the tracker
-  snapshot, in that order): three seconds each. The budget covers *acquiring*
-  each lock, not the filtering between them — that walk is synchronous with no
+- **Selection**: the tracker snapshot, then `connections` (under which the
+  validator also reads `host_documents` and the live reverse index) — three
+  seconds each. The budget covers *acquiring* each lock, not the filtering
+  between them — that walk is synchronous with no
   await, so a timeout could not preempt it anyway, and bounding what cannot be
   interrupted would promise something the runtime does not deliver.
 - **Each send's pre-enqueue re-acquisition** of `connections`: three seconds,
@@ -1365,9 +1379,9 @@ Including it would defeat dedup on a field carrying no identity.
   user expecting an indexed whole-project search will find this surprising.
 - Latency is max-over-live-targets, and every *wait* is bounded: the pool's 30s
   request timeout and liveness timeout, a three-second budget on **every** lock
-  this path acquires (`connections`, `host_documents`, the tracker snapshot,
-  each send's re-acquisition, and each host's `edit_lock`), and the reopen
-  barrier's two seconds. Total latency is not bounded, because the synchronous
+  this path acquires (the tracker snapshot, `connections`, each send's
+  re-acquisition, and each host's `edit_lock`), and the reopen barrier's two
+  seconds. Total latency is not bounded, because the synchronous
   filtering between those waits cannot be preempted. Forwarded cancellation is
   best-effort, since a downstream may ignore it.
 - One request per keystroke, un-coalesced (point 9).
@@ -1387,9 +1401,9 @@ Including it would defeat dedup on a field carrying no identity.
   in methods that have no use for it.
 - A server still `Initializing` when the query arrives is skipped entirely, so
   a search in the seconds after opening a file can miss it (point 3).
-- Every lock this path takes — the tracker snapshot, `host_documents`,
-  `connections`, each send's re-acquisition, each host's `edit_lock` — is
-  bounded only in its **acquisition**, because other paths hold these across
+- Every lock this path takes — the tracker snapshot, `connections` (under which
+  `host_documents` and the reverse index are read), each send's re-acquisition,
+  each host's `edit_lock` — is bounded only in its **acquisition**, because other paths hold these across
   unbounded async work (point 6); the filtering between them is synchronous and
   cannot be preempted, so neither total selection time nor cancellation blocking
   is capped. Expiring either

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -255,7 +255,7 @@ from an empty response — which is the distinction that makes it acceptable her
 and `preferred` not. It does cost the user an edit in **every** pair that names
 the unwanted server, because fan-out unions candidates across all pairs.
 
-### 3. Fan-out: live connections first, then the configuration filter
+### 3. Fan-out: select synchronously, then wait per target
 
 A request has no document, so it cannot pick one `(host_language, bridge_key)`
 pair — it walks **all** of them, purely to collect candidates. Both axes must be
@@ -331,21 +331,36 @@ the opt-out, wildcard-resolved gate beside it.
 set only on `bridge._` still apply to a concrete pair — the property that keeps
 existing configuration from becoming a silent no-op here.
 
-**Order matters, and it is liveness first:**
+**Order matters. Everything synchronous happens first; only then does any
+target wait:**
 
 1. Take the pool's connection map and keep only `Ready` and `Initializing`
    entries. `connections()` returns the raw map, and `ConnectionState` also has
    `Failed`, `Closing`, and `Closed`, which linger until lazily evicted — none
-   of them is a valid target.
-2. Wait for the surviving `Initializing` entries to reach Ready.
-3. **Then** check `has_capability("workspace/symbol")` (see point 4 for why this
-   order is forced, and what `has_capability` needs first).
-4. **Then** apply the per-pair `priorities` allowlist and `max_fan_out` cap.
-5. Dedup the survivors by **connection key** `(server, root)`.
+   of them is a valid target. This is a map read, not a wait.
+2. Apply the per-pair `priorities` allowlist and `max_fan_out` cap to what
+   survived. Also synchronous.
+3. Dedup the survivors by **connection key** `(server, root)`.
+4. **Per target, independently**: wait for `Ready`, then check
+   `has_capability("workspace/symbol")` (point 4 explains why the capability
+   check cannot precede the wait), then send.
 
-Applying the cap before the liveness filter would let dead or absent servers
-consume cap slots and silently exclude a live server ranked below the cutoff —
-which would contradict this decision's own "coverage is what is live" contract.
+The cap sits between the two: after the liveness filter, before any waiting.
+Both halves of that placement are load-bearing.
+
+Putting the cap *before* the liveness filter would let dead or absent servers
+consume cap slots and silently exclude a live server ranked below the cutoff,
+contradicting this decision's own coverage contract. Putting it *after* the
+Ready wait would make the cap a global barrier: with `max_fan_out = 1` and
+priorities `[initializing_A, ready_B]`, nothing could dispatch until A's wait
+resolved — up to the full 30 seconds — even though B was ready immediately.
+Deciding membership synchronously and waiting per target removes the
+interaction entirely.
+
+The residual cost is stated rather than engineered away: a target that is
+`Initializing` at selection time consumes a cap slot even if it later turns out
+to lack the capability. Selecting on a fact that is not yet knowable is the
+alternative, and it is worse.
 
 `priorities` is an allowlist: listed servers are candidates, `"*"` stands for
 the rest, and an explicit `[]` remains the per-method kill switch. Its **order**
@@ -367,11 +382,20 @@ connection's own indexed workspace, so a connection named by several pairs is
 asked **once**, while the same server name under two roots is genuinely two
 connections and two requests.
 
-`max_fan_out` therefore bounds a **pair's** contribution, not the query's total
-fan-out. A connection dropped by one pair's cap still enters through another
-pair that names it, and no global cap exists. Under `preferred` the cap was also
-a cost bound; here it is only a per-pair selection rule. What actually bounds
-the total is the live-connection set (point 7).
+`max_fan_out` counts **server names**, not connections — `truncate_entries`
+truncates a flattened name list in walk order. A surviving name then contributes
+**every** live connection it has, so a server live under two roots sends two
+requests against one cap slot. No root is dropped and no root-ordering policy is
+needed, which is the point: this method queries every live root of a selected
+server by design.
+
+The setting's documented promise ("cap the number of concurrent server
+requests") is therefore not what happens here, and could not be — a cap on names
+cannot bound requests once one name means several connections. Combined with the
+fact that a connection dropped by one pair's cap still enters through another
+pair that names it, `max_fan_out` is a **per-pair name-selection rule** for this
+method and nothing more. What actually bounds the total is the live-connection
+set (point 7).
 
 ```
   open host docs × their open virtual docs    ← concrete languages only,
@@ -495,7 +519,19 @@ may not: the goto filter exists because only one region's offset is in hand.
      TRANSLATE
        uri   := host_url
        range := translate_virtual_range_to_host(range, offset)
+       └─ reject if the translated range escapes the region's current
+          bounds — see below
 ```
+
+Translation **validates the region bounds**; it does not translate blindly.
+Region ids deliberately survive edits, so an in-flight response can carry a
+range measured against an older, larger region while offset resolution against
+the current parse still succeeds — and plain range translation performs no
+boundary check, so the result could point into the closing fence or the host
+text after it. `resolve_region_offset` already returns the region's current
+`region_end` alongside the offset; that bound is retained and a translated range
+falling outside it is rejected, the same discipline workspace-edit translation
+already applies.
 
 The range check comes first because `WorkspaceSymbol.location` is
 `OneOf<Location, WorkspaceLocation>` and the `WorkspaceLocation` form carries a
@@ -516,13 +552,38 @@ this classifier would silently turn into "no embedded symbols". The
 whole-document handlers avoid this by calling `ensure_document_parsed` first;
 this method has no target document to name.
 
-Fan-in therefore runs in **three passes**, not one:
+Fan-in therefore runs in **three passes**, not one, over a **request-local
+index** built once up front:
 
-1. Classify every entry and resolve its virtual URI to a `host_url`, **grouping
-   entries by host**. This pass needs no parse — `resolve_virtual_uri` is a map
-   lookup — so nothing waits here.
+0. Snapshot the tracker's host→virtual map once and build a
+   `virtual_uri_string → (host_url, region_id)` map for this request.
+1. Classify every entry against that index, **grouping entries by host**. No
+   parse and no lock is involved, so nothing waits here.
 2. Ensure the distinct hosts that actually appear, **concurrently**.
 3. Resolve each entry's offset and translate, per group.
+
+Pass 0 is not an optimization. `BridgeCoordinator::resolve_virtual_uri` is
+**not** a map lookup: its own doc comment records that it is "O(N) over open
+virtual docs" — the virtual URI encodes the host *directory* and region id but
+not the host filename, so the host cannot be derived without a scan — and
+justifies that cost with "`window/showDocument` is rare, so the scan is
+acceptable". Calling it once per returned symbol destroys exactly that premise:
+an interactive endpoint returning thousands of symbols would pay
+`symbols × open_virtual_docs`, serialized through repeated acquisition of the
+tracker's async mutex. Snapshotting once makes it one scan plus O(1) per entry,
+and the snapshot is the same data point 3's validation already takes.
+
+The index also becomes the **identity test**. `is_virtual_uri` is only a
+basename pattern — it accepts any URI ending in
+`kakehashi-virtual-uri-<id>.<ext>` — so pattern-matching alone would let a real
+file that happens to be named that way be treated as virtual. Membership in the
+index is the real answer for the entries that matter. What the pattern still
+decides is the *drop* case: a pattern match that is absent from the index is
+either a region that has since died or a real file with that name, and the two
+are indistinguishable. Dropping is chosen, because letting a dead region's
+virtual URI reach the editor is the worse failure. **The
+`kakehashi-virtual-uri-*` filename space is reserved**; a real file named into
+it is not visible to workspace symbol search.
 
 Ensuring one host at a time while translating would make the cost additive:
 `distinct_hosts × 200ms` in series, which for a query touching many stale hosts
@@ -542,6 +603,12 @@ asks for a 200ms wait, but `wait_for_current_snapshot` escalates to the
 the caller's wait. Skipping them loses nothing: a never-parsed document has no
 resolved injection regions, hence no virtual documents downstream, hence no
 result can address it.
+
+The precheck alone does not make the 200ms hold: a close/reopen between the
+check and the ensure moves the URI into a fresh, snapshot-less lifetime and the
+15-second deadline applies after all. Each ensure therefore carries its **own
+outer 200ms timeout**, so the phase's bound is a property of this call site
+rather than an inference about the callee's internal state.
 
 A residual race remains and is **accepted**: a `didChange` landing between the
 ensure and the offset resolution clears the tree again, and that entry is
@@ -566,7 +633,16 @@ in `ls-types`, whose variant names are a misnomer: **both** variants are flat
 arrays, and the choice is the element type, not hierarchy (there is no nested
 form for this method; `containerName` is spec-documented as unusable for
 re-inferring one). `SymbolInformation[]` is the deprecated alternative and is
-not emitted. No client capability governs the choice, so none is consulted.
+not emitted.
+
+One client capability *does* govern the payload, though not the element type:
+`workspace.symbol.tagSupport` declares which `SymbolTag`s the client accepts.
+kakehashi already stores the upstream capabilities, so tags are filtered to the
+declared set and omitted entirely for a client that declares none. This matters
+because the `SymbolInformation` normalization in point 4 *creates* a tag —
+folding the legacy `deprecated` flag into `SymbolTag::DEPRECATED` — so without
+the filter kakehashi would hand a tag-less client a tag it never asked for, and
+the legacy `deprecated` field that client could have understood is gone.
 
 ### 6. Latency is bounded by the pool's timeouts, not by cancellation
 
@@ -772,6 +848,14 @@ Including it would defeat dedup on a field carrying no identity.
   touches is how many are live.
 - Adding the `Union` variant forces a `Union` arm at 7 exhaustive `match` sites
   in methods that have no use for it.
+- A target that is `Initializing` when the candidate set is fixed consumes a
+  `max_fan_out` slot even if it later proves incapable — the cost of deciding
+  membership synchronously (point 3).
+- `max_fan_out` does not mean here what its own documentation promises. It caps
+  server *names*, and one selected name still queries every live root, so it
+  bounds neither requests nor connections.
+- The `kakehashi-virtual-uri-*` filename space is reserved: a real workspace
+  file named into it is invisible to symbol search (point 5).
 - `strategy` becomes a knob that this one method ignores (with a warning). Users
   who reach for `preferred` to suppress a noisy server must instead leave it out
   of `priorities` — in every pair that names it.
@@ -790,7 +874,17 @@ Including it would defeat dedup on a field carrying no identity.
 
 - `Union` is a named strategy but is meaningful only for this method; elsewhere
   it is normalized to that method's existing default before any handler runs, so
-  configuring it there changes nothing.
+  configuring it there changes nothing. `layers.aggregation["workspace/symbol"]
+  .strategy = "union"` is schema-valid and inert for the same reason this method
+  never reaches the cross-layer walk.
+- Exposing `union` in the serialized config and the generated schema is a
+  **one-way door**: it is public API from the first release that ships it, yet
+  it offers no choice anywhere — it is mandatory where it applies and inert
+  where it does not. Keeping the merge internal to this method would have left
+  that door open. It is exposed because a named, inspectable strategy value was
+  the maintainer's explicit preference over a hidden merge rule; the cost is
+  recorded here so a later reversal is a deliberate deprecation rather than a
+  surprise.
 - Result ordering is deterministic but not relevance-ranked. LSP delegates
   scoring to the client ("editors will apply their own highlighting and scoring
   on the results"), so a client that re-sorts sees no change and one that does

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -73,10 +73,11 @@ WORKSPACE-SCOPED  (workspace/symbol)
 
 Three facts in the existing code make the feature tractable anyway:
 
-- `BridgeCoordinator::resolve_virtual_uri(uri) -> Option<(host_url, region_id)>`
-  is a **global** virtual→host reverse map (it is what `window/showDocument`
-  translation already uses), and `resolve_region_offset` rebuilds the
-  `RegionOffset` from the live parse for any given `host_url` and `region_id`.
+- The pool's tracker holds a **global** virtual→host mapping — it is what
+  `window/showDocument` translation reaches through `resolve_virtual_uri` — and
+  the document store keeps **generation-stamped resolved-region snapshots**,
+  from which a region's offset, end, content, and language can be read without
+  re-resolving anything.
 - `LanguageServerPool::connections()` enumerates the pool's connection map.
 - `send_execute_command_on_handle` (`bridge/workspace/execute_command.rs`) is an
   existing precedent for sending a request on a connection **without** a virtual
@@ -522,12 +523,12 @@ arrives between request acceptance and subscription and delivers it on
 subscribe — but because selecting on it is what makes the handler abandon
 promptly rather than only at its next dispatch boundary.
 
-Fan-in cannot live in the `bridge` module, because `resolve_region_offset` is
-`pub(super)` to `lsp_impl`. So unlike every `transform_*_response_to_host`
-function — which is pure because the caller already resolved *the* offset — this
-translator resolves a different offset per entry and must sit where the
-`DocumentStore` / `LanguageCoordinator` / `BridgeCoordinator` handles are, as
-`ShowDocumentTranslator` does.
+Fan-in cannot live in the `bridge` module: it reads the document store's
+resolved-region snapshots, which `lsp_impl` owns. So unlike every
+`transform_*_response_to_host` function — pure because the caller already handed
+it *the* offset — this translator selects a different region's geometry per
+entry and must sit where the `DocumentStore` / `LanguageCoordinator` /
+`BridgeCoordinator` handles are, as `ShowDocumentTranslator` does.
 
 The value crossing that boundary is **typed, not raw JSON**: the bridge module
 owns deserialization for every other bridged request, and this one keeps that
@@ -593,8 +594,8 @@ Region ids deliberately survive edits, so an in-flight response can carry a
 range measured against an older, larger region while offset resolution against
 the current parse still succeeds — and plain range translation performs no
 boundary check, so the result could point into the closing fence or the host
-text after it. `resolve_region_offset` already returns the region's current
-`region_end` alongside the offset, but that bound alone is not enough: a stale
+text after it. The region map already carries each region's current
+`region_end` alongside its offset, but that bound alone is not enough: a stale
 virtual position like `(0, 1000)` inside a region ending on line 5 compares as
 before the end while carrying a column that never existed, and the workspace-edit
 precedent checks only per-line floors and a global endpoint.
@@ -618,9 +619,10 @@ deliberate: a virtual URI that escapes to the editor names a file that does not
 exist on disk, so the symbol is unopenable. This mirrors `window/showDocument`
 translation, which drops the selection it cannot translate.
 
-**Parse freshness is load-bearing here.** `resolve_region_offset` reads the live
+**Parse freshness is load-bearing here.** The region snapshot tracks the live
 parse, and `didChange` clears the tree and reparses off-ingress, so during the
-reparse window it returns `None` for every region of the edited document — which
+reparse window the edited document has no current geometry for any of its
+regions — which
 this classifier would silently turn into "no embedded symbols". The
 whole-document handlers avoid this by calling `ensure_document_parsed` first;
 this method has no target document to name.
@@ -652,9 +654,9 @@ classification.
 Staleness in the other direction is worse and survives any snapshot time, so it
 is closed by a check rather than by timing. A region keeps its ULID across
 edits, but its **injection language can change** — the close path removes the old
-virtual URI and a new one is opened for the new language. `resolve_region_offset`
-resolves by host and region id alone and discards the language, so a stale entry
-naming the *old* URI would still resolve, and a Python result would be
+virtual URI and a new one is opened for the new language. The geometry is keyed
+by host and region id alone, so a stale entry naming the *old* URI would still
+find a live region, and a Python result would be
 translated into a region that is now Rust. So the index must carry each entry's
 **language**, taken from `OpenedVirtualDoc.virtual_uri.language()`, and that
 language must equal the region's current `injection_language`; a mismatch is a
@@ -708,8 +710,8 @@ Sweeping every open document up front instead — alongside the fan-out — was 
 first shape considered and is worse on both axes. It does work for documents no
 result mentions, and it completes up to 30 seconds before the value is used (a
 target may take the full response timeout), so an edit arriving in between
-re-clears the tree and the sweep guarantees nothing. Ensuring immediately before
-resolution and translation closes that gap to the width of one pass.
+re-clears the tree and the sweep guarantees nothing. Ensuring immediately before the
+snapshot is read closes that gap to the width of one pass.
 
 Only documents that **already have a snapshot** are ensured. `ensure_document_parsed`
 asks for a 200ms wait, but `wait_for_current_snapshot` escalates to the
@@ -724,22 +726,14 @@ check and the ensure moves the URI into a fresh, snapshot-less lifetime and the
 outer 200ms timeout**, so the phase's bound is a property of this call site
 rather than an inference about the callee's internal state.
 
-Resolution also **post-checks the snapshot's freshness**. `resolve_region_offset`
-takes an owned snapshot before it consults the tracker and walks the tree, while
-`didChange` updates tracker positions *before* it clears the visible tree — so a
-resolution that reads the tracker just ahead of that update finishes against its
-own stale snapshot and passes both the language and range checks with old
-coordinates.
+**Geometry is read per host, not resolved per entry.** Calling the resolver per
+entry would run the whole injection walk over the host every time —
+`symbols × regions` work, a 2,000-symbol response walking a 100-region host
+2,000 times — while holding a lock that blocks every `didChange` and close for
+it. Memoizing individual ids does not fix that: the first lookup for each
+distinct region still walks, so the worst case stays quadratic.
 
-**Resolution is per host, not per entry.** `resolve_by_region_id` runs the whole
-injection walk over the host on every call, so resolving each entry
-independently would be `symbols × regions` work — a 2,000-symbol response from a
-100-region host would walk that host 2,000 times — while holding a lock that
-blocks every `didChange` and close for it. Memoizing individual ids does not fix
-this: the first lookup for each distinct region still walks, so the worst case
-stays quadratic.
-
-Each host is therefore resolved **once** into a request-local
+Each host's geometry is therefore read **once** into a request-local
 `region_id → (offset, region_end, virtual_content, injection_language)` map,
 built from the **generation-stamped resolved-region snapshot** the document
 store already keeps. When a host has no current snapshot, its entries are
@@ -764,12 +758,26 @@ Every attempt to make that safe produced a worse problem than it solved:
 - Timing out the awaiter does not rescue it; that is precisely the detached-work
   case above.
 
-Dropping instead costs one query's entries for one host, in a state that is
-transient by construction: the pre-warm in pass 2 exists to make the snapshot
-current, and anything still missing self-corrects on the next query. This is the
-same failure kakehashi already accepts for a region invalidated mid-flight, and
-it keeps the whole fan-in **read-only** — no minting, no detached work, no
-unbounded wait, and no global guard held across one.
+Dropping keeps the whole fan-in **read-only** — no minting, no detached work, no
+unbounded wait, and no global guard held across one — which is what makes every
+other guarantee in this section cheap enough to hold.
+
+Its cost is **not** uniformly transient, and this decision does not claim
+otherwise. Usually it is: the pre-warm in pass 2 exists to make the snapshot
+current, and a host caught mid-reparse is served on the next query. But the
+region cache can also be left **persistently** empty. A populate pass refused
+after an epoch race publishes a current snapshot whose resolved regions are
+`None` and marks parsing finished, while injection processing falls back inline
+and still opens the virtual documents — and `ensure_document_parsed` only checks
+that the snapshot is current, so it will not repopulate that field. A host in
+that state has indexable virtual URIs and no geometry, so symbol search silently
+drops it until an unrelated edit forces a reparse.
+
+That is real coverage loss with no signal, and it is accepted here only because
+the alternative was the resolve-inline path rejected above. The durable fixes
+are outside this decision: populate the region cache whenever virtual documents
+exist for a host, or give the cache a repair path an idle reader may trigger
+safely. Either is a better place to spend the effort than making fan-in mutate.
 
 Two identities must hold, not one:
 
@@ -799,6 +807,14 @@ Because the path is read-only, that lock is held only across a map lookup, a
 version comparison, and arithmetic — no parse, no walk, no await on another
 runtime. That is the whole reason it is safe to hold at all.
 
+Keeping it that short requires care with the range validation above, which is
+where the cost hides. The strict position machinery builds a `PositionMapper`
+whose line index scans the whole text, and the codebase documents that as
+O(document). Rebuilding it per symbol under the lock would be
+`symbols × virtual_content` — the same multiplicative shape this section already
+rejected once. One mapper is built **per referenced region**, before the lock is
+taken; only the freshness comparison and the arithmetic happen inside it.
+
 Taking that lock carries an obligation the happy path hides. `edit_lock`
 **creates** an entry unconditionally, so a host that closed between indexing and
 fan-in yields no live `SnapshotView` — and simply dropping the symbol would
@@ -808,12 +824,11 @@ reaches this case routinely, because the index is built from documents that may
 close while other targets are still answering.
 
 A residual race remains and is **accepted**: a `didChange` landing between the
-ensure and the offset resolution clears the tree again, and that entry is
-dropped like any other unresolvable one. Closing it entirely would mean pinning
-a per-document snapshot generation across the whole fan-in and resolving against
-the pinned tree — which would translate results against text the client has
-already replaced. Dropping is the safer failure, and it self-corrects on the
-next query.
+ensure and the freshness check invalidates the geometry, and those entries are
+dropped like any other unresolvable ones. Closing it entirely would mean pinning
+a per-document snapshot across the whole fan-in and translating against the
+pinned text — which would answer with coordinates into text the client has
+already replaced. Dropping is the safer failure.
 
 The response to the client is always an **array**, never `null`, so "no server
 was running", "everything was dropped", and "every target errored or timed out"
@@ -1082,10 +1097,12 @@ Including it would defeat dedup on a field carrying no identity.
 - Fan-in can wait on a parse: the distinct host documents a result addresses are
   ensured before translation. Because they are ensured concurrently the pass
   costs about one 200ms wait rather than one per document (point 5).
-- An edit landing between that ensure and the freshness check still drops the
-  affected entries, as does a host whose resolved-region snapshot is not current
-  when fan-in reaches it. The window is small but not closed, and the failure is
-  silent — the symbols simply are not there.
+- An edit landing between that ensure and the freshness check drops the affected
+  entries. The window is small but not closed, and the failure is silent.
+- A host whose region cache was left empty by a refused populate pass loses its
+  embedded symbols **until an unrelated edit forces a reparse** — not just for
+  one query (point 5). This is the one accepted failure here that is not
+  self-correcting, and it has no signal to the user.
 - `max_fan_out` no longer bounds a query's total fan-out — only each pair's
   contribution — so the only real bound on how many connections one query
   touches is how many are live.

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -297,6 +297,26 @@ region's real one.
 so the walk can pair each open virtual document with its host document's
 language directly rather than taking a cross product of the two axes.
 
+An entry must be **validated before it contributes**, because the tracker's
+host→virtual map is not an "already open downstream" set: `register_pending_document`
+inserts an entry to own its close-cleanup *before* `didOpen` reaches the writer
+FIFO, and only `mark_open_sent` promotes it into the live reverse index. A
+cloned entry can also outlive a connection purge. Taken at face value, the walk
+would derive a pair from a `didOpen` the downstream has not seen, or from a
+replaced connection whose documents were never replayed.
+
+The save path already establishes the discipline this needs, and the reasoning
+there applies unchanged: snapshot the tracker, then take `connections` **once**
+and hold it across the checks with no `.await` inside, require the handle to be
+the current `Ready` one, and only then consult
+`is_virtual_doc_open_on_connection`. Holding `connections` is what makes it
+sound — a reverse-index check alone would not, since a purge could swap in a
+fresh `Ready` handle that never opened the document. The lock order is
+`connections` → tracker, matching the respawn purge. This composes with the
+stale-handle re-check the send already performs (point 4): the enqueue is
+non-blocking, so both happen under the same lock and only the response is
+awaited outside it.
+
 Candidates for each `(host, injection)` pair then come from the **existing
 routing entry point**, `get_all_configs_for_language`, rather than from a
 hand-rolled lookup. That function already applies the `is_language_bridgeable`

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -4,7 +4,11 @@
 [language-server-bridge-virtual-document-model](language-server-bridge-virtual-document-model.md),
 [language-server-bridge-request-strategies](language-server-bridge-request-strategies.md),
 [aggregation-priorities-wildcard](aggregation-priorities-wildcard.md),
-[host-document-bridge](host-document-bridge.md)
+[host-document-bridge](host-document-bridge.md),
+[ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md),
+[ls-bridge-timeout-hierarchy](ls-bridge-timeout-hierarchy.md),
+[respawn-reopen-derives-its-targets](respawn-reopen-derives-its-targets.md),
+[parse-decoupled-document-lifecycle](parse-decoupled-document-lifecycle.md)
 
 ## Context
 
@@ -18,13 +22,19 @@ current fan-out and fan-in work:
 - **Fan-in** is driven by `transform_location_for_goto(location,
   request_virtual_uri, host_uri, offset)`, whose contract is "translate results
   addressed to *the request's* virtual URI, drop every other virtual URI".
-- **Layer arbitration** is `walk_layers`, first-non-empty-wins (`preferred`).
+- **Arbitration** is `preferred`, first-non-empty-wins, at both the bridge and
+  the layer level.
 
 None of the three survives the loss of the document. There is no injection
-language to select servers with, no single virtual URI to translate against, and
-`preferred` would let whichever layer answers first hide the other layer's
-symbols entirely — which for a *search* is a silent loss of results, not a
-tie-break.
+language to select servers with, and no single virtual URI to translate against.
+
+The arbitration problem is subtler than "no document", and it is the one that
+shapes this decision: a `workspace/symbol` response is **not attributable to a
+language**. A server answers "here are the workspace's symbols matching
+`query`", and what it indexes is its workspace root, not a language — so a
+server reached through one configured pair routinely returns symbols belonging
+to another pair's language. Nothing in the response says which configured pair
+"owns" an entry, so no arbitration between pairs can be principled.
 
 ```
 DOCUMENT-SCOPED  (every existing bridged request)
@@ -44,7 +54,7 @@ DOCUMENT-SCOPED  (every existing bridged request)
          │                   ▼
          │              FAN-OUT set
          ▼
-   walk_layers → first non-empty layer wins (preferred)
+   arbitration: first non-empty wins (preferred)
 
 
 WORKSPACE-SCOPED  (workspace/symbol)
@@ -55,39 +65,47 @@ WORKSPACE-SCOPED  (workspace/symbol)
          │
          ├─▶ FAN-OUT cannot be selected by injection language
          ├─▶ FAN-IN has no "request virtual URI" to filter against
-         └─▶ preferred would let one layer hide the other layer's symbols
+         └─▶ ARBITRATION has no way to attribute an entry to a pair, so any
+             "prefer A over B" silently discards symbols on a basis kakehashi
+             cannot compute
 ```
 
-Two facts in the existing code make the feature tractable anyway:
+Three facts in the existing code make the feature tractable anyway:
 
 - `BridgeCoordinator::resolve_virtual_uri(uri) -> Option<(host_url, region_id)>`
   is a **global** virtual→host reverse map (it is what `window/showDocument`
   translation already uses), and `resolve_region_offset` rebuilds the
   `RegionOffset` from the live parse for any `(host_url, region_id)` pair.
-- `LanguageServerPool::connections()` enumerates every live connection, and
-  `ConnectionHandle` exposes `has_capability` / `send_request` /
-  `wait_for_response`, so a request can be sent to a connection without going
-  through `get_or_create_connection`.
+- `LanguageServerPool::connections()` enumerates the pool's connection map.
+- `send_execute_command_on_handle` (`bridge/workspace/execute_command.rs`) is an
+  existing precedent for sending a request on a connection **without** a virtual
+  document, and it shows exactly what that costs (see point 3).
 
-kakehashi does **not** declare `workspace.symbol.resolveSupport` in the
-capabilities it sends downstream (`bridge/protocol/client_capabilities.rs`), so a
-conformant downstream must return `WorkspaceSymbol`s carrying a full `Location`
-rather than the 3.17 location-less form.
+kakehashi sends downstream no `workspace.symbol` client capability at all
+(`bridge/protocol/client_capabilities.rs` sets no `symbol` field on
+`WorkspaceClientCapabilities`), so in particular no `resolveSupport`. Per LSP
+3.18, a conformant downstream must therefore return a full `Location` rather
+than the location-without-range form.
+
+Nothing currently advertises the provider: `workspace_symbol_provider` is never
+set in the initialize result, and `LanguageServer::symbol` is never overridden,
+so the request today reaches tower-lsp-server's default and is unimplemented.
 
 ## Decision
 
-Implement `workspace/symbol` as a **workspace-scoped** bridged request with its
-own aggregation strategy, its own fan-out enumeration, and a global fan-in
-translator. Defer `workspaceSymbol/resolve`.
+Implement `workspace/symbol` as a **workspace-scoped** bridged request: a
+candidate-set walk over configuration intersected with live connections, a
+per-entry global fan-in translator, and a single deduplicating union. Defer
+`workspaceSymbol/resolve`.
 
 ```
  client                    kakehashi                    downstream servers
    │
    │ workspace/symbol   ┌───────────────┐
    │  { query }    ────▶│ candidate set │─── request ──▶  lua_ls   @ rootA
-   │                    │ dedup by      │─── request ──▶  tsgo     @ rootA
-   │                    │ connection    │─── request ──▶  tsgo     @ rootB
-   │                    │ (fan-out, §3) │─── request ──▶  pyright  @ rootA
+   │                    │ ∩ live conns  │─── request ──▶  tsgo     @ rootA
+   │                    │ dedup by key  │─── request ──▶  tsgo     @ rootB
+   │                    │ (fan-out, §3) │
    │                    └───────────────┘                         │
    │                                                              │
    │                    ┌───────────────┐                         │
@@ -100,17 +118,17 @@ translator. Defer `workspaceSymbol/resolve`.
    │             │ union (§1) — the ONLY merge,   │
    │             │ no per-target arbitration      │
    │             │  1. collect every entry        │
-   │             │  2. dedup  (name, kind, uri,   │
-   │             │             range, container)  │
+   │             │  2. dedup  (name, kind,        │
+   │             │             uri, range)        │
    │             │  3. sort   (uri, line, char,   │
    │             │             name, kind)        │
    │             └───────────────┬────────────────┘
-   │◀── Flat | Nested ───────────┘
-   │    (per client capability)
+   │◀── WorkspaceSymbol[] ───────┘
+   │    (always an array, never null)
    │
-   │ $/cancelRequest ─▶ forwarded to every in-flight target. This is the
-   │                    ONLY bound on latency — no deadline is imposed.
-   │                    Practical because no target is ever cold-started (§4).
+   │ $/cancelRequest ─▶ forwarded to every in-flight target, best effort:
+   │                    a downstream may ignore it (LSP allows this). The
+   │                    hard bounds are the pool's own timeouts (§6).
 ```
 
 ### 1. A dedicated `union` aggregation strategy
@@ -126,38 +144,53 @@ pub enum AggregationStrategy {
 ```
 
 `Union` = collect from **every** target, then **deduplicate** on
-`(name, kind, uri, range, container_name)`, then **sort deterministically** by
+`(name, kind, uri, range)`, then **sort deterministically** by
 `(uri, start.line, start.character, name, kind)`.
 
 It is a distinct value rather than a reuse of `Concatenated` because
 `Concatenated` deliberately preserves duplicates and source ordering (diagnostics
 and code actions from different servers are complementary and each must survive).
 A symbol search is set-valued: the same real file indexed by two servers, or by
-one server under two workspace roots, must appear once. Sorting is part of the
+one server under two workspace roots, should appear once. Sorting is part of the
 strategy, not a caller detail — `JoinSet` completion order is nondeterministic
 and an unstable result order is a self-inflicted test flake.
 
-`Union` is the **only** strategy for `workspace/symbol`, at both the bridge level
-and the layer level. It is the default, and an explicitly configured `preferred`
-or `concatenated` is overridden back to it with a warning (point 2).
+`container_name` is deliberately **excluded** from the dedup key. LSP defines it
+as "for user interface purposes… It can't be used to re-infer a hierarchy" and
+imposes no format or stability contract, so two servers naming the same symbol
+`"Foo"` and `"Foo.Bar"` (or omitting it) would defeat dedup on a field the spec
+says carries no identity. `(uri, range)` after translation already identifies a
+location; `(name, kind)` guards against a server reporting several symbols at one
+range.
 
-### 2. `preferred` is wrong for this method at every level
+Dedup is **exact-match only**. Two servers that disagree on range granularity —
+a full-declaration span versus a name-only span — produce two entries that both
+survive. That is a real limit of the mechanism, not something the strategy
+promises away.
+
+Adding the variant is not free: `AggregationStrategy` is matched exhaustively,
+with no wildcard arm, at 14 sites across `lsp_impl/bridge_context.rs`,
+`text_document/formatting.rs`, `text_document/code_action.rs`, and
+`text_document/diagnostic.rs`. Each must gain a `Union` arm, and none of those
+methods has a response shape `Union`'s key tuple applies to. Those arms
+therefore fall back to each site's existing `Concatenated` behavior: `Union` is
+meaningful for `workspace/symbol` and for nothing else. It is a named strategy,
+not a generally useful one.
+
+`workspace/symbol` does not go through the cross-layer walk at all — there are
+no layers without a document — so only the bridge-level default matters.
+The cross-layer-aggregation per-method table gains no row.
+
+### 2. `preferred` is wrong for this method, and is overridden
 
 The repo's own criterion for choosing a strategy is stated at
 `default_aggregation_strategy_for_method`: code actions concatenate because,
 "unlike formatting (**competing** whole-document edits), code actions from
 different servers are **complementary**."
 
-Two servers' `workspace/symbol` responses are complementary in exactly that
-sense — they index different parts of the workspace. `preferred` would discard
-one of them.
-
-The reason it cannot be rescued is that **a `workspace/symbol` response is not
-attributable to a language**. A server answers "here are the workspace's symbols
-matching `query`"; a server configured only under LANG_1 may perfectly well
-return LANG_2 symbols, because what it indexes is its workspace root, not a
-language. kakehashi therefore cannot decompose one response into the share that
-"belongs to" LANG_1 and the share that "belongs to" LANG_2. Concretely, given
+Two servers' `workspace/symbol` responses are complementary in that sense, and —
+per the attribution argument in Context — kakehashi cannot even tell which parts
+of a response a given pair "asked for". Concretely, given
 
 ```toml
 [languages.LANG_1.bridge._self.aggregation]
@@ -172,53 +205,83 @@ C would assume C covers what B indexes — unknowable, and pure loss whenever it
 is false.
 
 An explicit non-`union` strategy for this method is therefore overridden to
-`union`, with one warning at settings-apply time. This follows the existing
+`union`, with one warning at settings-apply time, following the existing
 misconfiguration path (`misconfigured_settings_warnings`, which already warns
-about `concatenated`-without-`priorities` for formatting) rather than silently
-discarding symbols the user never intended to lose.
+about `concatenated`-without-`priorities` for formatting).
 
-### 3. Fan-out: a candidate-set walk, deduplicated by connection
+Two servers indexing the *identical* root — say two TypeScript servers — are
+genuinely competing rather than complementary, and this decision does make their
+near-duplicate entries survive when their ranges differ. The lever for that case
+is `priorities`, which is an allowlist: name only the server you want. That is a
+static, deliberate exclusion the user writes, not an inference kakehashi draws
+from an empty response — which is the distinction that makes it acceptable here
+and `preferred` not. It does cost the user an edit in **every** pair that names
+the unwanted server, because fan-out unions candidates across all pairs.
 
-Because every level unions, there is no per-target arbitration left to do, and
-the configuration walk collapses to a **candidate-set** walk. A request has no
-document, so it cannot pick one `(host_language, bridge_key)` pair — it walks
-**all** of them (`settings.languages` × `bridge_map.keys()`, exactly as
-`concatenated_formatting_pairs` already does) purely to collect candidates.
+### 3. Fan-out: live connections first, then the configuration filter
 
-`priorities` and `max_fan_out` still filter, per pair:
+A request has no document, so it cannot pick one `(host_language, bridge_key)`
+pair — it walks **all** of them, purely to collect candidates.
 
-- `priorities` is an **allowlist**: listed servers are candidates, `"*"` stands
-  for the rest, and an explicit `[]` remains the per-method kill switch.
-- Its **order** still matters when `max_fan_out` caps the candidates — the cap
-  keeps the highest-priority N. Order is what nothing else can express; it is
-  only the *arbitration* meaning of order that this method drops.
-- A `_self` pair contributes candidates only when
-  `bridge._self.enabled = true` for that language. `is_host_bridging_enabled` is
-  a **direct** lookup with no wildcard fallback, so a `bridge._self.aggregation`
-  block without `enabled` contributes nothing at all.
+The walk mirrors `concatenated_formatting_pairs`, including the part that is
+easy to miss: each bridge key must be resolved through
+`resolve_with_wildcard(bridge_map, key, merge_bridge_language_configs)` before
+`resolve_aggregation(method)`, so that `priorities` / `strategy` /
+`max_fan_out` set only on the `bridge._` wildcard still apply to a concrete
+pair. Without that step the "no existing configuration becomes a silent no-op"
+property this decision claims would not hold. The literal `"_"` key is itself
+present in `bridge_map` for essentially every deployment (the shipped defaults
+populate `languages._.bridge._`); it is walked like any other key, which is
+idempotent under the self-merge and contributes the wildcard's own candidates.
 
-The candidate list is then **intersected with the live connections** (point 4):
-a query never spawns a server. What survives is deduplicated by **connection
-key** `(server, root)`, not by server name — the response is a function of
-`query` alone, so a connection named by several pairs is asked **once**. If two
-pairs resolve the same server name to configs producing different connection
-keys, those are genuinely two connections and two requests.
+**Order matters, and it is liveness first:**
+
+1. Take the pool's connection map and keep only `Ready` and `Initializing`
+   entries. `connections()` returns the raw map, and `ConnectionState` also has
+   `Failed`, `Closing`, and `Closed`, which linger until lazily evicted — none
+   of them is a valid target.
+2. Wait for the surviving `Initializing` entries to reach Ready.
+3. **Then** check `has_capability("workspace/symbol")` (see point 4 for why this
+   order is forced, and what `has_capability` needs first).
+4. **Then** apply the per-pair `priorities` allowlist and `max_fan_out` cap.
+5. Dedup the survivors by **connection key** `(server, root)`.
+
+Applying the cap before the liveness filter would let dead or absent servers
+consume cap slots and silently exclude a live server ranked below the cutoff —
+which would contradict this decision's own "coverage is what is live" contract.
+
+`priorities` is an allowlist: listed servers are candidates, `"*"` stands for
+the rest, and an explicit `[]` remains the per-method kill switch. Its **order**
+still decides which N survive a `max_fan_out` cap (`truncate_entries` keeps the
+highest-priority N in walk order); only the *arbitration* meaning of order is
+dropped. A `_self` pair contributes candidates only when
+`bridge._self.enabled = true` for that language — `is_host_bridging_enabled` is
+a **direct** lookup with no wildcard fallback, unlike the aggregation fields
+beside it, so a `bridge._self.aggregation` block without `enabled` contributes
+nothing at all.
+
+Dedup is by connection key, not server name: the response depends on the
+connection's own indexed workspace, so a connection named by several pairs is
+asked **once**, while the same server name under two roots is genuinely two
+connections and two requests.
 
 ```
   settings.languages × bridge_map.keys()      ← candidate walk only,
-        │                                       no arbitration
+        │  (each key via resolve_with_wildcard) no arbitration
         ▼
   ┌──────────────────────┐   ┌──────────────────────┐
   │ (LANG_1, _self)      │   │ (LANG_2, _self)      │  ... every pair
   │ priorities ["B"]     │   │ priorities ["C"]     │
   └──────────┬───────────┘   └──────────┬───────────┘
-             │                          │  apply allowlist + max_fan_out
              └────────────┬─────────────┘
                           ▼
         ┌──────────────────────────────────────┐
-        │ ∩ live connections — NEVER spawns    │
-        │   pool.connections(), Ready or       │
-        │   Initializing, has_capability       │
+        │ 1. keep Ready + Initializing only    │
+        │    (NOT Failed/Closing/Closed)       │
+        │ 2. wait for Ready                    │
+        │ 3. THEN has_capability               │
+        │ 4. THEN allowlist + max_fan_out      │
+        │    NEVER spawns a connection         │
         └──────────────────┬───────────────────┘
                            ▼
         ┌──────────────────────────────────────┐
@@ -227,83 +290,78 @@ keys, those are genuinely two connections and two requests.
         │   (B, rootB)  ← same server, another │
         │                 root: 2 connections  │
         │   (C, rootA)  ← named by LANG_2      │
-        │   B@rootA is asked ONCE even if      │
-        │   several pairs name it              │
         └──────────────────┬───────────────────┘
                            ▼
-              one request per connection, sent on the
-              handle — no re-acquire, no spawn
-                           │
-                           ▼
-              per-entry fan-in (§5), then
-              UNION → dedup → sort  (§1)
+              one request per connection (§4),
+              then per-entry fan-in (§5),
+              then UNION → dedup → sort (§1)
 ```
 
-### 4. Coverage is what is live, and a query never cold-starts a server
+### 4. The send lives in the bridge layer; the translation does not
 
-A candidate with no live connection is **skipped**, not spawned. Coverage is
-therefore "the servers that are running because of what the client has opened",
-and it grows when the client opens more files — opening a host document spawns
-its servers and opens its virtual documents, so the next query sees more.
+`connections()` is `pub(super)` to `crate::lsp::bridge`, and `lsp_impl` is a
+sibling module, not a descendant — so the fan-out **cannot** live beside the
+handler. It goes in `src/lsp/bridge/workspace/symbol.rs` as an
+`impl LanguageServerPool`, exactly where `execute_command.rs` already puts the
+one existing document-free send.
 
-This is not merely a cost trade. Cold-starting cannot deliver the coverage it
-appears to promise:
+That precedent also shows the primitive list is longer than
+`has_capability` / `send_request` / `wait_for_response`. Per target:
+`register_upstream_request(id, key)` at the pool level, then
+`handle.register_request_with_upstream(...)`, a `RouterCleanupGuard` armed
+around the request, and — under the `connections()` lock — a re-check that the
+handle is *still* the pool's current connection for its key before enqueueing,
+because a concurrent respawn may have replaced it. Unregistering on every early
+return is part of the pattern.
 
-- **Embedded-block symbols cannot be reached by spawning at all.** A virtual
-  document does not exist on disk, so a downstream learns of it only through
-  `didOpen`, and kakehashi opens virtual documents only for host documents the
-  *client* has opened. Reaching embedded code in unopened files would mean
-  parsing every candidate host file in the workspace and opening every region —
-  precisely the unbounded work this method must not do. Spawning a server buys
-  exactly zero embedded-block coverage, which is kakehashi's own contribution.
-- **Real-file symbols would be reached, but at one root only.** A server spawned
-  without a document hint resolves to the `ClientFallback` key
-  (`resolve_acquire`: "no document hint … stays on the client-root fallback"),
-  so a multi-root workspace gets the client root and none of the marker-derived
-  per-root connections. The coverage gained is partial and hard to explain.
-- **Scoping by "does this language occur in the workspace?" would need a
-  mechanism that does not exist.** The LSP server is document-driven and holds
-  no workspace index — nothing walks the filesystem on the server path (the
-  `ignore` crate is used only by the `src/cli/files.rs` subcommand). Under the
-  live-only rule that question answers itself for free: a language with no open
-  file has no live server and is not queried.
+`has_capability` needs two things before it can be used at all:
 
-Connections that are live but still `Initializing` are **included**, waiting for
-Ready with the existing acquisition timeout. They were already being paid for,
-and excluding them would make a query issued just after opening a file depend on
-timing — a nondeterminism this codebase does not need more of.
+- **A `workspace/symbol` arm.** Its `match` ends in `_ => false`, so an unlisted
+  method reports every server incapable. The arm reads
+  `workspace_symbol_provider: Option<OneOf<bool, WorkspaceSymbolOptions>>` in the
+  same shape as the existing `textDocument/definition` arm.
+- **To be called after the Ready wait.** It falls back to
+  `server_capabilities()`, which is `None` until `set_server_capabilities` runs
+  during the handshake — so prefiltering an `Initializing` connection drops
+  exactly the connections point 3 decided to keep.
 
-Two ordering constraints follow from that choice, and getting either wrong
-silently returns no results rather than failing:
+Cancellation needs nothing new: `register_upstream_request` already holds many
+`(server, root)` keys per upstream id, `forward_cancel_by_upstream_id_if_current`
+already iterates all of them, and `UpstreamRegistrySweepGuard` unregisters the
+whole entry. Multi-target cancellation falls out of using the pattern.
 
-- **Capability prefiltering must happen *after* the Ready wait, not before it.**
-  `has_capability` falls back to `server_capabilities()`, which is `None` until
-  `set_server_capabilities` runs during the handshake. Prefiltering an
-  `Initializing` connection therefore drops exactly the connections this section
-  just decided to keep.
-- **`has_capability` needs a `workspace/symbol` arm.** Its `match` ends in
-  `_ => false`, so an unlisted method reports *every* server as incapable. The
-  arm reads `workspace_symbol_provider: Option<OneOf<bool,
-  WorkspaceSymbolOptions>>` in the same shape as the existing
-  `textDocument/definition` arm.
+Fan-in cannot live in the bridge layer, because `resolve_region_offset` is
+`pub(super)` to `lsp_impl`. So unlike every `transform_*_response_to_host`
+function — which is pure because the caller already resolved *the* offset — this
+translator resolves a different offset per entry and must sit where the
+`DocumentStore` / `LanguageCoordinator` / `BridgeCoordinator` handles are, as
+`ShowDocumentTranslator` does. The bridge layer returns each target's raw
+result; `lsp_impl` classifies and translates. The classification is testable as
+a pure function only if the resolver is injected.
 
-### 5. Fan-in: a global virtual→host translator over four result classes
+### 5. Fan-in: a global virtual→host translator
 
-A pure function over the downstream's `serde_json::Value` response classifies
-every returned entry by its URI:
+Every entry is classified independently. Because each one resolves **its own**
+`(host_url, region_id, offset)`, this path may cross blocks where the goto path
+may not: the goto filter exists because only one region's offset is in hand.
 
 ```
   one entry of the downstream's result array
              │
              ▼
      ┌───────────────────┐  no
-     │ is_virtual_uri ?  ├─────▶ REAL FILE  ─▶ pass through untouched
-     └─────────┬─────────┘                     (external definition, a
-               │ yes                            file the server indexed)
+     │ has a range?      ├─────▶ DROP  (uri-only location — see below)
+     └─────────┬─────────┘
+               │ yes
+               ▼
+     ┌───────────────────┐  no
+     │ is_virtual_uri ?  ├─────▶ REAL FILE ─▶ pass through untouched
+     └─────────┬─────────┘
+               │ yes
                ▼
      ┌───────────────────┐  yes
-     │ is_scratch_uri ?  ├─────▶ DROP  (a non-region virtual document;
-     └─────────┬─────────┘              names no place in any host file)
+     │ is_scratch_uri ?  ├─────▶ DROP  (a formatting scratch document; names
+     └─────────┬─────────┘             no place in any host file)
                │ no
                ▼
      resolve_virtual_uri(uri)
@@ -314,75 +372,170 @@ every returned entry by its URI:
      resolve_region_offset(host_url, region_id)
                │
                ├── None ─────────▶ DROP  (region invalidated by edits, or
-               │                          host document closed — a virtual
-               │                          URI reaching the editor names a
-               ▼ Some(offset)              file that is not on disk)
+               │                          host document closed)
+               ▼ Some(offset)
      TRANSLATE
        uri   := host_url
        range := translate_virtual_range_to_host(range, offset)
 ```
 
-Every entry resolves **its own** `(host_url, region_id, offset)`. That is the
-whole reason this path may cross blocks where the goto path may not: the goto
-filter exists because only one region's offset is in hand, and here each entry
-brings its own.
+The range check comes first because `WorkspaceSymbol.location` is
+`OneOf<Location, WorkspaceLocation>` and the `WorkspaceLocation` form carries a
+`uri` and nothing else. A conformant downstream cannot send it here — kakehashi
+declares no `resolveSupport` (point 9) — but `OneOf` is `#[serde(untagged)]`, so
+it deserializes anyway. The classifier must reject it explicitly rather than
+reach for a `range` that is not there.
 
 Dropping — rather than passing through — an unresolvable virtual URI is
 deliberate: a virtual URI that escapes to the editor names a file that does not
 exist on disk, so the symbol is unopenable. This mirrors `window/showDocument`
 translation, which drops the selection it cannot translate.
 
-### 6. This is the first deliberate cross-block feature
+**Parse freshness is load-bearing here.** `resolve_region_offset` reads the live
+parse, and `didChange` clears the tree and reparses off-ingress, so during the
+reparse window it returns `None` for every region of the edited document — which
+this classifier would silently turn into "no embedded symbols". The
+whole-document handlers avoid this by calling `ensure_document_parsed` first;
+this method has no target document to name. It therefore calls
+`ensure_document_parsed` for **every open host document** before consuming
+responses. That set is bounded by what the client has open (virtual documents
+exist only for open hosts), and the pre-warm is issued concurrently with the
+fan-out requests, so it costs latency only when a parse is genuinely in flight.
+
+The response to the client is always an **array**, never `null`, so "no server
+was running" and "everything was dropped" are not distinguished — the spec
+assigns no distinct meaning to `null` here, and an array keeps the empty case
+uniform.
+
+Entries are emitted as `WorkspaceSymbol[]` — `WorkspaceSymbolResponse::Nested`
+in `ls-types`, whose variant names are a misnomer: **both** variants are flat
+arrays, and the choice is the element type, not hierarchy (there is no nested
+form for this method; `containerName` is spec-documented as unusable for
+re-inferring one). `SymbolInformation[]` is the deprecated alternative and is
+not emitted. No client capability governs the choice, so none is consulted.
+
+### 6. Latency is bounded by the pool's timeouts, not by cancellation
+
+Every target is awaited, so latency is max-over-targets. The bounds are:
+
+- `wait_for_response` wraps each request in a hardcoded **30-second** timeout and
+  removes the router entry when it fires.
+- The reader's **liveness timeout** can independently fail a connection that has
+  gone silent, transitioning it to `Failed`.
+- `$/cancelRequest` is forwarded to every in-flight target, but LSP explicitly
+  permits a downstream to ignore `$/` notifications, so it is best-effort and
+  cannot be the guarantee.
+
+No *additional* per-request deadline is introduced. Because no target is ever
+cold-started (point 7), the practical worst case is bounded by servers that are
+already running and already answering other requests.
+
+### 7. Coverage is what is live, and a query never cold-starts a server
+
+A candidate with no live connection is **skipped**, not spawned. Coverage is
+"the servers that are running because of what the client has opened", and it
+grows as the client opens more files — opening a host document spawns its
+servers and opens its virtual documents.
+
+This is not merely a cost trade. Cold-starting cannot deliver the coverage it
+appears to promise:
+
+- **Embedded-block symbols cannot be reached by spawning at all.** A virtual
+  document does not exist on disk, so a downstream learns of it only through
+  `didOpen`, and kakehashi opens virtual documents only for host documents the
+  *client* has opened. Reaching embedded code in unopened files would mean
+  parsing every candidate host file in the workspace and opening every region —
+  precisely the unbounded work this method must not do.
+- **Real-file symbols would be reached, but at one root only.** A server spawned
+  without a document hint resolves to the `ClientFallback` key, so a multi-root
+  workspace gets the client root and none of the marker-derived per-root
+  connections.
+- **Scoping by "does this language occur in the workspace?" would need a
+  mechanism that does not exist.** The LSP server is document-driven and holds
+  no workspace index; nothing walks the filesystem on the server path. Under the
+  live-only rule that question answers itself: a language with no open file has
+  no live server and is not queried.
+
+Coverage is not monotonic. `didClose` is forwarded downstream, a respawned
+connection starts with nothing open and regains virtual documents only via a
+best-effort re-open sweep, and a `Failed` connection is replaced lazily on next
+use — so a host document can stay open with its connection dead. Each of those
+shrinks coverage with no signal to the user.
+
+### 8. This is the first deliberate cross-block feature
 
 Every other bridged navigation path filters out results addressed to a region
 other than the request's own, because a cross-region offset is unsafe when only
-one region's offset is known. Workspace symbol search resolves **each** result's
+one region's offset is known. Workspace symbol search resolves each result's
 region independently, so the offset is always the right one for the entry being
-translated. `docs/language-features.md`'s blanket "navigation and edits do not
-cross between blocks" claim is amended accordingly.
+translated.
 
-### 7. Deferred in this decision
+Two user-facing docs state the no-cross-block rule as a blanket claim and must
+be amended, not merely appended to — the wrong part is the framing sentence in
+each: `docs/language-features.md` ("Bridged features are also limited to
+embedded code blocks in one respect: navigation and edits do not cross between
+blocks", and separately "features that need to see across blocks do not work
+between them") and `docs/README.md` ("**No cross-region results within the host
+document**"). Both files' itemized bodies are already correctly scoped to the
+goto/references/rename transforms and stay true. The
+language-server-bridge-request-strategies per-method table gains no row for this
+method and is left incomplete rather than wrong.
+
+### 9. Deferred in this decision
 
 - `workspaceSymbol/resolve` — `resolveProvider` is advertised as `false`. Because
-  kakehashi does not declare `resolveSupport` downstream, entries arriving
-  without a resolvable `Location` are a downstream conformance bug; they are
-  dropped rather than surfaced unresolvable.
-- `workDoneToken` / `partialResultToken` — neither is forwarded downstream. The
-  existing client-progress aggregator (`mint_region_progress_source`) is keyed by
+  kakehashi declares no `workspace.symbol` capability downstream, an entry
+  arriving without a range is a downstream conformance bug; §5 drops it.
+- `workDoneToken` / `partialResultToken` — neither is forwarded downstream, and
+  `workDoneProgress` is left unset on the advertised
+  `workspaceSymbolProvider`. The existing client-progress aggregator is keyed by
   region and has no meaning for a request that has no region. Both tokens are
   optional in LSP 3.18.
+- **Request coalescing.** A symbol picker typically fires one request per
+  keystroke, and this design has no single-flight, debounce, or supersession —
+  each keystroke fans out to every live connection. The repo has prior art for
+  exactly this failure mode in the semantic-token and diagnostic wire floods.
+  Nothing here prevents it; it is left for a follow-up once real traffic exists
+  to measure, and is the most likely first regression.
+- **The respawn re-open window.** A connection reaches `Ready` *before* its
+  virtual documents are replayed; the barrier that signals replay completion
+  (`wait_for_pending_reopen`) is today awaited only by `workspace/executeCommand`.
+  A query landing in that window under-reports a respawned server's
+  embedded-block symbols, indistinguishably from "no matches". Awaiting the
+  barrier per target would add unbounded latency to every query, so this is
+  accepted rather than fixed.
 
 ## Considered Options
 
-**`preferred`, as everywhere else.** Rejected at every level, per point 2:
-`preferred` encodes "these are competing answers to one question", and two
-servers' workspace symbol sets are complementary, not competing.
+**`preferred`, as everywhere else.** Rejected: `preferred` encodes "these are
+competing answers to one question", and — because a response cannot be
+attributed to a pair — kakehashi has no way to tell competing from
+complementary here. Every arbitration it could perform discards symbols on a
+basis it cannot compute.
 
-**Keep `preferred` across groups but allow it *within* a group.** Rejected —
-this was an intermediate position, and it does not survive the attribution
-argument. A server named by LANG_1's group can return LANG_2 symbols, so
-"within a group" does not delimit a coherent set of results to arbitrate over.
-Rejecting it is what collapses the group model: once no level arbitrates, the
-per-pair walk reduces to a candidate-set walk (point 3).
+**Allow `preferred` within a single pair, union only across pairs.** Rejected:
+it sounds like a smaller change, but "within a pair" does not delimit a coherent
+set of results, since a server named by LANG_1's pair can return LANG_2 symbols.
+Rejecting it is what collapses the design: once no level arbitrates, the
+per-pair walk reduces to a candidate-set walk.
 
 **Attribute each returned symbol to a language by detecting its URI's language,
-then apply the owning language's strategy.** Rejected: it would put language
-detection in the fan-in hot path, and it still cannot recover which *pair* owns
-a result — a file may be claimed by several — so it buys a fragile mechanism
-that does not answer the question it was built for.
+then apply the owning pair's strategy.** Rejected: it would put language
+detection in the fan-in hot path, and it still cannot recover which pair owns a
+result — a file may be claimed by several — so it buys a fragile mechanism that
+does not answer the question it was built for.
 
 **Reuse `concatenated` instead of adding `union`.** Rejected: `concatenated`
 must not deduplicate (see the diagnostics and codeAction defaults), and a symbol
-search must. Overloading it would make the existing strategy's contract
+search should. Overloading it would make the existing strategy's contract
 conditional on the method.
 
 **Cold-start every configured server so a query covers languages no open file
-uses.** Rejected, per point 4. It reads like the thorough option, but it buys no
-embedded-block coverage at all (those need `didOpen` of virtual documents that
-only an open host document produces), and the real-file coverage it does buy
-lands on the `ClientFallback` root alone. It also cannot answer "does this
-language even occur in the workspace?" without a workspace file walk the LSP
-server does not have.
+uses.** Rejected, per point 7. It reads like the thorough option, but it buys no
+embedded-block coverage at all, and the real-file coverage it does buy lands on
+the `ClientFallback` root alone. It also cannot answer "does this language even
+occur in the workspace?" without a workspace file walk the LSP server does not
+have.
 
 **Cold-start, and additionally `didOpen` the workspace's files so the spawned
 servers have something to index.** Rejected as unbounded: covering embedded code
@@ -399,28 +552,24 @@ synthetic value either drops everything or defeats the guard.
 **Resolve `priorities`/`max_fan_out` from the wildcard
 (`languages._._.aggregation["workspace/symbol"]`) entry only.** Rejected: it
 gives the feature exactly one knob, but it makes every per-language
-`bridge.<key>.aggregation` block a **silent no-op** for this method. A user who
-writes `[languages.LANG_1.bridge._self.aggregation] workspace/symbol = {...}`
-would see it ignored with no diagnostic. Silently discarding valid configuration
-is worse than the complexity it avoids.
+`bridge.<key>.aggregation` block a **silent no-op** for this method. Silently
+discarding valid configuration is worse than the complexity it avoids.
 
 **Merge every pair's `priorities` into one global ordered allowlist.** Rejected:
 a server configured under several pairs would hold several conflicting positions
 and several `max_fan_out` caps, with no principled merge. Under `union` the
 question dissolves — each pair contributes candidates independently, and the
-result set is order-free — so nothing has to be reconciled.
-
-**Walk every pair for candidates only, and union the results** (chosen). The
-per-pair walk is not new: `concatenated_formatting_pairs` already enumerates
-`settings.languages` × `bridge_map.keys()` and calls `resolve_aggregation(method)`
-on each. Per-pair `priorities` and `max_fan_out` keep working, so no existing
-configuration becomes a silent no-op, and no result is discarded on a basis
-kakehashi cannot compute.
+result set is order-free.
 
 **Honour an explicitly configured `preferred` instead of overriding it.**
-Rejected by the maintainer: overriding explicit configuration is a real cost,
-but silently losing symbols the user did not know they were excluding is worse,
-and the override is announced once at settings-apply time rather than hidden.
+Rejected: overriding explicit configuration is a real cost, but silently losing
+symbols the user did not know they were excluding is worse, and the override is
+announced once at settings-apply time rather than hidden.
+
+**Include `container_name` in the dedup key.** Rejected: LSP documents it as a
+UI-only field that cannot be used to re-infer hierarchy, and imposes no format
+contract, so two servers describing the same symbol routinely disagree on it.
+Including it would defeat dedup on a field carrying no identity.
 
 ## Consequences
 
@@ -430,37 +579,36 @@ and the override is announced once at settings-apply time rather than hidden.
   own indexes) and symbols inside embedded code blocks, in one result set.
 - The global virtual→host translator is reusable by any future workspace-scoped
   method (call hierarchy, type hierarchy) that faces the same fan-in problem.
-- `union` is available as an explicit, user-selectable strategy for other
-  methods.
 - Per-language `aggregation` blocks keep selecting servers for this method — a
   workspace-scoped request does not force users into a separate configuration
   dialect, and no existing block silently becomes a no-op.
-- No result is ever discarded on a basis kakehashi cannot compute. A server
+- No result is discarded on a basis kakehashi cannot compute. A server
   configured under one language may return another language's symbols, and they
   survive.
-- Because nothing arbitrates, there is no per-target response buffer to hold
-  and no ordering dependency between targets — the handler is a flat
-  fan-out/translate/merge, which is why this is a smaller change than an
-  arbitrating design.
-- A query never spawns a process. Latency is bounded by the servers already
-  running, so declining to impose a deadline stays practical, and `Ctrl-T` in a
-  fresh session cannot stampede every configured language server.
-- Coverage is explainable in one sentence — "the servers running because of what
-  you have opened" — and it grows monotonically as the client opens files, with
-  no separate indexing mode to understand or invalidate.
+- Because nothing arbitrates, there is no per-target response buffer to hold and
+  no ordering dependency between targets — the handler is a flat
+  fan-out/translate/merge.
+- A query never spawns a process, so `Ctrl-T` in a fresh session cannot stampede
+  every configured language server.
 
 ### Negative
 
-- Latency is max-over-live-servers, not first-win: the response waits for every
-  target. No deadline is imposed in this version; the client's `$/cancelRequest`
-  is the only bound.
-- Results depend on what is open. A language whose files the user has not opened
-  contributes nothing, and the same query answers differently later in a
-  session. LSP permits partial `workspace/symbol` results, but a user expecting
-  an indexed whole-project search will find this surprising.
+- Results depend on what is open, and coverage can shrink (close, respawn,
+  silent connection death). The same query answers differently at different
+  points in a session. LSP permits partial `workspace/symbol` results, but a
+  user expecting an indexed whole-project search will find this surprising.
+- Latency is max-over-live-targets, bounded only by the pool's existing 30s
+  request timeout and liveness timeout; forwarded cancellation is best-effort
+  because a downstream may ignore it.
+- One request per keystroke, un-coalesced (point 9).
+- Adding the `Union` variant forces a `Union` arm at 14 exhaustive match sites
+  in methods that have no use for it.
 - `strategy` becomes a knob that this one method ignores (with a warning). Users
   who reach for `preferred` to suppress a noisy server must instead leave it out
-  of `priorities`, which is the allowlist that already expresses exactly that.
+  of `priorities` — in every pair that names it.
+- Dedup is exact-match, so two servers that disagree on a symbol's range both
+  survive. The redundant-server case is a config edit, not something the merge
+  resolves.
 - Whether a downstream includes kakehashi's virtual documents in its own symbol
   index is server-specific — the virtual files do not exist on disk, and servers
   that index only on-disk workspace contents will contribute real-file symbols
@@ -468,7 +616,12 @@ and the override is announced once at settings-apply time rather than hidden.
 
 ### Neutral
 
-- The `union` strategy is selectable for other methods, but no other method
-  defaults to it.
-- Result ordering is defined by the strategy, so clients that re-sort see no
-  change and clients that do not get a stable order.
+- `Union` is a named strategy but is meaningful only for this method; elsewhere
+  it behaves as `Concatenated`.
+- Result ordering is deterministic but not relevance-ranked. LSP delegates
+  scoring to the client ("editors will apply their own highlighting and scoring
+  on the results"), so a client that re-sorts sees no change and one that does
+  not gets a stable order.
+- The fan-out and fan-in halves live in different modules
+  (`bridge/workspace/symbol.rs` and `lsp_impl/workspace/symbol.rs`) because of
+  the `pub(super)` boundaries between them, not because of a design preference.

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -175,14 +175,33 @@ a full-declaration span versus a name-only span — produce two entries that bot
 survive. That is a real limit of the mechanism, not something the strategy
 promises away.
 
-Adding the variant is not free: `AggregationStrategy` is matched exhaustively,
-with no wildcard arm, at 7 `match` sites across `lsp_impl/bridge_context.rs`,
-`text_document/formatting.rs`, `text_document/code_action.rs`, and
-`text_document/diagnostic.rs`. Each must gain a `Union` arm, and none of those
-methods has a response shape `Union`'s key tuple applies to. Those arms
-therefore fall back to each site's existing `Concatenated` behavior: `Union` is
-meaningful for `workspace/symbol` and for nothing else. It is a named strategy,
-not a generally useful one.
+When two entries *do* collide, the survivor's non-key fields are **merged by
+rule**, not taken from whichever arrived first — otherwise the payload would
+still vary with `JoinSet` completion order even though its ordering does not.
+`tags` are unioned and sorted; `container_name` takes the lexicographically
+smallest `Some`, or `None` if no entry carried one; `data` is **dropped
+entirely**, since it is server-private state whose only purpose is
+`workspaceSymbol/resolve`, which this decision does not support.
+
+`Union` is **normalized away at resolution time** for every other method:
+`resolve_aggregation` yields `Union` only for `workspace/symbol`, and a `Union`
+configured anywhere else resolves to that method's existing default before any
+handler sees it. The same normalization applies to `LayerAggregationConfig`,
+which shares this enum.
+
+Normalizing at the single resolution point — rather than adding behavior at each
+consumer — is not a style preference. `AggregationStrategy` is matched
+exhaustively at 7 sites, but `plan_region_format` does **not** match: it tests
+`strategy != Concatenated` and treats everything else as `Preferred`. So a
+`Union` that reached the handlers would mean `Concatenated` at the exhaustive
+sites and `Preferred` inside formatting — one configured value with two
+behaviors in the same method. And because a method-level `"_"` entry resolves
+into every method, `_ = union` is a configuration a user can plausibly write,
+so this is reachable, not hypothetical.
+
+The exhaustive sites still need a `Union` arm to compile; with normalization in
+front of them it is unreachable, and each site should say so rather than invent
+a behavior. `Union` is meaningful for `workspace/symbol` and nothing else.
 
 `workspace/symbol` does not go through the cross-layer walk at all — there are
 no layers without a document — so only the bridge-level default matters.
@@ -239,18 +258,45 @@ the unwanted server, because fan-out unions candidates across all pairs.
 ### 3. Fan-out: live connections first, then the configuration filter
 
 A request has no document, so it cannot pick one `(host_language, bridge_key)`
-pair — it walks **all** of them, purely to collect candidates.
+pair — it walks **all** of them, purely to collect candidates. Both axes must be
+**concrete**, and neither is the config map's raw key set.
 
-The walk mirrors `concatenated_formatting_pairs`, including the part that is
-easy to miss: each bridge key must be resolved through
-`resolve_with_wildcard(bridge_map, key, merge_bridge_language_configs)` before
-`resolve_aggregation(method)`, so that `priorities` / `strategy` /
-`max_fan_out` set only on the `bridge._` wildcard still apply to a concrete
-pair. Without that step the "no existing configuration becomes a silent no-op"
-property this decision claims would not hold. The literal `"_"` key is itself
-present in `bridge_map` for essentially every deployment (the shipped defaults
-populate `languages._.bridge._`); it is walked like any other key, which is
-idempotent under the self-merge and contributes the wildcard's own candidates.
+`"_"` is a configuration **template**, never a target. Everywhere else in
+kakehashi it is resolved *against an actual language*:
+`is_language_bridgeable("python")` merges `_` into `python`, and servers are
+then selected by whether they handle `python`. Walking `bridge_map.keys()`
+literally would ask for the servers that handle a language named `_` — and
+because the shipped defaults populate only `languages._.bridge._`, the default
+configuration would contribute **no candidates at all**. Treating `_` instead as
+"every server" is worse: it would re-admit servers that a concrete
+`bridge.python.enabled = false` or `priorities = []` excluded, and union has no
+way to subtract that contribution.
+
+So the axes are:
+
+- **Host languages**: the languages of the **currently open documents**. This is
+  concrete by construction (it comes from language detection, never from a map
+  key), and it is the right set for the same reason the whole method is
+  live-only — virtual documents, and therefore downstream connections, exist
+  only for documents the client has opened.
+- **Injection languages**: the concrete (non-`_`) bridge keys under those host
+  languages, plus `_self`, plus the languages configured servers declare in
+  `languages = [...]`. A `languages = ["*"]` server needs no entry of its own:
+  it is admitted for every concrete language by the normal routing check.
+
+Candidates for each `(host, injection)` pair then come from the **existing
+routing entry point**, `get_all_configs_for_language`, rather than from a
+hand-rolled lookup. That function already applies the `is_language_bridgeable`
+gate — with `_` inheritance — and already selects servers by whether they handle
+the injection language, so reusing it is what keeps this method's routing
+identical to every other method's. `_self` goes through the host tier's own
+gate instead (`is_host_bridging_enabled`), which is opt-in and direct, unlike
+the opt-out, wildcard-resolved gate beside it.
+
+`priorities` / `strategy` / `max_fan_out` are read with
+`resolve_aggregation(method)` on the wildcard-resolved bridge config, so values
+set only on `bridge._` still apply to a concrete pair — the property that keeps
+existing configuration from becoming a silent no-op here.
 
 **Order matters, and it is liveness first:**
 
@@ -278,12 +324,10 @@ a **direct** lookup with no wildcard fallback, unlike the aggregation fields
 beside it, so a `bridge._self.aggregation` block without `enabled` contributes
 nothing at all.
 
-Every **other** bridge key needs the sibling gate, `is_language_bridgeable`,
-which resolves `enabled` through the wildcard and defaults to `true`. The two
-gates are deliberately asymmetric — host bridging is opt-in, injection bridging
-is opt-out — and the walk must apply the right one per key, or a pair the user
-switched off with `bridge.<key>.enabled = false` would still contribute
-candidates here while contributing to no other bridged method.
+Every **other** bridge key is gated by `is_language_bridgeable`, which resolves
+`enabled` through the wildcard and defaults to `true` — and which
+`get_all_configs_for_language` already applies, which is the main reason to
+route through it rather than re-deriving the gates.
 
 Dedup is by connection key, not server name: the response depends on the
 connection's own indexed workspace, so a connection named by several pairs is
@@ -437,25 +481,32 @@ parse, and `didChange` clears the tree and reparses off-ingress, so during the
 reparse window it returns `None` for every region of the edited document — which
 this classifier would silently turn into "no embedded symbols". The
 whole-document handlers avoid this by calling `ensure_document_parsed` first;
-this method has no target document to name. It therefore pre-warms **every open
-host document** before consuming responses, enumerated via
-`DocumentStore::open_uris()` — which holds host URIs only, so formatting's
-scratch documents are not in the set.
+this method has no target document to name.
 
-The sweep is **concurrent**, one `JoinSet` task per document, matching the
-diagnostic publisher's shape rather than the serial shared-budget sweep in
-`lifecycle.rs`, and it is issued alongside the fan-out requests so it overlaps
-them.
+It therefore ensures **lazily, at translation time**: as entries are classified,
+each distinct `host_url` they resolve to is ensured once, immediately before its
+entries are translated. Doing this up front instead — a sweep over every open
+document, issued alongside the fan-out — was the first shape considered and is
+worse on both axes. It does work for documents no result mentions, and, more
+importantly, it completes up to 30 seconds before the value is used (a target
+may take the full response timeout), so an edit arriving in between re-clears
+the tree and the sweep guarantees nothing. Ensuring next to the use closes that
+gap to the width of one classification step.
 
-It pre-warms only documents that **already have a snapshot**. That is not an
-optimization but a correctness-preserving bound: `ensure_document_parsed` asks
-for a 200ms wait, but `wait_for_current_snapshot` escalates to the 15-second
-`FIRST_PARSE_BACKSTOP` when no snapshot exists at all, regardless of the
-caller's wait — so a sweep that included never-parsed documents could block a
-query for 15 seconds. Skipping them loses nothing: a document that has never
-been parsed has no resolved injection regions, hence no virtual documents opened
-downstream, hence no result can address it. The reparse window this pre-warm
-exists for is by definition a document that has a snapshot and a cleared tree.
+Only documents that **already have a snapshot** are ensured. `ensure_document_parsed`
+asks for a 200ms wait, but `wait_for_current_snapshot` escalates to the
+15-second `FIRST_PARSE_BACKSTOP` when no snapshot exists at all, regardless of
+the caller's wait. Skipping them loses nothing: a never-parsed document has no
+resolved injection regions, hence no virtual documents downstream, hence no
+result can address it.
+
+A residual race remains and is **accepted**: a `didChange` landing between the
+ensure and the offset resolution clears the tree again, and that entry is
+dropped like any other unresolvable one. Closing it entirely would mean pinning
+a per-document snapshot generation across the whole fan-in and resolving against
+the pinned tree — which would translate results against text the client has
+already replaced. Dropping is the safer failure, and it self-corrects on the
+next query.
 
 The response to the client is always an **array**, never `null`, so "no server
 was running", "everything was dropped", and "every target errored or timed out"
@@ -667,10 +718,11 @@ Including it would defeat dedup on a field carrying no identity.
   request timeout and liveness timeout; forwarded cancellation is best-effort
   because a downstream may ignore it.
 - One request per keystroke, un-coalesced (point 9).
-- Every query pre-warms the parse of every open host document (point 5). The
-  sweep is concurrent and each task carries the existing 200ms bound, but it is
-  per-query work that scales with the number of open documents, and it compounds
-  with the un-coalesced fan-out above.
+- Fan-in can wait on a parse: each distinct host document a result addresses is
+  ensured before translation, up to 200ms each (point 5).
+- An edit landing between that ensure and the offset resolution still drops the
+  affected entries. The window is small but not closed, and the failure is
+  silent — the symbols simply are not there.
 - `max_fan_out` no longer bounds a query's total fan-out — only each pair's
   contribution — so the only real bound on how many connections one query
   touches is how many are live.

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -103,10 +103,10 @@ per-entry global fan-in translator, and a single deduplicating union. Defer
  client                    kakehashi                    downstream servers
    │
    │ workspace/symbol   ┌───────────────┐
-   │  { query }    ────▶│ candidate set │─── request ──▶  lua_ls   @ rootA
-   │                    │ ∩ live conns  │─── request ──▶  tsgo     @ rootA
-   │                    │ dedup by conn │─── request ──▶  tsgo     @ rootB
-   │                    │ (fan-out, §3) │
+   │  { query }    ────▶│ fan-out (§3): │─── request ──▶  lua_ls   @ rootA
+   │                    │ pairs ∩ live, │─── request ──▶  tsgo     @ rootA
+   │                    │ capped, then  │─── request ──▶  tsgo     @ rootB
+   │                    │ deduped       │
    │                    └───────────────┘                         │
    │                                                              │
    │                    ┌───────────────┐                         │
@@ -214,6 +214,13 @@ The same walk warns in the **other** direction too: `strategy = "union"` on any
 method other than `workspace/symbol` is equally inert (point 1), and warning on
 only one of the two would leave the more likely user mistake silent.
 
+Both directions must decide "which method is this?" by **resolving** the
+aggregation entry, not by comparing map keys. A method-level `"_"` wildcard
+entry legitimately supplies a strategy to `workspace/symbol` through the same
+`resolve_with_wildcard` fallback used everywhere else, so a walk that only
+inspects literal key names would both miss the override it should apply and warn
+about a `union` that is in fact reaching this method.
+
 Two servers indexing the *identical* root — say two TypeScript servers — are
 genuinely competing rather than complementary, and this decision does make their
 near-duplicate entries survive when their ranges differ. The lever for that case
@@ -264,6 +271,13 @@ dropped. A `_self` pair contributes candidates only when
 a **direct** lookup with no wildcard fallback, unlike the aggregation fields
 beside it, so a `bridge._self.aggregation` block without `enabled` contributes
 nothing at all.
+
+Every **other** bridge key needs the sibling gate, `is_language_bridgeable`,
+which resolves `enabled` through the wildcard and defaults to `true`. The two
+gates are deliberately asymmetric — host bridging is opt-in, injection bridging
+is opt-out — and the walk must apply the right one per key, or a pair the user
+switched off with `bridge.<key>.enabled = false` would still contribute
+candidates here while contributing to no other bridged method.
 
 Dedup is by connection key, not server name: the response depends on the
 connection's own indexed workspace, so a connection named by several pairs is
@@ -351,9 +365,12 @@ translator resolves a different offset per entry and must sit where the
 The value crossing that boundary is **typed, not raw JSON**: the bridge module
 owns deserialization for every other bridged request, and this one keeps that
 property. Each target's response is parsed into `Vec<WorkspaceSymbol>` there,
-normalizing a `SymbolInformation[]` answer into the same shape, which is
-possible precisely because `WorkspaceSymbol.location` is a `OneOf` that models
-the range-less form rather than rejecting it. `lsp_impl` then classifies and
+normalizing a `SymbolInformation[]` answer into the same shape. That works for
+`location` because `WorkspaceSymbol.location` is a `OneOf` that models the
+range-less form rather than rejecting it, but it is not field-for-field:
+`SymbolInformation` carries a (itself deprecated) `deprecated: Option<bool>`
+that `WorkspaceSymbol` has no counterpart for, so the normalization must fold
+`Some(true)` into `tags` as `SymbolTag::DEPRECATED` or silently lose it. `lsp_impl` then classifies and
 translates typed values, and its classification is unit-testable as a pure
 function once the offset resolver is injected.
 
@@ -421,16 +438,28 @@ scratch documents are not in the set.
 
 The sweep is **concurrent**, one `JoinSet` task per document, matching the
 diagnostic publisher's shape rather than the serial shared-budget sweep in
-`lifecycle.rs`. Each call carries `ensure_document_parsed`'s own 200ms bound, so
-the sweep costs roughly one such wait in wall time rather than one per document,
-and it is issued alongside the fan-out requests so it overlaps them. No
-additional total budget is imposed: the set is bounded by what the client has
-open, and every task's own bound is the existing one.
+`lifecycle.rs`, and it is issued alongside the fan-out requests so it overlaps
+them.
+
+It pre-warms only documents that **already have a snapshot**. That is not an
+optimization but a correctness-preserving bound: `ensure_document_parsed` asks
+for a 200ms wait, but `wait_for_current_snapshot` escalates to the 15-second
+`FIRST_PARSE_BACKSTOP` when no snapshot exists at all, regardless of the
+caller's wait — so a sweep that included never-parsed documents could block a
+query for 15 seconds. Skipping them loses nothing: a document that has never
+been parsed has no resolved injection regions, hence no virtual documents opened
+downstream, hence no result can address it. The reparse window this pre-warm
+exists for is by definition a document that has a snapshot and a cleared tree.
 
 The response to the client is always an **array**, never `null`, so "no server
-was running" and "everything was dropped" are not distinguished — the spec
-assigns no distinct meaning to `null` here, and an array keeps the empty case
-uniform.
+was running", "everything was dropped", and "every target errored or timed out"
+are not distinguished — the spec assigns no distinct meaning to `null` here, and
+an array keeps the empty case uniform. This last case needs stating because the
+existing fan-in outcomes are mapped inconsistently elsewhere (the diagnostics
+path turns a total failure into an empty vector, formatting and code actions
+into `None`); here it is the empty array, so a downstream outage degrades to
+"no matches" rather than to a protocol-level nothing. A target that errors or
+hits the 30-second timeout contributes nothing and does not fail the query.
 
 Entries are emitted as `WorkspaceSymbol[]` — `WorkspaceSymbolResponse::Nested`
 in `ls-types`, whose variant names are a misnomer: **both** variants are flat

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -398,8 +398,7 @@ contradicting this decision's own coverage contract. (In the abandoned waiting
 design this placement had a second failure mode too — the cap became a global
 barrier — but with `Initializing` excluded there is nothing left to wait for,
 so only the coverage argument applies.)
-Deciding membership synchronously and waiting per target removes the
-interaction entirely.
+Deciding membership synchronously removes the interaction entirely.
 
 Step 2 must precede step 3: capping first would let a **known-incapable**
 server take a slot from a capable one — with `priorities = [A, B]`,
@@ -544,9 +543,10 @@ function once the offset resolver is injected.
 
 ### 5. Fan-in: a global virtual→host translator
 
-Every entry is classified independently. Because each one resolves **its own**
-`(host_url, region_id, offset)`, this path may cross blocks where the goto path
-may not: the goto filter exists because only one region's offset is in hand.
+Every entry is classified independently, and each is translated against **its
+own** region's offset — which is what lets this path cross blocks where the goto
+path may not: the goto filter exists because only one region's offset is in
+hand. "Its own offset" does not mean "its own resolution", though; see pass 3.
 
 ```
   one entry of the downstream's result array
@@ -630,7 +630,8 @@ index** built once up front:
 1. Classify every entry against that index, **grouping entries by host**. No
    parse and no lock is involved, so nothing waits here.
 2. Ensure the distinct hosts that actually appear, **concurrently**.
-3. Resolve each entry's offset and translate, per group.
+3. Resolve each host's regions **once**, then translate its entries against
+   that one resolution.
 
 Pass 0 is built **late, and verified late**, because a single early snapshot
 is wrong in both directions across a collection phase that runs concurrently and
@@ -725,27 +726,52 @@ resolution that reads the tracker just ahead of that update finishes against its
 own stale snapshot and passes both the language and range checks with old
 coordinates.
 
-The check must be on **incarnation *and* content version**, not incarnation
-alone. An ordinary edit preserves the incarnation and only bumps the content
-version, and `DocumentSnapshot` does not carry that version — so an
-incarnation-only comparison would miss precisely the race described above.
-The resolution variant therefore retains the snapshot's content/parsed version
-alongside the language and virtual content, and compares both fields against a
-single live `SnapshotView`.
+**Resolution is per host, not per entry.** `resolve_by_region_id` runs the whole
+injection walk over the host on every call, so resolving each entry
+independently would be `symbols × regions` work — a 2,000-symbol response from a
+100-region host would walk that host 2,000 times — while holding a lock that
+blocks every `didChange` and close for it. Memoizing individual ids does not fix
+this: the first lookup for each distinct region still walks, so the worst case
+stays quadratic.
 
-The document edit lock must be acquired **before the resolution snapshot is
-taken**, not merely around that comparison, and held through translation. This
-is not just about making the comparison unraceable: `resolve_by_region_id`
-**mutates** the tracker — it goes through the named-layer allocator and then
-`calculate_region_id`, which can mint a ULID. A resolution that reads stale
-coordinates and loses the race to `didChange` would therefore mint a **ghost id
-at coordinates that no longer exist**, and the version check afterwards drops
-the symbol but cannot undo the mutation. Post-checking a side-effecting
-resolution is not enough; the lock has to cover the side effect. (A genuinely
-read-only resolver that reused the requested id and never reached a minting
-helper would be the alternative, and does not exist today.) This is the discipline the semantic
-token path already uses, and only the whole of it works; the incarnation half
-alone would leave "the tree is gone" as the only edit race the design notices.
+Each host is therefore resolved **once** into a request-local
+`region_id → (offset, region_end, virtual_content, injection_language)` map, and
+every entry for that host is translated against it. The preferred source is the
+**generation-stamped resolved-region snapshot** the document store already
+keeps; only when that is unavailable does fan-in run one full resolution for the
+host and build the map from it.
+
+Preferring the cached snapshot is not only about cost. `resolve_by_region_id`
+**mutates** the tracker — it reaches the named-layer allocator and then
+`calculate_region_id`, which can mint a ULID — so an inline resolution that
+loses a race mints a **ghost id at coordinates that no longer exist**, and no
+post-check can undo that. Reading an already-resolved snapshot has no such side
+effect.
+
+Two identities must hold, not one:
+
+- **Document freshness.** The retained content/parsed version *and* incarnation
+  are compared against a single live `SnapshotView`. Incarnation alone is
+  insufficient: an ordinary edit preserves it and only bumps the content
+  version, which `DocumentSnapshot` does not carry. This is the discipline the
+  semantic token path already uses, and only the whole of it works — the
+  incarnation half alone would leave "the tree is gone" as the only edit race
+  the design notices.
+- **Query generation.** A settings reload replaces the injection queries and
+  bumps the settings generation *before* invalidating parses, and takes no
+  document edit lock — so a resolution can straddle a reload, use
+  mixed-generation query state, and still pass the document-version check. The
+  generation is captured and re-checked, as the other query-sensitive paths
+  already do. Because an inline resolution mutates the tracker, detecting a
+  mismatch afterwards cannot undo it; this is the second reason the
+  generation-stamped snapshot is the preferred source, and the reason the inline
+  fallback must be serialized against reload.
+
+The inline fallback additionally requires the document edit lock **before its
+resolution snapshot is taken**, not merely around the comparison, and held
+through translation — the lock has to cover the side effect, not merely observe
+it. (A genuinely read-only resolver, reusing the requested id and never reaching
+a minting helper, would remove that requirement; it does not exist today.)
 
 Taking that lock carries an obligation the happy path hides. `edit_lock`
 **creates** an entry unconditionally, so a host that closed between indexing and

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -32,8 +32,9 @@ The arbitration problem is subtler than "no document", and it is the one that
 shapes this decision: a `workspace/symbol` response is **not attributable to a
 language**. A server answers "here are the workspace's symbols matching
 `query`", and what it indexes is its workspace root, not a language — so a
-server reached through one configured pair routinely returns symbols belonging
-to another pair's language. Nothing in the response says which configured pair
+server reached through one configured **pair** (throughout this decision, a
+`(host_language, bridge_key)` entry in `languages.<lang>.bridge.<key>`)
+routinely returns symbols belonging to another pair's language. Nothing in the response says which configured pair
 "owns" an entry, so no arbitration between pairs can be principled.
 
 ```
@@ -75,11 +76,11 @@ Three facts in the existing code make the feature tractable anyway:
 - `BridgeCoordinator::resolve_virtual_uri(uri) -> Option<(host_url, region_id)>`
   is a **global** virtual→host reverse map (it is what `window/showDocument`
   translation already uses), and `resolve_region_offset` rebuilds the
-  `RegionOffset` from the live parse for any `(host_url, region_id)` pair.
+  `RegionOffset` from the live parse for any given `host_url` and `region_id`.
 - `LanguageServerPool::connections()` enumerates the pool's connection map.
 - `send_execute_command_on_handle` (`bridge/workspace/execute_command.rs`) is an
   existing precedent for sending a request on a connection **without** a virtual
-  document, and it shows exactly what that costs (see point 3).
+  document, and it shows exactly what that costs (see point 4).
 
 kakehashi sends downstream no `workspace.symbol` client capability at all
 (`bridge/protocol/client_capabilities.rs` sets no `symbol` field on
@@ -104,7 +105,7 @@ per-entry global fan-in translator, and a single deduplicating union. Defer
    │ workspace/symbol   ┌───────────────┐
    │  { query }    ────▶│ candidate set │─── request ──▶  lua_ls   @ rootA
    │                    │ ∩ live conns  │─── request ──▶  tsgo     @ rootA
-   │                    │ dedup by key  │─── request ──▶  tsgo     @ rootB
+   │                    │ dedup by conn │─── request ──▶  tsgo     @ rootB
    │                    │ (fan-out, §3) │
    │                    └───────────────┘                         │
    │                                                              │
@@ -169,7 +170,7 @@ survive. That is a real limit of the mechanism, not something the strategy
 promises away.
 
 Adding the variant is not free: `AggregationStrategy` is matched exhaustively,
-with no wildcard arm, at 14 sites across `lsp_impl/bridge_context.rs`,
+with no wildcard arm, at 7 `match` sites across `lsp_impl/bridge_context.rs`,
 `text_document/formatting.rs`, `text_document/code_action.rs`, and
 `text_document/diagnostic.rs`. Each must gain a `Union` arm, and none of those
 methods has a response shape `Union`'s key tuple applies to. Those arms
@@ -208,6 +209,10 @@ An explicit non-`union` strategy for this method is therefore overridden to
 `union`, with one warning at settings-apply time, following the existing
 misconfiguration path (`misconfigured_settings_warnings`, which already warns
 about `concatenated`-without-`priorities` for formatting).
+
+The same walk warns in the **other** direction too: `strategy = "union"` on any
+method other than `workspace/symbol` is equally inert (point 1), and warning on
+only one of the two would leave the more likely user mistake silent.
 
 Two servers indexing the *identical* root — say two TypeScript servers — are
 genuinely competing rather than complementary, and this decision does make their
@@ -265,6 +270,12 @@ connection's own indexed workspace, so a connection named by several pairs is
 asked **once**, while the same server name under two roots is genuinely two
 connections and two requests.
 
+`max_fan_out` therefore bounds a **pair's** contribution, not the query's total
+fan-out. A connection dropped by one pair's cap still enters through another
+pair that names it, and no global cap exists. Under `preferred` the cap was also
+a cost bound; here it is only a per-pair selection rule. What actually bounds
+the total is the live-connection set (point 7).
+
 ```
   settings.languages × bridge_map.keys()      ← candidate walk only,
         │  (each key via resolve_with_wildcard) no arbitration
@@ -297,7 +308,7 @@ connections and two requests.
               then UNION → dedup → sort (§1)
 ```
 
-### 4. The send lives in the bridge layer; the translation does not
+### 4. The send lives in the `bridge` module; the translation does not
 
 `connections()` is `pub(super)` to `crate::lsp::bridge`, and `lsp_impl` is a
 sibling module, not a descendant — so the fan-out **cannot** live beside the
@@ -330,14 +341,21 @@ Cancellation needs nothing new: `register_upstream_request` already holds many
 already iterates all of them, and `UpstreamRegistrySweepGuard` unregisters the
 whole entry. Multi-target cancellation falls out of using the pattern.
 
-Fan-in cannot live in the bridge layer, because `resolve_region_offset` is
+Fan-in cannot live in the `bridge` module, because `resolve_region_offset` is
 `pub(super)` to `lsp_impl`. So unlike every `transform_*_response_to_host`
 function — which is pure because the caller already resolved *the* offset — this
 translator resolves a different offset per entry and must sit where the
 `DocumentStore` / `LanguageCoordinator` / `BridgeCoordinator` handles are, as
-`ShowDocumentTranslator` does. The bridge layer returns each target's raw
-result; `lsp_impl` classifies and translates. The classification is testable as
-a pure function only if the resolver is injected.
+`ShowDocumentTranslator` does.
+
+The value crossing that boundary is **typed, not raw JSON**: the bridge module
+owns deserialization for every other bridged request, and this one keeps that
+property. Each target's response is parsed into `Vec<WorkspaceSymbol>` there,
+normalizing a `SymbolInformation[]` answer into the same shape, which is
+possible precisely because `WorkspaceSymbol.location` is a `OneOf` that models
+the range-less form rather than rejecting it. `lsp_impl` then classifies and
+translates typed values, and its classification is unit-testable as a pure
+function once the offset resolver is injected.
 
 ### 5. Fan-in: a global virtual→host translator
 
@@ -396,11 +414,18 @@ parse, and `didChange` clears the tree and reparses off-ingress, so during the
 reparse window it returns `None` for every region of the edited document — which
 this classifier would silently turn into "no embedded symbols". The
 whole-document handlers avoid this by calling `ensure_document_parsed` first;
-this method has no target document to name. It therefore calls
-`ensure_document_parsed` for **every open host document** before consuming
-responses. That set is bounded by what the client has open (virtual documents
-exist only for open hosts), and the pre-warm is issued concurrently with the
-fan-out requests, so it costs latency only when a parse is genuinely in flight.
+this method has no target document to name. It therefore pre-warms **every open
+host document** before consuming responses, enumerated via
+`DocumentStore::open_uris()` — which holds host URIs only, so formatting's
+scratch documents are not in the set.
+
+The sweep is **concurrent**, one `JoinSet` task per document, matching the
+diagnostic publisher's shape rather than the serial shared-budget sweep in
+`lifecycle.rs`. Each call carries `ensure_document_parsed`'s own 200ms bound, so
+the sweep costs roughly one such wait in wall time rather than one per document,
+and it is issued alongside the fan-out requests so it overlaps them. No
+additional total budget is imposed: the set is bounded by what the client has
+open, and every task's own bound is the existing one.
 
 The response to the client is always an **array**, never `null`, so "no server
 was running" and "everything was dropped" are not distinguished — the spec
@@ -601,7 +626,14 @@ Including it would defeat dedup on a field carrying no identity.
   request timeout and liveness timeout; forwarded cancellation is best-effort
   because a downstream may ignore it.
 - One request per keystroke, un-coalesced (point 9).
-- Adding the `Union` variant forces a `Union` arm at 14 exhaustive match sites
+- Every query pre-warms the parse of every open host document (point 5). The
+  sweep is concurrent and each task carries the existing 200ms bound, but it is
+  per-query work that scales with the number of open documents, and it compounds
+  with the un-coalesced fan-out above.
+- `max_fan_out` no longer bounds a query's total fan-out — only each pair's
+  contribution — so the only real bound on how many connections one query
+  touches is how many are live.
+- Adding the `Union` variant forces a `Union` arm at 7 exhaustive `match` sites
   in methods that have no use for it.
 - `strategy` becomes a knob that this one method ignores (with a warning). Users
   who reach for `preferred` to suppress a noisy server must instead leave it out
@@ -613,6 +645,9 @@ Including it would defeat dedup on a field carrying no identity.
   index is server-specific — the virtual files do not exist on disk, and servers
   that index only on-disk workspace contents will contribute real-file symbols
   only.
+- Shipping this obliges a documentation change, not just an addition: two
+  user-facing files state the no-cross-block rule as a blanket claim and one
+  states the strategy set as a closed pair (point 8).
 
 ### Neutral
 

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -121,7 +121,7 @@ per-entry global fan-in translator, and a single deduplicating union. Defer
    │             │  1. collect every entry        │
    │             │  2. dedup  (name, kind,        │
    │             │             uri, range)        │
-   │             │  3. sort   (uri, line, char,   │
+   │             │  3. sort   (uri, start, end,   │
    │             │             name, kind)        │
    │             └───────────────┬────────────────┘
    │◀── WorkspaceSymbol[] ───────┘
@@ -146,7 +146,13 @@ pub enum AggregationStrategy {
 
 `Union` = collect from **every** target, then **deduplicate** on
 `(name, kind, uri, range)`, then **sort deterministically** by
-`(uri, start.line, start.character, name, kind)`.
+`(uri, start.line, start.character, end.line, end.character, name, kind)`.
+
+The sort key is deliberately a **superset** of the dedup key. Two entries that
+survive dedup differ in at least one key field, so a superset sort leaves no
+ties and the order cannot fall back to `JoinSet` completion order. Dropping
+`end` from the sort would break exactly the case this decision predicts below —
+two servers agreeing on a symbol's start and disagreeing on its end.
 
 It is a distinct value rather than a reuse of `Concatenated` because
 `Concatenated` deliberately preserves duplicates and source ordering (diagnostics
@@ -472,6 +478,10 @@ not emitted. No client capability governs the choice, so none is consulted.
 
 Every target is awaited, so latency is max-over-targets. The bounds are:
 
+- The Ready wait in point 3 is bounded by `wait_for_ready`'s
+  `INIT_TIMEOUT_SECS`, also **30 seconds**, and it happens *before* the target's
+  request is sent. Each target waits independently: a slow `Initializing`
+  connection must not delay dispatch to connections that are already `Ready`.
 - `wait_for_response` wraps each request in a hardcoded **30-second** timeout and
   removes the router entry when it fires.
 - The reader's **liveness timeout** can independently fail a connection that has
@@ -480,9 +490,11 @@ Every target is awaited, so latency is max-over-targets. The bounds are:
   permits a downstream to ignore `$/` notifications, so it is best-effort and
   cannot be the guarantee.
 
-No *additional* per-request deadline is introduced. Because no target is ever
-cold-started (point 7), the practical worst case is bounded by servers that are
-already running and already answering other requests.
+So a single target's worst case is the two 30-second bounds in series, not one.
+No *additional* deadline is introduced. Because no target is ever cold-started
+(point 7), the practical case is bounded by servers that are already running and
+already answering other requests — a target that is still `Initializing` at
+query time is one the client's own file-open just started.
 
 ### 7. Coverage is what is live, and a query never cold-starts a server
 

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -256,9 +256,14 @@ An explicit non-`union` strategy for this method is therefore overridden to
 `union`, with one warning at settings-apply time, following the existing
 misconfiguration path (`misconfigured_settings_warnings`, which already warns
 about `concatenated`-without-`priorities` for formatting). The same walk warns
-in the **other** direction too: `strategy = "union"` on any method other than
-`workspace/symbol` is equally inert (point 1), and warning on only one of the
-two would leave the more likely user mistake silent.
+in the **other** direction too: a `union` that cannot take effect is worth
+saying so about, and warning on only one direction would leave the more likely
+user mistake silent. "Cannot take effect" is broader than "another method",
+though — at the **bridge** level `union` is inert for every method but this one,
+and at the **layer** level it is inert for *every* method including this one,
+since a document-less request never reaches the cross-layer walk. So
+`layers.aggregation["workspace/symbol"].strategy = "union"` warns too, rather
+than looking correct because the method name matches.
 
 The override and the warning ask **different questions**, and conflating them
 would make the warning fire for everyone.
@@ -397,10 +402,11 @@ be missing its documents, which is the failure step 5 exists to prevent. Losing
 that one target is the same coverage cost point 7 already describes, now with a
 bound on how long the query waits to find out.
 
-Selection's outer deadline (point 6) must exceed this two-second budget, or it
-would cancel the barrier it is waiting for; **five seconds** leaves room for the
-`connections` acquisition ahead of it without letting an unrelated stall hold
-the query indefinitely.
+The bounds here are **per phase, not one budget spanning them** (point 6). A
+single outer deadline would let a slow `connections` acquisition eat into the
+barrier's two seconds and cancel it early — and that cancellation is not the
+barrier returning `false`, so the drop policy above would not even cover it.
+Each phase that can block on the pool gets its own budget instead.
 
 **`Initializing` connections are excluded.** Including them, and waiting for
 Ready before dispatch, was tried and abandoned — it looked like it removed a
@@ -464,8 +470,7 @@ connection's own indexed workspace, so a connection named by several pairs is
 asked **once**, while the same server name under two roots is genuinely two
 connections and two requests.
 
-`max_fan_out` is applied **twice**, and the second application is what makes it
-mean what it says.
+`max_fan_out` applies **per pair only**, and that is the whole of it here.
 
 Within a pair it works as everywhere else: `truncate_entries` truncates a
 flattened name list in walk order, keeping the highest-priority N names. A
@@ -514,7 +519,7 @@ with its own name and semantics rather than smuggled into this one.
              └────────────┬─────────────┘
                           ▼
         ┌──────────────────────────────────────┐
-        │ SELECTION (own outer deadline, §6)   │
+        │ SELECTION (own 3s budget, §6)        │
         │ 1. keep Ready ONLY (not Initializing,│
         │    Failed, Closing, Closed)          │
         │ 2. drop handles lacking capability   │
@@ -595,7 +600,10 @@ fan-out's placement in point 4, which is a real visibility constraint.
 The value crossing that boundary is **typed, not raw JSON**: the bridge module
 owns deserialization for every other bridged request, and this one keeps that
 property. Each target's response is parsed into `Vec<WorkspaceSymbol>` there,
-normalizing a `SymbolInformation[]` answer into the same shape. That works for
+normalizing a `SymbolInformation[]` answer into the same shape, and is handed
+back **with its source connection key and that connection's URI→content-identity
+snapshot** — fan-in cannot validate a symbol without knowing which connection
+produced it (point 5). That works for
 `location` because `WorkspaceSymbol.location` is a `OneOf` that models the
 range-less form rather than rejecting it, but it is not field-for-field:
 `SymbolInformation` carries a (itself deprecated) `deprecated: Option<bool>`
@@ -666,6 +674,22 @@ Each virtual document's **content identity at dispatch** is therefore captured
 and re-checked before its entries are translated, using the per-connection
 revision and the fingerprint of the content last *confirmed sent* that the
 tracker already maintains.
+
+Two things about *when* and *per what* are load-bearing:
+
+- **Captured before the request is enqueued**, not after. Requests and
+  `didChange` notifications share one writer FIFO, so capturing afterwards
+  inverts the check: enqueue R against content A, let a `didChange(B)` follow,
+  then read identity as B — R still executes first, against A, while every
+  later comparison sees B and agrees. Capturing first makes the recorded
+  identity the one the request actually raced.
+- **Per connection, not per URI.** Both tracker values are keyed by
+  `ConnectionKey`, and one virtual URI can be open on several connections with
+  different confirmed content. An identity snapshot is therefore taken per
+  target, and travels **with that target's response** — the bridge module hands
+  back the source connection key and its URI→identity map alongside the
+  `Vec<WorkspaceSymbol>`, rather than a bare vector. Fan-in validates each
+  entry against the identity of the connection that produced it.
 
 Comparing those two values across dispatch and translation is not enough on its
 own. The revision advances before the `didChange` is enqueued and stays advanced
@@ -970,7 +994,7 @@ normalization**: set `deprecated = Some(true)` when the normalized tags contain
 it was meant to preserve. It is bounded: the modern type is used everywhere
 else.
 
-### 6. Latency is bounded by the pool's timeouts and one deadline of our own
+### 6. Latency is bounded by the pool's timeouts and our own phase budgets
 
 Every target is awaited, so latency is max-over-targets. The bounds are:
 
@@ -990,13 +1014,25 @@ waits. None of those carries a deadline, and cancel forwarding acquires the same
 mutex before it can notify a subscribed handler, so early subscription cannot
 interrupt a stall behind it.
 
-Selection therefore runs under its own **outer deadline** — five seconds,
-chosen in point 3 to sit above the reopen barrier's two-second budget. Expiring
-it answers from whatever was already selectable rather than blocking the query
-behind unrelated pool work. This is the one deadline the design imposes; every
-other bound it relies on already existed.
+Every phase that can block on that mutex therefore carries **its own budget**,
+and there are two — because the mutex is taken twice, not once. Selection takes
+it to read the connection map; then each send **re-acquires** it for the
+stale-handle check before enqueueing, which is the precedent's own discipline
+and can stall behind exactly the same holders, after selection's budget has
+already been spent.
 
-Beyond that one deadline, nothing new is introduced: every target is already
+- **Selection**: three seconds to acquire and filter.
+- **Each send's pre-enqueue re-acquisition**: three seconds, per target,
+  independently. A target that cannot get the lock in time is dropped like any
+  other unreachable one.
+
+Separate budgets rather than one deadline spanning the whole dispatch, because a
+single outer deadline would silently consume the reopen barrier's two seconds
+(point 3) and cancel it in a way its own timeout never reports. These are the
+only deadlines the design imposes; every other bound it relies on already
+existed.
+
+Beyond those budgets, nothing new is introduced: every target is already
 `Ready` when chosen (point 3), so nothing waits for a handshake before the
 request goes out, and the reopen barrier in step 5 is itself bounded to two
 seconds. Because no target is ever cold-started (point 7), the practical case is
@@ -1066,9 +1102,13 @@ assert that every other method dispatches `preferred` regardless:
   table and its lead-in ("one of two strategies").
 - `docs/README.md` — the `strategy` row of the aggregation table.
 
-And `maxFanOut`'s own description in `docs/README.md` must record that for
-`workspace/symbol` it selects names per pair and does **not** cap the query's
-total requests or connections.
+And `maxFanOut`'s description must record, in **all three** places that state
+its contract, that for `workspace/symbol` it selects names per pair and does
+**not** cap the query's total requests or connections:
+`docs/README.md`'s aggregation table, `docs/language-features.md`'s
+"`maxFanOut` limits how many servers are queried", and the doc-comment on the
+field in `src/config/settings.rs` — which is the source of the generated schema,
+and so the one users are most likely to read.
 
 *And the feature must move* out of `docs/language-features.md`'s "Not currently
 provided" list into a section of its own, and into `docs/README.md`'s
@@ -1199,9 +1239,10 @@ Including it would defeat dedup on a field carrying no identity.
   points in a session. LSP permits partial `workspace/symbol` results, but a
   user expecting an indexed whole-project search will find this surprising.
 - Latency is max-over-live-targets, bounded by the pool's existing 30s request
-  timeout and liveness timeout, plus selection's own five-second deadline and
-  the reopen barrier's two seconds; forwarded cancellation is best-effort
-  because a downstream may ignore it.
+  timeout and liveness timeout, plus a three-second budget on selection, three
+  seconds on each send's pre-enqueue lock acquisition, and the reopen barrier's
+  two seconds; forwarded cancellation is best-effort because a downstream may
+  ignore it.
 - One request per keystroke, un-coalesced (point 9).
 - Fan-in can wait on a parse: the distinct host documents a result addresses are
   ensured before translation. Because they are ensured concurrently the pass
@@ -1219,9 +1260,9 @@ Including it would defeat dedup on a field carrying no identity.
   in methods that have no use for it.
 - A server still `Initializing` when the query arrives is skipped entirely, so
   a search in the seconds after opening a file can miss it (point 3).
-- Selection carries its own deadline, because it must take the pool's
-  `connections` mutex and other paths hold that across unbounded async work
-  (point 6). Expiring it answers from a partial target set.
+- Selection and each send carry their own budgets, because both must take the
+  pool's `connections` mutex and other paths hold that across unbounded async
+  work (point 6). Expiring either answers from a partial target set.
 - `max_fan_out` does not bound this method's total fan-out. It selects names
   per pair, and one name still queries every `Ready`, capable root while a
   connection excluded by one pair re-enters through another. Its documented

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -294,18 +294,26 @@ Two servers indexing the *identical* root — say two TypeScript servers — are
 genuinely competing rather than complementary, and this decision does make their
 near-duplicate entries survive when their ranges differ.
 
-Overriding `preferred` costs less than it appears to here, because `union`
-already provides the half of it that matters. `preferred`'s value is "use A,
-fall back to B" — and it distinguishes two cases the ADR must not conflate. When
-A **fails or times out**, union covers it: A contributes nothing and B's results
-are in the answer anyway, without anyone having to declare a fallback. What is
-lost is only fallback when A returns **empty**, and that is precisely the
-semantics rejected above: for a search, empty means "no matches", so consulting
-B on it produces results for a query A said had none. The case `preferred` can
-express and `union` cannot is the case it should not express.
+Overriding `preferred` does cost something real, and it should be stated
+plainly rather than argued away: **`union` cannot express conditional fallback
+at all.** `preferred` suppresses B when A answers non-empty and consults B when
+A fails or comes back empty. `union` has no such conditional — with both
+selected it always merges B, and with `priorities` naming only A there is no B
+to fall back to. So a user gets *either* B's duplicates always, *or* no backup;
+not "A normally, B when A has nothing".
 
-What remains is suppressing a redundant server's near-duplicates, and the lever
-for that is `priorities`, which is an allowlist: name only the server you want. That is a
+The trade is accepted because the conditional's remaining half is the one this
+method should not have. Falling back on **failure** is not really needed: a
+failed A contributes nothing and B, if selected, is in the answer regardless.
+Falling back on **empty** is the case `preferred` uniquely provides, and it is
+wrong here — for a search, empty means "no matches", so consulting B on it
+answers a query A already said had none. What is genuinely lost is the
+combination: suppressing B's duplicates while keeping it as a failure backup.
+
+If that combination turns out to matter, it belongs in a mode of its own with a
+name that says what it does, not in `preferred` — whose empty-means-retry
+semantics are the part that must not apply. Until then the lever is
+`priorities`, an allowlist: name only the server you want. That is a
 static, deliberate exclusion the user writes, not an inference kakehashi draws
 from an empty response — which is the distinction that makes it acceptable here
 and `preferred` not. It does cost the user an edit in **every** pair that names
@@ -352,6 +360,20 @@ region's real one.
 `OpenedVirtualDoc` also carries the `connection_key` the document was opened on,
 so the walk can pair each open virtual document with its host document's
 language directly rather than taking a cross product of the two axes.
+
+`_self` needs its **own** source. Host-bridge opens are not `OpenedVirtualDoc`s
+— they live in the pool's `host_documents`, keyed by `(uri, ConnectionKey)` — so
+a host-only document can have a perfectly valid `_self` connection that no
+virtual document names. Deriving `_self` targets from virtual documents would
+therefore either omit host bridging entirely or fall back to expanding a server
+name across roots, recreating the leak point 3 exists to prevent. The
+`(host_language, _self, ConnectionKey)` triples come from `host_documents`
+directly.
+
+That is a second async map, so selection acquires two: the lock order is
+`connections` → `host_documents`, matching the pool's own, and both acquisitions
+fall under point 6's budget rather than the "one acquisition then synchronous
+work" shape the earlier draft assumed.
 
 An entry must be **validated before it contributes**, because the tracker's
 host→virtual map is not an "already open downstream" set: `register_pending_document`
@@ -1220,8 +1242,9 @@ conditional on the method.
 
 **Cold-start every configured server so a query covers languages no open file
 uses.** Rejected, per point 7. It reads like the thorough option, but it buys no
-embedded-block coverage at all, and the real-file coverage it does buy lands on
-the `ClientFallback` root alone. It also cannot answer "does this language even
+embedded-block coverage at all, and the real-file coverage it does buy comes
+from a single fallback connection that receives the client's declared folders
+but none of the marker-derived subroots normal routing would have produced. It also cannot answer "does this language even
 occur in the workspace?" without a workspace file walk the LSP server does not
 have.
 
@@ -1319,12 +1342,14 @@ Including it would defeat dedup on a field carrying no identity.
   notifications carry no acknowledgement and a failed write does not fail the
   connection. The stale-result window is narrowed, not closed (point 5).
 - `max_fan_out` does not bound this method's total fan-out. It selects names
-  per pair, and one name still queries every `Ready`, capable root while a
-  connection excluded by one pair re-enters through another. Its documented
-  promise to cap concurrent server requests does not hold here, which is why
-  the documentation must say so.
+  per pair, and a connection one pair excluded re-enters through another pair
+  that legitimately opened it. Its documented promise to cap concurrent server
+  requests does not hold here, which is why the documentation must say so.
 - The `kakehashi-virtual-uri-*` filename space is reserved: a real workspace
   file named into it is invisible to symbol search (point 5).
+- No configuration can express "suppress B's duplicates, but fall back to B when
+  A fails" — `union` has no conditional and `priorities` is unconditional, so
+  users pick one or the other (point 2).
 - `strategy` becomes a knob that this one method ignores. A **method-specific**
   entry warns; a `_` wildcard that happens to reach the method is overridden
   silently, by design (point 2). Users

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -260,24 +260,30 @@ in the **other** direction too: `strategy = "union"` on any method other than
 `workspace/symbol` is equally inert (point 1), and warning on only one of the
 two would leave the more likely user mistake silent.
 
-The word doing the work is **explicit**, and the existing hook cannot see it.
-`misconfigured_settings_warnings` receives effective `WorkspaceSettings`, and
-the built-in defaults themselves install a wildcard `preferred`. After wildcard
-resolution an untouched session is indistinguishable from a user who wrote that
-wildcard by hand — so a warning driven off effective settings would fire for
-**everyone**, which is worse than not warning at all.
+The override and the warning ask **different questions**, and conflating them
+would make the warning fire for everyone.
 
-The warning therefore needs **provenance**: it is driven off the raw
-user-supplied layers, not the merged result, and fires only where a non-`union`
-strategy for this method was actually written. The override itself still applies
-to the effective settings unconditionally; only the diagnostic is provenance-
-gated.
+The **override** asks "what strategy would this method resolve to?", so it
+resolves through `resolve_with_wildcard` like everything else — a method-level
+`"_"` entry legitimately supplies a strategy to `workspace/symbol`, and the
+override must catch that.
 
-Whichever settings it reads, the walk must decide "which method is this?" by
-**resolving** the aggregation entry rather than comparing map keys: a
-method-level `"_"` wildcard legitimately supplies a strategy to
-`workspace/symbol` through the same `resolve_with_wildcard` fallback used
-everywhere else.
+The **warning** asks "did a user ask for this?", and must not answer it by
+resolution. The built-in defaults themselves install a wildcard `preferred`, so
+after resolution an untouched session is indistinguishable from a hand-written
+override — a warning driven off the resolved value would fire for every user.
+Nor can it be answered from provenance: `load_settings` merges the default,
+user, project and override layers and keeps only the merged result, so no layer
+attribution survives, and naively scanning the original layers would warn about
+a lower-precedence `preferred` that a higher layer already replaced with
+`union`.
+
+So the warning fires only on a **method-specific `workspace/symbol` entry**
+whose strategy is non-`union`. Writing that key is unambiguously deliberate, the
+shipped defaults never do it, and it needs no provenance machinery. A `_`
+wildcard that happens to reach this method is silently overridden without a
+warning — deliberately, since it is far more likely to be the user configuring
+everything else than to be an opinion about workspace symbols.
 
 Two servers indexing the *identical* root — say two TypeScript servers — are
 genuinely competing rather than complementary, and this decision does make their
@@ -382,8 +388,19 @@ documents are replayed after a respawn, so a query landing in that window would
 under-report that server's embedded symbols indistinguishably from "no matches".
 The barrier is **bounded to two seconds** and enforced with a timeout, and
 awaiting the survivors concurrently costs that bound once for the whole query —
-not once per target. That is a cheap price for not silently losing a server's
-regions, and it is the only wait in selection.
+not once per target.
+
+A target whose barrier **fails** — timeout, or repair that did not complete — is
+**dropped, not sent to**. The barrier reports that outcome and its contract is
+that callers must not proceed; sending anyway would query a connection known to
+be missing its documents, which is the failure step 5 exists to prevent. Losing
+that one target is the same coverage cost point 7 already describes, now with a
+bound on how long the query waits to find out.
+
+Selection's outer deadline (point 6) must exceed this two-second budget, or it
+would cancel the barrier it is waiting for; **five seconds** leaves room for the
+`connections` acquisition ahead of it without letting an unrelated stall hold
+the query indefinitely.
 
 **`Initializing` connections are excluded.** Including them, and waiting for
 Ready before dispatch, was tried and abandoned — it looked like it removed a
@@ -464,12 +481,27 @@ arbitrarily many requests, contradicting the setting's documented promise to
 "cap the number of concurrent server requests" — a generic load control quietly
 losing its load-controlling property in exactly the method most able to fan out.
 
-So after dedup, the **largest `max_fan_out` among the contributing pairs** is
-applied once more, as a final cap on the number of connections queried, in
-priority order. Taking the largest rather than the smallest keeps a restrictive
-setting on one pair from silently throttling unrelated languages, while still
-giving the setting a real ceiling. A pair that set no cap contributes none, and
-if no pair caps, nothing is capped.
+A second, global cap after dedup was tried and **rejected**. It cannot be given
+coherent semantics:
+
+- An uncapped pair must mean "no limit" — that is what `None` means everywhere
+  else — so any workspace containing one uncapped pair has no global cap at all.
+  Since uncapped is the default, the cap would be inert in almost every real
+  configuration, and present only where a user capped *something*, throttling
+  languages they never mentioned.
+- It has no principled victim order. `priorities` exists per pair and pairs may
+  rank the same server differently; merging those rankings is exactly what this
+  decision rejects elsewhere as unprincipled. Falling back to walk order is
+  worse than arbitrary — open documents and connections live in hash maps, so
+  which connections survived would vary run to run.
+
+So `max_fan_out` stays a **per-pair name-selection rule** here and bounds
+neither the query's requests nor its connections. That is a real divergence from
+its documented promise to "cap the number of concurrent server requests", and
+the fix is documentation, not a mechanism: the setting's description must say so
+(point 8). What actually bounds the total is the live-connection set (point 7).
+A workspace-level ceiling, if one is ever wanted, belongs in a separate setting
+with its own name and semantics rather than smuggled into this one.
 
 ```
   open host docs × their open virtual docs    ← concrete languages only,
@@ -496,10 +528,11 @@ if no pair caps, nothing is capped.
         │   (B, rootB)  ← same server, another │
         │                 root: 2 connections  │
         │   (C, rootA)  ← named by LANG_2      │
-        │ then ONE global max_fan_out cap      │
+        │ (no global cap — see §3)             │
         └──────────────────┬───────────────────┘
                            ▼
-              await the bounded reopen barrier,
+              await the 2s reopen barrier concurrently,
+              dropping targets whose repair failed,
               then send to each survivor (§4),
               then per-entry fan-in (§5),
               then UNION → dedup → sort (§1)
@@ -630,11 +663,23 @@ catches that, because the geometry is fine; what changed is the text the
 downstream was looking at.
 
 Each virtual document's **content identity at dispatch** is therefore captured
-and re-checked before its entries are translated. The tracker already maintains
-what this needs — per-connection virtual-document revisions and the fingerprint
-of the content last confirmed sent — so the check is a comparison, not new
-bookkeeping. Entries from a virtual document whose content moved between
-dispatch and translation are dropped, exactly like entries whose region moved.
+and re-checked before its entries are translated, using the per-connection
+revision and the fingerprint of the content last *confirmed sent* that the
+tracker already maintains.
+
+Comparing those two values across dispatch and translation is not enough on its
+own. The revision advances before the `didChange` is enqueued and stays advanced
+when the enqueue fails, while the confirmed-sent fingerprint deliberately does
+not move — so after an `A → B` edit whose notification was dropped, both
+readings agree at `(revision 2, fingerprint A)` while the current geometry
+describes B and the server is still answering about A. Stability across the
+request proves nothing when both halves were already wrong.
+
+The confirmed-sent fingerprint must therefore also **equal the current region's
+content identity**. That is the check that ties what the server saw to what the
+geometry describes; the dispatch/translation comparison only catches movement
+during the request. Entries failing either are dropped, exactly like entries
+whose region moved.
 
 With that in place, translation **validates the region bounds** too; it does not
 translate blindly.
@@ -925,7 +970,7 @@ normalization**: set `deprecated = Some(true)` when the normalized tags contain
 it was meant to preserve. It is bounded: the modern type is used everywhere
 else.
 
-### 6. Latency is bounded by the pool's timeouts, not by cancellation
+### 6. Latency is bounded by the pool's timeouts and one deadline of our own
 
 Every target is awaited, so latency is max-over-targets. The bounds are:
 
@@ -945,13 +990,13 @@ waits. None of those carries a deadline, and cancel forwarding acquires the same
 mutex before it can notify a subscribed handler, so early subscription cannot
 interrupt a stall behind it.
 
-Selection therefore runs under its own **outer deadline**; expiring it answers
-from whatever was already selectable rather than blocking the query behind
-unrelated pool work. This is the one place the design imposes a deadline of its
-own, and it exists because the lock's holders make no promise it could otherwise
-rely on.
+Selection therefore runs under its own **outer deadline** — five seconds,
+chosen in point 3 to sit above the reopen barrier's two-second budget. Expiring
+it answers from whatever was already selectable rather than blocking the query
+behind unrelated pool work. This is the one deadline the design imposes; every
+other bound it relies on already existed.
 
-Beyond that, no *additional* deadline is introduced: every target is already
+Beyond that one deadline, nothing new is introduced: every target is already
 `Ready` when chosen (point 3), so nothing waits for a handshake before the
 request goes out, and the reopen barrier in step 5 is itself bounded to two
 seconds. Because no target is ever cold-started (point 7), the practical case is
@@ -1021,10 +1066,9 @@ assert that every other method dispatches `preferred` regardless:
   table and its lead-in ("one of two strategies").
 - `docs/README.md` — the `strategy` row of the aggregation table.
 
-And `maxFanOut`'s own description in `docs/README.md` needs the second,
-post-dedup application spelled out: its promise to cap concurrent server
-requests holds here only because of that final cap, and the per-pair half alone
-would not deliver it.
+And `maxFanOut`'s own description in `docs/README.md` must record that for
+`workspace/symbol` it selects names per pair and does **not** cap the query's
+total requests or connections.
 
 *And the feature must move* out of `docs/language-features.md`'s "Not currently
 provided" list into a section of its own, and into `docs/README.md`'s
@@ -1154,8 +1198,9 @@ Including it would defeat dedup on a field carrying no identity.
   silent connection death). The same query answers differently at different
   points in a session. LSP permits partial `workspace/symbol` results, but a
   user expecting an indexed whole-project search will find this surprising.
-- Latency is max-over-live-targets, bounded only by the pool's existing 30s
-  request timeout and liveness timeout; forwarded cancellation is best-effort
+- Latency is max-over-live-targets, bounded by the pool's existing 30s request
+  timeout and liveness timeout, plus selection's own five-second deadline and
+  the reopen barrier's two seconds; forwarded cancellation is best-effort
   because a downstream may ignore it.
 - One request per keystroke, un-coalesced (point 9).
 - Fan-in can wait on a parse: the distinct host documents a result addresses are
@@ -1177,9 +1222,11 @@ Including it would defeat dedup on a field carrying no identity.
 - Selection carries its own deadline, because it must take the pool's
   `connections` mutex and other paths hold that across unbounded async work
   (point 6). Expiring it answers from a partial target set.
-- `max_fan_out` is applied twice — per pair by name, then once globally after
-  dedup — so it keeps its documented ceiling, but its per-pair half no longer
-  predicts how many connections a query touches.
+- `max_fan_out` does not bound this method's total fan-out. It selects names
+  per pair, and one name still queries every `Ready`, capable root while a
+  connection excluded by one pair re-enters through another. Its documented
+  promise to cap concurrent server requests does not hold here, which is why
+  the documentation must say so.
 - The `kakehashi-virtual-uri-*` filename space is reserved: a real workspace
   file named into it is invisible to symbol search (point 5).
 - `strategy` becomes a knob that this one method ignores (with a warning). Users

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -625,7 +625,7 @@ this classifier would silently turn into "no embedded symbols". The
 whole-document handlers avoid this by calling `ensure_document_parsed` first;
 this method has no target document to name.
 
-Fan-in therefore runs in **three passes**, not one, over a **request-local
+Fan-in therefore runs in **four passes**, not one, over a **request-local
 index** built once up front:
 
 0. **After every target's result is collected**, and not before, snapshot the
@@ -670,10 +670,9 @@ Both that check and the range validation below need data the current helper
 throws away rather than data the system lacks: `ResolvedInjection` already
 carries `injection_language` and `virtual_content`, and
 `resolved_region_geometry` discards both, returning only offset, region end, and
-contiguity. The fan-in path needs a resolution variant that **retains** them.
-No second parse is involved either way: the preferred path reads an
-already-resolved snapshot, and the fallback runs the one resolution that path
-would have read.
+contiguity. The fan-in path needs a snapshot accessor that **retains** them.
+No parse and no resolution is involved: fan-in only reads what the store has
+already resolved.
 
 Pass 0 is also not an optimization. `BridgeCoordinator::resolve_virtual_uri` is
 **not** a map lookup: its own doc comment records that it is "O(N) over open
@@ -709,8 +708,8 @@ Sweeping every open document up front instead — alongside the fan-out — was 
 first shape considered and is worse on both axes. It does work for documents no
 result mentions, and it completes up to 30 seconds before the value is used (a
 target may take the full response timeout), so an edit arriving in between
-re-clears the tree and the sweep guarantees nothing. Ensuring between resolution
-and translation closes that gap to the width of one pass.
+re-clears the tree and the sweep guarantees nothing. Ensuring immediately before
+resolution and translation closes that gap to the width of one pass.
 
 Only documents that **already have a snapshot** are ensured. `ensure_document_parsed`
 asks for a 200ms wait, but `wait_for_current_snapshot` escalates to the
@@ -741,18 +740,36 @@ this: the first lookup for each distinct region still walks, so the worst case
 stays quadratic.
 
 Each host is therefore resolved **once** into a request-local
-`region_id → (offset, region_end, virtual_content, injection_language)` map, and
-every entry for that host is translated against it. The preferred source is the
-**generation-stamped resolved-region snapshot** the document store already
-keeps; only when that is unavailable does fan-in run one full resolution for the
-host and build the map from it.
+`region_id → (offset, region_end, virtual_content, injection_language)` map,
+built from the **generation-stamped resolved-region snapshot** the document
+store already keeps. When a host has no current snapshot, its entries are
+**dropped** — fan-in never resolves inline.
 
-Preferring the cached snapshot is not only about cost. `resolve_by_region_id`
-**mutates** the tracker — it reaches the named-layer allocator and then
-`calculate_region_id`, which can mint a ULID — so an inline resolution that
-loses a race mints a **ghost id at coordinates that no longer exist**, and no
-post-check can undo that. Reading an already-resolved snapshot has no such side
-effect.
+That refusal is the load-bearing part, not a shortcut. Resolving inline would
+mean calling `resolve_by_region_id`, which **mutates** the tracker: it reaches
+the named-layer allocator and then `calculate_region_id`, which can mint a ULID.
+Every attempt to make that safe produced a worse problem than it solved:
+
+- Guarding it with the edit lock and a generation check does not help on
+  cancellation. The walk must run on the compute pool (it is documented as
+  taking hundreds of milliseconds and having starved Tokio before), and the pool
+  **detaches** its work behind a oneshot — dropping the awaiting future does not
+  stop the closure. A cancelled query would therefore release both guards while
+  `resolve_all` kept mutating the tracker, reopening exactly the ghost-id and
+  mixed-generation races the guards existed to close.
+- The pool has no queue or execution deadline, so the wait is unbounded — while
+  holding that host's edit lock *and* the process-wide settings-reload guard.
+  One symbol search could stall edits for a document and configuration reload
+  for the whole server.
+- Timing out the awaiter does not rescue it; that is precisely the detached-work
+  case above.
+
+Dropping instead costs one query's entries for one host, in a state that is
+transient by construction: the pre-warm in pass 2 exists to make the snapshot
+current, and anything still missing self-corrects on the next query. This is the
+same failure kakehashi already accepts for a region invalidated mid-flight, and
+it keeps the whole fan-in **read-only** — no minting, no detached work, no
+unbounded wait, and no global guard held across one.
 
 Two identities must hold, not one:
 
@@ -765,32 +782,22 @@ Two identities must hold, not one:
   the design notices.
 - **Query generation.** A settings reload replaces the injection queries and
   bumps the settings generation *before* invalidating parses, and takes no
-  document edit lock — so a resolution can straddle a reload, use
-  mixed-generation query state, and still pass the document-version check. The
-  generation is captured and re-checked, as the other query-sensitive paths
-  already do. Because an inline resolution mutates the tracker, detecting a
-  mismatch afterwards cannot undo it; this is the second reason the
-  generation-stamped snapshot is the preferred source, and the reason the inline
-  fallback must be serialized against reload.
+  document edit lock — so a document-version check alone would accept geometry
+  produced under queries that no longer apply. The generation is captured and
+  re-checked, as the other query-sensitive paths already do. Because the
+  snapshot is generation-stamped, this is a comparison rather than a repair:
+  a mismatch drops the entries, and nothing has been mutated to undo.
 
-**Both** paths take the host's document edit lock before the final freshness
-comparison and hold it through translation. The cached snapshot is not exempt:
-it validates freshness only while handing out its `Arc`, so a `didChange`
-landing afterwards invalidates the geometry before the translation uses it, and
-an unlocked post-check races the same way. The lock is what makes "validated"
-and "used" the same instant.
+Translation takes the host's document edit lock before the final freshness
+comparison and holds it through translation. The cached snapshot is not exempt
+from needing this: it validates freshness only while handing out its `Arc`, so a
+`didChange` landing afterwards invalidates the geometry before the translation
+uses it, and an unlocked post-check races the same way. The lock is what makes
+"validated" and "used" the same instant.
 
-The inline fallback needs the lock **earlier still** — before its resolution
-snapshot is taken, not merely around the comparison — because there the lock has
-to cover a side effect rather than observe a value. (A genuinely read-only
-resolver, reusing the requested id and never reaching a minting helper, would
-remove that requirement; it does not exist today.)
-
-The fallback also must not run the injection walk on the async runtime. That
-walk is documented as taking hundreds of milliseconds and having starved Tokio
-before, which is why production parsing hands it to the compute pool; the
-fallback does the same, with the caller holding the edit and generation guards
-across it. A once-per-host cost is acceptable, a stalled runtime is not.
+Because the path is read-only, that lock is held only across a map lookup, a
+version comparison, and arithmetic — no parse, no walk, no await on another
+runtime. That is the whole reason it is safe to hold at all.
 
 Taking that lock carries an obligation the happy path hides. `edit_lock`
 **creates** an entry unconditionally, so a host that closed between indexing and
@@ -1075,8 +1082,9 @@ Including it would defeat dedup on a field carrying no identity.
 - Fan-in can wait on a parse: the distinct host documents a result addresses are
   ensured before translation. Because they are ensured concurrently the pass
   costs about one 200ms wait rather than one per document (point 5).
-- An edit landing between that ensure and the offset resolution still drops the
-  affected entries. The window is small but not closed, and the failure is
+- An edit landing between that ensure and the freshness check still drops the
+  affected entries, as does a host whose resolved-region snapshot is not current
+  when fan-in reaches it. The window is small but not closed, and the failure is
   silent — the symbols simply are not there.
 - `max_fan_out` no longer bounds a query's total fan-out — only each pair's
   contribution — so the only real bound on how many connections one query

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -373,10 +373,23 @@ name across roots, recreating the leak point 3 exists to prevent. The
 `(host_language, _self, ConnectionKey)` triples come from `host_documents`
 directly.
 
-That is a second async map, so selection acquires two: the lock order is
-`connections` → `host_documents`, matching the pool's own, and both acquisitions
-fall under point 6's budget rather than the "one acquisition then synchronous
-work" shape the earlier draft assumed.
+That is a second async map, so selection acquires three locks in all — the
+tracker snapshot, `host_documents`, then `connections` — and each falls under
+point 6's budget rather than the "one acquisition then synchronous work" shape
+an earlier draft assumed. The first two are snapshots taken and released before
+`connections` is held, so the only nesting is `connections` → tracker, which is
+the pool's own order.
+
+The two snapshots also have to be **joined safely**. Host language comes from
+the document store, while the exact keys come from pool tracking read later, and
+neither `OpenedVirtualDoc` nor the host-document sync state records the host
+language or its incarnation. A close/reopen — or a language change — between the
+two reads would therefore apply the *new* lifetime's policy to the *old*
+lifetime's downstream opens: precisely the policy-boundary leak this point
+exists to prevent, in transient form. So before a pair contributes, the host
+document's current language and incarnation are re-read and must match what the
+walk assumed; a mismatch drops that pair's contribution rather than guessing
+which lifetime it belonged to.
 
 An entry must be **validated before it contributes**, because the tracker's
 host→virtual map is not an "already open downstream" set: `register_pending_document`
@@ -386,11 +399,10 @@ cloned entry can also outlive a connection purge. Taken at face value, the walk
 would derive a pair from a `didOpen` the downstream has not seen, or from a
 replaced connection whose documents were never replayed.
 
-The save path already establishes the discipline this needs, and the reasoning
-there applies unchanged: snapshot the tracker, then take `connections` **once**
-and hold it across the checks with no `.await` inside, require the handle to be
-the current `Ready` one, and only then consult
-`is_virtual_doc_open_on_connection`. Holding `connections` is what makes it
+The save path already establishes the discipline this needs, and the ordering
+below follows it: snapshot the tracker, then take `connections` **once** and
+hold it across the checks with no `.await` inside, require the handle to be the
+current `Ready` one, and only then consult `is_virtual_doc_open_on_connection`. Holding `connections` is what makes it
 sound — a reverse-index check alone would not, since a purge could swap in a
 fresh `Ready` handle that never opened the document. The lock order is
 `connections` → tracker, matching the respawn purge. This composes with the
@@ -412,22 +424,36 @@ the opt-out, wildcard-resolved gate beside it.
 set only on `bridge._` still apply to a concrete pair — the property that keeps
 existing configuration from becoming a silent no-op here.
 
-**Selection is entirely synchronous. No candidate is waited for:**
+**No candidate is waited for; the only waits are lock acquisitions and the
+final barrier.** The order is fixed:
 
-1. Take the pool's connection map and keep only `Ready` entries.
-   `connections()` returns the raw map, and `ConnectionState` also has
-   `Initializing`, `Failed`, `Closing`, and `Closed`.
-2. Drop handles that lack `workspace/symbol`. This is knowable now, because
-   every candidate is `Ready` — `server_capabilities()` is populated during the
-   handshake.
-3. Apply the per-pair `priorities` allowlist and `max_fan_out` cap, and drop
-   any handle whose recorded launch configuration no longer matches the
-   `BridgeServerConfig` that admitted it.
-4. Dedup the survivors by **connection key** `(server, root)`.
-5. Await `wait_for_pending_reopen` for the survivors, **concurrently**, then
+1. **Snapshot the tracker's host→virtual map, then `host_documents`**, each
+   under its own lock and each **released before the next**. Nothing is held
+   across them, so no ordering question arises between the two.
+2. **Take `connections` once** and hold it across every per-handle check below,
+   with no `.await` inside. Consulting the tracker's live reverse index while
+   holding it is the pool's own `connections` → tracker order, which the
+   respawn purge also takes.
+3. Under that lock, per candidate: keep only `Ready` handles (`connections()`
+   returns the raw map, and `ConnectionState` also has `Initializing`,
+   `Failed`, `Closing`, `Closed`); drop handles lacking `workspace/symbol`;
+   drop handles whose recorded launch configuration no longer matches the
+   `BridgeServerConfig` that admitted them; and confirm the
+   `(virtual_uri, connection)` pair is still in the live reverse index.
+4. Release the lock, then apply the per-pair `priorities` allowlist and
+   `max_fan_out` cap — pure computation over what survived.
+5. Dedup the survivors by **connection key** `(server, root)`.
+6. Await `wait_for_pending_reopen` for the survivors, **concurrently**, then
    send.
 
-Step 5 exists because a connection reaches `Ready` *before* its virtual
+Every filter in step 3 precedes the cap in step 4, and that ordering is
+load-bearing for each of them: with `priorities = [A, B]` and
+`max_fan_out = 1`, an A that is incapable, stale-configured, or no longer
+holding its documents would otherwise take the only slot and then be dropped,
+leaving the query to consult nobody. Filtering on what is already knowable
+before allocating slots costs nothing and removes all three cases at once.
+
+Step 6 exists because a connection reaches `Ready` *before* its virtual
 documents are replayed after a respawn, so a query landing in that window would
 under-report that server's embedded symbols indistinguishably from "no matches".
 The barrier is **bounded to two seconds** and enforced with a timeout, and
@@ -573,13 +599,13 @@ with its own name and semantics rather than smuggled into this one.
              └────────────┬─────────────┘
                           ▼
         ┌──────────────────────────────────────┐
-        │ SELECTION (3s to ACQUIRE lock, §6)   │
-        │ 1. keep Ready ONLY (not Initializing,│
-        │    Failed, Closing, Closed)          │
-        │ 2. drop handles lacking capability   │
-        │ 3. allowlist + per-pair max_fan_out, │
-        │    drop stale-config handles         │
-        │    NEVER spawns a connection         │
+        │ SELECTION (3s per lock ACQUIRE, §6)  │
+        │ under `connections`, all before the  │
+        │ cap: keep Ready only, drop incapable,│
+        │ drop stale-config, confirm still     │
+        │ open on that connection              │
+        │ then: allowlist + per-pair maxFanOut │
+        │ NEVER spawns a connection            │
         └──────────────────┬───────────────────┘
                            ▼
         ┌──────────────────────────────────────┐
@@ -1361,10 +1387,12 @@ Including it would defeat dedup on a field carrying no identity.
   in methods that have no use for it.
 - A server still `Initializing` when the query arrives is skipped entirely, so
   a search in the seconds after opening a file can miss it (point 3).
-- Selection and each send bound only their `connections` **lock acquisition**,
-  because other paths hold that mutex across unbounded async work (point 6);
-  the filtering that follows is synchronous and cannot be preempted, so neither
-  total selection time nor cancellation blocking is capped. Expiring either
+- Every lock this path takes — the tracker snapshot, `host_documents`,
+  `connections`, each send's re-acquisition, each host's `edit_lock` — is
+  bounded only in its **acquisition**, because other paths hold these across
+  unbounded async work (point 6); the filtering between them is synchronous and
+  cannot be preempted, so neither total selection time nor cancellation blocking
+  is capped. Expiring either
   budget answers from a partial target set — and a
   cancellation queued behind that same mutex may arrive too late to stop it, so
   a cancelled request can still be answered.

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -255,18 +255,29 @@ is false.
 An explicit non-`union` strategy for this method is therefore overridden to
 `union`, with one warning at settings-apply time, following the existing
 misconfiguration path (`misconfigured_settings_warnings`, which already warns
-about `concatenated`-without-`priorities` for formatting).
+about `concatenated`-without-`priorities` for formatting). The same walk warns
+in the **other** direction too: `strategy = "union"` on any method other than
+`workspace/symbol` is equally inert (point 1), and warning on only one of the
+two would leave the more likely user mistake silent.
 
-The same walk warns in the **other** direction too: `strategy = "union"` on any
-method other than `workspace/symbol` is equally inert (point 1), and warning on
-only one of the two would leave the more likely user mistake silent.
+The word doing the work is **explicit**, and the existing hook cannot see it.
+`misconfigured_settings_warnings` receives effective `WorkspaceSettings`, and
+the built-in defaults themselves install a wildcard `preferred`. After wildcard
+resolution an untouched session is indistinguishable from a user who wrote that
+wildcard by hand — so a warning driven off effective settings would fire for
+**everyone**, which is worse than not warning at all.
 
-Both directions must decide "which method is this?" by **resolving** the
-aggregation entry, not by comparing map keys. A method-level `"_"` wildcard
-entry legitimately supplies a strategy to `workspace/symbol` through the same
-`resolve_with_wildcard` fallback used everywhere else, so a walk that only
-inspects literal key names would both miss the override it should apply and warn
-about a `union` that is in fact reaching this method.
+The warning therefore needs **provenance**: it is driven off the raw
+user-supplied layers, not the merged result, and fires only where a non-`union`
+strategy for this method was actually written. The override itself still applies
+to the effective settings unconditionally; only the diagnostic is provenance-
+gated.
+
+Whichever settings it reads, the walk must decide "which method is this?" by
+**resolving** the aggregation entry rather than comparing map keys: a
+method-level `"_"` wildcard legitimately supplies a strategy to
+`workspace/symbol` through the same `resolve_with_wildcard` fallback used
+everywhere else.
 
 Two servers indexing the *identical* root — say two TypeScript servers — are
 genuinely competing rather than complementary, and this decision does make their
@@ -363,7 +374,16 @@ existing configuration from becoming a silent no-op here.
    handshake.
 3. Apply the per-pair `priorities` allowlist and `max_fan_out` cap.
 4. Dedup the survivors by **connection key** `(server, root)`.
-5. Send to each survivor.
+5. Await `wait_for_pending_reopen` for the survivors, **concurrently**, then
+   send.
+
+Step 5 exists because a connection reaches `Ready` *before* its virtual
+documents are replayed after a respawn, so a query landing in that window would
+under-report that server's embedded symbols indistinguishably from "no matches".
+The barrier is **bounded to two seconds** and enforced with a timeout, and
+awaiting the survivors concurrently costs that bound once for the whole query —
+not once per target. That is a cheap price for not silently losing a server's
+regions, and it is the only wait in selection.
 
 **`Initializing` connections are excluded.** Including them, and waiting for
 Ready before dispatch, was tried and abandoned — it looked like it removed a
@@ -427,23 +447,29 @@ connection's own indexed workspace, so a connection named by several pairs is
 asked **once**, while the same server name under two roots is genuinely two
 connections and two requests.
 
-`max_fan_out` counts **server names**, not connections — `truncate_entries`
-truncates a flattened name list in walk order. A surviving name then contributes
-every connection **that survived steps 1 and 2** — every `Ready`, capable handle
-in the selection snapshot — so a server live under two roots sends two requests
-against one cap slot. It contributes those, not "every live connection": if
-`A/root1` advertises `workspace/symbol` and `A/root2` does not, selecting the
-name A must not smuggle root2 back past the capability filter. Beyond that
-filter no root is dropped and no root-ordering policy is needed: this method
-queries every `Ready`, capable root of a selected server by design.
+`max_fan_out` is applied **twice**, and the second application is what makes it
+mean what it says.
 
-The setting's documented promise ("cap the number of concurrent server
-requests") is therefore not what happens here, and could not be — a cap on names
-cannot bound requests once one name means several connections. Combined with the
-fact that a connection dropped by one pair's cap still enters through another
-pair that names it, `max_fan_out` is a **per-pair name-selection rule** for this
-method and nothing more. What actually bounds the total is the live-connection
-set (point 7).
+Within a pair it works as everywhere else: `truncate_entries` truncates a
+flattened name list in walk order, keeping the highest-priority N names. A
+surviving name contributes every connection that survived steps 1 and 2 — every
+`Ready`, capable handle in the selection snapshot — so if `A/root1` advertises
+`workspace/symbol` and `A/root2` does not, selecting the name A must not smuggle
+root2 back past the capability filter.
+
+But a per-pair name cap bounds neither requests nor connections here: one name
+can mean several roots, and a connection one pair's cap excluded re-enters
+through another pair that names it. Left there, `max_fan_out = 1` could produce
+arbitrarily many requests, contradicting the setting's documented promise to
+"cap the number of concurrent server requests" — a generic load control quietly
+losing its load-controlling property in exactly the method most able to fan out.
+
+So after dedup, the **largest `max_fan_out` among the contributing pairs** is
+applied once more, as a final cap on the number of connections queried, in
+priority order. Taking the largest rather than the smallest keeps a restrictive
+setting on one pair from silently throttling unrelated languages, while still
+giving the setting a real ceiling. A pair that set no cap contributes none, and
+if no pair caps, nothing is capped.
 
 ```
   open host docs × their open virtual docs    ← concrete languages only,
@@ -456,11 +482,11 @@ set (point 7).
              └────────────┬─────────────┘
                           ▼
         ┌──────────────────────────────────────┐
-        │ SYNCHRONOUS selection — nothing waits│
+        │ SELECTION (own outer deadline, §6)   │
         │ 1. keep Ready ONLY (not Initializing,│
         │    Failed, Closing, Closed)          │
         │ 2. drop handles lacking capability   │
-        │ 3. allowlist + max_fan_out           │
+        │ 3. allowlist + per-pair max_fan_out  │
         │    NEVER spawns a connection         │
         └──────────────────┬───────────────────┘
                            ▼
@@ -470,8 +496,10 @@ set (point 7).
         │   (B, rootB)  ← same server, another │
         │                 root: 2 connections  │
         │   (C, rootA)  ← named by LANG_2      │
+        │ then ONE global max_fan_out cap      │
         └──────────────────┬───────────────────┘
                            ▼
+              await the bounded reopen barrier,
               then send to each survivor (§4),
               then per-entry fan-in (§5),
               then UNION → dedup → sort (§1)
@@ -593,7 +621,23 @@ hand. "Its own offset" does not mean "its own resolution", though; see pass 3.
   region map once per host.
 ```
 
-Translation **validates the region bounds**; it does not translate blindly.
+Bounds validation is necessary but **not sufficient**, so translation also
+pins the content the result was computed from. A range measured against an older
+version of a region can remain perfectly in-bounds in the current one — insert a
+line above a symbol while the request is in flight and its old range still
+validates, then translates onto unrelated text. No amount of geometry checking
+catches that, because the geometry is fine; what changed is the text the
+downstream was looking at.
+
+Each virtual document's **content identity at dispatch** is therefore captured
+and re-checked before its entries are translated. The tracker already maintains
+what this needs — per-connection virtual-document revisions and the fingerprint
+of the content last confirmed sent — so the check is a comparison, not new
+bookkeeping. Entries from a virtual document whose content moved between
+dispatch and translation are dropped, exactly like entries whose region moved.
+
+With that in place, translation **validates the region bounds** too; it does not
+translate blindly.
 Region ids deliberately survive edits, so an in-flight response can carry a
 range measured against an older, larger region while offset resolution against
 the current parse still succeeds — and plain range translation performs no
@@ -893,9 +937,24 @@ Every target is awaited, so latency is max-over-targets. The bounds are:
   permits a downstream to ignore `$/` notifications, so it is best-effort and
   cannot be the guarantee.
 
-No *additional* deadline is introduced, and selection adds none: every target is
-already `Ready` when it is chosen (point 3), so nothing waits before the request
-goes out. Because no target is ever cold-started (point 7), the practical case is
+Selection is not quite free, and the earlier claim that it "adds no wait" was
+too strong. It must take the pool's `connections` mutex, and other paths hold
+that mutex across `.await`s — eager `didOpen` holds it while opening documents,
+and respawn and config invalidation hold it across purges and transition-lock
+waits. None of those carries a deadline, and cancel forwarding acquires the same
+mutex before it can notify a subscribed handler, so early subscription cannot
+interrupt a stall behind it.
+
+Selection therefore runs under its own **outer deadline**; expiring it answers
+from whatever was already selectable rather than blocking the query behind
+unrelated pool work. This is the one place the design imposes a deadline of its
+own, and it exists because the lock's holders make no promise it could otherwise
+rely on.
+
+Beyond that, no *additional* deadline is introduced: every target is already
+`Ready` when chosen (point 3), so nothing waits for a handshake before the
+request goes out, and the reopen barrier in step 5 is itself bounded to two
+seconds. Because no target is ever cold-started (point 7), the practical case is
 bounded by servers that are already running and already answering other
 requests.
 
@@ -962,6 +1021,11 @@ assert that every other method dispatches `preferred` regardless:
   table and its lead-in ("one of two strategies").
 - `docs/README.md` — the `strategy` row of the aggregation table.
 
+And `maxFanOut`'s own description in `docs/README.md` needs the second,
+post-dedup application spelled out: its promise to cap concurrent server
+requests holds here only because of that final cap, and the per-pair half alone
+would not deliver it.
+
 *And the feature must move* out of `docs/language-features.md`'s "Not currently
 provided" list into a section of its own, and into `docs/README.md`'s
 bridge-backed request list — carrying the live-only coverage contract and the
@@ -994,13 +1058,9 @@ documenting only two values.
   exactly this failure mode in the semantic-token and diagnostic wire floods.
   Nothing here prevents it; it is left for a follow-up once real traffic exists
   to measure, and is the most likely first regression.
-- **The respawn re-open window.** A connection reaches `Ready` *before* its
-  virtual documents are replayed; the barrier that signals replay completion
-  (`wait_for_pending_reopen`) is today awaited only by `workspace/executeCommand`.
-  A query landing in that window under-reports a respawned server's
-  embedded-block symbols, indistinguishably from "no matches". Awaiting the
-  barrier per target would add unbounded latency to every query, so this is
-  accepted rather than fixed.
+- ~~**The respawn re-open window.**~~ Not deferred — see point 3. A connection
+  reaches `Ready` before its virtual documents are replayed, and the barrier is
+  awaited rather than skipped.
 
 ## Considered Options
 
@@ -1114,9 +1174,12 @@ Including it would defeat dedup on a field carrying no identity.
   in methods that have no use for it.
 - A server still `Initializing` when the query arrives is skipped entirely, so
   a search in the seconds after opening a file can miss it (point 3).
-- `max_fan_out` does not mean here what its own documentation promises. It caps
-  server *names*, and one selected name still queries every `Ready`, capable
-  root, so it bounds neither requests nor connections.
+- Selection carries its own deadline, because it must take the pool's
+  `connections` mutex and other paths hold that across unbounded async work
+  (point 6). Expiring it answers from a partial target set.
+- `max_fan_out` is applied twice — per pair by name, then once globally after
+  dedup — so it keeps its documented ceiling, but its per-pair half no longer
+  predicts how many connections a query touches.
 - The `kakehashi-virtual-uri-*` filename space is reserved: a real workspace
   file named into it is invisible to symbol search (point 5).
 - `strategy` becomes a knob that this one method ignores (with a warning). Users

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -394,10 +394,10 @@ load-bearing.
 
 Putting the cap *before* the liveness filter would let dead or absent servers
 consume cap slots and silently exclude a live server ranked below the cutoff,
-contradicting this decision's own coverage contract. Putting it *after* the
-Ready wait would make the cap a global barrier: with `max_fan_out = 1` and
-priorities `[initializing_A, ready_B]`, nothing could dispatch until A's wait
-resolved — up to the full 30 seconds — even though B was ready immediately.
+contradicting this decision's own coverage contract. (In the abandoned waiting
+design this placement had a second failure mode too — the cap became a global
+barrier — but with `Initializing` excluded there is nothing left to wait for,
+so only the coverage argument applies.)
 Deciding membership synchronously and waiting per target removes the
 interaction entirely.
 
@@ -730,9 +730,20 @@ alone. An ordinary edit preserves the incarnation and only bumps the content
 version, and `DocumentSnapshot` does not carry that version — so an
 incarnation-only comparison would miss precisely the race described above.
 The resolution variant therefore retains the snapshot's content/parsed version
-alongside the language and virtual content, compares both fields against a
-single live `SnapshotView`, and holds the document edit lock through validation
-so the comparison cannot itself be raced. This is the discipline the semantic
+alongside the language and virtual content, and compares both fields against a
+single live `SnapshotView`.
+
+The document edit lock must be acquired **before the resolution snapshot is
+taken**, not merely around that comparison, and held through translation. This
+is not just about making the comparison unraceable: `resolve_by_region_id`
+**mutates** the tracker — it goes through the named-layer allocator and then
+`calculate_region_id`, which can mint a ULID. A resolution that reads stale
+coordinates and loses the race to `didChange` would therefore mint a **ghost id
+at coordinates that no longer exist**, and the version check afterwards drops
+the symbol but cannot undo the mutation. Post-checking a side-effecting
+resolution is not enough; the lock has to cover the side effect. (A genuinely
+read-only resolver that reused the requested id and never reached a minting
+helper would be the alternative, and does not exist today.) This is the discipline the semantic
 token path already uses, and only the whole of it works; the incarnation half
 alone would leave "the tree is gone" as the only edit race the design notices.
 

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -384,6 +384,13 @@ highest-priority candidate not yet selected takes it. Backfill runs only on that
 failure path, so the common case stays a single synchronous selection, and the
 pathological case degrades to "slower" instead of "empty".
 
+Backfill is deterministic and terminates: the replacement is always the
+highest-priority candidate not yet selected, which is a total order fixed before
+any waiting, and each backfill consumes one candidate from a finite list. A
+chain of failures therefore walks the priority order once and stops, and the
+resulting target set does not depend on the order failures happened to occur
+in.
+
 `priorities` is an allowlist: listed servers are candidates, `"*"` stands for
 the rest, and an explicit `[]` remains the per-method kill switch. Its **order**
 still decides which N survive a `max_fan_out` cap (`truncate_entries` keeps the
@@ -557,11 +564,11 @@ virtual position like `(0, 1000)` inside a region ending on line 5 compares as
 before the end while carrying a column that never existed, and the workspace-edit
 precedent checks only per-line floors and a global endpoint.
 
-Validation therefore runs against the region's **current `virtual_content`**:
-both endpoints must be real positions in that text and the range must be
-correctly ordered — using the existing strict position machinery rather than a
-new comparison — and only then is the range translated and checked against the
-host-side region bound. Validating in virtual coordinates before translating is
+Validation therefore runs against the region's **current `virtual_content`** —
+the same field the language check above needs retained: both endpoints must be
+real positions in that text and the range must be correctly ordered, using the
+existing strict position machinery rather than a new comparison, and only then
+is the range translated and checked against the host-side region bound. Validating in virtual coordinates before translating is
 what catches the column case; the host bound catches what survives it.
 
 The range check comes first because `WorkspaceSymbol.location` is
@@ -611,6 +618,13 @@ naming the *old* URI would still resolve, and a Python result would be
 translated into a region that is now Rust. So the indexed URI must **match the
 URI reconstructed from the region's current injection language**; a mismatch is
 a retired document and the entry is dropped.
+
+Both that check and the range validation below need data the current helper
+throws away rather than data the system lacks: `ResolvedInjection` already
+carries `injection_language` and `virtual_content`, and
+`resolved_region_geometry` discards both, returning only offset, region end, and
+contiguity. The fan-in path needs a resolution variant that **retains** them.
+That is the whole mechanism — no new resolution, no second parse.
 
 Pass 0 is also not an optimization. `BridgeCoordinator::resolve_virtual_uri` is
 **not** a map lookup: its own doc comment records that it is "O(N) over open

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -534,9 +534,18 @@ finishes propagating them, so a reload leaves a window in which a live handle
 was spawned from a configuration the current settings have already superseded.
 Being `Ready`, capable, and holding the right documents does not make it the
 process the current config describes; the pool's own by-key acquisition compares
-launch configurations for exactly this reason. The resolved config is therefore
-carried into selection and re-compared at the pre-enqueue check, and a mismatched
-handle is dropped rather than queried.
+launch configurations for exactly this reason. The resolved config is therefore compared inside the batch validator, which is
+also where it is reachable at all.
+
+The pre-enqueue check does **not** repeat that comparison, and does not need to.
+It checks pointer identity — that this handle is still the pool's current one
+for its key — which is the precedent's own discipline and is sufficient here: a
+settings reload removes and shuts down a connection whose spawn-time config
+changed rather than mutating it in place, so a config change necessarily
+installs a different handle and fails the identity check. Pointer identity after
+batch validation therefore implies config validity, and re-comparing would need
+either a pool-owned check-and-enqueue primitive or wider visibility for a
+guarantee already in hand.
 
 Step 2 must precede step 3: capping first would let a **known-incapable**
 server take a slot from a capable one — with `priorities = [A, B]`,
@@ -1143,12 +1152,14 @@ stale-handle check before enqueueing, which is the precedent's own discipline
 and can stall behind exactly the same holders, after selection's budget has
 already been spent.
 
-The rule is uniform: **every lock this path acquires carries a three-second
+The rule is uniform: **every lock this path *awaits* carries a three-second
 budget, and failing to acquire it drops the affected target or host** rather
 than blocking the query. That is more than the `connections` mutex — selection
-also takes `host_documents` (for `_self` targets) and the tracker snapshot, each
-send re-acquires `connections` before enqueue, and translation takes each host's
-`edit_lock`. None of these is safe to assume fast: injection processing holds
+also awaits the tracker snapshot, each send re-acquires `connections` before
+enqueue, and translation takes each host's `edit_lock`. (`host_documents` is not
+in that list: it is `try_lock`ed under `connections` and never awaited, so
+contention drops the `_self` candidates immediately rather than consuming a
+budget.) None of these is safe to assume fast: injection processing holds
 `edit_lock` across downstream close, change, and eager-spawn awaits, so a query
 arriving mid-processing would otherwise wait on unrelated work with no bound.
 

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -1,0 +1,474 @@
+# Workspace Scoped Symbol Search
+
+**Related Decisions**: [cross-layer-aggregation](cross-layer-aggregation.md),
+[language-server-bridge-virtual-document-model](language-server-bridge-virtual-document-model.md),
+[language-server-bridge-request-strategies](language-server-bridge-request-strategies.md),
+[aggregation-priorities-wildcard](aggregation-priorities-wildcard.md),
+[host-document-bridge](host-document-bridge.md)
+
+## Context
+
+`workspace/symbol` is the first request kakehashi bridges that carries **no
+`textDocument`**. Every existing bridged request resolves a host document, then
+an injection region, then a `RegionOffset`, and that chain is what makes the
+current fan-out and fan-in work:
+
+- **Fan-out** is driven by `bridge_configs_for_injection_language(host_language,
+  injection_language)` — the region's language picks the servers.
+- **Fan-in** is driven by `transform_location_for_goto(location,
+  request_virtual_uri, host_uri, offset)`, whose contract is "translate results
+  addressed to *the request's* virtual URI, drop every other virtual URI".
+- **Layer arbitration** is `walk_layers`, first-non-empty-wins (`preferred`).
+
+None of the three survives the loss of the document. There is no injection
+language to select servers with, no single virtual URI to translate against, and
+`preferred` would let whichever layer answers first hide the other layer's
+symbols entirely — which for a *search* is a silent loss of results, not a
+tie-break.
+
+```
+DOCUMENT-SCOPED  (every existing bridged request)
+
+  params.textDocument.uri
+         │
+         ▼
+   host document ──▶ region at position ──▶ RegionOffset ──▶ one virtual URI
+         │                   │                    │                 │
+         │                   ▼                    └────────┬────────┘
+         │           injection_language                    ▼
+         │                   │                    FAN-IN filter: keep THIS
+         │                   ▼                    virtual URI, translate by
+         │      bridge_configs_for_               THIS offset, drop every
+         │      injection_language()              other virtual URI
+         │                   │
+         │                   ▼
+         │              FAN-OUT set
+         ▼
+   walk_layers → first non-empty layer wins (preferred)
+
+
+WORKSPACE-SCOPED  (workspace/symbol)
+
+  params.query                        ← no textDocument at all
+         │
+         ✗ no host document   ✗ no region   ✗ no offset   ✗ no virtual URI
+         │
+         ├─▶ FAN-OUT cannot be selected by injection language
+         ├─▶ FAN-IN has no "request virtual URI" to filter against
+         └─▶ preferred would let one layer hide the other layer's symbols
+```
+
+Two facts in the existing code make the feature tractable anyway:
+
+- `BridgeCoordinator::resolve_virtual_uri(uri) -> Option<(host_url, region_id)>`
+  is a **global** virtual→host reverse map (it is what `window/showDocument`
+  translation already uses), and `resolve_region_offset` rebuilds the
+  `RegionOffset` from the live parse for any `(host_url, region_id)` pair.
+- `LanguageServerPool::connections()` enumerates every live connection, and
+  `ConnectionHandle` exposes `has_capability` / `send_request` /
+  `wait_for_response`, so a request can be sent to a connection without going
+  through `get_or_create_connection`.
+
+kakehashi does **not** declare `workspace.symbol.resolveSupport` in the
+capabilities it sends downstream (`bridge/protocol/client_capabilities.rs`), so a
+conformant downstream must return `WorkspaceSymbol`s carrying a full `Location`
+rather than the 3.17 location-less form.
+
+## Decision
+
+Implement `workspace/symbol` as a **workspace-scoped** bridged request with its
+own aggregation strategy, its own fan-out enumeration, and a global fan-in
+translator. Defer `workspaceSymbol/resolve`.
+
+```
+ client                    kakehashi                    downstream servers
+   │
+   │ workspace/symbol   ┌───────────────┐
+   │  { query }    ────▶│ candidate set │─── request ──▶  lua_ls   @ rootA
+   │                    │ dedup by      │─── request ──▶  tsgo     @ rootA
+   │                    │ connection    │─── request ──▶  tsgo     @ rootB
+   │                    │ (fan-out, §3) │─── request ──▶  pyright  @ rootA
+   │                    └───────────────┘                         │
+   │                                                              │
+   │                    ┌───────────────┐                         │
+   │                    │ classify and  │◀── every response ──────┘
+   │                    │ translate     │    NOT first-win: every target
+   │                    │ (fan-in, §5)  │    is awaited before answering
+   │                    └───────┬───────┘
+   │                            ▼
+   │             ┌────────────────────────────────┐
+   │             │ union (§1) — the ONLY merge,   │
+   │             │ no per-target arbitration      │
+   │             │  1. collect every entry        │
+   │             │  2. dedup  (name, kind, uri,   │
+   │             │             range, container)  │
+   │             │  3. sort   (uri, line, char,   │
+   │             │             name, kind)        │
+   │             └───────────────┬────────────────┘
+   │◀── Flat | Nested ───────────┘
+   │    (per client capability)
+   │
+   │ $/cancelRequest ─▶ forwarded to every in-flight target. This is the
+   │                    ONLY bound on latency — no deadline is imposed.
+   │                    Practical because no target is ever cold-started (§4).
+```
+
+### 1. A dedicated `union` aggregation strategy
+
+`AggregationStrategy` gains a third variant:
+
+```rust
+pub enum AggregationStrategy {
+    Preferred,
+    Concatenated,
+    Union,
+}
+```
+
+`Union` = collect from **every** target, then **deduplicate** on
+`(name, kind, uri, range, container_name)`, then **sort deterministically** by
+`(uri, start.line, start.character, name, kind)`.
+
+It is a distinct value rather than a reuse of `Concatenated` because
+`Concatenated` deliberately preserves duplicates and source ordering (diagnostics
+and code actions from different servers are complementary and each must survive).
+A symbol search is set-valued: the same real file indexed by two servers, or by
+one server under two workspace roots, must appear once. Sorting is part of the
+strategy, not a caller detail — `JoinSet` completion order is nondeterministic
+and an unstable result order is a self-inflicted test flake.
+
+`Union` is the **only** strategy for `workspace/symbol`, at both the bridge level
+and the layer level. It is the default, and an explicitly configured `preferred`
+or `concatenated` is overridden back to it with a warning (point 2).
+
+### 2. `preferred` is wrong for this method at every level
+
+The repo's own criterion for choosing a strategy is stated at
+`default_aggregation_strategy_for_method`: code actions concatenate because,
+"unlike formatting (**competing** whole-document edits), code actions from
+different servers are **complementary**."
+
+Two servers' `workspace/symbol` responses are complementary in exactly that
+sense — they index different parts of the workspace. `preferred` would discard
+one of them.
+
+The reason it cannot be rescued is that **a `workspace/symbol` response is not
+attributable to a language**. A server answers "here are the workspace's symbols
+matching `query`"; a server configured only under LANG_1 may perfectly well
+return LANG_2 symbols, because what it indexes is its workspace root, not a
+language. kakehashi therefore cannot decompose one response into the share that
+"belongs to" LANG_1 and the share that "belongs to" LANG_2. Concretely, given
+
+```toml
+[languages.LANG_1.bridge._self.aggregation]
+workspace/symbol = { priorities = ["B"] }
+
+[languages.LANG_2.bridge._self.aggregation]
+workspace/symbol = { priorities = ["C"] }
+```
+
+B's LANG_2-related symbols are **kept**. Dropping them because LANG_2 nominates
+C would assume C covers what B indexes — unknowable, and pure loss whenever it
+is false.
+
+An explicit non-`union` strategy for this method is therefore overridden to
+`union`, with one warning at settings-apply time. This follows the existing
+misconfiguration path (`misconfigured_settings_warnings`, which already warns
+about `concatenated`-without-`priorities` for formatting) rather than silently
+discarding symbols the user never intended to lose.
+
+### 3. Fan-out: a candidate-set walk, deduplicated by connection
+
+Because every level unions, there is no per-target arbitration left to do, and
+the configuration walk collapses to a **candidate-set** walk. A request has no
+document, so it cannot pick one `(host_language, bridge_key)` pair — it walks
+**all** of them (`settings.languages` × `bridge_map.keys()`, exactly as
+`concatenated_formatting_pairs` already does) purely to collect candidates.
+
+`priorities` and `max_fan_out` still filter, per pair:
+
+- `priorities` is an **allowlist**: listed servers are candidates, `"*"` stands
+  for the rest, and an explicit `[]` remains the per-method kill switch.
+- Its **order** still matters when `max_fan_out` caps the candidates — the cap
+  keeps the highest-priority N. Order is what nothing else can express; it is
+  only the *arbitration* meaning of order that this method drops.
+- A `_self` pair contributes candidates only when
+  `bridge._self.enabled = true` for that language. `is_host_bridging_enabled` is
+  a **direct** lookup with no wildcard fallback, so a `bridge._self.aggregation`
+  block without `enabled` contributes nothing at all.
+
+The candidate list is then **intersected with the live connections** (point 4):
+a query never spawns a server. What survives is deduplicated by **connection
+key** `(server, root)`, not by server name — the response is a function of
+`query` alone, so a connection named by several pairs is asked **once**. If two
+pairs resolve the same server name to configs producing different connection
+keys, those are genuinely two connections and two requests.
+
+```
+  settings.languages × bridge_map.keys()      ← candidate walk only,
+        │                                       no arbitration
+        ▼
+  ┌──────────────────────┐   ┌──────────────────────┐
+  │ (LANG_1, _self)      │   │ (LANG_2, _self)      │  ... every pair
+  │ priorities ["B"]     │   │ priorities ["C"]     │
+  └──────────┬───────────┘   └──────────┬───────────┘
+             │                          │  apply allowlist + max_fan_out
+             └────────────┬─────────────┘
+                          ▼
+        ┌──────────────────────────────────────┐
+        │ ∩ live connections — NEVER spawns    │
+        │   pool.connections(), Ready or       │
+        │   Initializing, has_capability       │
+        └──────────────────┬───────────────────┘
+                           ▼
+        ┌──────────────────────────────────────┐
+        │ dedup by CONNECTION KEY (server,root)│
+        │   (B, rootA)  ← named by LANG_1      │
+        │   (B, rootB)  ← same server, another │
+        │                 root: 2 connections  │
+        │   (C, rootA)  ← named by LANG_2      │
+        │   B@rootA is asked ONCE even if      │
+        │   several pairs name it              │
+        └──────────────────┬───────────────────┘
+                           ▼
+              one request per connection, sent on the
+              handle — no re-acquire, no spawn
+                           │
+                           ▼
+              per-entry fan-in (§5), then
+              UNION → dedup → sort  (§1)
+```
+
+### 4. Coverage is what is live, and a query never cold-starts a server
+
+A candidate with no live connection is **skipped**, not spawned. Coverage is
+therefore "the servers that are running because of what the client has opened",
+and it grows when the client opens more files — opening a host document spawns
+its servers and opens its virtual documents, so the next query sees more.
+
+This is not merely a cost trade. Cold-starting cannot deliver the coverage it
+appears to promise:
+
+- **Embedded-block symbols cannot be reached by spawning at all.** A virtual
+  document does not exist on disk, so a downstream learns of it only through
+  `didOpen`, and kakehashi opens virtual documents only for host documents the
+  *client* has opened. Reaching embedded code in unopened files would mean
+  parsing every candidate host file in the workspace and opening every region —
+  precisely the unbounded work this method must not do. Spawning a server buys
+  exactly zero embedded-block coverage, which is kakehashi's own contribution.
+- **Real-file symbols would be reached, but at one root only.** A server spawned
+  without a document hint resolves to the `ClientFallback` key
+  (`resolve_acquire`: "no document hint … stays on the client-root fallback"),
+  so a multi-root workspace gets the client root and none of the marker-derived
+  per-root connections. The coverage gained is partial and hard to explain.
+- **Scoping by "does this language occur in the workspace?" would need a
+  mechanism that does not exist.** The LSP server is document-driven and holds
+  no workspace index — nothing walks the filesystem on the server path (the
+  `ignore` crate is used only by the `src/cli/files.rs` subcommand). Under the
+  live-only rule that question answers itself for free: a language with no open
+  file has no live server and is not queried.
+
+Connections that are live but still `Initializing` are **included**, waiting for
+Ready with the existing acquisition timeout. They were already being paid for,
+and excluding them would make a query issued just after opening a file depend on
+timing — a nondeterminism this codebase does not need more of.
+
+Two ordering constraints follow from that choice, and getting either wrong
+silently returns no results rather than failing:
+
+- **Capability prefiltering must happen *after* the Ready wait, not before it.**
+  `has_capability` falls back to `server_capabilities()`, which is `None` until
+  `set_server_capabilities` runs during the handshake. Prefiltering an
+  `Initializing` connection therefore drops exactly the connections this section
+  just decided to keep.
+- **`has_capability` needs a `workspace/symbol` arm.** Its `match` ends in
+  `_ => false`, so an unlisted method reports *every* server as incapable. The
+  arm reads `workspace_symbol_provider: Option<OneOf<bool,
+  WorkspaceSymbolOptions>>` in the same shape as the existing
+  `textDocument/definition` arm.
+
+### 5. Fan-in: a global virtual→host translator over four result classes
+
+A pure function over the downstream's `serde_json::Value` response classifies
+every returned entry by its URI:
+
+```
+  one entry of the downstream's result array
+             │
+             ▼
+     ┌───────────────────┐  no
+     │ is_virtual_uri ?  ├─────▶ REAL FILE  ─▶ pass through untouched
+     └─────────┬─────────┘                     (external definition, a
+               │ yes                            file the server indexed)
+               ▼
+     ┌───────────────────┐  yes
+     │ is_scratch_uri ?  ├─────▶ DROP  (a non-region virtual document;
+     └─────────┬─────────┘              names no place in any host file)
+               │ no
+               ▼
+     resolve_virtual_uri(uri)
+               │
+               ├── None ─────────▶ DROP  (no host mapping for this URI)
+               │
+               ▼ Some((host_url, region_id))
+     resolve_region_offset(host_url, region_id)
+               │
+               ├── None ─────────▶ DROP  (region invalidated by edits, or
+               │                          host document closed — a virtual
+               │                          URI reaching the editor names a
+               ▼ Some(offset)              file that is not on disk)
+     TRANSLATE
+       uri   := host_url
+       range := translate_virtual_range_to_host(range, offset)
+```
+
+Every entry resolves **its own** `(host_url, region_id, offset)`. That is the
+whole reason this path may cross blocks where the goto path may not: the goto
+filter exists because only one region's offset is in hand, and here each entry
+brings its own.
+
+Dropping — rather than passing through — an unresolvable virtual URI is
+deliberate: a virtual URI that escapes to the editor names a file that does not
+exist on disk, so the symbol is unopenable. This mirrors `window/showDocument`
+translation, which drops the selection it cannot translate.
+
+### 6. This is the first deliberate cross-block feature
+
+Every other bridged navigation path filters out results addressed to a region
+other than the request's own, because a cross-region offset is unsafe when only
+one region's offset is known. Workspace symbol search resolves **each** result's
+region independently, so the offset is always the right one for the entry being
+translated. `docs/language-features.md`'s blanket "navigation and edits do not
+cross between blocks" claim is amended accordingly.
+
+### 7. Deferred in this decision
+
+- `workspaceSymbol/resolve` — `resolveProvider` is advertised as `false`. Because
+  kakehashi does not declare `resolveSupport` downstream, entries arriving
+  without a resolvable `Location` are a downstream conformance bug; they are
+  dropped rather than surfaced unresolvable.
+- `workDoneToken` / `partialResultToken` — neither is forwarded downstream. The
+  existing client-progress aggregator (`mint_region_progress_source`) is keyed by
+  region and has no meaning for a request that has no region. Both tokens are
+  optional in LSP 3.18.
+
+## Considered Options
+
+**`preferred`, as everywhere else.** Rejected at every level, per point 2:
+`preferred` encodes "these are competing answers to one question", and two
+servers' workspace symbol sets are complementary, not competing.
+
+**Keep `preferred` across groups but allow it *within* a group.** Rejected —
+this was an intermediate position, and it does not survive the attribution
+argument. A server named by LANG_1's group can return LANG_2 symbols, so
+"within a group" does not delimit a coherent set of results to arbitrate over.
+Rejecting it is what collapses the group model: once no level arbitrates, the
+per-pair walk reduces to a candidate-set walk (point 3).
+
+**Attribute each returned symbol to a language by detecting its URI's language,
+then apply the owning language's strategy.** Rejected: it would put language
+detection in the fan-in hot path, and it still cannot recover which *pair* owns
+a result — a file may be claimed by several — so it buys a fragile mechanism
+that does not answer the question it was built for.
+
+**Reuse `concatenated` instead of adding `union`.** Rejected: `concatenated`
+must not deduplicate (see the diagnostics and codeAction defaults), and a symbol
+search must. Overloading it would make the existing strategy's contract
+conditional on the method.
+
+**Cold-start every configured server so a query covers languages no open file
+uses.** Rejected, per point 4. It reads like the thorough option, but it buys no
+embedded-block coverage at all (those need `didOpen` of virtual documents that
+only an open host document produces), and the real-file coverage it does buy
+lands on the `ClientFallback` root alone. It also cannot answer "does this
+language even occur in the workspace?" without a workspace file walk the LSP
+server does not have.
+
+**Cold-start, and additionally `didOpen` the workspace's files so the spawned
+servers have something to index.** Rejected as unbounded: covering embedded code
+in unopened files means parsing every candidate host file in the workspace and
+opening every extracted region, on a request the user expects to be interactive.
+This is the option that shows the cold-start direction has no cheap stopping
+point — which is what makes live-only the right cut rather than merely the
+cheap one.
+
+**Reuse `transform_location_for_goto` with a synthetic "request virtual URI".**
+Rejected: its filter exists to *prevent* cross-region translation, so any
+synthetic value either drops everything or defeats the guard.
+
+**Resolve `priorities`/`max_fan_out` from the wildcard
+(`languages._._.aggregation["workspace/symbol"]`) entry only.** Rejected: it
+gives the feature exactly one knob, but it makes every per-language
+`bridge.<key>.aggregation` block a **silent no-op** for this method. A user who
+writes `[languages.LANG_1.bridge._self.aggregation] workspace/symbol = {...}`
+would see it ignored with no diagnostic. Silently discarding valid configuration
+is worse than the complexity it avoids.
+
+**Merge every pair's `priorities` into one global ordered allowlist.** Rejected:
+a server configured under several pairs would hold several conflicting positions
+and several `max_fan_out` caps, with no principled merge. Under `union` the
+question dissolves — each pair contributes candidates independently, and the
+result set is order-free — so nothing has to be reconciled.
+
+**Walk every pair for candidates only, and union the results** (chosen). The
+per-pair walk is not new: `concatenated_formatting_pairs` already enumerates
+`settings.languages` × `bridge_map.keys()` and calls `resolve_aggregation(method)`
+on each. Per-pair `priorities` and `max_fan_out` keep working, so no existing
+configuration becomes a silent no-op, and no result is discarded on a basis
+kakehashi cannot compute.
+
+**Honour an explicitly configured `preferred` instead of overriding it.**
+Rejected by the maintainer: overriding explicit configuration is a real cost,
+but silently losing symbols the user did not know they were excluding is worse,
+and the override is announced once at settings-apply time rather than hidden.
+
+## Consequences
+
+### Positive
+
+- Symbol search reaches both real project files (via the downstream servers'
+  own indexes) and symbols inside embedded code blocks, in one result set.
+- The global virtual→host translator is reusable by any future workspace-scoped
+  method (call hierarchy, type hierarchy) that faces the same fan-in problem.
+- `union` is available as an explicit, user-selectable strategy for other
+  methods.
+- Per-language `aggregation` blocks keep selecting servers for this method — a
+  workspace-scoped request does not force users into a separate configuration
+  dialect, and no existing block silently becomes a no-op.
+- No result is ever discarded on a basis kakehashi cannot compute. A server
+  configured under one language may return another language's symbols, and they
+  survive.
+- Because nothing arbitrates, there is no per-target response buffer to hold
+  and no ordering dependency between targets — the handler is a flat
+  fan-out/translate/merge, which is why this is a smaller change than an
+  arbitrating design.
+- A query never spawns a process. Latency is bounded by the servers already
+  running, so declining to impose a deadline stays practical, and `Ctrl-T` in a
+  fresh session cannot stampede every configured language server.
+- Coverage is explainable in one sentence — "the servers running because of what
+  you have opened" — and it grows monotonically as the client opens files, with
+  no separate indexing mode to understand or invalidate.
+
+### Negative
+
+- Latency is max-over-live-servers, not first-win: the response waits for every
+  target. No deadline is imposed in this version; the client's `$/cancelRequest`
+  is the only bound.
+- Results depend on what is open. A language whose files the user has not opened
+  contributes nothing, and the same query answers differently later in a
+  session. LSP permits partial `workspace/symbol` results, but a user expecting
+  an indexed whole-project search will find this surprising.
+- `strategy` becomes a knob that this one method ignores (with a warning). Users
+  who reach for `preferred` to suppress a noisy server must instead leave it out
+  of `priorities`, which is the allowlist that already expresses exactly that.
+- Whether a downstream includes kakehashi's virtual documents in its own symbol
+  index is server-specific — the virtual files do not exist on disk, and servers
+  that index only on-disk workspace contents will contribute real-file symbols
+  only.
+
+### Neutral
+
+- The `union` strategy is selectable for other methods, but no other method
+  defaults to it.
+- Result ordering is defined by the strategy, so clients that re-sort see no
+  change and clients that do not get a stable order.

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -88,6 +88,15 @@ kakehashi sends downstream no `workspace.symbol` client capability at all
 3.18, a conformant downstream must therefore return a full `Location` rather
 than the location-without-range form.
 
+Absence is the right answer only for `resolveSupport`. `symbolKind` and
+`tagSupport` are independent of it, and leaving the whole capability absent
+tells a conformant server to omit tags and to restrict itself to the legacy
+`File`–`Array` kind set — silently degrading results kakehashi's own client
+could have used. So this decision **declares `workspace.symbol` downstream**,
+mirroring the upstream client's `symbolKind` and `tagSupport` while keeping
+`resolveSupport` absent. Mirroring rather than asserting is deliberate:
+kakehashi must not accept a kind or tag it cannot pass on.
+
 Nothing currently advertises the provider: `workspace_symbol_provider` is never
 set in the initialize result, and `LanguageServer::symbol` is never overridden,
 so the request today reaches tower-lsp-server's default and is unimplemented.
@@ -338,12 +347,15 @@ target wait:**
    entries. `connections()` returns the raw map, and `ConnectionState` also has
    `Failed`, `Closing`, and `Closed`, which linger until lazily evicted — none
    of them is a valid target. This is a map read, not a wait.
-2. Apply the per-pair `priorities` allowlist and `max_fan_out` cap to what
+2. Drop `Ready` handles already known to lack `workspace/symbol`. Capability is
+   synchronously knowable for a `Ready` handle; only an `Initializing` one is
+   genuinely unknown, and those are carried forward as unknown.
+3. Apply the per-pair `priorities` allowlist and `max_fan_out` cap to what
    survived. Also synchronous.
-3. Dedup the survivors by **connection key** `(server, root)`.
-4. **Per target, independently**: wait for `Ready`, then check
-   `has_capability("workspace/symbol")` (point 4 explains why the capability
-   check cannot precede the wait), then send.
+4. Dedup the survivors by **connection key** `(server, root)`.
+5. **Per target, independently**: wait for `Ready`, re-check
+   `has_capability("workspace/symbol")` — now knowable for the ones that were
+   `Initializing` — then send.
 
 The cap sits between the two: after the liveness filter, before any waiting.
 Both halves of that placement are load-bearing.
@@ -357,10 +369,20 @@ resolved — up to the full 30 seconds — even though B was ready immediately.
 Deciding membership synchronously and waiting per target removes the
 interaction entirely.
 
-The residual cost is stated rather than engineered away: a target that is
-`Initializing` at selection time consumes a cap slot even if it later turns out
-to lack the capability. Selecting on a fact that is not yet knowable is the
-alternative, and it is worse.
+Step 2 exists because capping first would let a **known-incapable** server take
+a slot from a capable one: with `priorities = [A, B]`, `max_fan_out = 1`, both
+`Ready`, and A incapable, the query would consult nobody. Filtering on what is
+already knowable costs nothing and removes that case entirely.
+
+What remains unknowable is an `Initializing` target, and reserving its slot has
+teeth: `wait_for_ready` can end in timeout, failure, close, or handle
+replacement, and the target may also turn out to lack the capability. With
+`max_fan_out = 1` and `priorities = [initializing_A, ready_B]`, a naive
+reservation would not merely delay B — it would exclude B for the whole query
+and answer empty. So a reserved slot that **dies** is **backfilled**: the
+highest-priority candidate not yet selected takes it. Backfill runs only on that
+failure path, so the common case stays a single synchronous selection, and the
+pathological case degrades to "slower" instead of "empty".
 
 `priorities` is an allowlist: listed servers are candidates, `"*"` stands for
 the rest, and an explicit `[]` remains the per-method kill switch. Its **order**
@@ -408,11 +430,11 @@ set (point 7).
              └────────────┬─────────────┘
                           ▼
         ┌──────────────────────────────────────┐
+        │ SYNCHRONOUS selection — no waiting:  │
         │ 1. keep Ready + Initializing only    │
         │    (NOT Failed/Closing/Closed)       │
-        │ 2. wait for Ready                    │
-        │ 3. THEN has_capability               │
-        │ 4. THEN allowlist + max_fan_out      │
+        │ 2. drop known-incapable Ready handles│
+        │ 3. allowlist + max_fan_out           │
         │    NEVER spawns a connection         │
         └──────────────────┬───────────────────┘
                            ▼
@@ -424,7 +446,8 @@ set (point 7).
         │   (C, rootA)  ← named by LANG_2      │
         └──────────────────┬───────────────────┘
                            ▼
-              one request per connection (§4),
+              THEN per target, independently:
+              wait Ready → re-check capability → send (§4),
               then per-entry fan-in (§5),
               then UNION → dedup → sort (§1)
 ```
@@ -529,9 +552,17 @@ range measured against an older, larger region while offset resolution against
 the current parse still succeeds — and plain range translation performs no
 boundary check, so the result could point into the closing fence or the host
 text after it. `resolve_region_offset` already returns the region's current
-`region_end` alongside the offset; that bound is retained and a translated range
-falling outside it is rejected, the same discipline workspace-edit translation
-already applies.
+`region_end` alongside the offset, but that bound alone is not enough: a stale
+virtual position like `(0, 1000)` inside a region ending on line 5 compares as
+before the end while carrying a column that never existed, and the workspace-edit
+precedent checks only per-line floors and a global endpoint.
+
+Validation therefore runs against the region's **current `virtual_content`**:
+both endpoints must be real positions in that text and the range must be
+correctly ordered — using the existing strict position machinery rather than a
+new comparison — and only then is the range translated and checked against the
+host-side region bound. Validating in virtual coordinates before translating is
+what catches the column case; the host bound catches what survives it.
 
 The range check comes first because `WorkspaceSymbol.location` is
 `OneOf<Location, WorkspaceLocation>` and the `WorkspaceLocation` form carries a
@@ -555,14 +586,33 @@ this method has no target document to name.
 Fan-in therefore runs in **three passes**, not one, over a **request-local
 index** built once up front:
 
-0. Snapshot the tracker's host→virtual map once and build a
+0. **When fan-in begins** — not at fan-out time — snapshot the tracker's
+   host→virtual map once and build a
    `virtual_uri_string → (host_url, region_id)` map for this request.
 1. Classify every entry against that index, **grouping entries by host**. No
    parse and no lock is involved, so nothing waits here.
 2. Ensure the distinct hosts that actually appear, **concurrently**.
 3. Resolve each entry's offset and translate, per group.
 
-Pass 0 is not an optimization. `BridgeCoordinator::resolve_virtual_uri` is
+Pass 0 is built **late, and verified late**, because a single early snapshot
+is wrong in both directions across a wait that can reach a minute.
+
+Too-early **under-reports**: a virtual document opened after the snapshot but
+before the downstream request can legitimately appear in that response, and
+would then be dropped for being absent from a map that predates it. Building the
+index when the first response is in hand removes that whole class.
+
+Staleness in the other direction is worse and survives any snapshot time, so it
+is closed by a check rather than by timing. A region keeps its ULID across
+edits, but its **injection language can change** — the close path removes the old
+virtual URI and a new one is opened for the new language. `resolve_region_offset`
+resolves by host and region id alone and discards the language, so a stale entry
+naming the *old* URI would still resolve, and a Python result would be
+translated into a region that is now Rust. So the indexed URI must **match the
+URI reconstructed from the region's current injection language**; a mismatch is
+a retired document and the entry is dropped.
+
+Pass 0 is also not an optimization. `BridgeCoordinator::resolve_virtual_uri` is
 **not** a map lookup: its own doc comment records that it is "O(N) over open
 virtual docs" — the virtual URI encodes the host *directory* and region id but
 not the host filename, so the host cannot be derived without a scan — and
@@ -635,14 +685,22 @@ form for this method; `containerName` is spec-documented as unusable for
 re-inferring one). `SymbolInformation[]` is the deprecated alternative and is
 not emitted.
 
-One client capability *does* govern the payload, though not the element type:
-`workspace.symbol.tagSupport` declares which `SymbolTag`s the client accepts.
-kakehashi already stores the upstream capabilities, so tags are filtered to the
-declared set and omitted entirely for a client that declares none. This matters
-because the `SymbolInformation` normalization in point 4 *creates* a tag —
-folding the legacy `deprecated` flag into `SymbolTag::DEPRECATED` — so without
-the filter kakehashi would hand a tag-less client a tag it never asked for, and
-the legacy `deprecated` field that client could have understood is gone.
+One client capability *does* govern the payload, and it turns out to govern the
+element type too: `workspace.symbol.tagSupport` declares which `SymbolTag`s the
+client accepts, and kakehashi already stores the upstream capabilities.
+
+- A client **with** `tagSupport` gets `WorkspaceSymbol[]`, tags filtered to the
+  set it declared.
+- A client **without** it gets `SymbolInformation[]`.
+
+The second case is why the element type cannot simply be "always the modern
+one". Point 4 *creates* a tag during normalization, folding the legacy
+`deprecated` flag into `SymbolTag::DEPRECATED`. Emitting `WorkspaceSymbol[]`
+with tags stripped would therefore destroy deprecation outright for exactly the
+clients too old to read tags — while `SymbolInformation.deprecated` is a field
+those clients do understand and that the deprecated element type still carries.
+Emitting the deprecated type for a client that declared no tag support is the
+lesser evil, and it is bounded: the modern type is used everywhere else.
 
 ### 6. Latency is bounded by the pool's timeouts, not by cancellation
 

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -101,8 +101,10 @@ kakehashi must not accept a kind or tag it cannot pass on.
 Exact mirroring has one exception, and it is the legacy spelling again. An
 upstream `tagSupport: true` deserializes to an empty `value_set`, and mirroring
 that verbatim would advertise `{ valueSet: [] }` downstream — telling a
-conformant server to send neither a `DEPRECATED` tag *nor* the legacy
-`deprecated` field, leaving the fallback below nothing to preserve. For that
+conformant server that no tag is supported. The legacy `deprecated` field is
+modelled independently and is not forbidden by that, but neither is it
+guaranteed: a server may reasonably send neither form, leaving the fallback
+below nothing to preserve. For that
 representation kakehashi advertises `DEPRECATED` downstream instead, because it
 can convert a tag back into the legacy boolean but cannot invent information a
 server was told not to send.
@@ -387,8 +389,8 @@ coverage already grows and shrinks under the client's own actions (point 7). It
 buys a selection that is synchronous, deterministic, capability-exact, and free
 of every failure mode above.
 
-The cap sits between the two: after the liveness filter, before any waiting.
-Both halves of that placement are load-bearing.
+The cap sits after the liveness and capability filters, and that placement is
+load-bearing.
 
 Putting the cap *before* the liveness filter would let dead or absent servers
 consume cap slots and silently exclude a live server ranked below the cutoff,
@@ -431,9 +433,9 @@ every connection **that survived steps 1 and 2** — every `Ready`, capable hand
 in the selection snapshot — so a server live under two roots sends two requests
 against one cap slot. It contributes those, not "every live connection": if
 `A/root1` advertises `workspace/symbol` and `A/root2` does not, selecting the
-name A must not smuggle root2 back past the capability filter. No root is dropped and no root-ordering policy is
-needed, which is the point: this method queries every live root of a selected
-server by design.
+name A must not smuggle root2 back past the capability filter. Beyond that
+filter no root is dropped and no root-ordering policy is needed: this method
+queries every `Ready`, capable root of a selected server by design.
 
 The setting's documented promise ("cap the number of concurrent server
 requests") is therefore not what happens here, and could not be — a cap on names
@@ -498,7 +500,7 @@ return is part of the pattern.
   method reports every server incapable. The arm reads
   `workspace_symbol_provider: Option<OneOf<bool, WorkspaceSymbolOptions>>` in the
   same shape as the existing `textDocument/definition` arm.
-- **To be called after the Ready wait.** It falls back to
+- **A `Ready` handle to read.** It falls back to
   `server_capabilities()`, which is `None` until `set_server_capabilities` runs
   during the handshake. Point 3 keeps only `Ready` candidates precisely so this
   is knowable at selection time — an `Initializing` handle reports every server
@@ -631,7 +633,8 @@ index** built once up front:
 3. Resolve each entry's offset and translate, per group.
 
 Pass 0 is built **late, and verified late**, because a single early snapshot
-is wrong in both directions across a wait that can reach a minute.
+is wrong in both directions across a collection phase that runs concurrently and
+can reach the 30-second response bound.
 
 Too-early **under-reports**: a virtual document opened after the snapshot but
 before a downstream request can legitimately appear in that response, and would
@@ -732,6 +735,14 @@ single live `SnapshotView`, and holds the document edit lock through validation
 so the comparison cannot itself be raced. This is the discipline the semantic
 token path already uses, and only the whole of it works; the incarnation half
 alone would leave "the tree is gone" as the only edit race the design notices.
+
+Taking that lock carries an obligation the happy path hides. `edit_lock`
+**creates** an entry unconditionally, so a host that closed between indexing and
+fan-in yields no live `SnapshotView` — and simply dropping the symbol would
+leave the lock entry behind forever. The miss path must call
+`remove_edit_lock_if_unshared`, exactly as the semantic token path does. Fan-in
+reaches this case routinely, because the index is built from documents that may
+close while other targets are still answering.
 
 A residual race remains and is **accepted**: a `didChange` landing between the
 ensure and the offset resolution clears the tree again, and that entry is
@@ -874,8 +885,15 @@ provided" list into a section of its own, and into `docs/README.md`'s
 bridge-backed request list — carrying the live-only coverage contract and the
 fact that coverage can shrink.
 
-The language-server-bridge-request-strategies per-method table gains no row for
-this method and is left incomplete rather than wrong.
+One more site is a **related ADR**, and it is wrong rather than merely
+incomplete: language-server-bridge-request-strategies states universally that
+every other method dispatches `preferred`, and `workspace/symbol` is now a
+counterexample. Its per-method table gains no row — that part is only an
+omission — but the universal sentence must be corrected.
+
+`docs/README.md`'s cross-layer `layers.aggregation` `strategy` row belongs to
+the closed-set list above too: it will schema-accept an inert `union` while
+documenting only two values.
 
 ### 9. Deferred in this decision
 
@@ -1012,8 +1030,8 @@ Including it would defeat dedup on a field carrying no identity.
 - A server still `Initializing` when the query arrives is skipped entirely, so
   a search in the seconds after opening a file can miss it (point 3).
 - `max_fan_out` does not mean here what its own documentation promises. It caps
-  server *names*, and one selected name still queries every live root, so it
-  bounds neither requests nor connections.
+  server *names*, and one selected name still queries every `Ready`, capable
+  root, so it bounds neither requests nor connections.
 - The `kakehashi-virtual-uri-*` filename space is reserved: a real workspace
   file named into it is invisible to symbol search (point 5).
 - `strategy` becomes a knob that this one method ignores (with a warning). Users
@@ -1026,9 +1044,10 @@ Including it would defeat dedup on a field carrying no identity.
   index is server-specific — the virtual files do not exist on disk, and servers
   that index only on-disk workspace contents will contribute real-file symbols
   only.
-- Shipping this obliges a documentation change, not just an addition: two
-  user-facing files state the no-cross-block rule as a blanket claim and one
-  states the strategy set as a closed pair (point 8).
+- Shipping this obliges documentation changes, not just additions: both
+  user-facing files state the no-cross-block rule as a blanket claim, both
+  describe the strategy set as a closed pair, and a related ADR states the
+  same closure as a universal rule (point 8).
 
 ### Neutral
 

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -519,7 +519,7 @@ with its own name and semantics rather than smuggled into this one.
              └────────────┬─────────────┘
                           ▼
         ┌──────────────────────────────────────┐
-        │ SELECTION (own 3s budget, §6)        │
+        │ SELECTION (3s to ACQUIRE lock, §6)   │
         │ 1. keep Ready ONLY (not Initializing,│
         │    Failed, Closing, Closed)          │
         │ 2. drop handles lacking capability   │
@@ -672,7 +672,7 @@ downstream was looking at.
 
 Each virtual document's **content identity at dispatch** is therefore captured
 and re-checked before its entries are translated, using the per-connection
-revision and the fingerprint of the content last *confirmed sent* that the
+revision and the fingerprint of the content last *confirmed enqueued* that the
 tracker already maintains.
 
 Two things about *when* and *per what* are load-bearing:
@@ -693,17 +693,28 @@ Two things about *when* and *per what* are load-bearing:
 
 Comparing those two values across dispatch and translation is not enough on its
 own. The revision advances before the `didChange` is enqueued and stays advanced
-when the enqueue fails, while the confirmed-sent fingerprint deliberately does
+when the enqueue fails, while the recorded fingerprint deliberately does
 not move — so after an `A → B` edit whose notification was dropped, both
 readings agree at `(revision 2, fingerprint A)` while the current geometry
 describes B and the server is still answering about A. Stability across the
 request proves nothing when both halves were already wrong.
 
-The confirmed-sent fingerprint must therefore also **equal the current region's
-content identity**. That is the check that ties what the server saw to what the
-geometry describes; the dispatch/translation comparison only catches movement
-during the request. Entries failing either are dropped, exactly like entries
-whose region moved.
+The recorded fingerprint must therefore also **equal the current region's
+content identity**. That is the check relating what the downstream was told to
+what the geometry describes; the dispatch/translation comparison only catches
+movement *during* the request. Entries failing either are dropped, exactly like
+entries whose region moved.
+
+The fingerprint is content **confirmed enqueued**, not confirmed delivered, and
+this decision claims no more than that. It is recorded once the `didChange`
+enters the writer queue; notifications carry no acknowledgement, and the writer
+continues after a write error rather than failing the connection. So a
+notification that was queued and then failed to write leaves a fingerprint
+naming content the server never received, and these checks narrow the
+stale-result window sharply without closing it. Closing it needs either writer
+acknowledgement, or a rule that a failed notification write makes the connection
+terminal before any later request on it can succeed — both broader than this
+decision, and both better fixed once for every bridged request than here.
 
 With that in place, translation **validates the region bounds** too; it does not
 translate blindly.
@@ -1254,9 +1265,9 @@ Including it would defeat dedup on a field carrying no identity.
   points in a session. LSP permits partial `workspace/symbol` results, but a
   user expecting an indexed whole-project search will find this surprising.
 - Latency is max-over-live-targets, bounded by the pool's existing 30s request
-  timeout and liveness timeout, plus a three-second budget on selection, three
-  seconds on each send's pre-enqueue lock acquisition, and the reopen barrier's
-  two seconds; forwarded cancellation is best-effort because a downstream may
+  timeout and liveness timeout, plus three-second budgets on selection's and
+  each send's `connections` **lock acquisition** — the synchronous filtering
+  that follows is outside them — and the reopen barrier's two seconds; forwarded cancellation is best-effort because a downstream may
   ignore it.
 - One request per keystroke, un-coalesced (point 9).
 - Fan-in can wait on a parse: the distinct host documents a result addresses are
@@ -1275,9 +1286,11 @@ Including it would defeat dedup on a field carrying no identity.
   in methods that have no use for it.
 - A server still `Initializing` when the query arrives is skipped entirely, so
   a search in the seconds after opening a file can miss it (point 3).
-- Selection and each send carry their own budgets, because both must take the
-  pool's `connections` mutex and other paths hold that across unbounded async
-  work (point 6). Expiring either answers from a partial target set — and a
+- Selection and each send bound only their `connections` **lock acquisition**,
+  because other paths hold that mutex across unbounded async work (point 6);
+  the filtering that follows is synchronous and cannot be preempted, so neither
+  total selection time nor cancellation blocking is capped. Expiring either
+  budget answers from a partial target set — and a
   cancellation queued behind that same mutex may arrive too late to stop it, so
   a cancelled request can still be answered.
 - The content-identity check proves a `didChange` was *enqueued*, not delivered:

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -292,8 +292,20 @@ everything else than to be an opinion about workspace symbols.
 
 Two servers indexing the *identical* root — say two TypeScript servers — are
 genuinely competing rather than complementary, and this decision does make their
-near-duplicate entries survive when their ranges differ. The lever for that case
-is `priorities`, which is an allowlist: name only the server you want. That is a
+near-duplicate entries survive when their ranges differ.
+
+Overriding `preferred` costs less than it appears to here, because `union`
+already provides the half of it that matters. `preferred`'s value is "use A,
+fall back to B" — and it distinguishes two cases the ADR must not conflate. When
+A **fails or times out**, union covers it: A contributes nothing and B's results
+are in the answer anyway, without anyone having to declare a fallback. What is
+lost is only fallback when A returns **empty**, and that is precisely the
+semantics rejected above: for a search, empty means "no matches", so consulting
+B on it produces results for a query A said had none. The case `preferred` can
+express and `union` cannot is the case it should not express.
+
+What remains is suppressing a redundant server's near-duplicates, and the lever
+for that is `priorities`, which is an allowlist: name only the server you want. That is a
 static, deliberate exclusion the user writes, not an inference kakehashi draws
 from an empty response — which is the distinction that makes it acceptable here
 and `preferred` not. It does cost the user an edit in **every** pair that names
@@ -473,18 +485,24 @@ connections and two requests.
 `max_fan_out` applies **per pair only**, and that is the whole of it here.
 
 Within a pair it works as everywhere else: `truncate_entries` truncates a
-flattened name list in walk order, keeping the highest-priority N names. A
-surviving name contributes every connection that survived steps 1 and 2 — every
-`Ready`, capable handle in the selection snapshot — so if `A/root1` advertises
-`workspace/symbol` and `A/root2` does not, selecting the name A must not smuggle
-root2 back past the capability filter.
+flattened name list in walk order, keeping the highest-priority N names.
 
-But a per-pair name cap bounds neither requests nor connections here: one name
-can mean several roots, and a connection one pair's cap excluded re-enters
-through another pair that names it. Left there, `max_fan_out = 1` could produce
-arbitrarily many requests, contradicting the setting's documented promise to
-"cap the number of concurrent server requests" — a generic load control quietly
-losing its load-controlling property in exactly the method most able to fan out.
+A surviving name admits **only the connections that pair actually opened**, not
+every live connection of that server. The tracker records each open virtual
+document's `ConnectionKey` next to its language, so a pair's targets are known
+exactly and never derived by expanding a name across roots. That distinction is
+load-bearing: expanding would let a Python pair that admits A reach `A/root2`
+even when the pair that actually opened A on root2 excluded it with
+`priorities = []` — turning `priorities` from a policy boundary into a hint, and
+leaking one language's configuration into another's connections. The exact keys
+are already there; deriving them would be both more work and wrong.
+
+A per-pair name cap still bounds neither requests nor connections overall,
+because a connection one pair's cap excluded re-enters through another pair that
+legitimately opened it. So `max_fan_out = 1` can still produce more than one
+request, contradicting the setting's documented promise to "cap the number of
+concurrent server requests" — a generic load control quietly losing its
+load-controlling property in exactly the method most able to fan out.
 
 A second, global cap after dedup was tried and **rejected**. It cannot be given
 coherent semantics:
@@ -529,10 +547,9 @@ with its own name and semantics rather than smuggled into this one.
                            ▼
         ┌──────────────────────────────────────┐
         │ dedup by CONNECTION KEY (server,root)│
-        │   (B, rootA)  ← named by LANG_1      │
-        │   (B, rootB)  ← same server, another │
-        │                 root: 2 connections  │
-        │   (C, rootA)  ← named by LANG_2      │
+        │   each pair admits ONLY the conns it │
+        │   actually opened — never a name     │
+        │   expanded across roots              │
         │ (no global cap — see §3)             │
         └──────────────────┬───────────────────┘
                            ▼
@@ -1081,10 +1098,14 @@ appears to promise:
   *client* has opened. Reaching embedded code in unopened files would mean
   parsing every candidate host file in the workspace and opening every region —
   precisely the unbounded work this method must not do.
-- **Real-file symbols would be reached, but at one root only.** A server spawned
-  without a document hint resolves to the `ClientFallback` key, so a multi-root
-  workspace gets the client root and none of the marker-derived per-root
-  connections.
+- **Real-file coverage would be partial and hard to predict.** A server spawned
+  without a document hint lands on the single `ClientFallback` connection key.
+  That is not as limiting as one root, since the pool hands such a connection
+  the client root *and* the full upstream `workspaceFolders` snapshot, which
+  initialization forwards verbatim — a multi-root-capable server can index every
+  folder the client declared. What it misses is everything derived from root
+  markers: a monorepo's per-package roots become one undifferentiated workspace
+  instead of the per-root connections normal routing would have produced.
 - **Scoping by "does this language occur in the workspace?" would need a
   mechanism that does not exist.** The LSP server is document-driven and holds
   no workspace index; nothing walks the filesystem on the server path. Under the

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -98,6 +98,15 @@ mirroring the upstream client's `symbolKind` and `tagSupport` while keeping
 `resolveSupport` absent. Mirroring rather than asserting is deliberate:
 kakehashi must not accept a kind or tag it cannot pass on.
 
+Exact mirroring has one exception, and it is the legacy spelling again. An
+upstream `tagSupport: true` deserializes to an empty `value_set`, and mirroring
+that verbatim would advertise `{ valueSet: [] }` downstream — telling a
+conformant server to send neither a `DEPRECATED` tag *nor* the legacy
+`deprecated` field, leaving the fallback below nothing to preserve. For that
+representation kakehashi advertises `DEPRECATED` downstream instead, because it
+can convert a tag back into the legacy boolean but cannot invent information a
+server was told not to send.
+
 Nothing currently advertises the provider: `workspace_symbol_provider` is never
 set in the initialize result, and `LanguageServer::symbol` is never overridden,
 so the request today reaches tower-lsp-server's default and is unimplemented.
@@ -265,7 +274,7 @@ from an empty response — which is the distinction that makes it acceptable her
 and `preferred` not. It does cost the user an edit in **every** pair that names
 the unwanted server, because fan-out unions candidates across all pairs.
 
-### 3. Fan-out: select synchronously, then wait per target
+### 3. Fan-out: select synchronously, and never wait to select
 
 A request has no document, so it cannot pick one `(host_language, bridge_key)`
 pair — it walks **all** of them, purely to collect candidates. Both axes must be
@@ -390,10 +399,11 @@ resolved — up to the full 30 seconds — even though B was ready immediately.
 Deciding membership synchronously and waiting per target removes the
 interaction entirely.
 
-Step 2 must precede step 3, for the reason the abandoned design could not
-honour: capping first would let a **known-incapable** server take a slot from a
-capable one — with `priorities = [A, B]`, `max_fan_out = 1`, and A incapable,
-the query would consult nobody.
+Step 2 must precede step 3: capping first would let a **known-incapable**
+server take a slot from a capable one — with `priorities = [A, B]`,
+`max_fan_out = 1`, and A incapable, the query would consult nobody. Keeping only
+`Ready` candidates is what makes that ordering possible at all, since capability
+is unknowable before the handshake.
 
 `priorities` is an allowlist: listed servers are candidates, `"*"` stands for
 the rest, and an explicit `[]` remains the per-method kill switch. Its **order**
@@ -417,8 +427,11 @@ connections and two requests.
 
 `max_fan_out` counts **server names**, not connections — `truncate_entries`
 truncates a flattened name list in walk order. A surviving name then contributes
-**every** live connection it has, so a server live under two roots sends two
-requests against one cap slot. No root is dropped and no root-ordering policy is
+every connection **that survived steps 1 and 2** — every `Ready`, capable handle
+in the selection snapshot — so a server live under two roots sends two requests
+against one cap slot. It contributes those, not "every live connection": if
+`A/root1` advertises `workspace/symbol` and `A/root2` does not, selecting the
+name A must not smuggle root2 back past the capability filter. No root is dropped and no root-ordering policy is
 needed, which is the point: this method queries every live root of a selected
 server by design.
 
@@ -488,8 +501,8 @@ return is part of the pattern.
 - **To be called after the Ready wait.** It falls back to
   `server_capabilities()`, which is `None` until `set_server_capabilities` runs
   during the handshake. Point 3 keeps only `Ready` candidates precisely so this
-  is knowable at selection time; an `Initializing` handle would report every
-  server incapable.
+  is knowable at selection time — an `Initializing` handle reports every server
+  incapable, which is why it cannot be a candidate.
 
 Cancellation needs nothing new **downstream**: `register_upstream_request`
 already holds many `(server, root)` keys per upstream id,
@@ -497,13 +510,16 @@ already holds many `(server, root)` keys per upstream id,
 `UpstreamRegistrySweepGuard` unregisters the whole entry. Multi-target
 cancellation falls out of using the pattern.
 
-It does need something **upstream**. Registration happens inside the per-target
-send, and cancel forwarding records nothing for an id that is not yet
-registered — so a cancel arriving before the sends would be dropped and the
-query would run to completion regardless. The handler therefore subscribes to
+It does need something **upstream**. Downstream registration happens inside the
+per-target send, so it can only cancel work that has already been dispatched —
+it does nothing for the selection and index-building the handler does first, nor
+for the handler's own future. The handler therefore subscribes to
 `$/cancelRequest` **before its first await** and selects against the whole
-dispatch, exactly as the existing document-free handler does, rather than
-relying on per-target registration alone.
+dispatch, exactly as the existing document-free handler does. Not because the
+signal would otherwise be lost — the request registry latches a cancel that
+arrives between request acceptance and subscription and delivers it on
+subscribe — but because selecting on it is what makes the handler abandon
+promptly rather than only at its next dispatch boundary.
 
 Fan-in cannot live in the `bridge` module, because `resolve_region_offset` is
 `pub(super)` to `lsp_impl`. So unlike every `transform_*_response_to_host`
@@ -699,15 +715,23 @@ check and the ensure moves the URI into a fresh, snapshot-less lifetime and the
 outer 200ms timeout**, so the phase's bound is a property of this call site
 rather than an inference about the callee's internal state.
 
-Resolution also **post-checks the snapshot incarnation**. `resolve_region_offset`
+Resolution also **post-checks the snapshot's freshness**. `resolve_region_offset`
 takes an owned snapshot before it consults the tracker and walks the tree, while
 `didChange` updates tracker positions *before* it clears the visible tree — so a
 resolution that reads the tracker just ahead of that update finishes against its
 own stale snapshot and passes both the language and range checks with old
-coordinates. Re-reading the incarnation after resolution and discarding the
-entry when it moved closes that, following the same discipline the semantic
-token path already uses. Without it, "the tree is gone" is the only edit race
-the design would notice, and it is not the only one that exists.
+coordinates.
+
+The check must be on **incarnation *and* content version**, not incarnation
+alone. An ordinary edit preserves the incarnation and only bumps the content
+version, and `DocumentSnapshot` does not carry that version — so an
+incarnation-only comparison would miss precisely the race described above.
+The resolution variant therefore retains the snapshot's content/parsed version
+alongside the language and virtual content, compares both fields against a
+single live `SnapshotView`, and holds the document edit lock through validation
+so the comparison cannot itself be raced. This is the discipline the semantic
+token path already uses, and only the whole of it works; the incarnation half
+alone would leave "the tree is gone" as the only edit race the design notices.
 
 A residual race remains and is **accepted**: a `didChange` landing between the
 ensure and the offset resolution clears the tree again, and that entry is
@@ -731,8 +755,8 @@ Entries are emitted as `WorkspaceSymbol[]` — `WorkspaceSymbolResponse::Nested`
 in `ls-types`, whose variant names are a misnomer: **both** variants are flat
 arrays, and the choice is the element type, not hierarchy (there is no nested
 form for this method; `containerName` is spec-documented as unusable for
-re-inferring one). `SymbolInformation[]` is the deprecated alternative and is
-not emitted.
+re-inferring one). `SymbolInformation[]` is the deprecated alternative, emitted only in the
+compatibility case below.
 
 One client capability *does* govern the payload, and it turns out to govern the
 element type too: `workspace.symbol.tagSupport` declares which `SymbolTag`s the
@@ -752,12 +776,17 @@ that actually matters.
 
 The second case is why the element type cannot simply be "always the modern
 one". Point 4 *creates* a tag during normalization, folding the legacy
-`deprecated` flag into `SymbolTag::DEPRECATED`. Emitting `WorkspaceSymbol[]`
-with tags stripped would therefore destroy deprecation outright for exactly the
-clients too old to read tags — while `SymbolInformation.deprecated` is a field
-those clients do understand and that the deprecated element type still carries.
-Emitting the deprecated type for a client that declared no tag support is the
-lesser evil, and it is bounded: the modern type is used everywhere else.
+`deprecated` flag into `SymbolTag::DEPRECATED` and discarding the original
+field. Emitting `WorkspaceSymbol[]` with tags stripped would therefore destroy
+deprecation outright for exactly the clients too old to read tags.
+
+Choosing the legacy element type is not by itself enough to undo that, because
+the information now lives in a tag. The legacy path must **reverse the
+normalization**: set `deprecated = Some(true)` when the normalized tags contain
+`DEPRECATED`, and drop tags the client cannot represent. Selecting
+`SymbolInformation[]` without that conversion would lose exactly what selecting
+it was meant to preserve. It is bounded: the modern type is used everywhere
+else.
 
 ### 6. Latency is bounded by the pool's timeouts, not by cancellation
 
@@ -817,22 +846,43 @@ one region's offset is known. Workspace symbol search resolves each result's
 region independently, so the offset is always the right one for the entry being
 translated.
 
-Two user-facing docs state the no-cross-block rule as a blanket claim and must
-be amended, not merely appended to — the wrong part is the framing sentence in
-each: `docs/language-features.md` ("Bridged features are also limited to
-embedded code blocks in one respect: navigation and edits do not cross between
-blocks", and separately "features that need to see across blocks do not work
-between them") and `docs/README.md` ("**No cross-region results within the host
-document**"). Both files' itemized bodies are already correctly scoped to the
-goto/references/rename transforms and stay true. The
-language-server-bridge-request-strategies per-method table gains no row for this
-method and is left incomplete rather than wrong.
+Shipping this obliges edits in **both** user-facing docs, in three separate
+respects each. They are listed here because more than one review round found the
+inventory incomplete.
+
+*The no-cross-block rule is stated as a blanket claim and must be amended, not
+appended to* — the wrong part is the framing sentence, while both files'
+itemized bodies are already correctly scoped to the goto/references/rename
+transforms and stay true:
+
+- `docs/language-features.md` — "Bridged features are also limited to embedded
+  code blocks in one respect: navigation and edits do not cross between blocks",
+  and separately "features that need to see across blocks do not work between
+  them".
+- `docs/README.md` — "**No cross-region results within the host document**".
+
+*The strategy set is described as closed* in two more places, both of which
+enumerate exactly `preferred`/`concatenated` and both of which additionally
+assert that every other method dispatches `preferred` regardless:
+
+- `docs/language-features.md` — the "When several servers handle one language"
+  table and its lead-in ("one of two strategies").
+- `docs/README.md` — the `strategy` row of the aggregation table.
+
+*And the feature must move* out of `docs/language-features.md`'s "Not currently
+provided" list into a section of its own, and into `docs/README.md`'s
+bridge-backed request list — carrying the live-only coverage contract and the
+fact that coverage can shrink.
+
+The language-server-bridge-request-strategies per-method table gains no row for
+this method and is left incomplete rather than wrong.
 
 ### 9. Deferred in this decision
 
 - `workspaceSymbol/resolve` — `resolveProvider` is advertised as `false`. Because
-  kakehashi declares no `workspace.symbol` capability downstream, an entry
-  arriving without a range is a downstream conformance bug; §5 drops it.
+  kakehashi keeps `resolveSupport` absent from the `workspace.symbol` capability
+  it declares downstream (point 5), an entry arriving without a range is a
+  downstream conformance bug; point 5 drops it.
 - `workDoneToken` / `partialResultToken` — neither is forwarded downstream, and
   `workDoneProgress` is left unset on the advertised
   `workspaceSymbolProvider`. The existing client-progress aggregator is keyed by

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -242,10 +242,10 @@ of a response a given pair "asked for". Concretely, given
 
 ```toml
 [languages.LANG_1.bridge._self.aggregation]
-workspace/symbol = { priorities = ["B"] }
+"workspace/symbol" = { priorities = ["B"] }
 
 [languages.LANG_2.bridge._self.aggregation]
-workspace/symbol = { priorities = ["C"] }
+"workspace/symbol" = { priorities = ["C"] }
 ```
 
 B's LANG_2-related symbols are **kept**. Dropping them because LANG_2 nominates
@@ -1014,6 +1014,17 @@ waits. None of those carries a deadline, and cancel forwarding acquires the same
 mutex before it can notify a subscribed handler, so early subscription cannot
 interrupt a stall behind it.
 
+That last part has a consequence **accepted rather than solved**: a cancellation
+issued while selection is queued behind the mutex may not reach the handler
+before selection's budget expires, because local notification happens only after
+cancel forwarding has itself acquired the mutex and captured its downstream
+targets. The handler can therefore answer a partial success for a request the
+client already cancelled. Fixing it properly means a local wake-up path
+independent of target capture — worth doing, but a change to the cancellation
+machinery rather than to this method. The observable cost is small: the client
+discards an answer it no longer wants, and the alternative failure — holding the
+query open behind an unrelated stall — is worse.
+
 Every phase that can block on that mutex therefore carries **its own budget**,
 and there are two — because the mutex is taken twice, not once. Selection takes
 it to read the connection map; then each send **re-acquires** it for the
@@ -1021,7 +1032,11 @@ stale-handle check before enqueueing, which is the precedent's own discipline
 and can stall behind exactly the same holders, after selection's budget has
 already been spent.
 
-- **Selection**: three seconds to acquire and filter.
+- **Selection's lock acquisition**: three seconds. The budget covers
+  *acquiring* the mutex, not the filtering that follows — that walk is
+  synchronous with no await, so a timeout could not preempt it anyway, and
+  bounding what cannot be interrupted would be a promise the runtime does not
+  keep. The walk is over in-memory maps and is not where a query stalls.
 - **Each send's pre-enqueue re-acquisition**: three seconds, per target,
   independently. A target that cannot get the lock in time is dropped like any
   other unreachable one.
@@ -1262,7 +1277,12 @@ Including it would defeat dedup on a field carrying no identity.
   a search in the seconds after opening a file can miss it (point 3).
 - Selection and each send carry their own budgets, because both must take the
   pool's `connections` mutex and other paths hold that across unbounded async
-  work (point 6). Expiring either answers from a partial target set.
+  work (point 6). Expiring either answers from a partial target set — and a
+  cancellation queued behind that same mutex may arrive too late to stop it, so
+  a cancelled request can still be answered.
+- The content-identity check proves a `didChange` was *enqueued*, not delivered:
+  notifications carry no acknowledgement and a failed write does not fail the
+  connection. The stale-result window is narrowed, not closed (point 5).
 - `max_fan_out` does not bound this method's total fan-out. It selects names
   per pair, and one name still queries every `Ready`, capable root while a
   connection excluded by one pair re-enters through another. Its documented
@@ -1270,7 +1290,9 @@ Including it would defeat dedup on a field carrying no identity.
   the documentation must say so.
 - The `kakehashi-virtual-uri-*` filename space is reserved: a real workspace
   file named into it is invisible to symbol search (point 5).
-- `strategy` becomes a knob that this one method ignores (with a warning). Users
+- `strategy` becomes a knob that this one method ignores. A **method-specific**
+  entry warns; a `_` wildcard that happens to reach the method is overridden
+  silently, by design (point 2). Users
   who reach for `preferred` to suppress a noisy server must instead leave it out
   of `priorities` — in every pair that names it.
 - Dedup is exact-match, so two servers that disagree on a symbol's range both

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -272,17 +272,30 @@ configuration would contribute **no candidates at all**. Treating `_` instead as
 `bridge.python.enabled = false` or `priorities = []` excluded, and union has no
 way to subtract that contribution.
 
-So the axes are:
+Both axes therefore come from **what is actually open**, which is also the set
+the live-only rule already commits to:
 
-- **Host languages**: the languages of the **currently open documents**. This is
-  concrete by construction (it comes from language detection, never from a map
-  key), and it is the right set for the same reason the whole method is
-  live-only — virtual documents, and therefore downstream connections, exist
-  only for documents the client has opened.
-- **Injection languages**: the concrete (non-`_`) bridge keys under those host
-  languages, plus `_self`, plus the languages configured servers declare in
-  `languages = [...]`. A `languages = ["*"]` server needs no entry of its own:
-  it is admitted for every concrete language by the normal routing check.
+- **Host languages**: the languages of the currently open documents
+  (`DocumentStore::open_uris()` + language detection). Concrete by
+  construction — it never comes from a map key.
+- **Injection languages**: the languages of the currently **open virtual
+  documents**, read from `VirtualDocumentUri::language()` on the pool's tracked
+  `OpenedVirtualDoc` entries, plus `_self` for the host tier.
+
+Deriving the injection axis from configuration instead — concrete bridge keys
+plus the languages servers declare — looks equivalent and is not. It loses every
+`languages = ["*"]` server, which is the whole point of the any-language-server
+wildcard: an open Markdown document with Python fences, the default `bridge._`,
+and only a `["*"]` server configured yields no non-`_` bridge key and no
+declared concrete language, so no injection language would be generated and the
+server would never be asked. Normal routing avoids this because it starts from
+the region's actual `"python"` and lets `handles_language` recognize `"*"`.
+Starting from open virtual documents restores exactly that: the language is the
+region's real one.
+
+`OpenedVirtualDoc` also carries the `connection_key` the document was opened on,
+so the walk can pair each open virtual document with its host document's
+language directly rather than taking a cross product of the two axes.
 
 Candidates for each `(host, injection)` pair then come from the **existing
 routing entry point**, `get_all_configs_for_language`, rather than from a
@@ -341,8 +354,8 @@ a cost bound; here it is only a per-pair selection rule. What actually bounds
 the total is the live-connection set (point 7).
 
 ```
-  settings.languages × bridge_map.keys()      ← candidate walk only,
-        │  (each key via resolve_with_wildcard) no arbitration
+  open host docs × their open virtual docs    ← concrete languages only,
+        │  (never a raw `_` map key)             no arbitration
         ▼
   ┌──────────────────────┐   ┌──────────────────────┐
   │ (LANG_1, _self)      │   │ (LANG_2, _self)      │  ... every pair
@@ -483,15 +496,25 @@ this classifier would silently turn into "no embedded symbols". The
 whole-document handlers avoid this by calling `ensure_document_parsed` first;
 this method has no target document to name.
 
-It therefore ensures **lazily, at translation time**: as entries are classified,
-each distinct `host_url` they resolve to is ensured once, immediately before its
-entries are translated. Doing this up front instead — a sweep over every open
-document, issued alongside the fan-out — was the first shape considered and is
-worse on both axes. It does work for documents no result mentions, and, more
-importantly, it completes up to 30 seconds before the value is used (a target
-may take the full response timeout), so an edit arriving in between re-clears
-the tree and the sweep guarantees nothing. Ensuring next to the use closes that
-gap to the width of one classification step.
+Fan-in therefore runs in **three passes**, not one:
+
+1. Classify every entry and resolve its virtual URI to a `host_url`, **grouping
+   entries by host**. This pass needs no parse — `resolve_virtual_uri` is a map
+   lookup — so nothing waits here.
+2. Ensure the distinct hosts that actually appear, **concurrently**.
+3. Resolve each entry's offset and translate, per group.
+
+Ensuring one host at a time while translating would make the cost additive:
+`distinct_hosts × 200ms` in series, which for a query touching many stale hosts
+would dwarf the fan-out it follows and contradict point 6's max-over-targets
+account. Grouping first makes the whole pass cost about one 200ms wait.
+
+Sweeping every open document up front instead — alongside the fan-out — was the
+first shape considered and is worse on both axes. It does work for documents no
+result mentions, and it completes up to 30 seconds before the value is used (a
+target may take the full response timeout), so an edit arriving in between
+re-clears the tree and the sweep guarantees nothing. Ensuring between resolution
+and translation closes that gap to the width of one pass.
 
 Only documents that **already have a snapshot** are ensured. `ensure_document_parsed`
 asks for a 200ms wait, but `wait_for_current_snapshot` escalates to the
@@ -718,8 +741,9 @@ Including it would defeat dedup on a field carrying no identity.
   request timeout and liveness timeout; forwarded cancellation is best-effort
   because a downstream may ignore it.
 - One request per keystroke, un-coalesced (point 9).
-- Fan-in can wait on a parse: each distinct host document a result addresses is
-  ensured before translation, up to 200ms each (point 5).
+- Fan-in can wait on a parse: the distinct host documents a result addresses are
+  ensured before translation. Because they are ensured concurrently the pass
+  costs about one 200ms wait rather than one per document (point 5).
 - An edit landing between that ensure and the offset resolution still drops the
   affected entries. The window is small but not closed, and the failure is
   silent — the symbols simply are not there.
@@ -745,7 +769,8 @@ Including it would defeat dedup on a field carrying no identity.
 ### Neutral
 
 - `Union` is a named strategy but is meaningful only for this method; elsewhere
-  it behaves as `Concatenated`.
+  it is normalized to that method's existing default before any handler runs, so
+  configuring it there changes nothing.
 - Result ordering is deterministic but not relevance-ranked. LSP delegates
   scoring to the client ("editors will apply their own highlighting and scoring
   on the results"), so a client that re-sorts sees no change and one that does

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -82,11 +82,12 @@ Three facts in the existing code make the feature tractable anyway:
   existing precedent for sending a request on a connection **without** a virtual
   document, and it shows exactly what that costs (see point 4).
 
-kakehashi sends downstream no `workspace.symbol` client capability at all
+kakehashi today sends downstream no `workspace.symbol` client capability at all
 (`bridge/protocol/client_capabilities.rs` sets no `symbol` field on
 `WorkspaceClientCapabilities`), so in particular no `resolveSupport`. Per LSP
 3.18, a conformant downstream must therefore return a full `Location` rather
-than the location-without-range form.
+than the location-without-range form. Point 5 keeps that property for
+`resolveSupport` while declaring the rest of the capability.
 
 Absence is the right answer only for `resolveSupport`. `symbolKind` and
 `tagSupport` are independent of it, and leaving the whole capability absent
@@ -133,8 +134,8 @@ per-entry global fan-in translator, and a single deduplicating union. Defer
    │             │  3. sort   (uri, start, end,   │
    │             │             name, kind)        │
    │             └───────────────┬────────────────┘
-   │◀── WorkspaceSymbol[] ───────┘
-   │    (always an array, never null)
+   │◀── Symbol array ────────────┘
+   │    (element type per client, §5; never null)
    │
    │ $/cancelRequest ─▶ forwarded to every in-flight target, best effort:
    │                    a downstream may ignore it (LSP allows this). The
@@ -340,22 +341,42 @@ the opt-out, wildcard-resolved gate beside it.
 set only on `bridge._` still apply to a concrete pair — the property that keeps
 existing configuration from becoming a silent no-op here.
 
-**Order matters. Everything synchronous happens first; only then does any
-target wait:**
+**Selection is entirely synchronous. No candidate is waited for:**
 
-1. Take the pool's connection map and keep only `Ready` and `Initializing`
-   entries. `connections()` returns the raw map, and `ConnectionState` also has
-   `Failed`, `Closing`, and `Closed`, which linger until lazily evicted — none
-   of them is a valid target. This is a map read, not a wait.
-2. Drop `Ready` handles already known to lack `workspace/symbol`. Capability is
-   synchronously knowable for a `Ready` handle; only an `Initializing` one is
-   genuinely unknown, and those are carried forward as unknown.
-3. Apply the per-pair `priorities` allowlist and `max_fan_out` cap to what
-   survived. Also synchronous.
+1. Take the pool's connection map and keep only `Ready` entries.
+   `connections()` returns the raw map, and `ConnectionState` also has
+   `Initializing`, `Failed`, `Closing`, and `Closed`.
+2. Drop handles that lack `workspace/symbol`. This is knowable now, because
+   every candidate is `Ready` — `server_capabilities()` is populated during the
+   handshake.
+3. Apply the per-pair `priorities` allowlist and `max_fan_out` cap.
 4. Dedup the survivors by **connection key** `(server, root)`.
-5. **Per target, independently**: wait for `Ready`, re-check
-   `has_capability("workspace/symbol")` — now knowable for the ones that were
-   `Initializing` — then send.
+5. Send to each survivor.
+
+**`Initializing` connections are excluded.** Including them, and waiting for
+Ready before dispatch, was tried and abandoned — it looked like it removed a
+timing dependence and instead produced a cascade:
+
+- Capability is unknowable for an `Initializing` handle, so the cap either ran
+  before the capability check (letting a known-incapable server take the last
+  slot and answer nobody) or after the wait (making the cap a global barrier
+  that delayed a ready target by another target's 30-second `wait_for_ready`).
+- A reserved slot could die four ways — timeout, failure, close, handle
+  replacement — turning `max_fan_out = 1` with a slow high-priority candidate
+  from "slower" into "empty".
+- Backfilling the dead slot has no well-defined unit: the cap selects server
+  *names* per pair, while failure happens per `(server, root)` *connection*, and
+  a deduplicated connection can carry several pairs' priority lists, so there is
+  no single "next candidate". Sequential backfill also gives each replacement a
+  fresh 30-second wait, so three slow candidates cost 90 seconds before any
+  response wait — breaking the latency account outright.
+
+Excluding them costs one thing: a query issued in the seconds after opening a
+file may miss a server still starting for it. That is not a new class of
+surprise — this method's contract is already "coverage is what is live", and
+coverage already grows and shrinks under the client's own actions (point 7). It
+buys a selection that is synchronous, deterministic, capability-exact, and free
+of every failure mode above.
 
 The cap sits between the two: after the liveness filter, before any waiting.
 Both halves of that placement are load-bearing.
@@ -369,27 +390,10 @@ resolved — up to the full 30 seconds — even though B was ready immediately.
 Deciding membership synchronously and waiting per target removes the
 interaction entirely.
 
-Step 2 exists because capping first would let a **known-incapable** server take
-a slot from a capable one: with `priorities = [A, B]`, `max_fan_out = 1`, both
-`Ready`, and A incapable, the query would consult nobody. Filtering on what is
-already knowable costs nothing and removes that case entirely.
-
-What remains unknowable is an `Initializing` target, and reserving its slot has
-teeth: `wait_for_ready` can end in timeout, failure, close, or handle
-replacement, and the target may also turn out to lack the capability. With
-`max_fan_out = 1` and `priorities = [initializing_A, ready_B]`, a naive
-reservation would not merely delay B — it would exclude B for the whole query
-and answer empty. So a reserved slot that **dies** is **backfilled**: the
-highest-priority candidate not yet selected takes it. Backfill runs only on that
-failure path, so the common case stays a single synchronous selection, and the
-pathological case degrades to "slower" instead of "empty".
-
-Backfill is deterministic and terminates: the replacement is always the
-highest-priority candidate not yet selected, which is a total order fixed before
-any waiting, and each backfill consumes one candidate from a finite list. A
-chain of failures therefore walks the priority order once and stops, and the
-resulting target set does not depend on the order failures happened to occur
-in.
+Step 2 must precede step 3, for the reason the abandoned design could not
+honour: capping first would let a **known-incapable** server take a slot from a
+capable one — with `priorities = [A, B]`, `max_fan_out = 1`, and A incapable,
+the query would consult nobody.
 
 `priorities` is an allowlist: listed servers are candidates, `"*"` stands for
 the rest, and an explicit `[]` remains the per-method kill switch. Its **order**
@@ -437,10 +441,10 @@ set (point 7).
              └────────────┬─────────────┘
                           ▼
         ┌──────────────────────────────────────┐
-        │ SYNCHRONOUS selection — no waiting:  │
-        │ 1. keep Ready + Initializing only    │
-        │    (NOT Failed/Closing/Closed)       │
-        │ 2. drop known-incapable Ready handles│
+        │ SYNCHRONOUS selection — nothing waits│
+        │ 1. keep Ready ONLY (not Initializing,│
+        │    Failed, Closing, Closed)          │
+        │ 2. drop handles lacking capability   │
         │ 3. allowlist + max_fan_out           │
         │    NEVER spawns a connection         │
         └──────────────────┬───────────────────┘
@@ -453,8 +457,7 @@ set (point 7).
         │   (C, rootA)  ← named by LANG_2      │
         └──────────────────┬───────────────────┘
                            ▼
-              THEN per target, independently:
-              wait Ready → re-check capability → send (§4),
+              then send to each survivor (§4),
               then per-entry fan-in (§5),
               then UNION → dedup → sort (§1)
 ```
@@ -484,13 +487,23 @@ return is part of the pattern.
   same shape as the existing `textDocument/definition` arm.
 - **To be called after the Ready wait.** It falls back to
   `server_capabilities()`, which is `None` until `set_server_capabilities` runs
-  during the handshake — so prefiltering an `Initializing` connection drops
-  exactly the connections point 3 decided to keep.
+  during the handshake. Point 3 keeps only `Ready` candidates precisely so this
+  is knowable at selection time; an `Initializing` handle would report every
+  server incapable.
 
-Cancellation needs nothing new: `register_upstream_request` already holds many
-`(server, root)` keys per upstream id, `forward_cancel_by_upstream_id_if_current`
-already iterates all of them, and `UpstreamRegistrySweepGuard` unregisters the
-whole entry. Multi-target cancellation falls out of using the pattern.
+Cancellation needs nothing new **downstream**: `register_upstream_request`
+already holds many `(server, root)` keys per upstream id,
+`forward_cancel_by_upstream_id_if_current` already iterates all of them, and
+`UpstreamRegistrySweepGuard` unregisters the whole entry. Multi-target
+cancellation falls out of using the pattern.
+
+It does need something **upstream**. Registration happens inside the per-target
+send, and cancel forwarding records nothing for an id that is not yet
+registered — so a cancel arriving before the sends would be dropped and the
+query would run to completion regardless. The handler therefore subscribes to
+`$/cancelRequest` **before its first await** and selects against the whole
+dispatch, exactly as the existing document-free handler does, rather than
+relying on per-target registration alone.
 
 Fan-in cannot live in the `bridge` module, because `resolve_region_offset` is
 `pub(super)` to `lsp_impl`. So unlike every `transform_*_response_to_host`
@@ -593,9 +606,9 @@ this method has no target document to name.
 Fan-in therefore runs in **three passes**, not one, over a **request-local
 index** built once up front:
 
-0. **When fan-in begins** — not at fan-out time — snapshot the tracker's
-   host→virtual map once and build a
-   `virtual_uri_string → (host_url, region_id)` map for this request.
+0. **After every target's result is collected**, and not before, snapshot the
+   tracker's host→virtual map once and build a
+   `virtual_uri_string → (host_url, region_id, language)` map for this request.
 1. Classify every entry against that index, **grouping entries by host**. No
    parse and no lock is involved, so nothing waits here.
 2. Ensure the distinct hosts that actually appear, **concurrently**.
@@ -605,9 +618,12 @@ Pass 0 is built **late, and verified late**, because a single early snapshot
 is wrong in both directions across a wait that can reach a minute.
 
 Too-early **under-reports**: a virtual document opened after the snapshot but
-before the downstream request can legitimately appear in that response, and
-would then be dropped for being absent from a map that predates it. Building the
-index when the first response is in hand removes that whole class.
+before a downstream request can legitimately appear in that response, and would
+then be dropped for being absent from a map that predates it. Waiting for the
+*first* response is not enough either — other targets can stay in flight for
+another 30 seconds and answer with documents opened in the meantime. The index
+is therefore built once all results are in hand, immediately before
+classification.
 
 Staleness in the other direction is worse and survives any snapshot time, so it
 is closed by a check rather than by timing. A region keeps its ULID across
@@ -615,9 +631,16 @@ edits, but its **injection language can change** — the close path removes the 
 virtual URI and a new one is opened for the new language. `resolve_region_offset`
 resolves by host and region id alone and discards the language, so a stale entry
 naming the *old* URI would still resolve, and a Python result would be
-translated into a region that is now Rust. So the indexed URI must **match the
-URI reconstructed from the region's current injection language**; a mismatch is
-a retired document and the entry is dropped.
+translated into a region that is now Rust. So the index must carry each entry's
+**language**, taken from `OpenedVirtualDoc.virtual_uri.language()`, and that
+language must equal the region's current `injection_language`; a mismatch is a
+retired document and the entry is dropped.
+
+Comparing *reconstructed URIs* instead would not work. A virtual URI renders the
+language only as a file extension, and that mapping is not injective —
+`python` and a literal `py` both render `.py`, as do `rust`/`rs` and
+`javascript`/`js` — so exactly the language changes most likely to occur would
+compare equal. The tracked language string is the identity; the URI is not.
 
 Both that check and the range validation below need data the current helper
 throws away rather than data the system lacks: `ResolvedInjection` already
@@ -634,8 +657,10 @@ justifies that cost with "`window/showDocument` is rare, so the scan is
 acceptable". Calling it once per returned symbol destroys exactly that premise:
 an interactive endpoint returning thousands of symbols would pay
 `symbols × open_virtual_docs`, serialized through repeated acquisition of the
-tracker's async mutex. Snapshotting once makes it one scan plus O(1) per entry,
-and the snapshot is the same data point 3's validation already takes.
+tracker's async mutex. Snapshotting once makes it one scan plus O(1) per entry.
+It is a *separate* snapshot from the one point 3 takes to validate candidates —
+that one is taken at selection time under the `connections` lock and answers a
+different question.
 
 The index also becomes the **identity test**. `is_virtual_uri` is only a
 basename pattern — it accepts any URI ending in
@@ -674,6 +699,16 @@ check and the ensure moves the URI into a fresh, snapshot-less lifetime and the
 outer 200ms timeout**, so the phase's bound is a property of this call site
 rather than an inference about the callee's internal state.
 
+Resolution also **post-checks the snapshot incarnation**. `resolve_region_offset`
+takes an owned snapshot before it consults the tracker and walks the tree, while
+`didChange` updates tracker positions *before* it clears the visible tree — so a
+resolution that reads the tracker just ahead of that update finishes against its
+own stale snapshot and passes both the language and range checks with old
+coordinates. Re-reading the incarnation after resolution and discarding the
+entry when it moved closes that, following the same discipline the semantic
+token path already uses. Without it, "the tree is gone" is the only edit race
+the design would notice, and it is not the only one that exists.
+
 A residual race remains and is **accepted**: a `didChange` landing between the
 ensure and the offset resolution clears the tree again, and that entry is
 dropped like any other unresolvable one. Closing it entirely would mean pinning
@@ -703,9 +738,17 @@ One client capability *does* govern the payload, and it turns out to govern the
 element type too: `workspace.symbol.tagSupport` declares which `SymbolTag`s the
 client accepts, and kakehashi already stores the upstream capabilities.
 
-- A client **with** `tagSupport` gets `WorkspaceSymbol[]`, tags filtered to the
-  set it declared.
-- A client **without** it gets `SymbolInformation[]`.
+- A client that can represent `SymbolTag::DEPRECATED` gets `WorkspaceSymbol[]`,
+  tags filtered to the set it declared.
+- Every other client gets `SymbolInformation[]`.
+
+The discriminator is **representability, not presence**. `tagSupport` cannot be
+tested for existence: the legacy boolean form `tagSupport: true` deserializes to
+`Some(TagSupport { value_set: [] })`, so a client that declares tag support in
+the old spelling would pass a presence check, have every tag filtered away
+against its empty set, and lose deprecation exactly as if it had declared
+nothing. Asking whether `DEPRECATED` survives the filter answers the question
+that actually matters.
 
 The second case is why the element type cannot simply be "always the modern
 one". Point 4 *creates* a tag during normalization, folding the legacy
@@ -720,10 +763,6 @@ lesser evil, and it is bounded: the modern type is used everywhere else.
 
 Every target is awaited, so latency is max-over-targets. The bounds are:
 
-- The Ready wait in point 3 is bounded by `wait_for_ready`'s
-  `INIT_TIMEOUT_SECS`, also **30 seconds**, and it happens *before* the target's
-  request is sent. Each target waits independently: a slow `Initializing`
-  connection must not delay dispatch to connections that are already `Ready`.
 - `wait_for_response` wraps each request in a hardcoded **30-second** timeout and
   removes the router entry when it fires.
 - The reader's **liveness timeout** can independently fail a connection that has
@@ -732,11 +771,11 @@ Every target is awaited, so latency is max-over-targets. The bounds are:
   permits a downstream to ignore `$/` notifications, so it is best-effort and
   cannot be the guarantee.
 
-So a single target's worst case is the two 30-second bounds in series, not one.
-No *additional* deadline is introduced. Because no target is ever cold-started
-(point 7), the practical case is bounded by servers that are already running and
-already answering other requests — a target that is still `Initializing` at
-query time is one the client's own file-open just started.
+No *additional* deadline is introduced, and selection adds none: every target is
+already `Ready` when it is chosen (point 3), so nothing waits before the request
+goes out. Because no target is ever cold-started (point 7), the practical case is
+bounded by servers that are already running and already answering other
+requests.
 
 ### 7. Coverage is what is live, and a query never cold-starts a server
 
@@ -920,9 +959,8 @@ Including it would defeat dedup on a field carrying no identity.
   touches is how many are live.
 - Adding the `Union` variant forces a `Union` arm at 7 exhaustive `match` sites
   in methods that have no use for it.
-- A target that is `Initializing` when the candidate set is fixed consumes a
-  `max_fan_out` slot even if it later proves incapable — the cost of deciding
-  membership synchronously (point 3).
+- A server still `Initializing` when the query arrives is skipped entirely, so
+  a search in the seconds after opening a file can miss it (point 3).
 - `max_fan_out` does not mean here what its own documentation promises. It caps
   server *names*, and one selected name still queries every live root, so it
   bounds neither requests nor connections.

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -567,21 +567,25 @@ hand. "Its own offset" does not mean "its own resolution", though; see pass 3.
      └─────────┬─────────┘             no place in any host file)
                │ no
                ▼
-     resolve_virtual_uri(uri)
+     look up in the REQUEST-LOCAL URI index (pass 0)
                │
-               ├── None ─────────▶ DROP  (no host mapping for this URI)
+               ├── absent ───────▶ DROP  (retired region, or a real file in
+               │                          the reserved virtual-URI namespace)
+               ▼ (host_url, region_id, language)
+     look up region_id in that HOST's region map (pass 3, resolved once)
                │
-               ▼ Some((host_url, region_id))
-     resolve_region_offset(host_url, region_id)
-               │
-               ├── None ─────────▶ DROP  (region invalidated by edits, or
+               ├── absent ───────▶ DROP  (region invalidated by edits, or
                │                          host document closed)
-               ▼ Some(offset)
+               ├── language ≠ ────▶ DROP  (region now hosts another language)
+               │   current
+               ▼ (offset, region_end, virtual_content)
      TRANSLATE
        uri   := host_url
        range := translate_virtual_range_to_host(range, offset)
-       └─ reject if the translated range escapes the region's current
-          bounds — see below
+       └─ validate against virtual_content and region_end — see below
+
+  Neither lookup rescans: the URI index is built once per request and the
+  region map once per host.
 ```
 
 Translation **validates the region bounds**; it does not translate blindly.
@@ -667,7 +671,9 @@ throws away rather than data the system lacks: `ResolvedInjection` already
 carries `injection_language` and `virtual_content`, and
 `resolved_region_geometry` discards both, returning only offset, region end, and
 contiguity. The fan-in path needs a resolution variant that **retains** them.
-That is the whole mechanism — no new resolution, no second parse.
+No second parse is involved either way: the preferred path reads an
+already-resolved snapshot, and the fallback runs the one resolution that path
+would have read.
 
 Pass 0 is also not an optimization. `BridgeCoordinator::resolve_virtual_uri` is
 **not** a map lookup: its own doc comment records that it is "O(N) over open
@@ -767,11 +773,24 @@ Two identities must hold, not one:
   generation-stamped snapshot is the preferred source, and the reason the inline
   fallback must be serialized against reload.
 
-The inline fallback additionally requires the document edit lock **before its
-resolution snapshot is taken**, not merely around the comparison, and held
-through translation — the lock has to cover the side effect, not merely observe
-it. (A genuinely read-only resolver, reusing the requested id and never reaching
-a minting helper, would remove that requirement; it does not exist today.)
+**Both** paths take the host's document edit lock before the final freshness
+comparison and hold it through translation. The cached snapshot is not exempt:
+it validates freshness only while handing out its `Arc`, so a `didChange`
+landing afterwards invalidates the geometry before the translation uses it, and
+an unlocked post-check races the same way. The lock is what makes "validated"
+and "used" the same instant.
+
+The inline fallback needs the lock **earlier still** — before its resolution
+snapshot is taken, not merely around the comparison — because there the lock has
+to cover a side effect rather than observe a value. (A genuinely read-only
+resolver, reusing the requested id and never reaching a minting helper, would
+remove that requirement; it does not exist today.)
+
+The fallback also must not run the injection walk on the async runtime. That
+walk is documented as taking hundreds of milliseconds and having starved Tokio
+before, which is why production parsing hands it to the compute pool; the
+fallback does the same, with the caller holding the edit and generation guards
+across it. A once-per-host cost is acceptable, a stalled runtime is not.
 
 Taking that lock carries an obligation the happy path hides. `edit_lock`
 **creates** an entry unconditionally, so a host that closed between indexing and

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -302,18 +302,21 @@ selected it always merges B, and with `priorities` naming only A there is no B
 to fall back to. So a user gets *either* B's duplicates always, *or* no backup;
 not "A normally, B when A has nothing".
 
-The trade is accepted because the conditional's remaining half is the one this
-method should not have. Falling back on **failure** is not really needed: a
-failed A contributes nothing and B, if selected, is in the answer regardless.
-Falling back on **empty** is the case `preferred` uniquely provides, and it is
-wrong here — for a search, empty means "no matches", so consulting B on it
-answers a query A already said had none. What is genuinely lost is the
-combination: suppressing B's duplicates while keeping it as a failure backup.
+The trade is accepted as **uniformity**, not because fallback-on-empty is
+invalid. It would be easy to over-argue this, so: an empty answer from A
+establishes only that A's index has no match, and says nothing about B's — which
+is exactly why `union` returns B's matches when A is empty, and why treating
+empty as a reason to consult B is a defensible policy rather than a semantic
+error. `preferred` already treats empty as failed for priority purposes.
 
-If that combination turns out to matter, it belongs in a mode of its own with a
-name that says what it does, not in `preferred` — whose empty-means-retry
-semantics are the part that must not apply. Until then the lever is
-`priorities`, an allowlist: name only the server you want. That is a
+What this decision chooses instead is that **every selected server's view
+appears, unconditionally**, because kakehashi cannot attribute a response to a
+pair (point 2's central argument) and so cannot justify suppressing one server's
+results on the strength of another's. Accepting that means accepting its
+corollary: no configuration expresses "suppress B's duplicates but keep B as a
+backup". If that combination turns out to matter, it belongs in a mode of its
+own with a name that says what it does. Until then the lever is `priorities`, an
+allowlist: name only the server you want. That is a
 static, deliberate exclusion the user writes, not an inference kakehashi draws
 from an empty response — which is the distinction that makes it acceptable here
 and `preferred` not. It does cost the user an edit in **every** pair that names
@@ -417,7 +420,9 @@ existing configuration from becoming a silent no-op here.
 2. Drop handles that lack `workspace/symbol`. This is knowable now, because
    every candidate is `Ready` — `server_capabilities()` is populated during the
    handshake.
-3. Apply the per-pair `priorities` allowlist and `max_fan_out` cap.
+3. Apply the per-pair `priorities` allowlist and `max_fan_out` cap, and drop
+   any handle whose recorded launch configuration no longer matches the
+   `BridgeServerConfig` that admitted it.
 4. Dedup the survivors by **connection key** `(server, root)`.
 5. Await `wait_for_pending_reopen` for the survivors, **concurrently**, then
    send.
@@ -477,6 +482,15 @@ design this placement had a second failure mode too — the cap became a global
 barrier — but with `Initializing` excluded there is nothing left to wait for,
 so only the coverage argument applies.)
 Deciding membership synchronously removes the interaction entirely.
+
+Step 3's config check exists because settings are published before the pool
+finishes propagating them, so a reload leaves a window in which a live handle
+was spawned from a configuration the current settings have already superseded.
+Being `Ready`, capable, and holding the right documents does not make it the
+process the current config describes; the pool's own by-key acquisition compares
+launch configurations for exactly this reason. The resolved config is therefore
+carried into selection and re-compared at the pre-enqueue check, and a mismatched
+handle is dropped rather than queried.
 
 Step 2 must precede step 3: capping first would let a **known-incapable**
 server take a slot from a capable one — with `priorities = [A, B]`,
@@ -563,7 +577,8 @@ with its own name and semantics rather than smuggled into this one.
         │ 1. keep Ready ONLY (not Initializing,│
         │    Failed, Closing, Closed)          │
         │ 2. drop handles lacking capability   │
-        │ 3. allowlist + per-pair max_fan_out  │
+        │ 3. allowlist + per-pair max_fan_out, │
+        │    drop stale-config handles         │
         │    NEVER spawns a connection         │
         └──────────────────┬───────────────────┘
                            ▼
@@ -1082,14 +1097,26 @@ stale-handle check before enqueueing, which is the precedent's own discipline
 and can stall behind exactly the same holders, after selection's budget has
 already been spent.
 
-- **Selection's lock acquisition**: three seconds. The budget covers
-  *acquiring* the mutex, not the filtering that follows — that walk is
-  synchronous with no await, so a timeout could not preempt it anyway, and
-  bounding what cannot be interrupted would be a promise the runtime does not
-  keep. The walk is over in-memory maps and is not where a query stalls.
-- **Each send's pre-enqueue re-acquisition**: three seconds, per target,
-  independently. A target that cannot get the lock in time is dropped like any
-  other unreachable one.
+The rule is uniform: **every lock this path acquires carries a three-second
+budget, and failing to acquire it drops the affected target or host** rather
+than blocking the query. That is more than the `connections` mutex — selection
+also takes `host_documents` (for `_self` targets) and the tracker snapshot, each
+send re-acquires `connections` before enqueue, and translation takes each host's
+`edit_lock`. None of these is safe to assume fast: injection processing holds
+`edit_lock` across downstream close, change, and eager-spawn awaits, so a query
+arriving mid-processing would otherwise wait on unrelated work with no bound.
+
+- **Selection** (`connections`, then `host_documents`, then the tracker
+  snapshot, in that order): three seconds each. The budget covers *acquiring*
+  each lock, not the filtering between them — that walk is synchronous with no
+  await, so a timeout could not preempt it anyway, and bounding what cannot be
+  interrupted would promise something the runtime does not deliver.
+- **Each send's pre-enqueue re-acquisition** of `connections`: three seconds,
+  per target, independently. A target that cannot get the lock in time is
+  dropped like any other unreachable one.
+- **Translation's `edit_lock`** per host: three seconds. A host whose lock
+  cannot be taken in time loses that query's entries, exactly like a host whose
+  geometry was stale.
 
 Separate budgets rather than one deadline spanning the whole dispatch, because a
 single outer deadline would silently consume the reopen barrier's two seconds
@@ -1296,9 +1323,11 @@ Including it would defeat dedup on a field carrying no identity.
 - No result is discarded on a basis kakehashi cannot compute. A server
   configured under one language may return another language's symbols, and they
   survive.
-- Because nothing arbitrates, there is no per-target response buffer to hold and
-  no ordering dependency between targets — the handler is a flat
-  fan-out/translate/merge.
+- Because nothing arbitrates, there is no ordering dependency between targets —
+  the handler is a flat fan-out/translate/merge. This removes ordering state,
+  **not** storage: fan-in waits for every target before classifying anything
+  (point 5), so peak memory is the sum of all targets' complete responses, held
+  while the slowest target runs out its 30-second budget.
 - A query never spawns a process, so `Ctrl-T` in a fresh session cannot stampede
   every configured language server.
 
@@ -1309,10 +1338,11 @@ Including it would defeat dedup on a field carrying no identity.
   points in a session. LSP permits partial `workspace/symbol` results, but a
   user expecting an indexed whole-project search will find this surprising.
 - Latency is max-over-live-targets, and every *wait* is bounded: the pool's 30s
-  request timeout and liveness timeout, three-second budgets on selection's and
-  each send's `connections` lock **acquisition**, and the reopen barrier's two
-  seconds. Total latency is not bounded, because the synchronous filtering
-  between those waits cannot be preempted. Forwarded cancellation is
+  request timeout and liveness timeout, a three-second budget on **every** lock
+  this path acquires (`connections`, `host_documents`, the tracker snapshot,
+  each send's re-acquisition, and each host's `edit_lock`), and the reopen
+  barrier's two seconds. Total latency is not bounded, because the synchronous
+  filtering between those waits cannot be preempted. Forwarded cancellation is
   best-effort, since a downstream may ignore it.
 - One request per keystroke, un-coalesced (point 9).
 - Fan-in can wait on a parse: the distinct host documents a result addresses are

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -436,6 +436,13 @@ final barrier.** The order is fixed:
    configuration no longer matches the `BridgeServerConfig` that admitted them;
    and confirms current membership — the live reverse index for a virtual
    candidate, `host_documents` for a `_self` one.
+
+   The reverse index is a sharded map and answers synchronously. `host_documents`
+   is a separate Tokio mutex, so it is taken with **`try_lock`**, never awaited:
+   on contention the `_self` candidates are dropped for that query and the
+   virtual ones are unaffected. Awaiting it while holding `connections` would
+   make this path exactly the kind of unbounded holder that forced every budget
+   in point 6, and there is no version of "briefly" that is safe there.
 3. Apply the per-pair `priorities` allowlist and `max_fan_out` cap to the
    survivors — pure computation, after the lock is released.
 4. Dedup by **connection key** `(server, root)`.
@@ -447,8 +454,8 @@ this under one acquisition — `launch_config` and its comparator are private to
 the pool, and the exposed comparison helper takes `connections` itself, so a
 caller in `bridge/workspace/symbol.rs` doing these checks piecemeal would
 re-lock between them and validate against a map that had already moved. And it
-is what lets `host_documents` be read **while `connections` is held** rather
-than snapshotted first: a `_self` candidate has no reverse-index check to fall
+is what lets `host_documents` be consulted **while `connections` is held**
+rather than snapshotted first: a `_self` candidate has no reverse-index check to fall
 back on, `HostDocSyncState` records neither connection generation nor handle
 identity, and a respawn can purge the entry and install a fresh `Ready` handle
 under the same `ConnectionKey` — so a released snapshot would let a connection
@@ -1145,10 +1152,11 @@ send re-acquires `connections` before enqueue, and translation takes each host's
 `edit_lock` across downstream close, change, and eager-spawn awaits, so a query
 arriving mid-processing would otherwise wait on unrelated work with no bound.
 
-- **Selection**: the tracker snapshot, then `connections` (under which the
-  validator also reads `host_documents` and the live reverse index) — three
-  seconds each. The budget covers *acquiring* each lock, not the filtering
-  between them — that walk is synchronous with no
+- **Selection**: the tracker snapshot, then `connections` — three seconds each.
+  Nothing else is *awaited*: under `connections` the validator queries the
+  reverse index synchronously and `host_documents` with `try_lock`, so there is
+  no third acquisition to budget and no await while a lock is held. The budget
+  covers *acquiring* each lock, not the filtering between them — that walk is synchronous with no
   await, so a timeout could not preempt it anyway, and bounding what cannot be
   interrupted would promise something the runtime does not deliver.
 - **Each send's pre-enqueue re-acquisition** of `connections`: three seconds,
@@ -1379,7 +1387,7 @@ Including it would defeat dedup on a field carrying no identity.
   user expecting an indexed whole-project search will find this surprising.
 - Latency is max-over-live-targets, and every *wait* is bounded: the pool's 30s
   request timeout and liveness timeout, a three-second budget on **every** lock
-  this path acquires (the tracker snapshot, `connections`, each send's
+  this path awaits (the tracker snapshot, `connections`, each send's
   re-acquisition, and each host's `edit_lock`), and the reopen barrier's two
   seconds. Total latency is not bounded, because the synchronous
   filtering between those waits cannot be preempted. Forwarded cancellation is
@@ -1401,9 +1409,14 @@ Including it would defeat dedup on a field carrying no identity.
   in methods that have no use for it.
 - A server still `Initializing` when the query arrives is skipped entirely, so
   a search in the seconds after opening a file can miss it (point 3).
-- Every lock this path takes — the tracker snapshot, `connections` (under which
-  `host_documents` and the reverse index are read), each send's re-acquisition,
-  each host's `edit_lock` — is bounded only in its **acquisition**, because other paths hold these across
+- `_self` targets are dropped when `host_documents` is contended at validation
+  time, since it is `try_lock`ed rather than awaited (point 3). Host-bridged
+  symbols can therefore be absent from one query for a reason the user cannot
+  see.
+- Every lock this path *awaits* — the tracker snapshot, `connections`, each
+  send's re-acquisition, each host's `edit_lock` — is bounded only in its
+  **acquisition** (`host_documents` is never awaited; it is `try_lock`ed under
+  `connections`, and contention drops that query's `_self` candidates), because other paths hold these across
   unbounded async work (point 6); the filtering between them is synchronous and
   cannot be preempted, so neither total selection time nor cancellation blocking
   is capped. Expiring either

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -523,12 +523,13 @@ arrives between request acceptance and subscription and delivers it on
 subscribe — but because selecting on it is what makes the handler abandon
 promptly rather than only at its next dispatch boundary.
 
-Fan-in cannot live in the `bridge` module: it reads the document store's
-resolved-region snapshots, which `lsp_impl` owns. So unlike every
-`transform_*_response_to_host` function — pure because the caller already handed
-it *the* offset — this translator selects a different region's geometry per
-entry and must sit where the `DocumentStore` / `LanguageCoordinator` /
-`BridgeCoordinator` handles are, as `ShowDocumentTranslator` does.
+Fan-in lives in `lsp_impl`. Not because it must — the store's snapshot
+accessor is `pub(crate)`, so a `bridge` module handed the store could call it —
+but because that is where the `DocumentStore` / `LanguageCoordinator` /
+`BridgeCoordinator` handles already sit together, as they do for
+`ShowDocumentTranslator`. Putting it in `bridge` would mean threading the store
+into a module whose job is wire protocol. This is a coupling choice, unlike the
+fan-out's placement in point 4, which is a real visibility constraint.
 
 The value crossing that boundary is **typed, not raw JSON**: the bridge module
 owns deserialization for every other bridged request, and this one keeps that
@@ -538,9 +539,12 @@ normalizing a `SymbolInformation[]` answer into the same shape. That works for
 range-less form rather than rejecting it, but it is not field-for-field:
 `SymbolInformation` carries a (itself deprecated) `deprecated: Option<bool>`
 that `WorkspaceSymbol` has no counterpart for, so the normalization must fold
-`Some(true)` into `tags` as `SymbolTag::DEPRECATED` or silently lose it. `lsp_impl` then classifies and
-translates typed values, and its classification is unit-testable as a pure
-function once the offset resolver is injected.
+`Some(true)` into `tags` as `SymbolTag::DEPRECATED` or silently lose it.
+
+`lsp_impl` then classifies and translates those typed values. Its classification
+is unit-testable as a pure function once the URI index and the per-host geometry
+map are injected — both are plain data, which is a side benefit of fan-in
+resolving nothing.
 
 ### 5. Fan-in: a global virtual→host translator
 
@@ -573,7 +577,7 @@ hand. "Its own offset" does not mean "its own resolution", though; see pass 3.
                ├── absent ───────▶ DROP  (retired region, or a real file in
                │                          the reserved virtual-URI namespace)
                ▼ (host_url, region_id, language)
-     look up region_id in that HOST's region map (pass 3, resolved once)
+     look up region_id in that HOST's geometry map (pass 3, read once)
                │
                ├── absent ───────▶ DROP  (region invalidated by edits, or
                │                          host document closed)
@@ -636,8 +640,8 @@ index** built once up front:
 1. Classify every entry against that index, **grouping entries by host**. No
    parse and no lock is involved, so nothing waits here.
 2. Ensure the distinct hosts that actually appear, **concurrently**.
-3. Resolve each host's regions **once**, then translate its entries against
-   that one resolution.
+3. Read each host's region geometry **once** from its snapshot, then translate
+   that host's entries against it.
 
 Pass 0 is built **late, and verified late**, because a single early snapshot
 is wrong in both directions across a collection phase that runs concurrently and
@@ -931,9 +935,9 @@ shrinks coverage with no signal to the user.
 
 Every other bridged navigation path filters out results addressed to a region
 other than the request's own, because a cross-region offset is unsafe when only
-one region's offset is known. Workspace symbol search resolves each result's
-region independently, so the offset is always the right one for the entry being
-translated.
+one region's offset is known. Workspace symbol search holds every region's
+geometry for the hosts it touches, so each entry is translated by its own
+region's offset rather than by a single borrowed one.
 
 Shipping this obliges edits in **both** user-facing docs, in three separate
 respects each. They are listed here because more than one review round found the

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -805,18 +805,29 @@ Two things about *when* and *per what* are load-bearing:
   later comparison sees B and agrees. Capturing first makes the recorded
   identity the one the request actually raced.
 
-  **Atomically with the enqueue**, moreover — not merely before it. The
-  revisions live behind their own Tokio mutex, so the snapshot is taken with
-  `try_lock` inside the same `connections` critical section that performs the
-  stale-handle check and the enqueue, never awaited beside it. Contention drops
-  that target, counted as a failure like any other.
+  **In the same `connections` critical section as the enqueue**, not merely
+  before it. The revisions live behind their own Tokio mutex, so the snapshot is
+  taken with `try_lock` inside the section that performs the stale-handle check
+  and the enqueue, never awaited beside it. Contention drops that target,
+  counted as a failure like any other.
 
-  Taking it *outside* that section would leave a gap: eager `didOpen` holds
-  `connections` while opening, so a virtual document can be opened between the
-  snapshot and the enqueue. The request would then see that document and the
-  late URI index would contain it, while the target's identity map would not —
-  and its symbols would be dropped, silently, for a document that was legitimately
-  open when the request ran. Capturing inside the section closes it.
+  This closes the `didOpen` gap: eager open holds `connections` while opening,
+  so taking the snapshot outside the section would let a virtual document be
+  opened between snapshot and enqueue — the request would see it and the late
+  URI index would contain it, while the target's identity map would not, and its
+  symbols would be dropped for a document legitimately open when the request
+  ran.
+
+  It does **not** make the pair atomic against `didChange`, and the ADR does not
+  claim it does. `didChange` releases `connections` *before* it increments the
+  revision, enqueues, and records the fingerprint, so an already-admitted change
+  can land in that window or expose an intermediate revision/fingerprint pair
+  that no snapshot matches. The checks fail safe — the entries are dropped, not
+  mistranslated — so this is a **false-negative window**, not a correctness
+  hole: symbols that were legitimately valid can go missing from one query while
+  a document is being edited. Closing it needs an enqueue-coupled identity
+  primitive or synchronization with the per-document transition state, and both
+  are changes to the bridge's write path rather than to this method.
 - **Per connection, not per URI.** Both tracker values are keyed by
   `ConnectionKey`, and one virtual URI can be open on several connections with
   different confirmed content. An identity snapshot is therefore taken per
@@ -950,9 +961,9 @@ acceptable". Calling it once per returned symbol destroys exactly that premise:
 an interactive endpoint returning thousands of symbols would pay
 `symbols × open_virtual_docs`, serialized through repeated acquisition of the
 tracker's async mutex. Snapshotting once makes it one scan plus O(1) per entry.
-It is a *separate* snapshot from the one point 3 takes to validate candidates —
-that one is taken at selection time under the `connections` lock and answers a
-different question.
+It is a *separate* snapshot from the one point 3 takes to enumerate candidates —
+that one is taken at selection time, before `connections` is acquired, and
+answers a different question.
 
 The index also becomes the **identity test**. `is_virtual_uri` is only a
 basename pattern — it accepts any URI ending in
@@ -1112,18 +1123,26 @@ re-check, or the enqueue fails. Counting only "dispatched targets that errored"
 would let a query whose every target died pre-dispatch report a confident empty
 answer, since zero dispatches looks the same as zero results.
 
+The unit is a **successfully processed answer**: a target that answered *and*
+whose entries fan-in could classify and translate. Anything short of that is
+"we could not find out", not "there is nothing".
+
 - Selection **completed** and found no candidates → `[]`. Nothing failed; there
   was nothing to ask.
-- **At least one** target answered → `[]` or its results, as they came. Partial
-  failure stays soft.
-- Candidates existed and **none answered** — for any reason, at any phase →
-  **request error**.
-- Selection **did not complete** and nothing answered → **request error**. Its
-  tracker or `connections` acquisition can expire, and `_self` discovery is
-  incomplete whenever `host_documents` was contended, so "no candidates" and
-  "we could not find out" are different states. Only the first may claim `[]`;
-  reporting the second as an empty search would be the same confident falsehood
-  as reporting an outage that way.
+- **At least one** successfully processed answer → its results, or `[]` if they
+  genuinely contained nothing. Partial failure stays soft.
+- Candidates existed and **no answer was successfully processed** — for any
+  reason, at any phase → **request error**.
+- Selection **did not complete** and nothing was processed → **request error**.
+
+The last two cases are why the unit is processing rather than response. Selection
+can expire its tracker or `connections` acquisition, and `_self` discovery is
+incomplete whenever `host_documents` was contended, so "no candidates" and "we
+could not find out" are different states. Just as importantly, a fan-in failure
+counts: if servers returned symbols and every entry was dropped because the
+late host→virtual snapshot or the identity re-read could not be acquired, the
+client would otherwise be told the search found nothing — the same confident
+falsehood as reporting an outage that way, arrived at from the other end.
 
 A downstream `null` is an answer, not a failure. The method's result type is
 `Option<WorkspaceSymbolResponse>` precisely because `null` is valid, so it
@@ -1233,7 +1252,8 @@ arriving mid-processing would otherwise wait on unrelated work with no bound.
   identity re-read — three seconds each. These come *after* every downstream
   response, so they are easy to overlook, and unbudgeted they would reintroduce
   an unbounded wait at the very end of the query. Expiry drops the affected
-  entries.
+  entries **and counts against the outcome rule** (point 5): entries lost to a
+  fan-in failure are not evidence that the search found nothing.
 - **Translation's `edit_lock`** per host: three seconds. A host whose lock
   cannot be taken in time loses that query's entries, exactly like a host whose
   geometry was stale.
@@ -1526,6 +1546,10 @@ Including it would defeat dedup on a field carrying no identity.
 - The content-identity check proves a `didChange` was *enqueued*, not delivered:
   notifications carry no acknowledgement and a failed write does not fail the
   connection. The stale-result window is narrowed, not closed (point 5).
+- It also has a false-negative window in the other direction: `didChange`
+  releases `connections` before bumping its revision and recording its
+  fingerprint, so a change landing beside a dispatch can expose a pair no
+  snapshot matches, and those symbols are dropped from that query (point 4).
 - `max_fan_out` does not bound this method's total fan-out. It selects names
   per pair, and a connection one pair excluded re-enters through another pair
   that legitimately opened it. Its documented promise to cap concurrent server

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -435,17 +435,32 @@ final barrier.** The order is fixed:
    it. This only *enumerates* candidates; every entry is re-validated in step 2
    before it can contribute.
 2. Hand the candidate set to a **pool-owned batch validator**, which takes
-   `connections` **once** and, without awaiting inside, per candidate: keeps
-   only `Ready` handles (`connections()` returns the raw map, and
-   `ConnectionState` also has `Initializing`, `Failed`, `Closing`, `Closed`).
-   A candidate dropped because its connection is `Failed`, `Closing`, or
-   `Closed` is recorded as an **infrastructure failure** (point 5) rather than
-   as an absent candidate — but only if policy would have admitted it; see
-   below;
-   drops handles lacking `workspace/symbol`; drops handles whose recorded launch
-   configuration no longer matches the `BridgeServerConfig` that admitted them;
-   and confirms current membership — the live reverse index for a virtual
-   candidate, `host_documents` for a `_self` one.
+   `connections` **once** and, without awaiting inside, per candidate — **in
+   this order**:
+
+   a. **Confirm the candidate is still current** — the live reverse index for a
+      virtual candidate, `host_documents` for a `_self` one, and in both cases
+      the stored connection generation matching the handle's. A candidate that
+      fails this is **stale, not failed**: it is discarded silently, before any
+      accounting.
+
+   b. Then keep only `Ready` handles (`connections()` returns the raw map, and
+      `ConnectionState` also has `Initializing`, `Failed`, `Closing`, `Closed`),
+      drop handles lacking `workspace/symbol`, and drop handles whose recorded
+      launch configuration no longer matches the `BridgeServerConfig` that
+      admitted them. A candidate dropped here because its connection is
+      `Failed`, `Closing`, or `Closed` is recorded as an **infrastructure
+      failure** (point 5) rather than as an absent candidate — but only if
+      policy would have admitted it; see below.
+
+   Step (a) must precede (b), and this is the subtle part. A purge removes the
+   document state and then installs a replacement under the **same**
+   `ConnectionKey`; if that replacement fails its handshake, a cloned snapshot
+   entry from before the purge resolves to a brand-new `Failed` handle with no
+   capabilities recorded. Accounting first would file that as an infrastructure
+   failure — reintroducing the "never initialized" case this decision withdrew
+   as unreachable, through a door the ordering closes. The stale entry never
+   named a live document on that connection, so it is not evidence of anything.
 
    The reverse index is a sharded map and answers synchronously. `host_documents`
    is a separate Tokio mutex, so it is taken with **`try_lock`**, never awaited:
@@ -544,7 +559,10 @@ than leaving a reader to wonder. A candidate exists only because a document was
 successfully opened on that connection, and both eager-open paths wait for
 `Ready` and bail on initialization failure *before* recording any document
 state. A handle that never completed its handshake is therefore named by no
-candidate at all — selection cannot see it, so it cannot classify it.
+candidate at all — selection cannot see it, so it cannot classify it. The one
+way it could have been seen is a stale snapshot entry resolving to a failed
+replacement under the same key, which step 2(a) discards before any accounting
+runs.
 
 The consequence is a real one and belongs to point 9's first blocker rather than
 to this rule: a workspace whose servers **all failed to start** answers `[]`,

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -302,14 +302,8 @@ selected it always merges B, and with `priorities` naming only A there is no B
 to fall back to. So a user gets *either* B's duplicates always, *or* no backup;
 not "A normally, B when A has nothing".
 
-It is also implementable, and the ADR should not pretend otherwise. The
-attribution argument in point 2 is about *symbols* — no entry can be traced to a
-configured pair — but a whole *response* is plainly attributable to the
-connection that produced it, and this design already carries that key through
-fan-in. `preferred` over connections could be built.
-
 The trade is accepted as **uniformity**, not because fallback-on-empty is
-invalid or unbuildable. It would be easy to over-argue this, so: an empty answer from A
+invalid. It would be easy to over-argue this, so: an empty answer from A
 establishes only that A's index has no match, and says nothing about B's — which
 is exactly why `union` returns B's matches when A is empty, and why treating
 empty as a reason to consult B is a defensible policy rather than a semantic
@@ -345,21 +339,15 @@ configuration would contribute **no candidates at all**. Treating `_` instead as
 `bridge.python.enabled = false` or `priorities = []` excluded, and union has no
 way to subtract that contribution.
 
-Both axes therefore come from **admission records** — the concrete pairs that
-justified opening a document on a connection, retained per connection and
-keyed by `ConnectionKey` (point 7). A record is written when a document is
-opened:
+Both axes therefore come from **what is actually open**, which is also the set
+the live-only rule already commits to:
 
-- **Host language**: taken from the host document at open time
+- **Host languages**: the languages of the currently open documents
   (`DocumentStore::open_uris()` + language detection). Concrete by
-  construction — never a map key.
-- **Injection language**: `VirtualDocumentUri::language()` for a virtual
-  document, or `_self` for a host-tier open.
-
-Reading admission records keeps both the tracker and `host_documents` off the
-query path **entirely** — validation as much as discovery. Consulting either
-during validation would undo the point, since a candidate would disappear again
-the moment its document closed.
+  construction — it never comes from a map key.
+- **Injection languages**: the languages of the currently **open virtual
+  documents**, read from `VirtualDocumentUri::language()` on the pool's tracked
+  `OpenedVirtualDoc` entries, plus `_self` for the host tier.
 
 Deriving the injection axis from configuration instead — concrete bridge keys
 plus the languages servers declare — looks equivalent and is not. It loses every
@@ -372,10 +360,9 @@ the region's actual `"python"` and lets `handles_language` recognize `"*"`.
 Starting from open virtual documents restores exactly that: the language is the
 region's real one.
 
-`OpenedVirtualDoc` carries the `connection_key` the document was opened on,
-which is what a record captures at open time — the pair and the exact
-connection, together, from one event, rather than a cross product of two axes
-read at different moments.
+`OpenedVirtualDoc` also carries the `connection_key` the document was opened on,
+so the walk can pair each open virtual document with its host document's
+language directly rather than taking a cross product of the two axes.
 
 `_self` needs its **own** source. Host-bridge opens are not `OpenedVirtualDoc`s
 — they live in the pool's `host_documents`, keyed by `(uri, ConnectionKey)` — so
@@ -383,23 +370,43 @@ a host-only document can have a perfectly valid `_self` connection that no
 virtual document names. Deriving `_self` targets from virtual documents would
 therefore either omit host bridging entirely or fall back to expanding a server
 name across roots, recreating the leak point 3 exists to prevent. The
-`(host_language, _self, ConnectionKey)` admission records are therefore written
-at host-open time from `host_documents`' own key, alongside the virtual ones.
+`(host_language, _self, ConnectionKey)` triples come from `host_documents`
+directly.
 
-`host_documents` is read only at *open* time, to write that record — never
-during a query, which is why selection takes `connections` alone.
+That is a second async map, read **under** `connections` by the batch validator
+below rather than snapshotted separately, so selection's acquisitions are the
+tracker snapshot and then `connections`, each falling under point 6's budget —
+not the "one acquisition then synchronous work" shape an earlier draft assumed.
 
-Both fields of a record are captured at open time, from the same event, so the
-lifetime-join problem an earlier draft had does not arise: there is no later
-read to disagree with. A `didClose` followed by a reopen under a different
-language simply writes a second record; the first stays until its key does, and
-names a pair the connection genuinely served.
+The two snapshots also have to be **joined safely**. Host language comes from
+the document store, while the exact keys come from pool tracking read later, and
+neither `OpenedVirtualDoc` nor the host-document sync state records the host
+language or its incarnation. A close/reopen — or a language change — between the
+two reads would therefore apply the *new* lifetime's policy to the *old*
+lifetime's downstream opens: precisely the policy-boundary leak this point
+exists to prevent, in transient form. So before a pair contributes, the host
+document's current language and incarnation are re-read and must match what the
+walk assumed; a mismatch drops that pair's contribution rather than guessing
+which lifetime it belonged to.
 
-A record is written **once the `didOpen` is confirmed enqueued**, not when it is
-merely intended. The tracker's own `register_pending_document` /
-`mark_open_sent` split exists for exactly that distinction, and a record written
-on the pending half would claim an admission the downstream may never have
-received.
+An entry must be **validated before it contributes**, because the tracker's
+host→virtual map is not an "already open downstream" set: `register_pending_document`
+inserts an entry to own its close-cleanup *before* `didOpen` reaches the writer
+FIFO, and only `mark_open_sent` promotes it into the live reverse index. A
+cloned entry can also outlive a connection purge. Taken at face value, the walk
+would derive a pair from a `didOpen` the downstream has not seen, or from a
+replaced connection whose documents were never replayed.
+
+The save path already establishes the discipline this needs, and the ordering
+below follows it: snapshot the tracker, then take `connections` **once** and
+hold it across the checks with no `.await` inside, require the handle to be the
+current `Ready` one, and only then consult `is_virtual_doc_open_on_connection`. Holding `connections` is what makes it
+sound — a reverse-index check alone would not, since a purge could swap in a
+fresh `Ready` handle that never opened the document. The lock order is
+`connections` → tracker, matching the respawn purge. This composes with the
+stale-handle re-check the send already performs (point 4): the enqueue is
+non-blocking, so both happen under the same lock and only the response is
+awaited outside it.
 
 Candidates for each `(host, injection)` pair then come from the **existing
 routing entry point**, `get_all_configs_for_language`, rather than from a
@@ -418,71 +425,51 @@ existing configuration from becoming a silent no-op here.
 **No candidate is waited for; the only waits are lock acquisitions and the
 final barrier.** The order is fixed:
 
-0. If the method is **disabled** — `workspaceSymbolMaxFanOut = 0` — return `[]`
-   immediately, before any lock is taken. "Disable entirely" has to mean that
-   literally: applying zero at the end would make a disabled method still walk
-   admissions, take `connections`, and wait on barriers, any of which can expire
-   and turn a deliberate disable into a request error.
-
-1. **Read the admission records** — `ConnectionKey → the pairs it serves`. This
-   is the *whole* of discovery. Nothing here consults the document tracker,
-   which is the point: `didClose` removes tracking while leaving the connection
-   open, so any discovery that went through the tracker would lose that
-   connection the moment its last document closed, and supplementing the records
-   with a tracker check would reintroduce exactly the defect they exist to fix.
+1. **Snapshot the tracker's host→virtual map** under its own lock and release
+   it. This only *enumerates* candidates; every entry is re-validated in step 2
+   before it can contribute.
 2. Hand the candidate set to a **pool-owned batch validator**, which takes
    `connections` **once** and, without awaiting inside, per candidate: keeps
    only `Ready` handles (`connections()` returns the raw map, and
    `ConnectionState` also has `Initializing`, `Failed`, `Closing`, `Closed`);
-   drops handles lacking `workspace/symbol`; and drops handles whose recorded
-   launch configuration no longer matches the `BridgeServerConfig` that admitted
-   them.
+   drops handles lacking `workspace/symbol`; drops handles whose recorded launch
+   configuration no longer matches the `BridgeServerConfig` that admitted them;
+   and confirms current membership — the live reverse index for a virtual
+   candidate, `host_documents` for a `_self` one.
 
-   These are the only checks, and they are all about the **connection**, not
-   about any document. Whether a document is currently open on it is
-   deliberately not asked — that is what step 1 stopped depending on. Whether
-   its documents have been *replayed* after a respawn is asked, but later and
-   differently, by the barrier in step 5.
+   The reverse index is a sharded map and answers synchronously. `host_documents`
+   is a separate Tokio mutex, so it is taken with **`try_lock`**, never awaited:
+   on contention the `_self` candidates are dropped for that query and the
+   virtual ones are unaffected. Awaiting it while holding `connections` would
+   make this path exactly the kind of unbounded holder that forced every budget
+   in point 6, and there is no version of "briefly" that is safe there.
 3. Apply the per-pair `priorities` allowlist and `max_fan_out` cap to the
    survivors — pure computation, after the lock is released.
 4. Dedup by **connection key** `(server, root)`.
-5. Await `wait_for_pending_reopen` for the survivors, **concurrently**, dropping
-   any whose barrier fails.
-6. Apply `workspaceSymbolMaxFanOut` to what is left, then send.
-
-The ceiling comes **after** the barrier, not before, because a cap allocated to
-connections that then fail their barrier wastes its slots: with a ceiling of one
-and a first-ordered connection whose repair fails, the healthy connections below
-it would already have been truncated away and the query would error despite
-having had a sendable target.
-
-For the same reason each candidate's handle is **re-checked as its slot is
-assigned**, not only when it was validated. The barrier is keyed by
-`ConnectionKey`, not by handle identity, so a connection can pass its barrier
-and be replaced before the cap runs — consuming a slot and then failing the
-stale-handle check at enqueue, after the healthy connections below it were
-truncated. Re-checking at assignment keeps the cap spent on connections that
-still exist, which is what makes a backfill rule unnecessary rather than merely
-unstated. A candidate that fails it is dropped and the slot goes to the next in
-order.
+5. Await `wait_for_pending_reopen` for the survivors, **concurrently**, then
+   send.
 
 The validator is **pool-owned** for two reasons. It is the only way to do all of
 this under one acquisition — `launch_config` and its comparator are private to
 the pool, and the exposed comparison helper takes `connections` itself, so a
 caller in `bridge/workspace/symbol.rs` doing these checks piecemeal would
-re-lock between them and validate against a map that had already moved.
+re-lock between them and validate against a map that had already moved. And it
+is what lets `host_documents` be consulted **while `connections` is held**
+rather than snapshotted first: a `_self` candidate has no reverse-index check to fall
+back on, `HostDocSyncState` records neither connection generation nor handle
+identity, and a respawn can purge the entry and install a fresh `Ready` handle
+under the same `ConnectionKey` — so a released snapshot would let a connection
+that never opened the host document pass every other check. The language and
+incarnation recheck does not catch that, because the host lifetime never
+changed; only the connection did.
 
-It also takes only **one** lock. Because discovery reads admission records and
-validation asks only about connections, neither `host_documents` nor the
-tracker is on this path at all — which removes the lock-ordering question that
-earlier drafts kept getting wrong, and with it the `try_lock` policy that made
-`_self` coverage depend on whether host synchronization happened to hold its
-mutex.
+The resulting order is `connections` → {tracker, `host_documents`}, which is the
+pool's own nesting and the one the respawn purge takes.
 
 Every filter in step 2 precedes the cap in step 3, and that ordering is
 load-bearing for each of them: with `priorities = [A, B]` and
-`max_fan_out = 1`, an A that is incapable or stale-configured would otherwise
-take the only slot and then be dropped,
+`max_fan_out = 1`, an A that is incapable, stale-configured, or no longer
+holding its documents would otherwise take the only slot and then be dropped,
 leaving the query to consult nobody. Filtering on what is already knowable
 before allocating slots costs nothing and removes all three cases at once.
 
@@ -490,12 +477,14 @@ Step 5 exists because a connection reaches `Ready` *before* its virtual
 documents are replayed after a respawn, so a query landing in that window would
 under-report that server's embedded symbols indistinguishably from "no matches".
 
-It closes that window because admission records survive the purge. A selection
-that went through the tracker could not: the purge removes exactly the records
-such a selection depends on, so a query arriving between the purge and the first
-replayed `didOpen` would have found no candidate and never reached the barrier
-at all. Keyed by `ConnectionKey`, the admission stays, the target stays
-discoverable, and the barrier is what decides whether it is ready to answer.
+It closes **part** of that window, not all of it. Selection admits a candidate
+only if the tracker still records the document on that connection, and a respawn
+purge removes exactly those records — so a query arriving between the purge and
+the first replayed `didOpen` discovers no candidate at all and never reaches the
+barrier. The barrier helps once a target is discoverable but not yet replayed;
+before that, the connection is invisible to selection. Both halves have the same
+root cause and the same fix — retaining a connection's admitting policy
+independently of document tracking (point 7) — so neither is patched here.
 The barrier is **bounded to two seconds** and enforced with a timeout, and
 awaiting the survivors concurrently costs that bound once for the whole query —
 not once per target.
@@ -599,9 +588,9 @@ Within a pair it works as everywhere else: `truncate_entries` truncates a
 flattened name list in walk order, keeping the highest-priority N names.
 
 A surviving name admits **only the connections that pair actually opened**, not
-every live connection of that server. Each admission record pairs a language
-pair with the exact `ConnectionKey` it was opened on, so a pair's targets are
-known and never derived by expanding a name across roots. That distinction is
+every live connection of that server. The tracker records each open virtual
+document's `ConnectionKey` next to its language, so a pair's targets are known
+exactly and never derived by expanding a name across roots. That distinction is
 load-bearing: expanding would let a Python pair that admits A reach `A/root2`
 even when the pair that actually opened A on root2 excluded it with
 `priorities = []` — turning `priorities` from a policy boundary into a hint, and
@@ -615,62 +604,33 @@ request, contradicting the setting's documented promise to "cap the number of
 concurrent server requests" — a generic load control quietly losing its
 load-controlling property in exactly the method most able to fan out.
 
+A second, global cap after dedup was tried and **rejected**. It cannot be given
+coherent semantics:
+
+- An uncapped pair must mean "no limit" — that is what `None` means everywhere
+  else — so any workspace containing one uncapped pair has no global cap at all.
+  Since uncapped is the default, the cap would be inert in almost every real
+  configuration, and present only where a user capped *something*, throttling
+  languages they never mentioned.
+- It has no principled victim order. `priorities` exists per pair and pairs may
+  rank the same server differently; merging those rankings is exactly what this
+  decision rejects elsewhere as unprincipled. Falling back to walk order is
+  worse than arbitrary — open documents and connections live in hash maps, so
+  which connections survived would vary run to run.
+
 So `max_fan_out` stays a **per-pair name-selection rule** here and bounds
-neither the query's requests nor its connections — a real divergence from its
-documented promise to "cap the number of concurrent server requests", which the
-setting's description must record (point 8).
-
-Deriving a global cap from the per-pair values was tried and **rejected**: an
-uncapped pair must mean "no limit", so any workspace containing one has no
-global cap at all — and uncapped is the default, making such a cap inert in
-almost every real configuration and active only where a user capped something
-unrelated. It also has no principled victim order, since pairs may rank the same
-server differently and merging those rankings is what this decision rejects
-elsewhere.
-
-What ships instead is a **separate top-level ceiling**, `workspaceSymbolMaxFanOut`.
-Leaving the query unbounded was the alternative, and it is not acceptable for
-the widest fan-out kakehashi has: documentation cannot restore a guarantee the
-code stopped providing.
-
-It is a single value, which is what makes it definable where a derived global
-cap was not: there is no "uncapped pair means infinity" to reconcile and no
-per-pair priority list to merge.
-
-As a configuration surface it is `workspaceSymbolMaxFanOut`, a top-level
-`Option<i64>` alongside the existing top-level settings, mirroring
-`max_fan_out`'s value conventions so users meet no new ones: `0` = disable the
-method entirely, positive = cap, negative = treated as no limit, **absent =
-inherit, defaulting to no limit**.
-
-"Absent" is deliberately not spelled "`null` clears it". Scalar layers merge
-with `overlay.or(base)`, and serde collapses an absent key and an explicit
-`null` to the same `None`, so a higher layer writing `null` would inherit a
-lower layer's cap rather than remove it. Rather than introduce a presence-aware
-`Option<Option<i64>>` for one setting, `null` is documented as inheritance —
-matching what the merge actually does. Clearing a cap means setting it to a
-negative value.
-
-Adding a top-level key is more than a struct field. It needs the raw/resolved
-field pair, the layered-merge entry, the default, the schema, the user
-documentation — **and registration in `KNOWN_WORKSPACE_SETTING_KEYS`**, which is
-the one an implementer is most likely to miss: `didChangeConfiguration` rejects
-an update containing an unregistered top-level key *before* deserialization, so
-without it the setting would work from a config file and be rejected on live
-reload.
-
-It applies **after dedup and after the reopen barrier**, to the connections that
-are actually sendable, and truncates in a **stable documented order** rather
-than by priority — per-pair priorities conflict, and
-walk order varies run to run. The order is `(server name, root discriminator,
-root path)`: the discriminator is required because `ClientFallback` and `Shared`
-both report no marker root and can coexist for one server, so comparing only the
-name and the marker path leaves them tied and the tie falls back to hash
-iteration order — the nondeterminism this ordering exists to remove.
+neither the query's requests nor its connections. That is a real divergence from
+its documented promise to "cap the number of concurrent server requests", and
+the fix is documentation, not a mechanism: the setting's description must say so
+(point 8). What actually bounds the total is the live-connection set (point 7).
+A workspace-level ceiling belongs in a separate setting with its own name and
+semantics rather than smuggled into this one, and is listed as deferred work in
+point 9 rather than left as a vague possibility — this method is the widest
+fan-out kakehashi has, and it is the one the existing guard does not bound.
 
 ```
-  admission records, keyed by ConnectionKey   ← concrete languages only,
-        │  (outlive didClose and respawn)        no arbitration
+  open host docs × their open virtual docs    ← concrete languages only,
+        │  (never a raw `_` map key)             no arbitration
         ▼
   ┌──────────────────────┐   ┌──────────────────────┐
   │ (LANG_1, _self)      │   │ (LANG_2, _self)      │  ... every pair
@@ -682,8 +642,8 @@ iteration order — the nondeterminism this ordering exists to remove.
         │ SELECTION (3s per AWAITED lock, §6)  │
         │ pool-owned batch validator, one lock:│
         │ Ready only, drop incapable, drop     │
-        │ stale-config. No document check —    │
-        │ that is what admissions replaced.    │
+        │ stale-config, confirm still open on  │
+        │ that exact connection                │
         │ then: allowlist + per-pair maxFanOut │
         │ NEVER spawns a connection            │
         └──────────────────┬───────────────────┘
@@ -693,12 +653,11 @@ iteration order — the nondeterminism this ordering exists to remove.
         │   each pair admits ONLY the conns it │
         │   actually opened — never a name     │
         │   expanded across roots              │
+        │ (no global cap — see §3)             │
         └──────────────────┬───────────────────┘
                            ▼
               await the 2s reopen barrier concurrently,
               dropping targets whose repair failed,
-              THEN workspaceSymbolMaxFanOut in
-              (name, root-kind, root) order,
               then send to each survivor (§4),
               then per-entry fan-in (§5),
               then UNION → dedup → sort (§1)
@@ -1193,10 +1152,8 @@ contended host must not turn an answer whose other entries translated fine into
 a request error, so poisoning is decided per entry and rolled up, never per
 response.
 
-- Selection **completed** and found no candidates, or the method is **disabled**
-  (`workspaceSymbolMaxFanOut = 0`, or every pair's `priorities` is `[]`) → `[]`.
-  Nothing failed; there was nothing to ask, or the user asked for nothing. A
-  deliberate disable must not surface as an error.
+- Selection **completed** and found no candidates → `[]`. Nothing failed; there
+  was nothing to ask.
 - **At least one informative** answer → its results, or `[]` if they genuinely
   contained nothing. Partial failure stays soft.
 - Candidates existed and **no answer was informative** — for any reason, at any
@@ -1205,8 +1162,9 @@ response.
   error**.
 
 The last two cases are why the unit is the entry rather than the response.
-Selection can expire its `connections` acquisition, so "no candidates" and "we
-could not find out" are different states. And a fan-in
+Selection can expire its tracker or `connections` acquisition, and `_self`
+discovery is incomplete whenever `host_documents` was contended, so "no
+candidates" and "we could not find out" are different states. And a fan-in
 failure counts: if servers returned symbols and every entry was lost to a lock
 that could not be acquired or a parse that had not settled, the client would
 otherwise be told the search found nothing — the same confident falsehood as
@@ -1295,20 +1253,19 @@ already been spent.
 
 The rule is uniform: **every lock this path *awaits* carries a three-second
 budget, and failing to acquire it drops the affected target or host** rather
-than blocking the query. That is more than one acquisition — each send
-re-acquires `connections` before enqueue, fan-in reads the tracker twice, and
-translation takes each host's `edit_lock`. (`host_documents` is not
-in that list at all: selection no longer consults it, since `_self` candidates
-come from admission records instead — see point 3 for why `try_lock`ing it was
-abandoned.) None of these is safe to assume fast: injection
-processing holds
+than blocking the query. That is more than the `connections` mutex — selection
+also awaits the tracker snapshot, each send re-acquires `connections` before
+enqueue, and translation takes each host's `edit_lock`. (`host_documents` is not
+in that list: it is `try_lock`ed under `connections` and never awaited, so
+contention drops the `_self` candidates immediately rather than consuming a
+budget.) None of these is safe to assume fast: injection processing holds
 `edit_lock` across downstream close, change, and eager-spawn awaits, so a query
 arriving mid-processing would otherwise wait on unrelated work with no bound.
 
-- **Selection**: `connections` — three seconds. That is the only lock selection
-  takes: discovery reads admission records and validation asks only about
-  connections, so there is no tracker or `host_documents` acquisition to budget
-  and no await while a lock is held. The budget
+- **Selection**: the tracker snapshot, then `connections` — three seconds each.
+  Nothing else is *awaited*: under `connections` the validator queries the
+  reverse index synchronously and `host_documents` with `try_lock`, so there is
+  no third acquisition to budget and no await while a lock is held. The budget
   covers *acquiring* each lock, not the filtering between them — that walk is synchronous with no
   await, so a timeout could not preempt it anyway, and bounding what cannot be
   interrupted would promise something the runtime does not deliver.
@@ -1346,86 +1303,22 @@ requests.
 A candidate with no live connection is **skipped**, not spawned. Coverage is
 therefore bounded by what the client has opened, and grows as it opens more.
 
-Stated precisely, it is **every live connection some open document once
-justified** — not "every running server", and not "servers with a document open
-right now". The middle reading is the one that matters: `didClose` removes
-kakehashi's document tracking but deliberately leaves the downstream connection
-running, and whether that server keeps a usable workspace index afterwards is
-server-specific. Selecting on live documents would therefore make closing the
-last buffer for a language silently drop a `Ready`, possibly well-indexed server
-— so selection uses retained admission records instead (point 3).
+Stated precisely, it is **the servers currently holding an open document for
+this workspace** — not "every running server". The two differ, and the gap is
+user-visible: `didClose` removes kakehashi's document tracking but deliberately
+leaves the downstream connection running, so closing the last buffer for a
+language drops that server from selection even though it is still `Ready`. What
+that costs depends on the server: whether a downstream retains a usable
+workspace index after `didClose` is server-specific and not something kakehashi
+can know. Where it does, a query that would have been answered comes back
+empty — and if that server was the only one selected, the whole search does,
+with no failure anywhere.
 
-This is **not** deferred, because a provider that quietly stops answering when
-you close a buffer is not a workspace search. The pool retains an **admission
-record** keyed by **`ConnectionKey`** — the concrete
-`(host_language, injection_language_or__self)` pairs that have justified opening
-a document on that `(server, root)` — written when a document is opened and
-removed only when the key itself goes away. Candidates come from these records
-instead of from live document tracking, and the tracker is consulted only for
-things that genuinely are about documents.
-
-Keying on `ConnectionKey` rather than on a handle is what makes them survive a
-`didClose`, which does not touch them, and a **failure respawn**, where the
-replacement serves the same `(server, root)` under the same configuration and
-so is admitted by the pairs that admitted its predecessor. That is not stale
-inheritance but the correct answer, and an earlier draft's generation stamp —
-added to prevent exactly that inheritance — was solving a problem that does not
-exist. The reopen barrier, not a generation check, handles a replacement whose
-documents are not yet replayed.
-
-Survival must be **reason-aware**, though, because the pool removes the same key
-for three different reasons and only one of them preserves meaning:
-
-- **Failure respawn** — the process died and is being replaced with an
-  equivalent one. Records survive; this is the case the whole mechanism exists
-  for.
-- **Configuration change or removal** — the server's spawn-time config changed,
-  or it left the config entirely. Records are **cleared**: the pairs that
-  admitted the old executable say nothing about a differently-configured one.
-- **Client workspace invalidation under `ClientFallback`** — that key is reused
-  across workspaces, so retaining records would transfer one workspace's
-  admissions into another. **Cleared** *when the connection is torn down*.
-
-Clearing on every removal would break respawn survival; retaining on every
-removal would leak admissions into a reconfigured server or a different
-workspace. Neither is safe, so the removal reason has to reach the records.
-
-Two edges follow from that, and both cut against a naive "clear on workspace
-change":
-
-- A client root change **keeps** a `Ready` fallback connection that supports
-  workspace-folder changes — it is updated dynamically, not replaced. Clearing
-  its admissions would make its already-open documents undiscoverable with no
-  replay to rebuild them. So a same-handle dynamic update **retains** its
-  records; only a teardown clears.
-- A failure respawn **removes the old connection before it knows whether a
-  replacement will start**, and a spawn can fail. A preserved record can
-  therefore be orphaned — no live connection under its key — and settings
-  propagation discovers changed or removed servers by iterating *live*
-  connections, so an orphan would evade invalidation and later admit a
-  differently-configured process under the reused key. Configuration and
-  workspace invalidation must therefore sweep the **admission registry itself**,
-  not only the connections map.
-
-One case is **accepted rather than solved**: marker-root migration. Routing
-re-walks filesystem markers on every acquisition, so adding or removing a marker
-moves a document to a different `ConnectionKey` while the old connection keeps
-running. Its admission survives its documents and keeps that obsolete root
-queryable, which can return stale or duplicate symbols until the connection
-ends. Evicting on migration would mean detecting it, and routing does not report
-it; the duplicates are visible and the staleness is bounded by the old process's
-own index, so this is recorded rather than mechanised.
-
-The records stay concrete because each was created from a real open document
-(point 3's requirement).
-
-Their size is bounded by **distinct `(host_language, injection_language)` pairs
-per key**, not by session history. That is small for ordinary configurations,
-but it is not closed: a `languages = ["*"]` server admits any injection language
-a document happens to contain, so a long-lived connection in a polyglot
-workspace accumulates one entry per language ever seen on it. Entries are
-`(String, String)`; the growth is real but slow, and capping it would trade a
-bounded leak for silently forgetting a language the user still has open.
+That follows from deriving the candidate axes from open documents, which is what
+makes them concrete (point 3) — the alternative derivations lose `_` handling or
+`["*"]` servers entirely. Closing it properly means letting a connection outlive
+the document that justified it — a change to what the pool remembers rather than
+to this method. Point 9 records it as a blocker, not a follow-up.
 
 This is not merely a cost trade. Cold-starting cannot deliver the coverage it
 appears to promise:
@@ -1510,7 +1403,30 @@ omission — but the universal sentence must be corrected.
 the closed-set list above too: it will schema-accept an inert `union` while
 documenting only two values.
 
-### 9. Deferred in this decision
+### 9. Two gaps that must be closed before this ships
+
+These are **not** accepted limitations. Both were argued through in review and
+both survive as real defects of the design above; what this decision does *not*
+do is specify their mechanisms, for a reason given in Considered Options.
+
+- **Closing the last buffer for a language removes its server from search.**
+  Candidates are derived from open documents, but `didClose` removes kakehashi's
+  document tracking while deliberately leaving the downstream connection
+  running — so a `Ready` server that may still hold a usable real-file index
+  stops being asked, and if it was the only one selected the search goes empty
+  with no failure anywhere. The respawn purge window is the same defect seen
+  twice: a purged connection is invisible to selection until its documents are
+  replayed. A workspace search that silently narrows when you close a file is
+  not one; whatever mechanism is chosen, this must behave correctly at ship.
+- **`max_fan_out` does not bound this query.** It selects server *names* per
+  pair, one name reaches every root it is live on, and a connection one pair
+  excluded re-enters through another — so `max_fan_out = 1` can issue many
+  concurrent requests, against a setting documented as capping exactly that.
+  This is the widest fan-out kakehashi has and the one its only load control
+  stops bounding. Documentation cannot repair a guarantee the code stopped
+  providing.
+
+### 10. Deferred in this decision
 
 - `workspaceSymbol/resolve` — `resolveProvider` is advertised as `false`. Because
   kakehashi keeps `resolveSupport` absent from the `workspace.symbol` capability
@@ -1521,6 +1437,12 @@ documenting only two values.
   `workspaceSymbolProvider`. The existing client-progress aggregator is keyed by
   region and has no meaning for a request that has no region. Both tokens are
   optional in LSP 3.18.
+- **A request-wide fan-out ceiling.** `max_fan_out` bounds a pair's name
+  selection, not the query (point 3), so nothing caps how many connections one
+  query touches except how many are live. That is a real gap in a generic load
+  control, and this is the method most able to expose it. The fix is a
+  separately named workspace-level limit — a new user-facing setting, which is
+  why it is deferred rather than decided here.
 - **Request coalescing.** A symbol picker typically fires one request per
   keystroke, and this design has no single-flight, debounce, or supersession —
   each keystroke fans out to every live connection. The repo has prior art for
@@ -1588,6 +1510,25 @@ and several `max_fan_out` caps, with no principled merge. Under `union` the
 question dissolves — each pair contributes candidates independently, and the
 result set is order-free.
 
+**Specify the two shipping blockers' mechanisms in this ADR.** Attempted and
+abandoned. Point 9's gaps were pursued concretely — a pool-held admission
+registry keyed by `ConnectionKey` to outlive `didClose` and the respawn purge,
+and a new top-level `workspaceSymbolMaxFanOut` to restore the ceiling. Both are
+plausible directions and may well be the right ones. But specifying them here
+did not work: across four review rounds the findings against them grew rather
+than shrank (4 → 5 → 7 → 8), and nearly every new finding was an edge of those
+two mechanisms rather than of the design they were added to — invalidation that
+must distinguish a failure respawn from a reconfiguration, snapshots that can
+outlive the invalidation that cleared them, cap slots spent on connections that
+are replaced before enqueue, an early-return the disable case needs, a total
+order the truncation needs.
+
+Every one of those is a question about *runtime behaviour under concurrent
+lifecycle events*, which is the class of question a document cannot settle and a
+test can. Continuing would have kept trading a stated gap for an unvalidatable
+mechanism. So this decision names the gaps as blockers and leaves their design
+to the change that implements them, where each answer is checkable.
+
 **Honour an explicitly configured `preferred` instead of overriding it.**
 Rejected: overriding explicit configuration is a real cost, but silently losing
 symbols the user did not know they were excluding is worse, and the override is
@@ -1623,13 +1564,16 @@ Including it would defeat dedup on a field carrying no identity.
 ### Negative
 
 - Results depend on what is open, and coverage can shrink (close, respawn,
-  silent connection death). Closing a buffer no longer removes its server —
-  admission records outlive `didClose` and the respawn purge (point 3) — but the
-  same query still answers differently at different points in a session. LSP permits partial `workspace/symbol` results, but a
+  silent connection death). Closing the last buffer for a language removes its
+  server from search even though the process is still running and may still be
+  usefully indexed — the sharpest form of this, and a follow-up rather than a
+  fix here (point 7). The respawn window has the same cause: a purged
+  connection is invisible to selection until its documents are replayed. The same query answers differently at different
+  points in a session. LSP permits partial `workspace/symbol` results, but a
   user expecting an indexed whole-project search will find this surprising.
 - Latency is max-over-live-targets, and every *wait* is bounded: the pool's 30s
   request timeout and liveness timeout, a three-second budget on **every** lock
-  this path awaits (selection's `connections`, each send's
+  this path awaits (the candidate tracker snapshot, `connections`, each send's
   `connections` re-acquisition, the pass-0 host→virtual snapshot, the
   translation-time identity re-read, and each host's `edit_lock`), and the
   reopen barrier's two seconds. Total latency is not bounded, because the synchronous
@@ -1646,25 +1590,21 @@ Including it would defeat dedup on a field carrying no identity.
   one query (point 5). This is the one accepted failure here that is not
   self-correcting, and it has no signal to the user.
 - `max_fan_out` no longer bounds a query's total fan-out — only each pair's
-  contribution. `workspaceSymbolMaxFanOut` is what bounds the query.
+  contribution — so nothing bounds how many connections one query touches. This
+  is a **shipping blocker**, not an accepted cost (point 9).
 - Adding the `Union` variant forces a `Union` arm at 7 exhaustive `match` sites
   in methods that have no use for it.
 - A server still `Initializing` when the query arrives is skipped entirely, so
   a search in the seconds after opening a file can miss it (point 3).
-- Admission records add per-`ConnectionKey` state the pool must maintain, and it
-  must be swept by configuration and workspace invalidation independently of the
-  connections map. It is bounded by distinct `(host_language, injection_language)`
-  pairs per key rather than by session history, but not closed: a
-  `languages = ["*"]` connection in a polyglot workspace gains an entry per
-  language ever seen on it (point 3).
-- After a marker-root migration the old connection stays queryable at its
-  obsolete root until it ends, so a query can see stale or duplicated symbols
-  from a root the document no longer belongs to (point 3).
-- Every lock this path *awaits* — selection's `connections`, each send's
-  re-acquisition, the two fan-in tracker reads, each host's `edit_lock` — is
-  bounded only in its **acquisition** (the per-send identity
-  snapshot is `try_lock`ed under `connections` rather than awaited, and
-  contention drops that target), because
+- `_self` targets are dropped when `host_documents` is contended at validation
+  time, since it is `try_lock`ed rather than awaited (point 3). Host-bridged
+  symbols can therefore be absent from one query for a reason the user cannot
+  see.
+- Every lock this path *awaits* — the candidate tracker snapshot, `connections`,
+  each send's re-acquisition, the two fan-in tracker reads, each host's
+  `edit_lock` — is bounded only in its **acquisition** (`host_documents` and the
+  per-send identity snapshot are never awaited; they are `try_lock`ed under
+  `connections`, and contention drops the affected candidates), because
   other paths hold these across unbounded async work (point 6); the filtering
   between them is synchronous and cannot be preempted, so neither total
   selection time nor cancellation blocking is capped. Expiring any of those
@@ -1678,17 +1618,15 @@ Including it would defeat dedup on a field carrying no identity.
   releases `connections` before bumping its revision and recording its
   fingerprint, so a change landing beside a dispatch can expose a pair no
   snapshot matches, and those symbols are dropped from that query (point 4).
-- `max_fan_out` does not bound this method's total fan-out on its own — it
-  selects names per pair, and a connection one pair excluded re-enters through
-  another. `workspaceSymbolMaxFanOut` bounds the query instead, at the cost of
-  one more user-facing setting to learn, document, merge, and schema (point 3).
+- `max_fan_out` does not bound this method's total fan-out. It selects names
+  per pair, and a connection one pair excluded re-enters through another pair
+  that legitimately opened it. Its documented promise to cap concurrent server
+  requests does not hold here, which is why the documentation must say so.
 - The `kakehashi-virtual-uri-*` filename space is reserved: a real workspace
   file named into it is invisible to symbol search (point 5).
 - No configuration can express "suppress B's duplicates, but fall back to B when
   A fails" — `union` has no conditional and `priorities` is unconditional, so
-  users pick one or the other. This is a choice, not a limitation: a
-  per-connection `preferred` is implementable, and was declined for uniformity
-  (point 2).
+  users pick one or the other (point 2).
 - `strategy` becomes a knob that this one method ignores. A **method-specific**
   entry warns; a `_` wildcard that happens to reach the method is overridden
   silently, by design (point 2). Users

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -403,13 +403,18 @@ cloned entry can also outlive a connection purge. Taken at face value, the walk
 would derive a pair from a `didOpen` the downstream has not seen, or from a
 replaced connection whose documents were never replayed.
 
-The save path already establishes the discipline this needs, and the ordering
-below follows it: snapshot the tracker, then take `connections` **once** and
-hold it across the checks with no `.await` inside, require the handle to be the
-current `Ready` one, and only then consult `is_virtual_doc_open_on_connection`. Holding `connections` is what makes it
-sound — a reverse-index check alone would not, since a purge could swap in a
-fresh `Ready` handle that never opened the document. The lock order is
-`connections` → tracker, matching the respawn purge. This composes with the
+The save path establishes most of the discipline this needs: snapshot the
+tracker, then take `connections` **once** and hold it across the checks with no
+`.await` inside. Holding `connections` is what makes it sound — a membership
+check alone would not, since a purge could swap in a fresh handle that never
+opened the document. The lock order is `connections` → tracker, matching the
+respawn purge.
+
+This method departs from that precedent in one respect, and step 2 below spells
+it out: **currency is confirmed first**, before state, capability or
+configuration. The save path can check liveness first because it only decides
+whether to send; this one also has to decide what a *missing* target means, and
+a stale entry misclassified as a dead connection would be counted as an outage. This composes with the
 stale-handle re-check the send already performs (point 4): the enqueue is
 non-blocking, so both happen under the same lock and only the response is
 awaited outside it.
@@ -732,9 +737,10 @@ fix. Nothing in this design bounds the query at all, which point 9 names as a
         ┌──────────────────────────────────────┐
         │ SELECTION (3s per AWAITED lock, §6)  │
         │ pool-owned batch validator, one lock:│
-        │ Ready only, drop incapable, drop     │
-        │ stale-config, confirm still open on  │
-        │ that exact connection                │
+        │ (a) confirm still current — else it  │
+        │     is STALE, not failed             │
+        │ (b) Ready only, drop incapable, drop │
+        │     stale-config                     │
         │ then: allowlist + per-pair maxFanOut │
         │ NEVER spawns a connection            │
         └──────────────────┬───────────────────┘

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -526,11 +526,21 @@ an error would make a deliberate exclusion behave like an outage. `priorities =
 []` and `max_fan_out = 0` admit **no** candidates, so there is nothing for them
 to fail.
 
-Capability is deliberately not part of that test, because it cannot be: a dead
-handle's `server_capabilities()` is whatever it was, and for one that never
-reached `Ready` there is nothing to read. A server the user configured and
-allowed, now unreachable, is an outage whether or not we can confirm what it
-could have done.
+Capability **is** part of that test, wherever it can be read. A handle's
+initialize capabilities live in a `OnceLock` that outlives its state, and
+`has_capability` does not require `Ready` — so a server that was once up and is
+known not to support `workspace/symbol` is still known not to. Its death removes
+no symbol-search coverage, and counting it would turn a legitimate "no matches"
+into an outage on the strength of a server that was never going to answer.
+
+That leaves three cases for a dead candidate, and only the first is silent:
+
+- **Known incapable** — excluded, exactly as it would be while alive. Not a
+  failure.
+- **Known capable** — an infrastructure failure. It would have answered.
+- **Never initialized**, so nothing was ever recorded — an infrastructure
+  failure too. Whether it would have contributed is unknowable, and the whole
+  point of this accounting is that unknown must not read as absent.
 
 Recording a dead connection as a failure rather than as a non-candidate is what
 keeps the outcome rule honest. A liveness timeout marks a handle `Failed` in
@@ -1175,10 +1185,10 @@ those rather than from whole responses:
   answer was processed; it yielded fewer symbols. These are the silent drops
   points 5 and 7 already accept.
 - **Infrastructure-failed** — never examined at all, so nothing was learned. A
-  candidate **that policy admitted** whose connection was already `Failed`,
-  `Closing`, or `Closed` at selection (point 3) starts here rather than never
-  existing; one the allowlist or cap excluded is simply not a candidate. Also:
-  the
+  candidate **that policy admitted and is not known to be incapable**, whose
+  connection was already `Failed`, `Closing`, or `Closed` at selection (point 3),
+  starts here rather than never existing; one the allowlist, the cap, or a
+  recorded lack of the capability excluded is simply not a candidate. Also: the
   pass-0 host→virtual snapshot, the translation-time identity re-read, or a
   host's `edit_lock` expiring; and, importantly, geometry that is *unsettled*
   rather than gone — a host still parsing, a pass whose 200ms ensure timed out,

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -628,7 +628,7 @@ with its own name and semantics rather than smuggled into this one.
              └────────────┬─────────────┘
                           ▼
         ┌──────────────────────────────────────┐
-        │ SELECTION (3s per lock ACQUIRE, §6)  │
+        │ SELECTION (3s per AWAITED lock, §6)  │
         │ pool-owned batch validator, one lock:│
         │ Ready only, drop incapable, drop     │
         │ stale-config, confirm still open on  │
@@ -1179,9 +1179,9 @@ arriving mid-processing would otherwise wait on unrelated work with no bound.
 
 Separate budgets rather than one deadline spanning the whole dispatch, because a
 single outer deadline would silently consume the reopen barrier's two seconds
-(point 3) and cancel it in a way its own timeout never reports. These are the
-only deadlines the design imposes; every other bound it relies on already
-existed.
+(point 3) and cancel it in a way its own timeout never reports. Together with
+the 200ms bound on each parse ensure (point 5), these are the deadlines the
+design adds; every other bound it relies on already existed.
 
 Beyond those budgets, nothing new is introduced: every target is already
 `Ready` when chosen (point 3), so nothing waits for a handshake before the
@@ -1427,13 +1427,13 @@ Including it would defeat dedup on a field carrying no identity.
 - Every lock this path *awaits* — the tracker snapshot, `connections`, each
   send's re-acquisition, each host's `edit_lock` — is bounded only in its
   **acquisition** (`host_documents` is never awaited; it is `try_lock`ed under
-  `connections`, and contention drops that query's `_self` candidates), because other paths hold these across
-  unbounded async work (point 6); the filtering between them is synchronous and
-  cannot be preempted, so neither total selection time nor cancellation blocking
-  is capped. Expiring either
-  budget answers from a partial target set — and a
-  cancellation queued behind that same mutex may arrive too late to stop it, so
-  a cancelled request can still be answered.
+  `connections`, and contention drops that query's `_self` candidates), because
+  other paths hold these across unbounded async work (point 6); the filtering
+  between them is synchronous and cannot be preempted, so neither total
+  selection time nor cancellation blocking is capped. Expiring any of those
+  budgets answers from a partial target set — and a cancellation queued behind
+  the `connections` mutex may arrive too late to stop it, so a cancelled request
+  can still be answered.
 - The content-identity check proves a `didChange` was *enqueued*, not delivered:
   notifications carry no acknowledgement and a failed write does not fail the
   connection. The stale-result window is narrowed, not closed (point 5).

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -1116,47 +1116,59 @@ searched and found nothing" — and making it while every server was unreachable
 is confidently wrong at exactly the moment the user is least able to tell. A
 client shown "no matches" during an outage concludes the symbol does not exist.
 
-So the outcome is decided on whether any server's answer was **successfully
-processed**, tracked **across every phase**, not just the response phase. A target can be lost after
+So the outcome is decided on whether any server's answer was **informative**,
+tracked **across every phase**, not just the response phase. A target can be lost after
 selection and before dispatch too: its reopen barrier fails, its send cannot
 re-acquire `connections` within budget, or registration, the stale-handle
 re-check, or the enqueue fails. Counting only "dispatched targets that errored"
 would let a query whose every target died pre-dispatch report a confident empty
 answer, since zero dispatches looks the same as zero results.
 
-The unit is a **successfully processed answer**, and the line that defines it is
-between *semantic* rejection and *infrastructure* failure:
+Every entry ends in exactly one of three states, and the outcome is derived from
+those rather than from whole responses:
 
-- **Semantic rejection is successful processing.** An entry dropped because its
-  region died, its language changed, its range escaped the region, its host has
-  no current geometry, or its content identity moved was examined and found not
-  to describe a place in this workspace. The answer was processed; it yielded
-  fewer symbols. These are the silent drops points 5 and 7 already accept, and
-  they do not poison anything.
-- **Infrastructure failure poisons the answer.** The pass-0 host→virtual
-  snapshot, the translation-time identity re-read, or a host's `edit_lock`
-  expiring means the entries were never examined at all. Nothing was learned
-  about them, so they are not evidence of absence.
+- **Translated** — it reached the client.
+- **Semantically rejected** — examined, and found not to describe a place in
+  this workspace: the region is *gone*, its language changed, the indexed URI is
+  retired, the range escaped its region, or the content identity moved. The
+  answer was processed; it yielded fewer symbols. These are the silent drops
+  points 5 and 7 already accept.
+- **Infrastructure-failed** — never examined at all, so nothing was learned. The
+  pass-0 host→virtual snapshot, the translation-time identity re-read, or a
+  host's `edit_lock` expiring; and, importantly, geometry that is *unsettled*
+  rather than gone — a host still parsing, a pass whose 200ms ensure timed out,
+  or a region cache left empty by a population that lost an epoch race and could
+  not commit. "The parse has not caught up" is not "the symbol is not there",
+  even though both surface as no current geometry.
 
-Anything short of one processed answer is "we could not find out", not "there
-is nothing".
+An answer is **informative** when it produced at least one translated entry, or
+when every one of its entries was semantically rejected — including a
+legitimately empty response, which is a server saying it searched and found
+nothing.
+
+Granularity matters here: `edit_lock` expiry is per *host*, while one response
+can carry real-file entries and virtual entries from several hosts. One
+contended host must not turn an answer whose other entries translated fine into
+a request error, so poisoning is decided per entry and rolled up, never per
+response.
 
 - Selection **completed** and found no candidates → `[]`. Nothing failed; there
   was nothing to ask.
-- **At least one** successfully processed answer → its results, or `[]` if they
-  genuinely contained nothing. Partial failure stays soft.
-- Candidates existed and **no answer was successfully processed** — for any
-  reason, at any phase → **request error**.
-- Selection **did not complete** and nothing was processed → **request error**.
+- **At least one informative** answer → its results, or `[]` if they genuinely
+  contained nothing. Partial failure stays soft.
+- Candidates existed and **no answer was informative** — for any reason, at any
+  phase → **request error**.
+- Selection **did not complete** and nothing was informative → **request
+  error**.
 
-The last two cases are why the unit is processing rather than response. Selection
-can expire its tracker or `connections` acquisition, and `_self` discovery is
-incomplete whenever `host_documents` was contended, so "no candidates" and "we
-could not find out" are different states. Just as importantly, a fan-in failure
-counts: if servers returned symbols and every entry was dropped because the
-late host→virtual snapshot or the identity re-read could not be acquired, the
-client would otherwise be told the search found nothing — the same confident
-falsehood as reporting an outage that way, arrived at from the other end.
+The last two cases are why the unit is the entry rather than the response.
+Selection can expire its tracker or `connections` acquisition, and `_self`
+discovery is incomplete whenever `host_documents` was contended, so "no
+candidates" and "we could not find out" are different states. And a fan-in
+failure counts: if servers returned symbols and every entry was lost to a lock
+that could not be acquired or a parse that had not settled, the client would
+otherwise be told the search found nothing — the same confident falsehood as
+reporting an outage that way, arrived at from the other end.
 
 A downstream `null` is an answer, not a failure. The method's result type is
 `Option<WorkspaceSymbolResponse>` precisely because `null` is valid, so it
@@ -1265,13 +1277,13 @@ arriving mid-processing would otherwise wait on unrelated work with no bound.
 - **Fan-in**: the pass-0 host→virtual snapshot, and the translation-time
   identity re-read — three seconds each. These come *after* every downstream
   response, so they are easy to overlook, and unbudgeted they would reintroduce
-  an unbounded wait at the very end of the query. Expiry drops the affected
-  entries **and counts against the outcome rule** (point 5) as infrastructure
-  failure, not semantic rejection: entries never examined are not evidence that
-  the search found nothing.
+  an unbounded wait at the very end of the query. Expiry marks the affected
+  entries **infrastructure-failed** (point 5), not semantically rejected:
+  entries never examined are not evidence that the search found nothing.
 - **Translation's `edit_lock`** per host: three seconds. A host whose lock
-  cannot be taken in time loses that query's entries, exactly like a host whose
-  geometry was stale.
+  cannot be taken in time loses that query's entries — marked
+  infrastructure-failed, like unsettled geometry and unlike a region that is
+  genuinely gone (point 5).
 
 Separate budgets rather than one deadline spanning the whole dispatch, because a
 single outer deadline would silently consume the reopen barrier's two seconds

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -95,8 +95,14 @@ Absence is the right answer only for `resolveSupport`. `symbolKind` and
 tells a conformant server to omit tags and to restrict itself to the legacy
 `File`–`Array` kind set — silently degrading results kakehashi's own client
 could have used. So this decision **declares `workspace.symbol` downstream**,
-mirroring the upstream client's `symbolKind` and `tagSupport` while keeping
-`resolveSupport` absent. Mirroring rather than asserting is deliberate:
+mirroring the upstream client's `symbolKind` and `tagSupport`, setting
+`dynamicRegistration: true`, and keeping `resolveSupport` absent.
+
+`dynamicRegistration` is an independent field and needs its own answer, not
+silence. The bridge already records downstream registrations and consults them
+*before* static capabilities, so a server that registers `workspace/symbol`
+dynamically would be usable — but only if it was told it could. Leaving the
+field absent would tell it otherwise and lose those servers entirely. Mirroring rather than asserting is deliberate:
 kakehashi must not accept a kind or tag it cannot pass on.
 
 Exact mirroring has one exception, and it is the legacy spelling again. An
@@ -146,8 +152,8 @@ per-entry global fan-in translator, and a single deduplicating union. Defer
    │             │  3. sort   (uri, start, end,   │
    │             │             name, kind)        │
    │             └───────────────┬────────────────┘
-   │◀── Symbol array ────────────┘
-   │    (element type per client, §5; never null)
+   │◀── SymbolInformation[] ─────┘
+   │    (always; never null — §5)
    │
    │ $/cancelRequest ─▶ forwarded to every in-flight target, best effort:
    │                    a downstream may ignore it (LSP allows this). The
@@ -483,8 +489,8 @@ purge removes exactly those records — so a query arriving between the purge an
 the first replayed `didOpen` discovers no candidate at all and never reaches the
 barrier. The barrier helps once a target is discoverable but not yet replayed;
 before that, the connection is invisible to selection. Both halves have the same
-root cause and the same fix — retaining a connection's admitting policy
-independently of document tracking (point 7) — so neither is patched here.
+root cause, and point 9 names it as a **shipping blocker** rather than
+something this decision patches.
 The barrier is **bounded to two seconds** and enforced with a timeout, and
 awaiting the survivors concurrently costs that bound once for the whole query —
 not once per target.
@@ -619,14 +625,11 @@ coherent semantics:
   which connections survived would vary run to run.
 
 So `max_fan_out` stays a **per-pair name-selection rule** here and bounds
-neither the query's requests nor its connections. That is a real divergence from
-its documented promise to "cap the number of concurrent server requests", and
-the fix is documentation, not a mechanism: the setting's description must say so
-(point 8). What actually bounds the total is the live-connection set (point 7).
-A workspace-level ceiling belongs in a separate setting with its own name and
-semantics rather than smuggled into this one, and is listed as deferred work in
-point 9 rather than left as a vague possibility — this method is the widest
-fan-out kakehashi has, and it is the one the existing guard does not bound.
+neither the query's requests nor its connections. Its documented promise to
+"cap the number of concurrent server requests" therefore does not hold, and the
+setting's description must record that (point 8) — but recording it is not the
+fix. Nothing in this design bounds the query at all, which point 9 names as a
+**shipping blocker**; what closes it is left to the change that implements it.
 
 ```
   open host docs × their open virtual docs    ← concrete languages only,
@@ -1176,42 +1179,32 @@ normalizes to a successful empty vector **before** either array form is parsed.
 Treating it as a parse failure would let a conformant "I found nothing" trip the
 total-failure rule — the exact inversion this rule exists to prevent.
 
-Entries are emitted as `WorkspaceSymbol[]` — `WorkspaceSymbolResponse::Nested`
-in `ls-types`, whose variant names are a misnomer: **both** variants are flat
-arrays, and the choice is the element type, not hierarchy (there is no nested
-form for this method; `containerName` is spec-documented as unusable for
-re-inferring one). `SymbolInformation[]` is the deprecated alternative, emitted only in the
-compatibility case below.
+Entries are emitted as **`SymbolInformation[]`, always** —
+`WorkspaceSymbolResponse::Flat` in `ls-types`, whose variant names are a
+misnomer: **both** variants are flat arrays, and the choice is the element type,
+not hierarchy (there is no nested form for this method, and `containerName` is
+spec-documented as unusable for re-inferring one). No client capability is
+consulted to decide it.
 
-One client capability *does* govern the payload, and it turns out to govern the
-element type too: `workspace.symbol.tagSupport` declares which `SymbolTag`s the
-client accepts, and kakehashi already stores the upstream capabilities.
+`WorkspaceSymbol` earns nothing here. Its one advantage over the older type is
+the location-without-range form, which this design cannot use — every entry must
+carry a full `Location` (point 5) — and its `data` field, which is dropped
+because `workspaceSymbol/resolve` is not supported. What it costs is a shape
+risk: LSP gates the `WorkspaceSymbol[]` result form on
+`workspace.symbol.resolveSupport`, not on tag support, so a client that declares
+tags but not `resolveSupport` could be handed a form it does not accept.
 
-- A client that can represent `SymbolTag::DEPRECATED` gets `WorkspaceSymbol[]`,
-  tags filtered to the set it declared.
-- Every other client gets `SymbolInformation[]`.
+Gating on `tagSupport` instead was drafted and is wrong for exactly that reason.
+It also solved a problem `SymbolInformation` does not have: that type carries
+**both** `tags` and the legacy `deprecated` flag, so a modern client reads the
+tag and an older one reads the field, from one payload, with no branch and
+nothing to reverse. The normalization in point 4 folds an incoming `deprecated`
+into `SymbolTag::DEPRECATED`; on the way out both are populated, and tags are
+filtered to what the client declared.
 
-The discriminator is **representability, not presence**. `tagSupport` cannot be
-tested for existence: the legacy boolean form `tagSupport: true` deserializes to
-`Some(TagSupport { value_set: [] })`, so a client that declares tag support in
-the old spelling would pass a presence check, have every tag filtered away
-against its empty set, and lose deprecation exactly as if it had declared
-nothing. Asking whether `DEPRECATED` survives the filter answers the question
-that actually matters.
-
-The second case is why the element type cannot simply be "always the modern
-one". Point 4 *creates* a tag during normalization, folding the legacy
-`deprecated` flag into `SymbolTag::DEPRECATED` and discarding the original
-field. Emitting `WorkspaceSymbol[]` with tags stripped would therefore destroy
-deprecation outright for exactly the clients too old to read tags.
-
-Choosing the legacy element type is not by itself enough to undo that, because
-the information now lives in a tag. The legacy path must **reverse the
-normalization**: set `deprecated = Some(true)` when the normalized tags contain
-`DEPRECATED`, and drop tags the client cannot represent. Selecting
-`SymbolInformation[]` without that conversion would lose exactly what selecting
-it was meant to preserve. It is bounded: the modern type is used everywhere
-else.
+The cost is using a type the spec marks deprecated. That is the honest trade:
+the deprecated type is the one that is universally accepted and loses no
+information this design produces.
 
 ### 6. Every wait is bounded; the synchronous work between them is not
 
@@ -1437,21 +1430,12 @@ do is specify their mechanisms, for a reason given in Considered Options.
   `workspaceSymbolProvider`. The existing client-progress aggregator is keyed by
   region and has no meaning for a request that has no region. Both tokens are
   optional in LSP 3.18.
-- **A request-wide fan-out ceiling.** `max_fan_out` bounds a pair's name
-  selection, not the query (point 3), so nothing caps how many connections one
-  query touches except how many are live. That is a real gap in a generic load
-  control, and this is the method most able to expose it. The fix is a
-  separately named workspace-level limit — a new user-facing setting, which is
-  why it is deferred rather than decided here.
 - **Request coalescing.** A symbol picker typically fires one request per
   keystroke, and this design has no single-flight, debounce, or supersession —
   each keystroke fans out to every live connection. The repo has prior art for
   exactly this failure mode in the semantic-token and diagnostic wire floods.
   Nothing here prevents it; it is left for a follow-up once real traffic exists
   to measure, and is the most likely first regression.
-- ~~**The respawn re-open window.**~~ Not deferred — see point 3. A connection
-  reaches `Ready` before its virtual documents are replayed, and the barrier is
-  awaited rather than skipped.
 
 ## Considered Options
 
@@ -1566,9 +1550,9 @@ Including it would defeat dedup on a field carrying no identity.
 - Results depend on what is open, and coverage can shrink (close, respawn,
   silent connection death). Closing the last buffer for a language removes its
   server from search even though the process is still running and may still be
-  usefully indexed — the sharpest form of this, and a follow-up rather than a
-  fix here (point 7). The respawn window has the same cause: a purged
-  connection is invisible to selection until its documents are replayed. The same query answers differently at different
+  usefully indexed; the respawn window has the same cause, since a purged
+  connection is invisible to selection until its documents are replayed. Both
+  are **shipping blockers** (point 9), not costs this decision accepts. The same query answers differently at different
   points in a session. LSP permits partial `workspace/symbol` results, but a
   user expecting an indexed whole-project search will find this surprising.
 - Latency is max-over-live-targets, and every *wait* is bounded: the pool's 30s

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -486,10 +486,21 @@ final barrier.** The order is fixed:
       The filter is on the **connection's root**, not on result URIs: a server
       legitimately rooted inside the workspace may return symbols from a
       dependency outside it, and that is its own call, not pollution.
+      The boundary is the declared **workspace folders**, or — when the client
+      sent an explicit empty folder list but did keep a `rootUri` — that root.
+      The two are stored separately and an empty list is preserved deliberately,
+      so this case is real and needs saying: without the rule, an implementer
+      could equally drop every marker-rooted target or admit every disjoint
+      project. Filtering is disabled only when **neither** exists, where there
+      is no boundary to enforce and the alternative would be to answer nothing.
+
       `ClientFallback`-rooted connections sit at the client root and always
-      pass. A session that declared **no** root or folders at all has no
-      boundary to enforce, so nothing is filtered — the alternative would be to
-      answer nothing.
+      pass. That is a **third leak**, not a clean case: a stray file with no
+      marker above it — or with markers disabled — also routes to
+      `ClientFallback`, so its document is opened on that process and its
+      symbols can come back. Since result URIs are deliberately unfiltered,
+      nothing here removes them. Dropping the fallback connection instead would
+      discard the client root's own symbols, which is worse.
 
       A `preferSharedInstance` connection needs its own rule, because `Shared`
       exposes **no** marker root: the roots it actually serves live in the
@@ -896,7 +907,7 @@ hand. "Its own offset" does not mean "its own resolution", though; see pass 3.
              │
              ▼
      ┌───────────────────┐  no
-     │ has a range?      ├─────▶ DROP  (uri-only location — see below)
+     │ has a range?      ├─────▶ DROP as a PROTOCOL FAILURE (see below)
      └─────────┬─────────┘
                │ yes
                ▼
@@ -1039,6 +1050,13 @@ real positions in that text and the range must be correctly ordered, using the
 existing strict position machinery rather than a new comparison, and only then
 is the range translated and checked against the host-side region bound. Validating in virtual coordinates before translating is
 what catches the column case; the host bound catches what survives it.
+
+A range-less entry is **not** a semantic rejection, and the distinction matters:
+the server reported a match and kakehashi could not use it. Counting it as
+semantic would let a response consisting entirely of range-less entries come
+back as an informative `[]` — telling the user there are no symbols at the
+moment a server has just said there are. It is an infrastructure failure in the
+accounting of point 5, so such a response errors instead.
 
 The range check comes first because `WorkspaceSymbol.location` is
 `OneOf<Location, WorkspaceLocation>` and the `WorkspaceLocation` form carries a
@@ -1293,7 +1311,9 @@ those rather than from whole responses:
   retired, or the range escaped its region. The answer was processed; it yielded
   fewer symbols. These are the silent drops points 5 and 7 already accept.
 - **Infrastructure-failed** — nothing was learned. This covers entries never
-  examined, and also entries whose **content identity moved**: an edit during
+  examined — including an entry a downstream returned **without a range**, which
+  it reported as a match and kakehashi could not place — and also entries whose
+  **content identity moved**: an edit during
   the request means the downstream answered about text that no longer exists, so
   a symbol it did not mention may simply have shifted. The bridge learned
   neither that the workspace has no match nor where the match now is, which is
@@ -1750,11 +1770,12 @@ Including it would defeat dedup on a field carrying no identity.
 
 - A file opened from outside the client's workspace no longer contributes its
   project's symbols here, though the connection it spawned still serves that
-  file's own bridged requests. Two leaks remain by design (point 3): a
+  file's own bridged requests. Three leaks remain by design (point 3): a
   `preferSharedInstance` server holding both an in-workspace and an external
-  root is indivisible, and a server rooted *above* the workspace — the ordinary
-  case when `.git` sits above the opened folder — indexes its whole tree, so a
-  search returns sibling packages too.
+  root is indivisible; a server rooted *above* the workspace — the ordinary case
+  when `.git` sits above the opened folder — indexes its whole tree, so a search
+  returns sibling packages too; and a stray file with no marker above it lands
+  on the always-admitted `ClientFallback` connection.
 - Results depend on what is open, and coverage can shrink (close, respawn,
   silent connection death). Closing the last buffer for a language removes its
   server from search even though the process is still running and may still be

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -385,40 +385,20 @@ name across roots, recreating the leak point 3 exists to prevent. The
 `(host_language, _self, ConnectionKey)` admission records are therefore written
 at host-open time from `host_documents`' own key, alongside the virtual ones.
 
-That is a second async map, read **under** `connections` by the batch validator
-below rather than snapshotted separately, so selection's acquisitions are the
-tracker snapshot and then `connections`, each falling under point 6's budget —
-not the "one acquisition then synchronous work" shape an earlier draft assumed.
+`host_documents` is read only at *open* time, to write that record — never
+during a query, which is why selection takes `connections` alone.
 
-The two snapshots also have to be **joined safely**. Host language comes from
-the document store, while the exact keys come from pool tracking read later, and
-neither `OpenedVirtualDoc` nor the host-document sync state records the host
-language or its incarnation. A close/reopen — or a language change — between the
-two reads would therefore apply the *new* lifetime's policy to the *old*
-lifetime's downstream opens: precisely the policy-boundary leak this point
-exists to prevent, in transient form. So before a pair contributes, the host
-document's current language and incarnation are re-read and must match what the
-walk assumed; a mismatch drops that pair's contribution rather than guessing
-which lifetime it belonged to.
+Both fields of a record are captured at open time, from the same event, so the
+lifetime-join problem an earlier draft had does not arise: there is no later
+read to disagree with. A `didClose` followed by a reopen under a different
+language simply writes a second record; the first stays until its key does, and
+names a pair the connection genuinely served.
 
-An entry must be **validated before it contributes**, because the tracker's
-host→virtual map is not an "already open downstream" set: `register_pending_document`
-inserts an entry to own its close-cleanup *before* `didOpen` reaches the writer
-FIFO, and only `mark_open_sent` promotes it into the live reverse index. A
-cloned entry can also outlive a connection purge. Taken at face value, the walk
-would derive a pair from a `didOpen` the downstream has not seen, or from a
-replaced connection whose documents were never replayed.
-
-The save path already establishes the discipline this needs, and the ordering
-below follows it: snapshot the tracker, then take `connections` **once** and
-hold it across the checks with no `.await` inside, require the handle to be the
-current `Ready` one, and only then consult `is_virtual_doc_open_on_connection`. Holding `connections` is what makes it
-sound — a reverse-index check alone would not, since a purge could swap in a
-fresh `Ready` handle that never opened the document. The lock order is
-`connections` → tracker, matching the respawn purge. This composes with the
-stale-handle re-check the send already performs (point 4): the enqueue is
-non-blocking, so both happen under the same lock and only the response is
-awaited outside it.
+A record is written **once the `didOpen` is confirmed enqueued**, not when it is
+merely intended. The tracker's own `register_pending_document` /
+`mark_open_sent` split exists for exactly that distinction, and a record written
+on the pending half would claim an admission the downstream may never have
+received.
 
 Candidates for each `(host, injection)` pair then come from the **existing
 routing entry point**, `get_all_configs_for_language`, rather than from a
@@ -459,8 +439,16 @@ final barrier.** The order is fixed:
 3. Apply the per-pair `priorities` allowlist and `max_fan_out` cap to the
    survivors — pure computation, after the lock is released.
 4. Dedup by **connection key** `(server, root)`.
-5. Await `wait_for_pending_reopen` for the survivors, **concurrently**, then
-   send.
+5. Await `wait_for_pending_reopen` for the survivors, **concurrently**, dropping
+   any whose barrier fails.
+6. Apply `workspaceSymbolMaxFanOut` to what is left, then send.
+
+The ceiling comes **after** the barrier, not before, because a cap allocated to
+connections that then fail their barrier wastes its slots: with a ceiling of one
+and a first-ordered connection whose repair fails, the healthy connections below
+it would already have been truncated away and the query would error despite
+having had a sendable target. Capping what is actually sendable avoids needing a
+backfill rule at all.
 
 The validator is **pool-owned** for two reasons. It is the only way to do all of
 this under one acquisition — `launch_config` and its comparator are private to
@@ -644,16 +632,29 @@ per-pair priority list to merge.
 
 As a configuration surface it is `workspaceSymbolMaxFanOut`, a top-level
 `Option<i64>` alongside the existing top-level settings, mirroring
-`max_fan_out`'s own conventions so users meet no new ones: absent or `null` =
-no limit, `0` = disable the method entirely, positive = cap, negative = treated
-as no limit. It merges like every other scalar — a later layer's value replaces
-an earlier one — which means it needs the same raw/resolved field pair, the same
-layered-merge entry, the same default, and the same schema and documentation
-coverage as its neighbours. Naming it here without that inventory would leave an
-implementer unable to expose or reload it consistently.
+`max_fan_out`'s value conventions so users meet no new ones: `0` = disable the
+method entirely, positive = cap, negative = treated as no limit, **absent =
+inherit, defaulting to no limit**.
 
-It applies **after dedup**, to the connection set, and truncates in a **stable
-documented order** rather than by priority — per-pair priorities conflict, and
+"Absent" is deliberately not spelled "`null` clears it". Scalar layers merge
+with `overlay.or(base)`, and serde collapses an absent key and an explicit
+`null` to the same `None`, so a higher layer writing `null` would inherit a
+lower layer's cap rather than remove it. Rather than introduce a presence-aware
+`Option<Option<i64>>` for one setting, `null` is documented as inheritance —
+matching what the merge actually does. Clearing a cap means setting it to a
+negative value.
+
+Adding a top-level key is more than a struct field. It needs the raw/resolved
+field pair, the layered-merge entry, the default, the schema, the user
+documentation — **and registration in `KNOWN_WORKSPACE_SETTING_KEYS`**, which is
+the one an implementer is most likely to miss: `didChangeConfiguration` rejects
+an update containing an unregistered top-level key *before* deserialization, so
+without it the setting would work from a config file and be rejected on live
+reload.
+
+It applies **after dedup and after the reopen barrier**, to the connections that
+are actually sendable, and truncates in a **stable documented order** rather
+than by priority — per-pair priorities conflict, and
 walk order varies run to run. The order is `(server name, root discriminator,
 root path)`: the discriminator is required because `ClientFallback` and `Shared`
 both report no marker root and can coexist for one server, so comparing only the
@@ -685,12 +686,12 @@ iteration order — the nondeterminism this ordering exists to remove.
         │   each pair admits ONLY the conns it │
         │   actually opened — never a name     │
         │   expanded across roots              │
-        │ then workspaceSymbolMaxFanOut, in    │
-        │ (name, root-kind, root) order        │
         └──────────────────┬───────────────────┘
                            ▼
               await the 2s reopen barrier concurrently,
               dropping targets whose repair failed,
+              THEN workspaceSymbolMaxFanOut in
+              (name, root-kind, root) order,
               then send to each survivor (§4),
               then per-entry fan-in (§5),
               then UNION → dedup → sort (§1)
@@ -1185,8 +1186,10 @@ contended host must not turn an answer whose other entries translated fine into
 a request error, so poisoning is decided per entry and rolled up, never per
 response.
 
-- Selection **completed** and found no candidates → `[]`. Nothing failed; there
-  was nothing to ask.
+- Selection **completed** and found no candidates, or the method is **disabled**
+  (`workspaceSymbolMaxFanOut = 0`, or every pair's `priorities` is `[]`) → `[]`.
+  Nothing failed; there was nothing to ask, or the user asked for nothing. A
+  deliberate disable must not surface as an error.
 - **At least one informative** answer → its results, or `[]` if they genuinely
   contained nothing. Partial failure stays soft.
 - Candidates existed and **no answer was informative** — for any reason, at any
@@ -1354,20 +1357,34 @@ removed only when the key itself goes away. Candidates come from these records
 instead of from live document tracking, and the tracker is consulted only for
 things that genuinely are about documents.
 
-Keying on `ConnectionKey` rather than on a handle is what makes them survive
-both events that motivated this. A `didClose` does not touch them. Neither does
-a respawn: the replacement serves the same `(server, root)` under the same
-configuration, so the pairs that admitted its predecessor admit it too — that
-is not stale inheritance but the correct answer. An earlier draft stamped
-records with the connection generation to prevent exactly that inheritance,
-which was solving a problem that does not exist; the reopen barrier, not a
-generation check, is what handles a replacement whose documents are not yet
-replayed.
+Keying on `ConnectionKey` rather than on a handle is what makes them survive a
+`didClose`, which does not touch them, and a **failure respawn**, where the
+replacement serves the same `(server, root)` under the same configuration and
+so is admitted by the pairs that admitted its predecessor. That is not stale
+inheritance but the correct answer, and an earlier draft's generation stamp —
+added to prevent exactly that inheritance — was solving a problem that does not
+exist. The reopen barrier, not a generation check, handles a replacement whose
+documents are not yet replayed.
+
+Survival must be **reason-aware**, though, because the pool removes the same key
+for three different reasons and only one of them preserves meaning:
+
+- **Failure respawn** — the process died and is being replaced with an
+  equivalent one. Records survive; this is the case the whole mechanism exists
+  for.
+- **Configuration change or removal** — the server's spawn-time config changed,
+  or it left the config entirely. Records are **cleared**: the pairs that
+  admitted the old executable say nothing about a differently-configured one.
+- **Client workspace invalidation, or a changed client root under
+  `ClientFallback`** — that key is reused across workspaces, so retaining
+  records would transfer one workspace's admissions into another. **Cleared.**
+
+Clearing on every removal would break respawn survival; retaining on every
+removal would leak admissions into a reconfigured server or a different
+workspace. Neither is safe, so the removal reason has to reach the records.
 
 The records stay concrete because each was created from a real open document
-(point 3's requirement). They are removed when their `ConnectionKey` is — a
-server dropped from configuration, or a root that no longer resolves — so a
-long-lived session does not accumulate keys for servers it no longer has.
+(point 3's requirement).
 
 Their size is bounded by **distinct `(host_language, injection_language)` pairs
 per key**, not by session history. That is small for ordinary configurations,

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -924,8 +924,9 @@ another 30 seconds and answer with documents opened in the meantime. The index
 is therefore built once all results are in hand, immediately before
 classification. It covers documents opened up to the enqueue of each request,
 which is as far as it can: a per-target identity map fixes what that target
-could legitimately have seen, and it is captured atomically with that target's
-enqueue (point 4).
+could legitimately have seen, captured in the same `connections` section as that
+target's enqueue — which excludes a concurrent `didOpen`, though not a
+concurrent `didChange` (point 4).
 
 Staleness in the other direction is worse and survives any snapshot time, so it
 is closed by a check rather than by timing. A region keeps its ULID across
@@ -1115,17 +1116,30 @@ searched and found nothing" — and making it while every server was unreachable
 is confidently wrong at exactly the moment the user is least able to tell. A
 client shown "no matches" during an outage concludes the symbol does not exist.
 
-So the outcome is decided on whether *any* server actually answered, tracked
-**across every phase**, not just the response phase. A target can be lost after
+So the outcome is decided on whether any server's answer was **successfully
+processed**, tracked **across every phase**, not just the response phase. A target can be lost after
 selection and before dispatch too: its reopen barrier fails, its send cannot
 re-acquire `connections` within budget, or registration, the stale-handle
 re-check, or the enqueue fails. Counting only "dispatched targets that errored"
 would let a query whose every target died pre-dispatch report a confident empty
 answer, since zero dispatches looks the same as zero results.
 
-The unit is a **successfully processed answer**: a target that answered *and*
-whose entries fan-in could classify and translate. Anything short of that is
-"we could not find out", not "there is nothing".
+The unit is a **successfully processed answer**, and the line that defines it is
+between *semantic* rejection and *infrastructure* failure:
+
+- **Semantic rejection is successful processing.** An entry dropped because its
+  region died, its language changed, its range escaped the region, its host has
+  no current geometry, or its content identity moved was examined and found not
+  to describe a place in this workspace. The answer was processed; it yielded
+  fewer symbols. These are the silent drops points 5 and 7 already accept, and
+  they do not poison anything.
+- **Infrastructure failure poisons the answer.** The pass-0 host→virtual
+  snapshot, the translation-time identity re-read, or a host's `edit_lock`
+  expiring means the entries were never examined at all. Nothing was learned
+  about them, so they are not evidence of absence.
+
+Anything short of one processed answer is "we could not find out", not "there
+is nothing".
 
 - Selection **completed** and found no candidates → `[]`. Nothing failed; there
   was nothing to ask.
@@ -1252,8 +1266,9 @@ arriving mid-processing would otherwise wait on unrelated work with no bound.
   identity re-read — three seconds each. These come *after* every downstream
   response, so they are easy to overlook, and unbudgeted they would reintroduce
   an unbounded wait at the very end of the query. Expiry drops the affected
-  entries **and counts against the outcome rule** (point 5): entries lost to a
-  fan-in failure are not evidence that the search found nothing.
+  entries **and counts against the outcome rule** (point 5) as infrastructure
+  failure, not semantic rejection: entries never examined are not evidence that
+  the search found nothing.
 - **Translation's `edit_lock`** per host: three seconds. A host whose lock
   cannot be taken in time loses that query's entries, exactly like a host whose
   geometry was stale.

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -614,8 +614,10 @@ neither the query's requests nor its connections. That is a real divergence from
 its documented promise to "cap the number of concurrent server requests", and
 the fix is documentation, not a mechanism: the setting's description must say so
 (point 8). What actually bounds the total is the live-connection set (point 7).
-A workspace-level ceiling, if one is ever wanted, belongs in a separate setting
-with its own name and semantics rather than smuggled into this one.
+A workspace-level ceiling belongs in a separate setting with its own name and
+semantics rather than smuggled into this one, and is listed as deferred work in
+point 9 rather than left as a vague possibility — this method is the widest
+fan-out kakehashi has, and it is the one the existing guard does not bound.
 
 ```
   open host docs × their open virtual docs    ← concrete languages only,
@@ -1067,15 +1069,22 @@ a per-document snapshot across the whole fan-in and translating against the
 pinned text — which would answer with coordinates into text the client has
 already replaced. Dropping is the safer failure.
 
-The response to the client is always an **array**, never `null`, so "no server
-was running", "everything was dropped", and "every target errored or timed out"
-are not distinguished — the spec assigns no distinct meaning to `null` here, and
-an array keeps the empty case uniform. This last case needs stating because the
-existing fan-in outcomes are mapped inconsistently elsewhere (the diagnostics
-path turns a total failure into an empty vector, formatting and code actions
-into `None`); here it is the empty array, so a downstream outage degrades to
-"no matches" rather than to a protocol-level nothing. A target that errors or
-hits the 30-second timeout contributes nothing and does not fail the query.
+The response is an **array**, never `null`: the spec assigns no distinct meaning
+to `null` here, so "no server was selected" and "servers answered nothing" both
+come back empty.
+
+**Total failure is the exception.** If every dispatched target errored or timed
+out, the query answers with a **request error**, not `[]`. An empty array is a
+claim — "these servers searched and found nothing" — and making it while every
+server was unreachable is confidently wrong at exactly the moment the user is
+least able to tell. A client shown "no matches" during an outage concludes the
+symbol does not exist. The existing concatenated fan-in already draws this line,
+distinguishing zero successes with errors from an empty target set, and this
+method keeps it.
+
+Partial failure stays soft: a target that errors or times out while others
+answer contributes nothing and does not fail the query. The distinction is
+between *some* evidence and *none*.
 
 Entries are emitted as `WorkspaceSymbol[]` — `WorkspaceSymbolResponse::Nested`
 in `ls-types`, whose variant names are a misnomer: **both** variants are flat
@@ -1193,9 +1202,22 @@ requests.
 ### 7. Coverage is what is live, and a query never cold-starts a server
 
 A candidate with no live connection is **skipped**, not spawned. Coverage is
-"the servers that are running because of what the client has opened", and it
-grows as the client opens more files — opening a host document spawns its
-servers and opens its virtual documents.
+therefore bounded by what the client has opened, and grows as it opens more.
+
+Stated precisely, it is **the servers currently holding an open document for
+this workspace** — not "every running server". The two differ, and the gap is
+user-visible: `didClose` removes kakehashi's document tracking but deliberately
+leaves the downstream connection running, so closing the last buffer for a
+language drops that server from selection even though it is still `Ready` and
+still holds a complete real-file index it could have answered from. Symbol
+search goes empty with no failure anywhere.
+
+That follows from deriving the candidate axes from open documents, which is what
+makes them concrete (point 3) — the alternative derivations lose `_` handling or
+`["*"]` servers entirely. Closing it properly means retaining each connection's
+admitting policy independently of document tracking, so a connection can outlive
+the document that justified it. That is a change to what the pool remembers, not
+to this method, and is left as a follow-up rather than smuggled in here.
 
 This is not merely a cost trade. Cold-starting cannot deliver the coverage it
 appears to promise:
@@ -1291,6 +1313,12 @@ documenting only two values.
   `workspaceSymbolProvider`. The existing client-progress aggregator is keyed by
   region and has no meaning for a request that has no region. Both tokens are
   optional in LSP 3.18.
+- **A request-wide fan-out ceiling.** `max_fan_out` bounds a pair's name
+  selection, not the query (point 3), so nothing caps how many connections one
+  query touches except how many are live. That is a real gap in a generic load
+  control, and this is the method most able to expose it. The fix is a
+  separately named workspace-level limit — a new user-facing setting, which is
+  why it is deferred rather than decided here.
 - **Request coalescing.** A symbol picker typically fires one request per
   keystroke, and this design has no single-flight, debounce, or supersession —
   each keystroke fans out to every live connection. The repo has prior art for
@@ -1393,7 +1421,10 @@ Including it would defeat dedup on a field carrying no identity.
 ### Negative
 
 - Results depend on what is open, and coverage can shrink (close, respawn,
-  silent connection death). The same query answers differently at different
+  silent connection death). Closing the last buffer for a language removes its
+  server from search even though the process is still running and still
+  indexed — the sharpest form of this, and a follow-up rather than a fix here
+  (point 7). The same query answers differently at different
   points in a session. LSP permits partial `workspace/symbol` results, but a
   user expecting an indexed whole-project search will find this surprising.
 - Latency is max-over-live-targets, and every *wait* is bounded: the pool's 30s
@@ -1472,12 +1503,16 @@ Including it would defeat dedup on a field carrying no identity.
   never reaches the cross-layer walk.
 - Exposing `union` in the serialized config and the generated schema is a
   **one-way door**: it is public API from the first release that ships it, yet
-  it offers no choice anywhere — it is mandatory where it applies and inert
-  where it does not. Keeping the merge internal to this method would have left
-  that door open. It is exposed because a named, inspectable strategy value was
-  the maintainer's explicit preference over a hidden merge rule; the cost is
-  recorded here so a later reversal is a deliberate deprecation rather than a
-  surprise.
+  it offers no choice anywhere — mandatory where it applies, inert everywhere
+  else, including every document-scoped method and every layer entry that will
+  now schema-accept it as a no-op. Keeping the merge internal would have left
+  that door open.
+
+  This was weighed and **settled**: a named, inspectable strategy value is the
+  maintainer's explicit preference over a hidden merge rule, on the grounds that
+  a user reading the config should be able to see what this method does. The
+  cost is recorded here so that a later reversal is a deliberate deprecation
+  rather than a surprise — and so that it is not re-litigated as an oversight.
 - Result ordering is deterministic but not relevance-ranked. LSP delegates
   scoring to the client ("editors will apply their own highlighting and scoring
   on the results"), so a client that re-sorts sees no change and one that does

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -460,7 +460,23 @@ final barrier.** The order is fixed:
       A candidate that fails this is **stale, not failed**: it is discarded
       silently, before any accounting.
 
-   b. Then keep only `Ready` handles (`connections()` returns the raw map, and
+   b. **Drop connections rooted outside the client's workspace.** `open_uris()`
+      returns every document opened in the session, `didOpen` accepts any URI
+      the client sends, and marker discovery walks a stray file's ancestors with
+      no workspace boundary — so opening one file from another project spawns a
+      connection rooted there, and its real-file symbols would flow into this
+      workspace's search unchanged. A connection whose root lies outside every
+      declared workspace folder is not a candidate for a *workspace* query.
+
+      The filter is on the **connection's root**, not on result URIs: a server
+      legitimately rooted inside the workspace may return symbols from a
+      dependency outside it, and that is its own call, not pollution.
+      `ClientFallback`-rooted connections sit at the client root and always
+      pass. A session that declared **no** root or folders at all has no
+      boundary to enforce, so nothing is filtered — the alternative would be to
+      answer nothing.
+
+   c. Then keep only `Ready` handles (`connections()` returns the raw map, and
       `ConnectionState` also has `Initializing`, `Failed`, `Closing`, `Closed`),
       drop handles lacking `workspace/symbol`, and drop handles whose recorded
       launch configuration no longer matches the `BridgeServerConfig` that
@@ -469,7 +485,7 @@ final barrier.** The order is fixed:
       failure** (point 5) rather than as an absent candidate — but only if
       policy would have admitted it; see below.
 
-   Step (a) must precede (b), and this is the subtle part. A purge removes the
+   Step (a) must precede (c), and this is the subtle part. A purge removes the
    document state and then installs a replacement under the **same**
    `ConnectionKey`; if that replacement fails its handshake, a cloned snapshot
    entry from before the purge resolves to a brand-new `Failed` handle with no
@@ -739,7 +755,8 @@ fix. Nothing in this design bounds the query at all, which point 9 names as a
         │ pool-owned batch validator, one lock:│
         │ (a) confirm still current — else it  │
         │     is STALE, not failed             │
-        │ (b) Ready only, drop incapable, drop │
+        │ (b) drop roots outside the workspace │
+        │ (c) Ready only, drop incapable, drop │
         │     stale-config                     │
         │ then: allowlist + per-pair maxFanOut │
         │ NEVER spawns a connection            │
@@ -1228,10 +1245,15 @@ those rather than from whole responses:
 - **Translated** — it reached the client.
 - **Semantically rejected** — examined, and found not to describe a place in
   this workspace: the region is *gone*, its language changed, the indexed URI is
-  retired, the range escaped its region, or the content identity moved. The
-  answer was processed; it yielded fewer symbols. These are the silent drops
-  points 5 and 7 already accept.
-- **Infrastructure-failed** — never examined at all, so nothing was learned. A
+  retired, or the range escaped its region. The answer was processed; it yielded
+  fewer symbols. These are the silent drops points 5 and 7 already accept.
+- **Infrastructure-failed** — nothing was learned. This covers entries never
+  examined, and also entries whose **content identity moved**: an edit during
+  the request means the downstream answered about text that no longer exists, so
+  a symbol it did not mention may simply have shifted. The bridge learned
+  neither that the workspace has no match nor where the match now is, which is
+  the definition of uninformative — and it is why the same paragraph calls this a
+  false-negative window rather than a filter. A
   candidate **that policy admitted and is known to be capable**, whose connection
   was already `Failed`, `Closing`, or `Closed` at selection (point 3), starts
   here rather than never existing; one the allowlist, the cap, or a recorded
@@ -1653,6 +1675,9 @@ Including it would defeat dedup on a field carrying no identity.
 
 ### Negative
 
+- A file opened from outside the client's workspace no longer contributes its
+  project's symbols here, though the connection it spawned still serves that
+  file's own bridged requests (point 3).
 - Results depend on what is open, and coverage can shrink (close, respawn,
   silent connection death). Closing the last buffer for a language removes its
   server from search even though the process is still running and may still be

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -356,10 +356,10 @@ opened:
 - **Injection language**: `VirtualDocumentUri::language()` for a virtual
   document, or `_self` for a host-tier open.
 
-Reading admission records rather than live document tracking is what keeps
-`host_documents` and the tracker off the selection path for *discovery*; they
-are still consulted for validation, but a candidate no longer disappears merely
-because its document closed.
+Reading admission records keeps both the tracker and `host_documents` off the
+query path **entirely** — validation as much as discovery. Consulting either
+during validation would undo the point, since a candidate would disappear again
+the moment its document closed.
 
 Deriving the injection axis from configuration instead — concrete bridge keys
 plus the languages servers declare — looks equivalent and is not. It loses every
@@ -372,9 +372,10 @@ the region's actual `"python"` and lets `handles_language` recognize `"*"`.
 Starting from open virtual documents restores exactly that: the language is the
 region's real one.
 
-`OpenedVirtualDoc` also carries the `connection_key` the document was opened on,
-so the walk can pair each open virtual document with its host document's
-language directly rather than taking a cross product of the two axes.
+`OpenedVirtualDoc` carries the `connection_key` the document was opened on,
+which is what a record captures at open time — the pair and the exact
+connection, together, from one event, rather than a cross product of two axes
+read at different moments.
 
 `_self` needs its **own** source. Host-bridge opens are not `OpenedVirtualDoc`s
 — they live in the pool's `host_documents`, keyed by `(uri, ConnectionKey)` — so
@@ -417,6 +418,12 @@ existing configuration from becoming a silent no-op here.
 **No candidate is waited for; the only waits are lock acquisitions and the
 final barrier.** The order is fixed:
 
+0. If the method is **disabled** — `workspaceSymbolMaxFanOut = 0` — return `[]`
+   immediately, before any lock is taken. "Disable entirely" has to mean that
+   literally: applying zero at the end would make a disabled method still walk
+   admissions, take `connections`, and wait on barriers, any of which can expire
+   and turn a deliberate disable into a request error.
+
 1. **Read the admission records** — `ConnectionKey → the pairs it serves`. This
    is the *whole* of discovery. Nothing here consults the document tracker,
    which is the point: `didClose` removes tracking while leaving the connection
@@ -447,8 +454,17 @@ The ceiling comes **after** the barrier, not before, because a cap allocated to
 connections that then fail their barrier wastes its slots: with a ceiling of one
 and a first-ordered connection whose repair fails, the healthy connections below
 it would already have been truncated away and the query would error despite
-having had a sendable target. Capping what is actually sendable avoids needing a
-backfill rule at all.
+having had a sendable target.
+
+For the same reason each candidate's handle is **re-checked as its slot is
+assigned**, not only when it was validated. The barrier is keyed by
+`ConnectionKey`, not by handle identity, so a connection can pass its barrier
+and be replaced before the cap runs — consuming a slot and then failing the
+stale-handle check at enqueue, after the healthy connections below it were
+truncated. Re-checking at assignment keeps the cap spent on connections that
+still exist, which is what makes a backfill rule unnecessary rather than merely
+unstated. A candidate that fails it is dropped and the slot goes to the next in
+order.
 
 The validator is **pool-owned** for two reasons. It is the only way to do all of
 this under one acquisition — `launch_config` and its comparator are private to
@@ -474,14 +490,12 @@ Step 5 exists because a connection reaches `Ready` *before* its virtual
 documents are replayed after a respawn, so a query landing in that window would
 under-report that server's embedded symbols indistinguishably from "no matches".
 
-It closes **part** of that window, not all of it. Selection admits a candidate
-only if the tracker still records the document on that connection, and a respawn
-purge removes exactly those records — so a query arriving between the purge and
-the first replayed `didOpen` discovers no candidate at all and never reaches the
-barrier. The barrier helps once a target is discoverable but not yet replayed;
-before that, the connection is invisible to selection. Both halves have the same
-root cause and the same fix — retaining a connection's admitting policy
-independently of document tracking (point 7) — so neither is patched here.
+It closes that window because admission records survive the purge. A selection
+that went through the tracker could not: the purge removes exactly the records
+such a selection depends on, so a query arriving between the purge and the first
+replayed `didOpen` would have found no candidate and never reached the barrier
+at all. Keyed by `ConnectionKey`, the admission stays, the target stays
+discoverable, and the barrier is what decides whether it is ready to answer.
 The barrier is **bounded to two seconds** and enforced with a timeout, and
 awaiting the survivors concurrently costs that bound once for the whole query —
 not once per target.
@@ -585,9 +599,9 @@ Within a pair it works as everywhere else: `truncate_entries` truncates a
 flattened name list in walk order, keeping the highest-priority N names.
 
 A surviving name admits **only the connections that pair actually opened**, not
-every live connection of that server. The tracker records each open virtual
-document's `ConnectionKey` next to its language, so a pair's targets are known
-exactly and never derived by expanding a name across roots. That distinction is
+every live connection of that server. Each admission record pairs a language
+pair with the exact `ConnectionKey` it was opened on, so a pair's targets are
+known and never derived by expanding a name across roots. That distinction is
 load-bearing: expanding would let a Python pair that admits A reach `A/root2`
 even when the pair that actually opened A on root2 excluded it with
 `priorities = []` — turning `priorities` from a policy boundary into a hint, and
@@ -601,30 +615,23 @@ request, contradicting the setting's documented promise to "cap the number of
 concurrent server requests" — a generic load control quietly losing its
 load-controlling property in exactly the method most able to fan out.
 
-A second, global cap after dedup was tried and **rejected**. It cannot be given
-coherent semantics:
-
-- An uncapped pair must mean "no limit" — that is what `None` means everywhere
-  else — so any workspace containing one uncapped pair has no global cap at all.
-  Since uncapped is the default, the cap would be inert in almost every real
-  configuration, and present only where a user capped *something*, throttling
-  languages they never mentioned.
-- It has no principled victim order. `priorities` exists per pair and pairs may
-  rank the same server differently; merging those rankings is exactly what this
-  decision rejects elsewhere as unprincipled. Falling back to walk order is
-  worse than arbitrary — open documents and connections live in hash maps, so
-  which connections survived would vary run to run.
-
 So `max_fan_out` stays a **per-pair name-selection rule** here and bounds
-neither the query's requests nor its connections. That is a real divergence from
-its documented promise to "cap the number of concurrent server requests", and
-the fix is documentation, not a mechanism: the setting's description must say so
-(point 8). What actually bounds the total is the live-connection set (point 7).
-A workspace-level ceiling therefore **ships with the feature**, as its own
-top-level setting rather than smuggled into this one. Leaving it out would mean
-advertising the widest fan-out kakehashi has with its only load control
-documented as applying and not applying — and documentation cannot restore a
-guarantee the code stopped providing.
+neither the query's requests nor its connections — a real divergence from its
+documented promise to "cap the number of concurrent server requests", which the
+setting's description must record (point 8).
+
+Deriving a global cap from the per-pair values was tried and **rejected**: an
+uncapped pair must mean "no limit", so any workspace containing one has no
+global cap at all — and uncapped is the default, making such a cap inert in
+almost every real configuration and active only where a user capped something
+unrelated. It also has no principled victim order, since pairs may rank the same
+server differently and merging those rankings is what this decision rejects
+elsewhere.
+
+What ships instead is a **separate top-level ceiling**, `workspaceSymbolMaxFanOut`.
+Leaving the query unbounded was the alternative, and it is not acceptable for
+the widest fan-out kakehashi has: documentation cannot restore a guarantee the
+code stopped providing.
 
 It is a single value, which is what makes it definable where a derived global
 cap was not: there is no "uncapped pair means infinity" to reconcile and no
@@ -675,8 +682,8 @@ iteration order — the nondeterminism this ordering exists to remove.
         │ SELECTION (3s per AWAITED lock, §6)  │
         │ pool-owned batch validator, one lock:│
         │ Ready only, drop incapable, drop     │
-        │ stale-config, confirm still open on  │
-        │ that exact connection                │
+        │ stale-config. No document check —    │
+        │ that is what admissions replaced.    │
         │ then: allowlist + per-pair maxFanOut │
         │ NEVER spawns a connection            │
         └──────────────────┬───────────────────┘
@@ -1375,13 +1382,39 @@ for three different reasons and only one of them preserves meaning:
 - **Configuration change or removal** — the server's spawn-time config changed,
   or it left the config entirely. Records are **cleared**: the pairs that
   admitted the old executable say nothing about a differently-configured one.
-- **Client workspace invalidation, or a changed client root under
-  `ClientFallback`** — that key is reused across workspaces, so retaining
-  records would transfer one workspace's admissions into another. **Cleared.**
+- **Client workspace invalidation under `ClientFallback`** — that key is reused
+  across workspaces, so retaining records would transfer one workspace's
+  admissions into another. **Cleared** *when the connection is torn down*.
 
 Clearing on every removal would break respawn survival; retaining on every
 removal would leak admissions into a reconfigured server or a different
 workspace. Neither is safe, so the removal reason has to reach the records.
+
+Two edges follow from that, and both cut against a naive "clear on workspace
+change":
+
+- A client root change **keeps** a `Ready` fallback connection that supports
+  workspace-folder changes — it is updated dynamically, not replaced. Clearing
+  its admissions would make its already-open documents undiscoverable with no
+  replay to rebuild them. So a same-handle dynamic update **retains** its
+  records; only a teardown clears.
+- A failure respawn **removes the old connection before it knows whether a
+  replacement will start**, and a spawn can fail. A preserved record can
+  therefore be orphaned — no live connection under its key — and settings
+  propagation discovers changed or removed servers by iterating *live*
+  connections, so an orphan would evade invalidation and later admit a
+  differently-configured process under the reused key. Configuration and
+  workspace invalidation must therefore sweep the **admission registry itself**,
+  not only the connections map.
+
+One case is **accepted rather than solved**: marker-root migration. Routing
+re-walks filesystem markers on every acquisition, so adding or removing a marker
+moves a document to a different `ConnectionKey` while the old connection keeps
+running. Its admission survives its documents and keeps that obsolete root
+queryable, which can return stale or duplicate symbols until the connection
+ends. Evicting on migration would mean detecting it, and routing does not report
+it; the duplicates are visible and the staleness is bounded by the old process's
+own index, so this is recorded rather than mechanised.
 
 The records stay concrete because each was created from a real open document
 (point 3's requirement).
@@ -1590,12 +1623,9 @@ Including it would defeat dedup on a field carrying no identity.
 ### Negative
 
 - Results depend on what is open, and coverage can shrink (close, respawn,
-  silent connection death). Closing the last buffer for a language removes its
-  server from search even though the process is still running and may still be
-  usefully indexed — the sharpest form of this, and a follow-up rather than a
-  fix here (point 7). The respawn window has the same cause: a purged
-  connection is invisible to selection until its documents are replayed. The same query answers differently at different
-  points in a session. LSP permits partial `workspace/symbol` results, but a
+  silent connection death). Closing a buffer no longer removes its server —
+  admission records outlive `didClose` and the respawn purge (point 3) — but the
+  same query still answers differently at different points in a session. LSP permits partial `workspace/symbol` results, but a
   user expecting an indexed whole-project search will find this surprising.
 - Latency is max-over-live-targets, and every *wait* is bounded: the pool's 30s
   request timeout and liveness timeout, a three-second budget on **every** lock
@@ -1622,10 +1652,15 @@ Including it would defeat dedup on a field carrying no identity.
   in methods that have no use for it.
 - A server still `Initializing` when the query arrives is skipped entirely, so
   a search in the seconds after opening a file can miss it (point 3).
-- Admission records add per-`ConnectionKey` state the pool must maintain. It is
-  bounded by distinct `(host_language, injection_language)` pairs per key rather
-  than by session history, but not closed: a `languages = ["*"]` connection in a
-  polyglot workspace gains an entry per language ever seen on it (point 3).
+- Admission records add per-`ConnectionKey` state the pool must maintain, and it
+  must be swept by configuration and workspace invalidation independently of the
+  connections map. It is bounded by distinct `(host_language, injection_language)`
+  pairs per key rather than by session history, but not closed: a
+  `languages = ["*"]` connection in a polyglot workspace gains an entry per
+  language ever seen on it (point 3).
+- After a marker-root migration the old connection stays queryable at its
+  obsolete root until it ends, so a query can see stale or duplicated symbols
+  from a root the document no longer belongs to (point 3).
 - Every lock this path *awaits* — selection's `connections`, each send's
   re-acquisition, the two fan-in tracker reads, each host's `edit_lock` — is
   bounded only in its **acquisition** (the per-send identity
@@ -1646,8 +1681,8 @@ Including it would defeat dedup on a field carrying no identity.
   snapshot matches, and those symbols are dropped from that query (point 4).
 - `max_fan_out` does not bound this method's total fan-out on its own — it
   selects names per pair, and a connection one pair excluded re-enters through
-  another. `workspaceSymbolMaxFanOut` restores the guarantee, at the cost of one
-  more user-facing setting to learn, document, merge, and schema (point 3).
+  another. `workspaceSymbolMaxFanOut` bounds the query instead, at the cost of
+  one more user-facing setting to learn, document, merge, and schema (point 3).
 - The `kakehashi-virtual-uri-*` filename space is reserved: a real workspace
   file named into it is invisible to symbol search (point 5).
 - No configuration can express "suppress B's duplicates, but fall back to B when

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -476,6 +476,23 @@ final barrier.** The order is fixed:
       boundary to enforce, so nothing is filtered — the alternative would be to
       answer nothing.
 
+      A `preferSharedInstance` connection needs its own rule, because `Shared`
+      exposes **no** marker root: the roots it actually serves live in the
+      handle's mutable **workspace-folder set**, which grows as capable servers
+      take on later roots. So a `Shared` connection is admitted if **any folder
+      in that set** is inside the client workspace, and dropped only if none is.
+      Reading the folder set rather than the key is the whole of the rule;
+      testing the key would either drop every shared target or treat it as
+      rootless.
+
+      That admission is all-or-nothing, and it leaks: an instance that took on
+      both an in-workspace root and a stray external one brings the external
+      project's symbols with it. One connection cannot be half-admitted, and
+      filtering the external *candidate* does not help, because an in-workspace
+      candidate selects the same connection. The durable fix is to keep external
+      roots out of shared instances in the first place, which belongs to the
+      routing change rather than to this query.
+
    c. Then keep only `Ready` handles (`connections()` returns the raw map, and
       `ConnectionState` also has `Initializing`, `Failed`, `Closing`, `Closed`),
       drop handles lacking `workspace/symbol`, and drop handles whose recorded
@@ -943,9 +960,12 @@ Two things about *when* and *per what* are load-bearing:
   a document is being edited. Closing it needs an enqueue-coupled identity
   primitive or synchronization with the per-document transition state, and both
   are changes to the bridge's write path rather than to this method.
-- **Per connection, not per URI.** Both tracker values are keyed by
+- **Per connection, and covering `_self`.** Both tracker values are keyed by
   `ConnectionKey`, and one virtual URI can be open on several connections with
-  different confirmed content. An identity snapshot is therefore taken per
+  different confirmed content. A `_self` target's identity is its host
+  document's own downstream version and fingerprint from `host_documents`, not a
+  virtual one — captured and compared the same way, so a host edit after
+  dispatch voids that target's negative evidence exactly as a region edit does. An identity snapshot is therefore taken per
   target, and travels **with that target's response** — the bridge module hands
   back the source connection key and its URI→identity map alongside the
   `Vec<WorkspaceSymbol>`, rather than a bare vector. Fan-in validates each
@@ -1269,15 +1289,25 @@ An answer is **informative** when it produced at least one translated entry, or
 when every one of its entries was semantically rejected — including an empty
 response, which is a server saying it searched and found nothing.
 
-With one exception, and it is the reason identity is checked **per target** and
-not only per entry: if any virtual document that target was dispatched against
-changed between dispatch and translation, its answer is **uninformative
-regardless of content**, empty included. An empty answer over stale text says
-nothing about the current text — the match it omitted may have been added or
-shifted by the very edit that invalidated it — and there is no returned entry to
-mark, so a purely entry-level rollup would quietly count it as evidence of
-absence. The per-target identity snapshot already exists for this; it just has
-to be consulted even when the response carried nothing.
+With one qualification, and it is the reason identity is checked **per target**
+and not only per entry. If any document that target was dispatched against
+changed between dispatch and translation — a virtual document, or the **host**
+document for a `_self` target, whose sync state carries its own downstream
+version and fingerprint — then that target's **negative** evidence is void: an
+empty answer, or one whose entries were all semantically rejected, stops
+counting as informative. An empty answer over stale text says nothing about the
+current text, since the match it omitted may have been added or shifted by the
+very edit that invalidated it, and there is no returned entry for an
+entry-level rollup to mark.
+
+Its **positive** evidence survives. A drifted target can still have translated a
+real-file symbol, or one from a region nothing touched, and those entries are as
+good as any — drift on one document is no reason to discard a correct result
+from another, and identity is tracked per connection across documents that
+change independently. So a drifted target with at least one translated entry
+remains informative; only a drifted target that produced none loses its vote.
+Anything stronger would let an unrelated keystroke turn a working search into a
+request error.
 
 Granularity matters here: `edit_lock` expiry is per *host*, while one response
 can carry real-file entries and virtual entries from several hosts. One

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -302,8 +302,14 @@ selected it always merges B, and with `priorities` naming only A there is no B
 to fall back to. So a user gets *either* B's duplicates always, *or* no backup;
 not "A normally, B when A has nothing".
 
+It is also implementable, and the ADR should not pretend otherwise. The
+attribution argument in point 2 is about *symbols* — no entry can be traced to a
+configured pair — but a whole *response* is plainly attributable to the
+connection that produced it, and this design already carries that key through
+fan-in. `preferred` over connections could be built.
+
 The trade is accepted as **uniformity**, not because fallback-on-empty is
-invalid. It would be easy to over-argue this, so: an empty answer from A
+invalid or unbuildable. It would be easy to over-argue this, so: an empty answer from A
 establishes only that A's index has no match, and says nothing about B's — which
 is exactly why `union` returns B's matches when A is empty, and why treating
 empty as a reason to consult B is a defensible policy rather than a semantic
@@ -339,15 +345,20 @@ configuration would contribute **no candidates at all**. Treating `_` instead as
 `bridge.python.enabled = false` or `priorities = []` excluded, and union has no
 way to subtract that contribution.
 
-Both axes therefore come from **what is actually open**, which is also the set
-the live-only rule already commits to:
+Both axes therefore come from **admission records** — the concrete pairs that
+justified opening a document on a connection, retained per connection and
+generation-stamped (point 7). A record is written when a document is opened:
 
-- **Host languages**: the languages of the currently open documents
+- **Host language**: taken from the host document at open time
   (`DocumentStore::open_uris()` + language detection). Concrete by
-  construction — it never comes from a map key.
-- **Injection languages**: the languages of the currently **open virtual
-  documents**, read from `VirtualDocumentUri::language()` on the pool's tracked
-  `OpenedVirtualDoc` entries, plus `_self` for the host tier.
+  construction — never a map key.
+- **Injection language**: `VirtualDocumentUri::language()` for a virtual
+  document, or `_self` for a host-tier open.
+
+Reading admission records rather than live document tracking is what keeps
+`host_documents` and the tracker off the selection path for *discovery*; they
+are still consulted for validation, but a candidate no longer disappears merely
+because its document closed.
 
 Deriving the injection axis from configuration instead — concrete bridge keys
 plus the languages servers declare — looks equivalent and is not. It loses every
@@ -370,8 +381,8 @@ a host-only document can have a perfectly valid `_self` connection that no
 virtual document names. Deriving `_self` targets from virtual documents would
 therefore either omit host bridging entirely or fall back to expanding a server
 name across roots, recreating the leak point 3 exists to prevent. The
-`(host_language, _self, ConnectionKey)` triples come from `host_documents`
-directly.
+`(host_language, _self, ConnectionKey)` admission records are therefore written
+at host-open time from `host_documents`' own key, alongside the virtual ones.
 
 That is a second async map, read **under** `connections` by the batch validator
 below rather than snapshotted separately, so selection's acquisitions are the
@@ -434,15 +445,20 @@ final barrier.** The order is fixed:
    `ConnectionState` also has `Initializing`, `Failed`, `Closing`, `Closed`);
    drops handles lacking `workspace/symbol`; drops handles whose recorded launch
    configuration no longer matches the `BridgeServerConfig` that admitted them;
-   and confirms current membership — the live reverse index for a virtual
-   candidate, `host_documents` for a `_self` one.
+   and confirms the admission record's **generation** still matches the
+   connection's.
 
-   The reverse index is a sharded map and answers synchronously. `host_documents`
-   is a separate Tokio mutex, so it is taken with **`try_lock`**, never awaited:
-   on contention the `_self` candidates are dropped for that query and the
-   virtual ones are unaffected. Awaiting it while holding `connections` would
-   make this path exactly the kind of unbounded holder that forced every budget
-   in point 6, and there is no version of "briefly" that is safe there.
+   The generation comparison is a field read on the handle — synchronous, no
+   second lock — which is why admission records carry it. An earlier draft
+   validated `_self` candidates against `host_documents` instead, taken with
+   `try_lock` under `connections`; that had to be abandoned because the mutex is
+   not brief bookkeeping. Host synchronization holds it across awaited
+   downstream notification sends, so ordinary editing or writer backpressure
+   would contend it, and a `_self` server would vanish from search — or the
+   query would fail outright — for reasons that are pure scheduling. Coverage
+   must not be a function of who happened to hold a lock. Virtual candidates are
+   additionally confirmed against the live reverse index, which is a sharded map
+   and answers synchronously.
 3. Apply the per-pair `priorities` allowlist and `max_fan_out` cap to the
    survivors — pure computation, after the lock is released.
 4. Dedup by **connection key** `(server, root)`.
@@ -453,18 +469,18 @@ The validator is **pool-owned** for two reasons. It is the only way to do all of
 this under one acquisition — `launch_config` and its comparator are private to
 the pool, and the exposed comparison helper takes `connections` itself, so a
 caller in `bridge/workspace/symbol.rs` doing these checks piecemeal would
-re-lock between them and validate against a map that had already moved. And it
-is what lets `host_documents` be consulted **while `connections` is held**
-rather than snapshotted first: a `_self` candidate has no reverse-index check to fall
-back on, `HostDocSyncState` records neither connection generation nor handle
-identity, and a respawn can purge the entry and install a fresh `Ready` handle
-under the same `ConnectionKey` — so a released snapshot would let a connection
-that never opened the host document pass every other check. The language and
-incarnation recheck does not catch that, because the host lifetime never
-changed; only the connection did.
+re-lock between them and validate against a map that had already moved.
 
-The resulting order is `connections` → {tracker, `host_documents`}, which is the
-pool's own nesting and the one the respawn purge takes.
+It is also where the generation comparison happens, and why admission records
+carry one. `HostDocSyncState` records neither connection generation nor handle
+identity, and a respawn can install a fresh `Ready` handle under the same
+`ConnectionKey` — so a `_self` candidate carrying only a key would let a
+connection that never opened the host document pass every other check. The
+language and incarnation recheck does not catch that, because the host lifetime
+never changed; only the connection did. A stamped record does.
+
+The resulting order is `connections` → tracker, which is the pool's own nesting
+and the one the respawn purge takes.
 
 Every filter in step 2 precedes the cap in step 3, and that ordering is
 load-bearing for each of them: with `priorities = [A, B]` and
@@ -623,14 +639,22 @@ neither the query's requests nor its connections. That is a real divergence from
 its documented promise to "cap the number of concurrent server requests", and
 the fix is documentation, not a mechanism: the setting's description must say so
 (point 8). What actually bounds the total is the live-connection set (point 7).
-A workspace-level ceiling belongs in a separate setting with its own name and
-semantics rather than smuggled into this one, and is listed as deferred work in
-point 9 rather than left as a vague possibility — this method is the widest
-fan-out kakehashi has, and it is the one the existing guard does not bound.
+A workspace-level ceiling therefore **ships with the feature**, as its own
+top-level setting rather than smuggled into this one. Leaving it out would mean
+advertising the widest fan-out kakehashi has with its only load control
+documented as applying and not applying — and documentation cannot restore a
+guarantee the code stopped providing.
+
+It is a single value, which is what makes it definable where a derived global
+cap was not: there is no "uncapped pair means infinity" to reconcile and no
+per-pair priority list to merge. It applies **after dedup**, to the connection
+set, and when it truncates it does so in a **stable documented order** —
+`(server name, root)` — rather than by priority, since per-pair priorities
+conflict and walk order varies run to run. Unset means no limit.
 
 ```
-  open host docs × their open virtual docs    ← concrete languages only,
-        │  (never a raw `_` map key)             no arbitration
+  admission records (per connection,          ← concrete languages only,
+        │  generation-stamped, outlive close)    no arbitration
         ▼
   ┌──────────────────────┐   ┌──────────────────────┐
   │ (LANG_1, _self)      │   │ (LANG_2, _self)      │  ... every pair
@@ -645,6 +669,8 @@ fan-out kakehashi has, and it is the one the existing guard does not bound.
         │ stale-config, confirm still open on  │
         │ that exact connection                │
         │ then: allowlist + per-pair maxFanOut │
+        │ then dedup, then the workspace-wide  │
+        │ ceiling (stable server,root order)   │
         │ NEVER spawns a connection            │
         └──────────────────┬───────────────────┘
                            ▼
@@ -1162,8 +1188,7 @@ response.
   error**.
 
 The last two cases are why the unit is the entry rather than the response.
-Selection can expire its tracker or `connections` acquisition, and `_self`
-discovery is incomplete whenever `host_documents` was contended, so "no
+Selection can expire its tracker or `connections` acquisition, so "no
 candidates" and "we could not find out" are different states. And a fan-in
 failure counts: if servers returned symbols and every entry was lost to a lock
 that could not be acquired or a parse that had not settled, the client would
@@ -1256,16 +1281,17 @@ budget, and failing to acquire it drops the affected target or host** rather
 than blocking the query. That is more than the `connections` mutex — selection
 also awaits the tracker snapshot, each send re-acquires `connections` before
 enqueue, and translation takes each host's `edit_lock`. (`host_documents` is not
-in that list: it is `try_lock`ed under `connections` and never awaited, so
-contention drops the `_self` candidates immediately rather than consuming a
-budget.) None of these is safe to assume fast: injection processing holds
+in that list at all: selection no longer consults it, since `_self` candidates
+are validated by generation comparison instead — see point 3 for why
+`try_lock`ing it was abandoned.) None of these is safe to assume fast: injection
+processing holds
 `edit_lock` across downstream close, change, and eager-spawn awaits, so a query
 arriving mid-processing would otherwise wait on unrelated work with no bound.
 
 - **Selection**: the tracker snapshot, then `connections` — three seconds each.
   Nothing else is *awaited*: under `connections` the validator queries the
-  reverse index synchronously and `host_documents` with `try_lock`, so there is
-  no third acquisition to budget and no await while a lock is held. The budget
+  reverse index synchronously and compares generations as field reads, so there
+  is no third acquisition to budget and no await while a lock is held. The budget
   covers *acquiring* each lock, not the filtering between them — that walk is synchronous with no
   await, so a timeout could not preempt it anyway, and bounding what cannot be
   interrupted would promise something the runtime does not deliver.
@@ -1303,23 +1329,32 @@ requests.
 A candidate with no live connection is **skipped**, not spawned. Coverage is
 therefore bounded by what the client has opened, and grows as it opens more.
 
-Stated precisely, it is **the servers currently holding an open document for
-this workspace** — not "every running server". The two differ, and the gap is
-user-visible: `didClose` removes kakehashi's document tracking but deliberately
-leaves the downstream connection running, so closing the last buffer for a
-language drops that server from selection even though it is still `Ready`. What
-that costs depends on the server: whether a downstream retains a usable
-workspace index after `didClose` is server-specific and not something kakehashi
-can know. Where it does, a query that would have been answered comes back
-empty — and if that server was the only one selected, the whole search does,
-with no failure anywhere.
+Stated precisely, it is **every live connection some open document once
+justified** — not "every running server", and not "servers with a document open
+right now". The middle reading is the one that matters: `didClose` removes
+kakehashi's document tracking but deliberately leaves the downstream connection
+running, and whether that server keeps a usable workspace index afterwards is
+server-specific. Selecting on live documents would therefore make closing the
+last buffer for a language silently drop a `Ready`, possibly well-indexed server
+— so selection uses retained admission records instead (point 3).
 
-That follows from deriving the candidate axes from open documents, which is what
-makes them concrete (point 3) — the alternative derivations lose `_` handling or
-`["*"]` servers entirely. Closing it properly means retaining each connection's
-admitting policy independently of document tracking, so a connection can outlive
-the document that justified it. That is a change to what the pool remembers, not
-to this method, and is left as a follow-up rather than smuggled in here.
+This is **not** deferred, because a provider that quietly stops answering when
+you close a buffer is not a workspace search. The pool retains an **admission
+record** per connection — the concrete `(host_language, injection_language_or_
+_self)` pairs that ever justified opening a document on it, stamped with the
+connection's generation — written when the document is opened and *not* removed
+when it closes. Candidates come from those records rather than from live
+document tracking.
+
+The records stay concrete, because each was created from a real open document at
+the time (point 3's requirement), and they survive both closure and the respawn
+purge window, which is the same root cause seen twice. The generation stamp is
+what makes them safe to hold: a record whose generation no longer matches the
+connection's is stale and is discarded rather than trusted, so a replaced
+process cannot inherit its predecessor's admissions.
+
+A record is dropped when its connection is, so this bounds memory by live
+connections, not by session history.
 
 This is not merely a cost trade. Cold-starting cannot deliver the coverage it
 appears to promise:
@@ -1415,12 +1450,6 @@ documenting only two values.
   `workspaceSymbolProvider`. The existing client-progress aggregator is keyed by
   region and has no meaning for a request that has no region. Both tokens are
   optional in LSP 3.18.
-- **A request-wide fan-out ceiling.** `max_fan_out` bounds a pair's name
-  selection, not the query (point 3), so nothing caps how many connections one
-  query touches except how many are live. That is a real gap in a generic load
-  control, and this is the method most able to expose it. The fix is a
-  separately named workspace-level limit — a new user-facing setting, which is
-  why it is deferred rather than decided here.
 - **Request coalescing.** A symbol picker typically fires one request per
   keystroke, and this design has no single-flight, debounce, or supersession —
   each keystroke fans out to every live connection. The repo has prior art for
@@ -1555,15 +1584,14 @@ Including it would defeat dedup on a field carrying no identity.
   in methods that have no use for it.
 - A server still `Initializing` when the query arrives is skipped entirely, so
   a search in the seconds after opening a file can miss it (point 3).
-- `_self` targets are dropped when `host_documents` is contended at validation
-  time, since it is `try_lock`ed rather than awaited (point 3). Host-bridged
-  symbols can therefore be absent from one query for a reason the user cannot
-  see.
+- Admission records add per-connection state the pool must maintain and expire
+  with the connection (point 3) — the cost of not tying coverage to document
+  lifetime.
 - Every lock this path *awaits* — the candidate tracker snapshot, `connections`,
   each send's re-acquisition, the two fan-in tracker reads, each host's
-  `edit_lock` — is bounded only in its **acquisition** (`host_documents` and the
-  per-send identity snapshot are never awaited; they are `try_lock`ed under
-  `connections`, and contention drops the affected candidates), because
+  `edit_lock` — is bounded only in its **acquisition** (the per-send identity
+  snapshot is `try_lock`ed under `connections` rather than awaited, and
+  contention drops that target), because
   other paths hold these across unbounded async work (point 6); the filtering
   between them is synchronous and cannot be preempted, so neither total
   selection time nor cancellation blocking is capped. Expiring any of those
@@ -1577,15 +1605,17 @@ Including it would defeat dedup on a field carrying no identity.
   releases `connections` before bumping its revision and recording its
   fingerprint, so a change landing beside a dispatch can expose a pair no
   snapshot matches, and those symbols are dropped from that query (point 4).
-- `max_fan_out` does not bound this method's total fan-out. It selects names
-  per pair, and a connection one pair excluded re-enters through another pair
-  that legitimately opened it. Its documented promise to cap concurrent server
-  requests does not hold here, which is why the documentation must say so.
+- `max_fan_out` does not bound this method's total fan-out on its own — it
+  selects names per pair, and a connection one pair excluded re-enters through
+  another. A new top-level ceiling restores the guarantee, at the cost of one
+  more user-facing setting to learn (point 3).
 - The `kakehashi-virtual-uri-*` filename space is reserved: a real workspace
   file named into it is invisible to symbol search (point 5).
 - No configuration can express "suppress B's duplicates, but fall back to B when
   A fails" — `union` has no conditional and `priorities` is unconditional, so
-  users pick one or the other (point 2).
+  users pick one or the other. This is a choice, not a limitation: a
+  per-connection `preferred` is implementable, and was declined for uniformity
+  (point 2).
 - `strategy` becomes a knob that this one method ignores. A **method-specific**
   entry warns; a `_` wildcard that happens to reach the method is overridden
   silently, by design (point 2). Users

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -1266,9 +1266,18 @@ those rather than from whole responses:
   even though both surface as no current geometry.
 
 An answer is **informative** when it produced at least one translated entry, or
-when every one of its entries was semantically rejected — including a
-legitimately empty response, which is a server saying it searched and found
-nothing.
+when every one of its entries was semantically rejected — including an empty
+response, which is a server saying it searched and found nothing.
+
+With one exception, and it is the reason identity is checked **per target** and
+not only per entry: if any virtual document that target was dispatched against
+changed between dispatch and translation, its answer is **uninformative
+regardless of content**, empty included. An empty answer over stale text says
+nothing about the current text — the match it omitted may have been added or
+shifted by the very edit that invalidated it — and there is no returned entry to
+mark, so a purely entry-level rollup would quietly count it as evidence of
+absence. The per-target identity snapshot already exists for this; it just has
+to be consulted even when the response carried nothing.
 
 Granularity matters here: `edit_lock` expiry is per *host*, while one response
 can carry real-file entries and virtual entries from several hosts. One
@@ -1677,7 +1686,9 @@ Including it would defeat dedup on a field carrying no identity.
 
 - A file opened from outside the client's workspace no longer contributes its
   project's symbols here, though the connection it spawned still serves that
-  file's own bridged requests (point 3).
+  file's own bridged requests. One exception survives: a `preferSharedInstance`
+  server that took on both an in-workspace root and an external one is
+  indivisible, so admitting it for the former also admits the latter (point 3).
 - Results depend on what is open, and coverage can shrink (close, respawn,
   silent connection death). Closing the last buffer for a language removes its
   server from search even though the process is still running and may still be

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -907,7 +907,9 @@ hand. "Its own offset" does not mean "its own resolution", though; see pass 3.
              │
              ▼
      ┌───────────────────┐  no
-     │ has a range?      ├─────▶ DROP as a PROTOCOL FAILURE (see below)
+     │ has a WELL-FORMED ├─────▶ DROP as a PROTOCOL FAILURE (see below)
+     │ range? (present,  │
+     │ start ≤ end)      │
      └─────────┬─────────┘
                │ yes
                ▼
@@ -993,8 +995,19 @@ Two things about *when* and *per what* are load-bearing:
   document's own downstream version and fingerprint from `host_documents`, not a
   virtual one.
 
-  Comparing that recorded pair across the request is **not enough on its own**,
-  and for a sharper reason than in the virtual case. Downstream host
+  Version and fingerprint alone cannot tell a **close/reopen** from no change at
+  all. Closing removes the sync state and reopening recreates it at version 1
+  with the same fingerprint when the text is unchanged, so both the recorded
+  comparison and the current-text comparison pass — while on a multilingual
+  server the document may have reopened under a *different language*, and an
+  answer computed for the prior lifetime would be accepted. So the host's
+  **incarnation and language** are captured per URI alongside the `_self`
+  dispatch identity and compared with it. This is the same lifetime check the
+  candidate walk already makes at selection; it has to survive into fan-in,
+  because the reopen can happen after dispatch.
+
+  Comparing the recorded pair across the request is also **not enough on its
+  own**, and for a sharper reason than in the virtual case. Downstream host
   synchronization is deferred to the diagnostic debounce and then launched
   asynchronously, so an edit can update the `DocumentStore` and leave
   `HostDocSyncState` untouched for some time — both readings equal, both stale.
@@ -1051,7 +1064,16 @@ existing strict position machinery rather than a new comparison, and only then
 is the range translated and checked against the host-side region bound. Validating in virtual coordinates before translating is
 what catches the column case; the host bound catches what survives it.
 
-A range-less entry is **not** a semantic rejection, and the distinction matters:
+The first check is **well-formedness, before the virtual/real branch** — the
+range must be present *and* correctly ordered. Bounds validation is necessarily
+per-document and happens later, against the region's own content, but ordering
+is not: a `start > end` range is malformed whatever it describes, and a real-file
+or `_self` entry carrying one would otherwise sail past untouched, since
+non-virtual locations are passed through unvalidated. Checking order once, up
+front, is what makes "an unusable range is a failure" true for every entry
+rather than only for the ones that happen to be translated.
+
+A malformed entry is **not** a semantic rejection, and the distinction matters:
 the server reported a match and kakehashi could not use it. Counting it as
 semantic would let a response consisting entirely of range-less entries come
 back as an informative `[]` — telling the user there are no symbols at the

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -347,7 +347,8 @@ way to subtract that contribution.
 
 Both axes therefore come from **admission records** — the concrete pairs that
 justified opening a document on a connection, retained per connection and
-generation-stamped (point 7). A record is written when a document is opened:
+keyed by `ConnectionKey` (point 7). A record is written when a document is
+opened:
 
 - **Host language**: taken from the host document at open time
   (`DocumentStore::open_uris()` + language detection). Concrete by
@@ -436,29 +437,25 @@ existing configuration from becoming a silent no-op here.
 **No candidate is waited for; the only waits are lock acquisitions and the
 final barrier.** The order is fixed:
 
-1. **Snapshot the tracker's host→virtual map** under its own lock and release
-   it. This only *enumerates* candidates; every entry is re-validated in step 2
-   before it can contribute.
+1. **Read the admission records** — `ConnectionKey → the pairs it serves`. This
+   is the *whole* of discovery. Nothing here consults the document tracker,
+   which is the point: `didClose` removes tracking while leaving the connection
+   open, so any discovery that went through the tracker would lose that
+   connection the moment its last document closed, and supplementing the records
+   with a tracker check would reintroduce exactly the defect they exist to fix.
 2. Hand the candidate set to a **pool-owned batch validator**, which takes
    `connections` **once** and, without awaiting inside, per candidate: keeps
    only `Ready` handles (`connections()` returns the raw map, and
    `ConnectionState` also has `Initializing`, `Failed`, `Closing`, `Closed`);
-   drops handles lacking `workspace/symbol`; drops handles whose recorded launch
-   configuration no longer matches the `BridgeServerConfig` that admitted them;
-   and confirms the admission record's **generation** still matches the
-   connection's.
+   drops handles lacking `workspace/symbol`; and drops handles whose recorded
+   launch configuration no longer matches the `BridgeServerConfig` that admitted
+   them.
 
-   The generation comparison is a field read on the handle — synchronous, no
-   second lock — which is why admission records carry it. An earlier draft
-   validated `_self` candidates against `host_documents` instead, taken with
-   `try_lock` under `connections`; that had to be abandoned because the mutex is
-   not brief bookkeeping. Host synchronization holds it across awaited
-   downstream notification sends, so ordinary editing or writer backpressure
-   would contend it, and a `_self` server would vanish from search — or the
-   query would fail outright — for reasons that are pure scheduling. Coverage
-   must not be a function of who happened to hold a lock. Virtual candidates are
-   additionally confirmed against the live reverse index, which is a sharded map
-   and answers synchronously.
+   These are the only checks, and they are all about the **connection**, not
+   about any document. Whether a document is currently open on it is
+   deliberately not asked — that is what step 1 stopped depending on. Whether
+   its documents have been *replayed* after a respawn is asked, but later and
+   differently, by the barrier in step 5.
 3. Apply the per-pair `priorities` allowlist and `max_fan_out` cap to the
    survivors — pure computation, after the lock is released.
 4. Dedup by **connection key** `(server, root)`.
@@ -471,16 +468,12 @@ the pool, and the exposed comparison helper takes `connections` itself, so a
 caller in `bridge/workspace/symbol.rs` doing these checks piecemeal would
 re-lock between them and validate against a map that had already moved.
 
-It is also where the generation comparison happens, and why admission records
-carry one. `HostDocSyncState` records neither connection generation nor handle
-identity, and a respawn can install a fresh `Ready` handle under the same
-`ConnectionKey` — so a `_self` candidate carrying only a key would let a
-connection that never opened the host document pass every other check. The
-language and incarnation recheck does not catch that, because the host lifetime
-never changed; only the connection did. A stamped record does.
-
-The resulting order is `connections` → tracker, which is the pool's own nesting
-and the one the respawn purge takes.
+It also takes only **one** lock. Because discovery reads admission records and
+validation asks only about connections, neither `host_documents` nor the
+tracker is on this path at all — which removes the lock-ordering question that
+earlier drafts kept getting wrong, and with it the `try_lock` policy that made
+`_self` coverage depend on whether host synchronization happened to hold its
+mutex.
 
 Every filter in step 2 precedes the cap in step 3, and that ordering is
 load-bearing for each of them: with `priorities = [A, B]` and
@@ -647,14 +640,29 @@ guarantee the code stopped providing.
 
 It is a single value, which is what makes it definable where a derived global
 cap was not: there is no "uncapped pair means infinity" to reconcile and no
-per-pair priority list to merge. It applies **after dedup**, to the connection
-set, and when it truncates it does so in a **stable documented order** —
-`(server name, root)` — rather than by priority, since per-pair priorities
-conflict and walk order varies run to run. Unset means no limit.
+per-pair priority list to merge.
+
+As a configuration surface it is `workspaceSymbolMaxFanOut`, a top-level
+`Option<i64>` alongside the existing top-level settings, mirroring
+`max_fan_out`'s own conventions so users meet no new ones: absent or `null` =
+no limit, `0` = disable the method entirely, positive = cap, negative = treated
+as no limit. It merges like every other scalar — a later layer's value replaces
+an earlier one — which means it needs the same raw/resolved field pair, the same
+layered-merge entry, the same default, and the same schema and documentation
+coverage as its neighbours. Naming it here without that inventory would leave an
+implementer unable to expose or reload it consistently.
+
+It applies **after dedup**, to the connection set, and truncates in a **stable
+documented order** rather than by priority — per-pair priorities conflict, and
+walk order varies run to run. The order is `(server name, root discriminator,
+root path)`: the discriminator is required because `ClientFallback` and `Shared`
+both report no marker root and can coexist for one server, so comparing only the
+name and the marker path leaves them tied and the tie falls back to hash
+iteration order — the nondeterminism this ordering exists to remove.
 
 ```
-  admission records (per connection,          ← concrete languages only,
-        │  generation-stamped, outlive close)    no arbitration
+  admission records, keyed by ConnectionKey   ← concrete languages only,
+        │  (outlive didClose and respawn)        no arbitration
         ▼
   ┌──────────────────────┐   ┌──────────────────────┐
   │ (LANG_1, _self)      │   │ (LANG_2, _self)      │  ... every pair
@@ -669,8 +677,6 @@ conflict and walk order varies run to run. Unset means no limit.
         │ stale-config, confirm still open on  │
         │ that exact connection                │
         │ then: allowlist + per-pair maxFanOut │
-        │ then dedup, then the workspace-wide  │
-        │ ceiling (stable server,root order)   │
         │ NEVER spawns a connection            │
         └──────────────────┬───────────────────┘
                            ▼
@@ -679,7 +685,8 @@ conflict and walk order varies run to run. Unset means no limit.
         │   each pair admits ONLY the conns it │
         │   actually opened — never a name     │
         │   expanded across roots              │
-        │ (no global cap — see §3)             │
+        │ then workspaceSymbolMaxFanOut, in    │
+        │ (name, root-kind, root) order        │
         └──────────────────┬───────────────────┘
                            ▼
               await the 2s reopen barrier concurrently,
@@ -1278,20 +1285,20 @@ already been spent.
 
 The rule is uniform: **every lock this path *awaits* carries a three-second
 budget, and failing to acquire it drops the affected target or host** rather
-than blocking the query. That is more than the `connections` mutex — selection
-also awaits the tracker snapshot, each send re-acquires `connections` before
-enqueue, and translation takes each host's `edit_lock`. (`host_documents` is not
+than blocking the query. That is more than one acquisition — each send
+re-acquires `connections` before enqueue, fan-in reads the tracker twice, and
+translation takes each host's `edit_lock`. (`host_documents` is not
 in that list at all: selection no longer consults it, since `_self` candidates
-are validated by generation comparison instead — see point 3 for why
-`try_lock`ing it was abandoned.) None of these is safe to assume fast: injection
+come from admission records instead — see point 3 for why `try_lock`ing it was
+abandoned.) None of these is safe to assume fast: injection
 processing holds
 `edit_lock` across downstream close, change, and eager-spawn awaits, so a query
 arriving mid-processing would otherwise wait on unrelated work with no bound.
 
-- **Selection**: the tracker snapshot, then `connections` — three seconds each.
-  Nothing else is *awaited*: under `connections` the validator queries the
-  reverse index synchronously and compares generations as field reads, so there
-  is no third acquisition to budget and no await while a lock is held. The budget
+- **Selection**: `connections` — three seconds. That is the only lock selection
+  takes: discovery reads admission records and validation asks only about
+  connections, so there is no tracker or `host_documents` acquisition to budget
+  and no await while a lock is held. The budget
   covers *acquiring* each lock, not the filtering between them — that walk is synchronous with no
   await, so a timeout could not preempt it anyway, and bounding what cannot be
   interrupted would promise something the runtime does not deliver.
@@ -1340,21 +1347,35 @@ last buffer for a language silently drop a `Ready`, possibly well-indexed server
 
 This is **not** deferred, because a provider that quietly stops answering when
 you close a buffer is not a workspace search. The pool retains an **admission
-record** per connection — the concrete `(host_language, injection_language_or_
-_self)` pairs that ever justified opening a document on it, stamped with the
-connection's generation — written when the document is opened and *not* removed
-when it closes. Candidates come from those records rather than from live
-document tracking.
+record** keyed by **`ConnectionKey`** — the concrete
+`(host_language, injection_language_or__self)` pairs that have justified opening
+a document on that `(server, root)` — written when a document is opened and
+removed only when the key itself goes away. Candidates come from these records
+instead of from live document tracking, and the tracker is consulted only for
+things that genuinely are about documents.
 
-The records stay concrete, because each was created from a real open document at
-the time (point 3's requirement), and they survive both closure and the respawn
-purge window, which is the same root cause seen twice. The generation stamp is
-what makes them safe to hold: a record whose generation no longer matches the
-connection's is stale and is discarded rather than trusted, so a replaced
-process cannot inherit its predecessor's admissions.
+Keying on `ConnectionKey` rather than on a handle is what makes them survive
+both events that motivated this. A `didClose` does not touch them. Neither does
+a respawn: the replacement serves the same `(server, root)` under the same
+configuration, so the pairs that admitted its predecessor admit it too — that
+is not stale inheritance but the correct answer. An earlier draft stamped
+records with the connection generation to prevent exactly that inheritance,
+which was solving a problem that does not exist; the reopen barrier, not a
+generation check, is what handles a replacement whose documents are not yet
+replayed.
 
-A record is dropped when its connection is, so this bounds memory by live
-connections, not by session history.
+The records stay concrete because each was created from a real open document
+(point 3's requirement). They are removed when their `ConnectionKey` is — a
+server dropped from configuration, or a root that no longer resolves — so a
+long-lived session does not accumulate keys for servers it no longer has.
+
+Their size is bounded by **distinct `(host_language, injection_language)` pairs
+per key**, not by session history. That is small for ordinary configurations,
+but it is not closed: a `languages = ["*"]` server admits any injection language
+a document happens to contain, so a long-lived connection in a polyglot
+workspace accumulates one entry per language ever seen on it. Entries are
+`(String, String)`; the growth is real but slow, and capping it would trade a
+bounded leak for silently forgetting a language the user still has open.
 
 This is not merely a cost trade. Cold-starting cannot deliver the coverage it
 appears to promise:
@@ -1561,7 +1582,7 @@ Including it would defeat dedup on a field carrying no identity.
   user expecting an indexed whole-project search will find this surprising.
 - Latency is max-over-live-targets, and every *wait* is bounded: the pool's 30s
   request timeout and liveness timeout, a three-second budget on **every** lock
-  this path awaits (the candidate tracker snapshot, `connections`, each send's
+  this path awaits (selection's `connections`, each send's
   `connections` re-acquisition, the pass-0 host→virtual snapshot, the
   translation-time identity re-read, and each host's `edit_lock`), and the
   reopen barrier's two seconds. Total latency is not bounded, because the synchronous
@@ -1584,12 +1605,13 @@ Including it would defeat dedup on a field carrying no identity.
   in methods that have no use for it.
 - A server still `Initializing` when the query arrives is skipped entirely, so
   a search in the seconds after opening a file can miss it (point 3).
-- Admission records add per-connection state the pool must maintain and expire
-  with the connection (point 3) — the cost of not tying coverage to document
-  lifetime.
-- Every lock this path *awaits* — the candidate tracker snapshot, `connections`,
-  each send's re-acquisition, the two fan-in tracker reads, each host's
-  `edit_lock` — is bounded only in its **acquisition** (the per-send identity
+- Admission records add per-`ConnectionKey` state the pool must maintain. It is
+  bounded by distinct `(host_language, injection_language)` pairs per key rather
+  than by session history, but not closed: a `languages = ["*"]` connection in a
+  polyglot workspace gains an entry per language ever seen on it (point 3).
+- Every lock this path *awaits* — selection's `connections`, each send's
+  re-acquisition, the two fan-in tracker reads, each host's `edit_lock` — is
+  bounded only in its **acquisition** (the per-send identity
   snapshot is `try_lock`ed under `connections` rather than awaited, and
   contention drops that target), because
   other paths hold these across unbounded async work (point 6); the filtering
@@ -1607,8 +1629,8 @@ Including it would defeat dedup on a field carrying no identity.
   snapshot matches, and those symbols are dropped from that query (point 4).
 - `max_fan_out` does not bound this method's total fan-out on its own — it
   selects names per pair, and a connection one pair excluded re-enters through
-  another. A new top-level ceiling restores the guarantee, at the cost of one
-  more user-facing setting to learn (point 3).
+  another. `workspaceSymbolMaxFanOut` restores the guarantee, at the cost of one
+  more user-facing setting to learn, document, merge, and schema (point 3).
 - The `kakehashi-virtual-uri-*` filename space is reserved: a real workspace
   file named into it is invisible to symbol search (point 5).
 - No configuration can express "suppress B's duplicates, but fall back to B when

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -533,14 +533,25 @@ known not to support `workspace/symbol` is still known not to. Its death removes
 no symbol-search coverage, and counting it would turn a legitimate "no matches"
 into an outage on the strength of a server that was never going to answer.
 
-That leaves three cases for a dead candidate, and only the first is silent:
+That leaves two cases for a dead candidate, and only the first is silent:
 
 - **Known incapable** — excluded, exactly as it would be while alive. Not a
   failure.
 - **Known capable** — an infrastructure failure. It would have answered.
-- **Never initialized**, so nothing was ever recorded — an infrastructure
-  failure too. Whether it would have contributed is unknowable, and the whole
-  point of this accounting is that unknown must not read as absent.
+
+There is no third, "never initialized" case, and it is worth saying why rather
+than leaving a reader to wonder. A candidate exists only because a document was
+successfully opened on that connection, and both eager-open paths wait for
+`Ready` and bail on initialization failure *before* recording any document
+state. A handle that never completed its handshake is therefore named by no
+candidate at all — selection cannot see it, so it cannot classify it.
+
+The consequence is a real one and belongs to point 9's first blocker rather than
+to this rule: a workspace whose servers **all failed to start** answers `[]`,
+because coverage is derived from successful document opens and there were none.
+That is the same defect as a connection not outliving its documents, seen from
+the other end — coverage tied to document lifecycle — and it is fixed by
+whatever fixes that.
 
 Recording a dead connection as a failure rather than as a non-candidate is what
 keeps the outcome rule honest. A liveness timeout marks a handle `Failed` in
@@ -737,11 +748,12 @@ return is part of the pattern.
   method reports every server incapable. The arm reads
   `workspace_symbol_provider: Option<OneOf<bool, WorkspaceSymbolOptions>>` in the
   same shape as the existing `textDocument/definition` arm.
-- **A `Ready` handle to read.** It falls back to
-  `server_capabilities()`, which is `None` until `set_server_capabilities` runs
-  during the handshake. Point 3 keeps only `Ready` candidates precisely so this
-  is knowable at selection time — an `Initializing` handle reports every server
-  incapable, which is why it cannot be a candidate.
+- **A completed handshake to read.** It falls back to `server_capabilities()`,
+  which is `None` until `set_server_capabilities` runs — but that is a
+  `OnceLock`, so it stays readable afterwards regardless of state. `Ready` is
+  what *dispatch* requires; capability classification only requires that the
+  handshake happened, which is why point 3 can classify a dead handle and cannot
+  classify an `Initializing` one, where every server would report incapable.
 
 Cancellation needs nothing new **downstream**: `register_upstream_request`
 already holds many `(server, root)` keys per upstream id,
@@ -1185,10 +1197,10 @@ those rather than from whole responses:
   answer was processed; it yielded fewer symbols. These are the silent drops
   points 5 and 7 already accept.
 - **Infrastructure-failed** — never examined at all, so nothing was learned. A
-  candidate **that policy admitted and is not known to be incapable**, whose
-  connection was already `Failed`, `Closing`, or `Closed` at selection (point 3),
-  starts here rather than never existing; one the allowlist, the cap, or a
-  recorded lack of the capability excluded is simply not a candidate. Also: the
+  candidate **that policy admitted and is known to be capable**, whose connection
+  was already `Failed`, `Closing`, or `Closed` at selection (point 3), starts
+  here rather than never existing; one the allowlist, the cap, or a recorded
+  lack of the capability excluded is simply not a candidate. Also: the
   pass-0 host→virtual snapshot, the translation-time identity re-read, or a
   host's `edit_lock` expiring; and, importantly, geometry that is *unsettled*
   rather than gone — a host still parsing, a pass whose 200ms ensure timed out,
@@ -1208,9 +1220,10 @@ a request error, so poisoning is decided per entry and rolled up, never per
 response.
 
 - Selection **completed** and found no candidates → `[]`. Nothing failed; there
-  was nothing to ask. "No candidates" means the admissions named none, or only
-  ones that are still `Initializing` — **not** ones whose connections had died,
-  which are infrastructure failures and fall to the error case below (point 3).
+  was nothing to ask. "No candidates" covers admissions that named none, ones
+  still `Initializing`, and dead ones **known to be incapable** — but not dead
+  ones known to be capable, which are infrastructure failures and fall to the
+  error case below (point 3).
 - **At least one informative** answer → its results, or `[]` if they genuinely
   contained nothing. Partial failure stays soft.
 - Candidates existed and **no answer was informative** — for any reason, at any
@@ -1463,8 +1476,12 @@ do is specify their mechanisms, for a reason given in Considered Options.
   stops being asked, and if it was the only one selected the search goes empty
   with no failure anywhere. The respawn purge window is the same defect seen
   twice: a purged connection is invisible to selection until its documents are
-  replayed. A workspace search that silently narrows when you close a file is
-  not one; whatever mechanism is chosen, this must behave correctly at ship.
+  replayed. The same derivation has a third face: a workspace whose servers
+  **all failed to start** answers `[]` rather than reporting an outage, because
+  coverage comes from successful document opens and there were none. A workspace
+  search that silently narrows when you close a file — or that reports "no
+  matches" when nothing ever started — is not one; whatever mechanism is chosen,
+  this must behave correctly at ship.
 - **`max_fan_out` does not bound this query.** It selects server *names* per
   pair, one name reaches every root it is live on, and a connection one pair
   excluded re-enters through another — so `max_fan_out = 1` can issue many

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -476,6 +476,15 @@ before allocating slots costs nothing and removes all three cases at once.
 Step 5 exists because a connection reaches `Ready` *before* its virtual
 documents are replayed after a respawn, so a query landing in that window would
 under-report that server's embedded symbols indistinguishably from "no matches".
+
+It closes **part** of that window, not all of it. Selection admits a candidate
+only if the tracker still records the document on that connection, and a respawn
+purge removes exactly those records — so a query arriving between the purge and
+the first replayed `didOpen` discovers no candidate at all and never reaches the
+barrier. The barrier helps once a target is discoverable but not yet replayed;
+before that, the connection is invisible to selection. Both halves have the same
+root cause and the same fix — retaining a connection's admitting policy
+independently of document tracking (point 7) — so neither is patched here.
 The barrier is **bounded to two seconds** and enforced with a timeout, and
 awaiting the survivors concurrently costs that bound once for the whole query —
 not once per target.
@@ -710,7 +719,8 @@ fan-out's placement in point 4, which is a real visibility constraint.
 
 The value crossing that boundary is **typed, not raw JSON**: the bridge module
 owns deserialization for every other bridged request, and this one keeps that
-property. Each target's response is parsed into `Vec<WorkspaceSymbol>` there,
+property. A `null` result normalizes to an empty vector first (point 5);
+otherwise each target's response is parsed into `Vec<WorkspaceSymbol>` there,
 normalizing a `SymbolInformation[]` answer into the same shape, and is handed
 back **with its source connection key and that connection's URI→content-identity
 snapshot** — fan-in cannot validate a symbol without knowing which connection
@@ -794,6 +804,13 @@ Two things about *when* and *per what* are load-bearing:
   then read identity as B — R still executes first, against A, while every
   later comparison sees B and agrees. Capturing first makes the recorded
   identity the one the request actually raced.
+
+  Reading it is a **third awaited lock** on the send path, not a free lookup:
+  the revisions live behind their own Tokio mutex (the fingerprints behind a
+  separate synchronous one), so the snapshot is taken per target before the
+  `connections` re-acquisition, under the same three-second budget as every
+  other awaited lock, and a target whose snapshot cannot be taken in time is
+  dropped and counted as a failure like any other.
 - **Per connection, not per URI.** Both tracker values are keyed by
   `ConnectionKey`, and one virtual URI can be open on several connections with
   different confirmed content. An identity snapshot is therefore taken per
@@ -1073,18 +1090,31 @@ The response is an **array**, never `null`: the spec assigns no distinct meaning
 to `null` here, so "no server was selected" and "servers answered nothing" both
 come back empty.
 
-**Total failure is the exception.** If every dispatched target errored or timed
-out, the query answers with a **request error**, not `[]`. An empty array is a
-claim — "these servers searched and found nothing" — and making it while every
-server was unreachable is confidently wrong at exactly the moment the user is
-least able to tell. A client shown "no matches" during an outage concludes the
-symbol does not exist. The existing concatenated fan-in already draws this line,
-distinguishing zero successes with errors from an empty target set, and this
-method keeps it.
+**Total failure is the exception.** An empty array is a claim — "these servers
+searched and found nothing" — and making it while every server was unreachable
+is confidently wrong at exactly the moment the user is least able to tell. A
+client shown "no matches" during an outage concludes the symbol does not exist.
 
-Partial failure stays soft: a target that errors or times out while others
-answer contributes nothing and does not fail the query. The distinction is
-between *some* evidence and *none*.
+So the outcome is decided on whether *any* server actually answered, tracked
+**across every phase**, not just the response phase. A target can be lost after
+selection and before dispatch too: its reopen barrier fails, its send cannot
+re-acquire `connections` within budget, or registration, the stale-handle
+re-check, or the enqueue fails. Counting only "dispatched targets that errored"
+would let a query whose every target died pre-dispatch report a confident empty
+answer, since zero dispatches looks the same as zero results.
+
+- Selection found **no candidates at all** → `[]`. Nothing failed; there was
+  nothing to ask.
+- **At least one** target answered → `[]` or its results, as they came. Partial
+  failure stays soft.
+- Candidates existed and **none answered** — for any reason, at any phase →
+  **request error**.
+
+A downstream `null` is an answer, not a failure. The method's result type is
+`Option<WorkspaceSymbolResponse>` precisely because `null` is valid, so it
+normalizes to a successful empty vector **before** either array form is parsed.
+Treating it as a parse failure would let a conformant "I found nothing" trip the
+total-failure rule — the exact inversion this rule exists to prevent.
 
 Entries are emitted as `WorkspaceSymbol[]` — `WorkspaceSymbolResponse::Nested`
 in `ls-types`, whose variant names are a misnomer: **both** variants are flat
@@ -1179,9 +1209,10 @@ arriving mid-processing would otherwise wait on unrelated work with no bound.
   covers *acquiring* each lock, not the filtering between them — that walk is synchronous with no
   await, so a timeout could not preempt it anyway, and bounding what cannot be
   interrupted would promise something the runtime does not deliver.
-- **Each send's pre-enqueue re-acquisition** of `connections`: three seconds,
-  per target, independently. A target that cannot get the lock in time is
-  dropped like any other unreachable one.
+- **Each send**: the content-identity snapshot's tracker mutex, then the
+  pre-enqueue re-acquisition of `connections` — three seconds each, per target,
+  independently. A target that cannot get either in time is dropped, and counts
+  as a failed target for the outcome rule in point 5.
 - **Translation's `edit_lock`** per host: three seconds. A host whose lock
   cannot be taken in time loses that query's entries, exactly like a host whose
   geometry was stale.
@@ -1208,9 +1239,12 @@ Stated precisely, it is **the servers currently holding an open document for
 this workspace** — not "every running server". The two differ, and the gap is
 user-visible: `didClose` removes kakehashi's document tracking but deliberately
 leaves the downstream connection running, so closing the last buffer for a
-language drops that server from selection even though it is still `Ready` and
-still holds a complete real-file index it could have answered from. Symbol
-search goes empty with no failure anywhere.
+language drops that server from selection even though it is still `Ready`. What
+that costs depends on the server: whether a downstream retains a usable
+workspace index after `didClose` is server-specific and not something kakehashi
+can know. Where it does, a query that would have been answered comes back
+empty — and if that server was the only one selected, the whole search does,
+with no failure anywhere.
 
 That follows from deriving the candidate axes from open documents, which is what
 makes them concrete (point 3) — the alternative derivations lose `_` handling or
@@ -1422,16 +1456,17 @@ Including it would defeat dedup on a field carrying no identity.
 
 - Results depend on what is open, and coverage can shrink (close, respawn,
   silent connection death). Closing the last buffer for a language removes its
-  server from search even though the process is still running and still
-  indexed — the sharpest form of this, and a follow-up rather than a fix here
-  (point 7). The same query answers differently at different
+  server from search even though the process is still running and may still be
+  usefully indexed — the sharpest form of this, and a follow-up rather than a
+  fix here (point 7). The respawn window has the same cause: a purged
+  connection is invisible to selection until its documents are replayed. The same query answers differently at different
   points in a session. LSP permits partial `workspace/symbol` results, but a
   user expecting an indexed whole-project search will find this surprising.
 - Latency is max-over-live-targets, and every *wait* is bounded: the pool's 30s
   request timeout and liveness timeout, a three-second budget on **every** lock
-  this path awaits (the tracker snapshot, `connections`, each send's
-  re-acquisition, and each host's `edit_lock`), and the reopen barrier's two
-  seconds. Total latency is not bounded, because the synchronous
+  this path awaits (the candidate tracker snapshot, `connections`, each send's
+  identity snapshot and `connections` re-acquisition, and each host's
+  `edit_lock`), and the reopen barrier's two seconds. Total latency is not bounded, because the synchronous
   filtering between those waits cannot be preempted. Forwarded cancellation is
   best-effort, since a downstream may ignore it.
 - One request per keystroke, un-coalesced (point 9).

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -439,8 +439,9 @@ final barrier.** The order is fixed:
    only `Ready` handles (`connections()` returns the raw map, and
    `ConnectionState` also has `Initializing`, `Failed`, `Closing`, `Closed`).
    A candidate dropped because its connection is `Failed`, `Closing`, or
-   `Closed` is recorded as an **infrastructure failure** (point 5), not as an
-   absent candidate — see below;
+   `Closed` is recorded as an **infrastructure failure** (point 5) rather than
+   as an absent candidate — but only if policy would have admitted it; see
+   below;
    drops handles lacking `workspace/symbol`; drops handles whose recorded launch
    configuration no longer matches the `BridgeServerConfig` that admitted them;
    and confirms current membership — the live reverse index for a virtual
@@ -476,11 +477,15 @@ The resulting order is `connections` → {tracker, `host_documents`}, which is t
 pool's own nesting and the one the respawn purge takes.
 
 Every filter in step 2 precedes the cap in step 3, and that ordering is
-load-bearing for each of them: with `priorities = [A, B]` and
-`max_fan_out = 1`, an A that is incapable, stale-configured, or no longer
-holding its documents would otherwise take the only slot and then be dropped,
-leaving the query to consult nobody. Filtering on what is already knowable
-before allocating slots costs nothing and removes all three cases at once.
+load-bearing: with `priorities = [A, B]` and `max_fan_out = 1`, an A that is
+incapable or stale-configured would otherwise take the only slot and then be
+dropped, leaving the query to consult nobody. Filtering on what is already
+knowable before allocating slots costs nothing.
+
+Failure *bookkeeping*, though, runs the other way round — a candidate must clear
+the allowlist and cap before its death counts against the query, per the rule
+above. Filtering and accounting are separate questions: the first asks who to
+ask, the second asks whether silence means anything.
 
 Step 5 exists because a connection reaches `Ready` *before* its virtual
 documents are replayed after a respawn, so a query landing in that window would
@@ -510,6 +515,22 @@ single outer deadline would let a slow `connections` acquisition eat into the
 barrier's two seconds and cancel it early — and that cancellation is not the
 barrier returning `false`, so the drop policy above would not even cover it.
 Each phase that can block on the pool gets its own budget instead.
+
+**Only a candidate the request would actually have used counts as a failure.**
+The dead-connection bookkeeping is applied to what survives current
+configuration and the `priorities` allowlist and cap — not to every dead handle
+the admissions name. A server the user removed from `priorities`, or excluded
+with the `[]` kill switch, or capped out, is not part of this query; whether its
+process is alive is none of the query's business, and letting its death produce
+an error would make a deliberate exclusion behave like an outage. `priorities =
+[]` and `max_fan_out = 0` admit **no** candidates, so there is nothing for them
+to fail.
+
+Capability is deliberately not part of that test, because it cannot be: a dead
+handle's `server_capabilities()` is whatever it was, and for one that never
+reached `Ready` there is nothing to read. A server the user configured and
+allowed, now unreachable, is an outage whether or not we can confirm what it
+could have done.
 
 Recording a dead connection as a failure rather than as a non-candidate is what
 keeps the outcome rule honest. A liveness timeout marks a handle `Failed` in
@@ -1154,8 +1175,10 @@ those rather than from whole responses:
   answer was processed; it yielded fewer symbols. These are the silent drops
   points 5 and 7 already accept.
 - **Infrastructure-failed** — never examined at all, so nothing was learned. A
-  candidate whose connection was already `Failed`, `Closing`, or `Closed` at
-  selection (point 3) starts here rather than never existing. Also: the
+  candidate **that policy admitted** whose connection was already `Failed`,
+  `Closing`, or `Closed` at selection (point 3) starts here rather than never
+  existing; one the allowlist or cap excluded is simply not a candidate. Also:
+  the
   pass-0 host→virtual snapshot, the translation-time identity re-read, or a
   host's `edit_lock` expiring; and, importantly, geometry that is *unsettled*
   rather than gone — a host still parsing, a pass whose 200ms ensure timed out,

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -481,8 +481,8 @@ mutex.
 
 Every filter in step 2 precedes the cap in step 3, and that ordering is
 load-bearing for each of them: with `priorities = [A, B]` and
-`max_fan_out = 1`, an A that is incapable, stale-configured, or no longer
-holding its documents would otherwise take the only slot and then be dropped,
+`max_fan_out = 1`, an A that is incapable or stale-configured would otherwise
+take the only slot and then be dropped,
 leaving the query to consult nobody. Filtering on what is already knowable
 before allocating slots costs nothing and removes all three cases at once.
 
@@ -1205,8 +1205,8 @@ response.
   error**.
 
 The last two cases are why the unit is the entry rather than the response.
-Selection can expire its tracker or `connections` acquisition, so "no
-candidates" and "we could not find out" are different states. And a fan-in
+Selection can expire its `connections` acquisition, so "no candidates" and "we
+could not find out" are different states. And a fan-in
 failure counts: if servers returned symbols and every entry was lost to a lock
 that could not be acquired or a parse that had not settled, the client would
 otherwise be told the search found nothing — the same confident falsehood as
@@ -1646,8 +1646,7 @@ Including it would defeat dedup on a field carrying no identity.
   one query (point 5). This is the one accepted failure here that is not
   self-correcting, and it has no signal to the user.
 - `max_fan_out` no longer bounds a query's total fan-out — only each pair's
-  contribution — so the only real bound on how many connections one query
-  touches is how many are live.
+  contribution. `workspaceSymbolMaxFanOut` is what bounds the query.
 - Adding the `Union` variant forces a `Union` arm at 7 exhaustive `match` sites
   in methods that have no use for it.
 - A server still `Initializing` when the query arrives is skipped entirely, so

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -437,7 +437,10 @@ final barrier.** The order is fixed:
 2. Hand the candidate set to a **pool-owned batch validator**, which takes
    `connections` **once** and, without awaiting inside, per candidate: keeps
    only `Ready` handles (`connections()` returns the raw map, and
-   `ConnectionState` also has `Initializing`, `Failed`, `Closing`, `Closed`);
+   `ConnectionState` also has `Initializing`, `Failed`, `Closing`, `Closed`).
+   A candidate dropped because its connection is `Failed`, `Closing`, or
+   `Closed` is recorded as an **infrastructure failure** (point 5), not as an
+   absent candidate — see below;
    drops handles lacking `workspace/symbol`; drops handles whose recorded launch
    configuration no longer matches the `BridgeServerConfig` that admitted them;
    and confirms current membership — the live reverse index for a virtual
@@ -507,6 +510,20 @@ single outer deadline would let a slow `connections` acquisition eat into the
 barrier's two seconds and cancel it early — and that cancellation is not the
 barrier returning `false`, so the drop policy above would not even cover it.
 Each phase that can block on the pool gets its own budget instead.
+
+Recording a dead connection as a failure rather than as a non-candidate is what
+keeps the outcome rule honest. A liveness timeout marks a handle `Failed` in
+place, and the pool only replaces it when a later acquisition happens to
+encounter it — so a workspace whose servers have all died sits with every
+connection `Failed` indefinitely. Treating those as "no candidates" would answer
+`[]`, telling the user the workspace contains no matching symbols at the exact
+moment nothing is running. They were routable; they are unreachable; that is an
+outage.
+
+`Initializing` is different and keeps its own behavior: those connections are
+skipped as a deliberate coverage choice below, not because they failed, so a
+query that finds only initializing candidates legitimately answers `[]` — the
+servers are starting, not dead.
 
 **`Initializing` connections are excluded.** Including them, and waiting for
 Ready before dispatch, was tried and abandoned — it looked like it removed a
@@ -1136,7 +1153,9 @@ those rather than from whole responses:
   retired, the range escaped its region, or the content identity moved. The
   answer was processed; it yielded fewer symbols. These are the silent drops
   points 5 and 7 already accept.
-- **Infrastructure-failed** — never examined at all, so nothing was learned. The
+- **Infrastructure-failed** — never examined at all, so nothing was learned. A
+  candidate whose connection was already `Failed`, `Closing`, or `Closed` at
+  selection (point 3) starts here rather than never existing. Also: the
   pass-0 host→virtual snapshot, the translation-time identity re-read, or a
   host's `edit_lock` expiring; and, importantly, geometry that is *unsettled*
   rather than gone — a host still parsing, a pass whose 200ms ensure timed out,
@@ -1156,7 +1175,9 @@ a request error, so poisoning is decided per entry and rolled up, never per
 response.
 
 - Selection **completed** and found no candidates → `[]`. Nothing failed; there
-  was nothing to ask.
+  was nothing to ask. "No candidates" means the admissions named none, or only
+  ones that are still `Initializing` — **not** ones whose connections had died,
+  which are infrastructure failures and fall to the error case below (point 3).
 - **At least one informative** answer → its results, or `[]` if they genuinely
   contained nothing. Partial failure stays soft.
 - Candidates existed and **no answer was informative** — for any reason, at any

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -805,12 +805,18 @@ Two things about *when* and *per what* are load-bearing:
   later comparison sees B and agrees. Capturing first makes the recorded
   identity the one the request actually raced.
 
-  Reading it is a **third awaited lock** on the send path, not a free lookup:
-  the revisions live behind their own Tokio mutex (the fingerprints behind a
-  separate synchronous one), so the snapshot is taken per target before the
-  `connections` re-acquisition, under the same three-second budget as every
-  other awaited lock, and a target whose snapshot cannot be taken in time is
-  dropped and counted as a failure like any other.
+  **Atomically with the enqueue**, moreover — not merely before it. The
+  revisions live behind their own Tokio mutex, so the snapshot is taken with
+  `try_lock` inside the same `connections` critical section that performs the
+  stale-handle check and the enqueue, never awaited beside it. Contention drops
+  that target, counted as a failure like any other.
+
+  Taking it *outside* that section would leave a gap: eager `didOpen` holds
+  `connections` while opening, so a virtual document can be opened between the
+  snapshot and the enqueue. The request would then see that document and the
+  late URI index would contain it, while the target's identity map would not —
+  and its symbols would be dropped, silently, for a document that was legitimately
+  open when the request ran. Capturing inside the section closes it.
 - **Per connection, not per URI.** Both tracker values are keyed by
   `ConnectionKey`, and one virtual URI can be open on several connections with
   different confirmed content. An identity snapshot is therefore taken per
@@ -905,7 +911,10 @@ then be dropped for being absent from a map that predates it. Waiting for the
 *first* response is not enough either — other targets can stay in flight for
 another 30 seconds and answer with documents opened in the meantime. The index
 is therefore built once all results are in hand, immediately before
-classification.
+classification. It covers documents opened up to the enqueue of each request,
+which is as far as it can: a per-target identity map fixes what that target
+could legitimately have seen, and it is captured atomically with that target's
+enqueue (point 4).
 
 Staleness in the other direction is worse and survives any snapshot time, so it
 is closed by a check rather than by timing. A region keeps its ULID across
@@ -1103,12 +1112,18 @@ re-check, or the enqueue fails. Counting only "dispatched targets that errored"
 would let a query whose every target died pre-dispatch report a confident empty
 answer, since zero dispatches looks the same as zero results.
 
-- Selection found **no candidates at all** → `[]`. Nothing failed; there was
-  nothing to ask.
+- Selection **completed** and found no candidates → `[]`. Nothing failed; there
+  was nothing to ask.
 - **At least one** target answered → `[]` or its results, as they came. Partial
   failure stays soft.
 - Candidates existed and **none answered** — for any reason, at any phase →
   **request error**.
+- Selection **did not complete** and nothing answered → **request error**. Its
+  tracker or `connections` acquisition can expire, and `_self` discovery is
+  incomplete whenever `host_documents` was contended, so "no candidates" and
+  "we could not find out" are different states. Only the first may claim `[]`;
+  reporting the second as an empty search would be the same confident falsehood
+  as reporting an outage that way.
 
 A downstream `null` is an answer, not a failure. The method's result type is
 `Option<WorkspaceSymbolResponse>` precisely because `null` is valid, so it
@@ -1209,10 +1224,16 @@ arriving mid-processing would otherwise wait on unrelated work with no bound.
   covers *acquiring* each lock, not the filtering between them — that walk is synchronous with no
   await, so a timeout could not preempt it anyway, and bounding what cannot be
   interrupted would promise something the runtime does not deliver.
-- **Each send**: the content-identity snapshot's tracker mutex, then the
-  pre-enqueue re-acquisition of `connections` — three seconds each, per target,
-  independently. A target that cannot get either in time is dropped, and counts
-  as a failed target for the outcome rule in point 5.
+- **Each send**: the pre-enqueue re-acquisition of `connections` — three
+  seconds, per target, independently. The content-identity snapshot is
+  `try_lock`ed *inside* that section rather than awaited, so it adds no wait;
+  contention drops the target. Either failure counts as a failed target for the
+  outcome rule in point 5.
+- **Fan-in**: the pass-0 host→virtual snapshot, and the translation-time
+  identity re-read — three seconds each. These come *after* every downstream
+  response, so they are easy to overlook, and unbudgeted they would reintroduce
+  an unbounded wait at the very end of the query. Expiry drops the affected
+  entries.
 - **Translation's `edit_lock`** per host: three seconds. A host whose lock
   cannot be taken in time loses that query's entries, exactly like a host whose
   geometry was stale.
@@ -1465,8 +1486,9 @@ Including it would defeat dedup on a field carrying no identity.
 - Latency is max-over-live-targets, and every *wait* is bounded: the pool's 30s
   request timeout and liveness timeout, a three-second budget on **every** lock
   this path awaits (the candidate tracker snapshot, `connections`, each send's
-  identity snapshot and `connections` re-acquisition, and each host's
-  `edit_lock`), and the reopen barrier's two seconds. Total latency is not bounded, because the synchronous
+  `connections` re-acquisition, the pass-0 host→virtual snapshot, the
+  translation-time identity re-read, and each host's `edit_lock`), and the
+  reopen barrier's two seconds. Total latency is not bounded, because the synchronous
   filtering between those waits cannot be preempted. Forwarded cancellation is
   best-effort, since a downstream may ignore it.
 - One request per keystroke, un-coalesced (point 9).
@@ -1490,10 +1512,11 @@ Including it would defeat dedup on a field carrying no identity.
   time, since it is `try_lock`ed rather than awaited (point 3). Host-bridged
   symbols can therefore be absent from one query for a reason the user cannot
   see.
-- Every lock this path *awaits* — the tracker snapshot, `connections`, each
-  send's re-acquisition, each host's `edit_lock` — is bounded only in its
-  **acquisition** (`host_documents` is never awaited; it is `try_lock`ed under
-  `connections`, and contention drops that query's `_self` candidates), because
+- Every lock this path *awaits* — the candidate tracker snapshot, `connections`,
+  each send's re-acquisition, the two fan-in tracker reads, each host's
+  `edit_lock` — is bounded only in its **acquisition** (`host_documents` and the
+  per-send identity snapshot are never awaited; they are `try_lock`ed under
+  `connections`, and contention drops the affected candidates), because
   other paths hold these across unbounded async work (point 6); the filtering
   between them is synchronous and cannot be preempted, so neither total
   selection time nor cancellation blocking is capped. Expiring any of those

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -465,8 +465,23 @@ final barrier.** The order is fixed:
       the client sends, and marker discovery walks a stray file's ancestors with
       no workspace boundary — so opening one file from another project spawns a
       connection rooted there, and its real-file symbols would flow into this
-      workspace's search unchanged. A connection whose root lies outside every
-      declared workspace folder is not a candidate for a *workspace* query.
+      workspace's search unchanged.
+
+      The test is **overlap**, not containment in one direction: a connection is
+      admitted if its root either lies inside a declared workspace folder **or
+      encloses one**. Requiring the root to be inside the workspace would be
+      wrong for the most ordinary layout there is — open `/repo/pkg` as the
+      workspace with `.git` at `/repo`, and marker discovery roots the server at
+      `/repo`, which is outside `/repo/pkg`. That test would drop the only
+      server serving the workspace's own documents.
+
+      Admitting an enclosing root has an unavoidable cost, stated rather than
+      hidden: such a server indexes `/repo` entire, so a search of `/repo/pkg`
+      also returns symbols from sibling packages. That is inherent to the
+      server's rooting, not something this query can filter without also
+      discarding legitimate in-workspace results, and it is the better error —
+      too many symbols is recoverable, none is not. Only roots that neither
+      contain nor are contained by any declared folder are dropped.
 
       The filter is on the **connection's root**, not on result URIs: a server
       legitimately rooted inside the workspace may return symbols from a
@@ -480,7 +495,8 @@ final barrier.** The order is fixed:
       exposes **no** marker root: the roots it actually serves live in the
       handle's mutable **workspace-folder set**, which grows as capable servers
       take on later roots. So a `Shared` connection is admitted if **any folder
-      in that set** is inside the client workspace, and dropped only if none is.
+      in that set** overlaps the client workspace by the same test, and dropped
+      only if none does.
       Reading the folder set rather than the key is the whole of the rule;
       testing the key would either drop every shared target or treat it as
       rootless.
@@ -885,9 +901,9 @@ hand. "Its own offset" does not mean "its own resolution", though; see pass 3.
                │ yes
                ▼
      ┌───────────────────┐  no
-     │ is_virtual_uri ?  ├─────▶ REAL FILE ─▶ pass through untouched
-     └─────────┬─────────┘
-               │ yes
+     │ is_virtual_uri ?  ├─────▶ REAL FILE ─▶ pass through untouched,
+     └─────────┬─────────┘                     unless it names a drifted
+               │ yes                            `_self` host (§5)
                ▼
      ┌───────────────────┐  yes
      │ is_scratch_uri ?  ├─────▶ DROP  (a formatting scratch document; names
@@ -964,8 +980,17 @@ Two things about *when* and *per what* are load-bearing:
   `ConnectionKey`, and one virtual URI can be open on several connections with
   different confirmed content. A `_self` target's identity is its host
   document's own downstream version and fingerprint from `host_documents`, not a
-  virtual one — captured and compared the same way, so a host edit after
-  dispatch voids that target's negative evidence exactly as a region edit does. An identity snapshot is therefore taken per
+  virtual one.
+
+  Comparing that recorded pair across the request is **not enough on its own**,
+  and for a sharper reason than in the virtual case. Downstream host
+  synchronization is deferred to the diagnostic debounce and then launched
+  asynchronously, so an edit can update the `DocumentStore` and leave
+  `HostDocSyncState` untouched for some time — both readings equal, both stale.
+  The recorded fingerprint must therefore also be compared against the host's
+  **current `DocumentStore` text**, exactly as the virtual path compares against
+  the region's current content. Only that catches an edit the downstream has not
+  been told about yet. An identity snapshot is therefore taken per
   target, and travels **with that target's response** — the bridge module hands
   back the source connection key and its URI→identity map alongside the
   `Vec<WorkspaceSymbol>`, rather than a bare vector. Fan-in validates each
@@ -1300,14 +1325,23 @@ current text, since the match it omitted may have been added or shifted by the
 very edit that invalidated it, and there is no returned entry for an
 entry-level rollup to mark.
 
-Its **positive** evidence survives. A drifted target can still have translated a
-real-file symbol, or one from a region nothing touched, and those entries are as
-good as any — drift on one document is no reason to discard a correct result
-from another, and identity is tracked per connection across documents that
-change independently. So a drifted target with at least one translated entry
-remains informative; only a drifted target that produced none loses its vote.
-Anything stronger would let an unrelated keystroke turn a working search into a
-request error.
+Its **positive** evidence survives, with one exclusion. A drifted target can
+still have translated a symbol from an unrelated real file, or from a region
+nothing touched, and those entries are as good as any — drift on one document is
+no reason to discard a correct result from another, and identity is tracked per
+connection across documents that change independently.
+
+The exclusion is the drifted document's **own** entries. A `_self` server is
+handed the host under its real URI, so its results come back as real-file
+entries and pass through untranslated — which means a symbol it reported for a
+host that has since drifted carries a range measured against text that no longer
+exists, and nothing downstream of here would catch it. Real-file entries whose
+URI names a drifted `_self` host are therefore rejected, while entries naming
+any other file survive.
+
+So a drifted target with at least one surviving translated entry remains
+informative; only one that produced none loses its vote. Anything stronger would
+let an unrelated keystroke turn a working search into a request error.
 
 Granularity matters here: `edit_lock` expiry is per *host*, while one response
 can carry real-file entries and virtual entries from several hosts. One
@@ -1716,9 +1750,11 @@ Including it would defeat dedup on a field carrying no identity.
 
 - A file opened from outside the client's workspace no longer contributes its
   project's symbols here, though the connection it spawned still serves that
-  file's own bridged requests. One exception survives: a `preferSharedInstance`
-  server that took on both an in-workspace root and an external one is
-  indivisible, so admitting it for the former also admits the latter (point 3).
+  file's own bridged requests. Two leaks remain by design (point 3): a
+  `preferSharedInstance` server holding both an in-workspace and an external
+  root is indivisible, and a server rooted *above* the workspace — the ordinary
+  case when `.git` sits above the opened folder — indexes its whole tree, so a
+  search returns sibling packages too.
 - Results depend on what is open, and coverage can shrink (close, respawn,
   silent connection death). Closing the last buffer for a language removes its
   server from search even though the process is still running and may still be

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -438,11 +438,22 @@ final barrier.** The order is fixed:
    `connections` **once** and, without awaiting inside, per candidate — **in
    this order**:
 
-   a. **Confirm the candidate is still current** — the live reverse index for a
-      virtual candidate, `host_documents` for a `_self` one, and in both cases
-      the stored connection generation matching the handle's. A candidate that
-      fails this is **stale, not failed**: it is discarded silently, before any
-      accounting.
+   a. **Confirm the candidate is still current.** The check differs by kind,
+      because the available evidence does:
+
+      - *Virtual* — the live reverse index, **and**
+        `OpenedVirtualDoc.connection_generation` equal to the tracker's current
+        generation for that key. The generation lives on the tracked document
+        and the tracker, not on the handle: `ConnectionHandle` has no such
+        field, so "matches the handle's generation" would be unimplementable.
+      - *`_self`* — fresh `host_documents` membership, read while `connections`
+        is held. No generation is needed or available (`HostDocSyncState`
+        carries only a version and a fingerprint); holding `connections` across
+        the read is itself what prevents a purge and replacement from
+        interleaving.
+
+      A candidate that fails this is **stale, not failed**: it is discarded
+      silently, before any accounting.
 
    b. Then keep only `Ready` handles (`connections()` returns the raw map, and
       `ConnectionState` also has `Initializing`, `Failed`, `Closing`, `Closed`),

--- a/docs/architecture-decisions/workspace-scoped-symbol-search.md
+++ b/docs/architecture-decisions/workspace-scoped-symbol-search.md
@@ -1307,13 +1307,17 @@ those rather than from whole responses:
 
 - **Translated** — it reached the client.
 - **Semantically rejected** — examined, and found not to describe a place in
-  this workspace: the region is *gone*, its language changed, the indexed URI is
-  retired, or the range escaped its region. The answer was processed; it yielded
-  fewer symbols. These are the silent drops points 5 and 7 already accept.
+  this workspace: the region is *gone*, its language changed, or the indexed URI
+  is retired. The answer was processed; it yielded fewer symbols. These are the
+  silent drops points 5 and 7 already accept. The common thread is that the
+  *place* no longer exists — kakehashi looked and there was nothing there.
 - **Infrastructure-failed** — nothing was learned. This covers entries never
-  examined — including an entry a downstream returned **without a range**, which
-  it reported as a match and kakehashi could not place — and also entries whose
-  **content identity moved**: an edit during
+  examined — including entries a downstream returned **without a range**, or
+  with a range that is reversed or escapes its region once content identity has
+  already passed. Those are matches the server reported and kakehashi could not
+  place: unusable output, not an absent place, which is the line between this
+  state and the one above. Also entries whose **content identity moved**: an
+  edit during
   the request means the downstream answered about text that no longer exists, so
   a symbol it did not mention may simply have shifted. The bridge learned
   neither that the workspace has no match nor where the match now is, which is


### PR DESCRIPTION
Design record for `workspace/symbol` — the first bridged request that carries no `textDocument`, which breaks all three mechanisms every existing handler relies on.

## Why this needed its own decision

Every bridged request today resolves a host document → an injection region → a `RegionOffset`, and that chain is what selects servers (by injection language), filters results (against *the* request's virtual URI), and arbitrates between them (first-non-empty wins). A workspace query has none of it.

The subtler problem is arbitration: **a `workspace/symbol` response is not attributable to a language.** A server answers "here are the workspace's symbols matching `query`" and what it indexes is its root, not a language — so a server reached through one configured pair routinely returns another pair's symbols. Nothing in the response says which pair owns an entry, so no arbitration between pairs can be principled. That single fact drives most of what follows.

## What it decides

- **`union` everywhere, `preferred` overridden.** Two servers' symbol sets are complementary, not competing — the repo's own criterion, applied. Collect from every target, dedup on `(name, kind, uri, range)`, sort on a superset of that key.
- **Coverage is what is live.** A query never cold-starts a server; spawning buys *zero* embedded-block coverage, since virtual documents reach a downstream only via `didOpen` of host documents the client opened.
- **Cross-block, deliberately.** Each result resolves its own region's geometry, which is exactly what the goto filter lacks — and why goto must drop cross-region results.
- **Split by visibility**: the send lives in `bridge` (`connections()` is `pub(super)` there); fan-in lives in `lsp_impl` by coupling, not constraint.
- **Every entry ends in one of three states** — translated, semantically rejected, infrastructure-failed — and the outcome rolls up from those. The line: semantic rejection is *a place that no longer exists*; infrastructure failure is *output that cannot be used*. An all-failed query returns an error, never a confident `[]`.

## Two shipping blockers

§9 names two gaps as **blockers, not accepted limitations** — and deliberately does not specify their mechanisms:

1. A connection must outlive the documents that justified it. `didClose` leaves the connection running while removing document tracking, so closing the last buffer for a language drops a still-`Ready` server; the respawn window and an all-failed-startup workspace are the same defect from other angles.
2. This query's total fan-out must be bounded. `max_fan_out` selects server *names* per pair and does not cap the query.

Both **were** specified here (a pool-held admission registry; a new top-level ceiling) and that was rolled back. Across four review rounds the findings against those two mechanisms grew rather than shrank, and nearly all were runtime-lifecycle questions — invalidation distinguishing a failure respawn from a reconfiguration, snapshots outliving the invalidation that cleared them, cap slots spent on connections replaced before enqueue. Those are settled by tests, not prose. Considered Options records the attempt so it is not repeated by accident.

## Review

`/review` (10 perspectives, 4 rounds) then codex MCP across seven independent fresh sessions. A fresh session now returns clean on its first response.

Substantive corrections the review forced, among others: `preferred` never short-circuits sending; `resolve_virtual_uri` is an O(N) scan whose own doc comment justifies itself on rarity; `wait_for_response` has a hardcoded 30s timeout; the workspace-membership test must be **overlap**, not containment (`.git` above the opened folder is the ordinary case); and `resolve_by_region_id` *mutates* the tracker, so fan-in must never resolve inline.

Follow-up work is tracked as tasks, including the two blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)