### PR TITLE
test: satisfy clippy --all-targets in test-only code

### DIFF
--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -307,6 +307,10 @@ mod tests {
     #[test]
     fn sequential_injection_does_not_start_after_host_cancel() {
         let starts = std::cell::Cell::new(0);
+        // Captures `&starts` (a `Copy` reference), so the closure itself is
+        // `Copy` — calling it three times below by value into an `impl
+        // FnOnce() -> T` parameter copies the closure rather than moving it,
+        // and every copy still shares the one underlying `Cell`.
         let work = || {
             starts.set(starts.get() + 1);
             "ran"

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -307,18 +307,15 @@ mod tests {
     #[test]
     fn sequential_injection_does_not_start_after_host_cancel() {
         let starts = std::cell::Cell::new(0);
-        let mut work = || {
+        let work = || {
             starts.set(starts.get() + 1);
             "ran"
         };
 
-        assert_eq!(run_sequential_injection(false, false, &mut work), None);
-        assert_eq!(run_sequential_injection(true, true, &mut work), None);
+        assert_eq!(run_sequential_injection(false, false, work), None);
+        assert_eq!(run_sequential_injection(true, true, work), None);
         assert_eq!(starts.get(), 0);
-        assert_eq!(
-            run_sequential_injection(true, false, &mut work),
-            Some("ran")
-        );
+        assert_eq!(run_sequential_injection(true, false, work), Some("ran"));
         assert_eq!(starts.get(), 1);
     }
     use tower_lsp_server::ls_types::{Range, SemanticToken};

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -1572,8 +1572,11 @@ mod tests {
     fn combined_content_snaps_stale_span_start_before_slicing() {
         let text = "éx\n";
 
-        let (content, offsets) =
-            build_combined_virtual_content(text, 1..text.len(), &[1..text.len()]);
+        let (content, offsets) = build_combined_virtual_content(
+            text,
+            1..text.len(),
+            std::slice::from_ref(&(1..text.len())),
+        );
 
         assert_eq!(content, "x\n");
         assert_eq!(offsets, vec![1, 0]);
@@ -1582,8 +1585,11 @@ mod tests {
     #[test]
     fn combined_blank_included_line_records_its_prefix_offset() {
         let text = "> \n";
-        let (content, offsets) =
-            build_combined_virtual_content(text, 0..text.len(), &[2..text.len()]);
+        let (content, offsets) = build_combined_virtual_content(
+            text,
+            0..text.len(),
+            std::slice::from_ref(&(2..text.len())),
+        );
 
         assert_eq!(content, "\n");
         assert_eq!(offsets, vec![2, 0]);

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -595,15 +595,18 @@ mod tests {
 
         // `runtime/queries` sits two components below the tempdir root, so the
         // pre-fix join cleaned to exactly the file planted above.
-        let result =
-            QueryLoader::find_query_file(&[runtime.clone()], "../../outside", "highlights.scm");
+        let result = QueryLoader::find_query_file(
+            std::slice::from_ref(&runtime),
+            "../../outside",
+            "highlights.scm",
+        );
 
         assert_eq!(result, None);
 
         // An absolute name is the worse variant: `join` discards the base
         // outright, so no `..` arithmetic is needed to escape.
         let result = QueryLoader::find_query_file(
-            &[runtime.clone()],
+            std::slice::from_ref(&runtime),
             outside.to_str().unwrap(),
             "highlights.scm",
         );

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -449,68 +449,6 @@ impl Kakehashi {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tower_lsp_server::LspService;
-
-    #[tokio::test]
-    async fn injection_node_rejects_close_reopen_during_language_load() {
-        let (service, _socket) = LspService::new(Kakehashi::new);
-        let server = service.inner();
-        server
-            .language
-            .language_registry_for_parallel()
-            .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
-        server
-            .language
-            .language_registry_for_parallel()
-            .register("go".to_string(), tree_sitter_go::LANGUAGE.into());
-        let uri = Url::parse("file:///workspace/reopened.rs").unwrap();
-        let old_incarnation = server.documents.insert(
-            uri.clone(),
-            "fn old() {}".to_string(),
-            Some("rust".to_string()),
-            None,
-        );
-        assert!(
-            server
-                .parse_coordinator()
-                .parse_document(uri.clone(), Some("rust"), None)
-                .await
-        );
-        let params = NodeParams {
-            text_document: TextDocumentIdentifier {
-                uri: uri.as_str().parse().unwrap(),
-            },
-            position: Position::new(0, 0),
-            injection: Some(Value::Bool(true)),
-        };
-
-        let result = server
-            .kakehashi_node_after_injection_load(params, async {
-                server.documents.remove(&uri);
-                let new_incarnation = server.documents.insert(
-                    uri.clone(),
-                    "package main".to_string(),
-                    Some("go".to_string()),
-                    None,
-                );
-                assert_ne!(new_incarnation, old_incarnation);
-                assert!(
-                    server
-                        .parse_coordinator()
-                        .parse_document(uri.clone(), Some("go"), None)
-                        .await
-                );
-            })
-            .await
-            .unwrap();
-
-        assert_eq!(result, Value::Null);
-    }
-}
-
 /// Find the smallest node containing `byte` under the half-open `[start, end)` rule,
 /// with the node-reference-protocol end-of-document exception.
 ///
@@ -582,4 +520,66 @@ fn deepest_node_ending_at(node: tree_sitter::Node<'_>, target_end: usize) -> tre
         }
     }
     current
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp_server::LspService;
+
+    #[tokio::test]
+    async fn injection_node_rejects_close_reopen_during_language_load() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("go".to_string(), tree_sitter_go::LANGUAGE.into());
+        let uri = Url::parse("file:///workspace/reopened.rs").unwrap();
+        let old_incarnation = server.documents.insert(
+            uri.clone(),
+            "fn old() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        assert!(
+            server
+                .parse_coordinator()
+                .parse_document(uri.clone(), Some("rust"), None)
+                .await
+        );
+        let params = NodeParams {
+            text_document: TextDocumentIdentifier {
+                uri: uri.as_str().parse().unwrap(),
+            },
+            position: Position::new(0, 0),
+            injection: Some(Value::Bool(true)),
+        };
+
+        let result = server
+            .kakehashi_node_after_injection_load(params, async {
+                server.documents.remove(&uri);
+                let new_incarnation = server.documents.insert(
+                    uri.clone(),
+                    "package main".to_string(),
+                    Some("go".to_string()),
+                    None,
+                );
+                assert_ne!(new_incarnation, old_incarnation);
+                assert!(
+                    server
+                        .parse_coordinator()
+                        .parse_document(uri.clone(), Some("go"), None)
+                        .await
+                );
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result, Value::Null);
+    }
 }

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -276,7 +276,7 @@ mod tests {
         let diagnostics = collect_joined_region_diagnostics(join_set, &sink, "test").await;
 
         assert!(diagnostics.is_empty());
-        assert_eq!(sink.unwrap().load(Ordering::Relaxed), 1);
+        assert_eq!(sink.as_ref().unwrap().load(Ordering::Relaxed), 1);
     }
 
     /// An all-incapable virt snapshot must still publish an (empty) pull layer,

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -1841,9 +1841,7 @@ mod tests {
         use std::os::unix::ffi::OsStrExt;
 
         let parent = TempDir::new().unwrap();
-        let dir = parent
-            .path()
-            .join(OsStr::from_bytes(b"proj-\xFF").to_os_string());
+        let dir = parent.path().join(OsStr::from_bytes(b"proj-\xFF"));
         if std::fs::create_dir(&dir).is_err() {
             eprintln!(
                 "skipping: this filesystem rejects non-UTF-8 directory names, so the case \
@@ -1854,8 +1852,11 @@ mod tests {
 
         let relative = dir.join("relative.toml");
         std::fs::write(&relative, "searchPaths = ['./runtime']\n").unwrap();
-        let rejected =
-            read_explicit_layers(&[relative.clone()], None, crate::config::make_env(&[]));
+        let rejected = read_explicit_layers(
+            std::slice::from_ref(&relative),
+            None,
+            crate::config::make_env(&[]),
+        );
         assert!(
             rejected
                 .fatal_error


### PR DESCRIPTION
## Summary

- Fixes 11 pre-existing `clippy::*` errors that only surface under `cargo clippy --all-targets --all-features -- -D warnings`, which CI does not run (CI runs the bare `--all-features` form, which was already green). The repo's pre-commit hook *does* run `--all-targets`, so these 11 errors — invisible to CI — had silently accumulated on `main` and blocked every local commit through the hook.
- All 11 are mechanical, non-behavioral fixes confined to test code / test-helper call sites:
  - `needless_borrows_for_generic_args` — drop a redundant `&mut` on a `Copy` closure passed to an `FnOnce` parameter (`src/analysis/semantic.rs`).
  - `single_range_in_vec_init` (x2) — replace a one-element `&[a..b]` array literal with `std::slice::from_ref(&(a..b))` (`src/language/injection/discovery.rs`).
  - `cloned_ref_to_slice_refs` (x3) — replace `&[x.clone()]` with `std::slice::from_ref(&x)` (`src/language/query_loader.rs`, `src/lsp/settings.rs`).
  - `items_after_test_module` — move `smallest_containing_node`/`deepest_node_ending_at` ahead of `mod tests` in `src/lsp/lsp_impl/kakehashi/node/entry.rs` (pure relocation — verified line-for-line against `origin/main` with `git diff`, nothing altered beyond position).
  - `unnecessary_literal_unwrap` — read the counter through `sink.as_ref().unwrap()` instead of unwrapping a traced `Some(...)` literal (`src/lsp/lsp_impl/text_document/publish_diagnostic.rs`).
  - `unnecessary_to_owned` — drop a redundant `.to_os_string()` before `.join()` (`src/lsp/settings.rs`).

## Scope note

This closes the *symptom* (the 11 errors), not the underlying CI/pre-commit-hook gap: CI's clippy step still omits `--all-targets`, so a future PR could reintroduce the same class of drift without CI noticing. Deliberately out of scope here — didn't want to bundle a CI workflow change into a lint-fix PR — but flagging it as a natural follow-up.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean (0 errors, was 11)
- [x] `cargo clippy --all-features -- -D warnings` (CI's existing check) — still clean, as before
- [x] `cargo test --lib --all-features` — 3362 passed, 0 failed, 2 ignored (no regressions)
- [x] `make check` (cargo check, clippy, fmt --check, dead_code ban) — clean
- [x] Local pre-commit hook (`make lint format test test_e2e`) ran to completion and passed, including the full E2E suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup and resource handling across language injection, query loading, diagnostics, and settings scenarios.
  * Preserved existing assertions while simplifying single-item input handling.
  * Relocated a language-loading regression test without changing its coverage or behavior.
  * Continued validating document close/reopen behavior and non-UTF-8 path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->