### PR TITLE
feat(install): make installing a language all-or-nothing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -874,6 +874,14 @@ kakehashi language uninstall lua --force
 kakehashi language uninstall --all --force
 ```
 
+Installing a language is all-or-nothing. The parser, the language's query
+files, and every query file it pulls in through `; inherits:` are prepared
+first, and only made visible once all of them are ready — so a failed install
+(no network, an unsupported language, a compile error) leaves the data
+directory exactly as it was. Re-running the command is always safe and never
+needs `--force`: whatever is already installed is left alone, and only the
+missing pieces are fetched.
+
 ### Configuration Management
 
 ```bash
@@ -1173,9 +1181,10 @@ RUST_LOG=kakehashi::lock_recovery=warn kakehashi
 
 ### Queries not working for TypeScript/JavaScript
 
-These languages use query inheritance. Ensure base queries are installed:
+These languages use query inheritance. Re-run the install to fetch any base
+queries that are missing:
 
 ```bash
-kakehashi language install typescript --force
-# This automatically installs 'ecma' queries
+kakehashi language install typescript
+# This also installs the 'ecma' queries typescript inherits from
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -897,7 +897,9 @@ languages are never replaced, so install one by name to refresh it.
 One gap `--force` is the only fix for: a `--force` reinstall that is killed
 between publishing the new queries and publishing the new parser leaves new
 queries against the old parser. Both halves look installed, so a plain re-run
-accepts them — reinstall with `--force` to line them up again.
+accepts them — reinstall with `--force` to line them up again. A kill that
+leaves the parser itself missing needs no `--force`: a plain re-run sees the
+missing half and fetches it.
 
 ### Configuration Management
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -901,6 +901,19 @@ accepts them — reinstall with `--force` to line them up again. A kill that
 leaves the parser itself missing needs no `--force`: a plain re-run sees the
 missing half and fetches it.
 
+Two more limits worth knowing:
+
+- Publication is atomic per file, not to readers. A running server that loads a
+  language *while* a `--force` reinstall is publishing can see the new queries
+  against the parser still being replaced, and keep that pairing until it
+  reloads. Installing while nothing is using the language avoids it.
+- A base language is fetched with the same query kinds as the language that
+  inherits it, but only the ones upstream publishes for it. If upstream names a
+  base language in, say, `injections.scm` without shipping that base language's
+  `injections.scm`, the install still succeeds and the query fails to load —
+  the missing file is upstream's, and installing the base language by name will
+  not conjure it either.
+
 ### Configuration Management
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -876,11 +876,17 @@ kakehashi language uninstall --all --force
 
 Installing a language is all-or-nothing. The parser, the language's query
 files, and every query file it pulls in through `; inherits:` are prepared
-first, and only made visible once all of them are ready — so a failed install
-(no network, an unsupported language, a compile error) leaves the data
-directory exactly as it was. Re-running the command is always safe and never
-needs `--force`: whatever is already installed is left alone, and only the
-missing pieces are fetched.
+first, and only made visible once all of them are ready. A failed install — no
+network, an unsupported language, a compile error, or a base language that
+cannot be downloaded — publishes neither half, so whatever was installed before
+is still exactly what is installed. (Bookkeeping is not covered by that: the
+parser metadata cache, the `parser/` and `queries/` directories, and the
+per-language lock files may be created or refreshed either way.)
+
+Re-running the command is safe: whatever is already installed is left alone,
+and the missing halves — including the queries of a base language it inherits —
+are fetched without `--force`. Use `--force` to *replace* something already on
+disk, such as a parser that fails to load.
 
 ### Configuration Management
 
@@ -1182,7 +1188,8 @@ RUST_LOG=kakehashi::lock_recovery=warn kakehashi
 ### Queries not working for TypeScript/JavaScript
 
 These languages use query inheritance. Re-run the install to fetch any base
-queries that are missing:
+queries that are missing; if a base language cannot be downloaded the install
+fails rather than leaving a dangling `; inherits:`:
 
 ```bash
 kakehashi language install typescript

--- a/docs/README.md
+++ b/docs/README.md
@@ -878,15 +878,21 @@ Installing a language is all-or-nothing. The parser, the language's query
 files, and every query file it pulls in through `; inherits:` are prepared
 first, and only made visible once all of them are ready. A failed install — no
 network, an unsupported language, a compile error, or a base language that
-cannot be downloaded — publishes neither half, so whatever was installed before
-is still exactly what is installed. (Bookkeeping is not covered by that: the
-parser metadata cache, the `parser/` and `queries/` directories, and the
-per-language lock files may be created or refreshed either way.)
+cannot be downloaded — never leaves the language you asked for half-installed:
+its parser and its queries are published together or not at all.
+
+Two things a failed install can still leave behind. Queries for a *base*
+language it had to fetch stay installed: they are shared with every language
+that inherits them, and a base language nothing uses is inert. And bookkeeping —
+the parser metadata cache, the `parser/` and `queries/` directories, the
+per-language lock files, and the clearing of the language's uninstall
+tombstone — is written either way.
 
 Re-running the command is safe: whatever is already installed is left alone,
 and the missing halves — including the queries of a base language it inherits —
-are fetched without `--force`. Use `--force` to *replace* something already on
-disk, such as a parser that fails to load.
+are fetched without `--force`. Use `--force` to *replace* the requested
+language's parser and queries, such as a parser that fails to load; base
+languages are never replaced, so install one by name to refresh it.
 
 ### Configuration Management
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -878,8 +878,10 @@ Installing a language is all-or-nothing. The parser, the language's query
 files, and every query file it pulls in through `; inherits:` are prepared
 first, and only made visible once all of them are ready. A failed install — no
 network, an unsupported language, a compile error, or a base language that
-cannot be downloaded — never leaves the language you asked for half-installed:
-its parser and its queries are published together or not at all.
+cannot be downloaded — does not leave the language you asked for
+half-installed: its parser and its queries are published together or not at
+all. (If undoing a publish itself fails — a permission error, a file held open
+— the command says so instead, and names what is left where.)
 
 Two things a failed install can still leave behind. Queries for a *base*
 language it had to fetch stay installed: they are shared with every language
@@ -901,18 +903,28 @@ accepts them — reinstall with `--force` to line them up again. A kill that
 leaves the parser itself missing needs no `--force`: a plain re-run sees the
 missing half and fetches it.
 
-Two more limits worth knowing:
+Three more limits worth knowing, all of them about a language being *loaded*
+while it is being installed, or about files upstream does not provide:
 
 - Publication is atomic per file, not to readers. A running server that loads a
   language *while* a `--force` reinstall is publishing can see the new queries
   against the parser still being replaced, and keep that pairing until it
-  reloads. Installing while nothing is using the language avoids it.
-- A base language is fetched with the same query kinds as the language that
-  inherits it, but only the ones upstream publishes for it. If upstream names a
-  base language in, say, `injections.scm` without shipping that base language's
-  `injections.scm`, the install still succeeds and the query fails to load —
-  the missing file is upstream's, and installing the base language by name will
-  not conjure it either.
+  reloads. Worse, a server that loads a language whose base language is being
+  removed at that moment registers it with the query error as a warning and
+  caches that verdict, so later opens do not retry the install. Both are fixed
+  by restarting the server or installing the language explicitly; installing
+  while nothing is using the language avoids them.
+- Base languages are tracked by name, not by which query kind needed them. A
+  base language is fetched with whatever kinds upstream publishes for it, and
+  the optional kinds are best-effort: if upstream does not ship the base
+  language's `injections.scm`, or that one download fails, a language whose own
+  `injections.scm` inherits it installs successfully and fails to load its
+  injections. A plain re-run skips the base language as complete —
+  `kakehashi language install <base> --force` is what re-fetches it.
+- Staging files left behind by a process that was killed are collected by
+  `kakehashi language status` on Linux and macOS. On Windows there is no
+  portable way to tell whether the owning process is still running, so they are
+  left alone; they are inert, and safe to delete by hand.
 
 ### Configuration Management
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -894,6 +894,11 @@ are fetched without `--force`. Use `--force` to *replace* the requested
 language's parser and queries, such as a parser that fails to load; base
 languages are never replaced, so install one by name to refresh it.
 
+One gap `--force` is the only fix for: a `--force` reinstall that is killed
+between publishing the new queries and publishing the new parser leaves new
+queries against the old parser. Both halves look installed, so a plain re-run
+accepts them — reinstall with `--force` to line them up again.
+
 ### Configuration Management
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -911,20 +911,25 @@ while it is being installed, or about files upstream does not provide:
   against the parser still being replaced, and keep that pairing until it
   reloads. Worse, a server that loads a language whose base language is being
   removed at that moment registers it with the query error as a warning and
-  caches that verdict, so later opens do not retry the install. Both are fixed
-  by restarting the server or installing the language explicitly; installing
-  while nothing is using the language avoids them.
+  caches that verdict, so later opens do not retry the install. Fixing that
+  takes both steps: install the missing language, then restart or reload the
+  server, since the install repairs the disk and the reload clears the cached
+  verdict. Installing while nothing is using the language avoids the whole
+  situation.
 - Base languages are tracked by name, not by which query kind needed them. A
   base language is fetched with whatever kinds upstream publishes for it, and
   the optional kinds are best-effort: if upstream does not ship the base
   language's `injections.scm`, or that one download fails, a language whose own
   `injections.scm` inherits it installs successfully and fails to load its
   injections. A plain re-run skips the base language as complete —
-  `kakehashi language install <base> --force` is what re-fetches it.
+  `kakehashi language install <base> --force` is what re-fetches it, followed by
+  a server reload if it has already cached the failure.
 - Staging files left behind by a process that was killed are collected by
   `kakehashi language status` on Linux and macOS. On Windows there is no
   portable way to tell whether the owning process is still running, so they are
-  left alone; they are inert, and safe to delete by hand.
+  left alone. They are inert, and safe to delete by hand once no kakehashi
+  server or install is running — while one is, a staging file may be the one it
+  is compiling into.
 
 ### Configuration Management
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -781,7 +781,18 @@ fn run_language_uninstall(
             }
             Err(e) => {
                 eprintln!("✗ Failed to remove queries for '{}': {}", lang, e);
+                eprintln!(
+                    "  Leaving the parser for '{}' in place; run the command again.",
+                    lang
+                );
                 any_failed = true;
+                // Removing the parser anyway would turn a failed uninstall into
+                // a half-removed language — the state this command exists to
+                // avoid. Leaving both halves keeps the retry a plain retry.
+                if removed_something {
+                    any_removed = true;
+                }
+                continue;
             }
         }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1044,11 +1044,12 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
     if !result.is_success() {
         // Both halves are staged before either is published, so a failure
         // published neither — say so, rather than leaving the user to guess
-        // which half survived and whether a retry needs --force. Scoped to what
-        // is published: a failed install can still have written the metadata
-        // cache or created the data directories.
+        // which half survived and whether a retry needs --force. Scoped to the
+        // requested language: queries for a base language it inherits stay
+        // published (they are shared), and bookkeeping is written either way.
         eprintln!(
-            "\nFailed to install '{}' language support. No parser or query files were published.",
+            "\nFailed to install '{}' language support. Neither its parser nor its queries were \
+             published.",
             language
         );
         return Err(ExitCode::FAILURE);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1026,20 +1026,29 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
         },
     );
 
-    if let Some(e) = &result.parser_error {
-        eprintln!("✗ Parser installation failed: {}", e);
-    }
-    if let Some(e) = &result.queries_error {
-        eprintln!("✗ Query installation failed: {}", e);
+    // The name guard reports the same reason for both halves; printing it once
+    // is the whole message.
+    if result.parser_error == result.queries_error {
+        if let Some(e) = &result.parser_error {
+            eprintln!("✗ Installation failed: {}", e);
+        }
+    } else {
+        if let Some(e) = &result.parser_error {
+            eprintln!("✗ Parser installation failed: {}", e);
+        }
+        if let Some(e) = &result.queries_error {
+            eprintln!("✗ Query installation failed: {}", e);
+        }
     }
 
     if !result.is_success() {
         // Both halves are staged before either is published, so a failure
-        // installed nothing — say so, rather than leaving the user to guess
-        // which half survived and whether a retry needs --force.
+        // published neither — say so, rather than leaving the user to guess
+        // which half survived and whether a retry needs --force. Scoped to what
+        // is published: a failed install can still have written the metadata
+        // cache or created the data directories.
         eprintln!(
-            "\nFailed to install '{}' language support. Nothing was installed; \
-             run the command again to retry.",
+            "\nFailed to install '{}' language support. No parser or query files were published.",
             language
         );
         return Err(ExitCode::FAILURE);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -783,13 +783,15 @@ fn run_language_uninstall(
                 eprintln!("✗ Failed to remove queries for '{}': {}", lang, failure);
                 any_failed = true;
                 removed_something |= failure.removal.removed_anything();
-                // Whether to go on to the parser depends on how far the removal
-                // got. With the queries gone, stopping would leave a
-                // parser-only language — the half-removed state this command
-                // exists to avoid — so finish the job. With them still there,
-                // taking the parser would *create* that state, so leave both
-                // and let the retry be a plain retry.
-                if !failure.removal.removed_queries {
+                // Whether to go on to the parser depends on the state the
+                // removal left, not on whether it did the removing: a language
+                // that was already parser-only still needs its parser taken.
+                // With the queries gone, stopping would leave a parser-only
+                // language — the half-removed state this command exists to
+                // avoid — so finish the job. With them still there, taking the
+                // parser would *create* that state, so leave both and let the
+                // retry be a plain retry.
+                if !failure.removal.queries_absent {
                     eprintln!(
                         "  Leaving the parser for '{}' in place; run the command again.",
                         lang

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1011,70 +1011,50 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
         ExitCode::FAILURE
     })?;
 
-    // Track success/failure for exit code
-    let mut parser_success = true;
-    let mut queries_success = true;
+    eprintln!("Installing '{}' to {:?}...", language, data_dir);
 
-    if let Err(e) = queries::clear_uninstall_tombstone_for_install(&data_dir, language) {
-        eprintln!("✗ Failed to prepare query installation: {}", e);
-        queries_success = false;
+    let result = kakehashi::install::install_language(
+        language,
+        &kakehashi::install::LanguageInstallOptions {
+            data_dir,
+            force,
+            verbose,
+            no_cache,
+            // The CLI runs from the kakehashi binary, so the killable subprocess path
+            // is available and a hung cc is deadline-bounded.
+            compile: parser::ParserCompile::KillableSubprocess,
+        },
+    );
+
+    if let Some(e) = &result.parser_error {
+        eprintln!("✗ Parser installation failed: {}", e);
+    }
+    if let Some(e) = &result.queries_error {
+        eprintln!("✗ Query installation failed: {}", e);
     }
 
-    // Install parser
-    eprintln!("Installing parser for '{}' to {:?}...", language, data_dir);
-
-    let options = parser::InstallOptions {
-        data_dir: data_dir.clone(),
-        force,
-        verbose,
-        no_cache,
-        // The CLI runs from the kakehashi binary, so the killable subprocess path
-        // is available and a hung cc is deadline-bounded.
-        compile: parser::ParserCompile::KillableSubprocess,
-    };
-
-    match parser::install_parser(language, &options) {
-        Ok(result) => {
-            eprintln!("✓ Parser installed: {}", result.install_path.display());
-            if verbose {
-                eprintln!("  Revision: {}", result.revision);
-            }
-        }
-        Err(e) => {
-            eprintln!("✗ Parser installation failed: {}", e);
-            parser_success = false;
-        }
+    if !result.is_success() {
+        // Both halves are staged before either is published, so a failure
+        // installed nothing — say so, rather than leaving the user to guess
+        // which half survived and whether a retry needs --force.
+        eprintln!(
+            "\nFailed to install '{}' language support. Nothing was installed; \
+             run the command again to retry.",
+            language
+        );
+        return Err(ExitCode::FAILURE);
     }
 
-    // Install queries (with inherited dependencies)
-    eprintln!("Installing queries for '{}' to {:?}...", language, data_dir);
-
-    match queries::install_queries_with_dependencies_after_install_started(
-        language, &data_dir, force,
-    ) {
-        Ok(result) => {
-            eprintln!("✓ Queries installed: {}", result.install_path.display());
-            if verbose {
-                eprintln!("  Files: {}", result.files_downloaded.join(", "));
-            }
-        }
-        Err(e) => {
-            eprintln!("✗ Query installation failed: {}", e);
-            queries_success = false;
-        }
+    // Paths are reported rather than "installed": either half may have already
+    // been present, in which case this run left it alone.
+    if let Some(path) = &result.parser_path {
+        eprintln!("✓ Parser: {}", path.display());
     }
-
-    // Summary
-    if parser_success && queries_success {
-        eprintln!("\nSuccessfully installed '{}' language support.", language);
-        Ok(())
-    } else if !parser_success && !queries_success {
-        eprintln!("\nFailed to install '{}' language support.", language);
-        Err(ExitCode::FAILURE)
-    } else {
-        eprintln!("\nPartially installed '{}' language support.", language);
-        Err(ExitCode::FAILURE)
+    if let Some(path) = &result.queries_path {
+        eprintln!("✓ Queries: {}", path.display());
     }
+    eprintln!("\nSuccessfully installed '{}' language support.", language);
+    Ok(())
 }
 
 /// Run the hidden `__compile-parser` subprocess entry: compile one grammar

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1094,6 +1094,9 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
                 kakehashi::install::RollbackResidue::PreviousQueriesStranded => {
                     "the queries it replaced could not be put back"
                 }
+                // The library can name a residue this build predates; the
+                // warnings above still say what and where.
+                _ => "it could not undo everything it had already published",
             };
             eprintln!(
                 "\nFailed to install '{}' language support, and {} — see the warnings above.",

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1061,6 +1061,9 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
     }
     if let Some(path) = &result.queries_path {
         eprintln!("✓ Queries: {}", path.display());
+        if verbose && !result.files_downloaded.is_empty() {
+            eprintln!("  Files: {}", result.files_downloaded.join(", "));
+        }
     }
     eprintln!("\nSuccessfully installed '{}' language support.", language);
     Ok(())

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -416,6 +416,9 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
         eprintln!("Error: failed to recover interrupted query installs: {e}");
         ExitCode::FAILURE
     })?;
+    if let Err(e) = parser::recover_interrupted_parser_installs(&parser_dir) {
+        eprintln!("Warning: failed to collect interrupted parser installs: {e}");
+    }
 
     // Collect all installed languages from both parser and queries directories
     let mut languages = BTreeSet::new();
@@ -1064,11 +1067,19 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
         // which half survived and whether a retry needs --force. Scoped to the
         // requested language: queries for a base language it inherits stay
         // published (they are shared), and bookkeeping is written either way.
-        eprintln!(
-            "\nFailed to install '{}' language support. Neither its parser nor its queries were \
-             published.",
-            language
-        );
+        if result.left_published_queries {
+            eprintln!(
+                "\nFailed to install '{}' language support, and the queries it had already \
+                 published could not be withdrawn — see the warnings above.",
+                language
+            );
+        } else {
+            eprintln!(
+                "\nFailed to install '{}' language support. Neither its parser nor its queries \
+                 were published.",
+                language
+            );
+        }
         return Err(ExitCode::FAILURE);
     }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -779,20 +779,26 @@ fn run_language_uninstall(
                 }
                 removed_something |= removal.removed_anything();
             }
-            Err(e) => {
-                eprintln!("✗ Failed to remove queries for '{}': {}", lang, e);
-                eprintln!(
-                    "  Leaving the parser for '{}' in place; run the command again.",
-                    lang
-                );
+            Err(failure) => {
+                eprintln!("✗ Failed to remove queries for '{}': {}", lang, failure);
                 any_failed = true;
-                // Removing the parser anyway would turn a failed uninstall into
-                // a half-removed language — the state this command exists to
-                // avoid. Leaving both halves keeps the retry a plain retry.
-                if removed_something {
-                    any_removed = true;
+                removed_something |= failure.removal.removed_anything();
+                // Whether to go on to the parser depends on how far the removal
+                // got. With the queries gone, stopping would leave a
+                // parser-only language — the half-removed state this command
+                // exists to avoid — so finish the job. With them still there,
+                // taking the parser would *create* that state, so leave both
+                // and let the retry be a plain retry.
+                if !failure.removal.removed_queries {
+                    eprintln!(
+                        "  Leaving the parser for '{}' in place; run the command again.",
+                        lang
+                    );
+                    if removed_something {
+                        any_removed = true;
+                    }
+                    continue;
                 }
-                continue;
             }
         }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -746,6 +746,18 @@ fn run_language_uninstall(
 
         let mut removed_something = false;
 
+        // Hold the language's install lock across both removals, so a
+        // concurrent install cannot publish one artifact between them and leave
+        // the language half-removed after this command reports success.
+        let _transaction = match queries::lock_language(&data_dir, lang) {
+            Ok(lock) => Some(lock),
+            Err(e) => {
+                eprintln!("✗ Failed to lock '{}' for uninstall: {}", lang, e);
+                any_failed = true;
+                continue;
+            }
+        };
+
         // Remove queries directory and any kakehashi-created backups under the
         // same lock used by install replacement, so uninstall cannot race a
         // concurrent install into resurrecting queries after reporting success.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1067,11 +1067,18 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
         // which half survived and whether a retry needs --force. Scoped to the
         // requested language: queries for a base language it inherits stay
         // published (they are shared), and bookkeeping is written either way.
-        if result.left_published_queries {
+        if let Some(residue) = result.rollback_residue {
+            let left = match residue {
+                kakehashi::install::RollbackResidue::NewQueriesLive => {
+                    "the queries it had already published could not be withdrawn"
+                }
+                kakehashi::install::RollbackResidue::PreviousQueriesStranded => {
+                    "the queries it replaced could not be put back"
+                }
+            };
             eprintln!(
-                "\nFailed to install '{}' language support, and the queries it had already \
-                 published could not be withdrawn — see the warnings above.",
-                language
+                "\nFailed to install '{}' language support, and {} — see the warnings above.",
+                language, left
             );
         } else {
             eprintln!(

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -746,23 +746,14 @@ fn run_language_uninstall(
 
         let mut removed_something = false;
 
-        // Remove parser file
-        if let Some(parser_path) = find_parser_file(&parser_dir, lang) {
-            match fs::remove_file(&parser_path) {
-                Ok(()) => {
-                    eprintln!("✓ Removed parser: {}", parser_path.display());
-                    removed_something = true;
-                }
-                Err(e) => {
-                    eprintln!("✗ Failed to remove parser {}: {}", parser_path.display(), e);
-                    any_failed = true;
-                }
-            }
-        }
-
         // Remove queries directory and any kakehashi-created backups under the
         // same lock used by install replacement, so uninstall cannot race a
         // concurrent install into resurrecting queries after reporting success.
+        //
+        // Before the parser, so the tombstone this writes is already visible to
+        // an install that is about to publish its parser: that install checks
+        // for it under this same lock and gives up instead of leaving a parser
+        // behind for a language the user just removed.
         match queries::remove_query_install_and_backups(&queries_dir, lang) {
             Ok(removal) => {
                 if removal.removed_queries {
@@ -776,6 +767,20 @@ fn run_language_uninstall(
             Err(e) => {
                 eprintln!("✗ Failed to remove queries for '{}': {}", lang, e);
                 any_failed = true;
+            }
+        }
+
+        // Remove parser file
+        if let Some(parser_path) = find_parser_file(&parser_dir, lang) {
+            match fs::remove_file(&parser_path) {
+                Ok(()) => {
+                    eprintln!("✓ Removed parser: {}", parser_path.display());
+                    removed_something = true;
+                }
+                Err(e) => {
+                    eprintln!("✗ Failed to remove parser {}: {}", parser_path.display(), e);
+                    any_failed = true;
+                }
             }
         }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -749,8 +749,8 @@ fn run_language_uninstall(
         // Hold the language's install lock across both removals, so a
         // concurrent install cannot publish one artifact between them and leave
         // the language half-removed after this command reports success.
-        let _transaction = match queries::lock_language(&data_dir, lang) {
-            Ok(lock) => Some(lock),
+        let transaction = match queries::lock_language(&data_dir, lang) {
+            Ok(lock) => lock,
             Err(e) => {
                 eprintln!("✗ Failed to lock '{}' for uninstall: {}", lang, e);
                 any_failed = true;
@@ -766,7 +766,7 @@ fn run_language_uninstall(
         // an install that is about to publish its parser: that install checks
         // for it under this same lock and gives up instead of leaving a parser
         // behind for a language the user just removed.
-        match queries::remove_query_install_and_backups(&queries_dir, lang) {
+        match queries::remove_query_install_and_backups(&transaction) {
             Ok(removal) => {
                 if removal.removed_queries {
                     eprintln!("✓ Removed queries: {}", queries_dir.join(lang).display());

--- a/src/install.rs
+++ b/src/install.rs
@@ -188,9 +188,13 @@ fn resolve_data_dir(env_fn: impl Fn(&str) -> Option<String>) -> Option<PathBuf> 
 /// Result of installing a language (both parser and queries).
 ///
 /// A language is installed as a unit: every failure path returns before
-/// publishing either half, or undoes the one it published. A `None` path with
-/// no matching error means that half was not left published — either it was
-/// never published, or it was undone when the other half failed.
+/// publishing either half, or undoes the one it published.
+///
+/// The paths describe what this run *settled on*, not what is on disk. They are
+/// populated together on success — including when a half was already installed
+/// and left alone — and a `None` path with no matching error means this run
+/// neither published that half nor left one it had published, which says
+/// nothing about a copy an earlier install put there. Read the disk for that.
 #[derive(Debug)]
 pub struct InstallResult {
     /// Path where the parser was installed, if successful.

--- a/src/install.rs
+++ b/src/install.rs
@@ -199,9 +199,10 @@ fn resolve_data_dir(env_fn: impl Fn(&str) -> Option<String>) -> Option<PathBuf> 
 
 /// Result of installing a language (both parser and queries).
 ///
-/// A language is installed as a unit, so a result carries either both paths or
-/// neither: a `None` path with no matching error means that half was never
-/// published because the other half failed.
+/// A language is installed as a unit: every failure path returns before
+/// publishing either half, or undoes the one it published. A `None` path with
+/// no matching error means that half was never published because the other half
+/// failed.
 #[derive(Debug)]
 pub struct InstallResult {
     /// Path where the parser was installed, if successful.
@@ -237,9 +238,11 @@ pub struct LanguageInstallOptions {
 
 /// Install a language's parser and queries as a unit.
 ///
-/// Both halves are prepared before either is published, so a failure leaves the
-/// data directory exactly as it was rather than installing one half and
-/// reporting the other as an error.
+/// Both halves are prepared before either is published, so a failure publishes
+/// neither, rather than installing one half and reporting the other as an
+/// error. Bookkeeping a failed install may still leave behind: the parser
+/// metadata cache, the `parser/` and `queries/` directories, the per-language
+/// lock files, and the removal of an uninstall tombstone for the language.
 pub fn install_language(language: &str, options: &LanguageInstallOptions) -> InstallResult {
     install_language_with_query_stager(
         language,
@@ -298,9 +301,13 @@ fn install_language_with_query_stager(
 
     // The queries installer re-checks names itself, but the parser
     // installer also builds paths from the name (`parser/<name>.<ext>`),
-    // so reject traversal-capable names before touching either.
+    // so reject traversal-capable names before touching either. Report the
+    // queries installer's wording, which names the allowed characters — the
+    // user's next move is to correct the name.
     if !queries::is_safe_language_name(language) {
-        let reason = format!("Language name '{}' is unsafe", language.escape_default());
+        let reason =
+            queries::QueryInstallError::InvalidLanguageName(language.escape_default().to_string())
+                .to_string();
         result.parser_error = Some(reason.clone());
         result.queries_error = Some(reason);
         return result;
@@ -313,7 +320,7 @@ fn install_language_with_query_stager(
 
     // Stage both halves before publishing either, so a language is never left
     // half-installed: whichever half fails, every staging artifact is dropped
-    // and the data directory is exactly as it was.
+    // and no parser or query files are published.
     //
     // Queries first because they are the cheap half — a language whose queries
     // cannot be fetched is rejected in seconds instead of after a parser
@@ -668,7 +675,7 @@ mod tests {
             result
                 .parser_error
                 .as_deref()
-                .is_some_and(|e| e.contains("unsafe")),
+                .is_some_and(|e| e.contains("Invalid language name")),
             "parser side must be blocked by the name guard, got {:?}",
             result.parser_error
         );
@@ -676,7 +683,7 @@ mod tests {
             result
                 .queries_error
                 .as_deref()
-                .is_some_and(|e| e.contains("unsafe")),
+                .is_some_and(|e| e.contains("Invalid language name")),
             "queries side must be blocked by the name guard, got {:?}",
             result.queries_error
         );

--- a/src/install.rs
+++ b/src/install.rs
@@ -436,6 +436,15 @@ fn install_language_with_query_stager(
     let published_queries = match staged_queries.publish() {
         Ok(published) => published,
         Err(e) => {
+            // Publishing can fail *after* it has moved the live queries aside,
+            // with no way to put them back. That is not a residue-free failure,
+            // and the command must not report it as one.
+            if matches!(
+                e,
+                queries::QueryInstallError::PreviousQueriesStranded { .. }
+            ) {
+                result.rollback_residue = Some(RollbackResidue::PreviousQueriesStranded);
+            }
             result.queries_error = Some(e.to_string());
             return result;
         }

--- a/src/install.rs
+++ b/src/install.rs
@@ -374,15 +374,12 @@ fn install_language_with_query_stager(
     }
 
     match published_queries.commit() {
-        Ok(query_result) => {
+        queries::CommittedQueryInstall::Installed(query_result) => {
             result.queries_path = Some(query_result.install_path);
             result.files_downloaded = query_result.files_downloaded;
         }
-        Err(queries::QueryInstallError::AlreadyExists(path)) => {
+        queries::CommittedQueryInstall::AlreadyInstalled(path) => {
             result.queries_path = Some(path);
-        }
-        Err(e) => {
-            result.queries_error = Some(e.to_string());
         }
     }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -347,7 +347,7 @@ fn install_language_with_query_stager(
         }
     };
 
-    let published_queries = match staged_queries.publish(force) {
+    let published_queries = match staged_queries.publish() {
         Ok(published) => published,
         Err(e) => {
             result.queries_error = Some(e.to_string());

--- a/src/install.rs
+++ b/src/install.rs
@@ -435,17 +435,19 @@ fn install_language_with_query_stager(
 
     let published_queries = match staged_queries.publish() {
         Ok(published) => published,
-        Err(e) => {
-            // Publishing can fail *after* it has moved the live queries aside,
-            // with no way to put them back. That is not a residue-free failure,
-            // and the command must not report it as one.
-            if matches!(
-                e,
-                queries::QueryInstallError::PreviousQueriesStranded { .. }
-            ) {
-                result.rollback_residue = Some(RollbackResidue::PreviousQueriesStranded);
-            }
-            result.queries_error = Some(e.to_string());
+        Err(failure) => {
+            // Publishing can fail *after* it has published something, and its
+            // own rollback can fail in turn. Either way this is not a
+            // residue-free failure: the error says what went wrong, the residue
+            // says what is still on disk because of it.
+            result.rollback_residue = rollback_residue(failure.residue).or_else(|| {
+                matches!(
+                    failure.error,
+                    queries::QueryInstallError::PreviousQueriesStranded { .. }
+                )
+                .then_some(RollbackResidue::PreviousQueriesStranded)
+            });
+            result.queries_error = Some(failure.error.to_string());
             return result;
         }
     };

--- a/src/install.rs
+++ b/src/install.rs
@@ -229,28 +229,28 @@ fn install_language_blocking(
     queries_base_url: &str,
     compile: parser::ParserCompile,
 ) -> InstallResult {
-    install_language_blocking_with_query_installer(
+    install_language_blocking_with_query_stager(
         language,
         data_dir,
         force,
         queries_base_url,
         compile,
-        queries::install_queries_with_dependencies_from,
+        queries::stage_queries_with_dependencies_from,
     )
 }
 
-fn install_language_blocking_with_query_installer(
+fn install_language_blocking_with_query_stager(
     language: &str,
     data_dir: &std::path::Path,
     force: bool,
     queries_base_url: &str,
     compile: parser::ParserCompile,
-    install_queries: fn(
+    stage_queries: fn(
         &str,
         &str,
         &std::path::Path,
         bool,
-    ) -> Result<queries::QueryInstallResult, queries::QueryInstallError>,
+    ) -> Result<queries::StagedQueryInstall, queries::QueryInstallError>,
 ) -> InstallResult {
     let mut result = InstallResult {
         parser_path: None,
@@ -270,11 +270,27 @@ fn install_language_blocking_with_query_installer(
     }
 
     if let Err(e) = queries::clear_uninstall_tombstone_for_install(data_dir, language) {
-        let reason = e.to_string();
-        result.queries_error = Some(reason);
+        result.queries_error = Some(e.to_string());
+        return result;
     }
 
-    // Install parser
+    // Stage both halves before publishing either, so a language is never left
+    // half-installed: whichever half fails, every staging artifact is dropped
+    // and the data directory is exactly as it was.
+    //
+    // Queries first because they are the cheap half — a language whose queries
+    // cannot be fetched is rejected in seconds instead of after a parser
+    // compile that would then be thrown away. Following `; inherits:` here is
+    // what makes languages like html (which keeps its @comment capture in
+    // html_tags) highlight correctly.
+    let staged_queries = match stage_queries(queries_base_url, language, data_dir, force) {
+        Ok(staged) => staged,
+        Err(e) => {
+            result.queries_error = Some(e.to_string());
+            return result;
+        }
+    };
+
     // For async/auto-install, always use cache (background operation)
     let parser_options = parser::InstallOptions {
         data_dir: data_dir.to_path_buf(),
@@ -287,25 +303,42 @@ fn install_language_blocking_with_query_installer(
         // for it; test/embedder callers pass InProcess.
         compile,
     };
-
-    // AlreadyExists means the artifact is present and usable — success,
-    // not failure; treating it as an error made the auto-install manager
-    // degrade a fully-installed language to "installed but with warnings".
-    match parser::install_parser(language, &parser_options) {
-        Ok(parser_result) => {
-            result.parser_path = Some(parser_result.install_path);
-        }
-        Err(parser::ParserInstallError::AlreadyExists(path)) => {
-            result.parser_path = Some(path);
-        }
+    let staged_parser = match parser::stage_parser(language, &parser_options) {
+        Ok(staged) => staged,
         Err(e) => {
             result.parser_error = Some(e.to_string());
+            return result;
         }
+    };
+
+    let published_queries = match staged_queries.publish(force) {
+        Ok(published) => published,
+        Err(e) => {
+            result.queries_error = Some(e.to_string());
+            return result;
+        }
+    };
+
+    // The parser is published last: requests are routed to a language only once
+    // its parser is registered, so an install cut short here leaves inert
+    // queries rather than a parser whose queries are missing.
+    //
+    // AlreadyInstalled means the artifact is present and usable — success, not
+    // failure; treating it as an error made the auto-install manager degrade a
+    // fully-installed language to "installed but with warnings".
+    match staged_parser {
+        parser::StagedParserOutcome::Staged(staged) => match staged.publish() {
+            Ok(parser_result) => result.parser_path = Some(parser_result.install_path),
+            Err(e) => {
+                published_queries.rollback();
+                result.parser_error = Some(e.to_string());
+                return result;
+            }
+        },
+        parser::StagedParserOutcome::AlreadyInstalled(path) => result.parser_path = Some(path),
     }
 
-    // Install queries, following `; inherits:` so languages like html
-    // (which keeps its @comment capture in html_tags) highlight correctly.
-    match install_queries(queries_base_url, language, data_dir, force) {
+    match published_queries.commit() {
         Ok(query_result) => {
             result.queries_path = Some(query_result.install_path);
         }
@@ -357,13 +390,13 @@ fn install_language_blocking_allowing_http_queries_for_tests(
     queries_base_url: &str,
     compile: parser::ParserCompile,
 ) -> InstallResult {
-    install_language_blocking_with_query_installer(
+    install_language_blocking_with_query_stager(
         language,
         data_dir,
         force,
         queries_base_url,
         compile,
-        queries::install_queries_with_dependencies_from_allowing_http_for_tests,
+        queries::stage_queries_with_dependencies_from_allowing_http_for_tests,
     )
 }
 
@@ -676,54 +709,105 @@ mod tests {
         let temp = tempfile::TempDir::new().unwrap();
         let data_dir = temp.path();
 
-        // Keep the parser side successful without fetching metadata or source:
-        // this test isolates how a query tombstone failure is classified.
-        let parser_dir = data_dir.join("parser");
-        std::fs::create_dir_all(&parser_dir).unwrap();
-        std::fs::write(
-            parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION)),
-            "",
-        )
-        .unwrap();
+        // A file where the queries directory belongs makes tombstone cleanup
+        // fail; the base URL points nowhere so a download would fail loudly.
         std::fs::write(data_dir.join("queries"), "not a directory").unwrap();
         let expected_queries_error =
             queries::clear_uninstall_tombstone_for_install(data_dir, "lua")
                 .unwrap_err()
                 .to_string();
 
-        fn successful_query_install(
-            _base_url: &str,
-            language: &str,
-            data_dir: &std::path::Path,
-            _force: bool,
-        ) -> Result<queries::QueryInstallResult, queries::QueryInstallError> {
-            Ok(queries::QueryInstallResult {
-                language: language.to_string(),
-                install_path: data_dir.join("queries").join(language),
-                files_downloaded: Vec::new(),
-            })
-        }
-
-        let result = install_language_blocking_with_query_installer(
+        let result = install_language_blocking(
             "lua",
             data_dir,
             false,
             "https://example.invalid",
             parser::ParserCompile::InProcess,
-            successful_query_install,
         );
 
         assert!(
             result.parser_error.is_none(),
             "tombstone cleanup must not be reported as a parser error"
         );
-        assert!(
-            result.parser_path.is_some(),
-            "query tombstone cleanup failures must preserve the available parser result"
-        );
         assert_eq!(
             result.queries_error.as_deref(),
             Some(expected_queries_error.as_str())
+        );
+        assert!(
+            result.parser_path.is_none(),
+            "a failure before staging must not report a parser as installed"
+        );
+    }
+
+    /// All-or-nothing: a language whose queries cannot be fetched must not
+    /// leave a compiled parser behind. The parser here is pre-installed, so
+    /// the assertion is about what the failed run publishes, not about
+    /// compiling one.
+    #[test]
+    fn failed_queries_publish_no_parser() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let data_dir = temp.path();
+        // No routes: highlights.scm 404s, so the language is unsupported.
+        let base_url = spawn_query_file_server(vec![]);
+
+        let result = install_language_blocking_allowing_http_queries_for_tests(
+            "unsupported_lang",
+            data_dir,
+            false,
+            &base_url,
+            parser::ParserCompile::InProcess,
+        );
+
+        assert!(!result.is_success(), "the install must fail");
+        assert!(
+            result.parser_path.is_none(),
+            "a failed install must not report an installed parser"
+        );
+        assert!(
+            parser_file_exists("unsupported_lang", data_dir).is_none(),
+            "a failed install must not leave a parser on disk"
+        );
+        assert!(
+            !data_dir.join("queries").join("unsupported_lang").exists(),
+            "a failed install must not leave queries on disk"
+        );
+    }
+
+    /// The inherited-parent chain is staged before anything is published, so a
+    /// parent that 404s takes the whole install down with it — including the
+    /// child's queries, which would otherwise be published with a dangling
+    /// `; inherits:`.
+    #[test]
+    fn a_failing_inherited_parent_publishes_neither_half() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let data_dir = temp.path();
+        let parser_dir = data_dir.join("parser");
+        std::fs::create_dir_all(&parser_dir).unwrap();
+        std::fs::write(
+            parser_dir.join(format!("orphan_child.{}", std::env::consts::DLL_EXTENSION)),
+            "",
+        )
+        .unwrap();
+        let base_url = spawn_query_file_server(vec![(
+            "/orphan_child/highlights.scm",
+            "; inherits: missing_parent\n(identifier) @variable\n",
+        )]);
+
+        let result = install_language_blocking_allowing_http_queries_for_tests(
+            "orphan_child",
+            data_dir,
+            false,
+            &base_url,
+            parser::ParserCompile::InProcess,
+        );
+
+        assert!(
+            !result.is_success(),
+            "a missing parent must fail the install"
+        );
+        assert!(
+            !data_dir.join("queries").join("orphan_child").exists(),
+            "the child's queries must not be published without the parent it inherits"
         );
     }
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -356,33 +356,35 @@ fn install_language_with_query_stager(
         }
     };
 
-    // From here on the two artifacts move together, so take the lock that
-    // orders this install against another install or an uninstall of the same
-    // language, and re-check that the language is still wanted. Taken after
-    // staging so a compile never blocks an uninstall.
-    let transaction = match queries::lock_language(data_dir, language) {
-        Ok(lock) if lock.language_was_uninstalled() => {
-            result.queries_error = Some(format!(
-                "'{}' was uninstalled while it was being installed",
-                language
-            ));
-            return result;
-        }
-        Ok(lock) => lock,
+    // From here on every artifact moves together, so take the locks that order
+    // this install against another install or an uninstall — one per language
+    // it depends on, since a base language it inherits is as load-bearing as
+    // its own queries. Taken after staging, so a compile never blocks anyone.
+    let transaction = match queries::lock_languages(data_dir, staged_queries.dependencies()) {
+        Ok(locks) => locks,
         Err(e) => {
             result.queries_error = Some(e.to_string());
             return result;
         }
     };
+    if transaction
+        .iter()
+        .any(queries::LanguageLock::language_was_uninstalled)
+    {
+        result.queries_error = Some(format!(
+            "'{}' or a language it inherits was uninstalled while it was being installed",
+            language
+        ));
+        return result;
+    }
 
     // Queries that staging found already complete were never copied, so this is
-    // the only thing that would notice an uninstall removing them since. Checked
-    // under the transaction lock, before anything is published, so there is
-    // nothing to undo.
-    if !staged_queries.requested_queries_still_complete() {
+    // the only thing that would notice them being removed since. Checked under
+    // the locks, before anything is published, so there is nothing to undo.
+    if let Some(missing) = staged_queries.missing_skipped_dependency() {
         result.queries_error = Some(format!(
-            "the installed queries for '{}' were removed while it was being installed",
-            language
+            "the installed queries for '{}' were removed while '{}' was being installed",
+            missing, language
         ));
         return result;
     }

--- a/src/install.rs
+++ b/src/install.rs
@@ -187,6 +187,10 @@ fn resolve_data_dir(env_fn: impl Fn(&str) -> Option<String>) -> Option<PathBuf> 
 
 /// Result of installing a language (both parser and queries).
 ///
+/// `#[non_exhaustive]`: what an install has to report about itself has grown
+/// twice already in review, and a downstream match or literal should not break
+/// the next time it does.
+///
 /// A language is installed as a unit: every failure path returns before
 /// publishing either half, or undoes the one it published.
 ///
@@ -196,6 +200,7 @@ fn resolve_data_dir(env_fn: impl Fn(&str) -> Option<String>) -> Option<PathBuf> 
 /// neither published that half nor left one it had published, which says
 /// nothing about a copy an earlier install put there. Read the disk for that.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct InstallResult {
     /// Path where the parser was installed, if successful.
     pub parser_path: Option<PathBuf>,
@@ -222,6 +227,7 @@ impl InstallResult {
 
 /// What a failed install left behind when it could not fully undo itself.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum RollbackResidue {
     /// The queries this install published are still live.
     NewQueriesLive,

--- a/src/install.rs
+++ b/src/install.rs
@@ -201,6 +201,9 @@ pub struct InstallResult {
     pub parser_error: Option<String>,
     /// Error message if queries install failed.
     pub queries_error: Option<String>,
+    /// True when a failed install could not withdraw queries it had already
+    /// published, so the data directory still holds them. The errors say which.
+    pub left_published_queries: bool,
     /// Query files this install downloaded, for the requested language.
     /// Empty when its queries were already present.
     pub files_downloaded: Vec<String>,
@@ -291,6 +294,7 @@ fn install_language_with_query_stager(
         queries_path: None,
         parser_error: None,
         queries_error: None,
+        left_published_queries: false,
         files_downloaded: Vec::new(),
     };
 
@@ -424,7 +428,8 @@ fn install_language_with_query_stager(
         parser::StagedParserOutcome::Staged(staged) => match staged.publish() {
             Ok(parser_result) => result.parser_path = Some(parser_result.install_path),
             Err(e) => {
-                published_queries.rollback();
+                result.left_published_queries =
+                    published_queries.rollback() == queries::RollbackOutcome::LeftPublished;
                 result.parser_error = Some(e.to_string());
                 return result;
             }
@@ -435,7 +440,8 @@ fn install_language_with_query_stager(
             // since removed is the queries-only state this lock exists to
             // prevent, and nothing was staged that could replace it.
             if !path.exists() {
-                published_queries.rollback();
+                result.left_published_queries =
+                    published_queries.rollback() == queries::RollbackOutcome::LeftPublished;
                 result.parser_error = Some(format!(
                     "the installed parser for '{}' was removed while it was being installed",
                     language
@@ -492,6 +498,7 @@ pub(crate) async fn install_language_async(
         queries_path: None,
         parser_error: Some(format!("Task panicked: {}", e)),
         queries_error: None,
+        left_published_queries: false,
         files_downloaded: Vec::new(),
     })
 }
@@ -810,6 +817,7 @@ mod tests {
             queries_path: Some(PathBuf::from("/tmp/queries")),
             parser_error: None,
             queries_error: None,
+            left_published_queries: false,
             files_downloaded: Vec::new(),
         };
         assert!(success.is_success());
@@ -819,6 +827,7 @@ mod tests {
             queries_path: None,
             parser_error: Some("Parser failed".to_string()),
             queries_error: Some("Queries failed".to_string()),
+            left_published_queries: false,
             files_downloaded: Vec::new(),
         };
         assert!(!failure.is_success());

--- a/src/install.rs
+++ b/src/install.rs
@@ -201,9 +201,9 @@ pub struct InstallResult {
     pub parser_error: Option<String>,
     /// Error message if queries install failed.
     pub queries_error: Option<String>,
-    /// True when a failed install could not withdraw queries it had already
-    /// published, so the data directory still holds them. The errors say which.
-    pub left_published_queries: bool,
+    /// What a failed install left of the queries it had already published, when
+    /// undoing them did not fully succeed. `None` on every other outcome.
+    pub rollback_residue: Option<RollbackResidue>,
     /// Query files this install downloaded, for the requested language.
     /// Empty when its queries were already present.
     pub files_downloaded: Vec<String>,
@@ -213,6 +213,26 @@ impl InstallResult {
     /// Check if the installation was fully successful.
     pub fn is_success(&self) -> bool {
         self.parser_error.is_none() && self.queries_error.is_none()
+    }
+}
+
+/// What a failed install left behind when it could not fully undo itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RollbackResidue {
+    /// The queries this install published are still live.
+    NewQueriesLive,
+    /// Its queries are gone, and so are the ones they displaced — those are in
+    /// a backup directory named by the warnings on stderr.
+    PreviousQueriesStranded,
+}
+
+fn rollback_residue(outcome: queries::RollbackOutcome) -> Option<RollbackResidue> {
+    match outcome {
+        queries::RollbackOutcome::Undone => None,
+        queries::RollbackOutcome::NewQueriesRemain => Some(RollbackResidue::NewQueriesLive),
+        queries::RollbackOutcome::PreviousQueriesStranded => {
+            Some(RollbackResidue::PreviousQueriesStranded)
+        }
     }
 }
 
@@ -294,7 +314,7 @@ fn install_language_with_query_stager(
         queries_path: None,
         parser_error: None,
         queries_error: None,
-        left_published_queries: false,
+        rollback_residue: None,
         files_downloaded: Vec::new(),
     };
 
@@ -428,26 +448,25 @@ fn install_language_with_query_stager(
         parser::StagedParserOutcome::Staged(staged) => match staged.publish() {
             Ok(parser_result) => result.parser_path = Some(parser_result.install_path),
             Err(e) => {
-                result.left_published_queries =
-                    published_queries.rollback() == queries::RollbackOutcome::LeftPublished;
+                result.rollback_residue = rollback_residue(published_queries.rollback());
                 result.parser_error = Some(e.to_string());
                 return result;
             }
         },
-        parser::StagedParserOutcome::AlreadyInstalled(path) => {
+        parser::StagedParserOutcome::AlreadyInstalled(_) => {
             // Staging saw this parser before the transaction lock was taken, so
-            // re-check it: publishing queries against a parser an uninstall has
-            // since removed is the queries-only state this lock exists to
-            // prevent, and nothing was staged that could replace it.
-            if !path.exists() {
-                result.left_published_queries =
-                    published_queries.rollback() == queries::RollbackOutcome::LeftPublished;
+            // re-check it rather than trusting what it found: publishing queries
+            // against a parser an uninstall has since removed is the
+            // queries-only state this lock exists to prevent, and nothing was
+            // staged that could replace it.
+            let Some(path) = parser_file_exists(language, data_dir) else {
+                result.rollback_residue = rollback_residue(published_queries.rollback());
                 result.parser_error = Some(format!(
                     "the installed parser for '{}' was removed while it was being installed",
                     language
                 ));
                 return result;
-            }
+            };
             result.parser_path = Some(path);
         }
     }
@@ -498,7 +517,7 @@ pub(crate) async fn install_language_async(
         queries_path: None,
         parser_error: Some(format!("Task panicked: {}", e)),
         queries_error: None,
-        left_published_queries: false,
+        rollback_residue: None,
         files_downloaded: Vec::new(),
     })
 }
@@ -817,7 +836,7 @@ mod tests {
             queries_path: Some(PathBuf::from("/tmp/queries")),
             parser_error: None,
             queries_error: None,
-            left_published_queries: false,
+            rollback_residue: None,
             files_downloaded: Vec::new(),
         };
         assert!(success.is_success());
@@ -827,7 +846,7 @@ mod tests {
             queries_path: None,
             parser_error: Some("Parser failed".to_string()),
             queries_error: Some("Queries failed".to_string()),
-            left_published_queries: false,
+            rollback_residue: None,
             files_downloaded: Vec::new(),
         };
         assert!(!failure.is_success());

--- a/src/install.rs
+++ b/src/install.rs
@@ -96,7 +96,6 @@ pub mod test_support {
 
     /// Languages whose parsers and queries every kakehashi test relies on.
     ///
-    /// Mirrors the `make deps/tree-sitter/.installed` Makefile target.
     /// Tests that open lua / markdown / rust / yaml documents expect
     /// parsers and highlight queries to already be present; without
     /// them, semantic-tokens and similar end-to-end tests come back
@@ -126,8 +125,9 @@ pub mod test_support {
     /// the `.installed` marker is missing, writing the marker only when
     /// every required install succeeded.
     ///
-    /// Covers the same languages as `make deps/tree-sitter/.installed`.
-    /// The install short-circuits when a language is up-to-date; any
+    /// Serves the same purpose as `make deps/tree-sitter/.installed` for the
+    /// in-process test suite, over an overlapping but not identical language
+    /// set. The install short-circuits when a language is up-to-date; any
     /// genuine failure is logged so tests depending on that language fail
     /// with a clearer error rather than the whole suite panicking in setup.
     ///
@@ -189,8 +189,8 @@ fn resolve_data_dir(env_fn: impl Fn(&str) -> Option<String>) -> Option<PathBuf> 
 ///
 /// A language is installed as a unit: every failure path returns before
 /// publishing either half, or undoes the one it published. A `None` path with
-/// no matching error means that half was never published because the other half
-/// failed.
+/// no matching error means that half was not left published — either it was
+/// never published, or it was undone when the other half failed.
 #[derive(Debug)]
 pub struct InstallResult {
     /// Path where the parser was installed, if successful.
@@ -229,11 +229,14 @@ pub struct LanguageInstallOptions {
 
 /// Install a language's parser and queries as a unit.
 ///
-/// Both halves are prepared before either is published, so a failure publishes
-/// neither, rather than installing one half and reporting the other as an
-/// error. Bookkeeping a failed install may still leave behind: the parser
-/// metadata cache, the `parser/` and `queries/` directories, the per-language
-/// lock files, and the removal of an uninstall tombstone for the language.
+/// Both halves are prepared before either is published, so a failure leaves the
+/// requested language neither half-installed nor reported as half-failed.
+///
+/// Two things a failure can still leave behind: queries for a base language the
+/// install had to fetch, which are shared with every language that inherits them
+/// and inert on their own, and bookkeeping — the parser metadata cache, the
+/// `parser/` and `queries/` directories, the per-language lock files, and the
+/// removal of an uninstall tombstone for the language.
 pub fn install_language(language: &str, options: &LanguageInstallOptions) -> InstallResult {
     install_language_with_query_stager(
         language,
@@ -312,7 +315,7 @@ fn install_language_with_query_stager(
 
     // Stage both halves before publishing either, so a language is never left
     // half-installed: whichever half fails, every staging artifact is dropped
-    // and no parser or query files are published.
+    // and the requested language's parser and queries stay unpublished.
     //
     // Queries first because they are the cheap half — a language whose queries
     // cannot be fetched is rejected in seconds instead of after a parser
@@ -360,7 +363,7 @@ fn install_language_with_query_stager(
     //
     // AlreadyInstalled means the artifact is present and usable — success, not
     // failure; treating it as an error made the auto-install manager degrade a
-    // fully-installed language to "installed but with warnings".
+    // fully-installed language to a warning about its own success.
     match staged_parser {
         parser::StagedParserOutcome::Staged(staged) => match staged.publish() {
             Ok(parser_result) => result.parser_path = Some(parser_result.install_path),
@@ -687,7 +690,7 @@ mod tests {
     /// A language whose parser and queries are already on disk is a
     /// successful install, not a failure: reporting AlreadyExists as an
     /// error made the auto-install manager degrade a fully-usable language
-    /// to "installed but with warnings".
+    /// to a warning about its own success.
     #[test]
     fn install_language_blocking_treats_already_installed_as_success() {
         let temp = tempfile::TempDir::new().unwrap();

--- a/src/install.rs
+++ b/src/install.rs
@@ -387,6 +387,21 @@ fn install_language_with_query_stager(
         return result;
     }
 
+    // A parser that appeared since staging belongs to a concurrent install of
+    // the same language. Without `force`, the query side already yields to such
+    // a winner (`PublishQueryDirOutcome::AlreadyComplete`); yield the parser the
+    // same way, or the two halves can end up published by different installs —
+    // one's queries beside the other's grammar. Dropping the staged parser here
+    // reclaims the compiled file.
+    let staged_parser = match staged_parser {
+        parser::StagedParserOutcome::Staged(_)
+            if !force && let Some(path) = parser_file_exists(language, data_dir) =>
+        {
+            parser::StagedParserOutcome::AlreadyInstalled(path)
+        }
+        outcome => outcome,
+    };
+
     let published_queries = match staged_queries.publish() {
         Ok(published) => published,
         Err(e) => {

--- a/src/install.rs
+++ b/src/install.rs
@@ -409,10 +409,11 @@ fn install_language_with_query_stager(
     // Queries that staging found already complete were never copied, so this is
     // the only thing that would notice them being removed since. Checked under
     // the locks, before anything is published, so there is nothing to undo.
-    if let Some(missing) = staged_queries.missing_skipped_dependency() {
+    if let Some(unstable) = staged_queries.unstable_skipped_dependency() {
         result.queries_error = Some(format!(
-            "the installed queries for '{}' were removed while '{}' was being installed",
-            missing, language
+            "the queries installed for '{}' were removed or replaced while '{}' was being \
+             installed",
+            unstable, language
         ));
         return result;
     }

--- a/src/install.rs
+++ b/src/install.rs
@@ -375,6 +375,18 @@ fn install_language_with_query_stager(
         }
     };
 
+    // Queries that staging found already complete were never copied, so this is
+    // the only thing that would notice an uninstall removing them since. Checked
+    // under the transaction lock, before anything is published, so there is
+    // nothing to undo.
+    if !staged_queries.requested_queries_still_complete() {
+        result.queries_error = Some(format!(
+            "the installed queries for '{}' were removed while it was being installed",
+            language
+        ));
+        return result;
+    }
+
     let published_queries = match staged_queries.publish() {
         Ok(published) => published,
         Err(e) => {

--- a/src/install.rs
+++ b/src/install.rs
@@ -342,17 +342,10 @@ fn install_language_with_query_stager(
         return result;
     }
 
-    // Clearing the tombstone is what makes this install override an earlier
-    // uninstall, so it has to wait for any uninstall in flight: clearing it
-    // between that uninstall's two removals would leave this install staging
-    // against a parser the uninstall was about to delete. The lock is released
-    // again immediately — the expensive staging below must not block anyone.
-    let cleared = queries::lock_language(data_dir, language)
-        .and_then(|_lock| queries::clear_uninstall_tombstone_for_install(data_dir, language));
-    if let Err(e) = cleared {
-        result.queries_error = Some(e.to_string());
-        return result;
-    }
+    // No tombstone clear here. Staging does it, once per language and under
+    // that language's lock — including the requested one, which is a dependency
+    // of itself. A second clear is exactly what erases a tombstone an uninstall
+    // wrote in between, which is the race clearing it once was written to close.
 
     // Stage both halves before publishing either, so a language is never left
     // half-installed: whichever half fails, every staging artifact is dropped

--- a/src/install.rs
+++ b/src/install.rs
@@ -198,30 +198,63 @@ fn resolve_data_dir(env_fn: impl Fn(&str) -> Option<String>) -> Option<PathBuf> 
 }
 
 /// Result of installing a language (both parser and queries).
+///
+/// A language is installed as a unit, so a result carries either both paths or
+/// neither: a `None` path with no matching error means that half was never
+/// published because the other half failed.
 #[derive(Debug)]
-pub(crate) struct InstallResult {
+pub struct InstallResult {
     /// Path where the parser was installed, if successful.
-    pub(crate) parser_path: Option<PathBuf>,
+    pub parser_path: Option<PathBuf>,
     /// Path where queries were installed, if successful.
-    pub(crate) queries_path: Option<PathBuf>,
+    pub queries_path: Option<PathBuf>,
     /// Error message if parser install failed.
-    pub(crate) parser_error: Option<String>,
+    pub parser_error: Option<String>,
     /// Error message if queries install failed.
-    pub(crate) queries_error: Option<String>,
+    pub queries_error: Option<String>,
 }
 
 impl InstallResult {
     /// Check if the installation was fully successful.
-    pub(crate) fn is_success(&self) -> bool {
+    pub fn is_success(&self) -> bool {
         self.parser_error.is_none() && self.queries_error.is_none()
     }
 }
 
-/// Install a language synchronously (both parser and queries).
+/// Options for installing one language's parser and queries.
+pub struct LanguageInstallOptions {
+    /// Base data directory the parser and queries are installed into.
+    pub data_dir: PathBuf,
+    /// Reinstall artifacts that are already present.
+    pub force: bool,
+    /// Print progress details to stderr.
+    pub verbose: bool,
+    /// Bypass the parser metadata cache.
+    pub no_cache: bool,
+    /// How to compile the parser source (see [`parser::ParserCompile`]).
+    pub compile: parser::ParserCompile,
+}
+
+/// Install a language's parser and queries as a unit.
 ///
-/// Production callers pass [`queries::NVIM_TREESITTER_QUERIES_URL`]. Tests
-/// can inject other HTTPS endpoints; local HTTP fixtures use a test-only
-/// wrapper below so production downloads stay HTTPS-only.
+/// Both halves are prepared before either is published, so a failure leaves the
+/// data directory exactly as it was rather than installing one half and
+/// reporting the other as an error.
+pub fn install_language(language: &str, options: &LanguageInstallOptions) -> InstallResult {
+    install_language_with_query_stager(
+        language,
+        options,
+        queries::NVIM_TREESITTER_QUERIES_URL,
+        queries::stage_queries_with_dependencies_from,
+    )
+}
+
+/// Install a language synchronously, downloading queries from `queries_base_url`.
+///
+/// Production goes through [`install_language`]; tests use this to point at a
+/// fixture server. Local HTTP fixtures need the test-only wrapper below so
+/// production downloads stay HTTPS-only.
+#[cfg(test)]
 fn install_language_blocking(
     language: &str,
     data_dir: &std::path::Path,
@@ -229,22 +262,24 @@ fn install_language_blocking(
     queries_base_url: &str,
     compile: parser::ParserCompile,
 ) -> InstallResult {
-    install_language_blocking_with_query_stager(
+    install_language_with_query_stager(
         language,
-        data_dir,
-        force,
+        &LanguageInstallOptions {
+            data_dir: data_dir.to_path_buf(),
+            force,
+            verbose: false,
+            no_cache: false,
+            compile,
+        },
         queries_base_url,
-        compile,
         queries::stage_queries_with_dependencies_from,
     )
 }
 
-fn install_language_blocking_with_query_stager(
+fn install_language_with_query_stager(
     language: &str,
-    data_dir: &std::path::Path,
-    force: bool,
+    options: &LanguageInstallOptions,
     queries_base_url: &str,
-    compile: parser::ParserCompile,
     stage_queries: fn(
         &str,
         &str,
@@ -252,6 +287,8 @@ fn install_language_blocking_with_query_stager(
         bool,
     ) -> Result<queries::StagedQueryInstall, queries::QueryInstallError>,
 ) -> InstallResult {
+    let data_dir = options.data_dir.as_path();
+    let force = options.force;
     let mut result = InstallResult {
         parser_path: None,
         queries_path: None,
@@ -291,17 +328,16 @@ fn install_language_blocking_with_query_stager(
         }
     };
 
-    // For async/auto-install, always use cache (background operation)
     let parser_options = parser::InstallOptions {
         data_dir: data_dir.to_path_buf(),
         force,
-        verbose: false,
-        no_cache: false,
+        verbose: options.verbose,
+        no_cache: options.no_cache,
         // Caller-chosen: the killable subprocess re-execs this binary's
         // `__compile-parser`, so it is valid only when `current_exe()` is the
         // kakehashi binary. The production caller (LSP auto-install) is, and asks
         // for it; test/embedder callers pass InProcess.
-        compile,
+        compile: options.compile,
     };
     let staged_parser = match parser::stage_parser(language, &parser_options) {
         Ok(staged) => staged,
@@ -365,12 +401,17 @@ pub(crate) async fn install_language_async(
 ) -> InstallResult {
     // Run blocking install operations in a separate thread pool
     tokio::task::spawn_blocking(move || {
-        install_language_blocking(
+        install_language(
             &language,
-            &data_dir,
-            force,
-            queries::NVIM_TREESITTER_QUERIES_URL,
-            compile,
+            &LanguageInstallOptions {
+                data_dir,
+                force,
+                // Auto-install runs in the background: no progress chatter on
+                // the server's stderr, and always use the metadata cache.
+                verbose: false,
+                no_cache: false,
+                compile,
+            },
         )
     })
     .await
@@ -390,12 +431,16 @@ fn install_language_blocking_allowing_http_queries_for_tests(
     queries_base_url: &str,
     compile: parser::ParserCompile,
 ) -> InstallResult {
-    install_language_blocking_with_query_stager(
+    install_language_with_query_stager(
         language,
-        data_dir,
-        force,
+        &LanguageInstallOptions {
+            data_dir: data_dir.to_path_buf(),
+            force,
+            verbose: false,
+            no_cache: false,
+            compile,
+        },
         queries_base_url,
-        compile,
         queries::stage_queries_with_dependencies_from_allowing_http_for_tests,
     )
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -329,7 +329,7 @@ fn install_language_with_query_stager(
     // compile that would then be thrown away. Following `; inherits:` here is
     // what makes languages like html (which keeps its @comment capture in
     // html_tags) highlight correctly.
-    let staged_queries = match stage_queries(queries_base_url, language, data_dir, force) {
+    let mut staged_queries = match stage_queries(queries_base_url, language, data_dir, force) {
         Ok(staged) => staged,
         Err(e) => {
             result.queries_error = Some(e.to_string());
@@ -393,14 +393,15 @@ fn install_language_with_query_stager(
     // same way, or the two halves can end up published by different installs —
     // one's queries beside the other's grammar. Dropping the staged parser here
     // reclaims the compiled file.
-    let staged_parser = match staged_parser {
-        parser::StagedParserOutcome::Staged(_)
-            if !force && let Some(path) = parser_file_exists(language, data_dir) =>
-        {
-            parser::StagedParserOutcome::AlreadyInstalled(path)
-        }
-        outcome => outcome,
-    };
+    let staged_parser =
+        staged_parser.yield_to_existing(force, parser_file_exists(language, data_dir));
+    if matches!(staged_parser, parser::StagedParserOutcome::Staged(_)) {
+        // This install is the one establishing the pair, so its queries publish
+        // with its parser instead of yielding to a copy that appeared since
+        // staging — an install of a language that *inherits* this one can
+        // publish these queries without holding this language's lock.
+        staged_queries.claim_requested_language();
+    }
 
     let published_queries = match staged_queries.publish() {
         Ok(published) => published,

--- a/src/install.rs
+++ b/src/install.rs
@@ -349,6 +349,25 @@ fn install_language_with_query_stager(
         }
     };
 
+    // From here on the two artifacts move together, so take the lock that
+    // orders this install against another install or an uninstall of the same
+    // language, and re-check that the language is still wanted. Taken after
+    // staging so a compile never blocks an uninstall.
+    let transaction = match queries::lock_language(data_dir, language) {
+        Ok(lock) if lock.language_was_uninstalled() => {
+            result.queries_error = Some(format!(
+                "'{}' was uninstalled while it was being installed",
+                language
+            ));
+            return result;
+        }
+        Ok(lock) => lock,
+        Err(e) => {
+            result.queries_error = Some(e.to_string());
+            return result;
+        }
+    };
+
     let published_queries = match staged_queries.publish() {
         Ok(published) => published,
         Err(e) => {
@@ -365,35 +384,20 @@ fn install_language_with_query_stager(
     // failure; treating it as an error made the auto-install manager degrade a
     // fully-installed language to a warning about its own success.
     match staged_parser {
-        parser::StagedParserOutcome::Staged(staged) => {
-            // Publishing a parser for a language `language uninstall` removed
-            // while this install was compiling would leave exactly the
-            // parser-only state that uninstall just reported as gone.
-            let published = match queries::hold_against_uninstall(data_dir, language) {
-                Ok(queries::UninstallClaim::Uninstalled) => Err(format!(
-                    "'{}' was uninstalled while it was being installed",
-                    language
-                )),
-                // The guard is arm-scoped, so the lock is released before the
-                // rollback below reaches for the same one.
-                Ok(queries::UninstallClaim::Clear(_guard)) => {
-                    staged.publish().map_err(|e| e.to_string())
-                }
-                Err(e) => Err(e.to_string()),
-            };
-            match published {
-                Ok(parser_result) => result.parser_path = Some(parser_result.install_path),
-                Err(reason) => {
-                    published_queries.rollback();
-                    result.parser_error = Some(reason);
-                    return result;
-                }
+        parser::StagedParserOutcome::Staged(staged) => match staged.publish() {
+            Ok(parser_result) => result.parser_path = Some(parser_result.install_path),
+            Err(e) => {
+                published_queries.rollback();
+                result.parser_error = Some(e.to_string());
+                return result;
             }
-        }
+        },
         parser::StagedParserOutcome::AlreadyInstalled(path) => result.parser_path = Some(path),
     }
 
-    match published_queries.commit() {
+    let committed = published_queries.commit();
+    drop(transaction);
+    match committed {
         queries::CommittedQueryInstall::Installed(query_result) => {
             result.queries_path = Some(query_result.install_path);
             result.files_downloaded = query_result.files_downloaded;

--- a/src/install.rs
+++ b/src/install.rs
@@ -201,6 +201,9 @@ pub struct InstallResult {
     pub parser_error: Option<String>,
     /// Error message if queries install failed.
     pub queries_error: Option<String>,
+    /// Query files this install downloaded, for the requested language.
+    /// Empty when its queries were already present.
+    pub files_downloaded: Vec<String>,
 }
 
 impl InstallResult {
@@ -285,6 +288,7 @@ fn install_language_with_query_stager(
         queries_path: None,
         parser_error: None,
         queries_error: None,
+        files_downloaded: Vec::new(),
     };
 
     // The queries installer re-checks names itself, but the parser
@@ -372,6 +376,7 @@ fn install_language_with_query_stager(
     match published_queries.commit() {
         Ok(query_result) => {
             result.queries_path = Some(query_result.install_path);
+            result.files_downloaded = query_result.files_downloaded;
         }
         Err(queries::QueryInstallError::AlreadyExists(path)) => {
             result.queries_path = Some(path);
@@ -415,6 +420,7 @@ pub(crate) async fn install_language_async(
         queries_path: None,
         parser_error: Some(format!("Task panicked: {}", e)),
         queries_error: None,
+        files_downloaded: Vec::new(),
     })
 }
 
@@ -732,6 +738,7 @@ mod tests {
             queries_path: Some(PathBuf::from("/tmp/queries")),
             parser_error: None,
             queries_error: None,
+            files_downloaded: Vec::new(),
         };
         assert!(success.is_success());
 
@@ -740,6 +747,7 @@ mod tests {
             queries_path: None,
             parser_error: Some("Parser failed".to_string()),
             queries_error: Some("Queries failed".to_string()),
+            files_downloaded: Vec::new(),
         };
         assert!(!failure.is_success());
     }
@@ -749,6 +757,12 @@ mod tests {
         let temp = tempfile::TempDir::new().unwrap();
         let data_dir = temp.path();
 
+        // An already-installed parser, so "no parser was published" is a claim
+        // about this run rather than about an empty data dir.
+        let parser_dir = data_dir.join("parser");
+        std::fs::create_dir_all(&parser_dir).unwrap();
+        let parser_file = parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION));
+        std::fs::write(&parser_file, "").unwrap();
         // A file where the queries directory belongs makes tombstone cleanup
         // fail; the base URL points nowhere so a download would fail loudly.
         std::fs::write(data_dir.join("queries"), "not a directory").unwrap();
@@ -775,7 +789,12 @@ mod tests {
         );
         assert!(
             result.parser_path.is_none(),
-            "a failure before staging must not report a parser as installed"
+            "a failure before staging must not report the already-installed parser as this \
+             run's work"
+        );
+        assert!(
+            parser_file.exists(),
+            "a failed install must not disturb an already-installed parser"
         );
     }
 
@@ -787,6 +806,16 @@ mod tests {
     fn failed_queries_publish_no_parser() {
         let temp = tempfile::TempDir::new().unwrap();
         let data_dir = temp.path();
+        // A parser is already on disk: the old installer reported it as this
+        // run's `parser_path`, which is exactly what must not happen when the
+        // queries half fails.
+        let parser_dir = data_dir.join("parser");
+        std::fs::create_dir_all(&parser_dir).unwrap();
+        let parser_file = parser_dir.join(format!(
+            "unsupported_lang.{}",
+            std::env::consts::DLL_EXTENSION
+        ));
+        std::fs::write(&parser_file, "").unwrap();
         // No routes: highlights.scm 404s, so the language is unsupported.
         let base_url = spawn_query_file_server(vec![]);
 
@@ -804,8 +833,8 @@ mod tests {
             "a failed install must not report an installed parser"
         );
         assert!(
-            parser_file_exists("unsupported_lang", data_dir).is_none(),
-            "a failed install must not leave a parser on disk"
+            parser_file.exists(),
+            "a failed install must leave the parser that was already there alone"
         );
         assert!(
             !data_dir.join("queries").join("unsupported_lang").exists(),
@@ -844,6 +873,10 @@ mod tests {
         assert!(
             !result.is_success(),
             "a missing parent must fail the install"
+        );
+        assert!(
+            result.parser_path.is_none(),
+            "a failed install must not report the pre-existing parser as installed"
         );
         assert!(
             !data_dir.join("queries").join("orphan_child").exists(),

--- a/src/install.rs
+++ b/src/install.rs
@@ -91,7 +91,7 @@ pub(crate) fn test_data_dir() -> PathBuf {
 /// in-tree test harness.
 #[cfg(any(test, feature = "e2e"))]
 pub mod test_support {
-    use super::{parser, queries};
+    use super::parser;
     use std::path::{Path, PathBuf};
 
     /// Languages whose parsers and queries every kakehashi test relies on.
@@ -126,11 +126,10 @@ pub mod test_support {
     /// the `.installed` marker is missing, writing the marker only when
     /// every required install succeeded.
     ///
-    /// Mirrors the install loop in `make deps/tree-sitter/.installed`.
-    /// Both the parser and queries installs short-circuit when a
-    /// language is up-to-date; any genuine failure is logged so tests
-    /// depending on that language fail with a clearer error rather than
-    /// the whole suite panicking in setup.
+    /// Covers the same languages as `make deps/tree-sitter/.installed`.
+    /// The install short-circuits when a language is up-to-date; any
+    /// genuine failure is logged so tests depending on that language fail
+    /// with a clearer error rather than the whole suite panicking in setup.
     ///
     /// A transient failure (network, file lock, compile error) must not
     /// leave the marker behind: a marker over a half-populated data dir
@@ -142,7 +141,7 @@ pub mod test_support {
         if marker.exists() {
             return Ok(());
         }
-        let parser_options = parser::InstallOptions {
+        let options = super::LanguageInstallOptions {
             data_dir: data_dir.to_path_buf(),
             force: false,
             verbose: false,
@@ -153,28 +152,17 @@ pub mod test_support {
         };
         let mut all_ok = true;
         for lang in TEST_LANGUAGES {
-            // `AlreadyExists` means the artifact is present from an earlier
-            // run — success for setup purposes, not a failure. Treating it as
-            // failure would make a partial prior run unrecoverable: if parsers
-            // installed but a query failed (so the marker was never written),
-            // every later run would see `AlreadyExists` for the parser and
-            // could never write the marker without deleting files by hand.
-            match parser::install_parser(lang, &parser_options) {
-                Ok(_) | Err(parser::ParserInstallError::AlreadyExists(_)) => {}
-                Err(e) => {
-                    eprintln!("[test setup] install_parser({}) failed: {}", lang, e);
-                    all_ok = false;
+            // Artifacts already present from an earlier run are a success for
+            // setup purposes, and `install_language` reports them as such.
+            let result = super::install_language(lang, &options);
+            if !result.is_success() {
+                for error in [result.parser_error, result.queries_error]
+                    .into_iter()
+                    .flatten()
+                {
+                    eprintln!("[test setup] install_language({}) failed: {}", lang, error);
                 }
-            }
-            match queries::install_queries_with_dependencies(lang, data_dir, false) {
-                Ok(_) | Err(queries::QueryInstallError::AlreadyExists(_)) => {}
-                Err(e) => {
-                    eprintln!(
-                        "[test setup] install_queries_with_dependencies({}) failed: {}",
-                        lang, e
-                    );
-                    all_ok = false;
-                }
+                all_ok = false;
             }
         }
         if all_ok {

--- a/src/install.rs
+++ b/src/install.rs
@@ -308,7 +308,14 @@ fn install_language_with_query_stager(
         return result;
     }
 
-    if let Err(e) = queries::clear_uninstall_tombstone_for_install(data_dir, language) {
+    // Clearing the tombstone is what makes this install override an earlier
+    // uninstall, so it has to wait for any uninstall in flight: clearing it
+    // between that uninstall's two removals would leave this install staging
+    // against a parser the uninstall was about to delete. The lock is released
+    // again immediately — the expensive staging below must not block anyone.
+    let cleared = queries::lock_language(data_dir, language)
+        .and_then(|_lock| queries::clear_uninstall_tombstone_for_install(data_dir, language));
+    if let Err(e) = cleared {
         result.queries_error = Some(e.to_string());
         return result;
     }
@@ -392,7 +399,21 @@ fn install_language_with_query_stager(
                 return result;
             }
         },
-        parser::StagedParserOutcome::AlreadyInstalled(path) => result.parser_path = Some(path),
+        parser::StagedParserOutcome::AlreadyInstalled(path) => {
+            // Staging saw this parser before the transaction lock was taken, so
+            // re-check it: publishing queries against a parser an uninstall has
+            // since removed is the queries-only state this lock exists to
+            // prevent, and nothing was staged that could replace it.
+            if !path.exists() {
+                published_queries.rollback();
+                result.parser_error = Some(format!(
+                    "the installed parser for '{}' was removed while it was being installed",
+                    language
+                ));
+                return result;
+            }
+            result.parser_path = Some(path);
+        }
     }
 
     let committed = published_queries.commit();
@@ -773,6 +794,9 @@ mod tests {
         assert!(!failure.is_success());
     }
 
+    /// Preparing the query side — taking the language lock and clearing any
+    /// uninstall tombstone — happens before either half is staged, so its
+    /// failure is a query error and nothing else.
     #[test]
     fn install_language_reports_tombstone_cleanup_as_query_error_only() {
         let temp = tempfile::TempDir::new().unwrap();
@@ -787,10 +811,12 @@ mod tests {
         // A file where the queries directory belongs makes tombstone cleanup
         // fail; the base URL points nowhere so a download would fail loudly.
         std::fs::write(data_dir.join("queries"), "not a directory").unwrap();
-        let expected_queries_error =
-            queries::clear_uninstall_tombstone_for_install(data_dir, "lua")
-                .unwrap_err()
-                .to_string();
+        // Derived the same way the installer does, so the assertion follows the
+        // code rather than a copy of its message.
+        let expected_queries_error = queries::lock_language(data_dir, "lua")
+            .and_then(|_lock| queries::clear_uninstall_tombstone_for_install(data_dir, "lua"))
+            .unwrap_err()
+            .to_string();
 
         let result = install_language_blocking(
             "lua",

--- a/src/install.rs
+++ b/src/install.rs
@@ -365,14 +365,31 @@ fn install_language_with_query_stager(
     // failure; treating it as an error made the auto-install manager degrade a
     // fully-installed language to a warning about its own success.
     match staged_parser {
-        parser::StagedParserOutcome::Staged(staged) => match staged.publish() {
-            Ok(parser_result) => result.parser_path = Some(parser_result.install_path),
-            Err(e) => {
-                published_queries.rollback();
-                result.parser_error = Some(e.to_string());
-                return result;
+        parser::StagedParserOutcome::Staged(staged) => {
+            // Publishing a parser for a language `language uninstall` removed
+            // while this install was compiling would leave exactly the
+            // parser-only state that uninstall just reported as gone.
+            let published = match queries::hold_against_uninstall(data_dir, language) {
+                Ok(queries::UninstallClaim::Uninstalled) => Err(format!(
+                    "'{}' was uninstalled while it was being installed",
+                    language
+                )),
+                // The guard is arm-scoped, so the lock is released before the
+                // rollback below reaches for the same one.
+                Ok(queries::UninstallClaim::Clear(_guard)) => {
+                    staged.publish().map_err(|e| e.to_string())
+                }
+                Err(e) => Err(e.to_string()),
+            };
+            match published {
+                Ok(parser_result) => result.parser_path = Some(parser_result.install_path),
+                Err(reason) => {
+                    published_queries.rollback();
+                    result.parser_error = Some(reason);
+                    return result;
+                }
             }
-        },
+        }
         parser::StagedParserOutcome::AlreadyInstalled(path) => result.parser_path = Some(path),
     }
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -295,8 +295,11 @@ impl StagedParser {
     /// published.
     pub(crate) fn publish(mut self) -> Result<ParserInstallResult, ParserInstallError> {
         // `cfg!` rather than `#[cfg]` so this compiles everywhere it is read,
-        // not only where it runs.
-        let displaced = if cfg!(windows) && self.parser_file.exists() {
+        // not only where it runs. `is_file`, so a directory sitting where the
+        // parser belongs is not moved aside and then left stranded by a
+        // `remove_file` that cannot remove it — the rename below fails instead,
+        // which is the error the user needs to see.
+        let displaced = if cfg!(windows) && self.parser_file.is_file() {
             let aside = self
                 .parser_file
                 .with_file_name(format!("{}.displaced", staging_file_name(&self.language)));

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -580,8 +580,11 @@ fn staging_file_owner(name: &str) -> Option<StagingFile<'_>> {
     let language = parts.next()?;
     let pid = parts.next()?;
     let counter = parts.next()?;
-    let _extension = parts.next()?;
+    // The real extension, not any segment: without this a user's own
+    // `.notes.123.0.bak.tmp` under `parser/` parses as one of ours.
+    let extension = parts.next()?;
     if parts.next().is_none()
+        && extension == std::env::consts::DLL_EXTENSION
         && super::queries::is_safe_language_name(language)
         && pid.bytes().all(|b| b.is_ascii_digit())
         && counter.bytes().all(|b| b.is_ascii_digit())
@@ -1704,6 +1707,28 @@ mod tests {
         assert!(
             !queries_parent.join(".lua.uninstalled").is_file(),
             "the marker saying the language is gone must not outlive the install"
+        );
+    }
+
+    /// The sweep only owns names it could have written. A user's own dotfile
+    /// that happens to have the same shape is not one, and a rename or a
+    /// removal of it would be this module reaching outside what it manages.
+    #[test]
+    #[cfg(unix)]
+    fn the_parser_sweep_leaves_lookalike_files_alone() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        // Same shape, but the extension segment is not the one this platform
+        // compiles parsers to.
+        let lookalike = parser_dir.join(format!(".notes.{}.0.bak.tmp", dead_pid()));
+        fs::write(&lookalike, b"mine").expect("write lookalike");
+
+        recover_interrupted_parser_installs(&parser_dir).expect("sweep should succeed");
+
+        assert!(
+            lookalike.exists(),
+            "a file this module could not have written is not its to collect"
         );
     }
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -120,7 +120,11 @@ pub fn parser_file_exists(language: &str, data_dir: &Path) -> Option<PathBuf> {
         data_dir
             .join("parser")
             .join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
-    if parser_file.exists() {
+    // A file, not merely an entry: a directory with a parser's name is not a
+    // parser, and reading it as one made an install report success over
+    // something it never wrote — while `language status`, which does check for
+    // a file, called the same language missing.
+    if parser_file.is_file() {
         Some(parser_file)
     } else {
         None
@@ -377,17 +381,7 @@ pub(crate) fn stage_parser(
     language: &str,
     options: &InstallOptions,
 ) -> Result<StagedParserOutcome, ParserInstallError> {
-    // `language` becomes path segments (`parser/<language>.<ext>` and the temp
-    // file) and a URL/metadata key, so reject traversal-capable names before
-    // touching the filesystem. Higher-level callers (auto-install) already gate
-    // this, but `install_parser` is a public entry point and must be safe on its
-    // own — a name like `../../evil` would otherwise write outside the data dir.
-    if !super::queries::is_safe_language_name(language) {
-        return Err(ParserInstallError::IoError(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("unsafe language name '{}'", language.escape_default()),
-        )));
-    }
+    reject_unsafe_language_name(language)?;
 
     let parser_dir = options.data_dir.join("parser");
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
@@ -462,6 +456,87 @@ pub(crate) fn stage_parser(
     Ok(StagedParserOutcome::Staged(staged))
 }
 
+/// Reject a language name that cannot be used to build a path.
+///
+/// `language` becomes path segments (`parser/<language>.<ext>` and the temp
+/// file) and a URL/metadata key. Higher-level callers (auto-install) already
+/// gate this, but the entry points below are public and must be safe on their
+/// own — a name like `../../evil` would otherwise write outside the data dir.
+fn reject_unsafe_language_name(language: &str) -> Result<(), ParserInstallError> {
+    if super::queries::is_safe_language_name(language) {
+        Ok(())
+    } else {
+        Err(ParserInstallError::IoError(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("unsafe language name '{}'", language.escape_default()),
+        )))
+    }
+}
+
+/// Collect parser staging files whose owning process is gone.
+///
+/// Publication renames the staging file away, and the drop guard reclaims it on
+/// every error path — but a killed process runs neither, and nothing else knows
+/// the name. The query side has had this since staging directories were
+/// introduced; this is its parser counterpart. Dot-prefixed staging files are
+/// already invisible to parser discovery, so this only reclaims disk.
+///
+/// Names carry the owning pid, and a live owner's file is left alone. Off unix
+/// there is no portable liveness test, so nothing is collected — the same
+/// conservative stance the query sweep takes.
+pub fn recover_interrupted_parser_installs(parser_dir: &Path) -> std::io::Result<()> {
+    let entries = match fs::read_dir(parser_dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e),
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !entry.file_type().is_ok_and(|kind| kind.is_file()) {
+            continue;
+        }
+        let Some(pid) = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(staging_file_owner)
+        else {
+            continue;
+        };
+        if super::queries::process_is_running(pid) {
+            continue;
+        }
+        let _ = fs::remove_file(&path);
+    }
+    Ok(())
+}
+
+/// The pid embedded in a generated staging file name, if it is one.
+///
+/// Shape: `.{language}.{pid}.{counter}.{ext}.tmp`, plus the `.displaced` copy a
+/// Windows publish moves the previous parser to. A user's own dot-file is left
+/// alone because it will not parse into these parts.
+fn staging_file_owner(name: &str) -> Option<&str> {
+    let rest = name
+        .strip_prefix('.')?
+        .strip_suffix(".displaced")
+        .unwrap_or(name.strip_prefix('.')?)
+        .strip_suffix(".tmp")?;
+    let mut parts = rest.split('.');
+    let language = parts.next()?;
+    let pid = parts.next()?;
+    let counter = parts.next()?;
+    let _extension = parts.next()?;
+    if parts.next().is_none()
+        && super::queries::is_safe_language_name(language)
+        && pid.bytes().all(|b| b.is_ascii_digit())
+        && counter.bytes().all(|b| b.is_ascii_digit())
+    {
+        Some(pid)
+    } else {
+        None
+    }
+}
+
 /// Name of the staging file a parser compiles into, inside `parser/`.
 ///
 /// Dot-prefixed and `.tmp`-suffixed so parser discovery walks past it, and
@@ -483,6 +558,14 @@ pub fn install_parser(
     language: &str,
     options: &InstallOptions,
 ) -> Result<ParserInstallResult, ParserInstallError> {
+    // Half of a language on its own, but still inside the transaction protocol:
+    // a parser published without this lock can land after an uninstall removed
+    // the other half, recreating the parser-only state that uninstall reported
+    // as gone. Checked before the lock so an unusable name keeps reporting
+    // itself rather than a lock failure.
+    reject_unsafe_language_name(language)?;
+    let _transaction = super::queries::lock_language(&options.data_dir, language)
+        .map_err(|e| ParserInstallError::IoError(std::io::Error::other(e.to_string())))?;
     match stage_parser(language, options)? {
         StagedParserOutcome::Staged(staged) => {
             let result = staged.publish()?;
@@ -1479,6 +1562,59 @@ mod tests {
         let status = run_with_timeout(cmd, Duration::from_secs(10), "test exit")
             .expect("fast command should complete within the deadline");
         assert!(status.success());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn interrupted_parser_staging_files_are_collected() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let ext = std::env::consts::DLL_EXTENSION;
+        let dead = parser_dir.join(format!(".lua.{}.0.{}.tmp", dead_pid(), ext));
+        let live = parser_dir.join(format!(".lua.{}.0.{}.tmp", std::process::id(), ext));
+        let installed = parser_dir.join(format!("lua.{}", ext));
+        let unmanaged = parser_dir.join(".notes.txt");
+        for path in [&dead, &live, &installed, &unmanaged] {
+            fs::write(path, b"x").expect("write file");
+        }
+
+        recover_interrupted_parser_installs(&parser_dir).expect("sweep should succeed");
+
+        assert!(!dead.exists(), "a dead owner's staging file is reclaimed");
+        assert!(
+            live.exists(),
+            "a live owner is still compiling into its file"
+        );
+        assert!(installed.exists(), "the installed parser is untouched");
+        assert!(
+            unmanaged.exists(),
+            "files this module did not name are left alone"
+        );
+    }
+
+    /// A pid no live process can have, found the same way the query sweep's
+    /// test finds one.
+    #[cfg(unix)]
+    fn dead_pid() -> u32 {
+        let mut pid = std::process::id().saturating_add(100_000);
+        while super::super::queries::process_is_running(&pid.to_string()) {
+            pid = pid.saturating_add(1);
+        }
+        pid
+    }
+
+    /// A directory that happens to carry a parser's name is not a parser —
+    /// `language status` already says so, and an install that disagreed
+    /// reported success over something it never wrote.
+    #[test]
+    fn a_parser_shaped_directory_is_not_an_installed_parser() {
+        let temp = tempdir().expect("temp dir");
+        let ext = std::env::consts::DLL_EXTENSION;
+        fs::create_dir_all(temp.path().join("parser").join(format!("lua.{}", ext)))
+            .expect("create parser-shaped directory");
+
+        assert!(parser_file_exists("lua", temp.path()).is_none());
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -261,11 +261,73 @@ fn compile_parser(grammar_path: &Path, output_path: &Path) -> Result<(), ParserI
     Ok(())
 }
 
-/// Install a Tree-sitter parser for a language.
-pub fn install_parser(
+/// A compiled parser that has not been moved into the data directory yet.
+///
+/// Installing a language means publishing two artifacts (parser and queries),
+/// and either can fail. Staging separates the expensive, failure-prone work
+/// (metadata, source fetch, compile) from the single rename that makes the
+/// parser visible, so a caller can prepare both halves first and publish only
+/// once both are ready. Dropping a staged parser without publishing removes the
+/// compiled artifact, leaving the data directory exactly as it was.
+pub(crate) struct StagedParser {
+    language: String,
+    revision: String,
+    tmp_file: PathBuf,
+    parser_file: PathBuf,
+    /// Whether the drop guard still owns `tmp_file`. Cleared by `publish`,
+    /// which hands the file over to the data directory.
+    armed: bool,
+}
+
+impl StagedParser {
+    /// Move the compiled library into its final location.
+    ///
+    /// On unix `rename` atomically replaces an existing parser. Windows
+    /// `rename` instead fails if the destination exists, which would make a
+    /// `force` reinstall fail after a good compile — remove the old file
+    /// first there (a small non-atomic window, acceptable on the
+    /// non-primary platform).
+    pub(crate) fn publish(mut self) -> Result<ParserInstallResult, ParserInstallError> {
+        #[cfg(windows)]
+        let _ = fs::remove_file(&self.parser_file);
+        if let Err(e) = fs::rename(&self.tmp_file, &self.parser_file) {
+            return Err(ParserInstallError::IoError(e));
+        }
+        // The rename consumed the staging file; anything the drop guard would
+        // remove now belongs to the data dir.
+        self.armed = false;
+        Ok(ParserInstallResult {
+            language: std::mem::take(&mut self.language),
+            install_path: std::mem::take(&mut self.parser_file),
+            revision: std::mem::take(&mut self.revision),
+        })
+    }
+}
+
+impl Drop for StagedParser {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = fs::remove_file(&self.tmp_file);
+        }
+    }
+}
+
+/// What [`stage_parser`] found or produced.
+pub(crate) enum StagedParserOutcome {
+    /// A parser was compiled and is waiting to be published.
+    Staged(StagedParser),
+    /// A usable parser is already installed and `force` was not requested, so
+    /// nothing was compiled.
+    AlreadyInstalled(PathBuf),
+}
+
+/// Compile a Tree-sitter parser into a staging file without publishing it.
+///
+/// See [`StagedParser`] for why publication is deferred.
+pub(crate) fn stage_parser(
     language: &str,
     options: &InstallOptions,
-) -> Result<ParserInstallResult, ParserInstallError> {
+) -> Result<StagedParserOutcome, ParserInstallError> {
     // `language` becomes path segments (`parser/<language>.<ext>` and the temp
     // file) and a URL/metadata key, so reject traversal-capable names before
     // touching the filesystem. Higher-level callers (auto-install) already gate
@@ -283,7 +345,7 @@ pub fn install_parser(
 
     // Check if parser already exists
     if parser_file.exists() && !options.force {
-        return Err(ParserInstallError::AlreadyExists(parser_file));
+        return Ok(StagedParserOutcome::AlreadyInstalled(parser_file));
     }
 
     // Fetch metadata (with caching support)
@@ -319,11 +381,11 @@ pub fn install_parser(
         eprintln!("Building parser in: {}", source_dir.display());
     }
 
-    // Compile to a temp path in the install dir, then atomically rename into place
-    // on success. A failed or deadline-killed compile can leave a partial/corrupt
-    // library behind (`parser_file_exists` only checks existence, so a leftover
-    // would make later runs skip reinstall and load a broken parser); writing to a
-    // temp and renaming only on success means a failure never clobbers a
+    // Compile to a temp path in the install dir; the caller renames it into place
+    // (see `StagedParser::publish`). A failed or deadline-killed compile can leave a
+    // partial/corrupt library behind (`parser_file_exists` only checks existence, so
+    // a leftover would make later runs skip reinstall and load a broken parser);
+    // writing to a temp and renaming only on success means a failure never clobbers a
     // previously-working parser (e.g. a `force` reinstall that fails) and concurrent
     // readers never observe a half-written file.
     //
@@ -341,39 +403,40 @@ pub fn install_parser(
         TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
         std::env::consts::DLL_EXTENSION
     ));
-    let compiled = match options.compile {
-        ParserCompile::KillableSubprocess => compile_parser(&source_dir, &tmp_file),
-        ParserCompile::InProcess => compile_parser_inprocess(&source_dir, &tmp_file),
+    let staged = StagedParser {
+        language: language.to_string(),
+        revision: metadata.revision,
+        tmp_file,
+        parser_file,
+        armed: true,
     };
-    match compiled {
-        Ok(()) => {
-            // On unix `rename` atomically replaces an existing parser. Windows
-            // `rename` instead fails if the destination exists, which would make a
-            // `force` reinstall fail after a good compile — remove the old file
-            // first there (a small non-atomic window, acceptable on the
-            // non-primary platform).
-            #[cfg(windows)]
-            let _ = fs::remove_file(&parser_file);
-            if let Err(e) = fs::rename(&tmp_file, &parser_file) {
-                let _ = fs::remove_file(&tmp_file);
-                return Err(ParserInstallError::IoError(e));
-            }
-        }
-        Err(e) => {
-            let _ = fs::remove_file(&tmp_file);
-            return Err(e);
-        }
-    }
+    match options.compile {
+        ParserCompile::KillableSubprocess => compile_parser(&source_dir, &staged.tmp_file),
+        ParserCompile::InProcess => compile_parser_inprocess(&source_dir, &staged.tmp_file),
+    }?;
 
     if options.verbose {
-        eprintln!("Installed to: {}", parser_file.display());
+        eprintln!("Compiled to: {}", staged.tmp_file.display());
     }
 
-    Ok(ParserInstallResult {
-        language: language.to_string(),
-        install_path: parser_file,
-        revision: metadata.revision,
-    })
+    Ok(StagedParserOutcome::Staged(staged))
+}
+
+/// Install a Tree-sitter parser for a language, publishing it immediately.
+pub fn install_parser(
+    language: &str,
+    options: &InstallOptions,
+) -> Result<ParserInstallResult, ParserInstallError> {
+    match stage_parser(language, options)? {
+        StagedParserOutcome::Staged(staged) => {
+            let result = staged.publish()?;
+            if options.verbose {
+                eprintln!("Installed to: {}", result.install_path.display());
+            }
+            Ok(result)
+        }
+        StagedParserOutcome::AlreadyInstalled(path) => Err(ParserInstallError::AlreadyExists(path)),
+    }
 }
 
 /// Construct a GitHub archive download URL from a repository URL and revision.
@@ -1383,6 +1446,102 @@ mod tests {
         let result = parser_file_exists("lua", temp.path());
         assert!(result.is_some());
         assert_eq!(result.unwrap(), parser_file);
+    }
+
+    /// Build a staged parser over a hand-written temp file, so the staging
+    /// contract can be tested without metadata, a clone, or a `cc` run.
+    fn fake_staged_parser(data_dir: &Path, language: &str) -> StagedParser {
+        let parser_dir = data_dir.join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let ext = std::env::consts::DLL_EXTENSION;
+        let tmp_file = parser_dir.join(format!(".{}.staged.{}.tmp", language, ext));
+        fs::write(&tmp_file, b"staged parser").expect("write staged parser");
+        StagedParser {
+            language: language.to_string(),
+            revision: "deadbeef".to_string(),
+            tmp_file,
+            parser_file: parser_dir.join(format!("{}.{}", language, ext)),
+            armed: true,
+        }
+    }
+
+    /// The whole point of staging: an install that gives up before publishing
+    /// must leave the parser directory byte-identical, with no stray temp file
+    /// for a later run (or `language status`) to trip over.
+    #[test]
+    fn dropping_a_staged_parser_leaves_the_parser_dir_unchanged() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+
+        drop(fake_staged_parser(temp.path(), "lua"));
+
+        let leftovers: Vec<_> = fs::read_dir(&parser_dir)
+            .expect("read parser dir")
+            .flatten()
+            .map(|entry| entry.file_name())
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "an unpublished staged parser must leave nothing behind, found {:?}",
+            leftovers
+        );
+    }
+
+    /// Dropping must not touch a parser that was already installed: the
+    /// abandoned install never owned it.
+    #[test]
+    fn dropping_a_staged_parser_preserves_an_existing_parser() {
+        let temp = tempdir().expect("temp dir");
+        let ext = std::env::consts::DLL_EXTENSION;
+        let parser_file = temp.path().join("parser").join(format!("lua.{}", ext));
+        let staged = fake_staged_parser(temp.path(), "lua");
+        fs::write(&parser_file, b"previously installed").expect("write existing parser");
+
+        drop(staged);
+
+        assert_eq!(
+            fs::read(&parser_file).expect("read existing parser"),
+            b"previously installed",
+            "staging cleanup must not remove an already-installed parser"
+        );
+    }
+
+    #[test]
+    fn publishing_a_staged_parser_moves_it_into_place() {
+        let temp = tempdir().expect("temp dir");
+        let ext = std::env::consts::DLL_EXTENSION;
+        let staged = fake_staged_parser(temp.path(), "lua");
+        let tmp_file = staged.tmp_file.clone();
+
+        let result = staged.publish().expect("publish should succeed");
+
+        assert_eq!(
+            result.install_path,
+            temp.path().join("parser").join(format!("lua.{}", ext))
+        );
+        assert_eq!(
+            fs::read(&result.install_path).expect("read published parser"),
+            b"staged parser"
+        );
+        assert!(
+            !tmp_file.exists(),
+            "publishing must consume the staging file"
+        );
+    }
+
+    /// A published parser is owned by the data dir, not by the (now dropped)
+    /// staging handle — the drop guard must not delete what it just handed over.
+    #[test]
+    fn publishing_disarms_the_staging_cleanup() {
+        let temp = tempdir().expect("temp dir");
+        let staged = fake_staged_parser(temp.path(), "lua");
+
+        let result = staged.publish().expect("publish should succeed");
+
+        assert!(
+            result.install_path.exists(),
+            "the published parser must survive the staging handle's drop"
+        );
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -354,6 +354,22 @@ pub(crate) enum StagedParserOutcome {
     AlreadyInstalled(PathBuf),
 }
 
+impl StagedParserOutcome {
+    /// Give way to a parser that appeared while this one was being compiled.
+    ///
+    /// Staging decides whether to compile from the state it sees, but the
+    /// compile takes long enough for a concurrent install of the same language
+    /// to finish. Without `force`, that install's parser is as good as ours and
+    /// is already paired with its queries, so replacing it would split the
+    /// pair. Dropping the staged parser here reclaims the compiled file.
+    pub(crate) fn yield_to_existing(self, force: bool, existing: Option<PathBuf>) -> Self {
+        match (self, existing) {
+            (Self::Staged(_), Some(path)) if !force => Self::AlreadyInstalled(path),
+            (outcome, _) => outcome,
+        }
+    }
+}
+
 /// Compile a Tree-sitter parser into a staging file without publishing it.
 ///
 /// See [`StagedParser`] for why publication is deferred.
@@ -1570,6 +1586,45 @@ mod tests {
         assert!(
             !tmp_file.exists(),
             "publishing must consume the staging file"
+        );
+    }
+
+    #[test]
+    fn a_staged_parser_yields_to_one_that_appeared_while_it_compiled() {
+        let temp = tempdir().expect("temp dir");
+        let ext = std::env::consts::DLL_EXTENSION;
+        let staged = fake_staged_parser(temp.path(), "lua");
+        let tmp_file = staged.tmp_file.clone();
+        let winner = temp.path().join("parser").join(format!("lua.{}", ext));
+
+        let outcome =
+            StagedParserOutcome::Staged(staged).yield_to_existing(false, Some(winner.clone()));
+
+        assert!(matches!(outcome, StagedParserOutcome::AlreadyInstalled(path) if path == winner));
+        assert!(
+            !tmp_file.exists(),
+            "yielding must reclaim the parser it compiled"
+        );
+    }
+
+    #[test]
+    fn a_staged_parser_keeps_its_place_when_forced_or_unopposed() {
+        let temp = tempdir().expect("temp dir");
+        let ext = std::env::consts::DLL_EXTENSION;
+        let winner = temp.path().join("parser").join(format!("lua.{}", ext));
+
+        let forced = StagedParserOutcome::Staged(fake_staged_parser(temp.path(), "lua"))
+            .yield_to_existing(true, Some(winner));
+        assert!(
+            matches!(forced, StagedParserOutcome::Staged(_)),
+            "--force replaces whatever is there"
+        );
+
+        let unopposed = StagedParserOutcome::Staged(fake_staged_parser(temp.path(), "lua"))
+            .yield_to_existing(false, None);
+        assert!(
+            matches!(unopposed, StagedParserOutcome::Staged(_)),
+            "with nothing to yield to, the staged parser is published"
         );
     }
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -495,9 +495,13 @@ pub fn recover_interrupted_parser_installs(parser_dir: &Path) -> std::io::Result
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(e) => return Err(e),
     };
-    for entry in entries.flatten() {
+    for entry in entries {
+        // An entry this pass cannot read is reported, not skipped: a sweep that
+        // returns success while residue remains is how the residue becomes
+        // permanent.
+        let entry = entry?;
         let path = entry.path();
-        if !entry.file_type().is_ok_and(|kind| kind.is_file()) {
+        if !entry.file_type()?.is_file() {
             continue;
         }
         let Some(pid) = path

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -302,13 +302,29 @@ impl StagedParser {
             None
         };
         if let Err(e) = fs::rename(&self.tmp_file, &self.parser_file) {
-            if let Some(aside) = &displaced {
-                let _ = fs::rename(aside, &self.parser_file);
+            if let Some(aside) = &displaced
+                && let Err(restore) = fs::rename(aside, &self.parser_file)
+            {
+                // Both halves of the swap failed: say where the previous parser
+                // is, because nothing else will move it back.
+                return Err(ParserInstallError::IoError(std::io::Error::other(format!(
+                    "failed to publish the compiled parser: {e}; failed to restore the previous \
+                     one from {}: {restore}",
+                    aside.display()
+                ))));
             }
             return Err(ParserInstallError::IoError(e));
         }
-        if let Some(aside) = &displaced {
-            let _ = fs::remove_file(aside);
+        if let Some(aside) = &displaced
+            && let Err(e) = fs::remove_file(aside)
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            eprintln!(
+                "Warning: the parser replaced for '{}' could not be removed from {}: {}",
+                self.language,
+                aside.display(),
+                e
+            );
         }
         // The rename consumed the staging file; anything the drop guard would
         // remove now belongs to the data dir.

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -389,20 +389,11 @@ pub(crate) fn stage_parser(
     // previously-working parser (e.g. a `force` reinstall that fails) and concurrent
     // readers never observe a half-written file.
     //
-    // The temp name combines the pid with a process-local counter so two installs
-    // in the same process never collide on it, independent of the per-language
-    // install dedup. (Windows caveat: replacing a parser that is *currently loaded*
-    // by this process still fails at the rename — a loaded DLL can't be removed — a
+    // (Windows caveat: replacing a parser that is *currently loaded* by this
+    // process still fails at the rename — a loaded DLL can't be removed — a
     // pre-existing platform limitation this scheme doesn't change.)
     fs::create_dir_all(&parser_dir)?;
-    static TMP_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-    let tmp_file = parser_dir.join(format!(
-        ".{}.{}.{}.{}.tmp",
-        language,
-        std::process::id(),
-        TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
-        std::env::consts::DLL_EXTENSION
-    ));
+    let tmp_file = parser_dir.join(staging_file_name(language));
     let staged = StagedParser {
         language: language.to_string(),
         revision: metadata.revision,
@@ -416,10 +407,26 @@ pub(crate) fn stage_parser(
     }?;
 
     if options.verbose {
-        eprintln!("Compiled to: {}", staged.tmp_file.display());
+        eprintln!("Compiled parser for '{}'", language);
     }
 
     Ok(StagedParserOutcome::Staged(staged))
+}
+
+/// Name of the staging file a parser compiles into, inside `parser/`.
+///
+/// Dot-prefixed and `.tmp`-suffixed so parser discovery walks past it, and
+/// combining the pid with a process-local counter so two installs in the same
+/// process never collide on it, independent of the per-language install dedup.
+fn staging_file_name(language: &str) -> String {
+    static TMP_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    format!(
+        ".{}.{}.{}.{}.tmp",
+        language,
+        std::process::id(),
+        TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+        std::env::consts::DLL_EXTENSION
+    )
 }
 
 /// Install a Tree-sitter parser for a language, publishing it immediately.
@@ -1450,11 +1457,15 @@ mod tests {
 
     /// Build a staged parser over a hand-written temp file, so the staging
     /// contract can be tested without metadata, a clone, or a `cc` run.
+    ///
+    /// The temp path is built the same way `stage_parser` builds it, so a
+    /// change to that shape cannot silently leave these tests pinning a name
+    /// production no longer produces.
     fn fake_staged_parser(data_dir: &Path, language: &str) -> StagedParser {
         let parser_dir = data_dir.join("parser");
         fs::create_dir_all(&parser_dir).expect("create parser dir");
         let ext = std::env::consts::DLL_EXTENSION;
-        let tmp_file = parser_dir.join(format!(".{}.staged.{}.tmp", language, ext));
+        let tmp_file = parser_dir.join(staging_file_name(language));
         fs::write(&tmp_file, b"staged parser").expect("write staged parser");
         StagedParser {
             language: language.to_string(),
@@ -1529,18 +1540,30 @@ mod tests {
         );
     }
 
-    /// A published parser is owned by the data dir, not by the (now dropped)
-    /// staging handle — the drop guard must not delete what it just handed over.
+    /// A publish that cannot complete must still reclaim its staging file:
+    /// the install is over, and a leftover temp file is exactly what the
+    /// staging design exists to avoid.
     #[test]
-    fn publishing_disarms_the_staging_cleanup() {
+    fn a_failed_publish_removes_the_staging_file() {
         let temp = tempdir().expect("temp dir");
+        let ext = std::env::consts::DLL_EXTENSION;
         let staged = fake_staged_parser(temp.path(), "lua");
+        let tmp_file = staged.tmp_file.clone();
+        // A non-empty directory where the parser file belongs: the rename
+        // cannot replace it.
+        let blocker = temp.path().join("parser").join(format!("lua.{}", ext));
+        fs::create_dir_all(blocker.join("occupied")).expect("create blocking dir");
 
-        let result = staged.publish().expect("publish should succeed");
+        let error = staged.publish().expect_err("publish must fail");
 
+        assert!(matches!(error, ParserInstallError::IoError(_)));
         assert!(
-            result.install_path.exists(),
-            "the published parser must survive the staging handle's drop"
+            !tmp_file.exists(),
+            "a failed publish must not leave its staging file behind"
+        );
+        assert!(
+            blocker.join("occupied").exists(),
+            "a failed publish must not disturb what was already there"
         );
     }
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -284,14 +284,31 @@ impl StagedParser {
     ///
     /// On unix `rename` atomically replaces an existing parser. Windows
     /// `rename` instead fails if the destination exists, which would make a
-    /// `force` reinstall fail after a good compile — remove the old file
-    /// first there (a small non-atomic window, acceptable on the
-    /// non-primary platform).
+    /// `force` reinstall fail after a good compile — so there the previous
+    /// parser is moved aside first, and moved back if the rename then fails.
+    /// Deleting it instead would leave a `force` reinstall that failed at the
+    /// rename with no parser at all, while the caller reports that nothing was
+    /// published.
     pub(crate) fn publish(mut self) -> Result<ParserInstallResult, ParserInstallError> {
-        #[cfg(windows)]
-        let _ = fs::remove_file(&self.parser_file);
+        // `cfg!` rather than `#[cfg]` so this compiles everywhere it is read,
+        // not only where it runs.
+        let displaced = if cfg!(windows) && self.parser_file.exists() {
+            let aside = self
+                .parser_file
+                .with_file_name(format!("{}.displaced", staging_file_name(&self.language)));
+            fs::rename(&self.parser_file, &aside)?;
+            Some(aside)
+        } else {
+            None
+        };
         if let Err(e) = fs::rename(&self.tmp_file, &self.parser_file) {
+            if let Some(aside) = &displaced {
+                let _ = fs::rename(aside, &self.parser_file);
+            }
             return Err(ParserInstallError::IoError(e));
+        }
+        if let Some(aside) = &displaced {
+            let _ = fs::remove_file(aside);
         }
         // The rename consumed the staging file; anything the drop guard would
         // remove now belongs to the data dir.
@@ -1537,6 +1554,37 @@ mod tests {
         assert!(
             !tmp_file.exists(),
             "publishing must consume the staging file"
+        );
+    }
+
+    /// The previous parser is displaced, not deleted, so a publish that fails
+    /// at the rename leaves the language exactly as it was. (The displacement
+    /// only happens on Windows, where rename cannot replace; elsewhere the
+    /// rename is atomic and there is nothing to displace.)
+    #[test]
+    fn publishing_over_an_existing_parser_replaces_it() {
+        let temp = tempdir().expect("temp dir");
+        let ext = std::env::consts::DLL_EXTENSION;
+        let parser_file = temp.path().join("parser").join(format!("lua.{}", ext));
+        let staged = fake_staged_parser(temp.path(), "lua");
+        fs::write(&parser_file, b"previous parser").expect("write previous parser");
+
+        let result = staged.publish().expect("publish should succeed");
+
+        assert_eq!(
+            fs::read(&result.install_path).expect("read published parser"),
+            b"staged parser"
+        );
+        let leftovers: Vec<_> = fs::read_dir(temp.path().join("parser"))
+            .expect("read parser dir")
+            .flatten()
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name != &format!("lua.{}", ext))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "replacing a parser must not strand the one it displaced, found {:?}",
+            leftovers
         );
     }
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -625,6 +625,12 @@ pub fn install_parser(
     reject_unsafe_language_name(language)?;
     let _transaction = super::queries::lock_language(&options.data_dir, language)
         .map_err(|e| ParserInstallError::IoError(std::io::Error::other(e.to_string())))?;
+    // An explicit install overrides an earlier uninstall, exactly as the
+    // whole-language one does — and clearing the marker under this lock is what
+    // keeps the two consistent. Leaving it would put a fresh parser next to a
+    // tombstone saying the language is gone, which the query side then honours.
+    super::queries::clear_uninstall_tombstone_for_install(&options.data_dir, language)
+        .map_err(|e| ParserInstallError::IoError(std::io::Error::other(e.to_string())))?;
     match stage_parser(language, options)? {
         StagedParserOutcome::Staged(staged) => {
             let result = staged.publish()?;
@@ -1661,6 +1667,44 @@ mod tests {
             pid = pid.saturating_add(1);
         }
         pid
+    }
+
+    /// A parser published beside a live uninstall tombstone is a language the
+    /// query side still believes is gone. An explicit install overrides the
+    /// uninstall — but it has to say so on disk, not leave the two disagreeing.
+    #[test]
+    fn installing_a_parser_clears_the_uninstall_tombstone() {
+        let temp = tempdir().expect("temp dir");
+        let data_dir = temp.path();
+        let queries_parent = data_dir.join("queries");
+        fs::create_dir_all(&queries_parent).expect("create queries dir");
+        super::super::queries::write_uninstall_tombstone_for_tests(&queries_parent, "lua")
+            .expect("write tombstone");
+        // A parser is already installed, so this returns before any network.
+        let parser_dir = data_dir.join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        fs::write(
+            parser_dir.join(format!("lua.{}", std::env::consts::DLL_EXTENSION)),
+            b"installed",
+        )
+        .expect("write parser");
+
+        let result = install_parser(
+            "lua",
+            &InstallOptions {
+                data_dir: data_dir.to_path_buf(),
+                force: false,
+                verbose: false,
+                no_cache: false,
+                compile: ParserCompile::InProcess,
+            },
+        );
+
+        assert!(matches!(result, Err(ParserInstallError::AlreadyExists(_))));
+        assert!(
+            !queries_parent.join(".lua.uninstalled").is_file(),
+            "the marker saying the language is gone must not outlive the install"
+        );
     }
 
     /// A displaced file is the previous parser, moved aside by a publish that

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -386,9 +386,14 @@ pub(crate) fn stage_parser(
     let parser_dir = options.data_dir.join("parser");
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
 
-    // Check if parser already exists
-    if parser_file.exists() && !options.force {
-        return Ok(StagedParserOutcome::AlreadyInstalled(parser_file));
+    // Check if a usable parser is already installed. `is_file` via
+    // `parser_file_exists`, not a bare existence check: a directory carrying a
+    // parser's name is not a parser, and treating it as one made the install
+    // report success over something it never wrote.
+    if !options.force
+        && let Some(installed) = parser_file_exists(language, &options.data_dir)
+    {
+        return Ok(StagedParserOutcome::AlreadyInstalled(installed));
     }
 
     // Fetch metadata (with caching support)
@@ -505,7 +510,12 @@ pub fn recover_interrupted_parser_installs(parser_dir: &Path) -> std::io::Result
         if super::queries::process_is_running(pid) {
             continue;
         }
-        let _ = fs::remove_file(&path);
+        match fs::remove_file(&path) {
+            Ok(()) => {}
+            // Someone else collected it between the scan and the removal.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
     }
     Ok(())
 }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -521,15 +521,30 @@ pub fn recover_interrupted_parser_installs(parser_dir: &Path) -> std::io::Result
         if !entry.file_type()?.is_file() {
             continue;
         }
-        let Some(pid) = path
+        let Some(staging) = path
             .file_name()
             .and_then(|name| name.to_str())
             .and_then(staging_file_owner)
         else {
             continue;
         };
-        if super::queries::process_is_running(pid) {
+        if super::queries::process_is_running(staging.pid) {
             continue;
+        }
+        // A displaced file is the previous parser, moved aside by a publish that
+        // then could not put it back. If the language has no parser now, it is
+        // the only copy left and the publication error told the user where it
+        // is — put it back instead of collecting it.
+        if staging.displaced {
+            let parser_file = parser_dir.join(format!(
+                "{}.{}",
+                staging.language,
+                std::env::consts::DLL_EXTENSION
+            ));
+            if !parser_file.is_file() {
+                fs::rename(&path, &parser_file)?;
+                continue;
+            }
         }
         match fs::remove_file(&path) {
             Ok(()) => {}
@@ -541,17 +556,26 @@ pub fn recover_interrupted_parser_installs(parser_dir: &Path) -> std::io::Result
     Ok(())
 }
 
-/// The pid embedded in a generated staging file name, if it is one.
+/// A generated staging file: which language and process it belongs to, and
+/// whether it is a compile's output or a parser moved aside by a publish.
+struct StagingFile<'a> {
+    language: &'a str,
+    pid: &'a str,
+    displaced: bool,
+}
+
+/// Read a generated staging file name, if it is one.
 ///
 /// Shape: `.{language}.{pid}.{counter}.{ext}.tmp`, plus the `.displaced` copy a
 /// Windows publish moves the previous parser to. A user's own dot-file is left
 /// alone because it will not parse into these parts.
-fn staging_file_owner(name: &str) -> Option<&str> {
-    let rest = name
-        .strip_prefix('.')?
-        .strip_suffix(".displaced")
-        .unwrap_or(name.strip_prefix('.')?)
-        .strip_suffix(".tmp")?;
+fn staging_file_owner(name: &str) -> Option<StagingFile<'_>> {
+    let body = name.strip_prefix('.')?;
+    let (body, displaced) = match body.strip_suffix(".displaced") {
+        Some(body) => (body, true),
+        None => (body, false),
+    };
+    let rest = body.strip_suffix(".tmp")?;
     let mut parts = rest.split('.');
     let language = parts.next()?;
     let pid = parts.next()?;
@@ -562,7 +586,11 @@ fn staging_file_owner(name: &str) -> Option<&str> {
         && pid.bytes().all(|b| b.is_ascii_digit())
         && counter.bytes().all(|b| b.is_ascii_digit())
     {
-        Some(pid)
+        Some(StagingFile {
+            language,
+            pid,
+            displaced,
+        })
     } else {
         None
     }
@@ -1633,6 +1661,53 @@ mod tests {
             pid = pid.saturating_add(1);
         }
         pid
+    }
+
+    /// A displaced file is the previous parser, moved aside by a publish that
+    /// could not put it back. If the language has no parser now it is the only
+    /// copy left — and the publication error told the user it was there, so a
+    /// sweep must not be what deletes it.
+    #[test]
+    #[cfg(unix)]
+    fn a_displaced_parser_is_restored_when_the_language_has_none() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let ext = std::env::consts::DLL_EXTENSION;
+        let displaced = parser_dir.join(format!(".lua.{}.0.{}.tmp.displaced", dead_pid(), ext));
+        fs::write(&displaced, b"previous parser").expect("write displaced parser");
+
+        recover_interrupted_parser_installs(&parser_dir).expect("sweep should succeed");
+
+        assert_eq!(
+            fs::read(parser_dir.join(format!("lua.{}", ext))).expect("read restored parser"),
+            b"previous parser",
+            "the only copy left must be put back, not collected"
+        );
+    }
+
+    /// Once the language has a parser again, the copy that was displaced is
+    /// superseded and only takes up room.
+    #[test]
+    #[cfg(unix)]
+    fn a_displaced_parser_is_collected_once_superseded() {
+        let temp = tempdir().expect("temp dir");
+        let parser_dir = temp.path().join("parser");
+        fs::create_dir_all(&parser_dir).expect("create parser dir");
+        let ext = std::env::consts::DLL_EXTENSION;
+        let installed = parser_dir.join(format!("lua.{}", ext));
+        fs::write(&installed, b"current parser").expect("write installed parser");
+        let displaced = parser_dir.join(format!(".lua.{}.0.{}.tmp.displaced", dead_pid(), ext));
+        fs::write(&displaced, b"previous parser").expect("write displaced parser");
+
+        recover_interrupted_parser_installs(&parser_dir).expect("sweep should succeed");
+
+        assert!(!displaced.exists(), "a superseded copy is collected");
+        assert_eq!(
+            fs::read(&installed).expect("read installed parser"),
+            b"current parser",
+            "and the installed parser is untouched"
+        );
     }
 
     /// A directory that happens to carry a parser's name is not a parser —

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -300,9 +300,14 @@ impl StagedParser {
         // `remove_file` that cannot remove it — the rename below fails instead,
         // which is the error the user needs to see.
         let displaced = if cfg!(windows) && self.parser_file.is_file() {
-            let aside = self
-                .parser_file
-                .with_file_name(format!("{}.displaced", staging_file_name(&self.language)));
+            // An unused name, not merely a generated one: pids are reused, and
+            // the staging sweep does not run off unix, so a `.displaced` file
+            // left by a crashed process that had this pid would otherwise make
+            // every later reinstall fail at this rename.
+            let mut aside = self.displaced_path();
+            while aside.exists() {
+                aside = self.displaced_path();
+            }
             fs::rename(&self.parser_file, &aside)?;
             Some(aside)
         } else {
@@ -341,6 +346,15 @@ impl StagedParser {
             install_path: std::mem::take(&mut self.parser_file),
             revision: std::mem::take(&mut self.revision),
         })
+    }
+}
+
+impl StagedParser {
+    /// A name to move the parser being replaced aside to. Each call returns a
+    /// different one; the caller checks it is actually free.
+    fn displaced_path(&self) -> PathBuf {
+        self.parser_file
+            .with_file_name(format!("{}.displaced", staging_file_name(&self.language)))
     }
 }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -202,6 +202,10 @@ pub fn install_queries_with_dependencies(
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
+    // Half of a language on its own, but still inside the transaction protocol:
+    // an unlocked publish here could land between the two halves of an install
+    // or an uninstall running in another process.
+    let _transaction = lock_language(data_dir, language)?;
     clear_uninstall_tombstone_for_install(data_dir, language)?;
     install_queries_with_dependencies_from_with_http_policy(
         NVIM_TREESITTER_QUERIES_URL,
@@ -454,7 +458,11 @@ impl StagedQueryInstall {
             language: requested_language.clone(),
             published: Vec::new(),
         };
-        for entry in entries {
+        // Deepest first: entries are collected requested-language-first, so
+        // reversing publishes every base language before the one that inherits
+        // it. A reader that catches the install mid-publish then sees a
+        // language whose chain is already there, never a dangling `; inherits:`.
+        for entry in entries.into_iter().rev() {
             let requested = entry.language == requested_language;
             // Each entry publishes with the `force` it was staged with, so an
             // inherited parent never overwrites a copy that appeared while this
@@ -481,7 +489,7 @@ impl StagedQueryInstall {
                     }
                 }
                 Ok(PublishQueryDirOutcome::Uninstalled) => {
-                    publish.rollback();
+                    let _ = publish.rollback();
                     return Err(QueryInstallError::IoError(std::io::Error::new(
                         std::io::ErrorKind::Interrupted,
                         format!(
@@ -491,7 +499,7 @@ impl StagedQueryInstall {
                     )));
                 }
                 Err(e) => {
-                    publish.rollback();
+                    let _ = publish.rollback();
                     return Err(e);
                 }
             }
@@ -551,7 +559,9 @@ impl PublishedQueryInstall {
     /// one was compiling would have its work undone here. Closing that needs
     /// provenance in the install marker; same-language cross-process installs
     /// are rare enough that the marker format has not been changed for it.
-    pub(crate) fn rollback(mut self) {
+    #[must_use = "a rollback that could not finish leaves published queries behind"]
+    pub(crate) fn rollback(mut self) -> RollbackOutcome {
+        let mut outcome = RollbackOutcome::Undone;
         for published in std::mem::take(&mut self.published) {
             if !published.requested {
                 discard_backup_locked(&published);
@@ -583,6 +593,7 @@ impl PublishedQueryInstall {
                      retrying.",
                     published.language, e, published.language
                 );
+                outcome = RollbackOutcome::LeftPublished;
                 continue;
             }
             let Some(backup) = &published.backup else {
@@ -598,16 +609,31 @@ impl PublishedQueryInstall {
                 Ok(()) => {
                     let _ = fs::remove_file(backup_ownership_sidecar(backup));
                 }
-                Err(e) => eprintln!(
-                    "Warning: failed to restore the previous queries for '{}': {}. They are kept \
-                     at {}.",
-                    published.language,
-                    e,
-                    backup.display()
-                ),
+                Err(e) => {
+                    eprintln!(
+                        "Warning: failed to restore the previous queries for '{}': {}. They are \
+                         kept at {}.",
+                        published.language,
+                        e,
+                        backup.display()
+                    );
+                    outcome = RollbackOutcome::LeftPublished;
+                }
             }
         }
+        outcome
     }
+}
+
+/// Whether a rollback actually put everything back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RollbackOutcome {
+    /// Nothing this install published is still published.
+    Undone,
+    /// A removal or restore failed, so the data directory still holds queries
+    /// this install wrote — the warnings say which. The caller must not tell
+    /// the user that nothing was published.
+    LeftPublished,
 }
 
 impl Drop for PublishedQueryInstall {
@@ -1156,7 +1182,7 @@ fn remove_interrupted_temp_query_install(
 }
 
 #[cfg(unix)]
-fn process_is_running(pid: &str) -> bool {
+pub(crate) fn process_is_running(pid: &str) -> bool {
     let Ok(pid) = pid.parse::<i32>() else {
         return false;
     };
@@ -1171,7 +1197,7 @@ fn process_is_running(pid: &str) -> bool {
 }
 
 #[cfg(not(unix))]
-fn process_is_running(pid: &str) -> bool {
+pub(crate) fn process_is_running(pid: &str) -> bool {
     // No portable std API can test another process's liveness. Be
     // conservative: generated temp names contain numeric PIDs, so treat them
     // as possibly live and leave cleanup to a future platform-specific pass.
@@ -1714,7 +1740,7 @@ mod staging_tests {
             "replacement",
             "publish must make the staged queries visible"
         );
-        published.rollback();
+        assert_eq!(published.rollback(), RollbackOutcome::Undone);
 
         assert_eq!(
             fs::read_to_string(queries_dir.join("highlights.scm")).unwrap(),
@@ -1753,7 +1779,7 @@ mod staging_tests {
             queries_parent: queries_parent.clone(),
         };
 
-        staged.publish().expect("publish should succeed").rollback();
+        let _ = staged.publish().expect("publish should succeed").rollback();
 
         assert!(
             !queries_parent.join("child").exists(),

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -1576,6 +1576,49 @@ mod staging_tests {
         );
     }
 
+    /// `--force` replaces the requested language, not the base languages it
+    /// inherits: staging decided a parent was missing, and by publish time a
+    /// concurrent install may have filled it in. Forcing over that would
+    /// destroy a copy this install never intended to touch.
+    #[test]
+    fn forcing_the_requested_language_leaves_an_inherited_parent_alone() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let parent_dir = queries_parent.join("parent");
+        let staged = StagedQueryInstall {
+            language: "child".to_string(),
+            install_path: queries_parent.join("child"),
+            files_downloaded: vec!["highlights.scm".to_string()],
+            requested_already_complete: false,
+            entries: vec![
+                stage(&queries_parent, "child", "; inherits: parent\n", true),
+                stage(&queries_parent, "parent", "ours", false),
+            ],
+        };
+        // The parent appears while this install is busy with the parser.
+        fs::create_dir_all(&parent_dir).unwrap();
+        fs::write(parent_dir.join("highlights.scm"), "theirs").unwrap();
+        write_install_marker(&parent_dir).unwrap();
+
+        staged.publish().expect("publish should succeed").commit();
+
+        assert_eq!(
+            fs::read_to_string(parent_dir.join("highlights.scm")).unwrap(),
+            "theirs",
+            "forcing the requested language must not overwrite an inherited parent"
+        );
+        assert_eq!(
+            fs::read_to_string(queries_parent.join("child").join("highlights.scm")).unwrap(),
+            "; inherits: parent\n",
+            "the requested language is still published"
+        );
+        assert_eq!(
+            residue(&queries_parent),
+            vec!["child".to_string(), "parent".to_string()],
+            "yielding to the parent must not leave a backup behind"
+        );
+    }
+
     /// Publishing stops at the first entry it cannot publish and undoes the
     /// requested language it had already made visible.
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -254,7 +254,7 @@ fn install_queries_with_dependencies_from_with_http_policy(
     http_policy: QueryHttpPolicy,
 ) -> Result<QueryInstallResult, QueryInstallError> {
     let staged = stage_queries_with_dependencies(base_url, language, data_dir, force, http_policy)?;
-    staged.publish(force)?.commit()
+    staged.publish()?.commit()
 }
 
 fn validate_url_http_policy(
@@ -276,6 +276,10 @@ fn validate_url_http_policy(
 struct StagedQueryDir {
     language: String,
     queries_dir: PathBuf,
+    /// The `force` this language was staged with — the install's flag for the
+    /// requested language, and always `false` for an inherited parent, which is
+    /// only ever fetched when it is missing.
+    force: bool,
     tmp: TempQueryDirGuard,
 }
 
@@ -300,8 +304,13 @@ pub(crate) struct StagedQueryInstall {
 /// A query directory that has been renamed into place, with the directory it
 /// displaced kept aside until the install as a whole is committed.
 struct PublishedQueryDir {
+    language: String,
     queries_dir: PathBuf,
     backup: Option<PathBuf>,
+    /// Whether this is the language the install was asked for, as opposed to
+    /// one it pulled in through `; inherits:`. Only the requested language is
+    /// un-published on rollback (see [`PublishedQueryInstall::rollback`]).
+    requested: bool,
 }
 
 /// The outcome of publishing a [`StagedQueryInstall`], still undoable.
@@ -316,25 +325,38 @@ pub(crate) struct PublishedQueryInstall {
 impl StagedQueryInstall {
     /// Rename every staged directory into place, keeping the displaced
     /// directories so the whole install can still be undone.
-    pub(crate) fn publish(
-        mut self,
-        force: bool,
-    ) -> Result<PublishedQueryInstall, QueryInstallError> {
-        let requested_language = std::mem::take(&mut self.language);
+    pub(crate) fn publish(self) -> Result<PublishedQueryInstall, QueryInstallError> {
+        let Self {
+            language: requested_language,
+            install_path,
+            files_downloaded,
+            requested_already_complete,
+            entries,
+        } = self;
         let mut publish = PublishedQueryInstall {
-            install_path: std::mem::take(&mut self.install_path),
-            files_downloaded: std::mem::take(&mut self.files_downloaded),
-            requested_already_complete: self.requested_already_complete,
+            install_path,
+            files_downloaded,
+            requested_already_complete,
             language: requested_language.clone(),
             published: Vec::new(),
         };
-        for entry in self.entries.drain(..) {
+        for entry in entries {
             let requested = entry.language == requested_language;
-            match publish_query_dir(&entry.tmp.path, &entry.queries_dir, &entry.language, force) {
+            // Each entry publishes with the `force` it was staged with, so an
+            // inherited parent never overwrites a copy that appeared while this
+            // install was busy compiling the parser.
+            match publish_query_dir(
+                &entry.tmp.path,
+                &entry.queries_dir,
+                &entry.language,
+                entry.force,
+            ) {
                 Ok(PublishQueryDirOutcome::Published { backup }) => {
                     publish.published.push(PublishedQueryDir {
+                        language: entry.language,
                         queries_dir: entry.queries_dir,
                         backup,
+                        requested,
                     });
                 }
                 // A concurrent installer completed this language while we were
@@ -370,46 +392,139 @@ impl PublishedQueryInstall {
     /// Reports `AlreadyExists` when the requested language needed nothing —
     /// callers treat that as a successful no-op, and it keeps the pre-staging
     /// contract of the `install_queries_*` entry points.
-    pub(crate) fn commit(self) -> Result<QueryInstallResult, QueryInstallError> {
-        for published in &self.published {
-            let Some(backup) = &published.backup else {
-                continue;
-            };
-            if fs::remove_dir_all(backup).is_ok() {
-                let _ = fs::remove_file(backup_ownership_sidecar(backup));
-            }
+    pub(crate) fn commit(mut self) -> Result<QueryInstallResult, QueryInstallError> {
+        for published in std::mem::take(&mut self.published) {
+            discard_backup_locked(&published);
         }
         if self.requested_already_complete {
-            return Err(QueryInstallError::AlreadyExists(self.install_path));
+            return Err(QueryInstallError::AlreadyExists(std::mem::take(
+                &mut self.install_path,
+            )));
         }
         Ok(QueryInstallResult {
-            language: self.language,
-            install_path: self.install_path,
-            files_downloaded: self.files_downloaded,
+            language: std::mem::take(&mut self.language),
+            install_path: std::mem::take(&mut self.install_path),
+            files_downloaded: std::mem::take(&mut self.files_downloaded),
         })
     }
 
-    /// Undo the publish, restoring each displaced directory.
+    /// Un-publish the requested language, restoring the directory it displaced.
     ///
-    /// Best-effort by construction: every step is a rename or removal that
-    /// already succeeded once in the other direction, and there is nothing
-    /// better to do with a failure here than leave the backup in place for
-    /// `language uninstall` to collect.
-    pub(crate) fn rollback(self) {
-        for published in self.published.into_iter().rev() {
-            match published.backup {
-                Some(backup) => {
-                    let _ = fs::remove_dir_all(&published.queries_dir);
-                    if fs::rename(&backup, &published.queries_dir).is_ok() {
-                        let _ = fs::remove_file(backup_ownership_sidecar(&backup));
+    /// Only the requested language is un-published. Query files for the base
+    /// languages it inherits are shared: another install running concurrently
+    /// may already have seen ours and skipped staging its own, so removing them
+    /// would break *its* language rather than undo ours. A base language whose
+    /// queries are present but unused is inert — no parser is registered for it
+    /// — so keeping them is the safe direction, and their backups are simply
+    /// discarded.
+    ///
+    /// Best-effort: every step is the inverse of a rename that already
+    /// succeeded, and a failure here is reported rather than retried, because
+    /// the alternative — leaving a half-restored directory — is worse than
+    /// telling the user what state they are in.
+    pub(crate) fn rollback(mut self) {
+        for published in std::mem::take(&mut self.published) {
+            if !published.requested {
+                discard_backup_locked(&published);
+                continue;
+            }
+            // Take the same lock the publish held, so the un-publish cannot
+            // land inside another installer's or the uninstaller's critical
+            // section.
+            let Some(queries_parent) = published.queries_dir.parent() else {
+                continue;
+            };
+            let _replace_lock =
+                match QueryReplaceLockGuard::acquire(queries_parent, &published.language) {
+                    Ok(guard) => guard,
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: could not lock '{}' to undo its query install: {}",
+                            published.language, e
+                        );
+                        continue;
                     }
+                };
+            if let Err(e) = fs::remove_dir_all(&published.queries_dir)
+                && e.kind() != std::io::ErrorKind::NotFound
+            {
+                eprintln!(
+                    "Warning: failed to remove the queries published for '{}': {}. The data \
+                     directory still holds them; run `kakehashi language uninstall {}` before \
+                     retrying.",
+                    published.language, e, published.language
+                );
+                continue;
+            }
+            let Some(backup) = &published.backup else {
+                continue;
+            };
+            // An uninstall that landed while this install ran wants the
+            // language gone; restoring the backup would resurrect it.
+            if uninstall_tombstone_path(queries_parent, &published.language).is_file() {
+                discard_backup(&published);
+                continue;
+            }
+            match fs::rename(backup, &published.queries_dir) {
+                Ok(()) => {
+                    let _ = fs::remove_file(backup_ownership_sidecar(backup));
                 }
-                None => {
-                    let _ = fs::remove_dir_all(&published.queries_dir);
-                }
+                Err(e) => eprintln!(
+                    "Warning: failed to restore the previous queries for '{}': {}. They are kept \
+                     at {}.",
+                    published.language,
+                    e,
+                    backup.display()
+                ),
             }
         }
     }
+}
+
+impl Drop for PublishedQueryInstall {
+    /// Backstop for an install abandoned without committing or rolling back —
+    /// today only a panic between the two.
+    ///
+    /// Keep the publish and drop the backups: a stranded backup is invisible to
+    /// every collector but `language uninstall` (`recover_interrupted_query_install`
+    /// returns early because the live directory is present again), so it would
+    /// linger forever.
+    fn drop(&mut self) {
+        for published in std::mem::take(&mut self.published) {
+            discard_backup(&published);
+        }
+    }
+}
+
+/// [`discard_backup`] under the language's replace lock.
+///
+/// `language uninstall` enumerates and removes owned backups while holding that
+/// lock; deleting one underneath it makes its own removal fail on a directory
+/// that is vanishing as it reads it, and the uninstall reports a failure for
+/// work that did happen.
+///
+/// Never call this while already holding the lock for the same language: the
+/// guard opens its own file descriptor, and `flock` blocks a second one even
+/// within one process.
+fn discard_backup_locked(published: &PublishedQueryDir) {
+    let _replace_lock = published
+        .queries_dir
+        .parent()
+        .map(|parent| QueryReplaceLockGuard::acquire(parent, &published.language));
+    discard_backup(published);
+}
+
+/// Drop a displaced query directory and the sidecar that marks it as ours.
+///
+/// The sidecar is removed even when the directory is already gone: gating it on
+/// a successful removal is how orphaned `.kakehashi-backup` files accumulate
+/// when a concurrent uninstall collects the directory first.
+fn discard_backup(published: &PublishedQueryDir) {
+    let Some(backup) = &published.backup else {
+        return;
+    };
+    let _ = fs::remove_dir_all(backup);
+    let _ = fs::remove_file(backup_ownership_sidecar(backup));
 }
 
 /// What staging found for one language.
@@ -521,6 +636,7 @@ fn stage_queries_recursive(
     let staged_dir = StagedQueryDir {
         language: language.to_string(),
         queries_dir,
+        force,
         tmp: TempQueryDirGuard {
             path: tmp_queries_dir.clone(),
         },
@@ -1181,16 +1297,18 @@ mod staging_tests {
     /// The per-language replace locks are long-lived by design: they serialize
     /// concurrent installers and are reused, so they are not install residue.
     fn residue(queries_parent: &Path) -> Vec<String> {
-        fs::read_dir(queries_parent)
+        let mut names: Vec<String> = fs::read_dir(queries_parent)
             .expect("read queries parent")
             .flatten()
             .map(|entry| entry.file_name().to_string_lossy().into_owned())
             .filter(|name| !name.ends_with(".replace.lock"))
-            .collect()
+            .collect();
+        names.sort();
+        names
     }
 
     /// Stage a query directory by hand, without touching the network.
-    fn stage(queries_parent: &Path, language: &str, contents: &str) -> StagedQueryDir {
+    fn stage(queries_parent: &Path, language: &str, contents: &str, force: bool) -> StagedQueryDir {
         fs::create_dir_all(queries_parent).expect("create queries parent");
         let tmp_dir = create_unique_temp_query_dir(queries_parent, language).expect("stage dir");
         fs::write(tmp_dir.join("highlights.scm"), contents).expect("write staged highlights");
@@ -1198,6 +1316,7 @@ mod staging_tests {
         StagedQueryDir {
             language: language.to_string(),
             queries_dir: queries_parent.join(language),
+            force,
             tmp: TempQueryDirGuard { path: tmp_dir },
         }
     }
@@ -1215,8 +1334,8 @@ mod staging_tests {
             files_downloaded: vec!["highlights.scm".to_string()],
             requested_already_complete: false,
             entries: vec![
-                stage(&queries_parent, "child", "; inherits: parent\n"),
-                stage(&queries_parent, "parent", "(comment) @comment\n"),
+                stage(&queries_parent, "child", "; inherits: parent\n", false),
+                stage(&queries_parent, "parent", "(comment) @comment\n", false),
             ],
         };
 
@@ -1246,10 +1365,10 @@ mod staging_tests {
             install_path: queries_parent.join("child"),
             files_downloaded: vec!["highlights.scm".to_string()],
             requested_already_complete: false,
-            entries: vec![stage(&queries_parent, "child", "replacement")],
+            entries: vec![stage(&queries_parent, "child", "replacement", true)],
         };
 
-        let published = staged.publish(true).expect("publish should succeed");
+        let published = staged.publish().expect("publish should succeed");
         assert_eq!(
             fs::read_to_string(queries_dir.join("highlights.scm")).unwrap(),
             "replacement",
@@ -1273,11 +1392,12 @@ mod staging_tests {
         );
     }
 
-    /// A language that had no queries before must be removed again on rollback:
-    /// leaving it behind is exactly the half-installed state staging exists to
-    /// prevent.
+    /// The requested language had no queries before, so rollback must remove it
+    /// again — leaving it behind is exactly the half-installed state staging
+    /// exists to prevent. Its inherited parent stays: another install may
+    /// already have skipped staging its own copy because ours was there.
     #[test]
-    fn rolling_back_a_first_install_removes_the_published_queries() {
+    fn rolling_back_a_first_install_removes_only_the_requested_queries() {
         let temp = TempDir::new().unwrap();
         let queries_parent = temp.path().join("queries");
         let staged = StagedQueryInstall {
@@ -1286,21 +1406,94 @@ mod staging_tests {
             files_downloaded: vec!["highlights.scm".to_string()],
             requested_already_complete: false,
             entries: vec![
-                stage(&queries_parent, "child", "; inherits: parent\n"),
-                stage(&queries_parent, "parent", "(comment) @comment\n"),
+                stage(&queries_parent, "child", "; inherits: parent\n", false),
+                stage(&queries_parent, "parent", "(comment) @comment\n", false),
             ],
         };
 
-        staged
-            .publish(false)
-            .expect("publish should succeed")
-            .rollback();
+        staged.publish().expect("publish should succeed").rollback();
 
-        let leftovers = residue(&queries_parent);
         assert!(
-            leftovers.is_empty(),
-            "rollback must remove every directory this install published, found {:?}",
-            leftovers
+            !queries_parent.join("child").exists(),
+            "the requested language must not stay published"
+        );
+        assert_eq!(
+            residue(&queries_parent),
+            vec!["parent".to_string()],
+            "an inherited parent must survive, with no backup or sidecar beside it"
+        );
+    }
+
+    /// A published install that is neither committed nor rolled back — only a
+    /// panic gets here — must still drop the directories it displaced, because
+    /// nothing else collects them once the live directory is back in place.
+    #[test]
+    fn dropping_a_published_install_discards_the_backups() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let queries_dir = queries_parent.join("child");
+        fs::create_dir_all(&queries_dir).unwrap();
+        fs::write(queries_dir.join("highlights.scm"), "previous").unwrap();
+        write_install_marker(&queries_dir).unwrap();
+        let staged = StagedQueryInstall {
+            language: "child".to_string(),
+            install_path: queries_dir.clone(),
+            files_downloaded: vec!["highlights.scm".to_string()],
+            requested_already_complete: false,
+            entries: vec![stage(&queries_parent, "child", "replacement", true)],
+        };
+
+        drop(staged.publish().expect("publish should succeed"));
+
+        assert_eq!(
+            fs::read_to_string(queries_dir.join("highlights.scm")).unwrap(),
+            "replacement",
+            "an abandoned publish keeps the queries it made visible"
+        );
+        assert_eq!(
+            residue(&queries_parent),
+            vec!["child".to_string()],
+            "the displaced directory and its sidecar must not be stranded"
+        );
+    }
+
+    /// Publishing stops at the first entry it cannot publish and undoes the
+    /// requested language it had already made visible.
+    #[test]
+    fn publishing_stops_at_an_uninstalled_entry_and_restores_the_earlier_ones() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let queries_dir = queries_parent.join("child");
+        fs::create_dir_all(&queries_dir).unwrap();
+        fs::write(queries_dir.join("highlights.scm"), "previous").unwrap();
+        write_install_marker(&queries_dir).unwrap();
+        let staged = StagedQueryInstall {
+            language: "child".to_string(),
+            install_path: queries_dir.clone(),
+            files_downloaded: vec!["highlights.scm".to_string()],
+            requested_already_complete: false,
+            entries: vec![
+                stage(&queries_parent, "child", "replacement", true),
+                stage(&queries_parent, "parent", "(comment) @comment\n", false),
+            ],
+        };
+        write_uninstall_tombstone(&queries_parent, "parent").unwrap();
+
+        let result = staged.publish();
+
+        assert!(
+            matches!(&result, Err(QueryInstallError::IoError(e)) if e.kind() == std::io::ErrorKind::Interrupted),
+            "a tombstoned entry must abort the publish"
+        );
+        assert_eq!(
+            fs::read_to_string(queries_dir.join("highlights.scm")).unwrap(),
+            "previous",
+            "the already-published requested language must be restored"
+        );
+        assert_eq!(
+            residue(&queries_parent),
+            vec![".parent.uninstalled".to_string(), "child".to_string()],
+            "no backup or sidecar may be stranded"
         );
     }
 }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -178,8 +178,13 @@ pub fn query_install_chain_is_complete(queries_parent: &Path, language: &str) ->
 /// would report success and leave the loader looking for a language nothing
 /// fetched.
 fn normalize_inherited_language_name(name: &str) -> String {
-    name.trim_start_matches('(')
-        .trim_end_matches(')')
+    // Character for character what `query_loader` does, including only
+    // stripping a *matched* pair: on `(cpp` the loader looks for a language
+    // literally called `(cpp`, and an installer that helpfully fetched `cpp`
+    // would report success over a language it still cannot load.
+    name.strip_prefix('(')
+        .and_then(|name| name.strip_suffix(')'))
+        .unwrap_or(name)
         .trim()
         .to_string()
 }
@@ -463,7 +468,7 @@ impl StagedQueryInstall {
                 !self
                     .entries
                     .iter()
-                    .any(|entry| &&entry.language == language)
+                    .any(|entry| entry.language == **language)
             })
             .find(|language| {
                 !query_install_is_complete(&self.queries_parent.join(language.as_str()))
@@ -807,9 +812,10 @@ fn stage_queries_with_dependencies(
 
 /// Internal recursive helper for staging queries with dependencies.
 ///
-/// Appends the requested language's staging directory to `entries` before
-/// recursing, so publication order matches the old install order: a language
-/// becomes visible before the parents it inherits from.
+/// Appends a language's staging directory to `entries` *after* recursing into
+/// the languages it inherits, so `entries` comes out in dependency order and
+/// publishing it forward puts every base language in place before the language
+/// that needs it.
 fn stage_queries_recursive(
     base_url: &str,
     language: &str,
@@ -1377,22 +1383,47 @@ pub fn lock_language(data_dir: &Path, language: &str) -> Result<LanguageLock, Qu
     })
 }
 
-/// [`lock_language`] without the wait: `None` when another install holds it.
+/// [`lock_language`] without the wait.
 ///
 /// For callers that must not block — the LSP's async path — and that only need
-/// to know whether the language is settled. A language someone is mid-publish
-/// on can still have those queries rolled back, so "busy" and "could not
-/// probe" both answer no. The guard is returned rather than the answer, because
-/// releasing it before reading the artifacts would put the whole publish back
-/// inside the window.
-pub fn try_lock_language(data_dir: &Path, language: &str) -> Option<LanguageLock> {
-    let (file, queries_parent) = open_language_lock_file(data_dir, language).ok()?;
-    file.try_lock().ok()?;
-    Some(LanguageLock {
-        _file: file,
-        queries_parent,
-        language: language.to_string(),
-    })
+/// to know whether the language is settled. The guard is returned rather than
+/// the answer, because releasing it before reading the artifacts would put the
+/// whole publish back inside the window.
+pub fn try_lock_language(data_dir: &Path, language: &str) -> LanguageLockProbe {
+    let Ok((file, queries_parent)) = open_language_lock_file(data_dir, language) else {
+        // The lock file cannot be created or opened for writing — a read-only
+        // or otherwise unwritable data directory. Nobody can be publishing into
+        // it either, so what is on disk is settled; answering "busy" here would
+        // make a perfectly good preinstalled language unusable.
+        return LanguageLockProbe::Unlockable;
+    };
+    match file.try_lock() {
+        Ok(()) => LanguageLockProbe::Idle(LanguageLock {
+            _file: file,
+            queries_parent,
+            language: language.to_string(),
+        }),
+        Err(_) => LanguageLockProbe::Busy,
+    }
+}
+
+/// What [`try_lock_language`] found.
+pub enum LanguageLockProbe {
+    /// Nobody holds the lock, and nobody can take it while the guard lives.
+    Idle(LanguageLock),
+    /// An install is mid-publish: what is on disk can still be rolled back.
+    Busy,
+    /// The lock cannot be taken at all, so nothing can be publishing either.
+    /// Whatever is on disk is as settled as it will ever be.
+    Unlockable,
+}
+
+impl LanguageLockProbe {
+    /// Whether the artifacts on disk can be trusted to stay put — either
+    /// because this probe holds the lock, or because nobody can publish.
+    pub fn is_settled(&self) -> bool {
+        !matches!(self, Self::Busy)
+    }
 }
 
 /// Open (creating if needed) the file behind a language's lock.
@@ -1920,6 +1951,35 @@ mod staging_tests {
         assert!(query_install_chain_is_complete(&queries_parent, "cyc_a"));
     }
 
+    /// A data directory nothing can write to has nothing in flight either, so
+    /// its languages must still read as settled — answering "busy" there would
+    /// make a read-only installation unusable.
+    #[test]
+    #[cfg(unix)]
+    fn an_unlockable_data_dir_is_settled() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let mut permissions = fs::metadata(&queries_parent).unwrap().permissions();
+        permissions.set_mode(0o500);
+        fs::set_permissions(&queries_parent, permissions).unwrap();
+
+        let probe = try_lock_language(temp.path(), "lua");
+
+        let settled = probe.is_settled();
+        // Restore before asserting, so a failure does not leave an
+        // undeletable directory behind for the whole test run.
+        let mut permissions = fs::metadata(&queries_parent).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&queries_parent, permissions).unwrap();
+        assert!(
+            settled,
+            "an unwritable data dir cannot have a publish in flight"
+        );
+    }
+
     /// A language nobody is publishing can be claimed without waiting; one an
     /// install holds cannot, because that install can still roll it back.
     #[test]
@@ -1928,17 +1988,20 @@ mod staging_tests {
         let data_dir = temp.path();
 
         let probe = try_lock_language(data_dir, "lua");
-        assert!(probe.is_some(), "a language nobody has touched is settled");
+        assert!(
+            matches!(probe, LanguageLockProbe::Idle(_)),
+            "a language nobody has touched is settled"
+        );
         drop(probe);
 
         let lock = lock_language(data_dir, "lua").unwrap();
         assert!(
-            try_lock_language(data_dir, "lua").is_none(),
+            matches!(try_lock_language(data_dir, "lua"), LanguageLockProbe::Busy),
             "a held lock means an install is between publishing and committing"
         );
         drop(lock);
         assert!(
-            try_lock_language(data_dir, "lua").is_some(),
+            try_lock_language(data_dir, "lua").is_settled(),
             "and it is settled again once that install is done"
         );
     }
@@ -2507,6 +2570,22 @@ mod tests {
         assert_eq!(
             parse_inherits_directive("; inherits: c, (cpp), (cuda)\n"),
             vec!["c".to_string(), "cpp".to_string(), "cuda".to_string()]
+        );
+    }
+
+    /// Only a matched pair is a wrapper. An unmatched one is part of the name
+    /// as far as the loader is concerned, so it must be part of it here too —
+    /// and such a name is then rejected as unsafe rather than turned into a
+    /// different language's.
+    #[test]
+    fn parse_inherits_directive_keeps_unmatched_parentheses() {
+        assert!(
+            parse_inherits_directive("; inherits: (cpp\n").is_empty(),
+            "an unmatched leading parenthesis is part of the name, and unsafe"
+        );
+        assert!(
+            parse_inherits_directive("; inherits: cpp)\n").is_empty(),
+            "and so is an unmatched trailing one"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -176,7 +176,50 @@ pub fn install_queries_with_dependencies_after_install_started(
     )
 }
 
+/// Stage the queries for `language` and its `; inherits:` chain from
+/// `base_url`, leaving publication to the caller.
+///
+/// Used by the language installer, which stages both halves of a language
+/// before publishing either.
+pub(crate) fn stage_queries_with_dependencies_from(
+    base_url: &str,
+    language: &str,
+    data_dir: &Path,
+    force: bool,
+) -> Result<StagedQueryInstall, QueryInstallError> {
+    stage_queries_with_dependencies(
+        base_url,
+        language,
+        data_dir,
+        force,
+        QueryHttpPolicy::HttpsOnly,
+    )
+}
+
+/// Like [`stage_queries_with_dependencies_from`] but disables the HTTPS-only
+/// policy for tests that serve fixture query files over local plain HTTP.
+#[cfg(test)]
+pub(crate) fn stage_queries_with_dependencies_from_allowing_http_for_tests(
+    base_url: &str,
+    language: &str,
+    data_dir: &Path,
+    force: bool,
+) -> Result<StagedQueryInstall, QueryInstallError> {
+    stage_queries_with_dependencies(
+        base_url,
+        language,
+        data_dir,
+        force,
+        QueryHttpPolicy::AllowHttpForTests,
+    )
+}
+
 /// Like [`install_queries_with_dependencies`] but downloading from `base_url`.
+///
+/// Production installs stage and publish in separate steps (see
+/// [`stage_queries_with_dependencies_from`]); this one-shot form is what the
+/// tests that only exercise the queries half use.
+#[cfg(test)]
 pub(crate) fn install_queries_with_dependencies_from(
     base_url: &str,
     language: &str,

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -224,15 +224,8 @@ fn install_queries_with_dependencies_from_with_http_policy(
     force: bool,
     http_policy: QueryHttpPolicy,
 ) -> Result<QueryInstallResult, QueryInstallError> {
-    let mut installed = std::collections::HashSet::new();
-    install_queries_recursive(
-        base_url,
-        language,
-        data_dir,
-        force,
-        &mut installed,
-        http_policy,
-    )
+    let staged = stage_queries_with_dependencies(base_url, language, data_dir, force, http_policy)?;
+    staged.publish(force)?.commit()
 }
 
 fn validate_url_http_policy(
@@ -249,28 +242,212 @@ fn validate_url_http_policy(
     }
 }
 
-/// Internal recursive helper for installing queries with dependencies.
-fn install_queries_recursive(
+/// One language's query files downloaded into a staging directory, waiting to
+/// be renamed into `queries/<language>`.
+struct StagedQueryDir {
+    language: String,
+    queries_dir: PathBuf,
+    tmp: TempQueryDirGuard,
+}
+
+/// Everything one install needs to publish: the requested language plus every
+/// language it reaches through `; inherits:`.
+///
+/// Staging the whole dependency chain before publishing any of it is what makes
+/// an install all-or-nothing — a parent that fails to download aborts the
+/// install with the data directory untouched, instead of leaving a language
+/// whose inherited queries are missing.
+pub(crate) struct StagedQueryInstall {
+    language: String,
+    /// Where the requested language's queries live once published.
+    install_path: PathBuf,
+    files_downloaded: Vec<String>,
+    /// True when the requested language was already installed and only its
+    /// missing parents (if any) were staged.
+    requested_already_complete: bool,
+    entries: Vec<StagedQueryDir>,
+}
+
+/// A query directory that has been renamed into place, with the directory it
+/// displaced kept aside until the install as a whole is committed.
+struct PublishedQueryDir {
+    queries_dir: PathBuf,
+    backup: Option<PathBuf>,
+}
+
+/// The outcome of publishing a [`StagedQueryInstall`], still undoable.
+pub(crate) struct PublishedQueryInstall {
+    language: String,
+    install_path: PathBuf,
+    files_downloaded: Vec<String>,
+    requested_already_complete: bool,
+    published: Vec<PublishedQueryDir>,
+}
+
+impl StagedQueryInstall {
+    /// Rename every staged directory into place, keeping the displaced
+    /// directories so the whole install can still be undone.
+    pub(crate) fn publish(
+        mut self,
+        force: bool,
+    ) -> Result<PublishedQueryInstall, QueryInstallError> {
+        let requested_language = std::mem::take(&mut self.language);
+        let mut publish = PublishedQueryInstall {
+            install_path: std::mem::take(&mut self.install_path),
+            files_downloaded: std::mem::take(&mut self.files_downloaded),
+            requested_already_complete: self.requested_already_complete,
+            language: requested_language.clone(),
+            published: Vec::new(),
+        };
+        for entry in self.entries.drain(..) {
+            let requested = entry.language == requested_language;
+            match publish_query_dir(&entry.tmp.path, &entry.queries_dir, &entry.language, force) {
+                Ok(PublishQueryDirOutcome::Published { backup }) => {
+                    publish.published.push(PublishedQueryDir {
+                        queries_dir: entry.queries_dir,
+                        backup,
+                    });
+                }
+                // A concurrent installer completed this language while we were
+                // downloading. Its files are as good as ours, so keep them.
+                Ok(PublishQueryDirOutcome::AlreadyComplete) => {
+                    if requested {
+                        publish.requested_already_complete = true;
+                    }
+                }
+                Ok(PublishQueryDirOutcome::Uninstalled) => {
+                    publish.rollback();
+                    return Err(QueryInstallError::IoError(std::io::Error::new(
+                        std::io::ErrorKind::Interrupted,
+                        format!(
+                            "Query install for {} was superseded by uninstall",
+                            entry.language
+                        ),
+                    )));
+                }
+                Err(e) => {
+                    publish.rollback();
+                    return Err(e);
+                }
+            }
+        }
+        Ok(publish)
+    }
+}
+
+impl PublishedQueryInstall {
+    /// Make the publish final by discarding the displaced directories.
+    ///
+    /// Reports `AlreadyExists` when the requested language needed nothing —
+    /// callers treat that as a successful no-op, and it keeps the pre-staging
+    /// contract of the `install_queries_*` entry points.
+    pub(crate) fn commit(self) -> Result<QueryInstallResult, QueryInstallError> {
+        for published in &self.published {
+            let Some(backup) = &published.backup else {
+                continue;
+            };
+            if fs::remove_dir_all(backup).is_ok() {
+                let _ = fs::remove_file(backup_ownership_sidecar(backup));
+            }
+        }
+        if self.requested_already_complete {
+            return Err(QueryInstallError::AlreadyExists(self.install_path));
+        }
+        Ok(QueryInstallResult {
+            language: self.language,
+            install_path: self.install_path,
+            files_downloaded: self.files_downloaded,
+        })
+    }
+
+    /// Undo the publish, restoring each displaced directory.
+    ///
+    /// Best-effort by construction: every step is a rename or removal that
+    /// already succeeded once in the other direction, and there is nothing
+    /// better to do with a failure here than leave the backup in place for
+    /// `language uninstall` to collect.
+    pub(crate) fn rollback(self) {
+        for published in self.published.into_iter().rev() {
+            match published.backup {
+                Some(backup) => {
+                    let _ = fs::remove_dir_all(&published.queries_dir);
+                    if fs::rename(&backup, &published.queries_dir).is_ok() {
+                        let _ = fs::remove_file(backup_ownership_sidecar(&backup));
+                    }
+                }
+                None => {
+                    let _ = fs::remove_dir_all(&published.queries_dir);
+                }
+            }
+        }
+    }
+}
+
+/// What staging found for one language.
+enum StageOutcome {
+    /// Query files were downloaded and are waiting to be published.
+    Staged { files_downloaded: Vec<String> },
+    /// The language's queries are already installed; nothing was downloaded.
+    NothingToDo,
+}
+
+/// Stage the queries for `language` and everything it inherits from.
+fn stage_queries_with_dependencies(
     base_url: &str,
     language: &str,
     data_dir: &Path,
     force: bool,
-    installed: &mut std::collections::HashSet<String>,
     http_policy: QueryHttpPolicy,
-) -> Result<QueryInstallResult, QueryInstallError> {
+) -> Result<StagedQueryInstall, QueryInstallError> {
+    let mut entries = Vec::new();
+    let mut staged = std::collections::HashSet::new();
+    // On any error the entries collected so far are dropped here, and with them
+    // every staging directory: a failed install publishes nothing.
+    let outcome = stage_queries_recursive(
+        base_url,
+        language,
+        data_dir,
+        force,
+        &mut staged,
+        &mut entries,
+        http_policy,
+    )?;
+    let (files_downloaded, requested_already_complete) = match outcome {
+        StageOutcome::Staged { files_downloaded } => (files_downloaded, false),
+        StageOutcome::NothingToDo => (Vec::new(), true),
+    };
+    Ok(StagedQueryInstall {
+        language: language.to_string(),
+        install_path: data_dir.join("queries").join(language),
+        files_downloaded,
+        requested_already_complete,
+        entries,
+    })
+}
+
+/// Internal recursive helper for staging queries with dependencies.
+///
+/// Appends the requested language's staging directory to `entries` before
+/// recursing, so publication order matches the old install order: a language
+/// becomes visible before the parents it inherits from.
+fn stage_queries_recursive(
+    base_url: &str,
+    language: &str,
+    data_dir: &Path,
+    force: bool,
+    staged: &mut std::collections::HashSet<String>,
+    entries: &mut Vec<StagedQueryDir>,
+    http_policy: QueryHttpPolicy,
+) -> Result<StageOutcome, QueryInstallError> {
     // The name becomes a path and URL segment below; reject anything that
     // could escape the data dir (e.g. a caller-provided `../../x`).
     // Escape the untrusted name: the error's Display is printed raw by
     // the CLI, so control characters must not reach the terminal.
     validate_safe_language_name(language)?;
 
-    // Skip if already installed in this session
-    if installed.contains(language) {
-        return Ok(QueryInstallResult {
-            language: language.to_string(),
-            install_path: data_dir.join("queries").join(language),
-            files_downloaded: vec![],
-        });
+    // Skip if already staged (or found complete) in this session
+    if staged.contains(language) {
+        return Ok(StageOutcome::NothingToDo);
     }
 
     let queries_dir = data_dir.join("queries").join(language);
@@ -282,11 +459,11 @@ fn install_queries_recursive(
     // leave a directory without the required highlights.scm; that is treated
     // as incomplete so a later install can repair it without --force.
     if query_install_is_complete(&queries_dir) && !force {
-        // Mark as installed BEFORE recursing into parents: an inheritance
+        // Mark as staged BEFORE recursing into parents: an inheritance
         // cycle among on-disk query files (self-inherit typo, A↔B) would
         // otherwise recurse forever and overflow the stack. The download
         // branch below already inserts before its parent loop.
-        installed.insert(language.to_string());
+        staged.insert(language.to_string());
 
         // Even if skipping, we need to check for inherited dependencies
         let highlights_path = queries_dir.join("highlights.scm");
@@ -295,32 +472,29 @@ fn install_queries_recursive(
         {
             let parents = parse_inherits_directive(&content);
             for parent in parents {
-                // Install parent dependencies (don't force, just ensure they exist)
+                // Stage parent dependencies (don't force, just ensure they exist)
                 clear_uninstall_tombstone(&queries_parent, &parent)?;
-                match install_queries_recursive(
+                stage_queries_recursive(
                     base_url,
                     &parent,
                     data_dir,
                     false,
-                    installed,
+                    staged,
+                    entries,
                     http_policy,
-                ) {
-                    Ok(_) | Err(QueryInstallError::AlreadyExists(_)) => {}
-                    Err(e) => {
-                        eprintln!(
-                            "Warning: Failed to install inherited queries '{}': {}",
-                            parent, e
-                        );
-                    }
-                }
+                )?;
             }
         }
-        return Err(QueryInstallError::AlreadyExists(queries_dir));
+        return Ok(StageOutcome::NothingToDo);
     }
 
     let tmp_queries_dir = create_unique_temp_query_dir(&queries_parent, language)?;
-    let _tmp_guard = TempQueryDirGuard {
-        path: tmp_queries_dir.clone(),
+    let staged_dir = StagedQueryDir {
+        language: language.to_string(),
+        queries_dir,
+        tmp: TempQueryDirGuard {
+            path: tmp_queries_dir.clone(),
+        },
     };
 
     let mut files_downloaded = Vec::new();
@@ -370,46 +544,28 @@ fn install_queries_recursive(
 
     write_install_marker(&tmp_queries_dir)?;
 
-    match replace_query_dir(&tmp_queries_dir, &queries_dir, language, force) {
-        Ok(ReplaceQueryDirResult::Replaced) => {}
-        Ok(ReplaceQueryDirResult::AlreadyComplete) => {
-            return Err(QueryInstallError::AlreadyExists(queries_dir));
-        }
-        Ok(ReplaceQueryDirResult::Uninstalled) => {
-            return Err(QueryInstallError::IoError(std::io::Error::new(
-                std::io::ErrorKind::Interrupted,
-                format!("Query install for {language} was superseded by uninstall"),
-            )));
-        }
-        Err(e) => {
-            return Err(e);
-        }
-    }
+    staged.insert(language.to_string());
+    entries.push(staged_dir);
 
-    installed.insert(language.to_string());
-
-    // Install parent dependencies
+    // Stage parent dependencies. A parent that cannot be downloaded fails the
+    // whole install: propagating the error here drops every staging directory
+    // collected so far, so a language is never published without the queries it
+    // inherits.
     for parent in parents_to_install {
-        eprintln!("Installing inherited queries: {}", parent);
-        // Don't fail if parent already exists
+        eprintln!("Staging inherited queries: {}", parent);
         clear_uninstall_tombstone(&queries_parent, &parent)?;
-        match install_queries_recursive(base_url, &parent, data_dir, false, installed, http_policy)
-        {
-            Ok(_) | Err(QueryInstallError::AlreadyExists(_)) => {}
-            Err(e) => {
-                eprintln!(
-                    "Warning: Failed to install inherited queries '{}': {}",
-                    parent, e
-                );
-            }
-        }
+        stage_queries_recursive(
+            base_url,
+            &parent,
+            data_dir,
+            false,
+            staged,
+            entries,
+            http_policy,
+        )?;
     }
 
-    Ok(QueryInstallResult {
-        language: language.to_string(),
-        install_path: queries_dir,
-        files_downloaded,
-    })
+    Ok(StageOutcome::Staged { files_downloaded })
 }
 
 pub fn query_install_is_complete(queries_dir: &Path) -> bool {
@@ -860,18 +1016,23 @@ pub(crate) fn write_install_marker_for_tests(queries_dir: &Path) -> Result<(), Q
     write_install_marker(queries_dir)
 }
 
-enum ReplaceQueryDirResult {
-    Replaced,
+enum PublishQueryDirOutcome {
+    /// The staged directory is now the live one. `backup` holds the directory
+    /// it displaced, kept until the install commits so a later failure can put
+    /// it back.
+    Published {
+        backup: Option<PathBuf>,
+    },
     AlreadyComplete,
     Uninstalled,
 }
 
-fn replace_query_dir(
+fn publish_query_dir(
     tmp_queries_dir: &Path,
     queries_dir: &Path,
     language: &str,
     force: bool,
-) -> Result<ReplaceQueryDirResult, QueryInstallError> {
+) -> Result<PublishQueryDirOutcome, QueryInstallError> {
     let _replace_lock = QueryReplaceLockGuard::acquire(
         queries_dir
             .parent()
@@ -880,7 +1041,7 @@ fn replace_query_dir(
     )?;
 
     if !force && query_install_is_complete(queries_dir) {
-        return Ok(ReplaceQueryDirResult::AlreadyComplete);
+        return Ok(PublishQueryDirOutcome::AlreadyComplete);
     }
     if uninstall_tombstone_path(
         queries_dir
@@ -890,12 +1051,12 @@ fn replace_query_dir(
     )
     .is_file()
     {
-        return Ok(ReplaceQueryDirResult::Uninstalled);
+        return Ok(PublishQueryDirOutcome::Uninstalled);
     }
 
     if !queries_dir.exists() {
         fs::rename(tmp_queries_dir, queries_dir)?;
-        return Ok(ReplaceQueryDirResult::Replaced);
+        return Ok(PublishQueryDirOutcome::Published { backup: None });
     }
 
     let backup_dir = unique_backup_query_dir(queries_dir, language);
@@ -908,7 +1069,7 @@ fn replace_query_dir(
         // of aborting the install.
         if e.kind() == std::io::ErrorKind::NotFound {
             fs::rename(tmp_queries_dir, queries_dir)?;
-            return Ok(ReplaceQueryDirResult::Replaced);
+            return Ok(PublishQueryDirOutcome::Published { backup: None });
         }
         return Err(QueryInstallError::IoError(e));
     }
@@ -927,10 +1088,14 @@ fn replace_query_dir(
         return Err(QueryInstallError::IoError(e));
     }
 
-    if fs::remove_dir_all(&backup_dir).is_ok() {
-        let _ = fs::remove_file(backup_ownership_sidecar(&backup_dir));
-    }
-    Ok(ReplaceQueryDirResult::Replaced)
+    // The backup outlives this function: it is dropped by
+    // `PublishedQueryInstall::commit` once every language in the install has
+    // been published. Until then `recover_interrupted_query_install` will not
+    // collect it — `queries_dir` exists again, so it returns early — which is
+    // the pre-existing orphan-backup window that `language uninstall` cleans up.
+    Ok(PublishQueryDirOutcome::Published {
+        backup: Some(backup_dir),
+    })
 }
 
 struct QueryReplaceLockGuard {
@@ -975,6 +1140,140 @@ fn download_file(url: &str, http_policy: QueryHttpPolicy) -> Result<String, Quer
         .body_mut()
         .read_to_string()
         .map_err(|e| QueryInstallError::HttpError(e.to_string()))
+}
+
+#[cfg(test)]
+mod staging_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Entries under `queries/` that an install is expected to leave behind.
+    ///
+    /// The per-language replace locks are long-lived by design: they serialize
+    /// concurrent installers and are reused, so they are not install residue.
+    fn residue(queries_parent: &Path) -> Vec<String> {
+        fs::read_dir(queries_parent)
+            .expect("read queries parent")
+            .flatten()
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| !name.ends_with(".replace.lock"))
+            .collect()
+    }
+
+    /// Stage a query directory by hand, without touching the network.
+    fn stage(queries_parent: &Path, language: &str, contents: &str) -> StagedQueryDir {
+        fs::create_dir_all(queries_parent).expect("create queries parent");
+        let tmp_dir = create_unique_temp_query_dir(queries_parent, language).expect("stage dir");
+        fs::write(tmp_dir.join("highlights.scm"), contents).expect("write staged highlights");
+        write_install_marker(&tmp_dir).expect("write staged marker");
+        StagedQueryDir {
+            language: language.to_string(),
+            queries_dir: queries_parent.join(language),
+            tmp: TempQueryDirGuard { path: tmp_dir },
+        }
+    }
+
+    /// An install abandoned before publication must leave `queries/` exactly as
+    /// it was — including for the inherited parents staged alongside the
+    /// requested language.
+    #[test]
+    fn dropping_a_staged_install_publishes_nothing() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let staged = StagedQueryInstall {
+            language: "child".to_string(),
+            install_path: queries_parent.join("child"),
+            files_downloaded: vec!["highlights.scm".to_string()],
+            requested_already_complete: false,
+            entries: vec![
+                stage(&queries_parent, "child", "; inherits: parent\n"),
+                stage(&queries_parent, "parent", "(comment) @comment\n"),
+            ],
+        };
+
+        drop(staged);
+
+        let leftovers = residue(&queries_parent);
+        assert!(
+            leftovers.is_empty(),
+            "an unpublished staged install must leave nothing behind, found {:?}",
+            leftovers
+        );
+    }
+
+    /// Rolling back an install that replaced existing queries must put the
+    /// previous directory back and drop the ownership sidecar, so the next run
+    /// sees a clean data dir rather than an orphaned backup.
+    #[test]
+    fn rolling_back_a_publish_restores_the_previous_queries() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let queries_dir = queries_parent.join("child");
+        fs::create_dir_all(&queries_dir).unwrap();
+        fs::write(queries_dir.join("highlights.scm"), "previous").unwrap();
+        write_install_marker(&queries_dir).unwrap();
+        let staged = StagedQueryInstall {
+            language: "child".to_string(),
+            install_path: queries_parent.join("child"),
+            files_downloaded: vec!["highlights.scm".to_string()],
+            requested_already_complete: false,
+            entries: vec![stage(&queries_parent, "child", "replacement")],
+        };
+
+        let published = staged.publish(true).expect("publish should succeed");
+        assert_eq!(
+            fs::read_to_string(queries_dir.join("highlights.scm")).unwrap(),
+            "replacement",
+            "publish must make the staged queries visible"
+        );
+        published.rollback();
+
+        assert_eq!(
+            fs::read_to_string(queries_dir.join("highlights.scm")).unwrap(),
+            "previous",
+            "rollback must restore the queries that were there before"
+        );
+        let leftovers: Vec<_> = residue(&queries_parent)
+            .into_iter()
+            .filter(|name| name != "child")
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "rollback must not strand a backup or its sidecar, found {:?}",
+            leftovers
+        );
+    }
+
+    /// A language that had no queries before must be removed again on rollback:
+    /// leaving it behind is exactly the half-installed state staging exists to
+    /// prevent.
+    #[test]
+    fn rolling_back_a_first_install_removes_the_published_queries() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let staged = StagedQueryInstall {
+            language: "child".to_string(),
+            install_path: queries_parent.join("child"),
+            files_downloaded: vec!["highlights.scm".to_string()],
+            requested_already_complete: false,
+            entries: vec![
+                stage(&queries_parent, "child", "; inherits: parent\n"),
+                stage(&queries_parent, "parent", "(comment) @comment\n"),
+            ],
+        };
+
+        staged
+            .publish(false)
+            .expect("publish should succeed")
+            .rollback();
+
+        let leftovers = residue(&queries_parent);
+        assert!(
+            leftovers.is_empty(),
+            "rollback must remove every directory this install published, found {:?}",
+            leftovers
+        );
+    }
 }
 
 #[cfg(test)]
@@ -1391,6 +1690,46 @@ mod tests {
         );
     }
 
+    /// Queries a language inherits are part of what makes it usable, so a
+    /// parent that cannot be downloaded fails the whole install — and, because
+    /// nothing is published until every dependency is staged, the data dir is
+    /// left untouched rather than holding a language whose `; inherits:` chain
+    /// is broken.
+    #[test]
+    fn a_failing_inherited_parent_publishes_nothing() {
+        let temp_dir = TempDir::new().unwrap();
+        let data_dir = temp_dir.path().to_path_buf();
+        let base_url = spawn_query_file_server(vec![(
+            "/orphan_child/highlights.scm",
+            "; inherits: missing_parent\n(identifier) @variable\n",
+        )]);
+
+        let result = install_queries_with_dependencies_from_allowing_http_for_tests(
+            &base_url,
+            "orphan_child",
+            &data_dir,
+            false,
+        );
+
+        assert!(
+            matches!(result, Err(QueryInstallError::LanguageNotSupported(lang)) if lang == "missing_parent"),
+            "an unavailable inherited parent must fail the install"
+        );
+        let leftovers: Vec<_> = fs::read_dir(data_dir.join("queries"))
+            .expect("read queries parent")
+            .flatten()
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            // The per-language replace locks are reused infrastructure, not
+            // install residue.
+            .filter(|name| !name.ends_with(".replace.lock"))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "a failed dependency must leave no queries behind, found {:?}",
+            leftovers
+        );
+    }
+
     #[test]
     fn install_preserves_legacy_non_marker_query_dir_without_force() {
         let temp_dir = TempDir::new().unwrap();
@@ -1452,7 +1791,7 @@ mod tests {
     }
 
     #[test]
-    fn replace_query_dir_aborts_when_uninstall_tombstone_exists() {
+    fn publish_query_dir_aborts_when_uninstall_tombstone_exists() {
         let temp_dir = TempDir::new().unwrap();
         let queries_parent = temp_dir.path().join("queries");
         fs::create_dir_all(&queries_parent).unwrap();
@@ -1465,7 +1804,7 @@ mod tests {
         write_install_marker_for_tests(&tmp_queries_dir).unwrap();
         write_uninstall_tombstone(&queries_parent, "raced_lang").unwrap();
 
-        let result = replace_query_dir(
+        let result = publish_query_dir(
             &tmp_queries_dir,
             &queries_parent.join("raced_lang"),
             "raced_lang",
@@ -1473,7 +1812,7 @@ mod tests {
         );
 
         assert!(
-            matches!(result, Ok(ReplaceQueryDirResult::Uninstalled)),
+            matches!(result, Ok(PublishQueryDirOutcome::Uninstalled)),
             "replacement should observe uninstall tombstone under the lock"
         );
         assert!(

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -48,6 +48,13 @@ pub enum QueryInstallError {
     IoError(std::io::Error),
     /// Queries already exist and --force not specified.
     AlreadyExists(PathBuf),
+    /// Publishing moved the live queries aside and could not put anything back:
+    /// the language has no queries, and the previous ones are in `backup`.
+    PreviousQueriesStranded {
+        language: String,
+        backup: PathBuf,
+        reason: String,
+    },
 }
 
 impl std::fmt::Display for QueryInstallError {
@@ -76,6 +83,19 @@ impl std::fmt::Display for QueryInstallError {
                     f,
                     "Queries already exist at {}. Use --force to overwrite.",
                     path.display()
+                )
+            }
+            Self::PreviousQueriesStranded {
+                language,
+                backup,
+                reason,
+            } => {
+                write!(
+                    f,
+                    "'{}' now has no queries: {}. The previous ones are kept at {}.",
+                    language,
+                    reason,
+                    backup.display()
                 )
             }
         }
@@ -1682,9 +1702,19 @@ fn publish_query_dir(
                 let _ = fs::remove_file(backup_ownership_sidecar(&backup_dir));
             }
             Err(rollback_error) => {
-                return Err(QueryInstallError::IoError(std::io::Error::other(format!(
-                    "failed to publish staged queries: {e}; failed to restore backup: {rollback_error}"
-                ))));
+                // The live directory was moved aside and neither the staged copy
+                // nor the original could be put in its place. The language has
+                // no queries at all now, and the caller has to say where the
+                // previous ones went — a typed error rather than a message,
+                // because "nothing was published" would be a lie.
+                return Err(QueryInstallError::PreviousQueriesStranded {
+                    language: language.to_string(),
+                    backup: backup_dir,
+                    reason: format!(
+                        "failed to publish staged queries: {e}; failed to restore backup: \
+                         {rollback_error}"
+                    ),
+                });
             }
         }
         return Err(QueryInstallError::IoError(e));
@@ -1969,6 +1999,29 @@ mod staging_tests {
         }
 
         assert!(query_install_chain_is_complete(&queries_parent, "cyc_a"));
+    }
+
+    /// Publishing can fail after it has already moved the live queries aside,
+    /// leaving the language with none. Reaching that needs two renames to fail
+    /// in a row, so what is pinned here is the part that matters to whoever
+    /// hits it: the error says where the previous queries went.
+    #[test]
+    fn the_stranded_queries_error_names_the_backup() {
+        let error = QueryInstallError::PreviousQueriesStranded {
+            language: "lua".to_string(),
+            backup: PathBuf::from("/data/queries/.lua.42.0.backup"),
+            reason: "rename failed".to_string(),
+        };
+
+        let reported = error.to_string();
+        assert!(
+            reported.contains("'lua' now has no queries"),
+            "the message must not read as a routine failure: {reported}"
+        );
+        assert!(
+            reported.contains(".lua.42.0.backup"),
+            "and it must say where to find them: {reported}"
+        );
     }
 
     /// Clearing a base language's tombstone goes through that language's own

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -123,6 +123,53 @@ fn validate_safe_language_name(language: &str) -> Result<(), QueryInstallError> 
     }
 }
 
+/// Languages an installed query directory inherits, across every query kind.
+///
+/// Each kind resolves its own `; inherits:` chain when it loads, and a parent it
+/// names but that is not installed makes that load fail outright — so
+/// injections.scm's parents matter exactly as much as highlights.scm's.
+fn inherited_languages_on_disk(queries_dir: &Path) -> Vec<String> {
+    let mut parents: Vec<String> = Vec::new();
+    for query_file in QUERY_FILES {
+        let Ok(content) = fs::read_to_string(queries_dir.join(query_file)) else {
+            continue;
+        };
+        for parent in parse_inherits_directive(&content) {
+            if !parents.contains(&parent) {
+                parents.push(parent);
+            }
+        }
+    }
+    parents
+}
+
+/// Whether a language and everything it inherits are installed and complete.
+///
+/// [`query_install_is_complete`] answers for one directory; a language whose own
+/// queries are complete still fails to load when a language they inherit is
+/// missing, because the loader resolves the chain and gives up on the first gap.
+pub fn query_install_chain_is_complete(queries_parent: &Path, language: &str) -> bool {
+    fn walk(queries_parent: &Path, language: &str, seen: &mut Vec<String>) -> bool {
+        // An inheritance cycle among on-disk files (a self-inherit typo, A↔B)
+        // is the loader's problem to report, not a reason to call the install
+        // incomplete and re-download forever.
+        if seen.iter().any(|visited| visited == language) {
+            return true;
+        }
+        seen.push(language.to_string());
+        let queries_dir = queries_parent.join(language);
+        query_install_is_complete(&queries_dir)
+            && inherited_languages_on_disk(&queries_dir)
+                .into_iter()
+                .all(|parent| walk(queries_parent, &parent, seen))
+    }
+
+    if !is_safe_language_name(language) {
+        return false;
+    }
+    walk(queries_parent, language, &mut Vec::new())
+}
+
 /// Parse the `; inherits: lang1,lang2` directive from query content.
 /// Returns the list of parent languages, dropping unsafe names
 /// (see [`is_safe_language_name`]).
@@ -732,24 +779,18 @@ fn stage_queries_recursive(
         staged.insert(language.to_string());
 
         // Even if skipping, we need to check for inherited dependencies
-        let highlights_path = queries_dir.join("highlights.scm");
-        if highlights_path.exists()
-            && let Ok(content) = std::fs::read_to_string(&highlights_path)
-        {
-            let parents = parse_inherits_directive(&content);
-            for parent in parents {
-                // Stage parent dependencies (don't force, just ensure they exist)
-                clear_uninstall_tombstone(&queries_parent, &parent)?;
-                stage_queries_recursive(
-                    base_url,
-                    &parent,
-                    data_dir,
-                    false,
-                    staged,
-                    entries,
-                    http_policy,
-                )?;
-            }
+        for parent in inherited_languages_on_disk(&queries_dir) {
+            // Stage parent dependencies (don't force, just ensure they exist)
+            clear_uninstall_tombstone(&queries_parent, &parent)?;
+            stage_queries_recursive(
+                base_url,
+                &parent,
+                data_dir,
+                false,
+                staged,
+                entries,
+                http_policy,
+            )?;
         }
         return Ok(StageOutcome::NothingToDo);
     }
@@ -774,9 +815,13 @@ fn stage_queries_recursive(
 
         match download_file(&url, http_policy) {
             Ok(content) => {
-                // Check for inherits directive in highlights.scm
-                if *query_file == "highlights.scm" {
-                    parents_to_install = parse_inherits_directive(&content);
+                // Every query kind resolves its own `; inherits:` chain at load
+                // time, so a parent named by injections.scm is as load-bearing
+                // as one named by highlights.scm.
+                for parent in parse_inherits_directive(&content) {
+                    if !parents_to_install.contains(&parent) {
+                        parents_to_install.push(parent);
+                    }
                 }
 
                 let file_path = tmp_queries_dir.join(query_file);
@@ -1756,6 +1801,55 @@ mod staging_tests {
         );
     }
 
+    /// The chain check is what a caller needs before deciding a language is
+    /// ready: its own queries being complete says nothing about the parents its
+    /// load will go looking for.
+    #[test]
+    fn the_inheritance_chain_decides_completeness() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let child_dir = queries_parent.join("child");
+        fs::create_dir_all(&child_dir).unwrap();
+        fs::write(child_dir.join("highlights.scm"), "; inherits: parent\n").unwrap();
+        write_install_marker(&child_dir).unwrap();
+
+        assert!(
+            query_install_is_complete(&child_dir),
+            "the language's own queries are complete"
+        );
+        assert!(
+            !query_install_chain_is_complete(&queries_parent, "child"),
+            "but the parent it inherits is missing"
+        );
+
+        let parent_dir = queries_parent.join("parent");
+        fs::create_dir_all(&parent_dir).unwrap();
+        fs::write(parent_dir.join("highlights.scm"), "(comment) @comment\n").unwrap();
+        write_install_marker(&parent_dir).unwrap();
+
+        assert!(query_install_chain_is_complete(&queries_parent, "child"));
+    }
+
+    /// A cycle among on-disk files is the loader's problem to report; treating
+    /// it as incomplete would make every caller reinstall forever.
+    #[test]
+    fn an_inheritance_cycle_does_not_read_as_incomplete() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        for (language, inherits) in [("cyc_a", "cyc_b"), ("cyc_b", "cyc_a")] {
+            let dir = queries_parent.join(language);
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(
+                dir.join("highlights.scm"),
+                format!("; inherits: {}\n", inherits),
+            )
+            .unwrap();
+            write_install_marker(&dir).unwrap();
+        }
+
+        assert!(query_install_chain_is_complete(&queries_parent, "cyc_a"));
+    }
+
     /// A language nobody is publishing can be claimed without waiting; one an
     /// install holds cannot, because that install can still roll it back.
     #[test]
@@ -2506,6 +2600,39 @@ mod tests {
             leftovers.is_empty(),
             "a failed dependency must leave no queries behind, found {:?}",
             leftovers
+        );
+    }
+
+    /// Every query kind resolves its own inheritance, so a parent named only by
+    /// injections.scm must be staged like one named by highlights.scm.
+    #[test]
+    fn injections_inheritance_is_followed_too() {
+        let temp_dir = TempDir::new().unwrap();
+        let data_dir = temp_dir.path().to_path_buf();
+        let base_url = spawn_query_file_server(vec![
+            ("/inj_child/highlights.scm", "(identifier) @variable\n"),
+            (
+                "/inj_child/injections.scm",
+                "; inherits: inj_parent\n(comment) @injection.content\n",
+            ),
+            ("/inj_parent/highlights.scm", "(comment) @comment\n"),
+        ]);
+
+        install_queries_with_dependencies_from_allowing_http_for_tests(
+            &base_url,
+            "inj_child",
+            &data_dir,
+            false,
+        )
+        .expect("install should succeed");
+
+        assert!(
+            data_dir
+                .join("queries")
+                .join("inj_parent")
+                .join("highlights.scm")
+                .exists(),
+            "a parent named by injections.scm must be installed"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -48,6 +48,10 @@ pub enum QueryInstallError {
     IoError(std::io::Error),
     /// Queries already exist and --force not specified.
     AlreadyExists(PathBuf),
+    /// A language this install needed was removed after staging found it
+    /// already installed. Not an upstream problem — the remedy is to retry, not
+    /// to look for a language nvim-treesitter does not have.
+    DependencyRemoved(String),
     /// Publishing moved the live queries aside and could not put anything back:
     /// the language has no queries, and the previous ones are in `backup`.
     PreviousQueriesStranded {
@@ -83,6 +87,13 @@ impl std::fmt::Display for QueryInstallError {
                     f,
                     "Queries already exist at {}. Use --force to overwrite.",
                     path.display()
+                )
+            }
+            Self::DependencyRemoved(language) => {
+                write!(
+                    f,
+                    "The installed queries for '{}' were removed while it was being installed",
+                    language
                 )
             }
             Self::PreviousQueriesStranded {
@@ -163,13 +174,26 @@ fn inherited_languages_on_disk(queries_dir: &Path) -> Vec<String> {
     parents
 }
 
-/// Whether a language and everything it inherits are installed and complete.
+/// Hold every language in an inheritance chain still, and report whether all of
+/// them are installed.
 ///
-/// [`query_install_is_complete`] answers for one directory; a language whose own
-/// queries are complete still fails to load when a language they inherit is
-/// missing, because the loader resolves the chain and gives up on the first gap.
-pub fn query_install_chain_is_complete(queries_parent: &Path, language: &str) -> bool {
-    fn walk(queries_parent: &Path, language: &str, seen: &mut Vec<String>) -> bool {
+/// `Some(guards)` means the chain is complete and stays that way while the
+/// guards live — so a caller can read the rest of its state (a parser file, say)
+/// without the answer moving underneath it. `None` means a language in the chain
+/// is missing, or one of them is mid-publish and its queries can still be rolled
+/// back, or the name is not one that could be installed.
+///
+/// Locks are taken with [`try_lock_language`], so this never waits: it runs on
+/// the LSP's async path, and there "someone is publishing, look again later" is
+/// as useful as an answer as blocking for one. Because nothing waits, taking
+/// them in discovery order cannot deadlock.
+pub fn lock_complete_chain(data_dir: &Path, language: &str) -> Option<Vec<LanguageLock>> {
+    fn walk(
+        data_dir: &Path,
+        language: &str,
+        seen: &mut Vec<String>,
+        guards: &mut Vec<LanguageLock>,
+    ) -> bool {
         // An inheritance cycle among on-disk files (a self-inherit typo, A↔B)
         // is the loader's problem to report, not a reason to call the install
         // incomplete and re-download forever.
@@ -177,17 +201,22 @@ pub fn query_install_chain_is_complete(queries_parent: &Path, language: &str) ->
             return true;
         }
         seen.push(language.to_string());
-        let queries_dir = queries_parent.join(language);
+        match try_lock_language(data_dir, language) {
+            LanguageLockProbe::Idle(guard) => guards.push(guard),
+            // Nothing can publish into a data directory nothing can write, so
+            // what is there is settled without a guard to prove it.
+            LanguageLockProbe::Unlockable => {}
+            LanguageLockProbe::Busy | LanguageLockProbe::UnusableName => return false,
+        }
+        let queries_dir = data_dir.join("queries").join(language);
         query_install_is_complete(&queries_dir)
             && inherited_languages_on_disk(&queries_dir)
                 .into_iter()
-                .all(|parent| walk(queries_parent, &parent, seen))
+                .all(|parent| walk(data_dir, &parent, seen, guards))
     }
 
-    if !is_safe_language_name(language) {
-        return false;
-    }
-    walk(queries_parent, language, &mut Vec::new())
+    let mut guards = Vec::new();
+    walk(data_dir, language, &mut Vec::new(), &mut guards).then_some(guards)
 }
 
 /// Strip the parentheses nvim-treesitter puts around some inherited names.
@@ -363,7 +392,7 @@ fn install_queries_with_dependencies_from_with_http_policy(
         )));
     }
     if let Some(missing) = staged.missing_skipped_dependency() {
-        return Err(QueryInstallError::LanguageNotSupported(missing.to_string()));
+        return Err(QueryInstallError::DependencyRemoved(missing.to_string()));
     }
     match staged.publish()?.commit() {
         CommittedQueryInstall::Installed(result) => Ok(result),
@@ -1410,6 +1439,12 @@ pub fn lock_language(data_dir: &Path, language: &str) -> Result<LanguageLock, Qu
 /// the answer, because releasing it before reading the artifacts would put the
 /// whole publish back inside the window.
 pub fn try_lock_language(data_dir: &Path, language: &str) -> LanguageLockProbe {
+    if !is_safe_language_name(language) {
+        // Nothing this module manages can be under such a name, so there is no
+        // on-disk state to call settled — and a caller that believed otherwise
+        // would go on to build paths out of it.
+        return LanguageLockProbe::UnusableName;
+    }
     let Ok((file, queries_parent)) = open_language_lock_file(data_dir, language) else {
         // The lock file cannot be created or opened for writing — a read-only
         // or otherwise unwritable data directory. Nobody can be publishing into
@@ -1436,13 +1471,15 @@ pub enum LanguageLockProbe {
     /// The lock cannot be taken at all, so nothing can be publishing either.
     /// Whatever is on disk is as settled as it will ever be.
     Unlockable,
+    /// The name is not one this module could have installed under.
+    UnusableName,
 }
 
 impl LanguageLockProbe {
     /// Whether the artifacts on disk can be trusted to stay put — either
     /// because this probe holds the lock, or because nobody can publish.
     pub fn is_settled(&self) -> bool {
-        !matches!(self, Self::Busy)
+        matches!(self, Self::Idle(_) | Self::Unlockable)
     }
 }
 
@@ -1969,7 +2006,7 @@ mod staging_tests {
             "the language's own queries are complete"
         );
         assert!(
-            !query_install_chain_is_complete(&queries_parent, "child"),
+            lock_complete_chain(temp.path(), "child").is_none(),
             "but the parent it inherits is missing"
         );
 
@@ -1978,7 +2015,7 @@ mod staging_tests {
         fs::write(parent_dir.join("highlights.scm"), "(comment) @comment\n").unwrap();
         write_install_marker(&parent_dir).unwrap();
 
-        assert!(query_install_chain_is_complete(&queries_parent, "child"));
+        assert!(lock_complete_chain(temp.path(), "child").is_some());
     }
 
     /// A cycle among on-disk files is the loader's problem to report; treating
@@ -1998,7 +2035,10 @@ mod staging_tests {
             write_install_marker(&dir).unwrap();
         }
 
-        assert!(query_install_chain_is_complete(&queries_parent, "cyc_a"));
+        assert!(
+            lock_complete_chain(temp.path(), "cyc_a").is_some(),
+            "a cycle is the loader's problem to report, not a reason to reinstall forever"
+        );
     }
 
     /// Publishing can fail after it has already moved the live queries aside,
@@ -2047,6 +2087,56 @@ mod staging_tests {
                 LanguageLockProbe::Idle(_)
             ),
             "and the lock it took must be free again"
+        );
+    }
+
+    /// A base language that is mid-publish, or missing, makes the whole chain
+    /// unusable — and the guards must be released when the answer is no, or the
+    /// install that follows would block on them.
+    #[test]
+    fn locking_a_chain_reports_and_releases() {
+        let temp = TempDir::new().unwrap();
+        let data_dir = temp.path();
+        let queries_parent = data_dir.join("queries");
+        for (language, content) in [
+            ("child", "; inherits: parent\n"),
+            ("parent", "(comment) @comment\n"),
+        ] {
+            let dir = queries_parent.join(language);
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(dir.join("highlights.scm"), content).unwrap();
+            write_install_marker(&dir).unwrap();
+        }
+
+        let held = lock_complete_chain(data_dir, "child").expect("a complete chain locks");
+        assert_eq!(held.len(), 2, "both languages in the chain are held");
+        assert!(
+            matches!(
+                try_lock_language(data_dir, "parent"),
+                LanguageLockProbe::Busy
+            ),
+            "including the base language, which is the point"
+        );
+        drop(held);
+
+        // A base language mid-publish makes the chain unusable...
+        let publishing_parent = lock_language(data_dir, "parent").unwrap();
+        assert!(lock_complete_chain(data_dir, "child").is_none());
+        drop(publishing_parent);
+        assert!(
+            lock_complete_chain(data_dir, "child").is_some(),
+            "and usable again once it is done"
+        );
+
+        // ...as does one that is simply gone.
+        fs::remove_dir_all(queries_parent.join("parent")).unwrap();
+        assert!(lock_complete_chain(data_dir, "child").is_none());
+        assert!(
+            matches!(
+                try_lock_language(data_dir, "child"),
+                LanguageLockProbe::Idle(_)
+            ),
+            "a chain that answered no must not leave its locks held"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -213,7 +213,9 @@ pub(crate) fn lock_complete_chain(data_dir: &Path, language: &str) -> Option<Vec
             // Nothing can publish into a data directory nothing can write, so
             // what is there is settled without a guard to prove it.
             LanguageLockProbe::Unlockable => {}
-            LanguageLockProbe::Busy | LanguageLockProbe::UnusableName => return false,
+            LanguageLockProbe::Busy
+            | LanguageLockProbe::UnusableName
+            | LanguageLockProbe::Unavailable => return false,
         }
         let queries_dir = data_dir.join("queries").join(language);
         query_install_is_complete(&queries_dir)
@@ -1541,12 +1543,22 @@ fn try_lock_language(data_dir: &Path, language: &str) -> LanguageLockProbe {
         // would go on to build paths out of it.
         return LanguageLockProbe::UnusableName;
     }
-    let Ok((file, queries_parent)) = open_language_lock_file(data_dir, language) else {
-        // The lock file cannot be created or opened for writing — a read-only
-        // or otherwise unwritable data directory. Nobody can be publishing into
-        // it either, so what is on disk is settled; answering "busy" here would
-        // make a perfectly good preinstalled language unusable.
-        return LanguageLockProbe::Unlockable;
+    let (file, queries_parent) = match open_language_lock_file(data_dir, language) {
+        Ok(opened) => opened,
+        // The data directory cannot be written at all. Nobody can be publishing
+        // into it either, so what is on disk is settled — answering otherwise
+        // would make a perfectly good preinstalled language unusable.
+        Err(QueryInstallError::IoError(e))
+            if matches!(
+                e.kind(),
+                std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::ReadOnlyFilesystem
+            ) =>
+        {
+            return LanguageLockProbe::Unlockable;
+        }
+        // Anything else — out of descriptors, an I/O error — says nothing about
+        // whether an install is in flight, so do not pretend it does.
+        Err(_) => return LanguageLockProbe::Unavailable,
     };
     match file.try_lock() {
         Ok(()) => LanguageLockProbe::Idle(LanguageLock {
@@ -1575,6 +1587,9 @@ enum LanguageLockProbe {
     Unlockable,
     /// The name is not one this module could have installed under.
     UnusableName,
+    /// The lock could not be probed for a reason that says nothing about
+    /// whether an install is in flight — no descriptors left, an I/O error.
+    Unavailable,
 }
 
 /// Open (creating if needed) the file behind a language's lock.

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -194,7 +194,7 @@ fn inherited_languages_on_disk(queries_dir: &Path) -> Option<Vec<String>> {
 /// the LSP's async path, and there "someone is publishing, look again later" is
 /// as useful as an answer as blocking for one. Because nothing waits, taking
 /// them in discovery order cannot deadlock.
-pub fn lock_complete_chain(data_dir: &Path, language: &str) -> Option<Vec<LanguageLock>> {
+pub(crate) fn lock_complete_chain(data_dir: &Path, language: &str) -> Option<Vec<LanguageLock>> {
     fn walk(
         data_dir: &Path,
         language: &str,
@@ -1539,7 +1539,7 @@ pub fn lock_language(data_dir: &Path, language: &str) -> Result<LanguageLock, Qu
 /// to know whether the language is settled. The guard is returned rather than
 /// the answer, because releasing it before reading the artifacts would put the
 /// whole publish back inside the window.
-pub fn try_lock_language(data_dir: &Path, language: &str) -> LanguageLockProbe {
+fn try_lock_language(data_dir: &Path, language: &str) -> LanguageLockProbe {
     if !is_safe_language_name(language) {
         // Nothing this module manages can be under such a name, so there is no
         // on-disk state to call settled — and a caller that believed otherwise
@@ -1570,7 +1570,7 @@ pub fn try_lock_language(data_dir: &Path, language: &str) -> LanguageLockProbe {
 }
 
 /// What [`try_lock_language`] found.
-pub enum LanguageLockProbe {
+enum LanguageLockProbe {
     /// Nobody holds the lock, and nobody can take it while the guard lives.
     Idle(LanguageLock),
     /// An install is mid-publish: what is on disk can still be rolled back.
@@ -1580,14 +1580,6 @@ pub enum LanguageLockProbe {
     Unlockable,
     /// The name is not one this module could have installed under.
     UnusableName,
-}
-
-impl LanguageLockProbe {
-    /// Whether the artifacts on disk can be trusted to stay put — either
-    /// because this probe holds the lock, or because nobody can publish.
-    pub fn is_settled(&self) -> bool {
-        matches!(self, Self::Idle(_) | Self::Unlockable)
-    }
 }
 
 /// Open (creating if needed) the file behind a language's lock.
@@ -2306,7 +2298,7 @@ mod staging_tests {
 
         let probe = try_lock_language(temp.path(), "lua");
 
-        let settled = probe.is_settled();
+        let settled = matches!(probe, LanguageLockProbe::Unlockable);
         // Restore before asserting, so a failure does not leave an
         // undeletable directory behind for the whole test run.
         let mut permissions = fs::metadata(&queries_parent).unwrap().permissions();
@@ -2339,7 +2331,10 @@ mod staging_tests {
         );
         drop(lock);
         assert!(
-            try_lock_language(data_dir, "lua").is_settled(),
+            matches!(
+                try_lock_language(data_dir, "lua"),
+                LanguageLockProbe::Idle(_)
+            ),
             "and it is settled again once that install is done"
         );
     }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -254,7 +254,15 @@ fn install_queries_with_dependencies_from_with_http_policy(
     http_policy: QueryHttpPolicy,
 ) -> Result<QueryInstallResult, QueryInstallError> {
     let staged = stage_queries_with_dependencies(base_url, language, data_dir, force, http_policy)?;
-    staged.publish()?.commit()
+    match staged.publish()?.commit() {
+        CommittedQueryInstall::Installed(result) => Ok(result),
+        // The `install_queries_*` entry points predate staging and report an
+        // untouched language as `AlreadyExists`; their callers read it as a
+        // successful no-op.
+        CommittedQueryInstall::AlreadyInstalled(path) => {
+            Err(QueryInstallError::AlreadyExists(path))
+        }
+    }
 }
 
 fn validate_url_http_policy(
@@ -386,22 +394,30 @@ impl StagedQueryInstall {
     }
 }
 
+/// What committing a publish left in place.
+pub(crate) enum CommittedQueryInstall {
+    /// This install published the requested language's queries.
+    Installed(QueryInstallResult),
+    /// The requested language's queries were already there, so only the
+    /// parents it was missing (if any) were published.
+    AlreadyInstalled(PathBuf),
+}
+
 impl PublishedQueryInstall {
     /// Make the publish final by discarding the displaced directories.
     ///
-    /// Reports `AlreadyExists` when the requested language needed nothing —
-    /// callers treat that as a successful no-op, and it keeps the pre-staging
-    /// contract of the `install_queries_*` entry points.
-    pub(crate) fn commit(mut self) -> Result<QueryInstallResult, QueryInstallError> {
+    /// Infallible on purpose. It runs after the parser has been published, so
+    /// there is no half-installed state left to report — and a fallible commit
+    /// would give callers an error arm whose only honest handling is to undo
+    /// work that already succeeded.
+    pub(crate) fn commit(mut self) -> CommittedQueryInstall {
         for published in std::mem::take(&mut self.published) {
             discard_backup_locked(&published);
         }
         if self.requested_already_complete {
-            return Err(QueryInstallError::AlreadyExists(std::mem::take(
-                &mut self.install_path,
-            )));
+            return CommittedQueryInstall::AlreadyInstalled(std::mem::take(&mut self.install_path));
         }
-        Ok(QueryInstallResult {
+        CommittedQueryInstall::Installed(QueryInstallResult {
             language: std::mem::take(&mut self.language),
             install_path: std::mem::take(&mut self.install_path),
             files_downloaded: std::mem::take(&mut self.files_downloaded),
@@ -794,6 +810,7 @@ pub fn recover_interrupted_query_installs(queries_parent: &Path) -> Result<(), Q
         if let Some(language) = backup_language_name(&path) {
             if recovered_languages.insert(language.clone()) {
                 recover_interrupted_query_install(queries_parent, &language)?;
+                collect_superseded_backups(queries_parent, &language)?;
             }
         } else if let Some((language, _)) = temp_language_name_and_pid(&path) {
             remove_interrupted_temp_query_install(queries_parent, &language, &path)?;
@@ -1045,6 +1062,61 @@ fn recover_interrupted_query_install(
         Err(e) => return Err(QueryInstallError::IoError(e)),
     }
     let _ = fs::remove_file(ownership);
+    Ok(())
+}
+
+/// Drop backups left behind by an install that died after publishing a query
+/// directory but before committing.
+///
+/// [`recover_interrupted_query_install`] restores a backup only when the live
+/// directory is missing. Once the publish landed, the directory it displaced is
+/// superseded — and invisible to that recovery for exactly that reason — so
+/// without this it would sit under `queries/` until the user uninstalled the
+/// language by name. An install publishes one such backup per language in the
+/// `; inherits:` chain, so the leak is per-chain, not per-install.
+///
+/// Only backups whose owning process is gone are collected, mirroring
+/// [`remove_interrupted_temp_query_install`]; a live install's backup is still
+/// its rollback target. As there, `process_is_running` is conservative off
+/// unix, so nothing is collected there.
+fn collect_superseded_backups(
+    queries_parent: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    validate_safe_language_name(language)?;
+    if !queries_parent.join(language).exists() {
+        return Ok(());
+    }
+
+    let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
+    // Re-check under the lock: a concurrent uninstall may have removed the
+    // directory, which makes these backups restore candidates again.
+    if !queries_parent.join(language).exists() {
+        return Ok(());
+    }
+
+    let entries = match fs::read_dir(queries_parent) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(QueryInstallError::IoError(e)),
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() || !backup_is_owned(&path) {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        let Some((backup_language, pid, _)) = generated_backup_parts(name) else {
+            continue;
+        };
+        if backup_language != language || process_is_running(pid) {
+            continue;
+        }
+        let _ = fs::remove_dir_all(&path);
+        let _ = fs::remove_file(backup_ownership_sidecar(&path));
+    }
     Ok(())
 }
 
@@ -1708,6 +1780,62 @@ mod tests {
         assert!(
             !queries_parent.exists(),
             "unsafe cleanup must not even create the queries directory"
+        );
+    }
+
+    /// An install killed between publishing a query directory and committing
+    /// leaves the directory it displaced behind, and the restore path skips it
+    /// because the live directory is present again. Something has to collect it.
+    #[test]
+    #[cfg(unix)]
+    fn recover_interrupted_query_installs_collects_superseded_backups() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let live = queries_parent.join("lua");
+        fs::create_dir_all(&live).unwrap();
+        fs::write(live.join("highlights.scm"), "published").unwrap();
+        write_install_marker(&live).unwrap();
+        let backup = queries_parent.join(format!(".lua.{}.0.backup", dead_test_pid()));
+        fs::create_dir_all(&backup).unwrap();
+        fs::write(backup.join("highlights.scm"), "displaced").unwrap();
+        write_install_marker(&backup).unwrap();
+        write_backup_ownership_marker(&backup).unwrap();
+
+        recover_interrupted_query_installs(&queries_parent).unwrap();
+
+        assert!(!backup.exists(), "a superseded backup must be collected");
+        assert!(
+            !backup_ownership_sidecar(&backup).exists(),
+            "its ownership sidecar must go with it"
+        );
+        assert_eq!(
+            fs::read_to_string(live.join("highlights.scm")).unwrap(),
+            "published",
+            "collecting a backup must not disturb the live queries"
+        );
+    }
+
+    /// A backup whose install is still running is that install's rollback
+    /// target, not garbage.
+    #[test]
+    fn recover_interrupted_query_installs_keeps_a_live_installs_backup() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let live = queries_parent.join("lua");
+        fs::create_dir_all(&live).unwrap();
+        fs::write(live.join("highlights.scm"), "published").unwrap();
+        write_install_marker(&live).unwrap();
+        let backup = queries_parent.join(format!(".lua.{}.0.backup", std::process::id()));
+        fs::create_dir_all(&backup).unwrap();
+        fs::write(backup.join("highlights.scm"), "displaced").unwrap();
+        write_install_marker(&backup).unwrap();
+        write_backup_ownership_marker(&backup).unwrap();
+
+        recover_interrupted_query_installs(&queries_parent).unwrap();
+
+        assert!(
+            backup.exists(),
+            "a running install's backup must not be collected"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -1273,6 +1273,45 @@ pub fn lock_language(data_dir: &Path, language: &str) -> Result<LanguageLock, Qu
     })
 }
 
+/// Whether another install is between publishing this language's queries and
+/// committing them.
+///
+/// Non-blocking, unlike [`lock_language`]: this answers on the LSP's async path,
+/// where waiting on another process is not acceptable. A language someone is
+/// mid-publish on reads as unsettled — its queries can still be rolled back —
+/// so a caller that would otherwise treat it as installed falls through to a
+/// real install instead, and that install queues on the same lock properly.
+///
+/// A language nobody is publishing, and any error taking the probe, read as
+/// settled: this only withholds a shortcut, and failing to take a lock is not
+/// evidence of an install in flight.
+pub fn language_publish_in_flight(data_dir: &Path, language: &str) -> bool {
+    if !is_safe_language_name(language) {
+        return false;
+    }
+    let path = data_dir
+        .join("queries")
+        .join(format!(".{}{}", language, LANGUAGE_LOCK_SUFFIX));
+    if !path.is_file() {
+        return false;
+    }
+    let Ok(file) = fs::OpenOptions::new()
+        .create(false)
+        .write(true)
+        .truncate(false)
+        .open(path)
+    else {
+        return false;
+    };
+    match file.try_lock() {
+        Ok(()) => {
+            let _ = file.unlock();
+            false
+        }
+        Err(_) => true,
+    }
+}
+
 /// Take [`lock_language`] for every language an install depends on.
 ///
 /// `languages` must be sorted: two installs whose dependency sets overlap
@@ -1725,6 +1764,30 @@ mod staging_tests {
             residue(&queries_parent),
             vec!["child".to_string()],
             "the displaced directory and its sidecar must not be stranded"
+        );
+    }
+
+    /// A language nobody is publishing is settled; one whose lock is held is
+    /// not, because that install can still roll its queries back.
+    #[test]
+    fn a_publish_in_flight_is_visible_without_waiting_for_it() {
+        let temp = TempDir::new().unwrap();
+        let data_dir = temp.path();
+
+        assert!(
+            !language_publish_in_flight(data_dir, "lua"),
+            "a language nobody has touched is settled"
+        );
+
+        let lock = lock_language(data_dir, "lua").unwrap();
+        assert!(
+            language_publish_in_flight(data_dir, "lua"),
+            "a held lock means an install is between publishing and committing"
+        );
+        drop(lock);
+        assert!(
+            !language_publish_in_flight(data_dir, "lua"),
+            "and it is settled again once that install is done"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -394,7 +394,8 @@ fn install_queries_with_dependencies_from_with_http_policy(
     if let Some(missing) = staged.missing_skipped_dependency() {
         return Err(QueryInstallError::DependencyRemoved(missing.to_string()));
     }
-    match staged.publish()?.commit() {
+    let published = staged.publish().map_err(|failure| failure.error)?;
+    match published.commit() {
         CommittedQueryInstall::Installed(result) => Ok(result),
         // The `install_queries_*` entry points predate staging and report an
         // untouched language as `AlreadyExists`; their callers read it as a
@@ -527,7 +528,7 @@ impl StagedQueryInstall {
 
     /// Rename every staged directory into place, keeping the displaced
     /// directories so the whole install can still be undone.
-    pub(crate) fn publish(self) -> Result<PublishedQueryInstall, QueryInstallError> {
+    pub(crate) fn publish(self) -> Result<PublishedQueryInstall, PublishFailure> {
         let Self {
             language: requested_language,
             install_path,
@@ -576,18 +577,21 @@ impl StagedQueryInstall {
                     }
                 }
                 Ok(PublishQueryDirOutcome::Uninstalled) => {
-                    let _ = publish.rollback();
-                    return Err(QueryInstallError::IoError(std::io::Error::new(
-                        std::io::ErrorKind::Interrupted,
-                        format!(
-                            "Query install for {} was superseded by uninstall",
-                            entry.language
-                        ),
-                    )));
+                    let residue = publish.rollback();
+                    return Err(PublishFailure {
+                        error: QueryInstallError::IoError(std::io::Error::new(
+                            std::io::ErrorKind::Interrupted,
+                            format!(
+                                "Query install for {} was superseded by uninstall",
+                                entry.language
+                            ),
+                        )),
+                        residue,
+                    });
                 }
                 Err(e) => {
-                    let _ = publish.rollback();
-                    return Err(e);
+                    let residue = publish.rollback();
+                    return Err(PublishFailure { error: e, residue });
                 }
             }
         }
@@ -714,6 +718,17 @@ impl PublishedQueryInstall {
         }
         outcome
     }
+}
+
+/// A publish that failed, and what its rollback could not put back.
+///
+/// The two travel together because the caller reports them together: an error
+/// on its own would let a command say nothing was published while the queries
+/// this install wrote are still live.
+#[derive(Debug)]
+pub(crate) struct PublishFailure {
+    pub(crate) error: QueryInstallError,
+    pub(crate) residue: RollbackOutcome,
 }
 
 /// What a rollback managed to put back.
@@ -1458,7 +1473,13 @@ pub fn try_lock_language(data_dir: &Path, language: &str) -> LanguageLockProbe {
             queries_parent,
             language: language.to_string(),
         }),
-        Err(_) => LanguageLockProbe::Busy,
+        // Only contention means an install is in flight. A filesystem that
+        // cannot do advisory locks at all — some NFS and FUSE mounts — errors
+        // here too, and calling that busy would make every language on such a
+        // mount read as unusable while the repair it triggers fails for the
+        // same reason. Nobody can lock there, so nobody can publish there.
+        Err(std::fs::TryLockError::WouldBlock) => LanguageLockProbe::Busy,
+        Err(std::fs::TryLockError::Error(_)) => LanguageLockProbe::Unlockable,
     }
 }
 
@@ -2344,7 +2365,7 @@ mod staging_tests {
         let result = staged.publish();
 
         assert!(
-            matches!(&result, Err(QueryInstallError::IoError(e)) if e.kind() == std::io::ErrorKind::Interrupted),
+            matches!(&result, Err(failure) if matches!(&failure.error, QueryInstallError::IoError(e) if e.kind() == std::io::ErrorKind::Interrupted)),
             "a tombstoned entry must abort the publish"
         );
         assert_eq!(

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -526,7 +526,17 @@ fn discard_backup_locked(published: &PublishedQueryDir) {
     let _replace_lock = published
         .queries_dir
         .parent()
-        .map(|parent| QueryReplaceLockGuard::acquire(parent, &published.language));
+        .map(|parent| QueryReplaceLockGuard::acquire(parent, &published.language))
+        .transpose()
+        .inspect_err(|e| {
+            // Still discard: an uncollected backup is worse than an unlocked
+            // removal, and the lock only avoids making a concurrent uninstall
+            // report a failure for work that did happen.
+            eprintln!(
+                "Warning: could not lock '{}' before dropping its query backup: {}",
+                published.language, e
+            )
+        });
     discard_backup(published);
 }
 
@@ -539,8 +549,28 @@ fn discard_backup(published: &PublishedQueryDir) {
     let Some(backup) = &published.backup else {
         return;
     };
-    let _ = fs::remove_dir_all(backup);
-    let _ = fs::remove_file(backup_ownership_sidecar(backup));
+    discard_backup_dir(backup);
+}
+
+/// Remove a backup directory and, once it is confirmed gone, the sidecar that
+/// marks it as ours.
+///
+/// The sidecar outlives a removal that *failed*: every collector — uninstall,
+/// the recovery sweep, `newest_complete_backup_dir` — gates on it, so dropping
+/// it while the directory survives would make that directory unreachable by all
+/// of them. It is dropped when the directory is confirmed absent, which is how
+/// a concurrent uninstall's collection stops leaving sidecars behind.
+fn discard_backup_dir(backup: &Path) {
+    match remove_dir_all_tolerating_vanished(backup) {
+        Ok(_) => {
+            let _ = fs::remove_file(backup_ownership_sidecar(backup));
+        }
+        Err(e) => eprintln!(
+            "Warning: failed to remove the superseded query backup at {}: {}",
+            backup.display(),
+            e
+        ),
+    }
 }
 
 /// What staging found for one language.
@@ -1084,14 +1114,21 @@ fn collect_superseded_backups(
     language: &str,
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
-    if !queries_parent.join(language).exists() {
+    // "Superseded" means a *complete* directory took the backup's place. A live
+    // directory that is merely present is not enough: an interrupted uninstall
+    // can leave a partially emptied one, and then the backup is the only intact
+    // copy — the same reason `newest_complete_backup_dir` refuses to restore an
+    // incomplete backup, applied in the other direction. A publish always
+    // produces a complete directory, so this still covers the case the sweep
+    // exists for.
+    if !query_install_is_complete(&queries_parent.join(language)) {
         return Ok(());
     }
 
     let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
     // Re-check under the lock: a concurrent uninstall may have removed the
     // directory, which makes these backups restore candidates again.
-    if !queries_parent.join(language).exists() {
+    if !query_install_is_complete(&queries_parent.join(language)) {
         return Ok(());
     }
 
@@ -1114,8 +1151,7 @@ fn collect_superseded_backups(
         if backup_language != language || process_is_running(pid) {
             continue;
         }
-        let _ = fs::remove_dir_all(&path);
-        let _ = fs::remove_file(backup_ownership_sidecar(&path));
+        discard_backup_dir(&path);
     }
     Ok(())
 }
@@ -1812,6 +1848,35 @@ mod tests {
             fs::read_to_string(live.join("highlights.scm")).unwrap(),
             "published",
             "collecting a backup must not disturb the live queries"
+        );
+    }
+
+    /// A live directory that is merely present is not proof the backup is
+    /// superseded: an interrupted uninstall leaves a partially emptied one, and
+    /// then the backup is the only intact copy.
+    #[test]
+    #[cfg(unix)]
+    fn recover_interrupted_query_installs_keeps_a_backup_over_an_incomplete_dir() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let live = queries_parent.join("lua");
+        fs::create_dir_all(&live).unwrap();
+        fs::write(live.join("bindings.scm"), "user managed query").unwrap();
+        let backup = queries_parent.join(format!(".lua.{}.0.backup", dead_test_pid()));
+        fs::create_dir_all(&backup).unwrap();
+        fs::write(backup.join("highlights.scm"), "(comment) @comment\n").unwrap();
+        write_install_marker(&backup).unwrap();
+        write_backup_ownership_marker(&backup).unwrap();
+
+        recover_interrupted_query_installs(&queries_parent).unwrap();
+
+        assert!(
+            backup.join("highlights.scm").exists(),
+            "the only complete copy must survive an incomplete live directory"
+        );
+        assert!(
+            backup_ownership_sidecar(&backup).is_file(),
+            "and stay owned, so it is still a restore candidate"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -170,6 +170,20 @@ pub fn query_install_chain_is_complete(queries_parent: &Path, language: &str) ->
     walk(queries_parent, language, &mut Vec::new())
 }
 
+/// Strip the parentheses nvim-treesitter puts around some inherited names.
+///
+/// Must match what the query loader does with the same line
+/// (`language::query_loader::normalize_inherited_language_name`): the loader
+/// resolves `(cpp)` as `cpp`, so an installer that dropped it as an unsafe name
+/// would report success and leave the loader looking for a language nothing
+/// fetched.
+fn normalize_inherited_language_name(name: &str) -> String {
+    name.trim_start_matches('(')
+        .trim_end_matches(')')
+        .trim()
+        .to_string()
+}
+
 /// Parse the `; inherits: lang1,lang2` directive from query content.
 /// Returns the list of parent languages, dropping unsafe names
 /// (see [`is_safe_language_name`]).
@@ -177,7 +191,7 @@ fn parse_inherits_directive(content: &str) -> Vec<String> {
     let first_line = content.lines().next().unwrap_or("");
     if let Some(rest) = first_line.strip_prefix("; inherits:") {
         rest.split(',')
-            .map(|s| s.trim().to_string())
+            .map(|s| normalize_inherited_language_name(s.trim()))
             .filter(|s| !s.is_empty())
             .filter(|s| {
                 let safe = is_safe_language_name(s);
@@ -458,11 +472,12 @@ impl StagedQueryInstall {
             language: requested_language.clone(),
             published: Vec::new(),
         };
-        // Deepest first: entries are collected requested-language-first, so
-        // reversing publishes every base language before the one that inherits
-        // it. A reader that catches the install mid-publish then sees a
-        // language whose chain is already there, never a dangling `; inherits:`.
-        for entry in entries.into_iter().rev() {
+        // Staging appends a language only once every language it inherits is
+        // already in the list, so publishing in order puts each base language
+        // in place before the one that needs it. A reader that catches the
+        // install mid-publish then sees a language whose chain is already
+        // there, never a dangling `; inherits:`.
+        for entry in entries {
             let requested = entry.language == requested_language;
             // Each entry publishes with the `force` it was staged with, so an
             // inherited parent never overwrites a copy that appeared while this
@@ -593,7 +608,7 @@ impl PublishedQueryInstall {
                      retrying.",
                     published.language, e, published.language
                 );
-                outcome = RollbackOutcome::LeftPublished;
+                outcome = RollbackOutcome::NewQueriesRemain;
                 continue;
             }
             let Some(backup) = &published.backup else {
@@ -617,7 +632,7 @@ impl PublishedQueryInstall {
                         e,
                         backup.display()
                     );
-                    outcome = RollbackOutcome::LeftPublished;
+                    outcome = RollbackOutcome::PreviousQueriesStranded;
                 }
             }
         }
@@ -625,15 +640,19 @@ impl PublishedQueryInstall {
     }
 }
 
-/// Whether a rollback actually put everything back.
+/// What a rollback managed to put back.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RollbackOutcome {
-    /// Nothing this install published is still published.
+    /// Nothing this install published is still published, and whatever it
+    /// displaced is back.
     Undone,
-    /// A removal or restore failed, so the data directory still holds queries
-    /// this install wrote — the warnings say which. The caller must not tell
-    /// the user that nothing was published.
-    LeftPublished,
+    /// The queries this install published are still live: they could not be
+    /// removed, or the lock needed to remove them could not be taken.
+    NewQueriesRemain,
+    /// The new queries are gone but the ones they displaced could not be put
+    /// back, so the language has no queries and the previous ones are in a
+    /// backup directory. The warnings name it.
+    PreviousQueriesStranded,
 }
 
 impl Drop for PublishedQueryInstall {
@@ -882,8 +901,10 @@ fn stage_queries_recursive(
 
     write_install_marker(&tmp_queries_dir)?;
 
+    // Marked as staged before recursing, so an inheritance cycle terminates;
+    // the entry itself is appended after, so `entries` comes out in dependency
+    // order and can be published base-language-first.
     staged.insert(language.to_string());
-    entries.push(staged_dir);
 
     // Stage parent dependencies. A parent that cannot be downloaded fails the
     // whole install: propagating the error here drops every staging directory
@@ -902,6 +923,7 @@ fn stage_queries_recursive(
             http_policy,
         )?;
     }
+    entries.push(staged_dir);
 
     Ok(StageOutcome::Staged { files_downloaded })
 }
@@ -2454,6 +2476,18 @@ mod tests {
     /// URL segments, so anything outside nvim-treesitter's `[a-z0-9_]+`
     /// naming must be dropped — `; inherits: ../../x` from a compromised or
     /// custom query source must not escape the data dir.
+    /// nvim-treesitter parenthesizes some inherited names, and the query loader
+    /// resolves `(cpp)` as `cpp`. An installer that read it any other way would
+    /// report success and leave the loader looking for a language nothing
+    /// fetched.
+    #[test]
+    fn parse_inherits_directive_strips_parentheses_like_the_loader() {
+        assert_eq!(
+            parse_inherits_directive("; inherits: c, (cpp), (cuda)\n"),
+            vec!["c".to_string(), "cpp".to_string(), "cuda".to_string()]
+        );
+    }
+
     #[test]
     fn parse_inherits_directive_drops_unsafe_language_names() {
         let parents = parse_inherits_directive(
@@ -2642,6 +2676,12 @@ mod tests {
                 "; inherits: inj_parent\n(comment) @injection.content\n",
             ),
             ("/inj_parent/highlights.scm", "(comment) @comment\n"),
+            // The kind that inherited it, too: loading the child's injections
+            // resolves the parent's injections, not its highlights.
+            (
+                "/inj_parent/injections.scm",
+                "(string) @injection.content\n",
+            ),
         ]);
 
         install_queries_with_dependencies_from_allowing_http_for_tests(
@@ -2656,9 +2696,9 @@ mod tests {
             data_dir
                 .join("queries")
                 .join("inj_parent")
-                .join("highlights.scm")
+                .join("injections.scm")
                 .exists(),
-            "a parent named by injections.scm must be installed"
+            "a parent named by injections.scm must be installed, with the kind that named it"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -1253,18 +1253,7 @@ fn collect_superseded_backups(
 /// replace lock — the operations it covers take that one underneath, and
 /// `flock` blocks a second descriptor even within one process.
 pub fn lock_language(data_dir: &Path, language: &str) -> Result<LanguageLock, QueryInstallError> {
-    validate_safe_language_name(language)?;
-    // The lock lives beside the query directories, so the directory has to
-    // exist to take it. Staging already created it; this also covers a caller
-    // that skipped straight here.
-    let queries_parent = data_dir.join("queries");
-    fs::create_dir_all(&queries_parent)?;
-    let path = queries_parent.join(format!(".{}{}", language, LANGUAGE_LOCK_SUFFIX));
-    let file = fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(false)
-        .open(path)?;
+    let (file, queries_parent) = open_language_lock_file(data_dir, language)?;
     file.lock()?;
     Ok(LanguageLock {
         _file: file,
@@ -1273,43 +1262,43 @@ pub fn lock_language(data_dir: &Path, language: &str) -> Result<LanguageLock, Qu
     })
 }
 
-/// Whether another install is between publishing this language's queries and
-/// committing them.
+/// [`lock_language`] without the wait: `None` when another install holds it.
 ///
-/// Non-blocking, unlike [`lock_language`]: this answers on the LSP's async path,
-/// where waiting on another process is not acceptable. A language someone is
-/// mid-publish on reads as unsettled — its queries can still be rolled back —
-/// so a caller that would otherwise treat it as installed falls through to a
-/// real install instead, and that install queues on the same lock properly.
+/// For callers that must not block — the LSP's async path — and that only need
+/// to know whether the language is settled. A language someone is mid-publish
+/// on can still have those queries rolled back, so "busy" and "could not
+/// probe" both answer no. The guard is returned rather than the answer, because
+/// releasing it before reading the artifacts would put the whole publish back
+/// inside the window.
+pub fn try_lock_language(data_dir: &Path, language: &str) -> Option<LanguageLock> {
+    let (file, queries_parent) = open_language_lock_file(data_dir, language).ok()?;
+    file.try_lock().ok()?;
+    Some(LanguageLock {
+        _file: file,
+        queries_parent,
+        language: language.to_string(),
+    })
+}
+
+/// Open (creating if needed) the file behind a language's lock.
 ///
-/// A language nobody is publishing, and any error taking the probe, read as
-/// settled: this only withholds a shortcut, and failing to take a lock is not
-/// evidence of an install in flight.
-pub fn language_publish_in_flight(data_dir: &Path, language: &str) -> bool {
-    if !is_safe_language_name(language) {
-        return false;
-    }
-    let path = data_dir
-        .join("queries")
-        .join(format!(".{}{}", language, LANGUAGE_LOCK_SUFFIX));
-    if !path.is_file() {
-        return false;
-    }
-    let Ok(file) = fs::OpenOptions::new()
-        .create(false)
+/// The lock lives beside the query directories, so the directory has to exist
+/// to take it. Staging already created it; this also covers a caller that
+/// skipped straight here.
+fn open_language_lock_file(
+    data_dir: &Path,
+    language: &str,
+) -> Result<(fs::File, PathBuf), QueryInstallError> {
+    validate_safe_language_name(language)?;
+    let queries_parent = data_dir.join("queries");
+    fs::create_dir_all(&queries_parent)?;
+    let path = queries_parent.join(format!(".{}{}", language, LANGUAGE_LOCK_SUFFIX));
+    let file = fs::OpenOptions::new()
+        .create(true)
         .write(true)
         .truncate(false)
-        .open(path)
-    else {
-        return false;
-    };
-    match file.try_lock() {
-        Ok(()) => {
-            let _ = file.unlock();
-            false
-        }
-        Err(_) => true,
-    }
+        .open(path)?;
+    Ok((file, queries_parent))
 }
 
 /// Take [`lock_language`] for every language an install depends on.
@@ -1767,26 +1756,25 @@ mod staging_tests {
         );
     }
 
-    /// A language nobody is publishing is settled; one whose lock is held is
-    /// not, because that install can still roll its queries back.
+    /// A language nobody is publishing can be claimed without waiting; one an
+    /// install holds cannot, because that install can still roll it back.
     #[test]
     fn a_publish_in_flight_is_visible_without_waiting_for_it() {
         let temp = TempDir::new().unwrap();
         let data_dir = temp.path();
 
-        assert!(
-            !language_publish_in_flight(data_dir, "lua"),
-            "a language nobody has touched is settled"
-        );
+        let probe = try_lock_language(data_dir, "lua");
+        assert!(probe.is_some(), "a language nobody has touched is settled");
+        drop(probe);
 
         let lock = lock_language(data_dir, "lua").unwrap();
         assert!(
-            language_publish_in_flight(data_dir, "lua"),
+            try_lock_language(data_dir, "lua").is_none(),
             "a held lock means an install is between publishing and committing"
         );
         drop(lock);
         assert!(
-            !language_publish_in_flight(data_dir, "lua"),
+            try_lock_language(data_dir, "lua").is_some(),
             "and it is settled again once that install is done"
         );
     }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -296,8 +296,8 @@ struct StagedQueryDir {
 ///
 /// Staging the whole dependency chain before publishing any of it is what makes
 /// an install all-or-nothing — a parent that fails to download aborts the
-/// install with the data directory untouched, instead of leaving a language
-/// whose inherited queries are missing.
+/// install before anything is published, instead of leaving a language whose
+/// inherited queries are missing.
 pub(crate) struct StagedQueryInstall {
     language: String,
     /// Where the requested language's queries live once published.
@@ -438,6 +438,13 @@ impl PublishedQueryInstall {
     /// succeeded, and a failure here is reported rather than retried, because
     /// the alternative — leaving a half-restored directory — is worse than
     /// telling the user what state they are in.
+    ///
+    /// Known gap: the lock keeps this out of another process's critical
+    /// section, but nothing records *whose* publish the live directory is. A
+    /// second process that installed the same language and committed while this
+    /// one was compiling would have its work undone here. Closing that needs
+    /// provenance in the install marker; same-language cross-process installs
+    /// are rare enough that the marker format has not been changed for it.
     pub(crate) fn rollback(mut self) {
         for published in std::mem::take(&mut self.published) {
             if !published.requested {
@@ -501,10 +508,14 @@ impl Drop for PublishedQueryInstall {
     /// Backstop for an install abandoned without committing or rolling back —
     /// today only a panic between the two.
     ///
-    /// Keep the publish and drop the backups: a stranded backup is invisible to
-    /// every collector but `language uninstall` (`recover_interrupted_query_install`
-    /// returns early because the live directory is present again), so it would
-    /// linger forever.
+    /// Keep the publish and drop the backups: a stranded backup is only
+    /// reachable by a later `language status`/`uninstall` sweep, so dropping it
+    /// here is what keeps the common case clean.
+    ///
+    /// Unlocked, unlike `commit`: this can run while unwinding, and blocking a
+    /// panic on another process's `flock` is worse than the race the lock
+    /// avoids (a concurrent uninstall reporting a failure for work that did
+    /// happen).
     fn drop(&mut self) {
         for published in std::mem::take(&mut self.published) {
             discard_backup(&published);
@@ -1343,9 +1354,9 @@ fn publish_query_dir(
 
     // The backup outlives this function: it is dropped by
     // `PublishedQueryInstall::commit` once every language in the install has
-    // been published. Until then `recover_interrupted_query_install` will not
-    // collect it — `queries_dir` exists again, so it returns early — which is
-    // the pre-existing orphan-backup window that `language uninstall` cleans up.
+    // been published. A process killed inside that window strands it —
+    // `recover_interrupted_query_install` will not restore it, `queries_dir`
+    // exists again — which is what `collect_superseded_backups` sweeps up.
     Ok(PublishQueryDirOutcome::Published {
         backup: Some(backup_dir),
     })

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -334,6 +334,19 @@ pub(crate) struct PublishedQueryInstall {
 }
 
 impl StagedQueryInstall {
+    /// Whether the requested language's queries are still where staging left
+    /// them.
+    ///
+    /// Staging skips a language whose queries are already complete, so there is
+    /// no staged copy to publish and nothing that would notice them
+    /// disappearing. An uninstall between staging and publication would
+    /// otherwise leave the install publishing a parser and reporting success
+    /// over queries that are gone. Callers check this once they hold the lock
+    /// that keeps the answer true.
+    pub(crate) fn requested_queries_still_complete(&self) -> bool {
+        !self.requested_already_complete || query_install_is_complete(&self.install_path)
+    }
+
     /// Rename every staged directory into place, keeping the displaced
     /// directories so the whole install can still be undone.
     pub(crate) fn publish(self) -> Result<PublishedQueryInstall, QueryInstallError> {
@@ -1628,6 +1641,49 @@ mod staging_tests {
             vec!["child".to_string()],
             "the displaced directory and its sidecar must not be stranded"
         );
+    }
+
+    /// Staging does not copy queries it found complete, so nothing else would
+    /// notice an uninstall removing them before the publish.
+    #[test]
+    fn a_skipped_requested_language_is_rechecked() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let queries_dir = queries_parent.join("child");
+        fs::create_dir_all(&queries_dir).unwrap();
+        fs::write(queries_dir.join("highlights.scm"), "complete").unwrap();
+        write_install_marker(&queries_dir).unwrap();
+        let staged = StagedQueryInstall {
+            language: "child".to_string(),
+            install_path: queries_dir.clone(),
+            files_downloaded: Vec::new(),
+            requested_already_complete: true,
+            entries: Vec::new(),
+        };
+
+        assert!(staged.requested_queries_still_complete());
+        fs::remove_dir_all(&queries_dir).unwrap();
+        assert!(
+            !staged.requested_queries_still_complete(),
+            "queries removed after staging must not pass as already installed"
+        );
+    }
+
+    /// A language this install staged for itself needs no such check — its
+    /// publish re-checks the directory under the lock.
+    #[test]
+    fn a_staged_requested_language_needs_no_recheck() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let staged = StagedQueryInstall {
+            language: "child".to_string(),
+            install_path: queries_parent.join("child"),
+            files_downloaded: vec!["highlights.scm".to_string()],
+            requested_already_complete: false,
+            entries: vec![stage(&queries_parent, "child", "staged", false)],
+        };
+
+        assert!(staged.requested_queries_still_complete());
     }
 
     /// `--force` replaces the requested language, not the base languages it

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -558,7 +558,7 @@ impl StagedQueryInstall {
             files_downloaded,
             requested_already_complete,
             entries,
-            dependencies: _,
+            dependencies,
             queries_parent: _,
         } = self;
         let mut publish = PublishedQueryInstall {
@@ -593,8 +593,23 @@ impl StagedQueryInstall {
                     });
                 }
                 // A concurrent installer completed this language while we were
-                // downloading. Its files are as good as ours, so keep them.
+                // downloading. Its files are as good as ours, so keep them —
+                // but only if they need the same base languages. A winner that
+                // inherits something this install never discovered leaves that
+                // language unlocked and unchecked, which is the dangling chain
+                // the whole dependency set exists to prevent.
                 Ok(PublishQueryDirOutcome::AlreadyComplete) => {
+                    let chain_matches = inherited_languages_on_disk(&entry.queries_dir)
+                        .is_some_and(|parents| {
+                            parents.iter().all(|parent| dependencies.contains(parent))
+                        });
+                    if !chain_matches {
+                        let residue = publish.rollback();
+                        return Err(PublishFailure {
+                            error: QueryInstallError::DependencyRemoved(entry.language),
+                            residue,
+                        });
+                    }
                     if requested {
                         publish.requested_already_complete = true;
                     }
@@ -2439,6 +2454,49 @@ mod staging_tests {
         };
 
         assert_eq!(staged.unstable_skipped_dependency(), None);
+    }
+
+    /// Yielding to a copy that appeared while this install was busy is right
+    /// only when that copy needs the same base languages. One that inherits
+    /// something this install never discovered leaves that language unlocked
+    /// and unchecked — the dangling chain the dependency set exists to prevent.
+    #[test]
+    fn yielding_to_a_winner_that_changed_the_chain_fails_the_publish() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let staged = StagedQueryInstall {
+            language: "child".to_string(),
+            install_path: queries_parent.join("child"),
+            files_downloaded: vec!["highlights.scm".to_string()],
+            requested_already_complete: false,
+            entries: vec![
+                stage(&queries_parent, "child", "; inherits: parent\n", false),
+                stage(&queries_parent, "parent", "(comment) @comment\n", false),
+            ],
+            dependencies: vec!["child".to_string(), "parent".to_string()],
+            queries_parent: queries_parent.clone(),
+        };
+        // Someone else finishes `parent` first, with queries that inherit a
+        // language this install never staged or locked.
+        let parent_dir = queries_parent.join("parent");
+        fs::create_dir_all(&parent_dir).unwrap();
+        fs::write(
+            parent_dir.join("highlights.scm"),
+            "; inherits: grandparent\n(comment) @comment\n",
+        )
+        .unwrap();
+        write_install_marker(&parent_dir).unwrap();
+
+        let Err(failure) = staged.publish() else {
+            panic!("a winner that changed the chain must fail the publish");
+        };
+        assert!(
+            matches!(&failure.error, QueryInstallError::DependencyRemoved(language) if language == "parent")
+        );
+        assert!(
+            !queries_parent.join("child").exists(),
+            "and the requested language must not be left published"
+        );
     }
 
     /// `--force` replaces the requested language, not the base languages it

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -159,11 +159,17 @@ fn validate_safe_language_name(language: &str) -> Result<(), QueryInstallError> 
 /// Each kind resolves its own `; inherits:` chain when it loads, and a parent it
 /// names but that is not installed makes that load fail outright — so
 /// injections.scm's parents matter exactly as much as highlights.scm's.
-fn inherited_languages_on_disk(queries_dir: &Path) -> Vec<String> {
+fn inherited_languages_on_disk(queries_dir: &Path) -> Option<Vec<String>> {
     let mut parents: Vec<String> = Vec::new();
     for query_file in QUERY_FILES {
-        let Ok(content) = fs::read_to_string(queries_dir.join(query_file)) else {
-            continue;
+        let content = match fs::read_to_string(queries_dir.join(query_file)) {
+            Ok(content) => content,
+            // A kind this language does not have.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            // A kind it has but that cannot be read. Answering "no parents"
+            // would let a caller call the chain complete on a file it never
+            // saw, so say the chain cannot be determined instead.
+            Err(_) => return None,
         };
         for parent in parse_inherits_directive(&content) {
             if !parents.contains(&parent) {
@@ -171,7 +177,7 @@ fn inherited_languages_on_disk(queries_dir: &Path) -> Vec<String> {
             }
         }
     }
-    parents
+    Some(parents)
 }
 
 /// Hold every language in an inheritance chain still, and report whether all of
@@ -210,9 +216,11 @@ pub fn lock_complete_chain(data_dir: &Path, language: &str) -> Option<Vec<Langua
         }
         let queries_dir = data_dir.join("queries").join(language);
         query_install_is_complete(&queries_dir)
-            && inherited_languages_on_disk(&queries_dir)
-                .into_iter()
-                .all(|parent| walk(data_dir, &parent, seen, guards))
+            && inherited_languages_on_disk(&queries_dir).is_some_and(|parents| {
+                parents
+                    .into_iter()
+                    .all(|parent| walk(data_dir, &parent, seen, guards))
+            })
     }
 
     let mut guards = Vec::new();
@@ -916,7 +924,12 @@ fn stage_queries_recursive(
         staged.insert(language.to_string());
 
         // Even if skipping, we need to check for inherited dependencies
-        for parent in inherited_languages_on_disk(&queries_dir) {
+        let parents = inherited_languages_on_disk(&queries_dir).ok_or_else(|| {
+            QueryInstallError::IoError(std::io::Error::other(format!(
+                "cannot read the query files installed for '{language}' to find what it inherits"
+            )))
+        })?;
+        for parent in parents {
             // Stage parent dependencies (don't force, just ensure they exist)
             clear_uninstall_tombstone_for_dependency(data_dir, &parent)?;
             stage_queries_recursive(
@@ -1115,6 +1128,11 @@ pub fn recover_interrupted_query_installs(queries_parent: &Path) -> Result<(), Q
 pub struct QueryRemoval {
     pub removed_queries: bool,
     pub removed_backups: bool,
+    /// Whether the language's query directory is gone — removed by this call or
+    /// already absent when it started. Distinct from `removed_queries`, which
+    /// only says whether *this* call did the removing: a caller deciding
+    /// whether it may now remove the parser needs the state, not the action.
+    pub queries_absent: bool,
 }
 
 impl QueryRemoval {
@@ -1135,6 +1153,7 @@ pub fn remove_query_install_and_backups(
     let mut removal = QueryRemoval {
         removed_queries: false,
         removed_backups: false,
+        queries_absent: false,
     };
     match remove_query_install_and_backups_inner(lock, &mut removal) {
         Ok(()) => Ok(removal),
@@ -1175,6 +1194,9 @@ fn remove_query_install_and_backups_inner(
     // installed" over a still-present unreadable dir. The tolerant removal
     // reports whether anything was actually removed.
     removal.removed_queries = remove_dir_all_tolerating_vanished(&queries_dir)?;
+    // Either branch of that call leaves the directory gone; anything else
+    // returned an error above.
+    removal.queries_absent = true;
 
     // Propagate per-entry read_dir errors: uninstall must not report success
     // while backups it could not even enumerate stay behind.
@@ -2143,6 +2165,39 @@ mod staging_tests {
                 LanguageLockProbe::Idle(_)
             ),
             "and the lock it took must be free again"
+        );
+    }
+
+    /// A query file that exists but cannot be read is not the same as a
+    /// language with no parents: answering "no parents" would let a caller call
+    /// the chain complete on a file it never saw.
+    #[test]
+    #[cfg(unix)]
+    fn an_unreadable_query_file_makes_the_chain_undecidable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let queries_dir = temp.path().join("queries").join("child");
+        fs::create_dir_all(&queries_dir).unwrap();
+        fs::write(queries_dir.join("highlights.scm"), "(x) @y\n").unwrap();
+        write_install_marker(&queries_dir).unwrap();
+        let injections = queries_dir.join("injections.scm");
+        fs::write(&injections, "; inherits: parent\n").unwrap();
+        let mut permissions = fs::metadata(&injections).unwrap().permissions();
+        permissions.set_mode(0o000);
+        fs::set_permissions(&injections, permissions).unwrap();
+
+        let parents = inherited_languages_on_disk(&queries_dir);
+        let chained = lock_complete_chain(temp.path(), "child").is_some();
+
+        // Restore before asserting so a failure cannot leave the file locked.
+        let mut permissions = fs::metadata(&injections).unwrap().permissions();
+        permissions.set_mode(0o600);
+        fs::set_permissions(&injections, permissions).unwrap();
+        assert!(parents.is_none(), "an unreadable kind hides its parents");
+        assert!(
+            !chained,
+            "so the chain cannot be called complete on the strength of it"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -1111,6 +1111,7 @@ pub fn recover_interrupted_query_installs(queries_parent: &Path) -> Result<(), Q
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct QueryRemoval {
     pub removed_queries: bool,
     pub removed_backups: bool,
@@ -1130,7 +1131,37 @@ impl QueryRemoval {
 /// the lock is what an install waits on.
 pub fn remove_query_install_and_backups(
     lock: &LanguageLock,
-) -> Result<QueryRemoval, QueryInstallError> {
+) -> Result<QueryRemoval, QueryRemovalFailure> {
+    let mut removal = QueryRemoval {
+        removed_queries: false,
+        removed_backups: false,
+    };
+    match remove_query_install_and_backups_inner(lock, &mut removal) {
+        Ok(()) => Ok(removal),
+        // The caller decides what to do next from how far this got — leaving a
+        // parser beside queries that *are* gone is the half-removed language
+        // the whole path avoids, so the progress travels with the error.
+        Err(error) => Err(QueryRemovalFailure { error, removal }),
+    }
+}
+
+/// A removal that failed, and how much of it had already happened.
+#[derive(Debug)]
+pub struct QueryRemovalFailure {
+    pub error: QueryInstallError,
+    pub removal: QueryRemoval,
+}
+
+impl std::fmt::Display for QueryRemovalFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.error)
+    }
+}
+
+fn remove_query_install_and_backups_inner(
+    lock: &LanguageLock,
+    removal: &mut QueryRemoval,
+) -> Result<(), QueryInstallError> {
     let queries_parent = lock.queries_parent.as_path();
     let language = lock.language.as_str();
     validate_safe_language_name(language)?;
@@ -1138,10 +1169,6 @@ pub fn remove_query_install_and_backups(
     let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
     write_uninstall_tombstone(queries_parent, language)?;
     let queries_dir = queries_parent.join(language);
-    let mut removal = QueryRemoval {
-        removed_queries: false,
-        removed_backups: false,
-    };
 
     // No exists() pre-check: Path::exists() reads false on metadata errors
     // (e.g. PermissionDenied), which would skip removal and report "not
@@ -1183,7 +1210,7 @@ pub fn remove_query_install_and_backups(
             }
         }
     }
-    Ok(removal)
+    Ok(())
 }
 
 /// `fs::remove_dir_all` that treats a CONFIRMED-vanished directory as the
@@ -1405,9 +1432,17 @@ fn collect_superseded_backups(
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(e) => return Err(QueryInstallError::IoError(e)),
     };
-    for entry in entries.flatten() {
+    for entry in entries {
+        // Propagated, not skipped: a sweep that reports success over entries it
+        // could not even read is how residue it never saw becomes permanent.
+        let entry = entry.map_err(QueryInstallError::IoError)?;
         let path = entry.path();
-        if !path.is_dir() || !backup_is_owned(&path) {
+        if !entry
+            .file_type()
+            .map_err(QueryInstallError::IoError)?
+            .is_dir()
+            || !backup_is_owned(&path)
+        {
             continue;
         }
         let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
@@ -2582,12 +2617,11 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let queries_parent = temp.path().join("queries");
 
-        let result = lock_language(temp.path(), "a/../../victim")
-            .map(|lock| remove_query_install_and_backups(&lock))
-            .and_then(|result| result);
+        // The lock itself refuses the name, so removal is never reached.
+        let locked = lock_language(temp.path(), "a/../../victim");
 
         assert!(
-            matches!(result, Err(QueryInstallError::InvalidLanguageName(_))),
+            matches!(locked, Err(QueryInstallError::InvalidLanguageName(_))),
             "unsafe language must be rejected before cleanup paths are derived"
         );
         assert!(

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -24,6 +24,9 @@ const QUERY_HTTP_TIMEOUT: Duration = Duration::from_secs(60);
 const QUERY_INSTALL_COMPLETE_MARKER: &str = ".kakehashi-install-complete";
 const QUERY_BACKUP_OWNERSHIP_MARKER: &str = ".kakehashi-backup";
 const QUERY_UNINSTALL_TOMBSTONE_SUFFIX: &str = ".uninstalled";
+/// Suffix of the per-language lock that orders a whole install against a whole
+/// uninstall. Distinct from the per-directory replace lock (`.replace.lock`).
+const LANGUAGE_LOCK_SUFFIX: &str = ".language.lock";
 
 static QUERY_TMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
@@ -1167,45 +1170,55 @@ fn collect_superseded_backups(
     Ok(())
 }
 
-/// Hold the language's replace lock and report whether an uninstall claimed it.
+/// Serialize one language's install against another install or an uninstall.
 ///
-/// The parser half has no lock of its own, so an install that published its
-/// queries and then took minutes to compile could publish a parser for a
-/// language `language uninstall` had removed in the meantime — leaving the
-/// parser-only state the uninstall reported as gone. Checking the tombstone
-/// under this lock, and keeping the lock until the parser rename is done,
-/// serializes the two: uninstall removes the queries and writes the tombstone
-/// under the same lock, and removes the parser after.
-pub(crate) fn hold_against_uninstall(
-    data_dir: &Path,
-    language: &str,
-) -> Result<UninstallClaim, QueryInstallError> {
+/// The per-directory replace lock covers a single query directory, so it cannot
+/// order the two artifacts a language is made of. Without something wider, an
+/// uninstall that removed the queries and then the parser could interleave with
+/// an install that published them in the same order, and both would report
+/// success over a half-removed language; two forced installs could likewise
+/// cross and leave one's parser beside the other's queries.
+///
+/// Held by an install from before it publishes anything until it commits, and
+/// by an uninstall across both removals. It is a different file from the
+/// replace lock — the operations it covers take that one underneath, and
+/// `flock` blocks a second descriptor even within one process.
+pub fn lock_language(data_dir: &Path, language: &str) -> Result<LanguageLock, QueryInstallError> {
     validate_safe_language_name(language)?;
-    let queries_parent = data_dir.join("queries");
     // The lock lives beside the query directories, so the directory has to
-    // exist to take it. Staging already created it; this only covers a caller
+    // exist to take it. Staging already created it; this also covers a caller
     // that skipped straight here.
+    let queries_parent = data_dir.join("queries");
     fs::create_dir_all(&queries_parent)?;
-    let guard = QueryReplaceLockGuard::acquire(&queries_parent, language)?;
-    if uninstall_tombstone_path(&queries_parent, language).is_file() {
-        return Ok(UninstallClaim::Uninstalled);
+    let path = queries_parent.join(format!(".{}{}", language, LANGUAGE_LOCK_SUFFIX));
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(path)?;
+    file.lock()?;
+    Ok(LanguageLock {
+        _file: file,
+        queries_parent,
+        language: language.to_string(),
+    })
+}
+
+/// Exclusive claim on one language's artifacts. See [`lock_language`].
+pub struct LanguageLock {
+    _file: fs::File,
+    queries_parent: PathBuf,
+    language: String,
+}
+
+impl LanguageLock {
+    /// Whether an uninstall claimed this language before the lock was taken.
+    ///
+    /// Publishing over that would resurrect half of what the user removed, so
+    /// an install that sees it gives up instead.
+    pub fn language_was_uninstalled(&self) -> bool {
+        uninstall_tombstone_path(&self.queries_parent, &self.language).is_file()
     }
-    Ok(UninstallClaim::Clear(UninstallGuard { _lock: guard }))
-}
-
-/// Whether an uninstall has claimed a language.
-pub(crate) enum UninstallClaim {
-    /// It has not, and will not while the guard is held.
-    Clear(UninstallGuard),
-    /// An uninstall removed this language; publishing anything for it now would
-    /// resurrect half of what the user removed.
-    Uninstalled,
-}
-
-/// Proof that no uninstall has claimed the language, held for as long as the
-/// caller needs the answer to stay true.
-pub(crate) struct UninstallGuard {
-    _lock: QueryReplaceLockGuard,
 }
 
 fn uninstall_tombstone_path(queries_parent: &Path, language: &str) -> PathBuf {
@@ -1454,14 +1467,14 @@ mod staging_tests {
 
     /// Entries under `queries/` that an install is expected to leave behind.
     ///
-    /// The per-language replace locks are long-lived by design: they serialize
+    /// The per-language locks are long-lived by design: they serialize
     /// concurrent installers and are reused, so they are not install residue.
     fn residue(queries_parent: &Path) -> Vec<String> {
         let mut names: Vec<String> = fs::read_dir(queries_parent)
             .expect("read queries parent")
             .flatten()
             .map(|entry| entry.file_name().to_string_lossy().into_owned())
-            .filter(|name| !name.ends_with(".replace.lock"))
+            .filter(|name| !name.ends_with(".lock"))
             .collect();
         names.sort();
         names
@@ -1946,36 +1959,28 @@ mod tests {
         );
     }
 
-    /// The parser half has no lock of its own, so this is what keeps an
-    /// install from publishing a parser for a language the user just removed.
+    /// The language lock is what keeps an install from publishing over a
+    /// language the user removed while it was compiling.
     #[test]
-    fn a_tombstoned_language_is_reported_as_uninstalled() {
+    fn a_locked_language_reports_a_concurrent_uninstall() {
         let temp = TempDir::new().unwrap();
         let data_dir = temp.path();
-        let queries_parent = data_dir.join("queries");
-        fs::create_dir_all(&queries_parent).unwrap();
-        write_uninstall_tombstone(&queries_parent, "lua").unwrap();
 
-        assert!(matches!(
-            hold_against_uninstall(data_dir, "lua").unwrap(),
-            UninstallClaim::Uninstalled
-        ));
-    }
+        let lock = lock_language(data_dir, "lua").unwrap();
+        assert!(
+            !lock.language_was_uninstalled(),
+            "an untouched language is not uninstalled"
+        );
+        drop(lock);
 
-    #[test]
-    fn an_untouched_language_is_held_clear_of_uninstall() {
-        let temp = TempDir::new().unwrap();
-
-        let claim = hold_against_uninstall(temp.path(), "lua").unwrap();
-
-        assert!(matches!(claim, UninstallClaim::Clear(_)));
-        drop(claim);
-        // The guard is released, so a second caller can take it in turn — a
+        write_uninstall_tombstone(&data_dir.join("queries"), "lua").unwrap();
+        // Re-taking the lock also proves the previous guard released it; a
         // guard that outlived its scope would hang here instead.
-        assert!(matches!(
-            hold_against_uninstall(temp.path(), "lua").unwrap(),
-            UninstallClaim::Clear(_)
-        ));
+        assert!(
+            lock_language(data_dir, "lua")
+                .unwrap()
+                .language_was_uninstalled()
+        );
     }
 
     /// A live directory that is merely present is not proof the backup is
@@ -2263,7 +2268,7 @@ mod tests {
             .map(|entry| entry.file_name().to_string_lossy().into_owned())
             // The per-language replace locks are reused infrastructure, not
             // install residue.
-            .filter(|name| !name.ends_with(".replace.lock"))
+            .filter(|name| !name.ends_with(".lock"))
             .collect();
         assert!(
             leftovers.is_empty(),

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -908,6 +908,13 @@ fn stage_queries_recursive(
         return Ok(StageOutcome::NothingToDo);
     }
 
+    // Clear any uninstall tombstone here rather than at the call sites, so a
+    // language the graph reaches twice — a cycle, or two languages sharing a
+    // base — is cleared once. A second clear on the revisit would erase a
+    // marker written by an uninstall that completed in between, and the
+    // transaction would then republish what that uninstall had removed.
+    clear_uninstall_tombstone_for_dependency(data_dir, language)?;
+
     let queries_dir = data_dir.join("queries").join(language);
     let queries_parent = data_dir.join("queries");
     fs::create_dir_all(&queries_parent)?;
@@ -931,7 +938,6 @@ fn stage_queries_recursive(
         })?;
         for parent in parents {
             // Stage parent dependencies (don't force, just ensure they exist)
-            clear_uninstall_tombstone_for_dependency(data_dir, &parent)?;
             stage_queries_recursive(
                 base_url,
                 &parent,
@@ -1017,7 +1023,6 @@ fn stage_queries_recursive(
     // inherits.
     for parent in parents_to_install {
         eprintln!("Staging inherited queries: {}", parent);
-        clear_uninstall_tombstone_for_dependency(data_dir, &parent)?;
         stage_queries_recursive(
             base_url,
             &parent,

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -854,7 +854,7 @@ fn stage_queries_recursive(
         // Even if skipping, we need to check for inherited dependencies
         for parent in inherited_languages_on_disk(&queries_dir) {
             // Stage parent dependencies (don't force, just ensure they exist)
-            clear_uninstall_tombstone(&queries_parent, &parent)?;
+            clear_uninstall_tombstone_for_dependency(data_dir, &parent)?;
             stage_queries_recursive(
                 base_url,
                 &parent,
@@ -940,7 +940,7 @@ fn stage_queries_recursive(
     // inherits.
     for parent in parents_to_install {
         eprintln!("Staging inherited queries: {}", parent);
-        clear_uninstall_tombstone(&queries_parent, &parent)?;
+        clear_uninstall_tombstone_for_dependency(data_dir, &parent)?;
         stage_queries_recursive(
             base_url,
             &parent,
@@ -1516,6 +1516,26 @@ fn clear_uninstall_tombstone(
     }
 }
 
+/// Clear a base language's uninstall tombstone while holding that language's
+/// lock.
+///
+/// Staging clears the tombstone of every base language it is about to fetch, so
+/// the later publish is not refused by a marker left by an old uninstall. Doing
+/// it without the language's own lock let it land *inside* a running
+/// `language uninstall` — between the marker that uninstall writes and the
+/// parser it removes — after which the uninstall reported success while this
+/// install went on to republish what it had just removed. Taking the lock orders
+/// the two: either the uninstall finishes first and this install knowingly
+/// refetches the base language it needs, or it supersedes this install through
+/// the tombstone check the publish makes under the same lock.
+fn clear_uninstall_tombstone_for_dependency(
+    data_dir: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    let _transaction = lock_language(data_dir, language)?;
+    clear_uninstall_tombstone(&data_dir.join("queries"), language)
+}
+
 pub fn clear_uninstall_tombstone_for_install(
     data_dir: &Path,
     language: &str,
@@ -1949,6 +1969,32 @@ mod staging_tests {
         }
 
         assert!(query_install_chain_is_complete(&queries_parent, "cyc_a"));
+    }
+
+    /// Clearing a base language's tombstone goes through that language's own
+    /// lock, so it cannot land inside a running uninstall of it. The lock is
+    /// released again, or the staging that follows would block on itself.
+    #[test]
+    fn clearing_a_dependency_tombstone_takes_and_releases_its_lock() {
+        let temp = TempDir::new().unwrap();
+        let data_dir = temp.path();
+        let queries_parent = data_dir.join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        write_uninstall_tombstone(&queries_parent, "parent").unwrap();
+
+        clear_uninstall_tombstone_for_dependency(data_dir, "parent").unwrap();
+
+        assert!(
+            !uninstall_tombstone_path(&queries_parent, "parent").is_file(),
+            "the tombstone must be gone"
+        );
+        assert!(
+            matches!(
+                try_lock_language(data_dir, "parent"),
+                LanguageLockProbe::Idle(_)
+            ),
+            "and the lock it took must be free again"
+        );
     }
 
     /// A data directory nothing can write to has nothing in flight either, so

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -1778,6 +1778,15 @@ fn write_backup_ownership_marker(backup_dir: &Path) -> Result<(), QueryInstallEr
 }
 
 #[cfg(test)]
+/// [`write_uninstall_tombstone`] for tests in sibling modules.
+#[cfg(test)]
+pub(crate) fn write_uninstall_tombstone_for_tests(
+    queries_parent: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    write_uninstall_tombstone(queries_parent, language)
+}
+
 pub(crate) fn write_install_marker_for_tests(queries_dir: &Path) -> Result<(), QueryInstallError> {
     write_install_marker(queries_dir)
 }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -1167,6 +1167,47 @@ fn collect_superseded_backups(
     Ok(())
 }
 
+/// Hold the language's replace lock and report whether an uninstall claimed it.
+///
+/// The parser half has no lock of its own, so an install that published its
+/// queries and then took minutes to compile could publish a parser for a
+/// language `language uninstall` had removed in the meantime — leaving the
+/// parser-only state the uninstall reported as gone. Checking the tombstone
+/// under this lock, and keeping the lock until the parser rename is done,
+/// serializes the two: uninstall removes the queries and writes the tombstone
+/// under the same lock, and removes the parser after.
+pub(crate) fn hold_against_uninstall(
+    data_dir: &Path,
+    language: &str,
+) -> Result<UninstallClaim, QueryInstallError> {
+    validate_safe_language_name(language)?;
+    let queries_parent = data_dir.join("queries");
+    // The lock lives beside the query directories, so the directory has to
+    // exist to take it. Staging already created it; this only covers a caller
+    // that skipped straight here.
+    fs::create_dir_all(&queries_parent)?;
+    let guard = QueryReplaceLockGuard::acquire(&queries_parent, language)?;
+    if uninstall_tombstone_path(&queries_parent, language).is_file() {
+        return Ok(UninstallClaim::Uninstalled);
+    }
+    Ok(UninstallClaim::Clear(UninstallGuard { _lock: guard }))
+}
+
+/// Whether an uninstall has claimed a language.
+pub(crate) enum UninstallClaim {
+    /// It has not, and will not while the guard is held.
+    Clear(UninstallGuard),
+    /// An uninstall removed this language; publishing anything for it now would
+    /// resurrect half of what the user removed.
+    Uninstalled,
+}
+
+/// Proof that no uninstall has claimed the language, held for as long as the
+/// caller needs the answer to stay true.
+pub(crate) struct UninstallGuard {
+    _lock: QueryReplaceLockGuard,
+}
+
 fn uninstall_tombstone_path(queries_parent: &Path, language: &str) -> PathBuf {
     queries_parent.join(format!(".{language}{QUERY_UNINSTALL_TOMBSTONE_SUFFIX}"))
 }
@@ -1903,6 +1944,38 @@ mod tests {
             "published",
             "collecting a backup must not disturb the live queries"
         );
+    }
+
+    /// The parser half has no lock of its own, so this is what keeps an
+    /// install from publishing a parser for a language the user just removed.
+    #[test]
+    fn a_tombstoned_language_is_reported_as_uninstalled() {
+        let temp = TempDir::new().unwrap();
+        let data_dir = temp.path();
+        let queries_parent = data_dir.join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        write_uninstall_tombstone(&queries_parent, "lua").unwrap();
+
+        assert!(matches!(
+            hold_against_uninstall(data_dir, "lua").unwrap(),
+            UninstallClaim::Uninstalled
+        ));
+    }
+
+    #[test]
+    fn an_untouched_language_is_held_clear_of_uninstall() {
+        let temp = TempDir::new().unwrap();
+
+        let claim = hold_against_uninstall(temp.path(), "lua").unwrap();
+
+        assert!(matches!(claim, UninstallClaim::Clear(_)));
+        drop(claim);
+        // The guard is released, so a second caller can take it in turn — a
+        // guard that outlived its scope would hang here instead.
+        assert!(matches!(
+            hold_against_uninstall(temp.path(), "lua").unwrap(),
+            UninstallClaim::Clear(_)
+        ));
     }
 
     /// A live directory that is merely present is not proof the backup is

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -216,11 +216,13 @@ pub fn install_queries_with_dependencies(
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
-    // Half of a language on its own, but still inside the transaction protocol:
-    // an unlocked publish here could land between the two halves of an install
-    // or an uninstall running in another process.
-    let _transaction = lock_language(data_dir, language)?;
-    clear_uninstall_tombstone_for_install(data_dir, language)?;
+    // Half of a language on its own, but still inside the transaction protocol.
+    // The clear takes the lock and gives it back before staging, exactly as a
+    // whole-language install does; the publish below takes one per dependency.
+    {
+        let _transaction = lock_language(data_dir, language)?;
+        clear_uninstall_tombstone_for_install(data_dir, language)?;
+    }
     install_queries_with_dependencies_from_with_http_policy(
         NVIM_TREESITTER_QUERIES_URL,
         language,
@@ -322,6 +324,22 @@ fn install_queries_with_dependencies_from_with_http_policy(
     http_policy: QueryHttpPolicy,
 ) -> Result<QueryInstallResult, QueryInstallError> {
     let staged = stage_queries_with_dependencies(base_url, language, data_dir, force, http_policy)?;
+    // One lock per language this install depends on, in the sorted order
+    // `dependencies()` returns, so publishing a base language cannot interleave
+    // with an install or uninstall of that language elsewhere.
+    let transaction = lock_languages(data_dir, staged.dependencies())?;
+    if transaction
+        .iter()
+        .any(LanguageLock::language_was_uninstalled)
+    {
+        return Err(QueryInstallError::IoError(std::io::Error::new(
+            std::io::ErrorKind::Interrupted,
+            format!("Query install for {language} was superseded by uninstall"),
+        )));
+    }
+    if let Some(missing) = staged.missing_skipped_dependency() {
+        return Err(QueryInstallError::LanguageNotSupported(missing.to_string()));
+    }
     match staged.publish()?.commit() {
         CommittedQueryInstall::Installed(result) => Ok(result),
         // The `install_queries_*` entry points predate staging and report an

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -728,7 +728,7 @@ pub fn query_install_is_complete(queries_dir: &Path) -> bool {
 
 /// RAII cleanup for a staging directory: removes it on drop so every error
 /// path (including `?` propagation added later) leaves nothing stranded. On
-/// the success path `replace_query_dir` renames the directory away, making
+/// the success path `publish_query_dir` renames the directory away, making
 /// the drop-time removal a harmless no-op.
 struct TempQueryDirGuard {
     path: PathBuf,

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -1777,7 +1777,6 @@ fn write_backup_ownership_marker(backup_dir: &Path) -> Result<(), QueryInstallEr
     Ok(())
 }
 
-#[cfg(test)]
 /// [`write_uninstall_tombstone`] for tests in sibling modules.
 #[cfg(test)]
 pub(crate) fn write_uninstall_tombstone_for_tests(
@@ -1787,6 +1786,7 @@ pub(crate) fn write_uninstall_tombstone_for_tests(
     write_uninstall_tombstone(queries_parent, language)
 }
 
+#[cfg(test)]
 pub(crate) fn write_install_marker_for_tests(queries_dir: &Path) -> Result<(), QueryInstallError> {
     write_install_marker(queries_dir)
 }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -1759,6 +1759,53 @@ mod tests {
         );
     }
 
+    /// Re-running an install is how a user repairs a language whose inherited
+    /// queries went missing (the documented fix for TypeScript/JavaScript), so
+    /// an already-complete language must still pull in the parents it is
+    /// missing — without `--force`, and without touching its own files.
+    #[test]
+    fn installing_a_complete_language_still_repairs_a_missing_parent() {
+        let temp_dir = TempDir::new().unwrap();
+        let data_dir = temp_dir.path().to_path_buf();
+        let child_dir = data_dir.join("queries").join("complete_child");
+        fs::create_dir_all(&child_dir).unwrap();
+        fs::write(
+            child_dir.join("highlights.scm"),
+            "; inherits: absent_parent\n(identifier) @variable\n",
+        )
+        .unwrap();
+        write_install_marker(&child_dir).unwrap();
+        let base_url = spawn_query_file_server(vec![(
+            "/absent_parent/highlights.scm",
+            "(comment) @comment\n",
+        )]);
+
+        let result = install_queries_with_dependencies_from_allowing_http_for_tests(
+            &base_url,
+            "complete_child",
+            &data_dir,
+            false,
+        );
+
+        assert!(
+            matches!(result, Err(QueryInstallError::AlreadyExists(path)) if path == child_dir),
+            "the requested language was already installed"
+        );
+        assert!(
+            data_dir
+                .join("queries")
+                .join("absent_parent")
+                .join("highlights.scm")
+                .exists(),
+            "the missing parent must be installed by the re-run"
+        );
+        assert_eq!(
+            fs::read_to_string(child_dir.join("highlights.scm")).unwrap(),
+            "; inherits: absent_parent\n(identifier) @variable\n",
+            "repairing a parent must not rewrite the language's own queries"
+        );
+    }
+
     #[test]
     fn install_preserves_legacy_non_marker_query_dir_without_force() {
         let temp_dir = TempDir::new().unwrap();

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -334,6 +334,23 @@ pub(crate) struct PublishedQueryInstall {
 }
 
 impl StagedQueryInstall {
+    /// Publish the requested language's queries even if a copy appeared since
+    /// staging.
+    ///
+    /// Yielding to a concurrent winner is right when this install is not
+    /// publishing a parser either — the whole language stays that install's.
+    /// But when this one publishes the parser, its queries have to come with
+    /// it: an install of a *different* language that inherits this one can
+    /// publish these queries without holding this language's lock, and the pair
+    /// would then be one install's grammar beside another's queries.
+    pub(crate) fn claim_requested_language(&mut self) {
+        for entry in &mut self.entries {
+            if entry.language == self.language {
+                entry.force = true;
+            }
+        }
+    }
+
     /// Whether the requested language's queries are still where staging left
     /// them.
     ///
@@ -888,10 +905,17 @@ impl QueryRemoval {
     }
 }
 
+/// Remove a language's queries and every backup kakehashi made of them.
+///
+/// Takes the [`LanguageLock`] rather than a path and a name so the transaction
+/// protocol is enforced by the signature: removing one half while an install is
+/// between its two publishes is exactly how a language ends up parser-only, and
+/// the lock is what an install waits on.
 pub fn remove_query_install_and_backups(
-    queries_parent: &Path,
-    language: &str,
+    lock: &LanguageLock,
 ) -> Result<QueryRemoval, QueryInstallError> {
+    let queries_parent = lock.queries_parent.as_path();
+    let language = lock.language.as_str();
     validate_safe_language_name(language)?;
     fs::create_dir_all(queries_parent)?;
     let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
@@ -1971,7 +1995,9 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let queries_parent = temp.path().join("queries");
 
-        let result = remove_query_install_and_backups(&queries_parent, "a/../../victim");
+        let result = lock_language(temp.path(), "a/../../victim")
+            .map(|lock| remove_query_install_and_backups(&lock))
+            .and_then(|result| result);
 
         assert!(
             matches!(result, Err(QueryInstallError::InvalidLanguageName(_))),

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -310,6 +310,13 @@ pub(crate) struct StagedQueryInstall {
     /// missing parents (if any) were staged.
     requested_already_complete: bool,
     entries: Vec<StagedQueryDir>,
+    /// Every language this install needs on disk — the requested one and its
+    /// whole `; inherits:` chain, whether staged or found already complete.
+    /// Sorted, so locking them in this order cannot deadlock against another
+    /// install locking an overlapping set.
+    dependencies: Vec<String>,
+    /// Where those languages live, for the completeness re-check.
+    queries_parent: PathBuf,
 }
 
 /// A query directory that has been renamed into place, with the directory it
@@ -351,17 +358,34 @@ impl StagedQueryInstall {
         }
     }
 
-    /// Whether the requested language's queries are still where staging left
-    /// them.
+    /// Languages this install needs to lock before publishing: the requested
+    /// one and every language it reaches through `; inherits:`, sorted.
+    pub(crate) fn dependencies(&self) -> &[String] {
+        &self.dependencies
+    }
+
+    /// The first language staging skipped as already complete whose queries are
+    /// no longer there.
     ///
-    /// Staging skips a language whose queries are already complete, so there is
-    /// no staged copy to publish and nothing that would notice them
-    /// disappearing. An uninstall between staging and publication would
-    /// otherwise leave the install publishing a parser and reporting success
-    /// over queries that are gone. Callers check this once they hold the lock
-    /// that keeps the answer true.
-    pub(crate) fn requested_queries_still_complete(&self) -> bool {
-        !self.requested_already_complete || query_install_is_complete(&self.install_path)
+    /// Staging does not copy a language whose queries are already complete, so
+    /// there is no staged copy to publish and nothing in the publish that would
+    /// notice them disappearing. An uninstall between staging and publication
+    /// would otherwise leave this install reporting success over a language
+    /// whose own queries — or a base language it inherits — are gone. Callers
+    /// check this once they hold the locks that keep the answer true.
+    pub(crate) fn missing_skipped_dependency(&self) -> Option<&str> {
+        self.dependencies
+            .iter()
+            .filter(|language| {
+                !self
+                    .entries
+                    .iter()
+                    .any(|entry| &&entry.language == language)
+            })
+            .find(|language| {
+                !query_install_is_complete(&self.queries_parent.join(language.as_str()))
+            })
+            .map(String::as_str)
     }
 
     /// Rename every staged directory into place, keeping the displaced
@@ -373,6 +397,8 @@ impl StagedQueryInstall {
             files_downloaded,
             requested_already_complete,
             entries,
+            dependencies: _,
+            queries_parent: _,
         } = self;
         let mut publish = PublishedQueryInstall {
             install_path,
@@ -634,6 +660,8 @@ fn stage_queries_with_dependencies(
     http_policy: QueryHttpPolicy,
 ) -> Result<StagedQueryInstall, QueryInstallError> {
     let mut entries = Vec::new();
+    // Every language the recursion visits, staged or already complete: the set
+    // this install needs to still be there when it publishes.
     let mut staged = std::collections::HashSet::new();
     // On any error the entries collected so far are dropped here, and with them
     // every staging directory: a failed install publishes nothing.
@@ -650,12 +678,16 @@ fn stage_queries_with_dependencies(
         StageOutcome::Staged { files_downloaded } => (files_downloaded, false),
         StageOutcome::NothingToDo => (Vec::new(), true),
     };
+    let mut dependencies: Vec<String> = staged.into_iter().collect();
+    dependencies.sort();
     Ok(StagedQueryInstall {
         language: language.to_string(),
         install_path: data_dir.join("queries").join(language),
         files_downloaded,
         requested_already_complete,
         entries,
+        dependencies,
+        queries_parent: data_dir.join("queries"),
     })
 }
 
@@ -1241,6 +1273,27 @@ pub fn lock_language(data_dir: &Path, language: &str) -> Result<LanguageLock, Qu
     })
 }
 
+/// Take [`lock_language`] for every language an install depends on.
+///
+/// `languages` must be sorted: two installs whose dependency sets overlap
+/// acquire the shared locks in the same order, so they queue instead of
+/// deadlocking. Holding the parents' locks too is what stops an install of one
+/// language from publishing over — or uninstalling — a base language another
+/// install has already decided to rely on.
+pub(crate) fn lock_languages(
+    data_dir: &Path,
+    languages: &[String],
+) -> Result<Vec<LanguageLock>, QueryInstallError> {
+    debug_assert!(
+        languages.windows(2).all(|pair| pair[0] <= pair[1]),
+        "dependency locks must be acquired in sorted order"
+    );
+    languages
+        .iter()
+        .map(|language| lock_language(data_dir, language))
+        .collect()
+}
+
 /// Exclusive claim on one language's artifacts. See [`lock_language`].
 pub struct LanguageLock {
     _file: fs::File,
@@ -1547,6 +1600,8 @@ mod staging_tests {
                 stage(&queries_parent, "child", "; inherits: parent\n", false),
                 stage(&queries_parent, "parent", "(comment) @comment\n", false),
             ],
+            dependencies: vec!["child".to_string(), "parent".to_string()],
+            queries_parent: queries_parent.clone(),
         };
 
         drop(staged);
@@ -1576,6 +1631,8 @@ mod staging_tests {
             files_downloaded: vec!["highlights.scm".to_string()],
             requested_already_complete: false,
             entries: vec![stage(&queries_parent, "child", "replacement", true)],
+            dependencies: Vec::new(),
+            queries_parent: queries_parent.clone(),
         };
 
         let published = staged.publish().expect("publish should succeed");
@@ -1619,6 +1676,8 @@ mod staging_tests {
                 stage(&queries_parent, "child", "; inherits: parent\n", false),
                 stage(&queries_parent, "parent", "(comment) @comment\n", false),
             ],
+            dependencies: vec!["child".to_string(), "parent".to_string()],
+            queries_parent: queries_parent.clone(),
         };
 
         staged.publish().expect("publish should succeed").rollback();
@@ -1651,6 +1710,8 @@ mod staging_tests {
             files_downloaded: vec!["highlights.scm".to_string()],
             requested_already_complete: false,
             entries: vec![stage(&queries_parent, "child", "replacement", true)],
+            dependencies: Vec::new(),
+            queries_parent: queries_parent.clone(),
         };
 
         drop(staged.publish().expect("publish should succeed"));
@@ -1670,7 +1731,7 @@ mod staging_tests {
     /// Staging does not copy queries it found complete, so nothing else would
     /// notice an uninstall removing them before the publish.
     #[test]
-    fn a_skipped_requested_language_is_rechecked() {
+    fn a_skipped_dependency_is_rechecked() {
         let temp = TempDir::new().unwrap();
         let queries_parent = temp.path().join("queries");
         let queries_dir = queries_parent.join("child");
@@ -1683,13 +1744,45 @@ mod staging_tests {
             files_downloaded: Vec::new(),
             requested_already_complete: true,
             entries: Vec::new(),
+            dependencies: vec!["child".to_string()],
+            queries_parent: queries_parent.clone(),
         };
 
-        assert!(staged.requested_queries_still_complete());
+        assert_eq!(staged.missing_skipped_dependency(), None);
         fs::remove_dir_all(&queries_dir).unwrap();
-        assert!(
-            !staged.requested_queries_still_complete(),
+        assert_eq!(
+            staged.missing_skipped_dependency(),
+            Some("child"),
             "queries removed after staging must not pass as already installed"
+        );
+    }
+
+    /// A base language the requested one inherits counts too: staging skipped
+    /// it because it was complete, and losing it leaves a dangling
+    /// `; inherits:` behind an install that reported success.
+    #[test]
+    fn a_skipped_inherited_parent_is_rechecked() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let staged = StagedQueryInstall {
+            language: "child".to_string(),
+            install_path: queries_parent.join("child"),
+            files_downloaded: vec!["highlights.scm".to_string()],
+            requested_already_complete: false,
+            entries: vec![stage(
+                &queries_parent,
+                "child",
+                "; inherits: parent\n",
+                false,
+            )],
+            dependencies: vec!["child".to_string(), "parent".to_string()],
+            queries_parent: queries_parent.clone(),
+        };
+
+        assert_eq!(
+            staged.missing_skipped_dependency(),
+            Some("parent"),
+            "a base language that is neither staged nor on disk must be caught"
         );
     }
 
@@ -1705,9 +1798,11 @@ mod staging_tests {
             files_downloaded: vec!["highlights.scm".to_string()],
             requested_already_complete: false,
             entries: vec![stage(&queries_parent, "child", "staged", false)],
+            dependencies: vec!["child".to_string()],
+            queries_parent: queries_parent.clone(),
         };
 
-        assert!(staged.requested_queries_still_complete());
+        assert_eq!(staged.missing_skipped_dependency(), None);
     }
 
     /// `--force` replaces the requested language, not the base languages it
@@ -1728,6 +1823,8 @@ mod staging_tests {
                 stage(&queries_parent, "child", "; inherits: parent\n", true),
                 stage(&queries_parent, "parent", "ours", false),
             ],
+            dependencies: vec!["child".to_string(), "parent".to_string()],
+            queries_parent: queries_parent.clone(),
         };
         // The parent appears while this install is busy with the parser.
         fs::create_dir_all(&parent_dir).unwrap();
@@ -1772,6 +1869,8 @@ mod staging_tests {
                 stage(&queries_parent, "child", "replacement", true),
                 stage(&queries_parent, "parent", "(comment) @comment\n", false),
             ],
+            dependencies: Vec::new(),
+            queries_parent: queries_parent.clone(),
         };
         write_uninstall_tombstone(&queries_parent, "parent").unwrap();
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -92,7 +92,8 @@ impl std::fmt::Display for QueryInstallError {
             Self::DependencyRemoved(language) => {
                 write!(
                     f,
-                    "The installed queries for '{}' were removed while it was being installed",
+                    "The queries installed for '{}' were removed or replaced while it was being \
+                     installed",
                     language
                 )
             }
@@ -399,8 +400,8 @@ fn install_queries_with_dependencies_from_with_http_policy(
             format!("Query install for {language} was superseded by uninstall"),
         )));
     }
-    if let Some(missing) = staged.missing_skipped_dependency() {
-        return Err(QueryInstallError::DependencyRemoved(missing.to_string()));
+    if let Some(unstable) = staged.unstable_skipped_dependency() {
+        return Err(QueryInstallError::DependencyRemoved(unstable.to_string()));
     }
     let published = staged.publish().map_err(|failure| failure.error)?;
     match published.commit() {
@@ -510,28 +511,42 @@ impl StagedQueryInstall {
         &self.dependencies
     }
 
-    /// The first language staging skipped as already complete whose queries are
-    /// no longer there.
+    /// The first language staging skipped as already installed whose state has
+    /// moved since — its queries gone, unreadable, or now inheriting something
+    /// this install never discovered.
     ///
     /// Staging does not copy a language whose queries are already complete, so
     /// there is no staged copy to publish and nothing in the publish that would
-    /// notice them disappearing. An uninstall between staging and publication
-    /// would otherwise leave this install reporting success over a language
-    /// whose own queries — or a base language it inherits — are gone. Callers
-    /// check this once they hold the locks that keep the answer true.
-    pub(crate) fn missing_skipped_dependency(&self) -> Option<&str> {
-        self.dependencies
-            .iter()
-            .filter(|language| {
-                !self
-                    .entries
-                    .iter()
-                    .any(|entry| entry.language == **language)
-            })
-            .find(|language| {
-                !query_install_is_complete(&self.queries_parent.join(language.as_str()))
-            })
-            .map(String::as_str)
+    /// notice it changing. Without this, an uninstall or a forced reinstall
+    /// between staging and publication would leave this install reporting
+    /// success over a chain nobody was holding still. Callers check it once
+    /// they hold the locks that keep the answer true.
+    pub(crate) fn unstable_skipped_dependency(&self) -> Option<&str> {
+        for language in &self.dependencies {
+            if self.entries.iter().any(|entry| &entry.language == language) {
+                // Staged by this install: its publish re-checks it under the
+                // lock, and what it publishes is what this install downloaded.
+                continue;
+            }
+            let queries_dir = self.queries_parent.join(language);
+            if !query_install_is_complete(&queries_dir) {
+                return Some(language);
+            }
+            // A forced reinstall of this language by someone else can replace
+            // it with queries that inherit something new — a language this
+            // install never discovered, so never locked and never checked. The
+            // chain it publishes would then be one nobody is holding still.
+            let Some(parents) = inherited_languages_on_disk(&queries_dir) else {
+                return Some(language);
+            };
+            if parents
+                .iter()
+                .any(|parent| !self.dependencies.contains(parent))
+            {
+                return Some(language);
+            }
+        }
+        None
     }
 
     /// Rename every staged directory into place, keeping the displaced
@@ -587,13 +602,7 @@ impl StagedQueryInstall {
                 Ok(PublishQueryDirOutcome::Uninstalled) => {
                     let residue = publish.rollback();
                     return Err(PublishFailure {
-                        error: QueryInstallError::IoError(std::io::Error::new(
-                            std::io::ErrorKind::Interrupted,
-                            format!(
-                                "Query install for {} was superseded by uninstall",
-                                entry.language
-                            ),
-                        )),
+                        error: QueryInstallError::DependencyRemoved(entry.language),
                         residue,
                     });
                 }
@@ -2331,12 +2340,56 @@ mod staging_tests {
             queries_parent: queries_parent.clone(),
         };
 
-        assert_eq!(staged.missing_skipped_dependency(), None);
+        assert_eq!(staged.unstable_skipped_dependency(), None);
         fs::remove_dir_all(&queries_dir).unwrap();
         assert_eq!(
-            staged.missing_skipped_dependency(),
+            staged.unstable_skipped_dependency(),
             Some("child"),
             "queries removed after staging must not pass as already installed"
+        );
+    }
+
+    /// A skipped language that grew a new base language while this install was
+    /// staging is as unstable as one that vanished: the new base was never
+    /// discovered, so it is neither locked nor checked, and publishing over it
+    /// would report success on a chain nobody was holding still.
+    #[test]
+    fn a_skipped_dependency_that_gained_a_parent_is_rechecked() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        let parent_dir = queries_parent.join("parent");
+        fs::create_dir_all(&parent_dir).unwrap();
+        fs::write(parent_dir.join("highlights.scm"), "(comment) @comment\n").unwrap();
+        write_install_marker(&parent_dir).unwrap();
+        let staged = StagedQueryInstall {
+            language: "child".to_string(),
+            install_path: queries_parent.join("child"),
+            files_downloaded: vec!["highlights.scm".to_string()],
+            requested_already_complete: false,
+            entries: vec![stage(
+                &queries_parent,
+                "child",
+                "; inherits: parent\n",
+                false,
+            )],
+            dependencies: vec!["child".to_string(), "parent".to_string()],
+            queries_parent: queries_parent.clone(),
+        };
+
+        assert_eq!(staged.unstable_skipped_dependency(), None);
+
+        // Someone force-reinstalls the parent, and its new queries inherit a
+        // language this install never saw.
+        fs::write(
+            parent_dir.join("highlights.scm"),
+            "; inherits: grandparent\n(comment) @comment\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            staged.unstable_skipped_dependency(),
+            Some("parent"),
+            "a base language that gained a parent must stop the publish"
         );
     }
 
@@ -2363,7 +2416,7 @@ mod staging_tests {
         };
 
         assert_eq!(
-            staged.missing_skipped_dependency(),
+            staged.unstable_skipped_dependency(),
             Some("parent"),
             "a base language that is neither staged nor on disk must be caught"
         );
@@ -2385,7 +2438,7 @@ mod staging_tests {
             queries_parent: queries_parent.clone(),
         };
 
-        assert_eq!(staged.missing_skipped_dependency(), None);
+        assert_eq!(staged.unstable_skipped_dependency(), None);
     }
 
     /// `--force` replaces the requested language, not the base languages it
@@ -2460,7 +2513,7 @@ mod staging_tests {
         let result = staged.publish();
 
         assert!(
-            matches!(&result, Err(failure) if matches!(&failure.error, QueryInstallError::IoError(e) if e.kind() == std::io::ErrorKind::Interrupted)),
+            matches!(&result, Err(failure) if matches!(&failure.error, QueryInstallError::DependencyRemoved(language) if language == "parent")),
             "a tombstoned entry must abort the publish"
         );
         assert_eq!(

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -162,20 +162,6 @@ pub fn install_queries_with_dependencies(
     )
 }
 
-pub fn install_queries_with_dependencies_after_install_started(
-    language: &str,
-    data_dir: &Path,
-    force: bool,
-) -> Result<QueryInstallResult, QueryInstallError> {
-    install_queries_with_dependencies_from_with_http_policy(
-        NVIM_TREESITTER_QUERIES_URL,
-        language,
-        data_dir,
-        force,
-        QueryHttpPolicy::HttpsOnly,
-    )
-}
-
 /// Stage the queries for `language` and its `; inherits:` chain from
 /// `base_url`, leaving publication to the caller.
 ///

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -604,6 +604,7 @@ impl PublishedQueryInstall {
             // land inside another installer's or the uninstaller's critical
             // section.
             let Some(queries_parent) = published.queries_dir.parent() else {
+                outcome = RollbackOutcome::NewQueriesRemain;
                 continue;
             };
             let _replace_lock =
@@ -614,6 +615,9 @@ impl PublishedQueryInstall {
                             "Warning: could not lock '{}' to undo its query install: {}",
                             published.language, e
                         );
+                        // Not undone: without the lock the queries stay live,
+                        // and the caller must not say nothing was published.
+                        outcome = RollbackOutcome::NewQueriesRemain;
                         continue;
                     }
                 };

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -279,13 +279,8 @@ pub fn install_queries_with_dependencies(
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
-    // Half of a language on its own, but still inside the transaction protocol.
-    // The clear takes the lock and gives it back before staging, exactly as a
-    // whole-language install does; the publish below takes one per dependency.
-    {
-        let _transaction = lock_language(data_dir, language)?;
-        clear_uninstall_tombstone_for_install(data_dir, language)?;
-    }
+    // No tombstone clear here either: staging does it once per language, under
+    // that language's lock. See `install_language`.
     install_queries_with_dependencies_from_with_http_policy(
         NVIM_TREESITTER_QUERIES_URL,
         language,

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -626,20 +626,19 @@ fn language_is_complete(language: &str, data_dir: &std::path::Path) -> bool {
     // async path, and "busy" is as useful an answer as waiting for one. A data
     // directory that cannot be locked at all — read-only, or predating the lock
     // files — is settled by definition, and must still be readable.
-    let settled = crate::install::queries::try_lock_language(data_dir, language);
-    if !settled.is_settled() {
+    // The whole chain, not just this language's own queries: a missing inherited
+    // parent makes the query load fail outright, and skipping the install over
+    // it is what leaves such a language unrepairable. Every language in the
+    // chain is held still while this decides — an install mid-publish can still
+    // roll its queries back, and a base language can be uninstalled out from
+    // under the walk. Non-blocking, so a busy language answers "not ready"
+    // rather than stalling the async path.
+    let Some(chain) = crate::install::queries::lock_complete_chain(data_dir, language) else {
         return false;
-    }
-    let complete = crate::install::parser_file_exists(language, data_dir).is_some()
-        // The whole chain, not just this language's own queries: a missing
-        // inherited parent makes the query load fail outright, and skipping the
-        // install over it is what leaves such a language unrepairable.
-        && crate::install::queries::query_install_chain_is_complete(
-            &data_dir.join("queries"),
-            language,
-        );
-    // Held until here on purpose: the reads above must not straddle a publish.
-    drop(settled);
+    };
+    let complete = crate::install::parser_file_exists(language, data_dir).is_some();
+    // The guards live until here: the parser read must not straddle a publish.
+    drop(chain);
     complete
 }
 

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -95,11 +95,12 @@ pub(crate) enum InstallOutcome {
         /// Directory where parser and queries were installed
         data_dir: PathBuf,
     },
-    /// The install failed, but a parser for the language is on disk from an
-    /// earlier or concurrent install, so the language is still loadable — with
-    /// whatever queries that other install left, which may be none.
+    /// The install failed, but a parser for the language was published by
+    /// another install while this one ran, so the language is still loadable —
+    /// with whatever queries that install left, which may be none.
     SuccessWithWarnings {
-        /// Directory where parser and queries were installed
+        /// Directory the language loads from. The parser there is another
+        /// install's, not this one's.
         data_dir: PathBuf,
     },
     /// Parser already exists, just needs reload (no installation performed)
@@ -562,8 +563,8 @@ impl AutoInstallManager {
             });
             InstallResult::with_claim(outcome, events, install_marker)
         } else if matches!(outcome, InstallOutcome::SuccessWithWarnings { .. }) {
-            // The install published nothing, but a parser is on disk from an
-            // earlier or concurrent install, so the language still loads. Only
+            // The install published nothing, but a concurrent install put a
+            // parser on disk, so the language still loads. Only
             // when the parser half itself did not fail: a parser that failed to
             // publish leaves a file whose provenance is somebody else's install,
             // and reporting that as a near-success would hide a real error.
@@ -612,9 +613,10 @@ impl AutoInstallManager {
 /// Decide what an install attempt means for the client.
 ///
 /// `parser_exists` is read from disk rather than from `result`, because a
-/// parser can be present without this install having published it — an earlier
-/// run, or another process installing the same language. That is the only way
-/// a failed install is still worth reloading for.
+/// parser can be present without this install having published it: an install
+/// that already had one short-circuits before reaching here, so what this
+/// catches is another process publishing one while this install ran. That is
+/// the only way a failed install is still worth reloading for.
 ///
 /// It is not enough on its own: an install whose *parser* half failed leaves a
 /// file whose provenance is somebody else's, and reporting that as a

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -95,7 +95,9 @@ pub(crate) enum InstallOutcome {
         /// Directory where parser and queries were installed
         data_dir: PathBuf,
     },
-    /// Parser compiled but queries had warnings (still usable)
+    /// The install failed, but a parser for the language is on disk from an
+    /// earlier or concurrent install, so the language is still loadable — with
+    /// whatever queries that other install left, which may be none.
     SuccessWithWarnings {
         /// Directory where parser and queries were installed
         data_dir: PathBuf,
@@ -526,17 +528,7 @@ impl AutoInstallManager {
             let result = install_executor(task_lang.clone(), task_data_dir.clone()).await;
             let parser_exists =
                 crate::install::parser_file_exists(&task_lang, &task_data_dir).is_some();
-            let terminal = if result.is_success() {
-                InstallOutcome::Success {
-                    data_dir: task_data_dir.clone(),
-                }
-            } else if parser_exists {
-                InstallOutcome::SuccessWithWarnings {
-                    data_dir: task_data_dir.clone(),
-                }
-            } else {
-                InstallOutcome::Failed
-            };
+            let terminal = classify_install_outcome(&result, parser_exists, &task_data_dir);
             let mut install_marker = install_marker;
             // If the caller awaiting this task is cancelled, the task output is
             // dropped. Keep the real install result on the guard so waiters see
@@ -561,18 +553,20 @@ impl AutoInstallManager {
             }
         };
 
+        let outcome = classify_install_outcome(&result, parser_exists, &data_dir);
         if result.is_success() {
             events.push(InstallEvent::ProgressEnd { success: true });
             events.push(InstallEvent::Log {
                 level: MessageType::INFO,
                 message: format!("Successfully installed language '{}'. Reloading...", lang),
             });
-            let outcome = InstallOutcome::Success {
-                data_dir: data_dir.clone(),
-            };
             InstallResult::with_claim(outcome, events, install_marker)
-        } else if parser_exists {
-            // Parser compiled but queries had issues - still usable
+        } else if matches!(outcome, InstallOutcome::SuccessWithWarnings { .. }) {
+            // The install published nothing, but a parser is on disk from an
+            // earlier or concurrent install, so the language still loads. Only
+            // when the parser half itself did not fail: a parser that failed to
+            // publish leaves a file whose provenance is somebody else's install,
+            // and reporting that as a near-success would hide a real error.
             events.push(InstallEvent::ProgressEnd { success: true });
 
             let mut warnings = Vec::new();
@@ -582,15 +576,13 @@ impl AutoInstallManager {
             events.push(InstallEvent::Log {
                 level: MessageType::WARNING,
                 message: format!(
-                    "Language '{}' parser installed but with warnings: {}. Reloading...",
+                    "Language '{}' was not installed ({}), but a parser is already present. \
+                     Reloading...",
                     lang,
                     warnings.join("; ")
                 ),
             });
 
-            let outcome = InstallOutcome::SuccessWithWarnings {
-                data_dir: data_dir.clone(),
-            };
             InstallResult::with_claim(outcome, events, install_marker)
         } else {
             // Installation failed
@@ -612,15 +604,87 @@ impl AutoInstallManager {
                 ),
             });
 
-            let outcome = InstallOutcome::Failed;
             InstallResult::with_claim(outcome, events, install_marker)
         }
+    }
+}
+
+/// Decide what an install attempt means for the client.
+///
+/// `parser_exists` is read from disk rather than from `result`, because a
+/// parser can be present without this install having published it — an earlier
+/// run, or another process installing the same language. That is the only way
+/// a failed install is still worth reloading for.
+///
+/// It is not enough on its own: an install whose *parser* half failed leaves a
+/// file whose provenance is somebody else's, and reporting that as a
+/// near-success would swallow a real error, so the parser half must be the one
+/// that did not fail.
+fn classify_install_outcome(
+    result: &crate::install::InstallResult,
+    parser_exists: bool,
+    data_dir: &std::path::Path,
+) -> InstallOutcome {
+    if result.is_success() {
+        InstallOutcome::Success {
+            data_dir: data_dir.to_path_buf(),
+        }
+    } else if parser_exists && result.parser_error.is_none() {
+        InstallOutcome::SuccessWithWarnings {
+            data_dir: data_dir.to_path_buf(),
+        }
+    } else {
+        InstallOutcome::Failed
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A failed install whose parser half is the half that failed must not be
+    /// dressed up as a near-success just because a parser file is on disk: the
+    /// file is another install's, and the error would be swallowed.
+    #[test]
+    fn a_failed_parser_half_is_never_reported_as_warnings() {
+        let data_dir = PathBuf::from("/data");
+        let result = crate::install::InstallResult {
+            parser_path: None,
+            queries_path: None,
+            parser_error: Some("compile failed".to_string()),
+            queries_error: None,
+        };
+
+        assert_eq!(
+            classify_install_outcome(&result, true, &data_dir),
+            InstallOutcome::Failed
+        );
+    }
+
+    /// The install published nothing, but a parser from an earlier or
+    /// concurrent install is present, so the language is still loadable.
+    #[test]
+    fn a_failed_queries_half_over_an_existing_parser_still_reloads() {
+        let data_dir = PathBuf::from("/data");
+        let result = crate::install::InstallResult {
+            parser_path: None,
+            queries_path: None,
+            parser_error: None,
+            queries_error: Some("network unreachable".to_string()),
+        };
+
+        assert_eq!(
+            classify_install_outcome(&result, true, &data_dir),
+            InstallOutcome::SuccessWithWarnings {
+                data_dir: data_dir.clone()
+            }
+        );
+        assert_eq!(
+            classify_install_outcome(&result, false, &data_dir),
+            InstallOutcome::Failed,
+            "with no parser on disk there is nothing to reload"
+        );
+    }
 
     fn create_test_manager() -> AutoInstallManager {
         AutoInstallManager::new(InstallingLanguages::new())

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -678,6 +678,7 @@ mod tests {
             queries_path: None,
             parser_error: None,
             queries_error: Some("network unreachable".to_string()),
+            left_published_queries: false,
             files_downloaded: Vec::new(),
         };
 
@@ -697,6 +698,7 @@ mod tests {
             queries_path: None,
             parser_error: Some("compile failed".to_string()),
             queries_error: None,
+            left_published_queries: false,
             files_downloaded: Vec::new(),
         };
 
@@ -775,6 +777,7 @@ mod tests {
                             queries_path: Some(PathBuf::from("/installed/queries")),
                             parser_error: None,
                             queries_error: None,
+                            left_published_queries: false,
                             files_downloaded: Vec::new(),
                         }
                     },

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -619,12 +619,15 @@ impl AutoInstallManager {
 /// Read from disk rather than from an `InstallResult`, so it answers for
 /// whatever another process published while this install ran.
 fn language_is_complete(language: &str, data_dir: &std::path::Path) -> bool {
-    // An install that is mid-publish can still roll its queries back, so what
-    // is on disk right now is not yet an answer. Treating it as one would let
-    // the editor load a language that is about to lose half of itself. The
-    // probe is non-blocking — this runs on the async path.
-    !crate::install::queries::language_publish_in_flight(data_dir, language)
-        && crate::install::parser_file_exists(language, data_dir).is_some()
+    // An install that is mid-publish can still roll its queries back, so what is
+    // on disk right now is not yet an answer. Hold the language's lock across
+    // both reads — releasing it first would leave room for an entire publish and
+    // rollback between the probe and the reads. Non-blocking: this runs on the
+    // async path, and "busy" is as useful an answer as waiting for one.
+    let Some(_settled) = crate::install::queries::try_lock_language(data_dir, language) else {
+        return false;
+    };
+    crate::install::parser_file_exists(language, data_dir).is_some()
         && crate::install::queries::query_install_is_complete(
             &data_dir.join("queries").join(language),
         )

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -628,8 +628,12 @@ fn language_is_complete(language: &str, data_dir: &std::path::Path) -> bool {
         return false;
     };
     crate::install::parser_file_exists(language, data_dir).is_some()
-        && crate::install::queries::query_install_is_complete(
-            &data_dir.join("queries").join(language),
+        // The whole chain, not just this language's own queries: a missing
+        // inherited parent makes the query load fail outright, and skipping the
+        // install over it is what leaves such a language unrepairable.
+        && crate::install::queries::query_install_chain_is_complete(
+            &data_dir.join("queries"),
+            language,
         )
 }
 

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -95,12 +95,11 @@ pub(crate) enum InstallOutcome {
         /// Directory where parser and queries were installed
         data_dir: PathBuf,
     },
-    /// The install failed, but a parser for the language was published by
-    /// another install while this one ran, so the language is still loadable —
-    /// with whatever queries that install left, which may be none.
+    /// This install failed, but another one completed the language while it
+    /// ran, so both halves are on disk and it is still loadable.
     SuccessWithWarnings {
-        /// Directory the language loads from. The parser there is another
-        /// install's, not this one's.
+        /// Directory the language loads from. What is there is another
+        /// install's work, not this one's.
         data_dir: PathBuf,
     },
     /// Parser already exists, just needs reload (no installation performed)
@@ -537,17 +536,16 @@ impl AutoInstallManager {
             // kakehashi binary — so the killable subprocess (re-exec
             // `__compile-parser`) is valid and bounds a hung `cc`.
             let result = install_executor(task_lang.clone(), task_data_dir.clone()).await;
-            let parser_exists =
-                crate::install::parser_file_exists(&task_lang, &task_data_dir).is_some();
-            let terminal = classify_install_outcome(&result, parser_exists, &task_data_dir);
+            let complete = language_is_complete(&task_lang, &task_data_dir);
+            let terminal = classify_install_outcome(&result, complete, &task_data_dir);
             let mut install_marker = install_marker;
             // If the caller awaiting this task is cancelled, the task output is
             // dropped. Keep the real install result on the guard so waiters see
             // success rather than the guard's fail-closed fallback.
             install_marker.preserve_terminal(terminal);
-            (result, parser_exists, install_marker)
+            (result, complete, install_marker)
         });
-        let (result, parser_exists, install_marker) = match install_task.await {
+        let (result, complete, install_marker) = match install_task.await {
             Ok(result) => result,
             Err(join_error) => {
                 events.push(InstallEvent::ProgressEnd { success: false });
@@ -564,7 +562,7 @@ impl AutoInstallManager {
             }
         };
 
-        let outcome = classify_install_outcome(&result, parser_exists, &data_dir);
+        let outcome = classify_install_outcome(&result, complete, &data_dir);
         if result.is_success() {
             events.push(InstallEvent::ProgressEnd { success: true });
             events.push(InstallEvent::Log {
@@ -573,22 +571,22 @@ impl AutoInstallManager {
             });
             InstallResult::with_claim(outcome, events, install_marker)
         } else if matches!(outcome, InstallOutcome::SuccessWithWarnings { .. }) {
-            // The install published nothing, but a concurrent install put a
-            // parser on disk, so the language still loads. Only
-            // when the parser half itself did not fail: a parser that failed to
-            // publish leaves a file whose provenance is somebody else's install,
-            // and reporting that as a near-success would hide a real error.
+            // This install published nothing, but the language is complete on
+            // disk because another one finished it while this ran, so it loads.
             events.push(InstallEvent::ProgressEnd { success: true });
 
             let mut warnings = Vec::new();
-            if let Some(e) = &result.queries_error {
-                warnings.push(format!("queries: {}", e));
+            for error in [&result.parser_error, &result.queries_error]
+                .into_iter()
+                .flatten()
+            {
+                warnings.push(error.clone());
             }
             events.push(InstallEvent::Log {
                 level: MessageType::WARNING,
                 message: format!(
-                    "Language '{}' was not installed ({}), but a parser is already present. \
-                     Reloading...",
+                    "Language '{}' was not installed by this attempt ({}), but another install \
+                     completed it. Reloading...",
                     lang,
                     warnings.join("; ")
                 ),
@@ -620,28 +618,34 @@ impl AutoInstallManager {
     }
 }
 
+/// Whether both halves of a language are on disk and usable.
+///
+/// Read from disk rather than from an `InstallResult`, so it answers for
+/// whatever another process published while this install ran.
+fn language_is_complete(language: &str, data_dir: &std::path::Path) -> bool {
+    crate::install::parser_file_exists(language, data_dir).is_some()
+        && crate::install::queries::query_install_is_complete(
+            &data_dir.join("queries").join(language),
+        )
+}
+
 /// Decide what an install attempt means for the client.
 ///
-/// `parser_exists` is read from disk rather than from `result`, because a
-/// parser can be present without this install having published it: an install
-/// that already had one short-circuits before reaching here, so what this
-/// catches is another process publishing one while this install ran. That is
-/// the only way a failed install is still worth reloading for.
-///
-/// It is not enough on its own: an install whose *parser* half failed leaves a
-/// file whose provenance is somebody else's, and reporting that as a
-/// near-success would swallow a real error, so the parser half must be the one
-/// that did not fail.
+/// A failed install is still worth reloading for in exactly one case: another
+/// process published the language while this one ran. That takes BOTH halves —
+/// a parser on its own is what the failed install was trying to complete, and
+/// reloading it registers a language with no highlighting while reporting
+/// success.
 fn classify_install_outcome(
     result: &crate::install::InstallResult,
-    parser_exists: bool,
+    language_is_complete: bool,
     data_dir: &std::path::Path,
 ) -> InstallOutcome {
     if result.is_success() {
         InstallOutcome::Success {
             data_dir: data_dir.to_path_buf(),
         }
-    } else if parser_exists && result.parser_error.is_none() {
+    } else if language_is_complete {
         InstallOutcome::SuccessWithWarnings {
             data_dir: data_dir.to_path_buf(),
         }
@@ -654,11 +658,31 @@ fn classify_install_outcome(
 mod tests {
     use super::*;
 
-    /// A failed install whose parser half is the half that failed must not be
-    /// dressed up as a near-success just because a parser file is on disk: the
-    /// file is another install's, and the error would be swallowed.
+    /// A failed install must not be dressed up as a near-success by a parser
+    /// that is on disk without its queries — that is the half-installed
+    /// language the attempt was trying to repair, and reloading it registers a
+    /// language with no highlighting while reporting success.
     #[test]
-    fn a_failed_parser_half_is_never_reported_as_warnings() {
+    fn a_failed_install_over_an_incomplete_language_stays_failed() {
+        let data_dir = PathBuf::from("/data");
+        let result = crate::install::InstallResult {
+            parser_path: None,
+            queries_path: None,
+            parser_error: None,
+            queries_error: Some("network unreachable".to_string()),
+            files_downloaded: Vec::new(),
+        };
+
+        assert_eq!(
+            classify_install_outcome(&result, false, &data_dir),
+            InstallOutcome::Failed
+        );
+    }
+
+    /// Another install finished the language while this one was failing, so
+    /// both halves are there and it loads.
+    #[test]
+    fn a_failed_install_over_a_complete_language_still_reloads() {
         let data_dir = PathBuf::from("/data");
         let result = crate::install::InstallResult {
             parser_path: None,
@@ -670,33 +694,9 @@ mod tests {
 
         assert_eq!(
             classify_install_outcome(&result, true, &data_dir),
-            InstallOutcome::Failed
-        );
-    }
-
-    /// The install published nothing, but a parser from an earlier or
-    /// concurrent install is present, so the language is still loadable.
-    #[test]
-    fn a_failed_queries_half_over_an_existing_parser_still_reloads() {
-        let data_dir = PathBuf::from("/data");
-        let result = crate::install::InstallResult {
-            parser_path: None,
-            queries_path: None,
-            parser_error: None,
-            queries_error: Some("network unreachable".to_string()),
-            files_downloaded: Vec::new(),
-        };
-
-        assert_eq!(
-            classify_install_outcome(&result, true, &data_dir),
             InstallOutcome::SuccessWithWarnings {
                 data_dir: data_dir.clone()
             }
-        );
-        assert_eq!(
-            classify_install_outcome(&result, false, &data_dir),
-            InstallOutcome::Failed,
-            "with no parser on disk there is nothing to reload"
         );
     }
 

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -491,12 +491,22 @@ impl AutoInstallManager {
             }
         };
 
-        // Check if parser already exists - skip installation and just signal reload
-        if crate::install::parser_file_exists(language, &data_dir).is_some() {
+        // Both halves already present — skip installation and just signal reload.
+        //
+        // The parser alone is not enough: a data directory written before
+        // installs became all-or-nothing can hold a parser whose queries never
+        // arrived, and skipping on the parser meant that language could never
+        // repair itself. Falling through costs a stat per half when everything
+        // is there, since staging short-circuits on both.
+        if crate::install::parser_file_exists(language, &data_dir).is_some()
+            && crate::install::queries::query_install_is_complete(
+                &data_dir.join("queries").join(language),
+            )
+        {
             events.push(InstallEvent::Log {
                 level: MessageType::INFO,
                 message: format!(
-                    "Parser for '{}' already exists. Loading without reinstall...",
+                    "Parser and queries for '{}' already exist. Loading without reinstall...",
                     language
                 ),
             });

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -678,7 +678,7 @@ mod tests {
             queries_path: None,
             parser_error: None,
             queries_error: Some("network unreachable".to_string()),
-            left_published_queries: false,
+            rollback_residue: None,
             files_downloaded: Vec::new(),
         };
 
@@ -698,7 +698,7 @@ mod tests {
             queries_path: None,
             parser_error: Some("compile failed".to_string()),
             queries_error: None,
-            left_published_queries: false,
+            rollback_residue: None,
             files_downloaded: Vec::new(),
         };
 
@@ -777,7 +777,7 @@ mod tests {
                             queries_path: Some(PathBuf::from("/installed/queries")),
                             parser_error: None,
                             queries_error: None,
-                            left_published_queries: false,
+                            rollback_residue: None,
                             files_downloaded: Vec::new(),
                         }
                     },

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -653,6 +653,7 @@ mod tests {
             queries_path: None,
             parser_error: Some("compile failed".to_string()),
             queries_error: None,
+            files_downloaded: Vec::new(),
         };
 
         assert_eq!(
@@ -671,6 +672,7 @@ mod tests {
             queries_path: None,
             parser_error: None,
             queries_error: Some("network unreachable".to_string()),
+            files_downloaded: Vec::new(),
         };
 
         assert_eq!(
@@ -753,6 +755,7 @@ mod tests {
                             queries_path: Some(PathBuf::from("/installed/queries")),
                             parser_error: None,
                             queries_error: None,
+                            files_downloaded: Vec::new(),
                         }
                     },
                 )

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -623,18 +623,24 @@ fn language_is_complete(language: &str, data_dir: &std::path::Path) -> bool {
     // on disk right now is not yet an answer. Hold the language's lock across
     // both reads — releasing it first would leave room for an entire publish and
     // rollback between the probe and the reads. Non-blocking: this runs on the
-    // async path, and "busy" is as useful an answer as waiting for one.
-    let Some(_settled) = crate::install::queries::try_lock_language(data_dir, language) else {
+    // async path, and "busy" is as useful an answer as waiting for one. A data
+    // directory that cannot be locked at all — read-only, or predating the lock
+    // files — is settled by definition, and must still be readable.
+    let settled = crate::install::queries::try_lock_language(data_dir, language);
+    if !settled.is_settled() {
         return false;
-    };
-    crate::install::parser_file_exists(language, data_dir).is_some()
+    }
+    let complete = crate::install::parser_file_exists(language, data_dir).is_some()
         // The whole chain, not just this language's own queries: a missing
         // inherited parent makes the query load fail outright, and skipping the
         // install over it is what leaves such a language unrepairable.
         && crate::install::queries::query_install_chain_is_complete(
             &data_dir.join("queries"),
             language,
-        )
+        );
+    // Held until here on purpose: the reads above must not straddle a publish.
+    drop(settled);
+    complete
 }
 
 /// Decide what an install attempt means for the client.

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -497,11 +497,7 @@ impl AutoInstallManager {
         // arrived, and skipping on the parser meant that language could never
         // repair itself. Falling through costs a stat per half when everything
         // is there, since staging short-circuits on both.
-        if crate::install::parser_file_exists(language, &data_dir).is_some()
-            && crate::install::queries::query_install_is_complete(
-                &data_dir.join("queries").join(language),
-            )
-        {
+        if language_is_complete(language, &data_dir) {
             events.push(InstallEvent::Log {
                 level: MessageType::INFO,
                 message: format!(
@@ -623,7 +619,12 @@ impl AutoInstallManager {
 /// Read from disk rather than from an `InstallResult`, so it answers for
 /// whatever another process published while this install ran.
 fn language_is_complete(language: &str, data_dir: &std::path::Path) -> bool {
-    crate::install::parser_file_exists(language, data_dir).is_some()
+    // An install that is mid-publish can still roll its queries back, so what
+    // is on disk right now is not yet an answer. Treating it as one would let
+    // the editor load a language that is about to lose half of itself. The
+    // probe is non-blocking — this runs on the async path.
+    !crate::install::queries::language_publish_in_flight(data_dir, language)
+        && crate::install::parser_file_exists(language, data_dir).is_some()
         && crate::install::queries::query_install_is_complete(
             &data_dir.join("queries").join(language),
         )

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1493,6 +1493,46 @@ fn test_language_status_preserves_incomplete_query_dir_when_backup_exists() {
     );
 }
 
+/// A failed query removal must not take the parser with it: half-removing a
+/// language is the state the atomic install/uninstall path exists to avoid, and
+/// leaving both halves keeps the retry a plain retry.
+#[test]
+fn test_language_uninstall_keeps_the_parser_when_queries_cannot_be_removed() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    let parser_file = test_dir.path().join(format!("parser/stuck_lang.{ext}"));
+    fs::write(&parser_file, "fake").expect("Failed to write parser");
+    // A file where the queries directory belongs makes the removal fail.
+    fs::write(test_dir.path().join("queries"), "not a directory")
+        .expect("Failed to write blocking file");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "stuck_lang",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "stderr: {stderr}");
+    assert!(
+        parser_file.exists(),
+        "a failed query removal must leave the parser alone: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Removed parser"),
+        "and must not claim it removed it: {stderr}"
+    );
+}
+
 /// Test that status does not recover user-created hidden backup directories
 #[test]
 fn test_language_status_ignores_manual_query_backup() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1497,17 +1497,28 @@ fn test_language_status_preserves_incomplete_query_dir_when_backup_exists() {
 /// language is the state the atomic install/uninstall path exists to avoid, and
 /// leaving both halves keeps the retry a plain retry.
 #[test]
+#[cfg(unix)]
 fn test_language_uninstall_keeps_the_parser_when_queries_cannot_be_removed() {
     use std::fs;
+    use std::os::unix::fs::PermissionsExt;
 
     let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
     fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
     let ext = std::env::consts::DLL_EXTENSION;
     let parser_file = test_dir.path().join(format!("parser/stuck_lang.{ext}"));
     fs::write(&parser_file, "fake").expect("Failed to write parser");
-    // A file where the queries directory belongs makes the removal fail.
-    fs::write(test_dir.path().join("queries"), "not a directory")
-        .expect("Failed to write blocking file");
+    // `queries/` itself must stay writable — the language lock lives there and
+    // is taken before the removal. Make the language's own directory
+    // undeletable instead, so the run reaches the removal and fails there.
+    let queries_dir = test_dir.path().join("queries/stuck_lang");
+    fs::create_dir_all(&queries_dir).expect("Failed to create queries dir");
+    fs::write(queries_dir.join("highlights.scm"), "(comment) @comment")
+        .expect("Failed to write queries");
+    let mut permissions = fs::metadata(&queries_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o500);
+    fs::set_permissions(&queries_dir, permissions).expect("Failed to seal queries dir");
 
     let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
         .args([
@@ -1522,7 +1533,19 @@ fn test_language_uninstall_keeps_the_parser_when_queries_cannot_be_removed() {
         .expect("Failed to execute command");
 
     let stderr = String::from_utf8_lossy(&output.stderr);
+    // Unseal before asserting, so a failure cannot leave an undeletable
+    // directory behind for the temp dir to trip over.
+    let mut permissions = fs::metadata(&queries_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o700);
+    fs::set_permissions(&queries_dir, permissions).expect("Failed to unseal queries dir");
+
     assert!(!output.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("Failed to remove queries"),
+        "the run must reach the removal and fail there, not earlier: {stderr}"
+    );
     assert!(
         parser_file.exists(),
         "a failed query removal must leave the parser alone: {stderr}"


### PR DESCRIPTION
## Why

`kakehashi language install` installed the parser and the query files independently, so either half could land without the other:

- A failed queries download left a parser with no highlighting; a failed compile left queries with no parser.
- Re-running to repair the missing half printed `✗ Parser already exists … Use --force` for the half that *was* fine, and exited 1 — even though it had just repaired the other one. A plain re-run of a fully installed language could never succeed, which is why `Makefile` passes `--force` on every install.
- A `; inherits:` parent that failed to download was a warning, so a language could be published with a dangling inherits chain that fails to load at runtime.

## What

Both halves are **staged** first — the parser compiled to a temp file, the queries (and every language they reach through `; inherits:`) downloaded into per-language staging directories — and published only once all of them are ready. Queries are staged first because they are the cheap half: an unsupported language now fails in seconds instead of after a parser compile that gets thrown away. The parser is published last, since request routing gates on a registered parser.

A per-language lock orders a whole install against another install or an uninstall, taken for every language in the dependency chain in sorted order. Publishing a query directory keeps the one it displaced until the install commits, so a failure can put it back.

The CLI reports what the data directory holds rather than which half this run wrote, so an already-installed half is no longer an error.

## Behavior changes

- A `; inherits:` parent that cannot be downloaded now **fails the install** instead of warning. Maintainer decision: a language whose inherited queries are missing does not load.
- A language whose queries do not exist upstream can no longer get its parser installed. Measured against current nvim-treesitter: 0 of 323 parsers lack `highlights.scm`, so nothing is affected today.
- `kakehashi language install <already-installed>` now exits 0 instead of 1. Scripts that used exit 1 to detect "already installed" will see success.
- Auto-install no longer skips a language on the strength of its parser alone; a data directory left parser-only by an older release repairs itself on open.

## Known limitations (documented in `docs/README.md`)

- A `--force` reinstall killed between the two publishes leaves new queries against the old parser; both halves look installed, so recovery is another `--force`.
- Publication is atomic per file, not to readers: a server loading a language *while* it is being published can cache a failed query load, and recovery is install-then-reload.
- Base languages are tracked by name, not by query kind, so a base language whose `injections.scm` upstream does not ship (or whose optional download failed) still passes.
- Staging-file recovery is a no-op on Windows, where process liveness cannot be tested portably.

## Review

Ten parallel single-perspective reviews plus nine rounds against the codex MCP server (two independent sessions, the second cold). Every finding was fixed or is listed above; the fixes are separate commits naming the finding. One finding was caught by an existing CLI test — `test_language_status_preserves_incomplete_query_dir_when_backup_exists` — which pinned the invariant a new backup sweep would have broken.

## Verification

- `make check` clean
- `cargo test --lib` 3325 pass, `cargo test --bins` 7 pass
- `make test_e2e` 1764 pass / 0 failing binaries
- Manual: clean install, repair from either half missing, re-install of a complete language, unsupported language, invalid name, install→uninstall→install, and a language with an inherits chain (`typescript` → `ecma`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Language installations now publish parsers and inherited queries transactionally.
  * Added recovery for interrupted or partially failed installations.
  * Coordinated concurrent installs and uninstalls to prevent conflicts.
  * Installation results report downloaded files, warnings, and rollback status.

* **Bug Fixes**
  * Prevented incomplete installations from being reported as successful.
  * Improved retries, temporary-file cleanup, and missing parser/query recovery.
  * Preserved parser files when query removal fails.
  * Improved handling of installation races and inherited queries.

* **Documentation**
  * Expanded guidance for retries, force reinstalls, cleanup, base-language queries, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->