### PR TITLE
chore(release): bump version to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "kakehashi"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "arc-swap",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kakehashi"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 # std's inherent `File::lock` (src/install/queries.rs) is stable from 1.89; the
 # 2024 edition alone would only require 1.85. Declared so an older toolchain


### PR DESCRIPTION
## Summary

Bump the crate version from 0.9.0 to 0.10.0. This PR rolls up everything merged since the v0.9.0 release (2026-07-30). Merging this PR is the v0.10.0 release point: the merge commit will be tagged `v0.10.0` and published as a GitHub release.

## User-facing changes since v0.9.0

### Configuration
- #960 — Pull the editor's configuration via `workspace/configuration` when the client advertises the capability (covers VS Code's `{"settings": null}` didChangeConfiguration pattern).
- #957 — Unify empty-means-clear semantics: an empty map (`{}`) or list (`[]`) in a config layer now *clears* the setting, distinct from omitting it (inherit) or providing values (merge/replace). Applies to `captureMappings`, query-type mappings, and friends. **Behavior change** for configs that relied on empty values being ignored.
- #925 — `autoInstall` is now per-language: `[languages.<lang>].autoInstall`, with `[languages._]` as the wildcard. The top-level `autoInstall` key still works but is **deprecated**.
- #738 — Relative paths in `searchPaths`, `languages.*.parser`, and `languages.*.queries[].path` now resolve against the *config layer that declared them* (the TOML file's own directory; the workspace root for `initializationOptions`), not the server process's working directory. **Behavior change** if you relied on CWD-relative resolution.
- #736 — `--config-file` strictness aimed at real mistakes: a named config that is present but unusable (unreadable, malformed, >8 MiB) rejects LSP initialization / exits `format`·`diagnose` with 2; an *absent* file is skipped with a warning so layered `--config-file` overlays still work.
- #954 — Keep a configuration root when the workspace-folder list empties instead of losing config anchoring.
- #795 / #788 — Surface broken workspace/user config paths as warnings instead of silently ignoring them.
- #804 / #803 / #765 — `config init`-style output hardening: refuse to force-write through symlinks, never leave a partial file on failed no-force output, create outputs without clobbering.

### Bridge (embedded language servers)
- #985 — Make the downstream frame reader cancel-safe. A cancelled request could previously desynchronize downstream message framing, dropping or corrupting server responses under load.
- #972 — Break the forwarded-refresh ↔ diagnostic-pull feedback loop that could ping-pong refresh requests with downstream servers.
- #951 — Every downstream connection gets its own command-palette entry, so per-root pooled servers with the same command name stay individually invokable.
- #950 — Palette commands are unregistered when no configured server can serve them anymore (server removed from config, connection purged).
- #827 — Ambiguous raw palette command names now refuse with a clear error instead of routing to an arbitrary workspace.
- #926 — `workspace/executeCommand` routes by connection identity instead of by document, decoupling command routing from virtual-document repair.
- #928 / #927 — Downstream server respawn re-opens exactly the virtual documents that are currently relevant, derived from current state rather than remembered sets.
- #963 — Host-layer completion items are now resolvable: `completionItem/resolve` round-trips for `bridge._self` servers.
- #786 — Preserve workspace marker entries so a marker-derived root isn't dropped mid-session.
- #744 — Preserve no-workspace initialization: bridging works when the editor opens a lone file with no workspace folder.

### LSP lifecycle & diagnostics
- #748 — Track the full workspace-folder lifecycle (`didChangeWorkspaceFolders` add/remove) and scope per-root server pools accordingly.
- #971 — Skip the config/server reload for empty workspace-folder change events.
- #749 — Scope diagnostic coverage to the document's lifetime, so a close/reopen doesn't inherit stale coverage state.

### CLI & installer
- #962 — `kakehashi language install` is all-or-nothing: parser and queries land together or not at all, re-runs repair the missing half and succeed idempotently, and a dangling `; inherits:` chain is an error rather than a warning.
- #782 / #769 — `language status` fails loudly on query-recovery errors and surfaces scan failures instead of reporting a clean-looking lie.
- #781 — Broken (dangling-symlink) query assets are reported as present-but-broken instead of silently absent.
- #768 — Runtime asset lookup is confined to the runtime asset boundary (no stray filesystem probing outside it).
- #834 / #831 — Parser discovery ignores invalid filename stems and parser-shaped directories instead of erroring on them.
- #778 — Directory walks detect shebang-only files correctly.
- #753 — Special-file paths (FIFOs, devices, …) are rejected up front.
- #762 — `format` refuses multiply-hard-linked targets to avoid writing through unexpected aliases.

## Not user-facing

- #924 — MSRV is now **Rust 1.89** (`fs4` was dropped in favor of `std`'s `File::lock`). Only relevant when building from source; prebuilt binary users are unaffected.

- #973 — CI runs on pull requests against any base branch (fixes the stacked-PR CI blind spot).
- #970 — Deterministic second-host open in the code-action E2E test.
- #967 — Satisfy `clippy --all-targets` in test-only code.
- #959 — Extract the config layer fold and document why its order binds.
- #921 — Remove the parser crash quarantine (`FailedParserRegistry` and its `KAKEHASHI_STATE_DIR` plumbing); it never detected the crash class it was built for.
- #930 — Link the known-limits docs to their tracking issue.
- #922 / #920 — Dependency updates (`serial_test`, `ulid` major bumps; Cargo.lock and flake inputs refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
