### PR TITLE
fix(completion): make host-layer completion items resolvable

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -606,8 +606,8 @@ The reserved `_self` key makes the host language its own bridge target: with
 it enabled, requests on the host document are forwarded to servers whose
 `languages` matches the **host** language (including a `"*"` server), with the real URI and no
 coordinate translation. All bridged request methods are wired (exceptions:
-semantic tokens; document color stays injection-only; host completion-item
-and code-lens resolves pass through unrouted); by default the host layer is
+semantic tokens; document color stays injection-only; host code-lens
+resolves pass through unrouted); by default the host layer is
 tried after
 `virt` (see `layers` above), so for `preferred` methods injections keep
 winning inside code fences while the host server answers everywhere else —

--- a/docs/architecture-decisions/cross-layer-aggregation.md
+++ b/docs/architecture-decisions/cross-layer-aggregation.md
@@ -21,8 +21,9 @@ Phased roadmap:
    settings arc), keyed `textDocument/publishDiagnostics` to match its
    aggregation config. With host bridging (host-document-bridge)
    implemented for the bridged request methods (documented exceptions:
-   document color is virt-only; host completion-item/code-lens resolves
-   pass through unrouted), handlers run the real
+   document color is virt-only; host code-lens resolves pass through
+   unrouted — host completion-item resolves ARE routed, see
+   host-document-bridge), handlers run the real
    stage-2 `preferred` walk (`Kakehashi::walk_layers` →
    `race_layers_preferred`): the virt and host layers fan out
    **concurrently** — the layer-level analogue of the stage-1 `preferred`

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -38,9 +38,11 @@ Partially implemented:
   merge host-server pulls (real URI) with the virt regions' results per the
   layer strategy. Not covered: semantic tokens (native-only) and the experimental
   documentColor/colorPresentation pair. `completionItem/resolve` routes by
-  the envelope the virt fan-out stamps into `CompletionItem.data`; host
-  completion items carry no envelope and resolve falls back gracefully
-  (item returned unresolved). Formatting additionally supports the cross-layer
+  the envelope stamped into `CompletionItem.data`; the host layer stamps one
+  too (marked `host_layer`, so the resolve forwards VERBATIM — no coordinate
+  translation and no injection-region edit guard), but only for a server that
+  advertises `completionItem/resolve`. Without that capability the items stay
+  bare and a resolve falls back gracefully (item returned unresolved). Formatting additionally supports the cross-layer
   `concatenated` pipeline: virt region edits apply first, the host
   formatter formats the intermediate text, and the chain collapses into one
   whole-document replacement edit. During that pipeline the host server's

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -28,7 +28,10 @@ Partially implemented:
   no per-method request builders or response transformers. Handlers run the
   layer walk (`Kakehashi::walk_layers`, cross-layer-aggregation,
   `preferred` semantics): layers are tried lazily in `priorities` — by default
-  virt first, host as fallback. Covered: definition, hover, declaration,
+  virt first, host as fallback. Two methods need per-server identity in the
+  host arm and so build their own (codeAction, for the `"{title} — {server}"`
+  suffix; completion, for the resolve-routing envelope), calling
+  `walk_layer_futures` / `walk_layers_by_strategy` with it. Covered: definition, hover, declaration,
   typeDefinition, implementation, references, completion, signatureHelp,
   documentHighlight, rename, prepareRename, linkedEditingRange, moniker,
   inlayHint, documentSymbol, documentLink, foldingRange, codeLens,
@@ -42,7 +45,8 @@ Partially implemented:
   too (marked `host_layer`, so the resolve forwards VERBATIM — no coordinate
   translation and no injection-region edit guard), but only for a server that
   advertises `completionItem/resolve`. Without that capability the items stay
-  bare and a resolve falls back gracefully (item returned unresolved). Formatting additionally supports the cross-layer
+  bare and a resolve falls back gracefully (item returned unresolved).
+  Formatting additionally supports the cross-layer
   `concatenated` pipeline: virt region edits apply first, the host
   formatter formats the intermediate text, and the chain collapses into one
   whole-document replacement edit. During that pipeline the host server's

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -395,7 +395,7 @@ foldingRange, linkedEditingRange, … — lives in `docs/language-features.md`.
 | hover | ✅ Implemented | Pass-through with position translation |
 | signatureHelp | ✅ Implemented | Pass-through |
 | completion | ✅ Implemented | Fail-closed edit guards; atomic additionalTextEdits drop |
-| completionItem/resolve | ✅ Implemented | Envelope-routed; an unsafe resolved PRIMARY edit serves the unresolved item, unsafe additionalTextEdits drop as an atomic set |
+| completionItem/resolve | ✅ Implemented | Envelope-routed (virt and host layers); an unsafe resolved PRIMARY edit serves the unresolved item, unsafe additionalTextEdits drop as an atomic set. Host-layer items forward verbatim — already host coordinates, so no translation and no region guard |
 | references | ✅ Implemented | Real-file URIs kept, cross-region virtual URIs dropped |
 | rename | ✅ Implemented | With workspace edit validation |
 | codeAction | ✅ Implemented | Edit-carrying, lazy (`codeAction/resolve` routed to the origin server), command-carrying (`workspace/executeCommand` name-routing + palette dispatch), host layer, multi-region menu merge; strict edit validation (cross-region / region bounds incl. per-line prefix floor) |

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -107,8 +107,8 @@ embedded blocks. Works for any grammar, no setup required.
 The features below are served by a language server configured for the
 embedded language — most of them also on the surrounding document itself,
 by a `bridge._self` host server (exceptions: document color stays
-injection-only, and host completion-item and code-lens resolves pass
-through unrouted). Placing the cursor outside an embedded
+injection-only, and host code-lens resolves pass through unrouted).
+Placing the cursor outside an embedded
 code block yields no result from the injection bridges; with `bridge._self`
 configured, the host language's own servers still answer there.
 

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -84,7 +84,7 @@ pub(crate) use text_document::{
     CodeActionEnvelope, CodeLensEnvelope, UpstreamCodeActionCaps, bridge_code_actions,
     extract_code_action_envelope, extract_code_lens_envelope, parse_code_actions_leniently,
 };
-pub(crate) use text_document::{KakehashiEnvelope, extract_envelope};
+pub(crate) use text_document::{KakehashiEnvelope, envelope_host_item, extract_envelope};
 pub(crate) use text_document::{OpenExpectation, OpenOutcome};
 pub(crate) use workspace::WorkspaceFolderSet;
 

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -84,7 +84,7 @@ pub(crate) use text_document::{
     CodeActionEnvelope, CodeLensEnvelope, UpstreamCodeActionCaps, bridge_code_actions,
     extract_code_action_envelope, extract_code_lens_envelope, parse_code_actions_leniently,
 };
-pub(crate) use text_document::{KakehashiEnvelope, envelope_host_item, extract_envelope};
+pub(crate) use text_document::{KakehashiEnvelope, bridge_host_completion_items, extract_envelope};
 pub(crate) use text_document::{OpenExpectation, OpenOutcome};
 pub(crate) use workspace::WorkspaceFolderSet;
 

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -556,6 +556,19 @@ impl ConnectionHandle {
         if self.dynamic_capabilities().has_registration(method) {
             return true;
         }
+        // A sub-capability that lives inside ANOTHER method's options has no
+        // method of its own to register, so the name match above can never see
+        // it: `completionItem/resolve` is `textDocument/completion`'s
+        // `resolveProvider`. Without this, a server that registers completion
+        // dynamically and advertises nothing statically reads as non-resolving,
+        // and its items are served with no way to resolve them.
+        if method == "completionItem/resolve"
+            && self
+                .dynamic_capabilities()
+                .registration_options_flag("textDocument/completion", "resolveProvider")
+        {
+            return true;
+        }
         // Fall back to static capabilities from initialize response
         let Some(caps) = self.server_capabilities() else {
             return false;
@@ -2634,6 +2647,54 @@ mod tests {
         handle.set_server_capabilities(ServerCapabilities::default());
 
         assert!(!handle.has_capability("completionItem/resolve"));
+    }
+
+    /// `completionItem/resolve` is not a registrable method — it is
+    /// `textDocument/completion`'s `resolveProvider` — so a server that
+    /// registers completion DYNAMICALLY carries the flag in that
+    /// registration's options, where a method-name match can never find it.
+    #[tokio::test]
+    async fn completion_resolve_capability_true_from_dynamic_completion_registration() {
+        use tower_lsp_server::ls_types::Registration;
+
+        let handle = spawn_sink_handle().await;
+        // Statically silent, exactly like a server that defers everything to
+        // client/registerCapability.
+        handle.set_server_capabilities(ServerCapabilities::default());
+        assert!(!handle.has_capability("completionItem/resolve"));
+
+        handle.dynamic_capabilities().register(vec![Registration {
+            id: "completion-1".to_string(),
+            method: "textDocument/completion".to_string(),
+            register_options: Some(serde_json::json!({ "resolveProvider": true })),
+        }]);
+
+        assert!(
+            handle.has_capability("completionItem/resolve"),
+            "a dynamic completion registration's resolveProvider must count"
+        );
+    }
+
+    /// The flag must be READ, not merely assumed from the registration's
+    /// presence: a server registering completion without resolve support still
+    /// gets its items served bare.
+    #[tokio::test]
+    async fn completion_resolve_capability_false_when_dynamic_registration_omits_the_flag() {
+        use tower_lsp_server::ls_types::Registration;
+
+        let handle = spawn_sink_handle().await;
+        handle.set_server_capabilities(ServerCapabilities::default());
+        handle.dynamic_capabilities().register(vec![Registration {
+            id: "completion-1".to_string(),
+            method: "textDocument/completion".to_string(),
+            register_options: Some(serde_json::json!({ "triggerCharacters": ["."] })),
+        }]);
+
+        assert!(!handle.has_capability("completionItem/resolve"));
+        assert!(
+            handle.has_capability("textDocument/completion"),
+            "the registration itself still provides completion"
+        );
     }
 
     // ========================================

--- a/src/lsp/bridge/pool/dynamic_capability_registry.rs
+++ b/src/lsp/bridge/pool/dynamic_capability_registry.rs
@@ -61,6 +61,30 @@ impl DynamicCapabilityRegistry {
             .any(|r| r.method == method)
     }
 
+    /// Whether any dynamic registration of `method` sets the boolean
+    /// `registerOptions.<flag>`.
+    ///
+    /// Sub-capabilities that live INSIDE another method's options have no
+    /// method of their own to register — `completionItem/resolve` is
+    /// `textDocument/completion`'s `resolveProvider`, not a registrable method
+    /// — so [`Self::has_registration`] can never see them. Without this, a
+    /// server that registers completion dynamically with `resolveProvider:
+    /// true` and advertises nothing statically reads as non-resolving.
+    pub(crate) fn registration_options_flag(&self, method: &str, flag: &str) -> bool {
+        self.registrations
+            .read()
+            .recover_poison("DynamicCapabilityRegistry::registration_options_flag")
+            .values()
+            .filter(|r| r.method == method)
+            .any(|r| {
+                r.register_options
+                    .as_ref()
+                    .and_then(|options| options.get(flag))
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false)
+            })
+    }
+
     pub(crate) fn store_log_message_level(&self, level: crate::config::settings::LogMessageLevel) {
         self.log_message_level
             .store(level.as_u8(), Ordering::Release);

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -15,7 +15,7 @@ pub(crate) use code_action::{
 };
 pub(crate) use code_lens::{CodeLensEnvelope, extract_code_lens_envelope};
 mod completion;
-pub(crate) use completion::{KakehashiEnvelope, extract_envelope};
+pub(crate) use completion::{KakehashiEnvelope, envelope_host_item, extract_envelope};
 mod completion_item;
 mod declaration;
 mod definition;

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -15,7 +15,7 @@ pub(crate) use code_action::{
 };
 pub(crate) use code_lens::{CodeLensEnvelope, extract_code_lens_envelope};
 mod completion;
-pub(crate) use completion::{KakehashiEnvelope, envelope_host_item, extract_envelope};
+pub(crate) use completion::{KakehashiEnvelope, bridge_host_completion_items, extract_envelope};
 mod completion_item;
 mod declaration;
 mod definition;

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -513,12 +513,55 @@ pub(crate) fn envelope_item_data(item: &mut CompletionItem, ctx: &EnvelopeContex
     item.data = Some(serde_json::json!({ ENVELOPE_KEY: envelope }));
 }
 
+/// Apply the HOST-layer completion policy to a host response (#958): envelope
+/// each item so a later `completionItem/resolve` routes back to the server that
+/// produced it. The bridge owns this the way it owns `bridge_code_actions` for
+/// the codeAction host layer; the handler only supplies `server_resolves`.
+///
+/// `server_resolves` — whether the answering connection advertises
+/// `completionItem/resolve` — gates the minting: without it the envelope would
+/// be pure wire weight on every item of every completion, and the resolve would
+/// fail soft back to the unresolved item anyway. An item whose OWN `data`
+/// already carries the envelope key is enveloped regardless: served verbatim it
+/// would be read back AS a Kakehashi envelope at resolve time, letting a
+/// downstream server author routing (an origin to spawn, a URI to root it at)
+/// that it never earned.
+///
+/// Both response shapes are covered — host servers answer with a bare array as
+/// often as with a `CompletionList`, and a List-only loop would leave array
+/// responses unresolvable, which is the very bug this fixes.
+pub(crate) fn bridge_host_completion_items(
+    response: &mut tower_lsp_server::ls_types::CompletionResponse,
+    server_name: &str,
+    host_uri: &str,
+    server_resolves: bool,
+) {
+    use tower_lsp_server::ls_types::CompletionResponse;
+    let items = match response {
+        CompletionResponse::Array(items) => items,
+        CompletionResponse::List(list) => &mut list.items,
+    };
+    for item in items.iter_mut() {
+        if server_resolves || data_carries_envelope_key(item) {
+            envelope_host_item(item, server_name, host_uri);
+        }
+    }
+}
+
+/// Whether an item's own `data` already occupies the envelope key — the one
+/// case a non-resolving server's item must still be wrapped.
+fn data_carries_envelope_key(item: &CompletionItem) -> bool {
+    item.data
+        .as_ref()
+        .is_some_and(|data| data.get(ENVELOPE_KEY).is_some())
+}
+
 /// Wrap a HOST-layer item's `data` in a routing envelope so a later
 /// `completionItem/resolve` routes back to the host server (#958). The host
 /// document is forwarded verbatim, so no region/offset is captured
 /// (`host_layer = true` tells the resolve path to skip all coordinate
 /// translation and its region-geometry guards).
-pub(crate) fn envelope_host_item(item: &mut CompletionItem, server_name: &str, host_uri: &str) {
+pub(super) fn envelope_host_item(item: &mut CompletionItem, server_name: &str, host_uri: &str) {
     let inner = item.data.take();
     let envelope = KakehashiEnvelope {
         origin: server_name.to_string(),
@@ -1138,6 +1181,88 @@ mod tests {
             serde_json::from_value(legacy).expect("legacy envelope must still deserialize");
         assert!(!envelope.host_layer);
         assert!(!envelope.is_host_layer());
+    }
+
+    /// The BARE-ARRAY response shape must be enveloped too. Host servers
+    /// answer with an array as often as with a `CompletionList`, and a
+    /// List-only loop would leave array responses unresolvable — the very bug
+    /// #958 is about.
+    #[test]
+    fn host_policy_envelopes_both_response_shapes() {
+        use tower_lsp_server::ls_types::{CompletionList, CompletionResponse};
+
+        let item = || CompletionItem {
+            label: "./test".to_string(),
+            ..Default::default()
+        };
+        let mut array = CompletionResponse::Array(vec![item()]);
+        let mut list = CompletionResponse::List(CompletionList {
+            is_incomplete: false,
+            items: vec![item()],
+        });
+        for response in [&mut array, &mut list] {
+            bridge_host_completion_items(response, "tsudoi-ls", "file:///doc.txt", true);
+        }
+
+        for (shape, items) in [("array", must_items(&array)), ("list", must_items(&list))] {
+            let envelope = extract_envelope(&items[0])
+                .unwrap_or_else(|| panic!("{shape} response must be enveloped"));
+            assert!(envelope.is_host_layer(), "{shape} envelope is host-layer");
+        }
+    }
+
+    /// Without `completionItem/resolve` the envelope is pure wire weight, so
+    /// items pass through bare — EXCEPT one whose own `data` already occupies
+    /// the envelope key. Served verbatim, that item would be read back AS a
+    /// Kakehashi envelope at resolve time, letting a downstream server author
+    /// an origin to spawn and a URI to root it at that it never earned.
+    #[test]
+    fn host_policy_wraps_a_colliding_data_even_without_resolve_support() {
+        use tower_lsp_server::ls_types::CompletionResponse;
+
+        let mut response = CompletionResponse::Array(vec![
+            CompletionItem {
+                label: "plain".to_string(),
+                data: Some(json!({"server": "own data"})),
+                ..Default::default()
+            },
+            CompletionItem {
+                label: "forged".to_string(),
+                data: Some(json!({ ENVELOPE_KEY: {
+                    "origin": "some-other-server",
+                    "host_uri": "file:///elsewhere",
+                    "region_id": "",
+                    "inner": null,
+                    "offset": { "line": 0, "column": 0 },
+                    "host_layer": true
+                }})),
+                ..Default::default()
+            },
+        ]);
+        bridge_host_completion_items(&mut response, "tsudoi-ls", "file:///doc.txt", false);
+
+        let items = must_items(&response);
+        assert_eq!(
+            items[0].data,
+            Some(json!({"server": "own data"})),
+            "an ordinary item from a non-resolving server stays bare"
+        );
+        let envelope = extract_envelope(&items[1]).expect("the forged item is wrapped");
+        assert_eq!(
+            envelope.origin, "tsudoi-ls",
+            "the wrap must route to the server that actually answered, not the forged origin"
+        );
+        assert_eq!(
+            envelope.host_uri, "file:///doc.txt",
+            "and to the real host document, not the forged URI"
+        );
+    }
+
+    fn must_items(response: &tower_lsp_server::ls_types::CompletionResponse) -> &[CompletionItem] {
+        match response {
+            tower_lsp_server::ls_types::CompletionResponse::Array(items) => items,
+            tower_lsp_server::ls_types::CompletionResponse::List(list) => &list.items,
+        }
     }
 
     /// A host-layer item is enveloped with the layer marker and NO region

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -401,6 +401,9 @@ pub(crate) struct KakehashiEnvelope {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub region_id: String,
     /// The downstream server's original `data` value (preserved verbatim).
+    /// Absent — not `null` — when the server sent none, which is most items
+    /// on most responses; `wrap_envelope` moves the value in afterwards.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inner: Option<Value>,
     /// Region offset snapshot for coordinate transformation of the resolved response.
     pub offset: EnvelopeOffset,
@@ -505,12 +508,38 @@ pub(crate) fn envelope_item_data(item: &mut CompletionItem, ctx: &EnvelopeContex
         origin: ctx.server_name.to_string(),
         host_uri: ctx.host_uri.to_string(),
         region_id: ctx.region_id.to_string(),
-        inner,
+        inner: None,
         offset: EnvelopeOffset::from(ctx.offset),
         region_end: ctx.region_end.map(|end| (end.line, end.character)),
         host_layer: ctx.host_layer,
     };
-    item.data = Some(serde_json::json!({ ENVELOPE_KEY: envelope }));
+    item.data = Some(wrap_envelope(envelope, inner));
+}
+
+/// Serialize an envelope into `{"kakehashi": {…}}`, MOVING the downstream's
+/// own `data` into `inner`.
+///
+/// The obvious `json!({ ENVELOPE_KEY: envelope })` would serialize `inner`
+/// through `Serialize`, i.e. deep-copy the downstream's `data` — once per
+/// item, on a response the client re-requests on every keystroke. Serializing
+/// the envelope with `inner: None` (skipped on the wire) and inserting the
+/// moved value afterwards costs one map insert instead.
+fn wrap_envelope(envelope: KakehashiEnvelope, inner: Option<Value>) -> Value {
+    debug_assert!(
+        envelope.inner.is_none(),
+        "inner must be moved in, not serialized"
+    );
+    let mut wrapped = serde_json::to_value(envelope).unwrap_or(Value::Null);
+    if let Some(inner) = inner
+        && let Some(fields) = wrapped.as_object_mut()
+    {
+        fields.insert("inner".to_string(), inner);
+    }
+    // Built by hand rather than `json!`, which would deep-copy `wrapped`
+    // (including the `inner` we just moved in) back out through `Serialize`.
+    let mut outer = serde_json::Map::with_capacity(1);
+    outer.insert(ENVELOPE_KEY.to_string(), wrapped);
+    Value::Object(outer)
 }
 
 /// Apply the HOST-layer completion policy to a host response (#958): envelope
@@ -567,7 +596,7 @@ pub(super) fn envelope_host_item(item: &mut CompletionItem, server_name: &str, h
         origin: server_name.to_string(),
         host_uri: host_uri.to_string(),
         region_id: String::new(),
-        inner,
+        inner: None,
         // Unused on the host path (resolve forwards verbatim); a zero offset.
         offset: EnvelopeOffset {
             line: 0,
@@ -577,7 +606,7 @@ pub(super) fn envelope_host_item(item: &mut CompletionItem, server_name: &str, h
         region_end: None,
         host_layer: true,
     };
-    item.data = Some(serde_json::json!({ ENVELOPE_KEY: envelope }));
+    item.data = Some(wrap_envelope(envelope, inner));
 }
 
 /// Extract the envelope from a completion item's `data` without modifying the item.
@@ -1367,10 +1396,58 @@ mod tests {
 
         let envelope = extract_envelope(&item).expect("should extract envelope");
         assert_eq!(envelope.inner, None);
+        assert!(
+            item.data.as_ref().expect("enveloped")["kakehashi"]
+                .get("inner")
+                .is_none(),
+            "an item whose server sent no data must not carry `inner: null`"
+        );
 
         let stripped = strip_envelope(&mut item).expect("should strip");
         assert_eq!(stripped.inner, None);
         assert_eq!(item.data, None);
+    }
+
+    /// `wrap_envelope` moves the downstream's `data` in rather than
+    /// re-serializing it (which would deep-copy every item's data on every
+    /// keystroke). Nested structure must survive the move byte for byte.
+    #[test]
+    fn envelope_moves_nested_downstream_data_in_unchanged() {
+        let original = json!({
+            "resolve_id": 42,
+            "nested": { "deep": ["a", 1, null, {"k": true}] }
+        });
+        let mut item = CompletionItem {
+            label: "print".to_string(),
+            data: Some(original.clone()),
+            ..Default::default()
+        };
+        let offset = RegionOffset::new(3, 4);
+        envelope_item_data(
+            &mut item,
+            &EnvelopeContext {
+                server_name: "lua-ls",
+                host_uri: "file:///test/doc.md",
+                region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                offset: &offset,
+                region_end: Some(TEST_REGION_END),
+                host_layer: false,
+            },
+        );
+
+        assert_eq!(
+            item.data.as_ref().expect("enveloped")["kakehashi"]["inner"],
+            original,
+            "the moved-in data must be identical to what the server sent"
+        );
+        assert_eq!(
+            extract_envelope(&item).expect("enveloped").inner,
+            Some(original.clone()),
+            "and must deserialize back to that same value"
+        );
+        // `strip_envelope` moves `inner` back out into the item's own data.
+        strip_envelope(&mut item).expect("should strip");
+        assert_eq!(item.data, Some(original));
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -395,8 +395,10 @@ pub(crate) struct KakehashiEnvelope {
     #[serde(default)]
     pub host_uri: String,
     /// Stable injection region identity for live resolve-time geometry checks.
-    /// Empty for envelopes minted before this field existed.
-    #[serde(default)]
+    /// Empty for envelopes minted before this field existed, and for every
+    /// host-layer envelope (which has no region) — skipped on the wire in
+    /// that case, since this rides in EVERY item of every completion response.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub region_id: String,
     /// The downstream server's original `data` value (preserved verbatim).
     pub inner: Option<Value>,
@@ -413,9 +415,16 @@ pub(crate) struct KakehashiEnvelope {
     /// coordinates, so `completionItem/resolve` routes to the host server
     /// VERBATIM — no virtual URI, region, or offset translation.
     /// `region_id`/`offset`/`region_end` are unused for these. Defaults to
-    /// `false` (virt layer) so existing enveloped items deserialize unchanged.
-    #[serde(default)]
+    /// `false` (virt layer) so existing enveloped items deserialize unchanged
+    /// — and is skipped on the wire in that case, so the far more numerous
+    /// virt items pay nothing for a marker only host items use.
+    #[serde(default, skip_serializing_if = "is_false")]
     pub host_layer: bool,
+}
+
+/// `skip_serializing_if` predicate for a `bool` that defaults to `false`.
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 impl KakehashiEnvelope {
@@ -1142,6 +1151,18 @@ mod tests {
         };
         envelope_host_item(&mut item, "tsudoi-ls", "file:///test/doc.txt");
 
+        // The two fields a host envelope leaves at their defaults must not
+        // ride the wire — this rides in every item of every response.
+        let wire = item.data.clone().expect("enveloped");
+        assert!(
+            wire["kakehashi"].get("region_id").is_none(),
+            "an empty region_id must be skipped on the wire: {wire}"
+        );
+        assert_eq!(
+            wire["kakehashi"]["host_layer"], true,
+            "the host marker is the one flag that must be serialized: {wire}"
+        );
+
         let envelope = extract_envelope(&item).expect("should extract envelope");
         assert!(envelope.is_host_layer());
         assert_eq!(envelope.origin, "tsudoi-ls");
@@ -1178,6 +1199,26 @@ mod tests {
         assert!(
             !envelope.is_host_layer(),
             "a region-carrying envelope stays on the virt resolve path"
+        );
+
+        // The virt envelope — minted for every item of every completion —
+        // must not carry the host marker on the wire at all.
+        let mut virt = CompletionItem::default();
+        envelope_item_data(
+            &mut virt,
+            &EnvelopeContext {
+                server_name: "lua-ls",
+                host_uri: "file:///test/doc.md",
+                region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                offset: &offset,
+                region_end: Some(TEST_REGION_END),
+                host_layer: false,
+            },
+        );
+        let wire = virt.data.expect("enveloped");
+        assert!(
+            wire["kakehashi"].get("host_layer").is_none(),
+            "a virt envelope must not pay for the host marker: {wire}"
         );
     }
 

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -80,6 +80,7 @@ impl LanguageServerPool {
                         region_id,
                         offset: ctx.offset,
                         region_end: Some(region_end),
+                        host_layer: false,
                     }),
                 )
             },
@@ -408,6 +409,29 @@ pub(crate) struct KakehashiEnvelope {
     /// fully fail-closed guard in prefixed regions.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub region_end: Option<(u32, u32)>,
+    /// Host-layer item (`bridge._self`, #958): it is already in host
+    /// coordinates, so `completionItem/resolve` routes to the host server
+    /// VERBATIM — no virtual URI, region, or offset translation.
+    /// `region_id`/`offset`/`region_end` are unused for these. Defaults to
+    /// `false` (virt layer) so existing enveloped items deserialize unchanged.
+    #[serde(default)]
+    pub host_layer: bool,
+}
+
+impl KakehashiEnvelope {
+    /// Whether this is a genuine HOST-layer envelope: `host_layer` set AND no
+    /// region identity. A host envelope is minted with an empty `region_id`
+    /// ([`envelope_host_item`]), so requiring both here means a CONFORMING
+    /// client that merely flips `host_layer = true` on a VIRT envelope (which
+    /// keeps its `region_id`) still can't route it through the translation-free
+    /// host path and skip the region freshness / coordinate validation. This is
+    /// not a security boundary: the envelope round-trips through client-supplied
+    /// `CompletionItem.data` and is not integrity-protected, so a client could
+    /// clear `region_id` too — the check guards against ACCIDENTAL bypass, not a
+    /// malicious one (which the translation-free host path also fails soft on).
+    pub(crate) fn is_host_layer(&self) -> bool {
+        self.host_layer && self.region_id.is_empty()
+    }
 }
 
 /// Offset snapshot stored in the envelope for coordinate back-translation.
@@ -456,6 +480,10 @@ pub(crate) struct EnvelopeContext<'a> {
     /// Region end (host coords) snapshot for the resolve-path safety guard;
     /// `None` only when re-enveloping a legacy envelope that never carried it.
     pub region_end: Option<Position>,
+    /// Carries the layer through a re-envelope: a host-layer item resolved
+    /// once must still route through the host path on the NEXT resolve.
+    /// Minting sites use `false` (virt) or [`envelope_host_item`].
+    pub host_layer: bool,
 }
 
 /// Wrap `item.data` in a Kakehashi envelope for origin tracking.
@@ -471,6 +499,31 @@ pub(crate) fn envelope_item_data(item: &mut CompletionItem, ctx: &EnvelopeContex
         inner,
         offset: EnvelopeOffset::from(ctx.offset),
         region_end: ctx.region_end.map(|end| (end.line, end.character)),
+        host_layer: ctx.host_layer,
+    };
+    item.data = Some(serde_json::json!({ ENVELOPE_KEY: envelope }));
+}
+
+/// Wrap a HOST-layer item's `data` in a routing envelope so a later
+/// `completionItem/resolve` routes back to the host server (#958). The host
+/// document is forwarded verbatim, so no region/offset is captured
+/// (`host_layer = true` tells the resolve path to skip all coordinate
+/// translation and its region-geometry guards).
+pub(crate) fn envelope_host_item(item: &mut CompletionItem, server_name: &str, host_uri: &str) {
+    let inner = item.data.take();
+    let envelope = KakehashiEnvelope {
+        origin: server_name.to_string(),
+        host_uri: host_uri.to_string(),
+        region_id: String::new(),
+        inner,
+        // Unused on the host path (resolve forwards verbatim); a zero offset.
+        offset: EnvelopeOffset {
+            line: 0,
+            column: 0,
+            line_column_offsets: None,
+        },
+        region_end: None,
+        host_layer: true,
     };
     item.data = Some(serde_json::json!({ ENVELOPE_KEY: envelope }));
 }
@@ -1015,6 +1068,7 @@ mod tests {
             region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
             offset: &offset,
             region_end: Some(TEST_REGION_END),
+            host_layer: false,
         };
         envelope_item_data(&mut item, &ctx);
 
@@ -1060,6 +1114,73 @@ mod tests {
         );
     }
 
+    /// A pre-#958 envelope carries no `host_layer` field; it must deserialize
+    /// as a VIRT envelope, not fail — `serde(default)` backward compatibility.
+    #[test]
+    fn envelope_without_host_layer_field_defaults_to_virt() {
+        let legacy = json!({
+            "origin": "lua-ls",
+            "host_uri": "file:///test/doc.md",
+            "region_id": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            "inner": null,
+            "offset": { "line": 1, "column": 0 }
+        });
+        let envelope: KakehashiEnvelope =
+            serde_json::from_value(legacy).expect("legacy envelope must still deserialize");
+        assert!(!envelope.host_layer);
+        assert!(!envelope.is_host_layer());
+    }
+
+    /// A host-layer item is enveloped with the layer marker and NO region
+    /// identity — the resolve path routes it verbatim off those two facts.
+    #[test]
+    fn host_envelope_is_marked_and_carries_no_region() {
+        let mut item = CompletionItem {
+            label: "./test".to_string(),
+            data: Some(json!({"pathCompletion": "/tmp/test"})),
+            ..Default::default()
+        };
+        envelope_host_item(&mut item, "tsudoi-ls", "file:///test/doc.txt");
+
+        let envelope = extract_envelope(&item).expect("should extract envelope");
+        assert!(envelope.is_host_layer());
+        assert_eq!(envelope.origin, "tsudoi-ls");
+        assert_eq!(envelope.host_uri, "file:///test/doc.txt");
+        assert_eq!(envelope.region_id, "");
+        assert_eq!(envelope.region_end, None);
+        assert_eq!(envelope.inner, Some(json!({"pathCompletion": "/tmp/test"})));
+    }
+
+    /// `host_layer` alone does not make an envelope host-layer: a conforming
+    /// client flipping the flag on a VIRT envelope (which keeps its
+    /// `region_id`) must not skip the region freshness / coordinate guards.
+    #[test]
+    fn is_host_layer_requires_an_empty_region_id() {
+        let mut item = CompletionItem {
+            label: "print".to_string(),
+            ..Default::default()
+        };
+        let offset = RegionOffset::new(3, 4);
+        envelope_item_data(
+            &mut item,
+            &EnvelopeContext {
+                server_name: "lua-ls",
+                host_uri: "file:///test/doc.md",
+                region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                offset: &offset,
+                region_end: Some(TEST_REGION_END),
+                host_layer: true,
+            },
+        );
+
+        let envelope = extract_envelope(&item).expect("should extract envelope");
+        assert!(envelope.host_layer);
+        assert!(
+            !envelope.is_host_layer(),
+            "a region-carrying envelope stays on the virt resolve path"
+        );
+    }
+
     #[test]
     fn envelope_round_trip_with_none_data() {
         let mut item = CompletionItem {
@@ -1074,6 +1195,7 @@ mod tests {
             region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
             offset: &offset,
             region_end: Some(TEST_REGION_END),
+            host_layer: false,
         };
         envelope_item_data(&mut item, &ctx);
 

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -746,15 +746,30 @@ mod tests {
         );
     }
 
-    /// A HOST-layer item whose origin cannot be reached comes back unresolved
-    /// with the layer marker intact, so the client's next resolve still routes
-    /// through the host path instead of falling into the virt geometry gate.
+    /// A HOST-layer item whose origin cannot be CONNECTED to comes back
+    /// unresolved with the layer marker intact, so the client's next resolve
+    /// still routes through the host path instead of falling into the virt
+    /// geometry gate.
+    ///
+    /// The origin must be spawnable for this to mean anything: with no config
+    /// the dispatch returns at the `is_server_spawnable` gate, several branches
+    /// above the host routing this is meant to exercise.
     #[tokio::test]
-    async fn dispatch_re_envelopes_host_item_when_server_not_configured() {
+    async fn dispatch_re_envelopes_host_item_when_origin_cannot_be_reached() {
         let pool = std::sync::Arc::new(LanguageServerPool::new());
-        let settings = WorkspaceSettings::default();
+        let mut settings = WorkspaceSettings::default();
+        settings.language_servers.insert(
+            "tsudoi-ls".to_string(),
+            BridgeServerConfig {
+                // Spawnable per config, unspawnable in fact — so the dispatch
+                // reaches `send_host_completion_resolve` and fails there.
+                cmd: Some(vec!["kakehashi-no-such-binary-958".to_string()]),
+                ..Default::default()
+            },
+        );
         let mut item = CompletionItem {
             label: "./test".to_string(),
+            data: Some(json!({"pathCompletion": "/tmp/test"})),
             ..Default::default()
         };
         crate::lsp::bridge::text_document::completion::envelope_host_item(
@@ -769,7 +784,15 @@ mod tests {
 
         let envelope = extract_envelope(&result).expect("should have envelope");
         assert_eq!(envelope.origin, "tsudoi-ls");
-        assert!(envelope.is_host_layer());
+        assert!(
+            envelope.is_host_layer(),
+            "the marker must survive so the next resolve still takes the host path"
+        );
+        assert_eq!(
+            envelope.inner,
+            Some(json!({"pathCompletion": "/tmp/test"})),
+            "and the downstream's own data must survive with it"
+        );
     }
 
     /// The disabled gate must also apply when the server inherits `enabled:

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -3,13 +3,19 @@
 //! the original completion fan-out. Uses `send_request()` for FIFO ordering
 //! through the single writer task (ls-bridge-message-ordering).
 //!
-//! No `didOpen` is sent here — the virtual document is already open from the
-//! completion that produced this item. If the downstream server has since
-//! restarted (or the connection was recreated), the resolve fails and we
-//! return the unresolved item with envelope intact: graceful degradation.
-//! The same degradation serves a resolved item whose primary edit is unsafe
-//! for the injection region — escapes it, breaks per-line prefixes, or merges
-//! content into the closing fence (see `resolve_guard_region_end`).
+//! No document sync is sent here — `completionItem/resolve` carries no
+//! `textDocument`, and the completion that produced the item already opened
+//! the virtual document (virt) or synced the host one (host). If the
+//! downstream server has since restarted (or the connection was recreated),
+//! the resolve fails and we return the unresolved item with envelope intact:
+//! graceful degradation.
+//!
+//! Two paths share that degradation. The VIRT path translates coordinates and
+//! additionally serves the unresolved item when the resolved primary edit is
+//! unsafe for the injection region — escapes it, breaks per-line prefixes, or
+//! merges content into the closing fence (see `resolve_guard_region_end`). The
+//! HOST path (#958) forwards verbatim: its item is already in host
+//! coordinates, so neither the translation nor that region guard applies.
 
 use std::sync::Arc;
 
@@ -36,9 +42,11 @@ impl LanguageServerPool {
     /// Route a `completionItem/resolve` request to the origin downstream server.
     ///
     /// Strips the Kakehashi envelope to identify the origin server, looks up
-    /// the server config from `settings`, and delegates to
-    /// `send_completion_resolve_request`. If any routing step fails (no envelope,
-    /// server not configured), the item is returned as-is.
+    /// the server config from `settings`, and delegates to whichever path the
+    /// envelope's layer selects: `send_host_completion_resolve` (verbatim) for
+    /// a host-layer item, `send_completion_resolve_request` (coordinate
+    /// translation + region guard) otherwise. If any routing step fails (no
+    /// envelope, server not configured), the item is returned as-is.
     pub(crate) async fn dispatch_completion_resolve(
         &self,
         mut item: CompletionItem,
@@ -101,12 +109,14 @@ impl LanguageServerPool {
     ) -> CompletionItem {
         let server_name = &envelope.origin;
         // `host_uri` comes from client-supplied `data` (the resolve params echo
-        // the item's envelope), so a malformed value must fail soft, NOT fall
-        // through to `get_or_create_connection(.., None)` — a `None` document
-        // hint routes to a rootless client-fallback / shared key that could run
-        // the resolve against the wrong workspace. The bridge only ever mints a
-        // valid `Url::as_str()` here, so a parse failure means a corrupt or
-        // foreign envelope.
+        // the item's envelope), so an unparseable value fails soft rather than
+        // falling through to `get_or_create_connection(.., None)`, whose `None`
+        // document hint routes to the rootless client-fallback key. The bridge
+        // only ever mints a valid `Url::as_str()` here, so a parse failure means
+        // a corrupt or foreign envelope. This rejects only UNPARSEABLE strings:
+        // a well-formed non-file URL parses, then fails root resolution and
+        // lands on that same fallback key anyway — the host path is fail-soft
+        // throughout, so that costs a wasted round trip, not correctness.
         let Ok(host_url) = Url::parse(&envelope.host_uri) else {
             warn!(
                 target: "kakehashi::bridge",
@@ -131,6 +141,15 @@ impl LanguageServerPool {
             }
         };
         if !handle.has_capability("completionItem/resolve") {
+            // Anomalous, unlike on the virt path (which envelopes
+            // unconditionally): a host envelope is minted ONLY for a server
+            // that advertised resolve, so reaching here means a respawn
+            // changed capabilities (or the handle is still initializing).
+            warn!(
+                target: "kakehashi::bridge",
+                "completionItem/resolve: host server {server_name:?} no longer advertises \
+                 resolveProvider; returning unresolved"
+            );
             re_envelope_item(&mut item, &envelope);
             return item;
         }
@@ -235,7 +254,11 @@ impl LanguageServerPool {
     /// parse the reply. `None` on every failure (registration, send, transport,
     /// error/malformed response) — the callers own the fail-soft policy of
     /// returning the unresolved item with its envelope restored. The upstream
-    /// registry entry is removed on every exit.
+    /// registry entry is removed on every `return`; a future DROPPED at the
+    /// response await leaks it, since (unlike the layer-walk arms) this has no
+    /// `UpstreamRegistrySweepGuard` above it — `completion_resolve_impl` calls
+    /// the dispatch directly rather than through `run_layer_race`. Pre-existing
+    /// and unchanged by the host path; noted so the claim is not read as RAII.
     async fn send_completion_resolve_on_handle(
         &self,
         handle: &Arc<ConnectionHandle>,

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -17,7 +17,7 @@ use log::warn;
 use tower_lsp_server::ls_types::{CompletionItem, Position};
 use url::Url;
 
-use super::super::pool::{LanguageServerPool, UpstreamId};
+use super::super::pool::{ConnectionHandle, LanguageServerPool, UpstreamId};
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, response_has_jsonrpc_error,
     translate_host_range_to_virtual,
@@ -73,8 +73,84 @@ impl LanguageServerPool {
             return item;
         };
 
+        // Host-layer items are already in host coordinates — route their
+        // resolve to the host server VERBATIM (no translation, #958). A genuine
+        // host envelope has no region identity; requiring that blocks a client
+        // flipping `host_layer` on a virt envelope to skip translation.
+        if envelope.is_host_layer() {
+            return self
+                .send_host_completion_resolve(&config, item, envelope, upstream_id)
+                .await;
+        }
+
         self.send_completion_resolve_request(&config, item, envelope, upstream_id)
             .await
+    }
+
+    /// Route a HOST-layer `completionItem/resolve` back to its host server
+    /// VERBATIM: the item is already in host coordinates, so nothing is
+    /// translated and the injection-region edit guard — which has no region to
+    /// judge against here — does not run. Fails soft (returns the item
+    /// unresolved, envelope restored) at every step.
+    async fn send_host_completion_resolve(
+        &self,
+        server_config: &BridgeServerConfig,
+        mut item: CompletionItem,
+        envelope: KakehashiEnvelope,
+        upstream_id: Option<UpstreamId>,
+    ) -> CompletionItem {
+        let server_name = &envelope.origin;
+        // `host_uri` comes from client-supplied `data` (the resolve params echo
+        // the item's envelope), so a malformed value must fail soft, NOT fall
+        // through to `get_or_create_connection(.., None)` — a `None` document
+        // hint routes to a rootless client-fallback / shared key that could run
+        // the resolve against the wrong workspace. The bridge only ever mints a
+        // valid `Url::as_str()` here, so a parse failure means a corrupt or
+        // foreign envelope.
+        let Ok(host_url) = Url::parse(&envelope.host_uri) else {
+            warn!(
+                target: "kakehashi::bridge",
+                "completionItem/resolve (host): envelope host_uri '{}' is not a valid URL; ignoring",
+                envelope.host_uri
+            );
+            re_envelope_item(&mut item, &envelope);
+            return item;
+        };
+        let handle = match self
+            .get_or_create_connection(server_name, server_config, Some(&host_url))
+            .await
+        {
+            Ok(h) => h,
+            Err(e) => {
+                warn!(
+                    target: "kakehashi::bridge",
+                    "completionItem/resolve (host): failed to connect to {server_name}: {e}"
+                );
+                re_envelope_item(&mut item, &envelope);
+                return item;
+            }
+        };
+        if !handle.has_capability("completionItem/resolve") {
+            re_envelope_item(&mut item, &envelope);
+            return item;
+        }
+
+        // Host coordinates throughout: the item goes out as served (minus the
+        // envelope, already stripped) and the resolved reply needs no
+        // translation on the way back.
+        match self
+            .send_completion_resolve_on_handle(&handle, item.clone(), upstream_id)
+            .await
+        {
+            Some(mut resolved) => {
+                re_envelope_item(&mut resolved, &envelope);
+                resolved
+            }
+            None => {
+                re_envelope_item(&mut item, &envelope);
+                item
+            }
+        }
     }
 
     /// Send a `completionItem/resolve` request to the downstream server that
@@ -120,74 +196,14 @@ impl LanguageServerPool {
             return item;
         }
 
-        // Route per-connection cancel state by this handle's pool key (#382) —
-        // the same connection the completion ran on, recovered from the
-        // envelope's host URI above.
-        let connection_key = handle.key();
-
-        // Register in the upstream request registry FIRST for cancel lookup.
-        if let Some(ref id) = upstream_id {
-            self.register_upstream_request(id.clone(), connection_key);
-        }
-
-        let (request_id, response_rx) =
-            match handle.register_request_with_upstream(upstream_id.clone()) {
-                Ok(pair) => pair,
-                Err(e) => {
-                    warn!(
-                        target: "kakehashi::bridge",
-                        "completionItem/resolve: failed to register request for {}: {}",
-                        server_name, e
-                    );
-                    if let Some(ref id) = upstream_id {
-                        self.unregister_upstream_request(id, connection_key);
-                    }
-                    re_envelope_item(&mut item, &envelope);
-                    return item;
-                }
-            };
-
         // The original host-coordinate `item` is kept untouched for the
-        // fail-soft returns below.
-        let request = prepare_completion_resolve_request(&item, &envelope, request_id);
+        // fail-soft returns below; the outgoing clone carries virtual ranges.
+        let outgoing = prepare_completion_resolve_item(&item, &envelope);
 
-        let mut router_guard = RouterCleanupGuard::new(Arc::clone(handle.router()), request_id);
-
-        if let Err(e) = handle.send_request(request, request_id) {
-            warn!(
-                target: "kakehashi::bridge",
-                "completionItem/resolve: failed to send request for {}: {}",
-                server_name, e
-            );
-            if let Some(ref id) = upstream_id {
-                self.unregister_upstream_request(id, connection_key);
-            }
-            re_envelope_item(&mut item, &envelope);
-            return item;
-        }
-
-        let response = handle.wait_for_response(request_id, response_rx).await;
-        router_guard.disarm();
-
-        // Unregister from the upstream request registry regardless of result
-        if let Some(ref id) = upstream_id {
-            self.unregister_upstream_request(id, connection_key);
-        }
-
-        let response = match response {
-            Ok(r) => r,
-            Err(e) => {
-                warn!(
-                    target: "kakehashi::bridge",
-                    "completionItem/resolve failed for server {}: {}",
-                    server_name, e
-                );
-                re_envelope_item(&mut item, &envelope);
-                return item;
-            }
-        };
-
-        match parse_completion_resolve_response(response) {
+        match self
+            .send_completion_resolve_on_handle(&handle, outgoing, upstream_id)
+            .await
+        {
             Some(mut resolved) => {
                 let offset = RegionOffset::from(&envelope.offset);
                 let region_end = resolve_guard_region_end(&envelope, &offset);
@@ -210,6 +226,78 @@ impl LanguageServerPool {
             None => {
                 re_envelope_item(&mut item, &envelope);
                 item
+            }
+        }
+    }
+
+    /// Transport half of `completionItem/resolve`, shared by the virt and host
+    /// paths: register for cancel forwarding, send `outgoing` on `handle`, and
+    /// parse the reply. `None` on every failure (registration, send, transport,
+    /// error/malformed response) — the callers own the fail-soft policy of
+    /// returning the unresolved item with its envelope restored. The upstream
+    /// registry entry is removed on every exit.
+    async fn send_completion_resolve_on_handle(
+        &self,
+        handle: &Arc<ConnectionHandle>,
+        outgoing: CompletionItem,
+        upstream_id: Option<UpstreamId>,
+    ) -> Option<CompletionItem> {
+        // Route per-connection cancel state by this handle's pool key (#382) —
+        // the same connection the completion ran on, recovered from the
+        // envelope's host URI by the caller.
+        let connection_key = handle.key();
+
+        // Register in the upstream request registry FIRST for cancel lookup.
+        if let Some(ref id) = upstream_id {
+            self.register_upstream_request(id.clone(), connection_key);
+        }
+
+        let (request_id, response_rx) = match handle
+            .register_request_with_upstream(upstream_id.clone())
+        {
+            Ok(pair) => pair,
+            Err(e) => {
+                warn!(
+                    target: "kakehashi::bridge",
+                    "completionItem/resolve: failed to register request on {connection_key:?}: {e}"
+                );
+                if let Some(ref id) = upstream_id {
+                    self.unregister_upstream_request(id, connection_key);
+                }
+                return None;
+            }
+        };
+
+        let request = build_completion_resolve_request(outgoing, request_id);
+        let mut router_guard = RouterCleanupGuard::new(Arc::clone(handle.router()), request_id);
+
+        if let Err(e) = handle.send_request(request, request_id) {
+            warn!(
+                target: "kakehashi::bridge",
+                "completionItem/resolve: failed to send request on {connection_key:?}: {e}"
+            );
+            if let Some(ref id) = upstream_id {
+                self.unregister_upstream_request(id, connection_key);
+            }
+            return None;
+        }
+
+        let response = handle.wait_for_response(request_id, response_rx).await;
+        router_guard.disarm();
+
+        // Unregister from the upstream request registry regardless of result
+        if let Some(ref id) = upstream_id {
+            self.unregister_upstream_request(id, connection_key);
+        }
+
+        match response {
+            Ok(response) => parse_completion_resolve_response(response),
+            Err(e) => {
+                warn!(
+                    target: "kakehashi::bridge",
+                    "completionItem/resolve failed on {connection_key:?}: {e}"
+                );
+                None
             }
         }
     }
@@ -240,19 +328,19 @@ fn parse_completion_resolve_response(mut response: serde_json::Value) -> Option<
     serde_json::from_value(result).ok()
 }
 
-/// Build the outgoing `completionItem/resolve` request from a SERVED item:
+/// Build the outgoing `completionItem/resolve` item from a SERVED one:
 /// a clone with its edit ranges restored to VIRTUAL coordinates (the served
 /// item is host-translated; a downstream that echoes the ranges verbatim
 /// would otherwise get them re-translated on the way back — a double shift
 /// the safety guard can't always catch). Mirrors the codeAction resolve path.
-fn prepare_completion_resolve_request(
+/// The HOST path has no such translation to undo and skips this entirely.
+fn prepare_completion_resolve_item(
     item: &CompletionItem,
     envelope: &KakehashiEnvelope,
-    request_id: RequestId,
-) -> JsonRpcRequest<CompletionItem> {
+) -> CompletionItem {
     let mut outgoing = item.clone();
     translate_item_ranges_host_to_virtual(&mut outgoing, &RegionOffset::from(&envelope.offset));
-    build_completion_resolve_request(outgoing, request_id)
+    outgoing
 }
 
 /// Translate a served (host-coordinate) item's edit ranges back to virtual
@@ -290,6 +378,9 @@ fn re_envelope_item(item: &mut CompletionItem, envelope: &KakehashiEnvelope) {
         region_end: envelope
             .region_end
             .map(|(line, character)| Position { line, character }),
+        // Preserve the layer: a host-layer item that has been resolved once
+        // must still take the host path on the client's NEXT resolve of it.
+        host_layer: envelope.host_layer,
     };
     envelope_item_data(item, &ctx);
 }
@@ -342,6 +433,7 @@ mod tests {
                 line_column_offsets: None,
             },
             region_end: Some((9, 0)),
+            host_layer: false,
         }
     }
 
@@ -500,6 +592,33 @@ mod tests {
         );
     }
 
+    /// A host-layer item resolved ONCE must still route through the host path
+    /// on the client's next resolve of it: `re_envelope_item` has to carry the
+    /// layer marker across, or the second resolve silently takes the virt path
+    /// and fails closed on a region that never existed. Two round trips —
+    /// a single one passes even when the marker is dropped.
+    #[test]
+    fn re_envelope_preserves_the_host_layer_marker() {
+        let mut item = CompletionItem {
+            label: "./test".to_string(),
+            ..Default::default()
+        };
+        crate::lsp::bridge::text_document::completion::envelope_host_item(
+            &mut item,
+            "tsudoi-ls",
+            "file:///test/doc.txt",
+        );
+
+        for round in 1..=2 {
+            let envelope = strip_envelope(&mut item).expect("should strip");
+            assert!(
+                envelope.is_host_layer(),
+                "envelope must stay host-layer through resolve round {round}"
+            );
+            re_envelope_item(&mut item, &envelope);
+        }
+    }
+
     #[test]
     fn re_envelope_preserves_none_data() {
         let envelope = test_envelope();
@@ -531,6 +650,7 @@ mod tests {
                 line_column_offsets: None,
             },
             region_end: Some((9, 0)),
+            host_layer: false,
         };
         let mut item = CompletionItem {
             label: "print".to_string(),
@@ -601,6 +721,32 @@ mod tests {
             envelope.origin, "lua-ls",
             "a disabled server's item is returned unresolved, not respawned"
         );
+    }
+
+    /// A HOST-layer item whose origin cannot be reached comes back unresolved
+    /// with the layer marker intact, so the client's next resolve still routes
+    /// through the host path instead of falling into the virt geometry gate.
+    #[tokio::test]
+    async fn dispatch_re_envelopes_host_item_when_server_not_configured() {
+        let pool = std::sync::Arc::new(LanguageServerPool::new());
+        let settings = WorkspaceSettings::default();
+        let mut item = CompletionItem {
+            label: "./test".to_string(),
+            ..Default::default()
+        };
+        crate::lsp::bridge::text_document::completion::envelope_host_item(
+            &mut item,
+            "tsudoi-ls",
+            "file:///test/doc.txt",
+        );
+
+        let result = pool
+            .dispatch_completion_resolve(item, &settings, None)
+            .await;
+
+        let envelope = extract_envelope(&result).expect("should have envelope");
+        assert_eq!(envelope.origin, "tsudoi-ls");
+        assert!(envelope.is_host_layer());
     }
 
     /// The disabled gate must also apply when the server inherits `enabled:
@@ -711,7 +857,10 @@ mod tests {
 
         // Go through the SAME request-preparation helper production uses, and
         // assert on the serialized request.
-        let request = prepare_completion_resolve_request(&item, &envelope, RequestId::new(7));
+        let request = build_completion_resolve_request(
+            prepare_completion_resolve_item(&item, &envelope),
+            RequestId::new(7),
+        );
         let wire = serde_json::to_value(&request).unwrap();
 
         assert_eq!(

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -253,12 +253,13 @@ impl LanguageServerPool {
     /// paths: register for cancel forwarding, send `outgoing` on `handle`, and
     /// parse the reply. `None` on every failure (registration, send, transport,
     /// error/malformed response) — the callers own the fail-soft policy of
-    /// returning the unresolved item with its envelope restored. The upstream
-    /// registry entry is removed on every `return`; a future DROPPED at the
-    /// response await leaks it, since (unlike the layer-walk arms) this has no
-    /// `UpstreamRegistrySweepGuard` above it — `completion_resolve_impl` calls
-    /// the dispatch directly rather than through `run_layer_race`. Pre-existing
-    /// and unchanged by the host path; noted so the claim is not read as RAII.
+    /// returning the unresolved item with its envelope restored.
+    ///
+    /// The upstream registry entry is removed on every `return` here, but that
+    /// is NOT RAII — a future dropped at the response await skips it. The
+    /// `UpstreamRegistrySweepGuard` in `completion_resolve_impl` covers that
+    /// case (this dispatch is called directly, not through `run_layer_race`,
+    /// so it has no walk-level sweep above it).
     async fn send_completion_resolve_on_handle(
         &self,
         handle: &Arc<ConnectionHandle>,

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -50,18 +50,20 @@ pub(crate) struct HostDocument<'a> {
     pub(crate) text: &'a str,
 }
 
-/// A raw host-server response plus the connection it came from.
+/// A raw host-server response plus the very connection that answered it.
 ///
-/// The key rides along because resolving it separately means repeating the
+/// The connection rides along because re-resolving it means repeating the
 /// marker filesystem walk that the request already performed — measurable on
-/// `textDocument/codeAction`, which some editors fire on cursor hold.
+/// `textDocument/codeAction`, which some editors fire on cursor hold, and on
+/// `textDocument/completion`, which fires per keystroke. Callers read the pool
+/// key from it (`workspace/executeCommand` routing tokens) or its advertised
+/// capabilities (`completionItem/resolve`, before minting resolve envelopes).
+///
+/// Asking THIS handle is also more accurate than a fresh lookup: it is the
+/// process that produced the response, where a re-resolve could answer for a
+/// replacement spawned since.
 pub(crate) struct HostRawResponse {
     pub(crate) value: serde_json::Value,
-    pub(crate) connection_key: ConnectionKey,
-    /// The very connection that answered, so a caller can consult its
-    /// advertised capabilities (e.g. `completionItem/resolve` before minting
-    /// resolve envelopes) without a second `get_or_create_connection` — that
-    /// lookup repeats the marker walk this request already paid for.
     pub(crate) handle: Arc<ConnectionHandle>,
 }
 
@@ -307,11 +309,11 @@ impl LanguageServerPool {
             return Ok(None);
         }
         // Carried out with the response so a caller that must name this exact
-        // connection (the `workspace/executeCommand` routing token) does not
-        // re-resolve it — that would repeat the marker filesystem walk on a
-        // request-frequency path (execute-command-routing-token).
-        let connection_key = handle.key().clone();
-        let capabilities_handle = Arc::clone(&handle);
+        // connection (the `workspace/executeCommand` routing token) or ask what
+        // it advertises (`completionItem/resolve`) does not re-resolve it —
+        // that would repeat the marker filesystem walk on a request-frequency
+        // path (execute-command-routing-token).
+        let answering = Arc::clone(&handle);
         let value = self
             .execute_host_request(
                 handle,
@@ -326,30 +328,8 @@ impl LanguageServerPool {
             .await??;
         Ok(value.map(|value| HostRawResponse {
             value,
-            connection_key,
-            handle: capabilities_handle,
+            handle: answering,
         }))
-    }
-
-    /// Whether the host server for `(server_name, uri)` advertises `method`
-    /// (e.g. `codeAction/resolve`). Reuses the existing connection when the
-    /// request that ran just before already opened it, but still goes through
-    /// `get_or_create_connection`, which re-resolves the marker/root and takes
-    /// the pool lock even on a cache hit — cheap, not free, so callers gate the
-    /// call when the answer can't change the outcome. Fail-closed (`false`) when
-    /// the server can't be reached. Used to decide whether a host lazy action can
-    /// be resolve-routed rather than disabled (#627).
-    pub(crate) async fn host_server_advertises(
-        &self,
-        server_name: &str,
-        server_config: &BridgeServerConfig,
-        uri: &url::Url,
-        method: &str,
-    ) -> bool {
-        self.get_or_create_connection(server_name, server_config, Some(uri))
-            .await
-            .map(|handle| handle.has_capability(method))
-            .unwrap_or(false)
     }
 
     /// Send a host formatting request. Unlike [`Self::send_host_raw_request`],

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -58,6 +58,11 @@ pub(crate) struct HostDocument<'a> {
 pub(crate) struct HostRawResponse {
     pub(crate) value: serde_json::Value,
     pub(crate) connection_key: ConnectionKey,
+    /// The very connection that answered, so a caller can consult its
+    /// advertised capabilities (e.g. `completionItem/resolve` before minting
+    /// resolve envelopes) without a second `get_or_create_connection` — that
+    /// lookup repeats the marker walk this request already paid for.
+    pub(crate) handle: Arc<ConnectionHandle>,
 }
 
 fn fingerprint(text: &str) -> u64 {
@@ -306,6 +311,7 @@ impl LanguageServerPool {
         // re-resolve it — that would repeat the marker filesystem walk on a
         // request-frequency path (execute-command-routing-token).
         let connection_key = handle.key().clone();
+        let capabilities_handle = Arc::clone(&handle);
         let value = self
             .execute_host_request(
                 handle,
@@ -321,6 +327,7 @@ impl LanguageServerPool {
         Ok(value.map(|value| HostRawResponse {
             value,
             connection_key,
+            handle: capabilities_handle,
         }))
     }
 

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1054,12 +1054,32 @@ impl Kakehashi {
         // registry on this arm's completion would drop a live sibling's
         // cancel registrations. The one non-walk caller
         // (`will_save_wait_until`) sweeps for itself.
-        // Quieter than `FanInResult::handle`: an all-empty host layer is the
-        // normal outcome whenever virt answers, and the virt arm already
-        // emits the client-visible "no response" LOG — only real host
-        // failures get surfaced here.
+        self.host_layer_result(result, request_method, |value| value)
+            .await
+    }
+
+    /// Fold a host-layer fan-in result into a handler's return.
+    ///
+    /// Quieter than [`FanInResult::handle`](crate::lsp::aggregation::server::FanInResult::handle):
+    /// an all-empty host layer is the normal outcome whenever virt answers,
+    /// and the virt arm already emits the client-visible "no response" LOG —
+    /// only real host failures get surfaced here. That deviation is exactly
+    /// why this is shared rather than written per handler: every host arm
+    /// (the verbatim raw walk above, codeAction, completion) must quiet the
+    /// same way, and three hand-copies would drift the moment the policy moves.
+    ///
+    /// `on_done` maps the winning fan-in payload to the handler's response —
+    /// identity for the arms whose payload already IS the response, and the
+    /// hook where a handler post-processes the winner (completion mints its
+    /// resolve envelopes there, so only the winner pays for them).
+    pub(crate) async fn host_layer_result<T, R>(
+        &self,
+        result: crate::lsp::aggregation::server::FanInResult<T>,
+        request_method: &str,
+        on_done: impl FnOnce(T) -> Option<R>,
+    ) -> tower_lsp_server::jsonrpc::Result<Option<R>> {
         match result {
-            crate::lsp::aggregation::server::FanInResult::Done(value) => Ok(value),
+            crate::lsp::aggregation::server::FanInResult::Done(value) => Ok(on_done(value)),
             crate::lsp::aggregation::server::FanInResult::NoResult { errors } => {
                 if errors > 0 {
                     self.notifier()

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -506,16 +506,22 @@ impl Kakehashi {
                 let Some(raw) = raw else {
                     return Ok(None);
                 };
-                let connection_key = raw.connection_key;
+                let answering = raw.handle;
+                let connection_key = answering.key().clone();
                 let Some(actions) = parse_code_actions_leniently(raw.value) else {
                     return Ok(None);
                 };
                 // Whether this host server advertises `codeAction/resolve`, so a
                 // host lazy action can be enveloped for resolve-routing back to
-                // it (#627) rather than disabled. Queried on the just-opened
-                // connection — but only when the answer can actually change the
-                // outcome, so the probe (and its marker-root resolution + pool
-                // lock) is skippable on this hot `textDocument/codeAction` path:
+                // it (#627) rather than disabled. Read off the connection that
+                // ANSWERED — which is both free (no re-resolution, so no marker
+                // walk or pool lock on this hot `textDocument/codeAction` path,
+                // which some editors fire on cursor hold) and more accurate than
+                // a fresh lookup, since a re-resolve could answer for a
+                // replacement spawned since these actions were produced.
+                //
+                // The two cheap terms still short-circuit ahead of it, because
+                // they also say the answer cannot change the outcome:
                 //
                 // - `server_resolves` is read by `bridge_code_action` ONLY for a
                 //   possibly-lazy action (no edit, no command, and not already
@@ -536,14 +542,7 @@ impl Kakehashi {
                 };
                 let server_resolves = client_can_use_resolve
                     && actions.iter().any(maybe_lazy)
-                    && t.pool
-                        .host_server_advertises(
-                            &t.server_name,
-                            &t.server_config,
-                            &t.uri,
-                            "codeAction/resolve",
-                        )
-                        .await;
+                    && answering.has_capability("codeAction/resolve");
                 Ok(Some(bridge_code_actions(
                     actions,
                     &connection_key,

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -21,7 +21,7 @@
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{
     CodeAction, CodeActionContext, CodeActionOrCommand, CodeActionParams, CodeActionResponse,
-    MessageType, NumberOrString, Position, Range, Uri,
+    NumberOrString, Position, Range, Uri,
 };
 use ulid::Ulid;
 use url::Url;
@@ -31,7 +31,7 @@ use super::super::{Kakehashi, detect_document_language};
 use crate::config::settings::AggregationStrategy;
 use crate::language::InjectionResolver;
 use crate::lsp::aggregation::server::{
-    FanInResult, FanOutTask, HostFanOutTask, dispatch_concatenated, dispatch_host_concatenated,
+    FanOutTask, HostFanOutTask, dispatch_concatenated, dispatch_host_concatenated,
     dispatch_host_preferred, dispatch_preferred,
 };
 use crate::lsp::bridge::{
@@ -568,39 +568,13 @@ impl Kakehashi {
                     cancel_rx,
                 )
                 .await;
-                self.host_code_action_result(fan_in, |v| v).await
+                self.host_layer_result(fan_in, METHOD, |v| v).await
             }
             AggregationStrategy::Concatenated => {
                 let fan_in =
                     dispatch_host_concatenated(&ctx, pool.clone(), f, cancel_rx, None, None).await;
-                self.host_code_action_result(fan_in, concat_merge).await
+                self.host_layer_result(fan_in, METHOD, concat_merge).await
             }
-        }
-    }
-
-    /// Fold a host-layer fan-in result into the handler's return, with the
-    /// host-arm quieting: an all-empty host layer is the normal outcome
-    /// whenever virt answers, so it stays SILENT (unlike [`FanInResult::handle`],
-    /// which logs a LOG-level message) and warns only on real failures.
-    async fn host_code_action_result<T>(
-        &self,
-        result: FanInResult<T>,
-        on_done: impl FnOnce(T) -> Option<CodeActionResponse>,
-    ) -> Result<Option<CodeActionResponse>> {
-        match result {
-            FanInResult::Done(value) => Ok(on_done(value)),
-            FanInResult::NoResult { errors } => {
-                if errors > 0 {
-                    self.notifier()
-                        .log(
-                            MessageType::WARNING,
-                            format!("No {METHOD} response from any host bridge server"),
-                        )
-                        .await;
-                }
-                Ok(None)
-            }
-            FanInResult::Cancelled => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
         }
     }
 }

--- a/src/lsp/lsp_impl/text_document/completion.rs
+++ b/src/lsp/lsp_impl/text_document/completion.rs
@@ -10,7 +10,8 @@
 //! The host layer cannot use the generic verbatim raw-value walk: its items
 //! need the routing envelope that makes `completionItem/resolve` reach the host
 //! server that produced them (#958), so it dispatches typed per server to keep
-//! the server name and its advertised capabilities.
+//! the server name and its advertised capabilities, and hands both to the
+//! bridge's `bridge_host_completion_items` policy.
 
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{
@@ -21,7 +22,7 @@ use super::super::Kakehashi;
 use crate::lsp::aggregation::server::{
     FanInResult, HostFanOutTask, dispatch_host_preferred, dispatch_preferred,
 };
-use crate::lsp::bridge::{HostDocument, envelope_host_item};
+use crate::lsp::bridge::{HostDocument, bridge_host_completion_items};
 use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
 
 const METHOD: &str = "textDocument/completion";
@@ -93,9 +94,12 @@ impl Kakehashi {
                 else {
                     return Ok(None);
                 };
-                if raw.handle.has_capability("completionItem/resolve") {
-                    envelope_host_completion_items(&mut response, &t.server_name, t.uri.as_str());
-                }
+                bridge_host_completion_items(
+                    &mut response,
+                    &t.server_name,
+                    t.uri.as_str(),
+                    raw.handle.has_capability("completionItem/resolve"),
+                );
                 Ok(Some(response))
             }
         };
@@ -178,24 +182,6 @@ impl Kakehashi {
                 Ok(v.map(CompletionResponse::List))
             })
             .await
-    }
-}
-
-/// Envelope every item of a host-layer response for `completionItem/resolve`
-/// routing. Both response shapes are enveloped: host servers answer with a bare
-/// array as often as with a `CompletionList`, and a List-only loop would leave
-/// array responses unresolvable — the very bug this fixes.
-fn envelope_host_completion_items(
-    response: &mut CompletionResponse,
-    server_name: &str,
-    host_uri: &str,
-) {
-    let items = match response {
-        CompletionResponse::Array(items) => items,
-        CompletionResponse::List(list) => &mut list.items,
-    };
-    for item in items.iter_mut() {
-        envelope_host_item(item, server_name, host_uri);
     }
 }
 

--- a/src/lsp/lsp_impl/text_document/completion.rs
+++ b/src/lsp/lsp_impl/text_document/completion.rs
@@ -15,12 +15,12 @@
 
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{
-    CompletionList, CompletionParams, CompletionResponse, MessageType, Position, Uri,
+    CompletionList, CompletionParams, CompletionResponse, Position, Uri,
 };
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::{
-    FanInResult, HostFanOutTask, dispatch_host_preferred, dispatch_preferred,
+    HostFanOutTask, dispatch_host_preferred, dispatch_preferred,
 };
 use crate::lsp::bridge::{HostDocument, bridge_host_completion_items};
 use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
@@ -121,23 +121,11 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        // Quieter than `FanInResult::handle`: an all-empty host layer is the
-        // normal outcome whenever virt answers, so only real failures surface.
-        match fan_in {
-            FanInResult::Done(won) => Ok(won.map(HostCompletion::into_enveloped_response)),
-            FanInResult::NoResult { errors } => {
-                if errors > 0 {
-                    self.notifier()
-                        .log(
-                            MessageType::WARNING,
-                            format!("No {METHOD} response from any host bridge server"),
-                        )
-                        .await;
-                }
-                Ok(None)
-            }
-            FanInResult::Cancelled => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
-        }
+        // The envelope pass rides in `on_done`, so only the WINNER pays it.
+        self.host_layer_result(fan_in, METHOD, |won| {
+            won.map(HostCompletion::into_enveloped_response)
+        })
+        .await
     }
 
     /// Virt layer: bridge the injection region under the cursor.

--- a/src/lsp/lsp_impl/text_document/completion.rs
+++ b/src/lsp/lsp_impl/text_document/completion.rs
@@ -59,6 +59,12 @@ impl Kakehashi {
     /// `completionItem/resolve`: for one that does not, it would be pure wire
     /// weight on every item of every completion, and the resolve would fail
     /// soft back to the unresolved item anyway.
+    ///
+    /// Minting also happens only for the server that WINS the fan-in. Each
+    /// fanned-out server carries its identity back beside its response
+    /// ([`HostCompletion`]) instead of enveloping in its own task, so a
+    /// multi-server `bridge._self` does not pay a per-item pass in every
+    /// losing task on every keystroke only to discard it.
     async fn completion_host_layer(
         &self,
         lsp_uri: &Uri,
@@ -90,17 +96,17 @@ impl Kakehashi {
                 let Some(raw) = raw else {
                     return Ok(None);
                 };
-                let Some(mut response) = parse_host_verbatim::<CompletionResponse>(raw.value)
-                else {
+                let Some(response) = parse_host_verbatim::<CompletionResponse>(raw.value) else {
                     return Ok(None);
                 };
-                bridge_host_completion_items(
-                    &mut response,
-                    &t.server_name,
-                    t.uri.as_str(),
-                    raw.handle.has_capability("completionItem/resolve"),
-                );
-                Ok(Some(response))
+                Ok(Some(HostCompletion {
+                    response,
+                    // Two allocations per SERVER, versus an envelope per item
+                    // in a task whose result the fan-in may well discard.
+                    server_resolves: raw.handle.has_capability("completionItem/resolve"),
+                    server_name: t.server_name,
+                    host_uri: t.uri.into(),
+                }))
             }
         };
         // No layer-level `unregister_all` here: the virt layer runs
@@ -111,14 +117,14 @@ impl Kakehashi {
             &ctx,
             pool.clone(),
             f,
-            |opt| matches!(opt, Some(v) if completion_response_has_result(v)),
+            |opt| matches!(opt, Some(v) if completion_response_has_result(&v.response)),
             cancel_rx,
         )
         .await;
         // Quieter than `FanInResult::handle`: an all-empty host layer is the
         // normal outcome whenever virt answers, so only real failures surface.
         match fan_in {
-            FanInResult::Done(value) => Ok(value),
+            FanInResult::Done(won) => Ok(won.map(HostCompletion::into_enveloped_response)),
             FanInResult::NoResult { errors } => {
                 if errors > 0 {
                     self.notifier()
@@ -182,6 +188,30 @@ impl Kakehashi {
                 Ok(v.map(CompletionResponse::List))
             })
             .await
+    }
+}
+
+/// One host server's completion response plus the identity the resolve
+/// envelope needs, carried through the fan-in so only the WINNER is enveloped.
+struct HostCompletion {
+    response: CompletionResponse,
+    /// The server that answered — the `origin` a later resolve routes to.
+    server_name: String,
+    /// The real host document URI the resolve reconnects on.
+    host_uri: String,
+    /// Whether that server advertises `completionItem/resolve`.
+    server_resolves: bool,
+}
+
+impl HostCompletion {
+    fn into_enveloped_response(mut self) -> CompletionResponse {
+        bridge_host_completion_items(
+            &mut self.response,
+            &self.server_name,
+            &self.host_uri,
+            self.server_resolves,
+        );
+        self.response
     }
 }
 

--- a/src/lsp/lsp_impl/text_document/completion.rs
+++ b/src/lsp/lsp_impl/text_document/completion.rs
@@ -6,14 +6,22 @@
 //! and the response verbatim. The first layer producing completion items, or an
 //! incomplete `CompletionList` that asks the client to re-query, wins
 //! (`preferred`).
+//!
+//! The host layer cannot use the generic verbatim raw-value walk: its items
+//! need the routing envelope that makes `completionItem/resolve` reach the host
+//! server that produced them (#958), so it dispatches typed per server to keep
+//! the server name and its advertised capabilities.
 
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{
-    CompletionList, CompletionParams, CompletionResponse, Position, Uri,
+    CompletionList, CompletionParams, CompletionResponse, MessageType, Position, Uri,
 };
 
 use super::super::Kakehashi;
-use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::aggregation::server::{
+    FanInResult, HostFanOutTask, dispatch_host_preferred, dispatch_preferred,
+};
+use crate::lsp::bridge::{HostDocument, envelope_host_item};
 use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
 
 const METHOD: &str = "textDocument/completion";
@@ -28,16 +36,98 @@ impl Kakehashi {
         let position = params.text_document_position.position;
 
         let virt = self.completion_virt_layer(&lsp_uri, position);
-        self.walk_layers(
+        let host = self.completion_host_layer(&lsp_uri, raw_params);
+        self.walk_layer_futures(
             &lsp_uri,
             METHOD,
             METHOD,
-            raw_params,
             virt,
-            parse_host_verbatim::<CompletionResponse>,
+            host,
+            std::future::ready(Ok(None)),
             completion_response_has_result,
         )
         .await
+    }
+
+    /// Host layer: forward the params verbatim to the host language's own
+    /// servers, then envelope each item so a later `completionItem/resolve`
+    /// routes back to the server that produced it (#958). Coordinates stay
+    /// untranslated — they are already real.
+    ///
+    /// The envelope is minted only for a server that advertises
+    /// `completionItem/resolve`: for one that does not, it would be pure wire
+    /// weight on every item of every completion, and the resolve would fail
+    /// soft back to the unresolved item anyway.
+    async fn completion_host_layer(
+        &self,
+        lsp_uri: &Uri,
+        raw_params: serde_json::Value,
+    ) -> Result<Option<CompletionResponse>> {
+        let Some(ctx) = self.resolve_host_bridge_context(lsp_uri, METHOD) else {
+            return Ok(None);
+        };
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(ctx.upstream_request_id.as_ref());
+        let pool = self.bridge.pool_arc();
+        let f = move |t: HostFanOutTask| {
+            let params = raw_params.clone();
+            async move {
+                let raw = t
+                    .pool
+                    .send_host_raw_request(
+                        &t.server_name,
+                        &t.server_config,
+                        &HostDocument {
+                            uri: &t.uri,
+                            language_id: &t.language_id,
+                            text: &t.text,
+                        },
+                        METHOD,
+                        params,
+                        t.upstream_id,
+                    )
+                    .await?;
+                let Some(raw) = raw else {
+                    return Ok(None);
+                };
+                let Some(mut response) = parse_host_verbatim::<CompletionResponse>(raw.value)
+                else {
+                    return Ok(None);
+                };
+                if raw.handle.has_capability("completionItem/resolve") {
+                    envelope_host_completion_items(&mut response, &t.server_name, t.uri.as_str());
+                }
+                Ok(Some(response))
+            }
+        };
+        // No layer-level `unregister_all` here: the virt layer runs
+        // concurrently under the SAME upstream id, so wiping the registry on
+        // this layer's completion would drop the sibling's live cancel
+        // registrations. `run_layer_race` sweeps after the whole race.
+        let fan_in = dispatch_host_preferred(
+            &ctx,
+            pool.clone(),
+            f,
+            |opt| matches!(opt, Some(v) if completion_response_has_result(v)),
+            cancel_rx,
+        )
+        .await;
+        // Quieter than `FanInResult::handle`: an all-empty host layer is the
+        // normal outcome whenever virt answers, so only real failures surface.
+        match fan_in {
+            FanInResult::Done(value) => Ok(value),
+            FanInResult::NoResult { errors } => {
+                if errors > 0 {
+                    self.notifier()
+                        .log(
+                            MessageType::WARNING,
+                            format!("No {METHOD} response from any host bridge server"),
+                        )
+                        .await;
+                }
+                Ok(None)
+            }
+            FanInResult::Cancelled => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
+        }
     }
 
     /// Virt layer: bridge the injection region under the cursor.
@@ -88,6 +178,24 @@ impl Kakehashi {
                 Ok(v.map(CompletionResponse::List))
             })
             .await
+    }
+}
+
+/// Envelope every item of a host-layer response for `completionItem/resolve`
+/// routing. Both response shapes are enveloped: host servers answer with a bare
+/// array as often as with a `CompletionList`, and a List-only loop would leave
+/// array responses unresolvable — the very bug this fixes.
+fn envelope_host_completion_items(
+    response: &mut CompletionResponse,
+    server_name: &str,
+    host_uri: &str,
+) {
+    let items = match response {
+        CompletionResponse::Array(items) => items,
+        CompletionResponse::List(list) => &mut list.items,
+    };
+    for item in items.iter_mut() {
+        envelope_host_item(item, server_name, host_uri);
     }
 }
 

--- a/src/lsp/lsp_impl/text_document/completion_item.rs
+++ b/src/lsp/lsp_impl/text_document/completion_item.rs
@@ -18,8 +18,10 @@ impl Kakehashi {
     /// Handle a `completionItem/resolve` request.
     ///
     /// Delegates to the pool's `dispatch_completion_resolve`, which strips the
-    /// envelope, routes to the origin server, transforms coordinates, and
-    /// re-envelopes the result. Falls back gracefully at every failure point.
+    /// envelope, routes to the origin server, and re-envelopes the result —
+    /// transforming coordinates on the virt path only, since a host-layer item
+    /// is already in host coordinates. Falls back gracefully at every failure
+    /// point.
     pub(crate) async fn completion_resolve_impl(
         &self,
         params: CompletionItem,

--- a/src/lsp/lsp_impl/text_document/completion_item.rs
+++ b/src/lsp/lsp_impl/text_document/completion_item.rs
@@ -27,7 +27,17 @@ impl Kakehashi {
         // A lazy resolve can arrive after edits changed a formerly contiguous
         // combined document into one with masked host gaps. Fail closed for
         // legacy/stale envelopes before the downstream can add new edits.
+        //
+        // A genuine HOST-layer item (#958) carries no region — it is forwarded
+        // verbatim in host coordinates — so this gate, which resolves the
+        // envelope's `region_id` and would find nothing for the empty host one,
+        // is skipped. `is_host_layer` additionally requires that empty
+        // `region_id`, so a conforming client can't skip the gate merely by
+        // toggling `host_layer` on a virt envelope. It is not a security
+        // boundary (the envelope round-trips through unprotected client `data`)
+        // — it guards against accidental bypass, and the host path fails soft.
         if let Some(envelope) = extract_envelope(&params)
+            && !envelope.is_host_layer()
             && !self.completion_envelope_is_fresh(&envelope)
         {
             return Ok(params);

--- a/src/lsp/lsp_impl/text_document/completion_item.rs
+++ b/src/lsp/lsp_impl/text_document/completion_item.rs
@@ -21,7 +21,7 @@ impl Kakehashi {
     /// envelope, routes to the origin server, and re-envelopes the result —
     /// transforming coordinates on the virt path only, since a host-layer item
     /// is already in host coordinates. Falls back gracefully at every failure
-    /// point.
+    /// point, except a client cancel, which surfaces as `RequestCancelled`.
     pub(crate) async fn completion_resolve_impl(
         &self,
         params: CompletionItem,
@@ -47,10 +47,31 @@ impl Kakehashi {
         let settings = self.settings_manager.load_settings();
         let pool = self.bridge.pool_arc();
         let upstream_id = current_upstream_id();
-        let item = pool
-            .dispatch_completion_resolve(params, &settings, upstream_id)
-            .await;
-        Ok(item)
+        // Propagate a client `$/cancelRequest` as RequestCancelled instead of
+        // masking it as an unresolved-item success: the cancel IS forwarded
+        // downstream, and the -32800 that comes back is collapsed to "no usable
+        // response" by the fail-soft parsing. Mirrors `code_action_resolve_impl`.
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
+        let sweep_id = upstream_id.clone();
+        let dispatch = pool.dispatch_completion_resolve(params, &settings, upstream_id);
+        // The cancel arm DROPS the in-flight dispatch, which then never reaches
+        // its own unregister. An RAII sweep covers that — and, unlike a trailing
+        // statement, also runs when this whole handler future is dropped (client
+        // disconnect / shutdown), which is how the entry leaked before. The
+        // CAPTURED id, not a re-read of the task-local: the sweep must target
+        // exactly the id the dispatch registered under.
+        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard::new(
+            std::sync::Arc::clone(&pool),
+            sweep_id,
+        );
+        match cancel_rx {
+            Some(rx) => tokio::select! {
+                biased;
+                _ = rx => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
+                item = dispatch => Ok(item),
+            },
+            None => Ok(dispatch.await),
+        }
     }
 
     fn completion_envelope_is_fresh(&self, envelope: &KakehashiEnvelope) -> bool {

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -234,6 +234,21 @@ fn main() {
                         "hoverProvider": mode == "diagnostics-refresh-prefetch-mixed",
                         "textDocumentSync": 1
                     }),
+                    // `completion-resolve`: advertises completion WITH
+                    // resolveProvider and fills `detail` on
+                    // completionItem/resolve — the shape that motivates #958
+                    // (a host-layer item must still be resolvable).
+                    // `completion-no-resolve` answers completion the same way
+                    // but does NOT advertise resolveProvider, so the bridge
+                    // must not weigh its items down with routing envelopes.
+                    "completion-resolve" => json!({
+                        "completionProvider": { "resolveProvider": true },
+                        "textDocumentSync": 1
+                    }),
+                    "completion-no-resolve" => json!({
+                        "completionProvider": {},
+                        "textDocumentSync": 1
+                    }),
                     "on-type" => json!({
                         "documentOnTypeFormattingProvider": {
                             "firstTriggerCharacter": "}",
@@ -549,6 +564,45 @@ fn main() {
                     })
                     .unwrap_or(Value::Null);
                 respond(&mut writer, id, result);
+            }
+            // Answers only for documents this server received via `didOpen`,
+            // so a non-null result proves the host document was synced and the
+            // request carried the real URI. The item's `data` carries that URI
+            // back, so `completionItem/resolve` can prove the downstream's own
+            // data survived the round trip through the routing envelope (#958).
+            "textDocument/completion" => {
+                let result = message
+                    .pointer("/params/textDocument/uri")
+                    .and_then(Value::as_str)
+                    .filter(|uri| documents.contains_key(*uri))
+                    .map(|uri| {
+                        json!({
+                            "isIncomplete": false,
+                            "items": [{
+                                "label": "./test",
+                                "kind": 19,
+                                "data": { "mockPath": uri }
+                            }]
+                        })
+                    })
+                    .unwrap_or(Value::Null);
+                respond(&mut writer, id, result);
+            }
+            // Fill in `detail` from the item's own `data` — absent in the
+            // completion response, so a resolved item that carries it proves
+            // the resolve actually reached this server.
+            "completionItem/resolve" => {
+                let mut item = message
+                    .pointer("/params")
+                    .cloned()
+                    .unwrap_or_else(|| json!({}));
+                let path = item
+                    .pointer("/data/mockPath")
+                    .and_then(Value::as_str)
+                    .unwrap_or("?")
+                    .to_string();
+                item["detail"] = json!(format!("mock-resolved:{path}"));
+                respond(&mut writer, id, item);
             }
             "textDocument/codeAction" => {
                 let result = message

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -591,6 +591,14 @@ fn main() {
             // Fill in `detail` from the item's own `data` — absent in the
             // completion response, so a resolved item that carries it proves
             // the resolve actually reached this server.
+            //
+            // The materialized `textEdit` is what makes the e2e discriminate
+            // the HOST routing branch: it sits on host line 2, which the VIRT
+            // resolve path would reject as unsafe for the injection region
+            // (a host envelope carries a zero offset and no region end, so
+            // that path's guard fails closed) and serve the item unresolved.
+            // Reaching the client intact proves the resolve took the verbatim
+            // host path, not merely that some server answered.
             "completionItem/resolve" => {
                 let mut item = message
                     .pointer("/params")
@@ -602,6 +610,13 @@ fn main() {
                     .unwrap_or("?")
                     .to_string();
                 item["detail"] = json!(format!("mock-resolved:{path}"));
+                item["textEdit"] = json!({
+                    "range": {
+                        "start": { "line": 2, "character": 4 },
+                        "end": { "line": 2, "character": 9 }
+                    },
+                    "newText": "resolved-edit"
+                });
                 respond(&mut writer, id, item);
             }
             "textDocument/codeAction" => {

--- a/tests/e2e_host_bridge.rs
+++ b/tests/e2e_host_bridge.rs
@@ -1547,27 +1547,48 @@ fn e2e_host_bridge_completion_resolve_round_trips_verbatim() {
         item["detail"].is_null(),
         "the item is unresolved (no detail yet), got: {item}"
     );
-    assert!(
-        item["data"].is_object(),
-        "a resolvable host item carries a routing envelope, got: {item}"
+    assert_eq!(
+        item["data"]["kakehashi"]["host_layer"], true,
+        "a resolvable host item carries a HOST-layer routing envelope: {item}"
+    );
+    assert_eq!(
+        item["data"]["kakehashi"]["inner"],
+        json!({ "mockPath": MARKDOWN_URI }),
+        "with the server's own data preserved inside it: {item}"
     );
 
-    let resolved = client.send_request("completionItem/resolve", item);
-    assert!(
-        resolved.get("error").is_none(),
-        "resolve errored: {resolved}"
-    );
-    let result = &resolved["result"];
-    assert_eq!(
-        result["detail"],
-        format!("mock-resolved:{MARKDOWN_URI}"),
-        "the resolve must reach the host server, which fills detail from the \
-         item's own data — proving both the routing and the data round trip: {result}"
-    );
-    assert!(
-        result["data"].is_object(),
-        "the resolved item keeps its envelope so it can be resolved again: {result}"
-    );
+    // Resolve twice: the second round is what proves the envelope survives a
+    // resolve with its layer marker intact. With the marker dropped, round two
+    // takes the virt path, fails the region gate, and comes back unresolved.
+    let mut resolved = client.send_request("completionItem/resolve", item);
+    for round in 1..=2 {
+        assert!(
+            resolved.get("error").is_none(),
+            "resolve round {round} errored: {resolved}"
+        );
+        let result = &resolved["result"];
+        assert_eq!(
+            result["detail"],
+            format!("mock-resolved:{MARKDOWN_URI}"),
+            "round {round}: the resolve must reach the host server, which fills detail from \
+             the item's own data — proving both the routing and the data round trip: {result}"
+        );
+        // The materialized edit sits on host line 2, outside any injection
+        // region. The virt resolve path would reject it as unsafe and serve
+        // the item unresolved, so its arrival — at its original coordinates —
+        // is what proves the VERBATIM host path ran.
+        assert_eq!(
+            result["textEdit"]["range"]["start"]["line"], 2,
+            "round {round}: the host resolve must not translate coordinates: {result}"
+        );
+        assert_eq!(result["textEdit"]["newText"], "resolved-edit");
+        assert_eq!(
+            result["data"]["kakehashi"]["host_layer"], true,
+            "round {round}: the resolved item keeps its host marker so the NEXT \
+             resolve still routes to the host server: {result}"
+        );
+        resolved = client.send_request("completionItem/resolve", result.clone());
+    }
 
     shutdown(&mut client);
 }

--- a/tests/e2e_host_bridge.rs
+++ b/tests/e2e_host_bridge.rs
@@ -1460,3 +1460,132 @@ fn e2e_host_bridge_codeaction_resolve_round_trips_verbatim() {
 
     shutdown(&mut client);
 }
+
+/// Bring up a host-bridged markdown client backed by one `mock-host` server
+/// running `mode`, and return it with the first completion response for a
+/// position outside any injection (so only the host layer can answer). Retries
+/// while the host connection warms up.
+fn init_host_completion_client(mode: &str) -> (LspClient, tempfile::TempDir, Value) {
+    let config_dir = tempfile::TempDir::new().expect("temp dir");
+    let config_path = config_dir.path().join("host_completion.toml");
+    std::fs::write(
+        &config_path,
+        "[languages.markdown.bridge._self]\nenabled = true\n",
+    )
+    .expect("write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("utf-8 path"))
+        .build();
+
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "mock-host": {
+                        "cmd": [mock_bin(), mode],
+                        "languages": ["markdown"]
+                    }
+                }
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": MARKDOWN_URI,
+                "languageId": "markdown",
+                "version": 1,
+                "text": MARKDOWN
+            }
+        }),
+    );
+
+    let item = (0..300)
+        .find_map(|_| {
+            let resp = client.send_request(
+                "textDocument/completion",
+                json!({
+                    "textDocument": { "uri": MARKDOWN_URI },
+                    "position": { "line": 2, "character": 6 }
+                }),
+            );
+            let first = resp["result"]["items"]
+                .as_array()
+                .and_then(|items| items.first().cloned());
+            if first.is_none() {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            first
+        })
+        .expect("host completion returns an item");
+
+    (client, config_dir, item)
+}
+
+#[test]
+fn e2e_host_bridge_completion_resolve_round_trips_verbatim() {
+    // #958: a HOST-layer (bridge._self) completion item is enveloped, and its
+    // completionItem/resolve routes back to the host server VERBATIM (no
+    // coordinate translation), so the server can fill in the lazy fields.
+    // Guards against the resolve path being inert — the symptom was a response
+    // byte-for-byte identical to the request, because an un-enveloped item has
+    // no origin to route to and the lsp_impl region-freshness gate would reject
+    // a host envelope, which carries no region.
+    let (mut client, _config_dir, item) = init_host_completion_client("completion-resolve");
+
+    assert_eq!(item["label"], "./test");
+    assert!(
+        item["detail"].is_null(),
+        "the item is unresolved (no detail yet), got: {item}"
+    );
+    assert!(
+        item["data"].is_object(),
+        "a resolvable host item carries a routing envelope, got: {item}"
+    );
+
+    let resolved = client.send_request("completionItem/resolve", item);
+    assert!(
+        resolved.get("error").is_none(),
+        "resolve errored: {resolved}"
+    );
+    let result = &resolved["result"];
+    assert_eq!(
+        result["detail"],
+        format!("mock-resolved:{MARKDOWN_URI}"),
+        "the resolve must reach the host server, which fills detail from the \
+         item's own data — proving both the routing and the data round trip: {result}"
+    );
+    assert!(
+        result["data"].is_object(),
+        "the resolved item keeps its envelope so it can be resolved again: {result}"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_host_bridge_completion_skips_envelope_without_resolve_support() {
+    // The envelope exists only to route completionItem/resolve. A host server
+    // that does not advertise resolveProvider gets none: it would be pure wire
+    // weight on every item of every completion.
+    let (mut client, _config_dir, item) = init_host_completion_client("completion-no-resolve");
+
+    assert_eq!(item["label"], "./test");
+    assert_eq!(
+        item["data"],
+        json!({ "mockPath": MARKDOWN_URI }),
+        "the server's own data must reach the client untouched, with no \
+         routing envelope wrapped around it: {item}"
+    );
+
+    shutdown(&mut client);
+}


### PR DESCRIPTION
Fixes #958.

## Problem

`completionItem/resolve` was inert for every item the **host layer**
(`bridge._self`) produced. Host completion responses are passed through
verbatim, so no `KakehashiEnvelope` was ever attached to their items, and
`dispatch_completion_resolve` — which identifies the origin server from that
envelope — returned the request unchanged without sending anything downstream.
The observed symptom was a resolve response byte-for-byte identical to the
request.

## Fix

The issue's option A, matching what `codeAction/resolve` already does for its
host layer (#627):

- The completion envelope carries a `host_layer` marker (`serde(default)`, so
  existing envelopes still deserialize as virt).
- The host completion layer dispatches typed per server (it can no longer use
  the generic verbatim raw-value walk), and the bridge's
  `bridge_host_completion_items` envelopes each item — both `CompletionList`
  and bare-array responses.
- `dispatch_completion_resolve` routes a host envelope to the host server
  **verbatim**: the item is already in host coordinates, so neither the
  coordinate translation nor the injection-region edit guard (which has no
  region to judge against) runs.
- The `lsp_impl` region-freshness gate is skipped for host envelopes, which
  carry no region. `is_host_layer()` requires the marker **and** an empty
  `region_id`, so a conforming client cannot skip the virt geometry gate by
  flipping the flag.
- `re_envelope_item` carries the marker across, so an item resolved once still
  routes through the host path on the next resolve.

The envelope is minted only for a server advertising `completionItem/resolve` —
on any other it would be pure wire weight on every item of every completion. The
capability answer rides out on `HostRawResponse` on the answering connection
itself, so the check costs no second connection lookup (and no repeat of its
marker walk) on this hot path.

One consequence of that gate: an item from a *non*-resolving server reaches the
client with its `data` untouched, so a downstream server emitting a
`{"kakehashi": …}` key would have it read back as a routing envelope at resolve
time. Such an item is enveloped regardless, which puts the downstream's value
safely in `inner`. One map lookup per item; allocates only on a collision.

## Also in this PR (from review)

- **Wire weight.** `host_layer` and `region_id` skip serialization at their
  defaults — this envelope rides in every item of every completion response.
  `offset` is deliberately left required: making it defaultable so the host zero
  could be skipped would let a truncated *virt* envelope deserialize with a zero
  offset and translate against it, rather than failing to parse.
- **Per-item cost.** `json!({ENVELOPE_KEY: envelope})` serialized `inner`
  through `Serialize`, deep-copying the `data` the line above had just moved out
  of the item. It is now moved in after serialization. This also fixes the
  pre-existing virt path.
- **Fan-out cost.** Only the fan-in *winner* is enveloped; losing host servers
  no longer pay a discarded per-item pass on every keystroke.
- **`host_server_advertises` deleted.** With the answering connection carried
  out, codeAction reads the capability off it instead of re-resolving through
  `get_or_create_connection` (marker walk + pool lock) — cheaper, and it cannot
  answer for a replacement spawned since the response.
- **`host_layer_result` extracted.** The host-arm fan-in fold existed twice
  before and this change made it three; all three deviate from
  `FanInResult::handle` in the same way.

## Verification

- `cargo test --lib`: 3312 passed
- `make test_e2e`: 59 binaries, 1798 passed, 0 failing
- `cargo clippy -- -D warnings`: clean

New e2e coverage in `tests/e2e_host_bridge.rs`, alongside the codeAction
equivalent. The mock's resolve fills `detail` from the item's own `data` and
materializes a `textEdit` on a host line the *virt* path would reject as unsafe
— so the test fails if the host routing branch is removed (verified by
removing it), not merely if some server answers. It resolves twice, pinning that
the layer marker survives a resolve. `completion-no-resolve` pins the other
half: a server without `resolveProvider` gets no envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added host-layer completion support, including completion-item resolution with preserved host coordinates and server data.
  * Host completion items now resolve across repeated requests when supported by the language server.
  * Added graceful fallback for servers that do not support completion-item resolution.
  * Improved cancellation handling during completion resolution.

* **Documentation**
  * Updated host bridging and completion-resolution behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->