### PR TITLE
fix(cli): uninstall --all must not swallow discovery I/O errors

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -613,16 +613,9 @@ fn safe_parser_language_name(stem: &str) -> Option<String> {
 }
 
 fn installed_query_language_name_checked(path: &Path) -> std::io::Result<Option<String>> {
-    let Some(file_name) = path.file_name() else {
+    let Some(name) = safe_query_entry_name(path) else {
         return Ok(None);
     };
-    let name = file_name.to_string_lossy();
-    if name.starts_with('.') {
-        return Ok(None);
-    }
-    if !queries::is_safe_language_name(&name) {
-        return Ok(None);
-    }
     let is_dir = match std::fs::metadata(path) {
         Ok(metadata) => metadata.is_dir(),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -638,7 +631,7 @@ fn installed_query_language_name_checked(path: &Path) -> std::io::Result<Option<
     if !is_dir {
         return Ok(None);
     }
-    Ok(Some(name.to_string()))
+    Ok(Some(name))
 }
 
 /// Say what discovery deliberately left on disk, and why.
@@ -690,12 +683,6 @@ fn run_language_uninstall(
     // command does not know the shape of, so it cannot know what it left.
     let mut unreadable = false;
 
-    // Languages whose own parser entry could not be read. Removing their
-    // queries would leave exactly the parser-only state this command exists to
-    // avoid — and unlike a removal that fails, this one is known BEFORE
-    // anything is taken, so the language can simply be left whole.
-    let mut undecidable: BTreeSet<String> = BTreeSet::new();
-
     // Determine which languages to uninstall
     let languages_to_uninstall: Vec<String> = if all {
         // Collect all installed languages
@@ -746,13 +733,6 @@ fn run_language_uninstall(
                     // could smuggle ANSI escapes into this line.
                     eprintln!("✗ Failed to inspect {:?}: {}", path, error);
                     unreadable = true;
-                    // The stem is legible even when the entry is not, and it is
-                    // what says which language must now be left alone.
-                    if let Some(stem) = path.file_stem()
-                        && let Some(language) = safe_parser_language_name(&stem.to_string_lossy())
-                    {
-                        undecidable.insert(language);
-                    }
                 }
             }
             Ok(())
@@ -776,9 +756,6 @@ fn run_language_uninstall(
                 Err(error) => {
                     eprintln!("✗ Failed to inspect {:?}: {}", path, error);
                     unreadable = true;
-                    if let Some(name) = safe_query_entry_name(&path) {
-                        undecidable.insert(name);
-                    }
                 }
             }
             Ok(())
@@ -857,20 +834,6 @@ fn run_language_uninstall(
             continue;
         }
 
-        // Discovery could not read this language's own parser entry. Taking its
-        // queries would leave the parser-only state the lock below exists to
-        // prevent, and unlike a removal that fails, this is known before
-        // anything is taken — so leave the language whole and say so. The run
-        // still fails; the neighbours still get removed.
-        if undecidable.contains(lang) {
-            eprintln!(
-                "✗ Leaving '{}' untouched: its parser entry could not be inspected.",
-                lang
-            );
-            any_failed = true;
-            continue;
-        }
-
         let mut removed_something = false;
         // Whether anything about THIS language went wrong. "Not installed" is a
         // claim about the filesystem, and a run that just failed to read or
@@ -885,6 +848,30 @@ fn run_language_uninstall(
             Ok(lock) => lock,
             Err(e) => {
                 eprintln!("✗ Failed to lock '{}' for uninstall: {}", lang, e);
+                any_failed = true;
+                continue;
+            }
+        };
+
+        // Look at the parser BEFORE taking the queries, under the same lock
+        // that will still be held when it is removed.
+        //
+        // Order matters for one reason: if we cannot tell what is at the parser
+        // path, removing the queries first would manufacture the parser-only
+        // state this whole transaction exists to avoid — #953's headline shape,
+        // reached through the per-entry door instead of the directory-level
+        // one. Unlike a removal that FAILS, this is knowable before anything is
+        // taken, so the language can simply be left whole. The run still fails,
+        // and the other languages are still removed.
+        let parser_entry = match find_parser_entry(&parser_dir, lang) {
+            Ok(entry) => entry,
+            Err(e) => {
+                eprintln!(
+                    "✗ Leaving '{}' untouched: failed to inspect its parser entry at {:?}: {}",
+                    lang,
+                    parser_entry_path(&parser_dir, lang),
+                    e
+                );
                 any_failed = true;
                 continue;
             }
@@ -934,39 +921,18 @@ fn run_language_uninstall(
             }
         }
 
-        // Remove parser file
-        match find_parser_entry(&parser_dir, lang) {
-            Ok(Some((parser_path, is_symlink))) => {
-                match remove_parser_entry(&parser_path, is_symlink) {
-                    Ok(()) => {
-                        eprintln!("✓ Removed parser: {}", parser_path.display());
-                        removed_something = true;
-                    }
-                    Err(e) => {
-                        eprintln!("✗ Failed to remove parser {}: {}", parser_path.display(), e);
-                        any_failed = true;
-                        lang_failed = true;
-                    }
+        // Remove the parser entry probed above, still under the same lock.
+        if let Some((parser_path, is_symlink)) = parser_entry {
+            match remove_parser_entry(&parser_path, is_symlink) {
+                Ok(()) => {
+                    eprintln!("✓ Removed parser: {}", parser_path.display());
+                    removed_something = true;
                 }
-            }
-            Ok(None) => {}
-            // Failing to look is not the same as finding nothing: reporting
-            // "not installed" here would be the command guessing, having just
-            // removed the language's queries.
-            //
-            // Naming the candidate entry rather than the directory, because
-            // "failed to inspect …/parser: No such file or directory" about a
-            // directory that plainly exists is precisely the message #953
-            // called out as unactionable.
-            Err(e) => {
-                eprintln!(
-                    "✗ Failed to inspect the parser for '{}' at {}: {}",
-                    lang,
-                    parser_entry_path(&parser_dir, lang).display(),
-                    e
-                );
-                any_failed = true;
-                lang_failed = true;
+                Err(e) => {
+                    eprintln!("✗ Failed to remove parser {}: {}", parser_path.display(), e);
+                    any_failed = true;
+                    lang_failed = true;
+                }
             }
         }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1151,10 +1151,17 @@ fn remove_parser_entry(path: &Path) -> std::io::Result<bool> {
         Err(error) => {
             let still_a_symlink = std::fs::symlink_metadata(path)
                 .is_ok_and(|metadata| metadata.file_type().is_symlink());
-            if still_a_symlink && std::fs::remove_dir(path).is_ok() {
-                Ok(true)
-            } else {
-                Err(error)
+            if !still_a_symlink {
+                return Err(error);
+            }
+            match std::fs::remove_dir(path) {
+                Ok(()) => Ok(true),
+                // Vanished between the two attempts. Same answer as the
+                // `remove_file` case above and for the same reason: the entry
+                // is gone, so surfacing the first error would report a
+                // half-removed language over a filesystem that is as asked.
+                Err(second) if second.kind() == std::io::ErrorKind::NotFound => Ok(false),
+                Err(_) => Err(error),
             }
         }
     }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -805,8 +805,8 @@ fn run_language_uninstall(
         }
 
         // Remove parser file
-        if let Some(parser_path) = find_parser_file(&parser_dir, lang) {
-            match fs::remove_file(&parser_path) {
+        match find_parser_entry(&parser_dir, lang) {
+            Ok(Some(parser_path)) => match fs::remove_file(&parser_path) {
                 Ok(()) => {
                     eprintln!("✓ Removed parser: {}", parser_path.display());
                     removed_something = true;
@@ -815,6 +815,19 @@ fn run_language_uninstall(
                     eprintln!("✗ Failed to remove parser {}: {}", parser_path.display(), e);
                     any_failed = true;
                 }
+            },
+            Ok(None) => {}
+            // Failing to look is not the same as finding nothing: reporting
+            // "not installed" here would be the command guessing, having just
+            // removed the language's queries.
+            Err(e) => {
+                eprintln!(
+                    "✗ Failed to inspect the parser for '{}' in {}: {}",
+                    lang,
+                    parser_dir.display(),
+                    e
+                );
+                any_failed = true;
             }
         }
 
@@ -857,10 +870,60 @@ fn run_language_uninstall(
     Ok(())
 }
 
-/// Find the parser file for a language.
+/// Find the LOADABLE parser file for a language.
+///
+/// Used by `status` to fill the parser column, where the question is whether the
+/// language can actually be loaded — so this follows symlinks and a broken one
+/// reads as absent. Uninstall asks a different question and uses
+/// [`find_parser_entry`]; see the note there for why the two must not be merged.
 fn find_parser_file(parser_dir: &std::path::Path, lang: &str) -> Option<PathBuf> {
     let path = parser_dir.join(format!("{}.{}", lang, std::env::consts::DLL_EXTENSION));
     if path.is_file() { Some(path) } else { None }
+}
+
+/// The parser entry `unlink` can take for a language, if there is one.
+///
+/// Uninstall's question is not "can this load" but "is there a directory entry
+/// here to remove", and the two differ exactly where it matters: a dangling
+/// symlink does not load, yet `remove_file` unlinks it happily because unlink
+/// acts on the link rather than its target. Asking `is_file()` — which follows
+/// the link — made the entry invisible, so `uninstall <lang>` answered "is not
+/// installed" and exited 0 while it sat on disk with no CLI path to clear it.
+///
+/// `Err` means the entry could not be classified at all. That is deliberately
+/// distinct from `Ok(None)`: "there is nothing here" and "I could not tell"
+/// must not collapse into the same answer one step before a destructive action.
+fn find_parser_entry(parser_dir: &Path, lang: &str) -> std::io::Result<Option<PathBuf>> {
+    let path = parser_dir.join(format!("{}.{}", lang, std::env::consts::DLL_EXTENSION));
+    match parser_entry_kind(&path)? {
+        Some(()) => Ok(Some(path)),
+        None => Ok(None),
+    }
+}
+
+/// Whether a path in `parser/` is an entry uninstall may remove.
+///
+/// `symlink_metadata` rather than `metadata`, so a dangling symlink is a normal
+/// answer instead of a `NotFound` error; and rather than `DirEntry::file_type`,
+/// which can be served from `readdir`'s cached `d_type` and so would report
+/// success on some filesystems and fail on others for an unreadable directory.
+///
+/// A regular file or a symlink counts — those are the two shapes an install
+/// produces, and a symlink is how a locally built parser gets pointed at. A
+/// directory does not (see #828: `remove_file` cannot take one). Other special
+/// file types are left out for the same reason a directory is: discovery would
+/// be inventing an install that nothing here created.
+fn parser_entry_kind(path: &Path) -> std::io::Result<Option<()>> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            let file_type = metadata.file_type();
+            Ok((file_type.is_file() || file_type.is_symlink()).then_some(()))
+        }
+        // Absent is the ordinary "not installed" answer; every other failure
+        // means we could not tell, which must not read as absent.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
 }
 
 /// What to tell someone whose `--output` path is already taken. A regular
@@ -1487,6 +1550,44 @@ mod tests {
         );
         assert_eq!(installed_query_language_name(&unsafe_name), None);
         assert_eq!(installed_query_language_name(&hidden), None);
+    }
+
+    /// A dangling parser entry is what uninstall must be able to remove, and
+    /// `is_file()` — which follows the link — is what hid it. `Ok(None)` here
+    /// would put the entry back out of reach of every CLI path.
+    #[test]
+    #[cfg(unix)]
+    fn find_parser_entry_sees_a_dangling_symlink() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let ext = std::env::consts::DLL_EXTENSION;
+        let path = temp.path().join(format!("dangling.{ext}"));
+        std::os::unix::fs::symlink(temp.path().join("missing"), &path).unwrap();
+
+        assert_eq!(
+            find_parser_entry(temp.path(), "dangling").unwrap(),
+            Some(path)
+        );
+        // The loadability question has the opposite answer, which is why the
+        // two helpers exist separately.
+        assert_eq!(find_parser_file(temp.path(), "dangling"), None);
+    }
+
+    /// A parser-shaped directory is not an entry `remove_file` can take (#828).
+    #[test]
+    fn find_parser_entry_rejects_a_directory() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let ext = std::env::consts::DLL_EXTENSION;
+        std::fs::create_dir_all(temp.path().join(format!("fakeparser.{ext}"))).unwrap();
+
+        assert_eq!(find_parser_entry(temp.path(), "fakeparser").unwrap(), None);
+    }
+
+    /// "Nothing here" and "could not tell" must stay distinguishable: the gate
+    /// they feed is one step before `fs::remove_file`.
+    #[test]
+    fn find_parser_entry_reports_absence_but_not_failure() {
+        let temp = tempfile::TempDir::new().unwrap();
+        assert_eq!(find_parser_entry(temp.path(), "absent").unwrap(), None);
     }
 
     /// `Path::exists()` follows symlinks, so the old precheck read a dangling

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -974,10 +974,14 @@ fn run_language_uninstall(
         // Remove the parser entry probed above, still under the same lock.
         if let Some(parser_path) = parser_entry {
             match remove_parser_entry(&parser_path) {
-                Ok(()) => {
+                Ok(true) => {
                     eprintln!("✓ Removed parser: {}", parser_path.display());
                     removed_something = true;
                 }
+                // Already gone. The end state is the one asked for, so this is
+                // not a failure — and claiming the removal would be claiming
+                // work another actor did.
+                Ok(false) => {}
                 Err(e) => {
                     eprintln!("✗ Failed to remove parser {}: {}", parser_path.display(), e);
                     // The queries are already gone by now — the tombstone has
@@ -1135,14 +1139,20 @@ fn parser_entry_kind(path: &Path) -> std::io::Result<Option<ParserEntry>> {
 /// between — the one thing this function must never do. The re-check narrows
 /// that to the window between it and the call, which is the same irreducible
 /// race any unlink runs; closing it fully would need `openat`/`O_NOFOLLOW`.
-fn remove_parser_entry(path: &Path) -> std::io::Result<()> {
+///
+/// `Ok(false)` means the entry was already gone — someone else unlinked it
+/// between classification and here. That is the state this call wanted, so it
+/// is not a failure; reporting it as one would make the command claim a
+/// half-removed language while the filesystem is exactly as asked.
+fn remove_parser_entry(path: &Path) -> std::io::Result<bool> {
     match std::fs::remove_file(path) {
-        Ok(()) => Ok(()),
+        Ok(()) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
         Err(error) => {
             let still_a_symlink = std::fs::symlink_metadata(path)
                 .is_ok_and(|metadata| metadata.file_type().is_symlink());
             if still_a_symlink && std::fs::remove_dir(path).is_ok() {
-                Ok(())
+                Ok(true)
             } else {
                 Err(error)
             }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1862,6 +1862,23 @@ mod tests {
         assert_eq!(entry, ParserEntry::WrongShape);
     }
 
+    /// Removing and finding-already-gone are different answers. A parser that
+    /// another actor unlinked between classification and removal leaves the
+    /// filesystem in exactly the asked-for state, so it must not be reported as
+    /// a failed removal — nor as work this run did.
+    #[test]
+    fn remove_parser_entry_distinguishes_removing_from_already_gone() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let present = temp.path().join("present");
+        std::fs::write(&present, "parser").unwrap();
+
+        assert_eq!(remove_parser_entry(&present).unwrap(), true);
+        assert!(!present.exists());
+        // The same call again: the entry is gone, which is success, but not a
+        // removal this run performed.
+        assert_eq!(remove_parser_entry(&present).unwrap(), false);
+    }
+
     /// "Nothing here" and "could not tell" must stay distinguishable: the gate
     /// they feed is one step before `fs::remove_file`.
     #[test]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -881,7 +881,7 @@ fn run_language_uninstall(
         // and the other languages are still removed.
         let parser_entry = match find_parser_entry(&parser_dir, lang) {
             Ok(None) => None,
-            Ok(Some((path, ParserEntry::Removable { is_symlink }))) => Some((path, is_symlink)),
+            Ok(Some((path, ParserEntry::Removable { .. }))) => Some(path),
             // A shape removal cannot take is not "no parser here" — but #828
             // settled that such an entry does not count as an installed parser,
             // and that answer stands when there is nothing else to lose. What
@@ -890,7 +890,22 @@ fn run_language_uninstall(
             // (which has no leftovers summary), report it as a clean uninstall.
             // So the refusal is scoped to exactly that case.
             Ok(Some((path, ParserEntry::WrongShape))) => {
-                if std::fs::symlink_metadata(queries_dir.join(lang)).is_ok() {
+                // Only a confirmed absence permits going on. Reading any other
+                // error as "no queries here" would hand back the half-removal
+                // this branch exists to prevent, decided on a guess.
+                let queries_present = match std::fs::symlink_metadata(queries_dir.join(lang)) {
+                    Ok(_) => true,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+                    Err(e) => {
+                        eprintln!(
+                            "✗ Leaving '{}' untouched: {:?} is not a shape this CLI can remove, and whether it has queries could not be determined: {}",
+                            lang, path, e
+                        );
+                        any_failed = true;
+                        continue;
+                    }
+                };
+                if queries_present {
                     eprintln!(
                         "✗ Leaving '{}' untouched: {:?} is not a shape this CLI can remove, and taking its queries alone would half-remove it.",
                         lang, path
@@ -957,8 +972,8 @@ fn run_language_uninstall(
         }
 
         // Remove the parser entry probed above, still under the same lock.
-        if let Some((parser_path, is_symlink)) = parser_entry {
-            match remove_parser_entry(&parser_path, is_symlink) {
+        if let Some(parser_path) = parser_entry {
+            match remove_parser_entry(&parser_path) {
                 Ok(()) => {
                     eprintln!("✓ Removed parser: {}", parser_path.display());
                     removed_something = true;
@@ -1112,14 +1127,21 @@ fn parser_entry_kind(path: &Path) -> std::io::Result<Option<ParserEntry>> {
 /// loses the link and whatever it pointed at survives. Windows is the exception
 /// worth naming: a directory symlink or junction is a reparse point that
 /// `DeleteFileW` refuses, and `RemoveDirectoryW` is what removes the link there
-/// — also without touching the target. The retry is gated on the entry being a
-/// symlink, and on Unix it simply fails (a symlink is not a directory), so the
-/// fallback cannot reach a real directory on either platform.
-fn remove_parser_entry(path: &Path, is_symlink: bool) -> std::io::Result<()> {
+/// — also without touching the target.
+///
+/// The symlink test is re-taken here rather than carried from discovery. A flag
+/// decided earlier is a statement about what the path WAS, and `remove_dir`
+/// acting on a stale one could take a real directory that replaced the link in
+/// between — the one thing this function must never do. The re-check narrows
+/// that to the window between it and the call, which is the same irreducible
+/// race any unlink runs; closing it fully would need `openat`/`O_NOFOLLOW`.
+fn remove_parser_entry(path: &Path) -> std::io::Result<()> {
     match std::fs::remove_file(path) {
         Ok(()) => Ok(()),
         Err(error) => {
-            if is_symlink && std::fs::remove_dir(path).is_ok() {
+            let still_a_symlink = std::fs::symlink_metadata(path)
+                .is_ok_and(|metadata| metadata.file_type().is_symlink());
+            if still_a_symlink && std::fs::remove_dir(path).is_ok() {
                 Ok(())
             } else {
                 Err(error)

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -604,8 +604,10 @@ fn visit_install_directory(
 ///
 /// Shared by `status` and `uninstall --all` so they agree on which NAMES count —
 /// a name one lists and the other refuses to touch is what made `uninstall --all`
-/// fail partway. They still differ on I/O errors (status propagates, uninstall
-/// swallows); that divergence predates this and is tracked separately.
+/// fail partway. They still differ on a per-entry I/O failure, but no longer in
+/// the direction that hid one: `status` aborts rather than describe an
+/// installation it could not fully observe, while uninstall names the entry,
+/// skips it, and fails the run so what unlink CAN take stays removable (#953).
 fn safe_parser_language_name(stem: &str) -> Option<String> {
     queries::is_safe_language_name(stem).then(|| stem.to_string())
 }
@@ -639,6 +641,26 @@ fn installed_query_language_name_checked(path: &Path) -> std::io::Result<Option<
     Ok(Some(name.to_string()))
 }
 
+/// Say what discovery deliberately left on disk, and why.
+///
+/// Called on EVERY exit that makes a claim about the directory — including the
+/// failing ones and the "nothing installed" one — because the claim is exactly
+/// what these notes qualify. An exit that skipped them would be the summary and
+/// the thing it is honest about parting company.
+///
+/// Debug-formatted: these paths are on the list precisely because their names
+/// are unusual, so they are the likeliest place for an ANSI escape to arrive
+/// from the filesystem.
+fn report_unmanaged(unmanaged: &[(PathBuf, &'static str)]) {
+    if unmanaged.is_empty() {
+        return;
+    }
+    eprintln!();
+    for (path, reason) in unmanaged {
+        eprintln!("Note: left {:?} in place — {}.", path, reason);
+    }
+}
+
 /// Run the language uninstall command
 fn run_language_uninstall(
     language: Option<String>,
@@ -646,7 +668,6 @@ fn run_language_uninstall(
     all: bool,
 ) -> Result<(), ExitCode> {
     use std::collections::BTreeSet;
-    use std::fs;
     use std::io::{self, Write};
 
     let data_dir = default_data_dir().ok_or_else(|| {
@@ -660,15 +681,20 @@ fn run_language_uninstall(
         eprintln!("Warning: failed to recover interrupted query installs: {e}");
     }
 
-    // Parser files discovery walked past because their names are not ones this
-    // CLI manages. Kept so the summary cannot claim it removed everything while
-    // one of them is still on disk.
-    let mut unmanaged: Vec<PathBuf> = Vec::new();
+    // Entries discovery deliberately walked past, with why. Kept so the summary
+    // cannot claim it removed everything while one of them is still on disk.
+    let mut unmanaged: Vec<(PathBuf, &'static str)> = Vec::new();
 
     // Entries discovery could not classify at all. Distinct from `unmanaged`,
     // which is a deliberate skip of something understood: these are entries the
     // command does not know the shape of, so it cannot know what it left.
     let mut unreadable = false;
+
+    // Languages whose own parser entry could not be read. Removing their
+    // queries would leave exactly the parser-only state this command exists to
+    // avoid — and unlike a removal that fails, this one is known BEFORE
+    // anything is taken, so the language can simply be left whole.
+    let mut undecidable: BTreeSet<String> = BTreeSet::new();
 
     // Determine which languages to uninstall
     let languages_to_uninstall: Vec<String> = if all {
@@ -697,7 +723,7 @@ fn run_language_uninstall(
             }
             match parser_entry_kind(&path) {
                 Ok(None) => {}
-                Ok(Some(())) => {
+                Ok(Some(ParserEntry::Removable { .. })) => {
                     if let Some(stem) = path.file_stem() {
                         let stem = stem.to_string_lossy();
                         match safe_parser_language_name(&stem) {
@@ -707,13 +733,26 @@ fn run_language_uninstall(
                             // Remembered, not just skipped: this command goes on
                             // to say it uninstalled everything, and a parser file
                             // left on disk makes that false.
-                            None => unmanaged.push(path.clone()),
+                            None => unmanaged
+                                .push((path.clone(), "its name is not one this CLI manages")),
                         }
                     }
                 }
+                Ok(Some(ParserEntry::WrongShape)) => {
+                    unmanaged.push((path.clone(), "it is not a shape this CLI can remove"));
+                }
                 Err(error) => {
-                    eprintln!("✗ Failed to inspect {}: {}", path.display(), error);
+                    // Debug-format: the name comes from the filesystem, so it
+                    // could smuggle ANSI escapes into this line.
+                    eprintln!("✗ Failed to inspect {:?}: {}", path, error);
                     unreadable = true;
+                    // The stem is legible even when the entry is not, and it is
+                    // what says which language must now be left alone.
+                    if let Some(stem) = path.file_stem()
+                        && let Some(language) = safe_parser_language_name(&stem.to_string_lossy())
+                    {
+                        undecidable.insert(language);
+                    }
                 }
             }
             Ok(())
@@ -723,19 +762,23 @@ fn run_language_uninstall(
                 "Error: failed to inspect parser directory '{}': {e}",
                 parser_dir.display()
             );
+            report_unmanaged(&unmanaged);
             ExitCode::FAILURE
         })?;
 
         visit_install_directory(&queries_dir, |entry| {
             let path = entry.path();
-            match installed_query_language_name_checked(&path) {
+            match query_entry_language_name(&path) {
                 Ok(Some(name)) => {
                     languages.insert(name);
                 }
                 Ok(None) => {}
                 Err(error) => {
-                    eprintln!("✗ Failed to inspect {}: {}", path.display(), error);
+                    eprintln!("✗ Failed to inspect {:?}: {}", path, error);
                     unreadable = true;
+                    if let Some(name) = safe_query_entry_name(&path) {
+                        undecidable.insert(name);
+                    }
                 }
             }
             Ok(())
@@ -745,6 +788,7 @@ fn run_language_uninstall(
                 "Error: failed to inspect query directory '{}': {e}",
                 queries_dir.display()
             );
+            report_unmanaged(&unmanaged);
             ExitCode::FAILURE
         })?;
 
@@ -758,9 +802,11 @@ fn run_language_uninstall(
         // only available when the whole directory was legible.
         if unreadable {
             eprintln!("Found no languages to uninstall, but some entries could not be read.");
+            report_unmanaged(&unmanaged);
             return Err(ExitCode::FAILURE);
         }
         eprintln!("No languages installed to uninstall.");
+        report_unmanaged(&unmanaged);
         return Ok(());
     }
 
@@ -777,9 +823,23 @@ fn run_language_uninstall(
         io::stderr().flush().unwrap();
 
         let mut input = String::new();
-        if io::stdin().read_line(&mut input).is_err() || !input.trim().eq_ignore_ascii_case("y") {
+        // A failed read is not a declined prompt. Both stop the command, but
+        // one is the user's decision and the other is an I/O error, and
+        // reporting the second as the first is the same lie in miniature.
+        if let Err(e) = io::stdin().read_line(&mut input) {
+            eprintln!("✗ Failed to read the confirmation response: {e}");
+            return Err(ExitCode::FAILURE);
+        }
+        if !input.trim().eq_ignore_ascii_case("y") {
             eprintln!("Cancelled.");
-            return Ok(());
+            // Declining cancels the removal, not the fact that discovery could
+            // not read part of the directory. That finding stands on its own,
+            // so the exit code has to keep carrying it.
+            return if unreadable {
+                Err(ExitCode::FAILURE)
+            } else {
+                Ok(())
+            };
         }
     }
 
@@ -788,7 +848,7 @@ fn run_language_uninstall(
     let mut any_failed = false;
     for lang in &languages_to_uninstall {
         // Reject unsafe names before building any path from them: `lang` is
-        // user input and feeds fs::remove_file via find_parser_file, so a
+        // user input and feeds fs::remove_file via find_parser_entry, so a
         // separator-carrying name must not escape the data dir.
         if !queries::is_safe_language_name(lang) {
             // Debug-format: untrusted input could smuggle ANSI escapes.
@@ -797,7 +857,26 @@ fn run_language_uninstall(
             continue;
         }
 
+        // Discovery could not read this language's own parser entry. Taking its
+        // queries would leave the parser-only state the lock below exists to
+        // prevent, and unlike a removal that fails, this is known before
+        // anything is taken — so leave the language whole and say so. The run
+        // still fails; the neighbours still get removed.
+        if undecidable.contains(lang) {
+            eprintln!(
+                "✗ Leaving '{}' untouched: its parser entry could not be inspected.",
+                lang
+            );
+            any_failed = true;
+            continue;
+        }
+
         let mut removed_something = false;
+        // Whether anything about THIS language went wrong. "Not installed" is a
+        // claim about the filesystem, and a run that just failed to read or
+        // remove an artifact has not earned it — the language-level flag is
+        // what keeps that claim from riding on the absence of a success.
+        let mut lang_failed = false;
 
         // Hold the language's install lock across both removals, so a
         // concurrent install cannot publish one artifact between them and leave
@@ -832,6 +911,7 @@ fn run_language_uninstall(
             Err(failure) => {
                 eprintln!("✗ Failed to remove queries for '{}': {}", lang, failure);
                 any_failed = true;
+                lang_failed = true;
                 removed_something |= failure.removal.removed_anything();
                 // Whether to go on to the parser depends on the state the
                 // removal left, not on whether it did the removing: a language
@@ -856,34 +936,45 @@ fn run_language_uninstall(
 
         // Remove parser file
         match find_parser_entry(&parser_dir, lang) {
-            Ok(Some(parser_path)) => match fs::remove_file(&parser_path) {
-                Ok(()) => {
-                    eprintln!("✓ Removed parser: {}", parser_path.display());
-                    removed_something = true;
+            Ok(Some((parser_path, is_symlink))) => {
+                match remove_parser_entry(&parser_path, is_symlink) {
+                    Ok(()) => {
+                        eprintln!("✓ Removed parser: {}", parser_path.display());
+                        removed_something = true;
+                    }
+                    Err(e) => {
+                        eprintln!("✗ Failed to remove parser {}: {}", parser_path.display(), e);
+                        any_failed = true;
+                        lang_failed = true;
+                    }
                 }
-                Err(e) => {
-                    eprintln!("✗ Failed to remove parser {}: {}", parser_path.display(), e);
-                    any_failed = true;
-                }
-            },
+            }
             Ok(None) => {}
             // Failing to look is not the same as finding nothing: reporting
             // "not installed" here would be the command guessing, having just
             // removed the language's queries.
+            //
+            // Naming the candidate entry rather than the directory, because
+            // "failed to inspect …/parser: No such file or directory" about a
+            // directory that plainly exists is precisely the message #953
+            // called out as unactionable.
             Err(e) => {
                 eprintln!(
-                    "✗ Failed to inspect the parser for '{}' in {}: {}",
+                    "✗ Failed to inspect the parser for '{}' at {}: {}",
                     lang,
-                    parser_dir.display(),
+                    parser_entry_path(&parser_dir, lang).display(),
                     e
                 );
                 any_failed = true;
+                lang_failed = true;
             }
         }
 
         if removed_something {
             any_removed = true;
-        } else if !all {
+        } else if !all && !lang_failed {
+            // Only when nothing went wrong: otherwise the run would be
+            // asserting an absence it just said it could not determine.
             eprintln!("Language '{}' is not installed.", lang);
         }
     }
@@ -891,15 +982,7 @@ fn run_language_uninstall(
     // Before the failure return, not after it: what was left behind is most
     // worth saying on a run that went wrong, and discovery can now fail on its
     // own, so a late note block would be the first casualty of its own fix.
-    if !unmanaged.is_empty() {
-        eprintln!();
-        for path in &unmanaged {
-            eprintln!(
-                "Note: left '{}' in place — its name is not one this CLI manages.",
-                path.display()
-            );
-        }
-    }
+    report_unmanaged(&unmanaged);
 
     if any_failed || unreadable {
         return Err(ExitCode::FAILURE);
@@ -926,12 +1009,23 @@ fn run_language_uninstall(
 /// Find the LOADABLE parser file for a language.
 ///
 /// Used by `status` to fill the parser column, where the question is whether the
-/// language can actually be loaded — so this follows symlinks and a broken one
-/// reads as absent. Uninstall asks a different question and uses
-/// [`find_parser_entry`]; see the note there for why the two must not be merged.
+/// language can actually be loaded — so this follows symlinks and answers
+/// loadability, not presence. (For a dangling `parser/` entry `status` never
+/// gets this far: its own scan fails on the entry first.) Uninstall asks a
+/// different question and uses [`find_parser_entry`]; see the note there for
+/// why the two must not be merged.
 fn find_parser_file(parser_dir: &std::path::Path, lang: &str) -> Option<PathBuf> {
-    let path = parser_dir.join(format!("{}.{}", lang, std::env::consts::DLL_EXTENSION));
+    let path = parser_entry_path(parser_dir, lang);
     if path.is_file() { Some(path) } else { None }
+}
+
+/// Where a language's parser file would live, whether or not anything is there.
+///
+/// Shared so the path an error message names is the same one the lookup tried;
+/// reporting a failure against a differently built path is how a diagnostic
+/// ends up pointing somewhere the command never looked.
+fn parser_entry_path(parser_dir: &Path, lang: &str) -> PathBuf {
+    parser_dir.join(format!("{}.{}", lang, std::env::consts::DLL_EXTENSION))
 }
 
 /// The parser entry `unlink` can take for a language, if there is one.
@@ -946,37 +1040,116 @@ fn find_parser_file(parser_dir: &std::path::Path, lang: &str) -> Option<PathBuf>
 /// `Err` means the entry could not be classified at all. That is deliberately
 /// distinct from `Ok(None)`: "there is nothing here" and "I could not tell"
 /// must not collapse into the same answer one step before a destructive action.
-fn find_parser_entry(parser_dir: &Path, lang: &str) -> std::io::Result<Option<PathBuf>> {
-    let path = parser_dir.join(format!("{}.{}", lang, std::env::consts::DLL_EXTENSION));
+fn find_parser_entry(parser_dir: &Path, lang: &str) -> std::io::Result<Option<(PathBuf, bool)>> {
+    let path = parser_entry_path(parser_dir, lang);
     match parser_entry_kind(&path)? {
-        Some(()) => Ok(Some(path)),
-        None => Ok(None),
+        Some(ParserEntry::Removable { is_symlink }) => Ok(Some((path, is_symlink))),
+        // A shape removal cannot take reads as "no parser to remove" here. The
+        // `--all` path is where it gets named, because that is the path whose
+        // summary would otherwise claim it removed everything.
+        Some(ParserEntry::WrongShape) | None => Ok(None),
     }
 }
 
-/// Whether a path in `parser/` is an entry uninstall may remove.
+/// What a path in `parser/` is, as far as uninstall is concerned.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ParserEntry {
+    /// An entry removal can take: a regular file, or a symlink.
+    Removable { is_symlink: bool },
+    /// An entry that is plainly there but is not a shape removal can take —
+    /// a directory (#828), or a special file. Discovery must remember these
+    /// rather than skip them silently, because the summary goes on to claim
+    /// it removed everything and one of these on disk makes that false.
+    WrongShape,
+}
+
+/// Classify a path in `parser/` for uninstall.
 ///
 /// `symlink_metadata` rather than `metadata`, so a dangling symlink is a normal
 /// answer instead of a `NotFound` error; and rather than `DirEntry::file_type`,
 /// which can be served from `readdir`'s cached `d_type` and so would report
 /// success on some filesystems and fail on others for an unreadable directory.
 ///
-/// A regular file or a symlink counts — those are the two shapes an install
-/// produces, and a symlink is how a locally built parser gets pointed at. A
-/// directory does not (see #828: `remove_file` cannot take one). Other special
-/// file types are left out for the same reason a directory is: discovery would
-/// be inventing an install that nothing here created.
-fn parser_entry_kind(path: &Path) -> std::io::Result<Option<()>> {
+/// A regular file or a symlink is removable — install produces the first, and a
+/// hand-pointed local build the second. Everything else is [`WrongShape`]:
+/// `remove_file` cannot take a directory (#828), and a FIFO or socket named
+/// `lua.dylib` is not an install this CLI created, so removing it would be
+/// discovery inventing one.
+///
+/// [`WrongShape`]: ParserEntry::WrongShape
+fn parser_entry_kind(path: &Path) -> std::io::Result<Option<ParserEntry>> {
     match std::fs::symlink_metadata(path) {
         Ok(metadata) => {
             let file_type = metadata.file_type();
-            Ok((file_type.is_file() || file_type.is_symlink()).then_some(()))
+            Ok(Some(if file_type.is_file() || file_type.is_symlink() {
+                ParserEntry::Removable {
+                    is_symlink: file_type.is_symlink(),
+                }
+            } else {
+                ParserEntry::WrongShape
+            }))
         }
         // Absent is the ordinary "not installed" answer; every other failure
         // means we could not tell, which must not read as absent.
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(error) => Err(error),
     }
+}
+
+/// Remove a parser entry, taking the entry itself and never its target.
+///
+/// `remove_file` is `unlink`, which acts on the final component, so a symlink
+/// loses the link and whatever it pointed at survives. Windows is the exception
+/// worth naming: a directory symlink or junction is a reparse point that
+/// `DeleteFileW` refuses, and `RemoveDirectoryW` is what removes the link there
+/// — also without touching the target. The retry is gated on the entry being a
+/// symlink, and on Unix it simply fails (a symlink is not a directory), so the
+/// fallback cannot reach a real directory on either platform.
+fn remove_parser_entry(path: &Path, is_symlink: bool) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            if is_symlink && std::fs::remove_dir(path).is_ok() {
+                Ok(())
+            } else {
+                Err(error)
+            }
+        }
+    }
+}
+
+/// The language an entry in `queries/` installs, for uninstall's purposes.
+///
+/// The queries counterpart of [`parser_entry_kind`], and separate from
+/// [`installed_query_language_name_checked`] for the same reason: `status` asks
+/// what is USABLE and must not describe an installation it could not observe,
+/// while uninstall asks what is THERE and must be able to take it. A dangling
+/// `queries/lua` is unusable but perfectly removable, so calling it an I/O
+/// error — as the shared helper does, correctly, for `status` — would leave
+/// `uninstall --all` failing on it forever while `uninstall lua` cleared it.
+fn query_entry_language_name(path: &Path) -> std::io::Result<Option<String>> {
+    let Some(name) = safe_query_entry_name(path) else {
+        return Ok(None);
+    };
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            let file_type = metadata.file_type();
+            Ok((file_type.is_dir() || file_type.is_symlink()).then(|| name.to_string()))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+/// The entry name, when it is one this CLI may manage. Shared so `status` and
+/// uninstall cannot disagree about which NAMES count.
+fn safe_query_entry_name(path: &Path) -> Option<String> {
+    let file_name = path.file_name()?;
+    let name = file_name.to_string_lossy();
+    if name.starts_with('.') || !queries::is_safe_language_name(&name) {
+        return None;
+    }
+    Some(name.to_string())
 }
 
 /// What to tell someone whose `--output` path is already taken. A regular
@@ -1588,7 +1761,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn installed_query_language_name_filters_unsafe_dirs() {
+    fn installed_query_language_name_checked_filters_unsafe_dirs() {
         let temp = tempfile::TempDir::new().unwrap();
         let safe = temp.path().join("lua");
         let unsafe_name = temp.path().join("foo.bar");
@@ -1624,7 +1797,7 @@ mod tests {
 
         assert_eq!(
             find_parser_entry(temp.path(), "dangling").unwrap(),
-            Some(path)
+            Some((path, true))
         );
         // The loadability question has the opposite answer, which is why the
         // two helpers exist separately.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -668,6 +668,20 @@ fn run_language_uninstall(
         ExitCode::FAILURE
     })?;
 
+    // Same gate `status` applies, and for the stronger reason: a data dir that
+    // is a dangling symlink makes `read_dir` report its children as simply
+    // absent, so without this the command would survey nothing and call the
+    // installation empty. Answering "No languages installed to uninstall." for
+    // a directory it never reached is the completeness claim this whole change
+    // exists to stop.
+    validate_install_root(&data_dir).map_err(|e| {
+        eprintln!(
+            "Error: failed to inspect data directory '{}': {e}",
+            data_dir.display()
+        );
+        ExitCode::FAILURE
+    })?;
+
     let parser_dir = data_dir.join("parser");
     let queries_dir = data_dir.join("queries");
     if let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {
@@ -835,10 +849,12 @@ fn run_language_uninstall(
         }
 
         let mut removed_something = false;
-        // Whether anything about THIS language went wrong. "Not installed" is a
-        // claim about the filesystem, and a run that just failed to read or
-        // remove an artifact has not earned it — the language-level flag is
-        // what keeps that claim from riding on the absence of a success.
+        // Whether removing this language went wrong. "Not installed" is a
+        // claim about the filesystem, and a run that just failed to remove an
+        // artifact has not earned it — the language-level flag is what keeps
+        // that claim from riding on the mere absence of a success. (The cases
+        // where the parser could not be CLASSIFIED never reach it; they leave
+        // the language whole and `continue` above.)
         let mut lang_failed = false;
 
         // Hold the language's install lock across both removals, so a
@@ -864,7 +880,26 @@ fn run_language_uninstall(
         // taken, so the language can simply be left whole. The run still fails,
         // and the other languages are still removed.
         let parser_entry = match find_parser_entry(&parser_dir, lang) {
-            Ok(entry) => entry,
+            Ok(None) => None,
+            Ok(Some((path, ParserEntry::Removable { is_symlink }))) => Some((path, is_symlink)),
+            // A shape removal cannot take is not "no parser here" — but #828
+            // settled that such an entry does not count as an installed parser,
+            // and that answer stands when there is nothing else to lose. What
+            // it never considered is queries sitting beside one: taking those
+            // would leave the half-removed language and, on the named path
+            // (which has no leftovers summary), report it as a clean uninstall.
+            // So the refusal is scoped to exactly that case.
+            Ok(Some((path, ParserEntry::WrongShape))) => {
+                if std::fs::symlink_metadata(queries_dir.join(lang)).is_ok() {
+                    eprintln!(
+                        "✗ Leaving '{}' untouched: {:?} is not a shape this CLI can remove, and taking its queries alone would half-remove it.",
+                        lang, path
+                    );
+                    any_failed = true;
+                    continue;
+                }
+                None
+            }
             Err(e) => {
                 eprintln!(
                     "✗ Leaving '{}' untouched: failed to inspect its parser entry at {:?}: {}",
@@ -930,6 +965,18 @@ fn run_language_uninstall(
                 }
                 Err(e) => {
                     eprintln!("✗ Failed to remove parser {}: {}", parser_path.display(), e);
+                    // The queries are already gone by now — the tombstone has
+                    // to be published before the parser, or a concurrent
+                    // install republishes what this just removed. There is no
+                    // rollback, so the state is named instead of implied: the
+                    // language IS half-removed, and the user needs to know
+                    // which half to chase rather than infer it from two lines.
+                    if removed_something {
+                        eprintln!(
+                            "  '{}' is now half-removed: its queries are gone and its parser is not.",
+                            lang
+                        );
+                    }
                     any_failed = true;
                     lang_failed = true;
                 }
@@ -1006,19 +1053,16 @@ fn parser_entry_path(parser_dir: &Path, lang: &str) -> PathBuf {
 /// `Err` means the entry could not be classified at all. That is deliberately
 /// distinct from `Ok(None)`: "there is nothing here" and "I could not tell"
 /// must not collapse into the same answer one step before a destructive action.
-fn find_parser_entry(parser_dir: &Path, lang: &str) -> std::io::Result<Option<(PathBuf, bool)>> {
+fn find_parser_entry(
+    parser_dir: &Path,
+    lang: &str,
+) -> std::io::Result<Option<(PathBuf, ParserEntry)>> {
     let path = parser_entry_path(parser_dir, lang);
-    match parser_entry_kind(&path)? {
-        Some(ParserEntry::Removable { is_symlink }) => Ok(Some((path, is_symlink))),
-        // A shape removal cannot take reads as "no parser to remove" here. The
-        // `--all` path is where it gets named, because that is the path whose
-        // summary would otherwise claim it removed everything.
-        Some(ParserEntry::WrongShape) | None => Ok(None),
-    }
+    Ok(parser_entry_kind(&path)?.map(|entry| (path, entry)))
 }
 
 /// What a path in `parser/` is, as far as uninstall is concerned.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum ParserEntry {
     /// An entry removal can take: a regular file, or a symlink.
     Removable { is_symlink: bool },
@@ -1763,7 +1807,7 @@ mod tests {
 
         assert_eq!(
             find_parser_entry(temp.path(), "dangling").unwrap(),
-            Some((path, true))
+            Some((path, ParserEntry::Removable { is_symlink: true }))
         );
         // The loadability question has the opposite answer, which is why the
         // two helpers exist separately.
@@ -1772,12 +1816,18 @@ mod tests {
 
     /// A parser-shaped directory is not an entry `remove_file` can take (#828).
     #[test]
-    fn find_parser_entry_rejects_a_directory() {
+    fn find_parser_entry_reports_a_directory_as_the_wrong_shape() {
         let temp = tempfile::TempDir::new().unwrap();
         let ext = std::env::consts::DLL_EXTENSION;
         std::fs::create_dir_all(temp.path().join(format!("fakeparser.{ext}"))).unwrap();
 
-        assert_eq!(find_parser_entry(temp.path(), "fakeparser").unwrap(), None);
+        let (path, entry) = find_parser_entry(temp.path(), "fakeparser")
+            .unwrap()
+            .expect("a directory is present, not absent");
+        assert_eq!(path, temp.path().join(format!("fakeparser.{ext}")));
+        // Not `None`: "there is a directory here I cannot remove" and "there is
+        // nothing here" lead to opposite actions one step before removal.
+        assert_eq!(entry, ParserEntry::WrongShape);
     }
 
     /// "Nothing here" and "could not tell" must stay distinguishable: the gate

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -610,10 +610,6 @@ fn safe_parser_language_name(stem: &str) -> Option<String> {
     queries::is_safe_language_name(stem).then(|| stem.to_string())
 }
 
-fn installed_query_language_name(path: &Path) -> Option<String> {
-    installed_query_language_name_checked(path).ok().flatten()
-}
-
 fn installed_query_language_name_checked(path: &Path) -> std::io::Result<Option<String>> {
     let Some(file_name) = path.file_name() else {
         return Ok(None);
@@ -669,40 +665,88 @@ fn run_language_uninstall(
     // one of them is still on disk.
     let mut unmanaged: Vec<PathBuf> = Vec::new();
 
+    // Entries discovery could not classify at all. Distinct from `unmanaged`,
+    // which is a deliberate skip of something understood: these are entries the
+    // command does not know the shape of, so it cannot know what it left.
+    let mut unreadable = false;
+
     // Determine which languages to uninstall
     let languages_to_uninstall: Vec<String> = if all {
         // Collect all installed languages
         let mut languages = BTreeSet::new();
 
-        if let Ok(entries) = fs::read_dir(&parser_dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                let is_parser = path.is_file()
-                    && path
-                        .extension()
-                        .is_some_and(|ext| ext == std::env::consts::DLL_EXTENSION);
-                if is_parser && let Some(stem) = path.file_stem() {
-                    let stem = stem.to_string_lossy();
-                    match safe_parser_language_name(&stem) {
-                        Some(language) => {
-                            languages.insert(language);
+        // Discovery distinguishes two failure classes, and conflating them is
+        // what made this command lie in one direction and seize up in the other:
+        //
+        // - DIRECTORY-level failure means the installation was never observed,
+        //   so there is no honest way to act on a partial view. Abort before
+        //   removing anything, matching `status`. Swallowing it is what let an
+        //   unreadable `parser/` beside a readable `queries/` remove the
+        //   queries, leave the parser, and report success (#953).
+        // - PER-ENTRY failure means one entry is opaque while the rest of the
+        //   directory is plainly legible. Report it, skip it, and carry on:
+        //   aborting here would make a real language sitting beside one bad
+        //   entry unremovable, which is strictly worse than the lie.
+        visit_install_directory(&parser_dir, |entry| {
+            let path = entry.path();
+            if !path
+                .extension()
+                .is_some_and(|ext| ext == std::env::consts::DLL_EXTENSION)
+            {
+                return Ok(());
+            }
+            match parser_entry_kind(&path) {
+                Ok(None) => {}
+                Ok(Some(())) => {
+                    if let Some(stem) = path.file_stem() {
+                        let stem = stem.to_string_lossy();
+                        match safe_parser_language_name(&stem) {
+                            Some(language) => {
+                                languages.insert(language);
+                            }
+                            // Remembered, not just skipped: this command goes on
+                            // to say it uninstalled everything, and a parser file
+                            // left on disk makes that false.
+                            None => unmanaged.push(path.clone()),
                         }
-                        // Remembered, not just skipped: this command goes on to
-                        // say it uninstalled everything, and a parser file left
-                        // on disk makes that false.
-                        None => unmanaged.push(path.clone()),
                     }
                 }
-            }
-        }
-
-        if let Ok(entries) = fs::read_dir(&queries_dir) {
-            for entry in entries.flatten() {
-                if let Some(name) = installed_query_language_name(&entry.path()) {
-                    languages.insert(name);
+                Err(error) => {
+                    eprintln!("✗ Failed to inspect {}: {}", path.display(), error);
+                    unreadable = true;
                 }
             }
-        }
+            Ok(())
+        })
+        .map_err(|e| {
+            eprintln!(
+                "Error: failed to inspect parser directory '{}': {e}",
+                parser_dir.display()
+            );
+            ExitCode::FAILURE
+        })?;
+
+        visit_install_directory(&queries_dir, |entry| {
+            let path = entry.path();
+            match installed_query_language_name_checked(&path) {
+                Ok(Some(name)) => {
+                    languages.insert(name);
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    eprintln!("✗ Failed to inspect {}: {}", path.display(), error);
+                    unreadable = true;
+                }
+            }
+            Ok(())
+        })
+        .map_err(|e| {
+            eprintln!(
+                "Error: failed to inspect query directory '{}': {e}",
+                queries_dir.display()
+            );
+            ExitCode::FAILURE
+        })?;
 
         languages.into_iter().collect()
     } else {
@@ -710,6 +754,12 @@ fn run_language_uninstall(
     };
 
     if languages_to_uninstall.is_empty() {
+        // "Nothing installed" is a claim about the whole directory, so it is
+        // only available when the whole directory was legible.
+        if unreadable {
+            eprintln!("Found no languages to uninstall, but some entries could not be read.");
+            return Err(ExitCode::FAILURE);
+        }
         eprintln!("No languages installed to uninstall.");
         return Ok(());
     }
@@ -838,10 +888,9 @@ fn run_language_uninstall(
         }
     }
 
-    if any_failed {
-        return Err(ExitCode::FAILURE);
-    }
-
+    // Before the failure return, not after it: what was left behind is most
+    // worth saying on a run that went wrong, and discovery can now fail on its
+    // own, so a late note block would be the first casualty of its own fix.
     if !unmanaged.is_empty() {
         eprintln!();
         for path in &unmanaged {
@@ -850,6 +899,10 @@ fn run_language_uninstall(
                 path.display()
             );
         }
+    }
+
+    if any_failed || unreadable {
+        return Err(ExitCode::FAILURE);
     }
 
     if any_removed {
@@ -1545,11 +1598,17 @@ mod tests {
         std::fs::create_dir_all(&hidden).unwrap();
 
         assert_eq!(
-            installed_query_language_name(&safe),
+            installed_query_language_name_checked(&safe).unwrap(),
             Some("lua".to_string())
         );
-        assert_eq!(installed_query_language_name(&unsafe_name), None);
-        assert_eq!(installed_query_language_name(&hidden), None);
+        assert_eq!(
+            installed_query_language_name_checked(&unsafe_name).unwrap(),
+            None
+        );
+        assert_eq!(
+            installed_query_language_name_checked(&hidden).unwrap(),
+            None
+        );
     }
 
     /// A dangling parser entry is what uninstall must be able to remove, and

--- a/tests/integration/test_cli.rs
+++ b/tests/integration/test_cli.rs
@@ -2457,6 +2457,162 @@ fn test_language_uninstall_all_keeps_failing_when_a_declined_prompt_follows_a_ba
     );
 }
 
+/// A parser entry of the wrong SHAPE is not "no parser here". Going on would
+/// remove the queries, step over the parser, and — on the named path, which has
+/// no leftovers summary — report a clean uninstall over a half-removed language.
+#[test]
+fn test_language_uninstall_leaves_a_language_whole_when_its_parser_is_the_wrong_shape() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    let shaped_dir = test_dir.path().join(format!("parser/lua.{ext}"));
+    fs::create_dir_all(&shaped_dir).expect("Failed to create parser-shaped directory");
+    let queries_lua = test_dir.path().join("queries/lua");
+    fs::create_dir_all(&queries_lua).expect("Failed to create queries dir");
+    fs::write(queries_lua.join("highlights.scm"), "(comment) @comment")
+        .expect("Failed to write queries");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "lua",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !output.status.success(),
+        "a language that cannot be fully removed must fail the run: {combined}"
+    );
+    assert!(
+        !combined.contains("Uninstalled 'lua'."),
+        "a half-removal must never be reported as a clean uninstall: {combined}"
+    );
+    assert!(
+        queries_lua.is_dir(),
+        "the queries must not be taken while the parser cannot be: {combined}"
+    );
+    assert!(
+        shaped_dir.is_dir(),
+        "the entry must be left alone: {combined}"
+    );
+}
+
+/// A removal that FAILS is a different case from one that could not be
+/// classified: the queries are already gone, so the language really is
+/// half-removed. It must say which half, and must not go on to call the
+/// language absent — that claim rides on the mere absence of a success.
+#[test]
+#[cfg(unix)]
+fn test_language_uninstall_names_the_half_removed_state_when_the_parser_cannot_be_taken() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    let parser_dir = test_dir.path().join("parser");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    let parser_file = parser_dir.join(format!("lua.{ext}"));
+    fs::write(&parser_file, "parser").expect("Failed to write parser");
+    let queries_lua = test_dir.path().join("queries/lua");
+    fs::create_dir_all(&queries_lua).expect("Failed to create queries dir");
+    fs::write(queries_lua.join("highlights.scm"), "(comment) @comment")
+        .expect("Failed to write queries");
+    // 0500: readable and searchable, so the entry classifies fine and the run
+    // reaches the removal — which then fails for want of write permission.
+    let mut permissions = fs::metadata(&parser_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o500);
+    fs::set_permissions(&parser_dir, permissions).expect("Failed to seal parser dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "lua",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let mut permissions = fs::metadata(&parser_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o700);
+    fs::set_permissions(&parser_dir, permissions).expect("Failed to unseal parser dir");
+
+    assert!(!output.status.success(), "the run must fail: {combined}");
+    // Discriminates against the removal never being attempted.
+    assert!(
+        combined.contains("Failed to remove parser"),
+        "the run must reach the removal and fail there: {combined}"
+    );
+    assert!(
+        !combined.contains("is not installed"),
+        "a language whose parser removal just failed must not be called absent: {combined}"
+    );
+    assert!(
+        combined.contains("half-removed"),
+        "the state it actually left must be named: {combined}"
+    );
+}
+
+/// A data directory that is a dangling symlink makes `read_dir` report its
+/// children as absent, so surveying it would find nothing and call the
+/// installation empty — the completeness claim over a directory never reached.
+#[test]
+#[cfg(unix)]
+fn test_language_uninstall_all_fails_for_a_dangling_data_directory() {
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let data_dir = test_dir.path().join("data");
+    std::os::unix::fs::symlink(test_dir.path().join("missing-target"), &data_dir)
+        .expect("Failed to create dangling symlink");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--force",
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !output.status.success(),
+        "an unreachable data directory must fail the command: {combined}"
+    );
+    assert!(
+        !combined.contains("No languages installed to uninstall"),
+        "a directory it never reached must not be reported as empty: {combined}"
+    );
+}
+
 /// The issue's other half: a dangling entry needs SOME way to be removed.
 /// Naming it used to answer "is not installed" and exit 0, because the gate
 /// asked `is_file()`, which follows the link.

--- a/tests/integration/test_cli.rs
+++ b/tests/integration/test_cli.rs
@@ -1898,6 +1898,50 @@ fn test_language_uninstall_all_leaves_unmanaged_artifacts_and_says_so() {
     );
 }
 
+/// The issue's other half: a dangling entry needs SOME way to be removed.
+/// Naming it used to answer "is not installed" and exit 0, because the gate
+/// asked `is_file()`, which follows the link.
+#[test]
+#[cfg(unix)]
+fn test_language_uninstall_removes_a_dangling_parser_entry_by_name() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    let parser_dir = test_dir.path().join("parser");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    let dangling = parser_dir.join(format!("dangling.{ext}"));
+    std::os::unix::fs::symlink(test_dir.path().join("missing-target"), &dangling)
+        .expect("Failed to create dangling symlink");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "dangling",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success(), "uninstall failed: {combined}");
+    assert!(
+        !combined.contains("is not installed"),
+        "an entry that is plainly on disk must not be called absent: {combined}"
+    );
+    assert!(
+        fs::symlink_metadata(&dangling).is_err(),
+        "the dangling entry must be unlinked: {combined}"
+    );
+}
+
 /// Explicit uninstall must use the same regular-file check as discovery, so a
 /// parser-shaped directory is reported as absent and never passed to removal.
 #[test]

--- a/tests/integration/test_cli.rs
+++ b/tests/integration/test_cli.rs
@@ -1969,10 +1969,13 @@ fn test_language_uninstall_all_aborts_when_parser_directory_cannot_be_read() {
     );
 }
 
-/// A per-entry failure must NOT abort the command: that was the regression that
-/// made a real language beside a bad entry unremovable. It is reported, named,
-/// skipped, and the run still fails — a destructive command that could not read
-/// one entry does not know what it left behind.
+/// A per-entry classification failure is named by full path and fails the run
+/// without claiming an uninstall.
+///
+/// This fixture cannot also pin "does not abort": mode 0644 removes SEARCH on
+/// the directory, so every entry's stat fails and no legible language is left
+/// beside the opaque one. The neighbour-survives half is pinned separately —
+/// see the dangling-entry tests, which build exactly that shape.
 #[test]
 #[cfg(unix)]
 fn test_language_uninstall_all_reports_and_skips_an_unreadable_parser_entry() {
@@ -2028,6 +2031,170 @@ fn test_language_uninstall_all_reports_and_skips_an_unreadable_parser_entry() {
     assert!(
         !combined.contains("Uninstalled all languages."),
         "'all' is false while an unread entry is still on disk: {combined}"
+    );
+}
+
+/// The queries counterpart of the dangling-parser case, and a regression this
+/// branch introduced and had to take back: treating a dangling `queries/<lang>`
+/// as an I/O error made `uninstall --all` fail on it on every run while
+/// `uninstall <lang>` cleared it happily — the exact inversion of the rule the
+/// parser side had just adopted. Discovery offers what removal can take.
+#[test]
+#[cfg(unix)]
+fn test_language_uninstall_all_removes_a_dangling_query_entry() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let dangling = test_dir.path().join("queries/lua");
+    fs::create_dir_all(test_dir.path().join("queries")).expect("Failed to create queries dir");
+    std::os::unix::fs::symlink(test_dir.path().join("missing-target"), &dangling)
+        .expect("Failed to create dangling symlink");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.status.success(),
+        "a removable entry must not fail the run: {combined}"
+    );
+    assert!(
+        fs::symlink_metadata(&dangling).is_err(),
+        "the dangling entry must be unlinked, so a second run converges: {combined}"
+    );
+}
+
+/// A language whose OWN parser entry could not be read must be left whole.
+/// Removing its queries anyway would manufacture the parser-only state — which
+/// is #953's headline shape, reached through the per-entry door instead of the
+/// directory-level one.
+#[test]
+#[cfg(unix)]
+fn test_language_uninstall_all_leaves_a_language_whole_when_its_parser_is_unreadable() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    let parser_dir = test_dir.path().join("parser");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    let parser_file = parser_dir.join(format!("lua.{ext}"));
+    fs::write(&parser_file, "parser").expect("Failed to write parser");
+    let queries_lua = test_dir.path().join("queries/lua");
+    fs::create_dir_all(&queries_lua).expect("Failed to create queries dir");
+    fs::write(queries_lua.join("highlights.scm"), "(comment) @comment")
+        .expect("Failed to write queries");
+
+    let mut permissions = fs::metadata(&parser_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o644);
+    fs::set_permissions(&parser_dir, permissions).expect("Failed to seal parser dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let mut permissions = fs::metadata(&parser_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o700);
+    fs::set_permissions(&parser_dir, permissions).expect("Failed to unseal parser dir");
+
+    assert!(!output.status.success(), "the run must fail: {combined}");
+    assert!(
+        queries_lua.is_dir(),
+        "half-removing the language is the state this avoids: {combined}"
+    );
+    assert!(
+        parser_file.is_file(),
+        "nothing about the language may be taken: {combined}"
+    );
+}
+
+/// The notes must survive the run they matter most on. Discovery can now fail
+/// on its own, so a note block below the failure return would be the first
+/// casualty of its own fix — and reverting that reorder left every test green.
+#[test]
+#[cfg(unix)]
+fn test_language_uninstall_all_still_reports_leftovers_when_a_removal_fails() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    let parser_dir = test_dir.path().join("parser");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    fs::write(parser_dir.join(format!("lua.{ext}")), "parser").expect("Failed to write parser");
+    fs::write(
+        parser_dir.join(format!("not-a-language.{ext}")),
+        "unmanaged",
+    )
+    .expect("Failed to write unmanaged artifact");
+    // Readable and searchable but not writable: discovery sees both entries,
+    // and the removal of the managed one then fails.
+    let mut permissions = fs::metadata(&parser_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o500);
+    fs::set_permissions(&parser_dir, permissions).expect("Failed to seal parser dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let mut permissions = fs::metadata(&parser_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o700);
+    fs::set_permissions(&parser_dir, permissions).expect("Failed to unseal parser dir");
+
+    assert!(
+        !output.status.success(),
+        "the removal must fail: {combined}"
+    );
+    assert!(
+        combined.contains("not-a-language"),
+        "a failing run must still say what it left behind: {combined}"
     );
 }
 
@@ -2146,6 +2313,133 @@ fn test_language_uninstall_all_aborts_when_query_directory_cannot_be_read() {
     );
 }
 
+/// "Not installed" is a claim about the filesystem, and a run that just failed
+/// to read the parser has not earned it. Reporting an absence it had explicitly
+/// said it could not determine is the same class of lie as #953's headline.
+#[test]
+#[cfg(unix)]
+fn test_language_uninstall_does_not_call_a_language_absent_after_failing_to_inspect_it() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    let parser_dir = test_dir.path().join("parser");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    fs::write(parser_dir.join(format!("lua.{ext}")), "parser").expect("Failed to write parser");
+    // `queries/` stays writable — the language lock lives there and is taken
+    // first, so sealing it would fail the run earlier than the parser lookup.
+    let mut permissions = fs::metadata(&parser_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o644);
+    fs::set_permissions(&parser_dir, permissions).expect("Failed to seal parser dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "lua",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let mut permissions = fs::metadata(&parser_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o700);
+    fs::set_permissions(&parser_dir, permissions).expect("Failed to unseal parser dir");
+
+    assert!(!output.status.success(), "the run must fail: {combined}");
+    assert!(
+        !combined.contains("is not installed"),
+        "a language whose parser could not be inspected must not be called absent: {combined}"
+    );
+    // #953 asks for the entry at fault by name, not the directory it sits in.
+    assert!(
+        combined.contains(&format!("lua.{ext}")),
+        "the failure must name the entry it could not inspect: {combined}"
+    );
+}
+
+/// Declining the prompt cancels the removal, not the fact that discovery could
+/// not read part of the directory — so the exit code must keep carrying it.
+#[test]
+#[cfg(unix)]
+fn test_language_uninstall_all_keeps_failing_when_a_declined_prompt_follows_a_bad_entry() {
+    use std::fs;
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Stdio;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    let parser_dir = test_dir.path().join("parser");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    fs::write(parser_dir.join(format!("lua.{ext}")), "parser").expect("Failed to write parser");
+    let queries_rust = test_dir.path().join("queries/rust");
+    fs::create_dir_all(&queries_rust).expect("Failed to create queries dir");
+    fs::write(queries_rust.join("highlights.scm"), "(comment) @comment")
+        .expect("Failed to write queries");
+    let mut permissions = fs::metadata(&parser_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o644);
+    fs::set_permissions(&parser_dir, permissions).expect("Failed to seal parser dir");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn command");
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(b"n\n").expect("Failed to write to stdin");
+    }
+    let output = child
+        .wait_with_output()
+        .expect("Failed to wait for command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let mut permissions = fs::metadata(&parser_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o700);
+    fs::set_permissions(&parser_dir, permissions).expect("Failed to unseal parser dir");
+
+    assert!(
+        combined.contains("Cancelled."),
+        "the decline must still be honoured: {combined}"
+    );
+    assert!(
+        queries_rust.is_dir(),
+        "declining must remove nothing: {combined}"
+    );
+    assert!(
+        !output.status.success(),
+        "the unread entry stands on its own and must survive the decline: {combined}"
+    );
+}
+
 /// The issue's other half: a dangling entry needs SOME way to be removed.
 /// Naming it used to answer "is not installed" and exit 0, because the gate
 /// asked `is_file()`, which follows the link.
@@ -2190,7 +2484,7 @@ fn test_language_uninstall_removes_a_dangling_parser_entry_by_name() {
     );
 }
 
-/// Explicit uninstall must use the same regular-file check as discovery, so a
+/// Explicit uninstall must use the same entry-kind check as discovery, so a
 /// parser-shaped directory is reported as absent and never passed to removal.
 #[test]
 fn test_language_uninstall_ignores_parser_shaped_directory() {

--- a/tests/integration/test_cli.rs
+++ b/tests/integration/test_cli.rs
@@ -1898,6 +1898,38 @@ fn test_language_uninstall_all_leaves_unmanaged_artifacts_and_says_so() {
     );
 }
 
+/// Whether restrictive directory modes actually deny access to this process.
+///
+/// A privileged runner — root, or a container holding `CAP_DAC_OVERRIDE` —
+/// ignores the mode bits, so the fixtures the permission tests are built on
+/// silently do not hold and the assertions fail as if the product regressed.
+///
+/// This probes the PROPERTY rather than the uid: it seals a throwaway directory
+/// and checks whether the seal bites. That cannot mask a real regression, since
+/// it only reports when the fixture itself failed to take effect, and it needs
+/// no privilege-querying dependency.
+#[cfg(unix)]
+fn restrictive_modes_are_enforced() -> bool {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let probe = tempfile::tempdir().expect("Failed to create probe dir");
+    let sealed = probe.path().join("sealed");
+    fs::create_dir(&sealed).expect("Failed to create probe subdir");
+    let mut permissions = fs::metadata(&sealed)
+        .expect("Failed to read probe permissions")
+        .permissions();
+    permissions.set_mode(0o000);
+    fs::set_permissions(&sealed, permissions).expect("Failed to seal probe dir");
+    let enforced = fs::read_dir(&sealed).is_err();
+    let mut permissions = fs::metadata(&sealed)
+        .expect("Failed to read probe permissions")
+        .permissions();
+    permissions.set_mode(0o700);
+    fs::set_permissions(&sealed, permissions).expect("Failed to unseal probe dir");
+    enforced
+}
+
 /// A directory-level scan failure means uninstall never observed the
 /// installation, so it must abort before removing anything. The bug this pins:
 /// an unreadable `parser/` beside a readable `queries/` used to remove the
@@ -1905,6 +1937,11 @@ fn test_language_uninstall_all_leaves_unmanaged_artifacts_and_says_so() {
 #[test]
 #[cfg(unix)]
 fn test_language_uninstall_all_aborts_when_parser_directory_cannot_be_read() {
+    if !restrictive_modes_are_enforced() {
+        eprintln!("skipping: this environment ignores restrictive directory modes");
+        return;
+    }
+
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
 
@@ -1979,6 +2016,11 @@ fn test_language_uninstall_all_aborts_when_parser_directory_cannot_be_read() {
 #[test]
 #[cfg(unix)]
 fn test_language_uninstall_all_reports_and_skips_an_unreadable_parser_entry() {
+    if !restrictive_modes_are_enforced() {
+        eprintln!("skipping: this environment ignores restrictive directory modes");
+        return;
+    }
+
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
 
@@ -2084,6 +2126,11 @@ fn test_language_uninstall_all_removes_a_dangling_query_entry() {
 #[test]
 #[cfg(unix)]
 fn test_language_uninstall_all_leaves_a_language_whole_when_its_parser_is_unreadable() {
+    if !restrictive_modes_are_enforced() {
+        eprintln!("skipping: this environment ignores restrictive directory modes");
+        return;
+    }
+
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
 
@@ -2144,6 +2191,11 @@ fn test_language_uninstall_all_leaves_a_language_whole_when_its_parser_is_unread
 #[test]
 #[cfg(unix)]
 fn test_language_uninstall_all_still_reports_leftovers_when_a_removal_fails() {
+    if !restrictive_modes_are_enforced() {
+        eprintln!("skipping: this environment ignores restrictive directory modes");
+        return;
+    }
+
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
 
@@ -2250,6 +2302,11 @@ fn test_language_uninstall_all_removes_a_dangling_parser_entry() {
 #[test]
 #[cfg(unix)]
 fn test_language_uninstall_all_aborts_when_query_directory_cannot_be_read() {
+    if !restrictive_modes_are_enforced() {
+        eprintln!("skipping: this environment ignores restrictive directory modes");
+        return;
+    }
+
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
 
@@ -2319,6 +2376,11 @@ fn test_language_uninstall_all_aborts_when_query_directory_cannot_be_read() {
 #[test]
 #[cfg(unix)]
 fn test_language_uninstall_does_not_call_a_language_absent_after_failing_to_inspect_it() {
+    if !restrictive_modes_are_enforced() {
+        eprintln!("skipping: this environment ignores restrictive directory modes");
+        return;
+    }
+
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
 
@@ -2392,6 +2454,11 @@ fn test_language_uninstall_does_not_call_a_language_absent_after_failing_to_insp
 #[test]
 #[cfg(unix)]
 fn test_language_uninstall_all_keeps_failing_when_a_declined_prompt_follows_a_bad_entry() {
+    if !restrictive_modes_are_enforced() {
+        eprintln!("skipping: this environment ignores restrictive directory modes");
+        return;
+    }
+
     use std::fs;
     use std::io::Write;
     use std::os::unix::fs::PermissionsExt;
@@ -2515,6 +2582,11 @@ fn test_language_uninstall_leaves_a_language_whole_when_its_parser_is_the_wrong_
 #[test]
 #[cfg(unix)]
 fn test_language_uninstall_names_the_half_removed_state_when_the_parser_cannot_be_taken() {
+    if !restrictive_modes_are_enforced() {
+        eprintln!("skipping: this environment ignores restrictive directory modes");
+        return;
+    }
+
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
 

--- a/tests/integration/test_cli.rs
+++ b/tests/integration/test_cli.rs
@@ -1898,6 +1898,254 @@ fn test_language_uninstall_all_leaves_unmanaged_artifacts_and_says_so() {
     );
 }
 
+/// A directory-level scan failure means uninstall never observed the
+/// installation, so it must abort before removing anything. The bug this pins:
+/// an unreadable `parser/` beside a readable `queries/` used to remove the
+/// queries, leave the parser, and report success.
+#[test]
+#[cfg(unix)]
+fn test_language_uninstall_all_aborts_when_parser_directory_cannot_be_read() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    let parser_dir = test_dir.path().join("parser");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    let parser_file = parser_dir.join(format!("lua.{ext}"));
+    fs::write(&parser_file, "parser").expect("Failed to write parser");
+    let queries_dir = test_dir.path().join("queries/lua");
+    fs::create_dir_all(&queries_dir).expect("Failed to create queries dir");
+    fs::write(queries_dir.join("highlights.scm"), "(comment) @comment")
+        .expect("Failed to write queries");
+
+    // Mode 0000: `read_dir` itself fails, which is the directory-level class.
+    let mut permissions = fs::metadata(&parser_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o000);
+    fs::set_permissions(&parser_dir, permissions).expect("Failed to seal parser dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // Unseal before asserting so a failure cannot leave an unreadable directory
+    // behind for the temp dir to trip over.
+    let mut permissions = fs::metadata(&parser_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o700);
+    fs::set_permissions(&parser_dir, permissions).expect("Failed to unseal parser dir");
+
+    assert!(
+        !output.status.success(),
+        "an unobservable parser directory must fail the command: {combined}"
+    );
+    assert!(
+        combined.contains(&parser_dir.display().to_string()),
+        "the failure must name the directory it could not read: {combined}"
+    );
+    assert!(
+        queries_dir.is_dir(),
+        "aborting means removing nothing — the queries must survive: {combined}"
+    );
+    assert!(
+        !combined.contains("Uninstalled"),
+        "a command that removed nothing must not report an uninstall: {combined}"
+    );
+}
+
+/// A per-entry failure must NOT abort the command: that was the regression that
+/// made a real language beside a bad entry unremovable. It is reported, named,
+/// skipped, and the run still fails — a destructive command that could not read
+/// one entry does not know what it left behind.
+#[test]
+#[cfg(unix)]
+fn test_language_uninstall_all_reports_and_skips_an_unreadable_parser_entry() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    let parser_dir = test_dir.path().join("parser");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    let parser_file = parser_dir.join(format!("lua.{ext}"));
+    fs::write(&parser_file, "parser").expect("Failed to write parser");
+
+    // Mode 0644: readable but not searchable. `read_dir` succeeds and yields the
+    // entry name; stat on the entry fails. That is the per-entry class.
+    let mut permissions = fs::metadata(&parser_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o644);
+    fs::set_permissions(&parser_dir, permissions).expect("Failed to seal parser dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let mut permissions = fs::metadata(&parser_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o700);
+    fs::set_permissions(&parser_dir, permissions).expect("Failed to unseal parser dir");
+
+    assert!(
+        !output.status.success(),
+        "an entry discovery could not classify must fail the command: {combined}"
+    );
+    assert!(
+        combined.contains(&parser_file.display().to_string()),
+        "the entry at fault must be named, not just its directory: {combined}"
+    );
+    assert!(
+        !combined.contains("Uninstalled all languages."),
+        "'all' is false while an unread entry is still on disk: {combined}"
+    );
+}
+
+/// The regression the earlier fail-closed attempt introduced: ONE dangling
+/// symlink aborted the whole command, so a real language beside it could no
+/// longer be removed. A dangling entry is not an I/O error — it is a directory
+/// entry `unlink` can take — so both must go.
+#[test]
+#[cfg(unix)]
+fn test_language_uninstall_all_removes_a_dangling_parser_entry() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    let parser_dir = test_dir.path().join("parser");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    let real = parser_dir.join(format!("lua.{ext}"));
+    fs::write(&real, "parser").expect("Failed to write parser");
+    let dangling = parser_dir.join(format!("dangling.{ext}"));
+    std::os::unix::fs::symlink(test_dir.path().join("missing-target"), &dangling)
+        .expect("Failed to create dangling symlink");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success(), "uninstall failed: {combined}");
+    assert!(
+        !real.exists(),
+        "a real language beside a dangling entry must still be removed: {combined}"
+    );
+    assert!(
+        fs::symlink_metadata(&dangling).is_err(),
+        "the dangling entry must be unlinked, not stepped over: {combined}"
+    );
+}
+
+/// The queries side of discovery swallowed the same two error classes. A
+/// directory-level failure there must abort too, leaving the parser alone.
+#[test]
+#[cfg(unix)]
+fn test_language_uninstall_all_aborts_when_query_directory_cannot_be_read() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    let parser_dir = test_dir.path().join("parser");
+    fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
+    let parser_file = parser_dir.join(format!("lua.{ext}"));
+    fs::write(&parser_file, "parser").expect("Failed to write parser");
+    let queries_dir = test_dir.path().join("queries");
+    fs::create_dir_all(&queries_dir).expect("Failed to create queries dir");
+
+    let mut permissions = fs::metadata(&queries_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o000);
+    fs::set_permissions(&queries_dir, permissions).expect("Failed to seal queries dir");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--force",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let mut permissions = fs::metadata(&queries_dir)
+        .expect("Failed to read permissions")
+        .permissions();
+    permissions.set_mode(0o700);
+    fs::set_permissions(&queries_dir, permissions).expect("Failed to unseal queries dir");
+
+    assert!(
+        !output.status.success(),
+        "an unobservable query directory must fail the command: {combined}"
+    );
+    assert!(
+        parser_file.is_file(),
+        "aborting means removing nothing — the parser must survive: {combined}"
+    );
+    assert!(
+        combined.contains(&queries_dir.display().to_string()),
+        "the failure must name the directory it could not read: {combined}"
+    );
+    // Without the checked scan this run still failed — but only later, when
+    // taking the language lock under the same unreadable directory. Asserting
+    // it never got that far is what distinguishes aborting at discovery from
+    // stumbling into the same error one step downstream.
+    assert!(
+        !combined.contains("Failed to lock"),
+        "discovery must abort before any per-language work begins: {combined}"
+    );
+}
+
 /// The issue's other half: a dangling entry needs SOME way to be removed.
 /// Naming it used to answer "is not installed" and exit 0, because the gate
 /// asked `is_file()`, which follows the link.

--- a/tests/integration/test_cli.rs
+++ b/tests/integration/test_cli.rs
@@ -2326,9 +2326,16 @@ fn test_language_uninstall_does_not_call_a_language_absent_after_failing_to_insp
     let ext = std::env::consts::DLL_EXTENSION;
     let parser_dir = test_dir.path().join("parser");
     fs::create_dir_all(&parser_dir).expect("Failed to create parser dir");
-    fs::write(parser_dir.join(format!("lua.{ext}")), "parser").expect("Failed to write parser");
-    // `queries/` stays writable — the language lock lives there and is taken
-    // first, so sealing it would fail the run earlier than the parser lookup.
+    let parser_file = parser_dir.join(format!("lua.{ext}"));
+    fs::write(&parser_file, "parser").expect("Failed to write parser");
+    // Queries must be present for this to reach the removal at all — and they
+    // are what proves the run left the language WHOLE rather than half-taken.
+    // `queries/` itself stays writable: the language lock lives there and is
+    // taken first, so sealing it would fail the run before the parser lookup.
+    let queries_lua = test_dir.path().join("queries/lua");
+    fs::create_dir_all(&queries_lua).expect("Failed to create queries dir");
+    fs::write(queries_lua.join("highlights.scm"), "(comment) @comment")
+        .expect("Failed to write queries");
     let mut permissions = fs::metadata(&parser_dir)
         .expect("Failed to read permissions")
         .permissions();
@@ -2367,6 +2374,16 @@ fn test_language_uninstall_does_not_call_a_language_absent_after_failing_to_insp
     assert!(
         combined.contains(&format!("lua.{ext}")),
         "the failure must name the entry it could not inspect: {combined}"
+    );
+    // The probe happens before the queries are taken, so an unreadable parser
+    // leaves the language whole instead of manufacturing the parser-only state.
+    assert!(
+        queries_lua.is_dir(),
+        "the queries must survive an undecidable parser: {combined}"
+    );
+    assert!(
+        parser_file.is_file(),
+        "nothing about the language may be taken: {combined}"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #953. `language status` discovers installs through a checked traversal;
`language uninstall --all` still used `if let Ok(entries) = read_dir(..)` with
`.flatten()`, swallowing both the directory-level failure and every per-entry
one. An unreadable `parser/` beside a readable `queries/` removed the queries,
left the parser, and exited 0:

```
✓ Removed queries: …/queries/lua
Uninstalled all languages.        exit=0     # parser/lua.dylib still on disk
```

## Why it is not simply "make it propagate"

That was tried in #831 and reverted: failing closed made one dangling
`parser/x.dylib` abort the whole command, so a real `lua` beside it became
unremovable. The resolution is that **these are two different failures** and
only one of them justifies aborting.

- **Directory-level** — the installation was never observed, so no partial view
  is honest to act on. Abort before removing anything, matching `status`.
- **Per-entry** — one entry is opaque while the rest of the directory is
  legible. Name it, skip it, finish the job, exit non-zero. Neighbours stay
  removable, but a destructive command that could not read an entry does not
  know what it left behind, so it must not report success.

The issue's own **0644 reproduction is the per-entry class**, not the directory
one: mode 0644 leaves a directory readable but not searchable, so `read_dir`
succeeds and the stat on each entry is what fails. Mode 0000 is the
directory-level trigger. Both are tested.

## The dangling entry needed a way out, and it was a discovery bug

`unlink` acts on the link, not its target, so `fs::remove_file` removes a
dangling symlink perfectly well. The gate — `Path::is_file()`, which *follows*
the link — is what made the entry invisible, so `uninstall dangling` answered
"Language 'dangling' is not installed." and exited 0. No new flag was needed;
splitting the gate from status's loadability question was enough.

The governing rule is **discovery offers exactly what removal can take**, and it
now holds on both sides of the data dir — see the review round below, where
getting it wrong on the queries side was the most interesting bug in the branch.

## Deliberately unchanged

**`status` still fails on a dangling parser entry** (pinned by
`test_language_status_fails_for_dangling_parser_entry_symlink`). It must not
describe an installation it could not fully observe, whereas uninstall must be
able to take what unlink can take — and once uninstall clears the entry, status
recovers. The asymmetry is the point, and it is why the parser and queries
helpers are split per command rather than shared.

## What local review changed — including a regression this branch introduced

Round 1 ran seven dedicated single-perspective sweeps. Five findings, fixed in
`72bea99`:

1. **A dangling `queries/<lang>` became a permanent failure — the branch's own
   regression.** Deleting the `.ok().flatten()` wrapper routed
   `installed_query_language_name_checked`'s `Err` into the new per-entry path,
   so `--all` printed "could not be read" and exited 1 on *every* run while
   `uninstall <lang>` cleared the entry happily. The exact inversion of the rule
   the parser side had just adopted, and a state the CLI could reach but never
   clear. Uninstall now has its own symlink-based queries classifier.
2. **"Not installed" was still claimed after a failed inspection** — fourteen
   lines below a new comment saying that would be "the command guessing".
3. **Wrong-*shape* entries** (a directory, a FIFO named `lua.dylib`) were
   invisible to both removal and the leftovers note, so the summary said
   "Uninstalled all languages." with one on disk.
4. **A language whose own parser entry was unreadable had its queries removed
   anyway** — #953's headline half-removal, reached through the per-entry door.
   The stem is legible even when the entry is not, so the language is left whole.
5. **ANSI-escape smuggling**: filesystem-supplied paths are now Debug-formatted,
   matching the convention at the invalid-name check.

Portability, same round: on Windows a directory symlink or junction is a reparse
point `DeleteFileW` refuses, so classifying it removable would have made it
undeletable where the old `is_file()` merely skipped it. Removal retries with
`remove_dir`, gated on the entry being a symlink — that removes the link, not
the target, and simply fails on Unix.

**No data-loss bug found.** An adversarial pass confirmed `remove_file` is
`unlink`: a `parser/lua.dylib` pointing at an important file loses the link and
the target survives, including for symlinks-to-directories and symlink loops.

## Tests

The revert in #831 left all 60 `test_cli` tests green, so nothing pinned this.
Every new test was **run red first**, and two were caught passing for the wrong
reason and strengthened:

- the query-directory abort initially failed later at `lock_language` rather
  than aborting at discovery — it now asserts it never reaches per-language work
- the notes-on-a-failing-run reorder was **unpinned**: reverting it left all 71
  tests green, the same trap that got #831 reverted

Coverage now includes: directory-level abort (parser and queries), per-entry
report-and-skip, dangling parser entry removed under `--all` and by name,
dangling queries entry converging, the whole-language skip, the absent-claim,
the declined-prompt exit code, and three `find_parser_entry` unit tests.

Gated with bare `cargo test` (no target filter), since `--lib` and
`--test integration` build neither of `src/bin/main.rs`'s unit tests.

## What the two independent review rounds changed

Codex reviewed three times on one thread plus a fresh session. Fixed:

- **A parser entry of the wrong SHAPE mapped to "no parser here"**, so a named
  `uninstall lua` with `parser/lua.dylib` a directory removed the queries and
  printed `Uninstalled 'lua'.` at exit 0 — a half-removed language reported as a
  clean uninstall, on the one path with no leftovers summary. The refusal is
  scoped to the case that actually loses something, keeping #828's decided
  answer when nothing sits beside the entry.
- **The refusal then decided on a guess** — `symlink_metadata(..).is_ok()` read
  every error as "no queries here". Only a confirmed `NotFound` proceeds now.
- **A stale `is_symlink` flag could authorise deleting a real directory.** The
  flag stated what the path *was*; if a symlink were replaced by a directory in
  between, the `remove_dir` fallback would have taken it — the one thing that
  function must never do, and the opposite of what its doc claimed. The test is
  re-taken at the point of use, and the comment now states the residual window
  instead of claiming impossibility.
- **`NotFound` from a removal was treated as failure**, so a parser another
  actor unlinked first was reported as a half-removal while the filesystem had
  reached exactly the asked-for state. Both removal attempts now agree that
  already-gone is success.
- **Uninstall now applies `status`'s data-directory gate.** With a dangling data
  dir, `read_dir` reports the children as absent, so the command surveyed
  nothing and answered "No languages installed to uninstall." at exit 0. Note
  this is a **new precondition on a destructive command**: a data dir that fails
  the gate now fails the run.

Two reviewer findings were **refused, with evidence**:

- *Keep iterating after per-entry `read_dir` iterator errors.* A `readdir`
  failure yields no `DirEntry` and therefore no name — nothing to report, skip,
  or bound. That is a directory-level condition by this PR's own definition, and
  skipping it would drop unknown entries and then claim completeness. `status`
  treats it identically. Recovery is `uninstall <lang>`, which does not enumerate.
- *Skip the permission tests when running as root.* Taken, but not as a uid
  check: `restrictive_modes_are_enforced()` probes whether a seal actually bites.
  That covers `CAP_DAC_OVERRIDE` without uid 0 and the `0644` cases (which need
  *search* to fail), needs no new dependency, and cannot manufacture a vacuous
  pass — it fires only when the fixture failed to take effect.

## Known gaps, filed rather than smuggled in

**#1005** — completeness claims over entries `--all` cannot see: case-insensitive
filesystems hide `parser/Lua.DYLIB`; unsafe-named `queries/` directories are not
in the leftovers bookkeeping (parser-side only); `recover_interrupted_query_installs`
is warn-only here but fatal in `status`. It also records two **lock-protocol**
races the final round surfaced, which the per-language lock cannot close: a
concurrent install of a *new* language defeating `--all`'s snapshot, and query
recovery (which takes the *replace* lock) racing the wrong-shape guard.

**#1006** — entries no CLI path can clear: a `queries/<lang>` that is a plain
file blocks its own parser's removal on every retry, and a wrong-shaped
`parser/<lang>.<ext>` with no queries beside it is still reported absent per
#828's decided contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
