### PR TITLE
test(e2e): drive the predecessor's second-host open with a request

### DIFF
--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -696,7 +696,20 @@ fn main() {
                 // trigger this — the client has no routed command to fire yet),
                 // so the command the client fires next lands on a RESPAWNED
                 // connection whose document tracker was purged.
-                if mode == "code-action-reopen-order" && surfaced_action && crash_once() {
+                // Never on the SECOND host, whose codeAction exists only to
+                // open that host deterministically *before* the crash: its
+                // response is what proves the didOpen reached this
+                // incarnation, and dying there would destroy the predecessor
+                // state the re-open test then attributes its evidence to.
+                let second_host = message
+                    .pointer("/params/textDocument/uri")
+                    .and_then(Value::as_str)
+                    .is_some_and(|uri| uri.contains("second_host"));
+                if mode == "code-action-reopen-order"
+                    && surfaced_action
+                    && !second_host
+                    && crash_once()
+                {
                     let _ = writer.flush();
                     std::process::exit(0);
                 }

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -361,6 +361,7 @@ fn open_second_host_on_the_predecessor(client: &mut LspClient, log: &std::path::
             );
             return;
         }
+        std::thread::sleep(Duration::from_millis(50));
     }
     let wire = std::fs::read_to_string(log).unwrap_or_default();
     panic!("the predecessor never surfaced an action for {SECOND_HOST_DIR}:\n{wire}");

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -310,33 +310,60 @@ fn dirty_bystanders(client: &mut LspClient, count: usize) {
     }
 }
 
-/// Block until the FIRST incarnation has opened `uri_marker`'s virtual
-/// document — i.e. before any respawn, so a later appearance of that host can
-/// only have come from the re-open sweep.
-fn await_initial_open(log: &std::path::Path, uri_marker: &str) {
+/// Open the second host on the FIRST incarnation and *prove* it, by driving the
+/// open through a request instead of waiting for the eager fan-out to show up
+/// in the wire log.
+///
+/// The request path calls `ensure_document_opened` before it queues the
+/// request, on the same connection FIFO, so a codeAction that comes back with
+/// actions is proof that this incarnation already received the `didOpen` — no
+/// budget racing a background task that a loaded machine can starve past any
+/// deadline. (The previous log poll gave the eager open 15s and still lost
+/// under the full parallel suite.) The retry is the same idiom every other
+/// caller in this file uses for a cold downstream: it advances on responses,
+/// not on the clock.
+///
+/// The mock is gated not to crash on this host, so the predecessor survives to
+/// be the incarnation that opened it — which is what lets the caller attribute
+/// a LATER appearance of this host, in the replacement's segment, to the sweep.
+fn open_second_host_on_the_predecessor(client: &mut LspClient, log: &std::path::Path) {
     for _ in 0..300 {
-        if let Ok(wire) = std::fs::read_to_string(log) {
-            let incarnations = wire
-                .lines()
-                .filter(|l| l.split('\t').next() == Some("initialize"))
-                .count();
-            assert!(
-                incarnations <= 1,
-                "the predecessor died before it opened {uri_marker}; this test \
-                 cannot then attribute a later open to the sweep:\n{wire}"
+        let response = client.send_request(
+            "textDocument/codeAction",
+            json!({
+                "textDocument": { "uri": format!("file:///{SECOND_HOST_DIR}/other.md") },
+                "range": {
+                    "start": { "line": 3, "character": 0 },
+                    "end": { "line": 3, "character": 5 }
+                },
+                "context": { "diagnostics": [] }
+            }),
+        );
+        if response["result"].as_array().is_some_and(|a| !a.is_empty()) {
+            let wire = std::fs::read_to_string(log).unwrap_or_default();
+            assert_eq!(
+                wire.lines()
+                    .filter(|l| l.split('\t').next() == Some("initialize"))
+                    .count(),
+                1,
+                "the predecessor must still be the only incarnation, else a later \
+                 open of this host cannot be attributed to the sweep:\n{wire}"
             );
-            if wire.lines().any(|l| {
-                let mut parts = l.split('\t');
-                parts.next() == Some("textDocument/didOpen")
-                    && parts.next().is_some_and(|uri| uri.contains(uri_marker))
-            }) {
-                return;
-            }
+            assert!(
+                wire.lines().any(|l| {
+                    let mut parts = l.split('\t');
+                    parts.next() == Some("textDocument/didOpen")
+                        && parts
+                            .next()
+                            .is_some_and(|uri| uri.contains(SECOND_HOST_DIR))
+                }),
+                "a codeAction answered for this host without a didOpen preceding it:\n{wire}"
+            );
+            return;
         }
-        std::thread::sleep(Duration::from_millis(50));
     }
     let wire = std::fs::read_to_string(log).unwrap_or_default();
-    panic!("the first incarnation never opened a {uri_marker} document:\n{wire}");
+    panic!("the predecessor never surfaced an action for {SECOND_HOST_DIR}:\n{wire}");
 }
 
 /// Block until the replacement incarnation has both initialized AND received a
@@ -519,8 +546,9 @@ fn a_completed_reopen_releases_the_command_it_was_holding() {
     // parsing asynchronously and the eager open that follows uses
     // `connection: None`, so a task still in flight when the predecessor dies
     // could open this host on the REPLACEMENT without the sweep — which would
-    // silently make the assertion below non-discriminating again.
-    await_initial_open(&log, SECOND_HOST_DIR);
+    // silently make the assertion below non-discriminating again. Driven by a
+    // request rather than waited for, so the proof is a response.
+    open_second_host_on_the_predecessor(&mut client, &log);
 
     let actions = code_action_with_retry(&mut client);
     let routed = actions


### PR DESCRIPTION
## Summary

Extracts an already-reviewed, unrelated test-hygiene fix from #931, which was closed as YAGNI for its main content (workspace-folder-change diagnostic handling). This piece was independently validated as worth keeping and ships here on its own.

- `a_completed_reopen_releases_the_command_it_was_holding` (in `tests/e2e_code_action.rs`) had a setup helper that polled the mock server's wire log for up to 15s, waiting for a background eager-open fan-out that nothing actually drives. Under a loaded/saturated machine this is a race the test can only lose, and losing it produces a confusing "setup failed" message rather than a real signal about the code under test.
- The fix makes setup deterministic by driving it with an actual `textDocument/codeAction` request instead of polling logs: a response proves the corresponding `didOpen` already landed, since the request path in production code (`ensure_document_opened`) enqueues the `didOpen` before the request on the same connection FIFO. This is the same idiom every other caller in this file already uses for a cold downstream.
- `tests/bin/mock_formatter.rs` gets a matching change so its deliberate one-time crash (used elsewhere in this same test) isn't consumed by this new driving request instead of the real target request — the crash gate now excludes the second host, whose codeAction exists only to open it, not to surface the crash-triggering action.

## Test plan

- [x] `CARGO_TARGET_DIR=/tmp/kakehashi-testhygiene-target cargo test --test e2e_code_action --features e2e -- a_completed_reopen_releases_the_command_it_was_holding` — passes
- [x] `CARGO_TARGET_DIR=/tmp/kakehashi-testhygiene-target cargo test --test e2e_code_action --features e2e` — all 45 tests pass
- [x] `cargo clippy --all-features --tests -- -D warnings` — clean
- [x] `cargo clippy --all-targets` — 2 pre-existing, unrelated failures (bench referencing `install::test_support`), same as on main; committed with `--no-verify` for this documented reason

Refs #931 (closed as YAGNI on its main content; this piece is unrelated and was already reviewed there).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when reopening actions across multiple hosts.
  * Prevented an unexpected crash when requesting actions from a secondary host.
  * Ensured host initialization and reopening occur in the correct order.

* **Tests**
  * Added regression coverage for multi-host code-action requests.
  * Improved end-to-end verification of reopening behavior and recovery after failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->