### PR TITLE
fix(bridge): make the downstream frame reader cancel-safe

### DIFF
--- a/docs/architecture-decisions/ls-bridge-async-connection.md
+++ b/docs/architecture-decisions/ls-bridge-async-connection.md
@@ -150,10 +150,11 @@ The system uses two distinct timeout mechanisms with different purposes:
 - **Timer Lifecycle**:
   - **Start**: First request sent when pending count transitions 0→1
   - **Keep running**: Additional requests sent (pending count increases)
-  - **Reset**: Each successfully parsed LSP message (response or notification)
-    while active. Not raw stdout activity: a downstream that dribbles out a
-    partial frame resets nothing and is still caught, which is what makes the
-    timer the backstop for a server that stalls mid-frame.
+  - **Reset**: Each framed and JSON-decoded downstream message while active
+    (the reset happens before the message is classified, so server-initiated
+    requests count too). Not raw stdout activity: a downstream that dribbles
+    out a partial frame resets nothing and is still caught, which is what makes
+    the timer the backstop for a server that stalls mid-frame.
   - **Stop**: Last response received (pending count returns to 0)
 - **Behavior on Timeout**: Connection transitions to Failed state
 

--- a/docs/architecture-decisions/ls-bridge-async-connection.md
+++ b/docs/architecture-decisions/ls-bridge-async-connection.md
@@ -44,7 +44,7 @@ Three critical requirements drive this decision:
 │  │  │ send_request │    │     reader task        │ │    │
 │  │  │   (async)    │    │                        │ │    │
 │  │  └──────┬───────┘    │  select! {             │ │    │
-│  │         │            │    line = read =>      │ │    │
+│  │         │            │    result = read_msg =>│ │    │
 │  │         ▼            │    _ = shutdown =>     │ │    │
 │  │  ┌──────────────┐    │    _ = timeout =>      │ │    │
 │  │  │ AsyncWrite   │    │  }                     │ │    │
@@ -79,6 +79,15 @@ Three critical requirements drive this decision:
   - Shutdown signals
   - Timeout detection
 - Route responses to pending request handlers via shared map
+
+**Cancel-safety of the read branch:** because the read is a `select!` branch,
+any other branch completing drops the read future mid-frame. The framing parser
+must therefore hold its partial-frame progress in the reader
+(`BridgeReader::frame`), not in the read future's locals, and must await only
+cancel-safe primitives. A parser built on `read_line`/`read_exact` silently
+loses a consumed header on every liveness tick and then resyncs onto the
+message body, reporting a framing error against a well-framed stream and
+killing the connection.
 
 **Writer Pattern:**
 - Write requests to server stdin using async mutex-protected writer
@@ -255,3 +264,4 @@ Use standard library's `std::process` with one blocking OS thread per server rea
 
 - **2026-01-06**: Merged Amendment 001 - Added pending request cleanup requirements and race prevention pattern to prevent indefinite client hangs on reader task exit
 - **2026-01-06**: Merged Amendment 002 - Added state-based liveness timeout gating and separate initialization timeout mechanism to prevent liveness timeout from firing during slow initialization
+- **2026-08-10**: Amendment — reader framing must be cancel-safe across `select!` wake-ups; partial-frame state moved into `BridgeReader`

--- a/docs/architecture-decisions/ls-bridge-async-connection.md
+++ b/docs/architecture-decisions/ls-bridge-async-connection.md
@@ -150,7 +150,10 @@ The system uses two distinct timeout mechanisms with different purposes:
 - **Timer Lifecycle**:
   - **Start**: First request sent when pending count transitions 0→1
   - **Keep running**: Additional requests sent (pending count increases)
-  - **Reset**: Any stdout activity (response or notification) while active
+  - **Reset**: Each successfully parsed LSP message (response or notification)
+    while active. Not raw stdout activity: a downstream that dribbles out a
+    partial frame resets nothing and is still caught, which is what makes the
+    timer the backstop for a server that stalls mid-frame.
   - **Stop**: Last response received (pending count returns to 0)
 - **Behavior on Timeout**: Connection transitions to Failed state
 

--- a/docs/architecture-decisions/ls-bridge-message-ordering.md
+++ b/docs/architecture-decisions/ls-bridge-message-ordering.md
@@ -335,11 +335,18 @@ When the writer task panics, the reader task must also exit to prevent CPU spin 
 ```rust
 // Reader task select! loop
 select! {
-    line = reader.read_line() => { /* handle response */ }
+    result = reader.read_message() => { /* handle response */ }
     _ = token.cancelled() => { break; }  // Writer panicked, exit
     _ = shutdown_rx.recv() => { break; } // Graceful shutdown
 }
 ```
+
+`read_message` must be cancel-safe. Every other branch completing first drops
+the read future, so a parser holding frame progress in future-local state
+loses a consumed header and resyncs onto the next message body — reporting a
+framing error against a well-framed stream. See
+`BridgeReader::read_message_bytes`, which keeps that progress in the reader and
+awaits only cancel-safe primitives.
 
 ## Consequences
 

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -704,8 +704,10 @@ async fn reader_loop(
 ///
 /// The liveness timer (when configured) detects a hung server: firing triggers a
 /// Ready→Failed transition via `router.fail_all()` and signals `liveness_failed_tx`.
-/// Its start/reset/stop lifecycle is driven by the `liveness_*` channels and stdout
-/// activity (see `LivenessTimerState`).
+/// Its start/reset/stop lifecycle is driven by the `liveness_*` channels and by
+/// each framed and JSON-decoded downstream message — not by raw stdout activity,
+/// so a server dribbling out a partial frame is still caught (see
+/// `LivenessTimerState`).
 async fn reader_loop_with_liveness(
     mut reader: BridgeReader,
     router: Arc<ResponseRouter>,
@@ -3537,47 +3539,73 @@ mod tests {
     /// and still route the response.
     ///
     /// The unit tests in `connection.rs` pin the parser's resumption at exact
-    /// byte offsets; this one pins that the actor actually benefits. The
-    /// downstream sends a response header, pauses, then the body. Throughout
-    /// the pause the test fires `notify_liveness_start`, whose `select!` branch
-    /// wins against the read and drops the read future — the precise event that
-    /// used to discard the consumed header and resync onto the body.
+    /// byte offsets; this one pins that the actor actually benefits.
     ///
-    /// Against origin/main's parser this fails: the reader reports
-    /// `missing Content-Length header (stray stdout line: ...)` and `fail_all`s
-    /// the request instead of delivering it.
+    /// The downstream emits a complete response for request 2, then the header
+    /// for request 1, and then blocks reading stdin. Two things follow, and
+    /// both are needed for the test to mean anything:
+    ///
+    /// - receiving response 2 proves the reader is running and has reached the
+    ///   dangling header that was written right behind it, and
+    /// - the body cannot arrive until the test releases the shell, so every
+    ///   cancellation fired in between necessarily lands mid-frame.
+    ///
+    /// The cancellations come from `notify_liveness_start`, whose `select!`
+    /// branch beats the read under `biased` and drops the read future — the
+    /// precise event that used to discard the consumed header and resync onto
+    /// the body. Against origin/main's parser this fails: request 1 comes back
+    /// `bridge: reader error` instead of the response.
     #[tokio::test]
     async fn a_response_split_across_cancellations_is_still_routed() {
         use crate::lsp::bridge::protocol::RequestId;
         use std::time::Duration;
 
-        let body = r#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#;
+        let sync = r#"{"jsonrpc":"2.0","id":2,"result":null}"#;
+        let target = r#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#;
         let script = format!(
-            "printf 'Content-Length: {}\\r\\n\\r\\n'; sleep 0.5; printf '%s' '{}'; sleep 5",
-            body.len(),
-            body,
+            "printf 'Content-Length: {}\\r\\n\\r\\n%s' '{}'; \
+             printf 'Content-Length: {}\\r\\n\\r\\n'; \
+             read _release; \
+             printf '%s' '{}'; \
+             sleep 5",
+            sync.len(),
+            sync,
+            target.len(),
+            target,
         );
         let mut conn =
             AsyncBridgeConnection::spawn(vec!["sh".to_string(), "-c".to_string(), script])
                 .await
                 .expect("should spawn process");
 
-        let (_writer, reader) = conn.split();
+        let (mut writer, reader) = conn.split();
         let router = Arc::new(ResponseRouter::new());
-        let rx = router.register(RequestId::new(1)).unwrap();
+        let target_rx = router.register(RequestId::new(1)).unwrap();
+        let sync_rx = router.register(RequestId::new(2)).unwrap();
 
         // No liveness timeout: this test is about cancellation, and a firing
         // timer would fail the request for an unrelated reason.
         let handle = spawn_reader_task_with_liveness(reader, Arc::clone(&router), None);
 
-        // Cancel the read repeatedly across the whole gap between header and
-        // body, so the drops land after the header has been consumed.
-        for _ in 0..100 {
+        tokio::time::timeout(Duration::from_secs(5), sync_rx)
+            .await
+            .expect("the synchronizing response must arrive")
+            .expect("channel should not be closed");
+
+        // The reader is now at (or about to consume) the dangling header, and
+        // the body is held behind the shell's blocking read.
+        for _ in 0..50 {
             handle.notify_liveness_start(1);
-            tokio::time::sleep(Duration::from_millis(5)).await;
+            tokio::time::sleep(Duration::from_millis(2)).await;
         }
 
-        let result = tokio::time::timeout(Duration::from_secs(5), rx)
+        // Release the shell: any line will do, and write_message ends with one.
+        writer
+            .write_message(&json!({"jsonrpc": "2.0", "method": "release"}))
+            .await
+            .expect("should write to child stdin");
+
+        let result = tokio::time::timeout(Duration::from_secs(5), target_rx)
             .await
             .expect("a well-framed response must still arrive")
             .expect("channel should not be closed");

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -3530,43 +3530,57 @@ mod tests {
         drop(writer);
     }
 
-    /// Test that liveness timeout fires and fails pending requests.
-    ///
-    /// ls-bridge-async-connection: Ready to Failed transition on liveness timeout expiry.
-    /// When timeout fires while pending > 0, router.fail_all() is called.
     /// A downstream that stalls PART WAY THROUGH a frame must still be caught.
     ///
-    /// Since the framing parser became resumable, a half-read frame now
-    /// survives every cancellation instead of being discarded — so the liveness
-    /// timer is the only thing that still notices this server is hung. The
-    /// existing liveness test uses a server that emits nothing at all, which
-    /// never parks a partial frame.
+    /// Since the framing parser became resumable, a half-read frame survives
+    /// every cancellation instead of being discarded, so the liveness timer is
+    /// the only thing left that notices this server is hung.
+    ///
+    /// The downstream answers request 1 in full and only then emits a bare
+    /// header and stalls. Waiting for that first response before arming the
+    /// timer is what keeps the test honest: it proves the reader is alive and
+    /// has consumed everything up to the dangling header, so this cannot pass
+    /// through the "server emitted nothing at all" path that
+    /// `liveness_timeout_fires_and_fails_pending_requests` already covers.
     #[tokio::test]
     async fn liveness_timeout_fires_when_downstream_stalls_mid_frame() {
         use crate::lsp::bridge::protocol::RequestId;
         use std::time::Duration;
 
-        // A header with no body: the reader parks inside the frame.
-        let mut conn = AsyncBridgeConnection::spawn(vec![
-            "sh".to_string(),
-            "-c".to_string(),
-            "printf 'Content-Length: 100\\r\\n\\r\\n'; sleep 30".to_string(),
-        ])
-        .await
-        .expect("should spawn process");
+        let first = r#"{"jsonrpc":"2.0","id":1,"result":{}}"#;
+        let script = format!(
+            "printf 'Content-Length: {}\\r\\n\\r\\n{}'; \
+             printf 'Content-Length: 100\\r\\n\\r\\n'; \
+             sleep 30",
+            first.len(),
+            first,
+        );
+        let mut conn =
+            AsyncBridgeConnection::spawn(vec!["sh".to_string(), "-c".to_string(), script])
+                .await
+                .expect("should spawn process");
 
         let (_writer, reader) = conn.split();
         let router = Arc::new(ResponseRouter::new());
-        let rx = router.register(RequestId::new(1)).unwrap();
+        let rx1 = router.register(RequestId::new(1)).unwrap();
+        let rx2 = router.register(RequestId::new(2)).unwrap();
 
         let handle = spawn_reader_task_with_liveness(
             reader,
             Arc::clone(&router),
-            Some(Duration::from_millis(50)),
+            Some(Duration::from_millis(200)),
         );
+
+        // Request 1 comes back only if the reader really is reading, which
+        // leaves it parked on the dangling header that follows.
+        tokio::time::timeout(Duration::from_secs(5), rx1)
+            .await
+            .expect("the first frame must be delivered")
+            .expect("channel should not be closed");
+
         handle.notify_liveness_start(1);
 
-        let result = tokio::time::timeout(Duration::from_secs(5), rx)
+        let result = tokio::time::timeout(Duration::from_secs(5), rx2)
             .await
             .expect("liveness must fire even though a partial frame is parked")
             .expect("channel should not be closed");
@@ -3580,6 +3594,10 @@ mod tests {
         );
     }
 
+    /// Test that liveness timeout fires and fails pending requests.
+    ///
+    /// ls-bridge-async-connection: Ready to Failed transition on liveness timeout expiry.
+    /// When timeout fires while pending > 0, router.fail_all() is called.
     #[tokio::test]
     async fn liveness_timeout_fires_and_fails_pending_requests() {
         use crate::lsp::bridge::protocol::RequestId;

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -812,7 +812,13 @@ async fn reader_loop_with_liveness(
                 liveness.start(&server_prefix, router.liveness_epoch());
             }
 
-            // Try to read a message (lowest priority)
+            // Try to read a message (lowest priority).
+            //
+            // A fresh future every iteration, so every branch above drops a
+            // partly-read frame. That is only safe because the parser keeps its
+            // progress in `BridgeReader`, not in this future — see
+            // `BridgeReader::read_message_bytes`. Do not move that state back
+            // into locals.
             result = reader.read_message() => {
                 match result {
                     Ok(message) => {
@@ -3528,6 +3534,52 @@ mod tests {
     ///
     /// ls-bridge-async-connection: Ready to Failed transition on liveness timeout expiry.
     /// When timeout fires while pending > 0, router.fail_all() is called.
+    /// A downstream that stalls PART WAY THROUGH a frame must still be caught.
+    ///
+    /// Since the framing parser became resumable, a half-read frame now
+    /// survives every cancellation instead of being discarded — so the liveness
+    /// timer is the only thing that still notices this server is hung. The
+    /// existing liveness test uses a server that emits nothing at all, which
+    /// never parks a partial frame.
+    #[tokio::test]
+    async fn liveness_timeout_fires_when_downstream_stalls_mid_frame() {
+        use crate::lsp::bridge::protocol::RequestId;
+        use std::time::Duration;
+
+        // A header with no body: the reader parks inside the frame.
+        let mut conn = AsyncBridgeConnection::spawn(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "printf 'Content-Length: 100\\r\\n\\r\\n'; sleep 30".to_string(),
+        ])
+        .await
+        .expect("should spawn process");
+
+        let (_writer, reader) = conn.split();
+        let router = Arc::new(ResponseRouter::new());
+        let rx = router.register(RequestId::new(1)).unwrap();
+
+        let handle = spawn_reader_task_with_liveness(
+            reader,
+            Arc::clone(&router),
+            Some(Duration::from_millis(50)),
+        );
+        handle.notify_liveness_start(1);
+
+        let result = tokio::time::timeout(Duration::from_secs(5), rx)
+            .await
+            .expect("liveness must fire even though a partial frame is parked")
+            .expect("channel should not be closed");
+
+        assert!(
+            result["error"]["message"]
+                .as_str()
+                .unwrap_or("")
+                .contains("liveness timeout"),
+            "Error should mention liveness timeout, got: {result}"
+        );
+    }
+
     #[tokio::test]
     async fn liveness_timeout_fires_and_fails_pending_requests() {
         use crate::lsp::bridge::protocol::RequestId;

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -3530,30 +3530,29 @@ mod tests {
         drop(writer);
     }
 
-    /// A downstream that stalls PART WAY THROUGH a frame must still be caught.
+    /// End-to-end: the real select loop must survive being cancelled mid-frame
+    /// and still route the response.
     ///
-    /// Since the framing parser became resumable, a half-read frame survives
-    /// every cancellation instead of being discarded, so the liveness timer is
-    /// the only thing left that notices this server is hung.
+    /// The unit tests in `connection.rs` pin the parser's resumption at exact
+    /// byte offsets; this one pins that the actor actually benefits. The
+    /// downstream sends a response header, pauses, then the body. Throughout
+    /// the pause the test fires `notify_liveness_start`, whose `select!` branch
+    /// wins against the read and drops the read future — the precise event that
+    /// used to discard the consumed header and resync onto the body.
     ///
-    /// The downstream answers request 1 in full and only then emits a bare
-    /// header and stalls. Waiting for that first response before arming the
-    /// timer is what keeps the test honest: it proves the reader is alive and
-    /// has consumed everything up to the dangling header, so this cannot pass
-    /// through the "server emitted nothing at all" path that
-    /// `liveness_timeout_fires_and_fails_pending_requests` already covers.
+    /// Against origin/main's parser this fails: the reader reports
+    /// `missing Content-Length header (stray stdout line: ...)` and `fail_all`s
+    /// the request instead of delivering it.
     #[tokio::test]
-    async fn liveness_timeout_fires_when_downstream_stalls_mid_frame() {
+    async fn a_response_split_across_cancellations_is_still_routed() {
         use crate::lsp::bridge::protocol::RequestId;
         use std::time::Duration;
 
-        let first = r#"{"jsonrpc":"2.0","id":1,"result":{}}"#;
+        let body = r#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#;
         let script = format!(
-            "printf 'Content-Length: {}\\r\\n\\r\\n{}'; \
-             printf 'Content-Length: 100\\r\\n\\r\\n'; \
-             sleep 30",
-            first.len(),
-            first,
+            "printf 'Content-Length: {}\\r\\n\\r\\n'; sleep 0.5; printf '%s' '{}'; sleep 5",
+            body.len(),
+            body,
         );
         let mut conn =
             AsyncBridgeConnection::spawn(vec!["sh".to_string(), "-c".to_string(), script])
@@ -3562,35 +3561,27 @@ mod tests {
 
         let (_writer, reader) = conn.split();
         let router = Arc::new(ResponseRouter::new());
-        let rx1 = router.register(RequestId::new(1)).unwrap();
-        let rx2 = router.register(RequestId::new(2)).unwrap();
+        let rx = router.register(RequestId::new(1)).unwrap();
 
-        let handle = spawn_reader_task_with_liveness(
-            reader,
-            Arc::clone(&router),
-            Some(Duration::from_millis(200)),
-        );
+        // No liveness timeout: this test is about cancellation, and a firing
+        // timer would fail the request for an unrelated reason.
+        let handle = spawn_reader_task_with_liveness(reader, Arc::clone(&router), None);
 
-        // Request 1 comes back only if the reader really is reading, which
-        // leaves it parked on the dangling header that follows.
-        tokio::time::timeout(Duration::from_secs(5), rx1)
+        // Cancel the read repeatedly across the whole gap between header and
+        // body, so the drops land after the header has been consumed.
+        for _ in 0..100 {
+            handle.notify_liveness_start(1);
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        let result = tokio::time::timeout(Duration::from_secs(5), rx)
             .await
-            .expect("the first frame must be delivered")
+            .expect("a well-framed response must still arrive")
             .expect("channel should not be closed");
 
-        handle.notify_liveness_start(1);
-
-        let result = tokio::time::timeout(Duration::from_secs(5), rx2)
-            .await
-            .expect("liveness must fire even though a partial frame is parked")
-            .expect("channel should not be closed");
-
-        assert!(
-            result["error"]["message"]
-                .as_str()
-                .unwrap_or("")
-                .contains("liveness timeout"),
-            "Error should mention liveness timeout, got: {result}"
+        assert_eq!(
+            result["result"]["ok"], true,
+            "the response must survive being cancelled mid-frame, got: {result}"
         );
     }
 

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -378,7 +378,8 @@ fn new_liveness_timer(timeout: Duration) -> LivenessTimer {
 
 /// Reader-task liveness timer: `timer: Option<…>` (Some = armed) plus the
 /// configured `timeout`. Methods cover the `start` (pending 0→1) / `reset`
-/// (stdout activity) / `stop` (pending→0) lifecycle.
+/// (each framed and JSON-decoded downstream message) / `stop` (pending→0)
+/// lifecycle.
 struct LivenessTimerState {
     /// Active timer future, None when inactive.
     timer: Option<LivenessTimer>,
@@ -3413,7 +3414,9 @@ mod tests {
 
     /// Test that liveness timer resets on message activity.
     ///
-    /// ls-bridge-async-connection: Timer resets on any stdout activity (response or notification).
+    /// ls-bridge-async-connection: the timer resets on each framed and
+    /// JSON-decoded downstream message — not on raw stdout activity, since a
+    /// partial frame must not keep a stalled server alive.
     /// This verifies that receiving a message resets the timer to full duration.
     ///
     /// Uses paused time for deterministic testing - avoids CI flakiness from

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -237,10 +237,11 @@ impl<R: AsyncRead + Unpin> BridgeReader<R> {
     /// Parses headers until empty line, extracts Content-Length, and returns the body bytes.
     /// Handles multiple headers and different header orders per LSP spec.
     ///
-    /// Cancel-safe. Only `fill_buf` is awaited — tokio guarantees a dropped
-    /// `fill_buf` consumed nothing — and every byte taken out of the buffer is
-    /// recorded in `self.frame` before the next await. Cancelling this future
-    /// therefore loses no input, and the next call resumes mid-frame.
+    /// Cancel-safe. The only awaits are `fill_buf` and, on the large-body fast
+    /// path, `read_buf`; tokio documents both as consuming nothing when dropped.
+    /// Every byte they do take is recorded in `self.frame` before the next
+    /// await, so cancelling this future loses no input and the next call
+    /// resumes mid-frame.
     ///
     /// That matters because the reader task awaits this as a `tokio::select!`
     /// branch: `read_line`/`read_exact` would discard a partly-read frame on
@@ -265,14 +266,13 @@ impl<R: AsyncRead + Unpin> BridgeReader<R> {
                 // nothing when it returns Pending, and body.len() remains the
                 // resume marker.
                 //
-                // `take` bounds the read to this frame. It is deliberately
-                // forward-looking: today `Vec::with_capacity` returns an exact
-                // fit, so read_buf could not overshoot anyway (removing the cap
-                // keeps every test green). But the contract only promises *at
-                // least* the requested capacity, so a pooled or rounded-up buffer
-                // would silently read the next frame's header into this body —
-                // the exact desync this module exists to prevent. The cap makes
-                // that impossible by construction rather than by luck.
+                // `take` bounds the read to this frame. `Vec::with_capacity`
+                // happens to return an exact fit today, but the contract only
+                // promises *at least* the requested capacity, so a pooled or
+                // rounded-up buffer would let read_buf pull the next frame's
+                // header into this body — the exact desync this module exists to
+                // prevent. `a_large_body_with_spare_capacity_still_stops_at_the_frame_end`
+                // seeds that surplus capacity and fails if this cap is removed.
                 let read = (&mut *stdout.get_mut())
                     .take(body.remaining)
                     .read_buf(body.buf)

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -248,10 +248,12 @@ impl<R: AsyncRead + Unpin> BridgeReader<R> {
     /// every competing wake-up, and the next read would resync onto a message
     /// body and report a framing error against a perfectly well-framed stream.
     ///
-    /// An `Err` consumes the bytes that produced it and clears the frame state,
-    /// so a caller that keeps reading advances past the bad line rather than
-    /// re-parsing it forever. The reader task treats any error as terminal
-    /// anyway (`actor/reader.rs`), but the parser does not depend on that.
+    /// A *framing* error consumes the bytes that produced it and clears the
+    /// frame state, so a caller that keeps reading advances past the bad line
+    /// rather than re-parsing it forever. (An I/O error from the source leaves
+    /// the frame untouched — there is nothing to skip, and the source itself is
+    /// what failed.) The reader task treats any error as terminal anyway
+    /// (`actor/reader.rs`), but the parser does not depend on that.
     async fn read_message_bytes(&mut self) -> io::Result<Vec<u8>> {
         // Split the borrow so the buffer and the parse state can be held at once.
         let Self { stdout, frame } = self;
@@ -1370,13 +1372,22 @@ mod tests {
             .expect("a fresh 100 KiB body is worth reading directly");
         assert_eq!(remainder.remaining, 100 * 1024);
 
-        // Fill it to within a BufReader-full of the end: staging now batches the
-        // syscall instead of issuing its own.
+        // Exactly one BufReader-full left: still direct, since reading it
+        // straight in costs the same one source read without the extra copy.
         frame
             .body
             .as_mut()
             .unwrap()
-            .resize(100 * 1024 - BUF_READER_CAPACITY + 1, 0);
+            .resize(100 * 1024 - BUF_READER_CAPACITY, 0);
+        assert_eq!(
+            frame.large_body_remainder(true).map(|r| r.remaining),
+            Some(BUF_READER_CAPACITY as u64),
+            "the boundary itself is inclusive"
+        );
+
+        // One byte below it: staging now batches the syscall instead of
+        // issuing its own.
+        frame.body.as_mut().unwrap().push(0);
         assert!(
             frame.large_body_remainder(true).is_none(),
             "a remainder below the BufReader capacity belongs on the staged path"

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -1347,9 +1347,58 @@ mod tests {
         assert_eq!(reader.read_message_bytes().await.unwrap(), small);
     }
 
+    /// Which read path runs is otherwise invisible from the outside — the two
+    /// produce identical bytes, so a test that only checks the decoded frame
+    /// passes even if the direct path is never entered. Pin the predicate
+    /// itself so the large-body tests are known to exercise it.
+    #[test]
+    fn the_direct_read_path_is_chosen_only_when_it_is_safe_and_worth_it() {
+        let mut frame = FrameParseState {
+            content_length: Some(100 * 1024),
+            body: Some(Vec::new()),
+            started: true,
+            ..FrameParseState::default()
+        };
+
+        assert!(
+            frame.large_body_remainder(false).is_none(),
+            "bypassing a BufReader that still holds bytes would reorder the stream"
+        );
+
+        let remainder = frame
+            .large_body_remainder(true)
+            .expect("a fresh 100 KiB body is worth reading directly");
+        assert_eq!(remainder.remaining, 100 * 1024);
+
+        // Fill it to within a BufReader-full of the end: staging now batches the
+        // syscall instead of issuing its own.
+        frame
+            .body
+            .as_mut()
+            .unwrap()
+            .resize(100 * 1024 - BUF_READER_CAPACITY + 1, 0);
+        assert!(
+            frame.large_body_remainder(true).is_none(),
+            "a remainder below the BufReader capacity belongs on the staged path"
+        );
+
+        // A small frame never takes the direct path at all.
+        let mut small = FrameParseState {
+            content_length: Some(64),
+            body: Some(Vec::new()),
+            started: true,
+            ..FrameParseState::default()
+        };
+        assert!(small.large_body_remainder(true).is_none());
+    }
+
     /// The large-body bypass is a second await point, so it needs the same
     /// cancel-safety as the staged path: bytes already read stay in the frame
     /// and the read resumes at the right offset.
+    ///
+    /// `the_direct_read_path_is_chosen_only_when_it_is_safe_and_worth_it` is
+    /// what establishes that a 100 KiB body actually goes down that path; this
+    /// test then cancels inside it.
     #[tokio::test]
     async fn read_resumes_after_cancellation_inside_a_large_body() {
         let big = vec![b'y'; 100 * 1024];

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -588,7 +588,7 @@ async fn drain_stderr_lines<R: tokio::io::AsyncRead + Unpin>(
             if byte == b'\n' {
                 total += 1;
                 if emitted < STDERR_LOG_MAX_LINES {
-                    emit(render_stderr_line(&line, overflowed));
+                    emit(render_capped_line(&line, overflowed));
                     emitted += 1;
                 }
                 line.clear();
@@ -604,18 +604,19 @@ async fn drain_stderr_lines<R: tokio::io::AsyncRead + Unpin>(
     if !line.is_empty() || overflowed {
         total += 1;
         if emitted < STDERR_LOG_MAX_LINES {
-            emit(render_stderr_line(&line, overflowed));
+            emit(render_capped_line(&line, overflowed));
             emitted += 1;
         }
     }
     (emitted, total)
 }
 
-/// Render one captured stderr line for the log: strip a trailing `'\r'`
-/// (CRLF), decode loss-tolerantly, and mark a byte-capped line with `'…'`
-/// (after dropping a trailing UTF-8 sequence the cap cut in half, so the
-/// truncation reads as one marker instead of U+FFFD noise).
-fn render_stderr_line(bytes: &[u8], overflowed: bool) -> String {
+/// Render one captured line of downstream output for a log or error message:
+/// strip a trailing `'\r'` (CRLF), decode loss-tolerantly, and mark a
+/// byte-capped line with `'…'` (after dropping a trailing UTF-8 sequence the
+/// cap cut in half, so the truncation reads as one marker instead of U+FFFD
+/// noise).
+fn render_capped_line(bytes: &[u8], overflowed: bool) -> String {
     let mut bytes = bytes.strip_suffix(b"\r").unwrap_or(bytes);
     if overflowed {
         bytes = trim_partial_utf8_tail(bytes);
@@ -1019,4 +1020,5 @@ mod tests {
             .await
             .expect("should write initialized notification");
     }
+
 }

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -1313,6 +1313,40 @@ mod tests {
         assert_eq!(reader.read_message_bytes().await.unwrap(), small);
     }
 
+    /// The same guarantee when the body buffer has spare capacity beyond the
+    /// frame's length.
+    ///
+    /// `Vec::with_capacity` happens to return an exact fit today, so the test
+    /// above passes even with the read's `take` cap removed. Seeding a body
+    /// with surplus capacity — what a pooled or rounded-up buffer would give —
+    /// makes the cap the only thing standing between the direct read and the
+    /// next frame's header, so this test fails if it is ever dropped.
+    #[tokio::test]
+    async fn a_large_body_with_spare_capacity_still_stops_at_the_frame_end() {
+        let big = vec![b'x'; 100 * 1024];
+        let small = br#"{"id":2}"#;
+
+        let (mut tx, mut reader) = duplex_reader();
+        // Resume as if the header had just been parsed, but hand the body a
+        // buffer four times larger than the frame.
+        reader.frame = FrameParseState {
+            content_length: Some(big.len()),
+            body: Some(Vec::with_capacity(big.len() * 4)),
+            started: true,
+            ..FrameParseState::default()
+        };
+
+        let mut stream = big.clone();
+        stream.extend_from_slice(&header_for(small));
+        stream.extend_from_slice(small);
+        tokio::spawn(async move {
+            tx.write_all(&stream).await.unwrap();
+        });
+
+        assert_eq!(reader.read_message_bytes().await.unwrap(), big);
+        assert_eq!(reader.read_message_bytes().await.unwrap(), small);
+    }
+
     /// The large-body bypass is a second await point, so it needs the same
     /// cancel-safety as the staged path: bytes already read stay in the frame
     /// and the read resumes at the right offset.

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -722,6 +722,7 @@ fn trim_partial_utf8_tail(bytes: &[u8]) -> &[u8] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::DuplexStream;
 
     #[tokio::test]
     async fn drain_emits_lines_truncated_at_char_boundaries() {
@@ -1083,72 +1084,150 @@ mod tests {
             .expect("should write initialized notification");
     }
 
-    /// Emit `frames` well-formed LSP frames, writing the header and the body as
-    /// separate writes with a gap between them.
+    const PROGRESS: &[u8] = br#"{"jsonrpc":"2.0","method":"$/progress"}"#;
+
+    /// A reader fed by an in-memory pipe.
     ///
-    /// That gap is not artificial: vscode-jsonrpc's `WriteableStreamMessageWriter`
-    /// awaits the header write before writing the body, so every message has one.
-    /// Measured against basedpyright 1.39.8 under a pull-diagnostics load, a reader
-    /// landed between the two ~120 times per second.
-    fn framed_producer_with_gap(frames: usize) -> Vec<String> {
-        let body = r#"{"jsonrpc":"2.0","method":"$/progress"}"#;
-        let script = format!(
-            "for i in $(seq {frames}); do \
-               printf 'Content-Length: {len}\\r\\n\\r\\n'; sleep 0.05; printf '%s' '{body}'; \
-             done; sleep 5",
-            len = body.len(),
-        );
-        vec!["sh".to_string(), "-c".to_string(), script]
+    /// The cancellation tests below need to cancel at an exact byte offset. A
+    /// spawned producer cannot offer that: its spawn latency (measured median
+    /// 19ms) is the same order as any cancel deadline you could pick, so the
+    /// cancel lands before the header is even written and the test passes
+    /// against a broken parser. In-memory, the cancellation point is exact and
+    /// no clock is involved at all.
+    fn duplex_reader() -> (DuplexStream, BridgeReader<DuplexStream>) {
+        let (tx, rx) = tokio::io::duplex(64 * 1024);
+        (tx, BridgeReader::new(rx))
     }
 
-    /// The reader loop awaits `read_message` as one branch of a `tokio::select!`
-    /// (actor/reader.rs), so any other branch completing first drops the read
-    /// future. If that happens after the header is consumed but before the body
-    /// arrives, a non-cancel-safe parser loses the header and resyncs onto the
-    /// body — reporting a framing error against a perfectly well-framed stream
-    /// and killing the connection.
-    #[tokio::test]
-    async fn read_message_resumes_after_cancellation_between_header_and_body() {
-        let mut conn = AsyncBridgeConnection::spawn(framed_producer_with_gap(1))
-            .await
-            .expect("spawn should succeed");
+    fn header_for(body: &[u8]) -> Vec<u8> {
+        format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes()
+    }
 
-        // Cancel while the parser is parked waiting for the body.
+    /// Poll the read exactly once and drop it — what `select!` does to a losing
+    /// branch. The frame is always incomplete here, so a read that *completes*
+    /// means the test set up the wrong cancellation point and would be proving
+    /// nothing; fail loudly instead.
+    async fn cancel_a_read<R: AsyncRead + Unpin>(reader: &mut BridgeReader<R>) {
         tokio::select! {
             biased;
-            _ = tokio::time::sleep(std::time::Duration::from_millis(20)) => {}
-            _ = conn.read_message() => panic!("body cannot have arrived yet"),
+            _ = reader.read_message_bytes() => {
+                panic!("the frame is incomplete, so the read cannot have finished")
+            }
+            _ = std::future::ready(()) => {}
         }
-
-        let parsed = tokio::time::timeout(std::time::Duration::from_secs(5), conn.read_message())
-            .await
-            .expect("read should not hang")
-            .expect("the stream is well framed, so the message must still parse");
-
-        assert_eq!(parsed["method"], "$/progress");
     }
 
-    /// Repeated cancellation must not desync the stream either: the reader loop
-    /// re-enters `select!` on every iteration, so a busy connection is cancelled
-    /// over and over.
+    /// The reader task awaits `read_message` as one branch of a `tokio::select!`
+    /// (actor/reader.rs), so any other branch completing first drops the read
+    /// future. Dropping it between the header and its body must not lose the
+    /// header: a parser that kept progress in the future's locals resynced onto
+    /// the body and reported a framing error against a well-framed stream.
     #[tokio::test]
-    async fn repeated_cancellation_never_desyncs_the_stream() {
-        const FRAMES: usize = 5;
-        let mut conn = AsyncBridgeConnection::spawn(framed_producer_with_gap(FRAMES))
-            .await
-            .expect("spawn should succeed");
+    async fn read_resumes_after_cancellation_between_header_and_body() {
+        let (mut tx, mut reader) = duplex_reader();
+        tx.write_all(&header_for(PROGRESS)).await.unwrap();
+        cancel_a_read(&mut reader).await;
 
-        let mut read = 0;
-        while read < FRAMES {
-            tokio::select! {
-                biased;
-                _ = tokio::time::sleep(std::time::Duration::from_millis(10)) => {}
-                result = conn.read_message() => {
-                    let parsed = result.expect("well-framed stream must keep parsing");
-                    assert_eq!(parsed["method"], "$/progress");
-                    read += 1;
-                }
-            }
+        tx.write_all(PROGRESS).await.unwrap();
+        drop(tx);
+        assert_eq!(reader.read_message_bytes().await.unwrap(), PROGRESS);
+    }
+
+    /// Cancelling in the middle of a header LINE must not lose the partial
+    /// line: the next read continues accumulating instead of restarting on
+    /// `gth: 39` and reporting a framing error.
+    #[tokio::test]
+    async fn read_resumes_after_cancellation_mid_header_line() {
+        let (mut tx, mut reader) = duplex_reader();
+        let header = header_for(PROGRESS);
+        let (head, tail) = header.split_at(11); // "Content-Len"
+
+        tx.write_all(head).await.unwrap();
+        cancel_a_read(&mut reader).await;
+
+        tx.write_all(tail).await.unwrap();
+        cancel_a_read(&mut reader).await;
+
+        tx.write_all(PROGRESS).await.unwrap();
+        drop(tx);
+        assert_eq!(reader.read_message_bytes().await.unwrap(), PROGRESS);
+    }
+
+    /// Cancelling PART WAY THROUGH the body: the only case that exercises the
+    /// body phase's `length - body.len()` accounting and `take_completed_frame`'s
+    /// short-body guard.
+    #[tokio::test]
+    async fn read_resumes_after_cancellation_mid_body() {
+        let (mut tx, mut reader) = duplex_reader();
+        let (head, tail) = PROGRESS.split_at(10);
+
+        tx.write_all(&header_for(PROGRESS)).await.unwrap();
+        tx.write_all(head).await.unwrap();
+        cancel_a_read(&mut reader).await;
+
+        tx.write_all(tail).await.unwrap();
+        drop(tx);
+        assert_eq!(reader.read_message_bytes().await.unwrap(), PROGRESS);
+    }
+
+    /// A chunk carrying two whole frames must yield them one at a time: the
+    /// parser must never take bytes belonging to the next frame.
+    #[tokio::test]
+    async fn two_frames_in_one_chunk_are_read_separately() {
+        let (mut tx, mut reader) = duplex_reader();
+        let first = br#"{"id":1}"#;
+        let second = br#"{"id":2}"#;
+
+        let mut chunk = header_for(first);
+        chunk.extend_from_slice(first);
+        chunk.extend_from_slice(&header_for(second));
+        chunk.extend_from_slice(second);
+        tx.write_all(&chunk).await.unwrap();
+        drop(tx);
+
+        assert_eq!(reader.read_message_bytes().await.unwrap(), first);
+        assert_eq!(reader.read_message_bytes().await.unwrap(), second);
+    }
+
+    /// `Content-Length: 0` must complete on the iteration that closes the
+    /// header block. Waiting for one more read would park the empty frame until
+    /// the NEXT message arrived — on an idle link, forever. Framed at the byte
+    /// layer because `read_message`'s JSON parse rejects an empty body, so the
+    /// framing contract is only observable here.
+    #[tokio::test]
+    async fn zero_length_body_completes_without_waiting_for_more_input() {
+        let (mut tx, mut reader) = duplex_reader();
+        tx.write_all(b"Content-Length: 0\r\n\r\n").await.unwrap();
+        // Deliberately no further writes and no EOF.
+        assert_eq!(reader.read_message_bytes().await.unwrap(), b"");
+    }
+
+    /// Repeated cancellation must not desync the stream: the reader loop
+    /// re-enters `select!` on every iteration, so a busy connection is
+    /// cancelled over and over and the parse state must reset cleanly between
+    /// frames.
+    #[tokio::test(start_paused = true)]
+    async fn repeated_cancellation_never_desyncs_the_stream() {
+        let (mut tx, mut reader) = duplex_reader();
+        let (head, tail) = PROGRESS.split_at(10);
+
+        for _ in 0..5 {
+            tx.write_all(&header_for(PROGRESS)).await.unwrap();
+            cancel_a_read(&mut reader).await;
+            tx.write_all(head).await.unwrap();
+            cancel_a_read(&mut reader).await;
+            tx.write_all(tail).await.unwrap();
+            // A desync parks the read forever with no EOF to end it. The paused
+            // clock auto-advances as soon as nothing else can run, so this bound
+            // costs no wall time and turns that hang into a failure.
+            let frame = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                reader.read_message_bytes(),
+            )
+            .await
+            .expect("a well-framed stream must not park the reader")
+            .unwrap();
+            assert_eq!(frame, PROGRESS);
         }
     }
 }

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -6,7 +6,7 @@
 use std::io;
 use std::process::Stdio;
 
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
 
 /// Writer handle for sending LSP messages to downstream language server.
@@ -37,6 +37,17 @@ impl BridgeWriter {
 
 /// Longest stray line quoted back in a framing error.
 const STRAY_LINE_MAX_QUOTE_BYTES: usize = 300;
+
+/// tokio's `BufReader` default capacity, and so the point above which reading a
+/// body remainder directly beats staging it through that buffer.
+const BUF_READER_CAPACITY: usize = 8 * 1024;
+
+/// A body remainder large enough to read straight from the source.
+struct LargeBodyRead<'a> {
+    /// Bytes this frame still owes — the cap that keeps the read inside it.
+    remaining: u64,
+    buf: &'a mut Vec<u8>,
+}
 
 /// How far into the current frame the parser has got.
 ///
@@ -170,6 +181,27 @@ impl FrameParseState {
         }
     }
 
+    /// The body buffer and how much it still owes, when the remainder is big
+    /// enough to be worth reading straight from the source instead of staging
+    /// through the `BufReader`.
+    ///
+    /// `buffer_drained` must be the caller's `BufReader` state: bypassing it
+    /// while it still holds bytes would read past them and reorder the stream.
+    fn large_body_remainder(&mut self, buffer_drained: bool) -> Option<LargeBodyRead<'_>> {
+        if !buffer_drained {
+            return None;
+        }
+        let length = self.content_length?;
+        let body = self.body.as_mut()?;
+        let remaining = length - body.len();
+        // Below one BufReader-full, staging is the cheaper path: it batches the
+        // syscall with whatever else is in flight instead of issuing its own.
+        (remaining >= BUF_READER_CAPACITY).then_some(LargeBodyRead {
+            remaining: remaining as u64,
+            buf: body,
+        })
+    }
+
     /// The finished body, if the frame is complete. Resets for the next frame.
     fn take_completed_frame(&mut self) -> Option<Vec<u8>> {
         let length = self.content_length?;
@@ -221,6 +253,34 @@ impl<R: AsyncRead + Unpin> BridgeReader<R> {
         // Split the borrow so the buffer and the parse state can be held at once.
         let Self { stdout, frame } = self;
         loop {
+            if let Some(body) = frame.large_body_remainder(stdout.buffer().is_empty()) {
+                // Staging a multi-megabyte body through the 8 KiB BufReader costs
+                // an extra copy of every byte and ~8x the read() syscalls, because
+                // poll_fill_buf (unlike poll_read) has no large-read bypass. Read
+                // straight into the frame buffer instead.
+                //
+                // Still cancel-safe: read_buf is a single poll_read that appends
+                // nothing when it returns Pending, and body.len() remains the
+                // resume marker.
+                //
+                // `take` bounds the read to this frame. It is deliberately
+                // forward-looking: today `Vec::with_capacity` returns an exact
+                // fit, so read_buf could not overshoot anyway (removing the cap
+                // keeps every test green). But the contract only promises *at
+                // least* the requested capacity, so a pooled or rounded-up buffer
+                // would silently read the next frame's header into this body —
+                // the exact desync this module exists to prevent. The cap makes
+                // that impossible by construction rather than by luck.
+                let read = (&mut *stdout.get_mut()).take(body.remaining).read_buf(body.buf).await?;
+                if read == 0 {
+                    return Err(frame.eof_error());
+                }
+                if let Some(done) = frame.take_completed_frame() {
+                    return Ok(done);
+                }
+                continue;
+            }
+
             let (consumed, outcome) = {
                 let available = stdout.fill_buf().await?;
                 if available.is_empty() {
@@ -1221,6 +1281,49 @@ mod tests {
         tx.write_all(b"Content-Length: 0\r\n\r\n").await.unwrap();
         // Deliberately no further writes and no EOF.
         assert_eq!(reader.read_message_bytes().await.unwrap(), b"");
+    }
+
+    /// A body past the BufReader capacity is read straight from the source,
+    /// bypassing that buffer. The bypass must stop exactly at the frame's last
+    /// byte: `Vec::with_capacity` only promises *at least* the requested
+    /// capacity, so an unbounded read into the spare capacity would swallow the
+    /// next frame's header and desync the stream.
+    #[tokio::test]
+    async fn a_large_body_does_not_swallow_the_next_frame() {
+        let big = vec![b'x'; 100 * 1024];
+        let small = br#"{"id":2}"#;
+
+        let (mut tx, mut reader) = duplex_reader();
+        let mut stream = header_for(&big);
+        stream.extend_from_slice(&big);
+        stream.extend_from_slice(&header_for(small));
+        stream.extend_from_slice(small);
+        // The duplex buffer is smaller than this stream, so the writer has to
+        // stay live and be drained by the reads below.
+        tokio::spawn(async move {
+            tx.write_all(&stream).await.unwrap();
+        });
+
+        assert_eq!(reader.read_message_bytes().await.unwrap(), big);
+        assert_eq!(reader.read_message_bytes().await.unwrap(), small);
+    }
+
+    /// The large-body bypass is a second await point, so it needs the same
+    /// cancel-safety as the staged path: bytes already read stay in the frame
+    /// and the read resumes at the right offset.
+    #[tokio::test]
+    async fn read_resumes_after_cancellation_inside_a_large_body() {
+        let big = vec![b'y'; 100 * 1024];
+        let (mut tx, mut reader) = duplex_reader();
+
+        tx.write_all(&header_for(&big)).await.unwrap();
+        tx.write_all(&big[..32 * 1024]).await.unwrap();
+        cancel_a_read(&mut reader).await;
+
+        tokio::spawn(async move {
+            tx.write_all(&big[32 * 1024..]).await.unwrap();
+        });
+        assert_eq!(reader.read_message_bytes().await.unwrap(), vec![b'y'; 100 * 1024]);
     }
 
     /// A framing error must leave the reader able to move on: the bytes that

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -87,14 +87,24 @@ impl<R: AsyncRead + Unpin> BridgeReader<R> {
 impl FrameParseState {
     /// Take as much of `available` as this frame can use, returning how many
     /// bytes were consumed. Never consumes bytes belonging to the next frame.
-    fn absorb(&mut self, available: &[u8]) -> io::Result<usize> {
+    ///
+    /// The count is returned even when parsing fails, so the caller can consume
+    /// the offending bytes before propagating: a parser that errors *and* leaves
+    /// its input in the buffer can never advance past a bad line.
+    fn absorb(&mut self, available: &[u8]) -> (usize, io::Result<()>) {
         self.started = true;
 
         // Body phase: take only what this frame still owes.
-        if let (Some(body), Some(length)) = (self.body.as_mut(), self.content_length) {
+        if let Some(body) = self.body.as_mut() {
+            // `body` is opened only once Content-Length is known, so this cannot
+            // fail. Reading the length via the same `if let` would silently fall
+            // through to the header phase and parse body bytes as headers.
+            let length = self
+                .content_length
+                .expect("a body is only opened once Content-Length is known");
             let take = (length - body.len()).min(available.len());
             body.extend_from_slice(&available[..take]);
-            return Ok(take);
+            return (take, Ok(()));
         }
 
         // Header phase: a line is only complete once its newline arrives, so a
@@ -104,12 +114,11 @@ impl FrameParseState {
             Some(newline) => {
                 self.line.extend_from_slice(&available[..=newline]);
                 let line = std::mem::take(&mut self.line);
-                self.finish_header_line(&line)?;
-                Ok(newline + 1)
+                (newline + 1, self.finish_header_line(&line))
             }
             None => {
                 self.line.extend_from_slice(available);
-                Ok(available.len())
+                (available.len(), Ok(()))
             }
         }
     }
@@ -203,18 +212,30 @@ impl<R: AsyncRead + Unpin> BridgeReader<R> {
     /// branch: `read_line`/`read_exact` would discard a partly-read frame on
     /// every competing wake-up, and the next read would resync onto a message
     /// body and report a framing error against a perfectly well-framed stream.
+    ///
+    /// An `Err` consumes the bytes that produced it and clears the frame state,
+    /// so a caller that keeps reading advances past the bad line rather than
+    /// re-parsing it forever. The reader task treats any error as terminal
+    /// anyway (`actor/reader.rs`), but the parser does not depend on that.
     async fn read_message_bytes(&mut self) -> io::Result<Vec<u8>> {
         // Split the borrow so the buffer and the parse state can be held at once.
         let Self { stdout, frame } = self;
         loop {
-            let consumed = {
+            let (consumed, outcome) = {
                 let available = stdout.fill_buf().await?;
                 if available.is_empty() {
                     return Err(frame.eof_error());
                 }
-                frame.absorb(available)?
+                frame.absorb(available)
             };
+            // Consume before propagating: the bytes are already reflected in
+            // `frame`, so leaving them buffered would make a retry re-parse them
+            // into the same error forever, against half-advanced state.
             stdout.consume(consumed);
+            if let Err(error) = outcome {
+                *frame = FrameParseState::default();
+                return Err(error);
+            }
 
             if let Some(body) = frame.take_completed_frame() {
                 return Ok(body);
@@ -1200,6 +1221,28 @@ mod tests {
         tx.write_all(b"Content-Length: 0\r\n\r\n").await.unwrap();
         // Deliberately no further writes and no EOF.
         assert_eq!(reader.read_message_bytes().await.unwrap(), b"");
+    }
+
+    /// A framing error must leave the reader able to move on: the bytes that
+    /// caused it are consumed and the frame state is cleared. Otherwise the
+    /// offending line stays in the buffer and every subsequent read re-parses
+    /// it into the same error — the old parser advanced past it, so losing that
+    /// would be a regression that only shows up in a caller that retries.
+    #[tokio::test]
+    async fn a_framing_error_still_advances_past_the_offending_line() {
+        let (mut tx, mut reader) = duplex_reader();
+        tx.write_all(b"X-Not-A-Length: 1\r\n\r\n").await.unwrap();
+        tx.write_all(&header_for(PROGRESS)).await.unwrap();
+        tx.write_all(PROGRESS).await.unwrap();
+        drop(tx);
+
+        let error = reader
+            .read_message_bytes()
+            .await
+            .expect_err("a header block without Content-Length must fail");
+        assert!(error.to_string().contains("missing Content-Length header"));
+
+        assert_eq!(reader.read_message_bytes().await.unwrap(), PROGRESS);
     }
 
     /// Repeated cancellation must not desync the stream: the reader loop

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -35,12 +35,39 @@ impl BridgeWriter {
     }
 }
 
+/// Longest stray line quoted back in a framing error.
+const STRAY_LINE_MAX_QUOTE_BYTES: usize = 300;
+
+/// How far into the current frame the parser has got.
+///
+/// This lives in `BridgeReader` rather than in `read_message_bytes`'s locals so
+/// that a *cancelled* read resumes where it stopped. The reader task awaits
+/// `read_message` as one branch of a `tokio::select!` (see
+/// `actor/reader.rs`), so every other branch that completes first — a liveness
+/// tick, a pending-count wake-up — drops the read future mid-frame. Keeping the
+/// progress here is what makes that drop harmless.
+#[derive(Default)]
+struct FrameParseState {
+    /// Header line accumulated so far, still waiting for its newline.
+    line: Vec<u8>,
+    content_length: Option<usize>,
+    /// First non-`Content-Length` header line, quoted as evidence if the block
+    /// turns out to have no `Content-Length` at all.
+    stray_line: Option<String>,
+    /// Any byte of this frame consumed, so EOF now means a truncated frame
+    /// rather than an idle downstream closing cleanly between messages.
+    started: bool,
+    /// Body bytes accumulated once the header block ended.
+    body: Option<Vec<u8>>,
+}
+
 /// Reader handle for receiving LSP messages from downstream language server.
 ///
 /// Wraps `BufReader<ChildStdout>` to provide LSP message parsing. Used by the
 /// Reader Task (ls-bridge-message-ordering) for non-blocking response routing via ResponseRouter.
 pub(crate) struct BridgeReader {
     stdout: BufReader<ChildStdout>,
+    frame: FrameParseState,
 }
 
 impl BridgeReader {
@@ -48,7 +75,112 @@ impl BridgeReader {
     pub(crate) fn new(stdout: ChildStdout) -> Self {
         Self {
             stdout: BufReader::new(stdout),
+            frame: FrameParseState::default(),
         }
+    }
+}
+
+impl FrameParseState {
+    /// Take as much of `available` as this frame can use, returning how many
+    /// bytes were consumed. Never consumes bytes belonging to the next frame.
+    fn absorb(&mut self, available: &[u8]) -> io::Result<usize> {
+        self.started = true;
+
+        // Body phase: take only what this frame still owes.
+        if let (Some(body), Some(length)) = (self.body.as_mut(), self.content_length) {
+            let take = (length - body.len()).min(available.len());
+            body.extend_from_slice(&available[..take]);
+            return Ok(take);
+        }
+
+        // Header phase: a line is only complete once its newline arrives, so a
+        // separator cut short at EOF stays incomplete and is reported as a
+        // truncated frame instead of a header block without Content-Length.
+        match available.iter().position(|&byte| byte == b'\n') {
+            Some(newline) => {
+                self.line.extend_from_slice(&available[..=newline]);
+                let line = std::mem::take(&mut self.line);
+                self.finish_header_line(&line)?;
+                Ok(newline + 1)
+            }
+            None => {
+                self.line.extend_from_slice(available);
+                Ok(available.len())
+            }
+        }
+    }
+
+    /// Handle one complete header line (newline included). An empty line ends
+    /// the block and opens the body.
+    fn finish_header_line(&mut self, line: &[u8]) -> io::Result<()> {
+        let mut trimmed = line;
+        while let Some(rest) = trimmed
+            .strip_suffix(b"\n")
+            .or_else(|| trimmed.strip_suffix(b"\r"))
+        {
+            trimmed = rest;
+        }
+
+        if trimmed.is_empty() {
+            let length = self.content_length.ok_or_else(|| self.missing_length())?;
+            self.body = Some(Vec::with_capacity(length));
+            return Ok(());
+        }
+
+        if let Some(value) = trimmed.strip_prefix(b"Content-Length: ") {
+            let value = std::str::from_utf8(value).ok().map(str::trim);
+            let length = value.and_then(|v| v.parse().ok()).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "invalid Content-Length value")
+            })?;
+            self.content_length = Some(length);
+        } else if self.stray_line.is_none() {
+            // Remember the first non-Content-Length line for the framing
+            // error's quote. Legitimate blocks always carry Content-Length, so
+            // this is only ever REPORTED for a failed block — where any such
+            // line (including ones that merely look header-shaped, like a JSON
+            // fragment after a length mismatch or "Error: …") IS the evidence.
+            // Real spare headers (Content-Type) on healthy frames are ignored.
+            let overflowed = trimmed.len() > STRAY_LINE_MAX_QUOTE_BYTES;
+            let head = &trimmed[..trimmed.len().min(STRAY_LINE_MAX_QUOTE_BYTES)];
+            self.stray_line = Some(render_capped_line(head, overflowed));
+        }
+        Ok(())
+    }
+
+    fn missing_length(&self) -> io::Error {
+        match &self.stray_line {
+            Some(stray) => io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("missing Content-Length header (stray stdout line: {stray:?})"),
+            ),
+            None => io::Error::new(io::ErrorKind::InvalidData, "missing Content-Length header"),
+        }
+    }
+
+    /// The finished body, if the frame is complete. Resets for the next frame.
+    fn take_completed_frame(&mut self) -> Option<Vec<u8>> {
+        let length = self.content_length?;
+        if self.body.as_ref()?.len() < length {
+            return None;
+        }
+        let body = self.body.take();
+        *self = Self::default();
+        body
+    }
+
+    /// Classify a downstream EOF by how far into the frame we were. Name a
+    /// mid-frame EOF distinctly: the uniform crash triage reading these errors
+    /// depends on telling a truncated frame from a clean close and from a
+    /// genuine framing desync.
+    fn eof_error(&self) -> io::Error {
+        let reason = if self.body.is_some() {
+            "downstream closed stdout mid-body (truncated frame)"
+        } else if self.started {
+            "downstream closed stdout mid-headers (truncated frame)"
+        } else {
+            "downstream closed stdout (EOF)"
+        };
+        io::Error::new(io::ErrorKind::UnexpectedEof, reason)
     }
 }
 
@@ -57,107 +189,33 @@ impl BridgeReader {
     ///
     /// Parses headers until empty line, extracts Content-Length, and returns the body bytes.
     /// Handles multiple headers and different header orders per LSP spec.
+    ///
+    /// Cancel-safe. Only `fill_buf` is awaited — tokio guarantees a dropped
+    /// `fill_buf` consumed nothing — and every byte taken out of the buffer is
+    /// recorded in `self.frame` before the next await. Cancelling this future
+    /// therefore loses no input, and the next call resumes mid-frame.
+    ///
+    /// That matters because the reader task awaits this as a `tokio::select!`
+    /// branch: `read_line`/`read_exact` would discard a partly-read frame on
+    /// every competing wake-up, and the next read would resync onto a message
+    /// body and report a framing error against a perfectly well-framed stream.
     async fn read_message_bytes(&mut self) -> io::Result<Vec<u8>> {
-        use tokio::io::AsyncReadExt;
-
-        let mut content_length: Option<usize> = None;
-        let mut saw_header = false;
-        // First non-LSP-header line seen this frame, kept (truncated) so the
-        // genuine framing error below can QUOTE the offending bytes — when a
-        // downstream prints an error to STDOUT (observed: basedpyright), that
-        // text is the crash reason, and the frame that trips over it is the
-        // only place it is still readable.
-        let mut stray_line: Option<String> = None;
-
-        // Read headers until empty line
+        // Split the borrow so the buffer and the parse state can be held at once.
+        let Self { stdout, frame } = self;
         loop {
-            let mut line = String::new();
-            let bytes_read = self.stdout.read_line(&mut line).await?;
-
-            // `read_line` returning 0 is EOF, which would otherwise be
-            // indistinguishable from the end-of-headers empty line and
-            // misreport a dead process as "missing Content-Length header" —
-            // sending crash triage down a protocol-desync path.
-            if bytes_read == 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::UnexpectedEof,
-                    if saw_header {
-                        "downstream closed stdout mid-headers (truncated frame)"
-                    } else {
-                        "downstream closed stdout (EOF)"
-                    },
-                ));
-            }
-
-            // Trim CRLF/LF endings
-            let trimmed = line.trim_end_matches(['\r', '\n']);
-
-            if trimmed.is_empty() {
-                // Only a newline-TERMINATED empty line ends the headers. A
-                // lone '\r' (or bare partial) without its '\n' can only mean
-                // the stream ended mid-separator — `read_line` returns a
-                // newline-less line exclusively at EOF — so fall through to
-                // the next read, which reports the EOF instead of letting a
-                // dying gasp masquerade as a complete (and then
-                // Content-Length-less) header block.
-                if line.ends_with('\n') {
-                    break; // Empty line = end of headers
+            let consumed = {
+                let available = stdout.fill_buf().await?;
+                if available.is_empty() {
+                    return Err(frame.eof_error());
                 }
-                saw_header = true;
-                continue;
-            }
-            saw_header = true;
+                frame.absorb(available)?
+            };
+            stdout.consume(consumed);
 
-            if let Some(value) = trimmed.strip_prefix("Content-Length: ") {
-                content_length = Some(value.trim().parse().map_err(|_| {
-                    io::Error::new(io::ErrorKind::InvalidData, "invalid Content-Length value")
-                })?);
-            } else if stray_line.is_none() {
-                // Remember the first non-Content-Length line for the framing
-                // error's quote. Legitimate blocks always carry
-                // Content-Length, so this is only ever REPORTED for a failed
-                // block — where any such line (including ones that merely
-                // look header-shaped, like a JSON fragment after a length
-                // mismatch or "Error: …") IS the evidence. Real spare headers
-                // (Content-Type) on healthy frames are still ignored.
-                let mut quoted = trimmed.to_string();
-                const MAX_QUOTE: usize = 300;
-                if quoted.len() > MAX_QUOTE {
-                    let mut end = MAX_QUOTE;
-                    while !quoted.is_char_boundary(end) {
-                        end -= 1;
-                    }
-                    quoted.truncate(end);
-                    quoted.push('…');
-                }
-                stray_line = Some(quoted);
+            if let Some(body) = frame.take_completed_frame() {
+                return Ok(body);
             }
         }
-
-        let content_length = content_length.ok_or_else(|| match stray_line {
-            Some(stray) => io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("missing Content-Length header (stray stdout line: {stray:?})"),
-            ),
-            None => io::Error::new(io::ErrorKind::InvalidData, "missing Content-Length header"),
-        })?;
-
-        // Read exact body bytes. Name a mid-body EOF like the header-side
-        // classifications (tokio's generic "early eof" otherwise breaks the
-        // uniform crash-triage reading this reader's errors now have).
-        let mut body = vec![0u8; content_length];
-        self.stdout.read_exact(&mut body).await.map_err(|e| {
-            if e.kind() == io::ErrorKind::UnexpectedEof {
-                io::Error::new(
-                    io::ErrorKind::UnexpectedEof,
-                    "downstream closed stdout mid-body (truncated frame)",
-                )
-            } else {
-                e
-            }
-        })?;
-
-        Ok(body)
     }
 
     /// Read and parse a JSON-RPC message from the downstream language server.
@@ -1021,4 +1079,72 @@ mod tests {
             .expect("should write initialized notification");
     }
 
+    /// Emit `frames` well-formed LSP frames, writing the header and the body as
+    /// separate writes with a gap between them.
+    ///
+    /// That gap is not artificial: vscode-jsonrpc's `WriteableStreamMessageWriter`
+    /// awaits the header write before writing the body, so every message has one.
+    /// Measured against basedpyright 1.39.8 under a pull-diagnostics load, a reader
+    /// landed between the two ~120 times per second.
+    fn framed_producer_with_gap(frames: usize) -> Vec<String> {
+        let body = r#"{"jsonrpc":"2.0","method":"$/progress"}"#;
+        let script = format!(
+            "for i in $(seq {frames}); do \
+               printf 'Content-Length: {len}\\r\\n\\r\\n'; sleep 0.05; printf '%s' '{body}'; \
+             done; sleep 5",
+            len = body.len(),
+        );
+        vec!["sh".to_string(), "-c".to_string(), script]
+    }
+
+    /// The reader loop awaits `read_message` as one branch of a `tokio::select!`
+    /// (actor/reader.rs), so any other branch completing first drops the read
+    /// future. If that happens after the header is consumed but before the body
+    /// arrives, a non-cancel-safe parser loses the header and resyncs onto the
+    /// body — reporting a framing error against a perfectly well-framed stream
+    /// and killing the connection.
+    #[tokio::test]
+    async fn read_message_resumes_after_cancellation_between_header_and_body() {
+        let mut conn = AsyncBridgeConnection::spawn(framed_producer_with_gap(1))
+            .await
+            .expect("spawn should succeed");
+
+        // Cancel while the parser is parked waiting for the body.
+        tokio::select! {
+            biased;
+            _ = tokio::time::sleep(std::time::Duration::from_millis(20)) => {}
+            _ = conn.read_message() => panic!("body cannot have arrived yet"),
+        }
+
+        let parsed = tokio::time::timeout(std::time::Duration::from_secs(5), conn.read_message())
+            .await
+            .expect("read should not hang")
+            .expect("the stream is well framed, so the message must still parse");
+
+        assert_eq!(parsed["method"], "$/progress");
+    }
+
+    /// Repeated cancellation must not desync the stream either: the reader loop
+    /// re-enters `select!` on every iteration, so a busy connection is cancelled
+    /// over and over.
+    #[tokio::test]
+    async fn repeated_cancellation_never_desyncs_the_stream() {
+        const FRAMES: usize = 5;
+        let mut conn = AsyncBridgeConnection::spawn(framed_producer_with_gap(FRAMES))
+            .await
+            .expect("spawn should succeed");
+
+        let mut read = 0;
+        while read < FRAMES {
+            tokio::select! {
+                biased;
+                _ = tokio::time::sleep(std::time::Duration::from_millis(10)) => {}
+                result = conn.read_message() => {
+                    let parsed = result.expect("well-framed stream must keep parsing");
+                    assert_eq!(parsed["method"], "$/progress");
+                    read += 1;
+                }
+            }
+        }
+    }
 }

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -6,7 +6,7 @@
 use std::io;
 use std::process::Stdio;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
 
 /// Writer handle for sending LSP messages to downstream language server.
@@ -65,14 +65,18 @@ struct FrameParseState {
 ///
 /// Wraps `BufReader<ChildStdout>` to provide LSP message parsing. Used by the
 /// Reader Task (ls-bridge-message-ordering) for non-blocking response routing via ResponseRouter.
-pub(crate) struct BridgeReader {
-    stdout: BufReader<ChildStdout>,
+///
+/// The source is generic only so tests can drive the framing state machine over
+/// an in-memory pipe: cancellation points are then exact instead of racing a
+/// child process's spawn latency. Production always uses the default.
+pub(crate) struct BridgeReader<R = ChildStdout> {
+    stdout: BufReader<R>,
     frame: FrameParseState,
 }
 
-impl BridgeReader {
-    /// Create a new BridgeReader from a ChildStdout.
-    pub(crate) fn new(stdout: ChildStdout) -> Self {
+impl<R: AsyncRead + Unpin> BridgeReader<R> {
+    /// Create a new BridgeReader from a byte source (a `ChildStdout` in production).
+    pub(crate) fn new(stdout: R) -> Self {
         Self {
             stdout: BufReader::new(stdout),
             frame: FrameParseState::default(),
@@ -184,7 +188,7 @@ impl FrameParseState {
     }
 }
 
-impl BridgeReader {
+impl<R: AsyncRead + Unpin> BridgeReader<R> {
     /// Read the raw bytes of an LSP message body from stdout.
     ///
     /// Parses headers until empty line, extracts Content-Length, and returns the body bytes.

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -63,7 +63,9 @@ struct FrameParseState {
     line: Vec<u8>,
     content_length: Option<usize>,
     /// First non-`Content-Length` header line, quoted as evidence if the block
-    /// turns out to have no `Content-Length` at all.
+    /// turns out to have no `Content-Length` at all — when a downstream prints
+    /// an error to STDOUT (observed: basedpyright), the frame that trips over it
+    /// is the only place that crash reason is still readable.
     stray_line: Option<String>,
     /// Any byte of this frame consumed, so EOF now means a truncated frame
     /// rather than an idle downstream closing cleanly between messages.
@@ -271,7 +273,10 @@ impl<R: AsyncRead + Unpin> BridgeReader<R> {
                 // would silently read the next frame's header into this body —
                 // the exact desync this module exists to prevent. The cap makes
                 // that impossible by construction rather than by luck.
-                let read = (&mut *stdout.get_mut()).take(body.remaining).read_buf(body.buf).await?;
+                let read = (&mut *stdout.get_mut())
+                    .take(body.remaining)
+                    .read_buf(body.buf)
+                    .await?;
                 if read == 0 {
                     return Err(frame.eof_error());
                 }
@@ -641,7 +646,7 @@ impl AsyncBridgeConnection {
     /// Read and parse a JSON-RPC message from the child process stdout.
     ///
     /// Delegates to internal `BridgeReader`.
-    /// Returns None if the reader has been taken (via split()).
+    /// Returns an error if the reader has been taken (via split()).
     #[cfg(test)]
     pub(crate) async fn read_message(&mut self) -> io::Result<serde_json::Value> {
         match &mut self.reader {
@@ -1323,7 +1328,10 @@ mod tests {
         tokio::spawn(async move {
             tx.write_all(&big[32 * 1024..]).await.unwrap();
         });
-        assert_eq!(reader.read_message_bytes().await.unwrap(), vec![b'y'; 100 * 1024]);
+        assert_eq!(
+            reader.read_message_bytes().await.unwrap(),
+            vec![b'y'; 100 * 1024]
+        );
     }
 
     /// A framing error must leave the reader able to move on: the bytes that


### PR DESCRIPTION
## Problem

Connections to `basedpyright` were dying under a diagnostics-pull load with:

```
[basedpyright] Reader error: missing Content-Length header
  (stray stdout line: "{\"jsonrpc\":\"2.0\",\"method\":\"$/progress\",\"params\":{...}}Content-Length: 169")
```

taking every diagnostic that connection owned (observed: 616) with it. It read
like a downstream write race — load-correlated, always a whole `$/progress`
body, nothing on the server's stderr.

It is ours.

## Root cause

`read_message_bytes` used `read_line` for headers and `read_exact` for the
body. Neither is cancel-safe: bytes they have already taken out of the buffer
die with the future. `actor/reader.rs` awaits `read_message` as one branch of a
`tokio::select!`, so every competing branch that completes first — a liveness
tick, a pending-count wake-up — drops it. When the drop landed after the header
and before the body, the header was gone, and the next read started on the
body: hence a complete message body followed by the next frame's header, quoted
back as a "stray stdout line".

**The window is wide open, continuously.** vscode-jsonrpc's writer awaits its
header write before writing the body, so every message has one. Replaying 45s
of captured basedpyright 1.39.8 output (1,253,316 messages) through a chunked
reader shows a reader parked between header and body **5,469 times — about 120
per second** (plus 402 headers split across reads, which is the "stray extra
CRLF" variant).

basedpyright itself is fine: 3.28M messages / ~1GB captured straight off its
stdout, verified by an independent strict framer, **zero** framing deviations —
at 20x the notification density at which we were failing.

## Fix

Keep the parse progress in `BridgeReader` and await only cancel-safe
primitives. Every byte taken from the buffer is recorded in the state before
the next await, so cancellation loses no input and the next call resumes
mid-frame.

Chosen over moving the read into a spawned task + channel: that shape needs the
task aborted on every shutdown path or it leaks a task parked in
`read_message_bytes` until the child closes stdout, and it would leave the
parser itself still cancel-unsafe for any future caller.

Two things fell out of review and are folded in:

- **Errors now advance.** `absorb` returned through `?` before `consume`, so a
  parse error left its bytes buffered and the frame half-advanced. Measured
  against the old parser: on `Content-Length: abc`, old returned the error once
  and then read the next frame fine; new returned the same error forever. Fixed
  by consuming unconditionally and resetting frame state.
- **Large bodies keep the old I/O profile.** `poll_fill_buf` has no large-read
  bypass, so staging every body through the 8 KiB `BufReader` cost 512x the
  user-space copy and 7.9x the `read()` syscalls at 4 MB (+1.8-2.7% of that
  message's own JSON parse). Once the buffer is drained and the remainder is at
  least a BufReader-full, read straight into the frame's body — measured <= old
  at every body size.

## Tests

The cancellation tests are driven over `tokio::io::duplex`, so the cancellation
point is an exact byte offset: no shell, no sleeps, no child process. Verified
against `origin/main`'s parser in a scratch worktree — all four fail there in
0.16s:

```
read_resumes_after_cancellation_between_header_and_body  UnexpectedEof
read_resumes_after_cancellation_mid_header_line          read finished early
read_resumes_after_cancellation_mid_body                 UnexpectedEof
repeated_cancellation_never_desyncs_the_stream           Elapsed
```

The last of those reproduces the production error string byte-for-byte on the
old parser:

```
missing Content-Length header (stray stdout line: "{\"jsonrpc\":\"2.0\",\"method\":\"$/progress\"}Content-Length: 39")
```

Plus guards for invariants only the new parser can break: a chunk holding two
frames must not bleed across the boundary, `Content-Length: 0` must complete
without waiting for another read, a framing error must still advance, the
large-body path must stop at its own frame end (mutation-verified: removing the
read's `take` cap fails it), and a downstream stalling *mid-frame* must still
be caught by liveness.

Full suite: 3401 passed, 0 failed.

## Notes

- Byte-level header scanning drops the old UTF-8 requirement on header lines:
  invalid bytes now reach the stray-line quote loss-tolerantly instead of
  masking the framing error with a decode error. A 120,000-stream differential
  fuzz against a model of the old parser (7 chunkings each, 154,542 frames)
  found zero frame-content mismatches.
- `BridgeReader` gained a defaulted type parameter (`<R = ChildStdout>`) purely
  so tests can use an in-memory pipe. No production call site changed.
- Two ADRs still showed `line = reader.read_line()` inside the reader
  `select!` — the exact anti-pattern this fixes. Corrected, with the
  cancel-safety requirement written down.
- `Vec::with_capacity` on an unbounded wire `Content-Length` and the uncapped
  header line are **pre-existing** (identical exposure on `origin/main`) and
  left to #757 / #759. The new state machine gives both an obvious single home,
  and makes `try_reserve_exact` possible where `vec![0u8; n]` could only abort.
- Related: #977 (recovery after a connection dies) — this removes the main
  cause of those deaths, but not the need for recovery. #974 / #976 remain
  worthwhile as load and bandwidth work; neither was needed to avoid this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when processing messages delivered in partial or interrupted reads.
  - Preserved message framing across repeated read cancellations, preventing routing and synchronization errors.
  - Added clearer handling for incomplete, oversized, empty, and malformed messages.
  - Ensured stalled partial messages still respect liveness timeouts.

- **Documentation**
  - Updated architecture documentation to describe cancellation-safe message framing and complete-message liveness tracking.
  - Clarified message ordering and reader behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->