### PR TITLE
ci: run CI on pull requests against any base branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yaml` filters the `pull_request` trigger to `branches: [main]`. A pull request whose base is *not* `main` therefore matches no trigger and gets **zero checks** — it shows as green because nothing ever ran, not because anything passed.

This repo develops in stacked PRs. The current #899–#913 stack has 10 PRs based on other stack branches (900, 901, 905, 906, 908, 909, 910, 911, 912, 913); none of them has ever been CI-verified.

## Fix

Drop the `branches` filter from `pull_request` so every PR runs CI regardless of base.

## Run counts are unchanged

`push` stays filtered to `main`. A PR targeting main still gets exactly one `pull_request` run, and the merge still gets exactly one `push` run. The only new runs are for PRs that previously got none.

No job was touched — only the trigger block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Continuous integration checks now run for pull requests targeting any branch, rather than only the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->