### PR TITLE
feat(bridge): apply routing to host providers

### DIFF
--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -18,6 +18,8 @@ use crate::language::node_tracker::{EditInfo, NodeTracker};
 use crate::lsp::request_id::CancelForwarder;
 
 use super::LanguageServerPool;
+use super::pool::INIT_TIMEOUT_SECS;
+use super::protocol::{RoutingAnswer, RoutingLanguageServer, RoutingParams, RoutingTextDocument};
 
 /// A resolved bridge virtual-document payload from a host document.
 ///
@@ -1255,6 +1257,112 @@ impl BridgeCoordinator {
         );
     }
 
+    /// Ask one advertising host bridge for a routing decision over the full
+    /// candidate set, then mark every candidate connection with that decision
+    /// before any host `didOpen` is sent. This is deliberately one orchestration
+    /// step: asking each server about a projection containing only itself cannot
+    /// let a provider such as tsudoi suppress a sibling provider such as tsgo.
+    async fn resolve_host_routing(
+        pool: &LanguageServerPool,
+        host_uri: &Url,
+        language_id: &str,
+        configs: Vec<ResolvedServerConfig>,
+    ) -> Vec<ResolvedServerConfig> {
+        let language_servers = configs
+            .iter()
+            .map(|config| {
+                let workspace_markers = config
+                    .config
+                    .workspace_markers
+                    .clone()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|marker| serde_json::to_value(marker).expect("RootMarker is serializable"))
+                    .collect();
+                (
+                    config.server_name.clone(),
+                    RoutingLanguageServer {
+                        languages: config.config.languages.clone().unwrap_or_default(),
+                        workspace_markers,
+                        prefer_shared_instance: config
+                            .config
+                            .prefer_shared_instance
+                            .unwrap_or(false),
+                    },
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let params = RoutingParams {
+            text_document: RoutingTextDocument {
+                uri: host_uri.to_string(),
+                language_id: language_id.to_string(),
+                host: None,
+            },
+            language_servers,
+        };
+
+        let mut handles = Vec::with_capacity(configs.len());
+        let mut answer: Option<RoutingAnswer> = None;
+        for config in &configs {
+            let handle = match pool
+                .get_or_create_connection_wait_ready(
+                    &config.server_name,
+                    &config.config,
+                    Some(host_uri),
+                    std::time::Duration::from_secs(INIT_TIMEOUT_SECS),
+                )
+                .await
+            {
+                Ok(handle) => handle,
+                Err(error) => {
+                    log::debug!(
+                        target: "kakehashi::bridge::routing",
+                        "Routing candidate {} was not ready for {}: {}",
+                        config.server_name,
+                        host_uri,
+                        error
+                    );
+                    continue;
+                }
+            };
+            if answer.is_none() && handle.supports_bridge_routing() {
+                match handle.request_routing(params.clone()).await {
+                    Ok(Some(candidate_answer)) => answer = Some(candidate_answer),
+                    Ok(None) => {}
+                    Err(error) => log::debug!(
+                        target: "kakehashi::bridge::routing",
+                        "Routing provider {} failed for {}: {}",
+                        config.server_name,
+                        host_uri,
+                        error
+                    ),
+                }
+            }
+            handles.push((config.server_name.clone(), handle));
+        }
+
+        let mut selected = Vec::new();
+        for config in configs {
+            let Some((_, handle)) = handles.iter().find(|(name, _)| name == &config.server_name)
+            else {
+                selected.push(config);
+                continue;
+            };
+            let enabled = answer
+                .as_ref()
+                .and_then(|answer| answer.routing.get(&config.server_name))
+                .and_then(|entry| entry.enabled)
+                != Some(false);
+            pool.set_host_routing_decided(host_uri, handle.key());
+            if !enabled {
+                pool.set_host_routing_suppressed(host_uri, handle.key());
+                continue;
+            }
+            selected.push(config);
+        }
+        selected
+    }
+
     /// Sync the real host document to a resolved set of `_self` host servers
     /// (host-document-bridge). `sync_host_document` sends `didOpen` the first time
     /// and a versioned `didChange` when the text changed, so this is used both for
@@ -1311,36 +1419,35 @@ impl BridgeCoordinator {
         // `text` already arrives as `Arc<str>` (the debounce path hands over its
         // `HostRequestContext.text` without copying).
         let language_id: Arc<str> = Arc::from(language_id);
-        for config in configs {
-            let pool = self.pool_arc();
-            let host_uri_owned = host_uri.clone();
-            let language_id = Arc::clone(&language_id);
-            let text = Arc::clone(&text);
-            let server_name = config.server_name.clone();
-            let server_config = config.config.clone();
-            let cancel = cancel.clone();
-            // Each task shares the same live reader (cheap `Arc` clone) — it is
-            // evaluated inside `sync_host_document`'s lock, so the last task to sync
-            // sends the latest text regardless of which snapshot it was spawned with.
-            let live_text_reader = live_text_reader.clone();
-            let task = tokio::spawn(async move {
-                tokio::select! {
-                    biased;
-                    // Cancelled during the spawn→register window (or later) —
-                    // bail before the side effect (#435).
-                    _ = cancel.cancelled() => {}
-                    _ = pool.eager_open_host_document(
-                        &server_name,
-                        &server_config,
-                        &host_uri_owned,
-                        &language_id,
-                        &text,
-                        live_text_reader.as_deref(),
-                    ) => {}
+        let pool = self.pool_arc();
+        let host_uri_owned = host_uri.clone();
+        let configs_for_routing = configs;
+        let task = tokio::spawn(async move {
+            let configs = Self::resolve_host_routing(
+                &pool,
+                &host_uri_owned,
+                &language_id,
+                configs_for_routing,
+            )
+            .await;
+            for config in configs {
+                let server_name = config.server_name.clone();
+                let server_config = config.config.clone();
+                if cancel.is_cancelled() {
+                    break;
                 }
-            });
-            self.push_or_abort_host_eager_open_handle(host_uri, task.abort_handle(), generation);
-        }
+                pool.eager_open_host_document(
+                    &server_name,
+                    &server_config,
+                    &host_uri_owned,
+                    &language_id,
+                    &text,
+                    live_text_reader.as_deref(),
+                )
+                .await;
+            }
+        });
+        self.push_or_abort_host_eager_open_handle(host_uri, task.abort_handle(), generation);
     }
 
     /// Supersede the host eager-open batch for `uri` (abort old handles + cancel the

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
+use futures::StreamExt;
 use tokio_util::sync::CancellationToken;
 use ulid::Ulid;
 use url::Url;
@@ -1313,24 +1314,34 @@ impl BridgeCoordinator {
             language_servers,
         };
 
+        let mut candidates = futures::stream::FuturesUnordered::new();
+        for config in &configs {
+            let server_name = config.server_name.clone();
+            let server_config = Arc::clone(&config.config);
+            let host_uri = host_uri.clone();
+            candidates.push(async move {
+                let result = pool
+                    .get_or_create_connection_wait_ready(
+                        &server_name,
+                        &server_config,
+                        Some(&host_uri),
+                        std::time::Duration::from_secs(INIT_TIMEOUT_SECS),
+                    )
+                    .await;
+                (server_name, result)
+            });
+        }
+
         let mut handles = Vec::with_capacity(configs.len());
         let mut answer: Option<RoutingAnswer> = None;
-        for config in &configs {
-            let handle = match pool
-                .get_or_create_connection_wait_ready(
-                    &config.server_name,
-                    &config.config,
-                    Some(host_uri),
-                    std::time::Duration::from_secs(INIT_TIMEOUT_SECS),
-                )
-                .await
-            {
+        while let Some((server_name, result)) = candidates.next().await {
+            let handle = match result {
                 Ok(handle) => handle,
                 Err(error) => {
                     log::debug!(
                         target: "kakehashi::bridge::routing",
                         "Routing candidate {} was not ready for {}: {}",
-                        config.server_name,
+                        server_name,
                         host_uri,
                         error
                     );
@@ -1344,13 +1355,13 @@ impl BridgeCoordinator {
                     Err(error) => log::debug!(
                         target: "kakehashi::bridge::routing",
                         "Routing provider {} failed for {}: {}",
-                        config.server_name,
+                        server_name,
                         host_uri,
                         error
                     ),
                 }
             }
-            handles.push((config.server_name.clone(), handle));
+            handles.push((server_name, handle));
         }
 
         let mut selected = Vec::new();

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1268,6 +1268,18 @@ impl BridgeCoordinator {
         language_id: &str,
         configs: Vec<ResolvedServerConfig>,
     ) -> Vec<ResolvedServerConfig> {
+        if configs.iter().all(|config| {
+            pool.host_routing_by_server(host_uri, &config.server_name)
+                .is_some()
+        }) {
+            return configs
+                .into_iter()
+                .filter(|config| {
+                    pool.host_routing_by_server(host_uri, &config.server_name)
+                        .unwrap_or(true)
+                })
+                .collect();
+        }
         let language_servers = configs
             .iter()
             .map(|config| {
@@ -1343,16 +1355,19 @@ impl BridgeCoordinator {
 
         let mut selected = Vec::new();
         for config in configs {
-            let Some((_, handle)) = handles.iter().find(|(name, _)| name == &config.server_name)
-            else {
-                selected.push(config);
-                continue;
-            };
             let enabled = answer
                 .as_ref()
                 .and_then(|answer| answer.routing.get(&config.server_name))
                 .and_then(|entry| entry.enabled)
                 != Some(false);
+            pool.set_host_routing_by_server(host_uri, &config.server_name, enabled);
+            let Some((_, handle)) = handles.iter().find(|(name, _)| name == &config.server_name)
+            else {
+                if enabled {
+                    selected.push(config);
+                }
+                continue;
+            };
             pool.set_host_routing_decided(host_uri, handle.key());
             if !enabled {
                 pool.set_host_routing_suppressed(host_uri, handle.key());
@@ -1422,29 +1437,51 @@ impl BridgeCoordinator {
         let pool = self.pool_arc();
         let host_uri_owned = host_uri.clone();
         let configs_for_routing = configs;
+        let routing_sender = pool.begin_host_routing(host_uri);
         let task = tokio::spawn(async move {
-            let configs = Self::resolve_host_routing(
-                &pool,
-                &host_uri_owned,
-                &language_id,
-                configs_for_routing,
-            )
-            .await;
-            for config in configs {
-                let server_name = config.server_name.clone();
-                let server_config = config.config.clone();
-                if cancel.is_cancelled() {
-                    break;
+            let configs = tokio::select! {
+                _ = cancel.cancelled() => {
+                    pool.finish_host_routing(&host_uri_owned, &routing_sender);
+                    return;
                 }
-                pool.eager_open_host_document(
-                    &server_name,
-                    &server_config,
-                    &host_uri_owned,
-                    &language_id,
-                    &text,
-                    live_text_reader.as_deref(),
-                )
-                .await;
+                configs = async {
+                    let lifecycle = pool.host_lifecycle_lock(&host_uri_owned);
+                    let _guard = lifecycle.lock().await;
+                    Self::resolve_host_routing(
+                        &pool,
+                        &host_uri_owned,
+                        &language_id,
+                        configs_for_routing,
+                    ).await
+                } => configs,
+            };
+            pool.finish_host_routing(&host_uri_owned, &routing_sender);
+            let mut opens = Vec::new();
+            for config in configs {
+                let pool = Arc::clone(&pool);
+                let host_uri = host_uri_owned.clone();
+                let language_id = Arc::clone(&language_id);
+                let text = Arc::clone(&text);
+                let cancel = cancel.clone();
+                let live_text_reader = live_text_reader.clone();
+                opens.push(tokio::spawn(async move {
+                    let server_name = config.server_name;
+                    let server_config = config.config;
+                    tokio::select! {
+                        _ = cancel.cancelled() => {}
+                        _ = pool.eager_open_host_document(
+                            &server_name,
+                            &server_config,
+                            &host_uri,
+                            &language_id,
+                            &text,
+                            live_text_reader.as_deref(),
+                        ) => {}
+                    }
+                }));
+            }
+            for open in opens {
+                let _ = open.await;
             }
         });
         self.push_or_abort_host_eager_open_handle(host_uri, task.abort_handle(), generation);

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -375,6 +375,11 @@ pub struct LanguageServerPool {
     /// servers via `bridge._self`, with their version and content
     /// fingerprint for lazy full-text re-sync.
     host_documents: Mutex<HashMap<(String, ConnectionKey), HostDocSyncState>>,
+    /// Host documents explicitly suppressed by a downstream routing answer.
+    host_routing_suppressed: DashMap<(String, ConnectionKey), ()>,
+    /// Host/server pairs for which routing has already been decided, including
+    /// the fail-open case where no provider answered.
+    host_routing_decided: DashMap<(String, ConnectionKey), ()>,
     /// Connections whose replacement still owes a virtual-document re-open, and
     /// the barrier requests wait on (respawn-reopen-derives-its-targets).
     /// `Arc` because the claim runs inside the spawned handshake task.
@@ -509,6 +514,8 @@ impl LanguageServerPool {
             host_lifecycle_locks: DashMap::new(),
             latest_virtual_contents: DashMap::new(),
             host_documents: Mutex::new(HashMap::new()),
+            host_routing_suppressed: DashMap::new(),
+            host_routing_decided: DashMap::new(),
             pending_reopen: Arc::new(PendingReopenRegistry::default()),
             diagnostic_pull_baselines: DashMap::new(),
             diagnostic_document_generations: DashMap::new(),
@@ -1264,6 +1271,7 @@ impl LanguageServerPool {
     /// Whether the host document at `host_uri` has been synced (didOpen sent) to a
     /// `_self` host server named `server_name` — i.e. a `host_documents` sync-state
     /// entry exists for that `(uri, server)`. Used to verify host-layer eager open.
+    #[cfg(test)]
     pub(crate) async fn is_host_document_opened(&self, host_uri: &Url, server_name: &str) -> bool {
         // Key exactly as `sync_host_document` does (`doc.uri.to_string()`) so the
         // lookup can never diverge from the map's key construction.
@@ -1272,6 +1280,60 @@ impl LanguageServerPool {
             .await
             .keys()
             .any(|(uri, connection_key)| uri == &key && connection_key.server() == server_name)
+    }
+
+    /// Whether the host document has been synced on this exact pooled
+    /// connection, including its resolved workspace root.
+    pub(crate) async fn is_host_document_opened_on_connection(
+        &self,
+        host_uri: &Url,
+        connection_key: &ConnectionKey,
+    ) -> bool {
+        self.host_documents()
+            .await
+            .contains_key(&(host_uri.to_string(), connection_key.clone()))
+    }
+
+    pub(crate) fn set_host_routing_suppressed(
+        &self,
+        host_uri: &Url,
+        connection_key: &ConnectionKey,
+    ) {
+        self.host_routing_suppressed
+            .insert((host_uri.to_string(), connection_key.clone()), ());
+        self.host_routing_decided
+            .insert((host_uri.to_string(), connection_key.clone()), ());
+    }
+
+    pub(crate) fn set_host_routing_decided(&self, host_uri: &Url, connection_key: &ConnectionKey) {
+        self.host_routing_decided
+            .insert((host_uri.to_string(), connection_key.clone()), ());
+    }
+
+    pub(crate) fn is_host_routing_decided(
+        &self,
+        host_uri: &Url,
+        connection_key: &ConnectionKey,
+    ) -> bool {
+        self.host_routing_decided
+            .contains_key(&(host_uri.to_string(), connection_key.clone()))
+    }
+
+    pub(crate) fn is_host_routing_suppressed(
+        &self,
+        host_uri: &Url,
+        connection_key: &ConnectionKey,
+    ) -> bool {
+        self.host_routing_suppressed
+            .contains_key(&(host_uri.to_string(), connection_key.clone()))
+    }
+
+    pub(crate) fn clear_host_routing_suppression(&self, host_uri: &Url) {
+        let uri = host_uri.to_string();
+        self.host_routing_suppressed
+            .retain(|(doc_uri, _), _| doc_uri != &uri);
+        self.host_routing_decided
+            .retain(|(doc_uri, _), _| doc_uri != &uri);
     }
 
     /// The current sync version of the host document at `host_uri` on `server_name`,

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -380,6 +380,11 @@ pub struct LanguageServerPool {
     /// Host/server pairs for which routing has already been decided, including
     /// the fail-open case where no provider answered.
     host_routing_decided: DashMap<(String, ConnectionKey), ()>,
+    /// Host/server-name routing decisions, retained even before a concrete
+    /// connection can be acquired.
+    host_routing_by_server: DashMap<(String, String), bool>,
+    /// Host URIs whose routing decision is currently being resolved.
+    host_routing_pending: DashMap<Url, Arc<tokio::sync::watch::Sender<bool>>>,
     /// Connections whose replacement still owes a virtual-document re-open, and
     /// the barrier requests wait on (respawn-reopen-derives-its-targets).
     /// `Arc` because the claim runs inside the spawned handshake task.
@@ -516,6 +521,8 @@ impl LanguageServerPool {
             host_documents: Mutex::new(HashMap::new()),
             host_routing_suppressed: DashMap::new(),
             host_routing_decided: DashMap::new(),
+            host_routing_by_server: DashMap::new(),
+            host_routing_pending: DashMap::new(),
             pending_reopen: Arc::new(PendingReopenRegistry::default()),
             diagnostic_pull_baselines: DashMap::new(),
             diagnostic_document_generations: DashMap::new(),
@@ -1308,8 +1315,71 @@ impl LanguageServerPool {
     }
 
     pub(crate) fn set_host_routing_decided(&self, host_uri: &Url, connection_key: &ConnectionKey) {
-        self.host_routing_decided
-            .insert((host_uri.to_string(), connection_key.clone()), ());
+        let key = (host_uri.to_string(), connection_key.clone());
+        self.host_routing_suppressed.remove(&key);
+        self.host_routing_decided.insert(key, ());
+    }
+
+    pub(crate) fn set_host_routing_by_server(
+        &self,
+        host_uri: &Url,
+        server_name: &str,
+        enabled: bool,
+    ) {
+        self.host_routing_by_server
+            .insert((host_uri.to_string(), server_name.to_string()), enabled);
+    }
+
+    pub(crate) fn host_routing_by_server(&self, host_uri: &Url, server_name: &str) -> Option<bool> {
+        self.host_routing_by_server
+            .get(&(host_uri.to_string(), server_name.to_string()))
+            .map(|entry| *entry)
+    }
+
+    pub(crate) fn begin_host_routing(
+        &self,
+        host_uri: &Url,
+    ) -> Arc<tokio::sync::watch::Sender<bool>> {
+        let sender = Arc::new(tokio::sync::watch::channel(false).0);
+        self.host_routing_pending
+            .insert(host_uri.clone(), Arc::clone(&sender));
+        sender
+    }
+
+    pub(crate) async fn wait_for_host_routing(&self, host_uri: &Url) {
+        let Some(sender) = self
+            .host_routing_pending
+            .get(host_uri)
+            .map(|entry| Arc::clone(entry.value()))
+        else {
+            return;
+        };
+        let mut receiver = sender.subscribe();
+        while !*receiver.borrow() {
+            if receiver.changed().await.is_err() {
+                return;
+            }
+        }
+    }
+
+    pub(crate) fn finish_host_routing(
+        &self,
+        host_uri: &Url,
+        sender: &Arc<tokio::sync::watch::Sender<bool>>,
+    ) {
+        if self
+            .host_routing_pending
+            .remove_if(host_uri, |_, current| Arc::ptr_eq(current, sender))
+            .is_some()
+        {
+            let _ = sender.send(true);
+        }
+    }
+
+    pub(crate) fn finish_all_host_routing(&self, host_uri: &Url) {
+        if let Some((_, sender)) = self.host_routing_pending.remove(host_uri) {
+            let _ = sender.send(true);
+        }
     }
 
     pub(crate) fn is_host_routing_decided(
@@ -1336,6 +1406,9 @@ impl LanguageServerPool {
             .retain(|(doc_uri, _), _| doc_uri != &uri);
         self.host_routing_decided
             .retain(|(doc_uri, _), _| doc_uri != &uri);
+        self.host_routing_by_server
+            .retain(|(doc_uri, _), _| doc_uri != &uri);
+        self.finish_all_host_routing(host_uri);
     }
 
     pub(crate) fn clear_host_routing_for_connection(&self, connection_key: &ConnectionKey) {

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -779,6 +779,7 @@ impl LanguageServerPool {
                 .lock()
                 .await
                 .retain(|(_, connection_key), _| connection_key != &key);
+            self.clear_host_routing_for_connection(&key);
             self.document_tracker.purge_connection(&key).await;
             // Arm before the replacement can claim: what this connection held
             // is irrelevant, only that it owes a re-open. A connection dropped
@@ -936,6 +937,7 @@ impl LanguageServerPool {
                 .lock()
                 .await
                 .retain(|(_, connection_key), _| connection_key != &key);
+            self.clear_host_routing_for_connection(&key);
             self.document_tracker.purge_connection(&key).await;
             // Arm before the replacement can claim: what this connection held
             // is irrelevant, only that it owes a re-open.
@@ -1334,6 +1336,13 @@ impl LanguageServerPool {
             .retain(|(doc_uri, _), _| doc_uri != &uri);
         self.host_routing_decided
             .retain(|(doc_uri, _), _| doc_uri != &uri);
+    }
+
+    pub(crate) fn clear_host_routing_for_connection(&self, connection_key: &ConnectionKey) {
+        self.host_routing_suppressed
+            .retain(|(_, key), _| key != connection_key);
+        self.host_routing_decided
+            .retain(|(_, key), _| key != connection_key);
     }
 
     /// The current sync version of the host document at `host_uri` on `server_name`,
@@ -2723,6 +2732,7 @@ impl LanguageServerPool {
                         .lock()
                         .await
                         .retain(|(_, key), _| key != &connection_key);
+                    self.clear_host_routing_for_connection(&connection_key);
                     self.document_tracker
                         .purge_connection(&connection_key)
                         .await;

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -303,6 +303,14 @@ impl LanguageServerPool {
         // Borrow the key (no clone) — both `connections.get` and `sync_host_document`
         // take it by reference, like `execute_host_request`.
         let connection_key = handle.key();
+        if let Some(enabled) = self.host_routing_by_server(host_uri, server_name) {
+            if enabled {
+                self.set_host_routing_decided(host_uri, connection_key);
+            } else {
+                self.set_host_routing_suppressed(host_uri, connection_key);
+                return;
+            }
+        }
         // Serialize the routing decision with lazy host sync. A request that
         // arrives while routing is in flight must not open the document before
         // the eager path can honor a suppressing answer.

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -276,6 +276,8 @@ impl LanguageServerPool {
         text: &str,
         live_text_reader: Option<&(dyn Fn() -> Option<Arc<str>> + Send + Sync)>,
     ) {
+        let lifecycle = self.host_lifecycle_lock(host_uri);
+        let _lifecycle_guard = lifecycle.lock().await;
         let handle = match self
             .get_or_create_connection_wait_ready(
                 server_name,
@@ -301,6 +303,9 @@ impl LanguageServerPool {
         // Borrow the key (no clone) — both `connections.get` and `sync_host_document`
         // take it by reference, like `execute_host_request`.
         let connection_key = handle.key();
+        // Serialize the routing decision with lazy host sync. A request that
+        // arrives while routing is in flight must not open the document before
+        // the eager path can honor a suppressing answer.
         // The host-layer eager open is the first live consumer of the
         // downstream routing protocol. The provider-selection and decision
         // cache layers will widen this projection; this initial slice already
@@ -327,26 +332,42 @@ impl LanguageServerPool {
                 },
             )]),
         };
-        let already_open = self.is_host_document_opened(host_uri, server_name).await;
-        if !already_open {
+        let already_open = self
+            .is_host_document_opened_on_connection(host_uri, connection_key)
+            .await;
+        if !already_open && !self.is_host_routing_decided(host_uri, connection_key) {
             match handle.request_routing(routing_params).await {
-                Ok(Some(answer))
+                Ok(Some(answer)) => {
+                    let connections = self.connections().await;
+                    if !connections
+                        .get(connection_key)
+                        .is_some_and(|current| Arc::ptr_eq(current, &handle))
+                    {
+                        return;
+                    }
                     if answer
                         .routing
                         .get(server_name)
                         .and_then(|entry| entry.enabled)
-                        == Some(false) =>
-                {
-                    log::debug!(
-                        target: "kakehashi::bridge::routing",
-                        "Routing provider suppressed host document {} on {}",
-                        host_uri,
-                        server_name
-                    );
-                    return;
+                        != Some(false)
+                    {
+                        // The current connection remains eligible to receive
+                        // the normal eager open below.
+                        self.set_host_routing_decided(host_uri, connection_key);
+                    } else {
+                        self.set_host_routing_suppressed(host_uri, connection_key);
+                        log::debug!(
+                            target: "kakehashi::bridge::routing",
+                            "Routing provider suppressed host document {} on {}",
+                            host_uri,
+                            server_name
+                        );
+                        return;
+                    }
                 }
-                Ok(_) => {}
+                Ok(_) => self.set_host_routing_decided(host_uri, connection_key),
                 Err(error) => {
+                    self.set_host_routing_decided(host_uri, connection_key);
                     log::debug!(
                         target: "kakehashi::bridge::routing",
                         "Routing query failed for {} on {}: {}",

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -187,6 +187,9 @@ impl LanguageServerPool {
     /// Mirrors the virt path's `close_host_document`; called from the
     /// upstream `didClose` handler.
     pub(crate) async fn close_host_bridge_document(&self, uri: &Url) {
+        self.finish_all_host_routing(uri);
+        let lifecycle = self.host_lifecycle_lock(uri);
+        let _lifecycle_guard = lifecycle.lock().await;
         self.invalidate_diagnostic_host(uri);
         let Ok(uri_lsp) = host_url_to_lsp_uri(uri) else {
             return;
@@ -223,6 +226,7 @@ impl LanguageServerPool {
             .map(|(doc_uri, connection_key)| (connection_key, doc_uri))
             .collect::<Vec<_>>();
         docs.retain(|(doc_uri, _), _| *doc_uri != uri_string);
+        self.clear_host_routing_suppression(uri);
         for key in closed_keys {
             self.invalidate_diagnostic_document(&key);
         }
@@ -481,6 +485,15 @@ impl LanguageServerPool {
     ) -> io::Result<T> {
         // Route per-connection state by this handle's pool key (#382).
         let connection_key = handle.key();
+        self.wait_for_host_routing(doc.uri).await;
+        let lifecycle = self.host_lifecycle_lock(doc.uri);
+        let _lifecycle_guard = lifecycle.lock().await;
+        if self.is_host_routing_suppressed(doc.uri, connection_key) {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                format!("host document routing disabled on {connection_key}"),
+            ));
+        }
         if let Some(ref id) = upstream_request_id {
             self.register_upstream_request(id.clone(), connection_key);
         }


### PR DESCRIPTION
Apply the negotiated bridge routing answer to the complete host-provider candidate set before eager opening.

- send one routing request with every candidate projection
- let an advertising provider suppress sibling providers
- cache per-connection decisions for later host syncs
- preserve fail-open behavior when no provider answers

Follow-up to #1010; workspaceFolders application and virtual-document routing remain subsequent slices.