### PR TITLE
feat(bridge): negotiate routing capability

### DIFF
--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -2853,7 +2853,7 @@ impl LanguageServerPool {
 
             // Handle initialization result - transition state
             match init_result {
-                Ok(Ok(capabilities)) => {
+                Ok(Ok((capabilities, bridge_routing))) => {
                     // Init succeeded - store capabilities and transition to Ready
                     log::info!(
                         target: "kakehashi::bridge::init",
@@ -2868,6 +2868,7 @@ impl LanguageServerPool {
                         .as_ref()
                         .map(|options| options.commands.clone());
                     handle_for_handshake.set_server_capabilities(capabilities);
+                    handle_for_handshake.set_bridge_routing(bridge_routing);
                     // Path a: push this server's settings now that `initialized`
                     // has been sent, so push-model servers are configured even
                     // before they pull (downstream-settings-propagation). Queue it

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -127,6 +127,9 @@ pub(crate) struct ConnectionHandle {
     /// Server capabilities from the initialize response, used to skip unsupported
     /// requests. `OnceLock` for set-once/read-many.
     server_capabilities: OnceLock<ServerCapabilities>,
+    /// Whether the downstream opted into Kakehashi's bridge-routing protocol.
+    /// `OnceLock` for set-once/read-many after the initialize handshake.
+    bridge_routing: OnceLock<bool>,
     /// Dynamic capability registrations from server-initiated `client/registerCapability` requests.
     ///
     /// Updated by the reader task, queried by request handlers via `has_capability()`.
@@ -237,6 +240,7 @@ impl ConnectionHandle {
             // which is pre-registered before spawning the reader task.
             next_request_id: AtomicI64::new(2),
             server_capabilities: OnceLock::new(),
+            bridge_routing: OnceLock::new(),
             dynamic_capabilities,
             connection_key,
             workspace_folders,
@@ -548,6 +552,16 @@ impl ConnectionHandle {
     /// compile-time-safe capability checks.
     pub(crate) fn server_capabilities(&self) -> Option<&ServerCapabilities> {
         self.server_capabilities.get()
+    }
+
+    /// Store whether the downstream advertised bridge routing in `initialize`.
+    pub(super) fn set_bridge_routing(&self, advertised: bool) {
+        let _ = self.bridge_routing.set(advertised);
+    }
+
+    /// Whether the downstream advertised bridge routing during initialization.
+    pub(crate) fn supports_bridge_routing(&self) -> bool {
+        self.bridge_routing.get().copied().unwrap_or(false)
     }
 
     /// Access the dynamic capability registry for this connection.
@@ -1906,6 +1920,15 @@ mod tests {
 
         // Before setting capabilities, accessor should return None
         assert!(handle.server_capabilities().is_none());
+    }
+
+    #[tokio::test]
+    async fn bridge_routing_support_is_retained_after_handshake() {
+        let handle = spawn_sink_handle().await;
+
+        assert!(!handle.supports_bridge_routing());
+        handle.set_bridge_routing(true);
+        assert!(handle.supports_bridge_routing());
     }
 
     /// Test that server_capabilities returns typed struct with set fields.

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -127,9 +127,10 @@ pub(crate) struct ConnectionHandle {
     /// Server capabilities from the initialize response, used to skip unsupported
     /// requests. `OnceLock` for set-once/read-many.
     server_capabilities: OnceLock<ServerCapabilities>,
-    /// Whether the downstream opted into Kakehashi's bridge-routing protocol.
-    /// `OnceLock` for set-once/read-many after the initialize handshake.
-    bridge_routing: OnceLock<bool>,
+    /// Whether the downstream is currently eligible for Kakehashi's
+    /// bridge-routing protocol. This starts false, is set from the initialize
+    /// advertisement, and may be cleared after a downstream MethodNotFound.
+    bridge_routing: AtomicBool,
     /// Dynamic capability registrations from server-initiated `client/registerCapability` requests.
     ///
     /// Updated by the reader task, queried by request handlers via `has_capability()`.
@@ -240,7 +241,7 @@ impl ConnectionHandle {
             // which is pre-registered before spawning the reader task.
             next_request_id: AtomicI64::new(2),
             server_capabilities: OnceLock::new(),
-            bridge_routing: OnceLock::new(),
+            bridge_routing: AtomicBool::new(false),
             dynamic_capabilities,
             connection_key,
             workspace_folders,
@@ -556,14 +557,14 @@ impl ConnectionHandle {
 
     /// Store whether the downstream advertised bridge routing in `initialize`.
     pub(super) fn set_bridge_routing(&self, advertised: bool) {
-        let _ = self.bridge_routing.set(advertised);
+        self.bridge_routing.store(advertised, Ordering::Release);
     }
 
     /// Whether the downstream advertised bridge routing during initialization.
     // Kept on the handle for the routing-request slice stacked on this PR.
     #[allow(dead_code)]
     pub(crate) fn supports_bridge_routing(&self) -> bool {
-        self.bridge_routing.get().copied().unwrap_or(false)
+        self.bridge_routing.load(Ordering::Acquire)
     }
 
     /// Access the dynamic capability registry for this connection.
@@ -1931,6 +1932,8 @@ mod tests {
         assert!(!handle.supports_bridge_routing());
         handle.set_bridge_routing(true);
         assert!(handle.supports_bridge_routing());
+        handle.set_bridge_routing(false);
+        assert!(!handle.supports_bridge_routing());
     }
 
     /// Test that server_capabilities returns typed struct with set fields.

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -558,11 +558,11 @@ impl ConnectionHandle {
     /// Store whether the downstream advertised bridge routing in `initialize`.
     pub(super) fn set_bridge_routing(&self, advertised: bool) {
         self.bridge_routing.store(advertised, Ordering::Release);
+        debug_assert_eq!(self.supports_bridge_routing(), advertised);
     }
 
     /// Whether the downstream advertised bridge routing during initialization.
     // Kept on the handle for the routing-request slice stacked on this PR.
-    #[allow(dead_code)]
     pub(crate) fn supports_bridge_routing(&self) -> bool {
         self.bridge_routing.load(Ordering::Acquire)
     }

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -560,6 +560,8 @@ impl ConnectionHandle {
     }
 
     /// Whether the downstream advertised bridge routing during initialization.
+    // Kept on the handle for the routing-request slice stacked on this PR.
+    #[allow(dead_code)]
     pub(crate) fn supports_bridge_routing(&self) -> bool {
         self.bridge_routing.get().copied().unwrap_or(false)
     }

--- a/src/lsp/bridge/pool/handshake.rs
+++ b/src/lsp/bridge/pool/handshake.rs
@@ -37,7 +37,7 @@ pub(super) async fn perform_lsp_handshake(
     workspace_folders: Option<Vec<WorkspaceFolder>>,
     client_capabilities: Option<ClientCapabilities>,
     advertise_configuration: bool,
-) -> io::Result<ServerCapabilities> {
+) -> io::Result<(ServerCapabilities, bool)> {
     // 1. Build and send initialize request via the single-writer loop
     let init_request = build_initialize_request(
         init_request_id,
@@ -72,6 +72,7 @@ pub(super) async fn perform_lsp_handshake(
             dropped.error,
         );
     }
+    let bridge_routing = parsed.bridge_routing;
     let capabilities = parsed.capabilities;
 
     // 4. Send initialized notification via the single-writer loop
@@ -98,7 +99,7 @@ pub(super) async fn perform_lsp_handshake(
         }
     }
 
-    Ok(capabilities)
+    Ok((capabilities, bridge_routing))
 }
 
 #[cfg(all(test, unix))]
@@ -139,7 +140,7 @@ mod tests {
             }))
             .unwrap();
 
-        let capabilities = perform_lsp_handshake(
+        let (capabilities, bridge_routing) = perform_lsp_handshake(
             &handle,
             RequestId::new(1),
             response_rx,
@@ -154,6 +155,7 @@ mod tests {
 
         assert!(capabilities.hover_provider.is_none());
         assert!(capabilities.completion_provider.is_some());
+        assert!(!bridge_routing);
         let mut messages = String::new();
         for _ in 0..200 {
             messages = std::fs::read_to_string(&output).unwrap_or_default();

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -207,6 +207,29 @@ fn merge_upstream_capabilities(
         return base;
     };
 
+    // Preserve editor-provided experimental extensions. Object-shaped values
+    // can carry the bridge advertisement alongside the editor's keys; a
+    // non-object value cannot be extended without changing its shape, so it
+    // wins unchanged rather than being silently clobbered.
+    if let Some(upstream_experimental) = &upstream.experimental {
+        match upstream_experimental {
+            serde_json::Value::Object(upstream_experimental) => {
+                let mut experimental = upstream_experimental.clone();
+                let kakehashi = experimental
+                    .entry("kakehashi".to_string())
+                    .or_insert_with(|| serde_json::json!({}));
+                if let serde_json::Value::Object(kakehashi) = kakehashi {
+                    kakehashi.insert("bridgeRouting".to_string(), serde_json::Value::Bool(true));
+                    base.experimental = Some(serde_json::Value::Object(experimental));
+                } else {
+                    base.experimental =
+                        Some(serde_json::Value::Object(upstream_experimental.clone()));
+                }
+            }
+            upstream_experimental => base.experimental = Some(upstream_experimental.clone()),
+        }
+    }
+
     // Helper: replace base option with upstream if upstream is Some
     fn merge_option<T>(base: &mut Option<T>, upstream: Option<T>) {
         if upstream.is_some() {
@@ -1082,5 +1105,40 @@ mod tests {
                 Some(&serde_json::Value::Bool(true)),
             );
         }
+    }
+
+    #[test]
+    fn merge_preserves_upstream_experimental_extensions() {
+        let upstream = ClientCapabilities {
+            experimental: Some(serde_json::json!({
+                "editorFeature": {"enabled": true},
+                "kakehashi": {"other": "preserved"},
+            })),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            build_bridge_client_capabilities(Some(&upstream), false, false).experimental,
+            Some(serde_json::json!({
+                "editorFeature": {"enabled": true},
+                "kakehashi": {
+                    "other": "preserved",
+                    "bridgeRouting": true,
+                },
+            })),
+        );
+    }
+
+    #[test]
+    fn merge_preserves_non_object_upstream_experimental_value() {
+        let upstream = ClientCapabilities {
+            experimental: Some(serde_json::json!("editor-extension-payload")),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            build_bridge_client_capabilities(Some(&upstream), false, false).experimental,
+            upstream.experimental,
+        );
     }
 }

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -161,6 +161,14 @@ fn build_baseline_capabilities(
             position_encodings: Some(vec![PositionEncodingKind::UTF16]),
             ..Default::default()
         }),
+        // The routing protocol is negotiated independently of the
+        // process-wide experimental feature gate.  Downstream servers opt in
+        // by returning the matching advertisement in their capabilities.
+        experimental: Some(serde_json::json!({
+            "kakehashi": {
+                "bridgeRouting": true,
+            },
+        })),
         ..Default::default()
     }
 }
@@ -1059,5 +1067,20 @@ mod tests {
             None,
             "no settings to serve → capability withheld",
         );
+    }
+
+    #[test]
+    fn bridge_routing_capability_is_always_advertised() {
+        for experimental in [false, true] {
+            let capabilities = build_bridge_client_capabilities(None, false, experimental);
+            assert_eq!(
+                capabilities
+                    .experimental
+                    .as_ref()
+                    .and_then(|value| value.get("kakehashi"))
+                    .and_then(|value| value.get("bridgeRouting")),
+                Some(&serde_json::Value::Bool(true)),
+            );
+        }
     }
 }

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -209,8 +209,8 @@ fn merge_upstream_capabilities(
 
     // Preserve editor-provided experimental extensions. Object-shaped values
     // can carry the bridge advertisement alongside the editor's keys; a
-    // non-object value cannot be extended without changing its shape, so it
-    // wins unchanged rather than being silently clobbered.
+    // non-object value is retained under `upstream` while the bridge-owned
+    // advertisement remains present.
     if let Some(upstream_experimental) = &upstream.experimental {
         match upstream_experimental {
             serde_json::Value::Object(upstream_experimental) => {
@@ -222,11 +222,26 @@ fn merge_upstream_capabilities(
                     kakehashi.insert("bridgeRouting".to_string(), serde_json::Value::Bool(true));
                     base.experimental = Some(serde_json::Value::Object(experimental));
                 } else {
-                    base.experimental =
-                        Some(serde_json::Value::Object(upstream_experimental.clone()));
+                    let upstream_kakehashi = experimental
+                        .get("kakehashi")
+                        .cloned()
+                        .expect("kakehashi entry exists");
+                    let mut kakehashi = serde_json::Map::new();
+                    kakehashi.insert("bridgeRouting".to_string(), serde_json::Value::Bool(true));
+                    kakehashi.insert("upstream".to_string(), upstream_kakehashi);
+                    experimental.insert(
+                        "kakehashi".to_string(),
+                        serde_json::Value::Object(kakehashi),
+                    );
+                    base.experimental = Some(serde_json::Value::Object(experimental));
                 }
             }
-            upstream_experimental => base.experimental = Some(upstream_experimental.clone()),
+            upstream_experimental => {
+                base.experimental = Some(serde_json::json!({
+                    "kakehashi": {"bridgeRouting": true},
+                    "upstream": upstream_experimental,
+                }));
+            }
         }
     }
 
@@ -1130,7 +1145,7 @@ mod tests {
     }
 
     #[test]
-    fn merge_preserves_non_object_upstream_experimental_value() {
+    fn merge_preserves_non_object_upstream_experimental_value_and_advertises_routing() {
         let upstream = ClientCapabilities {
             experimental: Some(serde_json::json!("editor-extension-payload")),
             ..Default::default()
@@ -1138,7 +1153,10 @@ mod tests {
 
         assert_eq!(
             build_bridge_client_capabilities(Some(&upstream), false, false).experimental,
-            upstream.experimental,
+            Some(serde_json::json!({
+                "kakehashi": {"bridgeRouting": true},
+                "upstream": "editor-extension-payload",
+            })),
         );
     }
 }

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -138,6 +138,7 @@ pub(crate) struct DroppedCapability {
 pub(crate) struct ParsedInitializeCapabilities {
     pub(crate) capabilities: ServerCapabilities,
     pub(crate) dropped: Vec<DroppedCapability>,
+    pub(crate) bridge_routing: bool,
 }
 
 /// Validates a JSON-RPC initialize response and extracts usable capabilities.
@@ -194,6 +195,7 @@ pub(crate) fn parse_initialize_response_capabilities(
         return Ok(ParsedInitializeCapabilities {
             capabilities: ServerCapabilities::default(),
             dropped: Vec::new(),
+            bridge_routing: false,
         });
     };
     let Some(capabilities) = capabilities.as_object() else {
@@ -203,7 +205,16 @@ pub(crate) fn parse_initialize_response_capabilities(
         ));
     };
 
-    recover_server_capabilities(capabilities)
+    let bridge_routing = capabilities
+        .get("experimental")
+        .and_then(|experimental| experimental.get("kakehashi"))
+        .and_then(|kakehashi| kakehashi.get("bridgeRouting"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
+    let mut parsed = recover_server_capabilities(capabilities)?;
+    parsed.bridge_routing = bridge_routing;
+    Ok(parsed)
 }
 
 fn recover_server_capabilities(
@@ -246,6 +257,7 @@ fn recover_server_capabilities(
     Ok(ParsedInitializeCapabilities {
         capabilities,
         dropped,
+        bridge_routing: false,
     })
 }
 
@@ -628,6 +640,31 @@ mod tests {
             .expect("omitted or null capabilities remain compatible");
 
         assert_eq!(parsed.capabilities, ServerCapabilities::default());
+        assert!(parsed.dropped.is_empty());
+        assert!(!parsed.bridge_routing);
+    }
+
+    #[rstest]
+    #[case::advertised(serde_json::json!(true), true)]
+    #[case::not_advertised(serde_json::json!(false), false)]
+    #[case::malformed(serde_json::json!("yes"), false)]
+    fn parses_bridge_routing_advertisement(
+        #[case] advertisement: serde_json::Value,
+        #[case] expected: bool,
+    ) {
+        let response = serde_json::json!({
+            "result": {
+                "capabilities": {
+                    "experimental": {
+                        "kakehashi": {"bridgeRouting": advertisement}
+                    }
+                }
+            }
+        });
+
+        let parsed = parse_initialize_response_capabilities(&response)
+            .expect("custom routing capability must not affect standard parsing");
+        assert_eq!(parsed.bridge_routing, expected);
         assert!(parsed.dropped.is_empty());
     }
 

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
@@ -151,5 +151,10 @@ expression: merged
     "positionEncodings": [
       "utf-16"
     ]
+  },
+  "experimental": {
+    "kakehashi": {
+      "bridgeRouting": true
+    }
   }
 }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
@@ -154,5 +154,10 @@ expression: merged
     "positionEncodings": [
       "utf-16"
     ]
+  },
+  "experimental": {
+    "kakehashi": {
+      "bridgeRouting": true
+    }
   }
 }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
@@ -96,5 +96,10 @@ expression: capabilities
     "positionEncodings": [
       "utf-16"
     ]
+  },
+  "experimental": {
+    "kakehashi": {
+      "bridgeRouting": true
+    }
   }
 }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
@@ -99,5 +99,10 @@ expression: capabilities
     "positionEncodings": [
       "utf-16"
     ]
+  },
+  "experimental": {
+    "kakehashi": {
+      "bridgeRouting": true
+    }
   }
 }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
@@ -103,6 +103,11 @@ expression: request
         "positionEncodings": [
           "utf-16"
         ]
+      },
+      "experimental": {
+        "kakehashi": {
+          "bridgeRouting": true
+        }
       }
     }
   }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
@@ -106,6 +106,11 @@ expression: request
         "positionEncodings": [
           "utf-16"
         ]
+      },
+      "experimental": {
+        "kakehashi": {
+          "bridgeRouting": true
+        }
       }
     }
   }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
@@ -114,6 +114,11 @@ expression: request
         "positionEncodings": [
           "utf-16"
         ]
+      },
+      "experimental": {
+        "kakehashi": {
+          "bridgeRouting": true
+        }
       }
     }
   }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
@@ -117,6 +117,11 @@ expression: request
         "positionEncodings": [
           "utf-16"
         ]
+      },
+      "experimental": {
+        "kakehashi": {
+          "bridgeRouting": true
+        }
       }
     }
   }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
@@ -103,6 +103,11 @@ expression: request
         "positionEncodings": [
           "utf-16"
         ]
+      },
+      "experimental": {
+        "kakehashi": {
+          "bridgeRouting": true
+        }
       }
     },
     "workspaceFolders": [

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
@@ -106,6 +106,11 @@ expression: request
         "positionEncodings": [
           "utf-16"
         ]
+      },
+      "experimental": {
+        "kakehashi": {
+          "bridgeRouting": true
+        }
       }
     },
     "workspaceFolders": [

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
@@ -112,6 +112,11 @@ expression: request
         "positionEncodings": [
           "utf-16"
         ]
+      },
+      "experimental": {
+        "kakehashi": {
+          "bridgeRouting": true
+        }
       }
     }
   }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
@@ -115,6 +115,11 @@ expression: request
         "positionEncodings": [
           "utf-16"
         ]
+      },
+      "experimental": {
+        "kakehashi": {
+          "bridgeRouting": true
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- advertise `experimental.kakehashi.bridgeRouting` in downstream `initialize`
- parse and retain the downstream routing opt-in through the handshake
- allow the retained capability to be downgraded after `MethodNotFound`

This PR is intentionally stacked on #1002 (`feat/bridge-routing-protocol`) and provides the capability-negotiation foundation for the subsequent `kakehashi/bridge/routing` request implementation.

## Validation

- `cargo test --lib -q`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for detecting bridge-routing capabilities from connected language servers.
  * Bridge-routing support is now advertised during initialization and retained for connection readiness.
  * Connected servers can report whether bridge routing is enabled.

* **Bug Fixes**
  * Improved handling of bridge-routing capability values in initialization responses.
  * Missing, malformed, or unsupported routing information now safely defaults to disabled.
  * Existing experimental capabilities are preserved while bridge-routing support is added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->