### PR TITLE
feat(bridge): apply routed workspace folders

### DIFF
--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1372,6 +1372,14 @@ impl BridgeCoordinator {
                 .and_then(|entry| entry.enabled)
                 != Some(false);
             pool.set_host_routing_by_server(host_uri, &config.server_name, enabled);
+            pool.set_host_routing_workspace_folders(
+                host_uri,
+                &config.server_name,
+                answer
+                    .as_ref()
+                    .and_then(|answer| answer.routing.get(&config.server_name))
+                    .and_then(|entry| entry.workspace_folders.clone()),
+            );
             let Some((_, handle)) = handles.iter().find(|(name, _)| name == &config.server_name)
             else {
                 if enabled {

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1368,10 +1368,9 @@ impl LanguageServerPool {
             .map(|entry| entry.clone())
     }
 
-    /// Apply a routing-selected folder to a shared connection before its
-    /// document is opened. Routing answers currently use one folder for the
-    /// TypeScript providers; the existing shared-root announcement machinery
-    /// keeps the notification and folder-set update atomic with respect to the
+    /// Apply routing-selected folders to a shared connection before its
+    /// document is opened. The existing shared-root announcement machinery
+    /// keeps each notification and folder-set update ordered before the
     /// following `didOpen`.
     pub(crate) async fn apply_host_routing_workspace_folders(
         &self,
@@ -1382,19 +1381,22 @@ impl LanguageServerPool {
         let Some(Some(folders)) = self.host_routing_workspace_folders(host_uri, server_name) else {
             return Ok(());
         };
-        let Some(folder_uri) = folders.first().and_then(|uri| Url::parse(uri).ok()) else {
-            return Ok(());
-        };
-        let Some(marker) = super::root_markers::workspace_at_root(folder_uri.clone()) else {
-            log::debug!(
-                target: "kakehashi::bridge::routing",
-                "Ignoring invalid routing workspace folder {} for {}",
-                folder_uri,
-                server_name
-            );
-            return Ok(());
-        };
-        self.announce_shared_root(handle, &Some(marker)).await
+        for folder in folders {
+            let Some(folder_uri) = Url::parse(&folder).ok() else {
+                log::debug!(
+                    target: "kakehashi::bridge::routing",
+                    "Ignoring invalid routing workspace folder {} for {}",
+                    folder,
+                    server_name
+                );
+                continue;
+            };
+            let Some(marker) = super::root_markers::workspace_at_root(folder_uri) else {
+                continue;
+            };
+            self.announce_shared_root(handle, &Some(marker)).await?;
+        }
+        Ok(())
     }
 
     pub(crate) fn begin_host_routing(

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1378,17 +1378,27 @@ impl LanguageServerPool {
         server_name: &str,
         handle: &Arc<ConnectionHandle>,
     ) -> io::Result<()> {
-        let Some(Some(folders)) = self.host_routing_workspace_folders(host_uri, server_name) else {
+        let Some(folders) = self.host_routing_workspace_folders(host_uri, server_name) else {
             return Ok(());
         };
+        let Some(folders) = folders else {
+            log::debug!(
+                target: "kakehashi::bridge::routing",
+                "Routing provider supplied workspaceFolders=null for {}; keeping the connection's existing folders",
+                server_name
+            );
+            return Ok(());
+        };
+        if folders.is_empty() {
+            log::debug!(
+                target: "kakehashi::bridge::routing",
+                "Routing provider supplied an empty workspaceFolders list for {}; keeping the connection's existing folders",
+                server_name
+            );
+            return Ok(());
+        }
         for folder in folders {
             let Some(folder_uri) = Url::parse(&folder).ok() else {
-                log::debug!(
-                    target: "kakehashi::bridge::routing",
-                    "Ignoring invalid routing workspace folder {} for {}",
-                    folder,
-                    server_name
-                );
                 continue;
             };
             let Some(marker) = super::root_markers::workspace_at_root(folder_uri) else {

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -383,6 +383,10 @@ pub struct LanguageServerPool {
     /// Host/server-name routing decisions, retained even before a concrete
     /// connection can be acquired.
     host_routing_by_server: DashMap<(String, String), bool>,
+    /// Routing-selected workspace folders per host/server. An outer `Some`
+    /// means the routing provider supplied the field; an inner `None` is the
+    /// explicit JSON `null` value.
+    host_routing_workspace_folders: DashMap<(String, String), Option<Vec<String>>>,
     /// Host URIs whose routing decision is currently being resolved.
     host_routing_pending: DashMap<Url, Arc<tokio::sync::watch::Sender<bool>>>,
     /// Connections whose replacement still owes a virtual-document re-open, and
@@ -522,6 +526,7 @@ impl LanguageServerPool {
             host_routing_suppressed: DashMap::new(),
             host_routing_decided: DashMap::new(),
             host_routing_by_server: DashMap::new(),
+            host_routing_workspace_folders: DashMap::new(),
             host_routing_pending: DashMap::new(),
             pending_reopen: Arc::new(PendingReopenRegistry::default()),
             diagnostic_pull_baselines: DashMap::new(),
@@ -1336,6 +1341,62 @@ impl LanguageServerPool {
             .map(|entry| *entry)
     }
 
+    pub(crate) fn set_host_routing_workspace_folders(
+        &self,
+        host_uri: &Url,
+        server_name: &str,
+        folders: Option<Option<Vec<String>>>,
+    ) {
+        let key = (host_uri.to_string(), server_name.to_string());
+        match folders {
+            Some(folders) => {
+                self.host_routing_workspace_folders.insert(key, folders);
+            }
+            None => {
+                self.host_routing_workspace_folders.remove(&key);
+            }
+        }
+    }
+
+    pub(crate) fn host_routing_workspace_folders(
+        &self,
+        host_uri: &Url,
+        server_name: &str,
+    ) -> Option<Option<Vec<String>>> {
+        self.host_routing_workspace_folders
+            .get(&(host_uri.to_string(), server_name.to_string()))
+            .map(|entry| entry.clone())
+    }
+
+    /// Apply a routing-selected folder to a shared connection before its
+    /// document is opened. Routing answers currently use one folder for the
+    /// TypeScript providers; the existing shared-root announcement machinery
+    /// keeps the notification and folder-set update atomic with respect to the
+    /// following `didOpen`.
+    pub(crate) async fn apply_host_routing_workspace_folders(
+        &self,
+        host_uri: &Url,
+        server_name: &str,
+        handle: &Arc<ConnectionHandle>,
+    ) -> io::Result<()> {
+        let Some(Some(folders)) = self.host_routing_workspace_folders(host_uri, server_name) else {
+            return Ok(());
+        };
+        let Some(folder_uri) = folders.first().and_then(|uri| Url::parse(uri).ok()) else {
+            return Ok(());
+        };
+        let Some(marker) = super::root_markers::workspace_at_root(folder_uri.clone()) else {
+            log::debug!(
+                target: "kakehashi::bridge::routing",
+                "Ignoring invalid routing workspace folder {} for {}",
+                folder_uri,
+                server_name
+            );
+            return Ok(());
+        };
+        self.announce_shared_root(handle, &Some(marker)).await
+    }
+
     pub(crate) fn begin_host_routing(
         &self,
         host_uri: &Url,
@@ -1407,6 +1468,8 @@ impl LanguageServerPool {
         self.host_routing_decided
             .retain(|(doc_uri, _), _| doc_uri != &uri);
         self.host_routing_by_server
+            .retain(|(doc_uri, _), _| doc_uri != &uri);
+        self.host_routing_workspace_folders
             .retain(|(doc_uri, _), _| doc_uri != &uri);
         self.finish_all_host_routing(host_uri);
     }

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1398,8 +1398,18 @@ impl LanguageServerPool {
             return Ok(());
         }
         for folder in folders {
-            let Some(folder_uri) = Url::parse(&folder).ok() else {
-                continue;
+            let folder_uri = match Url::parse(&folder) {
+                Ok(uri) => uri,
+                Err(error) => {
+                    log::debug!(
+                        target: "kakehashi::bridge::routing",
+                        "Ignoring invalid routing workspace folder {} for {}: {}",
+                        folder,
+                        server_name,
+                        error
+                    );
+                    continue;
+                }
             };
             let Some(marker) = super::root_markers::workspace_at_root(folder_uri) else {
                 continue;

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -311,6 +311,19 @@ impl LanguageServerPool {
                 return;
             }
         }
+        if let Err(error) = self
+            .apply_host_routing_workspace_folders(host_uri, server_name, &handle)
+            .await
+        {
+            log::debug!(
+                target: "kakehashi::bridge::routing",
+                "Failed to apply routing workspace folders for {} on {}: {}",
+                host_uri,
+                server_name,
+                error
+            );
+            return;
+        }
         // Serialize the routing decision with lazy host sync. A request that
         // arrives while routing is in flight must not open the document before
         // the eager path can honor a suppressing answer.

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -498,8 +498,9 @@ impl LanguageServerPool {
             .apply_host_routing_workspace_folders(doc.uri, connection_key.server(), &handle)
             .await
         {
+            let kind = error.kind();
             return Err(io::Error::new(
-                io::ErrorKind::NotConnected,
+                kind,
                 format!("failed to apply host routing workspace folders: {error}"),
             ));
         }

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -494,6 +494,15 @@ impl LanguageServerPool {
                 format!("host document routing disabled on {connection_key}"),
             ));
         }
+        if let Err(error) = self
+            .apply_host_routing_workspace_folders(doc.uri, connection_key.server(), &handle)
+            .await
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                format!("failed to apply host routing workspace folders: {error}"),
+            ));
+        }
         if let Some(ref id) = upstream_request_id {
             self.register_upstream_request(id.clone(), connection_key);
         }


### PR DESCRIPTION
Apply the workspaceFolders returned by kakehashi/bridge/routing to shared host-provider connections before didOpen or the first lazy host request.

This completes the tsudoi routing contract for the configured preferSharedInstance TypeScript providers.