### PR TITLE
feat(bridge): route virtual documents

### DIFF
--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -625,8 +625,23 @@ impl BridgeCoordinator {
         server_name: &str,
     ) -> super::text_document::OpenOutcome {
         use super::text_document::OpenOutcome;
-        let (for_server, config) =
-            self.injections_for_server(settings, host_language, injections, server_name);
+        let Ok(host_uri_lsp) = crate::lsp::lsp_impl::url_to_uri(host_uri) else {
+            return OpenOutcome::NotOpened;
+        };
+        let routed = self
+            .route_virtual_injections(settings, host_language, host_uri, &host_uri_lsp, injections)
+            .await;
+        let mut config = None;
+        let for_server = routed
+            .into_iter()
+            .filter_map(|(injection, configs)| {
+                let resolved = configs
+                    .into_iter()
+                    .find(|resolved| resolved.server_name == server_name)?;
+                config.get_or_insert(Arc::clone(&resolved.config));
+                Some(injection)
+            })
+            .collect::<Vec<_>>();
         let Some(config) = config else {
             // No injected region on this host bridges to `server_name`, so this
             // host supplies nothing for that server on any connection. Pure
@@ -634,9 +649,6 @@ impl BridgeCoordinator {
             // walk, so the hosts that bridge nowhere near this server cost
             // nothing to reject.
             return OpenOutcome::NotApplicable;
-        };
-        let Ok(host_uri_lsp) = crate::lsp::lsp_impl::url_to_uri(host_uri) else {
-            return OpenOutcome::NotOpened;
         };
         self.pool
             .eager_open_virtual_documents(
@@ -673,6 +685,7 @@ impl BridgeCoordinator {
     /// single first pick would miss the origin when e.g. both ruff and pyright
     /// bridge python and the command came from ruff. Pure; the async open is
     /// separate so it is unit-testable.
+    #[cfg(test)]
     fn injections_for_server(
         &self,
         settings: &Arc<WorkspaceSettings>,
@@ -1068,6 +1081,74 @@ impl BridgeCoordinator {
     // Eager spawn + open (warmup with document content)
     // ========================================
 
+    async fn route_virtual_injections(
+        &self,
+        settings: &WorkspaceSettings,
+        host_language: &str,
+        host_uri: &Url,
+        host_uri_lsp: &tower_lsp_server::ls_types::Uri,
+        injections: Vec<BridgeInjection>,
+    ) -> Vec<(BridgeInjection, Vec<ResolvedServerConfig>)> {
+        let mut configs_by_lang: HashMap<String, Vec<ResolvedServerConfig>> = HashMap::new();
+        let mut routed = Vec::with_capacity(injections.len());
+        for injection in injections {
+            let virtual_uri = super::protocol::VirtualDocumentUri::new(
+                host_uri_lsp,
+                &injection.language,
+                &injection.region_id,
+            );
+            let Ok(document_uri) = Url::parse(&virtual_uri.to_uri_string()) else {
+                continue;
+            };
+            let configs = configs_by_lang
+                .entry(injection.language.clone())
+                .or_insert_with(|| {
+                    self.get_all_configs_for_language(settings, host_language, &injection.language)
+                })
+                .clone();
+            if configs.is_empty() {
+                continue;
+            }
+            let selected = Self::resolve_document_routing(
+                &self.pool,
+                &document_uri,
+                &injection.language,
+                Some(super::protocol::RoutingHostDocument {
+                    uri: host_uri.to_string(),
+                    language_id: host_language.to_string(),
+                }),
+                configs,
+            )
+            .await;
+            routed.push((injection, selected));
+        }
+        routed
+    }
+
+    fn eager_open_groups_for_configs(
+        routed: Vec<(BridgeInjection, Vec<ResolvedServerConfig>)>,
+    ) -> BTreeMap<String, ServerGroup> {
+        let mut groups: BTreeMap<String, ServerGroup> = BTreeMap::new();
+        for (injection, configs) in routed {
+            let Some((last, rest)) = configs.split_last() else {
+                continue;
+            };
+            for config in rest {
+                groups
+                    .entry(config.server_name.clone())
+                    .or_insert_with(|| (config.config.clone(), Vec::new()))
+                    .1
+                    .push(injection.clone());
+            }
+            groups
+                .entry(last.server_name.clone())
+                .or_insert_with(|| (last.config.clone(), Vec::new()))
+                .1
+                .push(injection);
+        }
+        groups
+    }
+
     /// Which servers should receive an eager `didOpen`, and for which
     /// injections. Grouped by server name, since several languages can share
     /// one server (e.g. ts/tsx → tsgo).
@@ -1089,6 +1170,7 @@ impl BridgeCoordinator {
     ///
     /// Pure, so the selection is unit-testable; resolving connection keys and
     /// skipping already-open regions needs `await` and stays in the caller.
+    #[cfg(test)]
     fn eager_open_groups(
         &self,
         settings: &WorkspaceSettings,
@@ -1156,7 +1238,10 @@ impl BridgeCoordinator {
 
         // Empty means current settings resolve no server for any injection —
         // the batch belongs to removed configuration and must stop.
-        let resolved_groups = self.eager_open_groups(settings, host_language, injections);
+        let routed = self
+            .route_virtual_injections(settings, host_language, host_uri, &host_uri_lsp, injections)
+            .await;
+        let resolved_groups = Self::eager_open_groups_for_configs(routed);
         if resolved_groups.is_empty() {
             self.cancel_eager_open(host_uri);
             return;
@@ -1263,20 +1348,21 @@ impl BridgeCoordinator {
     /// before any host `didOpen` is sent. This is deliberately one orchestration
     /// step: asking each server about a projection containing only itself cannot
     /// let a provider such as tsudoi suppress a sibling provider such as tsgo.
-    async fn resolve_host_routing(
+    async fn resolve_document_routing(
         pool: &LanguageServerPool,
-        host_uri: &Url,
+        document_uri: &Url,
         language_id: &str,
+        host: Option<super::protocol::RoutingHostDocument>,
         configs: Vec<ResolvedServerConfig>,
     ) -> Vec<ResolvedServerConfig> {
         if configs.iter().all(|config| {
-            pool.host_routing_by_server(host_uri, &config.server_name)
+            pool.host_routing_by_server(document_uri, &config.server_name)
                 .is_some()
         }) {
             return configs
                 .into_iter()
                 .filter(|config| {
-                    pool.host_routing_by_server(host_uri, &config.server_name)
+                    pool.host_routing_by_server(document_uri, &config.server_name)
                         .unwrap_or(true)
                 })
                 .collect();
@@ -1307,9 +1393,9 @@ impl BridgeCoordinator {
             .collect::<BTreeMap<_, _>>();
         let params = RoutingParams {
             text_document: RoutingTextDocument {
-                uri: host_uri.to_string(),
+                uri: document_uri.to_string(),
                 language_id: language_id.to_string(),
-                host: None,
+                host,
             },
             language_servers,
         };
@@ -1318,13 +1404,13 @@ impl BridgeCoordinator {
         for config in &configs {
             let server_name = config.server_name.clone();
             let server_config = Arc::clone(&config.config);
-            let host_uri = host_uri.clone();
+            let document_uri = document_uri.clone();
             candidates.push(async move {
                 let result = pool
                     .get_or_create_connection_wait_ready(
                         &server_name,
                         &server_config,
-                        Some(&host_uri),
+                        Some(&document_uri),
                         std::time::Duration::from_secs(INIT_TIMEOUT_SECS),
                     )
                     .await;
@@ -1342,7 +1428,7 @@ impl BridgeCoordinator {
                         target: "kakehashi::bridge::routing",
                         "Routing candidate {} was not ready for {}: {}",
                         server_name,
-                        host_uri,
+                        document_uri,
                         error
                     );
                     continue;
@@ -1356,7 +1442,7 @@ impl BridgeCoordinator {
                         target: "kakehashi::bridge::routing",
                         "Routing provider {} failed for {}: {}",
                         server_name,
-                        host_uri,
+                        document_uri,
                         error
                     ),
                 }
@@ -1371,9 +1457,9 @@ impl BridgeCoordinator {
                 .and_then(|answer| answer.routing.get(&config.server_name))
                 .and_then(|entry| entry.enabled)
                 != Some(false);
-            pool.set_host_routing_by_server(host_uri, &config.server_name, enabled);
+            pool.set_host_routing_by_server(document_uri, &config.server_name, enabled);
             pool.set_host_routing_workspace_folders(
-                host_uri,
+                document_uri,
                 &config.server_name,
                 answer
                     .as_ref()
@@ -1387,9 +1473,9 @@ impl BridgeCoordinator {
                 }
                 continue;
             };
-            pool.set_host_routing_decided(host_uri, handle.key());
+            pool.set_host_routing_decided(document_uri, handle.key());
             if !enabled {
-                pool.set_host_routing_suppressed(host_uri, handle.key());
+                pool.set_host_routing_suppressed(document_uri, handle.key());
                 continue;
             }
             selected.push(config);
@@ -1466,10 +1552,11 @@ impl BridgeCoordinator {
                 configs = async {
                     let lifecycle = pool.host_lifecycle_lock(&host_uri_owned);
                     let _guard = lifecycle.lock().await;
-                    Self::resolve_host_routing(
+                    Self::resolve_document_routing(
                         &pool,
                         &host_uri_owned,
                         &language_id,
+                        None,
                         configs_for_routing,
                     ).await
                 } => configs,

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -629,7 +629,14 @@ impl BridgeCoordinator {
             return OpenOutcome::NotOpened;
         };
         let routed = self
-            .route_virtual_injections(settings, host_language, host_uri, &host_uri_lsp, injections)
+            .route_virtual_injections(
+                settings,
+                host_language,
+                host_uri,
+                &host_uri_lsp,
+                injections,
+                Some(server_name),
+            )
             .await;
         let mut config = None;
         let for_server = routed
@@ -1088,6 +1095,7 @@ impl BridgeCoordinator {
         host_uri: &Url,
         host_uri_lsp: &tower_lsp_server::ls_types::Uri,
         injections: Vec<BridgeInjection>,
+        target_server: Option<&str>,
     ) -> Vec<(BridgeInjection, Vec<ResolvedServerConfig>)> {
         let mut configs_by_lang: HashMap<String, Vec<ResolvedServerConfig>> = HashMap::new();
         let mut routed = Vec::with_capacity(injections.len());
@@ -1106,6 +1114,13 @@ impl BridgeCoordinator {
                     self.get_all_configs_for_language(settings, host_language, &injection.language)
                 })
                 .clone();
+            let configs = match target_server {
+                Some(target) => configs
+                    .into_iter()
+                    .filter(|config| config.server_name == target)
+                    .collect(),
+                None => configs,
+            };
             if configs.is_empty() {
                 continue;
             }
@@ -1239,7 +1254,14 @@ impl BridgeCoordinator {
         // Empty means current settings resolve no server for any injection —
         // the batch belongs to removed configuration and must stop.
         let routed = self
-            .route_virtual_injections(settings, host_language, host_uri, &host_uri_lsp, injections)
+            .route_virtual_injections(
+                settings,
+                host_language,
+                host_uri,
+                &host_uri_lsp,
+                injections,
+                None,
+            )
             .await;
         let resolved_groups = Self::eager_open_groups_for_configs(routed);
         if resolved_groups.is_empty() {

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -143,6 +143,19 @@ impl LanguageServerPool {
         let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, injection_language, region_id);
 
         let host_lifecycle = self.request_host_lifecycle(host_uri).await?;
+        let routing_uri = url::Url::parse(&virtual_uri.to_uri_string())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        if self
+            .host_routing_by_server(&routing_uri, connection_key.server())
+            .is_some_and(|enabled| !enabled)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                format!("virtual document routing disabled on {connection_key}"),
+            ));
+        }
+        self.apply_host_routing_workspace_folders(&routing_uri, connection_key.server(), &handle)
+            .await?;
 
         // Register in the upstream request registry before downstream router
         // registration for cancel lookup. This relative order matters: if a

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -154,6 +154,9 @@ impl LanguageServerPool {
     /// and `close_invalidated_docs`. Errors are logged but do not prevent
     /// cleanup of the document_versions tracking.
     pub(crate) async fn close_single_virtual_doc(&self, doc: &OpenedVirtualDoc) {
+        if let Ok(uri) = url::Url::parse(&doc.virtual_uri.to_uri_string()) {
+            self.clear_host_routing_suppression(&uri);
+        }
         let handle = self.connection_for_didclose(&doc.connection_key).await;
         let transition = self.open_transition_lock(&doc.virtual_uri, &doc.connection_key);
         let transition_guard = transition.lock().await;

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -199,6 +199,33 @@ impl LanguageServerPool {
             }
             let virtual_uri =
                 VirtualDocumentUri::new(host_uri_lsp, &injection.language, &injection.region_id);
+            let Ok(routing_uri) = url::Url::parse(&virtual_uri.to_uri_string()) else {
+                enqueued_all = false;
+                drop(lifecycle_guard);
+                continue;
+            };
+            if self
+                .host_routing_by_server(&routing_uri, server_name)
+                .is_some_and(|enabled| !enabled)
+            {
+                drop(lifecycle_guard);
+                continue;
+            }
+            if let Err(error) = self
+                .apply_host_routing_workspace_folders(&routing_uri, server_name, &handle)
+                .await
+            {
+                log::debug!(
+                    target: "kakehashi::bridge::routing",
+                    "Failed to apply virtual routing workspace folders for {} on {}: {}",
+                    routing_uri,
+                    server_name,
+                    error
+                );
+                enqueued_all = false;
+                drop(lifecycle_guard);
+                continue;
+            }
 
             // Verify `handle` is still the pool's LIVE connection for its key and
             // claim + didOpen this ONE injection under the `connections` lock,

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1121,31 +1121,31 @@ impl Kakehashi {
         // become transport errors in the aggregation layer. The execution
         // guard remains as a defense against a stale decision or a race with
         // routing cleanup.
-        if let Ok(host_uri_lsp) = crate::lsp::lsp_impl::url_to_uri(&preamble.uri) {
-            if let Ok(virtual_uri) = url::Url::parse(
+        if let Ok(host_uri_lsp) = crate::lsp::lsp_impl::url_to_uri(&preamble.uri)
+            && let Ok(virtual_uri) = url::Url::parse(
                 &crate::lsp::bridge::VirtualDocumentUri::new(
                     &host_uri_lsp,
                     &preamble.resolved.injection_language,
                     &preamble.resolved.region.region_id,
                 )
                 .to_uri_string(),
-            ) {
-                let pool = self.bridge.pool_arc();
-                configs.retain(|config| {
-                    let suppressed = pool
-                        .host_routing_by_server(&virtual_uri, &config.server_name)
-                        .is_some_and(|enabled| !enabled);
-                    if suppressed {
-                        log::debug!(
-                            "{}: routing suppressed server '{}' for virtual document {}",
-                            method_name,
-                            config.server_name,
-                            virtual_uri
-                        );
-                    }
-                    !suppressed
-                });
-            }
+            )
+        {
+            let pool = self.bridge.pool_arc();
+            configs.retain(|config| {
+                let suppressed = pool
+                    .host_routing_by_server(&virtual_uri, &config.server_name)
+                    .is_some_and(|enabled| !enabled);
+                if suppressed {
+                    log::debug!(
+                        "{}: routing suppressed server '{}' for virtual document {}",
+                        method_name,
+                        config.server_name,
+                        virtual_uri
+                    );
+                }
+                !suppressed
+            });
         }
         if configs.is_empty() {
             return None;

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1116,6 +1116,41 @@ impl Kakehashi {
             }
         }
 
+        // Routing is decided per virtual document. Filter an explicitly
+        // suppressed server before fan-out so expected routing choices do not
+        // become transport errors in the aggregation layer. The execution
+        // guard remains as a defense against a stale decision or a race with
+        // routing cleanup.
+        if let Ok(host_uri_lsp) = crate::lsp::lsp_impl::url_to_uri(&preamble.uri) {
+            if let Ok(virtual_uri) = url::Url::parse(
+                &crate::lsp::bridge::VirtualDocumentUri::new(
+                    &host_uri_lsp,
+                    &preamble.resolved.injection_language,
+                    &preamble.resolved.region.region_id,
+                )
+                .to_uri_string(),
+            ) {
+                let pool = self.bridge.pool_arc();
+                configs.retain(|config| {
+                    let suppressed = pool
+                        .host_routing_by_server(&virtual_uri, &config.server_name)
+                        .is_some_and(|enabled| !enabled);
+                    if suppressed {
+                        log::debug!(
+                            "{}: routing suppressed server '{}' for virtual document {}",
+                            method_name,
+                            config.server_name,
+                            virtual_uri
+                        );
+                    }
+                    !suppressed
+                });
+            }
+        }
+        if configs.is_empty() {
+            return None;
+        }
+
         let agg = self.resolve_aggregation_config(
             &preamble.language_name,
             &preamble.resolved.injection_language,

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -293,8 +293,17 @@ impl InjectionCoordinator {
         };
         tokio::spawn(install_task);
 
-        self.eager_spawn_bridge_servers(uri, incarnation, &host_language, injections)
-            .await;
+        // Routing may need to wait for a downstream provider to become ready.
+        // Keep that wait out of the lifecycle pass: the pass must release its
+        // per-document lock promptly, while the detached task still observes
+        // the same incarnation and is cancelled by the next close/rebuild.
+        let coordinator = self.clone();
+        let uri = uri.clone();
+        tokio::spawn(async move {
+            coordinator
+                .eager_spawn_bridge_servers(&uri, incarnation, &host_language, injections)
+                .await;
+        });
         true
     }
 


### PR DESCRIPTION
Apply kakehashi/bridge/routing per virtual document, including the opaque virtual URI and host document identity. Suppress routed providers and apply routed workspace folders before virtual didOpen and request sends.