### PR TITLE
feat(bridge): issue routing requests

### DIFF
--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1264,7 +1264,6 @@ impl LanguageServerPool {
     /// Whether the host document at `host_uri` has been synced (didOpen sent) to a
     /// `_self` host server named `server_name` — i.e. a `host_documents` sync-state
     /// entry exists for that `(uri, server)`. Used to verify host-layer eager open.
-    #[cfg(test)]
     pub(crate) async fn is_host_document_opened(&self, host_uri: &Url, server_name: &str) -> bool {
         // Key exactly as `sync_host_document` does (`doc.uri.to_string()`) so the
         // lookup can never diverge from the map's key construction.

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -25,12 +25,14 @@ use super::dynamic_capability_registry::DynamicCapabilityRegistry;
 use super::{ConnectionState, UpstreamId};
 use crate::error::LockResultExt;
 use crate::lsp::bridge::actor::{
-    OUTBOUND_QUEUE_CAPACITY, OutboundMessage, ReaderTaskHandle, ResponseRouter, WriterTaskHandle,
+    OUTBOUND_QUEUE_CAPACITY, OutboundMessage, ReaderTaskHandle, ResponseRouter, RouterCleanupGuard,
+    WriterTaskHandle,
 };
 use crate::lsp::bridge::connection::SplitConnectionWriter;
 use crate::lsp::bridge::protocol::{
-    JsonRpcNotification, JsonRpcRequest, ROUTING_METHOD, RequestId, RoutingAnswer, RoutingParams,
-    build_exit_notification, build_shutdown_request, jsonrpc_error_code, parse_routing_response,
+    JsonRpcNotification, JsonRpcRequest, ROUTING_METHOD, ROUTING_TIMEOUT, RequestId, RoutingAnswer,
+    RoutingParams, build_exit_notification, build_shutdown_request, jsonrpc_error_code,
+    parse_routing_response,
 };
 use crate::lsp::bridge::workspace::WorkspaceFolderSet;
 
@@ -433,11 +435,41 @@ impl ConnectionHandle {
             return Ok(None);
         }
 
-        let (request_id, response_rx) = self.register_request()?;
+        // Routing is control traffic, not user request traffic: keep it out of
+        // the connection-wide liveness timer. Its own deadline below sends a
+        // cancellation and retires the router entry.
+        let request_id = RequestId::new(self.next_request_id());
+        let response_rx = self
+            .router()
+            .register(request_id)
+            .ok_or_else(|| io::Error::other("bridge: duplicate routing request ID"))?;
+        let mut cleanup = RouterCleanupGuard::new(Arc::clone(self.router()), request_id);
         let request = JsonRpcRequest::new(request_id.as_i64(), ROUTING_METHOD, params);
         self.send_request(request, request_id)
             .map_err(io::Error::other)?;
-        let response = self.wait_for_response(request_id, response_rx).await?;
+        let mut response_rx = response_rx;
+        let response = match tokio::time::timeout(ROUTING_TIMEOUT, &mut response_rx).await {
+            Ok(Ok(response)) => response,
+            Ok(Err(_)) => return Err(io::Error::other("bridge: routing response channel closed")),
+            Err(_) => {
+                let cancel = JsonRpcNotification::new(
+                    "$/cancelRequest",
+                    serde_json::json!({"id": request_id.as_i64()}),
+                );
+                if self.send_notification(cancel) != NotificationSendResult::Queued {
+                    log::warn!(
+                        target: "kakehashi::bridge::routing",
+                        "Routing request {} timed out and its cancellation was not queued",
+                        request_id.as_i64()
+                    );
+                }
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "bridge: routing request timeout",
+                ));
+            }
+        };
+        cleanup.disarm();
         if jsonrpc_error_code(&response) == Some(-32601) {
             self.set_bridge_routing(false);
         }

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -29,7 +29,8 @@ use crate::lsp::bridge::actor::{
 };
 use crate::lsp::bridge::connection::SplitConnectionWriter;
 use crate::lsp::bridge::protocol::{
-    JsonRpcNotification, JsonRpcRequest, RequestId, build_exit_notification, build_shutdown_request,
+    JsonRpcNotification, JsonRpcRequest, ROUTING_METHOD, RequestId, RoutingAnswer, RoutingParams,
+    build_exit_notification, build_shutdown_request, jsonrpc_error_code, parse_routing_response,
 };
 use crate::lsp::bridge::workspace::WorkspaceFolderSet;
 
@@ -415,6 +416,32 @@ impl ConnectionHandle {
                 Err(BridgeError::ChannelClosed)
             }
         }
+    }
+
+    /// Ask an advertising downstream server for its routing refinement.
+    ///
+    /// The request is deliberately scoped to the connection: provider
+    /// selection and decision caching belong to the pool/document layer, while
+    /// this method owns only the negotiated wire contract and response
+    /// lifetime. A `MethodNotFound` response permanently disables routing for
+    /// this connection until its next initialize handshake.
+    pub(crate) async fn request_routing(
+        &self,
+        params: RoutingParams,
+    ) -> io::Result<Option<RoutingAnswer>> {
+        if !self.supports_bridge_routing() {
+            return Ok(None);
+        }
+
+        let (request_id, response_rx) = self.register_request()?;
+        let request = JsonRpcRequest::new(request_id.as_i64(), ROUTING_METHOD, params);
+        self.send_request(request, request_id)
+            .map_err(io::Error::other)?;
+        let response = self.wait_for_response(request_id, response_rx).await?;
+        if jsonrpc_error_code(&response) == Some(-32601) {
+            self.set_bridge_routing(false);
+        }
+        parse_routing_response(&response)
     }
 
     /// Send a raw payload for echo-server tests.

--- a/src/lsp/bridge/protocol.rs
+++ b/src/lsp/bridge/protocol.rs
@@ -23,6 +23,7 @@ mod lifecycle;
 mod request;
 mod request_id;
 mod response;
+mod routing;
 mod translation;
 mod virtual_uri;
 mod workspace_edit;
@@ -36,6 +37,7 @@ pub(crate) use lifecycle::*;
 pub(crate) use request::*;
 pub(crate) use request_id::RequestId;
 pub(crate) use response::*;
+pub(crate) use routing::*;
 pub(crate) use translation::*;
 pub(crate) use virtual_uri::VirtualDocumentUri;
 pub(crate) use workspace_edit::{

--- a/src/lsp/bridge/protocol/routing.rs
+++ b/src/lsp/bridge/protocol/routing.rs
@@ -1,0 +1,160 @@
+//! Downstream-facing `kakehashi/bridge/routing` protocol.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+pub(crate) const ROUTING_METHOD: &str = "kakehashi/bridge/routing";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RoutingTextDocument {
+    pub(crate) uri: String,
+    pub(crate) language_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) host: Option<RoutingHostDocument>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RoutingHostDocument {
+    pub(crate) uri: String,
+    pub(crate) language_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RoutingLanguageServer {
+    pub(crate) languages: Vec<String>,
+    /// Each marker is either one marker name or an ordered marker group.
+    pub(crate) workspace_markers: Vec<serde_json::Value>,
+    pub(crate) prefer_shared_instance: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RoutingParams {
+    pub(crate) text_document: RoutingTextDocument,
+    pub(crate) language_servers: BTreeMap<String, RoutingLanguageServer>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RoutingEntry {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) workspace_folders: Option<Option<Vec<String>>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) enabled: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct RoutingAnswer {
+    pub(crate) routing: BTreeMap<String, RoutingEntry>,
+}
+
+/// Parse the response body of a routing request.
+///
+/// Routing is fail-open: a JSON-RPC error, a null result, or a malformed
+/// result means that Kakehashi keeps its own routing decision. The caller
+/// separately clears the capability when the error is `MethodNotFound`.
+pub(crate) fn parse_routing_response(
+    response: &serde_json::Value,
+) -> std::io::Result<Option<RoutingAnswer>> {
+    if response.get("error").is_some_and(|error| !error.is_null()) {
+        return Ok(None);
+    }
+    let Some(result) = response.get("result") else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "bridge: routing response missing result",
+        ));
+    };
+    if result.is_null() {
+        return Ok(None);
+    }
+    serde_json::from_value(result.clone())
+        .map(Some)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+}
+
+pub(crate) fn jsonrpc_error_code(response: &serde_json::Value) -> Option<i64> {
+    response
+        .get("error")
+        .filter(|error| !error.is_null())
+        .and_then(|error| error.get("code"))
+        .and_then(serde_json::Value::as_i64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_serializes_host_only_and_injection_documents() {
+        let mut language_servers = BTreeMap::new();
+        language_servers.insert(
+            "policy".to_string(),
+            RoutingLanguageServer {
+                languages: vec!["markdown".to_string()],
+                workspace_markers: vec![serde_json::json!("deno.json")],
+                prefer_shared_instance: true,
+            },
+        );
+        let host = RoutingParams {
+            text_document: RoutingTextDocument {
+                uri: "file:///workspace/a.md".to_string(),
+                language_id: "markdown".to_string(),
+                host: None,
+            },
+            language_servers: language_servers.clone(),
+        };
+        assert_eq!(
+            serde_json::to_value(host).unwrap()["textDocument"],
+            serde_json::json!({"uri":"file:///workspace/a.md","languageId":"markdown"}),
+        );
+
+        let injection = RoutingParams {
+            text_document: RoutingTextDocument {
+                uri: "file:///tmp/virtual.lua".to_string(),
+                language_id: "lua".to_string(),
+                host: Some(RoutingHostDocument {
+                    uri: "file:///workspace/a.md".to_string(),
+                    language_id: "markdown".to_string(),
+                }),
+            },
+            language_servers,
+        };
+        assert!(serde_json::to_value(injection).unwrap()["textDocument"]["host"].is_object());
+    }
+
+    #[test]
+    fn response_parser_is_fail_open_and_preserves_explicit_fields() {
+        assert_eq!(
+            parse_routing_response(&serde_json::json!({"result":null})).unwrap(),
+            None
+        );
+        assert_eq!(
+            parse_routing_response(&serde_json::json!({"error":{"code":-32601}})).unwrap(),
+            None
+        );
+        let answer = parse_routing_response(&serde_json::json!({
+            "result": {"routing": {"lua": {"enabled": false, "workspaceFolders": []}}}
+        }))
+        .unwrap()
+        .unwrap();
+        assert_eq!(answer.routing["lua"].enabled, Some(false));
+        assert_eq!(answer.routing["lua"].workspace_folders, Some(Some(vec![])));
+    }
+
+    #[test]
+    fn method_not_found_code_is_identifiable() {
+        assert_eq!(
+            jsonrpc_error_code(&serde_json::json!({"error":{"code":-32601}})),
+            Some(-32601)
+        );
+        assert_eq!(
+            jsonrpc_error_code(&serde_json::json!({"result":null})),
+            None
+        );
+    }
+}

--- a/src/lsp/bridge/protocol/routing.rs
+++ b/src/lsp/bridge/protocol/routing.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 pub(crate) const ROUTING_METHOD: &str = "kakehashi/bridge/routing";
+pub(crate) const ROUTING_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -327,31 +327,34 @@ impl LanguageServerPool {
                 },
             )]),
         };
-        match handle.request_routing(routing_params).await {
-            Ok(Some(answer))
-                if answer
-                    .routing
-                    .get(server_name)
-                    .and_then(|entry| entry.enabled)
-                    == Some(false) =>
-            {
-                log::debug!(
-                    target: "kakehashi::bridge::routing",
-                    "Routing provider suppressed host document {} on {}",
-                    host_uri,
-                    server_name
-                );
-                return;
-            }
-            Ok(_) => {}
-            Err(error) => {
-                log::debug!(
-                    target: "kakehashi::bridge::routing",
-                    "Routing query failed for {} on {}: {}",
-                    host_uri,
-                    server_name,
-                    error
-                );
+        let already_open = self.is_host_document_opened(host_uri, server_name).await;
+        if !already_open {
+            match handle.request_routing(routing_params).await {
+                Ok(Some(answer))
+                    if answer
+                        .routing
+                        .get(server_name)
+                        .and_then(|entry| entry.enabled)
+                        == Some(false) =>
+                {
+                    log::debug!(
+                        target: "kakehashi::bridge::routing",
+                        "Routing provider suppressed host document {} on {}",
+                        host_uri,
+                        server_name
+                    );
+                    return;
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    log::debug!(
+                        target: "kakehashi::bridge::routing",
+                        "Routing query failed for {} on {}: {}",
+                        host_uri,
+                        server_name,
+                        error
+                    );
+                }
             }
         }
         // Sync (sends didOpen) under the `connections` + `host_documents` locks in

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -4,6 +4,7 @@
 //! language servers when injection regions are detected during `did_open`
 //! or `did_change` processing.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -11,6 +12,7 @@ use super::super::pool::{
     ConnectionHandleSender, ConnectionKey, INIT_TIMEOUT_SECS, LanguageServerPool,
 };
 use super::super::protocol::VirtualDocumentUri;
+use super::super::protocol::{RoutingLanguageServer, RoutingParams, RoutingTextDocument};
 
 /// What the caller requires to STILL hold by the time an eager open actually
 /// runs. Both fields are preconditions checked inside the open, not inputs to
@@ -299,6 +301,59 @@ impl LanguageServerPool {
         // Borrow the key (no clone) — both `connections.get` and `sync_host_document`
         // take it by reference, like `execute_host_request`.
         let connection_key = handle.key();
+        // The host-layer eager open is the first live consumer of the
+        // downstream routing protocol. The provider-selection and decision
+        // cache layers will widen this projection; this initial slice already
+        // makes an advertised server able to suppress its own document open.
+        let workspace_markers = server_config
+            .workspace_markers
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|marker| serde_json::to_value(marker).expect("RootMarker is serializable"))
+            .collect();
+        let routing_params = RoutingParams {
+            text_document: RoutingTextDocument {
+                uri: host_uri.to_string(),
+                language_id: language_id.to_string(),
+                host: None,
+            },
+            language_servers: BTreeMap::from([(
+                server_name.to_string(),
+                RoutingLanguageServer {
+                    languages: server_config.languages.clone().unwrap_or_default(),
+                    workspace_markers,
+                    prefer_shared_instance: server_config.prefer_shared_instance.unwrap_or(false),
+                },
+            )]),
+        };
+        match handle.request_routing(routing_params).await {
+            Ok(Some(answer))
+                if answer
+                    .routing
+                    .get(server_name)
+                    .and_then(|entry| entry.enabled)
+                    == Some(false) =>
+            {
+                log::debug!(
+                    target: "kakehashi::bridge::routing",
+                    "Routing provider suppressed host document {} on {}",
+                    host_uri,
+                    server_name
+                );
+                return;
+            }
+            Ok(_) => {}
+            Err(error) => {
+                log::debug!(
+                    target: "kakehashi::bridge::routing",
+                    "Routing query failed for {} on {}: {}",
+                    host_uri,
+                    server_name,
+                    error
+                );
+            }
+        }
         // Sync (sends didOpen) under the `connections` + `host_documents` locks in
         // that order, with the live-handle `Arc::ptr_eq` check — identical to
         // `execute_host_request`, so a concurrent respawn purge cannot interleave


### PR DESCRIPTION
## Summary

- add the downstream `kakehashi/bridge/routing` request and response contract
- issue the request only to negotiated downstream connections
- fail open on provider errors and clear the advertisement after `MethodNotFound`
- apply `enabled: false` before the first host `didOpen`, with a bounded routing deadline

This PR is stacked on #1008. Provider selection, routing-answer application for all candidate servers, injection decisions, and decision caching remain subsequent stacked slices.

## Validation

- `cargo test --lib -q lsp::bridge::protocol::routing`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added intelligent document routing between the bridge and downstream language servers.
  * The system now evaluates routing before opening documents and can suppress synchronization when a server is not selected.
  * Added support for routing responses, timeouts, cancellation, and graceful handling of unsupported requests.
  * Routing decisions now account for the document’s active workspace and connection.

* **Bug Fixes**
  * Routing failures no longer interrupt document synchronization.
  * Coordinated document handling prevents requests from bypassing routing decisions during initial opening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->