### PR TITLE
fix(lsp): remove unused wrappedDidChangeConfigurationSettings capability

### DIFF
--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -688,11 +688,6 @@ impl Kakehashi {
                     },
                 )),
                 workspace: Some(workspace_server_capabilities()),
-                experimental: Some(serde_json::json!({
-                    "kakehashi": {
-                        "wrappedDidChangeConfigurationSettings": true,
-                    },
-                })),
                 ..ServerCapabilities::default()
             },
         })

--- a/tests/e2e_lsp_protocol.rs
+++ b/tests/e2e_lsp_protocol.rs
@@ -66,7 +66,7 @@ fn test_initialize_exposes_kakehashi_version() {
     assert_eq!(
         result["serverInfo"]["version"],
         json!(env!("CARGO_PKG_VERSION")),
-        "clients use serverInfo.version to distinguish old flat-only servers"
+        "initialize should expose the package version"
     );
 }
 

--- a/tests/e2e_lsp_protocol.rs
+++ b/tests/e2e_lsp_protocol.rs
@@ -47,7 +47,7 @@ fn test_initialize_returns_capabilities() {
 }
 
 #[test]
-fn test_initialize_exposes_kakehashi_version_and_wrapped_didchange_capability() {
+fn test_initialize_exposes_kakehashi_version() {
     let mut client = LspClient::new();
 
     let response = client.send_request(
@@ -67,11 +67,6 @@ fn test_initialize_exposes_kakehashi_version_and_wrapped_didchange_capability() 
         result["serverInfo"]["version"],
         json!(env!("CARGO_PKG_VERSION")),
         "clients use serverInfo.version to distinguish old flat-only servers"
-    );
-    assert_eq!(
-        result["capabilities"]["experimental"]["kakehashi"]["wrappedDidChangeConfigurationSettings"],
-        json!(true),
-        "clients should be able to choose wrapped didChangeConfiguration payloads without parsing versions"
     );
 }
 

--- a/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
+++ b/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
@@ -117,10 +117,5 @@ expression: capabilities
   "diagnosticProvider": {
     "interFileDependencies": false,
     "workspaceDiagnostics": false
-  },
-  "experimental": {
-    "kakehashi": {
-      "wrappedDidChangeConfigurationSettings": true
-    }
   }
 }


### PR DESCRIPTION
## Summary
- Removes the `experimental.kakehashi.wrappedDidChangeConfigurationSettings` capability flag from the `initialize` response — no client (kakehashi.nvim, kakehashi-lspconfig, kakehashi.vsix) reads it or its sibling signal (`serverInfo.version`), and it's purely advertisement: `workspace/didChangeConfiguration` already accepts both wrapped and unwrapped `settings.kakehashi` payloads unconditionally.
- Updates the e2e test and insta snapshot to match.
- Includes one unrelated 1-line clippy fix (`src/lsp/settings.rs`) needed to unblock the pre-commit lint gate.

## Review
Went through the local `/revise` pipeline: multi-perspective review (correctness, test coverage, compatibility risk) + two rounds of codex MCP review. One real finding fixed (a test assertion message overstating client behavior); one compatibility concern raised independently by codex twice, refuted both times with evidence (grep across all three companion client repos found zero references to either signal).

## Test plan
- [x] `cargo test --features e2e -- test_initialize` passes (renamed test + snapshot)
- [x] `cargo test --features e2e -- e2e_deprecation_warning e2e_config_file` passes (confirms wrapped/unwrapped settings parsing unchanged)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Full pre-commit hook (unit + e2e suite) passed for each commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the deprecated experimental configuration-change capability from the server’s initialization response.
  * Simplified initialization capability reporting to expose only supported features.
* **Tests**
  * Updated initialization checks to verify version information without relying on the removed experimental capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->