### PR TITLE
fix(diagnostic): break the forwarded-refresh↔pull feedback loop

### DIFF
--- a/docs/architecture-decisions/downstream-diagnostic-refresh-handling.md
+++ b/docs/architecture-decisions/downstream-diagnostic-refresh-handling.md
@@ -85,11 +85,19 @@ A downstream refresh is **workspace-wide** (it names no URI), so this trigger
 re-pulls every open document with a `pullFallback`-eligible downstream, unlike
 the per-URI host-event triggers.
 
-### 3. Forward iff the editor is refresh-capable
+### 3. Forward when the editor is refresh-capable AND the prefetch cannot vouch
 
 kakehashi forwards `workspace/diagnostic/refresh` to the editor only when the
 editor advertises `workspace.diagnostics.refreshSupport`
-(`check_diagnostic_refresh_support`). The gate's solid justification is
+(`check_diagnostic_refresh_support`) — refresh capability is necessary but not
+sufficient: the completed prefetch (rule 2) must additionally have changed some
+host's published set, or been unable to cover the editor's re-pull surface
+(a `pullFallback`-gated or per-method-diverging layer, a failed pull, a
+snapshot-less open document, an edit-raced commit, or an outstanding
+pull-view lag). An unchanged, fully covering prefetch after a covering editor
+pull absorbs the forward — that absorption is what starves the refresh↔pull
+feedback loop (nudge → editor re-pull → downstream analysis → downstream
+refresh → nudge, ~1 Hz on a quiescent multi-region file). The gate's solid justification is
 leak-avoidance: a non-refresh-capable editor would silently ignore the request and
 leak a tower-lsp pending-request entry (the same hazard
 push-propagation-diagnostic-forwarding's republish guards against). Its *intended*
@@ -101,8 +109,8 @@ on it. This gate is orthogonal to rule 2's *pull*.
 Forwarding is scheduled once per upstream workspace connection, not once per
 downstream server. The first downstream refresh after idle starts a leading
 cycle immediately. Each cycle first completes the workspace-wide Path A prefetch
-and only then forwards the editor refresh, so a client pull cannot race ahead of
-kakehashi's proactive cache. Further downstream refreshes join one trailing
+and only then decides the editor forward (see rule 3's absorption above), so a
+client pull cannot race ahead of kakehashi's proactive cache. Further downstream refreshes join one trailing
 debounce cycle. Its workspace-wide timing policy is configured independently of
 languages and downstream servers:
 
@@ -139,7 +147,7 @@ keeps the default `true`. kakehashi never guesses the editor's behavior.
 
 | editor refresh-capable | `pullFallback` | forward to editor | kakehashi pull + publish | editor stays fresh via |
 | --- | --- | --- | --- | --- |
-| yes | true  | yes | yes | the push (guaranteed); plus its re-pull if it pull-tracks — downstream pulled twice |
+| yes | true  | yes, unless the covering prefetch changed nothing after a covering editor pull | yes | the push (guaranteed); plus its re-pull if it pull-tracks — downstream pulled twice on a change |
 | yes | false | yes | no  | its re-pull **iff it actually pull-tracks**; otherwise stale |
 | no  | true  | no  | yes | the push (guaranteed) |
 | no  | false | no  | no  | **nothing** — stale (config-incoherent; default `true` avoids it) |
@@ -185,8 +193,10 @@ keeps the default `true`. kakehashi never guesses the editor's behavior.
 ### Negative (accepted cost)
 
 - **Double pull in matrix row 1** (refresh-capable editor, `pullFallback = true`):
-  if the editor actually pull-tracks, the forwarded refresh causes a Path B re-pull
-  alongside kakehashi's Path A pull, so the downstream is pulled twice. This is the
+  if the editor actually pull-tracks, a forwarded refresh causes a Path B re-pull
+  alongside kakehashi's Path A pull, so the downstream is pulled twice. (The
+  absorption in rule 3 removes the Path B half on the quiescent-unchanged
+  cycles; a genuinely changed cycle still pays both.) This is the
   accepted cost of keeping the pull client-independent — Considered Option 3 (skip
   the pull when the editor can pull) would remove it but couple Path A to a client
   capability. A user who
@@ -226,8 +236,14 @@ workspace-wide scheduler snapshots every open URI with the same
 `DiagnosticSnapshotPreparer` as didOpen/didSave/didChange, runs
 `collect_push_diagnostics`, and updates the shared pull layer before continuing.
 For rule 3, each completed prefetch cycle checks
-`workspace.diagnostics.refreshSupport` and sends through the existing detached
-single-flight path. A client without refresh support still runs rule 2 but skips
-only the editor-facing request.
+`workspace.diagnostics.refreshSupport` and the cycle's
+`ForwardedPrefetchSummary` (`set_changed || coverage_incomplete`), then sends
+through the existing detached single-flight path. A client without refresh
+support still runs rule 2 but skips only the editor-facing request.
 
-There is no current implementation gap for this decision.
+There is no current implementation gap for this decision. Known residual: any
+configuration whose prefetch can never vouch (a `pullFallback`-gated layer,
+per-method config divergence such as the publish wire seal) keeps the
+pre-absorption forward on every downstream refresh, so the feedback loop those
+configs allowed before is unchanged there; a consecutive-absorbed backoff is
+follow-up material.

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -7,7 +7,7 @@
 - [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md) — Server pool, document tracking, notification forwarding
 - [ls-bridge-message-ordering](ls-bridge-message-ordering.md) — Per-URI ordering the cache relies on
 - [host-document-bridge](host-document-bridge.md) — Host-layer (`_self`) participation
-- [downstream-diagnostic-refresh-handling](downstream-diagnostic-refresh-handling.md) — How a downstream `workspace/diagnostic/refresh` triggers the Path A pull and forwards to the editor
+- [downstream-diagnostic-refresh-handling](downstream-diagnostic-refresh-handling.md) — How a downstream `workspace/diagnostic/refresh` triggers the Path A pull and conditionally forwards to the editor
 
 ## Context
 

--- a/src/lsp/bridge/actor/writer.rs
+++ b/src/lsp/bridge/actor/writer.rs
@@ -17,9 +17,21 @@ use super::ResponseRouter;
 
 /// Queue capacity for outbound messages per ls-bridge-message-ordering.
 ///
-/// This bounds memory usage and provides backpressure. With 256 slots and
-/// typical message sizes, this uses approximately 32KB per connection.
-pub(crate) const OUTBOUND_QUEUE_CAPACITY: usize = 256;
+/// Sized for the region fan-out, not for typing traffic: a multi-region host
+/// document dispatches one pull per region per server in one burst (observed:
+/// 308 python regions on one markdown file), and the editor-pull and
+/// refresh-prefetch cycles can overlap, so a server can legitimately receive
+/// ~2× regions requests plus the didOpen/didChange notification burst at
+/// once. The old 256 overflowed there every cycle: `try_send` failures
+/// surfaced as "request queue full" (partial pull answers — user-visible
+/// diagnostic flicker — and a prefetch marked `coverage_incomplete`, whose
+/// forced refresh re-ran the fan-out, sustaining the overload), and dropped
+/// didOpen notifications wedged virtual documents. 4096 covers the observed
+/// burst with ~6× headroom; the queue still bounds a hung child (worst case
+/// is bounded by regions × in-flight cycles, far below the cap in steady
+/// state). A per-connection concurrency cap that would make the depth
+/// burst-independent is follow-up material.
+pub(crate) const OUTBOUND_QUEUE_CAPACITY: usize = 4096;
 
 /// Handle to a running Writer Task, managing its lifetime via RAII.
 ///

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -768,6 +768,37 @@ mod tests {
         );
     }
 
+    /// The genuine framing error must QUOTE the stray stdout line that broke
+    /// the frame: when a downstream prints an error to STDOUT (observed:
+    /// basedpyright emitting unframed output under load), that text IS the
+    /// crash reason, and the frame that trips over it is the only place the
+    /// evidence is still readable.
+    #[tokio::test]
+    async fn read_message_quotes_the_stray_line_in_the_framing_error() {
+        let cmd = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "printf 'Error: downstream exploded\\r\\n\\r\\n'".to_string(),
+        ];
+        let mut conn = AsyncBridgeConnection::spawn(cmd)
+            .await
+            .expect("spawn should succeed");
+
+        let err = conn
+            .read_message()
+            .await
+            .expect_err("a header block without Content-Length must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("missing Content-Length header"),
+            "the framing classification must be kept: {msg}"
+        );
+        assert!(
+            msg.contains("Error: downstream exploded"),
+            "the stray stdout line is the crash evidence and must be quoted: {msg}"
+        );
+    }
+
     /// Integration test: Initialize lua-language-server and verify response
     #[tokio::test]
     async fn initialize_lua_language_server() {

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -609,6 +609,61 @@ mod tests {
         assert_eq!(seen[2], "last");
     }
 
+    /// Invalid UTF-8 on stderr must not stop the drain: the drain is what
+    /// keeps the child's stderr pipe from filling up and blocking it, so it
+    /// must survive arbitrary bytes (a node crash dump, binary garbage) and
+    /// keep consuming to EOF. Bytes are decoded loss-tolerantly for the log.
+    #[tokio::test]
+    async fn drain_survives_invalid_utf8_and_keeps_draining() {
+        let (mut tx, rx) = tokio::io::duplex(64 * 1024);
+        tokio::io::AsyncWriteExt::write_all(&mut tx, b"good\r\n\xFF\xFEgarbage\nafter\n")
+            .await
+            .unwrap();
+        drop(tx);
+
+        let mut seen = Vec::new();
+        let (emitted, total) = drain_stderr_lines(rx, |line| seen.push(line)).await;
+        assert_eq!((emitted, total), (3, 3), "all three lines are consumed");
+        assert_eq!(seen[0], "good", "CRLF line endings are stripped");
+        assert!(
+            seen[1].contains("garbage"),
+            "the invalid-UTF-8 line is decoded loss-tolerantly: {:?}",
+            seen[1]
+        );
+        assert_eq!(seen[2], "after", "draining continues past invalid UTF-8");
+    }
+
+    /// A newline-free stderr stream must not buffer beyond the per-line cap:
+    /// the drain reads fixed-size chunks and discards bytes past
+    /// [`STDERR_LOG_MAX_LINE_BYTES`] as they stream by, so a downstream that
+    /// spews an endless unterminated line costs bounded memory.
+    #[tokio::test]
+    async fn drain_caps_a_newline_free_line_without_buffering_it() {
+        let (mut tx, rx) = tokio::io::duplex(64 * 1024);
+        let writer = tokio::spawn(async move {
+            let chunk = [b'x'; 4096];
+            for _ in 0..64 {
+                tokio::io::AsyncWriteExt::write_all(&mut tx, &chunk)
+                    .await
+                    .unwrap();
+            }
+        });
+
+        let mut seen = Vec::new();
+        let (emitted, total) = drain_stderr_lines(rx, |line| seen.push(line)).await;
+        writer.await.unwrap();
+        assert_eq!((emitted, total), (1, 1), "one (unterminated) line");
+        assert!(
+            seen[0].ends_with('…'),
+            "the capped line is marked truncated"
+        );
+        assert!(
+            seen[0].len() <= STDERR_LOG_MAX_LINE_BYTES + '…'.len_utf8(),
+            "buffered bytes stay within the per-line cap: {}",
+            seen[0].len()
+        );
+    }
+
     #[tokio::test]
     async fn drain_keeps_reading_past_the_log_cap() {
         let (mut tx, rx) = tokio::io::duplex(64 * 1024);

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -61,11 +61,27 @@ impl BridgeReader {
         use tokio::io::AsyncReadExt;
 
         let mut content_length: Option<usize> = None;
+        let mut saw_header = false;
 
         // Read headers until empty line
         loop {
             let mut line = String::new();
-            self.stdout.read_line(&mut line).await?;
+            let bytes_read = self.stdout.read_line(&mut line).await?;
+
+            // `read_line` returning 0 is EOF, which would otherwise be
+            // indistinguishable from the end-of-headers empty line and
+            // misreport a dead process as "missing Content-Length header" —
+            // sending crash triage down a protocol-desync path.
+            if bytes_read == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    if saw_header {
+                        "downstream closed stdout mid-headers (truncated frame)"
+                    } else {
+                        "downstream closed stdout (EOF)"
+                    },
+                ));
+            }
 
             // Trim CRLF/LF endings
             let trimmed = line.trim_end_matches(['\r', '\n']);
@@ -73,6 +89,7 @@ impl BridgeReader {
             if trimmed.is_empty() {
                 break; // Empty line = end of headers
             }
+            saw_header = true;
 
             if let Some(value) = trimmed.strip_prefix("Content-Length: ") {
                 content_length = Some(value.trim().parse().map_err(|_| {

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -493,6 +493,79 @@ mod tests {
         assert!(parsed["result"].is_object());
     }
 
+    /// A downstream that exits cleanly closes stdout; the reader must report
+    /// that as EOF, not as a framing error. The old message ("missing
+    /// Content-Length header") sent crash triage down the wrong path: it read
+    /// as protocol desync when the process had simply died (observed with a
+    /// basedpyright crash under load — and every clean shutdown logged the
+    /// same misleading warning).
+    #[tokio::test]
+    async fn read_message_reports_eof_when_downstream_closes_stdout() {
+        // `true` writes nothing and exits: a clean close before any message.
+        let cmd = vec!["true".to_string()];
+        let mut conn = AsyncBridgeConnection::spawn(cmd)
+            .await
+            .expect("spawn should succeed");
+
+        let err = conn
+            .read_message()
+            .await
+            .expect_err("EOF must surface as an error");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(
+            err.to_string().contains("closed stdout"),
+            "EOF must not masquerade as a framing error: {err}"
+        );
+    }
+
+    /// EOF in the middle of a header block is a truncated frame (the process
+    /// died mid-write) — still EOF, but named as truncation.
+    #[tokio::test]
+    async fn read_message_reports_truncated_frame_on_eof_mid_headers() {
+        let cmd = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "printf 'Content-Length: 10\\r\\n'".to_string(),
+        ];
+        let mut conn = AsyncBridgeConnection::spawn(cmd)
+            .await
+            .expect("spawn should succeed");
+
+        let err = conn
+            .read_message()
+            .await
+            .expect_err("a truncated header block must surface as an error");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(
+            err.to_string().contains("mid-headers"),
+            "mid-frame EOF should be named as truncation: {err}"
+        );
+    }
+
+    /// A COMPLETE header block (terminated by its empty line) that lacks
+    /// Content-Length is the one genuine framing error — the message is kept
+    /// for exactly this case.
+    #[tokio::test]
+    async fn read_message_keeps_framing_error_for_headers_without_content_length() {
+        let cmd = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "printf 'X-Whatever: 1\\r\\n\\r\\n'".to_string(),
+        ];
+        let mut conn = AsyncBridgeConnection::spawn(cmd)
+            .await
+            .expect("spawn should succeed");
+
+        let err = conn
+            .read_message()
+            .await
+            .expect_err("a header block without Content-Length must fail");
+        assert!(
+            err.to_string().contains("missing Content-Length header"),
+            "genuine framing errors keep the framing message: {err}"
+        );
+    }
+
     /// Integration test: Initialize lua-language-server and verify response
     #[tokio::test]
     async fn initialize_lua_language_server() {

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::process::Stdio;
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
 
 /// Writer handle for sending LSP messages to downstream language server.
 ///
@@ -150,6 +150,7 @@ pub(crate) struct AsyncBridgeConnection {
     child: Option<Child>,         // Option to support taking for split()
     writer: Option<BridgeWriter>, // Option to support taking for split()
     reader: Option<BridgeReader>, // Option to support taking for Reader Task
+    stderr: Option<ChildStderr>,  // Option to support taking for the drain task
 }
 
 /// Writer half of a split connection.
@@ -393,7 +394,11 @@ impl AsyncBridgeConnection {
             .args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            // Piped (not null) so a crashing downstream's dying words are
+            // observable: the pool spawns [`drain_downstream_stderr`] on it.
+            // The drain never stops reading (it only stops LOGGING past its
+            // cap), so a chatty child cannot block on a full stderr pipe.
+            .stderr(Stdio::piped())
             .spawn()?;
 
         let stdin = child
@@ -406,11 +411,20 @@ impl AsyncBridgeConnection {
             .take()
             .ok_or_else(|| io::Error::other("bridge: failed to capture stdout"))?;
 
+        let stderr = child.stderr.take();
+
         Ok(Self {
             child: Some(child),
             writer: Some(BridgeWriter { stdin }),
             reader: Some(BridgeReader::new(stdout)),
+            stderr,
         })
+    }
+
+    /// Take the child's stderr for the drain task (None after the first take,
+    /// or if capture failed at spawn).
+    pub(crate) fn take_stderr(&mut self) -> Option<ChildStderr> {
+        self.stderr.take()
     }
 
     /// Split into a `SplitConnectionWriter` (holds the child process) and a
@@ -487,9 +501,106 @@ impl Drop for AsyncBridgeConnection {
     }
 }
 
+/// Cap on stderr lines LOGGED per connection; the drain keeps reading past it
+/// (a full pipe would otherwise block the child) but stops the log noise.
+const STDERR_LOG_MAX_LINES: usize = 500;
+/// Cap on a single logged stderr line's bytes (truncated at a char boundary).
+const STDERR_LOG_MAX_LINE_BYTES: usize = 2000;
+
+/// Forward a downstream process's stderr into kakehashi's log, bounded (see
+/// the constants above). This is the crash-triage channel: a downstream that
+/// dies (e.g. a node heap OOM) writes its reason here, which `Stdio::null()`
+/// used to discard while the reader could only report the resulting EOF.
+pub(crate) async fn drain_downstream_stderr(stderr: ChildStderr, server_name: String) {
+    let (logged, total) = drain_stderr_lines(stderr, |line| {
+        log::warn!(target: "kakehashi::bridge::stderr", "[{server_name}] {line}");
+    })
+    .await;
+    if total > logged {
+        log::warn!(
+            target: "kakehashi::bridge::stderr",
+            "[{server_name}] (suppressed {} further stderr lines)",
+            total - logged
+        );
+    }
+}
+
+/// The testable core of [`drain_downstream_stderr`]: read lines until EOF,
+/// emit at most [`STDERR_LOG_MAX_LINES`] of them (truncated to
+/// [`STDERR_LOG_MAX_LINE_BYTES`] at a char boundary), keep DRAINING past the
+/// cap, and return `(emitted, total)` line counts.
+async fn drain_stderr_lines<R: tokio::io::AsyncRead + Unpin>(
+    reader: R,
+    mut emit: impl FnMut(String),
+) -> (usize, usize) {
+    let mut lines = BufReader::new(reader).lines();
+    let mut total = 0usize;
+    let mut emitted = 0usize;
+    while let Ok(Some(mut line)) = lines.next_line().await {
+        total += 1;
+        if emitted >= STDERR_LOG_MAX_LINES {
+            continue;
+        }
+        if line.len() > STDERR_LOG_MAX_LINE_BYTES {
+            let mut end = STDERR_LOG_MAX_LINE_BYTES;
+            while !line.is_char_boundary(end) {
+                end -= 1;
+            }
+            line.truncate(end);
+            line.push('…');
+        }
+        emit(line);
+        emitted += 1;
+    }
+    (emitted, total)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn drain_emits_lines_truncated_at_char_boundaries() {
+        let (mut tx, rx) = tokio::io::duplex(64 * 1024);
+        let long = format!("{}あ", "x".repeat(STDERR_LOG_MAX_LINE_BYTES - 1));
+        let payload = format!("first\n{long}\nlast\n");
+        tokio::io::AsyncWriteExt::write_all(&mut tx, payload.as_bytes())
+            .await
+            .unwrap();
+        drop(tx);
+
+        let mut seen = Vec::new();
+        let (emitted, total) = drain_stderr_lines(rx, |line| seen.push(line)).await;
+        assert_eq!((emitted, total), (3, 3));
+        assert_eq!(seen[0], "first");
+        assert!(seen[1].ends_with('…'), "over-long line is truncated");
+        assert!(
+            seen[1].len() <= STDERR_LOG_MAX_LINE_BYTES + '…'.len_utf8(),
+            "truncation respects the byte cap"
+        );
+        assert_eq!(seen[2], "last");
+    }
+
+    #[tokio::test]
+    async fn drain_keeps_reading_past_the_log_cap() {
+        let (mut tx, rx) = tokio::io::duplex(64 * 1024);
+        let writer = tokio::spawn(async move {
+            for i in 0..(STDERR_LOG_MAX_LINES + 50) {
+                tokio::io::AsyncWriteExt::write_all(&mut tx, format!("line{i}\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+        });
+
+        let (emitted, total) = drain_stderr_lines(rx, |_| {}).await;
+        writer.await.unwrap();
+        assert_eq!(emitted, STDERR_LOG_MAX_LINES);
+        assert_eq!(
+            total,
+            STDERR_LOG_MAX_LINES + 50,
+            "draining continues past the cap"
+        );
+    }
 
     #[tokio::test]
     async fn spawn_creates_child_process_with_stdio() {

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -62,6 +62,12 @@ impl BridgeReader {
 
         let mut content_length: Option<usize> = None;
         let mut saw_header = false;
+        // First non-LSP-header line seen this frame, kept (truncated) so the
+        // genuine framing error below can QUOTE the offending bytes — when a
+        // downstream prints an error to STDOUT (observed: basedpyright), that
+        // text is the crash reason, and the frame that trips over it is the
+        // only place it is still readable.
+        let mut stray_line: Option<String> = None;
 
         // Read headers until empty line
         loop {
@@ -106,12 +112,34 @@ impl BridgeReader {
                 content_length = Some(value.trim().parse().map_err(|_| {
                     io::Error::new(io::ErrorKind::InvalidData, "invalid Content-Length value")
                 })?);
+            } else if stray_line.is_none() {
+                // Remember the first non-Content-Length line for the framing
+                // error's quote. Legitimate blocks always carry
+                // Content-Length, so this is only ever REPORTED for a failed
+                // block — where any such line (including ones that merely
+                // look header-shaped, like a JSON fragment after a length
+                // mismatch or "Error: …") IS the evidence. Real spare headers
+                // (Content-Type) on healthy frames are still ignored.
+                let mut quoted = trimmed.to_string();
+                const MAX_QUOTE: usize = 300;
+                if quoted.len() > MAX_QUOTE {
+                    let mut end = MAX_QUOTE;
+                    while !quoted.is_char_boundary(end) {
+                        end -= 1;
+                    }
+                    quoted.truncate(end);
+                    quoted.push('…');
+                }
+                stray_line = Some(quoted);
             }
-            // Other headers (Content-Type, etc.) are silently ignored per LSP spec
         }
 
-        let content_length = content_length.ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidData, "missing Content-Length header")
+        let content_length = content_length.ok_or_else(|| match stray_line {
+            Some(stray) => io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("missing Content-Length header (stray stdout line: {stray:?})"),
+            ),
+            None => io::Error::new(io::ErrorKind::InvalidData, "missing Content-Length header"),
         })?;
 
         // Read exact body bytes. Name a mid-body EOF like the header-side

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -559,6 +559,58 @@ mod tests {
         );
     }
 
+    /// A dying gasp of a lone `\r` (a separator cut before its `\n`) must not
+    /// read as a complete empty line: that resurrects the phantom
+    /// "missing Content-Length header" on a 1-byte window of a crashing
+    /// process. Only a newline-terminated empty line ends the header block.
+    #[tokio::test]
+    async fn read_message_reports_eof_on_a_truncated_separator() {
+        let cmd = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "printf 'Content-Length: 10\\r\\n\\r'".to_string(),
+        ];
+        let mut conn = AsyncBridgeConnection::spawn(cmd)
+            .await
+            .expect("spawn should succeed");
+
+        let err = conn
+            .read_message()
+            .await
+            .expect_err("a truncated separator must surface as an error");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(
+            err.to_string().contains("mid-headers"),
+            "a separator cut before its newline is a truncated frame, \
+             not a framing error: {err}"
+        );
+    }
+
+    /// A process dying mid-body keeps the UnexpectedEof kind but previously
+    /// surfaced tokio's generic "early eof" — name it like the header-side
+    /// classifications so crash triage reads uniformly.
+    #[tokio::test]
+    async fn read_message_names_the_closed_stdout_on_a_truncated_body() {
+        let cmd = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "printf 'Content-Length: 100\\r\\n\\r\\nshort'".to_string(),
+        ];
+        let mut conn = AsyncBridgeConnection::spawn(cmd)
+            .await
+            .expect("spawn should succeed");
+
+        let err = conn
+            .read_message()
+            .await
+            .expect_err("a truncated body must surface as an error");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(
+            err.to_string().contains("mid-body"),
+            "mid-body EOF should carry the classification naming: {err}"
+        );
+    }
+
     /// A COMPLETE header block (terminated by its empty line) that lacks
     /// Content-Length is the one genuine framing error — the message is kept
     /// for exactly this case.

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -87,7 +87,18 @@ impl BridgeReader {
             let trimmed = line.trim_end_matches(['\r', '\n']);
 
             if trimmed.is_empty() {
-                break; // Empty line = end of headers
+                // Only a newline-TERMINATED empty line ends the headers. A
+                // lone '\r' (or bare partial) without its '\n' can only mean
+                // the stream ended mid-separator — `read_line` returns a
+                // newline-less line exclusively at EOF — so fall through to
+                // the next read, which reports the EOF instead of letting a
+                // dying gasp masquerade as a complete (and then
+                // Content-Length-less) header block.
+                if line.ends_with('\n') {
+                    break; // Empty line = end of headers
+                }
+                saw_header = true;
+                continue;
             }
             saw_header = true;
 
@@ -103,9 +114,20 @@ impl BridgeReader {
             io::Error::new(io::ErrorKind::InvalidData, "missing Content-Length header")
         })?;
 
-        // Read exact body bytes
+        // Read exact body bytes. Name a mid-body EOF like the header-side
+        // classifications (tokio's generic "early eof" otherwise breaks the
+        // uniform crash-triage reading this reader's errors now have).
         let mut body = vec![0u8; content_length];
-        self.stdout.read_exact(&mut body).await?;
+        self.stdout.read_exact(&mut body).await.map_err(|e| {
+            if e.kind() == io::ErrorKind::UnexpectedEof {
+                io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "downstream closed stdout mid-body (truncated frame)",
+                )
+            } else {
+                e
+            }
+        })?;
 
         Ok(body)
     }

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -553,34 +553,107 @@ pub(crate) async fn drain_downstream_stderr(stderr: ChildStderr, server_name: St
     }
 }
 
-/// The testable core of [`drain_downstream_stderr`]: read lines until EOF,
-/// emit at most [`STDERR_LOG_MAX_LINES`] of them (truncated to
-/// [`STDERR_LOG_MAX_LINE_BYTES`] at a char boundary), keep DRAINING past the
-/// cap, and return `(emitted, total)` line counts.
+/// The testable core of [`drain_downstream_stderr`]: read fixed-size byte
+/// chunks until EOF, emit at most [`STDERR_LOG_MAX_LINES`] lines (each capped
+/// at [`STDERR_LOG_MAX_LINE_BYTES`] buffered bytes, decoded loss-tolerantly),
+/// keep DRAINING past both caps, and return `(emitted, total)` line counts.
+///
+/// Deliberately NOT `BufReader::lines()`: that buffers a complete line before
+/// any cap applies (a newline-free stream allocates without bound) and errors
+/// out on invalid UTF-8 — and a drain that stops reading lets the child's
+/// stderr pipe fill up and block it. Stderr is arbitrary bytes, not UTF-8.
 async fn drain_stderr_lines<R: tokio::io::AsyncRead + Unpin>(
-    reader: R,
+    mut reader: R,
     mut emit: impl FnMut(String),
 ) -> (usize, usize) {
-    let mut lines = BufReader::new(reader).lines();
+    use tokio::io::AsyncReadExt;
+
+    let mut chunk = [0u8; 4096];
+    // Bytes of the current line, capped: anything past the per-line cap is
+    // discarded as it streams by, never buffered.
+    let mut line: Vec<u8> = Vec::new();
+    let mut overflowed = false;
     let mut total = 0usize;
     let mut emitted = 0usize;
-    while let Ok(Some(mut line)) = lines.next_line().await {
-        total += 1;
-        if emitted >= STDERR_LOG_MAX_LINES {
-            continue;
-        }
-        if line.len() > STDERR_LOG_MAX_LINE_BYTES {
-            let mut end = STDERR_LOG_MAX_LINE_BYTES;
-            while !line.is_char_boundary(end) {
-                end -= 1;
+
+    loop {
+        let n = match reader.read(&mut chunk).await {
+            Ok(0) => break,
+            Ok(n) => n,
+            // A read error on the pipe means the child is gone; the drain's
+            // job is over.
+            Err(_) => break,
+        };
+        for &byte in &chunk[..n] {
+            if byte == b'\n' {
+                total += 1;
+                if emitted < STDERR_LOG_MAX_LINES {
+                    emit(render_stderr_line(&line, overflowed));
+                    emitted += 1;
+                }
+                line.clear();
+                overflowed = false;
+            } else if line.len() < STDERR_LOG_MAX_LINE_BYTES {
+                line.push(byte);
+            } else {
+                overflowed = true;
             }
-            line.truncate(end);
-            line.push('…');
         }
-        emit(line);
-        emitted += 1;
+    }
+    // Trailing bytes without a final newline still form a (partial) line.
+    if !line.is_empty() || overflowed {
+        total += 1;
+        if emitted < STDERR_LOG_MAX_LINES {
+            emit(render_stderr_line(&line, overflowed));
+            emitted += 1;
+        }
     }
     (emitted, total)
+}
+
+/// Render one captured stderr line for the log: strip a trailing `'\r'`
+/// (CRLF), decode loss-tolerantly, and mark a byte-capped line with `'…'`
+/// (after dropping a trailing UTF-8 sequence the cap cut in half, so the
+/// truncation reads as one marker instead of U+FFFD noise).
+fn render_stderr_line(bytes: &[u8], overflowed: bool) -> String {
+    let mut bytes = bytes.strip_suffix(b"\r").unwrap_or(bytes);
+    if overflowed {
+        bytes = trim_partial_utf8_tail(bytes);
+    }
+    let mut text = String::from_utf8_lossy(bytes).into_owned();
+    if overflowed {
+        text.push('…');
+    }
+    text
+}
+
+/// Drop an incomplete trailing multibyte UTF-8 sequence (a leading byte whose
+/// continuation bytes are missing). Interior invalid bytes are left for the
+/// lossy decode — only a tail the byte cap visibly cut off is trimmed.
+fn trim_partial_utf8_tail(bytes: &[u8]) -> &[u8] {
+    let len = bytes.len();
+    for i in (len.saturating_sub(3)..len).rev() {
+        let byte = bytes[i];
+        if byte < 0x80 {
+            break; // ASCII tail: nothing to trim
+        }
+        if byte >= 0xC0 {
+            // Leading byte of a multibyte char at `i`.
+            let width = if byte >= 0xF0 {
+                4
+            } else if byte >= 0xE0 {
+                3
+            } else {
+                2
+            };
+            if i + width > len {
+                return &bytes[..i];
+            }
+            break; // Complete sequence: keep it
+        }
+        // Continuation byte: keep scanning backwards for its leading byte.
+    }
+    bytes
 }
 
 #[cfg(test)]

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -2511,6 +2511,16 @@ impl LanguageServerPool {
         // Spawn new connection (while holding lock to prevent concurrent spawns)
         let mut conn = AsyncBridgeConnection::spawn(server_config.cmd().to_vec()).await?;
 
+        // Crash-triage channel: forward the child's stderr into the log,
+        // bounded (see `drain_downstream_stderr`). Detached — it exits on the
+        // child's EOF, which the writer's Drop kill guarantees eventually.
+        if let Some(stderr) = conn.take_stderr() {
+            tokio::spawn(super::connection::drain_downstream_stderr(
+                stderr,
+                server_name.to_string(),
+            ));
+        }
+
         // Split connection immediately
         let (writer, reader) = conn.split();
         let router = Arc::new(ResponseRouter::new());

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1367,17 +1367,21 @@ impl DiagnosticAggregator {
     /// stay confirmed-only ([`Self::pull_view_lag_stamp`]): a pull must never
     /// clear what is not yet confirmed.
     pub(crate) fn has_pull_view_lag(&self, host: &Url) -> bool {
-        if self
-            .pull_view_lag
+        // Both maps are read under BOTH locks in the fixed pending → confirmed
+        // order shared with `settle_pending_pull_view_lag` and
+        // `forget_published`: two sequential single-lock reads could straddle
+        // a settle (pending removed, confirmed inserted) and see NEITHER —
+        // absorbing past a real lag mid-transition.
+        let pending = self
+            .pull_view_lag_pending
             .lock()
-            .recover_poison("DiagnosticAggregator::pull_view_lag")
-            .contains_key(host)
-        {
+            .recover_poison("DiagnosticAggregator::pull_view_lag_pending");
+        if pending.contains_key(host) {
             return true;
         }
-        self.pull_view_lag_pending
+        self.pull_view_lag
             .lock()
-            .recover_poison("DiagnosticAggregator::pull_view_lag_pending")
+            .recover_poison("DiagnosticAggregator::pull_view_lag")
             .contains_key(host)
     }
 
@@ -2232,6 +2236,47 @@ impl DiagnosticAggregator {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn pull_view_lag_is_visible_across_the_settle_transition_states() {
+        use super::*;
+        let agg = DiagnosticAggregator::new();
+        let host = Url::parse("file:///lag_states.md").unwrap();
+
+        // Pending-only (writer parked before its republish).
+        agg.set_pull_layer_nudgeless(&host, Vec::new());
+        assert!(
+            agg.has_pull_view_lag(&host),
+            "pending mark must read as lag"
+        );
+        assert!(
+            agg.pull_view_lag_stamp(&host).is_none(),
+            "a pull must not be able to clear an unconfirmed mark"
+        );
+
+        // Confirmed (a Changed republish settled it).
+        let (_, revision) = agg.snapshot_with_revision(&host);
+        agg.settle_pending_pull_view_lag(&host, revision, true);
+        assert!(
+            agg.has_pull_view_lag(&host),
+            "confirmed lag must read as lag"
+        );
+        let stamp = agg.pull_view_lag_stamp(&host);
+        assert!(
+            stamp.is_some(),
+            "a confirmed lag is clearable by a covering pull"
+        );
+
+        // Cleared by the covering pull.
+        agg.clear_pull_view_lag_up_to(&host, stamp);
+        assert!(!agg.has_pull_view_lag(&host));
+
+        // Unchanged settles drop the mark without minting a lag.
+        agg.set_pull_layer_nudgeless(&host, Vec::new());
+        let (_, revision) = agg.snapshot_with_revision(&host);
+        agg.settle_pending_pull_view_lag(&host, revision, false);
+        assert!(!agg.has_pull_view_lag(&host));
+    }
+
     use super::*;
     use tower_lsp_server::ls_types::{Position, Range};
 

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -649,6 +649,15 @@ struct HostCoverage {
     served: u64,
 }
 
+/// A provisional pull-view lag record (see
+/// [`DiagnosticAggregator::record_pull_view_lag`]): the minted serial plus
+/// the previous serial it displaced, which a retraction must restore.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProvisionalPullViewLag {
+    serial: u64,
+    previous: Option<u64>,
+}
+
 /// The diagnostic coverage observed when a pull begins.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct DiagnosticCoverageStamp {
@@ -1181,18 +1190,56 @@ impl DiagnosticAggregator {
             .remove(host);
     }
 
-    /// Record that `host`'s merged set moved through an editor-origin,
-    /// nudge-less republish (see the [`Self::pull_view_lag`] field doc). A
-    /// repeat record re-stamps the entry with a fresh serial, so an in-flight
-    /// pull that started before it cannot clear it.
-    pub(crate) fn record_pull_view_lag(&self, host: &Url) {
+    /// Record that `host`'s merged set is ABOUT to move through an
+    /// editor-origin, nudge-less republish (see the [`Self::pull_view_lag`]
+    /// field doc). Recorded BEFORE the republish, deliberately: the per-host
+    /// republish lock serializes the recorder's republish against the
+    /// forwarded-refresh prefetch's own commit, so record-before-republish
+    /// guarantees any change visible to the prefetch's compare had its lag
+    /// visible to the cycle's decision sweep first — the linearization that
+    /// makes the absorption race-free. A republish that turns out Unchanged
+    /// retracts its provisional record via
+    /// [`Self::retract_pull_view_lag`]. A repeat record re-stamps the entry
+    /// with a fresh serial, so an in-flight pull that started before it
+    /// cannot clear it. Returns the provisional record — serial plus the
+    /// PREVIOUS serial it displaced — for the retraction: a retraction must
+    /// restore that predecessor, never bare-remove, or a provisional
+    /// re-stamp followed by an Unchanged republish would erase an older,
+    /// still-owed lag.
+    pub(crate) fn record_pull_view_lag(&self, host: &Url) -> ProvisionalPullViewLag {
         let serial = self
             .next_pull_view_lag_serial
             .fetch_add(1, Ordering::Relaxed);
-        self.pull_view_lag
+        let previous = self
+            .pull_view_lag
             .lock()
             .recover_poison("DiagnosticAggregator::pull_view_lag")
             .insert(host.clone(), serial);
+        ProvisionalPullViewLag { serial, previous }
+    }
+
+    /// Retract a provisional lag record whose republish reported Unchanged:
+    /// restore the serial it displaced (an older lag is still owed a nudge)
+    /// or remove the entry when there was none — but only when no NEWER
+    /// record re-stamped the entry meanwhile (that newer recorder's own
+    /// retraction/confirmation owns it now). Restoring the OLDER serial keeps
+    /// pull stamps sound: a covering pull that captured the provisional
+    /// serial at entry may clear the restored (older) one.
+    pub(crate) fn retract_pull_view_lag(&self, host: &Url, provisional: ProvisionalPullViewLag) {
+        let mut lags = self
+            .pull_view_lag
+            .lock()
+            .recover_poison("DiagnosticAggregator::pull_view_lag");
+        if lags.get(host) == Some(&provisional.serial) {
+            match provisional.previous {
+                Some(previous) => {
+                    lags.insert(host.clone(), previous);
+                }
+                None => {
+                    lags.remove(host);
+                }
+            }
+        }
     }
 
     /// Whether `host` carries an outstanding pull-view lag — the recorded set

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -2255,13 +2255,6 @@ impl DiagnosticAggregator {
 
 #[cfg(test)]
 mod tests {
-    /// Lock-order pin for `has_pull_view_lag`: a pending-only host must be
-    /// answerable from the pending lock alone (pending → confirmed nesting,
-    /// pending read first with a short-circuit). The pre-fix implementation
-    /// acquired the confirmed lock FIRST, so with that lock held here it
-    /// would block forever — this test turns red (timeout) if the read order
-    /// regresses, which is exactly the order whose two unlocked halves let a
-    /// settle hide mid-transition.
     /// Qodo review finding (PR #972): a NO-OP nudgeless mutation (identical
     /// blob, or evicting an absent layer — no revision bump) must not stamp a
     /// pending mark, or an unrelated later Changed republish converts it into
@@ -2298,6 +2291,13 @@ mod tests {
         );
     }
 
+    /// Lock-order pin for `has_pull_view_lag`: a pending-only host must be
+    /// answerable from the pending lock alone (pending → confirmed nesting,
+    /// pending read first with a short-circuit). The pre-fix implementation
+    /// acquired the confirmed lock FIRST, so with that lock held here it
+    /// would block forever — this test turns red (timeout) if the read order
+    /// regresses, which is exactly the order whose two unlocked halves let a
+    /// settle hide mid-transition.
     #[test]
     fn pending_only_lag_is_answerable_without_the_confirmed_lock() {
         use super::*;

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1418,6 +1418,20 @@ impl DiagnosticAggregator {
         }
     }
 
+    /// Test-only: hold the CONFIRMED-lag lock open, so a test can prove
+    /// [`Self::has_pull_view_lag`] answers a pending-only host without ever
+    /// touching it (the pending → confirmed nesting: pending is read first
+    /// and short-circuits). The pre-fix implementation locked confirmed
+    /// FIRST and deadlocks against this guard.
+    #[cfg(test)]
+    pub(crate) fn lock_confirmed_pull_view_lag_for_test(
+        &self,
+    ) -> std::sync::MutexGuard<'_, HashMap<Url, u64>> {
+        self.pull_view_lag
+            .lock()
+            .recover_poison("DiagnosticAggregator::pull_view_lag")
+    }
+
     /// Test-only unconditional clear, standing in for a covering pull in unit
     /// fixtures that seed the cache directly.
     #[cfg(test)]
@@ -2236,6 +2250,38 @@ impl DiagnosticAggregator {
 
 #[cfg(test)]
 mod tests {
+    /// Lock-order pin for `has_pull_view_lag`: a pending-only host must be
+    /// answerable from the pending lock alone (pending → confirmed nesting,
+    /// pending read first with a short-circuit). The pre-fix implementation
+    /// acquired the confirmed lock FIRST, so with that lock held here it
+    /// would block forever — this test turns red (timeout) if the read order
+    /// regresses, which is exactly the order whose two unlocked halves let a
+    /// settle hide mid-transition.
+    #[test]
+    fn pending_only_lag_is_answerable_without_the_confirmed_lock() {
+        use super::*;
+        use std::sync::Arc as StdArc;
+        let agg = StdArc::new(DiagnosticAggregator::new());
+        let host = Url::parse("file:///lag_lock_order.md").unwrap();
+        agg.set_pull_layer_nudgeless(&host, Vec::new());
+
+        let _confirmed_guard = agg.lock_confirmed_pull_view_lag_for_test();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let reader = {
+            let agg = StdArc::clone(&agg);
+            let host = host.clone();
+            std::thread::spawn(move || {
+                let _ = tx.send(agg.has_pull_view_lag(&host));
+            })
+        };
+        let answered = rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("pending-only lag must be answerable while the confirmed lock is held");
+        assert!(answered, "the pending mark must read as lag");
+        drop(_confirmed_guard);
+        reader.join().expect("reader thread");
+    }
+
     #[test]
     fn pull_view_lag_is_visible_across_the_settle_transition_states() {
         use super::*;

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -445,8 +445,8 @@ pub(crate) struct DiagnosticAggregator {
     /// nudge-less** mutation (`publish_pull_layer`/`clear_pull_layer`, and
     /// the refresh prefetch's own commit) since the last **covering** editor
     /// pull — confirmed at the Changed republish that recorded the move (see
-    /// [`Self::mark_pull_view_lag_pending`] /
-    /// [`Self::convert_pending_pull_view_lag`]). Those writers never emit `workspace/diagnostic/refresh` (by
+    /// [`Self::set_pull_layer_nudgeless`] /
+    /// [`Self::settle_pending_pull_view_lag`]). Those writers never emit `workspace/diagnostic/refresh` (by
     /// design — they are normally paired with the editor's own event-driven
     /// pull), but that pairing is a race: the editor's pull can answer with
     /// the downstream's PRE-analysis state while the slower synthetic pull

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1281,12 +1281,16 @@ impl DiagnosticAggregator {
             );
         if changed {
             revisions.insert(host.clone(), self.allocate_cache_revision());
+            // Stamp only a REAL change (Qodo, PR #972): a no-op mutation owes
+            // the editor nothing, and its stale mark would otherwise be
+            // converted into a spurious lag by whatever unrelated Changed
+            // republish settles next.
+            let revision = revisions.get(host).copied().unwrap_or(0);
+            self.pull_view_lag_pending
+                .lock()
+                .recover_poison("DiagnosticAggregator::pull_view_lag_pending")
+                .insert(host.clone(), revision);
         }
-        let revision = revisions.get(host).copied().unwrap_or(0);
-        self.pull_view_lag_pending
-            .lock()
-            .recover_poison("DiagnosticAggregator::pull_view_lag_pending")
-            .insert(host.clone(), revision);
     }
 
     /// Evict the pull-layer blob AND stamp the pending mark, like
@@ -1309,12 +1313,13 @@ impl DiagnosticAggregator {
         };
         if removed {
             revisions.insert(host.clone(), self.allocate_cache_revision());
+            // Same real-change gate as `set_pull_layer_nudgeless`.
+            let revision = revisions.get(host).copied().unwrap_or(0);
+            self.pull_view_lag_pending
+                .lock()
+                .recover_poison("DiagnosticAggregator::pull_view_lag_pending")
+                .insert(host.clone(), revision);
         }
-        let revision = revisions.get(host).copied().unwrap_or(0);
-        self.pull_view_lag_pending
-            .lock()
-            .recover_poison("DiagnosticAggregator::pull_view_lag_pending")
-            .insert(host.clone(), revision);
     }
 
     /// Settle any pending mark covered by the revision a republish just

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -387,8 +387,9 @@ pub(crate) struct DiagnosticAggregator {
     /// refreshes (#789). Unlike [`Self::refresh_flight`], which only coalesces
     /// while the editor's acknowledgement is outstanding, this also collapses
     /// bursts when the editor answers each request immediately. The first
-    /// activity after idle sends without waiting; later activity produces a
-    /// trailing send only when no refresh from any origin has covered it.
+    /// activity after idle starts its cycle without waiting (the cycle's
+    /// prefetch may then absorb the send); later activity produces a
+    /// trailing cycle only when no refresh from any origin has covered it.
     forwarded_refresh_debounce: Mutex<ForwardedRefreshDebounce>,
     /// Per-host coverage versions for the refresh **coverage gate** (#497, commit 2).
     /// `current` bumps on every set-changing republish (the editor's pulled view is
@@ -771,9 +772,9 @@ impl DiagnosticAggregator {
 
     /// Check whether activity occurred during the debounce wait. A newer
     /// generation restarts the settle window. Once the wait settles, request a
-    /// trailing refresh only when no refresh send has covered the latest
-    /// downstream activity; the leading send or another refresh origin may
-    /// already have done so.
+    /// trailing cycle only when no cycle has covered the latest downstream
+    /// activity; the leading cycle (whose nudge may have been absorbed) or
+    /// another refresh origin may already have done so.
     pub(crate) fn finish_forwarded_refresh_wait(
         &self,
         observed: u64,
@@ -846,9 +847,14 @@ impl DiagnosticAggregator {
             .task_scheduled = false;
     }
 
-    /// Record that a forced refresh has been admitted for the latest downstream
-    /// activity. Admission is enough: the refresh single-flight guarantees that
-    /// an in-flight request will eventually emit its forced pending successor.
+    /// Record that the latest downstream activity is fully handled: a forced
+    /// refresh was admitted, the client lacks refresh support, or the cycle's
+    /// covering-unchanged prefetch absorbed the nudge. For the admitted case,
+    /// admission is enough: the refresh single-flight guarantees that an
+    /// in-flight request will eventually emit its forced pending successor.
+    /// For the absorbed case the prefetch itself is the handling — any NEW
+    /// downstream activity mints a new generation, which this mark (being
+    /// generation-guarded) can never cover.
     pub(crate) fn mark_forwarded_refresh_covered(&self, generation: u64) {
         let mut debounce = self
             .forwarded_refresh_debounce
@@ -872,9 +878,10 @@ impl DiagnosticAggregator {
         }
     }
 
-    /// Whether a completed prefetch for `generation` should still nudge the
-    /// editor. Newer activity must first receive its own prefetch, while another
-    /// refresh sent after this activity already supplies the nudge.
+    /// Whether a completed prefetch for `generation` still owes the editor
+    /// handling (the actual nudge is additionally gated by the prefetch
+    /// summary). Newer activity must first receive its own prefetch, while
+    /// another refresh sent after this activity already supplies the nudge.
     pub(crate) fn forwarded_refresh_needs_editor_send(&self, generation: u64) -> bool {
         let debounce = self
             .forwarded_refresh_debounce

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -916,6 +916,27 @@ impl DiagnosticAggregator {
             && debounce.refresh_epoch == debounce.refresh_epoch_at_last_activity
     }
 
+    /// Whether `generation` was suppressed ONLY by the epoch cover — an
+    /// intervening refresh from another origin was sent after this activity,
+    /// so [`Self::forwarded_refresh_needs_editor_send`] treats the cycle as
+    /// already nudged. That cover is a heuristic about ORDER: the intervening
+    /// refresh's induced re-pull can have answered BEFORE this cycle's
+    /// prefetch committed, in which case the editor holds the pre-commit set
+    /// and no later signal is guaranteed. A cycle whose prefetch produced a
+    /// changed/lagged summary uses this to coalesce a compensating forced
+    /// nudge into the refresh single-flight instead of trusting the cover.
+    /// Distinct from a GENERATION mismatch, where newer downstream activity
+    /// owns a fresh cycle (and prefetch) of its own — no compensation there.
+    pub(crate) fn forwarded_refresh_epoch_covered(&self, generation: u64) -> bool {
+        let debounce = self
+            .forwarded_refresh_debounce
+            .lock()
+            .recover_poison("DiagnosticAggregator::forwarded_refresh_debounce");
+        debounce.generation == generation
+            && debounce.covered_generation != Some(generation)
+            && debounce.refresh_epoch != debounce.refresh_epoch_at_last_activity
+    }
+
     pub(crate) fn new() -> Self {
         Self::default()
     }

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1110,6 +1110,21 @@ impl DiagnosticAggregator {
         cache.get(host).is_some_and(has_live_region_slots)
     }
 
+    /// Whether `host`'s cached `PullLayer` blob holds any diagnostics. The
+    /// degraded-pull guard consults this alongside [`Self::has_region_slots`]:
+    /// a tree-less pull answers without the virt layer entirely, so cached
+    /// pull-layer content (a pull-only server's home — it never has push
+    /// slots) is exactly what such an answer is missing. An empty blob has
+    /// nothing to miss.
+    pub(crate) fn has_nonempty_pull_layer(&self, host: &Url) -> bool {
+        let cache = self.lock();
+        cache.get(host).is_some_and(|slots| {
+            slots
+                .get(&DiagnosticSource::PullLayer)
+                .is_some_and(|servers| servers.values().any(|slot| !slot.diagnostics.is_empty()))
+        })
+    }
+
     /// Drop everything for a host (host `didClose`). Returns whether it existed.
     pub(crate) fn evict_host(&self, host: &Url) -> bool {
         let mut revisions = self

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -474,8 +474,12 @@ pub(crate) struct DiagnosticAggregator {
     /// converts it into the confirmed lag, an Unchanged record drops it (the
     /// mutation demonstrably left the merged set alone). Revision-keying is
     /// what stops an unrelated earlier Changed from consuming a mark whose
-    /// mutation it never saw, and marks are deliberately invisible to pull
-    /// stamps and the decision sweep until confirmed.
+    /// mutation it never saw. Marks are invisible to pull STAMPS until
+    /// confirmed (a pull must never clear an unconfirmed change), but the
+    /// absorption sweep counts them conservatively as lag
+    /// ([`Self::has_pull_view_lag`]): a writer parked between its mutation
+    /// and its republish is a real, unconfirmed change the cycle must not
+    /// absorb past.
     pull_view_lag_pending: Mutex<HashMap<Url, u64>>,
     /// Allocator for [`Self::pull_view_lag`] serials. Process-wide (not
     /// per-host) so a close/reopen can never re-mint an already-captured
@@ -1353,11 +1357,27 @@ impl DiagnosticAggregator {
     }
 
     /// Whether `host` carries an outstanding pull-view lag — the recorded set
-    /// moved without a nudge and no covering pull has been answered since.
+    /// moved without a nudge and no covering pull has been answered since —
+    /// or an UNSETTLED pending mark. The pending half is deliberate
+    /// conservatism for the absorption sweep: a writer that has mutated the
+    /// cache but not yet reached its republish is a real, unconfirmed change
+    /// (the republish that later confirms it emits no nudge of its own), so
+    /// the sweep must not absorb past it. A mark whose republish turns out
+    /// Unchanged costs one spurious nudge — the safe direction. Pull stamps
+    /// stay confirmed-only ([`Self::pull_view_lag_stamp`]): a pull must never
+    /// clear what is not yet confirmed.
     pub(crate) fn has_pull_view_lag(&self, host: &Url) -> bool {
-        self.pull_view_lag
+        if self
+            .pull_view_lag
             .lock()
             .recover_poison("DiagnosticAggregator::pull_view_lag")
+            .contains_key(host)
+        {
+            return true;
+        }
+        self.pull_view_lag_pending
+            .lock()
+            .recover_poison("DiagnosticAggregator::pull_view_lag_pending")
             .contains_key(host)
     }
 

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -466,13 +466,17 @@ pub(crate) struct DiagnosticAggregator {
     /// lifetime after a close raced the pull (#745's defect class) — carries
     /// a newer serial and survives the stale clear.
     pull_view_lag: Mutex<HashMap<Url, u64>>,
-    /// Nudge-less mutations announced but not yet confirmed by a Changed
-    /// republish (see [`Self::mark_pull_view_lag_pending`]). Deliberately
-    /// invisible to pull stamps and the decision sweep: only a mutation that
-    /// actually changed the recorded set owes the editor anything, and the
-    /// republish that records that change performs the conversion atomically
-    /// with it.
-    pull_view_lag_pending: Mutex<std::collections::HashSet<Url>>,
+    /// Nudge-less mutations performed but not yet settled by a recorded
+    /// republish, keyed to the CACHE REVISION current when the mutation
+    /// landed (stamped inside the same `cache_revisions` critical section —
+    /// see [`Self::set_pull_layer_nudgeless`]). The republish that validates
+    /// a revision `r` settles every mark with revision ≤ r: a Changed record
+    /// converts it into the confirmed lag, an Unchanged record drops it (the
+    /// mutation demonstrably left the merged set alone). Revision-keying is
+    /// what stops an unrelated earlier Changed from consuming a mark whose
+    /// mutation it never saw, and marks are deliberately invisible to pull
+    /// stamps and the decision sweep until confirmed.
+    pull_view_lag_pending: Mutex<HashMap<Url, u64>>,
     /// Allocator for [`Self::pull_view_lag`] serials. Process-wide (not
     /// per-host) so a close/reopen can never re-mint an already-captured
     /// value.
@@ -1039,6 +1043,10 @@ impl DiagnosticAggregator {
     ///
     /// The pull-layer is a cross-connection aggregate, not a single connection's
     /// push, so its slot is tagged `None` and is never touched by crash eviction.
+    /// Test-only since the production writers moved to
+    /// [`Self::set_pull_layer_nudgeless`] (which additionally stamps the
+    /// pending pull-view-lag mark in the same critical section).
+    #[cfg(test)]
     pub(crate) fn set_pull_layer(&self, host: &Url, diagnostics: Vec<Diagnostic>) {
         self.record(
             host,
@@ -1184,60 +1192,128 @@ impl DiagnosticAggregator {
             .lock()
             .recover_poison("DiagnosticAggregator::last_wire_published")
             .remove(host);
-        self.pull_view_lag
-            .lock()
-            .recover_poison("DiagnosticAggregator::pull_view_lag")
-            .remove(host);
-        self.pull_view_lag_pending
-            .lock()
-            .recover_poison("DiagnosticAggregator::pull_view_lag_pending")
-            .remove(host);
-    }
-
-    /// Mark that a nudge-less writer is ABOUT to mutate `host`'s slots (see
-    /// the [`Self::pull_view_lag`] field doc). The mark is set BEFORE the
-    /// mutation and converted into a confirmed lag by **whichever republish
-    /// records the resulting Changed set**
-    /// ([`Self::convert_pending_pull_view_lag`], called under the per-host
-    /// republish lock at the compare-and-record point) — not by the writer
-    /// itself. That closes both halves of the confirmation race: a stale-wire
-    /// retry (or any concurrent republish) that consumes the changed revision
-    /// converts the mark, and a writer preempted anywhere between its
-    /// mutation and its own republish has already made the mark visible. A
-    /// mutation that never changes the merged set leaves a sticky mark; a
-    /// LATER Changed republish then converts it into one spurious nudge —
-    /// the safe direction, cleared by the covering pull.
-    pub(crate) fn mark_pull_view_lag_pending(&self, host: &Url) {
-        self.pull_view_lag_pending
-            .lock()
-            .recover_poison("DiagnosticAggregator::pull_view_lag_pending")
-            .insert(host.clone());
-    }
-
-    /// Convert an outstanding pending mark into a confirmed lag. Called by
-    /// `republish` immediately after `published_set_changed_current_revision`
-    /// returns `Some(true)`, while the per-host republish lock is held — the
-    /// same serialization that orders every same-host republish, which is
-    /// what makes the forwarded-refresh decision sweep a linearization point:
-    /// any change the prefetch's Unchanged-compare could have observed was
-    /// recorded by an earlier (lock-ordered) Changed republish, whose
-    /// conversion made the lag visible before the sweep.
-    pub(crate) fn convert_pending_pull_view_lag(&self, host: &Url) {
-        let removed = self
+        // Pending and confirmed lag are cleared under BOTH locks, in the
+        // fixed pending → confirmed order shared with
+        // `settle_pending_pull_view_lag`, so a settle cannot interleave
+        // between the two removals and resurrect a closed host's lag.
+        let mut pending = self
             .pull_view_lag_pending
             .lock()
-            .recover_poison("DiagnosticAggregator::pull_view_lag_pending")
-            .remove(host);
-        if !removed {
-            return;
-        }
-        let serial = self
-            .next_pull_view_lag_serial
-            .fetch_add(1, Ordering::Relaxed);
+            .recover_poison("DiagnosticAggregator::pull_view_lag_pending");
+        pending.remove(host);
         self.pull_view_lag
             .lock()
             .recover_poison("DiagnosticAggregator::pull_view_lag")
-            .insert(host.clone(), serial);
+            .remove(host);
+        drop(pending);
+    }
+
+    /// Replace the pull-layer blob AND stamp the pending pull-view-lag mark
+    /// in one `cache_revisions` critical section — the nudge-less variant of
+    /// [`Self::set_pull_layer`] (see the [`Self::pull_view_lag_pending`]
+    /// field doc). Stamping atomically with the mutation ties the mark to
+    /// the exact revision carrying this data, so a republish can only settle
+    /// it once its validated snapshot INCLUDES the mutation.
+    pub(crate) fn set_pull_layer_nudgeless(&self, host: &Url, diagnostics: Vec<Diagnostic>) {
+        let mut revisions = self
+            .cache_revisions
+            .lock()
+            .recover_poison("DiagnosticAggregator::cache_revisions");
+        let mut cache = self.lock();
+        let source_slots = if let Some(source_slots) = cache.get_mut(host) {
+            source_slots
+        } else {
+            cache.entry(host.clone()).or_default()
+        };
+        let changed = source_slots
+            .get(&DiagnosticSource::PullLayer)
+            .and_then(|servers| servers.get(PULL_LAYER_SERVER))
+            .is_none_or(|slot| slot.diagnostics != diagnostics);
+        source_slots
+            .entry(DiagnosticSource::PullLayer)
+            .or_default()
+            .insert(
+                PULL_LAYER_SERVER.to_string(),
+                SlotEntry {
+                    diagnostics,
+                    connection_id: None,
+                },
+            );
+        if changed {
+            revisions.insert(host.clone(), self.allocate_cache_revision());
+        }
+        let revision = revisions.get(host).copied().unwrap_or(0);
+        self.pull_view_lag_pending
+            .lock()
+            .recover_poison("DiagnosticAggregator::pull_view_lag_pending")
+            .insert(host.clone(), revision);
+    }
+
+    /// Evict the pull-layer blob AND stamp the pending mark, like
+    /// [`Self::set_pull_layer_nudgeless`] — the nudge-less variant of
+    /// `evict_source(host, PullLayer)`.
+    pub(crate) fn evict_pull_layer_nudgeless(&self, host: &Url) {
+        let mut revisions = self
+            .cache_revisions
+            .lock()
+            .recover_poison("DiagnosticAggregator::cache_revisions");
+        let mut cache = self.lock();
+        let removed = if let Some(slots) = cache.get_mut(host) {
+            let removed = slots.remove(&DiagnosticSource::PullLayer).is_some();
+            if slots.is_empty() {
+                cache.remove(host);
+            }
+            removed
+        } else {
+            false
+        };
+        if removed {
+            revisions.insert(host.clone(), self.allocate_cache_revision());
+        }
+        let revision = revisions.get(host).copied().unwrap_or(0);
+        self.pull_view_lag_pending
+            .lock()
+            .recover_poison("DiagnosticAggregator::pull_view_lag_pending")
+            .insert(host.clone(), revision);
+    }
+
+    /// Settle any pending mark covered by the revision a republish just
+    /// validated (see the [`Self::pull_view_lag_pending`] field doc): a
+    /// Changed record converts it into the confirmed lag, an Unchanged
+    /// record drops it. Called by `republish` right after
+    /// `published_set_changed_current_revision` returns `Some(_)`, under the
+    /// per-host republish lock — that lock orders every same-host republish,
+    /// which is what makes the forwarded-refresh decision sweep a
+    /// linearization point. Both maps are locked in the fixed
+    /// pending → confirmed order (shared with [`Self::forget_published`]) so
+    /// a didClose cleanup can never interleave between the settle's two
+    /// halves and resurrect a closed host's lag.
+    pub(crate) fn settle_pending_pull_view_lag(
+        &self,
+        host: &Url,
+        cache_revision: u64,
+        changed: bool,
+    ) {
+        let mut pending = self
+            .pull_view_lag_pending
+            .lock()
+            .recover_poison("DiagnosticAggregator::pull_view_lag_pending");
+        let covered = pending
+            .get(host)
+            .is_some_and(|&revision| revision <= cache_revision);
+        if !covered {
+            return;
+        }
+        pending.remove(host);
+        if changed {
+            let serial = self
+                .next_pull_view_lag_serial
+                .fetch_add(1, Ordering::Relaxed);
+            self.pull_view_lag
+                .lock()
+                .recover_poison("DiagnosticAggregator::pull_view_lag")
+                .insert(host.clone(), serial);
+        }
     }
 
     /// Whether `host` carries an outstanding pull-view lag — the recorded set

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -2257,6 +2257,42 @@ mod tests {
     /// would block forever — this test turns red (timeout) if the read order
     /// regresses, which is exactly the order whose two unlocked halves let a
     /// settle hide mid-transition.
+    /// Qodo review finding (PR #972): a NO-OP nudgeless mutation (identical
+    /// blob, or evicting an absent layer — no revision bump) must not stamp a
+    /// pending mark, or an unrelated later Changed republish converts it into
+    /// a spurious confirmed lag that keeps forcing nudges until a covering
+    /// pull.
+    #[test]
+    fn a_no_op_nudgeless_mutation_mints_no_lag_from_an_unrelated_change() {
+        use super::*;
+        let agg = DiagnosticAggregator::new();
+        let host = Url::parse("file:///no_op_nudgeless.md").unwrap();
+
+        // No-op evict: no PullLayer exists.
+        agg.evict_pull_layer_nudgeless(&host);
+        let (_, revision) = agg.snapshot_with_revision(&host);
+        // An unrelated Changed republish settling at the current revision…
+        agg.settle_pending_pull_view_lag(&host, revision, true);
+        assert!(
+            !agg.has_pull_view_lag(&host),
+            "an absent-layer evict changed nothing — no lag may be minted"
+        );
+
+        // No-op set: identical blob twice. Settle the REAL first change away
+        // (as its own republish would), then repeat it verbatim.
+        agg.set_pull_layer_nudgeless(&host, Vec::new());
+        let (_, revision) = agg.snapshot_with_revision(&host);
+        agg.settle_pending_pull_view_lag(&host, revision, true);
+        agg.clear_pull_view_lag(&host);
+        agg.set_pull_layer_nudgeless(&host, Vec::new());
+        let (_, revision) = agg.snapshot_with_revision(&host);
+        agg.settle_pending_pull_view_lag(&host, revision, true);
+        assert!(
+            !agg.has_pull_view_lag(&host),
+            "an identical re-commit changed nothing — no lag may be minted"
+        );
+    }
+
     #[test]
     fn pending_only_lag_is_answerable_without_the_confirmed_lock() {
         use super::*;

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -442,9 +442,11 @@ pub(crate) struct DiagnosticAggregator {
     /// answer (#745).
     degraded_pulls: Mutex<HashMap<Url, Option<u64>>>,
     /// Hosts whose recorded merged set moved through an **editor-origin,
-    /// nudge-less** republish (`publish_pull_layer`/`clear_pull_layer`, and
+    /// nudge-less** mutation (`publish_pull_layer`/`clear_pull_layer`, and
     /// the refresh prefetch's own commit) since the last **covering** editor
-    /// pull. Those writers never emit `workspace/diagnostic/refresh` (by
+    /// pull — confirmed at the Changed republish that recorded the move (see
+    /// [`Self::mark_pull_view_lag_pending`] /
+    /// [`Self::convert_pending_pull_view_lag`]). Those writers never emit `workspace/diagnostic/refresh` (by
     /// design — they are normally paired with the editor's own event-driven
     /// pull), but that pairing is a race: the editor's pull can answer with
     /// the downstream's PRE-analysis state while the slower synthetic pull
@@ -464,6 +466,13 @@ pub(crate) struct DiagnosticAggregator {
     /// lifetime after a close raced the pull (#745's defect class) — carries
     /// a newer serial and survives the stale clear.
     pull_view_lag: Mutex<HashMap<Url, u64>>,
+    /// Nudge-less mutations announced but not yet confirmed by a Changed
+    /// republish (see [`Self::mark_pull_view_lag_pending`]). Deliberately
+    /// invisible to pull stamps and the decision sweep: only a mutation that
+    /// actually changed the recorded set owes the editor anything, and the
+    /// republish that records that change performs the conversion atomically
+    /// with it.
+    pull_view_lag_pending: Mutex<std::collections::HashSet<Url>>,
     /// Allocator for [`Self::pull_view_lag`] serials. Process-wide (not
     /// per-host) so a close/reopen can never re-mint an already-captured
     /// value.
@@ -647,15 +656,6 @@ struct HostCoverage {
     /// The `current` value a pull was last answered against (a lower bound — read
     /// before the pull's fold, so never ahead of what the editor actually received).
     served: u64,
-}
-
-/// A provisional pull-view lag record (see
-/// [`DiagnosticAggregator::record_pull_view_lag`]): the minted serial plus
-/// the previous serial it displaced, which a retraction must restore.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct ProvisionalPullViewLag {
-    serial: u64,
-    previous: Option<u64>,
 }
 
 /// The diagnostic coverage observed when a pull begins.
@@ -1188,58 +1188,56 @@ impl DiagnosticAggregator {
             .lock()
             .recover_poison("DiagnosticAggregator::pull_view_lag")
             .remove(host);
+        self.pull_view_lag_pending
+            .lock()
+            .recover_poison("DiagnosticAggregator::pull_view_lag_pending")
+            .remove(host);
     }
 
-    /// Record that `host`'s merged set is ABOUT to move through an
-    /// editor-origin, nudge-less republish (see the [`Self::pull_view_lag`]
-    /// field doc). Recorded BEFORE the republish, deliberately: the per-host
-    /// republish lock serializes the recorder's republish against the
-    /// forwarded-refresh prefetch's own commit, so record-before-republish
-    /// guarantees any change visible to the prefetch's compare had its lag
-    /// visible to the cycle's decision sweep first — the linearization that
-    /// makes the absorption race-free. A republish that turns out Unchanged
-    /// retracts its provisional record via
-    /// [`Self::retract_pull_view_lag`]. A repeat record re-stamps the entry
-    /// with a fresh serial, so an in-flight pull that started before it
-    /// cannot clear it. Returns the provisional record — serial plus the
-    /// PREVIOUS serial it displaced — for the retraction: a retraction must
-    /// restore that predecessor, never bare-remove, or a provisional
-    /// re-stamp followed by an Unchanged republish would erase an older,
-    /// still-owed lag.
-    pub(crate) fn record_pull_view_lag(&self, host: &Url) -> ProvisionalPullViewLag {
+    /// Mark that a nudge-less writer is ABOUT to mutate `host`'s slots (see
+    /// the [`Self::pull_view_lag`] field doc). The mark is set BEFORE the
+    /// mutation and converted into a confirmed lag by **whichever republish
+    /// records the resulting Changed set**
+    /// ([`Self::convert_pending_pull_view_lag`], called under the per-host
+    /// republish lock at the compare-and-record point) — not by the writer
+    /// itself. That closes both halves of the confirmation race: a stale-wire
+    /// retry (or any concurrent republish) that consumes the changed revision
+    /// converts the mark, and a writer preempted anywhere between its
+    /// mutation and its own republish has already made the mark visible. A
+    /// mutation that never changes the merged set leaves a sticky mark; a
+    /// LATER Changed republish then converts it into one spurious nudge —
+    /// the safe direction, cleared by the covering pull.
+    pub(crate) fn mark_pull_view_lag_pending(&self, host: &Url) {
+        self.pull_view_lag_pending
+            .lock()
+            .recover_poison("DiagnosticAggregator::pull_view_lag_pending")
+            .insert(host.clone());
+    }
+
+    /// Convert an outstanding pending mark into a confirmed lag. Called by
+    /// `republish` immediately after `published_set_changed_current_revision`
+    /// returns `Some(true)`, while the per-host republish lock is held — the
+    /// same serialization that orders every same-host republish, which is
+    /// what makes the forwarded-refresh decision sweep a linearization point:
+    /// any change the prefetch's Unchanged-compare could have observed was
+    /// recorded by an earlier (lock-ordered) Changed republish, whose
+    /// conversion made the lag visible before the sweep.
+    pub(crate) fn convert_pending_pull_view_lag(&self, host: &Url) {
+        let removed = self
+            .pull_view_lag_pending
+            .lock()
+            .recover_poison("DiagnosticAggregator::pull_view_lag_pending")
+            .remove(host);
+        if !removed {
+            return;
+        }
         let serial = self
             .next_pull_view_lag_serial
             .fetch_add(1, Ordering::Relaxed);
-        let previous = self
-            .pull_view_lag
+        self.pull_view_lag
             .lock()
             .recover_poison("DiagnosticAggregator::pull_view_lag")
             .insert(host.clone(), serial);
-        ProvisionalPullViewLag { serial, previous }
-    }
-
-    /// Retract a provisional lag record whose republish reported Unchanged:
-    /// restore the serial it displaced (an older lag is still owed a nudge)
-    /// or remove the entry when there was none — but only when no NEWER
-    /// record re-stamped the entry meanwhile (that newer recorder's own
-    /// retraction/confirmation owns it now). Restoring the OLDER serial keeps
-    /// pull stamps sound: a covering pull that captured the provisional
-    /// serial at entry may clear the restored (older) one.
-    pub(crate) fn retract_pull_view_lag(&self, host: &Url, provisional: ProvisionalPullViewLag) {
-        let mut lags = self
-            .pull_view_lag
-            .lock()
-            .recover_poison("DiagnosticAggregator::pull_view_lag");
-        if lags.get(host) == Some(&provisional.serial) {
-            match provisional.previous {
-                Some(previous) => {
-                    lags.insert(host.clone(), previous);
-                }
-                None => {
-                    lags.remove(host);
-                }
-            }
-        }
     }
 
     /// Whether `host` carries an outstanding pull-view lag — the recorded set

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -452,11 +452,22 @@ pub(crate) struct DiagnosticAggregator {
     /// compares against kakehashi's record, so without this debt it would
     /// read exactly that raced commit as "the editor already has it" and
     /// starve the one signal that heals the lag. A covering pull clears the
-    /// debt ([`Self::clear_pull_view_lag`] via the pull handler); `didClose`
-    /// forgets it ([`Self::forget_published`]). The debt is deliberately NOT
-    /// cleared when a nudge is sent — only the editor actually re-pulling
-    /// proves the lag closed.
-    pull_view_lag: Mutex<std::collections::HashSet<Url>>,
+    /// debt ([`Self::clear_pull_view_lag_up_to`] via the pull handler);
+    /// `didClose` forgets it ([`Self::forget_published`]). The debt is
+    /// deliberately NOT cleared when a nudge is sent — only the editor
+    /// actually re-pulling proves the lag closed.
+    ///
+    /// The value is a monotonic recording serial (from
+    /// [`Self::next_pull_view_lag_serial`]). A covering pull captures the
+    /// host's serial at ENTRY and clears only up to it: a lag recorded while
+    /// the pull was in flight — including one recorded by a reopened
+    /// lifetime after a close raced the pull (#745's defect class) — carries
+    /// a newer serial and survives the stale clear.
+    pull_view_lag: Mutex<HashMap<Url, u64>>,
+    /// Allocator for [`Self::pull_view_lag`] serials. Process-wide (not
+    /// per-host) so a close/reopen can never re-mint an already-captured
+    /// value.
+    next_pull_view_lag_serial: AtomicU64,
     /// Per-host coalescing state for the editor-facing `publishDiagnostics`
     /// wire sends (the quiet window): see [`WireGate`] and
     /// [`Self::wire_gate_admit`]. Mutated under the host's republish lock
@@ -1171,12 +1182,17 @@ impl DiagnosticAggregator {
     }
 
     /// Record that `host`'s merged set moved through an editor-origin,
-    /// nudge-less republish (see the [`Self::pull_view_lag`] field doc).
+    /// nudge-less republish (see the [`Self::pull_view_lag`] field doc). A
+    /// repeat record re-stamps the entry with a fresh serial, so an in-flight
+    /// pull that started before it cannot clear it.
     pub(crate) fn record_pull_view_lag(&self, host: &Url) {
+        let serial = self
+            .next_pull_view_lag_serial
+            .fetch_add(1, Ordering::Relaxed);
         self.pull_view_lag
             .lock()
             .recover_poison("DiagnosticAggregator::pull_view_lag")
-            .insert(host.clone());
+            .insert(host.clone(), serial);
     }
 
     /// Whether `host` carries an outstanding pull-view lag — the recorded set
@@ -1185,14 +1201,45 @@ impl DiagnosticAggregator {
         self.pull_view_lag
             .lock()
             .recover_poison("DiagnosticAggregator::pull_view_lag")
-            .contains(host)
+            .contains_key(host)
     }
 
-    /// A covering editor pull was answered for `host`: whatever the recorded
-    /// set is, the editor now holds it — the lag is closed. (A pull that
-    /// answered concurrently with the very commit that recorded the lag can
-    /// clear it while carrying the pre-commit set — a narrow race whose
-    /// consequence is the pre-debt behavior, i.e. one absorbed refresh.)
+    /// The serial a covering pull must capture at ENTRY to be allowed to
+    /// clear the lag it observed (`None` = no lag outstanding right now).
+    pub(crate) fn pull_view_lag_stamp(&self, host: &Url) -> Option<u64> {
+        self.pull_view_lag
+            .lock()
+            .recover_poison("DiagnosticAggregator::pull_view_lag")
+            .get(host)
+            .copied()
+    }
+
+    /// A covering editor pull that observed `stamp` at entry was answered for
+    /// `host`: the editor now holds everything recorded up to that point, so
+    /// clear the lag — but only when no NEWER lag was recorded meanwhile (a
+    /// mid-pull commit, or a close/reopen lifetime the stale pull must not
+    /// settle, #745). `stamp == None` means no lag was outstanding at entry,
+    /// so there is nothing this pull can vouch for — never clear. (A pull
+    /// that answered concurrently with the very commit whose serial it
+    /// captured can still clear while carrying the pre-commit set — a narrow
+    /// race whose consequence is the pre-debt behavior, i.e. one absorbed
+    /// refresh.)
+    pub(crate) fn clear_pull_view_lag_up_to(&self, host: &Url, stamp: Option<u64>) {
+        let Some(stamp) = stamp else {
+            return;
+        };
+        let mut lags = self
+            .pull_view_lag
+            .lock()
+            .recover_poison("DiagnosticAggregator::pull_view_lag");
+        if lags.get(host).is_some_and(|&serial| serial <= stamp) {
+            lags.remove(host);
+        }
+    }
+
+    /// Test-only unconditional clear, standing in for a covering pull in unit
+    /// fixtures that seed the cache directly.
+    #[cfg(test)]
     pub(crate) fn clear_pull_view_lag(&self, host: &Url) {
         self.pull_view_lag
             .lock()

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -440,6 +440,22 @@ pub(crate) struct DiagnosticAggregator {
     /// backstop would find nothing and the editor would keep a region-less
     /// answer (#745).
     degraded_pulls: Mutex<HashMap<Url, Option<u64>>>,
+    /// Hosts whose recorded merged set moved through an **editor-origin,
+    /// nudge-less** republish (`publish_pull_layer`/`clear_pull_layer`, and
+    /// the refresh prefetch's own commit) since the last **covering** editor
+    /// pull. Those writers never emit `workspace/diagnostic/refresh` (by
+    /// design — they are normally paired with the editor's own event-driven
+    /// pull), but that pairing is a race: the editor's pull can answer with
+    /// the downstream's PRE-analysis state while the slower synthetic pull
+    /// commits the post-analysis set. The forwarded-refresh absorption
+    /// compares against kakehashi's record, so without this debt it would
+    /// read exactly that raced commit as "the editor already has it" and
+    /// starve the one signal that heals the lag. A covering pull clears the
+    /// debt ([`Self::clear_pull_view_lag`] via the pull handler); `didClose`
+    /// forgets it ([`Self::forget_published`]). The debt is deliberately NOT
+    /// cleared when a nudge is sent — only the editor actually re-pulling
+    /// proves the lag closed.
+    pull_view_lag: Mutex<std::collections::HashSet<Url>>,
     /// Per-host coalescing state for the editor-facing `publishDiagnostics`
     /// wire sends (the quiet window): see [`WireGate`] and
     /// [`Self::wire_gate_admit`]. Mutated under the host's republish lock
@@ -1140,6 +1156,40 @@ impl DiagnosticAggregator {
         self.last_wire_published
             .lock()
             .recover_poison("DiagnosticAggregator::last_wire_published")
+            .remove(host);
+        self.pull_view_lag
+            .lock()
+            .recover_poison("DiagnosticAggregator::pull_view_lag")
+            .remove(host);
+    }
+
+    /// Record that `host`'s merged set moved through an editor-origin,
+    /// nudge-less republish (see the [`Self::pull_view_lag`] field doc).
+    pub(crate) fn record_pull_view_lag(&self, host: &Url) {
+        self.pull_view_lag
+            .lock()
+            .recover_poison("DiagnosticAggregator::pull_view_lag")
+            .insert(host.clone());
+    }
+
+    /// Whether `host` carries an outstanding pull-view lag — the recorded set
+    /// moved without a nudge and no covering pull has been answered since.
+    pub(crate) fn has_pull_view_lag(&self, host: &Url) -> bool {
+        self.pull_view_lag
+            .lock()
+            .recover_poison("DiagnosticAggregator::pull_view_lag")
+            .contains(host)
+    }
+
+    /// A covering editor pull was answered for `host`: whatever the recorded
+    /// set is, the editor now holds it — the lag is closed. (A pull that
+    /// answered concurrently with the very commit that recorded the lag can
+    /// clear it while carrying the pre-commit set — a narrow race whose
+    /// consequence is the pre-debt behavior, i.e. one absorbed refresh.)
+    pub(crate) fn clear_pull_view_lag(&self, host: &Url) {
+        self.pull_view_lag
+            .lock()
+            .recover_poison("DiagnosticAggregator::pull_view_lag")
             .remove(host);
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -201,8 +201,8 @@ impl DiagnosticSnapshotPreparer {
         // Whether `pullFallback = false` dropped a pull-eligible layer below —
         // the editor's own pull does not honor that gate, so a snapshot with
         // this set covers less than the editor's re-pull would (see
-        // `DiagnosticSnapshot::pull_gated`).
-        let mut pull_gated = false;
+        // `DiagnosticSnapshot::narrower_than_editor_pull`).
+        let mut narrower_than_editor_pull = false;
 
         // Virt layer: `None` = the document can never have virt diagnostics
         // (no injection query), distinct from `Some(vec![])` = gated off or
@@ -288,7 +288,7 @@ impl DiagnosticSnapshotPreparer {
                                             // fan-out too) narrows this snapshot below the
                                             // editor's re-pull surface — record it.
                                             if !agg.pull_fallback {
-                                                pull_gated = true;
+                                                narrower_than_editor_pull = true;
                                                 None
                                             } else if !dispatches_to_any_server(
                                                 &agg.priorities,
@@ -361,7 +361,7 @@ impl DiagnosticSnapshotPreparer {
             if !agg.pull_fallback {
                 // Same rule as the virt gate above: only the `pullFallback`
                 // drop narrows below the editor's re-pull surface.
-                pull_gated = true;
+                narrower_than_editor_pull = true;
             }
             Some(HostRequestContext {
                 uri: uri.clone(),
@@ -391,7 +391,7 @@ impl DiagnosticSnapshotPreparer {
             },
             virt_contexts,
             host_pull_enabled,
-            pull_gated,
+            narrower_than_editor_pull,
             host,
             layer_cfg,
         })

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -191,13 +191,12 @@ impl DiagnosticSnapshotPreparer {
         // aggregation configs below. A layer gated off still yields a
         // snapshot (with that layer absent) so that publishing an empty list
         // clears anything a previously-enabled configuration left behind.
-        // Generation captured BEFORE the load (see
-        // `SettingsManager::settings_generation`): the only racy arm is then
-        // a config store between the two, which flags the snapshot stale even
-        // though the load already saw the new settings — one over-nudge, the
-        // safe direction.
-        let settings_generation = self.settings_manager.settings_generation();
-        let settings = self.settings_manager.load_settings();
+        // One ArcSwap load supplies BOTH the settings and their generation,
+        // so the lineage's generation always names exactly the snapshot this
+        // surface was resolved from (see `SettingsSnapshot::generation`).
+        let settings_pair = self.settings_manager.load_settings_pair();
+        let settings_generation = settings_pair.generation;
+        let settings = std::sync::Arc::clone(&settings_pair.settings);
         let layer_cfg = crate::lsp::lsp_impl::bridge_context::resolve_layer_config_from_settings(
             &settings,
             &language_name,

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -198,6 +198,12 @@ impl DiagnosticSnapshotPreparer {
             "textDocument/publishDiagnostics",
         );
 
+        // Whether `pullFallback = false` dropped a pull-eligible layer below —
+        // the editor's own pull does not honor that gate, so a snapshot with
+        // this set covers less than the editor's re-pull would (see
+        // `DiagnosticSnapshot::pull_gated`).
+        let mut pull_gated = false;
+
         // Virt layer: `None` = the document can never have virt diagnostics
         // (no injection query), distinct from `Some(vec![])` = gated off or
         // currently no regions (publish-empty-to-clear).
@@ -276,13 +282,19 @@ impl DiagnosticSnapshotPreparer {
                                             // pull layer never falsely suppresses a
                                             // server's spontaneous push. The push path is
                                             // untouched — only kakehashi's pulling stops.
-                                            if !agg.pull_fallback
-                                                || !dispatches_to_any_server(
-                                                    &agg.priorities,
-                                                    &configs,
-                                                    agg.max_fan_out,
-                                                )
-                                            {
+                                            //
+                                            // A `pullFallback` drop (unlike an empty
+                                            // selection, which empties the editor's
+                                            // fan-out too) narrows this snapshot below the
+                                            // editor's re-pull surface — record it.
+                                            if !agg.pull_fallback {
+                                                pull_gated = true;
+                                                None
+                                            } else if !dispatches_to_any_server(
+                                                &agg.priorities,
+                                                &configs,
+                                                agg.max_fan_out,
+                                            ) {
                                                 None
                                             } else {
                                                 Some((configs, agg))
@@ -346,6 +358,11 @@ impl DiagnosticSnapshotPreparer {
             let agg = lang_settings.resolve_host_aggregation("textDocument/publishDiagnostics");
             host_pull_enabled = agg.pull_fallback
                 && dispatches_to_any_server(&agg.priorities, &configs, agg.max_fan_out);
+            if !agg.pull_fallback {
+                // Same rule as the virt gate above: only the `pullFallback`
+                // drop narrows below the editor's re-pull surface.
+                pull_gated = true;
+            }
             Some(HostRequestContext {
                 uri: uri.clone(),
                 language_id: language_name.clone(),
@@ -374,6 +391,7 @@ impl DiagnosticSnapshotPreparer {
             },
             virt_contexts,
             host_pull_enabled,
+            pull_gated,
             host,
             layer_cfg,
         })

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -424,6 +424,10 @@ impl DiagnosticSnapshotPreparer {
         // layer gate hid the host layer the diagnostic key keeps), so an
         // empty-but-flagged snapshot is returned to carry the flag to the
         // forwarded-refresh prefetch instead of vanishing into the skip.
+        // Accepted cost under a diverging config: every open unbridgeable
+        // document of this language now yields an empty snapshot per host
+        // event / prefetch cycle — a no-op Clear plus an Unchanged republish
+        // after the first, cleaned up on close.
         let virt_contexts = match (virt_contexts, host.is_some()) {
             (None, false) if !narrower_than_editor_pull => return None,
             (virt, _) => virt.unwrap_or_default(),

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -198,132 +198,166 @@ impl DiagnosticSnapshotPreparer {
             "textDocument/publishDiagnostics",
         );
 
-        // Whether `pullFallback = false` dropped a pull-eligible layer below —
-        // the editor's own pull does not honor that gate, so a snapshot with
-        // this set covers less than the editor's re-pull would (see
-        // `DiagnosticSnapshot::narrower_than_editor_pull`).
-        let mut narrower_than_editor_pull = false;
+        // Whether this snapshot's pull surface is (possibly) narrower than the
+        // editor's own re-pull surface (see
+        // `DiagnosticSnapshot::narrower_than_editor_pull`). Everything here is
+        // resolved under the `textDocument/publishDiagnostics` method key,
+        // while the editor's pull resolves under `textDocument/diagnostic` —
+        // two independent per-method config keys. The forwarded-refresh
+        // absorption may only trust this snapshot's coverage when the two
+        // resolutions agree, so ANY divergence sets the flag (a divergence
+        // where the editor's surface is the narrower one over-nudges — the
+        // safe direction). The `pullFallback` drop below is the one narrowing
+        // that exists even with identical resolutions (the editor's pull never
+        // honors it).
+        let editor_layer_cfg =
+            crate::lsp::lsp_impl::bridge_context::resolve_layer_config_from_settings(
+                &settings,
+                &language_name,
+                "textDocument/diagnostic",
+            );
+        let mut narrower_than_editor_pull = layer_cfg.priorities != editor_layer_cfg.priorities
+            || layer_cfg.strategy != editor_layer_cfg.strategy;
 
         // Virt layer: `None` = the document can never have virt diagnostics
         // (no injection query), distinct from `Some(vec![])` = gated off or
         // currently no regions (publish-empty-to-clear).
-        let virt_contexts: Option<Vec<DocumentRequestContext>> =
-            if !layer_cfg.allows(crate::config::settings::LayerSource::Virt) {
-                log::debug!(
-                    target: LOG_TARGET,
-                    "virt layer disabled for {} via layers.aggregation priorities",
-                    language_name
-                );
-                Some(Vec::new())
-            } else {
-                self.language
-                    .injection_query(&language_name)
-                    .map(|injection_query| {
-                        // Prefer the populate pass's regions riding the current
-                        // parse snapshot (never discover twice, ADR §3); fall
-                        // back to the inline resolution when absent/stale.
-                        let all_regions = match self
-                            .documents
-                            .current_resolved_regions(uri, self.cache.semantic_token_generation())
-                        {
-                            Some(regions) => regions,
-                            None => std::sync::Arc::new(InjectionResolver::resolve_all(
-                                &self.language,
-                                self.bridge.node_tracker(),
-                                uri,
-                                snapshot.tree(),
-                                snapshot.text(),
-                                injection_query.as_ref(),
-                                snapshot.incarnation(),
-                            )),
-                        };
+        let virt_contexts: Option<Vec<DocumentRequestContext>> = if !layer_cfg
+            .allows(crate::config::settings::LayerSource::Virt)
+        {
+            log::debug!(
+                target: LOG_TARGET,
+                "virt layer disabled for {} via layers.aggregation priorities",
+                language_name
+            );
+            Some(Vec::new())
+        } else {
+            self.language
+                .injection_query(&language_name)
+                .map(|injection_query| {
+                    // Prefer the populate pass's regions riding the current
+                    // parse snapshot (never discover twice, ADR §3); fall
+                    // back to the inline resolution when absent/stale.
+                    let all_regions = match self
+                        .documents
+                        .current_resolved_regions(uri, self.cache.semantic_token_generation())
+                    {
+                        Some(regions) => regions,
+                        None => std::sync::Arc::new(InjectionResolver::resolve_all(
+                            &self.language,
+                            self.bridge.node_tracker(),
+                            uri,
+                            snapshot.tree(),
+                            snapshot.text(),
+                            injection_query.as_ref(),
+                            snapshot.incarnation(),
+                        )),
+                    };
 
-                        let mut contexts = Vec::new();
-                        // Configs + aggregation are keyed by injection language, so
-                        // resolve them once per distinct language (a document can
-                        // hold many regions of one language). `None` caches a skipped
-                        // language: no configured server, OR the pull would dispatch
-                        // to none. The key is cloned only on the resolving miss, not
-                        // on every region.
-                        type ResolvedLang =
-                            Option<(Vec<ResolvedServerConfig>, ResolvedAggregationConfig)>;
-                        let mut resolved_by_lang: std::collections::HashMap<String, ResolvedLang> =
-                            std::collections::HashMap::new();
-                        for resolved in all_regions.iter() {
-                            // `get` on the common (cache-hit) path is a single lookup;
-                            // only the resolving miss touches the map again, cloning
-                            // the language key just for that insert.
-                            let entry = match resolved_by_lang.get(&resolved.injection_language) {
-                                Some(entry) => entry,
-                                None => {
-                                    let lang = &resolved.injection_language;
-                                    let computed: ResolvedLang = {
-                                        let configs = self.bridge.get_all_configs_for_language(
+                    let mut contexts = Vec::new();
+                    // Configs + aggregation are keyed by injection language, so
+                    // resolve them once per distinct language (a document can
+                    // hold many regions of one language). `None` caches a skipped
+                    // language: no configured server, OR the pull would dispatch
+                    // to none. The key is cloned only on the resolving miss, not
+                    // on every region.
+                    type ResolvedLang =
+                        Option<(Vec<ResolvedServerConfig>, ResolvedAggregationConfig)>;
+                    let mut resolved_by_lang: std::collections::HashMap<String, ResolvedLang> =
+                        std::collections::HashMap::new();
+                    for resolved in all_regions.iter() {
+                        // `get` on the common (cache-hit) path is a single lookup;
+                        // only the resolving miss touches the map again, cloning
+                        // the language key just for that insert.
+                        let entry = match resolved_by_lang.get(&resolved.injection_language) {
+                            Some(entry) => entry,
+                            None => {
+                                let lang = &resolved.injection_language;
+                                let computed: ResolvedLang = {
+                                    let configs = self.bridge.get_all_configs_for_language(
+                                        &settings,
+                                        &language_name,
+                                        lang,
+                                    );
+                                    if configs.is_empty() {
+                                        None
+                                    } else {
+                                        let agg = resolve_aggregation_config_from_settings(
                                             &settings,
                                             &language_name,
                                             lang,
+                                            "textDocument/publishDiagnostics",
                                         );
-                                        if configs.is_empty() {
+                                        // Per-method divergence: the editor's fan-out
+                                        // for this language resolves under the
+                                        // `textDocument/diagnostic` key; if the two
+                                        // selections differ in any fan-out field, this
+                                        // snapshot cannot vouch for the editor's
+                                        // surface (e.g. a publish-only `priorities =
+                                        // []` empties only the prefetch).
+                                        let editor_agg = resolve_aggregation_config_from_settings(
+                                            &settings,
+                                            &language_name,
+                                            lang,
+                                            "textDocument/diagnostic",
+                                        );
+                                        if agg.priorities != editor_agg.priorities
+                                            || agg.strategy != editor_agg.strategy
+                                            || agg.max_fan_out != editor_agg.max_fan_out
+                                        {
+                                            narrower_than_editor_pull = true;
+                                        }
+                                        // Only keep a language the pull will actually
+                                        // dispatch (#425): drop it when `pullFallback =
+                                        // false` OR its effective server selection is
+                                        // empty (`priorities = []`, `maxFanOut = 0`, or
+                                        // names only unconfigured servers). This keeps
+                                        // the invariant "PullLayer present ⟺ a pull
+                                        // dispatched to ≥1 server", so an absent/Clear
+                                        // pull layer never falsely suppresses a
+                                        // server's spontaneous push. The push path is
+                                        // untouched — only kakehashi's pulling stops.
+                                        //
+                                        // A `pullFallback` drop narrows this snapshot
+                                        // below the editor's re-pull surface even with
+                                        // identical per-method resolutions — record it.
+                                        if !agg.pull_fallback {
+                                            narrower_than_editor_pull = true;
+                                            None
+                                        } else if !dispatches_to_any_server(
+                                            &agg.priorities,
+                                            &configs,
+                                            agg.max_fan_out,
+                                        ) {
                                             None
                                         } else {
-                                            let agg = resolve_aggregation_config_from_settings(
-                                                &settings,
-                                                &language_name,
-                                                lang,
-                                                "textDocument/publishDiagnostics",
-                                            );
-                                            // Only keep a language the pull will actually
-                                            // dispatch (#425): drop it when `pullFallback =
-                                            // false` OR its effective server selection is
-                                            // empty (`priorities = []`, `maxFanOut = 0`, or
-                                            // names only unconfigured servers). This keeps
-                                            // the invariant "PullLayer present ⟺ a pull
-                                            // dispatched to ≥1 server", so an absent/Clear
-                                            // pull layer never falsely suppresses a
-                                            // server's spontaneous push. The push path is
-                                            // untouched — only kakehashi's pulling stops.
-                                            //
-                                            // A `pullFallback` drop (unlike an empty
-                                            // selection, which empties the editor's
-                                            // fan-out too) narrows this snapshot below the
-                                            // editor's re-pull surface — record it.
-                                            if !agg.pull_fallback {
-                                                narrower_than_editor_pull = true;
-                                                None
-                                            } else if !dispatches_to_any_server(
-                                                &agg.priorities,
-                                                &configs,
-                                                agg.max_fan_out,
-                                            ) {
-                                                None
-                                            } else {
-                                                Some((configs, agg))
-                                            }
+                                            Some((configs, agg))
                                         }
-                                    };
-                                    resolved_by_lang
-                                        .entry(resolved.injection_language.clone())
-                                        .or_insert(computed)
-                                }
-                            };
-                            let Some((configs, agg)) = entry else {
-                                continue;
-                            };
+                                    }
+                                };
+                                resolved_by_lang
+                                    .entry(resolved.injection_language.clone())
+                                    .or_insert(computed)
+                            }
+                        };
+                        let Some((configs, agg)) = entry else {
+                            continue;
+                        };
 
-                            contexts.push(DocumentRequestContext {
-                                uri: uri.clone(),
-                                resolved: resolved.clone(),
-                                configs: configs.clone(),
-                                upstream_request_id: None,
-                                priorities: agg.priorities.clone(),
-                                strategy: agg.strategy,
-                                max_fan_out: agg.max_fan_out,
-                                client_progress_token: None,
-                            });
-                        }
-                        contexts
-                    })
-            };
+                        contexts.push(DocumentRequestContext {
+                            uri: uri.clone(),
+                            resolved: resolved.clone(),
+                            configs: configs.clone(),
+                            upstream_request_id: None,
+                            priorities: agg.priorities.clone(),
+                            strategy: agg.strategy,
+                            max_fan_out: agg.max_fan_out,
+                            client_progress_token: None,
+                        });
+                    }
+                    contexts
+                })
+        };
 
         // Host layer (host-document-bridge): participates when listed in the
         // layer priorities AND opted in via bridge._self.enabled with a
@@ -358,9 +392,15 @@ impl DiagnosticSnapshotPreparer {
             let agg = lang_settings.resolve_host_aggregation("textDocument/publishDiagnostics");
             host_pull_enabled = agg.pull_fallback
                 && dispatches_to_any_server(&agg.priorities, &configs, agg.max_fan_out);
-            if !agg.pull_fallback {
-                // Same rule as the virt gate above: only the `pullFallback`
-                // drop narrows below the editor's re-pull surface.
+            // Same two rules as the virt gate above: a per-method resolution
+            // divergence or a `pullFallback` drop narrows this snapshot below
+            // the editor's re-pull surface.
+            let editor_agg = lang_settings.resolve_host_aggregation("textDocument/diagnostic");
+            if agg.priorities != editor_agg.priorities
+                || agg.strategy != editor_agg.strategy
+                || agg.max_fan_out != editor_agg.max_fan_out
+                || !agg.pull_fallback
+            {
                 narrower_than_editor_pull = true;
             }
             Some(HostRequestContext {
@@ -379,8 +419,13 @@ impl DiagnosticSnapshotPreparer {
         // configured host layer) keeps the old skip-publishing behavior. A
         // configured-but-pull-gated host still produces a snapshot so its stale
         // `PullLayer` is cleared on this event and its re-sync still runs.
+        // Exception: when the narrower flag is set, the editor's re-pull may
+        // still cover surface this snapshot cannot see (e.g. the publish-keyed
+        // layer gate hid the host layer the diagnostic key keeps), so an
+        // empty-but-flagged snapshot is returned to carry the flag to the
+        // forwarded-refresh prefetch instead of vanishing into the skip.
         let virt_contexts = match (virt_contexts, host.is_some()) {
-            (None, false) => return None,
+            (None, false) if !narrower_than_editor_pull => return None,
             (virt, _) => virt.unwrap_or_default(),
         };
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -191,6 +191,12 @@ impl DiagnosticSnapshotPreparer {
         // aggregation configs below. A layer gated off still yields a
         // snapshot (with that layer absent) so that publishing an empty list
         // clears anything a previously-enabled configuration left behind.
+        // Generation captured BEFORE the load (see
+        // `SettingsManager::settings_generation`): the only racy arm is then
+        // a config store between the two, which flags the snapshot stale even
+        // though the load already saw the new settings — one over-nudge, the
+        // safe direction.
+        let settings_generation = self.settings_manager.settings_generation();
         let settings = self.settings_manager.load_settings();
         let layer_cfg = crate::lsp::lsp_impl::bridge_context::resolve_layer_config_from_settings(
             &settings,
@@ -437,6 +443,7 @@ impl DiagnosticSnapshotPreparer {
             lineage: DiagnosticSnapshotLineage {
                 incarnation: snapshot.incarnation(),
                 content_version,
+                settings_generation,
             },
             virt_contexts,
             host_pull_enabled,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1769,6 +1769,82 @@ mod tests {
         );
     }
 
+    /// Behavior-level pin for the mid-flight reload guards (the per-commit
+    /// lineage check and the cycle-level fence): a settings reload landing
+    /// while the prefetch is in flight must force the send, whichever guard
+    /// catches it — deleting BOTH turns this red. The doc's edit lock is the
+    /// deterministic seam: the commit blocks on it, the reload lands, then
+    /// the commit resumes and must classify itself stale.
+    #[tokio::test]
+    async fn settings_reload_during_the_prefetch_forces_the_send() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .settings_manager
+            .set_capabilities(ClientCapabilities {
+                workspace: Some(WorkspaceClientCapabilities {
+                    diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
+                        refresh_support: Some(true),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        register_rust(server);
+        server.settings_manager.apply_settings(rust_settings(true));
+
+        let uri = Url::parse("file:///test/reload_mid_prefetch.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        server
+            .parse_coordinator()
+            .parse_document(uri.clone(), Some("rust"), None)
+            .await;
+        let publisher = DiagnosticPublisher::new(server);
+        // Establish a recorded set and clear the seed's lag so nothing but
+        // the reload guards can force the send below.
+        publisher.publish_pull_layer(&uri, Vec::new()).await;
+        server.diagnostics.clear_pull_view_lag(&uri);
+
+        // Park the commit on the edit lock, land the reload, release.
+        let edit_lock = server.documents.edit_lock(&uri);
+        let guard = edit_lock.lock().await;
+        let snapshot = server
+            .diagnostics
+            .begin_forwarded_refresh_debounce()
+            .expect("idle scheduler admits the cycle");
+        let cycle = {
+            let publisher = publisher.clone();
+            let generation = snapshot.generation;
+            tokio::spawn(
+                async move { publisher.complete_forwarded_refresh_cycle(generation).await },
+            )
+        };
+        // Let the cycle run up to the parked commit, then reload.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        server.settings_manager.apply_settings(rust_settings(true));
+        drop(guard);
+
+        assert!(cycle.await.expect("cycle task"), "the cycle must complete");
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        while server.diagnostics.metrics_snapshot().refreshes_sent == 0
+            && tokio::time::Instant::now() < deadline
+        {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            server.diagnostics.metrics_snapshot().refreshes_sent,
+            1,
+            "a reload landing mid-prefetch means the cycle cannot vouch for the \
+             editor's (new-config) re-pull — the send must survive"
+        );
+        server.diagnostics.cancel_forwarded_refresh_debounce();
+    }
+
     /// A prefetch whose surface was resolved under settings that changed
     /// mid-flight cannot vouch for the editor's re-pull (the new config can
     /// have widened the surface), and nothing re-pulls after a pure config

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -375,12 +375,18 @@ impl DiagnosticPublisher {
             let narrower_than_editor_pull = snapshot.narrower_than_editor_pull;
             let pool = self.bridge.pool_arc();
             let publisher = self.clone();
+            // An outstanding pull-view lag means the recorded set already
+            // moved without a nudge (see `pull_view_lag`): even an unchanged
+            // prefetch compares against data the editor may never have
+            // pulled, so the nudge must survive until a covering pull clears
+            // the lag.
+            let pull_view_lags = self.aggregator.has_pull_view_lag(&uri);
             tasks.spawn(async move {
                 let mut summary = ForwardedPrefetchSummary {
+                    set_changed: pull_view_lags,
                     // A pullFallback-gated layer is pulled by the editor but
                     // not by this prefetch — coverage is incomplete either way.
                     coverage_incomplete: narrower_than_editor_pull,
-                    ..Default::default()
                 };
                 let errors = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
                 let error_sink = Some(std::sync::Arc::clone(&errors));
@@ -478,10 +484,18 @@ impl DiagnosticPublisher {
             }
         }
         drop(edit_guard);
+        // `Deferred` counts as changed: the cache moved, only the geometry
+        // re-anchor is pending — the editor's view is stale either way.
+        let set_changed = self.republish(uri).await.nudges_pull_clients();
+        if set_changed {
+            // The in-cycle nudge below is only a request; record the lag so
+            // that if the editor does not actually re-pull, the NEXT cycle's
+            // unchanged prefetch still forwards instead of absorbing forever
+            // (cleared by the covering pull, like `publish_pull_layer`).
+            self.aggregator.record_pull_view_lag(uri);
+        }
         ForwardedPrefetchSummary {
-            // `Deferred` counts as changed: the cache moved, only the geometry
-            // re-anchor is pending — the editor's view is stale either way.
-            set_changed: self.republish(uri).await.nudges_pull_clients(),
+            set_changed,
             ..Default::default()
         }
     }
@@ -816,7 +830,14 @@ impl DiagnosticPublisher {
     /// self-heals on the next completed pull.
     pub(crate) async fn publish_pull_layer(&self, host: &Url, diagnostics: Vec<Diagnostic>) {
         self.aggregator.set_pull_layer(host, diagnostics);
-        self.republish(host).await;
+        if self.republish(host).await.nudges_pull_clients() {
+            // This commit moved the recorded set without any editor nudge; if
+            // the editor's own event-driven pull raced ahead of it, only a
+            // later covering pull closes the gap — record the lag so the
+            // forwarded-refresh absorption does not mistake kakehashi's own
+            // record for the editor's view (see `pull_view_lag`).
+            self.aggregator.record_pull_view_lag(host);
+        }
     }
 
     /// Evict the host's `PullLayer` blob and republish — the host-event pull had
@@ -839,7 +860,11 @@ impl DiagnosticPublisher {
     pub(crate) async fn clear_pull_layer(&self, host: &Url) {
         self.aggregator
             .evict_source(host, &DiagnosticSource::PullLayer);
-        self.republish(host).await;
+        if self.republish(host).await.nudges_pull_clients() {
+            // Same pull-view lag rule as `publish_pull_layer`: a cleared set
+            // the editor still displays is the worse variant of the lag.
+            self.aggregator.record_pull_view_lag(host);
+        }
     }
 
     /// Evict every diagnostic slot a now-exited downstream connection produced and

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1743,6 +1743,65 @@ mod tests {
         );
     }
 
+    /// A tree-less editor pull cannot see the virt layer at all — its answer
+    /// is missing everything a cached non-empty PullLayer holds — so it must
+    /// be treated as DEGRADED (like the cached-Region case) rather than as a
+    /// clean covering pull that clears the pull-view lag. codex fresh-session
+    /// finding: with a pull-only injected server (PullLayer, no Region push
+    /// slots), a pull landing in the parse gap answered empty, read as clean,
+    /// cleared the lag, and the next downstream refresh was absorbed while
+    /// the editor displayed the empty answer.
+    #[tokio::test]
+    async fn tree_less_pull_over_a_nonempty_pull_layer_does_not_clear_the_lag() {
+        use std::str::FromStr;
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        register_rust(server);
+        // Host bridging OFF: with a `_self` server configured, its failing
+        // fan-out would already count as a request error and keep the lag for
+        // the wrong reason — the hole under test is the VIRT layer being
+        // invisible to a tree-less pull while the cached PullLayer holds it.
+        server.settings_manager.apply_settings(rust_settings(false));
+
+        // Open WITHOUT parsing: the tree stays absent, like the didChange /
+        // invalidate_parse window.
+        let uri = Url::parse("file:///test/treeless_pull_layer.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+
+        // A committed non-empty pull layer records the lag (first commit is
+        // Changed; nothing has nudged the editor).
+        let publisher = DiagnosticPublisher::new(server);
+        publisher.publish_pull_layer(&uri, vec![diag("virt")]).await;
+        assert!(
+            server.diagnostics.has_pull_view_lag(&uri),
+            "precondition: the un-nudged commit recorded the lag"
+        );
+
+        // The editor pull answers without the virt layer (no tree): it must
+        // be degraded, not a covering clean pull.
+        let lsp_uri = tower_lsp_server::ls_types::Uri::from_str(uri.as_str()).unwrap();
+        let _ = server
+            .diagnostic_impl(tower_lsp_server::ls_types::DocumentDiagnosticParams {
+                text_document: tower_lsp_server::ls_types::TextDocumentIdentifier { uri: lsp_uri },
+                identifier: None,
+                previous_result_id: None,
+                work_done_progress_params: Default::default(),
+                partial_result_params: Default::default(),
+            })
+            .await;
+
+        assert!(
+            server.diagnostics.has_pull_view_lag(&uri),
+            "a tree-less answer misses the cached PullLayer content — it must \
+             not clear the pull-view lag"
+        );
+    }
+
     /// The epoch-cover compensation: an intervening refresh (sent after this
     /// cycle's activity, epoch bumped) suppresses the normal send path, but
     /// its induced re-pull can have answered before this cycle's prefetch

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -340,6 +340,20 @@ impl DiagnosticPublisher {
         if self.shutdown.is_cancelled() {
             return false;
         }
+        let mut summary = summary;
+        // Read the pull-view lag at DECISION time, after the prefetch joined:
+        // a host-event pull committing concurrently with the prefetch records
+        // its lag while the prefetch is in flight, and the prefetch — having
+        // pulled the same post-commit set — reports Unchanged. Sampling only
+        // at prefetch start would absorb this cycle despite the outstanding
+        // lag. (A lag recorded after this read belongs to the next
+        // generation: nothing clears it but a covering pull, so it survives
+        // to be read then.)
+        summary.set_changed |= self
+            .documents
+            .open_uris()
+            .iter()
+            .any(|uri| self.aggregator.has_pull_view_lag(uri));
         self.aggregator
             .mark_forwarded_refresh_prefetched(generation);
 
@@ -389,18 +403,15 @@ impl DiagnosticPublisher {
             let narrower_than_editor_pull = snapshot.narrower_than_editor_pull;
             let pool = self.bridge.pool_arc();
             let publisher = self.clone();
-            // An outstanding pull-view lag means the recorded set already
-            // moved without a nudge (see `pull_view_lag`): even an unchanged
-            // prefetch compares against data the editor may never have
-            // pulled, so the nudge must survive until a covering pull clears
-            // the lag.
-            let pull_view_lags = self.aggregator.has_pull_view_lag(&uri);
+            // The outstanding pull-view lag is deliberately NOT read here:
+            // the caller sweeps it at decision time, after the join, so a
+            // lag recorded while this prefetch is in flight is still seen.
             tasks.spawn(async move {
                 let mut summary = ForwardedPrefetchSummary {
-                    set_changed: pull_view_lags,
                     // A pullFallback-gated layer is pulled by the editor but
                     // not by this prefetch — coverage is incomplete either way.
                     coverage_incomplete: narrower_than_editor_pull,
+                    ..Default::default()
                 };
                 let errors = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
                 let error_sink = Some(std::sync::Arc::clone(&errors));

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -509,27 +509,25 @@ impl DiagnosticPublisher {
             // meaning, NOT a shortcut for "don't bother nudging".
             PullLayerOutcome::Skip => return ForwardedPrefetchSummary::default(),
             PullLayerOutcome::Clear => {
+                self.aggregator.mark_pull_view_lag_pending(uri);
                 self.aggregator
                     .evict_source(uri, &DiagnosticSource::PullLayer);
             }
             PullLayerOutcome::Publish(diagnostics) => {
+                self.aggregator.mark_pull_view_lag_pending(uri);
                 self.aggregator.set_pull_layer(uri, diagnostics);
             }
         }
-        // Provisional record-before-republish, like `publish_pull_layer`:
-        // the in-cycle nudge this commit may trigger is only a request — if
-        // the editor does not actually re-pull, the NEXT cycle's unchanged
-        // prefetch must still forward instead of absorbing forever (the lag
-        // is cleared by the covering pull). A racing didClose's forget wins
-        // regardless of which side of the republish it lands on.
-        let provisional = self.aggregator.record_pull_view_lag(uri);
+        // The pending marks above (announce-before-mutation, like
+        // `publish_pull_layer`) make this commit's change convert into a lag
+        // at whichever republish records it: the in-cycle nudge below is only
+        // a request — if the editor does not actually re-pull, the NEXT
+        // cycle's unchanged prefetch must still forward instead of absorbing
+        // forever (the lag is cleared by the covering pull).
         drop(edit_guard);
         // `Deferred` counts as changed: the cache moved, only the geometry
         // re-anchor is pending — the editor's view is stale either way.
         let set_changed = self.republish(uri).await.nudges_pull_clients();
-        if !set_changed {
-            self.aggregator.retract_pull_view_lag(uri, provisional);
-        }
         ForwardedPrefetchSummary {
             set_changed,
             ..Default::default()
@@ -865,16 +863,13 @@ impl DiagnosticPublisher {
     /// (push-propagation-diagnostic-forwarding) handles generally; until then it
     /// self-heals on the next completed pull.
     pub(crate) async fn publish_pull_layer(&self, host: &Url, diagnostics: Vec<Diagnostic>) {
-        // Record the lag BEFORE the republish (see `record_pull_view_lag` —
-        // this ordering is what linearizes the forwarded-refresh absorption
-        // against this nudge-less commit), retracting if nothing changed. A
-        // racing didClose's forget wins either way: it removes the record
-        // whether it lands before or after the republish.
-        let provisional = self.aggregator.record_pull_view_lag(host);
+        // Announce the nudge-less mutation BEFORE performing it; whichever
+        // republish records the resulting Changed set converts the mark into
+        // the pull-view lag (see `mark_pull_view_lag_pending`). A racing
+        // didClose's forget removes the mark on either side.
+        self.aggregator.mark_pull_view_lag_pending(host);
         self.aggregator.set_pull_layer(host, diagnostics);
-        if !self.republish(host).await.nudges_pull_clients() {
-            self.aggregator.retract_pull_view_lag(host, provisional);
-        }
+        self.republish(host).await;
     }
 
     /// Evict the host's `PullLayer` blob and republish — the host-event pull had
@@ -895,15 +890,12 @@ impl DiagnosticPublisher {
     /// here would therefore duplicate that cycle's nudge; an incapable editor still
     /// receives the clearing `publishDiagnostics` notification from `republish`.
     pub(crate) async fn clear_pull_layer(&self, host: &Url) {
-        // Same provisional record-before-republish as `publish_pull_layer`:
-        // a cleared set the editor still displays is the worse variant of
-        // the lag.
-        let provisional = self.aggregator.record_pull_view_lag(host);
+        // Same announce-before-mutation as `publish_pull_layer`: a cleared
+        // set the editor still displays is the worse variant of the lag.
+        self.aggregator.mark_pull_view_lag_pending(host);
         self.aggregator
             .evict_source(host, &DiagnosticSource::PullLayer);
-        if !self.republish(host).await.nudges_pull_clients() {
-            self.aggregator.retract_pull_view_lag(host, provisional);
-        }
+        self.republish(host).await;
     }
 
     /// Evict every diagnostic slot a now-exited downstream connection produced and
@@ -1108,7 +1100,17 @@ impl DiagnosticPublisher {
                 self.schedule_stale_wire_retry(host);
                 return RepublishOutcome::Deferred;
             }
-            Some(true) => RepublishOutcome::Changed,
+            Some(true) => {
+                // A recorded Changed set consumes any announced nudge-less
+                // mutation: convert it into the confirmed pull-view lag HERE,
+                // under the per-host republish lock and atomically with the
+                // record — whichever republish consumes the revision (the
+                // writer's own, the stale-wire retry, a concurrent push
+                // republish) performs the conversion, so no writer preemption
+                // window can lose it.
+                self.aggregator.convert_pending_pull_view_lag(host);
+                RepublishOutcome::Changed
+            }
             Some(false) => RepublishOutcome::Unchanged,
         };
         if changed == RepublishOutcome::Unchanged && !self.aggregator.wire_gate_is_dirty(host) {

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -508,7 +508,10 @@ impl DiagnosticPublisher {
         // `Deferred` counts as changed: the cache moved, only the geometry
         // re-anchor is pending — the editor's view is stale either way.
         let set_changed = self.republish(uri).await.nudges_pull_clients();
-        if set_changed {
+        // Re-check the store: a didClose can slip in after the edit guard
+        // dropped, and its forget must win — recording after it would leak a
+        // closed host's entry until reopen (one spurious nudge there).
+        if set_changed && self.documents.get(uri).is_some() {
             // The in-cycle nudge below is only a request; record the lag so
             // that if the editor does not actually re-pull, the NEXT cycle's
             // unchanged prefetch still forwards instead of absorbing forever
@@ -851,7 +854,9 @@ impl DiagnosticPublisher {
     /// self-heals on the next completed pull.
     pub(crate) async fn publish_pull_layer(&self, host: &Url, diagnostics: Vec<Diagnostic>) {
         self.aggregator.set_pull_layer(host, diagnostics);
-        if self.republish(host).await.nudges_pull_clients() {
+        // The store re-check mirrors `commit_refresh_prefetch`'s: a racing
+        // didClose's forget must win over this record.
+        if self.republish(host).await.nudges_pull_clients() && self.documents.get(host).is_some() {
             // This commit moved the recorded set without any editor nudge; if
             // the editor's own event-driven pull raced ahead of it, only a
             // later covering pull closes the gap — record the lag so the
@@ -881,7 +886,7 @@ impl DiagnosticPublisher {
     pub(crate) async fn clear_pull_layer(&self, host: &Url) {
         self.aggregator
             .evict_source(host, &DiagnosticSource::PullLayer);
-        if self.republish(host).await.nudges_pull_clients() {
+        if self.republish(host).await.nudges_pull_clients() && self.documents.get(host).is_some() {
             // Same pull-view lag rule as `publish_pull_layer`: a cleared set
             // the editor still displays is the worse variant of the lag.
             self.aggregator.record_pull_view_lag(host);

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -346,14 +346,15 @@ impl DiagnosticPublisher {
         // its lag while the prefetch is in flight, and the prefetch — having
         // pulled the same post-commit set — reports Unchanged. Sampling only
         // at prefetch start would absorb this cycle despite the outstanding
-        // lag. (A lag recorded after this read belongs to the next
-        // generation: nothing clears it but a covering pull, so it survives
-        // to be read then.)
-        summary.set_changed |= self
-            .documents
-            .open_uris()
-            .iter()
-            .any(|uri| self.aggregator.has_pull_view_lag(uri));
+        // lag.
+        let any_pull_view_lag = |publisher: &Self| {
+            publisher
+                .documents
+                .open_uris()
+                .iter()
+                .any(|uri| publisher.aggregator.has_pull_view_lag(uri))
+        };
+        summary.set_changed |= any_pull_view_lag(self);
         self.aggregator
             .mark_forwarded_refresh_prefetched(generation);
 
@@ -363,12 +364,21 @@ impl DiagnosticPublisher {
             .aggregator
             .forwarded_refresh_needs_editor_send(generation)
         {
-            if summary.needs_editor_nudge()
-                && !self.request_pull_diagnostic_refresh_inner(true, false)
-            {
+            let nudged = summary.needs_editor_nudge();
+            if nudged && !self.request_pull_diagnostic_refresh_inner(true, false) {
                 return false;
             }
             self.aggregator.mark_forwarded_refresh_covered(generation);
+            // The sweep→covered window: a lag recorded in between was seen by
+            // neither the sweep above nor any future cycle this (now covered)
+            // generation would trigger — and a lag-recording commit mints no
+            // refresh generation of its own. Re-check after covering and fire
+            // the nudge directly; a spurious double-nudge (the recorder's set
+            // change racing an already-sent nudge) is coalesced by the
+            // refresh single-flight.
+            if !nudged && any_pull_view_lag(self) {
+                let _ = self.request_pull_diagnostic_refresh_inner(true, false);
+            }
         }
         true
     }

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -509,21 +509,18 @@ impl DiagnosticPublisher {
             // meaning, NOT a shortcut for "don't bother nudging".
             PullLayerOutcome::Skip => return ForwardedPrefetchSummary::default(),
             PullLayerOutcome::Clear => {
-                self.aggregator.mark_pull_view_lag_pending(uri);
-                self.aggregator
-                    .evict_source(uri, &DiagnosticSource::PullLayer);
+                self.aggregator.evict_pull_layer_nudgeless(uri);
             }
             PullLayerOutcome::Publish(diagnostics) => {
-                self.aggregator.mark_pull_view_lag_pending(uri);
-                self.aggregator.set_pull_layer(uri, diagnostics);
+                self.aggregator.set_pull_layer_nudgeless(uri, diagnostics);
             }
         }
-        // The pending marks above (announce-before-mutation, like
-        // `publish_pull_layer`) make this commit's change convert into a lag
-        // at whichever republish records it: the in-cycle nudge below is only
-        // a request — if the editor does not actually re-pull, the NEXT
-        // cycle's unchanged prefetch must still forward instead of absorbing
-        // forever (the lag is cleared by the covering pull).
+        // The revision-stamped mutations above make this commit's change
+        // convert into a lag at whichever republish validates it: the
+        // in-cycle nudge below is only a request — if the editor does not
+        // actually re-pull, the NEXT cycle's unchanged prefetch must still
+        // forward instead of absorbing forever (the lag is cleared by the
+        // covering pull).
         drop(edit_guard);
         // `Deferred` counts as changed: the cache moved, only the geometry
         // re-anchor is pending — the editor's view is stale either way.
@@ -863,12 +860,12 @@ impl DiagnosticPublisher {
     /// (push-propagation-diagnostic-forwarding) handles generally; until then it
     /// self-heals on the next completed pull.
     pub(crate) async fn publish_pull_layer(&self, host: &Url, diagnostics: Vec<Diagnostic>) {
-        // Announce the nudge-less mutation BEFORE performing it; whichever
-        // republish records the resulting Changed set converts the mark into
-        // the pull-view lag (see `mark_pull_view_lag_pending`). A racing
-        // didClose's forget removes the mark on either side.
-        self.aggregator.mark_pull_view_lag_pending(host);
-        self.aggregator.set_pull_layer(host, diagnostics);
+        // The nudge-less mutation stamps its pending pull-view-lag mark
+        // atomically with the cache revision it produced; whichever republish
+        // validates a covering revision settles it — Changed converts it into
+        // the lag, Unchanged drops it (see `set_pull_layer_nudgeless`). A
+        // racing didClose's forget removes the mark on either side.
+        self.aggregator.set_pull_layer_nudgeless(host, diagnostics);
         self.republish(host).await;
     }
 
@@ -890,11 +887,9 @@ impl DiagnosticPublisher {
     /// here would therefore duplicate that cycle's nudge; an incapable editor still
     /// receives the clearing `publishDiagnostics` notification from `republish`.
     pub(crate) async fn clear_pull_layer(&self, host: &Url) {
-        // Same announce-before-mutation as `publish_pull_layer`: a cleared
+        // Same revision-stamped mutation as `publish_pull_layer`: a cleared
         // set the editor still displays is the worse variant of the lag.
-        self.aggregator.mark_pull_view_lag_pending(host);
-        self.aggregator
-            .evict_source(host, &DiagnosticSource::PullLayer);
+        self.aggregator.evict_pull_layer_nudgeless(host);
         self.republish(host).await;
     }
 
@@ -1101,17 +1096,23 @@ impl DiagnosticPublisher {
                 return RepublishOutcome::Deferred;
             }
             Some(true) => {
-                // A recorded Changed set consumes any announced nudge-less
-                // mutation: convert it into the confirmed pull-view lag HERE,
-                // under the per-host republish lock and atomically with the
-                // record — whichever republish consumes the revision (the
-                // writer's own, the stale-wire retry, a concurrent push
-                // republish) performs the conversion, so no writer preemption
-                // window can lose it.
-                self.aggregator.convert_pending_pull_view_lag(host);
+                // A validated record settles any pending nudge-less mutation
+                // the compared revision covers — whichever republish consumes
+                // the revision (the writer's own, the stale-wire retry, a
+                // concurrent push republish) performs the settle, so no
+                // writer preemption window can lose it. Changed converts the
+                // mark into the confirmed pull-view lag…
+                self.aggregator
+                    .settle_pending_pull_view_lag(host, cache_revision, true);
                 RepublishOutcome::Changed
             }
-            Some(false) => RepublishOutcome::Unchanged,
+            Some(false) => {
+                // …and Unchanged drops it: the covered mutation demonstrably
+                // left the merged set alone, so no nudge is owed for it.
+                self.aggregator
+                    .settle_pending_pull_view_lag(host, cache_revision, false);
+                RepublishOutcome::Unchanged
+            }
         };
         if changed == RepublishOutcome::Unchanged && !self.aggregator.wire_gate_is_dirty(host) {
             log::debug!(

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -342,14 +342,15 @@ impl DiagnosticPublisher {
         }
         let mut summary = summary;
         // Read the pull-view lag at DECISION time, after the prefetch
-        // joined. This read is race-free against the nudge-less recorders
-        // because they record BEFORE their republish (see
-        // `record_pull_view_lag`): the per-host republish lock serializes a
-        // recorder's republish against this cycle's own prefetch commit, so
+        // joined. This read is race-free against the nudge-less writers
+        // because their marks are revision-stamped with the mutation and
+        // settled by whichever republish validates a covering revision (see
+        // `settle_pending_pull_view_lag`): the per-host republish lock
+        // serializes that settle against this cycle's own prefetch commit, so
         // any change the prefetch's Unchanged-compare could have observed had
-        // its lag visible here first; a recorder whose lag lands after this
-        // read also republishes after it — its change postdates the cycle and
-        // its (uncleared) lag is this same sweep's input next generation.
+        // its lag confirmed here first; a mutation landing after that compare
+        // is settled by a later republish — its change postdates the cycle
+        // and its lag is this same sweep's input next generation.
         summary.set_changed |= self
             .documents
             .open_uris()

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -371,6 +371,18 @@ impl DiagnosticPublisher {
                 return false;
             }
             self.aggregator.mark_forwarded_refresh_covered(generation);
+        } else if summary.needs_editor_nudge()
+            && self.aggregator.forwarded_refresh_epoch_covered(generation)
+        {
+            // The epoch cover only proves ANOTHER refresh was sent after this
+            // activity — its induced re-pull can have answered before this
+            // cycle's prefetch committed, leaving the editor on the
+            // pre-commit set with no later signal owed. With a changed or
+            // lagged summary, coalesce a compensating forced nudge into the
+            // refresh single-flight (at worst one redundant re-pull answered
+            // `unchanged`); an absorbed summary keeps trusting the cover.
+            let _ = self.request_pull_diagnostic_refresh_inner(true, false);
+            self.aggregator.mark_forwarded_refresh_covered(generation);
         }
         true
     }

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1315,7 +1315,11 @@ impl DiagnosticPublisher {
     /// guard — consumes its debt on firing and the induced re-pull sees ready
     /// geometry and answers covering, so it begets at most one round; the indirect
     /// push→refresh→re-pull→downstream-re-push→here path is bounded by
-    /// `published_set_changed`, converging once the re-pushed set stabilizes.)
+    /// `published_set_changed`, converging once the re-pushed set stabilizes;
+    /// and the forwarded-refresh path — where the induced re-pull's downstream
+    /// fan-out makes servers like tsgo emit ANOTHER refresh, un-bounded by any
+    /// set comparison — is starved by `complete_forwarded_refresh_cycle`
+    /// dropping the nudge when its covering prefetch changed nothing.)
     ///
     /// **Spawned, not awaited:** `workspace/diagnostic/refresh` is a request whose
     /// future resolves only when the editor answers, so awaiting it inline would

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -372,14 +372,14 @@ impl DiagnosticPublisher {
                 continue;
             };
             let lineage = snapshot.lineage;
-            let pull_gated = snapshot.pull_gated;
+            let narrower_than_editor_pull = snapshot.narrower_than_editor_pull;
             let pool = self.bridge.pool_arc();
             let publisher = self.clone();
             tasks.spawn(async move {
                 let mut summary = ForwardedPrefetchSummary {
                     // A pullFallback-gated layer is pulled by the editor but
                     // not by this prefetch — coverage is incomplete either way.
-                    coverage_incomplete: pull_gated,
+                    coverage_incomplete: narrower_than_editor_pull,
                     ..Default::default()
                 };
                 let errors = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -1671,7 +1671,7 @@ mod tests {
         )]));
         server.settings_manager.apply_settings(settings);
 
-        let uri = Url::parse("file:///test/pull_gated_host.rs").unwrap();
+        let uri = Url::parse("file:///test/narrower_than_editor_pull_host.rs").unwrap();
         server.documents.insert(
             uri.clone(),
             "fn main() {}".to_string(),

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -504,6 +504,23 @@ impl DiagnosticPublisher {
                 && document.content_version() == lineage.content_version
         };
         drop(document);
+        // A `didChangeConfiguration` landing mid-prefetch can widen the
+        // editor's pull surface (new server/layer/priorities) without
+        // touching the document fields — an old-surface result must not
+        // vouch for the editor's re-pull, and (unlike the lineage discard
+        // below) nothing else is guaranteed to re-pull after a pure config
+        // change, so committing the possibly-narrower result is skipped too.
+        if lineage.settings_generation != self.settings_manager.settings_generation() {
+            log::debug!(
+                target: LOG_TARGET,
+                "Discarding refresh prefetch resolved under stale settings for {uri}"
+            );
+            drop(edit_guard);
+            return ForwardedPrefetchSummary {
+                coverage_incomplete: true,
+                ..Default::default()
+            };
+        }
         if !current {
             log::debug!(target: LOG_TARGET, "Discarding stale refresh prefetch for {uri}");
             // An edit raced the prefetch: this result says nothing about the
@@ -1740,6 +1757,61 @@ mod tests {
             tokio::time::Instant::now(),
             before,
             "the leading forced send must not wait for the settle window"
+        );
+    }
+
+    /// A prefetch whose surface was resolved under settings that changed
+    /// mid-flight cannot vouch for the editor's re-pull (the new config can
+    /// have widened the surface), and nothing re-pulls after a pure config
+    /// change — the commit must be discarded as incomplete coverage. codex
+    /// fresh-session finding.
+    #[tokio::test]
+    async fn stale_settings_prefetch_counts_as_incomplete_coverage() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        register_rust(server);
+        server.settings_manager.apply_settings(rust_settings(true));
+
+        let uri = Url::parse("file:///test/stale_settings_prefetch.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let (incarnation, content_version) = {
+            let doc = server.documents.get(&uri).expect("doc just inserted");
+            (doc.incarnation(), doc.content_version())
+        };
+        let lineage =
+            crate::lsp::lsp_impl::text_document::publish_diagnostic::DiagnosticSnapshotLineage {
+                incarnation,
+                content_version,
+                settings_generation: server.settings_manager.settings_generation(),
+            };
+        // The mid-flight config change: any apply bumps the generation.
+        server.settings_manager.apply_settings(rust_settings(true));
+
+        let publisher = DiagnosticPublisher::new(server);
+        let summary = publisher
+            .commit_refresh_prefetch(
+                &uri,
+                lineage,
+                PullLayerOutcome::Publish(vec![diag("old-surface")]),
+            )
+            .await;
+
+        assert!(
+            summary.coverage_incomplete,
+            "a prefetch resolved under stale settings cannot vouch for the editor's re-pull"
+        );
+        assert!(
+            !summary.set_changed,
+            "the old-surface result must not be committed as a change"
+        );
+        assert!(
+            server.diagnostics.snapshot(&uri).is_empty(),
+            "the old-surface result must not reach the cache"
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -76,6 +76,36 @@ impl RepublishOutcome {
     }
 }
 
+/// What a forwarded-refresh prefetch learned, folded across every open
+/// document: whether it moved any host's published set, and whether some
+/// document escaped its coverage — so the editor nudge can be dropped exactly
+/// when the prefetch proves the editor's re-pull would answer `unchanged`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct ForwardedPrefetchSummary {
+    /// Some host's merged set changed (`Changed`/`Deferred` republish): the
+    /// editor's pulled view is stale, nudge it.
+    set_changed: bool,
+    /// Some document's downstream state could not be determined — a
+    /// `pullFallback`-gated layer the editor would still pull, a failed pull
+    /// that kept the previous layer, or a commit discarded by an edit race.
+    /// Ambiguity resolves toward nudging: a spurious refresh costs one
+    /// round-trip, a suppressed one hides diagnostics until the next edit.
+    coverage_incomplete: bool,
+}
+
+impl ForwardedPrefetchSummary {
+    fn absorb(&mut self, other: Self) {
+        self.set_changed |= other.set_changed;
+        self.coverage_incomplete |= other.coverage_incomplete;
+    }
+
+    /// The forwarded refresh still needs its editor send: something changed,
+    /// or this prefetch cannot vouch that nothing did.
+    fn needs_editor_nudge(&self) -> bool {
+        self.set_changed || self.coverage_incomplete
+    }
+}
+
 /// Programmed quiet-window default used by paused-time tests. Runtime scheduling
 /// reads the top-level feature policy on each set-changing admission.
 #[cfg(test)]
@@ -276,9 +306,24 @@ impl DiagnosticPublisher {
     }
 
     /// Complete one scheduled downstream-refresh cycle: refresh every proactive
-    /// pullFallback cache entry first, then (when supported) notify the editor.
+    /// pullFallback cache entry first, then notify the editor — but only when
+    /// the prefetch either changed something or could not stand in for the
+    /// editor's re-pull ([`ForwardedPrefetchSummary::needs_editor_nudge`]).
+    ///
+    /// The unconditional forced send this replaces closed a feedback loop on
+    /// quiescent multi-region documents: the nudged editor re-pull fans out to
+    /// every region, the downstream servers analyze and send their own
+    /// `workspace/diagnostic/refresh`, which arrived here and was forwarded
+    /// forced again — ~1 Hz forever with zero edits. An unchanged covering
+    /// prefetch proves the editor's re-pull would answer `unchanged`, so the
+    /// nudge is dropped and the loop starves. The generation is still marked
+    /// covered: the downstream activity was fully handled (prefetched and
+    /// found current), and any NEW downstream refresh mints a new generation.
     async fn complete_forwarded_refresh_cycle(&self, generation: u64) -> bool {
-        if !self.prefetch_open_pull_fallback_diagnostics().await || self.shutdown.is_cancelled() {
+        let Some(summary) = self.prefetch_open_pull_fallback_diagnostics().await else {
+            return false;
+        };
+        if self.shutdown.is_cancelled() {
             return false;
         }
         self.aggregator
@@ -290,7 +335,9 @@ impl DiagnosticPublisher {
             .aggregator
             .forwarded_refresh_needs_editor_send(generation)
         {
-            if !self.request_pull_diagnostic_refresh_inner(true, false) {
+            if summary.needs_editor_nudge()
+                && !self.request_pull_diagnostic_refresh_inner(true, false)
+            {
                 return false;
             }
             self.aggregator.mark_forwarded_refresh_covered(generation);
@@ -298,16 +345,29 @@ impl DiagnosticPublisher {
         true
     }
 
-    async fn prefetch_open_pull_fallback_diagnostics(&self) -> bool {
+    /// Prefetch every open document's pullFallback cache entry. `None` means
+    /// the shutdown token aborted the prefetch; `Some` carries whether any
+    /// host's published set changed and whether some document escaped coverage
+    /// (see [`ForwardedPrefetchSummary`]).
+    async fn prefetch_open_pull_fallback_diagnostics(&self) -> Option<ForwardedPrefetchSummary> {
         let mut tasks = tokio::task::JoinSet::new();
         for uri in self.documents.open_uris() {
             let Some(snapshot) = self.snapshot_preparer.prepare_diagnostic_snapshot(&uri) else {
+                // Document gone or it can never contribute: the editor's
+                // re-pull would find the same nothing.
                 continue;
             };
             let lineage = snapshot.lineage;
+            let pull_gated = snapshot.pull_gated;
             let pool = self.bridge.pool_arc();
             let publisher = self.clone();
             tasks.spawn(async move {
+                let mut summary = ForwardedPrefetchSummary {
+                    // A pullFallback-gated layer is pulled by the editor but
+                    // not by this prefetch — coverage is incomplete either way.
+                    coverage_incomplete: pull_gated,
+                    ..Default::default()
+                };
                 let errors = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
                 let error_sink = Some(std::sync::Arc::clone(&errors));
                 let outcome = collect_push_diagnostics_with_error_sink(
@@ -320,33 +380,46 @@ impl DiagnosticPublisher {
                 .await;
                 if errors.load(std::sync::atomic::Ordering::Relaxed) != 0 {
                     log::warn!(target: LOG_TARGET, "Keeping the previous pull layer after refresh prefetch failed for {uri}");
-                    return;
+                    // The kept layer may lag the downstream's state.
+                    summary.coverage_incomplete = true;
+                    return summary;
                 }
-                publisher
-                    .commit_refresh_prefetch(&uri, lineage, outcome)
-                    .await;
+                summary.absorb(
+                    publisher
+                        .commit_refresh_prefetch(&uri, lineage, outcome)
+                        .await,
+                );
+                summary
             });
         }
 
+        let mut summary = ForwardedPrefetchSummary::default();
         while !tasks.is_empty() {
             tokio::select! {
                 biased;
                 _ = self.shutdown.cancelled() => {
                     tasks.abort_all();
                     while tasks.join_next().await.is_some() {}
-                    return false;
+                    return None;
                 }
                 result = tasks.join_next() => {
-                    if let Some(Err(error)) = result {
-                        log::warn!(target: LOG_TARGET, "Diagnostic refresh prefetch task failed: {error}");
+                    match result {
+                        Some(Ok(task_summary)) => summary.absorb(task_summary),
+                        Some(Err(error)) => {
+                            log::warn!(target: LOG_TARGET, "Diagnostic refresh prefetch task failed: {error}");
+                            // The doc's coverage state is unknown — safe direction.
+                            summary.coverage_incomplete = true;
+                        }
+                        None => {}
                     }
                 }
             }
         }
-        true
+        Some(summary)
     }
 
-    /// Commit a refresh prefetch only while its document inputs are current.
+    /// Commit a refresh prefetch only while its document inputs are current,
+    /// reporting what the commit means for the forwarded-refresh editor nudge.
     ///
     /// The lineage check and synchronous cache mutation share the document's
     /// edit lock with didChange/didClose/didOpen. This closes the check→commit
@@ -356,14 +429,15 @@ impl DiagnosticPublisher {
         uri: &Url,
         lineage: DiagnosticSnapshotLineage,
         outcome: PullLayerOutcome,
-    ) {
+    ) -> ForwardedPrefetchSummary {
         let edit_lock = self.documents.edit_lock(uri);
         let edit_guard = edit_lock.lock().await;
         let Some(document) = self.documents.get(uri) else {
             drop(edit_guard);
             self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
             log::debug!(target: LOG_TARGET, "Discarding refresh prefetch for closed {uri}");
-            return;
+            // Closed: nothing for the editor to re-pull.
+            return ForwardedPrefetchSummary::default();
         };
         let current = {
             document.incarnation() == lineage.incarnation
@@ -372,11 +446,16 @@ impl DiagnosticPublisher {
         drop(document);
         if !current {
             log::debug!(target: LOG_TARGET, "Discarding stale refresh prefetch for {uri}");
-            return;
+            // An edit raced the prefetch: this result says nothing about the
+            // downstream's state for the CURRENT content — safe direction.
+            return ForwardedPrefetchSummary {
+                coverage_incomplete: true,
+                ..Default::default()
+            };
         }
 
         match outcome {
-            PullLayerOutcome::Skip => return,
+            PullLayerOutcome::Skip => return ForwardedPrefetchSummary::default(),
             PullLayerOutcome::Clear => {
                 self.aggregator
                     .evict_source(uri, &DiagnosticSource::PullLayer);
@@ -386,7 +465,12 @@ impl DiagnosticPublisher {
             }
         }
         drop(edit_guard);
-        self.republish(uri).await;
+        ForwardedPrefetchSummary {
+            // `Deferred` counts as changed: the cache moved, only the geometry
+            // re-anchor is pending — the editor's view is stale either way.
+            set_changed: self.republish(uri).await.nudges_pull_clients(),
+            ..Default::default()
+        }
     }
 
     fn diagnostic_refresh_supported(&self) -> bool {

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -351,10 +351,24 @@ impl DiagnosticPublisher {
     /// (see [`ForwardedPrefetchSummary`]).
     async fn prefetch_open_pull_fallback_diagnostics(&self) -> Option<ForwardedPrefetchSummary> {
         let mut tasks = tokio::task::JoinSet::new();
+        let mut summary = ForwardedPrefetchSummary::default();
         for uri in self.documents.open_uris() {
             let Some(snapshot) = self.snapshot_preparer.prepare_diagnostic_snapshot(&uri) else {
-                // Document gone or it can never contribute: the editor's
-                // re-pull would find the same nothing.
+                // No snapshot conflates two very different states. A document
+                // that is gone or has no detectable language is covered: the
+                // editor's re-pull finds the same nothing. But an OPEN
+                // document whose parse snapshot is transiently absent
+                // (didChange cleared the tree, parse pending or given up,
+                // settings-reload invalidate) IS answerable by the editor's
+                // re-pull (bounded tree wait + tree-less host layer), so this
+                // prefetch cannot vouch for it — safe direction: nudge.
+                if self
+                    .documents
+                    .get(&uri)
+                    .is_some_and(|doc| doc.snapshot().is_none())
+                {
+                    summary.coverage_incomplete = true;
+                }
                 continue;
             };
             let lineage = snapshot.lineage;
@@ -393,7 +407,6 @@ impl DiagnosticPublisher {
             });
         }
 
-        let mut summary = ForwardedPrefetchSummary::default();
         while !tasks.is_empty() {
             tokio::select! {
                 biased;

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -79,7 +79,9 @@ impl RepublishOutcome {
 /// What a forwarded-refresh prefetch learned, folded across every open
 /// document: whether it moved any host's published set, and whether some
 /// document escaped its coverage — so the editor nudge can be dropped exactly
-/// when the prefetch proves the editor's re-pull would answer `unchanged`.
+/// when the prefetch indicates the editor's re-pull would answer `unchanged`
+/// (for a downstream that signals changes via refresh: a state move after the
+/// prefetch re-arrives as a new refresh generation and re-runs the cycle).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct ForwardedPrefetchSummary {
     /// Some host's merged set changed (`Changed`/`Deferred` republish): the
@@ -206,9 +208,11 @@ impl DiagnosticPublisher {
         (snapshot, settle_window, max_wait)
     }
 
-    /// Forward the first downstream `workspace/diagnostic/refresh` immediately,
-    /// then coalesce later burst activity into at most one trailing refresh
-    /// after quiet or the max-wait deadline (#789).
+    /// Run the first downstream `workspace/diagnostic/refresh`'s cycle
+    /// immediately (prefetch, then a conditional editor forward — see
+    /// [`Self::complete_forwarded_refresh_cycle`]), then coalesce later burst
+    /// activity into at most one trailing cycle after quiet or the max-wait
+    /// deadline (#789).
     pub(crate) fn request_forwarded_diagnostic_refresh(&self) {
         if self.shutdown.is_cancelled() {
             return;
@@ -315,10 +319,20 @@ impl DiagnosticPublisher {
     /// every region, the downstream servers analyze and send their own
     /// `workspace/diagnostic/refresh`, which arrived here and was forwarded
     /// forced again — ~1 Hz forever with zero edits. An unchanged covering
-    /// prefetch proves the editor's re-pull would answer `unchanged`, so the
-    /// nudge is dropped and the loop starves. The generation is still marked
-    /// covered: the downstream activity was fully handled (prefetched and
-    /// found current), and any NEW downstream refresh mints a new generation.
+    /// prefetch indicates the editor's re-pull would answer `unchanged` (any
+    /// later downstream state move re-arrives as a new refresh generation), so
+    /// the nudge is dropped and the EDITOR leg of the loop starves. The
+    /// generation is still marked covered: the downstream activity was fully
+    /// handled (prefetched and found current), and any NEW downstream refresh
+    /// mints a new generation.
+    ///
+    /// Scope of the starvation: the prefetch leg persists — every generation
+    /// still runs the full fan-out — and a configuration whose prefetch can
+    /// never vouch (`coverage_incomplete` every cycle: a pullFallback-gated or
+    /// per-method-diverging layer, a persistently failing downstream pull, a
+    /// tree-less document that never parses) keeps the pre-absorption forward
+    /// on every downstream refresh. A consecutive-absorbed backoff is
+    /// follow-up material.
     async fn complete_forwarded_refresh_cycle(&self, generation: u64) -> bool {
         let Some(summary) = self.prefetch_open_pull_fallback_diagnostics().await else {
             return false;
@@ -1356,8 +1370,11 @@ impl DiagnosticPublisher {
     /// `published_set_changed`, converging once the re-pushed set stabilizes;
     /// and the forwarded-refresh path — where the induced re-pull's downstream
     /// fan-out makes servers like tsgo emit ANOTHER refresh, un-bounded by any
-    /// set comparison — is starved by `complete_forwarded_refresh_cycle`
-    /// dropping the nudge when its covering prefetch changed nothing.)
+    /// set comparison — has its editor leg starved by
+    /// `complete_forwarded_refresh_cycle` dropping the nudge when its covering
+    /// prefetch changed nothing after a covering editor pull; the prefetch leg
+    /// persists at debounce cadence, and a config whose prefetch can never
+    /// vouch keeps the forward — see that method's scope note.)
     ///
     /// **Spawned, not awaited:** `workspace/diagnostic/refresh` is a request whose
     /// future resolves only when the editor answers, so awaiting it inline would

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -443,6 +443,8 @@ impl DiagnosticPublisher {
                             // The doc's coverage state is unknown — safe direction.
                             summary.coverage_incomplete = true;
                         }
+                        // Unreachable: `join_next` returns `None` only on an
+                        // empty set, and the loop guard checks `!is_empty()`.
                         None => {}
                     }
                 }
@@ -488,6 +490,11 @@ impl DiagnosticPublisher {
         }
 
         match outcome {
+            // Unreachable from the only caller (the prefetch always passes a
+            // `Some` snapshot, and `Skip` means "no snapshot"). Kept exhaustive
+            // deliberately: Skip ⇔ nothing to pull ⇔ the editor sees the same
+            // nothing — if a future caller reaches it, "covered" is its
+            // meaning, NOT a shortcut for "don't bother nudging".
             PullLayerOutcome::Skip => return ForwardedPrefetchSummary::default(),
             PullLayerOutcome::Clear => {
                 self.aggregator
@@ -1591,7 +1598,11 @@ mod tests {
     /// downstream refresh → forced nudge → pull → … at ~1 Hz on a quiescent
     /// file. With no open documents the prefetch vacuously covers everything,
     /// so no send may happen.
-    #[tokio::test]
+    // Paused time: with zero open documents the whole cycle is timer-free
+    // local work, so auto-advance fires only once every task (including the
+    // absorbed cycle) has run to completion — the `== 0` assert below is
+    // therefore ordering-deterministic, not a wall-clock race.
+    #[tokio::test(start_paused = true)]
     async fn forwarded_refresh_with_covering_unchanged_prefetch_sends_nothing() {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
@@ -1616,6 +1627,82 @@ mod tests {
         assert_eq!(
             metrics.refreshes_sent, 0,
             "an unchanged covering prefetch must not nudge the editor (refresh↔pull loop)"
+        );
+    }
+
+    /// The #789 leading-edge timing pin, relocated from the deleted
+    /// unconditional-send test: when the leading cycle DOES send (here via the
+    /// pullFallback coverage gap), it must fire without waiting for the
+    /// debounce/settle timer. The whole chain (prefetch with a gated host →
+    /// Clear → republish → forced send) is timer-free local work, so under
+    /// paused time it completes within bounded yields at an unmoved clock.
+    #[tokio::test(start_paused = true)]
+    async fn forwarded_refresh_leading_cycle_sends_before_the_settle_window() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .settings_manager
+            .set_capabilities(ClientCapabilities {
+                workspace: Some(WorkspaceClientCapabilities {
+                    diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
+                        refresh_support: Some(true),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        register_rust(server);
+        let mut settings = rust_settings(true);
+        let lang = settings
+            .languages
+            .get_mut("rust")
+            .expect("rust_settings defines the rust language");
+        let bridge = lang
+            .bridge
+            .as_mut()
+            .expect("rust_settings configures the _self bridge");
+        bridge
+            .get_mut(HOST_BRIDGE_KEY)
+            .expect("rust_settings configures the _self bridge")
+            .aggregation = Some(HashMap::from([(
+            "textDocument/publishDiagnostics".to_string(),
+            crate::config::settings::AggregationConfig {
+                pull_fallback: Some(false),
+                ..Default::default()
+            },
+        )]));
+        server.settings_manager.apply_settings(settings);
+
+        let uri = Url::parse("file:///test/leading_edge_host.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        server
+            .parse_coordinator()
+            .parse_document(uri.clone(), Some("rust"), None)
+            .await;
+
+        let publisher = DiagnosticPublisher::new(server);
+        publisher.publish_pull_layer(&uri, Vec::new()).await;
+        let before = tokio::time::Instant::now();
+        publisher.request_forwarded_diagnostic_refresh();
+
+        let mut yields = 0;
+        while server.diagnostics.metrics_snapshot().refreshes_sent == 0 {
+            yields += 1;
+            assert!(
+                yields < 10_000,
+                "the leading send must complete without any timer advance"
+            );
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            tokio::time::Instant::now(),
+            before,
+            "the leading forced send must not wait for the settle window"
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1743,6 +1743,136 @@ mod tests {
         );
     }
 
+    /// The epoch-cover compensation: an intervening refresh (sent after this
+    /// cycle's activity, epoch bumped) suppresses the normal send path, but
+    /// its induced re-pull can have answered before this cycle's prefetch
+    /// committed — a changed/lagged summary must coalesce a compensating
+    /// forced nudge instead of trusting the cover. Removing the compensation
+    /// branch turns the send below into silence (this test's RED).
+    #[tokio::test]
+    async fn forwarded_refresh_epoch_cover_is_compensated_when_the_prefetch_cannot_vouch() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .settings_manager
+            .set_capabilities(ClientCapabilities {
+                workspace: Some(WorkspaceClientCapabilities {
+                    diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
+                        refresh_support: Some(true),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        register_rust(server);
+        let mut settings = rust_settings(true);
+        let lang = settings
+            .languages
+            .get_mut("rust")
+            .expect("rust_settings defines the rust language");
+        let bridge = lang
+            .bridge
+            .as_mut()
+            .expect("rust_settings configures the _self bridge");
+        bridge
+            .get_mut(HOST_BRIDGE_KEY)
+            .expect("rust_settings configures the _self bridge")
+            .aggregation = Some(HashMap::from([(
+            "textDocument/publishDiagnostics".to_string(),
+            crate::config::settings::AggregationConfig {
+                pull_fallback: Some(false),
+                ..Default::default()
+            },
+        )]));
+        server.settings_manager.apply_settings(settings);
+
+        let uri = Url::parse("file:///test/epoch_covered_host.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        server
+            .parse_coordinator()
+            .parse_document(uri.clone(), Some("rust"), None)
+            .await;
+        let publisher = DiagnosticPublisher::new(server);
+        publisher.publish_pull_layer(&uri, Vec::new()).await;
+        server.diagnostics.clear_pull_view_lag(&uri);
+
+        // Register the downstream activity, then simulate the intervening
+        // refresh: a wire send AFTER the activity bumps the epoch, which is
+        // exactly the state the epoch cover suppresses.
+        let snapshot = server
+            .diagnostics
+            .begin_forwarded_refresh_debounce()
+            .expect("idle scheduler admits the cycle");
+        server.diagnostics.record_refresh_sent();
+        assert_eq!(server.diagnostics.metrics_snapshot().refreshes_sent, 1);
+
+        assert!(
+            publisher
+                .complete_forwarded_refresh_cycle(snapshot.generation)
+                .await,
+            "the cycle itself must complete"
+        );
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        while server.diagnostics.metrics_snapshot().refreshes_sent < 2
+            && tokio::time::Instant::now() < deadline
+        {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            server.diagnostics.metrics_snapshot().refreshes_sent,
+            2,
+            "a changed/lagged summary under the epoch cover must coalesce the \
+             compensating forced nudge"
+        );
+        server.diagnostics.cancel_forwarded_refresh_debounce();
+    }
+
+    /// The absorption arm of the epoch cover: an unchanged covering prefetch
+    /// keeps trusting the intervening refresh — no compensating send.
+    #[tokio::test]
+    async fn forwarded_refresh_epoch_cover_is_trusted_when_the_prefetch_vouches() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .settings_manager
+            .set_capabilities(ClientCapabilities {
+                workspace: Some(WorkspaceClientCapabilities {
+                    diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
+                        refresh_support: Some(true),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        let publisher = DiagnosticPublisher::new(server);
+
+        // No open documents: the prefetch vacuously covers and changes nothing.
+        let snapshot = server
+            .diagnostics
+            .begin_forwarded_refresh_debounce()
+            .expect("idle scheduler admits the cycle");
+        server.diagnostics.record_refresh_sent();
+
+        assert!(
+            publisher
+                .complete_forwarded_refresh_cycle(snapshot.generation)
+                .await
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert_eq!(
+            server.diagnostics.metrics_snapshot().refreshes_sent,
+            1,
+            "an absorbed summary must keep trusting the epoch cover"
+        );
+        server.diagnostics.cancel_forwarded_refresh_debounce();
+    }
+
     /// An OPEN document whose parse snapshot is transiently absent (didChange
     /// cleared the tree; parse pending or given up) must count as a coverage
     /// gap: the editor's re-pull answers it (bounded tree wait + tree-less

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1769,6 +1769,67 @@ mod tests {
         );
     }
 
+    /// A nudge-less writer that has mutated the cache (pending mark stamped)
+    /// but not yet reached its republish is a real, unconfirmed change the
+    /// sweep must treat conservatively as lag: absorbing past it and letting
+    /// the later republish confirm the lag nudge-lessly leaves a pull-first
+    /// editor stale until another refresh. codex fresh-session #4 finding —
+    /// the parked writer is simulated by mutating WITHOUT republishing.
+    #[tokio::test]
+    async fn pending_lag_mark_blocks_absorption_at_the_sweep() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .settings_manager
+            .set_capabilities(ClientCapabilities {
+                workspace: Some(WorkspaceClientCapabilities {
+                    diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
+                        refresh_support: Some(true),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        register_rust(server);
+        server.settings_manager.apply_settings(rust_settings(false));
+
+        // An open doc keeps the sweep's URI set non-empty; with host bridging
+        // off and no injection query the prefetch skips it without flags.
+        let uri = Url::parse("file:///test/pending_mark_sweep.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        server
+            .parse_coordinator()
+            .parse_document(uri.clone(), Some("rust"), None)
+            .await;
+
+        // The parked writer: mutation + pending mark stamped, republish not
+        // yet run (no settle, no confirmed lag).
+        server
+            .diagnostics
+            .set_pull_layer_nudgeless(&uri, vec![diag("in-flight")]);
+
+        let publisher = DiagnosticPublisher::new(server);
+        publisher.request_forwarded_diagnostic_refresh();
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        while server.diagnostics.metrics_snapshot().refreshes_sent == 0
+            && tokio::time::Instant::now() < deadline
+        {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            server.diagnostics.metrics_snapshot().refreshes_sent,
+            1,
+            "an unsettled pending mark is an unconfirmed change the sweep must \
+             not absorb past"
+        );
+    }
+
     /// Behavior-level pin for the mid-flight reload guards (the per-commit
     /// lineage check and the cycle-level fence): a settings reload landing
     /// while the prefetch is in flight must force the send, whichever guard

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -341,20 +341,20 @@ impl DiagnosticPublisher {
             return false;
         }
         let mut summary = summary;
-        // Read the pull-view lag at DECISION time, after the prefetch joined:
-        // a host-event pull committing concurrently with the prefetch records
-        // its lag while the prefetch is in flight, and the prefetch — having
-        // pulled the same post-commit set — reports Unchanged. Sampling only
-        // at prefetch start would absorb this cycle despite the outstanding
-        // lag.
-        let any_pull_view_lag = |publisher: &Self| {
-            publisher
-                .documents
-                .open_uris()
-                .iter()
-                .any(|uri| publisher.aggregator.has_pull_view_lag(uri))
-        };
-        summary.set_changed |= any_pull_view_lag(self);
+        // Read the pull-view lag at DECISION time, after the prefetch
+        // joined. This read is race-free against the nudge-less recorders
+        // because they record BEFORE their republish (see
+        // `record_pull_view_lag`): the per-host republish lock serializes a
+        // recorder's republish against this cycle's own prefetch commit, so
+        // any change the prefetch's Unchanged-compare could have observed had
+        // its lag visible here first; a recorder whose lag lands after this
+        // read also republishes after it — its change postdates the cycle and
+        // its (uncleared) lag is this same sweep's input next generation.
+        summary.set_changed |= self
+            .documents
+            .open_uris()
+            .iter()
+            .any(|uri| self.aggregator.has_pull_view_lag(uri));
         self.aggregator
             .mark_forwarded_refresh_prefetched(generation);
 
@@ -364,21 +364,12 @@ impl DiagnosticPublisher {
             .aggregator
             .forwarded_refresh_needs_editor_send(generation)
         {
-            let nudged = summary.needs_editor_nudge();
-            if nudged && !self.request_pull_diagnostic_refresh_inner(true, false) {
+            if summary.needs_editor_nudge()
+                && !self.request_pull_diagnostic_refresh_inner(true, false)
+            {
                 return false;
             }
             self.aggregator.mark_forwarded_refresh_covered(generation);
-            // The sweep→covered window: a lag recorded in between was seen by
-            // neither the sweep above nor any future cycle this (now covered)
-            // generation would trigger — and a lag-recording commit mints no
-            // refresh generation of its own. Re-check after covering and fire
-            // the nudge directly; a spurious double-nudge (the recorder's set
-            // change racing an already-sent nudge) is coalesced by the
-            // refresh single-flight.
-            if !nudged && any_pull_view_lag(self) {
-                let _ = self.request_pull_diagnostic_refresh_inner(true, false);
-            }
         }
         true
     }
@@ -525,19 +516,19 @@ impl DiagnosticPublisher {
                 self.aggregator.set_pull_layer(uri, diagnostics);
             }
         }
+        // Provisional record-before-republish, like `publish_pull_layer`:
+        // the in-cycle nudge this commit may trigger is only a request — if
+        // the editor does not actually re-pull, the NEXT cycle's unchanged
+        // prefetch must still forward instead of absorbing forever (the lag
+        // is cleared by the covering pull). A racing didClose's forget wins
+        // regardless of which side of the republish it lands on.
+        let provisional = self.aggregator.record_pull_view_lag(uri);
         drop(edit_guard);
         // `Deferred` counts as changed: the cache moved, only the geometry
         // re-anchor is pending — the editor's view is stale either way.
         let set_changed = self.republish(uri).await.nudges_pull_clients();
-        // Re-check the store: a didClose can slip in after the edit guard
-        // dropped, and its forget must win — recording after it would leak a
-        // closed host's entry until reopen (one spurious nudge there).
-        if set_changed && self.documents.get(uri).is_some() {
-            // The in-cycle nudge below is only a request; record the lag so
-            // that if the editor does not actually re-pull, the NEXT cycle's
-            // unchanged prefetch still forwards instead of absorbing forever
-            // (cleared by the covering pull, like `publish_pull_layer`).
-            self.aggregator.record_pull_view_lag(uri);
+        if !set_changed {
+            self.aggregator.retract_pull_view_lag(uri, provisional);
         }
         ForwardedPrefetchSummary {
             set_changed,
@@ -874,16 +865,15 @@ impl DiagnosticPublisher {
     /// (push-propagation-diagnostic-forwarding) handles generally; until then it
     /// self-heals on the next completed pull.
     pub(crate) async fn publish_pull_layer(&self, host: &Url, diagnostics: Vec<Diagnostic>) {
+        // Record the lag BEFORE the republish (see `record_pull_view_lag` —
+        // this ordering is what linearizes the forwarded-refresh absorption
+        // against this nudge-less commit), retracting if nothing changed. A
+        // racing didClose's forget wins either way: it removes the record
+        // whether it lands before or after the republish.
+        let provisional = self.aggregator.record_pull_view_lag(host);
         self.aggregator.set_pull_layer(host, diagnostics);
-        // The store re-check mirrors `commit_refresh_prefetch`'s: a racing
-        // didClose's forget must win over this record.
-        if self.republish(host).await.nudges_pull_clients() && self.documents.get(host).is_some() {
-            // This commit moved the recorded set without any editor nudge; if
-            // the editor's own event-driven pull raced ahead of it, only a
-            // later covering pull closes the gap — record the lag so the
-            // forwarded-refresh absorption does not mistake kakehashi's own
-            // record for the editor's view (see `pull_view_lag`).
-            self.aggregator.record_pull_view_lag(host);
+        if !self.republish(host).await.nudges_pull_clients() {
+            self.aggregator.retract_pull_view_lag(host, provisional);
         }
     }
 
@@ -905,12 +895,14 @@ impl DiagnosticPublisher {
     /// here would therefore duplicate that cycle's nudge; an incapable editor still
     /// receives the clearing `publishDiagnostics` notification from `republish`.
     pub(crate) async fn clear_pull_layer(&self, host: &Url) {
+        // Same provisional record-before-republish as `publish_pull_layer`:
+        // a cleared set the editor still displays is the worse variant of
+        // the lag.
+        let provisional = self.aggregator.record_pull_view_lag(host);
         self.aggregator
             .evict_source(host, &DiagnosticSource::PullLayer);
-        if self.republish(host).await.nudges_pull_clients() && self.documents.get(host).is_some() {
-            // Same pull-view lag rule as `publish_pull_layer`: a cleared set
-            // the editor still displays is the worse variant of the lag.
-            self.aggregator.record_pull_view_lag(host);
+        if !self.republish(host).await.nudges_pull_clients() {
+            self.aggregator.retract_pull_view_lag(host, provisional);
         }
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1564,6 +1564,59 @@ mod tests {
         );
     }
 
+    /// An OPEN document whose parse snapshot is transiently absent (didChange
+    /// cleared the tree; parse pending or given up) must count as a coverage
+    /// gap: the editor's re-pull answers it (bounded tree wait + tree-less
+    /// host layer), so the prefetch cannot vouch for it. Review finding
+    /// (contract regression, HIGH): the skip previously counted such a
+    /// document as vacuously covered, absorbing the refresh — with
+    /// `pullFallback = false` or a settings-reload `invalidate_parse` window
+    /// there is no later signal, and the editor rots until the next edit.
+    #[tokio::test]
+    async fn forwarded_refresh_still_sends_when_an_open_document_has_no_snapshot() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .settings_manager
+            .set_capabilities(ClientCapabilities {
+                workspace: Some(WorkspaceClientCapabilities {
+                    diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
+                        refresh_support: Some(true),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        register_rust(server);
+        server.settings_manager.apply_settings(rust_settings(true));
+
+        // Insert WITHOUT parsing: the document is open but has no tree, so
+        // `prepare_diagnostic_snapshot` returns `None` transiently.
+        let uri = Url::parse("file:///test/tree_pending_host.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+
+        let publisher = DiagnosticPublisher::new(server);
+        publisher.request_forwarded_diagnostic_refresh();
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        while server.diagnostics.metrics_snapshot().refreshes_sent == 0
+            && tokio::time::Instant::now() < deadline
+        {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            server.diagnostics.metrics_snapshot().refreshes_sent,
+            1,
+            "an open document without a parse snapshot is NOT covered by the \
+             prefetch — the forced send must survive"
+        );
+    }
+
     /// Safe direction: when `pullFallback = false` gates a pull-eligible layer
     /// out of the prefetch, the prefetch canNOT stand in for the editor's
     /// re-pull (the editor's live fan-out still pulls that layer), so the

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1630,6 +1630,141 @@ mod tests {
         );
     }
 
+    /// The publish wire SEAL (`layers.aggregation."textDocument/publishDiagnostics"
+    /// .priorities = []`, #685) is a documented pull-first setup whose delivery
+    /// signal IS the forwarded refresh. The seal narrows only the
+    /// publishDiagnostics-keyed prefetch surface — the editor's re-pull
+    /// resolves under `textDocument/diagnostic` and is unsealed — so the
+    /// prefetch cannot vouch and the forced send must survive. Review finding
+    /// (adversarial sweep, HIGH): absorbing here made the sealed config
+    /// permanently stale.
+    #[tokio::test]
+    async fn forwarded_refresh_still_sends_under_the_publish_seal() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .settings_manager
+            .set_capabilities(ClientCapabilities {
+                workspace: Some(WorkspaceClientCapabilities {
+                    diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
+                        refresh_support: Some(true),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        register_rust(server);
+        server
+            .settings_manager
+            .apply_settings(rust_settings_with_publish_seal());
+
+        let uri = Url::parse("file:///test/sealed_host.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        server
+            .parse_coordinator()
+            .parse_document(uri.clone(), Some("rust"), None)
+            .await;
+
+        let publisher = DiagnosticPublisher::new(server);
+        // Seed a recorded (empty) published set first: without it the cycle's
+        // very first republish compares against nothing and reports Changed,
+        // which would make this test pass without exercising the divergence
+        // flag at all (a first commit always nudges).
+        publisher.publish_pull_layer(&uri, Vec::new()).await;
+        publisher.request_forwarded_diagnostic_refresh();
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        while server.diagnostics.metrics_snapshot().refreshes_sent == 0
+            && tokio::time::Instant::now() < deadline
+        {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            server.diagnostics.metrics_snapshot().refreshes_sent,
+            1,
+            "the seal narrows only the prefetch surface, not the editor's re-pull — \
+             the forwarded refresh is the sealed setup's delivery signal and must survive"
+        );
+    }
+
+    /// Per-method aggregation divergence: an empty server selection keyed ONLY
+    /// under `textDocument/publishDiagnostics` empties the prefetch's fan-out
+    /// while the editor's `textDocument/diagnostic` fan-out keeps its default —
+    /// the prefetch surface is narrower, so the forced send must survive.
+    #[tokio::test]
+    async fn forwarded_refresh_still_sends_when_publish_selection_diverges() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .settings_manager
+            .set_capabilities(ClientCapabilities {
+                workspace: Some(WorkspaceClientCapabilities {
+                    diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
+                        refresh_support: Some(true),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        register_rust(server);
+        let mut settings = rust_settings(true);
+        let lang = settings
+            .languages
+            .get_mut("rust")
+            .expect("rust_settings defines the rust language");
+        let bridge = lang
+            .bridge
+            .as_mut()
+            .expect("rust_settings configures the _self bridge");
+        bridge
+            .get_mut(HOST_BRIDGE_KEY)
+            .expect("rust_settings configures the _self bridge")
+            .aggregation = Some(HashMap::from([(
+            "textDocument/publishDiagnostics".to_string(),
+            crate::config::settings::AggregationConfig {
+                priorities: Some(Vec::new()),
+                ..Default::default()
+            },
+        )]));
+        server.settings_manager.apply_settings(settings);
+
+        let uri = Url::parse("file:///test/diverged_host.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        server
+            .parse_coordinator()
+            .parse_document(uri.clone(), Some("rust"), None)
+            .await;
+
+        let publisher = DiagnosticPublisher::new(server);
+        // Seed a recorded set so the cycle's republish can genuinely report
+        // Unchanged (see the seal test above for why).
+        publisher.publish_pull_layer(&uri, Vec::new()).await;
+        publisher.request_forwarded_diagnostic_refresh();
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        while server.diagnostics.metrics_snapshot().refreshes_sent == 0
+            && tokio::time::Instant::now() < deadline
+        {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            server.diagnostics.metrics_snapshot().refreshes_sent,
+            1,
+            "a publishDiagnostics-only empty selection narrows the prefetch below \
+             the editor's diagnostic-keyed fan-out — the forced send must survive"
+        );
+    }
+
     /// Safe direction: when `pullFallback = false` gates a pull-eligible layer
     /// out of the prefetch, the prefetch canNOT stand in for the editor's
     /// re-pull (the editor's live fan-out still pulls that layer), so the
@@ -1684,6 +1819,9 @@ mod tests {
             .await;
 
         let publisher = DiagnosticPublisher::new(server);
+        // Seed a recorded set so the send below can only come from the
+        // narrower_than_editor_pull flag, not from a first-commit Changed.
+        publisher.publish_pull_layer(&uri, Vec::new()).await;
         publisher.request_forwarded_diagnostic_refresh();
 
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1441,8 +1441,15 @@ mod tests {
         }
     }
 
-    #[tokio::test(start_paused = true)]
-    async fn forwarded_refresh_sends_the_leading_edge_immediately() {
+    /// Loop-breaker: a downstream `workspace/diagnostic/refresh` whose prefetch
+    /// covered every open document and changed nothing must NOT nudge the
+    /// editor. The editor's re-pull would answer `unchanged`, and the nudge is
+    /// what closes the refresh↔pull feedback loop: pull → downstream analysis →
+    /// downstream refresh → forced nudge → pull → … at ~1 Hz on a quiescent
+    /// file. With no open documents the prefetch vacuously covers everything,
+    /// so no send may happen.
+    #[tokio::test]
+    async fn forwarded_refresh_with_covering_unchanged_prefetch_sends_nothing() {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
         server
@@ -1457,20 +1464,85 @@ mod tests {
                 ..Default::default()
             });
         let publisher = DiagnosticPublisher::new(server);
-        let before = tokio::time::Instant::now();
 
         publisher.request_forwarded_diagnostic_refresh();
-        tokio::time::advance(std::time::Duration::ZERO).await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
+        let metrics = server.diagnostics.metrics_snapshot();
+        assert_eq!(metrics.refreshes_requested, 1);
         assert_eq!(
-            tokio::time::Instant::now(),
-            before,
-            "the leading send must happen without advancing to the debounce timer"
+            metrics.refreshes_sent, 0,
+            "an unchanged covering prefetch must not nudge the editor (refresh↔pull loop)"
         );
+    }
+
+    /// Safe direction: when `pullFallback = false` gates a pull-eligible layer
+    /// out of the prefetch, the prefetch canNOT stand in for the editor's
+    /// re-pull (the editor's live fan-out still pulls that layer), so the
+    /// forwarded refresh must keep its forced editor send.
+    #[tokio::test]
+    async fn forwarded_refresh_still_sends_when_pull_fallback_gates_a_layer() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .settings_manager
+            .set_capabilities(ClientCapabilities {
+                workspace: Some(WorkspaceClientCapabilities {
+                    diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
+                        refresh_support: Some(true),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        register_rust(server);
+        let mut settings = rust_settings(true);
+        let lang = settings
+            .languages
+            .get_mut("rust")
+            .expect("rust_settings defines the rust language");
+        let bridge = lang
+            .bridge
+            .as_mut()
+            .expect("rust_settings configures the _self bridge");
+        bridge
+            .get_mut(HOST_BRIDGE_KEY)
+            .expect("rust_settings configures the _self bridge")
+            .aggregation = Some(HashMap::from([(
+            "textDocument/publishDiagnostics".to_string(),
+            crate::config::settings::AggregationConfig {
+                pull_fallback: Some(false),
+                ..Default::default()
+            },
+        )]));
+        server.settings_manager.apply_settings(settings);
+
+        let uri = Url::parse("file:///test/pull_gated_host.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        server
+            .parse_coordinator()
+            .parse_document(uri.clone(), Some("rust"), None)
+            .await;
+
+        let publisher = DiagnosticPublisher::new(server);
+        publisher.request_forwarded_diagnostic_refresh();
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        while server.diagnostics.metrics_snapshot().refreshes_sent == 0
+            && tokio::time::Instant::now() < deadline
+        {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
         assert_eq!(
             server.diagnostics.metrics_snapshot().refreshes_sent,
             1,
-            "the first refresh after idle must not wait for the debounce window"
+            "a pullFallback-gated layer means the prefetch did not cover the editor's \
+             re-pull surface — the forced send must survive"
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -334,6 +334,13 @@ impl DiagnosticPublisher {
     /// on every downstream refresh. A consecutive-absorbed backoff is
     /// follow-up material.
     async fn complete_forwarded_refresh_cycle(&self, generation: u64) -> bool {
+        // Cycle-level settings fence: the per-commit lineage check can pass
+        // just before a `didChangeConfiguration` stores a wider surface, so
+        // re-check across the WHOLE prefetch — any reload during it means
+        // this cycle cannot vouch for the editor's (new-config) re-pull. A
+        // reload after this fence postdates the refresh being handled; the
+        // config-apply path owns signaling its own changes.
+        let settings_generation = self.settings_manager.settings_generation();
         let Some(summary) = self.prefetch_open_pull_fallback_diagnostics().await else {
             return false;
         };
@@ -341,6 +348,8 @@ impl DiagnosticPublisher {
             return false;
         }
         let mut summary = summary;
+        summary.coverage_incomplete |=
+            self.settings_manager.settings_generation() != settings_generation;
         // Read the pull-view lag at DECISION time, after the prefetch
         // joined. This read is race-free against the nudge-less writers
         // because their marks are revision-stamped with the mutation and

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1687,6 +1687,9 @@ mod tests {
 
         let publisher = DiagnosticPublisher::new(server);
         publisher.publish_pull_layer(&uri, Vec::new()).await;
+        // Clear the seed's own pull-view lag so the timing below measures the
+        // narrower_than_editor_pull send path, like the other divergence pins.
+        server.diagnostics.clear_pull_view_lag(&uri);
         let before = tokio::time::Instant::now();
         publisher.request_forwarded_diagnostic_refresh();
 
@@ -1803,8 +1806,12 @@ mod tests {
         // Seed a recorded (empty) published set first: without it the cycle's
         // very first republish compares against nothing and reports Changed,
         // which would make this test pass without exercising the divergence
-        // flag at all (a first commit always nudges).
+        // flag at all (a first commit always nudges). The seed itself records
+        // a pull-view lag (it IS an un-nudged first commit) — clear it, as a
+        // covering editor pull would, so the send below can only come from
+        // the narrower_than_editor_pull flag.
         publisher.publish_pull_layer(&uri, Vec::new()).await;
+        server.diagnostics.clear_pull_view_lag(&uri);
         publisher.request_forwarded_diagnostic_refresh();
 
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
@@ -1876,8 +1883,10 @@ mod tests {
 
         let publisher = DiagnosticPublisher::new(server);
         // Seed a recorded set so the cycle's republish can genuinely report
-        // Unchanged (see the seal test above for why).
+        // Unchanged, and clear the seed's own pull-view lag (see the seal
+        // test above for why both steps are load-bearing).
         publisher.publish_pull_layer(&uri, Vec::new()).await;
+        server.diagnostics.clear_pull_view_lag(&uri);
         publisher.request_forwarded_diagnostic_refresh();
 
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
@@ -1949,8 +1958,10 @@ mod tests {
 
         let publisher = DiagnosticPublisher::new(server);
         // Seed a recorded set so the send below can only come from the
-        // narrower_than_editor_pull flag, not from a first-commit Changed.
+        // narrower_than_editor_pull flag — not from a first-commit Changed,
+        // and (after clearing the seed's own lag) not from pull-view lag.
         publisher.publish_pull_layer(&uri, Vec::new()).await;
+        server.diagnostics.clear_pull_view_lag(&uri);
         publisher.request_forwarded_diagnostic_refresh();
 
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -2061,12 +2061,14 @@ async fn deliver_upstream_notification(
     match notification {
         UpstreamNotification::DiagnosticRefresh => {
             // A downstream server asked the editor to re-pull diagnostics. Route it
-            // through `request_forwarded_diagnostic_refresh`, which forwards the
-            // leading edge immediately and debounces later burst activity before
-            // reusing the capability-gated, detached forced-refresh path. Detaching
-            // avoids blocking this delivery loop on the editor round-trip
-            // (head-of-line). A `None` publisher (test loop) has no settings to gate
-            // on, so the forward is dropped; production always has one (#521, #789).
+            // through `request_forwarded_diagnostic_refresh`, which runs the leading
+            // cycle immediately (prefetch, then a conditional editor forward — an
+            // unchanged covering prefetch absorbs the nudge) and debounces later
+            // burst activity, reusing the capability-gated, detached forced-refresh
+            // path when it does send. Detaching avoids blocking this delivery loop
+            // on the editor round-trip (head-of-line). A `None` publisher (test
+            // loop) has no settings to gate on, so the forward is dropped;
+            // production always has one (#521, #789).
             if let Some(publisher) =
                 delivery_context.map(|context| context.diagnostic_publisher.as_ref())
             {

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -139,7 +139,7 @@ impl Kakehashi {
         // Get the language for this document
         let Some(language_name) = self.document_language(&uri) else {
             log::debug!(target: "kakehashi::diagnostic", "No language detected");
-            self.mark_pull_covered(&uri, coverage_stamp, pull_view_lag_stamp);
+            self.mark_pull_covered(&uri, coverage_stamp, pull_view_lag_stamp, true);
             return Ok(empty_diagnostic_report());
         };
 
@@ -160,7 +160,7 @@ impl Kakehashi {
                 "no diagnostic layer enabled for {} (layers.aggregation priorities / bridge._self)",
                 language_name
             );
-            self.mark_pull_covered(&uri, coverage_stamp, pull_view_lag_stamp);
+            self.mark_pull_covered(&uri, coverage_stamp, pull_view_lag_stamp, true);
             return Ok(empty_diagnostic_report());
         }
 
@@ -442,20 +442,9 @@ impl Kakehashi {
             }
         } else {
             // A failed/partial fan-out (`!pull_clean`) still advances the
-            // coverage version (pre-existing #497 semantics: the editor got
-            // AN answer) but must not clear the pull-view lag — the editor's
-            // view may be missing exactly the servers whose lag is recorded,
-            // and clearing would let the next unchanged prefetch absorb the
-            // healing refresh.
-            self.mark_pull_covered(
-                &uri,
-                coverage_stamp,
-                if pull_clean {
-                    pull_view_lag_stamp
-                } else {
-                    None
-                },
-            );
+            // coverage version but clears neither the pull-view lag nor the
+            // degraded-pull debt — see `mark_pull_covered`.
+            self.mark_pull_covered(&uri, coverage_stamp, pull_view_lag_stamp, pull_clean);
         }
 
         let items = combine_layer_diagnostics(&layer_cfg, virt_items, host_items);
@@ -474,13 +463,16 @@ impl Kakehashi {
     }
 
     /// A pull answered with a covering (non-degraded) report: advance the
-    /// coverage `served` marker and clear any earlier degraded-pull debt —
-    /// every covering exit must do both, or a stale debt would later fire an
-    /// unnecessary recovery refresh. Not coverage-gated: both recovery paths
-    /// pass `forced`, so the debt is the only thing standing between a stale
-    /// entry and a refresh.
+    /// coverage `served` marker and — when the fan-out was CLEAN — clear any
+    /// earlier degraded-pull debt and the pull-view lag up to the observed
+    /// serial. A failed/partial fan-out is itself a non-covering view
+    /// (CodeRabbit, PR #972): clearing the debt there would remove the
+    /// post-parse recovery trigger, and clearing the lag would let the next
+    /// unchanged prefetch absorb the healing refresh. `mark_served` stays
+    /// unconditional (pre-existing #497 semantics: the editor did receive AN
+    /// answer for this coverage version).
     ///
-    /// Both halves are scoped to the coverage lifetime this pull observed. A
+    /// All halves are scoped to the lifetimes/serials this pull observed. A
     /// pull that started before a close+reopen may neither mark the reopened
     /// lifetime served nor clear a debt recorded within it (#745).
     fn mark_pull_covered(
@@ -488,16 +480,20 @@ impl Kakehashi {
         uri: &Url,
         coverage_stamp: Option<DiagnosticCoverageStamp>,
         pull_view_lag_stamp: Option<u64>,
+        pull_clean: bool,
     ) {
         self.diagnostics.mark_served(uri, coverage_stamp);
+        if !pull_clean {
+            return;
+        }
         self.diagnostics
             .forget_degraded_pull_from(uri, coverage_stamp);
         // The editor now holds the merged state recorded up to this pull's
         // entry, so the un-nudged pull-layer moves it observed are delivered —
         // the forwarded-refresh absorption may trust the recorded set again.
-        // Serial-scoped like the two stamped halves above: a lag recorded
-        // after this pull began (including by a reopened lifetime, #745's
-        // defect class) survives (see `pull_view_lag`).
+        // Serial-scoped like the stamped halves above: a lag recorded after
+        // this pull began (including by a reopened lifetime, #745's defect
+        // class) survives (see `pull_view_lag`).
         self.diagnostics
             .clear_pull_view_lag_up_to(uri, pull_view_lag_stamp);
     }

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -304,13 +304,23 @@ impl Kakehashi {
 
             // Cancellation is handled by the outer select dropping this
             // future (which drops the JoinSet, aborting region tasks).
-            crate::lsp::aggregation::region::collect_region_results_with_cancel(
-                outer_join_set,
-                None,
-                |acc, items: Vec<Diagnostic>| acc.extend(items),
-            )
-            .await
-            .unwrap_or_default()
+            // Drained inline (rather than via collect_region_results_with_cancel)
+            // so a PANICKED region task counts as a request failure: it dropped
+            // its whole region from the answer, and a partial answer must not
+            // read as clean to the pull-view lag check below.
+            let mut collected: Vec<Diagnostic> = Vec::new();
+            let mut panicked_regions = 0usize;
+            while let Some(result) = outer_join_set.join_next().await {
+                match result {
+                    Ok(items) => collected.extend(items),
+                    Err(join_err) => {
+                        log::warn!("region task panicked: {join_err}");
+                        panicked_regions += 1;
+                    }
+                }
+            }
+            count_request_errors(&request_error_sink, panicked_regions);
+            collected
         };
 
         // Host layer (host-document-bridge): the host language's own servers

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -432,6 +432,10 @@ impl Kakehashi {
         self.diagnostics.mark_served(uri, coverage_stamp);
         self.diagnostics
             .forget_degraded_pull_from(uri, coverage_stamp);
+        // The editor now holds the current merged state, so any un-nudged
+        // pull-layer move is delivered — the forwarded-refresh absorption may
+        // trust the recorded set again (see `pull_view_lag`).
+        self.diagnostics.clear_pull_view_lag(uri);
     }
 
     /// pushFallback fold (Path B, #425): append push-driven servers' cached

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -397,8 +397,15 @@ impl Kakehashi {
         // client back to a full view, instead of the gap being masked until
         // the next edit. The predicate mirrors `republish`'s `needs_geometry`
         // (non-empty region slots only).
-        let degraded_virt =
-            virt_enabled && snapshot.is_none() && self.diagnostics.has_region_slots(&uri);
+        // Missing-virt evidence for a tree-less answer: cached Region push
+        // slots (mirrors `republish`'s `needs_geometry`) OR a non-empty
+        // cached PullLayer — a pull-only injected server's diagnostics live
+        // only there, and this answer's virt layer silently skipped them
+        // just the same.
+        let degraded_virt = virt_enabled
+            && snapshot.is_none()
+            && (self.diagnostics.has_region_slots(&uri)
+                || self.diagnostics.has_nonempty_pull_layer(&uri));
 
         // The editor is about to receive the current merged set: advance `served` to
         // the version captured at entry, so the refresh gate stops treating those

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -177,6 +177,16 @@ impl Kakehashi {
             None
         };
 
+        // Tee the request-failure count through an internal sink: the caller's
+        // sink (CLI diagnose) receives the total after the fan-out settles,
+        // and this handler additionally learns whether ITS OWN fan-out was
+        // clean — a failed/partial pull hands the editor an incomplete set,
+        // which must not clear the pull-view lag (the absorption would then
+        // trust a view the editor does not actually hold).
+        let external_error_sink = request_error_sink;
+        let internal_errors = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let request_error_sink: RequestErrorSink = Some(std::sync::Arc::clone(&internal_errors));
+
         // Get upstream request ID from task-local storage (set by RequestIdCapture middleware)
         let upstream_request_id = crate::lsp::current_upstream_id();
 
@@ -354,6 +364,16 @@ impl Kakehashi {
         )
         .await;
 
+        // Settle the failure tee: hand the caller's sink (CLI diagnose) the
+        // total, and derive whether this pull's own fan-out was clean.
+        let request_failures = internal_errors.load(std::sync::atomic::Ordering::Relaxed);
+        if request_failures > 0
+            && let Some(external) = &external_error_sink
+        {
+            external.fetch_add(request_failures, std::sync::atomic::Ordering::Relaxed);
+        }
+        let pull_clean = request_failures == 0;
+
         // Degraded-answer guard (the pull-side sibling of `republish`'s
         // geometry-unknown deferral): the bounded parse wait above can lapse
         // under load, leaving `snapshot` `None` for an open document while the
@@ -404,7 +424,21 @@ impl Kakehashi {
                     .request_pull_diagnostic_refresh(true);
             }
         } else {
-            self.mark_pull_covered(&uri, coverage_stamp, pull_view_lag_stamp);
+            // A failed/partial fan-out (`!pull_clean`) still advances the
+            // coverage version (pre-existing #497 semantics: the editor got
+            // AN answer) but must not clear the pull-view lag — the editor's
+            // view may be missing exactly the servers whose lag is recorded,
+            // and clearing would let the next unchanged prefetch absorb the
+            // healing refresh.
+            self.mark_pull_covered(
+                &uri,
+                coverage_stamp,
+                if pull_clean {
+                    pull_view_lag_stamp
+                } else {
+                    None
+                },
+            );
         }
 
         let items = combine_layer_diagnostics(&layer_cfg, virt_items, host_items);

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -131,11 +131,15 @@ impl Kakehashi {
         // no-op against the new lifetime rather than poisoning it with a stale-high
         // version (#745).
         let coverage_stamp = self.diagnostics.coverage_stamp(&uri);
+        // Captured alongside: the pull-view lag serial this pull may clear.
+        // A lag recorded after this point (mid-pull commit, or a reopened
+        // lifetime after a close raced this pull) must survive our clear.
+        let pull_view_lag_stamp = self.diagnostics.pull_view_lag_stamp(&uri);
 
         // Get the language for this document
         let Some(language_name) = self.document_language(&uri) else {
             log::debug!(target: "kakehashi::diagnostic", "No language detected");
-            self.mark_pull_covered(&uri, coverage_stamp);
+            self.mark_pull_covered(&uri, coverage_stamp, pull_view_lag_stamp);
             return Ok(empty_diagnostic_report());
         };
 
@@ -156,7 +160,7 @@ impl Kakehashi {
                 "no diagnostic layer enabled for {} (layers.aggregation priorities / bridge._self)",
                 language_name
             );
-            self.mark_pull_covered(&uri, coverage_stamp);
+            self.mark_pull_covered(&uri, coverage_stamp, pull_view_lag_stamp);
             return Ok(empty_diagnostic_report());
         }
 
@@ -400,7 +404,7 @@ impl Kakehashi {
                     .request_pull_diagnostic_refresh(true);
             }
         } else {
-            self.mark_pull_covered(&uri, coverage_stamp);
+            self.mark_pull_covered(&uri, coverage_stamp, pull_view_lag_stamp);
         }
 
         let items = combine_layer_diagnostics(&layer_cfg, virt_items, host_items);
@@ -428,14 +432,23 @@ impl Kakehashi {
     /// Both halves are scoped to the coverage lifetime this pull observed. A
     /// pull that started before a close+reopen may neither mark the reopened
     /// lifetime served nor clear a debt recorded within it (#745).
-    fn mark_pull_covered(&self, uri: &Url, coverage_stamp: Option<DiagnosticCoverageStamp>) {
+    fn mark_pull_covered(
+        &self,
+        uri: &Url,
+        coverage_stamp: Option<DiagnosticCoverageStamp>,
+        pull_view_lag_stamp: Option<u64>,
+    ) {
         self.diagnostics.mark_served(uri, coverage_stamp);
         self.diagnostics
             .forget_degraded_pull_from(uri, coverage_stamp);
-        // The editor now holds the current merged state, so any un-nudged
-        // pull-layer move is delivered — the forwarded-refresh absorption may
-        // trust the recorded set again (see `pull_view_lag`).
-        self.diagnostics.clear_pull_view_lag(uri);
+        // The editor now holds the merged state recorded up to this pull's
+        // entry, so the un-nudged pull-layer moves it observed are delivered —
+        // the forwarded-refresh absorption may trust the recorded set again.
+        // Serial-scoped like the two stamped halves above: a lag recorded
+        // after this pull began (including by a reopened lifetime, #745's
+        // defect class) survives (see `pull_view_lag`).
+        self.diagnostics
+            .clear_pull_view_lag_up_to(uri, pull_view_lag_stamp);
     }
 
     /// pushFallback fold (Path B, #425): append push-driven servers' cached

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -906,7 +906,7 @@ print("hello")
                 },
             virt_contexts: vec![],
             host_pull_enabled: true,
-            pull_gated: false,
+            narrower_than_editor_pull: false,
             host: Some(HostRequestContext {
                 uri: uri.clone(),
                 language_id: "rust".to_string(),
@@ -1021,7 +1021,7 @@ print("hello")
                 },
             virt_contexts: vec![],
             host_pull_enabled: true,
-            pull_gated: false,
+            narrower_than_editor_pull: false,
             host: Some(HostRequestContext {
                 uri: uri.clone(),
                 language_id: "rust".to_string(),
@@ -1498,7 +1498,7 @@ print("hello")
     /// `_self` server. If the gate dropped the context, that server would analyze
     /// stale text (re-opening #380 for the host).
     #[tokio::test]
-    async fn prepare_diagnostic_snapshot_keeps_host_for_resync_when_pull_gated() {
+    async fn prepare_diagnostic_snapshot_keeps_host_for_resync_when_narrower_than_editor_pull() {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
         configure_rust_self_host(server);
@@ -1527,7 +1527,7 @@ print("hello")
         }
         server.settings_manager.apply_settings(settings);
 
-        let uri = Url::parse("file:///test/host_pull_gated.rs").unwrap();
+        let uri = Url::parse("file:///test/host_narrower_than_editor_pull.rs").unwrap();
         let text = "fn main() {}".to_string();
         server
             .documents

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -906,6 +906,7 @@ print("hello")
                 },
             virt_contexts: vec![],
             host_pull_enabled: true,
+            pull_gated: false,
             host: Some(HostRequestContext {
                 uri: uri.clone(),
                 language_id: "rust".to_string(),
@@ -1020,6 +1021,7 @@ print("hello")
                 },
             virt_contexts: vec![],
             host_pull_enabled: true,
+            pull_gated: false,
             host: Some(HostRequestContext {
                 uri: uri.clone(),
                 language_id: "rust".to_string(),

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -903,6 +903,7 @@ print("hello")
                 crate::lsp::lsp_impl::text_document::publish_diagnostic::DiagnosticSnapshotLineage {
                     incarnation: 0,
                     content_version: 0,
+                    settings_generation: 0,
                 },
             virt_contexts: vec![],
             host_pull_enabled: true,
@@ -1018,6 +1019,7 @@ print("hello")
                 crate::lsp::lsp_impl::text_document::publish_diagnostic::DiagnosticSnapshotLineage {
                     incarnation: 0,
                     content_version: 0,
+                    settings_generation: 0,
                 },
             virt_contexts: vec![],
             host_pull_enabled: true,

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -1549,6 +1549,44 @@ print("hello")
             !snapshot.host_pull_enabled,
             "pullFallback = false disables the host pull (host_pull_enabled = false)"
         );
+        assert!(
+            snapshot.narrower_than_editor_pull,
+            "a pullFallback drop must mark the snapshot narrower than the editor's re-pull"
+        );
+    }
+
+    /// The absorption's load-bearing negative: a DEFAULT configuration (no
+    /// per-method overrides) resolves identically under
+    /// `textDocument/publishDiagnostics` and `textDocument/diagnostic`, so the
+    /// snapshot must NOT be flagged narrower — otherwise every default setup
+    /// would force the forwarded-refresh nudge and the refresh↔pull loop the
+    /// flag exists to break would be back for everyone.
+    #[tokio::test]
+    async fn prepare_diagnostic_snapshot_is_not_narrower_under_default_config() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+
+        let uri = Url::parse("file:///test/host_default_not_narrower.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        server
+            .parse_coordinator()
+            .parse_document(uri.clone(), Some("rust"), None)
+            .await;
+
+        let snapshot = server
+            .diagnostic_scheduler()
+            .prepare_diagnostic_snapshot(&uri)
+            .expect("a parsed _self-bridged doc yields a snapshot");
+        assert!(
+            !snapshot.narrower_than_editor_pull,
+            "identical per-method resolutions must not flag the snapshot narrower"
+        );
     }
 
     /// #489: in one-shot CLI mode no editor consumes a proactive

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -48,6 +48,13 @@ pub(crate) struct DiagnosticSnapshot {
     /// selection is empty; the context still drives the re-sync. Always `false`
     /// when `host` is `None`.
     pub(crate) host_pull_enabled: bool,
+    /// Whether `pullFallback = false` excluded a pull-eligible layer from this
+    /// snapshot. The editor's own `textDocument/diagnostic` fan-out does not
+    /// honor `pullFallback` (it is a proactive-cache policy), so when this is
+    /// set, a pull built from this snapshot covers LESS than the editor's
+    /// re-pull would — the forwarded-refresh prefetch must then keep its
+    /// forced editor nudge instead of standing in for it.
+    pub(crate) pull_gated: bool,
     /// Cross-layer combine config for `textDocument/publishDiagnostics`.
     pub(crate) layer_cfg: ResolvedLayerConfig,
 }
@@ -129,6 +136,7 @@ pub(crate) async fn collect_push_diagnostics_with_error_sink(
         mut virt_contexts,
         host,
         host_pull_enabled,
+        pull_gated: _,
         layer_cfg,
     } = snapshot;
 
@@ -300,6 +308,7 @@ mod tests {
                 content_version: 0,
             },
             virt_contexts: vec![virt_ctx_for_server("test")],
+            pull_gated: false,
             host: None,
             host_pull_enabled: false,
             layer_cfg: ResolvedLayerConfig::with_defaults("textDocument/publishDiagnostics"),

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -54,7 +54,7 @@ pub(crate) struct DiagnosticSnapshot {
     /// set, a pull built from this snapshot covers LESS than the editor's
     /// re-pull would — the forwarded-refresh prefetch must then keep its
     /// forced editor nudge instead of standing in for it.
-    pub(crate) pull_gated: bool,
+    pub(crate) narrower_than_editor_pull: bool,
     /// Cross-layer combine config for `textDocument/publishDiagnostics`.
     pub(crate) layer_cfg: ResolvedLayerConfig,
 }
@@ -136,7 +136,7 @@ pub(crate) async fn collect_push_diagnostics_with_error_sink(
         mut virt_contexts,
         host,
         host_pull_enabled,
-        pull_gated: _,
+        narrower_than_editor_pull: _,
         layer_cfg,
     } = snapshot;
 
@@ -308,7 +308,7 @@ mod tests {
                 content_version: 0,
             },
             virt_contexts: vec![virt_ctx_for_server("test")],
-            pull_gated: false,
+            narrower_than_editor_pull: false,
             host: None,
             host_pull_enabled: false,
             layer_cfg: ResolvedLayerConfig::with_defaults("textDocument/publishDiagnostics"),

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -23,6 +23,15 @@ use super::{RequestErrorSink, count_request_errors};
 pub(crate) struct DiagnosticSnapshotLineage {
     pub(crate) incarnation: u64,
     pub(crate) content_version: u64,
+    /// The settings generation the pull surface was resolved under (captured
+    /// BEFORE loading the settings — see
+    /// `SettingsManager::settings_generation`). The refresh prefetch
+    /// re-checks it at commit: a `workspace/didChangeConfiguration` landing
+    /// mid-prefetch can widen the editor's pull surface (new
+    /// server/layer/priorities) without touching the document fields, and an
+    /// old-surface prefetch must then count as incomplete coverage rather
+    /// than vouch for the editor's re-pull.
+    pub(crate) settings_generation: u64,
 }
 
 /// Everything a push-diagnostics task needs, captured at schedule time
@@ -306,6 +315,7 @@ mod tests {
             lineage: DiagnosticSnapshotLineage {
                 incarnation: 0,
                 content_version: 0,
+                settings_generation: 0,
             },
             virt_contexts: vec![virt_ctx_for_server("test")],
             narrower_than_editor_pull: false,

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -58,6 +58,14 @@ pub(crate) struct SettingsManager {
     /// the handshake — only the folder list does.
     folderless_root_path: OnceLock<Option<PathBuf>>,
     settings_snapshot: ArcSwap<SettingsSnapshot>,
+    /// Monotonic count of settings applications. Captured by long-running
+    /// consumers (the diagnostic refresh prefetch) BEFORE loading the
+    /// settings they resolve against, and re-checked at commit: a mismatch
+    /// means a `didChangeConfiguration` landed mid-flight and the resolved
+    /// surface may be stale. Capture-before-load makes the only racy arm the
+    /// safe one (a store between capture and load flags a mismatch even
+    /// though the load already saw the new settings — one over-nudge).
+    settings_generation: std::sync::atomic::AtomicU64,
     /// Client capabilities from initialize() - immutable after initialization.
     /// Uses OnceLock to enforce "set once, read many" semantics per LSP protocol.
     client_capabilities: OnceLock<ClientCapabilities>,
@@ -118,6 +126,7 @@ impl SettingsManager {
                 raw_settings: Arc::new(raw_settings),
                 settings: Arc::new(settings),
             })),
+            settings_generation: std::sync::atomic::AtomicU64::new(0),
             client_capabilities: OnceLock::new(),
             root_markers_deprecation_warned: AtomicBool::new(false),
             auto_install_deprecation_warned: AtomicBool::new(false),
@@ -253,6 +262,17 @@ impl SettingsManager {
             raw_settings: Arc::new(raw_settings),
             settings: Arc::new(settings),
         }));
+        // After the store: a generation observed as unchanged across a
+        // capture→load→commit span then guarantees the loaded settings were
+        // at least as new as the capture (see the field doc).
+        self.settings_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
+    }
+
+    /// The current settings generation (see the field doc).
+    pub(crate) fn settings_generation(&self) -> u64 {
+        self.settings_generation
+            .load(std::sync::atomic::Ordering::Acquire)
     }
 
     /// Returns true only if client declared workspace.semanticTokens.refreshSupport.

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -40,6 +40,12 @@ use crate::lsp::client::check_semantic_tokens_refresh_support;
 pub(crate) struct SettingsSnapshot {
     pub(crate) raw_settings: Arc<RawWorkspaceSettings>,
     pub(crate) settings: Arc<WorkspaceSettings>,
+    /// Monotonic application count, embedded IN the snapshot so settings and
+    /// generation are read atomically from one `ArcSwap` load — a separate
+    /// counter would leave a store→increment gap in which a consumer could
+    /// pair the NEW settings' visibility question with the OLD generation
+    /// (see the diagnostic refresh prefetch's stale-settings guard).
+    pub(crate) generation: u64,
 }
 
 pub(crate) struct SettingsManager {
@@ -58,13 +64,9 @@ pub(crate) struct SettingsManager {
     /// the handshake — only the folder list does.
     folderless_root_path: OnceLock<Option<PathBuf>>,
     settings_snapshot: ArcSwap<SettingsSnapshot>,
-    /// Monotonic count of settings applications. Captured by long-running
-    /// consumers (the diagnostic refresh prefetch) BEFORE loading the
-    /// settings they resolve against, and re-checked at commit: a mismatch
-    /// means a `didChangeConfiguration` landed mid-flight and the resolved
-    /// surface may be stale. Capture-before-load makes the only racy arm the
-    /// safe one (a store between capture and load flags a mismatch even
-    /// though the load already saw the new settings — one over-nudge).
+    /// Allocator for [`SettingsSnapshot::generation`] values. Only ever read
+    /// through the snapshot (see [`Self::settings_generation`]); the atomic
+    /// exists to mint the next value across concurrent applies.
     settings_generation: std::sync::atomic::AtomicU64,
     /// Client capabilities from initialize() - immutable after initialization.
     /// Uses OnceLock to enforce "set once, read many" semantics per LSP protocol.
@@ -125,6 +127,7 @@ impl SettingsManager {
             settings_snapshot: ArcSwap::new(Arc::new(SettingsSnapshot {
                 raw_settings: Arc::new(raw_settings),
                 settings: Arc::new(settings),
+                generation: 0,
             })),
             settings_generation: std::sync::atomic::AtomicU64::new(0),
             client_capabilities: OnceLock::new(),
@@ -258,21 +261,24 @@ impl SettingsManager {
         raw_settings: RawWorkspaceSettings,
         settings: WorkspaceSettings,
     ) {
+        let generation = self
+            .settings_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
         self.settings_snapshot.store(Arc::new(SettingsSnapshot {
             raw_settings: Arc::new(raw_settings),
             settings: Arc::new(settings),
+            generation,
         }));
-        // After the store: a generation observed as unchanged across a
-        // capture→load→commit span then guarantees the loaded settings were
-        // at least as new as the capture (see the field doc).
-        self.settings_generation
-            .fetch_add(1, std::sync::atomic::Ordering::Release);
     }
 
-    /// The current settings generation (see the field doc).
+    /// The generation of the currently visible settings snapshot. Reading it
+    /// and the settings from the SAME `load_settings_pair` snapshot is what
+    /// gives consumers an atomic (settings, generation) view; two separate
+    /// loads can still straddle a store, which a guard must treat as a
+    /// mismatch in the safe (over-nudge) direction.
     pub(crate) fn settings_generation(&self) -> u64 {
-        self.settings_generation
-            .load(std::sync::atomic::Ordering::Acquire)
+        self.settings_snapshot.load().generation
     }
 
     /// Returns true only if client declared workspace.semanticTokens.refreshSupport.

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -1149,6 +1149,19 @@ fn main() {
                             }),
                         );
                     } else {
+                        // Up to TWO baseline-less fulls are legitimate (the
+                        // didOpen pull and the refresh prefetch can race
+                        // before either stores the baseline). A third one
+                        // means a later pull LOST the baseline and is
+                        // re-fetching — answer with a distinguishable message
+                        // so the retention assert cannot pass off a repairing
+                        // full instead of genuine baseline reuse.
+                        diagnostic_generation += 1;
+                        let full_message = if diagnostic_generation <= 2 {
+                            "mock-diagnostic-refresh-unchanged"
+                        } else {
+                            "mock-diagnostic-unexpected-refetch"
+                        };
                         respond(
                             &mut writer,
                             id,
@@ -1161,7 +1174,7 @@ fn main() {
                                         "end": { "line": 0, "character": 1 }
                                     },
                                     "severity": 2,
-                                    "message": "mock-diagnostic-refresh-unchanged"
+                                    "message": full_message
                                 }]
                             }),
                         );

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -75,10 +75,14 @@
 //!   prove that forward is capability-gated (#521).
 //! - `diagnostics-refresh-settled` — advertises pull diagnostics, answers every
 //!   pull with the SAME one-diagnostic set, and sends its refresh 300 ms after
-//!   answering the first pull. The bridge's prefetch then commits an identical
-//!   pull layer, so the editor nudge must be absorbed (the refresh↔pull loop
-//!   breaker); the post-answer delay makes the commit-before-prefetch order
-//!   deterministic.
+//!   answering the FIRST pull (the didOpen host-event pull). The commit was
+//!   never nudged and the editor never pulled, so the pull-view lag must keep
+//!   the forwarded refresh alive.
+//! - `diagnostics-refresh-settled-pulled` — same settled answers, but the
+//!   refresh fires 300 ms after the SECOND pull (the test client's covering
+//!   pull, which clears the lag): the prefetch then commits an identical pull
+//!   layer and the editor nudge must be absorbed (the refresh↔pull loop
+//!   breaker). The post-answer delay is a scheduling margin, not a proof.
 //! - `diagnostics-refresh-burst` — advertises pull diagnostics, sends generation
 //!   1's refresh on `didOpen`, then emits generations 2–10 after the first pull.
 //!   The editor-facing test keeps the leading refresh unacknowledged during that
@@ -232,6 +236,7 @@ fn main() {
                     | "diagnostics-refresh-prefetch-stale"
                     | "diagnostics-refresh-prefetch-unchanged"
                     | "diagnostics-refresh-settled"
+                    | "diagnostics-refresh-settled-pulled"
                     | "diagnostics-refresh-burst"
                     | "diagnostics-push-pullcap" => json!({
                         "diagnosticProvider": {
@@ -1038,15 +1043,23 @@ fn main() {
                     }
                     continue;
                 }
-                if mode == "diagnostics-refresh-settled" {
+                if mode == "diagnostics-refresh-settled"
+                    || mode == "diagnostics-refresh-settled-pulled"
+                {
                     diagnostic_generation += 1;
                     // Every pull answers the SAME settled set, so the
-                    // forwarded-refresh prefetch commits an identical pull layer
-                    // and the bridge absorbs the editor nudge (the refresh↔pull
-                    // loop breaker). The refresh fires only AFTER the first
-                    // pull's answer (plus a settle delay), so the pull layer is
-                    // deterministically committed before the prefetch runs —
-                    // no first-commit race can mark the prefetch as a change.
+                    // forwarded-refresh prefetch commits an identical pull
+                    // layer. In the plain mode the refresh fires after the
+                    // FIRST pull (the didOpen host-event pull) — the editor
+                    // has never pulled, so the un-nudged commit's pull-view
+                    // lag must keep the forward alive. In the `-pulled` mode
+                    // it fires after the SECOND pull (the test client's own
+                    // covering pull, which clears the lag) — the bridge must
+                    // then absorb the nudge (the refresh↔pull loop breaker).
+                    // The post-answer delay gives kakehashi's commit a large
+                    // head start over the refresh's prefetch; it is a margin,
+                    // not a proof — if load ever inverts it, the affected
+                    // test fails red (never a false green).
                     respond(
                         &mut writer,
                         id,
@@ -1062,7 +1075,12 @@ fn main() {
                             }]
                         }),
                     );
-                    if diagnostic_generation == 1 {
+                    let refresh_after = if mode == "diagnostics-refresh-settled" {
+                        1
+                    } else {
+                        2
+                    };
+                    if diagnostic_generation == refresh_after {
                         std::thread::sleep(std::time::Duration::from_millis(300));
                         request(&mut writer, json!(1000), "workspace/diagnostic/refresh");
                     }

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -1130,6 +1130,24 @@ fn main() {
                             id,
                             json!({ "kind": "unchanged", "resultId": "refresh-prefetch-stable" }),
                         );
+                        // Barrier for the retention e2e: the bridge forwards
+                        // downstream window/logMessage upstream, so the test
+                        // can wait until an UNCHANGED report was actually
+                        // answered (and thus resolved against the baseline)
+                        // before asserting retention — the publish marker
+                        // alone can come from the initial full answer.
+                        // type 2 (Warning): the bridge's workspace log
+                        // threshold drops Info-level downstream logs by
+                        // default, and the forward prefixes the server name —
+                        // the test matches by substring for that reason.
+                        notify(
+                            &mut writer,
+                            "window/logMessage",
+                            json!({
+                                "type": 2,
+                                "message": "mock-unchanged-report-answered"
+                            }),
+                        );
                     } else {
                         respond(
                             &mut writer,

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -73,6 +73,12 @@
 //! - `diagnostics-refresh` — sends a `workspace/diagnostic/refresh` server→client
 //!   request on `didOpen`. The bridge forwards it upstream to the editor; used to
 //!   prove that forward is capability-gated (#521).
+//! - `diagnostics-refresh-settled` — advertises pull diagnostics, answers every
+//!   pull with the SAME one-diagnostic set, and sends its refresh 300 ms after
+//!   answering the first pull. The bridge's prefetch then commits an identical
+//!   pull layer, so the editor nudge must be absorbed (the refresh↔pull loop
+//!   breaker); the post-answer delay makes the commit-before-prefetch order
+//!   deterministic.
 //! - `diagnostics-refresh-burst` — advertises pull diagnostics, sends generation
 //!   1's refresh on `didOpen`, then emits generations 2–10 after the first pull.
 //!   The editor-facing test keeps the leading refresh unacknowledged during that
@@ -225,6 +231,7 @@ fn main() {
                     | "diagnostics-refresh-prefetch-fail"
                     | "diagnostics-refresh-prefetch-stale"
                     | "diagnostics-refresh-prefetch-unchanged"
+                    | "diagnostics-refresh-settled"
                     | "diagnostics-refresh-burst"
                     | "diagnostics-push-pullcap" => json!({
                         "diagnosticProvider": {
@@ -999,8 +1006,8 @@ fn main() {
                 }
                 if mode == "diagnostics-refresh-prefetch-ack-order" {
                     diagnostic_generation += 1;
-                    respond(&mut writer, id, json!({ "kind": "full", "items": [] }));
                     if diagnostic_generation == 1 {
+                        respond(&mut writer, id, json!({ "kind": "full", "items": [] }));
                         request(&mut writer, json!(1000), "workspace/diagnostic/refresh");
                         match read_message(&mut reader) {
                             Some(reply) if reply.get("id") == Some(&json!(1000)) => {}
@@ -1008,6 +1015,56 @@ fn main() {
                                 "refresh prefetch started before its downstream ACK: {other:?}"
                             ),
                         }
+                    } else {
+                        // The prefetch pull (generation 2) answers with a CHANGED
+                        // set so the cycle keeps its editor-facing refresh — an
+                        // unchanged covering prefetch is absorbed by the bridge,
+                        // which would leave this test's completion signal unsent.
+                        respond(
+                            &mut writer,
+                            id,
+                            json!({
+                                "kind": "full",
+                                "items": [{
+                                    "range": {
+                                        "start": { "line": 0, "character": 0 },
+                                        "end": { "line": 0, "character": 1 }
+                                    },
+                                    "severity": 2,
+                                    "message": "mock-diagnostic-ack-order-changed"
+                                }]
+                            }),
+                        );
+                    }
+                    continue;
+                }
+                if mode == "diagnostics-refresh-settled" {
+                    diagnostic_generation += 1;
+                    // Every pull answers the SAME settled set, so the
+                    // forwarded-refresh prefetch commits an identical pull layer
+                    // and the bridge absorbs the editor nudge (the refresh↔pull
+                    // loop breaker). The refresh fires only AFTER the first
+                    // pull's answer (plus a settle delay), so the pull layer is
+                    // deterministically committed before the prefetch runs —
+                    // no first-commit race can mark the prefetch as a change.
+                    respond(
+                        &mut writer,
+                        id,
+                        json!({
+                            "kind": "full",
+                            "items": [{
+                                "range": {
+                                    "start": { "line": 0, "character": 0 },
+                                    "end": { "line": 0, "character": 1 }
+                                },
+                                "severity": 2,
+                                "message": "mock-diagnostic-refresh-settled"
+                            }]
+                        }),
+                    );
+                    if diagnostic_generation == 1 {
+                        std::thread::sleep(std::time::Duration::from_millis(300));
+                        request(&mut writer, json!(1000), "workspace/diagnostic/refresh");
                     }
                     continue;
                 }

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -155,6 +155,10 @@ fn main() {
     let mut did_save_count: usize = 0;
     let mut last_did_save_uri: Option<String> = None;
     let mut diagnostic_generation: u64 = 0;
+    // `diagnostics-refresh-prefetch-unchanged`: once ANY unchanged report was
+    // answered, the baseline demonstrably exists — a later baseline-less full
+    // request means a pull LOST it and is re-fetching.
+    let mut unchanged_answered = false;
 
     while let Some(message) = read_message(&mut reader) {
         let method = message
@@ -1136,6 +1140,7 @@ fn main() {
                         // answered (and thus resolved against the baseline)
                         // before asserting retention — the publish marker
                         // alone can come from the initial full answer.
+                        unchanged_answered = true;
                         // type 2 (Warning): the bridge's workspace log
                         // threshold drops Info-level downstream logs by
                         // default, and the forward prefixes the server name —
@@ -1149,18 +1154,18 @@ fn main() {
                             }),
                         );
                     } else {
-                        // Up to TWO baseline-less fulls are legitimate (the
-                        // didOpen pull and the refresh prefetch can race
-                        // before either stores the baseline). A third one
-                        // means a later pull LOST the baseline and is
-                        // re-fetching — answer with a distinguishable message
-                        // so the retention assert cannot pass off a repairing
-                        // full instead of genuine baseline reuse.
-                        diagnostic_generation += 1;
-                        let full_message = if diagnostic_generation <= 2 {
-                            "mock-diagnostic-refresh-unchanged"
-                        } else {
+                        // Baseline-less fulls are legitimate only BEFORE any
+                        // unchanged report was answered (the didOpen pull and
+                        // the prefetch may race before either stores the
+                        // baseline). After one, the baseline demonstrably
+                        // existed — a baseline-less request means a pull LOST
+                        // it and is re-fetching, so answer with a
+                        // distinguishable message: the retention assert must
+                        // not pass off a repairing full as baseline reuse.
+                        let full_message = if unchanged_answered {
                             "mock-diagnostic-unexpected-refetch"
+                        } else {
+                            "mock-diagnostic-refresh-unchanged"
                         };
                         respond(
                             &mut writer,

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -1010,6 +1010,34 @@ fn e2e_downstream_refresh_with_unchanged_prefetch_is_absorbed() {
 }
 
 #[test]
+fn e2e_downstream_refresh_forwarded_when_editor_never_pulled() {
+    // Pull-view lag debt: the didOpen host-event pull commits the settled set
+    // into the cache WITHOUT any editor nudge (pull-origin commits never
+    // refresh, by design), and this editor has never pulled — so its pull
+    // namespace cannot hold that set. The refresh's prefetch then compares
+    // equal against kakehashi's OWN record, but that record is exactly the
+    // data the editor is missing: absorbing here would let the editor rot
+    // until the next edit. The debt recorded by the un-nudged commit must
+    // keep the forward alive; it is cleared only by a covering editor pull
+    // (see e2e_downstream_refresh_with_unchanged_prefetch_is_absorbed for
+    // the post-pull absorption arm).
+    let (mut client, _config_dir) =
+        init_client_with_mode_caps("diagnostics-refresh-settled", refresh_capable_caps());
+    open_host(&mut client);
+
+    let (refresh_id, _) = client
+        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(15))
+        .expect(
+            "an un-nudged pull-layer commit the editor never pulled must keep \
+             the forwarded refresh alive (pull-view lag debt)",
+        );
+    client.send_response(refresh_id, json!(null));
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
 fn e2e_downstream_refresh_prefetches_before_forwarding() {
     let (mut client, _config_dir) =
         init_client_with_mode_caps("diagnostics-refresh-prefetch", refresh_capable_caps());

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -1135,8 +1135,14 @@ fn e2e_downstream_refresh_skips_pull_fallback_disabled_contexts() {
     );
     open_host(&mut client);
 
+    // Discrimination math for the window: the mock sleeps 1000 ms before
+    // answering any pull, so a wrongly-dispatched pull delays the refresh to
+    // ≥ 1000 ms + mock startup (~350 ms baseline observed); the skip path
+    // delivers at startup cost alone (~340-500 ms, jittering to ~900 ms under
+    // ambient load). 900 ms keeps a clean margin on both sides where the old
+    // 600 ms window flaked against the startup jitter.
     let (refresh_id, _) = client
-        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(600))
+        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(900))
         .expect("pullFallback=false must not delay the editor refresh with a downstream pull");
     client.send_response(refresh_id, json!(null));
     assert!(

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -1514,9 +1514,12 @@ fn e2e_downstream_refresh_gated_off_for_refresh_incapable_client() {
     // #521: the same downstream refresh must NOT be forwarded when the client did
     // not advertise `workspace.diagnostics.refreshSupport` — forwarding it would
     // leak a tower-lsp pending-request entry on a client that silently ignores it.
-    // Empty capabilities (`init_client_with_mode`) → refresh unsupported. Paired
-    // with the positive test above (same mock mode), so a "no refresh" result here
-    // is the gate working, not the mock failing to emit.
+    // Empty capabilities (`init_client_with_mode`) → refresh unsupported. Positive
+    // evidence that a refresh-capable, never-pulling client WOULD receive the
+    // forward (so "no refresh" here is the gate working, not the mock failing to
+    // emit or the absorption firing) is pinned by
+    // e2e_downstream_refresh_forwarded_when_editor_never_pulled and
+    // e2e_downstream_refresh_prefetches_before_forwarding.
     let (mut client, _config_dir) = init_client_with_mode("diagnostics-refresh");
     open_host(&mut client);
 

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -966,19 +966,43 @@ fn open_host_with_text(client: &mut LspClient, text: &str) {
 }
 
 #[test]
-fn e2e_downstream_refresh_forwarded_to_refresh_capable_client() {
-    // #521: a downstream server's own `workspace/diagnostic/refresh` request is
-    // forwarded upstream to the editor. With a refresh-capable client the bridge
-    // relays it (the `diagnostics-refresh` mock fires one on didOpen).
+fn e2e_downstream_refresh_with_unchanged_prefetch_is_absorbed() {
+    // The refresh↔pull loop breaker: a downstream `workspace/diagnostic/refresh`
+    // whose prefetch commits a pull layer IDENTICAL to the cached one proves the
+    // editor's re-pull would answer `unchanged`, so the bridge absorbs the nudge
+    // instead of forwarding it. Forwarding it unconditionally closed a feedback
+    // loop on quiescent multi-region files: nudge → editor re-pull → downstream
+    // analysis → another downstream refresh → nudge, ~1 Hz forever with zero
+    // edits. (The forward-when-something-changed guarantee (#521) stays pinned
+    // by e2e_downstream_refresh_prefetches_before_forwarding and the ack-order/
+    // failure/stale tests, whose prefetches all end in a change or a coverage
+    // gap.)
     let (mut client, _config_dir) =
-        init_client_with_mode_caps("diagnostics-refresh", refresh_capable_caps());
+        init_client_with_mode_caps("diagnostics-refresh-settled", refresh_capable_caps());
     open_host(&mut client);
+
+    // The didOpen host-event pull commits the settled set first — the mock
+    // fires its refresh only 300 ms after answering that pull.
+    client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(15),
+            |params| {
+                params["diagnostics"].as_array().is_some_and(|diagnostics| {
+                    diagnostics.iter().any(|diagnostic| {
+                        diagnostic["message"] == json!("mock-diagnostic-refresh-settled")
+                    })
+                })
+            },
+        )
+        .expect("precondition: the didOpen pull layer is committed and published");
 
     assert!(
         client
-            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(15))
-            .is_some(),
-        "a downstream's workspace/diagnostic/refresh must reach a refresh-capable editor (#521)"
+            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(1500))
+            .is_none(),
+        "a refresh whose covering prefetch changed nothing must be absorbed, \
+         not forwarded (refresh↔pull loop)"
     );
 
     client.send_request("shutdown", json!(null));
@@ -1197,10 +1221,31 @@ fn e2e_downstream_refresh_preserves_unchanged_prefetch_results() {
     );
     open_host(&mut client);
 
-    let (refresh_id, _) = client
-        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(5))
-        .expect("the unchanged prefetch must complete before forwarding");
-    client.send_response(refresh_id, json!(null));
+    // The completion signal is the committed pull layer's publish, NOT an
+    // editor refresh: the didOpen pull and the refresh prefetch race for the
+    // first commit, and on the arm where the didOpen pull wins the prefetch's
+    // `unchanged` report is absorbed without a forward (the loop breaker) —
+    // waiting on the refresh here would flake on exactly that arm.
+    client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(5),
+            |params| {
+                params["diagnostics"].as_array().is_some_and(|diagnostics| {
+                    diagnostics.iter().any(|diagnostic| {
+                        diagnostic["message"] == json!("mock-diagnostic-refresh-unchanged")
+                    })
+                })
+            },
+        )
+        .expect("the unchanged prefetch must preserve and publish the prior diagnostics");
+    // On the arm where the prefetch committed first, its change DID forward a
+    // refresh — answer it if present so shutdown is clean on both arms.
+    if let Some((refresh_id, _)) =
+        client.wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(100))
+    {
+        client.send_response(refresh_id, json!(null));
+    }
 
     let pulled = client.send_request(
         "textDocument/diagnostic",

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -1015,6 +1015,9 @@ fn e2e_downstream_refresh_with_unchanged_prefetch_is_absorbed() {
         "precondition: the covering pull delivers the settled set: {pulled}"
     );
 
+    // The negative window must exceed the forwarded-refresh max-wait (1 s
+    // default: features.workspace_diagnostic_refresh.max_wait_ms) plus margin,
+    // so a wrongly-sent trailing refresh would still land inside it.
     assert!(
         client
             .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(1500))

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -1296,6 +1296,31 @@ fn e2e_downstream_refresh_preserves_unchanged_prefetch_results() {
         client.send_response(refresh_id, json!(null));
     }
 
+    // First pull: by now the downstream baseline (resultId
+    // "refresh-prefetch-stable") is established by whichever earlier pull's
+    // FULL answer stored it, so this fan-out carries previousResultId and the
+    // mock answers `kind: unchanged`, emitting the marker. (The didOpen pull
+    // and the prefetch can BOTH land without a baseline on a racy arm — full
+    // answers only — which is why the barrier hangs off the client's own pull
+    // rather than the earlier publish.) Async + notification wait because the
+    // synchronous response helper discards notifications that arrive while it
+    // waits; this pull's response is deliberately dropped with them.
+    let _pull_id = client.send_request_async(
+        "textDocument/diagnostic",
+        json!({ "textDocument": { "uri": MD_URI } }),
+    );
+    client
+        .wait_for_notification_where(&["window/logMessage"], Duration::from_secs(5), |params| {
+            // Substring: the bridge prefixes the originating server's name.
+            params["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("mock-unchanged-report-answered"))
+        })
+        .expect("the pull must exercise the unchanged-report baseline reuse");
+
+    // Second pull, synchronous: its downstream fan-out resolves the unchanged
+    // report against the stored baseline again — the retention assert below
+    // therefore checks the baseline-reuse path, not an initial full answer.
     let pulled = client.send_request(
         "textDocument/diagnostic",
         json!({ "textDocument": { "uri": MD_URI } }),

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -968,21 +968,22 @@ fn open_host_with_text(client: &mut LspClient, text: &str) {
 #[test]
 fn e2e_downstream_refresh_with_unchanged_prefetch_is_absorbed() {
     // The refresh↔pull loop breaker: a downstream `workspace/diagnostic/refresh`
-    // whose prefetch commits a pull layer IDENTICAL to the cached one proves the
-    // editor's re-pull would answer `unchanged`, so the bridge absorbs the nudge
-    // instead of forwarding it. Forwarding it unconditionally closed a feedback
-    // loop on quiescent multi-region files: nudge → editor re-pull → downstream
-    // analysis → another downstream refresh → nudge, ~1 Hz forever with zero
-    // edits. (The forward-when-something-changed guarantee (#521) stays pinned
-    // by e2e_downstream_refresh_prefetches_before_forwarding and the ack-order/
+    // whose prefetch commits a pull layer IDENTICAL to the one a covering
+    // editor pull already received is absorbed instead of forwarded (the
+    // editor's re-pull would answer `unchanged`). Forwarding it
+    // unconditionally closed a feedback loop on quiescent multi-region files:
+    // nudge → editor re-pull → downstream analysis → another downstream
+    // refresh → nudge, ~1 Hz forever with zero edits. (The
+    // forward-when-something-changed guarantee (#521) stays pinned by
+    // e2e_downstream_refresh_prefetches_before_forwarding and the ack-order/
     // failure/stale tests, whose prefetches all end in a change or a coverage
-    // gap.)
+    // gap; the never-pulled arm is pinned by
+    // e2e_downstream_refresh_forwarded_when_editor_never_pulled.)
     let (mut client, _config_dir) =
-        init_client_with_mode_caps("diagnostics-refresh-settled", refresh_capable_caps());
+        init_client_with_mode_caps("diagnostics-refresh-settled-pulled", refresh_capable_caps());
     open_host(&mut client);
 
-    // The didOpen host-event pull commits the settled set first — the mock
-    // fires its refresh only 300 ms after answering that pull.
+    // The didOpen host-event pull commits the settled set first.
     client
         .wait_for_notification_where(
             &["textDocument/publishDiagnostics"],
@@ -997,12 +998,29 @@ fn e2e_downstream_refresh_with_unchanged_prefetch_is_absorbed() {
         )
         .expect("precondition: the didOpen pull layer is committed and published");
 
+    // A covering editor pull delivers that set into the pull namespace and
+    // clears the un-nudged commit's pull-view lag — only then is absorption
+    // legitimate. The mock fires its refresh 300 ms after answering THIS
+    // pull, so the lag-clearing order is under the test's control.
+    let pulled = client.send_request(
+        "textDocument/diagnostic",
+        json!({ "textDocument": { "uri": MD_URI } }),
+    );
+    assert!(
+        pulled["result"]["items"]
+            .as_array()
+            .is_some_and(|diagnostics| diagnostics.iter().any(|diagnostic| {
+                diagnostic["message"] == json!("mock-diagnostic-refresh-settled")
+            })),
+        "precondition: the covering pull delivers the settled set: {pulled}"
+    );
+
     assert!(
         client
             .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_millis(1500))
             .is_none(),
-        "a refresh whose covering prefetch changed nothing must be absorbed, \
-         not forwarded (refresh↔pull loop)"
+        "a refresh whose covering prefetch changed nothing (and whose set the \
+         editor already pulled) must be absorbed, not forwarded (refresh↔pull loop)"
     );
 
     client.send_request("shutdown", json!(null));


### PR DESCRIPTION
## Problem

On a quiescent multi-region markdown file (616 fenced regions: 308 python / 231 lua / 77 ts), diagnostics visibly appeared and disappeared with **zero edits**. Log forensics (`__ignored/log/01KZK63NB8ZFDVZT9HYS498RVG/`) showed a self-sustaining ~1 Hz feedback loop:

editor pull → live fan-out to all regions → downstream servers analyze → they emit `workspace/diagnostic/refresh` (tsgo 78×, basedpyright 21× in ~110 s) → kakehashi forwards it **forced** → editor re-pulls → … — even while every pull answered `kind: unchanged` (70 in a row). The load (~616 downstream pulls per second-with-activity; 49,002 basedpyright progress creates) eventually killed basedpyright; the in-flight cycle then answered without its diagnostics (2310 → 1694 items) — the visible flicker — and its respawn restored them 2 s later. The reader misreported that death as `missing Content-Length header`.

## Fix

**Absorption**: `complete_forwarded_refresh_cycle` forwards the editor nudge only when its prefetch **changed** some host's published set or **could not vouch** for the editor's re-pull surface (`ForwardedPrefetchSummary`). An unchanged, fully covering prefetch after a covering editor pull absorbs the forward — starving the loop's editor leg.

**Coverage gaps that keep the forced send** (each review-found, each pinned by a red-first test):
- `pullFallback = false` layers and any per-method config divergence (publish vs diagnostic keys — including the #685 publish wire SEAL, whose delivery signal this forward is): `DiagnosticSnapshot::narrower_than_editor_pull`.
- Open documents without a parse snapshot (didChange window, parse give-up, `invalidate_parse`).
- Failed/partial pulls (error tee; panicked region tasks counted), edit-raced commits, settings reloads mid-prefetch (generation embedded in the ArcSwap snapshot + cycle-level fence).
- **Pull-view lag**: editor-origin nudge-less commits (`publish_pull_layer`/`clear_pull_layer`/prefetch commit) can outrun the editor's own pull. A two-phase protocol (revision-stamped pending mark at mutation → converted to a confirmed, serial-stamped lag by whichever republish records the Changed set, under the per-host republish lock) anchors absorption to what the editor actually pulled; a covering pull clears only up to the serial it captured at entry (#745-class safe).
- A tree-less pull over a non-empty PullLayer is now a **degraded** answer (no serve-mark, recovery refresh once geometry lands), like the existing cached-Region case.

**Reader EOF classification**: `UnexpectedEof` with "downstream closed stdout (EOF / mid-headers / mid-body)" instead of the phantom framing error; the truncated `\r` separator window is closed; `missing Content-Length header` remains only for its genuine case — and now **quotes the stray stdout line** that broke the frame (truncated, char-boundary safe), since that line is the crash evidence.

**Outbound queue sizing**: `OUTBOUND_QUEUE_CAPACITY` 256 → 4096. The 308-region fan-out overflowed kakehashi's own per-connection queue (~16k `try_send` failures in 45 s), dropping `didOpen` notifications and failing requests — a self-inflicted partial-answer source.

**Downstream stderr capture**: downstream stderr was `Stdio::null()`; it is now drained into the log, bounded (500 lines × 2000 bytes, reading past the caps so the pipe never blocks the child; byte-chunked + loss-tolerant decode, so binary garbage can't stop the drain). This is the crash-triage channel that identified every downstream death during this investigation.

**Deliberately NOT fixed here** (maintainer decision): framing corruption from a downstream stays **fatal and honestly reported**. basedpyright under multi-hundred-region load intermittently writes an unframed `$/progress` body abutting the next frame's header — that is its bug to fix; kakehashi does not resync past it or tolerate stray blank lines. Instead, the load that triggers it is being reduced (#974, #975, #976), and the quoted framing error attributes each occurrence.

## Review

- /revise stage 1: 11-perspective local review ×2 rounds — all findings fixed or refuted with evidence.
- codex MCP: continued thread to "no comments to provide", then FRESH sessions until one answered clean on its first response (5 sessions; each round's findings fixed same-day, incl. the settle-transition lock-order race with a deterministic lock-order pin).
- Bots: Copilot, Gemini, Qodo, Greptile (5/5), CodeRabbit — all threads addressed; CodeRabbit's stderr-drain finding (UTF-8 abort / unbounded line buffering) fixed in-PR.
- Gates: lib 3390/0 · full e2e 59 binaries / 1800 tests · clippy `--all-targets --features e2e` clean · fmt clean.

## Follow-ups (filed)

- #974 — per-connection in-flight request cap (semaphore; timeout scoped after permit): root fix for the burst-tail timeout storm.
- #975 — single-flight the editor-pull / refresh-prefetch duplicate pulls per `(server, region)`.
- #976 — opt-out of advertising `workDoneProgress` to downstreams (kills the 49k-progress stream at the source).
- #977 — proactive recovery after crash-evict (respawn + re-pull; today diagnostics stay gone until an unrelated trigger).
- #978 — damp the forced nudge when prefetch coverage stays incomplete across consecutive cycles (backstop for any future saturation source).
- #979 — ResponseRouter mislabels late answers after timeout as "duplicate request ID".
- Upstream: report basedpyright's unframed-`$/progress` write race with the captured evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Diagnostic refreshes are forwarded only when needed, reducing duplicate pulls when results are unchanged.
  - Improved detection of incomplete coverage, configuration changes, and diagnostic updates.
  - Diagnostic snapshots more accurately reflect editor pull coverage and settings changes.
  - Improved handling of burst traffic between the editor and language servers.

- **Bug Fixes**
  - Incomplete diagnostic requests now retain pending updates for later pulls.
  - Improved handling of interrupted connections, truncated messages, clean shutdowns, and diagnostic server output.

- **Tests**
  - Expanded coverage for refresh suppression, incomplete diagnostics, configuration changes, and connection interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
