### PR TITLE
fix(lsp): skip the reload for an empty workspace-folder event

### DIFF
--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -683,11 +683,28 @@ impl LanguageServerPool {
 
     /// Update the upstream client workspace snapshot used by future
     /// client-fallback downstream connections.
+    ///
+    /// Returns whether the event described a change at all, so the caller
+    /// (`did_change_workspace_folders_impl`) can skip the settings reload it
+    /// owns for an event this function already found to be a no-op, instead
+    /// of duplicating the emptiness check.
     pub(crate) async fn apply_workspace_folder_change(
         &self,
         added: Vec<tower_lsp_server::ls_types::WorkspaceFolder>,
         removed: &[tower_lsp_server::ls_types::WorkspaceFolder],
-    ) {
+    ) -> bool {
+        // An event naming neither an addition nor a removal describes no
+        // change: `WorkspaceFolderSet::apply_change` is a no-op for it, so the
+        // client workspace snapshot cannot move. Returning here rather than
+        // letting the body run unconditionally matters beyond that snapshot,
+        // though — the recycle loop below does not look at the event either,
+        // so without this guard a folder-change-incapable fallback would be
+        // invalidated, recycled, and armed for re-open over a notification
+        // that named nothing.
+        if added.is_empty() && removed.is_empty() {
+            return false;
+        }
+
         self.workspace_folders.apply_change(added.clone(), removed);
         self.set_root_uri(
             self.workspace_folders()
@@ -752,6 +769,7 @@ impl LanguageServerPool {
         for (key, handle) in stale_handles {
             shutdown_invalidated_connection(key, handle);
         }
+        true
     }
 
     /// Set the upstream client capabilities.

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -3559,6 +3559,46 @@ mod tests {
         );
     }
 
+    /// An event naming neither an addition nor a removal describes no change:
+    /// nothing about the client's workspace moved. Recycling a
+    /// folder-change-incapable fallback anyway — which the capability check
+    /// below does unconditionally, without looking at the event it is
+    /// reacting to — costs a respawn and a re-open storm for a notification
+    /// that said nothing.
+    #[tokio::test]
+    async fn workspace_folder_change_skips_recycling_for_an_empty_event() {
+        let pool = LanguageServerPool::new();
+        let key = ConnectionKey::for_server("fallback");
+        let handle = create_handle_with_key(ConnectionState::Ready, key.clone()).await;
+        // No capabilities set: an incapable fallback, the shape the recycle
+        // branch claims for a real (non-empty) event.
+        handle.set_server_capabilities(Default::default());
+        pool.insert_connection(Arc::clone(&handle)).await;
+        let original = tower_lsp_server::ls_types::WorkspaceFolder {
+            uri: "file:///original".parse().unwrap(),
+            name: "original".to_string(),
+        };
+        pool.set_root_uri(Some(original.uri.to_string()));
+        pool.set_workspace_folders(Some(vec![original.clone()]));
+
+        pool.apply_workspace_folder_change(Vec::new(), &[]).await;
+
+        assert!(
+            pool.connections.lock().await.contains_key(&key),
+            "an event that names no folder must not recycle an incapable fallback"
+        );
+        assert!(
+            pool.pending_reopen.claim(&key).is_none(),
+            "and must not arm it for a re-open it never earned"
+        );
+        assert_eq!(
+            pool.root_uri(),
+            Some("file:///original".to_string()),
+            "and must not touch the client workspace snapshot"
+        );
+        assert_eq!(pool.workspace_folders(), Some(vec![original]));
+    }
+
     #[tokio::test]
     async fn workspace_folder_change_does_not_touch_marker_owned_connection() {
         let pool = LanguageServerPool::new();

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -104,3 +104,91 @@ impl Kakehashi {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tower_lsp_server::LspService;
+    use tower_lsp_server::ls_types::{WorkspaceFolder, WorkspaceFoldersChangeEvent};
+
+    /// An event naming neither an addition nor a removal describes no change
+    /// of project: `apply_workspace_folder_change` already reports as much
+    /// (see `pool.rs`), and this handler owns the expensive half of reacting
+    /// to a folder change — the settings reload, which invalidates every open
+    /// document's parse tree and pushes a workspace-wide
+    /// `semanticTokens/refresh`. Paying that cost for a notification that
+    /// changed nothing is wasteful.
+    ///
+    /// Asserted via the settings snapshot's own identity rather than a new
+    /// counter: `apply_raw_settings_locked` always publishes a fresh `Arc`
+    /// through `SettingsManager::apply_settings_with_raw`, regardless of
+    /// whether the content actually differs (see `apply_shared_settings_locked`
+    /// in `lsp_impl.rs`), so an unmoved pointer is proof the whole reload
+    /// transaction — `load_settings`, `WorkspaceSettings::try_from_settings`,
+    /// `apply_raw_settings_locked` — never ran.
+    ///
+    /// Bounded so a regression fails on the assertion rather than hanging: an
+    /// unskipped reload reaches client notifications this harness's unused
+    /// `_socket` never drains.
+    #[tokio::test]
+    async fn an_empty_folder_event_does_not_reload_settings() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let before = server.settings_manager.load_settings_pair();
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            server.did_change_workspace_folders_impl(DidChangeWorkspaceFoldersParams {
+                event: WorkspaceFoldersChangeEvent {
+                    added: Vec::new(),
+                    removed: Vec::new(),
+                },
+            }),
+        )
+        .await
+        .expect("an event that names no folder must return without a reload");
+
+        let after = server.settings_manager.load_settings_pair();
+        assert!(
+            Arc::ptr_eq(&before, &after),
+            "an event that names no folder must not run the settings-reload \
+             transaction at all"
+        );
+    }
+
+    /// Regression guard for the branch above: a real folder change must still
+    /// reach the reload. `WorkspaceSettings::try_from_settings` succeeds for
+    /// the default settings this session starts with, so the `Ok` arm runs
+    /// `apply_raw_settings_locked`, which republishes a fresh snapshot even
+    /// though its *content* is unchanged from the default.
+    #[tokio::test]
+    async fn a_non_empty_folder_event_still_reloads_settings() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let before = server.settings_manager.load_settings_pair();
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            server.did_change_workspace_folders_impl(DidChangeWorkspaceFoldersParams {
+                event: WorkspaceFoldersChangeEvent {
+                    added: vec![WorkspaceFolder {
+                        uri: "file:///added".parse().unwrap(),
+                        name: "added".to_string(),
+                    }],
+                    removed: Vec::new(),
+                },
+            }),
+        )
+        .await
+        .expect("a real folder change must not hang the reload");
+
+        let after = server.settings_manager.load_settings_pair();
+        assert!(
+            !Arc::ptr_eq(&before, &after),
+            "a real folder change must still run the settings-reload transaction"
+        );
+    }
+}

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -174,13 +174,20 @@ mod tests {
     /// transaction — `load_settings`, `WorkspaceSettings::try_from_settings`,
     /// `apply_raw_settings_locked` — never ran.
     ///
-    /// No `XDG_CONFIG_HOME` isolation needed here: the early return happens
-    /// before `load_settings` is ever called, so this path never reads real
-    /// environment state regardless of which machine runs it. Bounded anyway
-    /// so a regression fails on the assertion rather than hanging — see the
-    /// sibling test below for what an unskipped reload can actually block on.
+    /// `XDG_CONFIG_HOME` is isolated even though the *current* early return
+    /// never reaches `load_settings`: this test exists to catch a regression
+    /// that removes that early return, and a false pass is exactly what a
+    /// developer machine's real `~/.config/kakehashi/kakehashi.toml` could
+    /// produce in that case — e.g. an invalid real config makes
+    /// `WorkspaceSettings::try_from_settings` fail before publishing a new
+    /// snapshot, leaving `Arc::ptr_eq` true for the wrong reason and hiding
+    /// the very regression this test is meant to catch.
     #[tokio::test]
+    #[serial(xdg_env)]
     async fn an_empty_folder_event_does_not_reload_settings() {
+        let xdg_scratch = tempfile::tempdir().expect("failed to create scratch XDG_CONFIG_HOME");
+        let _xdg_guard = XdgConfigHomeGuard::set(xdg_scratch.path());
+
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
         let before = server.settings_manager.load_settings_pair();
@@ -220,11 +227,19 @@ mod tests {
     /// configuration can turn this call into actual disk work whose outcome
     /// (and duration, past the 5s bound below) depends on whoever's machine
     /// runs it, rather than on the code under test.
+    ///
+    /// The added folder is a real scratch directory rather than a bare
+    /// `file:///added`, for the same reason: `load_settings` also reads
+    /// `<root>/kakehashi.toml` from the folder it derives as the project
+    /// root, and a literal `/added` risks resolving to a real top-level
+    /// directory (and a real config file inside it) on some host.
     #[tokio::test]
     #[serial(xdg_env)]
     async fn a_non_empty_folder_event_still_reloads_settings() {
         let xdg_scratch = tempfile::tempdir().expect("failed to create scratch XDG_CONFIG_HOME");
         let _xdg_guard = XdgConfigHomeGuard::set(xdg_scratch.path());
+        let workspace_dir = tempfile::tempdir().expect("failed to create scratch workspace dir");
+        let folder_uri = format!("file://{}", workspace_dir.path().display());
 
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
@@ -235,7 +250,7 @@ mod tests {
             server.did_change_workspace_folders_impl(DidChangeWorkspaceFoldersParams {
                 event: WorkspaceFoldersChangeEvent {
                     added: vec![WorkspaceFolder {
-                        uri: "file:///added".parse().unwrap(),
+                        uri: folder_uri.parse().unwrap(),
                         name: "added".to_string(),
                     }],
                     removed: Vec::new(),

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -123,10 +123,40 @@ impl Kakehashi {
 mod tests {
     use super::*;
 
+    use serial_test::serial;
     use std::sync::Arc;
     use std::time::Duration;
     use tower_lsp_server::LspService;
     use tower_lsp_server::ls_types::{WorkspaceFolder, WorkspaceFoldersChangeEvent};
+
+    /// Restores `XDG_CONFIG_HOME` when dropped, even if the test body panics —
+    /// matching the convention in `src/config/user.rs` / `src/lsp/settings.rs`.
+    /// Callers must carry `#[serial(xdg_env)]`, since the variable is
+    /// process-wide.
+    struct XdgConfigHomeGuard(Option<std::ffi::OsString>);
+
+    impl XdgConfigHomeGuard {
+        fn set(path: &std::path::Path) -> Self {
+            let original = std::env::var_os("XDG_CONFIG_HOME");
+            // SAFETY: #[serial(xdg_env)] prevents concurrent modification of
+            // XDG_CONFIG_HOME.
+            unsafe { std::env::set_var("XDG_CONFIG_HOME", path) };
+            Self(original)
+        }
+    }
+
+    impl Drop for XdgConfigHomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: #[serial(xdg_env)] prevents concurrent modification of
+            // XDG_CONFIG_HOME.
+            unsafe {
+                match self.0.take() {
+                    Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+                    None => std::env::remove_var("XDG_CONFIG_HOME"),
+                }
+            }
+        }
+    }
 
     /// An event naming neither an addition nor a removal describes no change
     /// of project: `apply_workspace_folder_change` already reports as much
@@ -144,9 +174,11 @@ mod tests {
     /// transaction — `load_settings`, `WorkspaceSettings::try_from_settings`,
     /// `apply_raw_settings_locked` — never ran.
     ///
-    /// Bounded so a regression fails on the assertion rather than hanging: an
-    /// unskipped reload reaches client notifications this harness's unused
-    /// `_socket` never drains.
+    /// No `XDG_CONFIG_HOME` isolation needed here: the early return happens
+    /// before `load_settings` is ever called, so this path never reads real
+    /// environment state regardless of which machine runs it. Bounded anyway
+    /// so a regression fails on the assertion rather than hanging — see the
+    /// sibling test below for what an unskipped reload can actually block on.
     #[tokio::test]
     async fn an_empty_folder_event_does_not_reload_settings() {
         let (service, _socket) = LspService::new(Kakehashi::new);
@@ -178,8 +210,22 @@ mod tests {
     /// the default settings this session starts with, so the `Ok` arm runs
     /// `apply_raw_settings_locked`, which republishes a fresh snapshot even
     /// though its *content* is unchanged from the default.
+    ///
+    /// `XDG_CONFIG_HOME` is pointed at an empty scratch directory for the
+    /// duration of the call. Unlike the sibling test above, this path DOES
+    /// reach `load_settings`, which reads `$XDG_CONFIG_HOME` (falling back to
+    /// `~/.config`) for a real user config file — left unisolated, a
+    /// developer machine's own `~/.config/kakehashi/kakehashi.toml` loads
+    /// instead of empty defaults, and its real search paths / language
+    /// configuration can turn this call into actual disk work whose outcome
+    /// (and duration, past the 5s bound below) depends on whoever's machine
+    /// runs it, rather than on the code under test.
     #[tokio::test]
+    #[serial(xdg_env)]
     async fn a_non_empty_folder_event_still_reloads_settings() {
+        let xdg_scratch = tempfile::tempdir().expect("failed to create scratch XDG_CONFIG_HOME");
+        let _xdg_guard = XdgConfigHomeGuard::set(xdg_scratch.path());
+
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
         let before = server.settings_manager.load_settings_pair();

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -239,7 +239,12 @@ mod tests {
         let xdg_scratch = tempfile::tempdir().expect("failed to create scratch XDG_CONFIG_HOME");
         let _xdg_guard = XdgConfigHomeGuard::set(xdg_scratch.path());
         let workspace_dir = tempfile::tempdir().expect("failed to create scratch workspace dir");
-        let folder_uri = format!("file://{}", workspace_dir.path().display());
+        // `Url::from_directory_path` percent-encodes reserved characters and
+        // handles platform path quirks (e.g. Windows drive letters) that a
+        // bare `format!("file://{}", ...)` would mangle if the scratch path
+        // ever contained one — `$TMPDIR` is not guaranteed plain-ASCII.
+        let folder_uri = url::Url::from_directory_path(workspace_dir.path())
+            .expect("scratch workspace dir must convert to a file:// URL");
 
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
@@ -250,7 +255,7 @@ mod tests {
             server.did_change_workspace_folders_impl(DidChangeWorkspaceFoldersParams {
                 event: WorkspaceFoldersChangeEvent {
                     added: vec![WorkspaceFolder {
-                        uri: folder_uri.parse().unwrap(),
+                        uri: folder_uri.as_str().parse().unwrap(),
                         name: "added".to_string(),
                     }],
                     removed: Vec::new(),

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -26,13 +26,27 @@ impl Kakehashi {
         // let a push anchor against the old root after the workspace has
         // already moved. The lock order is reload-then-connections on every
         // path that takes both, since the settings reload also reaches the
-        // bridge.
+        // bridge. Taken even for an event that may turn out to name no
+        // folder: the pool's own emptiness check below returns before it
+        // ever reaches `connections`, so nothing is held across that check.
         let reload = lock_settings_reload().await;
 
-        self.bridge
+        // The pool owns the definition of "this event changed something" and
+        // reports it, so this reload cannot drift from that definition by
+        // duplicating its own emptiness check. An event that named no folder
+        // moved no project: re-deriving the settings root from it would drop
+        // the project config layer for a session whose folder list is empty,
+        // and reparsing every open document plus a semantic-tokens refresh is
+        // a high price for a notification that said nothing.
+        if !self
+            .bridge
             .pool()
             .apply_workspace_folder_change(added, &removed)
-            .await;
+            .await
+        {
+            drop(reload);
+            return;
+        }
 
         // An emptied folder list does not leave the session rootless when the
         // client named another root: the rungs below `workspaceFolders` answer,


### PR DESCRIPTION
## Summary

Extracts the one validated piece of #931 (closed as YAGNI for its other content — see that PR's discussion for why the pull-diagnostic-lineage fence and forced refresh were dropped).

Currently on main, `did_change_workspace_folders_impl` unconditionally re-derives the settings root and runs the full settings-reload transaction (`load_settings` → `WorkspaceSettings::try_from_settings` → `apply_raw_settings_locked`) for every `workspace/didChangeWorkspaceFolders` notification — even one naming neither an addition nor a removal (`params.event.added` and `params.event.removed` both empty). This happens in practice: some clients send duplicate/no-op folder-change notifications.

`apply_raw_settings_locked` invalidates every open document's parse tree and pushes a workspace-wide `semanticTokens/refresh` unconditionally, so paying that cost for a notification that provably changed nothing is wasteful.

## Changes

1. `LanguageServerPool::apply_workspace_folder_change` (`src/lsp/bridge/pool.rs`) now returns `bool` instead of `()`. It returns `false` immediately — before touching `self.connections` or anything else — when `added.is_empty() && removed.is_empty()`. Otherwise the existing body runs unchanged and it returns `true` at the end. This also fixes a related waste the guard exposed: the recycle loop never looked at the event either, so a folder-change-incapable client-fallback connection was previously invalidated/recycled/armed-for-reopen even for a no-op event.

2. `did_change_workspace_folders_impl` (`src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs`) uses that `bool`: on `false` it returns immediately, without computing `root_path`, calling `load_settings`/`WorkspaceSettings::try_from_settings`/`apply_raw_settings_locked`, or touching `self.settings_manager`.

## Explicitly out of scope

No pull-diagnostic-lineage fence, no forced client refresh, no push-diagnostic-cache handling — that was the part of #931 closed as YAGNI (theoretical risk, no observed real-world manifestation). This PR is only the early-return-on-empty-event optimization.

## Testing

- `test(bridge): pin no-op folder events against invalidation` — RED-verified against main: an incapable client-fallback connection was invalidated/recycled/armed-for-reopen for an empty event.
- `fix(bridge): skip folder-change work for an empty event` — makes it GREEN.
- `test(lsp): pin the settings-reload skip for an empty folder event` — RED-verified against main. Asserts via `Arc::ptr_eq` on the settings snapshot rather than a new counter: `apply_settings_with_raw` always publishes a fresh `Arc` regardless of content, so an unmoved pointer proves the reload transaction never ran. A companion regression test pins that a non-empty event still reaches the reload.
- `fix(lsp): skip the settings reload for an empty folder event` — makes it GREEN.
- Two follow-up hardening commits, driven by review findings (see below): both workspace-folder tests are now isolated from the real `$XDG_CONFIG_HOME`/`~/.config/kakehashi/kakehashi.toml` a developer machine may have configured (via a `#[serial(xdg_env)]`-tagged, panic-safe env-var guard matching the existing convention in `src/config/user.rs`/`src/lsp/settings.rs`), and the non-empty test's scratch folder URI is built with `url::Url::from_directory_path` instead of a naive format string.

`cargo test --lib --all-features`: 3365 passed, 0 failed (also verified directly against this development machine's real, populated `~/.config/kakehashi/kakehashi.toml` after the isolation fix — before it, the non-empty test hung for the full 5s bound on this exact machine).
`cargo check --all-features`, `cargo clippy --all-features -- -D warnings`, `cargo fmt --check`: clean.
CI: Check/Format/Clippy/Audit/Test all pass.

Committed with `--no-verify`: this repo's pre-commit hook runs `make lint format test test_e2e`, whose `clippy --all-targets` has pre-existing failures on main unrelated to this change (documented project convention).

## Review

Six independent local review perspectives (correctness, test-contract fidelity, doc drift, bot-anticipation, concurrency, scope-fidelity vs #931) plus two rounds of `codex` MCP review (`sandbox: read-only`, `approval-policy: never`), each converging on real, fixed findings:

- Two independent reviewers caught that the original tests transitively read this machine's real `$HOME`/`XDG_CONFIG_HOME` via `load_settings`, making them environment-dependent (and, on this exact machine, capable of hanging for the full 5s timeout). Fixed by isolating `XDG_CONFIG_HOME` to a scratch temp dir for the duration of the call, including for the empty-event test (so it can still catch a regression that removes the early return, rather than false-passing on an ambient invalid config).
- Codex caught that the scratch folder URI (`file:///added`) risked reading a real top-level directory's `kakehashi.toml` on some host, and then that the fix (`format!("file://{}", path.display())`) didn't percent-encode reserved characters or handle platform path quirks — resolved with `url::Url::from_directory_path`.
- No correctness, lock-ordering, concurrency, or scope-creep issues found; codex's final pass reports no actionable findings remaining.

Closes nothing directly but extracts from #931.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary workspace updates, connection recycling, and settings reloads when workspace folder events contain no actual changes.
  - Preserved workspace state and pending reopen behavior during no-op events.
  - Continued applying genuine workspace folder additions and removals, including required settings reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->