### PR TITLE
feat(bridge): proxy requests between downstream peers

### DIFF
--- a/docs/architecture-decisions/bridge-client-control-protocol.md
+++ b/docs/architecture-decisions/bridge-client-control-protocol.md
@@ -8,6 +8,7 @@
 - [ls-bridge-message-ordering](ls-bridge-message-ordering.md) — the cancellation forwarding that the pass-through request reuses
 - [ls-bridge-timeout-hierarchy](ls-bridge-timeout-hierarchy.md) — the timeout tiers `stop`, `restart`, and pass-through requests interact with
 - [bridge-routing-protocol](bridge-routing-protocol.md) — the reverse-direction sibling (kakehashi→downstream); reuses this protocol's discovery convention and liveness classification, and the stopped set outranks routing answers
+- [bridge-peer-protocol](bridge-peer-protocol.md) — the implemented downstream→kakehashi→downstream sibling; reuses the pass-through boundary but exposes only other running peers
 
 ## Context
 

--- a/docs/architecture-decisions/bridge-peer-protocol.md
+++ b/docs/architecture-decisions/bridge-peer-protocol.md
@@ -28,7 +28,7 @@ Introduce two custom requests handled only on downstream connections:
 
 | Method | Input | Output |
 |---|---|---|
-| `kakehashi/bridge/peer` | `{ name?: string }` | `Peer[]` |
+| `kakehashi/bridge/peer` | `{ textDocument?: TextDocumentIdentifier, name?: string }` | `Peer[]` |
 | `kakehashi/bridge/peer/request` | `{ id, method, params? }` | `ForwardResult` |
 
 kakehashi advertises the API to downstream servers as
@@ -46,7 +46,13 @@ type Peer = {
 ```
 
 Discovery returns only connections currently in `running` (`Ready`) state,
-sorted by `id`. `name` optionally filters by the exact configured server name.
+sorted by `id`. Its optional filters compose as AND:
+
+- `textDocument` retains peers that currently serve the exact downstream URI,
+  or an injection belonging to the supplied host URI. A document that is not
+  open matches nothing; discovery does not route, open, or start it.
+- `name` retains peers with the exact configured server name.
+
 The exact calling `ConnectionKey` is always excluded; a same-name connection at
 a different root remains a peer. Initializing, failed, stopping, closed, and
 configured-but-not-running slots are absent. Discovery never starts a process.

--- a/docs/architecture-decisions/bridge-peer-protocol.md
+++ b/docs/architecture-decisions/bridge-peer-protocol.md
@@ -1,0 +1,169 @@
+# Bridge Peer Protocol
+
+**Related Decisions**:
+- [bridge-client-control-protocol](bridge-client-control-protocol.md) — the planned editor-facing connection API; peer requests reuse its pass-through boundary but are available only to downstream servers
+- [bridge-routing-protocol](bridge-routing-protocol.md) — the existing kakehashi→downstream custom request and the per-side dispatch rule
+- [ls-bridge-message-ordering](ls-bridge-message-ordering.md) — downstream request IDs, cancellation, response routing, and the single-writer connection transport
+- [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md) — the per-root `ConnectionKey` slots exposed as peers
+- [ls-bridge-timeout-hierarchy](ls-bridge-timeout-hierarchy.md) — the managed downstream-request deadline inherited by peer requests
+
+## Context
+
+A downstream language server can decide a feature from project state more
+precisely than static kakehashi configuration can. A meta-server such as tsudoi
+may implement `textDocument/formatting`, inspect the project, and then choose
+denols for one TypeScript document and `oxfmt --lsp` for another. It cannot make
+that choice through the editor: the relevant language servers are kakehashi's
+private downstream connections, and forwarding through the editor would expose
+virtual-document and connection details on the wrong protocol side.
+
+The planned bridge-client-control-protocol solves the sibling editor→kakehashi→
+downstream case. This decision provides only the reverse ingress:
+downstream→kakehashi→another downstream. The caller and target are peers from
+kakehashi's point of view, but the caller must never discover or request itself.
+
+## Decision
+
+Introduce two custom requests handled only on downstream connections:
+
+| Method | Input | Output |
+|---|---|---|
+| `kakehashi/bridge/peer` | `{ name?: string }` | `Peer[]` |
+| `kakehashi/bridge/peer/request` | `{ id, method, params? }` | `ForwardResult` |
+
+kakehashi advertises the API to downstream servers as
+`initialize.params.capabilities.experimental.kakehashi.bridgePeer: true`.
+Neither method is registered on the editor-facing LSP service.
+
+### Peer Discovery
+
+```typescript
+type Peer = {
+  name: string;                    // languageServers map key
+  id: string;                      // opaque ConnectionKey slot identity
+  workspaceFolders: WorkspaceFolder[];
+};
+```
+
+Discovery returns only connections currently in `running` (`Ready`) state,
+sorted by `id`. `name` optionally filters by the exact configured server name.
+The exact calling `ConnectionKey` is always excluded; a same-name connection at
+a different root remains a peer. Initializing, failed, stopping, closed, and
+configured-but-not-running slots are absent. Discovery never starts a process.
+
+`id` is contractually opaque. It identifies the `(server name, root mode/root)`
+slot injectively even when a server name contains `@` or `#`; callers obtain it
+from discovery and echo it without parsing. `workspaceFolders` is the target
+connection's current folder snapshot, with a workspace-less/null snapshot
+represented as `[]`.
+
+### Peer Request
+
+The selected peer receives the inner `method` and optional `params` unchanged,
+under a fresh kakehashi-owned JSON-RPC request ID. An omitted `params` remains
+omitted. No URI translation, capability filtering, document opening, or
+virtual/host coordinate mapping occurs: the caller is responsible for using the
+target's downstream-facing document identities and protocol state correctly.
+
+`params`, when present, must be an object or array as required by JSON-RPC.
+`initialize`, `initialized`, `shutdown`, `exit`, and `$/cancelRequest` are denied
+because they would take over the target connection's lifecycle. Cancellation is
+instead expressed by cancelling the outer request; kakehashi cancels the inner
+request and answers the caller with `RequestCancelled` (`-32800`). Peer requests
+inherit the ordinary managed downstream-request deadline (currently 30 seconds)
+and Tier-2 liveness accounting.
+
+The successful outer result strips the internal JSON-RPC fields and contains
+exactly one branch:
+
+```typescript
+type ForwardResult =
+  | { result: LSPAny }             // present even when null
+  | { error: ResponseError };      // validated downstream error object
+```
+
+Bridge-level failures use `RequestFailed` (`-32803`) and `data.reason`:
+
+| Reason | Meaning |
+|---|---|
+| `unknownPeer` | The id is absent, names the caller, or is not currently running |
+| `methodDenied` | The inner method controls the connection lifecycle |
+| `forwardFailed` | The inner request could not be queued |
+| `connectionLost` | The target connection ended before answering |
+| `requestTimeout` | The managed downstream request deadline elapsed |
+| `malformedResponse` | The target returned an invalid JSON-RPC response envelope |
+
+Malformed outer parameters use `InvalidParams` (`-32602`). A valid downstream
+error remains data in a successful outer result; it is not confused with a
+failure of kakehashi to perform the forwarding.
+
+## Invariants
+
+> The invariants below are normative; the mechanisms that satisfy them are
+> deliberately unspecified.
+
+- The calling connection must never be returned or resolved as its own peer;
+  excluding all connections with the same server name is also wrong because
+  per-root pooling creates legitimate same-name peers.
+- A cancel arriving after the outer request is accepted must release the caller
+  and target the exact inner request; it must not be lost between forwarding and
+  becoming cancellable or fan out to unrelated requests.
+- Internal downstream request IDs must never escape in `ForwardResult`; they
+  share neither identity nor lifecycle with the caller's outer ID.
+- Per-side dispatch must remain strict: downstream peer methods are not an
+  editor control surface, and planned editor-facing `bridge/client/*` methods
+  are not thereby made callable from downstream connections.
+
+## Considered Options
+
+### Route the request through the editor
+
+Rejected. It requires editor-specific cooperation, exposes downstream
+connection identities on the wrong side, and cannot reliably preserve the
+virtual-document state that kakehashi owns.
+
+### Address a peer only by server name
+
+Rejected. Per-root pooling permits several live connections with one configured
+name. Choosing one would be ambiguous precisely in the monorepos where dynamic
+project-aware selection is most valuable.
+
+### Return configured servers and start one on request
+
+Rejected for this initial protocol. Starting a configured server needs a root,
+workspace, settings, and lifecycle decision that discovery alone cannot supply.
+Returning only live peers makes the request target unambiguous and keeps this
+API from becoming a second routing/spawn policy.
+
+## Consequences
+
+### Positive
+
+- Meta-servers can select an already-running formatter or other provider from
+  project state without making the editor understand kakehashi internals.
+- The API respects per-root connection identity and exposes enough workspace
+  context for a caller to select the intended slot.
+- Arbitrary downstream methods become usable without adding a dedicated bridge
+  implementation for each one.
+
+### Negative
+
+- Pass-through requests can desynchronize target protocol state. For example,
+  an inner `textDocument/didOpen` or `didClose` is invisible to kakehashi's
+  document tracker; this is the caller's responsibility.
+- A peer is discoverable only after something else has started it. The protocol
+  cannot select a configured but dormant formatter.
+- Slow arbitrary requests share the existing timeout and liveness policy; they
+  can contribute to a target connection being classified as failed.
+
+### Neutral
+
+- Discovery is a snapshot. A peer may stop after enumeration; the subsequent
+  request then fails rather than silently selecting a replacement.
+- The API grants no authority beyond the configured processes already running,
+  but one trusted downstream process can ask another to perform any non-denied
+  request it supports.
+
+## Decision–Implementation Gap
+
+None.

--- a/docs/architecture-decisions/bridge-peer-protocol.md
+++ b/docs/architecture-decisions/bridge-peer-protocol.md
@@ -96,6 +96,7 @@ Bridge-level failures use `RequestFailed` (`-32803`) and `data.reason`:
 | `unknownPeer` | The id is absent, names the caller, or is not currently running |
 | `methodDenied` | The inner method controls the connection lifecycle |
 | `forwardFailed` | The inner request could not be queued |
+| `tooManyRequests` | The caller already has 64 peer requests awaiting settlement |
 | `connectionLost` | The target connection ended before answering |
 | `requestTimeout` | The managed downstream request deadline elapsed |
 | `malformedResponse` | The target returned an invalid JSON-RPC response envelope |
@@ -162,11 +163,16 @@ API from becoming a second routing/spawn policy.
   cannot select a configured but dormant formatter.
 - Slow arbitrary requests share the existing timeout and liveness policy; they
   can contribute to a target connection being classified as failed.
+- Each calling connection may have at most 64 peer requests awaiting settlement,
+  bounding router entries and forwarding tasks even when targets consume input
+  without answering.
 
 ### Neutral
 
-- Discovery is a snapshot. A peer may stop after enumeration; the subsequent
-  request then fails rather than silently selecting a replacement.
+- Discovery is a snapshot of connection slots. A peer may stop after
+  enumeration; a subsequent request fails unless the same configured
+  server/root slot has already been replaced by a new ready process. Peer IDs
+  intentionally identify the stable slot rather than a process generation.
 - The API grants no authority beyond the configured processes already running,
   but one trusted downstream process can ask another to perform any non-denied
   request it supports.

--- a/docs/architecture-decisions/bridge-peer-protocol.md
+++ b/docs/architecture-decisions/bridge-peer-protocol.md
@@ -74,8 +74,9 @@ target's downstream-facing document identities and protocol state correctly.
 `params`, when present, must be an object or array as required by JSON-RPC.
 `initialize`, `initialized`, `shutdown`, `exit`, and `$/cancelRequest` are denied
 because they would take over the target connection's lifecycle. Cancellation is
-instead expressed by cancelling the outer request; kakehashi cancels the inner
-request and answers the caller with `RequestCancelled` (`-32800`). Peer requests
+instead expressed by cancelling the outer request; kakehashi retires the inner
+request, best-effort queues `$/cancelRequest` when its write already started,
+and answers the caller with `RequestCancelled` (`-32800`). Peer requests
 inherit the ordinary managed downstream-request deadline (currently 30 seconds)
 and Tier-2 liveness accounting.
 

--- a/docs/architecture-decisions/bridge-routing-protocol.md
+++ b/docs/architecture-decisions/bridge-routing-protocol.md
@@ -2,6 +2,7 @@
 
 **Related Decisions**:
 - [bridge-client-control-protocol](bridge-client-control-protocol.md) — the sibling `kakehashi/bridge/*` family (client→kakehashi); the `capabilities.experimental` discovery convention, the stopped set, and the liveness classification this protocol reuses
+- [bridge-peer-protocol](bridge-peer-protocol.md) — the downstream→kakehashi→downstream family that forms the explicit downstream-side dispatch surface
 - [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md) — the `ConnectionKey` model, per-root pooling, shared instances, and the workspace-folder capability fallback that a `workspaceFolders` override interacts with
 - [aggregation-priorities-wildcard](aggregation-priorities-wildcard.md) — the ordered-allowlist `priorities` semantics reused for provider selection
 - [language-server-bridge-request-strategies](language-server-bridge-request-strategies.md) — the `preferred` strategy whose fan-out/fan-in machinery this protocol dispatches
@@ -428,9 +429,10 @@ costing round trips, and waits, after the first.
 
 Method dispatch is **per side**: the editor-facing custom methods
 (`kakehashi/bridge/client/*` and the rest) are not registered on downstream
-connections, and `kakehashi/bridge/routing` is not an editor-facing method
-— a downstream server sending control-protocol requests back at kakehashi
-is answered `MethodNotFound`, never dispatched.
+connections, and `kakehashi/bridge/routing` is not an editor-facing method.
+The downstream-facing `kakehashi/bridge/peer*` family added by
+bridge-peer-protocol is the explicit exception on that side; it does not make
+the editor-facing control protocol callable from downstream connections.
 
 ### Provider Selection: Aggregation Machinery, `preferred` Dispatch
 

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -330,7 +330,8 @@ arbitrary non-lifecycle JSON-RPC request with `kakehashi/bridge/peer/request`.
 The caller itself is excluded, including only its exact per-root connection;
 same-name peers at other roots remain visible. These methods exist only on
 downstream connections and cannot be called by the editor. See
-bridge-peer-protocol for the complete wire and error contract.
+[bridge-peer-protocol](architecture-decisions/bridge-peer-protocol.md) for the
+complete wire and error contract.
 
 ---
 

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -321,6 +321,19 @@ without the opt-in the server does not advertise color support.
 
 ---
 
+## Downstream peer requests
+
+Downstream language servers can feature-detect
+`initialize.params.capabilities.experimental.kakehashi.bridgePeer: true`, list
+other running downstream connections with `kakehashi/bridge/peer`, and proxy an
+arbitrary non-lifecycle JSON-RPC request with `kakehashi/bridge/peer/request`.
+The caller itself is excluded, including only its exact per-root connection;
+same-name peers at other roots remain visible. These methods exist only on
+downstream connections and cannot be called by the editor. See
+bridge-peer-protocol for the complete wire and error contract.
+
+---
+
 ## `kakehashi/*` methods
 
 Beyond the standard LSP features, kakehashi exposes custom methods under the

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -328,8 +328,8 @@ Downstream language servers can feature-detect
 other running downstream connections with `kakehashi/bridge/peer`, and proxy an
 arbitrary non-lifecycle JSON-RPC request with `kakehashi/bridge/peer/request`.
 The caller itself is excluded, including only its exact per-root connection;
-same-name peers at other roots remain visible. These methods exist only on
-downstream connections and cannot be called by the editor. See
+same-name peers at other roots remain visible. These methods are registered
+only on downstream connections, not directly on the editor-facing service. See
 [bridge-peer-protocol](architecture-decisions/bridge-peer-protocol.md) for the
 complete wire and error contract.
 

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -30,6 +30,7 @@ mod client_progress;
 mod connection;
 pub(crate) mod coordinator;
 mod inbound_request_registry;
+mod peer;
 mod pool;
 mod progress_registry;
 mod protocol;

--- a/src/lsp/bridge/actor.rs
+++ b/src/lsp/bridge/actor.rs
@@ -27,5 +27,5 @@ pub(crate) use reader::{
 };
 #[cfg(test)]
 pub(crate) use response_router::RouteResult;
-pub(crate) use response_router::{ResponseRouter, RouterCleanupGuard};
+pub(crate) use response_router::{BridgeFailure, ResponseRouter, RouterCleanupGuard};
 pub(crate) use writer::{OUTBOUND_QUEUE_CAPACITY, WriterTaskHandle, spawn_writer_task};

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -1066,7 +1066,7 @@ async fn handle_server_request(
             workspace::configuration::handle(&message, server_prefix, deps)
         }
         "kakehashi/bridge/peer" => {
-            peer::list_result(&deps.peer_directory, &deps.connection_key, &message)
+            peer::list_result(&deps.peer_directory, &deps.connection_key, &message).await
         }
         _ => {
             debug!(

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -25,7 +25,7 @@ use tower_lsp_server::jsonrpc;
 use tower_lsp_server::ls_types::MessageType;
 
 use super::super::connection::BridgeReader;
-use super::super::{client, telemetry, text_document, window};
+use super::super::{client, peer, telemetry, text_document, window};
 use super::OutboundMessage;
 use super::ResponseRouter;
 use super::response_router::{LivenessExpiry, RouteResult};
@@ -288,6 +288,8 @@ pub(crate) struct ServerRequestDeps {
     /// downstream-supplied `TextDocumentEdit.version`s against the version the
     /// bridge tracks for the virtual document on THIS connection.
     pub(crate) connection_key: ConnectionKey,
+    /// Live downstream slots available to `kakehashi/bridge/peer*` handlers.
+    pub(crate) peer_directory: Arc<peer::PeerDirectory>,
     pub(crate) response_tx: mpsc::Sender<OutboundMessage>,
     pub(crate) dynamic_capabilities: Arc<DynamicCapabilityRegistry>,
     /// Loss-intolerant notifications (`DiagnosticRefresh` and work-done
@@ -594,6 +596,7 @@ pub(crate) fn spawn_reader_task_with_liveness(
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -686,6 +689,7 @@ async fn reader_loop(
         settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
         server_name: None,
         connection_key: ConnectionKey::for_server("test"),
+        peer_directory: Arc::new(peer::PeerDirectory::default()),
         response_tx,
         dynamic_capabilities,
         upstream_tx,
@@ -1037,6 +1041,10 @@ async fn handle_server_request(
             workspace::apply_edit::handle(&message, id, server_prefix, deps);
             return;
         }
+        "kakehashi/bridge/peer/request" => {
+            peer::request::handle(&message, id, server_prefix, deps);
+            return;
+        }
         _ => {}
     }
 
@@ -1056,6 +1064,9 @@ async fn handle_server_request(
         "workspace/workspaceFolders" => workspace::workspace_folders::handle(server_prefix, deps),
         "workspace/configuration" => {
             workspace::configuration::handle(&message, server_prefix, deps)
+        }
+        "kakehashi/bridge/peer" => {
+            peer::list_result(&deps.peer_directory, &deps.connection_key, &message)
         }
         _ => {
             debug!(
@@ -1133,6 +1144,7 @@ pub(in crate::lsp::bridge) async fn send_server_response(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lsp::bridge::ConnectionState;
     use crate::lsp::bridge::connection::AsyncBridgeConnection;
     use serde_json::json;
 
@@ -1306,6 +1318,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: server_name.map(String::from),
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx: tx,
             dynamic_capabilities: caps,
             upstream_tx,
@@ -1443,6 +1456,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: Some("mock-ls".to_string()),
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx: tx,
             dynamic_capabilities: caps,
             upstream_tx,
@@ -1521,6 +1535,7 @@ mod tests {
                 settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
                 server_name: None,
                 connection_key: ConnectionKey::for_server("test"),
+                peer_directory: Arc::new(peer::PeerDirectory::default()),
                 response_tx,
                 dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
                 upstream_tx,
@@ -1976,6 +1991,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities: Arc::clone(&dynamic_capabilities),
             upstream_tx,
@@ -2020,6 +2036,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_message_answers_peer_discovery_from_downstream_only() {
+        let router = ResponseRouter::new();
+        let (deps, (mut response_rx, _upstream_rx, _window_rx)) =
+            dummy_server_request_deps_with_rx();
+        let peer = crate::lsp::bridge::pool::test_helpers::create_handle_with_key(
+            ConnectionState::Ready,
+            ConnectionKey::for_server("oxfmt"),
+        )
+        .await;
+        deps.peer_directory.register(&peer);
+
+        handle_message(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "kakehashi/bridge/peer",
+                "params": {}
+            }),
+            &router,
+            "[tsudoi] ",
+            &deps,
+        )
+        .await;
+
+        let OutboundMessage::Untracked(response) = response_rx.recv().await.unwrap() else {
+            panic!("server-request responses are untracked")
+        };
+        assert_eq!(response["id"], 7);
+        assert_eq!(response["result"][0]["name"], "oxfmt");
+    }
+
+    #[tokio::test]
     async fn handle_message_unregister_capability_updates_registry() {
         let router = ResponseRouter::new();
         let (response_tx, mut response_rx) = mpsc::channel(16);
@@ -2039,6 +2087,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities: Arc::clone(&dynamic_capabilities),
             upstream_tx,
@@ -2102,6 +2151,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2192,6 +2242,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2253,6 +2304,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2312,6 +2364,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2372,6 +2425,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2441,6 +2495,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2528,6 +2583,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2586,6 +2642,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2672,6 +2729,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2713,6 +2771,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2770,6 +2829,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2816,6 +2876,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2862,6 +2923,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2914,6 +2976,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: Some("luals".to_string()),
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
             upstream_tx,
@@ -2974,6 +3037,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: Some("lua_ls".to_string()),
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
             upstream_tx,
@@ -3027,6 +3091,7 @@ mod tests {
                 settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
                 server_name: Some("luals".to_string()),
                 connection_key: ConnectionKey::for_server("test"),
+                peer_directory: Arc::new(peer::PeerDirectory::default()),
                 response_tx,
                 dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
                 upstream_tx,
@@ -3110,6 +3175,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -3152,6 +3218,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities: Arc::clone(&dynamic_capabilities),
             upstream_tx,
@@ -3209,6 +3276,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities: Arc::clone(&dynamic_capabilities),
             upstream_tx,
@@ -3277,6 +3345,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx: response_tx.clone(),
             dynamic_capabilities,
             upstream_tx,
@@ -3340,6 +3409,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -3814,6 +3884,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: Some("mock-ls".to_string()),
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx,
             dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
             upstream_tx,
@@ -4266,6 +4337,7 @@ mod tests {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             connection_key: ConnectionKey::for_server("test"),
+            peer_directory: Arc::new(peer::PeerDirectory::default()),
             response_tx: tx,
             dynamic_capabilities: caps,
             upstream_tx,

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -2142,14 +2142,17 @@ mod tests {
         .await;
         let peer_id = peer.key().peer_id();
         deps.peer_directory.register(&peer);
+        let mut permits = Vec::new();
         for n in 0..crate::lsp::bridge::inbound_request_registry::MAX_IN_FLIGHT_PEER_REQUESTS_PER_CONNECTION
         {
-            deps.inbound_request_registry
-                .try_register_peer(
+            permits.push(
+                deps.inbound_request_registry
+                    .try_register_peer(
                     deps.progress_connection_id,
                     jsonrpc::Id::Number(n as i64),
                 )
-                .expect("fill the per-origin allowance");
+                    .expect("fill the per-origin allowance"),
+            );
         }
 
         handle_message(

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -304,10 +304,9 @@ pub(crate) struct ServerRequestDeps {
     /// capability). Unbounded: a dropped request would hang the downstream.
     /// See [`UpstreamRequest`].
     pub(crate) upstream_request_tx: mpsc::UnboundedSender<UpstreamRequest>,
-    /// Tracks in-flight forwarded requests so a downstream `$/cancelRequest`
-    /// (or connection death) can cancel the editor-bound request (#404).
-    /// (Capability-gated applyEdits are registered too, though answered
-    /// locally.)
+    /// Tracks in-flight downstream-originated forwarding so a downstream
+    /// `$/cancelRequest` (or connection death) can cancel either the
+    /// editor-bound request (#404) or a peer-bound bridge request.
     pub(crate) inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry,
     /// The folders this connection currently serves, used to answer downstream
     /// `workspace/workspaceFolders` pulls. Mutable: a `preferSharedInstance`
@@ -960,9 +959,9 @@ async fn handle_message(
 }
 
 /// Handle an inbound downstream `$/cancelRequest`: if it targets a forwarded
-/// request still in flight (`window/showMessageRequest`, `window/showDocument`,
-/// or a supported `workspace/applyEdit`),
-/// cancel the editor-bound request so its dialog is dismissed (#404). The id is
+/// request still in flight (an editor-bound `window/*`/`workspace/applyEdit`
+/// request or a peer-bound bridge request), cancel that forwarding operation.
+/// For editor requests this dismisses an open dialog (#404). The id is
 /// parsed as a [`jsonrpc::Id`] exactly as the original request's id was, so the
 /// registry key matches. Ids that aren't tracked (e.g. the bridge's own outbound
 /// requests *to* the downstream, which the downstream can't cancel this way) are

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -1041,7 +1041,7 @@ async fn handle_server_request(
             return;
         }
         "kakehashi/bridge/peer/request" => {
-            peer::request::handle(&message, id, server_prefix, deps);
+            peer::request::handle(&message, id, server_prefix, deps).await;
             return;
         }
         _ => {}
@@ -2182,6 +2182,45 @@ mod tests {
             0,
             "rejection happens before target router/task state is created"
         );
+    }
+
+    #[tokio::test]
+    async fn peer_rejection_backpressures_reader_without_a_detached_task() {
+        let router = ResponseRouter::new();
+        let (deps, (mut response_rx, _upstream_rx, _window_rx)) =
+            dummy_server_request_deps_with_rx();
+        for n in 0..16 {
+            deps.response_tx
+                .try_send(OutboundMessage::Untracked(json!({ "occupied": n })))
+                .unwrap();
+        }
+
+        let mut dispatch = Box::pin(handle_message(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 77,
+                "method": "kakehashi/bridge/peer/request",
+                "params": { "id": "missing", "method": "custom/request" }
+            }),
+            &router,
+            "[tsudoi] ",
+            &deps,
+        ));
+        tokio::select! {
+            biased;
+            _ = &mut dispatch => panic!("rejection must not escape into a detached task"),
+            _ = tokio::task::yield_now() => {}
+        }
+
+        for _ in 0..16 {
+            let _occupied = response_rx.recv().await.unwrap();
+        }
+        dispatch.await;
+        let OutboundMessage::Untracked(response) = response_rx.recv().await.unwrap() else {
+            panic!("server-request responses are untracked")
+        };
+        assert_eq!(response["id"], 77);
+        assert_eq!(response["error"]["data"]["reason"], "unknownPeer");
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -341,8 +341,8 @@ struct ProgressPurgeGuard {
     registry: Arc<crate::lsp::bridge::ProgressRegistry>,
     connection_id: crate::lsp::bridge::ProgressConnectionId,
     upstream_tx: mpsc::UnboundedSender<UpstreamNotification>,
-    /// Cancel any forwarded requests still in flight when this connection's
-    /// reader exits, so their editor dialogs don't linger (#404).
+    /// Cancel editor- and peer-bound forwarding when this connection exits;
+    /// editor dialogs are dismissed as part of that cleanup (#404).
     inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry,
 }
 

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -2131,6 +2131,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_message_rejects_peer_request_when_origin_limit_is_full() {
+        let router = ResponseRouter::new();
+        let (deps, (mut response_rx, _upstream_rx, _window_rx)) =
+            dummy_server_request_deps_with_rx();
+        let peer = crate::lsp::bridge::pool::test_helpers::create_handle_with_key(
+            ConnectionState::Ready,
+            ConnectionKey::for_server("oxfmt"),
+        )
+        .await;
+        let peer_id = peer.key().peer_id();
+        deps.peer_directory.register(&peer);
+        for n in 0..crate::lsp::bridge::inbound_request_registry::MAX_IN_FLIGHT_PEER_REQUESTS_PER_CONNECTION
+        {
+            deps.inbound_request_registry
+                .try_register_peer(
+                    deps.progress_connection_id,
+                    jsonrpc::Id::Number(n as i64),
+                )
+                .expect("fill the per-origin allowance");
+        }
+
+        handle_message(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1000,
+                "method": "kakehashi/bridge/peer/request",
+                "params": {
+                    "id": peer_id,
+                    "method": "textDocument/formatting",
+                    "params": { "textDocument": { "uri": "file:///repo/main.ts" } }
+                }
+            }),
+            &router,
+            "[tsudoi] ",
+            &deps,
+        )
+        .await;
+
+        let OutboundMessage::Untracked(response) = response_rx.recv().await.unwrap() else {
+            panic!("server-request responses are untracked")
+        };
+        assert_eq!(response["id"], 1000);
+        assert_eq!(response["error"]["data"]["reason"], "tooManyRequests");
+        assert_eq!(
+            peer.router().pending_count(),
+            0,
+            "rejection happens before target router/task state is created"
+        );
+    }
+
+    #[tokio::test]
     async fn handle_message_unregister_capability_updates_registry() {
         let router = ResponseRouter::new();
         let (response_tx, mut response_rx) = mpsc::channel(16);

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -2067,6 +2067,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_message_forwards_peer_request_and_wraps_its_response() {
+        let router = ResponseRouter::new();
+        let (deps, (mut response_rx, _upstream_rx, _window_rx)) =
+            dummy_server_request_deps_with_rx();
+        let peer = crate::lsp::bridge::pool::test_helpers::create_handle_with_key(
+            ConnectionState::Ready,
+            ConnectionKey::for_server("oxfmt"),
+        )
+        .await;
+        let peer_id = peer.key().peer_id();
+        deps.peer_directory.register(&peer);
+
+        handle_message(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 41,
+                "method": "kakehashi/bridge/peer/request",
+                "params": {
+                    "id": peer_id,
+                    "method": "textDocument/formatting",
+                    "params": { "textDocument": { "uri": "file:///repo/main.ts" } }
+                }
+            }),
+            &router,
+            "[tsudoi] ",
+            &deps,
+        )
+        .await;
+
+        for _ in 0..100 {
+            if peer.router().pending_count() == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(peer.router().pending_count(), 1);
+        let downstream_id = peer.router().pending_ids()[0];
+        assert_ne!(downstream_id.as_i64(), 41);
+        assert_eq!(
+            peer.router().route(json!({
+                "jsonrpc": "2.0",
+                "id": downstream_id.as_i64(),
+                "result": [{ "newText": "formatted" }]
+            })),
+            RouteResult::Delivered
+        );
+
+        let OutboundMessage::Untracked(response) = response_rx.recv().await.unwrap() else {
+            panic!("server-request responses are untracked")
+        };
+        assert_eq!(response["id"], 41);
+        assert_eq!(
+            response["result"],
+            json!({ "result": [{ "newText": "formatted" }] })
+        );
+        assert_eq!(peer.router().pending_count(), 0);
+        assert!(
+            !deps
+                .inbound_request_registry
+                .is_registered(deps.progress_connection_id, &jsonrpc::Id::Number(41))
+        );
+    }
+
+    #[tokio::test]
     async fn handle_message_unregister_capability_updates_registry() {
         let router = ResponseRouter::new();
         let (response_tx, mut response_rx) = mpsc::channel(16);

--- a/src/lsp/bridge/actor/response_router.rs
+++ b/src/lsp/bridge/actor/response_router.rs
@@ -502,9 +502,12 @@ impl ResponseRouter {
         let entries = state.pending.drain().collect::<Vec<_>>();
         for (request_id, _) in &entries {
             if state.failure_tracked.remove(request_id) {
-                state
-                    .failures
-                    .insert(*request_id, BridgeFailure::RequestTimeout);
+                let failure = if *request_id == id {
+                    BridgeFailure::RequestTimeout
+                } else {
+                    BridgeFailure::ConnectionLost
+                };
+                state.failures.insert(*request_id, failure);
             }
         }
         state.upstream_to_downstream.clear();
@@ -512,12 +515,17 @@ impl ResponseRouter {
         drop(state);
         self.terminal.notify_waiters();
         for (request_id, pending) in entries {
+            let (code, message) = if pending.delivery == RequestDelivery::CancelledQueued {
+                (-32800, "bridge: request cancelled before downstream write")
+            } else {
+                (-32603, "bridge: cancelled peer write timed out")
+            };
             let response = serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": request_id.as_i64(),
                 "error": {
-                    "code": -32603,
-                    "message": "bridge: cancelled peer write timed out"
+                    "code": code,
+                    "message": message
                 }
             });
             if pending.response_tx.send(response).is_err() {

--- a/src/lsp/bridge/actor/response_router.rs
+++ b/src/lsp/bridge/actor/response_router.rs
@@ -360,6 +360,17 @@ impl ResponseRouter {
         state.pending.len()
     }
 
+    #[cfg(test)]
+    pub(crate) fn pending_ids(&self) -> Vec<RequestId> {
+        self.state
+            .lock()
+            .recover_poison("ResponseRouter::pending_ids")
+            .pending
+            .keys()
+            .copied()
+            .collect()
+    }
+
     /// Requests that can still make downstream progress. Cancelled queued
     /// entries remain only until the FIFO writer discards them.
     pub(crate) fn awaiting_downstream_count(&self) -> usize {

--- a/src/lsp/bridge/actor/response_router.rs
+++ b/src/lsp/bridge/actor/response_router.rs
@@ -86,6 +86,7 @@ enum RequestDelivery {
     Writing,
     Sent,
     CancelledQueued,
+    CancelledSent,
 }
 
 pub(crate) enum LivenessExpiry {
@@ -279,7 +280,7 @@ impl ResponseRouter {
                     pending.delivery = RequestDelivery::CancelledQueued;
                 }
                 RequestDelivery::Writing | RequestDelivery::Sent => sent.push(id),
-                RequestDelivery::CancelledQueued => {}
+                RequestDelivery::CancelledQueued | RequestDelivery::CancelledSent => {}
             }
         }
         (true, sent)
@@ -301,7 +302,9 @@ impl ResponseRouter {
                 pending.delivery = RequestDelivery::Writing;
                 return true;
             }
-            RequestDelivery::Writing | RequestDelivery::Sent => return false,
+            RequestDelivery::Writing | RequestDelivery::Sent | RequestDelivery::CancelledSent => {
+                return false;
+            }
             RequestDelivery::CancelledQueued => {}
         }
 
@@ -443,17 +446,23 @@ impl ResponseRouter {
             .state
             .lock()
             .recover_poison("ResponseRouter::cancel_and_remove");
-        let should_notify = state.pending.get(&id).is_some_and(|pending| {
-            matches!(
-                pending.delivery,
-                RequestDelivery::Writing | RequestDelivery::Sent
-            )
-        });
-        state.pending.remove(&id);
-        state.failures.remove(&id);
-        state.failure_tracked.remove(&id);
-        Self::remove_cancel_mapping_inner(&mut state, id);
-        should_notify
+        let Some(pending) = state.pending.get_mut(&id) else {
+            return false;
+        };
+        match pending.delivery {
+            RequestDelivery::Queued | RequestDelivery::CancelledQueued => {
+                state.pending.remove(&id);
+                state.failures.remove(&id);
+                state.failure_tracked.remove(&id);
+                Self::remove_cancel_mapping_inner(&mut state, id);
+                false
+            }
+            RequestDelivery::Writing | RequestDelivery::Sent => {
+                pending.delivery = RequestDelivery::CancelledSent;
+                true
+            }
+            RequestDelivery::CancelledSent => false,
+        }
     }
 
     pub(crate) fn take_failure(&self, id: RequestId) -> Option<BridgeFailure> {
@@ -673,7 +682,8 @@ mod tests {
     #[test]
     fn new_router_has_no_pending_requests() {
         let router = ResponseRouter::new();
-        assert_eq!(router.pending_count(), 0);
+        assert_eq!(router.pending_count(), 1);
+        assert_eq!(router.awaiting_downstream_count(), 1);
     }
 
     #[test]
@@ -710,7 +720,8 @@ mod tests {
 
         assert!(!router.cancel_and_remove(queued));
         assert!(router.cancel_and_remove(writing));
-        assert_eq!(router.pending_count(), 0);
+        assert_eq!(router.pending_count(), 1);
+        assert_eq!(router.awaiting_downstream_count(), 1);
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/actor/response_router.rs
+++ b/src/lsp/bridge/actor/response_router.rs
@@ -89,6 +89,8 @@ pub(crate) enum LivenessExpiry {
     Failed { pending_count: usize },
 }
 
+const BRIDGE_FAILURE_DATA_KEY: &str = "kakehashiBridgeFailure";
+
 impl ResponseRouter {
     /// Create a new empty ResponseRouter.
     pub(crate) fn new() -> Self {
@@ -437,7 +439,8 @@ impl ResponseRouter {
                     "id": id.as_i64(),
                     "error": {
                         "code": -32803, // REQUEST_FAILED per LSP spec
-                        "message": format!("bridge: {}", reason)
+                        "message": format!("bridge: {}", reason),
+                        "data": { (BRIDGE_FAILURE_DATA_KEY): "connectionLost" }
                     }
                 });
                 let _ = pending.response_tx.send(error_response);
@@ -479,7 +482,8 @@ impl ResponseRouter {
                 "id": id.as_i64(),
                 "error": {
                     "code": code,
-                    "message": message
+                    "message": message,
+                    "data": { (BRIDGE_FAILURE_DATA_KEY): "connectionLost" }
                 }
             });
             let _ = pending.response_tx.send(error_response);
@@ -534,7 +538,8 @@ impl ResponseRouter {
                 "id": id.as_i64(),
                 "error": {
                     "code": code,
-                    "message": message
+                    "message": message,
+                    "data": { (BRIDGE_FAILURE_DATA_KEY): "requestTimeout" }
                 }
             });
             let _ = pending.response_tx.send(error_response);

--- a/src/lsp/bridge/actor/response_router.rs
+++ b/src/lsp/bridge/actor/response_router.rs
@@ -86,6 +86,7 @@ enum RequestDelivery {
     Writing,
     Sent,
     CancelledQueued,
+    CancelledWriting,
     CancelledSent,
 }
 
@@ -280,7 +281,9 @@ impl ResponseRouter {
                     pending.delivery = RequestDelivery::CancelledQueued;
                 }
                 RequestDelivery::Writing | RequestDelivery::Sent => sent.push(id),
-                RequestDelivery::CancelledQueued | RequestDelivery::CancelledSent => {}
+                RequestDelivery::CancelledQueued
+                | RequestDelivery::CancelledWriting
+                | RequestDelivery::CancelledSent => {}
             }
         }
         (true, sent)
@@ -302,7 +305,10 @@ impl ResponseRouter {
                 pending.delivery = RequestDelivery::Writing;
                 return true;
             }
-            RequestDelivery::Writing | RequestDelivery::Sent | RequestDelivery::CancelledSent => {
+            RequestDelivery::Writing
+            | RequestDelivery::Sent
+            | RequestDelivery::CancelledWriting
+            | RequestDelivery::CancelledSent => {
                 return false;
             }
             RequestDelivery::CancelledQueued => {}
@@ -331,10 +337,12 @@ impl ResponseRouter {
             .state
             .lock()
             .recover_poison("ResponseRouter::mark_sent");
-        if let Some(pending) = state.pending.get_mut(&id)
-            && pending.delivery == RequestDelivery::Writing
-        {
-            pending.delivery = RequestDelivery::Sent;
+        if let Some(pending) = state.pending.get_mut(&id) {
+            pending.delivery = match pending.delivery {
+                RequestDelivery::Writing => RequestDelivery::Sent,
+                RequestDelivery::CancelledWriting => RequestDelivery::CancelledSent,
+                delivery => delivery,
+            };
         }
     }
 
@@ -441,28 +449,39 @@ impl ResponseRouter {
 
     /// Retire a peer request on outer cancellation and report whether its
     /// downstream write had started, requiring an exact `$/cancelRequest`.
-    pub(crate) fn cancel_and_remove(&self, id: RequestId) -> bool {
+    pub(crate) fn cancel_peer(&self, id: RequestId) -> Option<bool> {
         let mut state = self
             .state
             .lock()
             .recover_poison("ResponseRouter::cancel_and_remove");
-        let Some(pending) = state.pending.get_mut(&id) else {
-            return false;
-        };
+        let pending = state.pending.get_mut(&id)?;
         match pending.delivery {
             RequestDelivery::Queued | RequestDelivery::CancelledQueued => {
                 state.pending.remove(&id);
                 state.failures.remove(&id);
                 state.failure_tracked.remove(&id);
                 Self::remove_cancel_mapping_inner(&mut state, id);
-                false
+                Some(false)
             }
-            RequestDelivery::Writing | RequestDelivery::Sent => {
+            RequestDelivery::Writing => {
+                pending.delivery = RequestDelivery::CancelledWriting;
+                Some(true)
+            }
+            RequestDelivery::Sent => {
                 pending.delivery = RequestDelivery::CancelledSent;
-                true
+                Some(true)
             }
-            RequestDelivery::CancelledSent => false,
+            RequestDelivery::CancelledWriting | RequestDelivery::CancelledSent => Some(false),
         }
+    }
+
+    pub(crate) fn peer_cancel_is_writing(&self, id: RequestId) -> bool {
+        self.state
+            .lock()
+            .recover_poison("ResponseRouter::peer_cancel_is_writing")
+            .pending
+            .get(&id)
+            .is_some_and(|pending| pending.delivery == RequestDelivery::CancelledWriting)
     }
 
     pub(crate) fn take_failure(&self, id: RequestId) -> Option<BridgeFailure> {
@@ -718,8 +737,8 @@ mod tests {
         let _writing_rx = router.register(writing).unwrap();
         assert!(router.claim_for_write(writing));
 
-        assert!(!router.cancel_and_remove(queued));
-        assert!(router.cancel_and_remove(writing));
+        assert_eq!(router.cancel_peer(queued), Some(false));
+        assert_eq!(router.cancel_peer(writing), Some(true));
         assert_eq!(router.pending_count(), 1);
         assert_eq!(router.awaiting_downstream_count(), 1);
     }

--- a/src/lsp/bridge/actor/response_router.rs
+++ b/src/lsp/bridge/actor/response_router.rs
@@ -77,6 +77,9 @@ struct ResponseRouterState {
 
 struct PendingRequest {
     response_tx: oneshot::Sender<serde_json::Value>,
+    /// Peer cancellation cleanup waits for this sender to be dropped when the
+    /// router entry settles, without retaining the response receiver itself.
+    _settled_tx: Option<oneshot::Sender<()>>,
     delivery: RequestDelivery,
 }
 
@@ -150,14 +153,20 @@ impl ResponseRouter {
         downstream_id: RequestId,
         upstream_id: Option<UpstreamId>,
     ) -> Option<(oneshot::Receiver<serde_json::Value>, Option<u64>)> {
-        self.register_with_upstream_liveness_mode(downstream_id, upstream_id, false)
+        self.register_with_upstream_liveness_mode(downstream_id, upstream_id, false, None)
     }
 
     pub(crate) fn register_peer(
         &self,
         downstream_id: RequestId,
-    ) -> Option<(oneshot::Receiver<serde_json::Value>, Option<u64>)> {
-        self.register_with_upstream_liveness_mode(downstream_id, None, true)
+    ) -> Option<(
+        oneshot::Receiver<serde_json::Value>,
+        Option<u64>,
+        oneshot::Receiver<()>,
+    )> {
+        let (settled_tx, settled_rx) = oneshot::channel();
+        self.register_with_upstream_liveness_mode(downstream_id, None, true, Some(settled_tx))
+            .map(|(response_rx, epoch)| (response_rx, epoch, settled_rx))
     }
 
     fn register_with_upstream_liveness_mode(
@@ -165,6 +174,7 @@ impl ResponseRouter {
         downstream_id: RequestId,
         upstream_id: Option<UpstreamId>,
         track_failure: bool,
+        settled_tx: Option<oneshot::Sender<()>>,
     ) -> Option<(oneshot::Receiver<serde_json::Value>, Option<u64>)> {
         let (tx, rx) = oneshot::channel();
         let mut state = self
@@ -189,6 +199,7 @@ impl ResponseRouter {
             downstream_id,
             PendingRequest {
                 response_tx: tx,
+                _settled_tx: settled_tx,
                 delivery: RequestDelivery::Queued,
             },
         );
@@ -1040,7 +1051,7 @@ mod tests {
         let (_older_rx, epoch) = router
             .register_with_upstream_liveness(RequestId::new(1), None)
             .unwrap();
-        let (_peer_rx, peer_epoch) = router.register_peer(RequestId::new(2)).unwrap();
+        let (_peer_rx, peer_epoch, _settled_rx) = router.register_peer(RequestId::new(2)).unwrap();
         assert_eq!(
             peer_epoch, None,
             "the older request owns the liveness timer"

--- a/src/lsp/bridge/actor/response_router.rs
+++ b/src/lsp/bridge/actor/response_router.rs
@@ -682,8 +682,8 @@ mod tests {
     #[test]
     fn new_router_has_no_pending_requests() {
         let router = ResponseRouter::new();
-        assert_eq!(router.pending_count(), 1);
-        assert_eq!(router.awaiting_downstream_count(), 1);
+        assert_eq!(router.pending_count(), 0);
+        assert_eq!(router.awaiting_downstream_count(), 0);
     }
 
     #[test]

--- a/src/lsp/bridge/actor/response_router.rs
+++ b/src/lsp/bridge/actor/response_router.rs
@@ -4,7 +4,7 @@
 //! oneshot channels (ls-bridge-message-ordering). A requester registers before sending, then awaits
 //! the receiver without holding any Mutex; the Reader Task calls `route()` on arrival.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use tokio::sync::oneshot;
@@ -49,6 +49,11 @@ struct ResponseRouterState {
     liveness_epoch: u64,
     /// Pending requests waiting for responses.
     pending: HashMap<RequestId, PendingRequest>,
+    /// Out-of-band provenance for responses synthesized by bridge failures.
+    failures: HashMap<RequestId, BridgeFailure>,
+    /// Requests whose callers distinguish bridge transport failure from a
+    /// genuine downstream JSON-RPC error.
+    failure_tracked: HashSet<RequestId>,
     /// Maps upstream request ID (from client) to downstream request IDs (to LS).
     ///
     /// Used for $/cancelRequest forwarding: when the client cancels request 42,
@@ -89,7 +94,11 @@ pub(crate) enum LivenessExpiry {
     Failed { pending_count: usize },
 }
 
-const BRIDGE_FAILURE_DATA_KEY: &str = "kakehashiBridgeFailure";
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BridgeFailure {
+    ConnectionLost,
+    RequestTimeout,
+}
 
 impl ResponseRouter {
     /// Create a new empty ResponseRouter.
@@ -99,6 +108,8 @@ impl ResponseRouter {
                 accepting: true,
                 liveness_epoch: 0,
                 pending: HashMap::new(),
+                failures: HashMap::new(),
+                failure_tracked: HashSet::new(),
                 upstream_to_downstream: HashMap::new(),
                 downstream_to_upstream: HashMap::new(),
             }),
@@ -276,6 +287,7 @@ impl ResponseRouter {
         }
 
         let pending = state.pending.remove(&id);
+        state.failure_tracked.remove(&id);
         Self::remove_cancel_mapping_inner(&mut state, id);
         drop(state);
         if let Some(pending) = pending {
@@ -314,6 +326,7 @@ impl ResponseRouter {
 
         let mut state = self.state.lock().recover_poison("ResponseRouter::route");
         let pending = state.pending.remove(&id);
+        state.failure_tracked.remove(&id);
 
         // Clean up bidirectional cancel map entries in O(1)
         Self::remove_cancel_mapping_inner(&mut state, id);
@@ -394,6 +407,8 @@ impl ResponseRouter {
     pub(crate) fn remove(&self, id: RequestId) -> bool {
         let mut state = self.state.lock().recover_poison("ResponseRouter::remove");
         let removed = state.pending.remove(&id).is_some();
+        state.failures.remove(&id);
+        state.failure_tracked.remove(&id);
 
         if removed {
             Self::remove_cancel_mapping_inner(&mut state, id);
@@ -416,8 +431,27 @@ impl ResponseRouter {
             )
         });
         state.pending.remove(&id);
+        state.failures.remove(&id);
+        state.failure_tracked.remove(&id);
         Self::remove_cancel_mapping_inner(&mut state, id);
         should_notify
+    }
+
+    pub(crate) fn take_failure(&self, id: RequestId) -> Option<BridgeFailure> {
+        let mut state = self
+            .state
+            .lock()
+            .recover_poison("ResponseRouter::take_failure");
+        state.failure_tracked.remove(&id);
+        state.failures.remove(&id)
+    }
+
+    pub(crate) fn track_failure(&self, id: RequestId) {
+        self.state
+            .lock()
+            .recover_poison("ResponseRouter::track_failure")
+            .failure_tracked
+            .insert(id);
     }
 
     /// Fail a single pending request with an error response.
@@ -450,11 +484,25 @@ impl ResponseRouter {
                     "id": id.as_i64(),
                     "error": {
                         "code": -32803, // REQUEST_FAILED per LSP spec
-                        "message": format!("bridge: {}", reason),
-                        "data": { (BRIDGE_FAILURE_DATA_KEY): "connectionLost" }
+                        "message": format!("bridge: {}", reason)
                     }
                 });
-                let _ = pending.response_tx.send(error_response);
+                let tracked = self
+                    .state
+                    .lock()
+                    .recover_poison("ResponseRouter::fail_request provenance")
+                    .failure_tracked
+                    .contains(&id);
+                if tracked {
+                    self.state
+                        .lock()
+                        .recover_poison("ResponseRouter::fail_request provenance")
+                        .failures
+                        .insert(id, BridgeFailure::ConnectionLost);
+                }
+                if pending.response_tx.send(error_response).is_err() {
+                    self.take_failure(id);
+                }
                 true
             }
             None => false,
@@ -493,11 +541,20 @@ impl ResponseRouter {
                 "id": id.as_i64(),
                 "error": {
                     "code": code,
-                    "message": message,
-                    "data": { (BRIDGE_FAILURE_DATA_KEY): "connectionLost" }
+                    "message": message
                 }
             });
-            let _ = pending.response_tx.send(error_response);
+            let mut state = self
+                .state
+                .lock()
+                .recover_poison("ResponseRouter::fail_all provenance");
+            if state.failure_tracked.contains(&id) {
+                state.failures.insert(id, BridgeFailure::ConnectionLost);
+            }
+            drop(state);
+            if pending.response_tx.send(error_response).is_err() {
+                self.take_failure(id);
+            }
         }
     }
 
@@ -549,11 +606,20 @@ impl ResponseRouter {
                 "id": id.as_i64(),
                 "error": {
                     "code": code,
-                    "message": message,
-                    "data": { (BRIDGE_FAILURE_DATA_KEY): "requestTimeout" }
+                    "message": message
                 }
             });
-            let _ = pending.response_tx.send(error_response);
+            let mut state = self
+                .state
+                .lock()
+                .recover_poison("ResponseRouter::liveness provenance");
+            if state.failure_tracked.contains(&id) {
+                state.failures.insert(id, BridgeFailure::RequestTimeout);
+            }
+            drop(state);
+            if pending.response_tx.send(error_response).is_err() {
+                self.take_failure(id);
+            }
         }
         LivenessExpiry::Failed {
             pending_count: awaiting,

--- a/src/lsp/bridge/actor/response_router.rs
+++ b/src/lsp/bridge/actor/response_router.rs
@@ -528,8 +528,10 @@ impl ResponseRouter {
         for (request_id, pending) in entries {
             let (code, message) = if pending.delivery == RequestDelivery::CancelledQueued {
                 (-32800, "bridge: request cancelled before downstream write")
-            } else {
+            } else if request_id == id {
                 (-32603, "bridge: cancelled peer write timed out")
+            } else {
+                (-32603, "bridge: connection failed after peer write timeout")
             };
             let response = serde_json::json!({
                 "jsonrpc": "2.0",
@@ -1065,6 +1067,29 @@ mod tests {
             router.take_failure(RequestId::new(2)),
             Some(BridgeFailure::ConnectionLost),
             "a later peer request is a victim of connection-wide liveness failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn peer_write_expiry_distinguishes_connection_failure_victims() {
+        let router = ResponseRouter::new();
+        let peer_id = RequestId::new(1);
+        let (peer_rx, _epoch, _settled_rx) = router.register_peer(peer_id).unwrap();
+        assert!(router.claim_for_write(peer_id));
+        assert_eq!(router.cancel_peer(peer_id), Some(true));
+        let victim_id = RequestId::new(2);
+        let victim_rx = router.register(victim_id).unwrap();
+
+        assert!(router.expire_peer_cancel(peer_id));
+        let peer_error = peer_rx.await.unwrap();
+        let victim_error = victim_rx.await.unwrap();
+        assert_eq!(
+            peer_error["error"]["message"],
+            "bridge: cancelled peer write timed out"
+        );
+        assert_eq!(
+            victim_error["error"]["message"],
+            "bridge: connection failed after peer write timeout"
         );
     }
 

--- a/src/lsp/bridge/actor/response_router.rs
+++ b/src/lsp/bridge/actor/response_router.rs
@@ -148,6 +148,22 @@ impl ResponseRouter {
         downstream_id: RequestId,
         upstream_id: Option<UpstreamId>,
     ) -> Option<(oneshot::Receiver<serde_json::Value>, Option<u64>)> {
+        self.register_with_upstream_liveness_mode(downstream_id, upstream_id, false)
+    }
+
+    pub(crate) fn register_peer(
+        &self,
+        downstream_id: RequestId,
+    ) -> Option<(oneshot::Receiver<serde_json::Value>, Option<u64>)> {
+        self.register_with_upstream_liveness_mode(downstream_id, None, true)
+    }
+
+    fn register_with_upstream_liveness_mode(
+        &self,
+        downstream_id: RequestId,
+        upstream_id: Option<UpstreamId>,
+        track_failure: bool,
+    ) -> Option<(oneshot::Receiver<serde_json::Value>, Option<u64>)> {
         let (tx, rx) = oneshot::channel();
         let mut state = self
             .state
@@ -174,6 +190,9 @@ impl ResponseRouter {
                 delivery: RequestDelivery::Queued,
             },
         );
+        if track_failure {
+            state.failure_tracked.insert(downstream_id);
+        }
 
         // Store bidirectional mapping if upstream_id is provided. Appending
         // (not inserting) keeps every concurrent downstream request for this
@@ -446,14 +465,6 @@ impl ResponseRouter {
         state.failures.remove(&id)
     }
 
-    pub(crate) fn track_failure(&self, id: RequestId) {
-        self.state
-            .lock()
-            .recover_poison("ResponseRouter::track_failure")
-            .failure_tracked
-            .insert(id);
-    }
-
     /// Fail a single pending request with an error response.
     ///
     /// Called when a write fails or the connection is closing (ls-bridge-message-ordering). Uses
@@ -470,6 +481,10 @@ impl ResponseRouter {
             .recover_poison("ResponseRouter::fail_request");
 
         let pending = state.pending.remove(&id);
+        let tracked = state.failure_tracked.remove(&id);
+        if tracked {
+            state.failures.insert(id, BridgeFailure::ConnectionLost);
+        }
 
         // Clean up bidirectional cancel map entries in O(1)
         Self::remove_cancel_mapping_inner(&mut state, id);
@@ -487,19 +502,6 @@ impl ResponseRouter {
                         "message": format!("bridge: {}", reason)
                     }
                 });
-                let tracked = self
-                    .state
-                    .lock()
-                    .recover_poison("ResponseRouter::fail_request provenance")
-                    .failure_tracked
-                    .contains(&id);
-                if tracked {
-                    self.state
-                        .lock()
-                        .recover_poison("ResponseRouter::fail_request provenance")
-                        .failures
-                        .insert(id, BridgeFailure::ConnectionLost);
-                }
                 if pending.response_tx.send(error_response).is_err() {
                     self.take_failure(id);
                 }
@@ -521,6 +523,11 @@ impl ResponseRouter {
         let mut state = self.state.lock().recover_poison("ResponseRouter::fail_all");
         state.accepting = false;
         let entries: Vec<_> = state.pending.drain().collect();
+        for (id, _) in &entries {
+            if state.failure_tracked.remove(id) {
+                state.failures.insert(*id, BridgeFailure::ConnectionLost);
+            }
+        }
 
         // Clear both cancel map directions
         state.upstream_to_downstream.clear();
@@ -544,14 +551,6 @@ impl ResponseRouter {
                     "message": message
                 }
             });
-            let mut state = self
-                .state
-                .lock()
-                .recover_poison("ResponseRouter::fail_all provenance");
-            if state.failure_tracked.contains(&id) {
-                state.failures.insert(id, BridgeFailure::ConnectionLost);
-            }
-            drop(state);
             if pending.response_tx.send(error_response).is_err() {
                 self.take_failure(id);
             }
@@ -589,6 +588,11 @@ impl ResponseRouter {
         // Publish the connection failure before waking any drained waiter.
         state.accepting = false;
         let entries: Vec<_> = state.pending.drain().collect();
+        for (id, _) in &entries {
+            if state.failure_tracked.remove(id) {
+                state.failures.insert(*id, BridgeFailure::RequestTimeout);
+            }
+        }
         state.upstream_to_downstream.clear();
         state.downstream_to_upstream.clear();
         drop(state);
@@ -609,14 +613,6 @@ impl ResponseRouter {
                     "message": message
                 }
             });
-            let mut state = self
-                .state
-                .lock()
-                .recover_poison("ResponseRouter::liveness provenance");
-            if state.failure_tracked.contains(&id) {
-                state.failures.insert(id, BridgeFailure::RequestTimeout);
-            }
-            drop(state);
             if pending.response_tx.send(error_response).is_err() {
                 self.take_failure(id);
             }

--- a/src/lsp/bridge/actor/response_router.rs
+++ b/src/lsp/bridge/actor/response_router.rs
@@ -389,6 +389,24 @@ impl ResponseRouter {
         removed
     }
 
+    /// Retire a peer request on outer cancellation and report whether its
+    /// downstream write had started, requiring an exact `$/cancelRequest`.
+    pub(crate) fn cancel_and_remove(&self, id: RequestId) -> bool {
+        let mut state = self
+            .state
+            .lock()
+            .recover_poison("ResponseRouter::cancel_and_remove");
+        let should_notify = state.pending.get(&id).is_some_and(|pending| {
+            matches!(
+                pending.delivery,
+                RequestDelivery::Writing | RequestDelivery::Sent
+            )
+        });
+        state.pending.remove(&id);
+        Self::remove_cancel_mapping_inner(&mut state, id);
+        should_notify
+    }
+
     /// Fail a single pending request with an error response.
     ///
     /// Called when a write fails or the connection is closing (ls-bridge-message-ordering). Uses
@@ -601,6 +619,20 @@ mod tests {
         let rx2 = router.register(id);
         assert!(rx2.is_none(), "duplicate ID should return None");
         assert_eq!(router.pending_count(), 1, "count should not increase");
+    }
+
+    #[test]
+    fn cancel_and_remove_notifies_only_after_downstream_write_starts() {
+        let router = ResponseRouter::new();
+        let queued = RequestId::new(1);
+        let writing = RequestId::new(2);
+        let _queued_rx = router.register(queued).unwrap();
+        let _writing_rx = router.register(writing).unwrap();
+        assert!(router.claim_for_write(writing));
+
+        assert!(!router.cancel_and_remove(queued));
+        assert!(router.cancel_and_remove(writing));
+        assert_eq!(router.pending_count(), 0);
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/actor/response_router.rs
+++ b/src/lsp/bridge/actor/response_router.rs
@@ -669,7 +669,7 @@ impl ResponseRouter {
         let entries: Vec<_> = state.pending.drain().collect();
         for (id, _) in &entries {
             if state.failure_tracked.remove(id) {
-                state.failures.insert(*id, BridgeFailure::RequestTimeout);
+                state.failures.insert(*id, BridgeFailure::ConnectionLost);
             }
         }
         state.upstream_to_downstream.clear();
@@ -1031,6 +1031,29 @@ mod tests {
         assert!(
             router.register(RequestId::new(2)).is_none(),
             "a terminal router must reject new requests"
+        );
+    }
+
+    #[test]
+    fn connection_liveness_expiry_is_not_a_peer_request_deadline() {
+        let router = ResponseRouter::new();
+        let (_older_rx, epoch) = router
+            .register_with_upstream_liveness(RequestId::new(1), None)
+            .unwrap();
+        let (_peer_rx, peer_epoch) = router.register_peer(RequestId::new(2)).unwrap();
+        assert_eq!(
+            peer_epoch, None,
+            "the older request owns the liveness timer"
+        );
+
+        assert!(matches!(
+            router.fail_all_if_awaiting_downstream(epoch.unwrap(), "expired", || {}),
+            LivenessExpiry::Failed { pending_count: 2 }
+        ));
+        assert_eq!(
+            router.take_failure(RequestId::new(2)),
+            Some(BridgeFailure::ConnectionLost),
+            "a later peer request is a victim of connection-wide liveness failure"
         );
     }
 

--- a/src/lsp/bridge/actor/response_router.rs
+++ b/src/lsp/bridge/actor/response_router.rs
@@ -475,13 +475,56 @@ impl ResponseRouter {
         }
     }
 
-    pub(crate) fn peer_cancel_is_writing(&self, id: RequestId) -> bool {
-        self.state
+    /// Expire one cancelled peer request at its original deadline.
+    ///
+    /// Returns true only when its write is still blocked. In that case request
+    /// admission is closed and every waiter is failed under the same lock, so a
+    /// concurrent write completion/response cannot turn a healthy connection
+    /// failure into a false positive.
+    pub(crate) fn expire_peer_cancel(&self, id: RequestId) -> bool {
+        let mut state = self
+            .state
             .lock()
-            .recover_poison("ResponseRouter::peer_cancel_is_writing")
-            .pending
-            .get(&id)
-            .is_some_and(|pending| pending.delivery == RequestDelivery::CancelledWriting)
+            .recover_poison("ResponseRouter::expire_peer_cancel");
+        match state.pending.get(&id).map(|pending| pending.delivery) {
+            Some(RequestDelivery::CancelledWriting) => {}
+            Some(RequestDelivery::CancelledSent) => {
+                state.pending.remove(&id);
+                state.failure_tracked.remove(&id);
+                state.failures.remove(&id);
+                Self::remove_cancel_mapping_inner(&mut state, id);
+                return false;
+            }
+            _ => return false,
+        }
+
+        state.accepting = false;
+        let entries = state.pending.drain().collect::<Vec<_>>();
+        for (request_id, _) in &entries {
+            if state.failure_tracked.remove(request_id) {
+                state
+                    .failures
+                    .insert(*request_id, BridgeFailure::RequestTimeout);
+            }
+        }
+        state.upstream_to_downstream.clear();
+        state.downstream_to_upstream.clear();
+        drop(state);
+        self.terminal.notify_waiters();
+        for (request_id, pending) in entries {
+            let response = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": request_id.as_i64(),
+                "error": {
+                    "code": -32603,
+                    "message": "bridge: cancelled peer write timed out"
+                }
+            });
+            if pending.response_tx.send(response).is_err() {
+                self.take_failure(request_id);
+            }
+        }
+        true
     }
 
     pub(crate) fn take_failure(&self, id: RequestId) -> Option<BridgeFailure> {

--- a/src/lsp/bridge/inbound_request_registry.rs
+++ b/src/lsp/bridge/inbound_request_registry.rs
@@ -1,22 +1,22 @@
-//! Cancellation registry for downstream-initiated requests forwarded to the
-//! editor (`window/showMessageRequest`, `window/showDocument`,
-//! `workspace/applyEdit` — which is registered but answered locally, never
-//! editor-bound, when the editor lacks the capability).
+//! Cancellation registry for downstream-initiated requests forwarded either to
+//! the editor (`window/showMessageRequest`, `window/showDocument`, and
+//! `workspace/applyEdit`) or to another downstream peer.
 //!
 //! When a downstream server sends `$/cancelRequest` for such a request — or its
-//! connection dies while one is in flight — the bridge must tell the editor to
-//! cancel so a `showMessageRequest` dialog is dismissed. tower-lsp's `Client`
+//! connection dies while one is in flight — the bridge must cancel the matching
+//! forwarding operation. For editor-bound requests, tower-lsp's `Client`
 //! exposes no cancel API for an outgoing request, so the forwarding loop instead
 //! sends the request with an id it minted (see `send_editor_request`) and, on
-//! cancel, sends a correlated `$/cancelRequest` to the editor. (A locally
+//! cancel, sends a correlated `$/cancelRequest` to the editor. Peer forwarding
+//! similarly retires its target router entry and cancels a write that started. (A locally
 //! answered request — the capability-gated applyEdit — is unregistered before
 //! its token is ever awaited, so cancellation has nothing to do there.)
 //!
 //! This registry connects the two halves: the per-connection reader (which sees
 //! the downstream `$/cancelRequest` and the connection lifecycle) registers each
-//! in-flight forwarded request and fires its [`CancellationToken`]; the global
-//! forwarding loop awaits that token. Keyed by `(connection, downstream request
-//! id)`.
+//! in-flight forwarded request and fires its [`CancellationToken`]; the relevant
+//! editor or peer forwarding task awaits that token. Keyed by `(connection,
+//! downstream request id)`.
 //!
 //! Registration happens on the reader **before** the request is enqueued, so a
 //! `$/cancelRequest` that races in immediately after can't miss it. The token is

--- a/src/lsp/bridge/inbound_request_registry.rs
+++ b/src/lsp/bridge/inbound_request_registry.rs
@@ -129,9 +129,8 @@ impl InboundRequestRegistry {
         }
     }
 
-    /// Cancel and drop every in-flight request for a connection — used when a
-    /// downstream connection's reader exits, so its forwarded requests don't
-    /// linger as open editor dialogs.
+    /// Cancel and drop every in-flight request for a connection when its reader
+    /// exits, dismissing editor interactions and retiring peer forwarding.
     pub(crate) fn cancel_connection(&self, connection_id: ProgressConnectionId) {
         if let Some(requests) = self
             .inner

--- a/src/lsp/bridge/inbound_request_registry.rs
+++ b/src/lsp/bridge/inbound_request_registry.rs
@@ -41,13 +41,28 @@ use crate::error::LockResultExt;
 struct Entry {
     generation: u64,
     token: CancellationToken,
-    kind: EntryKind,
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
-enum EntryKind {
-    Editor,
-    Peer,
+/// Per-generation capacity held until target router state and cleanup work are
+/// both gone. It is deliberately independent of the outer request-id registry:
+/// cancellation settles the outer request before a written target request can
+/// be safely retired.
+pub(crate) struct PeerRequestPermit {
+    counts: Arc<Mutex<HashMap<ProgressConnectionId, usize>>>,
+    connection_id: ProgressConnectionId,
+}
+
+impl Drop for PeerRequestPermit {
+    fn drop(&mut self) {
+        let mut counts = self.counts.lock().recover_poison("PeerRequestPermit::drop");
+        let Some(count) = counts.get_mut(&self.connection_id) else {
+            return;
+        };
+        *count -= 1;
+        if *count == 0 {
+            counts.remove(&self.connection_id);
+        }
+    }
 }
 
 pub(crate) const MAX_IN_FLIGHT_PEER_REQUESTS_PER_CONNECTION: usize = 64;
@@ -60,6 +75,7 @@ pub(crate) const MAX_IN_FLIGHT_PEER_REQUESTS_PER_CONNECTION: usize = 64;
 pub(crate) struct InboundRequestRegistry {
     inner: Arc<Mutex<HashMap<ProgressConnectionId, HashMap<jsonrpc::Id, Entry>>>>,
     next_generation: Arc<AtomicU64>,
+    peer_request_counts: Arc<Mutex<HashMap<ProgressConnectionId, usize>>>,
 }
 
 impl InboundRequestRegistry {
@@ -72,8 +88,7 @@ impl InboundRequestRegistry {
         connection_id: ProgressConnectionId,
         request_id: jsonrpc::Id,
     ) -> (CancellationToken, u64) {
-        self.register_kind(connection_id, request_id, EntryKind::Editor)
-            .expect("editor forwarding is not subject to the peer request limit")
+        self.register_inner(connection_id, request_id)
     }
 
     /// Register peer forwarding while bounding the tasks and router state a
@@ -82,44 +97,51 @@ impl InboundRequestRegistry {
         &self,
         connection_id: ProgressConnectionId,
         request_id: jsonrpc::Id,
-    ) -> Option<(CancellationToken, u64)> {
-        self.register_kind(connection_id, request_id, EntryKind::Peer)
+    ) -> Option<(CancellationToken, u64, PeerRequestPermit)> {
+        let permit = self.try_acquire_peer_permit(connection_id)?;
+        let (token, generation) = self.register_inner(connection_id, request_id);
+        Some((token, generation, permit))
     }
 
-    fn register_kind(
+    fn try_acquire_peer_permit(
+        &self,
+        connection_id: ProgressConnectionId,
+    ) -> Option<PeerRequestPermit> {
+        let mut counts = self
+            .peer_request_counts
+            .lock()
+            .recover_poison("InboundRequestRegistry::try_acquire_peer_permit");
+        let count = counts.entry(connection_id).or_default();
+        if *count >= MAX_IN_FLIGHT_PEER_REQUESTS_PER_CONNECTION {
+            return None;
+        }
+        *count += 1;
+        Some(PeerRequestPermit {
+            counts: self.peer_request_counts.clone(),
+            connection_id,
+        })
+    }
+
+    fn register_inner(
         &self,
         connection_id: ProgressConnectionId,
         request_id: jsonrpc::Id,
-        kind: EntryKind,
-    ) -> Option<(CancellationToken, u64)> {
+    ) -> (CancellationToken, u64) {
         let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
         let token = CancellationToken::new();
-        let mut inner = self
+        let replaced = self
             .inner
             .lock()
-            .recover_poison("InboundRequestRegistry::register_kind");
-        let requests = inner.entry(connection_id).or_default();
-        let replaces_peer = requests
-            .get(&request_id)
-            .is_some_and(|entry| entry.kind == EntryKind::Peer);
-        if kind == EntryKind::Peer
-            && !replaces_peer
-            && requests
-                .values()
-                .filter(|entry| entry.kind == EntryKind::Peer)
-                .count()
-                >= MAX_IN_FLIGHT_PEER_REQUESTS_PER_CONNECTION
-        {
-            return None;
-        }
-        let replaced = requests.insert(
-            request_id,
-            Entry {
-                generation,
-                token: token.clone(),
-                kind,
-            },
-        );
+            .recover_poison("InboundRequestRegistry::register_inner")
+            .entry(connection_id)
+            .or_default()
+            .insert(
+                request_id,
+                Entry {
+                    generation,
+                    token: token.clone(),
+                },
+            );
         // A well-behaved downstream never reuses a request id while one is in
         // flight, but if it does, cancel the orphaned forwarding operation so
         // it does not dangle unreachable (including any editor dialog). The orphan's
@@ -127,7 +149,7 @@ impl InboundRequestRegistry {
         if let Some(old) = replaced {
             old.token.cancel();
         }
-        Some((token, generation))
+        (token, generation)
     }
 
     /// Cancel a specific in-flight request (a downstream `$/cancelRequest`). The
@@ -304,8 +326,35 @@ mod tests {
         assert!(
             registry
                 .try_register_peer(conn(1), jsonrpc::Id::Number(1000))
+                .is_none(),
+            "outer settlement alone does not release target-side capacity"
+        );
+        registrations.remove(0);
+        assert!(
+            registry
+                .try_register_peer(conn(1), jsonrpc::Id::Number(1000))
                 .is_some(),
             "settlement releases capacity"
         );
+    }
+
+    #[test]
+    fn reused_outer_id_counts_each_live_peer_generation() {
+        let registry = InboundRequestRegistry::default();
+        let mut registrations = Vec::new();
+        for _ in 0..MAX_IN_FLIGHT_PEER_REQUESTS_PER_CONNECTION {
+            registrations.push(
+                registry
+                    .try_register_peer(conn(1), jsonrpc::Id::Number(7))
+                    .expect("each generation owns independent capacity"),
+            );
+        }
+        assert!(
+            registry
+                .try_register_peer(conn(1), jsonrpc::Id::Number(7))
+                .is_none(),
+            "reusing one outer id cannot bypass the generation limit"
+        );
+        drop(registrations);
     }
 }

--- a/src/lsp/bridge/inbound_request_registry.rs
+++ b/src/lsp/bridge/inbound_request_registry.rs
@@ -41,7 +41,16 @@ use crate::error::LockResultExt;
 struct Entry {
     generation: u64,
     token: CancellationToken,
+    kind: EntryKind,
 }
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum EntryKind {
+    Editor,
+    Peer,
+}
+
+pub(crate) const MAX_IN_FLIGHT_PEER_REQUESTS_PER_CONNECTION: usize = 64;
 
 /// Shared (cheaply cloneable) registry of in-flight forwarded requests. Nested
 /// `connection → (request id → entry)` so per-id lookups don't clone the id and
@@ -63,21 +72,54 @@ impl InboundRequestRegistry {
         connection_id: ProgressConnectionId,
         request_id: jsonrpc::Id,
     ) -> (CancellationToken, u64) {
+        self.register_kind(connection_id, request_id, EntryKind::Editor)
+            .expect("editor forwarding is not subject to the peer request limit")
+    }
+
+    /// Register peer forwarding while bounding the tasks and router state a
+    /// single downstream connection can keep alive without responses.
+    pub(crate) fn try_register_peer(
+        &self,
+        connection_id: ProgressConnectionId,
+        request_id: jsonrpc::Id,
+    ) -> Option<(CancellationToken, u64)> {
+        self.register_kind(connection_id, request_id, EntryKind::Peer)
+    }
+
+    fn register_kind(
+        &self,
+        connection_id: ProgressConnectionId,
+        request_id: jsonrpc::Id,
+        kind: EntryKind,
+    ) -> Option<(CancellationToken, u64)> {
         let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
         let token = CancellationToken::new();
-        let replaced = self
+        let mut inner = self
             .inner
             .lock()
-            .recover_poison("InboundRequestRegistry::register")
-            .entry(connection_id)
-            .or_default()
-            .insert(
-                request_id,
-                Entry {
-                    generation,
-                    token: token.clone(),
-                },
-            );
+            .recover_poison("InboundRequestRegistry::register_kind");
+        let requests = inner.entry(connection_id).or_default();
+        let replaces_peer = requests
+            .get(&request_id)
+            .is_some_and(|entry| entry.kind == EntryKind::Peer);
+        if kind == EntryKind::Peer
+            && !replaces_peer
+            && requests
+                .values()
+                .filter(|entry| entry.kind == EntryKind::Peer)
+                .count()
+                >= MAX_IN_FLIGHT_PEER_REQUESTS_PER_CONNECTION
+        {
+            return None;
+        }
+        let replaced = requests.insert(
+            request_id,
+            Entry {
+                generation,
+                token: token.clone(),
+                kind,
+            },
+        );
         // A well-behaved downstream never reuses a request id while one is in
         // flight, but if it does, cancel the orphaned forwarding operation so
         // it does not dangle unreachable (including any editor dialog). The orphan's
@@ -85,7 +127,7 @@ impl InboundRequestRegistry {
         if let Some(old) = replaced {
             old.token.cancel();
         }
-        (token, generation)
+        Some((token, generation))
     }
 
     /// Cancel a specific in-flight request (a downstream `$/cancelRequest`). The
@@ -232,5 +274,38 @@ mod tests {
         assert!(a.is_cancelled());
         assert!(b.is_cancelled());
         assert!(!other.is_cancelled());
+    }
+
+    #[test]
+    fn peer_forwarding_is_bounded_per_origin_connection() {
+        let registry = InboundRequestRegistry::default();
+        let mut registrations = Vec::new();
+        for n in 0..MAX_IN_FLIGHT_PEER_REQUESTS_PER_CONNECTION {
+            registrations.push(
+                registry
+                    .try_register_peer(conn(1), jsonrpc::Id::Number(n as i64))
+                    .expect("requests up to the limit are admitted"),
+            );
+        }
+        assert!(
+            registry
+                .try_register_peer(conn(1), jsonrpc::Id::Number(1000))
+                .is_none(),
+            "one origin cannot grow peer forwarding state past the limit"
+        );
+        assert!(
+            registry
+                .try_register_peer(conn(2), jsonrpc::Id::Number(1000))
+                .is_some(),
+            "a different origin has its own allowance"
+        );
+
+        registry.unregister(conn(1), &jsonrpc::Id::Number(0), registrations[0].1);
+        assert!(
+            registry
+                .try_register_peer(conn(1), jsonrpc::Id::Number(1000))
+                .is_some(),
+            "settlement releases capacity"
+        );
     }
 }

--- a/src/lsp/bridge/inbound_request_registry.rs
+++ b/src/lsp/bridge/inbound_request_registry.rs
@@ -8,8 +8,9 @@
 //! exposes no cancel API for an outgoing request, so the forwarding loop instead
 //! sends the request with an id it minted (see `send_editor_request`) and, on
 //! cancel, sends a correlated `$/cancelRequest` to the editor. Peer forwarding
-//! similarly retires its target router entry and cancels a write that started. (A locally
-//! answered request — the capability-gated applyEdit — is unregistered before
+//! similarly retires its target router entry and requests downstream
+//! cancellation when writing has started. (A locally answered request — the
+//! capability-gated applyEdit — is unregistered before
 //! its token is ever awaited, so cancellation has nothing to do there.)
 //!
 //! This registry connects the two halves: the per-connection reader (which sees

--- a/src/lsp/bridge/inbound_request_registry.rs
+++ b/src/lsp/bridge/inbound_request_registry.rs
@@ -78,8 +78,8 @@ impl InboundRequestRegistry {
                 },
             );
         // A well-behaved downstream never reuses a request id while one is in
-        // flight, but if it does, cancel the orphaned request so its forwarded
-        // editor request (and dialog) doesn't dangle unreachable. The orphan's
+        // flight, but if it does, cancel the orphaned forwarding operation so
+        // it does not dangle unreachable (including any editor dialog). The orphan's
         // later unregister is a no-op — its generation no longer matches.
         if let Some(old) = replaced {
             old.token.cancel();

--- a/src/lsp/bridge/peer.rs
+++ b/src/lsp/bridge/peer.rs
@@ -62,12 +62,17 @@ impl PeerDirectory {
             .insert(handle.key().clone(), Arc::downgrade(handle));
     }
 
+    fn prune_dead(&self) {
+        self.handles.retain(|_, handle| handle.strong_count() != 0);
+    }
+
     pub(in crate::lsp::bridge) async fn list(
         &self,
         origin: &ConnectionKey,
         name: Option<&str>,
         text_document: Option<&TextDocumentIdentifier>,
     ) -> Vec<Peer> {
+        self.prune_dead();
         let serving_connections = match text_document {
             Some(text_document) => Some(self.serving_connections(text_document.uri.as_str()).await),
             None => None,
@@ -117,6 +122,7 @@ impl PeerDirectory {
         origin: &ConnectionKey,
         id: &str,
     ) -> Option<Arc<ConnectionHandle>> {
+        self.prune_dead();
         self.handles
             .iter()
             .find(|entry| entry.key() != origin && entry.key().peer_id() == id)
@@ -346,5 +352,21 @@ mod tests {
                 .resolve(&origin_key, "kakehashi-peer:6:tsudoi:fallback")
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn peer_lookup_prunes_connections_after_their_handles_drop() {
+        let directory = PeerDirectory::default();
+        let origin_key = ConnectionKey::for_server("tsudoi");
+        let peer = create_handle_with_key(
+            ConnectionState::Ready,
+            ConnectionKey::new("denols", Some("file:///old-root".to_string())),
+        )
+        .await;
+        directory.register(&peer);
+        drop(peer);
+
+        assert!(directory.list(&origin_key, None, None).await.is_empty());
+        assert!(directory.handles.is_empty());
     }
 }

--- a/src/lsp/bridge/peer.rs
+++ b/src/lsp/bridge/peer.rs
@@ -36,6 +36,7 @@ pub(in crate::lsp::bridge) struct PeerDirectory {
     host_documents: Arc<HostDocuments>,
 }
 
+#[cfg(test)]
 impl Default for PeerDirectory {
     fn default() -> Self {
         Self::new(

--- a/src/lsp/bridge/peer.rs
+++ b/src/lsp/bridge/peer.rs
@@ -111,9 +111,9 @@ impl PeerDirectory {
             self.host_documents
                 .lock()
                 .await
-                .keys()
-                .filter(|(document_uri, _)| document_uri == uri)
-                .map(|(_, connection_key)| connection_key.clone()),
+                .get(uri)
+                .into_iter()
+                .flat_map(|connections| connections.keys().cloned()),
         );
         connections
     }
@@ -295,20 +295,32 @@ mod tests {
         for handle in [&origin, &denols, &other_root] {
             directory.register(handle);
         }
-        directory.host_documents.lock().await.insert(
-            ("file:///repo/main.ts".to_string(), denols_key),
-            HostDocSyncState {
-                version: 1,
-                fingerprint: 0,
-            },
-        );
-        directory.host_documents.lock().await.insert(
-            ("file:///other/main.ts".to_string(), other_root_key),
-            HostDocSyncState {
-                version: 1,
-                fingerprint: 0,
-            },
-        );
+        directory
+            .host_documents
+            .lock()
+            .await
+            .entry("file:///repo/main.ts".to_string())
+            .or_default()
+            .insert(
+                denols_key,
+                HostDocSyncState {
+                    version: 1,
+                    fingerprint: 0,
+                },
+            );
+        directory
+            .host_documents
+            .lock()
+            .await
+            .entry("file:///other/main.ts".to_string())
+            .or_default()
+            .insert(
+                other_root_key,
+                HostDocSyncState {
+                    version: 1,
+                    fingerprint: 0,
+                },
+            );
 
         let result = list_result(
             &directory,

--- a/src/lsp/bridge/peer.rs
+++ b/src/lsp/bridge/peer.rs
@@ -136,9 +136,31 @@ impl PeerDirectory {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct PeerParams {
     #[serde(default)]
-    text_document: Option<TextDocumentIdentifier>,
+    text_document: OptionalFilter<TextDocumentIdentifier>,
     #[serde(default)]
-    name: Option<String>,
+    name: OptionalFilter<String>,
+}
+
+#[derive(Default)]
+enum OptionalFilter<T> {
+    #[default]
+    Missing,
+    Present(T),
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for OptionalFilter<T> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        T::deserialize(deserializer).map(Self::Present)
+    }
+}
+
+impl<T> OptionalFilter<T> {
+    fn as_ref(&self) -> Option<&T> {
+        match self {
+            Self::Missing => None,
+            Self::Present(value) => Some(value),
+        }
+    }
 }
 
 pub(in crate::lsp::bridge) async fn list_result(
@@ -156,7 +178,7 @@ pub(in crate::lsp::bridge) async fn list_result(
         directory
             .list(
                 origin,
-                params.name.as_deref(),
+                params.name.as_ref().map(String::as_str),
                 params.text_document.as_ref(),
             )
             .await,
@@ -280,6 +302,27 @@ mod tests {
         .unwrap();
 
         assert_eq!(result, serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn peer_discovery_rejects_explicit_null_filters() {
+        let directory = PeerDirectory::default();
+        let origin = ConnectionKey::for_server("tsudoi");
+        for filter in ["name", "textDocument"] {
+            let mut params = serde_json::Map::new();
+            params.insert(filter.to_string(), serde_json::Value::Null);
+            let error = list_result(
+                &directory,
+                &origin,
+                &serde_json::json!({ "params": params }),
+            )
+            .await
+            .unwrap_err();
+            assert_eq!(
+                error.code,
+                tower_lsp_server::jsonrpc::ErrorCode::InvalidParams
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/peer.rs
+++ b/src/lsp/bridge/peer.rs
@@ -171,7 +171,7 @@ fn peer_keys<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lsp::bridge::pool::test_helpers::create_handle_with_key;
+    use crate::lsp::bridge::pool::{HostDocSyncState, test_helpers::create_handle_with_key};
 
     #[test]
     fn peer_list_excludes_only_the_origin_connection() {
@@ -273,6 +273,57 @@ mod tests {
         .unwrap();
 
         assert_eq!(result, serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn peer_request_composes_text_document_and_name_filters() {
+        let directory = PeerDirectory::default();
+        let origin_key = ConnectionKey::for_server("tsudoi");
+        let denols_key = ConnectionKey::for_server("denols");
+        let other_root_key = ConnectionKey::new("denols", Some("file:///other".to_string()));
+        let origin = create_handle_with_key(ConnectionState::Ready, origin_key.clone()).await;
+        let denols = create_handle_with_key(ConnectionState::Ready, denols_key.clone()).await;
+        let other_root =
+            create_handle_with_key(ConnectionState::Ready, other_root_key.clone()).await;
+        for handle in [&origin, &denols, &other_root] {
+            directory.register(handle);
+        }
+        directory.host_documents.lock().await.insert(
+            ("file:///repo/main.ts".to_string(), denols_key),
+            HostDocSyncState {
+                version: 1,
+                fingerprint: 0,
+            },
+        );
+        directory.host_documents.lock().await.insert(
+            ("file:///other/main.ts".to_string(), other_root_key),
+            HostDocSyncState {
+                version: 1,
+                fingerprint: 0,
+            },
+        );
+
+        let result = list_result(
+            &directory,
+            &origin_key,
+            &serde_json::json!({
+                "params": {
+                    "textDocument": { "uri": "file:///repo/main.ts" },
+                    "name": "denols"
+                }
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result,
+            serde_json::json!([{
+                "name": "denols",
+                "id": "kakehashi-peer:6:denols:fallback",
+                "workspaceFolders": []
+            }])
+        );
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/peer.rs
+++ b/src/lsp/bridge/peer.rs
@@ -58,6 +58,7 @@ impl PeerDirectory {
     }
 
     pub(in crate::lsp::bridge) fn register(&self, handle: &Arc<ConnectionHandle>) {
+        self.prune_dead();
         self.handles
             .insert(handle.key().clone(), Arc::downgrade(handle));
     }
@@ -366,7 +367,14 @@ mod tests {
         directory.register(&peer);
         drop(peer);
 
-        assert!(directory.list(&origin_key, None, None).await.is_empty());
-        assert!(directory.handles.is_empty());
+        let replacement = create_handle_with_key(
+            ConnectionState::Ready,
+            ConnectionKey::new("denols", Some("file:///new-root".to_string())),
+        )
+        .await;
+        directory.register(&replacement);
+        assert_eq!(directory.handles.len(), 1);
+
+        assert_eq!(directory.list(&origin_key, None, None).await.len(), 1);
     }
 }

--- a/src/lsp/bridge/peer.rs
+++ b/src/lsp/bridge/peer.rs
@@ -1,0 +1,42 @@
+//! Downstream-facing `kakehashi/bridge/peer*` request handlers.
+//!
+//! A downstream language server uses these methods to discover and request
+//! another downstream connection through kakehashi. Unlike the editor-facing
+//! `kakehashi/bridge/client*` family, these handlers are registered only on a
+//! downstream connection's reader.
+
+use super::pool::ConnectionKey;
+
+#[cfg(test)]
+fn peer_keys<'a>(
+    keys: impl IntoIterator<Item = &'a ConnectionKey>,
+    origin: &ConnectionKey,
+) -> Vec<ConnectionKey> {
+    keys.into_iter()
+        .filter(|key| *key != origin)
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn peer_list_excludes_only_the_origin_connection() {
+        let origin = ConnectionKey::new("tsudoi", Some("file:///repo/a".to_string()));
+        let same_server_other_root =
+            ConnectionKey::new("tsudoi", Some("file:///repo/b".to_string()));
+        let formatter = ConnectionKey::new("denols", Some("file:///repo/a".to_string()));
+        let keys = [
+            origin.clone(),
+            same_server_other_root.clone(),
+            formatter.clone(),
+        ];
+
+        assert_eq!(
+            peer_keys(keys.iter(), &origin),
+            vec![same_server_other_root, formatter]
+        );
+    }
+}

--- a/src/lsp/bridge/peer.rs
+++ b/src/lsp/bridge/peer.rs
@@ -7,10 +7,13 @@
 
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::sync::{Arc, Weak};
-use tower_lsp_server::ls_types::WorkspaceFolder;
+use tower_lsp_server::ls_types::{TextDocumentIdentifier, WorkspaceFolder};
 
-use super::pool::{ConnectionHandle, ConnectionKey, ConnectionState};
+use super::pool::{
+    ConnectionHandle, ConnectionKey, ConnectionState, DocumentTracker, HostDocuments,
+};
 
 pub(in crate::lsp::bridge) mod request;
 
@@ -27,27 +30,58 @@ pub(in crate::lsp::bridge) struct Peer {
 ///
 /// Weak handles avoid a pool -> handle -> reader -> directory -> handle cycle.
 /// Re-inserting the same key on respawn replaces the old generation.
-#[derive(Default)]
 pub(in crate::lsp::bridge) struct PeerDirectory {
     handles: DashMap<ConnectionKey, Weak<ConnectionHandle>>,
+    document_tracker: Arc<DocumentTracker>,
+    host_documents: Arc<HostDocuments>,
+}
+
+impl Default for PeerDirectory {
+    fn default() -> Self {
+        Self::new(
+            Arc::new(DocumentTracker::new()),
+            Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+        )
+    }
 }
 
 impl PeerDirectory {
+    pub(in crate::lsp::bridge) fn new(
+        document_tracker: Arc<DocumentTracker>,
+        host_documents: Arc<HostDocuments>,
+    ) -> Self {
+        Self {
+            handles: DashMap::new(),
+            document_tracker,
+            host_documents,
+        }
+    }
+
     pub(in crate::lsp::bridge) fn register(&self, handle: &Arc<ConnectionHandle>) {
         self.handles
             .insert(handle.key().clone(), Arc::downgrade(handle));
     }
 
-    pub(in crate::lsp::bridge) fn list(
+    pub(in crate::lsp::bridge) async fn list(
         &self,
         origin: &ConnectionKey,
         name: Option<&str>,
+        text_document: Option<&TextDocumentIdentifier>,
     ) -> Vec<Peer> {
+        let serving_connections = match text_document {
+            Some(text_document) => Some(self.serving_connections(text_document.uri.as_str()).await),
+            None => None,
+        };
         let mut peers = self
             .handles
             .iter()
             .filter(|entry| entry.key() != origin)
             .filter(|entry| name.is_none_or(|name| entry.key().server() == name))
+            .filter(|entry| {
+                serving_connections
+                    .as_ref()
+                    .is_none_or(|connections| connections.contains(entry.key()))
+            })
             .filter_map(|entry| entry.value().upgrade())
             .filter(|handle| handle.state() == ConnectionState::Ready)
             .map(|handle| Peer {
@@ -58,6 +92,24 @@ impl PeerDirectory {
             .collect::<Vec<_>>();
         peers.sort_unstable_by(|left, right| left.id.cmp(&right.id));
         peers
+    }
+
+    async fn serving_connections(&self, uri: &str) -> HashSet<ConnectionKey> {
+        let mut connections = self
+            .document_tracker
+            .connections_serving_uri(uri)
+            .await
+            .into_iter()
+            .collect::<HashSet<_>>();
+        connections.extend(
+            self.host_documents
+                .lock()
+                .await
+                .keys()
+                .filter(|(document_uri, _)| document_uri == uri)
+                .map(|(_, connection_key)| connection_key.clone()),
+        );
+        connections
     }
 
     pub(in crate::lsp::bridge) fn resolve(
@@ -77,10 +129,12 @@ impl PeerDirectory {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct PeerParams {
     #[serde(default)]
+    text_document: Option<TextDocumentIdentifier>,
+    #[serde(default)]
     name: Option<String>,
 }
 
-pub(in crate::lsp::bridge) fn list_result(
+pub(in crate::lsp::bridge) async fn list_result(
     directory: &PeerDirectory,
     origin: &ConnectionKey,
     message: &serde_json::Value,
@@ -91,8 +145,16 @@ pub(in crate::lsp::bridge) fn list_result(
         .map_err(|error| {
             tower_lsp_server::jsonrpc::Error::invalid_params(format!("Invalid params: {error}"))
         })?;
-    serde_json::to_value(directory.list(origin, params.name.as_deref()))
-        .map_err(|_| tower_lsp_server::jsonrpc::Error::internal_error())
+    serde_json::to_value(
+        directory
+            .list(
+                origin,
+                params.name.as_deref(),
+                params.text_document.as_ref(),
+            )
+            .await,
+    )
+    .map_err(|_| tower_lsp_server::jsonrpc::Error::internal_error())
 }
 
 #[cfg(test)]
@@ -145,7 +207,7 @@ mod tests {
             directory.register(handle);
         }
 
-        let peers = directory.list(&origin_key, None);
+        let peers = directory.list(&origin_key, None, None).await;
         assert_eq!(
             peers
                 .iter()
@@ -176,6 +238,7 @@ mod tests {
             &origin_key,
             &serde_json::json!({ "params": { "name": "oxfmt" } }),
         )
+        .await
         .unwrap();
         assert_eq!(
             result,
@@ -185,6 +248,31 @@ mod tests {
                 "workspaceFolders": []
             }])
         );
+    }
+
+    #[tokio::test]
+    async fn peer_request_filters_out_peers_not_serving_the_text_document() {
+        let directory = PeerDirectory::default();
+        let origin_key = ConnectionKey::for_server("tsudoi");
+        let peer_key = ConnectionKey::for_server("oxfmt");
+        let origin = create_handle_with_key(ConnectionState::Ready, origin_key.clone()).await;
+        let peer = create_handle_with_key(ConnectionState::Ready, peer_key).await;
+        directory.register(&origin);
+        directory.register(&peer);
+
+        let result = list_result(
+            &directory,
+            &origin_key,
+            &serde_json::json!({
+                "params": {
+                    "textDocument": { "uri": "file:///repo/main.ts" }
+                }
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, serde_json::json!([]));
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/peer.rs
+++ b/src/lsp/bridge/peer.rs
@@ -5,7 +5,59 @@
 //! `kakehashi/bridge/client*` family, these handlers are registered only on a
 //! downstream connection's reader.
 
-use super::pool::ConnectionKey;
+use dashmap::DashMap;
+use serde::Serialize;
+use std::sync::{Arc, Weak};
+use tower_lsp_server::ls_types::WorkspaceFolder;
+
+use super::pool::{ConnectionHandle, ConnectionKey, ConnectionState};
+
+/// A callable downstream connection exposed to another downstream server.
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(in crate::lsp::bridge) struct Peer {
+    name: String,
+    id: String,
+    workspace_folders: Vec<WorkspaceFolder>,
+}
+
+/// Weak directory of pool connections shared with downstream reader tasks.
+///
+/// Weak handles avoid a pool -> handle -> reader -> directory -> handle cycle.
+/// Re-inserting the same key on respawn replaces the old generation.
+#[derive(Default)]
+pub(in crate::lsp::bridge) struct PeerDirectory {
+    handles: DashMap<ConnectionKey, Weak<ConnectionHandle>>,
+}
+
+impl PeerDirectory {
+    pub(in crate::lsp::bridge) fn register(&self, handle: &Arc<ConnectionHandle>) {
+        self.handles
+            .insert(handle.key().clone(), Arc::downgrade(handle));
+    }
+
+    pub(in crate::lsp::bridge) fn list(
+        &self,
+        origin: &ConnectionKey,
+        name: Option<&str>,
+    ) -> Vec<Peer> {
+        let mut peers = self
+            .handles
+            .iter()
+            .filter(|entry| entry.key() != origin)
+            .filter(|entry| name.is_none_or(|name| entry.key().server() == name))
+            .filter_map(|entry| entry.value().upgrade())
+            .filter(|handle| handle.state() == ConnectionState::Ready)
+            .map(|handle| Peer {
+                name: handle.key().server().to_string(),
+                id: handle.key().to_string(),
+                workspace_folders: handle.workspace_folders().snapshot().unwrap_or_default(),
+            })
+            .collect::<Vec<_>>();
+        peers.sort_unstable_by(|left, right| left.id.cmp(&right.id));
+        peers
+    }
+}
 
 #[cfg(test)]
 fn peer_keys<'a>(
@@ -21,6 +73,7 @@ fn peer_keys<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lsp::bridge::pool::test_helpers::create_handle_with_key;
 
     #[test]
     fn peer_list_excludes_only_the_origin_connection() {
@@ -37,6 +90,32 @@ mod tests {
         assert_eq!(
             peer_keys(keys.iter(), &origin),
             vec![same_server_other_root, formatter]
+        );
+    }
+
+    #[tokio::test]
+    async fn peer_directory_lists_only_other_running_connections_in_id_order() {
+        let directory = PeerDirectory::default();
+        let origin_key = ConnectionKey::for_server("tsudoi");
+        let failed_key = ConnectionKey::for_server("broken");
+        let z_key = ConnectionKey::for_server("zfmt");
+        let a_key = ConnectionKey::for_server("afmt");
+
+        let origin = create_handle_with_key(ConnectionState::Ready, origin_key.clone()).await;
+        let failed = create_handle_with_key(ConnectionState::Failed, failed_key).await;
+        let zfmt = create_handle_with_key(ConnectionState::Ready, z_key).await;
+        let afmt = create_handle_with_key(ConnectionState::Ready, a_key).await;
+        for handle in [&origin, &failed, &zfmt, &afmt] {
+            directory.register(handle);
+        }
+
+        let peers = directory.list(&origin_key, None);
+        assert_eq!(
+            peers
+                .iter()
+                .map(|peer| peer.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["afmt", "zfmt"]
         );
     }
 }

--- a/src/lsp/bridge/peer.rs
+++ b/src/lsp/bridge/peer.rs
@@ -6,11 +6,13 @@
 //! downstream connection's reader.
 
 use dashmap::DashMap;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Weak};
 use tower_lsp_server::ls_types::WorkspaceFolder;
 
 use super::pool::{ConnectionHandle, ConnectionKey, ConnectionState};
+
+pub(in crate::lsp::bridge) mod request;
 
 /// A callable downstream connection exposed to another downstream server.
 #[derive(Debug, PartialEq, Serialize)]
@@ -50,13 +52,47 @@ impl PeerDirectory {
             .filter(|handle| handle.state() == ConnectionState::Ready)
             .map(|handle| Peer {
                 name: handle.key().server().to_string(),
-                id: handle.key().to_string(),
+                id: handle.key().peer_id(),
                 workspace_folders: handle.workspace_folders().snapshot().unwrap_or_default(),
             })
             .collect::<Vec<_>>();
         peers.sort_unstable_by(|left, right| left.id.cmp(&right.id));
         peers
     }
+
+    pub(in crate::lsp::bridge) fn resolve(
+        &self,
+        origin: &ConnectionKey,
+        id: &str,
+    ) -> Option<Arc<ConnectionHandle>> {
+        self.handles
+            .iter()
+            .find(|entry| entry.key() != origin && entry.key().peer_id() == id)
+            .and_then(|entry| entry.value().upgrade())
+            .filter(|handle| handle.state() == ConnectionState::Ready)
+    }
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PeerParams {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+pub(in crate::lsp::bridge) fn list_result(
+    directory: &PeerDirectory,
+    origin: &ConnectionKey,
+    message: &serde_json::Value,
+) -> tower_lsp_server::jsonrpc::Result<serde_json::Value> {
+    let params = message
+        .get("params")
+        .map_or_else(|| Ok(PeerParams::default()), PeerParams::deserialize)
+        .map_err(|error| {
+            tower_lsp_server::jsonrpc::Error::invalid_params(format!("Invalid params: {error}"))
+        })?;
+    serde_json::to_value(directory.list(origin, params.name.as_deref()))
+        .map_err(|_| tower_lsp_server::jsonrpc::Error::internal_error())
 }
 
 #[cfg(test)]
@@ -115,7 +151,61 @@ mod tests {
                 .iter()
                 .map(|peer| peer.id.as_str())
                 .collect::<Vec<_>>(),
-            vec!["afmt", "zfmt"]
+            vec![
+                "kakehashi-peer:4:afmt:fallback",
+                "kakehashi-peer:4:zfmt:fallback"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn peer_request_filters_by_name_and_serializes_workspace_folders() {
+        let directory = PeerDirectory::default();
+        let origin_key = ConnectionKey::for_server("tsudoi");
+        let denols_key = ConnectionKey::for_server("denols");
+        let oxfmt_key = ConnectionKey::for_server("oxfmt");
+        let origin = create_handle_with_key(ConnectionState::Ready, origin_key.clone()).await;
+        let denols = create_handle_with_key(ConnectionState::Ready, denols_key).await;
+        let oxfmt = create_handle_with_key(ConnectionState::Ready, oxfmt_key).await;
+        for handle in [&origin, &denols, &oxfmt] {
+            directory.register(handle);
+        }
+
+        let result = list_result(
+            &directory,
+            &origin_key,
+            &serde_json::json!({ "params": { "name": "oxfmt" } }),
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            serde_json::json!([{
+                "name": "oxfmt",
+                "id": "kakehashi-peer:5:oxfmt:fallback",
+                "workspaceFolders": []
+            }])
+        );
+    }
+
+    #[tokio::test]
+    async fn peer_resolution_accepts_a_running_peer_but_never_the_origin() {
+        let directory = PeerDirectory::default();
+        let origin_key = ConnectionKey::for_server("tsudoi");
+        let peer_key = ConnectionKey::for_server("oxfmt");
+        let origin = create_handle_with_key(ConnectionState::Ready, origin_key.clone()).await;
+        let peer = create_handle_with_key(ConnectionState::Ready, peer_key).await;
+        directory.register(&origin);
+        directory.register(&peer);
+
+        assert!(
+            directory
+                .resolve(&origin_key, "kakehashi-peer:5:oxfmt:fallback")
+                .is_some()
+        );
+        assert!(
+            directory
+                .resolve(&origin_key, "kakehashi-peer:6:tsudoi:fallback")
+                .is_none()
         );
     }
 }

--- a/src/lsp/bridge/peer/request.rs
+++ b/src/lsp/bridge/peer/request.rs
@@ -85,7 +85,7 @@ async fn cleanup_cancelled_peer(
         _ = settled_rx => {}
         _ = tokio::time::sleep_until(deadline) => {
             if peer.router().expire_peer_cancel(downstream_id) {
-                peer.fail_if_ready();
+                peer.fail_and_abort_writer();
             }
         }
     }

--- a/src/lsp/bridge/peer/request.rs
+++ b/src/lsp/bridge/peer/request.rs
@@ -155,8 +155,8 @@ pub(in crate::lsp::bridge) fn handle(
         return;
     }
 
+    let deadline = tokio::time::Instant::now() + super::super::pool::REQUEST_TIMEOUT;
     tokio::spawn(async move {
-        let deadline = tokio::time::Instant::now() + super::super::pool::REQUEST_TIMEOUT;
         let body = tokio::select! {
             response = peer.wait_for_response_until(downstream_id, response_rx, deadline) => {
                 router_guard.disarm();

--- a/src/lsp/bridge/peer/request.rs
+++ b/src/lsp/bridge/peer/request.rs
@@ -79,7 +79,7 @@ async fn cleanup_cancelled_peer(
     downstream_id: RequestId,
     settled_rx: tokio::sync::oneshot::Receiver<()>,
     deadline: tokio::time::Instant,
-    _permit: PeerRequestPermit,
+    _permit: Arc<PeerRequestPermit>,
 ) {
     tokio::select! {
         _ = settled_rx => {}
@@ -180,8 +180,8 @@ pub(in crate::lsp::bridge) async fn handle(
     }
 
     let deadline = tokio::time::Instant::now() + super::super::pool::REQUEST_TIMEOUT;
+    let permit = Arc::new(permit);
     tokio::spawn(async move {
-        let mut permit = Some(permit);
         let body = tokio::select! {
             response = peer.wait_for_response_until(downstream_id, response_rx, deadline) => {
                 router_guard.disarm();
@@ -212,13 +212,12 @@ pub(in crate::lsp::bridge) async fn handle(
                             outcome
                         );
                     }
-                    let permit = permit.take();
                     tokio::spawn(cleanup_cancelled_peer(
                         peer.clone(),
                         downstream_id,
                         settled_rx,
                         deadline,
-                        permit.expect("an admitted request owns its capacity permit"),
+                        Arc::clone(&permit),
                     ));
                 }
                 Err(jsonrpc::Error::request_cancelled())
@@ -363,7 +362,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn target_response_releases_cancelled_peer_capacity_immediately() {
+    async fn cancelled_peer_capacity_waits_for_target_and_outer_settlement() {
         let registry = InboundRequestRegistry::default();
         let origin = ProgressConnectionId::for_test(1);
         let (_cancel, _generation, permit) = registry
@@ -390,12 +389,13 @@ mod tests {
         assert!(peer.router().claim_for_write(request_id));
         peer.router().mark_sent(request_id);
         assert_eq!(peer.router().cancel_peer(request_id), Some(true));
+        let permit = Arc::new(permit);
         let cleanup = tokio::spawn(cleanup_cancelled_peer(
             peer.clone(),
             request_id,
             settled_rx,
             tokio::time::Instant::now() + std::time::Duration::from_secs(30),
-            permit,
+            Arc::clone(&permit),
         ));
         drop(response_rx);
 
@@ -414,8 +414,15 @@ mod tests {
         assert!(
             registry
                 .try_register_peer(origin, jsonrpc::Id::Number(1000))
+                .is_none(),
+            "outer response delivery still owns the generation's capacity"
+        );
+        drop(permit);
+        assert!(
+            registry
+                .try_register_peer(origin, jsonrpc::Id::Number(1000))
                 .is_some(),
-            "target settlement releases the cancelled generation's capacity"
+            "capacity returns only after target cleanup and outer delivery settle"
         );
         drop(remaining);
     }

--- a/src/lsp/bridge/peer/request.rs
+++ b/src/lsp/bridge/peer/request.rs
@@ -1,12 +1,15 @@
 //! `kakehashi/bridge/peer/request`: downstream → kakehashi → peer request.
 
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::Arc};
 
 use serde::Deserialize;
 use tower_lsp_server::jsonrpc;
 
 use crate::lsp::bridge::actor::{RouterCleanupGuard, ServerRequestDeps, send_server_response};
+use crate::lsp::bridge::inbound_request_registry::PeerRequestPermit;
+use crate::lsp::bridge::pool::ConnectionHandle;
 use crate::lsp::bridge::protocol::JsonRpcNotification;
+use crate::lsp::bridge::protocol::RequestId;
 
 const METHOD: &str = "kakehashi/bridge/peer/request";
 const DENIED_METHODS: &[&str] = &[
@@ -71,9 +74,26 @@ fn validate_params(params: &PeerRequestParams) -> jsonrpc::Result<()> {
     Ok(())
 }
 
+async fn cleanup_cancelled_peer(
+    peer: Arc<ConnectionHandle>,
+    downstream_id: RequestId,
+    settled_rx: tokio::sync::oneshot::Receiver<()>,
+    deadline: tokio::time::Instant,
+    _permit: PeerRequestPermit,
+) {
+    tokio::select! {
+        _ = settled_rx => {}
+        _ = tokio::time::sleep_until(deadline) => {
+            if peer.router().expire_peer_cancel(downstream_id) {
+                peer.fail_if_ready();
+            }
+        }
+    }
+}
+
 /// Start an arbitrary request against one discovered peer without blocking the
 /// originating connection's reader loop.
-pub(in crate::lsp::bridge) fn handle(
+pub(in crate::lsp::bridge) async fn handle(
     message: &serde_json::Value,
     id: jsonrpc::Id,
     server_prefix: &str,
@@ -84,22 +104,18 @@ pub(in crate::lsp::bridge) fn handle(
     let params = match PeerRequestParams::deserialize(&message["params"]) {
         Ok(params) => params,
         Err(error) => {
-            tokio::spawn(async move {
-                let response = jsonrpc::Response::from_error(
-                    id,
-                    jsonrpc::Error::invalid_params(format!("Invalid params: {error}")),
-                );
-                send_server_response(&response_tx, response, &server_prefix, METHOD).await;
-            });
+            let response = jsonrpc::Response::from_error(
+                id,
+                jsonrpc::Error::invalid_params(format!("Invalid params: {error}")),
+            );
+            send_server_response(&response_tx, response, &server_prefix, METHOD).await;
             return;
         }
     };
 
     if let Err(error) = validate_params(&params) {
-        tokio::spawn(async move {
-            let response = jsonrpc::Response::from_error(id, error);
-            send_server_response(&response_tx, response, &server_prefix, METHOD).await;
-        });
+        let response = jsonrpc::Response::from_error(id, error);
+        send_server_response(&response_tx, response, &server_prefix, METHOD).await;
         return;
     }
 
@@ -107,16 +123,14 @@ pub(in crate::lsp::bridge) fn handle(
         .peer_directory
         .resolve(&deps.connection_key, &params.id)
     else {
-        tokio::spawn(async move {
-            let response = jsonrpc::Response::from_error(
-                id,
-                request_failed(
-                    "unknownPeer",
-                    "peer is absent, is the caller, or is not running",
-                ),
-            );
-            send_server_response(&response_tx, response, &server_prefix, METHOD).await;
-        });
+        let response = jsonrpc::Response::from_error(
+            id,
+            request_failed(
+                "unknownPeer",
+                "peer is absent, is the caller, or is not running",
+            ),
+        );
+        send_server_response(&response_tx, response, &server_prefix, METHOD).await;
         return;
     };
 
@@ -124,30 +138,27 @@ pub(in crate::lsp::bridge) fn handle(
     let registry = deps.inbound_request_registry.clone();
     let Some((cancel, generation, permit)) = registry.try_register_peer(connection_id, id.clone())
     else {
-        tokio::spawn(async move {
-            let response = jsonrpc::Response::from_error(
-                id,
-                request_failed(
-                    "tooManyRequests",
-                    "too many peer requests are awaiting responses",
-                ),
-            );
-            send_server_response(&response_tx, response, &server_prefix, METHOD).await;
-        });
+        let response = jsonrpc::Response::from_error(
+            id,
+            request_failed(
+                "tooManyRequests",
+                "too many peer requests are awaiting responses",
+            ),
+        );
+        send_server_response(&response_tx, response, &server_prefix, METHOD).await;
         return;
     };
 
-    let (downstream_id, response_rx) = match peer.register_peer_request() {
+    let (downstream_id, response_rx, settled_rx) = match peer.register_peer_request() {
         Ok(registered) => registered,
         Err(error) => {
             registry.unregister(connection_id, &id, generation);
-            tokio::spawn(async move {
-                let response = jsonrpc::Response::from_error(
-                    id,
-                    request_failed("forwardFailed", error.to_string()),
-                );
-                send_server_response(&response_tx, response, &server_prefix, METHOD).await;
-            });
+            drop(permit);
+            let response = jsonrpc::Response::from_error(
+                id,
+                request_failed("forwardFailed", error.to_string()),
+            );
+            send_server_response(&response_tx, response, &server_prefix, METHOD).await;
             return;
         }
     };
@@ -160,13 +171,11 @@ pub(in crate::lsp::bridge) fn handle(
     };
     if let Err(error) = peer.send_request_value(params.method, inner_params, downstream_id) {
         registry.unregister(connection_id, &id, generation);
-        tokio::spawn(async move {
-            let response = jsonrpc::Response::from_error(
-                id,
-                request_failed("forwardFailed", error.to_string()),
-            );
-            send_server_response(&response_tx, response, &server_prefix, METHOD).await;
-        });
+        drop(router_guard);
+        drop(permit);
+        let response =
+            jsonrpc::Response::from_error(id, request_failed("forwardFailed", error.to_string()));
+        send_server_response(&response_tx, response, &server_prefix, METHOD).await;
         return;
     }
 
@@ -203,16 +212,14 @@ pub(in crate::lsp::bridge) fn handle(
                             outcome
                         );
                     }
-                    let router = peer.router().clone();
-                    let peer = peer.clone();
                     let permit = permit.take();
-                    tokio::spawn(async move {
-                        tokio::time::sleep_until(deadline).await;
-                        if router.expire_peer_cancel(downstream_id) {
-                            peer.fail_if_ready();
-                        }
-                        drop(permit);
-                    });
+                    tokio::spawn(cleanup_cancelled_peer(
+                        peer.clone(),
+                        downstream_id,
+                        settled_rx,
+                        deadline,
+                        permit.expect("an admitted request owns its capacity permit"),
+                    ));
                 }
                 Err(jsonrpc::Error::request_cancelled())
             }
@@ -254,6 +261,10 @@ fn normalize_response(response: serde_json::Value) -> jsonrpc::Result<serde_json
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lsp::bridge::ProgressConnectionId;
+    use crate::lsp::bridge::inbound_request_registry::{
+        InboundRequestRegistry, MAX_IN_FLIGHT_PEER_REQUESTS_PER_CONNECTION,
+    };
     use crate::lsp::bridge::pool::{
         ConnectionKey, ConnectionState, test_helpers::create_handle_with_key,
     };
@@ -341,7 +352,7 @@ mod tests {
         let peer =
             create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("oxfmt"))
                 .await;
-        let (request_id, response_rx) = peer.register_peer_request().unwrap();
+        let (request_id, response_rx, _settled_rx) = peer.register_peer_request().unwrap();
         assert!(peer.router().fail_request(request_id, "write error"));
 
         let error = peer
@@ -349,6 +360,64 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
+    }
+
+    #[tokio::test]
+    async fn target_response_releases_cancelled_peer_capacity_immediately() {
+        let registry = InboundRequestRegistry::default();
+        let origin = ProgressConnectionId::for_test(1);
+        let (_cancel, _generation, permit) = registry
+            .try_register_peer(origin, jsonrpc::Id::Number(1))
+            .unwrap();
+        let mut remaining = Vec::new();
+        for n in 1..MAX_IN_FLIGHT_PEER_REQUESTS_PER_CONNECTION {
+            remaining.push(
+                registry
+                    .try_register_peer(origin, jsonrpc::Id::Number(n as i64 + 1))
+                    .unwrap(),
+            );
+        }
+        assert!(
+            registry
+                .try_register_peer(origin, jsonrpc::Id::Number(1000))
+                .is_none()
+        );
+
+        let peer =
+            create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("oxfmt"))
+                .await;
+        let (request_id, response_rx, settled_rx) = peer.register_peer_request().unwrap();
+        assert!(peer.router().claim_for_write(request_id));
+        peer.router().mark_sent(request_id);
+        assert_eq!(peer.router().cancel_peer(request_id), Some(true));
+        let cleanup = tokio::spawn(cleanup_cancelled_peer(
+            peer.clone(),
+            request_id,
+            settled_rx,
+            tokio::time::Instant::now() + std::time::Duration::from_secs(30),
+            permit,
+        ));
+        drop(response_rx);
+
+        assert_eq!(
+            peer.router().route(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": request_id.as_i64(),
+                "result": null
+            })),
+            crate::lsp::bridge::actor::RouteResult::ReceiverDropped
+        );
+        tokio::time::timeout(std::time::Duration::from_secs(1), cleanup)
+            .await
+            .expect("settlement wakes cleanup before the request deadline")
+            .unwrap();
+        assert!(
+            registry
+                .try_register_peer(origin, jsonrpc::Id::Number(1000))
+                .is_some(),
+            "target settlement releases the cancelled generation's capacity"
+        );
+        drop(remaining);
     }
 
     #[test]

--- a/src/lsp/bridge/peer/request.rs
+++ b/src/lsp/bridge/peer/request.rs
@@ -156,8 +156,9 @@ pub(in crate::lsp::bridge) fn handle(
     }
 
     tokio::spawn(async move {
+        let deadline = tokio::time::Instant::now() + super::super::pool::REQUEST_TIMEOUT;
         let body = tokio::select! {
-            response = peer.wait_for_response(downstream_id, response_rx) => {
+            response = peer.wait_for_response_until(downstream_id, response_rx, deadline) => {
                 router_guard.disarm();
                 match response {
                     Ok(response) => normalize_response(response),
@@ -189,12 +190,9 @@ pub(in crate::lsp::bridge) fn handle(
                     let router = peer.router().clone();
                     let peer = peer.clone();
                     tokio::spawn(async move {
-                        tokio::time::sleep(super::super::pool::REQUEST_TIMEOUT).await;
-                        if router.peer_cancel_is_writing(downstream_id) {
-                            peer.set_state(super::super::pool::ConnectionState::Failed);
-                            router.fail_all("bridge: cancelled peer write timed out");
-                        } else {
-                            router.remove(downstream_id);
+                        tokio::time::sleep_until(deadline).await;
+                        if router.expire_peer_cancel(downstream_id) {
+                            peer.fail_if_ready();
                         }
                     });
                 }

--- a/src/lsp/bridge/peer/request.rs
+++ b/src/lsp/bridge/peer/request.rs
@@ -168,8 +168,11 @@ pub(in crate::lsp::bridge) fn handle(
                 }
             }
             _ = cancel.cancelled() => {
-                let should_notify = peer.router().cancel_and_remove(downstream_id);
-                router_guard.disarm();
+                let cancellation = peer.router().cancel_peer(downstream_id);
+                let should_notify = cancellation.unwrap_or(false);
+                if cancellation.is_some() {
+                    router_guard.disarm();
+                }
                 if should_notify {
                     let outcome = peer.send_notification(JsonRpcNotification::new(
                         "$/cancelRequest",
@@ -184,9 +187,15 @@ pub(in crate::lsp::bridge) fn handle(
                         );
                     }
                     let router = peer.router().clone();
+                    let peer = peer.clone();
                     tokio::spawn(async move {
                         tokio::time::sleep(super::super::pool::REQUEST_TIMEOUT).await;
-                        router.remove(downstream_id);
+                        if router.peer_cancel_is_writing(downstream_id) {
+                            peer.set_state(super::super::pool::ConnectionState::Failed);
+                            router.fail_all("bridge: cancelled peer write timed out");
+                        } else {
+                            router.remove(downstream_id);
+                        }
                     });
                 }
                 Err(jsonrpc::Error::request_cancelled())

--- a/src/lsp/bridge/peer/request.rs
+++ b/src/lsp/bridge/peer/request.rs
@@ -122,7 +122,8 @@ pub(in crate::lsp::bridge) fn handle(
 
     let connection_id = deps.progress_connection_id;
     let registry = deps.inbound_request_registry.clone();
-    let Some((cancel, generation)) = registry.try_register_peer(connection_id, id.clone()) else {
+    let Some((cancel, generation, permit)) = registry.try_register_peer(connection_id, id.clone())
+    else {
         tokio::spawn(async move {
             let response = jsonrpc::Response::from_error(
                 id,
@@ -171,6 +172,7 @@ pub(in crate::lsp::bridge) fn handle(
 
     let deadline = tokio::time::Instant::now() + super::super::pool::REQUEST_TIMEOUT;
     tokio::spawn(async move {
+        let mut permit = Some(permit);
         let body = tokio::select! {
             response = peer.wait_for_response_until(downstream_id, response_rx, deadline) => {
                 router_guard.disarm();
@@ -203,11 +205,13 @@ pub(in crate::lsp::bridge) fn handle(
                     }
                     let router = peer.router().clone();
                     let peer = peer.clone();
+                    let permit = permit.take();
                     tokio::spawn(async move {
                         tokio::time::sleep_until(deadline).await;
                         if router.expire_peer_cancel(downstream_id) {
                             peer.fail_if_ready();
                         }
+                        drop(permit);
                     });
                 }
                 Err(jsonrpc::Error::request_cancelled())

--- a/src/lsp/bridge/peer/request.rs
+++ b/src/lsp/bridge/peer/request.rs
@@ -108,7 +108,7 @@ pub(in crate::lsp::bridge) fn handle(
         return;
     };
 
-    let (downstream_id, response_rx) = match peer.register_request() {
+    let (downstream_id, response_rx) = match peer.register_peer_request() {
         Ok(registered) => registered,
         Err(error) => {
             tokio::spawn(async move {
@@ -179,21 +179,6 @@ fn normalize_response(response: serde_json::Value) -> jsonrpc::Result<serde_json
             "peer returned a response without jsonrpc: 2.0",
         ));
     }
-    if let Some(reason) = response
-        .pointer("/error/data/kakehashiBridgeFailure")
-        .and_then(serde_json::Value::as_str)
-        .and_then(|reason| match reason {
-            "connectionLost" => Some("connectionLost"),
-            "requestTimeout" => Some("requestTimeout"),
-            _ => None,
-        })
-    {
-        let message = response
-            .pointer("/error/message")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("peer connection failed");
-        return Err(request_failed(reason, message));
-    }
     match (response.get("result"), response.get("error")) {
         (Some(result), None) => Ok(serde_json::json!({ "result": result })),
         (None, Some(error)) => serde_json::from_value::<jsonrpc::Error>(error.clone())
@@ -215,6 +200,9 @@ fn normalize_response(response: serde_json::Value) -> jsonrpc::Result<serde_json
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lsp::bridge::pool::{
+        ConnectionKey, ConnectionState, test_helpers::create_handle_with_key,
+    };
 
     #[test]
     fn downstream_result_and_error_are_wrapped_without_internal_ids() {
@@ -253,21 +241,41 @@ mod tests {
     }
 
     #[test]
-    fn bridge_failures_remain_outer_request_failures() {
-        for reason in ["connectionLost", "requestTimeout"] {
-            let error = normalize_response(serde_json::json!({
+    fn downstream_error_data_cannot_impersonate_a_bridge_failure() {
+        assert_eq!(
+            normalize_response(serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": 91,
                 "error": {
                     "code": -32603,
-                    "message": "bridge transport failed",
-                    "data": { "kakehashiBridgeFailure": reason }
+                    "message": "target error",
+                    "data": { "kakehashiBridgeFailure": "connectionLost" }
                 }
             }))
+            .unwrap(),
+            serde_json::json!({
+                "error": {
+                    "code": -32603,
+                    "message": "target error",
+                    "data": { "kakehashiBridgeFailure": "connectionLost" }
+                }
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn router_transport_failures_are_out_of_band() {
+        let peer =
+            create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("oxfmt"))
+                .await;
+        let (request_id, response_rx) = peer.register_peer_request().unwrap();
+        assert!(peer.router().fail_request(request_id, "write error"));
+
+        let error = peer
+            .wait_for_response(request_id, response_rx)
+            .await
             .unwrap_err();
-            assert_eq!(error.code, jsonrpc::ErrorCode::ServerError(-32803));
-            assert_eq!(error.data, Some(serde_json::json!({ "reason": reason })));
-        }
+        assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
     }
 
     #[test]

--- a/src/lsp/bridge/peer/request.rs
+++ b/src/lsp/bridge/peer/request.rs
@@ -120,9 +120,26 @@ pub(in crate::lsp::bridge) fn handle(
         return;
     };
 
+    let connection_id = deps.progress_connection_id;
+    let registry = deps.inbound_request_registry.clone();
+    let Some((cancel, generation)) = registry.try_register_peer(connection_id, id.clone()) else {
+        tokio::spawn(async move {
+            let response = jsonrpc::Response::from_error(
+                id,
+                request_failed(
+                    "tooManyRequests",
+                    "too many peer requests are awaiting responses",
+                ),
+            );
+            send_server_response(&response_tx, response, &server_prefix, METHOD).await;
+        });
+        return;
+    };
+
     let (downstream_id, response_rx) = match peer.register_peer_request() {
         Ok(registered) => registered,
         Err(error) => {
+            registry.unregister(connection_id, &id, generation);
             tokio::spawn(async move {
                 let response = jsonrpc::Response::from_error(
                     id,
@@ -136,9 +153,6 @@ pub(in crate::lsp::bridge) fn handle(
     let mut router_guard = RouterCleanupGuard::new(peer.clone().router().clone(), downstream_id);
     // Register before the inner send: a $/cancelRequest arriving immediately
     // after the outer request must not fall into a send/register gap.
-    let connection_id = deps.progress_connection_id;
-    let registry = deps.inbound_request_registry.clone();
-    let (cancel, generation) = registry.register(connection_id, id.clone());
     let inner_params = match params.params {
         OptionalParams::Missing => None,
         OptionalParams::Present(value) => Some(value),

--- a/src/lsp/bridge/peer/request.rs
+++ b/src/lsp/bridge/peer/request.rs
@@ -1,0 +1,248 @@
+//! `kakehashi/bridge/peer/request`: downstream → kakehashi → peer request.
+
+use std::borrow::Cow;
+
+use serde::Deserialize;
+use tower_lsp_server::jsonrpc;
+
+use crate::lsp::bridge::actor::{RouterCleanupGuard, ServerRequestDeps, send_server_response};
+use crate::lsp::bridge::protocol::JsonRpcNotification;
+
+const METHOD: &str = "kakehashi/bridge/peer/request";
+const DENIED_METHODS: &[&str] = &[
+    "initialize",
+    "initialized",
+    "shutdown",
+    "exit",
+    "$/cancelRequest",
+];
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PeerRequestParams {
+    id: String,
+    method: String,
+    #[serde(default)]
+    params: Option<serde_json::Value>,
+}
+
+fn request_failed(reason: &'static str, message: impl Into<String>) -> jsonrpc::Error {
+    jsonrpc::Error {
+        code: jsonrpc::ErrorCode::ServerError(-32803),
+        message: Cow::Owned(format!("bridge/peer: {}", message.into())),
+        data: Some(serde_json::json!({ "reason": reason })),
+    }
+}
+
+fn validate_params(params: &PeerRequestParams) -> jsonrpc::Result<()> {
+    if params.method.is_empty() {
+        return Err(jsonrpc::Error::invalid_params("method must not be empty"));
+    }
+    if DENIED_METHODS.contains(&params.method.as_str()) {
+        return Err(request_failed(
+            "methodDenied",
+            format!(
+                "method '{}' is reserved for connection lifecycle",
+                params.method
+            ),
+        ));
+    }
+    if params
+        .params
+        .as_ref()
+        .is_some_and(|value| !value.is_object() && !value.is_array())
+    {
+        return Err(jsonrpc::Error::invalid_params(
+            "inner params must be an object, array, or omitted",
+        ));
+    }
+    Ok(())
+}
+
+/// Start an arbitrary request against one discovered peer without blocking the
+/// originating connection's reader loop.
+pub(in crate::lsp::bridge) fn handle(
+    message: &serde_json::Value,
+    id: jsonrpc::Id,
+    server_prefix: &str,
+    deps: &ServerRequestDeps,
+) {
+    let response_tx = deps.response_tx.clone();
+    let server_prefix = server_prefix.to_string();
+    let params = match PeerRequestParams::deserialize(&message["params"]) {
+        Ok(params) => params,
+        Err(error) => {
+            tokio::spawn(async move {
+                let response = jsonrpc::Response::from_error(
+                    id,
+                    jsonrpc::Error::invalid_params(format!("Invalid params: {error}")),
+                );
+                send_server_response(&response_tx, response, &server_prefix, METHOD).await;
+            });
+            return;
+        }
+    };
+
+    if let Err(error) = validate_params(&params) {
+        tokio::spawn(async move {
+            let response = jsonrpc::Response::from_error(id, error);
+            send_server_response(&response_tx, response, &server_prefix, METHOD).await;
+        });
+        return;
+    }
+
+    let Some(peer) = deps
+        .peer_directory
+        .resolve(&deps.connection_key, &params.id)
+    else {
+        tokio::spawn(async move {
+            let response = jsonrpc::Response::from_error(
+                id,
+                request_failed(
+                    "unknownPeer",
+                    "peer is absent, is the caller, or is not running",
+                ),
+            );
+            send_server_response(&response_tx, response, &server_prefix, METHOD).await;
+        });
+        return;
+    };
+
+    let (downstream_id, response_rx) = match peer.register_request() {
+        Ok(registered) => registered,
+        Err(error) => {
+            tokio::spawn(async move {
+                let response = jsonrpc::Response::from_error(
+                    id,
+                    request_failed("forwardFailed", error.to_string()),
+                );
+                send_server_response(&response_tx, response, &server_prefix, METHOD).await;
+            });
+            return;
+        }
+    };
+    let mut router_guard = RouterCleanupGuard::new(peer.clone().router().clone(), downstream_id);
+    // Register before the inner send: a $/cancelRequest arriving immediately
+    // after the outer request must not fall into a send/register gap.
+    let connection_id = deps.progress_connection_id;
+    let registry = deps.inbound_request_registry.clone();
+    let (cancel, generation) = registry.register(connection_id, id.clone());
+    if let Err(error) = peer.send_request_value(params.method, params.params, downstream_id) {
+        registry.unregister(connection_id, &id, generation);
+        tokio::spawn(async move {
+            let response = jsonrpc::Response::from_error(
+                id,
+                request_failed("forwardFailed", error.to_string()),
+            );
+            send_server_response(&response_tx, response, &server_prefix, METHOD).await;
+        });
+        return;
+    }
+
+    tokio::spawn(async move {
+        let body = tokio::select! {
+            response = peer.wait_for_response(downstream_id, response_rx) => {
+                router_guard.disarm();
+                match response {
+                    Ok(response) => normalize_response(response),
+                    Err(error) if error.kind() == std::io::ErrorKind::TimedOut => {
+                        Err(request_failed("requestTimeout", error.to_string()))
+                    }
+                    Err(error) => Err(request_failed("connectionLost", error.to_string())),
+                }
+            }
+            _ = cancel.cancelled() => {
+                peer.send_notification(JsonRpcNotification::new(
+                    "$/cancelRequest",
+                    serde_json::json!({ "id": downstream_id.as_i64() }),
+                ));
+                Err(jsonrpc::Error::request_cancelled())
+            }
+        };
+        registry.unregister(connection_id, &id, generation);
+        let response = match body {
+            Ok(result) => jsonrpc::Response::from_ok(id, result),
+            Err(error) => jsonrpc::Response::from_error(id, error),
+        };
+        send_server_response(&response_tx, response, &server_prefix, METHOD).await;
+    });
+}
+
+fn normalize_response(response: serde_json::Value) -> jsonrpc::Result<serde_json::Value> {
+    if response.get("jsonrpc").and_then(serde_json::Value::as_str) != Some("2.0") {
+        return Err(request_failed(
+            "malformedResponse",
+            "peer returned a response without jsonrpc: 2.0",
+        ));
+    }
+    match (response.get("result"), response.get("error")) {
+        (Some(result), None) => Ok(serde_json::json!({ "result": result })),
+        (None, Some(error)) => serde_json::from_value::<jsonrpc::Error>(error.clone())
+            .and_then(serde_json::to_value)
+            .map(|error| serde_json::json!({ "error": error }))
+            .map_err(|_| {
+                request_failed(
+                    "malformedResponse",
+                    "peer returned a malformed JSON-RPC error object",
+                )
+            }),
+        _ => Err(request_failed(
+            "malformedResponse",
+            "peer returned an invalid JSON-RPC response envelope",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn downstream_result_and_error_are_wrapped_without_internal_ids() {
+        assert_eq!(
+            normalize_response(serde_json::json!({
+                "jsonrpc": "2.0", "id": 91, "result": null
+            }))
+            .unwrap(),
+            serde_json::json!({ "result": null })
+        );
+        assert_eq!(
+            normalize_response(serde_json::json!({
+                "jsonrpc": "2.0", "id": 92,
+                "error": { "code": -32601, "message": "missing" }
+            }))
+            .unwrap(),
+            serde_json::json!({
+                "error": { "code": -32601, "message": "missing" }
+            })
+        );
+    }
+
+    #[test]
+    fn lifecycle_methods_are_denied_with_a_machine_readable_reason() {
+        let params = PeerRequestParams {
+            id: "denols".to_string(),
+            method: "shutdown".to_string(),
+            params: None,
+        };
+        let error = validate_params(&params).unwrap_err();
+        assert_eq!(error.code, jsonrpc::ErrorCode::ServerError(-32803));
+        assert_eq!(
+            error.data,
+            Some(serde_json::json!({ "reason": "methodDenied" }))
+        );
+    }
+
+    #[test]
+    fn malformed_downstream_error_is_not_relayed() {
+        let error = normalize_response(serde_json::json!({
+            "jsonrpc": "2.0", "id": 92,
+            "error": { "message": "missing code" }
+        }))
+        .unwrap_err();
+        assert_eq!(
+            error.data,
+            Some(serde_json::json!({ "reason": "malformedResponse" }))
+        );
+    }
+}

--- a/src/lsp/bridge/peer/request.rs
+++ b/src/lsp/bridge/peer/request.rs
@@ -152,10 +152,14 @@ pub(in crate::lsp::bridge) fn handle(
                 }
             }
             _ = cancel.cancelled() => {
-                peer.send_notification(JsonRpcNotification::new(
-                    "$/cancelRequest",
-                    serde_json::json!({ "id": downstream_id.as_i64() }),
-                ));
+                let should_notify = peer.router().cancel_and_remove(downstream_id);
+                router_guard.disarm();
+                if should_notify {
+                    peer.send_notification(JsonRpcNotification::new(
+                        "$/cancelRequest",
+                        serde_json::json!({ "id": downstream_id.as_i64() }),
+                    ));
+                }
                 Err(jsonrpc::Error::request_cancelled())
             }
         };

--- a/src/lsp/bridge/peer/request.rs
+++ b/src/lsp/bridge/peer/request.rs
@@ -183,6 +183,11 @@ pub(in crate::lsp::bridge) fn handle(
                             outcome
                         );
                     }
+                    let router = peer.router().clone();
+                    tokio::spawn(async move {
+                        tokio::time::sleep(super::super::pool::REQUEST_TIMEOUT).await;
+                        router.remove(downstream_id);
+                    });
                 }
                 Err(jsonrpc::Error::request_cancelled())
             }

--- a/src/lsp/bridge/peer/request.rs
+++ b/src/lsp/bridge/peer/request.rs
@@ -23,7 +23,20 @@ struct PeerRequestParams {
     id: String,
     method: String,
     #[serde(default)]
-    params: Option<serde_json::Value>,
+    params: OptionalParams,
+}
+
+#[derive(Default)]
+enum OptionalParams {
+    #[default]
+    Missing,
+    Present(serde_json::Value),
+}
+
+impl<'de> Deserialize<'de> for OptionalParams {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        serde_json::Value::deserialize(deserializer).map(Self::Present)
+    }
 }
 
 fn request_failed(reason: &'static str, message: impl Into<String>) -> jsonrpc::Error {
@@ -47,11 +60,10 @@ fn validate_params(params: &PeerRequestParams) -> jsonrpc::Result<()> {
             ),
         ));
     }
-    if params
-        .params
-        .as_ref()
-        .is_some_and(|value| !value.is_object() && !value.is_array())
-    {
+    if matches!(
+        &params.params,
+        OptionalParams::Present(value) if !value.is_object() && !value.is_array()
+    ) {
         return Err(jsonrpc::Error::invalid_params(
             "inner params must be an object, array, or omitted",
         ));
@@ -127,7 +139,11 @@ pub(in crate::lsp::bridge) fn handle(
     let connection_id = deps.progress_connection_id;
     let registry = deps.inbound_request_registry.clone();
     let (cancel, generation) = registry.register(connection_id, id.clone());
-    if let Err(error) = peer.send_request_value(params.method, params.params, downstream_id) {
+    let inner_params = match params.params {
+        OptionalParams::Missing => None,
+        OptionalParams::Present(value) => Some(value),
+    };
+    if let Err(error) = peer.send_request_value(params.method, inner_params, downstream_id) {
         registry.unregister(connection_id, &id, generation);
         tokio::spawn(async move {
             let response = jsonrpc::Response::from_error(
@@ -238,7 +254,7 @@ mod tests {
         let params = PeerRequestParams {
             id: "denols".to_string(),
             method: "shutdown".to_string(),
-            params: None,
+            params: OptionalParams::Missing,
         };
         let error = validate_params(&params).unwrap_err();
         assert_eq!(error.code, jsonrpc::ErrorCode::ServerError(-32803));
@@ -246,6 +262,25 @@ mod tests {
             error.data,
             Some(serde_json::json!({ "reason": "methodDenied" }))
         );
+    }
+
+    #[test]
+    fn explicit_null_params_are_invalid_but_omission_is_allowed() {
+        let omitted = PeerRequestParams::deserialize(&serde_json::json!({
+            "id": "peer",
+            "method": "custom/request"
+        }))
+        .unwrap();
+        validate_params(&omitted).unwrap();
+
+        let explicit_null = PeerRequestParams::deserialize(&serde_json::json!({
+            "id": "peer",
+            "method": "custom/request",
+            "params": null
+        }))
+        .unwrap();
+        let error = validate_params(&explicit_null).unwrap_err();
+        assert_eq!(error.code, jsonrpc::ErrorCode::InvalidParams);
     }
 
     #[test]

--- a/src/lsp/bridge/peer/request.rs
+++ b/src/lsp/bridge/peer/request.rs
@@ -179,6 +179,21 @@ fn normalize_response(response: serde_json::Value) -> jsonrpc::Result<serde_json
             "peer returned a response without jsonrpc: 2.0",
         ));
     }
+    if let Some(reason) = response
+        .pointer("/error/data/kakehashiBridgeFailure")
+        .and_then(serde_json::Value::as_str)
+        .and_then(|reason| match reason {
+            "connectionLost" => Some("connectionLost"),
+            "requestTimeout" => Some("requestTimeout"),
+            _ => None,
+        })
+    {
+        let message = response
+            .pointer("/error/message")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("peer connection failed");
+        return Err(request_failed(reason, message));
+    }
     match (response.get("result"), response.get("error")) {
         (Some(result), None) => Ok(serde_json::json!({ "result": result })),
         (None, Some(error)) => serde_json::from_value::<jsonrpc::Error>(error.clone())
@@ -235,6 +250,24 @@ mod tests {
             error.data,
             Some(serde_json::json!({ "reason": "methodDenied" }))
         );
+    }
+
+    #[test]
+    fn bridge_failures_remain_outer_request_failures() {
+        for reason in ["connectionLost", "requestTimeout"] {
+            let error = normalize_response(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 91,
+                "error": {
+                    "code": -32603,
+                    "message": "bridge transport failed",
+                    "data": { "kakehashiBridgeFailure": reason }
+                }
+            }))
+            .unwrap_err();
+            assert_eq!(error.code, jsonrpc::ErrorCode::ServerError(-32803));
+            assert_eq!(error.data, Some(serde_json::json!({ "reason": reason })));
+        }
     }
 
     #[test]

--- a/src/lsp/bridge/peer/request.rs
+++ b/src/lsp/bridge/peer/request.rs
@@ -155,10 +155,18 @@ pub(in crate::lsp::bridge) fn handle(
                 let should_notify = peer.router().cancel_and_remove(downstream_id);
                 router_guard.disarm();
                 if should_notify {
-                    peer.send_notification(JsonRpcNotification::new(
+                    let outcome = peer.send_notification(JsonRpcNotification::new(
                         "$/cancelRequest",
                         serde_json::json!({ "id": downstream_id.as_i64() }),
                     ));
+                    if outcome != super::super::pool::NotificationSendResult::Queued {
+                        log::warn!(
+                            target: "kakehashi::bridge::peer",
+                            "Could not queue peer cancellation for request {}: {:?}",
+                            downstream_id.as_i64(),
+                            outcome
+                        );
+                    }
                 }
                 Err(jsonrpc::Error::request_cancelled())
             }

--- a/src/lsp/bridge/peer/request.rs
+++ b/src/lsp/bridge/peer/request.rs
@@ -394,7 +394,7 @@ mod tests {
             peer.clone(),
             request_id,
             settled_rx,
-            tokio::time::Instant::now() + std::time::Duration::from_secs(30),
+            tokio::time::Instant::now() + crate::lsp::bridge::pool::REQUEST_TIMEOUT,
             Arc::clone(&permit),
         ));
         drop(response_rx);

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -342,6 +342,8 @@ pub struct LanguageServerPool {
     /// workspace root (issue #382); documents sharing a root (or the
     /// client-root fallback) still share one process.
     connections: Mutex<HashMap<ConnectionKey, Arc<ConnectionHandle>>>,
+    /// Weak directory exposed to downstream `kakehashi/bridge/peer*` requests.
+    peer_directory: Arc<super::peer::PeerDirectory>,
     /// Gate that rejects **new** connection spawns once shutdown has begun.
     ///
     /// `shutdown_all` snapshots the live connections and tears them down, but a
@@ -522,6 +524,7 @@ impl LanguageServerPool {
         let (upstream_request_tx, upstream_request_rx) = tokio::sync::mpsc::unbounded_channel();
         Self {
             connections: Mutex::new(HashMap::new()),
+            peer_directory: Arc::new(super::peer::PeerDirectory::default()),
             shutting_down: AtomicBool::new(false),
             document_tracker: Arc::new(DocumentTracker::new()),
             open_transition_locks: Arc::new(DashMap::new()),
@@ -3163,6 +3166,7 @@ impl LanguageServerPool {
                 // The applyEdit version validation scopes downstream-supplied
                 // versions to this connection's version space (PR-L).
                 connection_key: connection_key.clone(),
+                peer_directory: Arc::clone(&self.peer_directory),
                 response_tx: tx.clone(),
                 dynamic_capabilities: Arc::clone(&dynamic_capabilities),
                 upstream_tx: self.upstream_tx.clone(),
@@ -3206,6 +3210,7 @@ impl LanguageServerPool {
 
         // Insert into pool immediately so concurrent requests see Initializing state
         connections.insert(connection_key.clone(), Arc::clone(&handle));
+        self.peer_directory.register(&handle);
 
         // Release lock before spawning handshake task
         drop(connections);

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -496,11 +496,10 @@ pub struct LanguageServerPool {
     /// route an incoming `$/progress`) and the dispatch path (register on
     /// fan-out / deregister on completion).
     client_progress_registry: Arc<super::ClientProgressRegistry>,
-    /// Tracks downstream-initiated requests forwarded to the editor so a
-    /// downstream `$/cancelRequest` (or connection death) can cancel the
-    /// editor-bound request (#404) — capability-gated applyEdits are
-    /// registered too, though answered locally. Shared with every reader task (to register /
-    /// fire) and the forwarding loop (to await / drop). Distinct from
+    /// Tracks downstream-initiated requests forwarded to the editor or another
+    /// peer so `$/cancelRequest` (or connection death) can stop the matching
+    /// operation. Shared with every reader task (to register/fire) and the
+    /// editor/peer forwarding tasks (to await/drop). Distinct from
     /// `upstream_request_registry`, which is the *outbound* (editor → downstream)
     /// cancel direction.
     inbound_request_registry: super::InboundRequestRegistry,

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -274,7 +274,7 @@ pub(super) struct HostDocSyncState {
 }
 
 pub(in crate::lsp::bridge) type HostDocuments =
-    Mutex<HashMap<(String, ConnectionKey), HostDocSyncState>>;
+    Mutex<HashMap<String, HashMap<ConnectionKey, HostDocSyncState>>>;
 
 /// Cancellation-safe rollback for the pre-send virtual-document claim.
 /// Eager-open tasks are deliberately aborted when a newer parse supersedes
@@ -804,10 +804,10 @@ impl LanguageServerPool {
             if let Some(handle) = connections.get(&key) {
                 handle.begin_shutdown();
             }
-            self.host_documents
-                .lock()
-                .await
-                .retain(|(_, connection_key), _| connection_key != &key);
+            self.host_documents.lock().await.retain(|_, connections| {
+                connections.remove(&key);
+                !connections.is_empty()
+            });
             self.clear_host_routing_for_connection(&key);
             self.document_tracker.purge_connection(&key).await;
             // Arm before the replacement can claim: what this connection held
@@ -962,10 +962,10 @@ impl LanguageServerPool {
             if let Some(handle) = connections.get(&key) {
                 handle.begin_shutdown();
             }
-            self.host_documents
-                .lock()
-                .await
-                .retain(|(_, connection_key), _| connection_key != &key);
+            self.host_documents.lock().await.retain(|_, connections| {
+                connections.remove(&key);
+                !connections.is_empty()
+            });
             self.clear_host_routing_for_connection(&key);
             self.document_tracker.purge_connection(&key).await;
             // Arm before the replacement can claim: what this connection held
@@ -1188,7 +1188,8 @@ impl LanguageServerPool {
     /// request path in `text_document/host.rs`.
     pub(super) async fn host_documents(
         &self,
-    ) -> tokio::sync::MutexGuard<'_, HashMap<(String, ConnectionKey), HostDocSyncState>> {
+    ) -> tokio::sync::MutexGuard<'_, HashMap<String, HashMap<ConnectionKey, HostDocSyncState>>>
+    {
         self.host_documents.lock().await
     }
 
@@ -1309,8 +1310,8 @@ impl LanguageServerPool {
         let key = host_uri.to_string();
         self.host_documents()
             .await
-            .keys()
-            .any(|(uri, connection_key)| uri == &key && connection_key.server() == server_name)
+            .get(&key)
+            .is_some_and(|connections| connections.keys().any(|key| key.server() == server_name))
     }
 
     /// Whether the host document has been synced on this exact pooled
@@ -1322,7 +1323,8 @@ impl LanguageServerPool {
     ) -> bool {
         self.host_documents()
             .await
-            .contains_key(&(host_uri.to_string(), connection_key.clone()))
+            .get(host_uri.as_str())
+            .is_some_and(|connections| connections.contains_key(connection_key))
     }
 
     pub(crate) fn set_host_routing_suppressed(
@@ -1632,10 +1634,9 @@ impl LanguageServerPool {
         let key = host_uri.to_string();
         self.host_documents()
             .await
+            .get(&key)?
             .iter()
-            .find(|((uri, connection_key), _)| {
-                uri == &key && connection_key.server() == server_name
-            })
+            .find(|(connection_key, _)| connection_key.server() == server_name)
             .map(|(_, state)| state.version)
     }
 
@@ -3064,10 +3065,10 @@ impl LanguageServerPool {
                     // sharing the server name keep their state. Lock order:
                     // connections → host_documents / document tracker,
                     // consistent with close_host_bridge_document's prefetch.
-                    self.host_documents
-                        .lock()
-                        .await
-                        .retain(|(_, key), _| key != &connection_key);
+                    self.host_documents.lock().await.retain(|_, connections| {
+                        connections.remove(&connection_key);
+                        !connections.is_empty()
+                    });
                     self.clear_host_routing_for_connection(&connection_key);
                     self.document_tracker
                         .purge_connection(&connection_key)

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -34,7 +34,7 @@ use handshake::perform_lsp_handshake;
 pub(crate) use connection_handle::{ConnectionHandle, NotificationSendResult};
 pub(crate) use connection_key::ConnectionKey;
 pub(crate) use connection_state::ConnectionState;
-use document_tracker::DocumentTracker;
+pub(in crate::lsp::bridge) use document_tracker::DocumentTracker;
 pub(crate) use document_tracker::OpenedVirtualDoc;
 pub(crate) use dynamic_capability_registry::DynamicCapabilityRegistry;
 pub(crate) use message_sender::{ConnectionHandleSender, MessageSender};
@@ -273,6 +273,9 @@ pub(super) struct HostDocSyncState {
     pub(super) fingerprint: u64,
 }
 
+pub(in crate::lsp::bridge) type HostDocuments =
+    Mutex<HashMap<(String, ConnectionKey), HostDocSyncState>>;
+
 /// Cancellation-safe rollback for the pre-send virtual-document claim.
 /// Eager-open tasks are deliberately aborted when a newer parse supersedes
 /// them; dropping the handler between claim and FIFO enqueue must not leave a
@@ -376,7 +379,7 @@ pub struct LanguageServerPool {
     /// (host-document-bridge): the real-URI documents opened on downstream
     /// servers via `bridge._self`, with their version and content
     /// fingerprint for lazy full-text re-sync.
-    host_documents: Mutex<HashMap<(String, ConnectionKey), HostDocSyncState>>,
+    host_documents: Arc<HostDocuments>,
     /// Host documents explicitly suppressed by a downstream routing answer.
     host_routing_suppressed: DashMap<(String, ConnectionKey), ()>,
     /// Host/server pairs for which routing has already been decided, including
@@ -522,15 +525,20 @@ impl LanguageServerPool {
         let (window_tx, window_rx) =
             tokio::sync::mpsc::channel(super::actor::WINDOW_NOTIFICATION_QUEUE_CAPACITY);
         let (upstream_request_tx, upstream_request_rx) = tokio::sync::mpsc::unbounded_channel();
+        let document_tracker = Arc::new(DocumentTracker::new());
+        let host_documents = Arc::new(Mutex::new(HashMap::new()));
         Self {
             connections: Mutex::new(HashMap::new()),
-            peer_directory: Arc::new(super::peer::PeerDirectory::default()),
+            peer_directory: Arc::new(super::peer::PeerDirectory::new(
+                Arc::clone(&document_tracker),
+                Arc::clone(&host_documents),
+            )),
             shutting_down: AtomicBool::new(false),
-            document_tracker: Arc::new(DocumentTracker::new()),
+            document_tracker,
             open_transition_locks: Arc::new(DashMap::new()),
             host_lifecycle_locks: DashMap::new(),
             latest_virtual_contents: DashMap::new(),
-            host_documents: Mutex::new(HashMap::new()),
+            host_documents,
             host_routing_suppressed: DashMap::new(),
             host_routing_decided: DashMap::new(),
             host_routing_by_server: DashMap::new(),

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -31,6 +31,7 @@ pub(crate) use connection_action::BridgeError;
 use connection_action::{ConnectionAction, decide_connection_action};
 use handshake::perform_lsp_handshake;
 
+pub(in crate::lsp::bridge) use connection_handle::REQUEST_TIMEOUT;
 pub(crate) use connection_handle::{ConnectionHandle, NotificationSendResult};
 pub(crate) use connection_key::ConnectionKey;
 pub(crate) use connection_state::ConnectionState;

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -1113,9 +1113,13 @@ impl ConnectionHandle {
 
     pub(in crate::lsp::bridge) fn register_peer_request(
         &self,
-    ) -> io::Result<(RequestId, tokio::sync::oneshot::Receiver<serde_json::Value>)> {
+    ) -> io::Result<(
+        RequestId,
+        tokio::sync::oneshot::Receiver<serde_json::Value>,
+        tokio::sync::oneshot::Receiver<()>,
+    )> {
         let request_id = RequestId::new(self.next_request_id());
-        let (response_rx, liveness_epoch) = self
+        let (response_rx, liveness_epoch, settled_rx) = self
             .router()
             .register_peer(request_id)
             .ok_or_else(|| io::Error::other("bridge: duplicate request ID"))?;
@@ -1124,7 +1128,7 @@ impl ConnectionHandle {
         {
             self.reader_handle.notify_liveness_start(epoch);
         }
-        Ok((request_id, response_rx))
+        Ok((request_id, response_rx, settled_rx))
     }
 
     /// Like `register_request()`, but also records the upstream→downstream ID

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -1101,8 +1101,16 @@ impl ConnectionHandle {
     pub(in crate::lsp::bridge) fn register_peer_request(
         &self,
     ) -> io::Result<(RequestId, tokio::sync::oneshot::Receiver<serde_json::Value>)> {
-        let (request_id, response_rx) = self.register_request()?;
-        self.router.track_failure(request_id);
+        let request_id = RequestId::new(self.next_request_id());
+        let (response_rx, liveness_epoch) = self
+            .router()
+            .register_peer(request_id)
+            .ok_or_else(|| io::Error::other("bridge: duplicate request ID"))?;
+        if let Some(epoch) = liveness_epoch
+            && self.state() == ConnectionState::Ready
+        {
+            self.reader_handle.notify_liveness_start(epoch);
+        }
         Ok((request_id, response_rx))
     }
 

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -607,6 +607,17 @@ impl ConnectionHandle {
         self.state_watch.send_replace(new_state);
     }
 
+    pub(in crate::lsp::bridge) fn fail_if_ready(&self) {
+        let mut state = self
+            .state
+            .write()
+            .recover_poison("ConnectionHandle::fail_if_ready");
+        if *state == ConnectionState::Ready {
+            *state = ConnectionState::Failed;
+            self.state_watch.send_replace(ConnectionState::Failed);
+        }
+    }
+
     /// Complete initialization only while this handle still belongs to its
     /// original lifecycle. A reload or global shutdown may move an
     /// initializing handle to `Closing`; the handshake task must not resurrect
@@ -1147,9 +1158,23 @@ impl ConnectionHandle {
         request_id: RequestId,
         response_rx: tokio::sync::oneshot::Receiver<serde_json::Value>,
     ) -> io::Result<serde_json::Value> {
-        use tokio::time::timeout;
+        self.wait_for_response_until(
+            request_id,
+            response_rx,
+            tokio::time::Instant::now() + REQUEST_TIMEOUT,
+        )
+        .await
+    }
 
-        match timeout(REQUEST_TIMEOUT, response_rx).await {
+    pub(in crate::lsp::bridge) async fn wait_for_response_until(
+        &self,
+        request_id: RequestId,
+        response_rx: tokio::sync::oneshot::Receiver<serde_json::Value>,
+        deadline: tokio::time::Instant,
+    ) -> io::Result<serde_json::Value> {
+        use tokio::time::timeout_at;
+
+        match timeout_at(deadline, response_rx).await {
             Ok(Ok(response)) => {
                 if let Some(failure) = self.router.take_failure(request_id) {
                     let (kind, message) = match failure {

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -476,6 +476,43 @@ impl ConnectionHandle {
         parse_routing_response(&response)
     }
 
+    /// Queue an arbitrary JSON-RPC request for the downstream peer escape hatch.
+    ///
+    /// Unlike [`Self::send_request`], `method` is runtime data and `params` may
+    /// be omitted. The request is still tracked by the same response router and
+    /// single-writer queue as bridge-managed requests.
+    pub(crate) fn send_request_value(
+        &self,
+        method: String,
+        params: Option<serde_json::Value>,
+        request_id: RequestId,
+    ) -> Result<(), BridgeError> {
+        let mut payload = serde_json::Map::with_capacity(4);
+        payload.insert(
+            "jsonrpc".to_string(),
+            serde_json::Value::String("2.0".to_string()),
+        );
+        payload.insert("id".to_string(), serde_json::json!(request_id.as_i64()));
+        payload.insert("method".to_string(), serde_json::Value::String(method));
+        if let Some(params) = params {
+            payload.insert("params".to_string(), params);
+        }
+        match self.tx.try_send(OutboundMessage::Tracked {
+            payload: serde_json::Value::Object(payload),
+            request_id,
+        }) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.router.remove(request_id);
+                Err(BridgeError::QueueFull)
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                self.router.remove(request_id);
+                Err(BridgeError::ChannelClosed)
+            }
+        }
+    }
+
     /// Send a raw payload for echo-server tests.
     ///
     /// Echo-server tests need to send a message that, when echoed back, is

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -607,15 +607,28 @@ impl ConnectionHandle {
         self.state_watch.send_replace(new_state);
     }
 
-    pub(in crate::lsp::bridge) fn fail_if_ready(&self) {
+    /// Fail a wedged connection and abort its writer immediately.
+    ///
+    /// Dropping the writer task handle cancels a write parked on a full stdin
+    /// pipe; the writer then drops its owned process handle, which force-kills
+    /// the downstream child. This is required when graceful shutdown cannot
+    /// make progress because the writer itself is the failed resource.
+    pub(in crate::lsp::bridge) fn fail_and_abort_writer(&self) {
         let mut state = self
             .state
             .write()
-            .recover_poison("ConnectionHandle::fail_if_ready");
+            .recover_poison("ConnectionHandle::fail_and_abort_writer");
         if *state == ConnectionState::Ready {
             *state = ConnectionState::Failed;
             self.state_watch.send_replace(ConnectionState::Failed);
         }
+        drop(state);
+        drop(
+            self.writer_handle
+                .lock()
+                .recover_poison("ConnectionHandle::fail_and_abort_writer")
+                .take(),
+        );
     }
 
     /// Complete initialization only while this handle still belongs to its
@@ -1406,6 +1419,33 @@ mod tests {
         // Can access router
         let _router = handle.router();
         // Router is accessible (test passes if no panic)
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn aborting_a_wedged_writer_kills_its_downstream_process() {
+        use crate::lsp::bridge::pool::test_helpers::{
+            create_handle_with_state_and_pid, process_stat,
+        };
+
+        let (handle, pid) = create_handle_with_state_and_pid(ConnectionState::Ready).await;
+        handle.fail_and_abort_writer();
+        assert_eq!(handle.state(), ConnectionState::Failed);
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            match process_stat(pid).expect("ps should inspect the test child") {
+                None => break,
+                Some(stat) if stat.starts_with('Z') => break,
+                Some(stat) => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "child {pid} survived writer abort (stat {stat})"
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+            }
+        }
     }
 
     /// Test that liveness timeout triggers Ready->Failed state transition (ls-bridge-async-connection Phase 3).

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -487,18 +487,8 @@ impl ConnectionHandle {
         params: Option<serde_json::Value>,
         request_id: RequestId,
     ) -> Result<(), BridgeError> {
-        let mut payload = serde_json::Map::with_capacity(4);
-        payload.insert(
-            "jsonrpc".to_string(),
-            serde_json::Value::String("2.0".to_string()),
-        );
-        payload.insert("id".to_string(), serde_json::json!(request_id.as_i64()));
-        payload.insert("method".to_string(), serde_json::Value::String(method));
-        if let Some(params) = params {
-            payload.insert("params".to_string(), params);
-        }
         match self.tx.try_send(OutboundMessage::Tracked {
-            payload: serde_json::Value::Object(payload),
+            payload: build_request_value(method, params, request_id),
             request_id,
         }) {
             Ok(()) => Ok(()),
@@ -1172,6 +1162,24 @@ impl ConnectionHandle {
     }
 }
 
+fn build_request_value(
+    method: String,
+    params: Option<serde_json::Value>,
+    request_id: RequestId,
+) -> serde_json::Value {
+    let mut payload = serde_json::Map::with_capacity(4);
+    payload.insert(
+        "jsonrpc".to_string(),
+        serde_json::Value::String("2.0".to_string()),
+    );
+    payload.insert("id".to_string(), serde_json::json!(request_id.as_i64()));
+    payload.insert("method".to_string(), serde_json::Value::String(method));
+    if let Some(params) = params {
+        payload.insert("params".to_string(), params);
+    }
+    serde_json::Value::Object(payload)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1181,6 +1189,21 @@ mod tests {
     /// Create a default DynamicCapabilityRegistry for tests that don't need it.
     fn default_dynamic_caps() -> Arc<DynamicCapabilityRegistry> {
         Arc::new(DynamicCapabilityRegistry::new())
+    }
+
+    #[test]
+    fn arbitrary_request_preserves_omitted_params() {
+        let without = build_request_value("custom/noParams".to_string(), None, RequestId::new(7));
+        assert_eq!(without["id"], 7);
+        assert_eq!(without["method"], "custom/noParams");
+        assert!(without.get("params").is_none());
+
+        let with = build_request_value(
+            "custom/withParams".to_string(),
+            Some(serde_json::json!({ "value": 1 })),
+            RequestId::new(8),
+        );
+        assert_eq!(with["params"], serde_json::json!({ "value": 1 }));
     }
 
     /// The settings cell stored on the handle is the *same* `Arc` the reader's

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -597,7 +597,7 @@ impl ConnectionHandle {
 
     /// Set the connection state, recovering from poisoned locks per project
     /// convention and notifying watchers via the watch channel.
-    pub(super) fn set_state(&self, new_state: ConnectionState) {
+    pub(in crate::lsp::bridge) fn set_state(&self, new_state: ConnectionState) {
         *self
             .state
             .write()

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -1098,6 +1098,14 @@ impl ConnectionHandle {
         self.register_request_with_upstream(None)
     }
 
+    pub(in crate::lsp::bridge) fn register_peer_request(
+        &self,
+    ) -> io::Result<(RequestId, tokio::sync::oneshot::Receiver<serde_json::Value>)> {
+        let (request_id, response_rx) = self.register_request()?;
+        self.router.track_failure(request_id);
+        Ok((request_id, response_rx))
+    }
+
     /// Like `register_request()`, but also records the upstream→downstream ID
     /// mapping in the router's cancel_map so `$/cancelRequest` can be translated
     /// and forwarded (`None` for internal requests).
@@ -1135,6 +1143,19 @@ impl ConnectionHandle {
 
         match timeout(REQUEST_TIMEOUT, response_rx).await {
             Ok(Ok(response)) => {
+                if let Some(failure) = self.router.take_failure(request_id) {
+                    let (kind, message) = match failure {
+                        super::super::actor::BridgeFailure::ConnectionLost => (
+                            io::ErrorKind::BrokenPipe,
+                            "bridge: downstream connection lost",
+                        ),
+                        super::super::actor::BridgeFailure::RequestTimeout => (
+                            io::ErrorKind::TimedOut,
+                            "bridge: downstream request timed out",
+                        ),
+                    };
+                    return Err(io::Error::new(kind, message));
+                }
                 // Check if this was an error response from liveness timeout
                 // If so, transition to Failed state (ls-bridge-async-connection Phase 3)
                 if self.reader_handle.check_liveness_failed() {

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -10,6 +10,8 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::time::Duration;
 
+pub(in crate::lsp::bridge) const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
 use tokio::sync::mpsc;
 use tower_lsp_server::ls_types::{
     CodeActionOptions, CodeActionProviderCapability, ColorProviderCapability,
@@ -1146,8 +1148,6 @@ impl ConnectionHandle {
         response_rx: tokio::sync::oneshot::Receiver<serde_json::Value>,
     ) -> io::Result<serde_json::Value> {
         use tokio::time::timeout;
-
-        const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
         match timeout(REQUEST_TIMEOUT, response_rx).await {
             Ok(Ok(response)) => {

--- a/src/lsp/bridge/pool/connection_key.rs
+++ b/src/lsp/bridge/pool/connection_key.rs
@@ -114,6 +114,24 @@ impl ConnectionKey {
             ConnectionRoot::ClientFallback | ConnectionRoot::Shared => None,
         }
     }
+
+    /// Opaque, injective wire identity for downstream peer discovery.
+    ///
+    /// The display form is human-oriented and can collide when a configured
+    /// server name itself contains `@` or `#`. Length-prefixing the unrestricted
+    /// server name and tagging the root variant keeps this identifier unambiguous.
+    pub(in crate::lsp::bridge) fn peer_id(&self) -> String {
+        let root = match &self.root {
+            ConnectionRoot::Marker(root) => format!("marker:{root}"),
+            ConnectionRoot::ClientFallback => "fallback".to_string(),
+            ConnectionRoot::Shared => "shared".to_string(),
+        };
+        format!(
+            "kakehashi-peer:{}:{}:{root}",
+            self.server.len(),
+            self.server
+        )
+    }
 }
 
 impl fmt::Display for ConnectionKey {
@@ -188,5 +206,17 @@ mod tests {
     #[test]
     fn shared_key_display_is_unambiguous() {
         assert_eq!(ConnectionKey::shared("tsgo").to_string(), "tsgo#shared");
+    }
+
+    #[test]
+    fn peer_id_does_not_confuse_server_name_markers_with_root_variants() {
+        assert_ne!(
+            ConnectionKey::for_server("a#shared").peer_id(),
+            ConnectionKey::shared("a").peer_id()
+        );
+        assert_ne!(
+            ConnectionKey::for_server("a@file:///repo").peer_id(),
+            ConnectionKey::new("a", Some("file:///repo".to_string())).peer_id()
+        );
     }
 }

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -947,6 +947,28 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn connections_serving_uri_matches_virtual_uri_and_its_host() {
+        let tracker = DocumentTracker::new();
+        let host_uri = Url::parse("file:///project/doc.md").unwrap();
+        let virtual_uri = VirtualDocumentUri::new(&url_to_uri(&host_uri), "typescript", "ts-0");
+        let connection = ConnectionKey::for_server("denols");
+        tracker
+            .register_opened_document(&host_uri, &virtual_uri, &connection)
+            .await;
+
+        assert_eq!(
+            tracker.connections_serving_uri(host_uri.as_str()).await,
+            vec![connection.clone()]
+        );
+        assert_eq!(
+            tracker
+                .connections_serving_uri(&virtual_uri.to_uri_string())
+                .await,
+            vec![connection]
+        );
+    }
+
     /// Test that register_opened_document records multiple virtual docs for same host.
     #[tokio::test]
     async fn register_opened_document_records_multiple_virtual_docs() {

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -841,18 +841,18 @@ impl DocumentTracker {
             .get(uri)
             .map(|keys| keys.clone())
             .unwrap_or_default();
-        let host_to_virtual = self.host_to_virtual.lock().await;
-        for document in host_to_virtual
-            .iter()
-            .filter(|(host_uri, _)| host_uri.as_str() == uri)
-            .flat_map(|(_, documents)| documents)
-        {
-            if self.is_virtual_doc_open_on_connection(
-                &document.virtual_uri.to_uri_string(),
-                &document.connection_key,
-            ) && !connections.contains(&document.connection_key)
-            {
-                connections.push(document.connection_key.clone());
+        if let Ok(host_uri) = Url::parse(uri) {
+            let host_to_virtual = self.host_to_virtual.lock().await;
+            if let Some(documents) = host_to_virtual.get(&host_uri) {
+                for document in documents {
+                    if self.is_virtual_doc_open_on_connection(
+                        &document.virtual_uri.to_uri_string(),
+                        &document.connection_key,
+                    ) && !connections.contains(&document.connection_key)
+                    {
+                        connections.push(document.connection_key.clone());
+                    }
+                }
             }
         }
         connections

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -847,7 +847,11 @@ impl DocumentTracker {
             .filter(|(host_uri, _)| host_uri.as_str() == uri)
             .flat_map(|(_, documents)| documents)
         {
-            if !connections.contains(&document.connection_key) {
+            if self.is_virtual_doc_open_on_connection(
+                &document.virtual_uri.to_uri_string(),
+                &document.connection_key,
+            ) && !connections.contains(&document.connection_key)
+            {
                 connections.push(document.connection_key.clone());
             }
         }
@@ -966,6 +970,24 @@ mod tests {
                 .connections_serving_uri(&virtual_uri.to_uri_string())
                 .await,
             vec![connection]
+        );
+    }
+
+    #[tokio::test]
+    async fn connections_serving_uri_ignores_pending_document_open() {
+        let tracker = DocumentTracker::new();
+        let host_uri = Url::parse("file:///project/doc.md").unwrap();
+        let virtual_uri = VirtualDocumentUri::new(&url_to_uri(&host_uri), "typescript", "ts-0");
+        let connection = ConnectionKey::for_server("denols");
+        tracker
+            .register_pending_document(&host_uri, &virtual_uri, &connection)
+            .await;
+
+        assert!(
+            tracker
+                .connections_serving_uri(host_uri.as_str())
+                .await
+                .is_empty()
         );
     }
 

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -830,6 +830,30 @@ impl DocumentTracker {
             .is_some_and(|entry| entry.value().contains(connection_key))
     }
 
+    /// Connections that currently serve `uri` either as that exact downstream
+    /// document or as an injection belonging to that host document.
+    pub(in crate::lsp::bridge) async fn connections_serving_uri(
+        &self,
+        uri: &str,
+    ) -> Vec<ConnectionKey> {
+        let mut connections = self
+            .virtual_to_servers
+            .get(uri)
+            .map(|keys| keys.clone())
+            .unwrap_or_default();
+        let host_to_virtual = self.host_to_virtual.lock().await;
+        for document in host_to_virtual
+            .iter()
+            .filter(|(host_uri, _)| host_uri.as_str() == uri)
+            .flat_map(|(_, documents)| documents)
+        {
+            if !connections.contains(&document.connection_key) {
+                connections.push(document.connection_key.clone());
+            }
+        }
+        connections
+    }
+
     /// Resolve a virtual-document URI string back to its `(host_url, region_id)`.
     ///
     /// Used by the inbound `window/showDocument` translation to recover which

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -167,6 +167,7 @@ fn build_baseline_capabilities(
         experimental: Some(serde_json::json!({
             "kakehashi": {
                 "bridgeRouting": true,
+                "bridgePeer": true,
             },
         })),
         ..Default::default()
@@ -461,6 +462,17 @@ mod tests {
     /// Snapshot suffixes predate the runtime opt-in (they matched the old
     /// "experimental" cargo feature); both variants now run in one process.
     const EXPERIMENTAL_VARIANTS: [(bool, &str); 2] = [(false, "default"), (true, "experimental")];
+
+    #[test]
+    fn downstream_initialize_advertises_bridge_peer_support() {
+        let capabilities = build_bridge_client_capabilities(None, false, false);
+        assert_eq!(
+            capabilities.experimental,
+            Some(serde_json::json!({
+                "kakehashi": { "bridgePeer": true }
+            }))
+        );
+    }
 
     #[test]
     fn bridge_client_capabilities_snapshot() {

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -469,7 +469,10 @@ mod tests {
         assert_eq!(
             capabilities.experimental,
             Some(serde_json::json!({
-                "kakehashi": { "bridgePeer": true }
+                "kakehashi": {
+                    "bridgePeer": true,
+                    "bridgeRouting": true
+                }
             }))
         );
     }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
@@ -154,7 +154,8 @@ expression: merged
   },
   "experimental": {
     "kakehashi": {
-      "bridgeRouting": true
+      "bridgeRouting": true,
+      "bridgePeer": true
     }
   }
 }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
@@ -157,7 +157,8 @@ expression: merged
   },
   "experimental": {
     "kakehashi": {
-      "bridgeRouting": true
+      "bridgeRouting": true,
+      "bridgePeer": true
     }
   }
 }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
@@ -99,7 +99,8 @@ expression: capabilities
   },
   "experimental": {
     "kakehashi": {
-      "bridgeRouting": true
+      "bridgeRouting": true,
+      "bridgePeer": true
     }
   }
 }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
@@ -102,7 +102,8 @@ expression: capabilities
   },
   "experimental": {
     "kakehashi": {
-      "bridgeRouting": true
+      "bridgeRouting": true,
+      "bridgePeer": true
     }
   }
 }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
@@ -106,7 +106,8 @@ expression: request
       },
       "experimental": {
         "kakehashi": {
-          "bridgeRouting": true
+          "bridgeRouting": true,
+          "bridgePeer": true
         }
       }
     }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
@@ -109,7 +109,8 @@ expression: request
       },
       "experimental": {
         "kakehashi": {
-          "bridgeRouting": true
+          "bridgeRouting": true,
+          "bridgePeer": true
         }
       }
     }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
@@ -117,7 +117,8 @@ expression: request
       },
       "experimental": {
         "kakehashi": {
-          "bridgeRouting": true
+          "bridgeRouting": true,
+          "bridgePeer": true
         }
       }
     }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
@@ -120,7 +120,8 @@ expression: request
       },
       "experimental": {
         "kakehashi": {
-          "bridgeRouting": true
+          "bridgeRouting": true,
+          "bridgePeer": true
         }
       }
     }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
@@ -106,7 +106,8 @@ expression: request
       },
       "experimental": {
         "kakehashi": {
-          "bridgeRouting": true
+          "bridgeRouting": true,
+          "bridgePeer": true
         }
       }
     },

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
@@ -109,7 +109,8 @@ expression: request
       },
       "experimental": {
         "kakehashi": {
-          "bridgeRouting": true
+          "bridgeRouting": true,
+          "bridgePeer": true
         }
       }
     },

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
@@ -115,7 +115,8 @@ expression: request
       },
       "experimental": {
         "kakehashi": {
-          "bridgeRouting": true
+          "bridgeRouting": true,
+          "bridgePeer": true
         }
       }
     }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
@@ -118,7 +118,8 @@ expression: request
       },
       "experimental": {
         "kakehashi": {
-          "bridgeRouting": true
+          "bridgeRouting": true,
+          "bridgePeer": true
         }
       }
     }

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -128,20 +128,22 @@ pub(super) async fn sync_host_document<S: MessageSender>(
     let live = live_text_reader.and_then(|read| read());
     let text: &str = live.as_deref().unwrap_or(doc.text);
     let fp = fingerprint(text);
-
-    if let Entry::Vacant(uri_entry) = docs.entry(uri_string.clone()) {
-        let notification = JsonRpcNotification::new(
+    let did_open = || {
+        JsonRpcNotification::new(
             "textDocument/didOpen",
             DidOpenTextDocumentParams {
                 text_document: TextDocumentItem::new(
-                    uri_lsp,
+                    uri_lsp.clone(),
                     doc.language_id.to_string(),
                     1,
                     text.to_string(),
                 ),
             },
-        );
-        sender.send_notification(notification).await?;
+        )
+    };
+
+    if let Entry::Vacant(uri_entry) = docs.entry(uri_string.clone()) {
+        sender.send_notification(did_open()).await?;
         uri_entry.insert(std::collections::HashMap::from([(
             connection_key.clone(),
             HostDocSyncState {
@@ -158,18 +160,7 @@ pub(super) async fn sync_host_document<S: MessageSender>(
         .entry(connection_key.clone())
     {
         Entry::Vacant(entry) => {
-            let notification = JsonRpcNotification::new(
-                "textDocument/didOpen",
-                DidOpenTextDocumentParams {
-                    text_document: TextDocumentItem::new(
-                        uri_lsp,
-                        doc.language_id.to_string(),
-                        1,
-                        text.to_string(),
-                    ),
-                },
-            );
-            sender.send_notification(notification).await?;
+            sender.send_notification(did_open()).await?;
             entry.insert(HostDocSyncState {
                 version: 1,
                 fingerprint: fp,

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -110,13 +110,16 @@ pub(crate) type HostTextReader = Arc<dyn Fn() -> Option<Arc<str>> + Send + Sync>
 /// `didOpen` pass `None` and are synced verbatim.
 pub(super) async fn sync_host_document<S: MessageSender>(
     sender: &mut S,
-    docs: &mut std::collections::HashMap<(String, ConnectionKey), HostDocSyncState>,
+    docs: &mut std::collections::HashMap<
+        String,
+        std::collections::HashMap<ConnectionKey, HostDocSyncState>,
+    >,
     doc: &HostDocument<'_>,
     live_text_reader: Option<&(dyn Fn() -> Option<Arc<str>> + Send + Sync)>,
     connection_key: &ConnectionKey,
 ) -> io::Result<()> {
     let uri_lsp = host_url_to_lsp_uri(doc.uri)?;
-    let key = (doc.uri.to_string(), connection_key.clone());
+    let connections = docs.entry(doc.uri.to_string()).or_default();
     // With a live reader, read the document's CURRENT text under this lock so a
     // late-unparking eager re-sync sends the latest text, not the snapshot it was
     // spawned with (#422); a `None` read (closed mid-sync) falls back to the
@@ -126,7 +129,7 @@ pub(super) async fn sync_host_document<S: MessageSender>(
     let text: &str = live.as_deref().unwrap_or(doc.text);
     let fp = fingerprint(text);
 
-    match docs.entry(key) {
+    match connections.entry(connection_key.clone()) {
         Entry::Vacant(entry) => {
             let notification = JsonRpcNotification::new(
                 "textDocument/didOpen",
@@ -206,7 +209,10 @@ impl LanguageServerPool {
 
         let mut docs = self.host_documents().await;
         for (connection_key, handle) in &handles {
-            if !docs.contains_key(&(uri_string.clone(), connection_key.clone())) {
+            if !docs
+                .get(&uri_string)
+                .is_some_and(|connections| connections.contains_key(connection_key))
+            {
                 continue;
             }
             let notification = JsonRpcNotification::new(
@@ -220,12 +226,13 @@ impl LanguageServerPool {
             handle.send_notification(notification);
         }
         let closed_keys = docs
-            .keys()
-            .filter(|(doc_uri, _)| doc_uri == &uri_string)
+            .get(&uri_string)
+            .into_iter()
+            .flat_map(|connections| connections.keys())
             .cloned()
-            .map(|(doc_uri, connection_key)| (connection_key, doc_uri))
+            .map(|connection_key| (connection_key, uri_string.clone()))
             .collect::<Vec<_>>();
-        docs.retain(|(doc_uri, _), _| *doc_uri != uri_string);
+        docs.remove(&uri_string);
         self.clear_host_routing_suppression(uri);
         for key in closed_keys {
             self.invalidate_diagnostic_document(&key);
@@ -267,7 +274,10 @@ impl LanguageServerPool {
         let connections = self.connections().await;
         let docs = self.host_documents().await;
         for (connection_key, handle) in connections.iter() {
-            if !docs.contains_key(&(uri_string.clone(), connection_key.clone())) {
+            if !docs
+                .get(&uri_string)
+                .is_some_and(|connections| connections.contains_key(connection_key))
+            {
                 continue;
             }
             if !handle.has_capability("textDocument/willSave") {
@@ -458,7 +468,8 @@ impl LanguageServerPool {
         let document_is_open = self
             .host_documents()
             .await
-            .contains_key(&(cache_key.1.clone(), cache_key.0.clone()));
+            .get(&cache_key.1)
+            .is_some_and(|connections| connections.contains_key(&cache_key.0));
         let report = match report {
             Ok(report) => report,
             Err(error) => {
@@ -1158,15 +1169,15 @@ mod tests {
         let uri_b = Url::parse("file:///test/b.md").unwrap();
         {
             let mut docs = pool.host_documents().await;
-            docs.insert(
-                (uri_a.to_string(), ConnectionKey::for_server("srv")),
+            docs.entry(uri_a.to_string()).or_default().insert(
+                ConnectionKey::for_server("srv"),
                 HostDocSyncState {
                     version: 1,
                     fingerprint: 1,
                 },
             );
-            docs.insert(
-                (uri_b.to_string(), ConnectionKey::for_server("srv")),
+            docs.entry(uri_b.to_string()).or_default().insert(
+                ConnectionKey::for_server("srv"),
                 HostDocSyncState {
                     version: 1,
                     fingerprint: 2,
@@ -1178,11 +1189,13 @@ mod tests {
 
         let docs = pool.host_documents().await;
         assert!(
-            !docs.contains_key(&(uri_a.to_string(), ConnectionKey::for_server("srv"))),
+            !docs.contains_key(uri_a.as_str()),
             "closed uri's state must be dropped"
         );
         assert!(
-            docs.contains_key(&(uri_b.to_string(), ConnectionKey::for_server("srv"))),
+            docs.get(uri_b.as_str()).is_some_and(
+                |connections| connections.contains_key(&ConnectionKey::for_server("srv"))
+            ),
             "other documents must be untouched"
         );
     }

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -119,7 +119,7 @@ pub(super) async fn sync_host_document<S: MessageSender>(
     connection_key: &ConnectionKey,
 ) -> io::Result<()> {
     let uri_lsp = host_url_to_lsp_uri(doc.uri)?;
-    let connections = docs.entry(doc.uri.to_string()).or_default();
+    let uri_string = doc.uri.to_string();
     // With a live reader, read the document's CURRENT text under this lock so a
     // late-unparking eager re-sync sends the latest text, not the snapshot it was
     // spawned with (#422); a `None` read (closed mid-sync) falls back to the
@@ -129,7 +129,34 @@ pub(super) async fn sync_host_document<S: MessageSender>(
     let text: &str = live.as_deref().unwrap_or(doc.text);
     let fp = fingerprint(text);
 
-    match connections.entry(connection_key.clone()) {
+    if let Entry::Vacant(uri_entry) = docs.entry(uri_string.clone()) {
+        let notification = JsonRpcNotification::new(
+            "textDocument/didOpen",
+            DidOpenTextDocumentParams {
+                text_document: TextDocumentItem::new(
+                    uri_lsp,
+                    doc.language_id.to_string(),
+                    1,
+                    text.to_string(),
+                ),
+            },
+        );
+        sender.send_notification(notification).await?;
+        uri_entry.insert(std::collections::HashMap::from([(
+            connection_key.clone(),
+            HostDocSyncState {
+                version: 1,
+                fingerprint: fp,
+            },
+        )]));
+        return Ok(());
+    }
+
+    match docs
+        .get_mut(&uri_string)
+        .expect("host URI presence checked above")
+        .entry(connection_key.clone())
+    {
         Entry::Vacant(entry) => {
             let notification = JsonRpcNotification::new(
                 "textDocument/didOpen",

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -1039,6 +1039,39 @@ mod tests {
         }
     }
 
+    struct FailingSender;
+
+    impl MessageSender for FailingSender {
+        async fn send_notification<P: serde::Serialize + Send>(
+            &mut self,
+            _notification: JsonRpcNotification<P>,
+        ) -> io::Result<()> {
+            Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "test backpressure",
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_initial_sync_does_not_publish_an_empty_uri_bucket() {
+        let mut docs = std::collections::HashMap::new();
+        let uri = Url::parse("file:///test/failed.md").unwrap();
+
+        let error = sync_host_document(
+            &mut FailingSender,
+            &mut docs,
+            &host_doc(&uri, "text"),
+            None,
+            &ConnectionKey::for_server("srv"),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+        assert!(!docs.contains_key(uri.as_str()));
+    }
+
     #[tokio::test]
     async fn sync_sends_didopen_once_then_versioned_didchange_on_drift() {
         use crate::lsp::bridge::actor::OutboundMessage;


### PR DESCRIPTION
## Summary

- add downstream-only `kakehashi/bridge/peer` discovery
- add `kakehashi/bridge/peer/request` arbitrary request forwarding
- support optional `name` and `textDocument` filters with AND semantics; unknown parameter members are ignored
- exclude the calling connection itself while preserving same-name peers under other roots
- bound peer forwarding and cover cancellation, timeout, liveness, backpressure, and cleanup races
- judge an inner write whose caller cancelled or timed out as wedged only once it has not completed within one full response cap of the target's writer claiming it, never by the outer request's age; a still-writing frame stays tracked on every managed request's timeout so a stalled writer remains visible to liveness
- close the writer's queue before its shutdown drain, so a request racing a target's shutdown fails immediately instead of at the response cap
- advertise `bridgePeer` in every capability-merge branch, including when the editor supplies its own `experimental` extensions
- relay downstream error objects verbatim once their shape is valid, and accept response envelopes the way the bridge already routes them (no `jsonrpc` member required)
- refuse inner params carrying a `partialResultToken`, whose result stream nothing routes back to the caller, instead of answering with an empty final result
- document the protocol, register the cancelled-peer-write bound in the timeout hierarchy, and cover the protocol end to end over the wire

## Why

Meta language servers such as tsudoi need to choose a formatter dynamically from project context. Delegating peer communication to kakehashi lets them select an already-running downstream server such as denols or oxfmt without coupling the editor to that selection policy.

## Protocol notes

- these methods are downstream-server-to-kakehashi requests, not editor-to-kakehashi requests
- `textDocument` matches peers currently serving the exact host or injected document
- peer IDs identify stable configured server/root slots
- each origin connection may keep at most 64 peer request generations in flight
- every configured server can drive every other running one; the feature page states the trust boundary

## Validation

- `cargo test --lib -q`: 3895 passed, 3 ignored
- `cargo test --features e2e --test e2e -q`: 503 passed, 1 ignored; the single failure, `e2e_lsp_protocol::test_initialize_returns_capabilities`, is a stale snapshot on main (it predates this branch: the type hierarchy merge advertises `typeHierarchyProvider` and CI runs the e2e suite only as named modules)
- `make check` and `cargo clippy --all-targets --all-features -- -D warnings` (modulo a pre-existing `drop_non_drop` lint in `did_close.rs` on main)
- revise Stage 1 multi-perspective review: two passes (10 and 6 reviewers), converged
- revise Stage 2 codex review: two threads (each converged to "no comments to provide" after fixes) and a final fresh session clean on its first response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7JLuc6zYJvDw8sRt8bSQV
