### PR TITLE
bridge: per-connection in-flight request cap; diagnostic deadline measured from send

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -506,6 +506,7 @@ Configure language servers for bridging LSP requests in injection regions.
 | `initializationOptions` | Optional initialization options forwarded during the downstream server's `initialize` request |
 | `workspaceMarkers` | Marker files/directories locating the workspace root the server is initialized with, following Neovim's `vim.fs.root` `(string\|string[])[]` shape. (The pre-rename key `rootMarkers` is still accepted as a deprecated alias.) Entries are tried **in list order** (earlier = higher priority): each entry is searched up the triggering document's ancestors nearest-first before the next entry is tried, so a higher-priority marker in a far ancestor outranks a lower-priority one sitting next to the document. A **nested array** is one equal-priority group where the nearest ancestor containing any of its names wins — e.g. `[["stylua.toml", ".luarc.json"], ".git"]` means "nearest of stylua.toml/.luarc.json, otherwise .git". The first matching entry's directory becomes the server's `rootUri` and sole workspace folder. Default: `[".git"]`. No marker hit falls back to the client-supplied root; an explicit `[]` disables the search. The connection pool is keyed by `(server, resolved root)`, so in a multi-root monorepo documents under different marker roots get their own downstream process, each rooted correctly; documents sharing a root (or the no-marker fallback) share one process. Trade-off: process count grows with the number of distinct roots opened, and there is currently no idle-eviction — a long session touching many roots keeps one process per root alive until shutdown. Servers that operate purely on `workspaceFolders` can opt out of this growth with `preferSharedInstance` (below). |
 | `onTypeFormattingTriggers` | Trigger characters for bridged `textDocument/onTypeFormatting` (e.g. `["}", ";"]`). kakehashi advertises the sorted union across all servers at initialize and forwards a request to a downstream server only when that server's own capabilities declare the typed character. Unset everywhere (default) → the capability is not advertised. |
+| `maxConcurrentRequests` | Cap on concurrent in-flight requests kakehashi keeps open to this server, **per spawned connection** (per-root pooling means one cap per `(server, root)` process). Requests beyond the cap wait for a free slot instead of piling onto the server, and the diagnostic answer deadline starts only when a request is actually sent, so a many-region burst queues instead of timing out. Default `256` — a generous backstop against pathological pile-ups; lower it per server for a downstream that struggles under concurrent load. Zero is rejected at parse time. The value sizes the connection's slot pool at spawn, so a change takes effect at the server's next (re)spawn — a config reload that changes it restarts the process. |
 | `preferSharedInstance` | Prefer reusing **one** downstream process across every workspace root for this server instead of the default one-process-per-marker-root (above). Default `false`. It is a *preference*, honored only when the downstream server advertises `workspace.workspaceFolders.{supported, changeNotifications}`: when it does, kakehashi routes all roots to a single connection and announces each new root with `workspace/didChangeWorkspaceFolders`; when it does not, kakehashi logs once and silently falls back to the per-root-instance model. Because that fallback is universal, a blanket `languageServers._.preferSharedInstance = true` is safe across a mixed set of servers. Use it to bound process count and get cross-root navigation for servers that key purely off `workspaceFolders`; leave it `false` for servers needing per-root isolation (per-root virtualenv, conflicting tool/package versions) or that key behavior off the immutable `rootUri`. Note: removal/idle-eviction of folders is not modeled yet — the set only grows. |
 
 > **Migration note**: `workspaceMarkers` was previously named `rootMarkers`
@@ -517,7 +518,8 @@ Configure language servers for bridging LSP requests in injection regions.
 
 A `languageServers._` wildcard entry supplies defaults that every server
 inherits field-by-field (wildcard-config-inheritance) — e.g. set
-`workspaceMarkers` or `preferSharedInstance` once for all servers. A concrete
+`workspaceMarkers`, `preferSharedInstance`, or `maxConcurrentRequests` once
+for all servers. A concrete
 server's explicit value overrides the wildcard, so `_.preferSharedInstance =
 true` can still be opted out of per server with `preferSharedInstance =
 false`. A wildcard-only entry is never spawned itself, and a concrete server
@@ -550,8 +552,10 @@ workspace root by default — the connection pool has no language dimension, and
 virtual `didOpen` for every injection *region* it matches, and joins every
 region's fan-out. That number is larger than it looks in markdown: the shipped
 injection query emits a `markdown_inline` region per inline node and per table
-cell, so a prose file yields regions in the hundreds. Nothing bounds it
-(`maxFanOut` caps servers per region, not regions). Use the per-host bridge
+cell, so a prose file yields regions in the hundreds. Nothing bounds the region
+count (`maxFanOut` caps servers per region, not regions), though in-flight
+requests to any one server are capped by `maxConcurrentRequests` — the excess
+queues rather than piling on. Use the per-host bridge
 filter to exclude what the server should not see:
 
 ```toml

--- a/docs/architecture-decisions/ls-bridge-timeout-hierarchy.md
+++ b/docs/architecture-decisions/ls-bridge-timeout-hierarchy.md
@@ -91,6 +91,14 @@ Initialization (60s) > Liveness (30-120s) > Per-request (5s)
 Global Shutdown overrides all (highest priority)
 ```
 
+> **#974 amendment**: the per-request deadline (5s, diagnostics) bounds only
+> the ANSWER, measured from send. Request-slot queue wait (the per-connection
+> `maxConcurrentRequests` cap) and connection init precede it and are bounded
+> by the holders' own deadlines and by Initialization respectively — so a
+> single request's wall clock is no longer nested inside the 5s figure. On
+> expiry the abandoned downstream request is `$/cancelRequest`ed.
+
+
 **Global Shutdown Design:**
 - Single ceiling for entire shutdown (not per-server)
 - Graceful attempts → SIGTERM → SIGKILL escalation

--- a/docs/architecture-decisions/ls-bridge-timeout-hierarchy.md
+++ b/docs/architecture-decisions/ls-bridge-timeout-hierarchy.md
@@ -16,7 +16,9 @@ This decision coordinates timeout mechanisms across the bridge architecture. It 
 
 **Phase 1 Timeouts** (implemented now): Initialization (Tier 0), Liveness (Tier 2), Global Shutdown (Tier 3)
 
-**Phase 3 Timeout** (future): Per-Request (Tier 1) — only needed for multi-server aggregation
+**Diagnostic answer deadline** (implemented, #974): 5s per diagnostic pull, measured from send — see the amendment under Relationships below. Distinct from the still-future aggregation deadline:
+
+**Phase 3 Timeout** (future): Per-Request (Tier 1) for multi-server aggregation — a wall-clock bound on the whole fan-out, which the #974 deadline deliberately is NOT
 
 ## Context
 
@@ -25,7 +27,7 @@ The async bridge architecture defines timeout systems across three decisions:
 1. **Initialization Timeout** (ls-bridge-async-connection): Bounds server initialization time during startup
 2. **Liveness Timeout** (ls-bridge-async-connection): Detects hung servers (unresponsive to pending requests)
 3. **Global Shutdown Timeout** (ls-bridge-graceful-shutdown): Bounds total shutdown time
-4. **Per-Request Timeout** (ls-bridge-server-pool-coordination): Bounds user-facing latency for multi-server aggregation *[Phase 3 only]*
+4. **Per-Request Timeout** (ls-bridge-server-pool-coordination): Bounds user-facing latency for multi-server aggregation *[Phase 3 only; the implemented #974 diagnostic deadline is a different instrument — it bounds one request's ANSWER from send, not the aggregation]*
 
 ### The Problem
 
@@ -51,9 +53,15 @@ Without clear precedence rules, timeout interactions are non-deterministic:
 - **Liveness timeout**: Only during `Ready` state with pending requests; disabled on shutdown
 - **Global shutdown**: Overrides all other timeouts (highest priority)
 
+### Implemented (#974): Diagnostic Answer Deadline
+
+| Timeout | Duration | Trigger | Action |
+|---------|----------|---------|--------|
+| Diagnostic answer deadline | 5s (`DIAGNOSTIC_RESPONSE_TIMEOUT`) | Every diagnostic pull (virt + host), any fan-out width, measured from send | `$/cancelRequest` the downstream request, count a request failure (→ `coverage_incomplete`) |
+
 ### Phase 3 Addition: Per-Request Timeout (Tier 1)
 
-> **Note**: Only needed for multi-server aggregation. In Phase 1, liveness timeout provides sufficient protection.
+> **Note**: Only needed for multi-server aggregation. In Phase 1, liveness timeout provides sufficient protection; since #974, diagnostics additionally carry the answer deadline above.
 
 | Tier | Timeout | Duration | Trigger | Action |
 |------|---------|----------|---------|--------|
@@ -83,7 +91,8 @@ Without clear precedence rules, timeout interactions are non-deterministic:
 | **Initialization** | 30-60s | Heavy servers (rust-analyzer) need time to index |
 | **Liveness** | 30-120s | Detect hung servers without false positives |
 | **Global Shutdown** | 5-15s | Balance clean exit vs user wait time |
-| **Per-Request** *(Phase 3)* | 2-5s | User-facing latency bound for aggregation |
+| **Diagnostic answer deadline** *(#974)* | 5s | Bound the wait for one diagnostic ANSWER, from send |
+| **Per-Request** *(Phase 3, future)* | 2-5s | User-facing latency bound for aggregation |
 
 **Relationships:**
 ```
@@ -158,6 +167,8 @@ Let implementation details determine which timeout wins.
 
 **Phase 1**: Three timeout tiers — Initialization (30-60s), Liveness (30-120s), Global Shutdown (5-15s)
 
-**Phase 3**: Adds Per-Request timeout (2-5s) for multi-server aggregation
+**#974 (implemented)**: Diagnostic answer deadline (5s from send, cancel on expiry); request-slot queue wait and init are outside it
+
+**Phase 3 (future)**: Adds Per-Request timeout (2-5s) for multi-server aggregation
 
 **Key Rule**: Global shutdown overrides all other timeouts

--- a/src/config.rs
+++ b/src/config.rs
@@ -861,6 +861,7 @@ mod tests {
             prefer_shared_instance: None,
             enabled: None,
             settings: None,
+            max_concurrent_requests: None,
         };
 
         // Only the built-in `_` defaults entry (empty cmd): not runnable.
@@ -897,6 +898,7 @@ mod tests {
             prefer_shared_instance: None,
             enabled,
             settings: None,
+            max_concurrent_requests: None,
         };
 
         // Directly disabled: not a willSave consumer even with a real cmd.

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -98,6 +98,12 @@ fn default_language_servers() -> HashMap<String, BridgeServerConfig> {
             // disables every server by default; a concrete server can then
             // opt back in individually with its own `enabled: true`.
             enabled: Some(true),
+            // Spell out the built-in in-flight request cap (#974) so the
+            // template documents the knob; parallel-capable servers can
+            // raise it per server.
+            max_concurrent_requests: std::num::NonZeroUsize::new(
+                crate::config::settings::DEFAULT_MAX_CONCURRENT_REQUESTS,
+            ),
         },
     )])
 }

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -539,6 +539,25 @@ mod tests {
         );
     }
 
+    /// Template ↔ runtime sync for the request-slot cap (#974): the `_`
+    /// wildcard the template emits must carry exactly the value
+    /// `effective_max_concurrent_requests()` falls back to, or the generated
+    /// config would document a different default than the one that runs.
+    #[test]
+    fn default_settings_documents_max_concurrent_requests_default() {
+        let settings = default_settings();
+        let servers = settings
+            .language_servers
+            .as_ref()
+            .expect("should have languageServers");
+        let wildcard = servers.get(WILDCARD_KEY).expect("should have '_' entry");
+        assert_eq!(
+            wildcard.max_concurrent_requests,
+            std::num::NonZeroUsize::new(crate::config::settings::DEFAULT_MAX_CONCURRENT_REQUESTS),
+            "the template documents the built-in in-flight request cap"
+        );
+    }
+
     #[test]
     fn default_capture_mappings_contains_variable_mapping() {
         let mappings = default_capture_mappings();

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -75,8 +75,8 @@ pub fn config_init_settings() -> RawWorkspaceSettings {
 
 /// Returns the default languageServers map: a defaults-only `_` wildcard
 /// entry documenting the built-in `workspaceMarkers`, `preferSharedInstance`,
-/// and `enabled` defaults that every concrete server inherits
-/// (wildcard-config-inheritance). Not spawnable itself — lookups skip the
+/// `enabled`, and `maxConcurrentRequests` defaults that every concrete server
+/// inherits (wildcard-config-inheritance). Not spawnable itself — lookups skip the
 /// wildcard key and any server that isn't [`BridgeServerConfig::is_spawnable`]
 /// (empty resolved cmd, or resolved `enabled: false`).
 fn default_language_servers() -> HashMap<String, BridgeServerConfig> {
@@ -99,8 +99,8 @@ fn default_language_servers() -> HashMap<String, BridgeServerConfig> {
             // opt back in individually with its own `enabled: true`.
             enabled: Some(true),
             // Spell out the built-in in-flight request cap (#974) so the
-            // template documents the knob; parallel-capable servers can
-            // raise it per server.
+            // template documents the knob; lower it per server for a
+            // downstream that struggles under concurrent load.
             max_concurrent_requests: std::num::NonZeroUsize::new(
                 crate::config::settings::DEFAULT_MAX_CONCURRENT_REQUESTS,
             ),

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -131,6 +131,11 @@ pub(crate) fn merge_bridge_server_configs(
         // concrete server's explicit `enabled` overrides the wildcard, so
         // `_.enabled: false` can be opted back into per server.
         enabled: overlay.enabled.or(base.enabled),
+        // Overlay-wins-when-present, mirroring `enabled`: a concrete server's
+        // explicit `maxConcurrentRequests` overrides the wildcard (#974).
+        max_concurrent_requests: overlay
+            .max_concurrent_requests
+            .or(base.max_concurrent_requests),
     }
 }
 
@@ -725,6 +730,7 @@ mod tests {
                         prefer_shared_instance: None,
                         enabled: None,
                         settings: None,
+                        max_concurrent_requests: None,
                     },
                 ),
                 (
@@ -738,6 +744,7 @@ mod tests {
                         prefer_shared_instance: None,
                         enabled: None,
                         settings: None,
+                        max_concurrent_requests: None,
                     },
                 ),
             ])),
@@ -808,6 +815,7 @@ mod tests {
                         prefer_shared_instance: None,
                         enabled: None,
                         settings: None,
+                        max_concurrent_requests: None,
                     },
                 ),
                 (
@@ -825,6 +833,7 @@ mod tests {
                         prefer_shared_instance: None,
                         enabled: None,
                         settings: None,
+                        max_concurrent_requests: None,
                     },
                 ),
             ])),
@@ -890,6 +899,7 @@ mod tests {
                     prefer_shared_instance: None,
                     enabled: None,
                     settings: None,
+                    max_concurrent_requests: None,
                 },
             )])),
             ..Default::default()
@@ -1281,6 +1291,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         )]);
         let resolved = resolve_with_wildcard(&servers, "ra", merge_bridge_server_configs).unwrap();
@@ -1299,6 +1310,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         )]);
         let resolved = resolve_with_wildcard(&servers, "ra", merge_bridge_server_configs).unwrap();
@@ -1318,6 +1330,7 @@ mod tests {
                     prefer_shared_instance: None,
                     enabled: None,
                     settings: None,
+                    max_concurrent_requests: None,
                 },
             ),
             (
@@ -1331,6 +1344,7 @@ mod tests {
                     prefer_shared_instance: None,
                     enabled: None,
                     settings: None,
+                    max_concurrent_requests: None,
                 },
             ),
         ]);
@@ -1362,6 +1376,7 @@ mod tests {
             prefer_shared_instance: None,
             enabled: None,
             settings: None,
+            max_concurrent_requests: None,
         };
 
         // Unset overlay inherits from base (wildcard default applies)
@@ -1374,6 +1389,7 @@ mod tests {
             prefer_shared_instance: None,
             enabled: None,
             settings: None,
+            max_concurrent_requests: None,
         };
         let merged = merge_bridge_server_configs(&base, &inheriting);
         assert_eq!(
@@ -1419,6 +1435,7 @@ mod tests {
             prefer_shared_instance: prefer,
             settings: None,
             enabled: None,
+            max_concurrent_requests: None,
         };
 
         // Unset overlay inherits the base (wildcard) value.
@@ -1444,6 +1461,35 @@ mod tests {
         );
     }
 
+    /// `maxConcurrentRequests` merges overlay-wins-when-present, exactly like
+    /// `enabled`: a wildcard `_` cap applies to every server, and a concrete
+    /// server's explicit value overrides it (#974).
+    #[test]
+    fn test_merge_bridge_server_configs_max_concurrent_requests() {
+        use settings::BridgeServerConfig;
+
+        let server = |cap: Option<usize>| BridgeServerConfig {
+            max_concurrent_requests: cap.and_then(std::num::NonZeroUsize::new),
+            ..Default::default()
+        };
+
+        let base = server(Some(4));
+        assert_eq!(
+            merge_bridge_server_configs(&base, &server(None))
+                .max_concurrent_requests
+                .map(|n| n.get()),
+            Some(4),
+            "unset overlay inherits the wildcard cap"
+        );
+        assert_eq!(
+            merge_bridge_server_configs(&base, &server(Some(32)))
+                .max_concurrent_requests
+                .map(|n| n.get()),
+            Some(32),
+            "explicit overlay overrides the wildcard cap"
+        );
+    }
+
     /// `enabled` merges overlay-wins-when-present, exactly like
     /// `prefer_shared_instance`, so a `languageServers._.enabled: false` can
     /// disable every server by default while a concrete server opts back in
@@ -1461,6 +1507,7 @@ mod tests {
             prefer_shared_instance: None,
             settings: None,
             enabled,
+            max_concurrent_requests: None,
         };
 
         // Unset overlay inherits the base (wildcard) value.
@@ -1510,6 +1557,7 @@ mod tests {
             prefer_shared_instance: None,
             enabled: None,
             settings: None,
+            max_concurrent_requests: None,
         };
         let overlay = BridgeServerConfig {
             cmd: Some(vec!["rust-analyzer".to_string()]),
@@ -1524,6 +1572,7 @@ mod tests {
             prefer_shared_instance: None,
             enabled: None,
             settings: None,
+            max_concurrent_requests: None,
         };
 
         let resolved = merge_bridge_server_configs(&base, &overlay);
@@ -1614,6 +1663,7 @@ mod tests {
             prefer_shared_instance: None,
             enabled: None,
             settings: None,
+            max_concurrent_requests: None,
         };
 
         let base = server(Some(vec!["}"]));
@@ -1767,6 +1817,7 @@ mod tests {
                     prefer_shared_instance: None,
                     enabled: None,
                     settings: None,
+                    max_concurrent_requests: None,
                 },
             ),
             // rust-analyzer: only specifies cmd and languages
@@ -1781,6 +1832,7 @@ mod tests {
                     prefer_shared_instance: None,
                     enabled: None,
                     settings: None,
+                    max_concurrent_requests: None,
                 },
             ),
         ]);
@@ -1822,6 +1874,7 @@ mod tests {
                     prefer_shared_instance: None,
                     enabled: None,
                     settings: None,
+                    max_concurrent_requests: None,
                 },
             ),
             // rust-analyzer: specifies only cmd, inherits languages from wildcard
@@ -1836,6 +1889,7 @@ mod tests {
                     prefer_shared_instance: None,
                     enabled: None,
                     settings: None,
+                    max_concurrent_requests: None,
                 },
             ),
         ]);
@@ -2180,6 +2234,7 @@ mod tests {
             prefer_shared_instance: None,
             enabled,
             settings: None,
+            max_concurrent_requests: None,
         };
 
         let full_resolution = |servers: &HashMap<String, settings::BridgeServerConfig>,

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -454,13 +454,40 @@ pub struct BridgeServerConfig {
     /// the wildcard, so `_.enabled: false` can disable every server by
     /// default while individual servers opt back in with `enabled: true`.
     pub enabled: Option<bool>,
+    /// Cap on concurrent in-flight requests kakehashi keeps open to this
+    /// server (per spawned connection). Requests beyond the cap wait for a
+    /// slot instead of piling onto the server, and the response deadline
+    /// starts only when the request is actually sent — so a burst over many
+    /// injection regions queues instead of timing out.
+    ///
+    /// `None` = inherit (built-in default `8`, sized for the common
+    /// single-threaded event-loop server). Raise it for servers that answer
+    /// requests in parallel. Zero is rejected; the cap applies from the next
+    /// (re)spawn of the server.
+    pub max_concurrent_requests: Option<std::num::NonZeroUsize>,
 }
+
+/// Built-in default for [`BridgeServerConfig::max_concurrent_requests`]
+/// (#974). Most downstreams (ruff, basedpyright, lua_ls) are effectively
+/// single-threaded event loops: a healthy ruff answered a 308-region burst in
+/// under 5 s (60+/s), so 8 concurrent requests with immediate refill lose no
+/// throughput — while an uncapped burst saturates the downstream and makes
+/// the response deadline meaningless (the tail times out while queued).
+pub(crate) const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 8;
 
 impl BridgeServerConfig {
     /// Effective `prefer_shared_instance` preference, resolving the inherit
     /// (`None`) case to the built-in default `false` (per-root instances).
     pub(crate) fn prefers_shared_instance(&self) -> bool {
         self.prefer_shared_instance.unwrap_or(false)
+    }
+
+    /// Effective in-flight request cap, resolving the inherit (`None`) case
+    /// to [`DEFAULT_MAX_CONCURRENT_REQUESTS`].
+    pub(crate) fn effective_max_concurrent_requests(&self) -> usize {
+        self.max_concurrent_requests
+            .map(std::num::NonZeroUsize::get)
+            .unwrap_or(DEFAULT_MAX_CONCURRENT_REQUESTS)
     }
 
     /// Effective `enabled` state, resolving the inherit (`None`) case to the
@@ -1894,6 +1921,7 @@ mod tests {
             prefer_shared_instance: None,
             enabled,
             settings: None,
+            max_concurrent_requests: None,
         };
 
         // Own cmd and enabled, no wildcard needed.
@@ -1946,6 +1974,50 @@ mod tests {
         assert_eq!(
             servers["pyright"].prefer_shared_instance, None,
             "absent preferSharedInstance parses as None (inherit -> per-root)"
+        );
+    }
+
+    #[test]
+    fn should_parse_max_concurrent_requests() {
+        let config_json = r#"{
+            "languageServers": {
+                "ruff": {
+                    "cmd": ["ruff", "server"],
+                    "languages": ["python"],
+                    "maxConcurrentRequests": 4
+                },
+                "pyright": {
+                    "cmd": ["pyright-langserver", "--stdio"],
+                    "languages": ["python"]
+                }
+            }
+        }"#;
+
+        let settings: RawWorkspaceSettings = serde_json::from_str(config_json).unwrap();
+        let servers = settings.language_servers.expect("languageServers parses");
+        assert_eq!(
+            servers["ruff"].max_concurrent_requests.map(|n| n.get()),
+            Some(4),
+            "explicit maxConcurrentRequests is preserved"
+        );
+        assert_eq!(
+            servers["pyright"].max_concurrent_requests, None,
+            "absent maxConcurrentRequests parses as None (inherit -> default)"
+        );
+    }
+
+    /// `maxConcurrentRequests = 0` would mean "never send any request" — a
+    /// config foot-gun, rejected at parse time by the NonZero type.
+    #[test]
+    fn zero_max_concurrent_requests_is_a_parse_error() {
+        let config_json = r#"{
+            "languageServers": {
+                "ruff": { "cmd": ["ruff", "server"], "maxConcurrentRequests": 0 }
+            }
+        }"#;
+        assert!(
+            serde_json::from_str::<RawWorkspaceSettings>(config_json).is_err(),
+            "zero must be rejected, not silently accepted"
         );
     }
 
@@ -2019,6 +2091,7 @@ mod tests {
             prefer_shared_instance: None,
             enabled: None,
             settings: None,
+            max_concurrent_requests: None,
         };
         let servers = HashMap::from([
             ("a".to_string(), server(Some(vec!["}", ";"]))),
@@ -2058,6 +2131,7 @@ mod tests {
             prefer_shared_instance: None,
             enabled,
             settings: None,
+            max_concurrent_requests: None,
         };
 
         // A disabled server's own trigger never spawns anything, so it must
@@ -2142,6 +2216,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         )]);
         assert_eq!(
@@ -2165,6 +2240,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         )]);
         assert_eq!(
@@ -2343,6 +2419,7 @@ mod tests {
             prefer_shared_instance: None,
             enabled: None,
             settings: None,
+            max_concurrent_requests: None,
         };
 
         let json = serde_json::to_value(&config).unwrap();

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -456,9 +456,11 @@ pub struct BridgeServerConfig {
     pub enabled: Option<bool>,
     /// Cap on concurrent in-flight requests kakehashi keeps open to this
     /// server (per spawned connection). Requests beyond the cap wait for a
-    /// slot instead of piling onto the server, and the response deadline
-    /// starts only when the request is actually sent — so a burst over many
-    /// injection regions queues instead of timing out.
+    /// slot instead of piling onto the server, and the diagnostic answer
+    /// deadline starts only when the request is actually sent — so a burst
+    /// over many injection regions queues instead of timing out. Caller-side
+    /// budgets (e.g. the formatting pipeline's step budget) still include
+    /// queueing time.
     ///
     /// `None` = inherit (built-in default `256` — a generous backstop).
     /// Lower it per server when a downstream struggles under concurrent
@@ -471,9 +473,10 @@ pub struct BridgeServerConfig {
 /// (#974). Deliberately generous (maintainer decision): the default is a
 /// backstop against pathological pile-ups, not throughput tuning — most
 /// documents never approach it, and a server that struggles under load is
-/// tuned DOWN per server rather than throttling everyone by default. The
-/// answer deadline being measured from send (not queue entry) is what
-/// actually defuses burst timeouts.
+/// tuned DOWN per server rather than throttling everyone by default. For
+/// requests that actually park, the answer deadline measured from send (not
+/// queue entry) is what defuses burst timeouts; requests admitted within the
+/// cap race the downstream's real service rate, as before.
 pub(crate) const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 256;
 
 impl BridgeServerConfig {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -487,11 +487,18 @@ impl BridgeServerConfig {
     }
 
     /// Effective in-flight request cap, resolving the inherit (`None`) case
-    /// to [`DEFAULT_MAX_CONCURRENT_REQUESTS`].
+    /// to [`DEFAULT_MAX_CONCURRENT_REQUESTS`] and clamping to the semaphore
+    /// ceiling — so two oversized configured values compare EQUAL here and a
+    /// reload between them doesn't respawn the process for nothing.
     pub(crate) fn effective_max_concurrent_requests(&self) -> usize {
+        // tokio's `Semaphore::MAX_PERMITS` (`usize::MAX >> 3`), spelled
+        // locally so the config layer doesn't import tokio; pinned equal by
+        // `max_permits_matches_tokio_semaphore`.
+        const MAX_PERMITS: usize = usize::MAX >> 3;
         self.max_concurrent_requests
             .map(std::num::NonZeroUsize::get)
             .unwrap_or(DEFAULT_MAX_CONCURRENT_REQUESTS)
+            .min(MAX_PERMITS)
     }
 
     /// Effective `enabled` state, resolving the inherit (`None`) case to the
@@ -2007,6 +2014,28 @@ mod tests {
         assert_eq!(
             servers["pyright"].max_concurrent_requests, None,
             "absent maxConcurrentRequests parses as None (inherit -> default)"
+        );
+    }
+
+    /// The local `MAX_PERMITS` mirror inside
+    /// `effective_max_concurrent_requests` must track tokio's constant, or
+    /// the clamp there and the one in `ConnectionHandle::with_state` drift.
+    #[test]
+    fn max_permits_matches_tokio_semaphore() {
+        assert_eq!(usize::MAX >> 3, tokio::sync::Semaphore::MAX_PERMITS);
+    }
+
+    /// Two oversized caps clamp to the same effective value: a reload
+    /// switching between them must not read as a launch-config change.
+    #[test]
+    fn oversized_caps_compare_equal_after_clamping() {
+        let server = |cap: usize| BridgeServerConfig {
+            max_concurrent_requests: std::num::NonZeroUsize::new(cap),
+            ..Default::default()
+        };
+        assert_eq!(
+            server(usize::MAX).effective_max_concurrent_requests(),
+            server(usize::MAX - 1).effective_max_concurrent_requests(),
         );
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -460,20 +460,21 @@ pub struct BridgeServerConfig {
     /// starts only when the request is actually sent — so a burst over many
     /// injection regions queues instead of timing out.
     ///
-    /// `None` = inherit (built-in default `8`, sized for the common
-    /// single-threaded event-loop server). Raise it for servers that answer
-    /// requests in parallel. Zero is rejected; the cap applies from the next
-    /// (re)spawn of the server.
+    /// `None` = inherit (built-in default `256` — a generous backstop).
+    /// Lower it per server when a downstream struggles under concurrent
+    /// load. Zero is rejected; the cap applies from the next (re)spawn of
+    /// the server.
     pub max_concurrent_requests: Option<std::num::NonZeroUsize>,
 }
 
 /// Built-in default for [`BridgeServerConfig::max_concurrent_requests`]
-/// (#974). Most downstreams (ruff, basedpyright, lua_ls) are effectively
-/// single-threaded event loops: a healthy ruff answered a 308-region burst in
-/// under 5 s (60+/s), so 8 concurrent requests with immediate refill lose no
-/// throughput — while an uncapped burst saturates the downstream and makes
-/// the response deadline meaningless (the tail times out while queued).
-pub(crate) const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 8;
+/// (#974). Deliberately generous (maintainer decision): the default is a
+/// backstop against pathological pile-ups, not throughput tuning — most
+/// documents never approach it, and a server that struggles under load is
+/// tuned DOWN per server rather than throttling everyone by default. The
+/// answer deadline being measured from send (not queue entry) is what
+/// actually defuses burst timeouts.
+pub(crate) const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 256;
 
 impl BridgeServerConfig {
     /// Effective `prefer_shared_instance` preference, resolving the inherit

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -2016,9 +2016,12 @@ mod tests {
                 "ruff": { "cmd": ["ruff", "server"], "maxConcurrentRequests": 0 }
             }
         }"#;
+        let error = serde_json::from_str::<RawWorkspaceSettings>(config_json)
+            .expect_err("zero must be rejected, not silently accepted");
+        let message = error.to_string();
         assert!(
-            serde_json::from_str::<RawWorkspaceSettings>(config_json).is_err(),
-            "zero must be rejected, not silently accepted"
+            message.contains("nonzero"),
+            "the user-facing error must say WHY the value is invalid: {message}"
         );
     }
 

--- a/src/config/snapshots/kakehashi__config__merge__tests__merge_workspace_settings_all_fields.snap
+++ b/src/config/snapshots/kakehashi__config__merge__tests__merge_workspace_settings_all_fields.snap
@@ -1,6 +1,6 @@
 ---
 source: src/config/merge.rs
-assertion_line: 871
+assertion_line: 878
 expression: result
 ---
 {
@@ -86,7 +86,8 @@ expression: result
       "workspaceMarkers": null,
       "onTypeFormattingTriggers": null,
       "preferSharedInstance": null,
-      "enabled": null
+      "enabled": null,
+      "maxConcurrentRequests": null
     },
     "pyright": {
       "cmd": [
@@ -100,7 +101,8 @@ expression: result
       "workspaceMarkers": null,
       "onTypeFormattingTriggers": null,
       "preferSharedInstance": null,
-      "enabled": null
+      "enabled": null,
+      "maxConcurrentRequests": null
     },
     "rust-analyzer": {
       "cmd": [
@@ -118,7 +120,8 @@ expression: result
       "workspaceMarkers": null,
       "onTypeFormattingTriggers": null,
       "preferSharedInstance": null,
-      "enabled": null
+      "enabled": null,
+      "maxConcurrentRequests": null
     }
   }
 }

--- a/src/config/snapshots/kakehashi__config__settings__tests__should_parse_language_servers_at_root.snap
+++ b/src/config/snapshots/kakehashi__config__settings__tests__should_parse_language_servers_at_root.snap
@@ -1,5 +1,6 @@
 ---
 source: src/config/settings.rs
+assertion_line: 1909
 expression: settings.language_servers
 ---
 {
@@ -15,7 +16,8 @@ expression: settings.language_servers
     "workspaceMarkers": null,
     "onTypeFormattingTriggers": null,
     "preferSharedInstance": null,
-    "enabled": null
+    "enabled": null,
+    "maxConcurrentRequests": null
   },
   "rust-analyzer": {
     "cmd": [
@@ -28,6 +30,7 @@ expression: settings.language_servers
     "workspaceMarkers": null,
     "onTypeFormattingTriggers": null,
     "preferSharedInstance": null,
-    "enabled": null
+    "enabled": null,
+    "maxConcurrentRequests": null
   }
 }

--- a/src/config/snapshots/kakehashi__config__settings__tests__should_parse_language_servers_at_root.snap
+++ b/src/config/snapshots/kakehashi__config__settings__tests__should_parse_language_servers_at_root.snap
@@ -1,6 +1,5 @@
 ---
 source: src/config/settings.rs
-assertion_line: 1909
 expression: settings.language_servers
 ---
 {

--- a/src/config/unknown_keys.rs
+++ b/src/config/unknown_keys.rs
@@ -45,6 +45,7 @@ pub(crate) const KNOWN_BRIDGE_SERVER_SETTING_KEYS: &[&str] = &[
     "enabled",
     "initializationOptions",
     "languages",
+    "maxConcurrentRequests",
     "onTypeFormattingTriggers",
     "preferSharedInstance",
     "rootMarkers",

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -269,6 +269,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             }),
         }
     }

--- a/src/lsp/aggregation/server/fan_out.rs
+++ b/src/lsp/aggregation/server/fan_out.rs
@@ -145,6 +145,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             }),
         }
     }

--- a/src/lsp/aggregation/server/priority.rs
+++ b/src/lsp/aggregation/server/priority.rs
@@ -158,6 +158,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             }),
         }
     }

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1530,6 +1530,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
 
@@ -1562,6 +1563,7 @@ mod tests {
             prefer_shared_instance: None,
             enabled: None,
             settings: None,
+            max_concurrent_requests: None,
         };
         let mut servers = HashMap::new();
         servers.insert("ruff".to_string(), server("python"));
@@ -1613,6 +1615,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
         servers.insert(
@@ -1627,6 +1630,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
         let settings = Arc::new(WorkspaceSettings {
@@ -1685,6 +1689,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
         let settings = Arc::new(WorkspaceSettings {
@@ -1733,6 +1738,7 @@ mod tests {
             prefer_shared_instance: None,
             enabled: None,
             settings: None,
+            max_concurrent_requests: None,
         };
         let mut servers = HashMap::new();
         servers.insert("ruff".to_string(), server("ruff"));
@@ -1898,6 +1904,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
 
@@ -1940,6 +1947,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
         servers.insert(
@@ -1953,6 +1961,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
 
@@ -2013,6 +2022,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: Some(false),
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
         servers.insert(
@@ -2026,6 +2036,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
 
@@ -2083,6 +2094,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: Some(false),
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
         servers.insert(
@@ -2096,6 +2108,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: Some(true),
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
 
@@ -2133,6 +2146,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
         servers.insert(
@@ -2146,6 +2160,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
 
@@ -2521,6 +2536,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
 
@@ -2559,6 +2575,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
 
@@ -2678,6 +2695,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
 
@@ -2904,6 +2922,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -77,6 +77,7 @@ fn same_launch_config(
         on_type_formatting_triggers: old_on_type_formatting_triggers,
         prefer_shared_instance: _,
         enabled: _,
+        max_concurrent_requests: _,
     } = old;
     let BridgeServerConfig {
         cmd: new_cmd,
@@ -87,6 +88,7 @@ fn same_launch_config(
         on_type_formatting_triggers: new_on_type_formatting_triggers,
         prefer_shared_instance: _,
         enabled: _,
+        max_concurrent_requests: _,
     } = new;
     old_cmd == new_cmd
         && old_languages == new_languages
@@ -95,6 +97,9 @@ fn same_launch_config(
         && old_on_type_formatting_triggers == new_on_type_formatting_triggers
         && old.prefers_shared_instance() == new.prefers_shared_instance()
         && old.is_enabled() == new.is_enabled()
+        // The request-slot semaphore is created at spawn time, so a changed
+        // cap needs a fresh process to take effect (#974).
+        && old.effective_max_concurrent_requests() == new.effective_max_concurrent_requests()
 }
 
 fn shutdown_invalidated_connection(key: ConnectionKey, handle: Arc<ConnectionHandle>) {
@@ -2622,6 +2627,7 @@ impl LanguageServerPool {
             connection_key.clone(),
             workspace_folders,
             settings_cell,
+            server_config.effective_max_concurrent_requests(),
         ));
         handle.record_launch_config(server_config);
 
@@ -4295,6 +4301,7 @@ mod tests {
             prefer_shared_instance: None,
             enabled: None,
             settings: None,
+            max_concurrent_requests: None,
         };
 
         let result = pool
@@ -5676,6 +5683,7 @@ mod tests {
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
             std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            crate::lsp::bridge::pool::DEFAULT_MAX_CONCURRENT_REQUESTS,
         ));
 
         // Add connection to pool
@@ -7726,6 +7734,27 @@ mod tests {
             ..Default::default()
         };
         assert!(same_launch_config(&inherited, &explicit));
+    }
+
+    /// The request-slot semaphore is sized at spawn, so a changed
+    /// `maxConcurrentRequests` must read as a different launch config (and
+    /// respawn the process on reload); an explicit value equal to the
+    /// built-in default must NOT (#974).
+    #[test]
+    fn launch_config_compares_request_cap_by_effective_value() {
+        let inherited = crate::config::settings::BridgeServerConfig::default();
+        let explicit_default = crate::config::settings::BridgeServerConfig {
+            max_concurrent_requests: std::num::NonZeroUsize::new(
+                crate::config::settings::DEFAULT_MAX_CONCURRENT_REQUESTS,
+            ),
+            ..Default::default()
+        };
+        let raised = crate::config::settings::BridgeServerConfig {
+            max_concurrent_requests: std::num::NonZeroUsize::new(32),
+            ..Default::default()
+        };
+        assert!(same_launch_config(&inherited, &explicit_default));
+        assert!(!same_launch_config(&inherited, &raised));
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -31,9 +31,9 @@ pub(crate) use connection_action::BridgeError;
 use connection_action::{ConnectionAction, decide_connection_action};
 use handshake::perform_lsp_handshake;
 
-pub(crate) use connection_handle::{
-    ConnectionHandle, DEFAULT_MAX_CONCURRENT_REQUESTS, NotificationSendResult,
-};
+#[cfg(test)]
+pub(crate) use connection_handle::DEFAULT_MAX_CONCURRENT_REQUESTS;
+pub(crate) use connection_handle::{ConnectionHandle, NotificationSendResult};
 pub(crate) use connection_key::ConnectionKey;
 pub(crate) use connection_state::ConnectionState;
 use document_tracker::DocumentTracker;

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -31,7 +31,9 @@ pub(crate) use connection_action::BridgeError;
 use connection_action::{ConnectionAction, decide_connection_action};
 use handshake::perform_lsp_handshake;
 
-pub(crate) use connection_handle::{ConnectionHandle, NotificationSendResult};
+pub(crate) use connection_handle::{
+    ConnectionHandle, DEFAULT_MAX_CONCURRENT_REQUESTS, NotificationSendResult,
+};
 pub(crate) use connection_key::ConnectionKey;
 pub(crate) use connection_state::ConnectionState;
 use document_tracker::DocumentTracker;

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -7736,6 +7736,38 @@ mod tests {
         assert!(same_launch_config(&inherited, &explicit));
     }
 
+    /// The one production line that makes `maxConcurrentRequests` real is
+    /// the spawn site passing `effective_max_concurrent_requests()` into the
+    /// semaphore — pin it end-to-end: a connection spawned from a cap-1
+    /// config must park the second acquisition (#974). Every other cap test
+    /// constructs its handle directly, so without this a regression to a
+    /// hardcoded default would stay green.
+    #[tokio::test]
+    async fn spawned_connection_is_capped_by_the_configured_max_concurrent_requests() {
+        if !is_lua_ls_available() {
+            return;
+        }
+        let pool = LanguageServerPool::new();
+        let mut config = lua_ls_config();
+        config.max_concurrent_requests = std::num::NonZeroUsize::new(1);
+
+        let handle = pool
+            .get_or_create_connection("capped", &config, None)
+            .await
+            .expect("spawn should succeed");
+
+        let _held = handle
+            .acquire_request_slot()
+            .await
+            .expect("the configured slot acquires");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), handle.acquire_request_slot())
+                .await
+                .is_err(),
+            "maxConcurrentRequests = 1 must park the second acquisition"
+        );
+    }
+
     /// The request-slot semaphore is sized at spawn, so a changed
     /// `maxConcurrentRequests` must read as a different launch config (and
     /// respawn the process on reload); an explicit value equal to the

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -31,8 +31,6 @@ pub(crate) use connection_action::BridgeError;
 use connection_action::{ConnectionAction, decide_connection_action};
 use handshake::perform_lsp_handshake;
 
-#[cfg(test)]
-pub(crate) use connection_handle::DEFAULT_MAX_CONCURRENT_REQUESTS;
 pub(crate) use connection_handle::{ConnectionHandle, NotificationSendResult};
 pub(crate) use connection_key::ConnectionKey;
 pub(crate) use connection_state::ConnectionState;
@@ -5683,7 +5681,7 @@ mod tests {
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
             std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
-            crate::lsp::bridge::pool::DEFAULT_MAX_CONCURRENT_REQUESTS,
+            crate::config::settings::DEFAULT_MAX_CONCURRENT_REQUESTS,
         ));
 
         // Add connection to pool

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -31,6 +31,7 @@ pub(crate) use connection_action::BridgeError;
 use connection_action::{ConnectionAction, decide_connection_action};
 use handshake::perform_lsp_handshake;
 
+pub(in crate::lsp::bridge) use connection_handle::CancelOnDropGuard;
 pub(crate) use connection_handle::{ConnectionHandle, NotificationSendResult};
 pub(crate) use connection_key::ConnectionKey;
 pub(crate) use connection_state::ConnectionState;
@@ -3042,7 +3043,7 @@ impl LanguageServerPool {
     /// via the single-writer loop (ls-bridge-message-ordering). The pending
     /// entry stays in place: the server may still respond with a result or
     /// `REQUEST_CANCELLED` (-32800).
-    pub(in crate::lsp::bridge) fn send_cancel_notification(
+    fn send_cancel_notification(
         &self,
         handle: &ConnectionHandle,
         connection_key: &ConnectionKey,

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -141,7 +141,7 @@ use dashmap::DashMap;
 use tokio::sync::Mutex;
 use url::Url;
 
-use tower_lsp_server::ls_types::{CancelParams, NumberOrString};
+use tower_lsp_server::ls_types::NumberOrString;
 
 use crate::error::LockResultExt;
 
@@ -3049,15 +3049,10 @@ impl LanguageServerPool {
         connection_key: &ConnectionKey,
         downstream_id: RequestId,
     ) -> io::Result<()> {
-        // Per LSP spec: $/cancelRequest is a notification with { id: request_id }
-        let notification = JsonRpcNotification::new(
-            "$/cancelRequest",
-            CancelParams {
-                // Safe: IDs are generated from an atomic counter starting at 0,
-                // well within i32 range. ls-types constrains Number to i32.
-                id: NumberOrString::Number(downstream_id.as_i64() as i32),
-            },
-        );
+        // Per LSP spec: $/cancelRequest is a notification with { id: request_id },
+        // carrying the full i64 id (ls_types::CancelParams would truncate to
+        // i32 and cancel nothing).
+        let notification = super::protocol::cancel_request_notification(downstream_id);
 
         match handle.send_notification(notification) {
             NotificationSendResult::Queued => {

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -3044,7 +3044,7 @@ impl LanguageServerPool {
     /// via the single-writer loop (ls-bridge-message-ordering). The pending
     /// entry stays in place: the server may still respond with a result or
     /// `REQUEST_CANCELLED` (-32800).
-    fn send_cancel_notification(
+    pub(in crate::lsp::bridge) fn send_cancel_notification(
         &self,
         handle: &ConnectionHandle,
         connection_key: &ConnectionKey,

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -153,6 +153,14 @@ pub(crate) struct ConnectionHandle {
     /// `settings` is ignored when comparing this snapshot on reload because it
     /// can be propagated at runtime; every other field is spawn-time state.
     launch_config: OnceLock<crate::config::settings::BridgeServerConfig>,
+    /// Cap on concurrent in-flight requests to this connection (#974).
+    ///
+    /// Acquired (owned, RAII) at the entry of the shared request-execution
+    /// paths, BEFORE the per-host lifecycle lock and the pool `connections`
+    /// lock — a task parked here must never hold anything another
+    /// connection's requests need. Notifications, `$/cancelRequest`, and the
+    /// initialize/shutdown lifecycle are deliberately exempt.
+    request_permits: Arc<tokio::sync::Semaphore>,
 }
 
 impl ConnectionHandle {
@@ -221,7 +229,27 @@ impl ConnectionHandle {
             incapable_fallback_logged: AtomicBool::new(false),
             settings,
             launch_config: OnceLock::new(),
+            request_permits: Arc::new(tokio::sync::Semaphore::new(DEFAULT_MAX_CONCURRENT_REQUESTS)),
         }
+    }
+
+    /// Acquire an in-flight request slot on this connection (#974). The
+    /// returned permit is held for the whole request lifetime — response,
+    /// error, or future drop all release it. Errors when the semaphore was
+    /// closed (connection evicted): failing fast beats parking on a dead
+    /// connection's permits.
+    pub(crate) async fn acquire_request_slot(
+        &self,
+    ) -> io::Result<tokio::sync::OwnedSemaphorePermit> {
+        Arc::clone(&self.request_permits)
+            .acquire_owned()
+            .await
+            .map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    "bridge: connection evicted while waiting for a request slot",
+                )
+            })
     }
 
     pub(super) fn record_launch_config(

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -81,6 +81,15 @@ pub(crate) enum NotificationSendResult {
 /// (`Closing`/`Failed` → `Closed`, terminal). FIFO writes flow `tx` → writer
 /// task → stdin; the reader task pushes incoming responses through `router` to
 /// oneshot waiters so callers can await without holding any Mutex.
+/// Default cap on concurrent in-flight requests per connection (#974).
+///
+/// Most downstreams (ruff, basedpyright, lua_ls) are effectively
+/// single-threaded event loops: a healthy ruff answered a 308-region burst in
+/// under 5 s (60+/s), so 8 concurrent requests with immediate refill lose no
+/// throughput — while an uncapped burst saturates the downstream and makes
+/// the response deadline meaningless (the tail times out while queued).
+pub(crate) const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 8;
+
 pub(crate) struct ConnectionHandle {
     /// Connection state - uses std::sync::RwLock for fast, synchronous state checks
     state: std::sync::RwLock<ConnectionState>,

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -502,6 +502,15 @@ impl ConnectionHandle {
         // Notify watchers of state change. send_replace() is non-blocking and
         // always succeeds (it replaces the current value regardless of receivers).
         self.state_watch.send_replace(new_state);
+        // A connection leaving service never frees its permits again — wake
+        // parked request-slot waiters with an error instead of letting them
+        // hang (#974). Idempotent; in-flight permit holders are unaffected.
+        match new_state {
+            ConnectionState::Failed | ConnectionState::Closing | ConnectionState::Closed => {
+                self.request_permits.close();
+            }
+            ConnectionState::Initializing | ConnectionState::Ready => {}
+        }
     }
 
     /// Complete initialization only while this handle still belongs to its

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -81,14 +81,12 @@ pub(crate) enum NotificationSendResult {
 /// (`Closing`/`Failed` → `Closed`, terminal). FIFO writes flow `tx` → writer
 /// task → stdin; the reader task pushes incoming responses through `router` to
 /// oneshot waiters so callers can await without holding any Mutex.
-/// Default cap on concurrent in-flight requests per connection (#974).
-///
-/// Most downstreams (ruff, basedpyright, lua_ls) are effectively
-/// single-threaded event loops: a healthy ruff answered a 308-region burst in
-/// under 5 s (60+/s), so 8 concurrent requests with immediate refill lose no
-/// throughput — while an uncapped burst saturates the downstream and makes
-/// the response deadline meaningless (the tail times out while queued).
-pub(crate) const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 8;
+/// The built-in in-flight request cap lives with the config knob it backs
+/// ([`crate::config::settings::DEFAULT_MAX_CONCURRENT_REQUESTS`]); production
+/// code passes a resolved capacity into [`ConnectionHandle::with_state`], so
+/// the alias below is only for tests.
+#[cfg(test)]
+pub(crate) use crate::config::settings::DEFAULT_MAX_CONCURRENT_REQUESTS;
 
 pub(crate) struct ConnectionHandle {
     /// Connection state - uses std::sync::RwLock for fast, synchronous state checks
@@ -187,6 +185,7 @@ impl ConnectionHandle {
             ConnectionKey::for_server("test"),
             WorkspaceFolderSet::new(None),
             Arc::new(arc_swap::ArcSwapOption::empty()),
+            DEFAULT_MAX_CONCURRENT_REQUESTS,
         )
     }
 
@@ -205,6 +204,7 @@ impl ConnectionHandle {
         connection_key: ConnectionKey,
         workspace_folders: WorkspaceFolderSet,
         settings: Arc<arc_swap::ArcSwapOption<serde_json::Value>>,
+        max_concurrent_requests: usize,
     ) -> Self {
         use crate::lsp::bridge::actor::spawn_writer_task;
 
@@ -229,7 +229,7 @@ impl ConnectionHandle {
             incapable_fallback_logged: AtomicBool::new(false),
             settings,
             launch_config: OnceLock::new(),
-            request_permits: Arc::new(tokio::sync::Semaphore::new(DEFAULT_MAX_CONCURRENT_REQUESTS)),
+            request_permits: Arc::new(tokio::sync::Semaphore::new(max_concurrent_requests)),
         }
     }
 
@@ -265,6 +265,7 @@ impl ConnectionHandle {
             on_type_formatting_triggers: config.on_type_formatting_triggers.clone(),
             prefer_shared_instance: config.prefer_shared_instance,
             enabled: config.enabled,
+            max_concurrent_requests: config.max_concurrent_requests,
         };
         let _ = self.launch_config.set(snapshot);
     }
@@ -1047,6 +1048,56 @@ mod tests {
         Arc::new(DynamicCapabilityRegistry::new())
     }
 
+    /// The configured `maxConcurrentRequests` sizes the request-slot
+    /// semaphore (#974): with capacity 1, a second acquisition pends until
+    /// the first permit drops.
+    #[tokio::test]
+    async fn with_state_honors_the_configured_request_cap() {
+        let mut conn = AsyncBridgeConnection::spawn(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "cat > /dev/null".to_string(),
+        ])
+        .await
+        .expect("spawn sink");
+        let (writer, reader) = conn.split();
+        let router = Arc::new(ResponseRouter::new());
+        let reader_handle = spawn_reader_task(reader, Arc::clone(&router));
+        let (tx, rx) = mpsc::channel(OUTBOUND_QUEUE_CAPACITY);
+        let handle = ConnectionHandle::with_state(
+            writer,
+            router,
+            reader_handle,
+            ConnectionState::Ready,
+            tx,
+            rx,
+            default_dynamic_caps(),
+            ConnectionKey::for_server("capped"),
+            crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            Arc::new(arc_swap::ArcSwapOption::empty()),
+            1,
+        );
+
+        let first = handle
+            .acquire_request_slot()
+            .await
+            .expect("first slot acquires");
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(50),
+                handle.acquire_request_slot()
+            )
+            .await
+            .is_err(),
+            "second acquisition must pend at capacity 1"
+        );
+        drop(first);
+        let _reacquired = handle
+            .acquire_request_slot()
+            .await
+            .expect("slot frees once the permit drops");
+    }
+
     /// The settings cell stored on the handle is the *same* `Arc` the reader's
     /// `ServerRequestDeps` clones, so a path-c `store_settings` is observable by a
     /// path-b pull (downstream-settings-propagation).
@@ -1080,6 +1131,7 @@ mod tests {
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
             Arc::clone(&cell),
+            DEFAULT_MAX_CONCURRENT_REQUESTS,
         );
 
         assert!(handle.current_settings().is_none(), "starts empty");
@@ -1234,6 +1286,7 @@ mod tests {
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
             std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            DEFAULT_MAX_CONCURRENT_REQUESTS,
         ));
 
         // Verify initial state is Ready
@@ -1310,6 +1363,7 @@ mod tests {
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
             std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            DEFAULT_MAX_CONCURRENT_REQUESTS,
         ));
 
         // Register a request to start the liveness timer
@@ -1370,6 +1424,7 @@ mod tests {
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
             std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            DEFAULT_MAX_CONCURRENT_REQUESTS,
         ));
 
         // Register a request - this should NOT start the liveness timer
@@ -1437,6 +1492,7 @@ mod tests {
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
             std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            DEFAULT_MAX_CONCURRENT_REQUESTS,
         ));
 
         // Register first request - this starts the liveness timer
@@ -1532,6 +1588,7 @@ mod tests {
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
             std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            DEFAULT_MAX_CONCURRENT_REQUESTS,
         );
 
         // Register a request with upstream ID
@@ -1576,6 +1633,7 @@ mod tests {
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
             std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            DEFAULT_MAX_CONCURRENT_REQUESTS,
         );
 
         // Register without upstream ID
@@ -1619,6 +1677,7 @@ mod tests {
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
             std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            DEFAULT_MAX_CONCURRENT_REQUESTS,
         );
 
         // Should return immediately
@@ -1654,6 +1713,7 @@ mod tests {
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
             std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            DEFAULT_MAX_CONCURRENT_REQUESTS,
         ));
 
         // Spawn a task that will transition to Ready after a delay
@@ -1697,6 +1757,7 @@ mod tests {
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
             std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            DEFAULT_MAX_CONCURRENT_REQUESTS,
         ));
 
         let waiter = tokio::spawn({
@@ -1747,6 +1808,7 @@ mod tests {
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
             std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            DEFAULT_MAX_CONCURRENT_REQUESTS,
         ));
 
         // Spawn a task that will transition to Failed
@@ -1795,6 +1857,7 @@ mod tests {
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
             std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            DEFAULT_MAX_CONCURRENT_REQUESTS,
         );
 
         // Wait with short timeout - should timeout
@@ -1832,6 +1895,7 @@ mod tests {
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
             std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            DEFAULT_MAX_CONCURRENT_REQUESTS,
         ));
 
         // Spawn a task that will transition to Closing

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -1098,6 +1098,59 @@ mod tests {
             .expect("slot frees once the permit drops");
     }
 
+    /// A connection leaving service (crash → `Failed`, teardown → `Closing`)
+    /// must WAKE tasks parked on its request slots with an error (#974): the
+    /// permits of a dead connection never free, so without this a parked
+    /// request would hang for its caller's full patience instead of failing
+    /// fast into the coverage machinery (the safe direction).
+    #[tokio::test]
+    async fn terminal_state_wakes_parked_request_slot_waiters() {
+        let mut conn = AsyncBridgeConnection::spawn(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "cat > /dev/null".to_string(),
+        ])
+        .await
+        .expect("spawn sink");
+        let (writer, reader) = conn.split();
+        let router = Arc::new(ResponseRouter::new());
+        let reader_handle = spawn_reader_task(reader, Arc::clone(&router));
+        let (tx, rx) = mpsc::channel(OUTBOUND_QUEUE_CAPACITY);
+        let handle = Arc::new(ConnectionHandle::with_state(
+            writer,
+            router,
+            reader_handle,
+            ConnectionState::Ready,
+            tx,
+            rx,
+            default_dynamic_caps(),
+            ConnectionKey::for_server("dying"),
+            crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            Arc::new(arc_swap::ArcSwapOption::empty()),
+            1,
+        ));
+
+        let _occupant = handle
+            .acquire_request_slot()
+            .await
+            .expect("first slot acquires");
+        let parked = {
+            let handle = Arc::clone(&handle);
+            tokio::spawn(async move { handle.acquire_request_slot().await })
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert!(!parked.is_finished(), "the waiter parks at capacity 1");
+
+        handle.set_state(ConnectionState::Failed);
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(1), parked)
+            .await
+            .expect("a terminal state must wake the parked waiter promptly")
+            .expect("waiter task must not panic");
+        let error = result.expect_err("a dead connection's slot must error, not acquire");
+        assert_eq!(error.kind(), std::io::ErrorKind::NotConnected);
+    }
+
     /// The settings cell stored on the handle is the *same* `Arc` the reader's
     /// `ServerRequestDeps` clones, so a path-c `store_settings` is observable by a
     /// path-b pull (downstream-settings-propagation).

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -141,16 +141,8 @@ impl CancelOnDropGuard {
 impl Drop for CancelOnDropGuard {
     fn drop(&mut self) {
         if let Some(handle) = self.handle.take() {
-            use tower_lsp_server::ls_types::{CancelParams, NumberOrString};
-            let notification = crate::lsp::bridge::protocol::JsonRpcNotification::new(
-                "$/cancelRequest",
-                CancelParams {
-                    // Safe: downstream ids come from an i64 counter starting
-                    // at 2, well within i32 range (ls-types constrains
-                    // Number to i32).
-                    id: NumberOrString::Number(self.request_id.as_i64() as i32),
-                },
-            );
+            let notification =
+                crate::lsp::bridge::protocol::cancel_request_notification(self.request_id);
             // Failure outcomes (QueueFull / ChannelClosed) are already
             // logged at warn by `send_notification` itself — log only the
             // SUCCESS context here, so mass abandonment during teardown

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -102,6 +102,15 @@ use crate::config::settings::DEFAULT_MAX_CONCURRENT_REQUESTS;
 /// arrives. Best-effort by nature: the send is a non-blocking queue write,
 /// and a dead writer just drops it — exactly like every other
 /// `$/cancelRequest`.
+///
+/// Deliberately NOT deduplicated against the upstream cancel forwarder: a
+/// client-initiated cancel can drop the request future (guard fires) AND
+/// send its own explicit cancel for the captured downstream id — two
+/// `$/cancelRequest`s for one request. That is bounded (≤2 per request,
+/// ≤2×cap per storm against a 4096-deep queue) and idempotent per the LSP
+/// spec (a server ignores cancels for unknown/finished ids). Exactly-once
+/// bookkeeping needs a recently-cancelled id set that survives router-entry
+/// removal — the same machinery issue #979 needs — and lives there.
 pub(in crate::lsp::bridge) struct CancelOnDropGuard {
     handle: Option<Arc<ConnectionHandle>>,
     request_id: crate::lsp::bridge::protocol::RequestId,

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -242,7 +242,11 @@ impl ConnectionHandle {
             incapable_fallback_logged: AtomicBool::new(false),
             settings,
             launch_config: OnceLock::new(),
-            request_permits: Arc::new(tokio::sync::Semaphore::new(max_concurrent_requests)),
+            // Clamped: tokio's Semaphore panics above MAX_PERMITS, and the
+            // config's NonZero type only floors the value (#974).
+            request_permits: Arc::new(tokio::sync::Semaphore::new(
+                max_concurrent_requests.min(tokio::sync::Semaphore::MAX_PERMITS),
+            )),
         }
     }
 

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -1087,6 +1087,42 @@ mod tests {
         Arc::new(DynamicCapabilityRegistry::new())
     }
 
+    /// A pathologically large configured cap must not panic at spawn:
+    /// tokio's `Semaphore::new` asserts `permits <= MAX_PERMITS`
+    /// (`usize::MAX >> 3`), and `maxConcurrentRequests` is only floor-checked
+    /// by its NonZero type — the ceiling is clamped here (#974).
+    #[tokio::test]
+    async fn with_state_clamps_an_oversized_request_cap() {
+        let mut conn = AsyncBridgeConnection::spawn(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "cat > /dev/null".to_string(),
+        ])
+        .await
+        .expect("spawn sink");
+        let (writer, reader) = conn.split();
+        let router = Arc::new(ResponseRouter::new());
+        let reader_handle = spawn_reader_task(reader, Arc::clone(&router));
+        let (tx, rx) = mpsc::channel(OUTBOUND_QUEUE_CAPACITY);
+        let handle = ConnectionHandle::with_state(
+            writer,
+            router,
+            reader_handle,
+            ConnectionState::Ready,
+            tx,
+            rx,
+            default_dynamic_caps(),
+            ConnectionKey::for_server("oversized"),
+            crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            Arc::new(arc_swap::ArcSwapOption::empty()),
+            usize::MAX,
+        );
+        let _permit = handle
+            .acquire_request_slot()
+            .await
+            .expect("a clamped cap still grants slots");
+    }
+
     /// The configured `maxConcurrentRequests` sizes the request-slot
     /// semaphore (#974): with capacity 1, a second acquisition pends until
     /// the first permit drops.

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -151,39 +151,25 @@ impl Drop for CancelOnDropGuard {
                     id: NumberOrString::Number(self.request_id.as_i64() as i32),
                 },
             );
-            match handle.send_notification(notification) {
-                NotificationSendResult::Queued => {
-                    log::debug!(
-                        target: "kakehashi::bridge::cancel",
-                        "[{}] cancelled abandoned downstream request {} on drop",
-                        handle.key(),
-                        self.request_id.as_i64()
-                    );
-                }
-                NotificationSendResult::QueueFull => {
-                    // No reserved control lane, deliberately: a full 4096-deep
-                    // queue means the writer is stalled far beyond anything
-                    // the request cap models — the connection is degenerate
-                    // and liveness/teardown will fail it. Say so honestly
-                    // instead of claiming the cancel went out.
-                    log::warn!(
-                        target: "kakehashi::bridge::cancel",
-                        "[{}] outbound queue full; cancel for abandoned request {} dropped",
-                        handle.key(),
-                        self.request_id.as_i64()
-                    );
-                }
-                NotificationSendResult::ChannelClosed
-                | NotificationSendResult::SerializationFailed => {
-                    // Writer gone (teardown) or unserializable (impossible for
-                    // CancelParams): nothing left to tell.
-                    log::debug!(
-                        target: "kakehashi::bridge::cancel",
-                        "[{}] cancel for abandoned request {} not sent (writer closed)",
-                        handle.key(),
-                        self.request_id.as_i64()
-                    );
-                }
+            // Failure outcomes (QueueFull / ChannelClosed) are already
+            // logged at warn by `send_notification` itself — log only the
+            // SUCCESS context here, so mass abandonment during teardown
+            // doesn't double every warning. No reserved control lane for the
+            // queue-full case, deliberately: a full 4096-deep queue means the
+            // writer is stalled far beyond anything the request cap models —
+            // the connection is degenerate and liveness/teardown owns it;
+            // holding the permit until the cancel queues would wedge a slot
+            // on exactly the connection that can least afford one.
+            if matches!(
+                handle.send_notification(notification),
+                NotificationSendResult::Queued
+            ) {
+                log::debug!(
+                    target: "kakehashi::bridge::cancel",
+                    "[{}] cancelled abandoned downstream request {} on drop",
+                    handle.key(),
+                    self.request_id.as_i64()
+                );
             }
         }
     }

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -94,12 +94,11 @@ fn closed_request_slots_error() -> io::Error {
     )
 }
 
-/// The built-in in-flight request cap lives with the config knob it backs
-/// ([`crate::config::settings::DEFAULT_MAX_CONCURRENT_REQUESTS`]); production
-/// code passes a resolved capacity into [`ConnectionHandle::with_state`], so
-/// the alias below is only for tests.
+// The built-in in-flight request cap lives with the config knob it backs;
+// production code passes a resolved capacity into `with_state`, so the
+// import is only for this module's test-only constructor and tests.
 #[cfg(test)]
-pub(crate) use crate::config::settings::DEFAULT_MAX_CONCURRENT_REQUESTS;
+use crate::config::settings::DEFAULT_MAX_CONCURRENT_REQUESTS;
 
 pub(crate) struct ConnectionHandle {
     /// Connection state - uses std::sync::RwLock for fast, synchronous state checks
@@ -255,7 +254,7 @@ impl ConnectionHandle {
     /// error, or future drop all release it. Errors when the semaphore was
     /// closed (connection evicted): failing fast beats parking on a dead
     /// connection's permits.
-    pub(crate) async fn acquire_request_slot(
+    pub(in crate::lsp::bridge) async fn acquire_request_slot(
         &self,
     ) -> io::Result<tokio::sync::OwnedSemaphorePermit> {
         // Fast path: a free slot needs no clock read.

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -1171,10 +1171,13 @@ mod tests {
             "second acquisition must pend at capacity 1"
         );
         drop(first);
-        let _reacquired = handle
-            .acquire_request_slot()
-            .await
-            .expect("slot frees once the permit drops");
+        let _reacquired = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            handle.acquire_request_slot(),
+        )
+        .await
+        .expect("re-acquisition must not hang: a regression here would wedge CI, not fail it")
+        .expect("slot frees once the permit drops");
     }
 
     /// A connection leaving service (crash → `Failed`, teardown → `Closing`)

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -81,6 +81,19 @@ pub(crate) enum NotificationSendResult {
 /// (`Closing`/`Failed` → `Closed`, terminal). FIFO writes flow `tx` → writer
 /// task → stdin; the reader task pushes incoming responses through `router` to
 /// oneshot waiters so callers can await without holding any Mutex.
+/// Park times at or above this on the request-slot semaphore are logged
+/// (`kakehashi::bridge::backpressure`, debug): long waits are the saturation
+/// signal, and an order of magnitude above scheduler noise keeps the log
+/// quiet under healthy load.
+const BACKPRESSURE_LOG_THRESHOLD: std::time::Duration = std::time::Duration::from_millis(100);
+
+fn closed_request_slots_error() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::NotConnected,
+        "bridge: connection evicted while waiting for a request slot",
+    )
+}
+
 /// The built-in in-flight request cap lives with the config knob it backs
 /// ([`crate::config::settings::DEFAULT_MAX_CONCURRENT_REQUESTS`]); production
 /// code passes a resolved capacity into [`ConnectionHandle::with_state`], so
@@ -241,15 +254,32 @@ impl ConnectionHandle {
     pub(crate) async fn acquire_request_slot(
         &self,
     ) -> io::Result<tokio::sync::OwnedSemaphorePermit> {
-        Arc::clone(&self.request_permits)
+        // Fast path: a free slot needs no clock read.
+        match Arc::clone(&self.request_permits).try_acquire_owned() {
+            Ok(permit) => return Ok(permit),
+            Err(tokio::sync::TryAcquireError::Closed) => {
+                return Err(closed_request_slots_error());
+            }
+            Err(tokio::sync::TryAcquireError::NoPermits) => {}
+        }
+        let parked_at = std::time::Instant::now();
+        let permit = Arc::clone(&self.request_permits)
             .acquire_owned()
             .await
-            .map_err(|_| {
-                io::Error::new(
-                    io::ErrorKind::NotConnected,
-                    "bridge: connection evicted while waiting for a request slot",
-                )
-            })
+            .map_err(|_| closed_request_slots_error())?;
+        let waited = parked_at.elapsed();
+        if waited >= BACKPRESSURE_LOG_THRESHOLD {
+            // Saturation must not be an invisible wait: this is the signal
+            // that a downstream is slower than its request supply (raise
+            // `maxConcurrentRequests`? server overloaded?).
+            log::debug!(
+                target: "kakehashi::bridge::backpressure",
+                "[{}] waited {}ms for a request slot",
+                self.connection_key,
+                waited.as_millis()
+            );
+        }
+        Ok(permit)
     }
 
     pub(super) fn record_launch_config(

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -223,17 +223,16 @@ pub(crate) struct ConnectionHandle {
     /// Cap on concurrent in-flight requests to this connection (#974).
     ///
     /// Acquired (owned, RAII) at the entry of the shared request-execution
-    /// paths (`execute_bridge_request_observed`, `execute_host_request`),
-    /// BEFORE the per-host lifecycle lock and the pool `connections` lock —
-    /// a task parked here must never hold anything another connection's
-    /// requests need. Exempt by design: notifications, `$/cancelRequest`
-    /// (it relieves saturation), and the initialize/shutdown lifecycle.
-    /// Also currently ungated because they build their requests inline
-    /// rather than through the shared paths: `workspace/executeCommand`,
-    /// `completionItem/resolve`, `codeAction/resolve`, and
-    /// `textDocument/codeLens` — all single user-gesture requests, not
-    /// fan-out sources; gating them is a follow-up, so the cap is a burst
-    /// bound, not a hard per-connection ceiling.
+    /// paths (`execute_bridge_request_observed`, `execute_host_request`) and
+    /// of the inline-send request paths (`workspace/executeCommand`,
+    /// `completionItem/resolve`, `codeAction/resolve`,
+    /// `textDocument/codeLens` — the eager code-action resolve pass batches
+    /// these, so they are burst sources too). Always taken BEFORE the
+    /// per-host lifecycle lock and the pool `connections` lock — a task
+    /// parked here must never hold anything another connection's requests
+    /// need. Exempt by design: notifications, `$/cancelRequest` (it relieves
+    /// saturation), and the initialize/shutdown lifecycle (which runs after
+    /// `set_state(Closing)` already closed this semaphore).
     request_permits: Arc<tokio::sync::Semaphore>,
 }
 

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -105,12 +105,16 @@ use crate::config::settings::DEFAULT_MAX_CONCURRENT_REQUESTS;
 ///
 /// Deliberately NOT deduplicated against the upstream cancel forwarder: a
 /// client-initiated cancel can drop the request future (guard fires) AND
-/// send its own explicit cancel for the captured downstream id — two
-/// `$/cancelRequest`s for one request. That is bounded (≤2 per request,
-/// ≤2×cap per storm against a 4096-deep queue) and idempotent per the LSP
-/// spec (a server ignores cancels for unknown/finished ids). Exactly-once
-/// bookkeeping needs a recently-cancelled id set that survives router-entry
-/// removal — the same machinery issue #979 needs — and lives there.
+/// send its own explicit cancel for the captured downstream id. The guard
+/// contributes at most ONE cancel per request; the forwarder contributes one
+/// per RECEIVED client cancel (it has never deduplicated repeats — a
+/// pre-existing property, not introduced by the guard), and the formatting
+/// pipeline's probe cancel is a third pre-existing source. All are
+/// idempotent per the LSP spec (a server ignores cancels for
+/// unknown/finished ids) and tiny against the 4096-deep dedicated-writer
+/// queue. Exactly-once bookkeeping needs a recently-cancelled id set that
+/// survives router-entry removal — the same machinery issue #979 needs —
+/// and lives there.
 pub(in crate::lsp::bridge) struct CancelOnDropGuard {
     handle: Option<Arc<ConnectionHandle>>,
     request_id: crate::lsp::bridge::protocol::RequestId,
@@ -484,6 +488,14 @@ impl ConnectionHandle {
     /// `QueueFull` immediately rather than awaiting capacity. On any send error
     /// the router entry is removed (`router.remove()` is idempotent, so this is
     /// safe against concurrent cleanup by the writer task).
+    ///
+    /// Deliberately does NOT check `ConnectionState`: a request that raced
+    /// `begin_shutdown` (state already `Closing` when this enqueues) is
+    /// drained by the writer's 3-phase shutdown ahead of the shutdown/exit
+    /// pair, and its waiter is woken by `fail_all`/channel-close if the
+    /// process exits first — a bounded, pre-existing race. Rejecting it here
+    /// would couple every hot-path send to the state lock for a window that
+    /// graceful shutdown already handles.
     pub(crate) fn send_request<P: serde::Serialize>(
         &self,
         request: JsonRpcRequest<P>,

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -151,13 +151,40 @@ impl Drop for CancelOnDropGuard {
                     id: NumberOrString::Number(self.request_id.as_i64() as i32),
                 },
             );
-            let _ = handle.send_notification(notification);
-            log::debug!(
-                target: "kakehashi::bridge::cancel",
-                "[{}] cancelled abandoned downstream request {} on drop",
-                handle.key(),
-                self.request_id.as_i64()
-            );
+            match handle.send_notification(notification) {
+                NotificationSendResult::Queued => {
+                    log::debug!(
+                        target: "kakehashi::bridge::cancel",
+                        "[{}] cancelled abandoned downstream request {} on drop",
+                        handle.key(),
+                        self.request_id.as_i64()
+                    );
+                }
+                NotificationSendResult::QueueFull => {
+                    // No reserved control lane, deliberately: a full 4096-deep
+                    // queue means the writer is stalled far beyond anything
+                    // the request cap models — the connection is degenerate
+                    // and liveness/teardown will fail it. Say so honestly
+                    // instead of claiming the cancel went out.
+                    log::warn!(
+                        target: "kakehashi::bridge::cancel",
+                        "[{}] outbound queue full; cancel for abandoned request {} dropped",
+                        handle.key(),
+                        self.request_id.as_i64()
+                    );
+                }
+                NotificationSendResult::ChannelClosed
+                | NotificationSendResult::SerializationFailed => {
+                    // Writer gone (teardown) or unserializable (impossible for
+                    // CancelParams): nothing left to tell.
+                    log::debug!(
+                        target: "kakehashi::bridge::cancel",
+                        "[{}] cancel for abandoned request {} not sent (writer closed)",
+                        handle.key(),
+                        self.request_id.as_i64()
+                    );
+                }
+            }
         }
     }
 }

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -92,6 +92,63 @@ fn closed_request_slots_error() -> io::Error {
 #[cfg(test)]
 use crate::config::settings::DEFAULT_MAX_CONCURRENT_REQUESTS;
 
+/// Queues `$/cancelRequest` for a SENT downstream request when dropped while
+/// armed. Every drop path — a JoinSet abort on a preferred-strategy loss,
+/// diagnostic supersession, a caller timeout dropping the future, and the
+/// response-deadline / internal-30s expiry error returns — releases the
+/// request slot, and without the cancel the downstream would keep computing
+/// work nobody will read: the cap would bound kakehashi's waiters, not the
+/// server's real in-flight depth (#974). Disarm once a response actually
+/// arrives. Best-effort by nature: the send is a non-blocking queue write,
+/// and a dead writer just drops it — exactly like every other
+/// `$/cancelRequest`.
+pub(in crate::lsp::bridge) struct CancelOnDropGuard {
+    handle: Option<Arc<ConnectionHandle>>,
+    request_id: crate::lsp::bridge::protocol::RequestId,
+}
+
+impl CancelOnDropGuard {
+    pub(in crate::lsp::bridge) fn new(
+        handle: Arc<ConnectionHandle>,
+        request_id: crate::lsp::bridge::protocol::RequestId,
+    ) -> Self {
+        Self {
+            handle: Some(handle),
+            request_id,
+        }
+    }
+
+    /// A response arrived (or the caller cancelled explicitly): the
+    /// downstream is done with this request, nothing to cancel.
+    pub(in crate::lsp::bridge) fn disarm(&mut self) {
+        self.handle = None;
+    }
+}
+
+impl Drop for CancelOnDropGuard {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            use tower_lsp_server::ls_types::{CancelParams, NumberOrString};
+            let notification = crate::lsp::bridge::protocol::JsonRpcNotification::new(
+                "$/cancelRequest",
+                CancelParams {
+                    // Safe: downstream ids come from an i64 counter starting
+                    // at 2, well within i32 range (ls-types constrains
+                    // Number to i32).
+                    id: NumberOrString::Number(self.request_id.as_i64() as i32),
+                },
+            );
+            let _ = handle.send_notification(notification);
+            log::debug!(
+                target: "kakehashi::bridge::cancel",
+                "[{}] cancelled abandoned downstream request {} on drop",
+                handle.key(),
+                self.request_id.as_i64()
+            );
+        }
+    }
+}
+
 /// Per-connection state + I/O actors (ls-bridge-message-ordering single-writer loop).
 ///
 /// Lifecycle: `Initializing` → `Ready` (after initialize/initialized) or

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -351,7 +351,14 @@ impl ConnectionHandle {
     ) -> io::Result<tokio::sync::OwnedSemaphorePermit> {
         // Fast path: a free slot needs no clock read.
         match Arc::clone(&self.request_permits).try_acquire_owned() {
-            Ok(permit) => return Ok(permit),
+            Ok(permit) => {
+                // See the router check below — the derived terminal state
+                // must reject the fast path too.
+                if !self.router.is_accepting() {
+                    return Err(closed_request_slots_error());
+                }
+                return Ok(permit);
+            }
             Err(tokio::sync::TryAcquireError::Closed) => {
                 return Err(closed_request_slots_error());
             }
@@ -362,6 +369,13 @@ impl ConnectionHandle {
             .acquire_owned()
             .await
             .map_err(|_| closed_request_slots_error())?;
+        // A reader-death terminal state is DERIVED (`state()` reads
+        // `!router.is_accepting()`; no `set_state` runs, so no semaphore
+        // close): a permit granted on such a connection is a permit to fail
+        // at register — reject here with the uniform error instead.
+        if !self.router.is_accepting() {
+            return Err(closed_request_slots_error());
+        }
         let waited = parked_at.elapsed();
         if waited >= BACKPRESSURE_LOG_THRESHOLD {
             // Saturation must not be an invisible wait: this is the signal

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -109,12 +109,12 @@ use crate::config::settings::DEFAULT_MAX_CONCURRENT_REQUESTS;
 /// contributes at most ONE cancel per request; the forwarder contributes one
 /// per RECEIVED client cancel (it has never deduplicated repeats — a
 /// pre-existing property, not introduced by the guard), and the formatting
-/// pipeline's probe cancel is a third pre-existing source. All are
-/// idempotent per the LSP spec (a server ignores cancels for
-/// unknown/finished ids) and tiny against the 4096-deep dedicated-writer
-/// queue. Exactly-once bookkeeping needs a recently-cancelled id set that
-/// survives router-entry removal — the same machinery issue #979 needs —
-/// and lives there.
+/// pipeline's probe cancel is a third pre-existing source. So the GUARD's
+/// contribution is bounded at one; total duplicate cancel traffic is not —
+/// a client repeating cancels can keep the forwarder sending until #979's
+/// recently-cancelled set (which must survive router-entry removal) lands.
+/// All duplicates are idempotent per the LSP spec (a server ignores cancels
+/// for unknown/finished ids).
 pub(in crate::lsp::bridge) struct CancelOnDropGuard {
     handle: Option<Arc<ConnectionHandle>>,
     request_id: crate::lsp::bridge::protocol::RequestId,
@@ -491,11 +491,12 @@ impl ConnectionHandle {
     ///
     /// Deliberately does NOT check `ConnectionState`: a request that raced
     /// `begin_shutdown` (state already `Closing` when this enqueues) is
-    /// drained by the writer's 3-phase shutdown ahead of the shutdown/exit
-    /// pair, and its waiter is woken by `fail_all`/channel-close if the
-    /// process exits first — a bounded, pre-existing race. Rejecting it here
-    /// would couple every hot-path send to the state lock for a window that
-    /// graceful shutdown already handles.
+    /// either drained by the writer's shutdown pass or — if it lands after
+    /// the drain's `try_recv` saw empty — abandoned when the writer's
+    /// receiver closes, with its waiter failed during connection teardown
+    /// (`fail_all`/channel-close). A bounded, pre-existing race either way;
+    /// rejecting it here would couple every hot-path send to the state lock
+    /// for a window teardown already handles.
     pub(crate) fn send_request<P: serde::Serialize>(
         &self,
         request: JsonRpcRequest<P>,

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -1280,6 +1280,64 @@ mod tests {
         .expect("slot frees once the permit drops");
     }
 
+    /// A reader-death terminal state is DERIVED, not set: `state()` reports
+    /// `Failed` from `!router.is_accepting()` without any `set_state` call,
+    /// so the semaphore never gets its close. A permit granted on such a
+    /// connection must still come out as an error — in production the freed
+    /// permits of failed in-flight requests would otherwise hand parked
+    /// waiters a permit to a corpse, which they'd only discover at register.
+    #[tokio::test]
+    async fn acquire_after_router_terminal_errors_even_without_set_state() {
+        let mut conn = AsyncBridgeConnection::spawn(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "cat > /dev/null".to_string(),
+        ])
+        .await
+        .expect("spawn sink");
+        let (writer, reader) = conn.split();
+        let router = Arc::new(ResponseRouter::new());
+        let reader_handle = spawn_reader_task(reader, Arc::clone(&router));
+        let (tx, rx) = mpsc::channel(OUTBOUND_QUEUE_CAPACITY);
+        let handle = Arc::new(ConnectionHandle::with_state(
+            writer,
+            Arc::clone(&router),
+            reader_handle,
+            ConnectionState::Ready,
+            tx,
+            rx,
+            default_dynamic_caps(),
+            ConnectionKey::for_server("reader-died"),
+            crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            Arc::new(arc_swap::ArcSwapOption::empty()),
+            1,
+        ));
+
+        let held = handle
+            .acquire_request_slot()
+            .await
+            .expect("the only slot acquires while healthy");
+        let parked = {
+            let handle = Arc::clone(&handle);
+            tokio::spawn(async move { handle.acquire_request_slot().await })
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        // Reader death: fail_all flips is_accepting without any set_state.
+        router.fail_all("test: reader died");
+        assert_eq!(handle.state(), ConnectionState::Failed, "derived terminal");
+
+        // The in-flight holder finishes (its oneshot failed) and frees the
+        // permit — the parked waiter must NOT be handed a permit to a corpse.
+        drop(held);
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), parked)
+            .await
+            .expect("waiter resolves promptly")
+            .expect("waiter task must not panic");
+        let error = result.expect_err("a derived-terminal connection must error, not acquire");
+        assert_eq!(error.kind(), std::io::ErrorKind::NotConnected);
+    }
+
     /// A connection leaving service (crash → `Failed`, teardown → `Closing`)
     /// must WAKE tasks parked on its request slots with an error (#974): the
     /// permits of a dead connection never free, so without this a parked

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -73,14 +73,6 @@ pub(crate) enum NotificationSendResult {
     SerializationFailed,
 }
 
-/// Per-connection state + I/O actors (ls-bridge-message-ordering single-writer loop).
-///
-/// Lifecycle: `Initializing` → `Ready` (after initialize/initialized) or
-/// `Failed` (timeout/error). Shutdown then drives `begin_shutdown`
-/// (`Initializing`/`Ready` → `Closing`) and `complete_shutdown`
-/// (`Closing`/`Failed` → `Closed`, terminal). FIFO writes flow `tx` → writer
-/// task → stdin; the reader task pushes incoming responses through `router` to
-/// oneshot waiters so callers can await without holding any Mutex.
 /// Park times at or above this on the request-slot semaphore are logged
 /// (`kakehashi::bridge::backpressure`, debug): long waits are the saturation
 /// signal, and an order of magnitude above scheduler noise keeps the log
@@ -100,6 +92,14 @@ fn closed_request_slots_error() -> io::Error {
 #[cfg(test)]
 use crate::config::settings::DEFAULT_MAX_CONCURRENT_REQUESTS;
 
+/// Per-connection state + I/O actors (ls-bridge-message-ordering single-writer loop).
+///
+/// Lifecycle: `Initializing` → `Ready` (after initialize/initialized) or
+/// `Failed` (timeout/error). Shutdown then drives `begin_shutdown`
+/// (`Initializing`/`Ready` → `Closing`) and `complete_shutdown`
+/// (`Closing`/`Failed` → `Closed`, terminal). FIFO writes flow `tx` → writer
+/// task → stdin; the reader task pushes incoming responses through `router` to
+/// oneshot waiters so callers can await without holding any Mutex.
 pub(crate) struct ConnectionHandle {
     /// Connection state - uses std::sync::RwLock for fast, synchronous state checks
     state: std::sync::RwLock<ConnectionState>,
@@ -166,10 +166,17 @@ pub(crate) struct ConnectionHandle {
     /// Cap on concurrent in-flight requests to this connection (#974).
     ///
     /// Acquired (owned, RAII) at the entry of the shared request-execution
-    /// paths, BEFORE the per-host lifecycle lock and the pool `connections`
-    /// lock — a task parked here must never hold anything another
-    /// connection's requests need. Notifications, `$/cancelRequest`, and the
-    /// initialize/shutdown lifecycle are deliberately exempt.
+    /// paths (`execute_bridge_request_observed`, `execute_host_request`),
+    /// BEFORE the per-host lifecycle lock and the pool `connections` lock —
+    /// a task parked here must never hold anything another connection's
+    /// requests need. Exempt by design: notifications, `$/cancelRequest`
+    /// (it relieves saturation), and the initialize/shutdown lifecycle.
+    /// Also currently ungated because they build their requests inline
+    /// rather than through the shared paths: `workspace/executeCommand`,
+    /// `completionItem/resolve`, `codeAction/resolve`, and
+    /// `textDocument/codeLens` — all single user-gesture requests, not
+    /// fan-out sources; gating them is a follow-up, so the cap is a burst
+    /// bound, not a hard per-connection ceiling.
     request_permits: Arc<tokio::sync::Semaphore>,
 }
 
@@ -254,6 +261,17 @@ impl ConnectionHandle {
     /// error, or future drop all release it. Errors when the semaphore was
     /// closed (connection evicted): failing fast beats parking on a dead
     /// connection's permits.
+    ///
+    /// The park itself carries no timeout, by design: every permit holder is
+    /// bounded (diagnostics by the 5s answer deadline, everything else by
+    /// `wait_for_response`'s 30s `REQUEST_TIMEOUT`), so the wait is bounded
+    /// by `ceil(queued / cap) ×` that; a connection leaving service closes
+    /// the semaphore via `set_state` and wakes waiters with `NotConnected`;
+    /// and a caller dropping its future releases everything via RAII. A
+    /// `$/cancelRequest` arriving while its request is still parked finds no
+    /// registration to cancel — the caller's own cancel subscription (where
+    /// one exists) drops the parked future instead; without one the request
+    /// runs to completion, the pre-existing best-effort cancel semantics.
     pub(in crate::lsp::bridge) async fn acquire_request_slot(
         &self,
     ) -> io::Result<tokio::sync::OwnedSemaphorePermit> {

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -556,6 +556,63 @@ mod tests {
         }
     }
 
+    /// The #974 user requirement, pinned directly: a connection saturated to
+    /// its in-flight cap must not delay requests to a DIFFERENT connection.
+    /// Permits are per-connection and a parked task holds no shared lock, so
+    /// an idle connection is fed immediately.
+    #[tokio::test]
+    async fn saturated_connection_does_not_delay_an_idle_connection() {
+        let cap = crate::lsp::bridge::pool::DEFAULT_MAX_CONCURRENT_REQUESTS;
+        let pool = Arc::new(LanguageServerPool::new());
+        let host_uri = test_host_uri("cross-connection");
+        pool.open_host_incarnation(&host_uri, 1).await;
+        let busy = create_handle_with_key(
+            ConnectionState::Ready,
+            ConnectionKey::for_server("busy-server"),
+        )
+        .await;
+        let idle = create_handle_with_key(
+            ConnectionState::Ready,
+            ConnectionKey::for_server("idle-server"),
+        )
+        .await;
+        pool.insert_connection(Arc::clone(&busy)).await;
+        pool.insert_connection(Arc::clone(&idle)).await;
+
+        // Saturate the busy connection past its cap (sink server: nothing
+        // ever completes, so all permits stay taken and one task is parked).
+        let mut busy_requests = Vec::new();
+        for i in 0..(cap + 1) {
+            let (request, _probe) = start_observed_request(
+                Arc::clone(&pool),
+                Arc::clone(&busy),
+                host_uri.clone(),
+                UpstreamId::Number(2_000 + i as i64),
+            );
+            busy_requests.push(request);
+        }
+
+        // A request to the idle connection must reach its downstream
+        // promptly (downstream id published) despite the saturation.
+        let (idle_request, idle_probe) = start_observed_request(
+            Arc::clone(&pool),
+            Arc::clone(&idle),
+            host_uri.clone(),
+            UpstreamId::Number(3_000),
+        );
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            wait_for_downstream_id(&idle_probe),
+        )
+        .await
+        .expect("an idle connection must be fed while another is saturated");
+
+        idle_request.abort();
+        for request in &busy_requests {
+            request.abort();
+        }
+    }
+
     #[tokio::test]
     async fn host_close_waits_for_request_enqueue_guard() {
         let pool = Arc::new(LanguageServerPool::new());

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -468,6 +468,86 @@ mod tests {
             .await;
     }
 
+    /// The per-connection in-flight cap (#974): with `cap + 1` concurrent
+    /// requests against one connection, only `cap` may reach the downstream
+    /// (observable via the downstream-id probe — publishing the id means the
+    /// request got past the permit gate). The extra request parks until a
+    /// permit frees (here: an in-flight request is aborted), then proceeds.
+    /// The backing process is a sink that never answers, so in-flight
+    /// requests stay in flight for the whole test.
+    #[tokio::test]
+    async fn requests_beyond_the_in_flight_cap_park_until_a_permit_frees() {
+        let cap = crate::lsp::bridge::pool::DEFAULT_MAX_CONCURRENT_REQUESTS;
+        let pool = Arc::new(LanguageServerPool::new());
+        let host_uri = test_host_uri("in-flight-cap");
+        pool.open_host_incarnation(&host_uri, 1).await;
+        let handle = create_handle_with_key(
+            ConnectionState::Ready,
+            ConnectionKey::for_server("test-server"),
+        )
+        .await;
+        pool.insert_connection(Arc::clone(&handle)).await;
+
+        let mut requests = Vec::new();
+        let mut probes = Vec::new();
+        for i in 0..(cap + 1) {
+            let (request, probe) = start_observed_request(
+                Arc::clone(&pool),
+                Arc::clone(&handle),
+                host_uri.clone(),
+                UpstreamId::Number(1_000 + i as i64),
+            );
+            requests.push(request);
+            probes.push(probe);
+        }
+
+        let published = |probes: &[Arc<std::sync::OnceLock<RequestId>>]| {
+            probes.iter().filter(|p| p.get().is_some()).count()
+        };
+
+        // Exactly `cap` requests get a permit and publish their downstream id.
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while published(&probes) < cap {
+                tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+            }
+        })
+        .await
+        .expect("the first `cap` requests should reach the downstream");
+
+        // The extra request must PARK: give it real time to (wrongly) proceed.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert_eq!(
+            published(&probes),
+            cap,
+            "request cap+1 must wait for a permit, not reach the downstream"
+        );
+
+        // Freeing one permit (aborting an in-flight request) unparks it.
+        let mut aborted_index = None;
+        for (i, probe) in probes.iter().enumerate() {
+            if probe.get().is_some() {
+                requests[i].abort();
+                aborted_index = Some(i);
+                break;
+            }
+        }
+        let aborted_index = aborted_index.expect("some request was in flight");
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while published(&probes) < cap + 1 {
+                tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+            }
+        })
+        .await
+        .expect("the parked request should proceed once a permit frees");
+
+        for (i, request) in requests.iter().enumerate() {
+            if i != aborted_index {
+                request.abort();
+            }
+        }
+    }
+
     #[tokio::test]
     async fn host_close_waits_for_request_enqueue_guard() {
         let pool = Arc::new(LanguageServerPool::new());

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -135,6 +135,14 @@ impl LanguageServerPool {
         // so per-root pooling (#382) stays consistent.
         let connection_key = handle.key();
 
+        // In-flight cap (#974): park here — BEFORE the host lifecycle lock
+        // and the `connections` lock below — until this connection has a free
+        // request slot. A task waiting on a saturated connection holds
+        // nothing, so requests to other (idle) connections proceed
+        // unhindered. The permit is RAII: response, error, and future drop
+        // (cancel, JoinSet abort) all release it.
+        let _request_slot = handle.acquire_request_slot().await?;
+
         // Convert host_uri to lsp_types::Uri for bridge protocol functions
         let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(host_uri)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -105,6 +105,7 @@ impl LanguageServerPool {
             build_request,
             transform_response,
             None,
+            None,
         )
         .await
     }
@@ -129,6 +130,7 @@ impl LanguageServerPool {
         build_request: impl FnOnce(&VirtualDocumentUri, RequestId) -> JsonRpcRequest<P>,
         transform_response: impl FnOnce(serde_json::Value, &BridgeResponseContext<'_>) -> T,
         downstream_id_probe: Option<&std::sync::OnceLock<RequestId>>,
+        response_timeout: Option<std::time::Duration>,
     ) -> io::Result<T> {
         // Route all per-connection state by this handle's pool key
         // `(server_name, root)` rather than a separately-threaded server name,
@@ -250,7 +252,41 @@ impl LanguageServerPool {
         // Wait for response via oneshot channel (no Mutex held) with timeout.
         // After this returns (success, channel-closed, or timeout),
         // the router entry has been consumed or cleaned up internally.
-        let response = handle.wait_for_response(request_id, response_rx).await;
+        //
+        // `response_timeout` starts HERE — after the request slot was granted
+        // and the request enqueued (#974). Measuring it from fan-out entry
+        // (as callers used to) made a burst's queue wait count against the
+        // deadline, so the tail of a burst timed out on a perfectly healthy
+        // downstream.
+        let response = match response_timeout {
+            Some(deadline) => {
+                match tokio::time::timeout(
+                    deadline,
+                    handle.wait_for_response(request_id, response_rx),
+                )
+                .await
+                {
+                    Ok(response) => response,
+                    Err(_) => {
+                        // wait_for_response's own cleanup branch never ran, so
+                        // the router entry is still pending; router_guard stays
+                        // ARMED and removes it on this early return.
+                        if let Some(ref id) = upstream_request_id {
+                            self.unregister_upstream_request(id, connection_key);
+                        }
+                        return Err(io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            format!(
+                                "bridge: no response for {} within {:?} (measured from send)",
+                                virtual_uri.to_uri_string(),
+                                deadline
+                            ),
+                        ));
+                    }
+                }
+            }
+            None => handle.wait_for_response(request_id, response_rx).await,
+        };
         router_guard.disarm();
 
         // Unregister from the upstream request registry regardless of result
@@ -394,6 +430,7 @@ mod tests {
                 },
                 |_, _| (),
                 Some(&request_probe),
+                None,
             )
             .await
         });
@@ -554,6 +591,127 @@ mod tests {
                 request.abort();
             }
         }
+    }
+
+    /// The `response_timeout` clock starts from SEND, not from fan-out entry
+    /// (#974): a request parked on the request-slot semaphore for longer than
+    /// its whole deadline must still be sent once a slot frees, and only then
+    /// time out. Under the old caller-side wrap, a burst's queue wait counted
+    /// against the deadline and the tail died before ever reaching a
+    /// healthy-but-saturated downstream.
+    #[tokio::test]
+    async fn response_deadline_excludes_request_slot_queue_wait() {
+        use crate::lsp::bridge::actor::{ResponseRouter, spawn_reader_task};
+        use crate::lsp::bridge::connection::AsyncBridgeConnection;
+        use crate::lsp::bridge::pool::DynamicCapabilityRegistry;
+        use tokio::sync::mpsc;
+
+        const DEADLINE: std::time::Duration = std::time::Duration::from_millis(150);
+        // Longer than DEADLINE: the parked request outlives its whole answer
+        // budget while waiting for a slot.
+        const PARKED: std::time::Duration = std::time::Duration::from_millis(400);
+
+        let pool = Arc::new(LanguageServerPool::new());
+        let host_uri = test_host_uri("deadline-from-send");
+        pool.open_host_incarnation(&host_uri, 1).await;
+
+        // Capacity-1 sink connection: one request occupies the only slot
+        // forever (the sink never answers).
+        let mut conn = AsyncBridgeConnection::spawn(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "cat > /dev/null".to_string(),
+        ])
+        .await
+        .expect("spawn sink");
+        let (writer, reader) = conn.split();
+        let router = Arc::new(ResponseRouter::new());
+        let reader_handle = spawn_reader_task(reader, Arc::clone(&router));
+        let (tx, rx) = mpsc::channel(crate::lsp::bridge::actor::OUTBOUND_QUEUE_CAPACITY);
+        let handle = Arc::new(ConnectionHandle::with_state(
+            writer,
+            router,
+            reader_handle,
+            ConnectionState::Ready,
+            tx,
+            rx,
+            Arc::new(DynamicCapabilityRegistry::new()),
+            ConnectionKey::for_server("test-server"),
+            crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            Arc::new(arc_swap::ArcSwapOption::empty()),
+            1,
+        ));
+        pool.insert_connection(Arc::clone(&handle)).await;
+
+        let (occupant, occupant_probe) = start_observed_request(
+            Arc::clone(&pool),
+            Arc::clone(&handle),
+            host_uri.clone(),
+            UpstreamId::Number(4_000),
+        );
+        wait_for_downstream_id(&occupant_probe).await;
+
+        // The deadlined request parks on the slot.
+        let probe = Arc::new(std::sync::OnceLock::new());
+        let request_probe = Arc::clone(&probe);
+        let request = {
+            let pool = Arc::clone(&pool);
+            let handle = Arc::clone(&handle);
+            let host_uri = host_uri.clone();
+            tokio::spawn(async move {
+                pool.execute_bridge_request_observed(
+                    handle,
+                    &host_uri,
+                    "lua",
+                    TEST_ULID_LUA_0,
+                    &RegionOffset::new(0, 0),
+                    "print('hello')",
+                    Some(UpstreamId::Number(4_001)),
+                    |_, request_id| {
+                        JsonRpcRequest::new(
+                            request_id.as_i64(),
+                            "test/request",
+                            serde_json::Value::Null,
+                        )
+                    },
+                    |_, _| (),
+                    Some(&request_probe),
+                    Some(DEADLINE),
+                )
+                .await
+            })
+        };
+
+        tokio::time::sleep(PARKED).await;
+        assert!(
+            !request.is_finished(),
+            "a parked request must not consume its answer deadline"
+        );
+        assert!(
+            probe.get().is_none(),
+            "the parked request must not have reached the downstream yet"
+        );
+
+        // Free the slot; the parked request must now be SENT, then time out
+        // on the (still silent) sink after its own full deadline.
+        let released_at = std::time::Instant::now();
+        occupant.abort();
+        let error = request
+            .await
+            .expect("request task must not panic")
+            .expect_err("the sink never answers, so the deadline must fire");
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut, "error: {error}");
+        assert!(
+            probe.get().is_some(),
+            "the request must reach the downstream once a slot frees"
+        );
+        assert!(
+            released_at.elapsed() >= DEADLINE,
+            "the deadline must be measured from send, not from entry: \
+             elapsed {:?} < deadline {:?}",
+            released_at.elapsed(),
+            DEADLINE
+        );
     }
 
     /// The #974 user requirement, pinned directly: a connection saturated to

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -529,15 +529,23 @@ mod tests {
     /// permit frees (here: an in-flight request is aborted), then proceeds.
     /// The backing process is a sink that never answers, so in-flight
     /// requests stay in flight for the whole test.
+    ///
+    /// A SMALL explicit cap, deliberately: the parking mechanics are
+    /// identical at any capacity, while `DEFAULT_MAX_CONCURRENT_REQUESTS + 1`
+    /// tasks would couple this test's wall time (and its poll windows) to a
+    /// tuning constant that is free to grow. The default's own wiring is
+    /// pinned by `spawned_connection_is_capped_by_the_configured_max_concurrent_requests`
+    /// and the config tests.
     #[tokio::test]
     async fn requests_beyond_the_in_flight_cap_park_until_a_permit_frees() {
-        let cap = crate::lsp::bridge::pool::DEFAULT_MAX_CONCURRENT_REQUESTS;
+        let cap = 4;
         let pool = Arc::new(LanguageServerPool::new());
         let host_uri = test_host_uri("in-flight-cap");
         pool.open_host_incarnation(&host_uri, 1).await;
-        let handle = create_handle_with_key(
+        let handle = create_capped_handle_with_key(
             ConnectionState::Ready,
             ConnectionKey::for_server("test-server"),
+            cap,
         )
         .await;
         pool.insert_connection(Arc::clone(&handle)).await;
@@ -610,11 +618,6 @@ mod tests {
     /// healthy-but-saturated downstream.
     #[tokio::test]
     async fn response_deadline_excludes_request_slot_queue_wait() {
-        use crate::lsp::bridge::actor::{ResponseRouter, spawn_reader_task};
-        use crate::lsp::bridge::connection::AsyncBridgeConnection;
-        use crate::lsp::bridge::pool::DynamicCapabilityRegistry;
-        use tokio::sync::mpsc;
-
         const DEADLINE: std::time::Duration = std::time::Duration::from_millis(150);
         // Longer than DEADLINE: the parked request outlives its whole answer
         // budget while waiting for a slot.
@@ -626,30 +629,12 @@ mod tests {
 
         // Capacity-1 sink connection: one request occupies the only slot
         // forever (the sink never answers).
-        let mut conn = AsyncBridgeConnection::spawn(vec![
-            "sh".to_string(),
-            "-c".to_string(),
-            "cat > /dev/null".to_string(),
-        ])
-        .await
-        .expect("spawn sink");
-        let (writer, reader) = conn.split();
-        let router = Arc::new(ResponseRouter::new());
-        let reader_handle = spawn_reader_task(reader, Arc::clone(&router));
-        let (tx, rx) = mpsc::channel(crate::lsp::bridge::actor::OUTBOUND_QUEUE_CAPACITY);
-        let handle = Arc::new(ConnectionHandle::with_state(
-            writer,
-            router,
-            reader_handle,
+        let handle = create_capped_handle_with_key(
             ConnectionState::Ready,
-            tx,
-            rx,
-            Arc::new(DynamicCapabilityRegistry::new()),
             ConnectionKey::for_server("test-server"),
-            crate::lsp::bridge::WorkspaceFolderSet::new(None),
-            Arc::new(arc_swap::ArcSwapOption::empty()),
             1,
-        ));
+        )
+        .await;
         pool.insert_connection(Arc::clone(&handle)).await;
 
         let (occupant, occupant_probe) = start_observed_request(
@@ -822,15 +807,22 @@ mod tests {
     /// its in-flight cap must not delay requests to a DIFFERENT connection.
     /// Permits are per-connection and a parked task holds no shared lock, so
     /// an idle connection is fed immediately.
+    ///
+    /// Saturation is ASSERTED before the idle request is spawned — without
+    /// that precondition the test would pass vacuously whenever the busy
+    /// requests errored out early (or, on a multi-thread runtime, hadn't
+    /// been polled yet), and a global-semaphore bug could hide behind the
+    /// scheduling order.
     #[tokio::test]
     async fn saturated_connection_does_not_delay_an_idle_connection() {
-        let cap = crate::lsp::bridge::pool::DEFAULT_MAX_CONCURRENT_REQUESTS;
+        let cap = 2;
         let pool = Arc::new(LanguageServerPool::new());
         let host_uri = test_host_uri("cross-connection");
         pool.open_host_incarnation(&host_uri, 1).await;
-        let busy = create_handle_with_key(
+        let busy = create_capped_handle_with_key(
             ConnectionState::Ready,
             ConnectionKey::for_server("busy-server"),
+            cap,
         )
         .await;
         let idle = create_handle_with_key(
@@ -844,15 +836,32 @@ mod tests {
         // Saturate the busy connection past its cap (sink server: nothing
         // ever completes, so all permits stay taken and one task is parked).
         let mut busy_requests = Vec::new();
+        let mut busy_probes = Vec::new();
         for i in 0..(cap + 1) {
-            let (request, _probe) = start_observed_request(
+            let (request, probe) = start_observed_request(
                 Arc::clone(&pool),
                 Arc::clone(&busy),
                 host_uri.clone(),
                 UpstreamId::Number(2_000 + i as i64),
             );
             busy_requests.push(request);
+            busy_probes.push(probe);
         }
+        let published = |probes: &[Arc<std::sync::OnceLock<RequestId>>]| {
+            probes.iter().filter(|p| p.get().is_some()).count()
+        };
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while published(&busy_probes) < cap {
+                tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+            }
+        })
+        .await
+        .expect("the busy connection must reach its cap before the idle probe runs");
+        assert_eq!(
+            published(&busy_probes),
+            cap,
+            "exactly `cap` busy requests in flight; the extra one is parked"
+        );
 
         // A request to the idle connection must reach its downstream
         // promptly (downstream id published) despite the saturation.
@@ -862,12 +871,7 @@ mod tests {
             host_uri.clone(),
             UpstreamId::Number(3_000),
         );
-        tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            wait_for_downstream_id(&idle_probe),
-        )
-        .await
-        .expect("an idle connection must be fed while another is saturated");
+        wait_for_downstream_id(&idle_probe).await;
 
         idle_request.abort();
         for request in &busy_requests {

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -268,6 +268,15 @@ impl LanguageServerPool {
                 {
                     Ok(response) => response,
                     Err(_) => {
+                        // The downstream is still computing the abandoned
+                        // request, and this return releases the permit — tell
+                        // it to stop, or each expiry would admit a NEW request
+                        // on top of the still-running one and the cap would
+                        // bound our waiters, not the server's in-flight work.
+                        // Sent BEFORE the unregister so the cancel mappings
+                        // are still consistent at send time; best-effort, like
+                        // every $/cancelRequest.
+                        let _ = self.send_cancel_notification(&handle, connection_key, request_id);
                         // wait_for_response's own cleanup branch never ran, so
                         // the router entry is still pending; router_guard stays
                         // ARMED and removes it on this early return.
@@ -792,11 +801,11 @@ mod tests {
         let request_id = probe.get().expect("the request was sent").as_i64();
 
         // The abandoned request's cancel must reach the wire.
-        let expected = format!("\"method\":\"$/cancelRequest\"");
+        let expected = "\"method\":\"$/cancelRequest\"";
         tokio::time::timeout(std::time::Duration::from_secs(2), async {
             loop {
                 if let Ok(wire) = std::fs::read_to_string(&wire_capture)
-                    && wire.contains(&expected)
+                    && wire.contains(expected)
                     && wire.contains(&format!("\"id\":{request_id}"))
                 {
                     break;

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -714,6 +714,101 @@ mod tests {
         );
     }
 
+    /// A request abandoned by its answer deadline must tell the downstream to
+    /// stop (`$/cancelRequest`): the permit is released at expiry, so without
+    /// the cancel each expiry admits a NEW request while the downstream still
+    /// computes the abandoned one — the cap would bound kakehashi's waiters,
+    /// not the server's actual in-flight work (#974).
+    #[tokio::test]
+    async fn deadline_expiry_cancels_the_downstream_request() {
+        use crate::lsp::bridge::actor::{ResponseRouter, spawn_reader_task};
+        use crate::lsp::bridge::connection::AsyncBridgeConnection;
+        use crate::lsp::bridge::pool::DynamicCapabilityRegistry;
+        use tokio::sync::mpsc;
+
+        // Sink that records everything kakehashi writes, so the wire is
+        // observable after the fact.
+        let wire_capture = std::env::temp_dir().join(format!(
+            "kakehashi-cancel-on-deadline-{}.jsonl",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&wire_capture);
+        let mut conn = AsyncBridgeConnection::spawn(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            // No `exec`: sh must stay alive holding its own stdout pipe,
+            // otherwise the redirect drops the pipe's write end and the
+            // reader sees EOF (fail_all) instead of a silent downstream.
+            format!("cat > {}", wire_capture.display()),
+        ])
+        .await
+        .expect("spawn capture sink");
+        let (writer, reader) = conn.split();
+        let router = Arc::new(ResponseRouter::new());
+        let reader_handle = spawn_reader_task(reader, Arc::clone(&router));
+        let (tx, rx) = mpsc::channel(crate::lsp::bridge::actor::OUTBOUND_QUEUE_CAPACITY);
+        let handle = Arc::new(ConnectionHandle::with_state(
+            writer,
+            router,
+            reader_handle,
+            ConnectionState::Ready,
+            tx,
+            rx,
+            Arc::new(DynamicCapabilityRegistry::new()),
+            ConnectionKey::for_server("test-server"),
+            crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            Arc::new(arc_swap::ArcSwapOption::empty()),
+            4,
+        ));
+        let pool = Arc::new(LanguageServerPool::new());
+        let host_uri = test_host_uri("cancel-on-deadline");
+        pool.open_host_incarnation(&host_uri, 1).await;
+        pool.insert_connection(Arc::clone(&handle)).await;
+
+        let probe = std::sync::OnceLock::new();
+        let error = pool
+            .execute_bridge_request_observed(
+                Arc::clone(&handle),
+                &host_uri,
+                "lua",
+                TEST_ULID_LUA_0,
+                &RegionOffset::new(0, 0),
+                "print('hello')",
+                None,
+                |_, request_id| {
+                    JsonRpcRequest::new(
+                        request_id.as_i64(),
+                        "test/request",
+                        serde_json::Value::Null,
+                    )
+                },
+                |_, _| (),
+                Some(&probe),
+                Some(std::time::Duration::from_millis(100)),
+            )
+            .await
+            .expect_err("the sink never answers, so the deadline must fire");
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut, "error: {error}");
+        let request_id = probe.get().expect("the request was sent").as_i64();
+
+        // The abandoned request's cancel must reach the wire.
+        let expected = format!("\"method\":\"$/cancelRequest\"");
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if let Ok(wire) = std::fs::read_to_string(&wire_capture)
+                    && wire.contains(&expected)
+                    && wire.contains(&format!("\"id\":{request_id}"))
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("a deadline expiry must forward $/cancelRequest downstream");
+        let _ = std::fs::remove_file(&wire_capture);
+    }
+
     /// The #974 user requirement, pinned directly: a connection saturated to
     /// its in-flight cap must not delay requests to a DIFFERENT connection.
     /// Permits are per-connection and a parked task holds no shared lock, so

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -80,7 +80,8 @@ impl LanguageServerPool {
     /// (callers obtain it via `get_or_create_connection`, usually because they
     /// need capability checks first). `build_request` shapes the JSON-RPC body
     /// once the virtual URI and request ID are known; `transform_response`
-    /// projects the raw response onto the typed result.
+    /// projects the raw response onto the typed result. May PARK at entry
+    /// until the connection has a free request slot (#974).
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn execute_bridge_request_with_handle<T, P: serde::Serialize>(
         &self,
@@ -117,6 +118,13 @@ impl LanguageServerPool {
     /// still cancel the in-flight downstream request precisely by that id —
     /// the upstream-id cancel mapping is removed by the router cleanup guard
     /// the moment the future is dropped, so it cannot be looked up afterward.
+    ///
+    /// `response_timeout`, when `Some`, bounds only the wait for the ANSWER:
+    /// the clock starts after the request slot is granted and the request is
+    /// enqueued (#974), so slot queue wait and connection state never consume
+    /// the deadline; on expiry the downstream request is cancelled and the
+    /// permit released. `None` leaves only `wait_for_response`'s internal 30s
+    /// cap — a `Some` above that is shadowed by it.
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn execute_bridge_request_observed<T, P: serde::Serialize>(
         &self,

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -257,6 +257,15 @@ impl LanguageServerPool {
         }
         drop(host_lifecycle);
 
+        // From here the request is ON THE WIRE: any exit that isn't a real
+        // response (deadline expiry, the internal 30s cap, a JoinSet abort or
+        // supersession dropping this future) must tell the downstream to
+        // stop, or the released permit would admit new work on top of the
+        // abandoned computation. Declared after `_request_slot`, so the drop
+        // order queues the cancel BEFORE the permit frees.
+        let mut cancel_on_drop =
+            super::connection_handle::CancelOnDropGuard::new(Arc::clone(&handle), request_id);
+
         // Wait for response via oneshot channel (no Mutex held) with timeout.
         // After this returns (success, channel-closed, or timeout),
         // the router entry has been consumed or cleaned up internally.
@@ -276,15 +285,10 @@ impl LanguageServerPool {
                 {
                     Ok(response) => response,
                     Err(_) => {
-                        // The downstream is still computing the abandoned
-                        // request, and this return releases the permit — tell
-                        // it to stop, or each expiry would admit a NEW request
-                        // on top of the still-running one and the cap would
-                        // bound our waiters, not the server's in-flight work.
-                        // Sent BEFORE the unregister so the cancel mappings
-                        // are still consistent at send time; best-effort, like
-                        // every $/cancelRequest.
-                        let _ = self.send_cancel_notification(&handle, connection_key, request_id);
+                        // cancel_on_drop stays armed: the downstream is still
+                        // computing the abandoned request, and this return
+                        // releases the permit — the guard's drop queues the
+                        // $/cancelRequest before the permit frees.
                         // wait_for_response's own cleanup branch never ran, so
                         // the router entry is still pending; router_guard stays
                         // ARMED and removes it on this early return.
@@ -318,7 +322,12 @@ impl LanguageServerPool {
             offset,
         };
 
-        Ok(transform_response(response?, &context))
+        // A real response arrived — nothing left to cancel. Error responses
+        // ARE responses; only the `response?` Err paths (timeout/closed
+        // channel) leave the guard armed.
+        let response = response?;
+        cancel_on_drop.disarm();
+        Ok(transform_response(response, &context))
     }
 
     /// Like [`execute_bridge_request_with_handle`](Self::execute_bridge_request_with_handle)

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -811,6 +811,81 @@ mod tests {
         let _ = std::fs::remove_file(&wire_capture);
     }
 
+    /// An ABORTED in-flight request (preferred-strategy loser, diagnostic
+    /// supersession, caller timeout dropping the future) must also cancel the
+    /// downstream request: the abort releases the permit, and without the
+    /// cancel the downstream keeps computing work nobody will read — with a
+    /// small cap, repeated aborts admit unbounded real downstream work.
+    #[tokio::test]
+    async fn aborting_a_sent_request_cancels_it_downstream() {
+        use crate::lsp::bridge::actor::{ResponseRouter, spawn_reader_task};
+        use crate::lsp::bridge::connection::AsyncBridgeConnection;
+        use crate::lsp::bridge::pool::DynamicCapabilityRegistry;
+        use tokio::sync::mpsc;
+
+        let wire_capture = std::env::temp_dir().join(format!(
+            "kakehashi-cancel-on-abort-{}.jsonl",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&wire_capture);
+        let mut conn = AsyncBridgeConnection::spawn(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            // No `exec`: sh must stay alive holding its own stdout pipe.
+            format!("cat > {}", wire_capture.display()),
+        ])
+        .await
+        .expect("spawn capture sink");
+        let (writer, reader) = conn.split();
+        let router = Arc::new(ResponseRouter::new());
+        let reader_handle = spawn_reader_task(reader, Arc::clone(&router));
+        let (tx, rx) = mpsc::channel(crate::lsp::bridge::actor::OUTBOUND_QUEUE_CAPACITY);
+        let handle = Arc::new(ConnectionHandle::with_state(
+            writer,
+            router,
+            reader_handle,
+            ConnectionState::Ready,
+            tx,
+            rx,
+            Arc::new(DynamicCapabilityRegistry::new()),
+            ConnectionKey::for_server("test-server"),
+            crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            Arc::new(arc_swap::ArcSwapOption::empty()),
+            4,
+        ));
+        let pool = Arc::new(LanguageServerPool::new());
+        let host_uri = test_host_uri("cancel-on-abort");
+        pool.open_host_incarnation(&host_uri, 1).await;
+        pool.insert_connection(Arc::clone(&handle)).await;
+
+        let (request, probe) = start_observed_request(
+            Arc::clone(&pool),
+            Arc::clone(&handle),
+            host_uri.clone(),
+            UpstreamId::Number(5_000),
+        );
+        let request_id = wait_for_downstream_id(&probe).await.as_i64();
+
+        // Abort the in-flight request — the JoinSet/supersession shape.
+        request.abort();
+
+        let expected = "\"method\":\"$/cancelRequest\"";
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if let Ok(wire) = std::fs::read_to_string(&wire_capture)
+                    && wire.contains(expected)
+                    && wire.contains(&format!("\"id\":{request_id}"))
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("aborting a sent request must forward $/cancelRequest downstream");
+        let _ = std::fs::remove_file(&wire_capture);
+    }
+
     /// The #974 user requirement, pinned directly: a connection saturated to
     /// its in-flight cap must not delay requests to a DIFFERENT connection.
     /// Permits are per-connection and a parked task holds no shared lock, so

--- a/src/lsp/bridge/pool/test_helpers.rs
+++ b/src/lsp/bridge/pool/test_helpers.rs
@@ -56,6 +56,7 @@ pub(in crate::lsp::bridge) fn lua_ls_config() -> BridgeServerConfig {
         prefer_shared_instance: None,
         enabled: None,
         settings: None,
+        max_concurrent_requests: None,
     }
 }
 
@@ -80,6 +81,7 @@ pub(in crate::lsp::bridge) fn devnull_config_for_language(language: &str) -> Bri
         prefer_shared_instance: None,
         enabled: None,
         settings: None,
+        max_concurrent_requests: None,
     }
 }
 
@@ -208,6 +210,7 @@ pub(in crate::lsp::bridge) async fn create_handle_with_state_and_pid_keyed(
         key,
         crate::lsp::bridge::WorkspaceFolderSet::new(None),
         std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+        crate::lsp::bridge::pool::DEFAULT_MAX_CONCURRENT_REQUESTS,
     ));
     (handle, pid)
 }

--- a/src/lsp/bridge/pool/test_helpers.rs
+++ b/src/lsp/bridge/pool/test_helpers.rs
@@ -211,7 +211,7 @@ pub(in crate::lsp::bridge) async fn create_handle_with_state_and_pid_keyed(
     create_handle_impl(
         state,
         key,
-        crate::lsp::bridge::pool::DEFAULT_MAX_CONCURRENT_REQUESTS,
+        crate::config::settings::DEFAULT_MAX_CONCURRENT_REQUESTS,
     )
     .await
 }

--- a/src/lsp/bridge/pool/test_helpers.rs
+++ b/src/lsp/bridge/pool/test_helpers.rs
@@ -139,6 +139,32 @@ pub(in crate::lsp::bridge) async fn create_handle_with_key(
     create_handle_with_state_and_pid_keyed(state, key).await.0
 }
 
+/// Advertise pull-diagnostic support on a test handle (the setter is
+/// `pub(super)` to the pool, so tests outside it go through this helper).
+pub(in crate::lsp::bridge) fn advertise_pull_diagnostics(handle: &ConnectionHandle) {
+    use tower_lsp_server::ls_types::{
+        DiagnosticOptions, DiagnosticServerCapabilities, ServerCapabilities,
+    };
+    handle.set_server_capabilities(ServerCapabilities {
+        diagnostic_provider: Some(DiagnosticServerCapabilities::Options(
+            DiagnosticOptions::default(),
+        )),
+        ..Default::default()
+    });
+}
+
+/// Like [`create_handle_with_key`], but with an explicit request-slot
+/// capacity (#974) for tests that pin parking behavior with tiny caps.
+pub(in crate::lsp::bridge) async fn create_capped_handle_with_key(
+    state: ConnectionState,
+    key: ConnectionKey,
+    max_concurrent_requests: usize,
+) -> Arc<ConnectionHandle> {
+    create_handle_impl(state, key, max_concurrent_requests)
+        .await
+        .0
+}
+
 /// Like [`create_handle_with_key`], but also advertises `commands` as the
 /// connection's static `executeCommandProvider.commands`, and optionally records
 /// `spawned_from` as the config the connection was launched with.
@@ -182,6 +208,19 @@ pub(in crate::lsp::bridge) async fn create_handle_with_state_and_pid_keyed(
     state: ConnectionState,
     key: ConnectionKey,
 ) -> (Arc<ConnectionHandle>, u32) {
+    create_handle_impl(
+        state,
+        key,
+        crate::lsp::bridge::pool::DEFAULT_MAX_CONCURRENT_REQUESTS,
+    )
+    .await
+}
+
+async fn create_handle_impl(
+    state: ConnectionState,
+    key: ConnectionKey,
+    max_concurrent_requests: usize,
+) -> (Arc<ConnectionHandle>, u32) {
     // Create a mock server process (sink — discards all input, no output)
     let mut conn = AsyncBridgeConnection::spawn(vec![
         "sh".to_string(),
@@ -210,7 +249,7 @@ pub(in crate::lsp::bridge) async fn create_handle_with_state_and_pid_keyed(
         key,
         crate::lsp::bridge::WorkspaceFolderSet::new(None),
         std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
-        crate::lsp::bridge::pool::DEFAULT_MAX_CONCURRENT_REQUESTS,
+        max_concurrent_requests,
     ));
     (handle, pid)
 }

--- a/src/lsp/bridge/protocol.rs
+++ b/src/lsp/bridge/protocol.rs
@@ -30,7 +30,8 @@ mod workspace_edit;
 // Re-export all public items for external use
 pub(crate) use command_routing::{decode_command, encode_command};
 pub(crate) use jsonrpc::{
-    JsonRpcNotification, JsonRpcRequest, jsonrpc_error_summary, response_has_jsonrpc_error,
+    JsonRpcNotification, JsonRpcRequest, cancel_request_notification, jsonrpc_error_summary,
+    response_has_jsonrpc_error,
 };
 pub(crate) use lifecycle::*;
 pub(crate) use request::*;

--- a/src/lsp/bridge/protocol/jsonrpc.rs
+++ b/src/lsp/bridge/protocol/jsonrpc.rs
@@ -90,9 +90,33 @@ impl<P> JsonRpcNotification<P> {
     }
 }
 
+/// Build a `$/cancelRequest` notification for a downstream request id,
+/// carrying the id as the SAME i64 JSON number the request went out with.
+/// Deliberately not `ls_types::CancelParams`: that type constrains numeric
+/// ids to i32, and a truncated id would cancel nothing (JSON-RPC matches the
+/// id by value), letting the abandoned request keep computing downstream.
+pub(crate) fn cancel_request_notification(
+    downstream_id: super::RequestId,
+) -> JsonRpcNotification<serde_json::Value> {
+    JsonRpcNotification::new(
+        "$/cancelRequest",
+        serde_json::json!({ "id": downstream_id.as_i64() }),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The cancel id must survive beyond i32: `ls_types::CancelParams` would
+    /// truncate 2^31 to a negative number, cancelling nothing.
+    #[test]
+    fn cancel_notification_keeps_the_full_i64_id() {
+        let id = super::super::RequestId::new(i64::from(i32::MAX) + 1);
+        let serialized = serde_json::to_value(cancel_request_notification(id)).expect("serializes");
+        assert_eq!(serialized["method"], "$/cancelRequest");
+        assert_eq!(serialized["params"]["id"], i64::from(i32::MAX) + 1);
+    }
 
     #[test]
     fn request_serializes_correctly() {

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -991,6 +991,21 @@ impl LanguageServerPool {
         upstream_id: Option<UpstreamId>,
     ) -> Option<CodeAction> {
         let connection_key = handle.key();
+
+        // In-flight cap (#974): the eager resolve pass batches these per
+        // phase-one response across regions — a genuine burst source, so it
+        // takes the same per-connection slot as every request.
+        let _request_slot = match handle.acquire_request_slot().await {
+            Ok(permit) => permit,
+            Err(e) => {
+                log::debug!(
+                    target: "kakehashi::bridge",
+                    "codeAction/resolve: no request slot on {connection_key:?}: {e}"
+                );
+                return None;
+            }
+        };
+
         if let Some(ref id) = upstream_id {
             self.register_upstream_request(id.clone(), connection_key);
         }
@@ -1051,6 +1066,10 @@ impl LanguageServerPool {
             }
         }
 
+        // On the wire: abandonment must cancel downstream before the slot
+        // frees (#974).
+        let mut cancel_on_drop =
+            super::super::pool::CancelOnDropGuard::new(Arc::clone(handle), request_id);
         let response = handle.wait_for_response(request_id, response_rx).await;
         router_guard.disarm();
         if let Some(ref id) = upstream_id {
@@ -1061,7 +1080,10 @@ impl LanguageServerPool {
         // action on the eager fan-out (unbounded by a hostile lazy-action
         // list); the callers own the bounded warn (aggregate / per-selection).
         let response = match response {
-            Ok(r) => r,
+            Ok(r) => {
+                cancel_on_drop.disarm();
+                r
+            }
             Err(e) => {
                 log::debug!(
                     target: "kakehashi::bridge",

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -240,6 +240,19 @@ impl LanguageServerPool {
         // Route per-connection cancel state by this handle's pool key (#382).
         let connection_key = handle.key();
 
+        // In-flight cap (#974): same per-connection slot as every request.
+        let _request_slot = match handle.acquire_request_slot().await {
+            Ok(permit) => permit,
+            Err(e) => {
+                warn!(
+                    target: "kakehashi::bridge",
+                    "codeLens/resolve: no request slot for {server_name}: {e}"
+                );
+                re_envelope_lens(&mut lens, &envelope);
+                return lens;
+            }
+        };
+
         // Register in the upstream request registry FIRST for cancel lookup.
         if let Some(ref id) = upstream_id {
             self.register_upstream_request(id.clone(), connection_key);
@@ -285,6 +298,10 @@ impl LanguageServerPool {
             return lens;
         }
 
+        // On the wire: abandonment must cancel downstream before the slot
+        // frees (#974).
+        let mut cancel_on_drop =
+            super::super::pool::CancelOnDropGuard::new(Arc::clone(&handle), request_id);
         let response = handle.wait_for_response(request_id, response_rx).await;
         router_guard.disarm();
 
@@ -293,7 +310,10 @@ impl LanguageServerPool {
         }
 
         let response = match response {
-            Ok(r) => r,
+            Ok(r) => {
+                cancel_on_drop.disarm();
+                r
+            }
             Err(e) => {
                 warn!(
                     target: "kakehashi::bridge",

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -285,17 +285,39 @@ impl LanguageServerPool {
 
         let mut router_guard = RouterCleanupGuard::new(Arc::clone(handle.router()), request_id);
 
-        if let Err(e) = handle.send_request(request, request_id) {
-            warn!(
-                target: "kakehashi::bridge",
-                "codeLens/resolve: failed to send request for {}: {}",
-                server_name, e
-            );
-            if let Some(ref id) = upstream_id {
-                self.unregister_upstream_request(id, connection_key);
+        // Live-handle check under the `connections` lock before sending —
+        // same rationale as completionItem/resolve: the slot park (#974)
+        // widens the window in which a reload can replace the handle.
+        {
+            let connections = self.connections().await;
+            if !connections
+                .get(connection_key)
+                .is_some_and(|current| Arc::ptr_eq(current, &handle))
+            {
+                drop(connections);
+                warn!(
+                    target: "kakehashi::bridge",
+                    "codeLens/resolve: connection {connection_key} was replaced before send"
+                );
+                if let Some(ref id) = upstream_id {
+                    self.unregister_upstream_request(id, connection_key);
+                }
+                re_envelope_lens(&mut lens, &envelope);
+                return lens;
             }
-            re_envelope_lens(&mut lens, &envelope);
-            return lens;
+            if let Err(e) = handle.send_request(request, request_id) {
+                drop(connections);
+                warn!(
+                    target: "kakehashi::bridge",
+                    "codeLens/resolve: failed to send request for {}: {}",
+                    server_name, e
+                );
+                if let Some(ref id) = upstream_id {
+                    self.unregister_upstream_request(id, connection_key);
+                }
+                re_envelope_lens(&mut lens, &envelope);
+                return lens;
+            }
         }
 
         // On the wire: abandonment must cancel downstream before the slot

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -461,6 +461,64 @@ mod tests {
         }
     }
 
+    /// `completionItem/resolve` must take the same per-connection request
+    /// slot as every other request (#974): eager resolve batches exist
+    /// (code actions resolve up to 8 at once per phase-one response), so the
+    /// inline-send paths are burst sources too — with the only slot held,
+    /// the resolve must PARK (never registers with the router) until the
+    /// slot frees.
+    #[tokio::test]
+    async fn completion_resolve_parks_on_the_request_slot_cap() {
+        use crate::lsp::bridge::pool::test_helpers::*;
+        use crate::lsp::bridge::pool::{ConnectionKey, ConnectionState, LanguageServerPool};
+        use std::sync::Arc;
+
+        let pool = Arc::new(LanguageServerPool::new());
+        let handle = create_capped_handle_with_key(
+            ConnectionState::Ready,
+            ConnectionKey::for_server("test-server"),
+            1,
+        )
+        .await;
+        pool.insert_connection(Arc::clone(&handle)).await;
+
+        let occupant = handle
+            .acquire_request_slot()
+            .await
+            .expect("the only slot acquires");
+
+        let resolve = {
+            let pool = Arc::clone(&pool);
+            let handle = Arc::clone(&handle);
+            tokio::spawn(async move {
+                pool.send_completion_resolve_on_handle(
+                    &handle,
+                    CompletionItem::new_simple("x".into(), "d".into()),
+                    None,
+                )
+                .await
+            })
+        };
+
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        assert_eq!(
+            handle.router().pending_count(),
+            0,
+            "with the only slot held, the resolve must not have been \
+             registered/sent yet"
+        );
+
+        drop(occupant);
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while handle.router().pending_count() == 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+            }
+        })
+        .await
+        .expect("the parked resolve proceeds once the slot frees");
+        resolve.abort();
+    }
+
     // ==========================================================================
     // resolve_guard_region_end tests
     // ==========================================================================

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -310,15 +310,39 @@ impl LanguageServerPool {
         let request = build_completion_resolve_request(outgoing, request_id);
         let mut router_guard = RouterCleanupGuard::new(Arc::clone(handle.router()), request_id);
 
-        if let Err(e) = handle.send_request(request, request_id) {
-            warn!(
-                target: "kakehashi::bridge",
-                "completionItem/resolve: failed to send request on {connection_key:?}: {e}"
-            );
-            if let Some(ref id) = upstream_id {
-                self.unregister_upstream_request(id, connection_key);
+        // Verify `handle` is still the pool's LIVE connection under the
+        // `connections` lock before sending (the guard the executeCommand and
+        // codeAction/resolve paths already use): the handle was fetched
+        // earlier — and the request may have PARKED on the slot since (#974)
+        // — so a reload could have replaced it, and enqueueing on the
+        // retiring process would wait out the full timeout for nothing.
+        {
+            let connections = self.connections().await;
+            if !connections
+                .get(connection_key)
+                .is_some_and(|current| Arc::ptr_eq(current, handle))
+            {
+                drop(connections);
+                warn!(
+                    target: "kakehashi::bridge",
+                    "completionItem/resolve: connection {connection_key} was replaced before send"
+                );
+                if let Some(ref id) = upstream_id {
+                    self.unregister_upstream_request(id, connection_key);
+                }
+                return None;
             }
-            return None;
+            if let Err(e) = handle.send_request(request, request_id) {
+                drop(connections);
+                warn!(
+                    target: "kakehashi::bridge",
+                    "completionItem/resolve: failed to send request on {connection_key:?}: {e}"
+                );
+                if let Some(ref id) = upstream_id {
+                    self.unregister_upstream_request(id, connection_key);
+                }
+                return None;
+            }
         }
 
         // On the wire: abandonment must cancel downstream before the slot

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -271,6 +271,21 @@ impl LanguageServerPool {
         // envelope's host URI by the caller.
         let connection_key = handle.key();
 
+        // In-flight cap (#974): resolves are burst sources too (eager
+        // code-action resolves batch per response), so they take the same
+        // per-connection slot as every other request. Fail-soft on a closed
+        // (evicted) connection.
+        let _request_slot = match handle.acquire_request_slot().await {
+            Ok(permit) => permit,
+            Err(e) => {
+                warn!(
+                    target: "kakehashi::bridge",
+                    "completionItem/resolve: no request slot on {connection_key:?}: {e}"
+                );
+                return None;
+            }
+        };
+
         // Register in the upstream request registry FIRST for cancel lookup.
         if let Some(ref id) = upstream_id {
             self.register_upstream_request(id.clone(), connection_key);
@@ -306,6 +321,10 @@ impl LanguageServerPool {
             return None;
         }
 
+        // On the wire: abandonment must cancel downstream before the slot
+        // frees (#974).
+        let mut cancel_on_drop =
+            super::super::pool::CancelOnDropGuard::new(Arc::clone(handle), request_id);
         let response = handle.wait_for_response(request_id, response_rx).await;
         router_guard.disarm();
 
@@ -315,7 +334,10 @@ impl LanguageServerPool {
         }
 
         match response {
-            Ok(response) => parse_completion_resolve_response(response),
+            Ok(response) => {
+                cancel_on_drop.disarm();
+                parse_completion_resolve_response(response)
+            }
             Err(e) => {
                 warn!(
                     target: "kakehashi::bridge",

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -30,6 +30,15 @@ use super::super::protocol::{
     response_has_jsonrpc_error, virtual_uri_to_lsp_uri,
 };
 
+/// How long a diagnostic pull may wait for the downstream's ANSWER, measured
+/// from send — after the request slot was granted and the request enqueued
+/// (#974). Queue wait deliberately doesn't count: under a many-region burst
+/// the tail used to time out on a healthy-but-saturated downstream (observed:
+/// ruff with 308 regions), and each such failure marked the refresh cycle
+/// incomplete, forcing a nudge that re-ran the burst.
+pub(in crate::lsp::bridge) const DIAGNOSTIC_RESPONSE_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(5);
+
 impl LanguageServerPool {
     /// Send a diagnostic request and wait for the response.
     ///
@@ -91,7 +100,7 @@ impl LanguageServerPool {
             .map(|entry| entry.result_id.clone());
 
         let report = self
-            .execute_bridge_request_with_handle(
+            .execute_bridge_request_observed(
                 handle,
                 host_uri,
                 injection_language,
@@ -119,6 +128,8 @@ impl LanguageServerPool {
                     // failure; `null` clears the baseline and `unchanged` reuses it.
                     parse_downstream_diagnostic_report(response)
                 },
+                None,
+                Some(DIAGNOSTIC_RESPONSE_TIMEOUT),
             )
             .await?;
 

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -32,10 +32,14 @@ use super::super::protocol::{
 
 /// How long a diagnostic pull may wait for the downstream's ANSWER, measured
 /// from send — after the request slot was granted and the request enqueued
-/// (#974). Queue wait deliberately doesn't count: under a many-region burst
-/// the tail used to time out on a healthy-but-saturated downstream (observed:
-/// ruff with 308 regions), and each such failure marked the refresh cycle
-/// incomplete, forcing a nudge that re-ran the burst.
+/// (#974). Slot queue wait and connection init deliberately don't count:
+/// under a many-region burst the tail used to time out on a
+/// healthy-but-saturated downstream (observed: ruff with 308 regions), and
+/// each such failure marked the refresh cycle incomplete, forcing a nudge
+/// that re-ran the burst. The writer-queue residence after enqueue DOES
+/// count, but it is a non-blocking `try_send` into a 4096-deep channel
+/// drained by a dedicated task — milliseconds, not the seconds-scale queue
+/// this exists to exclude.
 pub(in crate::lsp::bridge) const DIAGNOSTIC_RESPONSE_TIMEOUT: std::time::Duration =
     std::time::Duration::from_secs(5);
 
@@ -43,10 +47,11 @@ impl LanguageServerPool {
     /// Send a diagnostic request and wait for the response.
     ///
     /// Unlike other request types that fail fast when a server is initializing,
-    /// diagnostic requests wait for the server to become Ready so users see
-    /// diagnostics appear rather than empty results. After the wait and capability
-    /// check, delegates to
-    /// [`execute_bridge_request_with_handle`](Self::execute_bridge_request_with_handle).
+    /// diagnostic requests wait for the server to become Ready (bounded by
+    /// `INIT_TIMEOUT_SECS`) so users see diagnostics appear rather than empty
+    /// results. After the wait and capability check, delegates to
+    /// [`execute_bridge_request_observed`](Self::execute_bridge_request_observed)
+    /// with [`DIAGNOSTIC_RESPONSE_TIMEOUT`] as the answer deadline.
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn send_diagnostic_request(
         &self,
@@ -82,8 +87,8 @@ impl LanguageServerPool {
         }
 
         // Server is Ready and supports diagnostics — proceed with standard lifecycle.
-        // Use execute_bridge_request_with_handle to reuse the pre-fetched handle,
-        // avoiding a redundant HashMap lookup.
+        // Use execute_bridge_request_observed to reuse the pre-fetched handle,
+        // avoiding a redundant HashMap lookup, and to pass the answer deadline.
         let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(host_uri)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
         let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, injection_language, region_id);

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -104,6 +104,7 @@ impl LanguageServerPool {
                 .map(Some)
             },
             downstream_id_probe,
+            None,
         )
         .await?
     }

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -321,6 +321,7 @@ impl LanguageServerPool {
                 upstream_request_id,
                 |request_id| JsonRpcRequest::new(request_id.as_i64(), method, params),
                 move |response| parse_host_raw_response(response, method),
+                None,
             )
             // Outer `?`: transport/protocol failure from `execute_host_request`.
             // Inner `Result` from the parser: a downstream JSON-RPC error
@@ -367,6 +368,7 @@ impl LanguageServerPool {
             // mode maps onto its error exit code. Only the no-capability
             // early return above yields `Ok(None)`.
             move |response| parse_host_formatting_response(response, method).map(Some),
+            None,
         )
         .await?
     }
@@ -449,6 +451,7 @@ impl LanguageServerPool {
                     }
                     super::diagnostic::parse_downstream_diagnostic_report(response)
                 },
+                Some(super::diagnostic::DIAGNOSTIC_RESPONSE_TIMEOUT),
             )
             .await?;
         let document_is_open = self
@@ -478,6 +481,7 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
         build_request: impl FnOnce(RequestId) -> JsonRpcRequest<P>,
         transform_response: impl FnOnce(serde_json::Value) -> T,
+        response_timeout: Option<std::time::Duration>,
     ) -> io::Result<T> {
         // Route per-connection state by this handle's pool key (#382).
         let connection_key = handle.key();
@@ -555,7 +559,36 @@ impl LanguageServerPool {
             }
         }
 
-        let response = handle.wait_for_response(request_id, response_rx).await;
+        // `response_timeout` starts after send, mirroring
+        // `execute_bridge_request_observed` (#974): queue wait must not
+        // consume the answer deadline.
+        let response = match response_timeout {
+            Some(deadline) => {
+                match tokio::time::timeout(
+                    deadline,
+                    handle.wait_for_response(request_id, response_rx),
+                )
+                .await
+                {
+                    Ok(response) => response,
+                    Err(_) => {
+                        // Router entry still pending; router_guard stays ARMED
+                        // and removes it on this early return.
+                        if let Some(ref id) = upstream_request_id {
+                            self.unregister_upstream_request(id, connection_key);
+                        }
+                        return Err(io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            format!(
+                                "bridge: no response for {} within {:?} (measured from send)",
+                                doc.uri, deadline
+                            ),
+                        ));
+                    }
+                }
+            }
+            None => handle.wait_for_response(request_id, response_rx).await,
+        };
         router_guard.disarm();
 
         if let Some(ref id) = upstream_request_id {

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -485,6 +485,13 @@ impl LanguageServerPool {
     ) -> io::Result<T> {
         // Route per-connection state by this handle's pool key (#382).
         let connection_key = handle.key();
+
+        // In-flight cap (#974): park BEFORE the `connections` and
+        // `host_documents` locks below, mirroring
+        // `execute_bridge_request_observed` — a task waiting on a saturated
+        // connection must hold nothing other connections' requests need.
+        let _request_slot = handle.acquire_request_slot().await?;
+
         if let Some(ref id) = upstream_request_id {
             self.register_upstream_request(id.clone(), connection_key);
         }

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -579,6 +579,10 @@ impl LanguageServerPool {
                 {
                     Ok(response) => response,
                     Err(_) => {
+                        // Tell the downstream to stop computing the abandoned
+                        // request before this return releases the permit —
+                        // mirrors `execute_bridge_request_observed` (#974).
+                        let _ = self.send_cancel_notification(&handle, connection_key, request_id);
                         // Router entry still pending; router_guard stays ARMED
                         // and removes it on this early return.
                         if let Some(ref id) = upstream_request_id {

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -761,6 +761,70 @@ pub(crate) fn normalize_host_goto_result(result: serde_json::Value) -> Option<Ve
 mod tests {
     use super::*;
 
+    /// Host-layer requests take the same per-connection request slot as
+    /// injection-region requests (#974): with the only slot held, a host
+    /// diagnostic pull must PARK (observable: it never registers with the
+    /// router) until the slot frees.
+    #[tokio::test]
+    async fn host_request_parks_on_the_request_slot_cap() {
+        use crate::lsp::bridge::pool::test_helpers::*;
+        use crate::lsp::bridge::pool::{ConnectionKey, ConnectionState};
+        use std::sync::Arc;
+
+        let pool = Arc::new(crate::lsp::bridge::pool::LanguageServerPool::new());
+        let handle = create_capped_handle_with_key(
+            ConnectionState::Ready,
+            ConnectionKey::for_server("test-server"),
+            1,
+        )
+        .await;
+        advertise_pull_diagnostics(&handle);
+        pool.insert_connection(Arc::clone(&handle)).await;
+
+        let occupant = handle
+            .acquire_request_slot()
+            .await
+            .expect("the only slot acquires");
+
+        let host_uri = test_host_uri("host-slot");
+        let request = {
+            let pool = Arc::clone(&pool);
+            let host_uri = host_uri.clone();
+            tokio::spawn(async move {
+                pool.send_host_diagnostic_request(
+                    "test-server",
+                    &devnull_config(),
+                    &crate::lsp::bridge::HostDocument {
+                        uri: &host_uri,
+                        language_id: "markdown",
+                        text: "# doc",
+                    },
+                    serde_json::json!({ "textDocument": { "uri": host_uri.as_str() } }),
+                    None,
+                )
+                .await
+            })
+        };
+
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        assert_eq!(
+            handle.router().pending_count(),
+            0,
+            "with the only slot held, the host request must not have been \
+             registered/sent yet"
+        );
+
+        drop(occupant);
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while handle.router().pending_count() == 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+            }
+        })
+        .await
+        .expect("the parked host request proceeds once the slot frees");
+        request.abort();
+    }
+
     #[test]
     fn raw_response_strips_envelope_and_passes_result_verbatim() {
         let response = serde_json::json!({

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -386,8 +386,9 @@ impl LanguageServerPool {
     /// dedicated method keeps that strictness out of the
     /// shared raw path that other host methods rely on.
     ///
-    /// Waits through server initialization (the caller's request timeout bounds
-    /// the wait) — returning empty while a server initializes would silently
+    /// Waits through server initialization (bounded by `INIT_TIMEOUT_SECS`;
+    /// the answer itself by `DIAGNOSTIC_RESPONSE_TIMEOUT`, measured from send,
+    /// #974) — returning empty while a server initializes would silently
     /// lose the host layer on the first pull, like the virt diagnostic path.
     ///
     /// The method is fixed to `textDocument/diagnostic`: this path is dedicated
@@ -468,12 +469,20 @@ impl LanguageServerPool {
         Ok(self.resolve_diagnostic_pull_report(&cache_key, snapshot, report, document_is_open))
     }
 
-    /// Drive a host bridge request end-to-end: register for cancel
-    /// forwarding, sync the host document, send, await, transform.
+    /// Drive a host bridge request end-to-end: take a request slot (may PARK,
+    /// #974), register for cancel forwarding, sync the host document, send,
+    /// await, transform.
     ///
-    /// The skeleton mirrors `execute_bridge_request_with_handle` minus the
+    /// The skeleton mirrors `execute_bridge_request_observed` minus the
     /// virtual URI and the coordinate translation — host responses are the
-    /// downstream server's verbatim answer.
+    /// downstream server's verbatim answer. `response_timeout` bounds only
+    /// the answer wait, measured from send; `None` leaves the internal 30s.
+    ///
+    /// Known residual (pre-existing, widened by parking): the host document
+    /// is synced from the caller's TEXT SNAPSHOT after the park, so a sync
+    /// racing a newer eager re-sync can rewind the downstream's copy until
+    /// the next content change heals it — the request-path twin of #422;
+    /// fixing it needs a live-text reader plumbed through this API.
     async fn execute_host_request<T, P: serde::Serialize>(
         &self,
         handle: Arc<ConnectionHandle>,

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -575,6 +575,12 @@ impl LanguageServerPool {
             }
         }
 
+        // On the wire from here: abandonment (deadline, 30s cap, future drop)
+        // must cancel downstream before the permit frees — mirrors
+        // `execute_bridge_request_observed` (#974).
+        let mut cancel_on_drop =
+            super::super::pool::CancelOnDropGuard::new(Arc::clone(&handle), request_id);
+
         // `response_timeout` starts after send, mirroring
         // `execute_bridge_request_observed` (#974): queue wait must not
         // consume the answer deadline.
@@ -588,10 +594,8 @@ impl LanguageServerPool {
                 {
                     Ok(response) => response,
                     Err(_) => {
-                        // Tell the downstream to stop computing the abandoned
-                        // request before this return releases the permit —
-                        // mirrors `execute_bridge_request_observed` (#974).
-                        let _ = self.send_cancel_notification(&handle, connection_key, request_id);
+                        // cancel_on_drop stays armed and queues the
+                        // $/cancelRequest before the permit frees.
                         // Router entry still pending; router_guard stays ARMED
                         // and removes it on this early return.
                         if let Some(ref id) = upstream_request_id {
@@ -615,7 +619,10 @@ impl LanguageServerPool {
             self.unregister_upstream_request(id, connection_key);
         }
 
-        Ok(transform_response(response?))
+        // A real response arrived — nothing left to cancel.
+        let response = response?;
+        cancel_on_drop.disarm();
+        Ok(transform_response(response))
     }
 }
 

--- a/src/lsp/bridge/text_document/range_formatting.rs
+++ b/src/lsp/bridge/text_document/range_formatting.rs
@@ -104,6 +104,7 @@ impl LanguageServerPool {
                 .map(Some)
             },
             downstream_id_probe,
+            None,
         )
         .await?
     }

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -32,7 +32,9 @@ use crate::config::{merge_bridge_server_configs, resolve_with_wildcard};
 use crate::lsp::bridge::ConnectionKey;
 use crate::lsp::bridge::actor::RouterCleanupGuard;
 use crate::lsp::bridge::decode_command;
-use crate::lsp::bridge::pool::{ConnectionHandle, ConnectionState, LanguageServerPool, UpstreamId};
+use crate::lsp::bridge::pool::{
+    CancelOnDropGuard, ConnectionHandle, ConnectionState, LanguageServerPool, UpstreamId,
+};
 use crate::lsp::bridge::protocol::{JsonRpcRequest, response_has_jsonrpc_error};
 use tower_lsp_server::ls_types::ExecuteCommandParams;
 
@@ -558,6 +560,20 @@ impl LanguageServerPool {
         upstream_id: Option<UpstreamId>,
     ) -> Option<Value> {
         let connection_key = handle.key();
+
+        // In-flight cap (#974): same per-connection slot as every request.
+        let _request_slot = match handle.acquire_request_slot().await {
+            Ok(permit) => permit,
+            Err(e) => {
+                warn!(
+                    target: "kakehashi::bridge",
+                    "executeCommand: no request slot on {connection_key:?} for {:?}: {e}",
+                    params.command
+                );
+                return None;
+            }
+        };
+
         if let Some(ref id) = upstream_id {
             self.register_upstream_request(id.clone(), connection_key);
         }
@@ -619,6 +635,9 @@ impl LanguageServerPool {
             }
         }
 
+        // On the wire: abandonment must cancel downstream before the slot
+        // frees (#974).
+        let mut cancel_on_drop = CancelOnDropGuard::new(Arc::clone(handle), request_id);
         let response = handle.wait_for_response(request_id, response_rx).await;
         router_guard.disarm();
         if let Some(ref id) = upstream_id {
@@ -629,7 +648,10 @@ impl LanguageServerPool {
         // other branches so execute-time issues are debuggable (sibling sweep of
         // the codeAction/resolve logging fix).
         let response = match response {
-            Ok(r) => r,
+            Ok(r) => {
+                cancel_on_drop.disarm();
+                r
+            }
             Err(e) => {
                 warn!(
                     target: "kakehashi::bridge",

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1672,6 +1672,7 @@ mod tests {
             prefer_shared_instance: None,
             enabled: None,
             settings: None,
+            max_concurrent_requests: None,
         }
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -2590,6 +2590,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         )
     }

--- a/src/lsp/lsp_impl/text_document/code_lens.rs
+++ b/src/lsp/lsp_impl/text_document/code_lens.rs
@@ -68,9 +68,28 @@ impl Kakehashi {
         let settings = self.settings_manager.load_settings();
         let upstream_id = crate::lsp::current_upstream_id();
         let pool = self.bridge.pool_arc();
-        Ok(pool
-            .dispatch_code_lens_resolve(lens, &settings, upstream_id)
-            .await)
+        // Propagate a client `$/cancelRequest` instead of resolving on: the
+        // dispatch may PARK on the request slot (#974), where no downstream
+        // registration exists yet — dropping the dispatch future is the only
+        // cancel that reaches a parked resolve. Mirrors
+        // `completion_resolve_impl`, including the RAII sweep that covers
+        // the registry entry when the cancel arm (or a client disconnect)
+        // drops the dispatch mid-flight.
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
+        let sweep_id = upstream_id.clone();
+        let dispatch = pool.dispatch_code_lens_resolve(lens, &settings, upstream_id);
+        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard::new(
+            std::sync::Arc::clone(&pool),
+            sweep_id,
+        );
+        match cancel_rx {
+            Some(rx) => tokio::select! {
+                biased;
+                _ = rx => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
+                lens = dispatch => Ok(lens),
+            },
+            None => Ok(dispatch.await),
+        }
     }
 
     /// Whether the envelope's injection region still exists at the position it

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -9,7 +9,6 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
 
 use tokio::task::JoinSet;
 use tower_lsp_server::jsonrpc::Result;
@@ -41,12 +40,6 @@ use crate::lsp::lsp_impl::text_document::{
 // ============================================================================
 // Shared diagnostic utilities (used by both pull and push diagnostics)
 // ============================================================================
-
-/// Per-request timeout for diagnostic fan-out (pull-first-diagnostic-forwarding).
-///
-/// Used by both pull diagnostics (textDocument/diagnostic) and
-/// synthetic push diagnostics (didSave/didOpen/didChange triggered).
-const DIAGNOSTIC_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Collect diagnostics for a single injection region using strategy-aware dispatch.
 ///
@@ -712,14 +705,16 @@ pub(crate) async fn collect_host_diagnostics(
     }
 }
 
-/// Send a diagnostic request for a single fan-out task with timeout.
+/// Send a diagnostic request for a single fan-out task.
 ///
-/// Shared by both concatenated and preferred dispatch strategies.
+/// Shared by both concatenated and preferred dispatch strategies. The answer
+/// deadline (`DIAGNOSTIC_RESPONSE_TIMEOUT`) is applied inside the pool,
+/// measured from send — an outer timeout here would count request-slot queue
+/// wait (#974) and connection init against it, turning a saturated-but-healthy
+/// downstream's burst tail into spurious failures.
 async fn send_diagnostic_fan_out_request(t: FanOutTask) -> std::io::Result<Vec<Diagnostic>> {
-    let rid = t.region_id.clone();
-    tokio::time::timeout(
-        DIAGNOSTIC_REQUEST_TIMEOUT,
-        t.pool.send_diagnostic_request(
+    t.pool
+        .send_diagnostic_request(
             &t.server_name,
             &t.server_config,
             &t.uri,
@@ -728,26 +723,20 @@ async fn send_diagnostic_fan_out_request(t: FanOutTask) -> std::io::Result<Vec<D
             t.offset,
             &t.virtual_content,
             t.upstream_id,
-        ),
-    )
-    .await
-    .unwrap_or_else(|_| {
-        Err(std::io::Error::other(format!(
-            "diagnostic request timed out for region {rid}"
-        )))
-    })
+        )
+        .await
 }
 
-/// Send a host diagnostic request for a single fan-out task with timeout, with
-/// **no** error counting. The caller counts per strategy: concatenated counts
+/// Send a host diagnostic request for a single fan-out task, with **no**
+/// error counting. The caller counts per strategy: concatenated counts
 /// every failure in-task (a missing merge contribution); preferred counts only
-/// the no-winner case via [`count_no_winner_errors`] (#487).
+/// the no-winner case via [`count_no_winner_errors`] (#487). The answer
+/// deadline is applied inside the pool, measured from send (#974).
 async fn send_host_diagnostic_fan_out_request(
     t: HostFanOutTask,
 ) -> std::io::Result<Vec<Diagnostic>> {
-    tokio::time::timeout(
-        DIAGNOSTIC_REQUEST_TIMEOUT,
-        t.pool.send_host_diagnostic_request(
+    t.pool
+        .send_host_diagnostic_request(
             &t.server_name,
             &t.server_config,
             &crate::lsp::bridge::HostDocument {
@@ -757,15 +746,8 @@ async fn send_host_diagnostic_fan_out_request(
             },
             serde_json::json!({ "textDocument": { "uri": t.uri.as_str() } }),
             t.upstream_id,
-        ),
-    )
-    .await
-    .unwrap_or_else(|_| {
-        Err(std::io::Error::other(format!(
-            "host diagnostic request timed out for {}",
-            t.server_name
-        )))
-    })
+        )
+        .await
 }
 
 /// Send one fan-out diagnostic request, counting a request-time failure into

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -563,6 +563,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
         server.settings_manager.apply_settings(WorkspaceSettings {
@@ -657,6 +658,7 @@ print("hello")
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             },
         );
         let mut languages = HashMap::new();

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -1935,6 +1935,7 @@ mod tests {
                 prefer_shared_instance: None,
                 enabled: None,
                 settings: None,
+                max_concurrent_requests: None,
             }),
         }
     }

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -274,6 +274,7 @@ mod tests {
                     prefer_shared_instance: None,
                     enabled: None,
                     settings: None,
+                    max_concurrent_requests: None,
                 }),
             }],
             upstream_request_id: None,


### PR DESCRIPTION
Closes #974.

## Problem

A diagnostic pull on a many-region host fans out one request per region, all at once (616 regions: ruff/basedpyright get 308 each, plus the refresh prefetch doubling it). Two structural defects turned that burst into the observed ~1/s timeout loop (#972 forensics):

1. **No in-flight bound**: the whole burst lands on the downstream simultaneously; single-threaded servers (ruff, basedpyright, lua_ls) queue internally and answer the tail seconds later.
2. **The 5s deadline included queue wait**: `tokio::time::timeout(5s, send_diagnostic_request(…))` started counting at fan-out entry — connection init, slot wait, didOpen, everything. The burst tail expired on a healthy-but-saturated downstream; every spurious failure marked the refresh cycle `coverage_incomplete`, forcing a nudge that re-ran the very burst that caused it.

## Fix (design agreed in #974)

**Per-connection request slots.** `ConnectionHandle` carries a `tokio::sync::Semaphore` (`request_permits`). Both request paths — `execute_bridge_request_observed` (injection regions) and `execute_host_request` (host layer) — acquire an owned permit at entry, **before** the per-host lifecycle lock and the pool `connections` lock, so a task parked on a saturated connection holds nothing that requests to idle connections need. The permit is RAII: response, error, and future drop (editor cancel, JoinSet abort, preferred-strategy loser abort) all release it.

There is **no new queue or dispatcher**: fan-out already spawns one task per region, so the "queue" is the set of parked tasks — per-connection FIFO fairness and cross-connection independence come from the runtime. Notifications (didOpen/didChange), `$/cancelRequest`, and the initialize/shutdown lifecycle are deliberately exempt.

**Deadline measured from send.** `response_timeout: Option<Duration>` threads through both execute paths, applied only around `wait_for_response`. Diagnostic pulls (virt + host) pass `DIAGNOSTIC_RESPONSE_TIMEOUT = 5s` there and drop their outer wraps; other request kinds keep the internal 30s. A pull during a cold spawn may now wait for Ready (INIT_TIMEOUT bound) instead of dying at 5s — intended: fewer spurious failures feeding `coverage_incomplete`.

**Config**: `maxConcurrentRequests` per server (`Option<NonZeroUsize>`, zero is a parse error, wildcard-inheritable, overlay-wins). Default **256** (maintainer decision): the default is a backstop against pathological pile-ups, not throughput tuning — a downstream that struggles under concurrent load is tuned DOWN per server, rather than throttling everyone by default; the deadline-from-send change is what actually defuses burst timeouts. The value sizes the semaphore at spawn, so `same_launch_config` compares the effective cap and a reload that changes it respawns; an explicit value equal to the default does not.

**Eviction**: `set_state(Failed | Closing | Closed)` closes the semaphore — parked waiters wake with `NotConnected` instead of hanging on a dead connection's permits (fails fast into the coverage machinery, the safe direction).

**Observability**: slot waits ≥100ms log at debug under `kakehashi::bridge::backpressure`.

## Tests (each red-first unless noted)

- `requests_beyond_the_in_flight_cap_park_until_a_permit_frees` — cap+1 concurrent requests: only cap reach the downstream; the extra parks and proceeds when a permit frees.
- `saturated_connection_does_not_delay_an_idle_connection` — the head-of-line requirement, pinned directly (green-on-arrival by design; guards against moving the acquire inside a shared lock).
- `response_deadline_excludes_request_slot_queue_wait` — a request parked past its whole deadline is still sent when a slot frees, and only then times out.
- `terminal_state_wakes_parked_request_slot_waiters` — Failed/Closing/Closed wake parked waiters with an error.
- `host_request_parks_on_the_request_slot_cap` — the host layer shares the same cap (observable via router registration).
- `with_state_honors_the_configured_request_cap`, config parse (`maxConcurrentRequests`, zero rejected), merge rule, `launch_config_compares_request_cap_by_effective_value`.

## Review (stage 1: 11-perspective local review, all findings fact-checked)

Fixed on-branch, one commit each:
- **`$/cancelRequest` on deadline expiry** (5 reviewers converged): the Elapsed arm released the permit while the downstream still computed the abandoned request — each expiry admitted a new one, so the cap bounded kakehashi's waiters, not the server's real in-flight depth. Both arms now cancel synchronously before the permit frees; pinned by a wire-capture test.
- **`Semaphore::MAX_PERMITS` clamp**: a huge `maxConcurrentRequests` panicked at spawn (tokio asserts `permits <= usize::MAX >> 3`).
- **Production wiring test**: the one line that makes the knob real (`effective_max_concurrent_requests()` at the spawn site) had no test — a real spawn with cap 1 now pins it.
- **Test hardening**: cap tests decoupled from the production default (no more 257 tasks under 2s windows); the cross-connection test now asserts saturation before probing the idle side (was vacuous on early errors / multi-thread scheduling); bounded the re-acquisition await; template↔default sync test; zero-rejection asserts the user-facing message.
- **Docs**: the backpressure const had hijacked `ConnectionHandle`'s doc block (struct undocumented); `response_timeout` semantics documented on both paths; the exemption list now names the ungated resolve paths; `docs/README.md` server table row; `ls-bridge-timeout-hierarchy.md` #974 amendment; stale caller-timeout claims fixed.

Verified clean by dedicated reviewers (no re-investigation needed): no deadlock/lock-order inversion (permit is the first await on both paths; shutdown handshake is permit-exempt and closes the semaphore first); permit/router/registry cleanup correct on every early-return path; no #972 coverage-contract regression (new failure shapes tee kind-agnostically; stamps are entry-scoped); no error-shape consumers broken; hot path adds one lock-free CAS + one uncontended mutex per request.

## Review (stage 2: codex, converged)

Continued thread: 6 findings → all addressed (inline-send paths gated — closing the #983 gap in-PR after the eager code-action resolve batches disproved the "single user gesture" exemption; `CancelOnDropGuard` unifying abandonment cancellation across aborts/supersession/deadline/internal-30s; clamp folded into the effective cap so oversized reloads don't respawn; starvation → #981, prefetch cycle budget → #984). Two fresh sessions: the first surfaced the already-tracked #982 rewind plus honest cancel-outcome logging (fixed); the second found the i64→i32 cancel-id truncation (fixed at both constructors, sibling-swept into the pre-existing forwarder). A third fresh session answered **"no comments to provide" on its first response**.

## Follow-ups (filed from review findings)

- #981 — interactive requests (formatting/willSaveWaitUntil/hover) can burn their budgets parked behind background diagnostics at low caps; reserved slots / budget-from-send / priority classes.
- #982 — a parked host request can rewind the downstream's host document to a stale snapshot (request-path twin of #422); zombie region re-open rides along.
- #983 — resolved IN-PR after codex round 1 (all four inline-send paths now gated + cancel-guarded); closes on merge.
- #984 — end-to-end budget / generation supersession for the forwarded-refresh prefetch cycle (codex round 1).
- #979 — re-scoped with trace evidence: the "duplicate request ID" flood is the post-`fail_all` register rejection, not late-response routing.

## Interplay

- #975 (single-flight dedup) sits above the semaphore — independent, multiplicative.
- #976 (progress opt-out) is orthogonal; lower concurrency also reduces the odds of tripping basedpyright's unframed-`$/progress` write race.
- #978 (damping) remains the backstop; the timeout-driven `coverage_incomplete` source should mostly vanish here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
