### PR TITLE
fix(semantic): preserve exact multiline host tokens

### DIFF
--- a/docs/architecture-decisions/semantic-token-overlap-resolution.md
+++ b/docs/architecture-decisions/semantic-token-overlap-resolution.md
@@ -107,6 +107,8 @@ The single-line/multiline distinction applies only to **partial overlaps** and i
 - **Partially overlapping multiline regions** arise from container injections (e.g., blockquoted code fence content). The host token should not leak into the container's content.
 - **Exactly matching multiline regions** can represent two semantic views of the same source node (e.g., a TypeScript JSDoc capture and its comment injection). The host token remains available to fill gaps around the injected tokens.
 
+The exact-match exception is local to the matching region. If another active region overlaps the same host token, that region's normal containment or partial-overlap rule still applies.
+
 Key concepts:
 
 - **Active region**: An injection region that produced at least one token (depth >= 1). If a language was resolved but the highlight query produced no captures, the region is *inactive* and host tokens are preserved.

--- a/docs/architecture-decisions/semantic-token-overlap-resolution.md
+++ b/docs/architecture-decisions/semantic-token-overlap-resolution.md
@@ -102,9 +102,10 @@ Host tokens (depth=0) overlapping **active** injection regions are handled with 
 | **Partial overlap, single-line region** | Token extends beyond a single-line region | Keep entire token for sweep line | Heading `## foo **bar**` overlapping `(inline)` injection |
 | **Partial overlap, multiline region** | Token extends beyond a multiline region | Split, keep outside fragments only | In a blockquoted code fence, the `>` prefix and its following space survive; code content is removed |
 
-The single-line/multiline distinction for partial overlaps identifies the injection's nature:
+The single-line/multiline distinction applies only to **partial overlaps** and identifies the injection's nature. Exact matches are kept whether they span one line or many:
 - **Single-line regions** arise from direct child injections (e.g., `markdown_inline` within a heading). The host token should fill gaps where the injection produces no tokens (e.g., plain text in headings). Blockquote *prose* gaps are trimmed of their trailing newline at the exclusion-range push site (`rebuild_context`) precisely so they classify here and gap-fill uniformly on every paragraph line.
-- **Multiline regions** arise from container injections (e.g., blockquoted code fence content). The host token should not leak into the container's content.
+- **Partially overlapping multiline regions** arise from container injections (e.g., blockquoted code fence content). The host token should not leak into the container's content.
+- **Exactly matching multiline regions** can represent two semantic views of the same source node (e.g., a TypeScript JSDoc capture and its comment injection). The host token remains available to fill gaps around the injected tokens.
 
 Key concepts:
 
@@ -170,9 +171,11 @@ semantic.rs::handle_semantic_tokens_full
   |
   +-- finalize_tokens(all_tokens, &active_injection_regions, &lines)
         |
+        +-- Classify exact-match multiline host spans
         +-- split_multiline_tokens (normalize to single-line fragments)
         +-- retain(length > 0)
-        +-- Stage 1: injection region exclusion
+        +-- Stage 1: injection region exclusion for non-exact hosts
+        +-- Add normalized fragments from preserved exact hosts
         +-- Stage 2: split_overlapping_tokens (sweep line)
         |     +-- merge_adjacent_fragments
         +-- Delta encoding -> SemanticTokensResult
@@ -182,10 +185,10 @@ Note: The `exclusion_ranges` parameter in `collect_host_tokens` is still used fo
 
 ### Multiline Token Handling
 
-The sweep line operates **per-line**. Before running the sweep line, `finalize_tokens` calls `split_multiline_tokens`, which normalizes any multiline tokens into single-line fragments. The sweep line then processes those fragments together with tokens that were already single-line.
+The sweep line operates **per-line**. Before normalization destroys cross-line identity, `finalize_tokens` records top-level host tokens that exactly match multiline active regions. It then calls `split_multiline_tokens`, which normalizes multiline tokens into single-line fragments. Stage 1 filters non-exact host fragments, and the preserved exact hosts re-enter before the sweep line processes all remaining fragments.
 
-- When `supports_multiline = false` (the common case), tokens are already split per-line during collection
-- When `supports_multiline = true`, `split_multiline_tokens` ensures multiline tokens participate correctly in overlap resolution
+- Top-level host captures retain their multiline raw span until exact-match classification, independent of the client's `multilineTokenSupport` capability
+- Injection captures may still be collected per-line when `supports_multiline = false`; `split_multiline_tokens` normalizes every remaining multiline raw token before overlap resolution
 - Advanced cross-line merging heuristics (e.g., re-joining fragments after splitting) are deferred to a future phase
 
 ## Consequences

--- a/docs/architecture-decisions/semantic-token-overlap-resolution.md
+++ b/docs/architecture-decisions/semantic-token-overlap-resolution.md
@@ -200,7 +200,7 @@ The sweep line operates **per-line**. Before normalization destroys cross-line i
 - **Inactive region preservation**: Unknown-language code blocks (e.g., `` ```unknown ``) correctly preserve the parent `@markup.raw.block` token, since no injection tokens suppress it.
 - **Spanning node correctness**: Host captures on nodes spanning injection boundaries are correctly excluded, fixing the overlapping output bug.
 - **Unified resolution point**: All overlap resolution happens in `finalize_tokens`, making the algorithm easy to reason about, test, and extend.
-- **24 unit tests** cover sweep line splitting, injection exclusion, and edge cases.
+- **Regression tests** cover sweep line splitting, injection exclusion, multiline exact matches, and boundary cases.
 
 ### Negative
 

--- a/docs/architecture-decisions/semantic-token-overlap-resolution.md
+++ b/docs/architecture-decisions/semantic-token-overlap-resolution.md
@@ -187,7 +187,7 @@ Note: The `exclusion_ranges` parameter in `collect_host_tokens` is still used fo
 
 The sweep line operates **per-line**. Before normalization destroys cross-line identity, `finalize_tokens` records top-level host tokens that exactly match multiline active regions. It then calls `split_multiline_tokens`, which normalizes multiline tokens into single-line fragments. Stage 1 filters non-exact host fragments, and the preserved exact hosts re-enter before the sweep line processes all remaining fragments.
 
-- Top-level host captures retain their multiline raw span until exact-match classification, independent of the client's `multilineTokenSupport` capability
+- Prefix-free top-level host captures retain their multiline raw span until exact-match classification, independent of the client's `multilineTokenSupport` capability; captures with structural prefix widths remain per-line so prefixes can be excluded
 - Injection captures may still be collected per-line when `supports_multiline = false`; `split_multiline_tokens` normalizes every remaining multiline raw token before overlap resolution
 - Advanced cross-line merging heuristics (e.g., re-joining fragments after splitting) are deferred to a future phase
 

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -85,6 +85,15 @@ fn run_sequential_injection<T>(
     (!cancelled && host_complete).then(injection_work)
 }
 
+/// Choose the raw representation used while collecting top-level host tokens.
+///
+/// Kept separate from the client's wire capability because finalization owns
+/// the conversion to single-line LSP tokens. Retaining a multiline capture here
+/// also retains its source-span identity for injection exact-match handling.
+fn top_level_host_multiline_collection(_supports_multiline: bool) -> bool {
+    true
+}
+
 /// Compute full-document semantic tokens (host + injections) as one work-unit
 /// on the bounded compute pool; the injection fan-out's `par_iter` runs on the
 /// same pool (a Rayon parallel iterator invoked from a pool thread stays on
@@ -166,7 +175,7 @@ pub(crate) async fn handle_semantic_tokens_full(
                 &line_starts,
                 0,
                 0,
-                supports_multiline,
+                top_level_host_multiline_collection(supports_multiline),
                 &[],
                 &[],
                 cancel.as_ref(),
@@ -346,6 +355,82 @@ mod tests {
                 (abs_line, abs_col, st.length, st.token_type)
             })
             .collect()
+    }
+
+    #[rstest::rstest]
+    #[case(false)]
+    #[case(true)]
+    fn top_level_multiline_exact_host_survives_client_capability(#[case] supports_multiline: bool) {
+        use token_collector::ActiveInjectionBounds;
+
+        let text = "/**\n * ERROR text\n */";
+        let lines: Vec<&str> = text.lines().collect();
+        let language: tree_sitter::Language = tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into();
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&language).unwrap();
+        let tree = parser.parse(text, None).unwrap();
+        let query = Query::new(&language, "(comment) @comment.documentation").unwrap();
+        let mut tokens = Vec::new();
+
+        assert!(collect_host_tokens(
+            text,
+            &tree,
+            &query,
+            Some("typescript"),
+            None,
+            text,
+            &lines,
+            &build_line_start_bytes(text),
+            0,
+            0,
+            top_level_host_multiline_collection(supports_multiline),
+            &[],
+            &[],
+            None,
+            &mut tokens,
+        ));
+
+        let (keyword_type, keyword_modifiers) =
+            legend::map_capture_to_token_type_and_modifiers("keyword").unwrap();
+        tokens.push(RawToken {
+            line: 1,
+            column: 3,
+            length: 5,
+            kind: TokenKind::Mapped(keyword_type, keyword_modifiers),
+            depth: 1,
+            pattern_index: 0,
+            priority: 100,
+            node_byte_len: 5,
+        });
+        let regions = [ActiveInjectionBounds {
+            start_line: 0,
+            start_col: 0,
+            end_line: 2,
+            end_col: 3,
+        }];
+
+        let SemanticTokensResult::Tokens(result) =
+            finalize_tokens_cancellable(tokens, &regions, &lines, None)
+                .expect("exact host and injected token should survive")
+        else {
+            panic!("expected full semantic tokens");
+        };
+        let (comment_type, _) =
+            legend::map_capture_to_token_type_and_modifiers("comment.documentation").unwrap();
+        let decoded = decode_tokens(&result.data);
+
+        assert!(
+            [0, 1, 2].into_iter().all(|line| decoded
+                .iter()
+                .any(|token| token.0 == line && token.3 == comment_type)),
+            "the exact host comment must remain visible on every line: {decoded:?}"
+        );
+        assert!(
+            decoded
+                .iter()
+                .any(|token| token.0 == 1 && token.1 == 3 && token.3 == keyword_type),
+            "the injected token must remain visible: {decoded:?}"
+        );
     }
 
     #[test]

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -434,6 +434,77 @@ mod tests {
     }
 
     #[test]
+    fn top_level_trailing_newline_capture_retains_endpoint_identity() {
+        use token_collector::ActiveInjectionBounds;
+
+        let text = "xy\n";
+        let lines: Vec<&str> = text.lines().collect();
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&language).unwrap();
+        let tree = parser.parse(text, None).unwrap();
+        let query = Query::new(&language, "(source_file) @comment.documentation").unwrap();
+        let mut tokens = Vec::new();
+
+        assert!(collect_host_tokens(
+            text,
+            &tree,
+            &query,
+            Some("rust"),
+            None,
+            text,
+            &lines,
+            &build_line_start_bytes(text),
+            0,
+            0,
+            top_level_host_multiline_collection(false),
+            &[],
+            &[],
+            None,
+            &mut tokens,
+        ));
+        assert_eq!(
+            tokens[0].length, 3,
+            "the raw host span must retain its trailing newline"
+        );
+
+        let (keyword_type, keyword_modifiers) =
+            legend::map_capture_to_token_type_and_modifiers("keyword").unwrap();
+        tokens.push(RawToken {
+            line: 0,
+            column: 0,
+            length: 1,
+            kind: TokenKind::Mapped(keyword_type, keyword_modifiers),
+            depth: 1,
+            pattern_index: 0,
+            priority: 100,
+            node_byte_len: 1,
+        });
+        let regions = [ActiveInjectionBounds {
+            start_line: 0,
+            start_col: 0,
+            end_line: 1,
+            end_col: 0,
+        }];
+
+        let SemanticTokensResult::Tokens(result) =
+            finalize_tokens_cancellable(tokens, &regions, &lines, None)
+                .expect("exact host fallback should survive")
+        else {
+            panic!("expected full semantic tokens");
+        };
+        let (comment_type, _) =
+            legend::map_capture_to_token_type_and_modifiers("comment.documentation").unwrap();
+        let decoded = decode_tokens(&result.data);
+        assert!(
+            decoded
+                .iter()
+                .any(|token| token.0 == 0 && token.1 == 1 && token.3 == comment_type),
+            "the uncovered host character must remain highlighted: {decoded:?}"
+        );
+    }
+
+    #[test]
     fn test_semantic_tokens_range() {
         use tower_lsp_server::ls_types::Position;
 

--- a/src/analysis/semantic/finalize.rs
+++ b/src/analysis/semantic/finalize.rs
@@ -70,10 +70,6 @@ fn multiline_exact_match_keys(
     if crate::cancel::is_cancelled(cancel) {
         return None;
     }
-    if !regions.iter().any(|r| r.start_line != r.end_line) {
-        return Some(HashSet::new());
-    }
-
     let mut work_items = 0usize;
     let mut keys = HashSet::new();
     'regions: for region in regions {
@@ -1041,6 +1037,27 @@ mod tests {
             !cancel.is_cancelled(),
             "unrelated lines after the region must not be visited"
         );
+    }
+
+    #[test]
+    fn exact_match_key_collection_checks_cancellation_for_single_line_regions() {
+        let cancel = crate::cancel::CancelToken::default();
+        cancel.cancel_after_polls(2);
+        let lines = vec!["x"; 512];
+        let regions: Vec<_> = (0..512)
+            .map(|line| ActiveInjectionBounds {
+                start_line: line,
+                start_col: 0,
+                end_line: line,
+                end_col: 1,
+            })
+            .collect();
+
+        assert!(
+            multiline_exact_match_keys(&regions, &lines, Some(&cancel)).is_none(),
+            "the all-single-line region pass must remain cancellable"
+        );
+        assert!(cancel.is_cancelled());
     }
 
     #[test]

--- a/src/analysis/semantic/finalize.rs
+++ b/src/analysis/semantic/finalize.rs
@@ -60,72 +60,89 @@ fn cached_utf16_width(
     Some(*cache[line].get_or_insert_with(|| utf16_width(line_text)))
 }
 
+type MultilineSpanKey = (usize, usize, usize);
+
+fn multiline_region_key(
+    region: &ActiveInjectionBounds,
+    lines: &[&str],
+    cancel: Option<&crate::cancel::CancelToken>,
+    work_items: &mut usize,
+) -> Result<Option<MultilineSpanKey>, ()> {
+    if region.start_line == region.end_line {
+        return Ok(None);
+    }
+    let Some(start_line) = lines.get(region.start_line) else {
+        return Ok(None);
+    };
+    let end_width = match lines.get(region.end_line) {
+        Some(end_line) => utf16_width(end_line),
+        None if region.end_line == lines.len() && region.end_col == 0 => 0,
+        None => return Ok(None),
+    };
+    let start_width = utf16_width(start_line);
+    if region.start_col > start_width || region.end_col > end_width {
+        return Ok(None);
+    }
+    let Some(mut length) = start_width.checked_sub(region.start_col) else {
+        return Ok(None);
+    };
+    let Some(first_inner_line) = region.start_line.checked_add(1) else {
+        return Ok(None);
+    };
+    for line_index in first_inner_line..region.end_line {
+        if cancellation_requested(cancel, work_items) {
+            return Err(());
+        }
+        let Some(line) = lines.get(line_index) else {
+            return Ok(None);
+        };
+        let Some(next_length) = length
+            .checked_add(1)
+            .and_then(|value| value.checked_add(utf16_width(line)))
+        else {
+            return Ok(None);
+        };
+        length = next_length;
+    }
+    let Some(length) = length
+        .checked_add(1)
+        .and_then(|value| value.checked_add(region.end_col))
+    else {
+        return Ok(None);
+    };
+    Ok(Some((region.start_line, region.start_col, length)))
+}
+
 /// Identify multiline host tokens whose original span exactly matches an active
 /// injection region before per-line normalization destroys that information.
 fn multiline_exact_match_keys(
     regions: &[ActiveInjectionBounds],
     lines: &[&str],
     cancel: Option<&crate::cancel::CancelToken>,
-) -> Option<HashSet<(usize, usize, usize)>> {
+) -> Option<HashSet<MultilineSpanKey>> {
     if crate::cancel::is_cancelled(cancel) {
         return None;
     }
     let mut work_items = 0usize;
     let mut keys = HashSet::new();
-    'regions: for region in regions {
+    for region in regions {
         if cancellation_requested(cancel, &mut work_items) {
             return None;
         }
-        if region.start_line == region.end_line {
-            continue;
-        }
-        let Some(start_line) = lines.get(region.start_line) else {
-            continue;
-        };
-        let end_width = match lines.get(region.end_line) {
-            Some(end_line) => utf16_width(end_line),
-            None if region.end_line == lines.len() && region.end_col == 0 => 0,
-            None => continue,
-        };
-        let start_width = utf16_width(start_line);
-        if region.start_col > start_width || region.end_col > end_width {
-            continue;
-        }
-        let Some(mut length) = start_width.checked_sub(region.start_col) else {
-            continue;
-        };
-        let Some(first_inner_line) = region.start_line.checked_add(1) else {
-            continue;
-        };
-        for line_index in first_inner_line..region.end_line {
-            if cancellation_requested(cancel, &mut work_items) {
-                return None;
+        match multiline_region_key(region, lines, cancel, &mut work_items) {
+            Ok(Some(key)) => {
+                keys.insert(key);
             }
-            let Some(line) = lines.get(line_index) else {
-                continue 'regions;
-            };
-            let Some(next_length) = length
-                .checked_add(1)
-                .and_then(|value| value.checked_add(utf16_width(line)))
-            else {
-                continue 'regions;
-            };
-            length = next_length;
+            Ok(None) => {}
+            Err(()) => return None,
         }
-        let Some(length) = length
-            .checked_add(1)
-            .and_then(|value| value.checked_add(region.end_col))
-        else {
-            continue;
-        };
-        keys.insert((region.start_line, region.start_col, length));
     }
     Some(keys)
 }
 
 fn partition_multiline_exact_matches(
     tokens: Vec<RawToken>,
-    multiline_exact_matches: &HashSet<(usize, usize, usize)>,
+    multiline_exact_matches: &HashSet<MultilineSpanKey>,
     cancel: Option<&crate::cancel::CancelToken>,
 ) -> Option<(Vec<RawToken>, Vec<RawToken>)> {
     let is_exact_match = |token: &RawToken| {
@@ -816,6 +833,46 @@ pub(super) fn finalize_tokens(
     finalize_tokens_cancellable(all_tokens, active_injection_regions, lines, None)
 }
 
+fn filter_multiline_exact_match_tokens(
+    tokens: Vec<RawToken>,
+    active_injection_regions: &[ActiveInjectionBounds],
+    lines: &[&str],
+    cancel: Option<&crate::cancel::CancelToken>,
+) -> Option<Vec<RawToken>> {
+    let mut filtered = Vec::new();
+    let mut work_items = 0usize;
+    for token in tokens {
+        if cancellation_requested(cancel, &mut work_items) {
+            return None;
+        }
+        let token_key = (token.line, token.column, token.length);
+        // The exact-match exception is region-local. Exclude only regions with
+        // these original bounds, then apply normal Stage 1 filtering for any
+        // other overlapping active region before restoring the fragments.
+        let mut other_regions = Vec::with_capacity(active_injection_regions.len());
+        for region in active_injection_regions {
+            if cancellation_requested(cancel, &mut work_items) {
+                return None;
+            }
+            let matches_token = match multiline_region_key(region, lines, cancel, &mut work_items) {
+                Ok(key) => key == Some(token_key),
+                Err(()) => return None,
+            };
+            if !matches_token {
+                other_regions.push(region.clone());
+            }
+        }
+        let fragments = split_multiline_tokens_cancellable(vec![token], lines, cancel)?;
+        filtered.extend(filter_by_injection_regions(
+            fragments,
+            &other_regions,
+            lines,
+            cancel,
+        )?);
+    }
+    Some(filtered)
+}
+
 pub(super) fn finalize_tokens_cancellable(
     all_tokens: Vec<RawToken>,
     active_injection_regions: &[ActiveInjectionBounds],
@@ -831,7 +888,8 @@ pub(super) fn finalize_tokens_cancellable(
     // equal the original multiline injection region, so Stage 1 would mistake
     // them for fully-contained host leakage. Partial overlaps (notably Markdown
     // fenced-code containers) remain in `filterable_tokens` and are still
-    // removed inside the region.
+    // removed inside the region. Preserved exact hosts are later filtered
+    // against every *other* overlapping region; the exception is not global.
     let multiline_exact_matches =
         multiline_exact_match_keys(active_injection_regions, lines, cancel)?;
     let (exact_match_tokens, filterable_tokens) = if multiline_exact_matches.is_empty() {
@@ -850,8 +908,9 @@ pub(super) fn finalize_tokens_cancellable(
 
     let mut all_tokens =
         filter_by_injection_regions(all_tokens, active_injection_regions, lines, cancel)?;
-    all_tokens.extend(split_multiline_tokens_cancellable(
+    all_tokens.extend(filter_multiline_exact_match_tokens(
         exact_match_tokens,
+        active_injection_regions,
         lines,
         cancel,
     )?);
@@ -2350,6 +2409,62 @@ mod tests {
                 .any(|token| token.delta_line == 1 && token.token_type == comment_type),
             "the exact host must remain on the second line: {:?}",
             st.data
+        );
+    }
+
+    #[test]
+    fn multiline_exact_host_is_still_filtered_by_other_overlapping_region() {
+        let lines = vec!["abcdef", "ghijkl", "mnop"];
+        let tokens = vec![
+            make_token(0, 0, 18, "comment.documentation", 0, 0),
+            make_token(0, 0, 1, "keyword", 1, 0),
+        ];
+        let regions = vec![
+            // The host is exempt from this exact region only.
+            ActiveInjectionBounds {
+                start_line: 0,
+                start_col: 0,
+                end_line: 2,
+                end_col: 4,
+            },
+            // This overlapping multiline container must still punch a hole.
+            ActiveInjectionBounds {
+                start_line: 1,
+                start_col: 2,
+                end_line: 2,
+                end_col: 2,
+            },
+        ];
+
+        let SemanticTokensResult::Tokens(st) =
+            finalize_tokens(tokens, &regions, &lines).expect("should produce tokens")
+        else {
+            panic!("Expected Tokens");
+        };
+        let (comment_type, _) =
+            map_capture_to_token_type_and_modifiers("comment.documentation").unwrap();
+        let (keyword_type, _) = map_capture_to_token_type_and_modifiers("keyword").unwrap();
+        let positions: Vec<_> = st
+            .data
+            .iter()
+            .map(|token| {
+                (
+                    token.delta_line,
+                    token.delta_start,
+                    token.length,
+                    token.token_type,
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            positions,
+            vec![
+                (0, 0, 1, keyword_type),
+                (0, 1, 5, comment_type),
+                (1, 0, 2, comment_type),
+                (1, 2, 2, comment_type),
+            ]
         );
     }
 }

--- a/src/analysis/semantic/finalize.rs
+++ b/src/analysis/semantic/finalize.rs
@@ -128,6 +128,28 @@ fn partition_multiline_exact_matches(
     multiline_exact_matches: &HashSet<(usize, usize, usize)>,
     cancel: Option<&crate::cancel::CancelToken>,
 ) -> Option<(Vec<RawToken>, Vec<RawToken>)> {
+    let is_exact_match = |token: &RawToken| {
+        token.depth == 0
+            && multiline_exact_matches.contains(&(token.line, token.column, token.length))
+    };
+    let mut scan_work_items = 0usize;
+    let mut has_exact_match = false;
+    for token in &tokens {
+        if cancellation_requested(cancel, &mut scan_work_items) {
+            return None;
+        }
+        if is_exact_match(token) {
+            has_exact_match = true;
+            break;
+        }
+    }
+    if !has_exact_match {
+        if crate::cancel::is_cancelled(cancel) {
+            return None;
+        }
+        return Some((Vec::new(), tokens));
+    }
+
     let mut exact_match_tokens = Vec::new();
     let mut filterable_tokens = Vec::with_capacity(tokens.len());
     let mut work_items = 0usize;
@@ -135,9 +157,7 @@ fn partition_multiline_exact_matches(
         if cancellation_requested(cancel, &mut work_items) {
             return None;
         }
-        if token.depth == 0
-            && multiline_exact_matches.contains(&(token.line, token.column, token.length))
-        {
+        if is_exact_match(&token) {
             exact_match_tokens.push(token);
         } else {
             filterable_tokens.push(token);
@@ -1016,6 +1036,22 @@ mod tests {
             "classification must remain cancellable on large token sets"
         );
         assert!(cancel.is_cancelled());
+    }
+
+    #[test]
+    fn exact_match_partition_reuses_input_when_no_token_matches() {
+        let tokens = vec![make_token(0, 0, 1, "variable", 0, 0)];
+        let input_ptr = tokens.as_ptr();
+        let keys = HashSet::from([(1, 0, 1)]);
+
+        let (exact, filterable) = partition_multiline_exact_matches(tokens, &keys, None).unwrap();
+
+        assert!(exact.is_empty());
+        assert_eq!(
+            filterable.as_ptr(),
+            input_ptr,
+            "a nonmatching pass must return the original allocation"
+        );
     }
 
     #[test]

--- a/src/analysis/semantic/finalize.rs
+++ b/src/analysis/semantic/finalize.rs
@@ -83,12 +83,15 @@ fn multiline_exact_match_keys(
         if region.start_line == region.end_line {
             continue;
         }
-        let (Some(start_line), Some(end_line)) =
-            (lines.get(region.start_line), lines.get(region.end_line))
-        else {
+        let Some(start_line) = lines.get(region.start_line) else {
             continue;
         };
-        let (start_width, end_width) = (utf16_width(start_line), utf16_width(end_line));
+        let end_width = match lines.get(region.end_line) {
+            Some(end_line) => utf16_width(end_line),
+            None if region.end_line == lines.len() && region.end_col == 0 => 0,
+            None => continue,
+        };
+        let start_width = utf16_width(start_line);
         if region.start_col > start_width || region.end_col > end_width {
             continue;
         }
@@ -2262,6 +2265,38 @@ mod tests {
                 (0, 5, 5, comment_type, comment_modifiers),
                 (1, 0, 3, comment_type, comment_modifiers),
             ],
+        );
+    }
+
+    #[test]
+    fn finalize_preserves_exact_multiline_host_ending_after_trailing_newline() {
+        // `str::lines()` omits the virtual empty line after the final newline.
+        let lines: Vec<&str> = "a\nb\n".lines().collect();
+        let tokens = vec![
+            make_token(0, 0, 4, "comment.documentation", 0, 0),
+            make_token(0, 0, 1, "keyword", 1, 0),
+        ];
+        let regions = vec![ActiveInjectionBounds {
+            start_line: 0,
+            start_col: 0,
+            end_line: 2,
+            end_col: 0,
+        }];
+
+        let SemanticTokensResult::Tokens(st) =
+            finalize_tokens(tokens, &regions, &lines).expect("should produce tokens")
+        else {
+            panic!("Expected Tokens");
+        };
+        let (comment_type, _) =
+            map_capture_to_token_type_and_modifiers("comment.documentation").unwrap();
+
+        assert!(
+            st.data
+                .iter()
+                .any(|token| token.delta_line == 1 && token.token_type == comment_type),
+            "the exact host must remain on the second line: {:?}",
+            st.data
         );
     }
 }

--- a/src/analysis/semantic/finalize.rs
+++ b/src/analysis/semantic/finalize.rs
@@ -74,42 +74,49 @@ fn multiline_exact_match_keys(
         return Some(HashSet::new());
     }
 
-    let mut line_offsets = Vec::with_capacity(lines.len());
-    let mut offset = 0usize;
     let mut work_items = 0usize;
-    for line in lines {
-        if cancellation_requested(cancel, &mut work_items) {
-            return None;
-        }
-        line_offsets.push(offset);
-        let Some(next_offset) = offset
-            .checked_add(utf16_width(line))
-            .and_then(|value| value.checked_add(1))
-        else {
-            return Some(HashSet::new());
-        };
-        offset = next_offset;
-    }
-
     let mut keys = HashSet::new();
-    for region in regions {
+    'regions: for region in regions {
         if cancellation_requested(cancel, &mut work_items) {
             return None;
         }
         if region.start_line == region.end_line {
             continue;
         }
-        let (Some(start), Some(end)) = (
-            line_offsets
-                .get(region.start_line)
-                .and_then(|offset| offset.checked_add(region.start_col)),
-            line_offsets
-                .get(region.end_line)
-                .and_then(|offset| offset.checked_add(region.end_col)),
-        ) else {
+        let (Some(start_line), Some(end_line)) =
+            (lines.get(region.start_line), lines.get(region.end_line))
+        else {
             continue;
         };
-        let Some(length) = end.checked_sub(start) else {
+        let (start_width, end_width) = (utf16_width(start_line), utf16_width(end_line));
+        if region.start_col > start_width || region.end_col > end_width {
+            continue;
+        }
+        let Some(mut length) = start_width.checked_sub(region.start_col) else {
+            continue;
+        };
+        let Some(first_inner_line) = region.start_line.checked_add(1) else {
+            continue;
+        };
+        for line_index in first_inner_line..region.end_line {
+            if cancellation_requested(cancel, &mut work_items) {
+                return None;
+            }
+            let Some(line) = lines.get(line_index) else {
+                continue 'regions;
+            };
+            let Some(next_length) = length
+                .checked_add(1)
+                .and_then(|value| value.checked_add(utf16_width(line)))
+            else {
+                continue 'regions;
+            };
+            length = next_length;
+        }
+        let Some(length) = length
+            .checked_add(1)
+            .and_then(|value| value.checked_add(region.end_col))
+        else {
             continue;
         };
         keys.insert((region.start_line, region.start_col, length));
@@ -808,8 +815,11 @@ pub(super) fn finalize_tokens_cancellable(
     // removed inside the region.
     let multiline_exact_matches =
         multiline_exact_match_keys(active_injection_regions, lines, cancel)?;
-    let (exact_match_tokens, filterable_tokens) =
-        partition_multiline_exact_matches(all_tokens, &multiline_exact_matches, cancel)?;
+    let (exact_match_tokens, filterable_tokens) = if multiline_exact_matches.is_empty() {
+        (Vec::new(), all_tokens)
+    } else {
+        partition_multiline_exact_matches(all_tokens, &multiline_exact_matches, cancel)?
+    };
 
     // Split multiline tokens into per-line tokens before the sweep line,
     // which treats [column, column+length) as a 1D interval on a single line.
@@ -1007,6 +1017,27 @@ mod tests {
             "classification must remain cancellable on large token sets"
         );
         assert!(cancel.is_cancelled());
+    }
+
+    #[test]
+    fn exact_match_key_collection_does_not_scan_lines_after_region() {
+        let cancel = crate::cancel::CancelToken::default();
+        cancel.cancel_after_polls(3);
+        let lines = vec!["x"; 512];
+        let regions = [ActiveInjectionBounds {
+            start_line: 0,
+            start_col: 0,
+            end_line: 1,
+            end_col: 1,
+        }];
+
+        let keys = multiline_exact_match_keys(&regions, &lines, Some(&cancel));
+
+        assert_eq!(keys, Some(HashSet::from([(0, 0, 3)])));
+        assert!(
+            !cancel.is_cancelled(),
+            "unrelated lines after the region must not be visited"
+        );
     }
 
     #[test]

--- a/src/analysis/semantic/finalize.rs
+++ b/src/analysis/semantic/finalize.rs
@@ -117,6 +117,32 @@ fn multiline_exact_match_keys(
     Some(keys)
 }
 
+fn partition_multiline_exact_matches(
+    tokens: Vec<RawToken>,
+    multiline_exact_matches: &HashSet<(usize, usize, usize)>,
+    cancel: Option<&crate::cancel::CancelToken>,
+) -> Option<(Vec<RawToken>, Vec<RawToken>)> {
+    let mut exact_match_tokens = Vec::new();
+    let mut filterable_tokens = Vec::with_capacity(tokens.len());
+    let mut work_items = 0usize;
+    for token in tokens {
+        if cancellation_requested(cancel, &mut work_items) {
+            return None;
+        }
+        if token.depth == 0
+            && multiline_exact_matches.contains(&(token.line, token.column, token.length))
+        {
+            exact_match_tokens.push(token);
+        } else {
+            filterable_tokens.push(token);
+        }
+    }
+    if crate::cancel::is_cancelled(cancel) {
+        return None;
+    }
+    Some((exact_match_tokens, filterable_tokens))
+}
+
 /// Split multiline tokens into per-line fragments, skipping empty multiline fragments.
 ///
 /// The sweep line algorithm groups tokens by `token.line` and treats
@@ -782,11 +808,8 @@ pub(super) fn finalize_tokens_cancellable(
     // removed inside the region.
     let multiline_exact_matches =
         multiline_exact_match_keys(active_injection_regions, lines, cancel)?;
-    let (exact_match_tokens, filterable_tokens): (Vec<_>, Vec<_>) =
-        all_tokens.into_iter().partition(|token| {
-            token.depth == 0
-                && multiline_exact_matches.contains(&(token.line, token.column, token.length))
-        });
+    let (exact_match_tokens, filterable_tokens) =
+        partition_multiline_exact_matches(all_tokens, &multiline_exact_matches, cancel)?;
 
     // Split multiline tokens into per-line tokens before the sweep line,
     // which treats [column, column+length) as a 1D interval on a single line.
@@ -967,6 +990,22 @@ mod tests {
         let lines = vec!["x"; 512];
 
         assert!(finalize_tokens_cancellable(tokens, &[], &lines, Some(&cancel)).is_none());
+        assert!(cancel.is_cancelled());
+    }
+
+    #[test]
+    fn exact_match_partition_stops_at_periodic_mid_pass_checkpoint() {
+        let cancel = crate::cancel::CancelToken::default();
+        cancel.cancel_after_polls(1);
+        let tokens = (0..512)
+            .map(|line| make_token(line, 0, 1, "variable", 0, 0))
+            .collect();
+        let keys = HashSet::from([(0, 0, 1)]);
+
+        assert!(
+            partition_multiline_exact_matches(tokens, &keys, Some(&cancel)).is_none(),
+            "classification must remain cancellable on large token sets"
+        );
         assert!(cancel.is_cancelled());
     }
 

--- a/src/analysis/semantic/finalize.rs
+++ b/src/analysis/semantic/finalize.rs
@@ -10,7 +10,7 @@
 //! SemanticTokensDelta optimization which is handled by the `delta` module.
 
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::{BinaryHeap, HashMap, HashSet};
 
 use tower_lsp_server::ls_types::{SemanticToken, SemanticTokens, SemanticTokensResult};
 
@@ -58,6 +58,63 @@ fn cached_utf16_width(
         cache.resize(line + 1, None);
     }
     Some(*cache[line].get_or_insert_with(|| utf16_width(line_text)))
+}
+
+/// Identify multiline host tokens whose original span exactly matches an active
+/// injection region before per-line normalization destroys that information.
+fn multiline_exact_match_keys(
+    regions: &[ActiveInjectionBounds],
+    lines: &[&str],
+    cancel: Option<&crate::cancel::CancelToken>,
+) -> Option<HashSet<(usize, usize, usize)>> {
+    if crate::cancel::is_cancelled(cancel) {
+        return None;
+    }
+    if !regions.iter().any(|r| r.start_line != r.end_line) {
+        return Some(HashSet::new());
+    }
+
+    let mut line_offsets = Vec::with_capacity(lines.len());
+    let mut offset = 0usize;
+    let mut work_items = 0usize;
+    for line in lines {
+        if cancellation_requested(cancel, &mut work_items) {
+            return None;
+        }
+        line_offsets.push(offset);
+        let Some(next_offset) = offset
+            .checked_add(utf16_width(line))
+            .and_then(|value| value.checked_add(1))
+        else {
+            return Some(HashSet::new());
+        };
+        offset = next_offset;
+    }
+
+    let mut keys = HashSet::new();
+    for region in regions {
+        if cancellation_requested(cancel, &mut work_items) {
+            return None;
+        }
+        if region.start_line == region.end_line {
+            continue;
+        }
+        let (Some(start), Some(end)) = (
+            line_offsets
+                .get(region.start_line)
+                .and_then(|offset| offset.checked_add(region.start_col)),
+            line_offsets
+                .get(region.end_line)
+                .and_then(|offset| offset.checked_add(region.end_col)),
+        ) else {
+            continue;
+        };
+        let Some(length) = end.checked_sub(start) else {
+            continue;
+        };
+        keys.insert((region.start_line, region.start_col, length));
+    }
+    Some(keys)
 }
 
 /// Split multiline tokens into per-line fragments, skipping empty multiline fragments.
@@ -717,16 +774,35 @@ pub(super) fn finalize_tokens_cancellable(
         return None;
     }
 
+    // Preserve the exact-match exception across normalization. Once a multiline
+    // host token is split into per-line fragments, none of those fragments can
+    // equal the original multiline injection region, so Stage 1 would mistake
+    // them for fully-contained host leakage. Partial overlaps (notably Markdown
+    // fenced-code containers) remain in `filterable_tokens` and are still
+    // removed inside the region.
+    let multiline_exact_matches =
+        multiline_exact_match_keys(active_injection_regions, lines, cancel)?;
+    let (exact_match_tokens, filterable_tokens): (Vec<_>, Vec<_>) =
+        all_tokens.into_iter().partition(|token| {
+            token.depth == 0
+                && multiline_exact_matches.contains(&(token.line, token.column, token.length))
+        });
+
     // Split multiline tokens into per-line tokens before the sweep line,
     // which treats [column, column+length) as a 1D interval on a single line.
-    let mut all_tokens = split_multiline_tokens_cancellable(all_tokens, lines, cancel)?;
+    let mut all_tokens = split_multiline_tokens_cancellable(filterable_tokens, lines, cancel)?;
 
     // Filter out zero-length tokens before the sweep line overlap resolution.
     // Unknown captures are already filtered at collection time (CaptureResult::Suppressed → continue).
     all_tokens.retain(|token| token.length > 0);
 
-    let all_tokens =
+    let mut all_tokens =
         filter_by_injection_regions(all_tokens, active_injection_regions, lines, cancel)?;
+    all_tokens.extend(split_multiline_tokens_cancellable(
+        exact_match_tokens,
+        lines,
+        cancel,
+    )?);
 
     let all_tokens = apply_none_preprocessing(all_tokens, cancel)?;
 
@@ -2066,6 +2142,56 @@ mod tests {
                 (4, 5, comment_type),  // comment [19, 24)  delta=19-15=4
             ],
             "Host comment should be split around injection number by sweep-line"
+        );
+    }
+
+    #[test]
+    fn finalize_preserves_multiline_host_token_exactly_matching_active_injection_region() {
+        let lines: Vec<&str> = vec!["/**", " * ERROR text", " */"];
+        let tokens = vec![
+            // Multiline lengths include one UTF-16 unit for each newline.
+            make_token(0, 0, 21, "comment.documentation", 0, 0),
+            make_token(1, 3, 5, "keyword", 1, 0),
+        ];
+        let regions = vec![ActiveInjectionBounds {
+            start_line: 0,
+            start_col: 0,
+            end_line: 2,
+            end_col: 3,
+        }];
+
+        let SemanticTokensResult::Tokens(st) =
+            finalize_tokens(tokens, &regions, &lines).expect("should produce tokens")
+        else {
+            panic!("Expected Tokens");
+        };
+        let (comment_type, comment_modifiers) =
+            map_capture_to_token_type_and_modifiers("comment.documentation").unwrap();
+        let (keyword_type, keyword_modifiers) =
+            map_capture_to_token_type_and_modifiers("keyword").unwrap();
+
+        let positions: Vec<(u32, u32, u32, u32, u32)> = st
+            .data
+            .iter()
+            .map(|t| {
+                (
+                    t.delta_line,
+                    t.delta_start,
+                    t.length,
+                    t.token_type,
+                    t.token_modifiers_bitset,
+                )
+            })
+            .collect();
+        assert_eq!(
+            positions,
+            vec![
+                (0, 0, 3, comment_type, comment_modifiers),
+                (1, 0, 3, comment_type, comment_modifiers),
+                (0, 3, 5, keyword_type, keyword_modifiers),
+                (0, 5, 5, comment_type, comment_modifiers),
+                (1, 0, 3, comment_type, comment_modifiers),
+            ],
         );
     }
 }

--- a/src/analysis/semantic/finalize.rs
+++ b/src/analysis/semantic/finalize.rs
@@ -113,18 +113,24 @@ fn multiline_region_key(
     Ok(Some((region.start_line, region.start_col, length)))
 }
 
+struct MultilineRegionMetadata {
+    exact_match_keys: HashSet<MultilineSpanKey>,
+    keys_by_region: Vec<Option<MultilineSpanKey>>,
+}
+
 /// Identify multiline host tokens whose original span exactly matches an active
 /// injection region before per-line normalization destroys that information.
-fn multiline_exact_match_keys(
+fn multiline_region_metadata(
     regions: &[ActiveInjectionBounds],
     lines: &[&str],
     cancel: Option<&crate::cancel::CancelToken>,
-) -> Option<HashSet<MultilineSpanKey>> {
+) -> Option<MultilineRegionMetadata> {
     if crate::cancel::is_cancelled(cancel) {
         return None;
     }
     let mut work_items = 0usize;
     let mut keys = HashSet::new();
+    let mut keys_by_region = Vec::with_capacity(regions.len());
     for region in regions {
         if cancellation_requested(cancel, &mut work_items) {
             return None;
@@ -132,12 +138,16 @@ fn multiline_exact_match_keys(
         match multiline_region_key(region, lines, cancel, &mut work_items) {
             Ok(Some(key)) => {
                 keys.insert(key);
+                keys_by_region.push(Some(key));
             }
-            Ok(None) => {}
+            Ok(None) => keys_by_region.push(None),
             Err(()) => return None,
         }
     }
-    Some(keys)
+    Some(MultilineRegionMetadata {
+        exact_match_keys: keys,
+        keys_by_region,
+    })
 }
 
 fn partition_multiline_exact_matches(
@@ -693,7 +703,27 @@ fn apply_none_preprocessing(
     Some(result)
 }
 
-/// Filter host tokens (depth=0) against active injection regions.
+/// Request-local region metadata shared by ordinary and exact-host filtering.
+struct InjectionRegionIndex {
+    regions_by_line: HashMap<usize, Vec<usize>>,
+    region_intervals: HashMap<usize, Vec<(usize, usize)>>,
+    multiline_keys: Vec<Option<MultilineSpanKey>>,
+}
+
+fn build_injection_region_index(
+    regions: &[ActiveInjectionBounds],
+    lines: &[&str],
+    multiline_keys: Vec<Option<MultilineSpanKey>>,
+    cancel: Option<&crate::cancel::CancelToken>,
+) -> Option<InjectionRegionIndex> {
+    Some(InjectionRegionIndex {
+        regions_by_line: build_regions_by_line(regions, cancel)?,
+        region_intervals: build_region_intervals_map(regions, lines, cancel)?,
+        multiline_keys,
+    })
+}
+
+/// Filter host tokens (depth=0) against pre-indexed active injection regions.
 ///
 /// - Depth > 0 tokens pass through unchanged.
 /// - Exact-match tokens are kept for sweep-line resolution (fish comment pattern).
@@ -705,26 +735,14 @@ fn apply_none_preprocessing(
 /// - Multiline partial overlaps are split; only fragments outside the region
 ///   are kept (e.g., in a blockquoted code fence the `> ` prefix survives,
 ///   the code content is removed).
-fn filter_by_injection_regions(
+fn filter_by_injection_regions_indexed(
     tokens: Vec<RawToken>,
     regions: &[ActiveInjectionBounds],
     lines: &[&str],
+    index: &InjectionRegionIndex,
+    exempt_multiline_key: Option<MultilineSpanKey>,
     cancel: Option<&crate::cancel::CancelToken>,
 ) -> Option<Vec<RawToken>> {
-    if crate::cancel::is_cancelled(cancel) {
-        return None;
-    }
-    if regions.is_empty() {
-        return Some(tokens);
-    }
-    // Index regions by every host line they span, so each host token only
-    // examines the regions on its own line. Without this index the three
-    // per-token region checks below each scan ALL regions, making the pass
-    // O(tokens × regions); when the region count grows with document size
-    // (e.g. one injection per comment/macro in Rust), that is quadratic on
-    // the hot path — the dominant cost found by profiling.
-    let regions_by_line = build_regions_by_line(regions, cancel)?;
-    let region_map = build_region_intervals_map(regions, lines, cancel)?;
     let mut filtered = Vec::with_capacity(tokens.len());
     let mut work_items = 0usize;
     for token in tokens {
@@ -735,20 +753,26 @@ fn filter_by_injection_regions(
             filtered.push(token);
             continue;
         }
-        let line_regions = regions_by_line
+        let line_regions = index
+            .regions_by_line
             .get(&token.line)
             .map(|v| v.as_slice())
             .unwrap_or(&[]);
+        let is_exempt = |region_index: usize| {
+            exempt_multiline_key.is_some_and(|key| {
+                index.multiline_keys.get(region_index).copied().flatten() == Some(key)
+            })
+        };
         if line_regions
             .iter()
-            .any(|&i| token_exact_matches_region(&token, &regions[i]))
+            .any(|&i| !is_exempt(i) && token_exact_matches_region(&token, &regions[i]))
         {
             filtered.push(token);
             continue;
         }
         if line_regions
             .iter()
-            .any(|&i| token_fully_in_region(&token, &regions[i]))
+            .any(|&i| !is_exempt(i) && token_fully_in_region(&token, &regions[i]))
         {
             continue;
         }
@@ -766,7 +790,8 @@ fn filter_by_injection_regions(
         let token_end = token.column + token.length;
         let overlaps_single_line_region = line_regions.iter().any(|&i| {
             let r = &regions[i];
-            r.start_line == r.end_line
+            !is_exempt(i)
+                && r.start_line == r.end_line
                 && r.start_line == token.line
                 && r.start_col < token_end
                 && r.end_col > token.column
@@ -774,10 +799,39 @@ fn filter_by_injection_regions(
         if overlaps_single_line_region {
             filtered.push(token);
         } else {
-            let intervals = region_map
-                .get(&token.line)
-                .map(|v| v.as_slice())
-                .unwrap_or(&[]);
+            let mut unexempted_intervals = Vec::new();
+            let intervals = if exempt_multiline_key.is_some() {
+                let line_width = lines.get(token.line).map(|line| utf16_width(line));
+                if let Some(line_width) = line_width {
+                    for &i in line_regions {
+                        if is_exempt(i) {
+                            continue;
+                        }
+                        let region = &regions[i];
+                        let start_col = if token.line == region.start_line {
+                            region.start_col
+                        } else {
+                            0
+                        };
+                        let end_col = if token.line == region.end_line {
+                            region.end_col
+                        } else {
+                            line_width
+                        };
+                        if start_col < end_col {
+                            unexempted_intervals.push((start_col, end_col));
+                        }
+                    }
+                    unexempted_intervals.sort_unstable();
+                }
+                unexempted_intervals.as_slice()
+            } else {
+                index
+                    .region_intervals
+                    .get(&token.line)
+                    .map(|v| v.as_slice())
+                    .unwrap_or(&[])
+            };
             filtered.extend(split_host_token_around_regions(&token, intervals));
         }
     }
@@ -837,6 +891,7 @@ fn filter_multiline_exact_match_tokens(
     tokens: Vec<RawToken>,
     active_injection_regions: &[ActiveInjectionBounds],
     lines: &[&str],
+    index: &InjectionRegionIndex,
     cancel: Option<&crate::cancel::CancelToken>,
 ) -> Option<Vec<RawToken>> {
     let mut filtered = Vec::new();
@@ -849,24 +904,13 @@ fn filter_multiline_exact_match_tokens(
         // The exact-match exception is region-local. Exclude only regions with
         // these original bounds, then apply normal Stage 1 filtering for any
         // other overlapping active region before restoring the fragments.
-        let mut other_regions = Vec::with_capacity(active_injection_regions.len());
-        for region in active_injection_regions {
-            if cancellation_requested(cancel, &mut work_items) {
-                return None;
-            }
-            let matches_token = match multiline_region_key(region, lines, cancel, &mut work_items) {
-                Ok(key) => key == Some(token_key),
-                Err(()) => return None,
-            };
-            if !matches_token {
-                other_regions.push(region.clone());
-            }
-        }
         let fragments = split_multiline_tokens_cancellable(vec![token], lines, cancel)?;
-        filtered.extend(filter_by_injection_regions(
+        filtered.extend(filter_by_injection_regions_indexed(
             fragments,
-            &other_regions,
+            active_injection_regions,
             lines,
+            index,
+            Some(token_key),
             cancel,
         )?);
     }
@@ -890,13 +934,18 @@ pub(super) fn finalize_tokens_cancellable(
     // fenced-code containers) remain in `filterable_tokens` and are still
     // removed inside the region. Preserved exact hosts are later filtered
     // against every *other* overlapping region; the exception is not global.
-    let multiline_exact_matches =
-        multiline_exact_match_keys(active_injection_regions, lines, cancel)?;
-    let (exact_match_tokens, filterable_tokens) = if multiline_exact_matches.is_empty() {
+    let multiline_regions = multiline_region_metadata(active_injection_regions, lines, cancel)?;
+    let (exact_match_tokens, filterable_tokens) = if multiline_regions.exact_match_keys.is_empty() {
         (Vec::new(), all_tokens)
     } else {
-        partition_multiline_exact_matches(all_tokens, &multiline_exact_matches, cancel)?
+        partition_multiline_exact_matches(all_tokens, &multiline_regions.exact_match_keys, cancel)?
     };
+    let region_index = build_injection_region_index(
+        active_injection_regions,
+        lines,
+        multiline_regions.keys_by_region,
+        cancel,
+    )?;
 
     // Split multiline tokens into per-line tokens before the sweep line,
     // which treats [column, column+length) as a 1D interval on a single line.
@@ -906,12 +955,19 @@ pub(super) fn finalize_tokens_cancellable(
     // Unknown captures are already filtered at collection time (CaptureResult::Suppressed → continue).
     all_tokens.retain(|token| token.length > 0);
 
-    let mut all_tokens =
-        filter_by_injection_regions(all_tokens, active_injection_regions, lines, cancel)?;
+    let mut all_tokens = filter_by_injection_regions_indexed(
+        all_tokens,
+        active_injection_regions,
+        lines,
+        &region_index,
+        None,
+        cancel,
+    )?;
     all_tokens.extend(filter_multiline_exact_match_tokens(
         exact_match_tokens,
         active_injection_regions,
         lines,
+        &region_index,
         cancel,
     )?);
 
@@ -1125,9 +1181,12 @@ mod tests {
             end_col: 1,
         }];
 
-        let keys = multiline_exact_match_keys(&regions, &lines, Some(&cancel));
+        let metadata = multiline_region_metadata(&regions, &lines, Some(&cancel));
 
-        assert_eq!(keys, Some(HashSet::from([(0, 0, 3)])));
+        assert_eq!(
+            metadata.map(|metadata| metadata.exact_match_keys),
+            Some(HashSet::from([(0, 0, 3)]))
+        );
         assert!(
             !cancel.is_cancelled(),
             "unrelated lines after the region must not be visited"
@@ -1149,7 +1208,7 @@ mod tests {
             .collect();
 
         assert!(
-            multiline_exact_match_keys(&regions, &lines, Some(&cancel)).is_none(),
+            multiline_region_metadata(&regions, &lines, Some(&cancel)).is_none(),
             "the all-single-line region pass must remain cancellable"
         );
         assert!(cancel.is_cancelled());

--- a/src/analysis/semantic/token_collector.rs
+++ b/src/analysis/semantic/token_collector.rs
@@ -412,7 +412,10 @@ pub(super) fn collect_host_tokens(
             // Node byte length for specificity: smaller nodes win in sweep line
             let node_byte_len = node.end_byte() - node.start_byte();
 
-            // Check if this is a single-line token or trailing newline case
+            // A trailing-newline capture is only normalized early when raw
+            // multiline identity is not requested. Top-level host collection
+            // keeps that endpoint so finalize can recognize an exact injection
+            // span before converting it back to single-line LSP tokens.
             let is_single_line = start_pos.row == end_pos.row;
             let is_trailing_newline = end_pos.row == start_pos.row + 1 && end_pos.column == 0;
 
@@ -433,7 +436,7 @@ pub(super) fn collect_host_tokens(
                 continue;
             }
 
-            if is_single_line || is_trailing_newline {
+            if is_single_line || (is_trailing_newline && !supports_multiline) {
                 // Single-line token: emit as before
                 let host_line = content_start_line + start_pos.row;
                 let host_line_text = host_lines.get(host_line).unwrap_or(&"");


### PR DESCRIPTION
## Summary

- preserve top-level multiline host capture identity until injection exact-match classification
- keep exact host semantics available for gaps around injected tokens without changing Markdown container exclusion
- scope exact-match exemptions to the matching region while filtering other overlapping regions normally
- precompute and reuse region keys and line indexes across ordinary and exact-host filtering
- make the new classification cancellation-aware and avoid allocations/scans on common nonmatching paths
- handle virtual EOF and one-line-plus-trailing-newline endpoints
- update the overlap-resolution ADR to document the actual ordering and capability behavior

## Root cause

Host tokens were normalized to per-line fragments before Stage 1 injection exclusion. For a multiline TypeScript JSDoc capture whose source span exactly matched the active comment injection, normalization destroyed the exact-span identity. Every fragment then looked fully contained and was removed, so comments appeared to have no semantic token.

The client capability path made this worse: with `multilineTokenSupport=false`, top-level host collection split the capture even earlier.

## Impact

JSDoc and other prefix-free multiline host captures that exactly match active injection regions retain their host highlighting in portions not covered by injected tokens. Partially overlapping multiline containers such as Markdown fenced code blocks continue to suppress host leakage. If active regions overlap, the exception applies only to the matching region.

## Validation

- `cargo test -q analysis::semantic::finalize::tests:: -- --nocapture` (69 passed)
- `cargo test -q top_level_ -- --nocapture` (9 passed)
- `cargo test --features e2e --test e2e -- --exact e2e_semantic_blockquote::test_blockquote_injection_tokens --nocapture`
- related Markdown heading leak E2E snapshots
- `make check`
- multi-perspective review and two-stage Codex review converged with no actionable findings
- PR review rounds: CodeRabbit finding confirmed addressed, Qodo Bugs 0, Greptile 5/5, Codex no issues
- GitHub Actions: Check, Test, Format, Clippy, and Audit passed
- rebased onto latest `origin/main`; range-diff preserved all patches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved semantic highlighting for multiline regions with exact and partial overlaps.
  - Prevented injected tokens from leaking into unrelated highlighted regions.
  - Preserved correct token boundaries for multiline content and trailing newline cases.
  - Improved handling of injected tokens across lines, including when client multiline support varies.

- **Documentation**
  - Clarified the rules used to resolve overlapping semantic-token regions.
  - Updated regression coverage documentation for relevant multiline and overlap scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->