### PR TITLE
feat(bridge): honor routed workspace folder semantics

### DIFF
--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -653,7 +653,7 @@ impl BridgeCoordinator {
         let Ok(host_uri_lsp) = crate::lsp::lsp_impl::url_to_uri(host_uri) else {
             return OpenOutcome::NotOpened;
         };
-        let routed = self
+        let (routed, _) = self
             .route_virtual_injections(
                 settings,
                 host_language,
@@ -1155,9 +1155,10 @@ impl BridgeCoordinator {
         injections: Vec<BridgeInjection>,
         target_server: Option<&str>,
         routing_tokens: Option<&HashMap<Url, Arc<tokio::sync::watch::Sender<bool>>>>,
-    ) -> Vec<(BridgeInjection, Vec<ResolvedServerConfig>)> {
+    ) -> (Vec<(BridgeInjection, Vec<ResolvedServerConfig>)>, bool) {
         let mut configs_by_lang: HashMap<String, Vec<ResolvedServerConfig>> = HashMap::new();
         let mut routed = Vec::with_capacity(injections.len());
+        let mut superseded = false;
         for injection in injections {
             let virtual_uri = super::protocol::VirtualDocumentUri::new(
                 host_uri_lsp,
@@ -1182,6 +1183,12 @@ impl BridgeCoordinator {
             };
             if configs.is_empty() {
                 if let Some(token) = routing_tokens.and_then(|tokens| tokens.get(&document_uri)) {
+                    if !self
+                        .pool
+                        .is_virtual_routing_current(host_uri, &document_uri, token)
+                    {
+                        superseded = true;
+                    }
                     self.pool
                         .finish_virtual_routing(host_uri, &document_uri, token);
                 }
@@ -1203,12 +1210,18 @@ impl BridgeCoordinator {
             )
             .await;
             if let Some(token) = routing_tokens.and_then(|tokens| tokens.get(&document_uri)) {
+                if !self
+                    .pool
+                    .is_virtual_routing_current(host_uri, &document_uri, token)
+                {
+                    superseded = true;
+                }
                 self.pool
                     .finish_virtual_routing(host_uri, &document_uri, token);
             }
             routed.push((injection, selected));
         }
-        routed
+        (routed, superseded)
     }
 
     fn eager_open_groups_for_configs(
@@ -1325,7 +1338,7 @@ impl BridgeCoordinator {
 
         // Empty means current settings resolve no server for any injection —
         // the batch belongs to removed configuration and must stop.
-        let routed = self
+        let (routed, routing_superseded) = self
             .route_virtual_injections(
                 settings,
                 host_language,
@@ -1338,6 +1351,9 @@ impl BridgeCoordinator {
             .await;
         let resolved_groups = Self::eager_open_groups_for_configs(routed);
         if resolved_groups.is_empty() {
+            if routing_superseded {
+                return;
+            }
             self.cancel_eager_open(host_uri);
             return;
         }

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1349,11 +1349,11 @@ impl BridgeCoordinator {
                 Some(&routing_tokens),
             )
             .await;
+        if routing_superseded {
+            return;
+        }
         let resolved_groups = Self::eager_open_groups_for_configs(routed);
         if resolved_groups.is_empty() {
-            if routing_superseded {
-                return;
-            }
             self.cancel_eager_open(host_uri);
             return;
         }

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1175,8 +1175,7 @@ impl BridgeCoordinator {
                 None => configs,
             };
             if configs.is_empty() {
-                self.pool
-                    .finish_virtual_routing(host_uri, &document_uri);
+                self.pool.finish_virtual_routing(host_uri, &document_uri);
                 continue;
             }
             let selected = Self::resolve_document_routing(

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -658,6 +658,37 @@ impl BridgeCoordinator {
             // nothing to reject.
             return OpenOutcome::NotApplicable;
         };
+        // A repair is for one concrete connection. The same host can have
+        // injections routed to several keys, so do not pass the whole server
+        // batch to `eager_open_virtual_documents` and let its first injection
+        // represent the rest. The normal eager path is partitioned earlier;
+        // this filters the respawn path to the key being repaired.
+        let for_server = if let Some(expected_key) = expect.connection {
+            let mut matching = Vec::new();
+            for injection in for_server {
+                let virtual_uri = super::protocol::VirtualDocumentUri::new(
+                    &host_uri_lsp,
+                    &injection.language,
+                    &injection.region_id,
+                );
+                let Ok(routing_uri) = Url::parse(&virtual_uri.to_uri_string()) else {
+                    continue;
+                };
+                let routed_key = self
+                    .pool
+                    .resolved_connection_key(server_name, &config, &routing_uri)
+                    .await;
+                if &routed_key == expected_key {
+                    matching.push(injection);
+                }
+            }
+            matching
+        } else {
+            for_server
+        };
+        if for_server.is_empty() {
+            return OpenOutcome::NotApplicable;
+        }
         self.pool
             .eager_open_virtual_documents(
                 server_name,

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1285,6 +1285,7 @@ impl BridgeCoordinator {
 
         // Empty means current settings resolve no server for any injection —
         // the batch belongs to removed configuration and must stop.
+        let routing_sender = self.pool.begin_virtual_routing(host_uri);
         let routed = self
             .route_virtual_injections(
                 settings,
@@ -1295,6 +1296,7 @@ impl BridgeCoordinator {
                 None,
             )
             .await;
+        self.pool.finish_virtual_routing(host_uri, &routing_sender);
         let resolved_groups = Self::eager_open_groups_for_configs(routed);
         if resolved_groups.is_empty() {
             self.cancel_eager_open(host_uri);

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -239,11 +239,25 @@ impl ConfigMemo {
 }
 
 impl BridgeCoordinator {
-    pub(crate) fn begin_virtual_routing(
+    pub(crate) fn begin_virtual_routing_for_injections(
         &self,
         host_uri: &Url,
-    ) -> Arc<tokio::sync::watch::Sender<bool>> {
-        self.pool.begin_virtual_routing(host_uri)
+        injections: &[BridgeInjection],
+    ) {
+        let Ok(host_uri_lsp) = crate::lsp::lsp_impl::url_to_uri(host_uri) else {
+            return;
+        };
+        for injection in injections {
+            let virtual_uri = super::protocol::VirtualDocumentUri::new(
+                &host_uri_lsp,
+                &injection.language,
+                &injection.region_id,
+            );
+            let Ok(virtual_uri) = Url::parse(&virtual_uri.to_uri_string()) else {
+                continue;
+            };
+            self.pool.begin_virtual_routing(host_uri, &virtual_uri);
+        }
     }
 
     /// Create a new bridge coordinator with fresh pool and tracker.
@@ -1161,6 +1175,8 @@ impl BridgeCoordinator {
                 None => configs,
             };
             if configs.is_empty() {
+                self.pool
+                    .finish_virtual_routing(host_uri, &document_uri);
                 continue;
             }
             let selected = Self::resolve_document_routing(
@@ -1174,6 +1190,7 @@ impl BridgeCoordinator {
                 configs,
             )
             .await;
+            self.pool.finish_virtual_routing(host_uri, &document_uri);
             routed.push((injection, selected));
         }
         routed
@@ -1269,9 +1286,6 @@ impl BridgeCoordinator {
     ///
     /// Sending `didOpen` up front (not just a handshake) lets downstream servers
     /// start analyzing immediately, yielding faster diagnostics.
-    /// The lifecycle coordinator registers `routing_sender` synchronously,
-    /// before detaching this eager task, so interactive requests cannot pass
-    /// through the spawn-to-first-poll window.
     pub(crate) async fn eager_spawn_and_open_documents(
         &self,
         settings: &WorkspaceSettings,
@@ -1279,7 +1293,6 @@ impl BridgeCoordinator {
         host_uri: &Url,
         incarnation: u64,
         injections: Vec<BridgeInjection>,
-        routing_sender: Arc<tokio::sync::watch::Sender<bool>>,
     ) {
         // Convert host_uri to ls_types::Uri for VirtualDocumentUri construction
         let host_uri_lsp = match crate::lsp::lsp_impl::url_to_uri(host_uri) {
@@ -1306,7 +1319,6 @@ impl BridgeCoordinator {
                 None,
             )
             .await;
-        self.pool.finish_virtual_routing(host_uri, &routing_sender);
         let resolved_groups = Self::eager_open_groups_for_configs(routed);
         if resolved_groups.is_empty() {
             self.cancel_eager_open(host_uri);
@@ -3155,16 +3167,11 @@ mod tests {
             config.cmd = Some(vec!["/nonexistent/kakehashi-test-server".to_string()]);
         }
         let host_uri = Url::parse("file:///test.md").unwrap();
+        let injections = vec![injection("rust", "r1")];
+        coordinator.begin_virtual_routing_for_injections(&host_uri, &injections);
 
         coordinator
-            .eager_spawn_and_open_documents(
-                &settings,
-                "markdown",
-                &host_uri,
-                1,
-                vec![injection("rust", "r1")],
-                coordinator.begin_virtual_routing(&host_uri),
-            )
+            .eager_spawn_and_open_documents(&settings, "markdown", &host_uri, 1, injections)
             .await;
 
         let handles = coordinator

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1274,9 +1274,20 @@ impl BridgeCoordinator {
         // rather than once per region.
         let mut server_groups: BTreeMap<String, ServerGroup> = BTreeMap::new();
         for (server_name, (config, group_injections)) in resolved_groups {
+            let routing_uri = group_injections
+                .first()
+                .and_then(|injection| {
+                    let virtual_uri = super::protocol::VirtualDocumentUri::new(
+                        &host_uri_lsp,
+                        &injection.language,
+                        &injection.region_id,
+                    );
+                    Url::parse(&virtual_uri.to_uri_string()).ok()
+                })
+                .unwrap_or_else(|| host_uri.clone());
             let connection_key = self
                 .pool
-                .resolved_connection_key(&server_name, &config, host_uri)
+                .resolved_connection_key(&server_name, &config, &routing_uri)
                 .await;
             let pending: Vec<BridgeInjection> = group_injections
                 .into_iter()
@@ -1417,7 +1428,7 @@ impl BridgeCoordinator {
             text_document: RoutingTextDocument {
                 uri: document_uri.to_string(),
                 language_id: language_id.to_string(),
-                host: host.clone(),
+                host,
             },
             language_servers,
         };
@@ -1494,13 +1505,6 @@ impl BridgeCoordinator {
                 .and_then(|entry| entry.workspace_folders.as_ref())
                 .is_some_and(|folders| folders.as_ref().is_some_and(Vec::is_empty));
             pool.set_host_routing_rootless(document_uri, &config.server_name, rootless);
-            // Eager acquisition and host diagnostics start from the real host
-            // URI, while routing is requested for each virtual injection URI.
-            // Carry the explicit rootless decision to that host-level lookup;
-            // otherwise the virtual route is lost before the first didOpen.
-            if let Some(host_uri) = host.as_ref().and_then(|host| Url::parse(&host.uri).ok()) {
-                pool.set_host_routing_rootless(&host_uri, &config.server_name, rootless);
-            }
             let Some((_, handle)) = handles.iter().find(|(name, _)| name == &config.server_name)
             else {
                 if enabled {

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1272,19 +1272,42 @@ impl BridgeCoordinator {
         // Drop the regions already open on each server's connection. The key
         // is per SERVER (`(server, root)`), so it is resolved once per group
         // rather than once per region.
-        let mut server_groups: BTreeMap<String, ServerGroup> = BTreeMap::new();
+        // A single server can receive different routing answers for different
+        // virtual documents. In particular, rootless and rooted injections
+        // must not share one representative URI merely because their server
+        // names match.
+        let mut server_groups: BTreeMap<(String, bool), ServerGroup> = BTreeMap::new();
         for (server_name, (config, group_injections)) in resolved_groups {
-            let routing_uri = group_injections
-                .first()
-                .and_then(|injection| {
-                    let virtual_uri = super::protocol::VirtualDocumentUri::new(
-                        &host_uri_lsp,
-                        &injection.language,
-                        &injection.region_id,
-                    );
-                    Url::parse(&virtual_uri.to_uri_string()).ok()
-                })
-                .unwrap_or_else(|| host_uri.clone());
+            for injection in group_injections {
+                let routing_uri = super::protocol::VirtualDocumentUri::new(
+                    &host_uri_lsp,
+                    &injection.language,
+                    &injection.region_id,
+                );
+                let Ok(routing_uri) = Url::parse(&routing_uri.to_uri_string()) else {
+                    continue;
+                };
+                let rootless = self.pool.host_routing_rootless(&routing_uri, &server_name);
+                let entry = server_groups
+                    .entry((server_name.clone(), rootless))
+                    .or_insert_with(|| (Arc::clone(&config), Vec::new()));
+                entry.1.push(injection);
+            }
+        }
+
+        let mut pending_groups: BTreeMap<(String, bool), ServerGroup> = BTreeMap::new();
+        for ((server_name, rootless), (config, group_injections)) in server_groups {
+            let Some(first) = group_injections.first() else {
+                continue;
+            };
+            let routing_uri = super::protocol::VirtualDocumentUri::new(
+                &host_uri_lsp,
+                &first.language,
+                &first.region_id,
+            );
+            let Ok(routing_uri) = Url::parse(&routing_uri.to_uri_string()) else {
+                continue;
+            };
             let connection_key = self
                 .pool
                 .resolved_connection_key(&server_name, &config, &routing_uri)
@@ -1296,9 +1319,10 @@ impl BridgeCoordinator {
                 })
                 .collect();
             if !pending.is_empty() {
-                server_groups.insert(server_name, (config, pending));
+                pending_groups.insert((server_name, rootless), (config, pending));
             }
         }
+        let server_groups = pending_groups;
 
         // Every resolved injection is already sent/open — preserve the batch.
         if server_groups.is_empty() {
@@ -1312,7 +1336,7 @@ impl BridgeCoordinator {
         let (generation, cancel) = self.supersede_eager_open_tasks(host_uri);
 
         // Spawn one task per server group, registering each handle immediately
-        for (server_name, (config, group_injections)) in server_groups {
+        for ((server_name, _rootless), (config, group_injections)) in server_groups {
             log::debug!(
                 target: "kakehashi::bridge",
                 "Eager open: spawning {} with {} injections",

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1495,7 +1495,7 @@ impl BridgeCoordinator {
                     .as_ref()
                     .and_then(|answer| answer.routing.get(&config.server_name))
                     .and_then(|entry| entry.workspace_folders.as_ref())
-                    .is_some_and(Vec::is_empty),
+                    .is_some_and(|folders| folders.as_ref().is_some_and(Vec::is_empty)),
             );
             let Some((_, handle)) = handles.iter().find(|(name, _)| name == &config.server_name)
             else {

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -19,6 +19,7 @@ use crate::language::node_tracker::{EditInfo, NodeTracker};
 use crate::lsp::request_id::CancelForwarder;
 
 use super::LanguageServerPool;
+use super::pool::ConnectionKey;
 use super::pool::INIT_TIMEOUT_SECS;
 use super::protocol::{RoutingAnswer, RoutingLanguageServer, RoutingParams, RoutingTextDocument};
 
@@ -1269,14 +1270,11 @@ impl BridgeCoordinator {
             return;
         }
 
-        // Drop the regions already open on each server's connection. The key
-        // is per SERVER (`(server, root)`), so it is resolved once per group
-        // rather than once per region.
-        // A single server can receive different routing answers for different
-        // virtual documents. In particular, rootless and rooted injections
-        // must not share one representative URI merely because their server
-        // names match.
-        let mut server_groups: BTreeMap<(String, bool), ServerGroup> = BTreeMap::new();
+        // Drop the regions already open on each server's connection. A single
+        // server can receive different routing answers for different virtual
+        // documents, so group by the complete resolved connection key rather
+        // than only by server name or rootless-ness.
+        let mut server_groups: HashMap<ConnectionKey, (String, ServerGroup)> = HashMap::new();
         for (server_name, (config, group_injections)) in resolved_groups {
             for injection in group_injections {
                 let routing_uri = super::protocol::VirtualDocumentUri::new(
@@ -1287,31 +1285,19 @@ impl BridgeCoordinator {
                 let Ok(routing_uri) = Url::parse(&routing_uri.to_uri_string()) else {
                     continue;
                 };
-                let rootless = self.pool.host_routing_rootless(&routing_uri, &server_name);
+                let connection_key = self
+                    .pool
+                    .resolved_connection_key(&server_name, &config, &routing_uri)
+                    .await;
                 let entry = server_groups
-                    .entry((server_name.clone(), rootless))
-                    .or_insert_with(|| (Arc::clone(&config), Vec::new()));
-                entry.1.push(injection);
+                    .entry(connection_key)
+                    .or_insert_with(|| (server_name.clone(), (Arc::clone(&config), Vec::new())));
+                entry.1.1.push(injection);
             }
         }
 
-        let mut pending_groups: BTreeMap<(String, bool), ServerGroup> = BTreeMap::new();
-        for ((server_name, rootless), (config, group_injections)) in server_groups {
-            let Some(first) = group_injections.first() else {
-                continue;
-            };
-            let routing_uri = super::protocol::VirtualDocumentUri::new(
-                &host_uri_lsp,
-                &first.language,
-                &first.region_id,
-            );
-            let Ok(routing_uri) = Url::parse(&routing_uri.to_uri_string()) else {
-                continue;
-            };
-            let connection_key = self
-                .pool
-                .resolved_connection_key(&server_name, &config, &routing_uri)
-                .await;
+        let mut pending_groups: HashMap<ConnectionKey, (String, ServerGroup)> = HashMap::new();
+        for (connection_key, (server_name, (config, group_injections))) in server_groups {
             let pending: Vec<BridgeInjection> = group_injections
                 .into_iter()
                 .filter(|injection| {
@@ -1319,7 +1305,7 @@ impl BridgeCoordinator {
                 })
                 .collect();
             if !pending.is_empty() {
-                pending_groups.insert((server_name, rootless), (config, pending));
+                pending_groups.insert(connection_key, (server_name, (config, pending)));
             }
         }
         let server_groups = pending_groups;
@@ -1336,11 +1322,12 @@ impl BridgeCoordinator {
         let (generation, cancel) = self.supersede_eager_open_tasks(host_uri);
 
         // Spawn one task per server group, registering each handle immediately
-        for ((server_name, _rootless), (config, group_injections)) in server_groups {
+        for (connection_key, (server_name, (config, group_injections))) in server_groups {
             log::debug!(
                 target: "kakehashi::bridge",
-                "Eager open: spawning {} with {} injections",
+                "Eager open: spawning {} on {} with {} injections",
                 server_name,
+                connection_key,
                 group_injections.len()
             );
 

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1488,6 +1488,15 @@ impl BridgeCoordinator {
                     .and_then(|answer| answer.routing.get(&config.server_name))
                     .and_then(|entry| entry.workspace_folders.clone()),
             );
+            pool.set_host_routing_rootless(
+                document_uri,
+                &config.server_name,
+                answer
+                    .as_ref()
+                    .and_then(|answer| answer.routing.get(&config.server_name))
+                    .and_then(|entry| entry.workspace_folders.as_ref())
+                    .is_some_and(Vec::is_empty),
+            );
             let Some((_, handle)) = handles.iter().find(|(name, _)| name == &config.server_name)
             else {
                 if enabled {

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -239,6 +239,13 @@ impl ConfigMemo {
 }
 
 impl BridgeCoordinator {
+    pub(crate) fn begin_virtual_routing(
+        &self,
+        host_uri: &Url,
+    ) -> Arc<tokio::sync::watch::Sender<bool>> {
+        self.pool.begin_virtual_routing(host_uri)
+    }
+
     /// Create a new bridge coordinator with fresh pool and tracker.
     pub(crate) fn new() -> Self {
         let pool = Arc::new(LanguageServerPool::new());
@@ -1262,6 +1269,9 @@ impl BridgeCoordinator {
     ///
     /// Sending `didOpen` up front (not just a handshake) lets downstream servers
     /// start analyzing immediately, yielding faster diagnostics.
+    /// The lifecycle coordinator registers `routing_sender` synchronously,
+    /// before detaching this eager task, so interactive requests cannot pass
+    /// through the spawn-to-first-poll window.
     pub(crate) async fn eager_spawn_and_open_documents(
         &self,
         settings: &WorkspaceSettings,
@@ -1269,6 +1279,7 @@ impl BridgeCoordinator {
         host_uri: &Url,
         incarnation: u64,
         injections: Vec<BridgeInjection>,
+        routing_sender: Arc<tokio::sync::watch::Sender<bool>>,
     ) {
         // Convert host_uri to ls_types::Uri for VirtualDocumentUri construction
         let host_uri_lsp = match crate::lsp::lsp_impl::url_to_uri(host_uri) {
@@ -1285,7 +1296,6 @@ impl BridgeCoordinator {
 
         // Empty means current settings resolve no server for any injection —
         // the batch belongs to removed configuration and must stop.
-        let routing_sender = self.pool.begin_virtual_routing(host_uri);
         let routed = self
             .route_virtual_injections(
                 settings,
@@ -3153,6 +3163,7 @@ mod tests {
                 &host_uri,
                 1,
                 vec![injection("rust", "r1")],
+                coordinator.begin_virtual_routing(&host_uri),
             )
             .await;
 

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1439,6 +1439,7 @@ impl BridgeCoordinator {
                             incarnation,
                             // The eager batch opens wherever the host routes now.
                             connection: None,
+                            expected_connection: Some(connection_key.clone()),
                         },
                         group_injections,
                     ) => {}
@@ -2752,6 +2753,7 @@ mod tests {
                 crate::lsp::bridge::OpenExpectation {
                     incarnation: 1,
                     connection: None,
+                    expected_connection: None,
                 },
                 injections,
                 "other-server",

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -243,9 +243,10 @@ impl BridgeCoordinator {
         &self,
         host_uri: &Url,
         injections: &[BridgeInjection],
-    ) {
+    ) -> HashMap<Url, Arc<tokio::sync::watch::Sender<bool>>> {
+        let mut tokens = HashMap::new();
         let Ok(host_uri_lsp) = crate::lsp::lsp_impl::url_to_uri(host_uri) else {
-            return;
+            return tokens;
         };
         for injection in injections {
             let virtual_uri = super::protocol::VirtualDocumentUri::new(
@@ -256,8 +257,10 @@ impl BridgeCoordinator {
             let Ok(virtual_uri) = Url::parse(&virtual_uri.to_uri_string()) else {
                 continue;
             };
-            self.pool.begin_virtual_routing(host_uri, &virtual_uri);
+            let token = self.pool.begin_virtual_routing(host_uri, &virtual_uri);
+            tokens.insert(virtual_uri, token);
         }
+        tokens
     }
 
     /// Create a new bridge coordinator with fresh pool and tracker.
@@ -658,6 +661,7 @@ impl BridgeCoordinator {
                 &host_uri_lsp,
                 injections,
                 Some(server_name),
+                None,
             )
             .await;
         let mut config = None;
@@ -1141,6 +1145,7 @@ impl BridgeCoordinator {
     // Eager spawn + open (warmup with document content)
     // ========================================
 
+    #[allow(clippy::too_many_arguments)]
     async fn route_virtual_injections(
         &self,
         settings: &WorkspaceSettings,
@@ -1149,6 +1154,7 @@ impl BridgeCoordinator {
         host_uri_lsp: &tower_lsp_server::ls_types::Uri,
         injections: Vec<BridgeInjection>,
         target_server: Option<&str>,
+        routing_tokens: Option<&HashMap<Url, Arc<tokio::sync::watch::Sender<bool>>>>,
     ) -> Vec<(BridgeInjection, Vec<ResolvedServerConfig>)> {
         let mut configs_by_lang: HashMap<String, Vec<ResolvedServerConfig>> = HashMap::new();
         let mut routed = Vec::with_capacity(injections.len());
@@ -1175,9 +1181,15 @@ impl BridgeCoordinator {
                 None => configs,
             };
             if configs.is_empty() {
-                self.pool.finish_virtual_routing(host_uri, &document_uri);
+                if let Some(token) = routing_tokens.and_then(|tokens| tokens.get(&document_uri)) {
+                    self.pool
+                        .finish_virtual_routing(host_uri, &document_uri, token);
+                }
                 continue;
             }
+            let routing_guard = routing_tokens
+                .and_then(|tokens| tokens.get(&document_uri))
+                .map(|token| (host_uri, &document_uri, token));
             let selected = Self::resolve_document_routing(
                 &self.pool,
                 &document_uri,
@@ -1187,9 +1199,13 @@ impl BridgeCoordinator {
                     language_id: host_language.to_string(),
                 }),
                 configs,
+                routing_guard,
             )
             .await;
-            self.pool.finish_virtual_routing(host_uri, &document_uri);
+            if let Some(token) = routing_tokens.and_then(|tokens| tokens.get(&document_uri)) {
+                self.pool
+                    .finish_virtual_routing(host_uri, &document_uri, token);
+            }
             routed.push((injection, selected));
         }
         routed
@@ -1292,6 +1308,7 @@ impl BridgeCoordinator {
         host_uri: &Url,
         incarnation: u64,
         injections: Vec<BridgeInjection>,
+        routing_tokens: HashMap<Url, Arc<tokio::sync::watch::Sender<bool>>>,
     ) {
         // Convert host_uri to ls_types::Uri for VirtualDocumentUri construction
         let host_uri_lsp = match crate::lsp::lsp_impl::url_to_uri(host_uri) {
@@ -1316,6 +1333,7 @@ impl BridgeCoordinator {
                 &host_uri_lsp,
                 injections,
                 None,
+                Some(&routing_tokens),
             )
             .await;
         let resolved_groups = Self::eager_open_groups_for_configs(routed);
@@ -1452,7 +1470,13 @@ impl BridgeCoordinator {
         language_id: &str,
         host: Option<super::protocol::RoutingHostDocument>,
         configs: Vec<ResolvedServerConfig>,
+        routing_guard: Option<(&Url, &Url, &Arc<tokio::sync::watch::Sender<bool>>)>,
     ) -> Vec<ResolvedServerConfig> {
+        if routing_guard.is_some_and(|(host_uri, virtual_uri, token)| {
+            !pool.is_virtual_routing_current(host_uri, virtual_uri, token)
+        }) {
+            return Vec::new();
+        }
         if configs.iter().all(|config| {
             pool.host_routing_by_server(document_uri, &config.server_name)
                 .is_some()
@@ -1550,6 +1574,11 @@ impl BridgeCoordinator {
 
         let mut selected = Vec::new();
         for config in configs {
+            if routing_guard.is_some_and(|(host_uri, virtual_uri, token)| {
+                !pool.is_virtual_routing_current(host_uri, virtual_uri, token)
+            }) {
+                return Vec::new();
+            }
             let enabled = answer
                 .as_ref()
                 .and_then(|answer| answer.routing.get(&config.server_name))
@@ -1662,6 +1691,7 @@ impl BridgeCoordinator {
                         &language_id,
                         None,
                         configs_for_routing,
+                        None,
                     ).await
                 } => configs,
             };
@@ -3170,7 +3200,14 @@ mod tests {
         coordinator.begin_virtual_routing_for_injections(&host_uri, &injections);
 
         coordinator
-            .eager_spawn_and_open_documents(&settings, "markdown", &host_uri, 1, injections)
+            .eager_spawn_and_open_documents(
+                &settings,
+                "markdown",
+                &host_uri,
+                1,
+                injections,
+                HashMap::new(),
+            )
             .await;
 
         let handles = coordinator

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1417,7 +1417,7 @@ impl BridgeCoordinator {
             text_document: RoutingTextDocument {
                 uri: document_uri.to_string(),
                 language_id: language_id.to_string(),
-                host,
+                host: host.clone(),
             },
             language_servers,
         };
@@ -1488,15 +1488,19 @@ impl BridgeCoordinator {
                     .and_then(|answer| answer.routing.get(&config.server_name))
                     .and_then(|entry| entry.workspace_folders.clone()),
             );
-            pool.set_host_routing_rootless(
-                document_uri,
-                &config.server_name,
-                answer
-                    .as_ref()
-                    .and_then(|answer| answer.routing.get(&config.server_name))
-                    .and_then(|entry| entry.workspace_folders.as_ref())
-                    .is_some_and(|folders| folders.as_ref().is_some_and(Vec::is_empty)),
-            );
+            let rootless = answer
+                .as_ref()
+                .and_then(|answer| answer.routing.get(&config.server_name))
+                .and_then(|entry| entry.workspace_folders.as_ref())
+                .is_some_and(|folders| folders.as_ref().is_some_and(Vec::is_empty));
+            pool.set_host_routing_rootless(document_uri, &config.server_name, rootless);
+            // Eager acquisition and host diagnostics start from the real host
+            // URI, while routing is requested for each virtual injection URI.
+            // Carry the explicit rootless decision to that host-level lookup;
+            // otherwise the virtual route is lost before the first didOpen.
+            if let Some(host_uri) = host.as_ref().and_then(|host| Url::parse(&host.uri).ok()) {
+                pool.set_host_routing_rootless(&host_uri, &config.server_name, rootless);
+            }
             let Some((_, handle)) = handles.iter().find(|(name, _)| name == &config.server_name)
             else {
                 if enabled {

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1402,18 +1402,12 @@ impl LanguageServerPool {
         let Some(folders) = self.host_routing_workspace_folders(host_uri, server_name) else {
             return Ok(());
         };
-        let folders = folders.unwrap_or_else(|| {
-            log::debug!(
-                target: "kakehashi::bridge::routing",
-                "Routing provider supplied workspaceFolders=null for {}; using kakehashi's client workspace",
-                server_name
-            );
-            self.workspace_folders()
-                .unwrap_or_default()
-                .into_iter()
-                .map(|folder| folder.uri.to_string())
-                .collect()
-        });
+        let Some(folders) = folders else {
+            // `null` means that routing has no opinion. Let the ordinary
+            // kakehashi marker/client workspace resolution decide instead of
+            // replaying the client folders as routing announcements.
+            return Ok(());
+        };
         if folders.is_empty() {
             return Ok(());
         }
@@ -1791,7 +1785,11 @@ impl LanguageServerPool {
         document_uri: &Url,
     ) -> ConnectionKey {
         if self.host_routing_rootless(document_uri, server_name) {
-            return ConnectionKey::new(server_name, None);
+            return if server_config.prefers_shared_instance() {
+                ConnectionKey::rootless_shared(server_name)
+            } else {
+                ConnectionKey::new(server_name, None)
+            };
         }
         self.resolve_acquire(server_name, server_config, Some(document_uri))
             .await
@@ -2225,9 +2223,14 @@ impl LanguageServerPool {
         let (mut marker, mut connection_key) = self
             .resolve_acquire(server_name, server_config, document_uri)
             .await;
-        if document_uri.is_some_and(|uri| self.host_routing_rootless(uri, server_name)) {
+        let rootless = document_uri.is_some_and(|uri| self.host_routing_rootless(uri, server_name));
+        if rootless {
             marker = None;
-            connection_key = ConnectionKey::new(server_name, None);
+            connection_key = if server_config.prefers_shared_instance() {
+                ConnectionKey::rootless_shared(server_name)
+            } else {
+                ConnectionKey::new(server_name, None)
+            };
         }
 
         // Acquire and wait through initialization for the resolved key.
@@ -2294,7 +2297,9 @@ impl LanguageServerPool {
         // path already announced; on the initializing-retry path it is the only
         // announce. Propagates a queue-full failure so the caller retries rather
         // than open a document for an unannounced root.
-        self.announce_shared_root(&handle, &marker).await?;
+        if !rootless {
+            self.announce_shared_root(&handle, &marker).await?;
+        }
         Ok(handle)
     }
 
@@ -2656,6 +2661,9 @@ impl LanguageServerPool {
         let folders: Vec<tower_lsp_server::ls_types::WorkspaceFolder> = match marker {
             Some((_root, folder)) => vec![folder.clone()],
             None => {
+                if handle.key().is_rootless_shared() {
+                    return Ok(());
+                }
                 let snapshot = self.workspace_folders().unwrap_or_default();
                 if !snapshot.is_empty() {
                     snapshot
@@ -2784,9 +2792,18 @@ impl LanguageServerPool {
         timeout: Duration,
         admit: Option<&(dyn Fn() -> bool + Sync)>,
     ) -> io::Result<Arc<ConnectionHandle>> {
-        let (marker, connection_key) = self
+        let (marker, mut connection_key) = self
             .resolve_acquire(server_name, server_config, document_uri)
             .await;
+        let rootless = document_uri.is_some_and(|uri| self.host_routing_rootless(uri, server_name));
+        let marker = if rootless { None } else { marker };
+        if rootless {
+            connection_key = if server_config.prefers_shared_instance() {
+                ConnectionKey::rootless_shared(server_name)
+            } else {
+                ConnectionKey::new(server_name, None)
+            };
+        }
         self.get_or_create_connection_resolved(
             server_name,
             server_config,
@@ -2983,9 +3000,13 @@ impl LanguageServerPool {
         // matches `connection_key`.
         // Resolved before the reader task spawns because the reader answers
         // downstream `workspace/workspaceFolders` queries with these folders.
-        let (root_uri, init_folders) = super::root_markers::workspace_from_marker(marker, || {
-            (self.root_uri(), self.workspace_folders())
-        });
+        let (root_uri, init_folders) = if connection_key.is_rootless_shared() {
+            (None, Some(Vec::new()))
+        } else {
+            super::root_markers::workspace_from_marker(marker, || {
+                (self.root_uri(), self.workspace_folders())
+            })
+        };
         log::debug!(
             target: "kakehashi::bridge::init",
             "[{}] workspace root for spawn: {:?}",

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -387,6 +387,7 @@ pub struct LanguageServerPool {
     /// means the routing provider supplied the field; an inner `None` is the
     /// explicit JSON `null` value.
     host_routing_workspace_folders: DashMap<(String, String), Option<Vec<String>>>,
+    host_routing_rootless: DashMap<(String, String), ()>,
     /// Host URIs whose routing decision is currently being resolved.
     host_routing_pending: DashMap<Url, Arc<tokio::sync::watch::Sender<bool>>>,
     /// Connections whose replacement still owes a virtual-document re-open, and
@@ -527,6 +528,7 @@ impl LanguageServerPool {
             host_routing_decided: DashMap::new(),
             host_routing_by_server: DashMap::new(),
             host_routing_workspace_folders: DashMap::new(),
+            host_routing_rootless: DashMap::new(),
             host_routing_pending: DashMap::new(),
             pending_reopen: Arc::new(PendingReopenRegistry::default()),
             diagnostic_pull_baselines: DashMap::new(),
@@ -1358,6 +1360,25 @@ impl LanguageServerPool {
         }
     }
 
+    pub(crate) fn set_host_routing_rootless(
+        &self,
+        host_uri: &Url,
+        server_name: &str,
+        rootless: bool,
+    ) {
+        let key = (host_uri.to_string(), server_name.to_string());
+        if rootless {
+            self.host_routing_rootless.insert(key, ());
+        } else {
+            self.host_routing_rootless.remove(&key);
+        }
+    }
+
+    pub(crate) fn host_routing_rootless(&self, host_uri: &Url, server_name: &str) -> bool {
+        self.host_routing_rootless
+            .contains_key(&(host_uri.to_string(), server_name.to_string()))
+    }
+
     pub(crate) fn host_routing_workspace_folders(
         &self,
         host_uri: &Url,
@@ -1381,20 +1402,19 @@ impl LanguageServerPool {
         let Some(folders) = self.host_routing_workspace_folders(host_uri, server_name) else {
             return Ok(());
         };
-        let Some(folders) = folders else {
+        let folders = folders.unwrap_or_else(|| {
             log::debug!(
                 target: "kakehashi::bridge::routing",
-                "Routing provider supplied workspaceFolders=null for {}; keeping the connection's existing folders",
+                "Routing provider supplied workspaceFolders=null for {}; using kakehashi's client workspace",
                 server_name
             );
-            return Ok(());
-        };
+            self.workspace_folders()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|folder| folder.uri.to_string())
+                .collect()
+        });
         if folders.is_empty() {
-            log::debug!(
-                target: "kakehashi::bridge::routing",
-                "Routing provider supplied an empty workspaceFolders list for {}; keeping the connection's existing folders",
-                server_name
-            );
             return Ok(());
         }
         for folder in folders {
@@ -1492,6 +1512,8 @@ impl LanguageServerPool {
         self.host_routing_by_server
             .retain(|(doc_uri, _), _| doc_uri != &uri);
         self.host_routing_workspace_folders
+            .retain(|(doc_uri, _), _| doc_uri != &uri);
+        self.host_routing_rootless
             .retain(|(doc_uri, _), _| doc_uri != &uri);
         self.finish_all_host_routing(host_uri);
     }
@@ -1768,6 +1790,9 @@ impl LanguageServerPool {
         server_config: &crate::config::settings::BridgeServerConfig,
         document_uri: &Url,
     ) -> ConnectionKey {
+        if self.host_routing_rootless(document_uri, server_name) {
+            return ConnectionKey::new(server_name, None);
+        }
         self.resolve_acquire(server_name, server_config, Some(document_uri))
             .await
             .1
@@ -2197,9 +2222,13 @@ impl LanguageServerPool {
         let start = std::time::Instant::now();
         // Resolve the marker workspace + key ONCE (one filesystem walk, plus the
         // shared-instance capability probe).
-        let (marker, connection_key) = self
+        let (mut marker, mut connection_key) = self
             .resolve_acquire(server_name, server_config, document_uri)
             .await;
+        if document_uri.is_some_and(|uri| self.host_routing_rootless(uri, server_name)) {
+            marker = None;
+            connection_key = ConnectionKey::new(server_name, None);
+        }
 
         // Acquire and wait through initialization for the resolved key.
         let handle = self

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -2162,6 +2162,16 @@ impl LanguageServerPool {
         injection_language: &str,
         region_id: &str,
     ) -> io::Result<Arc<ConnectionHandle>> {
+        // Legacy or client-modified resolve envelopes may not carry the
+        // virtual identity. Do not feed an empty component to
+        // `VirtualDocumentUri::new` (debug builds assert, and release builds
+        // would select an unrelated `.txt` route); preserve the pre-routing
+        // host-URI fallback instead.
+        if injection_language.is_empty() || region_id.is_empty() {
+            return self
+                .get_or_create_connection(server_name, server_config, Some(host_uri))
+                .await;
+        }
         let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(host_uri)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
         let virtual_uri =

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -390,6 +390,10 @@ pub struct LanguageServerPool {
     host_routing_rootless: DashMap<(String, String), ()>,
     /// Host URIs whose routing decision is currently being resolved.
     host_routing_pending: DashMap<Url, Arc<tokio::sync::watch::Sender<bool>>>,
+    /// Pending per-host virtual-document routing. Interactive requests wait
+    /// here while the detached eager-routing pass is asking the provider, so
+    /// they cannot acquire a pre-routing marker connection.
+    virtual_routing_pending: DashMap<Url, Arc<tokio::sync::watch::Sender<bool>>>,
     /// Connections whose replacement still owes a virtual-document re-open, and
     /// the barrier requests wait on (respawn-reopen-derives-its-targets).
     /// `Arc` because the claim runs inside the spawned handshake task.
@@ -530,6 +534,7 @@ impl LanguageServerPool {
             host_routing_workspace_folders: DashMap::new(),
             host_routing_rootless: DashMap::new(),
             host_routing_pending: DashMap::new(),
+            virtual_routing_pending: DashMap::new(),
             pending_reopen: Arc::new(PendingReopenRegistry::default()),
             diagnostic_pull_baselines: DashMap::new(),
             diagnostic_document_generations: DashMap::new(),
@@ -1443,6 +1448,56 @@ impl LanguageServerPool {
         sender
     }
 
+    pub(crate) fn begin_virtual_routing(
+        &self,
+        host_uri: &Url,
+    ) -> Arc<tokio::sync::watch::Sender<bool>> {
+        let sender = Arc::new(tokio::sync::watch::channel(false).0);
+        if let Some(previous) = self
+            .virtual_routing_pending
+            .insert(host_uri.clone(), Arc::clone(&sender))
+        {
+            let _ = previous.send(true);
+        }
+        sender
+    }
+
+    pub(crate) async fn wait_for_virtual_routing(&self, host_uri: &Url) {
+        let Some(sender) = self
+            .virtual_routing_pending
+            .get(host_uri)
+            .map(|entry| Arc::clone(entry.value()))
+        else {
+            return;
+        };
+        let mut receiver = sender.subscribe();
+        while !*receiver.borrow() {
+            if receiver.changed().await.is_err() {
+                return;
+            }
+        }
+    }
+
+    pub(crate) fn finish_virtual_routing(
+        &self,
+        host_uri: &Url,
+        sender: &Arc<tokio::sync::watch::Sender<bool>>,
+    ) {
+        if self
+            .virtual_routing_pending
+            .remove_if(host_uri, |_, current| Arc::ptr_eq(current, sender))
+            .is_some()
+        {
+            let _ = sender.send(true);
+        }
+    }
+
+    pub(crate) fn finish_all_virtual_routing(&self, host_uri: &Url) {
+        if let Some((_, sender)) = self.virtual_routing_pending.remove(host_uri) {
+            let _ = sender.send(true);
+        }
+    }
+
     pub(crate) async fn wait_for_host_routing(&self, host_uri: &Url) {
         let Some(sender) = self
             .host_routing_pending
@@ -1510,6 +1565,7 @@ impl LanguageServerPool {
         self.host_routing_rootless
             .retain(|(doc_uri, _), _| doc_uri != &uri);
         self.finish_all_host_routing(host_uri);
+        self.finish_all_virtual_routing(host_uri);
     }
 
     pub(crate) fn clear_host_routing_for_connection(&self, connection_key: &ConnectionKey) {
@@ -2172,6 +2228,7 @@ impl LanguageServerPool {
                 .get_or_create_connection(server_name, server_config, Some(host_uri))
                 .await;
         }
+        self.wait_for_virtual_routing(host_uri).await;
         let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(host_uri)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
         let virtual_uri =
@@ -6230,6 +6287,28 @@ mod tests {
 
         done.send(true).expect("the waiter holds the receiver");
         waiter.await.expect("the request proceeds once re-opened");
+    }
+
+    /// Interactive virtual requests must not acquire a marker connection while
+    /// the detached eager pass is still waiting for the routing provider.
+    #[tokio::test]
+    async fn a_virtual_request_waits_for_pending_routing() {
+        let pool = Arc::new(LanguageServerPool::new());
+        let host_uri = Url::parse("file:///test/pending-routing.md").unwrap();
+        let sender = pool.begin_virtual_routing(&host_uri);
+        let waiter = {
+            let pool = Arc::clone(&pool);
+            let host_uri = host_uri.clone();
+            tokio::spawn(async move { pool.wait_for_virtual_routing(&host_uri).await })
+        };
+        tokio::task::yield_now().await;
+        assert!(
+            !waiter.is_finished(),
+            "a virtual request must wait for the routing answer"
+        );
+
+        pool.finish_virtual_routing(&host_uri, &sender);
+        waiter.await.expect("the request proceeds after routing");
     }
 
     /// A by-key fast path must not hand back a process spawned from a

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -2150,6 +2150,28 @@ impl LanguageServerPool {
         .await
     }
 
+    /// Acquire the connection for an injected document using the URI under
+    /// which routing decisions are cached. The request handlers receive the
+    /// host URI for coordinate translation, but routing is decided per virtual
+    /// document and must use that virtual URI for connection selection.
+    pub(super) async fn get_or_create_virtual_connection(
+        &self,
+        server_name: &str,
+        server_config: &crate::config::settings::BridgeServerConfig,
+        host_uri: &Url,
+        injection_language: &str,
+        region_id: &str,
+    ) -> io::Result<Arc<ConnectionHandle>> {
+        let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(host_uri)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+        let virtual_uri =
+            super::protocol::VirtualDocumentUri::new(&host_uri_lsp, injection_language, region_id);
+        let routing_uri = Url::parse(&virtual_uri.to_uri_string())
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+        self.get_or_create_connection(server_name, server_config, Some(&routing_uri))
+            .await
+    }
+
     /// [`Self::get_or_create_connection`], with a caller-supplied `admit`
     /// predicate evaluated **inside the acquire's critical section**.
     ///

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -393,7 +393,7 @@ pub struct LanguageServerPool {
     /// Pending per-host virtual-document routing. Interactive requests wait
     /// here while the detached eager-routing pass is asking the provider, so
     /// they cannot acquire a pre-routing marker connection.
-    virtual_routing_pending: DashMap<Url, Arc<tokio::sync::watch::Sender<bool>>>,
+    virtual_routing_pending: DashMap<(Url, Url), Arc<tokio::sync::watch::Sender<bool>>>,
     /// Connections whose replacement still owes a virtual-document re-open, and
     /// the barrier requests wait on (respawn-reopen-derives-its-targets).
     /// `Arc` because the claim runs inside the spawned handshake task.
@@ -1448,24 +1448,21 @@ impl LanguageServerPool {
         sender
     }
 
-    pub(crate) fn begin_virtual_routing(
-        &self,
-        host_uri: &Url,
-    ) -> Arc<tokio::sync::watch::Sender<bool>> {
+    pub(crate) fn begin_virtual_routing(&self, host_uri: &Url, virtual_uri: &Url) {
         let sender = Arc::new(tokio::sync::watch::channel(false).0);
+        let key = (host_uri.clone(), virtual_uri.clone());
         if let Some(previous) = self
             .virtual_routing_pending
-            .insert(host_uri.clone(), Arc::clone(&sender))
+            .insert(key, Arc::clone(&sender))
         {
             let _ = previous.send(true);
         }
-        sender
     }
 
-    pub(crate) async fn wait_for_virtual_routing(&self, host_uri: &Url) {
+    pub(crate) async fn wait_for_virtual_routing(&self, host_uri: &Url, virtual_uri: &Url) {
         let Some(sender) = self
             .virtual_routing_pending
-            .get(host_uri)
+            .get(&(host_uri.clone(), virtual_uri.clone()))
             .map(|entry| Arc::clone(entry.value()))
         else {
             return;
@@ -1478,23 +1475,28 @@ impl LanguageServerPool {
         }
     }
 
-    pub(crate) fn finish_virtual_routing(
-        &self,
-        host_uri: &Url,
-        sender: &Arc<tokio::sync::watch::Sender<bool>>,
-    ) {
-        if self
-            .virtual_routing_pending
-            .remove_if(host_uri, |_, current| Arc::ptr_eq(current, sender))
-            .is_some()
-        {
+    pub(crate) fn finish_virtual_routing(&self, host_uri: &Url, virtual_uri: &Url) {
+        let key = (host_uri.clone(), virtual_uri.clone());
+        if let Some((_, sender)) = self.virtual_routing_pending.remove(&key) {
             let _ = sender.send(true);
         }
     }
 
     pub(crate) fn finish_all_virtual_routing(&self, host_uri: &Url) {
-        if let Some((_, sender)) = self.virtual_routing_pending.remove(host_uri) {
-            let _ = sender.send(true);
+        let pending: Vec<_> = self
+            .virtual_routing_pending
+            .iter()
+            .filter(|entry| entry.key().0 == *host_uri)
+            .map(|entry| (entry.key().clone(), Arc::clone(entry.value())))
+            .collect();
+        for (key, sender) in pending {
+            if self
+                .virtual_routing_pending
+                .remove_if(&key, |_, current| Arc::ptr_eq(current, &sender))
+                .is_some()
+            {
+                let _ = sender.send(true);
+            }
         }
     }
 
@@ -2228,13 +2230,13 @@ impl LanguageServerPool {
                 .get_or_create_connection(server_name, server_config, Some(host_uri))
                 .await;
         }
-        self.wait_for_virtual_routing(host_uri).await;
         let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(host_uri)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
         let virtual_uri =
             super::protocol::VirtualDocumentUri::new(&host_uri_lsp, injection_language, region_id);
         let routing_uri = Url::parse(&virtual_uri.to_uri_string())
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+        self.wait_for_virtual_routing(host_uri, &routing_uri).await;
         self.get_or_create_connection(server_name, server_config, Some(&routing_uri))
             .await
     }
@@ -6295,11 +6297,16 @@ mod tests {
     async fn a_virtual_request_waits_for_pending_routing() {
         let pool = Arc::new(LanguageServerPool::new());
         let host_uri = Url::parse("file:///test/pending-routing.md").unwrap();
-        let sender = pool.begin_virtual_routing(&host_uri);
+        let virtual_uri =
+            Url::parse("deno:///test/pending-routing.md?language=lua&region=r0").unwrap();
+        pool.begin_virtual_routing(&host_uri, &virtual_uri);
         let waiter = {
             let pool = Arc::clone(&pool);
             let host_uri = host_uri.clone();
-            tokio::spawn(async move { pool.wait_for_virtual_routing(&host_uri).await })
+            let virtual_uri = virtual_uri.clone();
+            tokio::spawn(
+                async move { pool.wait_for_virtual_routing(&host_uri, &virtual_uri).await },
+            )
         };
         tokio::task::yield_now().await;
         assert!(
@@ -6307,7 +6314,7 @@ mod tests {
             "a virtual request must wait for the routing answer"
         );
 
-        pool.finish_virtual_routing(&host_uri, &sender);
+        pool.finish_virtual_routing(&host_uri, &virtual_uri);
         waiter.await.expect("the request proceeds after routing");
     }
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1476,18 +1476,25 @@ impl LanguageServerPool {
     }
 
     pub(crate) async fn wait_for_virtual_routing(&self, host_uri: &Url, virtual_uri: &Url) {
-        let Some(sender) = self
-            .virtual_routing_pending
-            .get(&(host_uri.clone(), virtual_uri.clone()))
-            .map(|entry| Arc::clone(entry.value()))
-        else {
-            return;
-        };
-        let mut receiver = sender.subscribe();
-        while !*receiver.borrow() {
-            if receiver.changed().await.is_err() {
+        let key = (host_uri.clone(), virtual_uri.clone());
+        loop {
+            let Some(sender) = self
+                .virtual_routing_pending
+                .get(&key)
+                .map(|entry| Arc::clone(entry.value()))
+            else {
                 return;
+            };
+            let mut receiver = sender.subscribe();
+            while !*receiver.borrow() {
+                if receiver.changed().await.is_err() {
+                    break;
+                }
             }
+            // A notification can mean either completion (the entry was
+            // removed) or handoff (the entry was replaced by a newer pass).
+            // Re-read the map so an old pass cannot release a waiter into a
+            // connection acquired before the newest routing answer.
         }
     }
 
@@ -6339,7 +6346,14 @@ mod tests {
             "a virtual request must wait for the routing answer"
         );
 
-        pool.finish_virtual_routing(&host_uri, &virtual_uri, &sender);
+        let replacement = pool.begin_virtual_routing(&host_uri, &virtual_uri);
+        tokio::task::yield_now().await;
+        assert!(
+            !waiter.is_finished(),
+            "handoff from an old routing pass must keep waiting"
+        );
+        let _ = sender.send(true);
+        pool.finish_virtual_routing(&host_uri, &virtual_uri, &replacement);
         waiter.await.expect("the request proceeds after routing");
     }
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1448,7 +1448,11 @@ impl LanguageServerPool {
         sender
     }
 
-    pub(crate) fn begin_virtual_routing(&self, host_uri: &Url, virtual_uri: &Url) {
+    pub(crate) fn begin_virtual_routing(
+        &self,
+        host_uri: &Url,
+        virtual_uri: &Url,
+    ) -> Arc<tokio::sync::watch::Sender<bool>> {
         let sender = Arc::new(tokio::sync::watch::channel(false).0);
         let key = (host_uri.clone(), virtual_uri.clone());
         if let Some(previous) = self
@@ -1457,6 +1461,18 @@ impl LanguageServerPool {
         {
             let _ = previous.send(true);
         }
+        sender
+    }
+
+    pub(crate) fn is_virtual_routing_current(
+        &self,
+        host_uri: &Url,
+        virtual_uri: &Url,
+        sender: &Arc<tokio::sync::watch::Sender<bool>>,
+    ) -> bool {
+        self.virtual_routing_pending
+            .get(&(host_uri.clone(), virtual_uri.clone()))
+            .is_some_and(|current| Arc::ptr_eq(current.value(), sender))
     }
 
     pub(crate) async fn wait_for_virtual_routing(&self, host_uri: &Url, virtual_uri: &Url) {
@@ -1475,9 +1491,18 @@ impl LanguageServerPool {
         }
     }
 
-    pub(crate) fn finish_virtual_routing(&self, host_uri: &Url, virtual_uri: &Url) {
+    pub(crate) fn finish_virtual_routing(
+        &self,
+        host_uri: &Url,
+        virtual_uri: &Url,
+        sender: &Arc<tokio::sync::watch::Sender<bool>>,
+    ) {
         let key = (host_uri.clone(), virtual_uri.clone());
-        if let Some((_, sender)) = self.virtual_routing_pending.remove(&key) {
+        if self
+            .virtual_routing_pending
+            .remove_if(&key, |_, current| Arc::ptr_eq(current, sender))
+            .is_some()
+        {
             let _ = sender.send(true);
         }
     }

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1762,6 +1762,7 @@ impl LanguageServerPool {
                 key.clone(),
                 marker,
                 Duration::from_secs(INIT_TIMEOUT_SECS),
+                false,
             )
             .await
         {
@@ -1785,7 +1786,7 @@ impl LanguageServerPool {
         document_uri: &Url,
     ) -> ConnectionKey {
         if self.host_routing_rootless(document_uri, server_name) {
-            return ConnectionKey::rootless_shared(server_name);
+            return ConnectionKey::shared(server_name);
         }
         self.resolve_acquire(server_name, server_config, Some(document_uri))
             .await
@@ -2222,7 +2223,7 @@ impl LanguageServerPool {
         let rootless = document_uri.is_some_and(|uri| self.host_routing_rootless(uri, server_name));
         if rootless {
             marker = None;
-            connection_key = ConnectionKey::rootless_shared(server_name);
+            connection_key = ConnectionKey::shared(server_name);
         }
 
         // Acquire and wait through initialization for the resolved key.
@@ -2233,6 +2234,7 @@ impl LanguageServerPool {
                 connection_key,
                 marker.clone(),
                 timeout,
+                rootless,
             )
             .await?;
 
@@ -2279,6 +2281,7 @@ impl LanguageServerPool {
                         per_root_key,
                         marker,
                         remaining,
+                        false,
                     )
                     .await;
             }
@@ -2306,6 +2309,7 @@ impl LanguageServerPool {
         connection_key: ConnectionKey,
         marker: Option<(Url, tower_lsp_server::ls_types::WorkspaceFolder)>,
         timeout: Duration,
+        rootless: bool,
     ) -> io::Result<Arc<ConnectionHandle>> {
         match self
             .get_or_create_connection_resolved(
@@ -2318,6 +2322,7 @@ impl LanguageServerPool {
                 // incapable-shared divert, which passes its REMAINING budget)
                 // stays within `timeout` overall.
                 timeout,
+                rootless,
                 None,
             )
             .await
@@ -2653,9 +2658,6 @@ impl LanguageServerPool {
         let folders: Vec<tower_lsp_server::ls_types::WorkspaceFolder> = match marker {
             Some((_root, folder)) => vec![folder.clone()],
             None => {
-                if handle.key().is_rootless_shared() {
-                    return Ok(());
-                }
                 let snapshot = self.workspace_folders().unwrap_or_default();
                 if !snapshot.is_empty() {
                     snapshot
@@ -2790,7 +2792,7 @@ impl LanguageServerPool {
         let rootless = document_uri.is_some_and(|uri| self.host_routing_rootless(uri, server_name));
         let marker = if rootless { None } else { marker };
         if rootless {
-            connection_key = ConnectionKey::rootless_shared(server_name);
+            connection_key = ConnectionKey::shared(server_name);
         }
         self.get_or_create_connection_resolved(
             server_name,
@@ -2798,6 +2800,7 @@ impl LanguageServerPool {
             connection_key,
             marker,
             timeout,
+            rootless,
             admit,
         )
         .await
@@ -2810,6 +2813,11 @@ impl LanguageServerPool {
     /// `Initializing`, and run the LSP initialize handshake in a background task
     /// that transitions Ready or Failed. Requests against Initializing fail with
     /// REQUEST_FAILED; Failed causes removal and respawn on the next call.
+    // The rootless bit is intentionally separate from `ConnectionKey::shared`:
+    // both ordinary shared acquisitions and routed `[]` acquisitions use the
+    // same key, but only the latter may seed a fresh process without the client
+    // workspace. Keep this explicit at the spawn boundary.
+    #[allow(clippy::too_many_arguments)]
     async fn get_or_create_connection_resolved(
         &self,
         server_name: &str,
@@ -2817,6 +2825,7 @@ impl LanguageServerPool {
         connection_key: ConnectionKey,
         marker: Option<(Url, tower_lsp_server::ls_types::WorkspaceFolder)>,
         timeout: Duration,
+        rootless: bool,
         admit: Option<&(dyn Fn() -> bool + Sync)>,
     ) -> io::Result<Arc<ConnectionHandle>> {
         let mut connections = self.connections.lock().await;
@@ -2887,7 +2896,9 @@ impl LanguageServerPool {
                 // check, so it must not be held here (the tokio mutex is not
                 // reentrant).
                 drop(connections);
-                self.announce_shared_root(&handle, &marker).await?;
+                if !rootless {
+                    self.announce_shared_root(&handle, &marker).await?;
+                }
                 return Ok(handle);
             }
             ConnectionAction::FailFast(err) => {
@@ -2988,7 +2999,7 @@ impl LanguageServerPool {
         // matches `connection_key`.
         // Resolved before the reader task spawns because the reader answers
         // downstream `workspace/workspaceFolders` queries with these folders.
-        let (root_uri, init_folders) = if connection_key.is_rootless_shared() {
+        let (root_uri, init_folders) = if rootless {
             (None, Some(Vec::new()))
         } else {
             super::root_markers::workspace_from_marker(marker, || {

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -5959,6 +5959,7 @@ mod tests {
                 OpenExpectation {
                     incarnation: 1,
                     connection: None,
+                    expected_connection: None,
                 },
                 vec![super::super::coordinator::BridgeInjection {
                     language: "lua".to_string(),
@@ -6004,6 +6005,7 @@ mod tests {
                 OpenExpectation {
                     incarnation: 1,
                     connection: None,
+                    expected_connection: None,
                 },
                 vec![super::super::coordinator::BridgeInjection {
                     language: "lua".to_string(),

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -6324,7 +6324,7 @@ mod tests {
         let host_uri = Url::parse("file:///test/pending-routing.md").unwrap();
         let virtual_uri =
             Url::parse("deno:///test/pending-routing.md?language=lua&region=r0").unwrap();
-        pool.begin_virtual_routing(&host_uri, &virtual_uri);
+        let sender = pool.begin_virtual_routing(&host_uri, &virtual_uri);
         let waiter = {
             let pool = Arc::clone(&pool);
             let host_uri = host_uri.clone();
@@ -6339,7 +6339,7 @@ mod tests {
             "a virtual request must wait for the routing answer"
         );
 
-        pool.finish_virtual_routing(&host_uri, &virtual_uri);
+        pool.finish_virtual_routing(&host_uri, &virtual_uri, &sender);
         waiter.await.expect("the request proceeds after routing");
     }
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1785,11 +1785,7 @@ impl LanguageServerPool {
         document_uri: &Url,
     ) -> ConnectionKey {
         if self.host_routing_rootless(document_uri, server_name) {
-            return if server_config.prefers_shared_instance() {
-                ConnectionKey::rootless_shared(server_name)
-            } else {
-                ConnectionKey::new(server_name, None)
-            };
+            return ConnectionKey::rootless_shared(server_name);
         }
         self.resolve_acquire(server_name, server_config, Some(document_uri))
             .await
@@ -2226,11 +2222,7 @@ impl LanguageServerPool {
         let rootless = document_uri.is_some_and(|uri| self.host_routing_rootless(uri, server_name));
         if rootless {
             marker = None;
-            connection_key = if server_config.prefers_shared_instance() {
-                ConnectionKey::rootless_shared(server_name)
-            } else {
-                ConnectionKey::new(server_name, None)
-            };
+            connection_key = ConnectionKey::rootless_shared(server_name);
         }
 
         // Acquire and wait through initialization for the resolved key.
@@ -2798,11 +2790,7 @@ impl LanguageServerPool {
         let rootless = document_uri.is_some_and(|uri| self.host_routing_rootless(uri, server_name));
         let marker = if rootless { None } else { marker };
         if rootless {
-            connection_key = if server_config.prefers_shared_instance() {
-                ConnectionKey::rootless_shared(server_name)
-            } else {
-                ConnectionKey::new(server_name, None)
-            };
+            connection_key = ConnectionKey::rootless_shared(server_name);
         }
         self.get_or_create_connection_resolved(
             server_name,

--- a/src/lsp/bridge/pool/connection_key.rs
+++ b/src/lsp/bridge/pool/connection_key.rs
@@ -37,6 +37,11 @@ enum ConnectionRoot {
     /// a per-root fallback after a capability miss) do not collide with the
     /// shared instance.
     Shared,
+    /// One shared connection whose initialize explicitly advertises no
+    /// workspace folders (`workspaceFolders: []`). Kept distinct from the
+    /// ordinary shared instance so a routed rootless session never reuses a
+    /// connection initialized with the client workspace.
+    RootlessShared,
 }
 
 /// Identity of one pooled downstream connection: `(server_name, root)`.
@@ -78,9 +83,23 @@ impl ConnectionKey {
         }
     }
 
+    pub(crate) fn rootless_shared(server: impl Into<String>) -> Self {
+        Self {
+            server: server.into(),
+            root: ConnectionRoot::RootlessShared,
+        }
+    }
+
     /// Whether this is a shared-instance key (#391).
     pub(crate) fn is_shared(&self) -> bool {
-        matches!(self.root, ConnectionRoot::Shared)
+        matches!(
+            self.root,
+            ConnectionRoot::Shared | ConnectionRoot::RootlessShared
+        )
+    }
+
+    pub(crate) fn is_rootless_shared(&self) -> bool {
+        matches!(self.root, ConnectionRoot::RootlessShared)
     }
 
     /// Whether this key is the client-root fallback (no resolved marker root).
@@ -115,7 +134,9 @@ impl ConnectionKey {
     pub(crate) fn marker_root(&self) -> Option<&str> {
         match &self.root {
             ConnectionRoot::Marker(root) => Some(root),
-            ConnectionRoot::ClientFallback | ConnectionRoot::Shared => None,
+            ConnectionRoot::ClientFallback
+            | ConnectionRoot::Shared
+            | ConnectionRoot::RootlessShared => None,
         }
     }
 }
@@ -126,6 +147,7 @@ impl fmt::Display for ConnectionKey {
             ConnectionRoot::Marker(root) => write!(f, "{}@{}", self.server, root),
             ConnectionRoot::ClientFallback => write!(f, "{}", self.server),
             ConnectionRoot::Shared => write!(f, "{}#shared", self.server),
+            ConnectionRoot::RootlessShared => write!(f, "{}#rootless-shared", self.server),
         }
     }
 }

--- a/src/lsp/bridge/pool/connection_key.rs
+++ b/src/lsp/bridge/pool/connection_key.rs
@@ -9,13 +9,10 @@
 //! one.
 //!
 //! `root` is the resolved root URI string from the `root_markers` walk, or
-//! `None` when no marker root applies (no document hint, non-file URI, no
-//! marker found, or the `[]` kill switch) — such a document falls back to the
-//! single client-rooted connection, matching the pre-#382 behavior, unless the
-//! server opted into `preferSharedInstance` (#391), in which case it joins the
-//! shared instance (on capable connections the complete client workspace —
-//! folder snapshot, or the bare rootUri when the client sent no folders — is
-//! announced on its behalf; admission itself needs no root).
+//! `None` when no marker root applies (no document hint, non-file URI, or no
+//! marker found). The routing provider's explicit `workspaceFolders: []` case
+//! uses the separate `RootlessShared` discriminator so it cannot inherit a
+//! client-rooted initialization.
 
 use std::fmt;
 
@@ -26,9 +23,9 @@ enum ConnectionRoot {
     /// Resolved marker workspace root URI string: documents under distinct
     /// marker roots get distinct connections (per-root pooling, #382).
     Marker(String),
-    /// No marker root applied (no document hint, non-file URI, no marker
-    /// found, or the `[]` kill switch). Every such document collapses onto the
-    /// single client-rooted fallback connection — the pre-#382 behavior.
+    /// No marker root applied (no document hint, non-file URI, or no marker
+    /// found). Such documents use the single client-rooted fallback connection
+    /// unless shared-instance routing applies.
     ClientFallback,
     /// One connection shared across *every* root for a `preferSharedInstance`
     /// server (#391), and — because they have no root to isolate by — every

--- a/src/lsp/bridge/pool/connection_key.rs
+++ b/src/lsp/bridge/pool/connection_key.rs
@@ -11,8 +11,7 @@
 //! `root` is the resolved root URI string from the `root_markers` walk, or
 //! `None` when no marker root applies (no document hint, non-file URI, or no
 //! marker found). The routing provider's explicit `workspaceFolders: []` case
-//! uses the separate `RootlessShared` discriminator so it cannot inherit a
-//! client-rooted initialization.
+//! uses the shared key and changes only the fresh-spawn workspace seed.
 
 use std::fmt;
 
@@ -34,11 +33,6 @@ enum ConnectionRoot {
     /// a per-root fallback after a capability miss) do not collide with the
     /// shared instance.
     Shared,
-    /// One shared connection whose initialize explicitly advertises no
-    /// workspace folders (`workspaceFolders: []`). Kept distinct from the
-    /// ordinary shared instance so a routed rootless session never reuses a
-    /// connection initialized with the client workspace.
-    RootlessShared,
 }
 
 /// Identity of one pooled downstream connection: `(server_name, root)`.
@@ -80,23 +74,9 @@ impl ConnectionKey {
         }
     }
 
-    pub(crate) fn rootless_shared(server: impl Into<String>) -> Self {
-        Self {
-            server: server.into(),
-            root: ConnectionRoot::RootlessShared,
-        }
-    }
-
     /// Whether this is a shared-instance key (#391).
     pub(crate) fn is_shared(&self) -> bool {
-        matches!(
-            self.root,
-            ConnectionRoot::Shared | ConnectionRoot::RootlessShared
-        )
-    }
-
-    pub(crate) fn is_rootless_shared(&self) -> bool {
-        matches!(self.root, ConnectionRoot::RootlessShared)
+        matches!(self.root, ConnectionRoot::Shared)
     }
 
     /// Whether this key is the client-root fallback (no resolved marker root).
@@ -131,9 +111,7 @@ impl ConnectionKey {
     pub(crate) fn marker_root(&self) -> Option<&str> {
         match &self.root {
             ConnectionRoot::Marker(root) => Some(root),
-            ConnectionRoot::ClientFallback
-            | ConnectionRoot::Shared
-            | ConnectionRoot::RootlessShared => None,
+            ConnectionRoot::ClientFallback | ConnectionRoot::Shared => None,
         }
     }
 }
@@ -144,7 +122,6 @@ impl fmt::Display for ConnectionKey {
             ConnectionRoot::Marker(root) => write!(f, "{}@{}", self.server, root),
             ConnectionRoot::ClientFallback => write!(f, "{}", self.server),
             ConnectionRoot::Shared => write!(f, "{}#shared", self.server),
-            ConnectionRoot::RootlessShared => write!(f, "{}#rootless-shared", self.server),
         }
     }
 }

--- a/src/lsp/bridge/protocol/routing.rs
+++ b/src/lsp/bridge/protocol/routing.rs
@@ -42,10 +42,26 @@ pub(crate) struct RoutingParams {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct RoutingEntry {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_workspace_folders",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub(crate) workspace_folders: Option<Option<Vec<String>>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) enabled: Option<bool>,
+}
+
+/// Preserve the protocol distinction between an omitted field and an explicit
+/// JSON `null`: both are meaningful to routing (`null` asks kakehashi to use
+/// its own workspace resolution, while omission leaves routing unspecified).
+fn deserialize_workspace_folders<'de, D>(
+    deserializer: D,
+) -> Result<Option<Option<Vec<String>>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<Vec<String>>::deserialize(deserializer).map(Some)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -145,6 +161,17 @@ mod tests {
         .unwrap();
         assert_eq!(answer.routing["lua"].enabled, Some(false));
         assert_eq!(answer.routing["lua"].workspace_folders, Some(Some(vec![])));
+
+        let answer = parse_routing_response(&serde_json::json!({
+            "result": {"routing": {
+                "null": {"workspaceFolders": null},
+                "missing": {}
+            }}
+        }))
+        .unwrap()
+        .unwrap();
+        assert_eq!(answer.routing["null"].workspace_folders, Some(None));
+        assert_eq!(answer.routing["missing"].workspace_folders, None);
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -782,7 +782,13 @@ impl LanguageServerPool {
             return action;
         };
         let handle = match self
-            .get_or_create_connection(server_name, server_config, Some(&host_url))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                &host_url,
+                &envelope.injection_language,
+                &envelope.region_id,
+            )
             .await
         {
             Ok(h) => h,

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -74,6 +74,9 @@ pub(crate) struct CodeActionEnvelope {
     pub(crate) original_title: String,
     /// The downstream server's original `data` value (preserved verbatim).
     pub(crate) inner: Option<Value>,
+    /// Host open incarnation that produced this action. Missing for legacy data.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) incarnation: Option<u64>,
     /// Host-layer action (`bridge._self`): its edit/data are already in host
     /// coordinates, so resolve routes to the host server VERBATIM — no virtual
     /// URI, region, or offset translation. `region_id`/`injection_language`/
@@ -106,6 +109,7 @@ pub(crate) struct CodeActionEnvelopeContext<'a> {
     region_id: &'a str,
     injection_language: &'a str,
     offset: &'a RegionOffset,
+    incarnation: Option<u64>,
 }
 
 /// Wrap `action.data` in a Kakehashi envelope for origin tracking, capturing
@@ -120,6 +124,7 @@ fn envelope_action_data(action: &mut CodeAction, ctx: &CodeActionEnvelopeContext
         offset: EnvelopeOffset::from(ctx.offset),
         original_title: action.title.clone(),
         inner,
+        incarnation: ctx.incarnation,
         host_layer: false,
     };
     action.data = Some(serde_json::json!({ ENVELOPE_KEY: envelope }));
@@ -145,6 +150,7 @@ fn envelope_host_action(action: &mut CodeAction, server_name: &str, host_uri: &s
         },
         original_title: action.title.clone(),
         inner,
+        incarnation: None,
         host_layer: true,
     };
     action.data = Some(serde_json::json!({ ENVELOPE_KEY: envelope }));
@@ -187,6 +193,7 @@ fn re_envelope_action(action: &mut CodeAction, envelope: &CodeActionEnvelope) {
             offset: envelope.offset.clone(),
             original_title: envelope.original_title.clone(),
             inner,
+            incarnation: envelope.incarnation,
             host_layer: envelope.host_layer,
         }
     }));
@@ -488,6 +495,7 @@ impl LanguageServerPool {
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
         let virtual_uri_string =
             VirtualDocumentUri::new(&host_uri_lsp, injection_language, region_id).to_uri_string();
+        let host_incarnation = self.current_host_incarnation(host_uri);
         let virt = VirtLayerContext {
             request_virtual_uri: &virtual_uri_string,
             host_uri: &host_uri_lsp,
@@ -499,6 +507,7 @@ impl LanguageServerPool {
             injection_language,
             host_uri_string: host_uri.as_str(),
             server_name,
+            incarnation: host_incarnation,
         };
         Ok(Some(bridge_code_actions(
             actions,
@@ -696,6 +705,13 @@ impl LanguageServerPool {
             re_envelope_action(&mut action, &envelope);
             return action;
         };
+        if envelope
+            .incarnation
+            .is_some_and(|expected| self.current_host_incarnation(&host_url) != Some(expected))
+        {
+            re_envelope_action(&mut action, &envelope);
+            return action;
+        }
         let handle = match self
             .get_or_create_connection(server_name, server_config, Some(&host_url))
             .await
@@ -781,6 +797,13 @@ impl LanguageServerPool {
             re_envelope_action(&mut action, &envelope);
             return action;
         };
+        if envelope
+            .incarnation
+            .is_some_and(|expected| self.current_host_incarnation(&host_url) != Some(expected))
+        {
+            re_envelope_action(&mut action, &envelope);
+            return action;
+        }
         let handle = match self
             .get_or_create_virtual_connection(
                 server_name,
@@ -1242,6 +1265,7 @@ pub(crate) struct VirtLayerContext<'a> {
     /// (`host_uri` above is the `Uri` form used for edit re-keying).
     host_uri_string: &'a str,
     server_name: &'a str,
+    incarnation: Option<u64>,
 }
 
 impl VirtLayerContext<'_> {
@@ -1252,6 +1276,7 @@ impl VirtLayerContext<'_> {
             region_id: self.region_id,
             injection_language: self.injection_language,
             offset: self.offset,
+            incarnation: self.incarnation,
         }
     }
 }
@@ -1916,6 +1941,7 @@ mod tests {
             injection_language: "lua",
             host_uri_string: "file:///test.md",
             server_name: "ruff",
+            incarnation: Some(1),
         };
         Some(bridge_code_actions(
             actions,
@@ -2675,6 +2701,7 @@ mod tests {
             region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
             injection_language: "lua",
             offset,
+            incarnation: Some(1),
         }
     }
 

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -425,7 +425,13 @@ impl LanguageServerPool {
         upstream_caps: UpstreamCodeActionCaps,
     ) -> io::Result<Option<CodeActionResponse>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/codeAction") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -135,7 +135,13 @@ impl LanguageServerPool {
         client_progress_token: Option<NumberOrString>,
     ) -> io::Result<Option<Vec<CodeLens>>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/codeLens") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -58,6 +58,9 @@ pub(crate) struct CodeLensEnvelope {
     /// ULID of the injection region the lens came from; resolve-time staleness
     /// checks look it up in the node tracker (fail-soft when invalidated).
     pub(crate) region_id: String,
+    /// Injection language needed to reconstruct the routed virtual URI during
+    /// a later `codeLens/resolve` request.
+    pub(crate) injection_language: String,
     /// Region offset snapshot for coordinate translation at resolve time.
     pub(crate) offset: EnvelopeOffset,
     /// The downstream server's original `data` value (preserved verbatim).
@@ -69,6 +72,7 @@ struct CodeLensEnvelopeContext<'a> {
     server_name: &'a str,
     host_uri: &'a str,
     region_id: &'a str,
+    injection_language: &'a str,
     offset: &'a RegionOffset,
 }
 
@@ -79,6 +83,7 @@ fn envelope_lens_data(lens: &mut CodeLens, ctx: &CodeLensEnvelopeContext) {
         origin: ctx.server_name.to_string(),
         host_uri: ctx.host_uri.to_string(),
         region_id: ctx.region_id.to_string(),
+        injection_language: ctx.injection_language.to_string(),
         offset: EnvelopeOffset::from(ctx.offset),
         inner,
     };
@@ -110,6 +115,7 @@ fn re_envelope_lens(lens: &mut CodeLens, envelope: &CodeLensEnvelope) {
         server_name: &envelope.origin,
         host_uri: &envelope.host_uri,
         region_id: &envelope.region_id,
+        injection_language: &envelope.injection_language,
         offset: &RegionOffset::from(&envelope.offset),
     };
     envelope_lens_data(lens, &ctx);
@@ -163,6 +169,7 @@ impl LanguageServerPool {
                     server_name,
                     host_uri: &host_uri_string,
                     region_id,
+                    injection_language,
                     offset: ctx.offset,
                 };
                 transform_code_lens_response_to_host(response, ctx.offset, &envelope_ctx)
@@ -221,9 +228,18 @@ impl LanguageServerPool {
         upstream_id: Option<UpstreamId>,
     ) -> CodeLens {
         let server_name = &envelope.origin;
-        let host_uri = Url::parse(&envelope.host_uri).ok();
+        let Ok(host_uri) = Url::parse(&envelope.host_uri) else {
+            re_envelope_lens(&mut lens, &envelope);
+            return lens;
+        };
         let handle = match self
-            .get_or_create_connection(server_name, server_config, host_uri.as_ref())
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                &host_uri,
+                &envelope.injection_language,
+                &envelope.region_id,
+            )
             .await
         {
             Ok(h) => h,
@@ -421,6 +437,7 @@ mod tests {
             server_name: "lua-ls",
             host_uri: "file:///test.md",
             region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            injection_language: "lua",
             offset,
         }
     }

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -61,6 +61,9 @@ pub(crate) struct CodeLensEnvelope {
     /// Injection language needed to reconstruct the routed virtual URI during
     /// a later `codeLens/resolve` request.
     pub(crate) injection_language: String,
+    /// Host open incarnation that produced this lens. Missing for legacy data.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) incarnation: Option<u64>,
     /// Region offset snapshot for coordinate translation at resolve time.
     pub(crate) offset: EnvelopeOffset,
     /// The downstream server's original `data` value (preserved verbatim).
@@ -73,6 +76,7 @@ struct CodeLensEnvelopeContext<'a> {
     host_uri: &'a str,
     region_id: &'a str,
     injection_language: &'a str,
+    incarnation: Option<u64>,
     offset: &'a RegionOffset,
 }
 
@@ -84,6 +88,7 @@ fn envelope_lens_data(lens: &mut CodeLens, ctx: &CodeLensEnvelopeContext) {
         host_uri: ctx.host_uri.to_string(),
         region_id: ctx.region_id.to_string(),
         injection_language: ctx.injection_language.to_string(),
+        incarnation: ctx.incarnation,
         offset: EnvelopeOffset::from(ctx.offset),
         inner,
     };
@@ -116,6 +121,7 @@ fn re_envelope_lens(lens: &mut CodeLens, envelope: &CodeLensEnvelope) {
         host_uri: &envelope.host_uri,
         region_id: &envelope.region_id,
         injection_language: &envelope.injection_language,
+        incarnation: envelope.incarnation,
         offset: &RegionOffset::from(&envelope.offset),
     };
     envelope_lens_data(lens, &ctx);
@@ -140,6 +146,7 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
         client_progress_token: Option<NumberOrString>,
     ) -> io::Result<Option<Vec<CodeLens>>> {
+        let host_incarnation = self.current_host_incarnation(host_uri);
         let handle = self
             .get_or_create_virtual_connection(
                 server_name,
@@ -170,6 +177,7 @@ impl LanguageServerPool {
                     host_uri: &host_uri_string,
                     region_id,
                     injection_language,
+                    incarnation: host_incarnation,
                     offset: ctx.offset,
                 };
                 transform_code_lens_response_to_host(response, ctx.offset, &envelope_ctx)
@@ -232,6 +240,13 @@ impl LanguageServerPool {
             re_envelope_lens(&mut lens, &envelope);
             return lens;
         };
+        if envelope
+            .incarnation
+            .is_some_and(|expected| self.current_host_incarnation(&host_uri) != Some(expected))
+        {
+            re_envelope_lens(&mut lens, &envelope);
+            return lens;
+        }
         let handle = match self
             .get_or_create_virtual_connection(
                 server_name,
@@ -438,6 +453,7 @@ mod tests {
             host_uri: "file:///test.md",
             region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
             injection_language: "lua",
+            incarnation: Some(1),
             offset,
         }
     }

--- a/src/lsp/bridge/text_document/color_presentation.rs
+++ b/src/lsp/bridge/text_document/color_presentation.rs
@@ -44,7 +44,13 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Vec<ColorPresentation>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/colorPresentation") {
             return Ok(vec![]);

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -83,6 +83,7 @@ impl LanguageServerPool {
                     Some(host_position.line),
                     Some(EnvelopeContext {
                         server_name,
+                        injection_language,
                         host_uri: host_uri.as_str(),
                         region_id,
                         offset: ctx.offset,
@@ -390,6 +391,10 @@ const ENVELOPE_KEY: &str = "kakehashi";
 pub(crate) struct KakehashiEnvelope {
     /// Server name identifying which downstream produced the item.
     pub origin: String,
+    /// Language used to construct the virtual document URI for resolve.
+    /// Empty for host-layer and legacy envelopes.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub injection_language: String,
     /// Host document URI the completion was requested on. Used to re-resolve the
     /// same `(server, root)` connection for `completionItem/resolve` so the
     /// resolve reaches the very process that produced the item (#382) — without
@@ -492,6 +497,7 @@ impl From<&EnvelopeOffset> for RegionOffset {
 /// Context needed to create envelopes during completion response processing.
 pub(crate) struct EnvelopeContext<'a> {
     pub server_name: &'a str,
+    pub injection_language: &'a str,
     /// Host document URI the completion ran on, stored in the envelope so
     /// `completionItem/resolve` can route back to the originating connection.
     pub host_uri: &'a str,
@@ -514,6 +520,7 @@ pub(crate) fn envelope_item_data(item: &mut CompletionItem, ctx: &EnvelopeContex
     let inner = item.data.take();
     let envelope = KakehashiEnvelope {
         origin: ctx.server_name.to_string(),
+        injection_language: ctx.injection_language.to_string(),
         host_uri: ctx.host_uri.to_string(),
         region_id: ctx.region_id.to_string(),
         inner: None,
@@ -602,6 +609,7 @@ pub(super) fn envelope_host_item(item: &mut CompletionItem, server_name: &str, h
     let inner = item.data.take();
     let envelope = KakehashiEnvelope {
         origin: server_name.to_string(),
+        injection_language: String::new(),
         host_uri: host_uri.to_string(),
         region_id: String::new(),
         inner: None,
@@ -1153,6 +1161,7 @@ mod tests {
         let offset = RegionOffset::new(3, 4);
         let ctx = EnvelopeContext {
             server_name: "lua-ls",
+            injection_language: "markdown",
             host_uri: "file:///test/doc.md",
             region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
             offset: &offset,
@@ -1348,6 +1357,7 @@ mod tests {
             &mut item,
             &EnvelopeContext {
                 server_name: "lua-ls",
+                injection_language: "markdown",
                 host_uri: "file:///test/doc.md",
                 region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
                 offset: &offset,
@@ -1370,6 +1380,7 @@ mod tests {
             &mut virt,
             &EnvelopeContext {
                 server_name: "lua-ls",
+                injection_language: "markdown",
                 host_uri: "file:///test/doc.md",
                 region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
                 offset: &offset,
@@ -1394,6 +1405,7 @@ mod tests {
         let offset = RegionOffset::new(3, 4);
         let ctx = EnvelopeContext {
             server_name: "lua-ls",
+            injection_language: "markdown",
             host_uri: "file:///test/doc.md",
             region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
             offset: &offset,
@@ -1435,6 +1447,7 @@ mod tests {
             &mut item,
             &EnvelopeContext {
                 server_name: "lua-ls",
+                injection_language: "markdown",
                 host_uri: "file:///test/doc.md",
                 region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
                 offset: &offset,

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -49,6 +49,7 @@ impl LanguageServerPool {
         virtual_content: &str,
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Option<CompletionList>> {
+        let host_incarnation = self.current_host_incarnation(host_uri);
         let handle = self
             .get_or_create_virtual_connection(
                 server_name,
@@ -84,6 +85,7 @@ impl LanguageServerPool {
                     Some(EnvelopeContext {
                         server_name,
                         injection_language,
+                        incarnation: host_incarnation,
                         host_uri: host_uri.as_str(),
                         region_id,
                         offset: ctx.offset,
@@ -395,6 +397,9 @@ pub(crate) struct KakehashiEnvelope {
     /// Empty for host-layer and legacy envelopes.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub injection_language: String,
+    /// Host open incarnation that produced this item. Missing for legacy data.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub incarnation: Option<u64>,
     /// Host document URI the completion was requested on. Used to re-resolve the
     /// same `(server, root)` connection for `completionItem/resolve` so the
     /// resolve reaches the very process that produced the item (#382) — without
@@ -498,6 +503,7 @@ impl From<&EnvelopeOffset> for RegionOffset {
 pub(crate) struct EnvelopeContext<'a> {
     pub server_name: &'a str,
     pub injection_language: &'a str,
+    pub incarnation: Option<u64>,
     /// Host document URI the completion ran on, stored in the envelope so
     /// `completionItem/resolve` can route back to the originating connection.
     pub host_uri: &'a str,
@@ -521,6 +527,7 @@ pub(crate) fn envelope_item_data(item: &mut CompletionItem, ctx: &EnvelopeContex
     let envelope = KakehashiEnvelope {
         origin: ctx.server_name.to_string(),
         injection_language: ctx.injection_language.to_string(),
+        incarnation: ctx.incarnation,
         host_uri: ctx.host_uri.to_string(),
         region_id: ctx.region_id.to_string(),
         inner: None,
@@ -610,6 +617,7 @@ pub(super) fn envelope_host_item(item: &mut CompletionItem, server_name: &str, h
     let envelope = KakehashiEnvelope {
         origin: server_name.to_string(),
         injection_language: String::new(),
+        incarnation: None,
         host_uri: host_uri.to_string(),
         region_id: String::new(),
         inner: None,
@@ -1162,6 +1170,7 @@ mod tests {
         let ctx = EnvelopeContext {
             server_name: "lua-ls",
             injection_language: "markdown",
+            incarnation: Some(1),
             host_uri: "file:///test/doc.md",
             region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
             offset: &offset,
@@ -1358,6 +1367,7 @@ mod tests {
             &EnvelopeContext {
                 server_name: "lua-ls",
                 injection_language: "markdown",
+                incarnation: Some(1),
                 host_uri: "file:///test/doc.md",
                 region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
                 offset: &offset,
@@ -1381,6 +1391,7 @@ mod tests {
             &EnvelopeContext {
                 server_name: "lua-ls",
                 injection_language: "markdown",
+                incarnation: Some(1),
                 host_uri: "file:///test/doc.md",
                 region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
                 offset: &offset,
@@ -1406,6 +1417,7 @@ mod tests {
         let ctx = EnvelopeContext {
             server_name: "lua-ls",
             injection_language: "markdown",
+            incarnation: Some(1),
             host_uri: "file:///test/doc.md",
             region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
             offset: &offset,
@@ -1448,6 +1460,7 @@ mod tests {
             &EnvelopeContext {
                 server_name: "lua-ls",
                 injection_language: "markdown",
+                incarnation: Some(1),
                 host_uri: "file:///test/doc.md",
                 region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
                 offset: &offset,

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -50,7 +50,13 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Option<CompletionList>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/completion") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -200,6 +200,13 @@ impl LanguageServerPool {
             re_envelope_item(&mut item, &envelope);
             return item;
         };
+        if envelope
+            .incarnation
+            .is_some_and(|expected| self.current_host_incarnation(&host_uri) != Some(expected))
+        {
+            re_envelope_item(&mut item, &envelope);
+            return item;
+        }
         let handle = match self
             .get_or_create_virtual_connection(
                 server_name,
@@ -409,6 +416,7 @@ fn re_envelope_item(item: &mut CompletionItem, envelope: &KakehashiEnvelope) {
     let ctx = EnvelopeContext {
         server_name: &envelope.origin,
         injection_language: &envelope.injection_language,
+        incarnation: envelope.incarnation,
         host_uri: &envelope.host_uri,
         region_id: &envelope.region_id,
         offset: &RegionOffset::from(&envelope.offset),
@@ -462,6 +470,7 @@ mod tests {
         KakehashiEnvelope {
             origin: "lua-ls".to_string(),
             injection_language: "markdown".to_string(),
+            incarnation: Some(1),
             host_uri: "file:///test/doc.md".to_string(),
             region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
             inner: Some(json!({"resolve_id": 99})),
@@ -680,6 +689,7 @@ mod tests {
         let envelope = KakehashiEnvelope {
             origin: server.to_string(),
             injection_language: "markdown".to_string(),
+            incarnation: Some(1),
             host_uri: "file:///test/doc.md".to_string(),
             region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
             inner: Some(json!({"resolve_id": 42})),

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -196,9 +196,18 @@ impl LanguageServerPool {
         // The origin
         // is normally already pooled by the completion request that produced the
         // item; only if it died in between does this respawn.
-        let host_uri = Url::parse(&envelope.host_uri).ok();
+        let Ok(host_uri) = Url::parse(&envelope.host_uri) else {
+            re_envelope_item(&mut item, &envelope);
+            return item;
+        };
         let handle = match self
-            .get_or_create_connection(server_name, server_config, host_uri.as_ref())
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                &host_uri,
+                &envelope.injection_language,
+                &envelope.region_id,
+            )
             .await
         {
             Ok(h) => h,
@@ -399,6 +408,7 @@ fn translate_item_ranges_host_to_virtual(item: &mut CompletionItem, offset: &Reg
 fn re_envelope_item(item: &mut CompletionItem, envelope: &KakehashiEnvelope) {
     let ctx = EnvelopeContext {
         server_name: &envelope.origin,
+        injection_language: &envelope.injection_language,
         host_uri: &envelope.host_uri,
         region_id: &envelope.region_id,
         offset: &RegionOffset::from(&envelope.offset),
@@ -451,6 +461,7 @@ mod tests {
     fn test_envelope() -> KakehashiEnvelope {
         KakehashiEnvelope {
             origin: "lua-ls".to_string(),
+            injection_language: "markdown".to_string(),
             host_uri: "file:///test/doc.md".to_string(),
             region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
             inner: Some(json!({"resolve_id": 99})),
@@ -668,6 +679,7 @@ mod tests {
     fn enveloped_item(server: &str) -> CompletionItem {
         let envelope = KakehashiEnvelope {
             origin: server.to_string(),
+            injection_language: "markdown".to_string(),
             host_uri: "file:///test/doc.md".to_string(),
             region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
             inner: Some(json!({"resolve_id": 42})),

--- a/src/lsp/bridge/text_document/declaration.rs
+++ b/src/lsp/bridge/text_document/declaration.rs
@@ -42,7 +42,13 @@ impl LanguageServerPool {
         client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> io::Result<Option<Vec<LocationLink>>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/declaration") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/definition.rs
+++ b/src/lsp/bridge/text_document/definition.rs
@@ -42,7 +42,13 @@ impl LanguageServerPool {
         client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> io::Result<Option<Vec<LocationLink>>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/definition") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -51,12 +51,17 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Vec<Diagnostic>> {
         let (host_generation, request_sequence) = self.begin_diagnostic_pull(host_uri);
+        let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(host_uri)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+        let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, injection_language, region_id);
+        let routing_uri = Url::parse(&virtual_uri.to_uri_string())
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
         // Pre-work: wait for server to become Ready (unlike other handlers that fail fast).
         let handle = self
             .get_or_create_connection_wait_ready(
                 server_name,
                 server_config,
-                Some(host_uri),
+                Some(&routing_uri),
                 Duration::from_secs(INIT_TIMEOUT_SECS),
             )
             .await?;
@@ -75,9 +80,6 @@ impl LanguageServerPool {
         // Server is Ready and supports diagnostics — proceed with standard lifecycle.
         // Use execute_bridge_request_with_handle to reuse the pre-fetched handle,
         // avoiding a redundant HashMap lookup.
-        let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(host_uri)
-            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
-        let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, injection_language, region_id);
         let cache_key = (handle.key().clone(), virtual_uri.to_uri_string());
         let snapshot = self.diagnostic_pull_snapshot(
             &cache_key,

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -51,12 +51,12 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Vec<Diagnostic>> {
         let (host_generation, request_sequence) = self.begin_diagnostic_pull(host_uri);
-        self.wait_for_virtual_routing(host_uri).await;
         let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(host_uri)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
         let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, injection_language, region_id);
         let routing_uri = Url::parse(&virtual_uri.to_uri_string())
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+        self.wait_for_virtual_routing(host_uri, &routing_uri).await;
         // Pre-work: wait for server to become Ready (unlike other handlers that fail fast).
         let handle = self
             .get_or_create_connection_wait_ready(

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -51,6 +51,7 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Vec<Diagnostic>> {
         let (host_generation, request_sequence) = self.begin_diagnostic_pull(host_uri);
+        self.wait_for_virtual_routing(host_uri).await;
         let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(host_uri)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
         let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, injection_language, region_id);

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -128,8 +128,8 @@ impl LanguageServerPool {
                 // compare. Read-only — unlike the `None` arm below it never
                 // spawns, so asking about a host that belongs to some other
                 // root cannot bring that root's server up.
-                let (_marker, routes_to) = self
-                    .resolve_acquire(server_name, server_config, Some(&routing_uri))
+                let routes_to = self
+                    .resolved_connection_key(server_name, server_config, &routing_uri)
                     .await;
                 if &routes_to != key {
                     log::debug!(

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -171,9 +171,25 @@ impl LanguageServerPool {
                 .await
             {
                 Ok(h) => {
+                    let capability_fallback = if let Some(expected) =
+                        expected_connection.as_ref().filter(|expected| {
+                            h.key() != *expected && expected.is_shared() && !h.key().is_shared()
+                        }) {
+                        // A shared connection can legitimately divert to a
+                        // per-root key after it is Ready but lacks
+                        // workspace-folder change support. Confirm that the
+                        // routing decision itself is still the expected
+                        // shared key before accepting that fallback.
+                        self.resolved_connection_key(server_name, server_config, &routing_uri)
+                            .await
+                            == *expected
+                    } else {
+                        false
+                    };
                     if expected_connection
                         .as_ref()
                         .is_some_and(|expected| h.key() != expected)
+                        && !capability_fallback
                     {
                         log::debug!(
                             target: "kakehashi::bridge",

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -61,6 +61,10 @@ pub(crate) struct OpenExpectation<'a> {
     /// `None` opens wherever the host routes now, spawning if needed, which is
     /// what every other caller wants.
     pub(crate) connection: Option<&'a ConnectionKey>,
+    /// Expected key for a normal eager batch. Unlike `connection`, this does
+    /// not force a ready-only repair; it rejects a race that reacquires a
+    /// different key after the group was formed.
+    pub(crate) expected_connection: Option<ConnectionKey>,
 }
 
 struct LifecycleCleanup<'a> {
@@ -96,6 +100,7 @@ impl LanguageServerPool {
         let OpenExpectation {
             incarnation: expected_incarnation,
             connection: expected_key,
+            expected_connection,
         } = expect;
         // Routing decisions for injected documents are cached by virtual URI.
         // Use one of those URIs for connection acquisition; resolving from the
@@ -165,7 +170,21 @@ impl LanguageServerPool {
                 )
                 .await
             {
-                Ok(h) => h,
+                Ok(h) => {
+                    if expected_connection
+                        .as_ref()
+                        .is_some_and(|expected| h.key() != expected)
+                    {
+                        log::debug!(
+                            target: "kakehashi::bridge",
+                            "Eager open: routing changed from expected {} to {}",
+                            expected_connection.as_ref().unwrap(),
+                            h.key()
+                        );
+                        return OpenOutcome::NotApplicable;
+                    }
+                    h
+                }
                 Err(e) => {
                     log::debug!(
                         target: "kakehashi::bridge",
@@ -532,6 +551,7 @@ mod tests {
                 OpenExpectation {
                     incarnation: 1,
                     connection: None,
+                    expected_connection: None,
                 },
                 injections,
             )
@@ -594,6 +614,7 @@ mod tests {
                 OpenExpectation {
                     incarnation: 1,
                     connection: Some(&claimed),
+                    expected_connection: None,
                 },
                 vec![BridgeInjection {
                     language: "lua".to_string(),
@@ -644,6 +665,7 @@ mod tests {
                 OpenExpectation {
                     incarnation: 1,
                     connection: Some(&gone),
+                    expected_connection: None,
                 },
                 injections,
             )
@@ -698,6 +720,7 @@ mod tests {
                 OpenExpectation {
                     incarnation: 1,
                     connection: Some(&elsewhere),
+                    expected_connection: None,
                 },
                 vec![BridgeInjection {
                     language: "lua".to_string(),
@@ -744,6 +767,7 @@ mod tests {
                 OpenExpectation {
                     incarnation: 1,
                     connection: Some(&routed_key),
+                    expected_connection: None,
                 },
                 vec![BridgeInjection {
                     language: "lua".to_string(),
@@ -800,6 +824,7 @@ mod tests {
                 OpenExpectation {
                     incarnation: 1,
                     connection: None,
+                    expected_connection: None,
                 },
                 injections.clone(),
             )
@@ -822,6 +847,7 @@ mod tests {
                 OpenExpectation {
                     incarnation: 1,
                     connection: None,
+                    expected_connection: None,
                 },
                 injections,
             )

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -97,6 +97,20 @@ impl LanguageServerPool {
             incarnation: expected_incarnation,
             connection: expected_key,
         } = expect;
+        // Routing decisions for injected documents are cached by virtual URI.
+        // Use one of those URIs for connection acquisition; resolving from the
+        // host URI would miss an explicit `workspaceFolders: []` answer.
+        let routing_uri = injections
+            .first()
+            .and_then(|injection| {
+                let virtual_uri = VirtualDocumentUri::new(
+                    host_uri_lsp,
+                    &injection.language,
+                    &injection.region_id,
+                );
+                url::Url::parse(&virtual_uri.to_uri_string()).ok()
+            })
+            .unwrap_or_else(|| host_uri.clone());
         // A caller repairing a NAMED connection is acquired BY KEY. Resolving
         // from `host_uri` would find whatever that host routes to *now*, which
         // after a re-rooting config change is a different connection — and then
@@ -115,7 +129,7 @@ impl LanguageServerPool {
                 // spawns, so asking about a host that belongs to some other
                 // root cannot bring that root's server up.
                 let (_marker, routes_to) = self
-                    .resolve_acquire(server_name, server_config, Some(host_uri))
+                    .resolve_acquire(server_name, server_config, Some(&routing_uri))
                     .await;
                 if &routes_to != key {
                     log::debug!(
@@ -146,7 +160,7 @@ impl LanguageServerPool {
                 .get_or_create_connection_wait_ready(
                     server_name,
                     server_config,
-                    Some(host_uri),
+                    Some(&routing_uri),
                     Duration::from_secs(INIT_TIMEOUT_SECS),
                 )
                 .await

--- a/src/lsp/bridge/text_document/document_color.rs
+++ b/src/lsp/bridge/text_document/document_color.rs
@@ -39,7 +39,13 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Vec<ColorInformation>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/documentColor") {
             return Ok(vec![]);

--- a/src/lsp/bridge/text_document/document_highlight.rs
+++ b/src/lsp/bridge/text_document/document_highlight.rs
@@ -43,7 +43,13 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Option<Vec<DocumentHighlight>>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/documentHighlight") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -39,7 +39,13 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Option<Vec<DocumentLink>>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/documentLink") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/document_symbol.rs
+++ b/src/lsp/bridge/text_document/document_symbol.rs
@@ -47,7 +47,13 @@ impl LanguageServerPool {
         client_progress_token: Option<NumberOrString>,
     ) -> io::Result<Option<Vec<DocumentSymbol>>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/documentSymbol") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/folding_range.rs
+++ b/src/lsp/bridge/text_document/folding_range.rs
@@ -38,7 +38,13 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Option<Vec<FoldingRange>>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/foldingRange") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -73,7 +73,13 @@ impl LanguageServerPool {
         downstream_id_probe: Option<&std::sync::OnceLock<RequestId>>,
     ) -> io::Result<Option<Vec<TextEdit>>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/formatting") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/hover.rs
+++ b/src/lsp/bridge/text_document/hover.rs
@@ -43,7 +43,13 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Option<Hover>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/hover") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/implementation.rs
+++ b/src/lsp/bridge/text_document/implementation.rs
@@ -42,7 +42,13 @@ impl LanguageServerPool {
         client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> io::Result<Option<Vec<LocationLink>>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/implementation") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/inlay_hint.rs
+++ b/src/lsp/bridge/text_document/inlay_hint.rs
@@ -54,7 +54,13 @@ impl LanguageServerPool {
         client_progress_token: Option<NumberOrString>,
     ) -> io::Result<Option<Vec<InlayHint>>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/inlayHint") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/linked_editing_range.rs
+++ b/src/lsp/bridge/text_document/linked_editing_range.rs
@@ -43,7 +43,13 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Option<LinkedEditingRanges>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/linkedEditingRange") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/moniker.rs
+++ b/src/lsp/bridge/text_document/moniker.rs
@@ -42,7 +42,13 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Option<Vec<Moniker>>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/moniker") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/on_type_formatting.rs
+++ b/src/lsp/bridge/text_document/on_type_formatting.rs
@@ -52,7 +52,13 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Option<Vec<TextEdit>>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/onTypeFormatting") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/prepare_rename.rs
+++ b/src/lsp/bridge/text_document/prepare_rename.rs
@@ -42,7 +42,13 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Option<PrepareRenameResponse>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/prepareRename") {
             // Returning None would cause clients to treat the symbol as "not renameable",

--- a/src/lsp/bridge/text_document/range_formatting.rs
+++ b/src/lsp/bridge/text_document/range_formatting.rs
@@ -65,7 +65,13 @@ impl LanguageServerPool {
         downstream_id_probe: Option<&std::sync::OnceLock<RequestId>>,
     ) -> io::Result<Option<Vec<TextEdit>>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/rangeFormatting") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/references.rs
+++ b/src/lsp/bridge/text_document/references.rs
@@ -44,7 +44,13 @@ impl LanguageServerPool {
         client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> io::Result<Option<Vec<Location>>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/references") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/rename.rs
+++ b/src/lsp/bridge/text_document/rename.rs
@@ -49,7 +49,13 @@ impl LanguageServerPool {
         client_progress_token: Option<NumberOrString>,
     ) -> io::Result<Option<WorkspaceEdit>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/rename") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/signature_help.rs
+++ b/src/lsp/bridge/text_document/signature_help.rs
@@ -78,7 +78,13 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Option<SignatureHelp>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/signatureHelp") {
             return Ok(None);

--- a/src/lsp/bridge/text_document/type_definition.rs
+++ b/src/lsp/bridge/text_document/type_definition.rs
@@ -42,7 +42,13 @@ impl LanguageServerPool {
         client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> io::Result<Option<Vec<LocationLink>>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .get_or_create_virtual_connection(
+                server_name,
+                server_config,
+                host_uri,
+                injection_language,
+                region_id,
+            )
             .await?;
         if !handle.has_capability("textDocument/typeDefinition") {
             return Ok(None);

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -1,4 +1,5 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use url::Url;
 
@@ -299,11 +300,18 @@ impl InjectionCoordinator {
         // the same incarnation and is cancelled by the next close/rebuild.
         let coordinator = self.clone();
         let uri = uri.clone();
-        self.bridge
+        let routing_tokens = self
+            .bridge
             .begin_virtual_routing_for_injections(&uri, &injections);
         tokio::spawn(async move {
             coordinator
-                .eager_spawn_bridge_servers(&uri, incarnation, &host_language, injections)
+                .eager_spawn_bridge_servers(
+                    &uri,
+                    incarnation,
+                    &host_language,
+                    injections,
+                    routing_tokens,
+                )
                 .await;
         });
         true
@@ -452,10 +460,18 @@ impl InjectionCoordinator {
         incarnation: u64,
         host_language: &str,
         injections: Vec<BridgeInjection>,
+        routing_tokens: HashMap<Url, Arc<tokio::sync::watch::Sender<bool>>>,
     ) {
         let settings = self.settings_manager.load_settings();
         self.bridge
-            .eager_spawn_and_open_documents(&settings, host_language, uri, incarnation, injections)
+            .eager_spawn_and_open_documents(
+                &settings,
+                host_language,
+                uri,
+                incarnation,
+                injections,
+                routing_tokens,
+            )
             .await;
     }
 

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::sync::Arc;
 
 use url::Url;
 
@@ -300,16 +299,11 @@ impl InjectionCoordinator {
         // the same incarnation and is cancelled by the next close/rebuild.
         let coordinator = self.clone();
         let uri = uri.clone();
-        let routing_sender = self.bridge.begin_virtual_routing(&uri);
+        self.bridge
+            .begin_virtual_routing_for_injections(&uri, &injections);
         tokio::spawn(async move {
             coordinator
-                .eager_spawn_bridge_servers(
-                    &uri,
-                    incarnation,
-                    &host_language,
-                    injections,
-                    routing_sender,
-                )
+                .eager_spawn_bridge_servers(&uri, incarnation, &host_language, injections)
                 .await;
         });
         true
@@ -458,18 +452,10 @@ impl InjectionCoordinator {
         incarnation: u64,
         host_language: &str,
         injections: Vec<BridgeInjection>,
-        routing_sender: Arc<tokio::sync::watch::Sender<bool>>,
     ) {
         let settings = self.settings_manager.load_settings();
         self.bridge
-            .eager_spawn_and_open_documents(
-                &settings,
-                host_language,
-                uri,
-                incarnation,
-                injections,
-                routing_sender,
-            )
+            .eager_spawn_and_open_documents(&settings, host_language, uri, incarnation, injections)
             .await;
     }
 

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use url::Url;
 
@@ -299,9 +300,16 @@ impl InjectionCoordinator {
         // the same incarnation and is cancelled by the next close/rebuild.
         let coordinator = self.clone();
         let uri = uri.clone();
+        let routing_sender = self.bridge.begin_virtual_routing(&uri);
         tokio::spawn(async move {
             coordinator
-                .eager_spawn_bridge_servers(&uri, incarnation, &host_language, injections)
+                .eager_spawn_bridge_servers(
+                    &uri,
+                    incarnation,
+                    &host_language,
+                    injections,
+                    routing_sender,
+                )
                 .await;
         });
         true
@@ -450,10 +458,18 @@ impl InjectionCoordinator {
         incarnation: u64,
         host_language: &str,
         injections: Vec<BridgeInjection>,
+        routing_sender: Arc<tokio::sync::watch::Sender<bool>>,
     ) {
         let settings = self.settings_manager.load_settings();
         self.bridge
-            .eager_spawn_and_open_documents(&settings, host_language, uri, incarnation, injections)
+            .eager_spawn_and_open_documents(
+                &settings,
+                host_language,
+                uri,
+                incarnation,
+                injections,
+                routing_sender,
+            )
             .await;
     }
 

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1773,6 +1773,7 @@ fn spawn_upstream_request(
                                     // that route here are opened, and they are
                                     // opened HERE.
                                     connection: Some(&key),
+                                    expected_connection: None,
                                 },
                                 injections,
                                 &reopen_server,


### PR DESCRIPTION
Implement the remaining routing workspaceFolders semantics.

- workspaceFolders: null falls back to kakehashi client workspace folders.
- workspaceFolders: [] records a rootless shared-instance route.
- Keep routing decisions scoped to host URI and server.

@greptileai review
@codex review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling for language servers that explicitly report no workspace folders.
  * Preserved rootless sessions without adding workspace or marker roots.
  * Prevented unspecified workspace-folder routing from replaying client-provided folders.
  * Improved connection sharing for rootless server sessions while keeping them separate from ordinary workspace connections.
  * Ensured language features for embedded documents use the correct virtual-document routing.
  * Preserved the distinction between omitted and explicitly null workspace-folder responses.
  * Prevented stale routing decisions from reopening or processing incorrect virtual documents.
  * Improved reliability for completion, hover, diagnostics, formatting, navigation, and other language features in embedded documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->