### PR TITLE
docs: clarify kakehashi smart features

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ kakehashi is a bridge (架け橋) across your editors, your languages, and the l
 ```mermaid
 flowchart TB
     subgraph K[" "]
+        direction TB
         T["🌉 kakehashi"] ~~~ B["Builtin smart features"]
     end
 

--- a/README.md
+++ b/README.md
@@ -11,23 +11,28 @@ kakehashi is a bridge (架け橋) across your editors, your languages, and the l
 ```mermaid
 ---
 config:
+  themeVariables:
+    fontSize: 20px
   flowchart:
     padding: 1
     rankSpacing: 1
+    subGraphTitleMargin:
+      top: 0
+      bottom: 12
 ---
 flowchart TB
-    subgraph K[" "]
-        direction TB
-        T["🌉 kakehashi"] ~~~ B["Builtin smart features"]
+    subgraph K["`**🌉 kakehashi**`"]
+        B["Builtin smart features"]
     end
 
     K <--->|Highlighting, selection, and more — everywhere| E["Your editor (any LSP client)"]
     K <-..->|The additional smarts of real language servers| LS["pyright, rust-analyzer, and friends"]
 
     style K fill:#e6f7f1,stroke:#5aa88b,stroke-width:2px
-    style T fill:transparent,stroke:transparent,font-size:20px,font-weight:bold
     style B fill:transparent,stroke:#aaa,stroke-dasharray:3 3,color:#666,font-size:12px
-    linkStyle 1,2 font-size:13px
+    style E font-size:16px
+    style LS font-size:16px
+    linkStyle 0,1 font-size:13px
 ```
 
 ## 🎨 Highlighting & smart selection, for any language

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ kakehashi is a bridge (架け橋) across your editors, your languages, and the l
 ---
 config:
   flowchart:
-    padding: 5
-    rankSpacing: 5
+    padding: 1
+    rankSpacing: 1
 ---
 flowchart TB
     subgraph K[" "]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ kakehashi is a bridge (架け橋) across your editors, your languages, and the l
 - bridge to all of the above — even for code embedded inside other code
 
 ```mermaid
+---
+config:
+  flowchart:
+    rankSpacing: 10
+---
 flowchart TB
     subgraph K[" "]
         direction TB
@@ -18,7 +23,7 @@ flowchart TB
     K <-->|Highlighting, selection, and more — everywhere| E["Your editor (any LSP client)"]
     K <-.->|The additional smarts of real language servers| LS["pyright, rust-analyzer, and friends"]
 
-    style K stroke-width:2px
+    style K fill:#e6f7f1,stroke:#5aa88b,stroke-width:2px
     style T fill:transparent,stroke:transparent,font-size:20px,font-weight:bold
     style B fill:transparent,stroke:#aaa,stroke-dasharray:3 3,color:#666,font-size:12px
 ```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ kakehashi is a bridge (架け橋) across your editors, your languages, and the l
 - bridge to all of the above — even for code embedded inside other code
 
 ```mermaid
+---
+config:
+  flowchart:
+    subGraphTitleMargin:
+      top: 10
+      bottom: 10
+---
 flowchart TB
     subgraph K["🌉 kakehashi"]
         B["Builtin smart features"]
@@ -16,6 +23,9 @@ flowchart TB
 
     K <-->|Highlighting, selection, and more — everywhere| E["Your editor (any LSP client)"]
     K <-.->|The additional smarts of real language servers| LS["pyright, rust-analyzer, and friends"]
+
+    style K stroke-width:2px,font-size:20px
+    style B fill:transparent,stroke:#aaa,stroke-dasharray:3 3,color:#666,font-size:12px
 ```
 
 ## 🎨 Highlighting & smart selection, for any language

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ kakehashi is a bridge (架け橋) across your editors, your languages, and the l
 ---
 config:
   flowchart:
-    rankSpacing: 30
+    rankSpacing: 5
 ---
 flowchart TB
     subgraph K[" "]
@@ -20,8 +20,8 @@ flowchart TB
         T["🌉 kakehashi"] ~~~ B["Builtin smart features"]
     end
 
-    K <-->|Highlighting, selection, and more — everywhere| E["Your editor (any LSP client)"]
-    K <-.->|The additional smarts of real language servers| LS["pyright, rust-analyzer, and friends"]
+    K <--->|Highlighting, selection, and more — everywhere| E["Your editor (any LSP client)"]
+    K <-..->|The additional smarts of real language servers| LS["pyright, rust-analyzer, and friends"]
 
     style K fill:#e6f7f1,stroke:#5aa88b,stroke-width:2px
     style T fill:transparent,stroke:transparent,font-size:20px,font-weight:bold

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ kakehashi is a bridge (架け橋) across your editors, your languages, and the l
 ---
 config:
   flowchart:
+    padding: 5
     rankSpacing: 5
 ---
 flowchart TB

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ kakehashi is a bridge (架け橋) across your editors, your languages, and the l
 ```mermaid
 flowchart TB
     subgraph K["🌉 kakehashi"]
-        B["Builtin smart features<br>semantic tokens, smart selection,<br>and more"]
+        B["Builtin smart features"]
     end
 
-    K <-->|Highlighting, selection,<br>and more — everywhere| E["Your editor<br>(any LSP client)"]
-    K <-.->|The additional smarts of<br>real language servers| LS["pyright, rust-analyzer,<br>and friends"]
+    K <-->|Highlighting, selection, and more — everywhere| E["Your editor (any LSP client)"]
+    K <-.->|The additional smarts of real language servers| LS["pyright, rust-analyzer, and friends"]
 ```
 
 ## 🎨 Highlighting & smart selection, for any language

--- a/README.md
+++ b/README.md
@@ -9,22 +9,16 @@ kakehashi is a bridge (架け橋) across your editors, your languages, and the l
 - bridge to all of the above — even for code embedded inside other code
 
 ```mermaid
----
-config:
-  flowchart:
-    subGraphTitleMargin:
-      top: 10
-      bottom: 10
----
 flowchart TB
-    subgraph K["🌉 kakehashi"]
-        B["Builtin smart features"]
+    subgraph K[" "]
+        T["🌉 kakehashi"] ~~~ B["Builtin smart features"]
     end
 
     K <-->|Highlighting, selection, and more — everywhere| E["Your editor (any LSP client)"]
     K <-.->|The additional smarts of real language servers| LS["pyright, rust-analyzer, and friends"]
 
-    style K stroke-width:2px,font-size:20px
+    style K stroke-width:2px
+    style T fill:transparent,stroke:transparent,font-size:20px,font-weight:bold
     style B fill:transparent,stroke:#aaa,stroke-dasharray:3 3,color:#666,font-size:12px
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ kakehashi is a bridge (架け橋) across your editors, your languages, and the l
 
 ```mermaid
 flowchart TB
-    K[🌉 kakehashi] <-->|Highlighting, selection,<br>and more — everywhere| E["Your editor<br>(any LSP client)"]
-    K <-.->|Borrows the smarts of<br>real language servers| LS["pyright, rust-analyzer,<br>and friends"]
+    subgraph K["🌉 kakehashi"]
+        B["Builtin smart features<br>semantic tokens, smart selection,<br>and more"]
+    end
+
+    K <-->|Highlighting, selection,<br>and more — everywhere| E["Your editor<br>(any LSP client)"]
+    K <-.->|The additional smarts of<br>real language servers| LS["pyright, rust-analyzer,<br>and friends"]
 ```
 
 ## 🎨 Highlighting & smart selection, for any language

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ kakehashi is a bridge (架け橋) across your editors, your languages, and the l
 ---
 config:
   flowchart:
-    rankSpacing: 10
+    rankSpacing: 30
 ---
 flowchart TB
     subgraph K[" "]
@@ -26,6 +26,7 @@ flowchart TB
     style K fill:#e6f7f1,stroke:#5aa88b,stroke-width:2px
     style T fill:transparent,stroke:transparent,font-size:20px,font-weight:bold
     style B fill:transparent,stroke:#aaa,stroke-dasharray:3 3,color:#666,font-size:12px
+    linkStyle 1,2 font-size:13px
 ```
 
 ## 🎨 Highlighting & smart selection, for any language


### PR DESCRIPTION
## Summary

- show kakehashi as a container around its built-in smart features
- keep the built-in feature label compact
- describe language servers as providing additional smarts
- use plain spaces instead of HTML line breaks for reliable Mermaid rendering

## Why

The previous diagram could imply that kakehashi only borrowed intelligence from downstream language servers. The nested layout makes it clear that kakehashi also provides smart features itself without making the diagram visually heavy.

HTML line breaks were also rendered without spacing in the target renderer, so the labels now use regular spaces.

## Impact

README readers can more easily distinguish kakehashi's built-in capabilities from features supplied by configured language servers.

## Validation

- `git diff --check`
- confirmed no `<br>` remains in the Mermaid diagram