### PR TITLE
feat(config): scope capture mappings to semantic tokens

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -413,11 +413,10 @@ the layer below decided". Removing a key never removes a value: to override
 one, write the value you want (see the `workspace/didChangeConfiguration`
 notes above).
 
-An *entry* is not a container:
-`[features."textDocument/semanticTokens".captureMappings.rust]` or
-`[languageServers.foo]` with no keys under it sets no field, so it inherits
-rather than clears. Clear a field, not the table —
-`features."textDocument/semanticTokens".captureMappings.rust = {}`.
+A semantic-token language entry is itself a map, so an empty
+`[features."textDocument/semanticTokens".captureMappings.rust]` table clears
+Rust's inherited mappings; omit the `rust` entry to inherit them. By contrast,
+`[languageServers.foo]` with no fields sets no field and therefore inherits.
 
 Two settings stand outside this: the top-level `languages` map still ignores
 `{}` (it has no clear spelling yet), and semantic-token `captureMappings` is

--- a/docs/README.md
+++ b/docs/README.md
@@ -415,8 +415,10 @@ notes above).
 
 A semantic-token language entry is itself a map, so an empty
 `[features."textDocument/semanticTokens".captureMappings.rust]` table clears
-Rust's inherited mappings; omit the `rust` entry to inherit them. By contrast,
-`[languageServers.foo]` with no fields sets no field and therefore inherits.
+the Rust-specific entry inherited from lower configuration layers; omit the
+`rust` entry to inherit it. The `_` wildcard mappings still apply afterward,
+so this is not a per-language opt-out. By contrast, `[languageServers.foo]`
+with no fields sets no field and therefore inherits.
 
 Two settings stand outside this: the top-level `languages` map still ignores
 `{}` (it has no clear spelling yet), and semantic-token `captureMappings` is

--- a/docs/README.md
+++ b/docs/README.md
@@ -464,7 +464,9 @@ Remap Tree-sitter capture names to LSP semantic token types. Use `_` as a wildca
 The former top-level `captureMappings.<language>.highlights` shape remains
 accepted for migration, but is deprecated. If both spellings occur in one
 layer, the feature-scoped value wins for duplicate capture names; otherwise
-their entries are combined. The old `folds` table was unused and has no
+their entries are combined. A legacy empty root or language map in that layer
+first clears the corresponding inherited mappings, then canonical entries in
+the same layer are added. The old `folds` table was unused and has no
 replacement. It is absent from the schema and has no effect. Like another
 unrecognized key, it is ignored where the configuration source tolerates
 unknown keys and causes a pushed runtime update to be rejected by that

--- a/docs/README.md
+++ b/docs/README.md
@@ -836,11 +836,11 @@ When `--config-file` is specified:
 - A key kakehashi does not recognise is **reported but not fatal**, so a file
   can carry a key a newer version understands without the older one refusing to
   start. Serde would otherwise drop `autoInstal = false` silently and leave you
-  wondering why the default applied. Two caveats: keys inside `features` are an
-  exception — the parser rejects them outright, so an unknown one there *is*
-  fatal — and in `format`/`diagnose` the warning has nowhere to go, since CLI
-  mode surfaces only hard errors. (`workspace/didChangeConfiguration` is
-  stricter still and rejects the whole update — that one is a live edit, not a
+  wondering why the default applied. Nested `features` keys follow the same
+  warning policy, and recognized sibling settings remain effective. One
+  caveat: in `format`/`diagnose` the warning has nowhere to go, since CLI mode
+  surfaces only hard errors. (`workspace/didChangeConfiguration` is stricter
+  still and rejects the whole pushed update — that one is a live edit, not a
   file you may share across versions.)
 - Cross-field invariants (e.g. `debounceMs` ≤ `maxWaitMs`) are judged on the
   merged explicit configuration, so splitting the two halves across two files is

--- a/docs/README.md
+++ b/docs/README.md
@@ -465,7 +465,11 @@ The former top-level `captureMappings.<language>.highlights` shape remains
 accepted for migration, but is deprecated. If both spellings occur in one
 layer, the feature-scoped value wins for duplicate capture names; otherwise
 their entries are combined. The old `folds` table was unused and has no
-replacement; it is no longer accepted.
+replacement. It is absent from the schema and has no effect. Like another
+unrecognized key, it is ignored where the configuration source tolerates
+unknown keys and causes a pushed runtime update to be rejected by that
+ingress's existing unknown-key policy; valid siblings such as `highlights` are
+not discarded merely because `folds` is present.
 
 ### Bridge Configuration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -465,7 +465,7 @@ The former top-level `captureMappings.<language>.highlights` shape remains
 accepted for migration, but is deprecated. If both spellings occur in one
 layer, the feature-scoped value wins for duplicate capture names; otherwise
 their entries are combined. The old `folds` table was unused and has no
-replacement.
+replacement; it is no longer accepted.
 
 ### Bridge Configuration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -184,10 +184,12 @@ default `info` forwards Error, Warning, and Info while suppressing LSP `Log` and
       }
     }
   },
-  "captureMappings": {
-    "_": {
-      "highlights": {
-        "variable.builtin": "variable.defaultLibrary"
+  "features": {
+    "textDocument/semanticTokens": {
+      "captureMappings": {
+        "_": {
+          "variable.builtin": "variable.defaultLibrary"
+        }
       }
     }
   }
@@ -405,18 +407,21 @@ it comes from:
 | list | inherit the layer below | **clear** it | replace wholesale |
 
 So `queries = []`, `bridge = {}`, `languageServers = {}`, `cmd = []`, and
-`captureMappings = {}` all mean "none", while leaving the key out means "I have
-nothing to say about this — keep what the layer below decided". Removing a key
-never removes a value: to override one, write the value you want (see the
-`workspace/didChangeConfiguration` notes above).
+`features.textDocument/semanticTokens.captureMappings = {}` all mean "none",
+while leaving the key out means "I have nothing to say about this — keep what
+the layer below decided". Removing a key never removes a value: to override
+one, write the value you want (see the `workspace/didChangeConfiguration`
+notes above).
 
-An *entry* is not a container: `[captureMappings.rust]` or `[languageServers.foo]`
-with no keys under it sets no field, so it inherits rather than clears. Clear a
-field, not the table — `[captureMappings.rust] highlights = {}`.
+An *entry* is not a container:
+`[features."textDocument/semanticTokens".captureMappings.rust]` or
+`[languageServers.foo]` with no keys under it sets no field, so it inherits
+rather than clears. Clear a field, not the table —
+`features."textDocument/semanticTokens".captureMappings.rust = {}`.
 
 Two settings stand outside this: the top-level `languages` map still ignores
-`{}` (it has no clear spelling yet), and `captureMappings` is additive per
-capture name rather than per language — see below.
+`{}` (it has no clear spelling yet), and semantic-token `captureMappings` is
+additive per capture name rather than per language — see below.
 
 For `rmd`, kakehashi will try `rmd`-specific parser/query settings first and fall back through `markdown` and then `_`. Fields set on the derived language override inherited fields. Omitted fields inherit from the base chain; `queries: []` and `bridge: {}` explicitly clear inherited query and bridge settings.
 
@@ -433,27 +438,33 @@ Set `base` to the same language name to make a self-contained language that does
 }
 ```
 
-#### `captureMappings`
+#### `features.textDocument/semanticTokens.captureMappings`
 
 Remap Tree-sitter capture names to LSP semantic token types. Use `_` as a wildcard for all languages.
 
 ```json
 {
-  "captureMappings": {
-    "_": {
-      "highlights": {
-        "variable.builtin": "variable.defaultLibrary",
-        "function.builtin": "function.defaultLibrary"
-      }
-    },
-    "python": {
-      "highlights": {
-        "type.builtin": "type.defaultLibrary"
+  "features": {
+    "textDocument/semanticTokens": {
+      "captureMappings": {
+        "_": {
+          "variable.builtin": "variable.defaultLibrary",
+          "function.builtin": "function.defaultLibrary"
+        },
+        "python": {
+          "type.builtin": "type.defaultLibrary"
+        }
       }
     }
   }
 }
 ```
+
+The former top-level `captureMappings.<language>.highlights` shape remains
+accepted for migration, but is deprecated. If both spellings occur in one
+layer, the feature-scoped value wins for duplicate capture names; otherwise
+their entries are combined. The old `folds` table was unused and has no
+replacement.
 
 ### Bridge Configuration
 
@@ -761,7 +772,7 @@ The `bridge` map in language configuration controls which injection languages ar
 kakehashi loads configuration from `~/.config/kakehashi/kakehashi.toml` (user config) and `./kakehashi.toml` (project config). Both use the same TOML format:
 
 ```toml
-[captureMappings._.highlights]
+[features."textDocument/semanticTokens".captureMappings._]
 "variable.builtin" = "variable.defaultLibrary"
 
 [languages.custom_lang]

--- a/docs/README.md
+++ b/docs/README.md
@@ -464,9 +464,11 @@ Remap Tree-sitter capture names to LSP semantic token types. Use `_` as a wildca
 The former top-level `captureMappings.<language>.highlights` shape remains
 accepted for migration, but is deprecated. If both spellings occur in one
 layer, the feature-scoped value wins for duplicate capture names; otherwise
-their entries are combined. A legacy empty root or language map in that layer
-first clears the corresponding inherited mappings, then canonical entries in
-the same layer are added. The old `folds` table was unused and has no
+their entries are combined. In the legacy spelling, `captureMappings = {}`
+clears the inherited root and `highlights = {}` under a
+`[captureMappings.<language>]` table clears that language's inherited entry.
+The clear is applied before canonical entries in the same layer are added. The
+old `folds` table was unused and has no
 replacement. It is absent from the schema and has no effect. Like another
 unrecognized key, it is ignored where the configuration source tolerates
 unknown keys and causes a pushed runtime update to be rejected by that

--- a/docs/architecture-decisions/captures-protocol.md
+++ b/docs/architecture-decisions/captures-protocol.md
@@ -3,6 +3,7 @@
 **Related Decisions**:
 - [node-reference-protocol](node-reference-protocol.md) — Node identity, `NodeInfo`, and the `kakehashi/node/*` accessor family the capture results compose with
 - [lazy-node-identity-tracking](lazy-node-identity-tracking.md) — ULID identity tracking reused to make captured nodes addressable across edits
+- [semantic-token-capture-mapping-config](semantic-token-capture-mapping-config.md) — capture-to-token remapping is scoped to semantic tokens and does not transform this protocol
 
 ## Context and Problem Statement
 
@@ -21,6 +22,10 @@ A first iteration shipped `kakehashi/query`: a one-shot method taking a **client
 * **Match correlation preserved**: `@context` and `@context.end` within one pattern must stay grouped; a flat capture stream loses which `.end` bounds which `@context`.
 * **Reuse proven mechanics**: the semanticTokens `full`/`delta`/`range` interaction model, the existing tolerant query compilation (`; inherits:`, per-pattern skip), predicate evaluation, ULID minting, and the prefix/suffix single-edit delta algorithm.
 * **Minimal API surface**: one protocol for query execution; `kakehashi/query` is replaced, not kept alongside.
+* **Raw capture identity**: capture names on this protocol are the query's names
+  after removing `@`; semantic-token `captureMappings` never renames or filters
+  them. Consumers can therefore address query-defined captures without a
+  presentation setting changing their protocol identity.
 
 ## Decision Outcome
 

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -13,7 +13,7 @@ The limitations of the current system are:
 
 - Missing **User-wide defaults**
 - **Project-specific settings** are only based on `./kakehashi.toml`
-- Complex `captureMappings` overrides must be duplicated in each project's `kakehashi.toml`
+- Complex semantic-token `captureMappings` overrides must be duplicated in each project's `kakehashi.toml`
 
 The standard pattern in many language servers and CLI tools is layered configuration with clear precedence rules. This decision proposes adding a **user configuration layer** between programmed defaults and project config.
 
@@ -66,7 +66,7 @@ queries = [
 2. **User configuration file**
    - Location: `$XDG_CONFIG_HOME/kakehashi/kakehashi.toml`
    - Falls back to `~/.config/kakehashi/kakehashi.toml` on most Unix systems
-   - Purpose: User-wide defaults (e.g., default `searchPaths`, global `captureMappings` overrides)
+   - Purpose: User-wide defaults (e.g., default `searchPaths`, global semantic-token `captureMappings` overrides)
 
 3. **Project configuration file**
    - Location: `./kakehashi.toml` in workspace root (loaded via `load_toml_settings()`)
@@ -251,22 +251,22 @@ silently shadow every user-supplied top-level opt-out.
   initializationOptions = { linkedProjects = ["./Cargo.toml"] }  # added by project
   ```
 
-**Capture mappings** (`captureMappings`):
-- **Deep merge**: Individual capture mappings are merged per-language, per-query-type
+**Capture mappings** (`features."textDocument/semanticTokens".captureMappings`):
+- **Deep merge**: Individual capture mappings are merged per-language and capture name
 - Later sources override specific keys while preserving unmentioned keys from earlier sources
 - Example:
   ```toml
   # user config
-  [captureMappings._.highlights]
+  [features."textDocument/semanticTokens".captureMappings._]
   "variable.builtin" = "fallback.variable"
   "function.builtin" = "fallback.function"
 
   # project config
-  [captureMappings._.highlights]
+  [features."textDocument/semanticTokens".captureMappings._]
   "variable.builtin" = "project.variable"
 
   # final (deep merge)
-  [captureMappings._.highlights]
+  [features."textDocument/semanticTokens".captureMappings._]
   "variable.builtin" = "project.variable"  # overridden
   "function.builtin" = "fallback.function" # inherited
   ```
@@ -419,7 +419,7 @@ fn load_settings(root, override_settings, home, env_fn, explicit) -> SettingsLoa
 - [x] Implement `merge_workspace_settings()` function for layered config merging
 - [x] Deep merge for `languages` HashMap
 - [x] Deep merge for `languageServers` HashMap
-- [x] Deep merge for `captureMappings`
+- [x] Deep merge for semantic-token `captureMappings`
 
 ### Phase 3: User Configuration File (Completed - Sprint 120, PBI-149)
 - [x] XDG Base Directory compliance for config path
@@ -444,7 +444,7 @@ fn load_settings(root, override_settings, home, env_fn, explicit) -> SettingsLoa
 - Pro: Simple to implement and understand
 - Con: Users must repeat all fields when overriding a single field (e.g., must specify `parser` again just to change `queries`)
 - Con: Less intuitive — users expect inheritance
-- Decision: **Change to deep merge** for `languages` to match `captureMappings` behavior; arrays within language config (e.g., `queries`) are replaced, not merged
+- Decision: **Change to deep merge** for `languages` to match semantic-token `captureMappings` behavior; arrays within language config (e.g., `queries`) are replaced, not merged
 
 ### 2. Prepend arrays instead of replace
 - Pro: Allow extending `searchPaths` from earlier layers

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -122,9 +122,10 @@ Bases per layer: a config file uses its own directory (each `--config-file`
 layer its own), `initializationOptions` and `didChangeConfiguration` use the
 workspace root, and the programmed defaults have no base. That root is not
 fixed at initialize: `workspace/didChangeWorkspaceFolders` re-selects it from
-the current folder list. Config-file layers keep their own anchoring, but client
-layers are retained in authored form and replayed against the newly selected
-root, including in an explicit `--config-file` session. Reusing an already
+the current folder list. Config-file layers keep their own anchoring, but
+accepted client layers are retained in authored form and replayed against the
+newly selected root, including in an explicit `--config-file` session. A client
+layer discarded by initialization fallback is not retained. Reusing an already
 anchored client layer would keep the old root because anchoring yields absolute
 paths and is idempotent — see #948.
 

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -122,9 +122,11 @@ Bases per layer: a config file uses its own directory (each `--config-file`
 layer its own), `initializationOptions` and `didChangeConfiguration` use the
 workspace root, and the programmed defaults have no base. That root is not
 fixed at initialize: `workspace/didChangeWorkspaceFolders` re-selects it from
-the current folder list. A layer anchored earlier keeps the root it was
-anchored to, because anchoring yields absolute paths and is idempotent — see
-#948.
+the current folder list. Config-file layers keep their own anchoring, but client
+layers are retained in authored form and replayed against the newly selected
+root, including in an explicit `--config-file` session. Reusing an already
+anchored client layer would keep the old root because anchoring yields absolute
+paths and is idempotent — see #948.
 
 Resolution is therefore two distinct steps, in this order:
 

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -321,13 +321,12 @@ path the user typed carries intent; a path kakehashi went looking for does not.
      "not specified"; but a key this version does not know may be one the next
      one does, and rejecting the file would version-lock it.
      `workspace/didChangeConfiguration` rejects the whole update instead —
-     a live edit is not a file shared across versions.
-   - Two known inconsistencies, both pre-existing and both worth closing
-     separately: `FeatureSettings` and its children carry
-     `deny_unknown_fields`, so an unknown key *inside* `features` fails typed
-     deserialization and is fatal before the warning walker ever sees it; and
-     CLI mode has no channel for non-fatal settings events at all, so
-     `format`/`diagnose` users never see these warnings.
+     a live edit is not a file shared across versions. Nested `features` keys
+     use this same walker and source-specific policy; a typo there does not
+     make an explicit file fatal or discard recognized sibling settings.
+   - One pre-existing inconsistency remains: CLI mode has no channel for
+     non-fatal settings events at all, so `format`/`diagnose` users never see
+     these warnings.
    - `initializationOptions`: never fatal, and judged last. A client-supplied
      override that fails to expand does not abort — but "non-fatal" only means
      the session starts: the *whole* merged configuration is discarded in

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -316,14 +316,18 @@ path the user typed carries intent; a path kakehashi went looking for does not.
    - Cross-field invariants (e.g. `debounceMs` ≤ `maxWaitMs`): on the merged
      explicit configuration only, because their operands merge independently —
      one file may legitimately supply just one half
-   - Unrecognised key names: reported as a warning on an explicit file, not
-     fatal. Serde drops an unknown field silently, so a typo otherwise reads as
-     "not specified"; but a key this version does not know may be one the next
-     one does, and rejecting the file would version-lock it.
+   - Unrecognised key names: reported as a warning on TOML configuration files,
+     both explicit `--config-file` layers and the discovered workspace
+     `kakehashi.toml`, but not fatal. Serde drops an unknown field silently, so
+     a typo otherwise reads as "not specified"; but a key this version does not
+     know may be one the next one does, and rejecting the file would
+     version-lock it.
      `workspace/didChangeConfiguration` rejects the whole update instead —
      a live edit is not a file shared across versions. Nested `features` keys
      use this same walker and source-specific policy; a typo there does not
-     make an explicit file fatal or discard recognized sibling settings.
+     make a TOML file fatal or discard recognized sibling settings.
+     Client-supplied `initializationOptions` remain tolerant and silent, as
+     before; they do not pass through the TOML warning channel.
    - One pre-existing inconsistency remains: CLI mode has no channel for
      non-fatal settings events at all, so `format`/`diagnose` users never see
      these warnings.

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -317,15 +317,19 @@ path the user typed carries intent; a path kakehashi went looking for does not.
      explicit configuration only, because their operands merge independently —
      one file may legitimately supply just one half
    - Unrecognised key names: reported as a warning on TOML configuration files,
-     both explicit `--config-file` layers and the discovered workspace
-     `kakehashi.toml`, but not fatal. Serde drops an unknown field silently, so
-     a typo otherwise reads as "not specified"; but a key this version does not
-     know may be one the next one does, and rejecting the file would
-     version-lock it.
-     `workspace/didChangeConfiguration` rejects the whole update instead —
-     a live edit is not a file shared across versions. Nested `features` keys
-     use this same walker and source-specific policy; a typo there does not
-     make a TOML file fatal or discard recognized sibling settings.
+     including the implicit user and workspace files and explicit
+     `--config-file` layers, but not fatal. Serde drops an unknown field
+     silently, so a typo otherwise reads as "not specified"; but a key this
+     version does not know may be one the next one does, and rejecting the file
+     would version-lock it.
+     A pushed `workspace/didChangeConfiguration` update rejects the whole layer
+     instead — a live edit is not a file shared across versions. When an empty
+     notification makes kakehashi pull `workspace/configuration`, unknown keys
+     are logged at info and ignored while recognized siblings apply: the editor
+     may return unrelated settings such as `trace.server` in that shared
+     section. Nested `features` keys use this same walker and source-specific
+     policy; a typo there does not make a TOML file fatal or discard recognized
+     sibling settings.
      Client-supplied `initializationOptions` remain tolerant and silent, as
      before; they do not pass through the TOML warning channel.
    - One pre-existing inconsistency remains: CLI mode has no channel for

--- a/docs/architecture-decisions/lexical-name-resolution.md
+++ b/docs/architecture-decisions/lexical-name-resolution.md
@@ -78,7 +78,7 @@ once the kind is gone — filename inference yields nothing for an unknown
 filename, so they degrade to silently skipped rather than erroring. The
 No capture-mapping counterpart appears for `bindings`, because its vocabulary
 is fixed by this spec rather than user-mapped. Capture remapping belongs only
-to `features.textDocument/semanticTokens` (see
+to `features."textDocument/semanticTokens".captureMappings` (see
 semantic-token-capture-mapping-config), so bindings resolution never consults
 it.
 

--- a/docs/architecture-decisions/lexical-name-resolution.md
+++ b/docs/architecture-decisions/lexical-name-resolution.md
@@ -76,10 +76,11 @@ surfaced as-is rather than aliased, per the delete-on-supersede posture —
 while stale `locals.scm` paths without an explicit kind stop being inferred
 once the kind is gone — filename inference yields nothing for an unknown
 filename, so they degrade to silently skipped rather than erroring. The
-`captureMappings.locals` table goes with the pipeline (it is equally
-consumerless — the semantic-token legend consults only `.highlights`); no
-`bindings` counterpart appears, because the bindings vocabulary is fixed by
-this spec, not user-mapped.
+No capture-mapping counterpart appears for `bindings`, because its vocabulary
+is fixed by this spec rather than user-mapped. Capture remapping belongs only
+to `features.textDocument/semanticTokens` (see
+semantic-token-capture-mapping-config), so bindings resolution never consults
+it.
 
 ### Capture vocabulary
 

--- a/docs/architecture-decisions/semantic-token-capture-mapping-config.md
+++ b/docs/architecture-decisions/semantic-token-capture-mapping-config.md
@@ -26,7 +26,12 @@ no intermediate `highlights` key.
 
 The former top-level `captureMappings.<language>.highlights` spelling remains
 accepted during migration and produces a deprecation warning at most once per
-session. The never-consumed `folds` field is removed without a replacement.
+session. The never-consumed `folds` field is removed from the schema without a
+replacement and has no effect. It follows the same source-specific unknown-key
+policy as any other unrecognized field: tolerant sources ignore it, while a
+pushed runtime update carrying it is rejected. Its presence does not turn an
+otherwise valid legacy layer into a parse error or discard sibling
+`highlights` entries.
 
 Configuration layering continues to follow configuration-merging-strategy:
 later layers override duplicate capture names while inheriting names they omit.
@@ -68,6 +73,8 @@ compatibility while making the new ownership visible.
 - The schema communicates that mappings affect semantic tokens only.
 - The unused query-kind level disappears from canonical configuration.
 - Raw capture protocols remain clearly independent of token presentation.
+- Removing `folds` does not introduce a stricter parser policy for the legacy
+  wrapper than sibling configuration uses.
 
 ### Negative
 

--- a/docs/architecture-decisions/semantic-token-capture-mapping-config.md
+++ b/docs/architecture-decisions/semantic-token-capture-mapping-config.md
@@ -26,7 +26,7 @@ no intermediate `highlights` key.
 
 The former top-level `captureMappings.<language>.highlights` spelling remains
 accepted during migration and produces a deprecation warning at most once per
-session. Its `folds` entries remain unused and have no replacement.
+session. The never-consumed `folds` field is removed without a replacement.
 
 Configuration layering continues to follow configuration-merging-strategy:
 later layers override duplicate capture names while inheriting names they omit.

--- a/docs/architecture-decisions/semantic-token-capture-mapping-config.md
+++ b/docs/architecture-decisions/semantic-token-capture-mapping-config.md
@@ -1,0 +1,77 @@
+# Semantic Token Capture Mapping Config
+
+**Related Decisions**:
+- [configuration-merging-strategy](configuration-merging-strategy.md)
+- [wildcard-config-inheritance](wildcard-config-inheritance.md)
+
+## Context
+
+The top-level `captureMappings.<language>.<query-kind>` schema suggests a
+general mapping facility shared by every Tree-sitter query consumer. In
+practice, only `highlights` mappings affect behavior: they translate
+Tree-sitter captures into LSP semantic token types. The sibling `folds` shape
+has no consumer, and raw-capture features such as `kakehashi/captures/full` do
+not consult these mappings.
+
+Keeping the setting at the workspace root therefore advertises a broader
+contract than kakehashi implements and makes it easy to assume that changing a
+mapping changes unrelated capture-based features.
+
+## Decision
+
+The canonical setting is
+`features.textDocument/semanticTokens.captureMappings.<language>`. Each
+language entry maps capture names directly to semantic token types; there is
+no intermediate `highlights` key.
+
+The former top-level `captureMappings.<language>.highlights` spelling remains
+accepted during migration and produces a deprecation warning at most once per
+session. Its `folds` entries remain unused and have no replacement.
+
+Configuration layering continues to follow configuration-merging-strategy:
+later layers override duplicate capture names while inheriting names they omit.
+Within one layer that contains both spellings, the canonical feature-scoped
+value wins duplicate names and retains names present only in the legacy shape.
+An explicitly empty root map clears every language mapping, and an explicitly
+empty language map clears that language's inherited captures.
+
+Wildcard resolution continues to follow wildcard-config-inheritance: `_`
+provides defaults for language-specific entries after cross-layer merging.
+
+## Considered Options
+
+### Keep the top-level schema and document its narrow use
+
+Rejected because the namespace would continue to imply that all capture
+consumers share the mapping, and the query-kind level would continue to expose
+an unused `folds` contract.
+
+### Place the map directly under `features.semanticTokens`
+
+Rejected because feature keys elsewhere mirror LSP method names. Using
+`textDocument/semanticTokens` makes ownership explicit and follows the existing
+feature configuration convention.
+
+### Remove the former spelling immediately
+
+Rejected because existing file configuration, initialization options, and
+runtime configuration can migrate without ambiguity. A warning preserves
+compatibility while making the new ownership visible.
+
+## Consequences
+
+### Positive
+
+- The schema communicates that mappings affect semantic tokens only.
+- The unused query-kind level disappears from canonical configuration.
+- Raw capture protocols remain clearly independent of token presentation.
+
+### Negative
+
+- Existing users must migrate a nested configuration shape.
+- Parsing and merging must temporarily support both spellings.
+
+### Neutral
+
+- Runtime semantic-token resolution still consumes the same effective mapping.
+- Wildcard and cross-layer precedence semantics do not change.

--- a/docs/architecture-decisions/semantic-token-capture-mapping-config.md
+++ b/docs/architecture-decisions/semantic-token-capture-mapping-config.md
@@ -37,15 +37,15 @@ Configuration layering continues to follow configuration-merging-strategy:
 later layers override duplicate capture names while inheriting names they omit.
 Within one layer that contains both spellings, the canonical feature-scoped
 value wins duplicate names and retains names present only in the legacy shape.
-Merge order is inherited mappings, then the legacy spelling (including an
-empty root or language clear), then the canonical spelling. Thus a legacy
-clear removes the corresponding inherited mappings before canonical entries
-from the same layer are added.
-An explicitly empty root map clears every language mapping, and an explicitly
-empty language map clears that language entry inherited from lower
-configuration layers. The `_` mappings still apply during the later wildcard
-resolution step, so an empty language entry does not opt that language out of
-wildcard mappings.
+Merge order is inherited mappings, then the legacy spelling (including a
+clear), then the canonical spelling. In the legacy spelling,
+`captureMappings = {}` clears every inherited language mapping, while
+`highlights = {}` under a `[captureMappings.<language>]` table clears that
+language's inherited entry. A bare legacy `[captureMappings.<language>]` table
+omits `highlights` and therefore does not clear it. The clear is applied before
+canonical entries from the same layer are added. The `_` mappings still apply
+during the later wildcard resolution step, so a language clear does not opt
+that language out of wildcard mappings.
 
 Wildcard resolution continues to follow wildcard-config-inheritance: `_`
 provides defaults for language-specific entries after cross-layer merging.

--- a/docs/architecture-decisions/semantic-token-capture-mapping-config.md
+++ b/docs/architecture-decisions/semantic-token-capture-mapping-config.md
@@ -37,6 +37,10 @@ Configuration layering continues to follow configuration-merging-strategy:
 later layers override duplicate capture names while inheriting names they omit.
 Within one layer that contains both spellings, the canonical feature-scoped
 value wins duplicate names and retains names present only in the legacy shape.
+Merge order is inherited mappings, then the legacy spelling (including an
+empty root or language clear), then the canonical spelling. Thus a legacy
+clear removes the corresponding inherited mappings before canonical entries
+from the same layer are added.
 An explicitly empty root map clears every language mapping, and an explicitly
 empty language map clears that language entry inherited from lower
 configuration layers. The `_` mappings still apply during the later wildcard

--- a/docs/architecture-decisions/semantic-token-capture-mapping-config.md
+++ b/docs/architecture-decisions/semantic-token-capture-mapping-config.md
@@ -33,7 +33,10 @@ later layers override duplicate capture names while inheriting names they omit.
 Within one layer that contains both spellings, the canonical feature-scoped
 value wins duplicate names and retains names present only in the legacy shape.
 An explicitly empty root map clears every language mapping, and an explicitly
-empty language map clears that language's inherited captures.
+empty language map clears that language entry inherited from lower
+configuration layers. The `_` mappings still apply during the later wildcard
+resolution step, so an empty language entry does not opt that language out of
+wildcard mappings.
 
 Wildcard resolution continues to follow wildcard-config-inheritance: `_`
 provides defaults for language-specific entries after cross-layer merging.

--- a/docs/architecture-decisions/wildcard-config-inheritance.md
+++ b/docs/architecture-decisions/wildcard-config-inheritance.md
@@ -4,9 +4,9 @@
 
 configuration-merging-strategy defines how configuration merges across layers (user → project → InitializationOptions). However, there's another dimension of merging: **within a single config**, the `_` (wildcard) key serves as defaults that should be inherited by specific entries.
 
-Currently in `captureMappings`:
-- `captureMappings._` defines default capture-to-token mappings for all languages
-- `captureMappings.rust` can define rust-specific overrides
+Currently in semantic-token `captureMappings`:
+- `features."textDocument/semanticTokens".captureMappings._` defines default capture-to-token mappings for all languages
+- `features."textDocument/semanticTokens".captureMappings.rust` can define rust-specific overrides
 
 The expected behavior is that `rust` inherits all mappings from `_` and only overrides what it explicitly specifies. This is similar to how CSS cascading works with wildcards.
 
@@ -42,14 +42,14 @@ Wildcard inheritance happens **after** cross-layer merging (configuration-mergin
 ```
 
 This means:
-- Layer merging produces a single `captureMappings` with both `_` and language-specific entries
+- Layer merging produces a single semantic-token `captureMappings` with both `_` and language-specific entries
 - At resolution time, `_` is applied as defaults for each language
 
 ### Affected HashMaps
 
 | HashMap | Wildcard Key | Use Case |
 |---------|--------------|----------|
-| `captureMappings` | `_` | Default capture-to-token mappings for all languages |
+| `features."textDocument/semanticTokens".captureMappings` | `_` | Default capture-to-token mappings for all languages |
 | `languages` | `_` | Default language settings (see nested wildcards below) |
 | `languages.{lang}.bridge` | `_` | Default bridge settings for all injection targets |
 | `languageServers` | `_` | Default server settings |
@@ -93,13 +93,13 @@ enabled = false
 ### Example: captureMappings
 
 ```toml
-[captureMappings._.highlights]
+[features."textDocument/semanticTokens".captureMappings._]
 "variable" = "variable"
 "variable.builtin" = "variable.defaultLibrary"
 "function" = "function"
 "function.builtin" = "function.defaultLibrary"
 
-[captureMappings.rust.highlights]
+[features."textDocument/semanticTokens".captureMappings.rust]
 "type.builtin" = "type.defaultLibrary"  # rust-specific addition
 
 # Effective config for rust:
@@ -113,10 +113,10 @@ enabled = false
 ### Example: Overriding a wildcard value
 
 ```toml
-[captureMappings._.highlights]
+[features."textDocument/semanticTokens".captureMappings._]
 "comment" = "comment"
 
-[captureMappings.lua.highlights]
+[features."textDocument/semanticTokens".captureMappings.lua]
 "comment" = ""  # suppress comments for lua specifically
 
 # Effective config for lua:

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -473,6 +473,11 @@ configured `searchPaths` — the same place highlight queries live, with the sam
 server configuration needed. (nvim-treesitter-context's own `context.scm` files
 work as-is once their directory is on a search path.)
 
+Capture names in these responses are the raw query capture names with `@`
+removed. `features.textDocument/semanticTokens.captureMappings` only controls
+semantic-token presentation; it never renames or filters
+`kakehashi/captures/*` results.
+
 The three methods mirror `textDocument/semanticTokens`, so live features can
 re-request cheaply on every cursor move or edit:
 

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -90,8 +90,9 @@ Highlights the whole document from Tree-sitter queries,
 **including embedded code blocks** — you get highlighting inside fenced code blocks
 even without a language server configured for that language. Delta updates and range
 requests are supported. Highlight colors are driven by the token types/modifiers
-kakehashi exposes; capture names can be remapped via `captureMappings`
-(see [the configuration guide](README.md#capturemappings)).
+kakehashi exposes; capture names can be remapped via
+`features.textDocument/semanticTokens.captureMappings`
+(see [the configuration guide](README.md#featurestextdocumentsemantictokenscapturemappings)).
 
 ### Selection range
 

--- a/src/analysis/semantic/legend.rs
+++ b/src/analysis/semantic/legend.rs
@@ -194,7 +194,6 @@ mod tests {
             WILDCARD_KEY.to_string(),
             QueryTypeMappings {
                 highlights: Some(wildcard_highlights),
-                folds: None,
             },
         );
 
@@ -209,7 +208,6 @@ mod tests {
             "rust".to_string(),
             QueryTypeMappings {
                 highlights: Some(rust_highlights),
-                folds: None,
             },
         );
 
@@ -248,7 +246,6 @@ mod tests {
             "rust".to_string(),
             QueryTypeMappings {
                 highlights: Some(highlights),
-                folds: None,
             },
         );
         assert_eq!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,7 +51,7 @@ fn base_convert(settings: &RawWorkspaceSettings) -> WorkspaceSettings {
     let legacy = settings
         .capture_mappings
         .clone()
-        .map(merge::legacy_capture_mappings_to_semantic);
+        .and_then(merge::legacy_capture_mappings_to_semantic);
     let canonical = settings
         .features
         .as_ref()

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,7 +65,6 @@ fn base_convert(settings: &RawWorkspaceSettings) -> WorkspaceSettings {
                 language,
                 settings::QueryTypeMappings {
                     highlights: Some(highlights),
-                    folds: None,
                 },
             )
         })
@@ -982,7 +981,6 @@ mod tests {
 
         let query_type_mappings = QueryTypeMappings {
             highlights: Some(highlights),
-            folds: None,
         };
 
         capture_mappings.insert(WILDCARD_KEY.to_string(), query_type_mappings);

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ pub(crate) use merge::{
     is_server_spawnable, merge_bridge_language_configs, merge_bridge_server_configs,
     merge_layer_aggregation_configs, merge_workspace_settings, resolve_with_wildcard,
 };
-pub(crate) use settings::{CaptureMapping, CaptureMappings, DEFAULT_DEBOUNCE_MS};
+pub(crate) use settings::{CaptureMappings, DEFAULT_DEBOUNCE_MS};
 // Raw and effective settings share this type, so converting between them no
 // longer names it; only the tests that build fixtures do.
 #[cfg(test)]
@@ -48,9 +48,28 @@ fn default_search_paths() -> Vec<String> {
 /// internally by `try_from_settings`.
 fn base_convert(settings: &RawWorkspaceSettings) -> WorkspaceSettings {
     let languages = settings.languages.clone();
-    // The raw and effective sides share `QueryTypeMappings`, so the layer's map
-    // carries over as-is; a raw layer that named none contributes nothing.
-    let capture_mappings = settings.capture_mappings.clone().unwrap_or_default();
+    let legacy = settings
+        .capture_mappings
+        .clone()
+        .map(merge::legacy_capture_mappings_to_semantic);
+    let canonical = settings
+        .features
+        .as_ref()
+        .and_then(|features| features.text_document_semantic_tokens.as_ref())
+        .and_then(|semantic_tokens| semantic_tokens.capture_mappings.clone());
+    let capture_mappings = merge::merge_semantic_token_capture_mappings(legacy, canonical)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(language, highlights)| {
+            (
+                language,
+                settings::QueryTypeMappings {
+                    highlights: Some(highlights),
+                    folds: None,
+                },
+            )
+        })
+        .collect();
 
     // Use explicit search_paths if provided, otherwise use platform defaults
     let search_paths = settings
@@ -448,17 +467,24 @@ impl WorkspaceSettings {
 impl From<&WorkspaceSettings> for RawWorkspaceSettings {
     fn from(settings: &WorkspaceSettings) -> Self {
         let languages = strip_inherited_languages(&settings.languages);
-        let capture_mappings = Some(settings.capture_mappings.clone());
+        let semantic_token_capture_mappings = settings
+            .capture_mappings
+            .iter()
+            .map(|(language, mappings)| (language.clone(), mappings.highlights().clone()))
+            .collect();
 
         let search_paths = Some(settings.search_paths.clone());
 
         RawWorkspaceSettings {
             search_paths,
             languages,
-            capture_mappings,
+            capture_mappings: None,
             auto_install: Some(settings.auto_install),
             diagnostics_debounce_ms: Some(settings.diagnostics_debounce_ms),
             features: Some(settings::FeatureSettings {
+                text_document_semantic_tokens: Some(settings::SemanticTokensFeatureSettings {
+                    capture_mappings: Some(semantic_token_capture_mappings),
+                }),
                 text_document_publish_diagnostics: Some(settings::DebounceFeatureSettings {
                     debounce_ms: Some(
                         settings
@@ -975,6 +1001,45 @@ mod tests {
     }
 
     #[test]
+    fn semantic_token_feature_capture_mappings_feed_token_resolution() {
+        let raw: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [features."textDocument/semanticTokens".captureMappings._]
+            "variable.builtin" = "variable.defaultLibrary"
+            "markup.strong" = ""
+
+            [features."textDocument/semanticTokens".captureMappings.rust]
+            "type.builtin" = "type.defaultLibrary"
+            "#,
+        )
+        .expect("the semantic-token feature schema should parse");
+
+        let settings = WorkspaceSettings::try_from_settings(&raw, None, |_| None)
+            .expect("the semantic-token feature settings should resolve");
+        assert_eq!(
+            settings.capture_mappings[WILDCARD_KEY]
+                .highlights()
+                .get("variable.builtin")
+                .map(String::as_str),
+            Some("variable.defaultLibrary")
+        );
+        assert_eq!(
+            settings.capture_mappings[WILDCARD_KEY]
+                .highlights()
+                .get("markup.strong")
+                .map(String::as_str),
+            Some("")
+        );
+        assert_eq!(
+            settings.capture_mappings["rust"]
+                .highlights()
+                .get("type.builtin")
+                .map(String::as_str),
+            Some("type.defaultLibrary")
+        );
+    }
+
+    #[test]
     fn test_default_search_paths_used_when_none_configured() {
         // When search_paths is None in RawWorkspaceSettings, WorkspaceSettings
         // should use the default data directory paths (not an empty vector)
@@ -1190,6 +1255,7 @@ mod tests {
         for max_wait_ms in [0, settings::MAX_FEATURE_TIMING_MS + 1] {
             let raw = RawWorkspaceSettings {
                 features: Some(settings::FeatureSettings {
+                    text_document_semantic_tokens: None,
                     text_document_publish_diagnostics: None,
                     window_log_message: None,
                     workspace_diagnostic_refresh: Some(settings::DebounceFeatureSettings {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1268,14 +1268,14 @@ mod tests {
     }
 
     #[test]
-    fn feature_policy_rejects_unknown_methods_and_fields() {
-        for invalid in [
+    fn feature_policy_deserialization_tolerates_unknown_methods_and_fields() {
+        for input in [
             r#"[features."workspace/diagnostic/refresh"]
                debouncMs = 100"#,
             r#"[features."workspace/diagnostics/refresh"]
                debounceMs = 100"#,
         ] {
-            assert!(toml::from_str::<RawWorkspaceSettings>(invalid).is_err());
+            assert!(toml::from_str::<RawWorkspaceSettings>(input).is_ok());
         }
     }
 

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -11,6 +11,7 @@ use super::settings::{
     DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_MAX_WAIT_MS, DebounceFeatureSettings, FeatureSettings,
     LanguageSettings, LayerAggregationConfig, LayerSource, LayersConfig, LogMessageFeatureSettings,
     LogMessageLevel, QueryTypeMappings, RawWorkspaceSettings, RootMarker,
+    SemanticTokenCaptureMappings, SemanticTokensFeatureSettings,
 };
 use std::collections::HashMap;
 
@@ -21,7 +22,7 @@ pub fn default_settings() -> RawWorkspaceSettings {
     RawWorkspaceSettings {
         search_paths: Some(vec!["${KAKEHASHI_DATA_DIR}".to_string()]),
         languages: default_languages(),
-        capture_mappings: Some(default_capture_mappings()),
+        capture_mappings: None,
         // Safe to carry here even though the key is deprecated: this struct is
         // also merge layer 1, and a user's own top-level value overlays THE
         // SAME key, so it wins. `languages._.autoInstall` is the one that must
@@ -31,6 +32,9 @@ pub fn default_settings() -> RawWorkspaceSettings {
         auto_install: Some(true),
         diagnostics_debounce_ms: Some(DEFAULT_DEBOUNCE_MS),
         features: Some(FeatureSettings {
+            text_document_semantic_tokens: Some(SemanticTokensFeatureSettings {
+                capture_mappings: Some(default_semantic_token_capture_mappings()),
+            }),
             text_document_publish_diagnostics: Some(DebounceFeatureSettings {
                 debounce_ms: Some(DEFAULT_PUBLISH_DIAGNOSTICS_DEBOUNCE_MS),
                 max_wait_ms: Some(DEFAULT_PUBLISH_DIAGNOSTICS_MAX_WAIT_MS),
@@ -241,6 +245,10 @@ pub fn default_capture_mappings() -> CaptureMappings {
 
     mappings.insert(WILDCARD_KEY.to_string(), wildcard);
     mappings
+}
+
+fn default_semantic_token_capture_mappings() -> SemanticTokenCaptureMappings {
+    SemanticTokenCaptureMappings::from([(WILDCARD_KEY.to_string(), default_highlight_mappings())])
 }
 
 /// Returns the default highlight capture mappings.
@@ -710,23 +718,19 @@ mod tests {
     #[test]
     fn default_settings_has_capture_mappings() {
         let settings = default_settings();
+        let mappings = settings
+            .features
+            .as_ref()
+            .and_then(|features| features.text_document_semantic_tokens.as_ref())
+            .and_then(|semantic_tokens| semantic_tokens.capture_mappings.as_ref())
+            .expect("semantic-token capture mappings");
 
         // Should have capture mappings populated
-        assert!(
-            settings
-                .capture_mappings
-                .as_ref()
-                .is_some_and(|m| !m.is_empty()),
-            "capture_mappings should not be empty"
-        );
+        assert!(!mappings.is_empty(), "capture_mappings should not be empty");
 
         // Should contain the wildcard "_" key
         assert!(
-            settings
-                .capture_mappings
-                .as_ref()
-                .unwrap()
-                .contains_key(WILDCARD_KEY),
+            mappings.contains_key(WILDCARD_KEY),
             "capture_mappings should contain wildcard '_' key"
         );
     }
@@ -755,7 +759,7 @@ mod tests {
 
         // Should contain captureMappings section
         assert!(
-            toml_string.contains("[captureMappings._.highlights]"),
+            toml_string.contains("[features.\"textDocument/semanticTokens\".captureMappings._]"),
             "TOML should contain captureMappings section. Got:\n{}",
             toml_string
         );

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -238,9 +238,6 @@ pub fn default_capture_mappings() -> CaptureMappings {
     let highlights = default_highlight_mappings();
     let wildcard = QueryTypeMappings {
         highlights: Some(highlights),
-        // Omitted rather than empty: the defaults layer names no folds, and an
-        // empty map would clear whatever a user layer supplies.
-        folds: None,
     };
 
     mappings.insert(WILDCARD_KEY.to_string(), wildcard);

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -70,8 +70,7 @@ pub(crate) const CAPTURE_MAPPINGS_DEPRECATION_NOTICE: &str = "kakehashi: the top
      `features.\"textDocument/semanticTokens\".captureMappings` in TOML (or \
      `features[\"textDocument/semanticTokens\"].captureMappings` in JSON) and remove the \
      intermediate `highlights` key. The top-level key still works for now but \
-     may be removed in a future release; its unused `folds` mappings have no \
-     replacement.";
+     may be removed in a future release.";
 
 /// Which deprecated keys the raw TOML text spells.
 ///

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -67,7 +67,8 @@ pub(crate) const AUTO_INSTALL_DEPRECATION_NOTICE: &str = "kakehashi: the top-lev
 /// User-facing text for the one-per-session top-level `captureMappings`
 /// notice. The dotted path is usable for both TOML and JSON configuration.
 pub(crate) const CAPTURE_MAPPINGS_DEPRECATION_NOTICE: &str = "kakehashi: the top-level `captureMappings` config key is deprecated; move highlight mappings to \
-     `features.textDocument/semanticTokens.captureMappings` and remove the \
+     `features.\"textDocument/semanticTokens\".captureMappings` in TOML (or \
+     `features[\"textDocument/semanticTokens\"].captureMappings` in JSON) and remove the \
      intermediate `highlights` key. The top-level key still works for now but \
      may be removed in a future release; its unused `folds` mappings have no \
      replacement.";
@@ -244,6 +245,18 @@ rootMarkers = [".git"]
             }
         });
         assert!(!json_deprecated_keys(&canonical).capture_mappings);
+    }
+
+    #[test]
+    fn capture_mapping_notice_gives_valid_toml_and_json_paths() {
+        assert!(
+            CAPTURE_MAPPINGS_DEPRECATION_NOTICE
+                .contains("features.\"textDocument/semanticTokens\".captureMappings")
+        );
+        assert!(
+            CAPTURE_MAPPINGS_DEPRECATION_NOTICE
+                .contains("features[\"textDocument/semanticTokens\"].captureMappings")
+        );
     }
 
     #[test]

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -29,12 +29,15 @@ pub(crate) struct DeprecatedKeysSeen {
     pub(crate) root_markers: bool,
     /// Top-level `autoInstall`, superseded by `[languages.*] autoInstall`.
     pub(crate) auto_install: bool,
+    /// Top-level `captureMappings`, superseded by the semantic-token feature.
+    pub(crate) capture_mappings: bool,
 }
 
 impl DeprecatedKeysSeen {
     pub(crate) fn merge(&mut self, other: Self) {
         self.root_markers |= other.root_markers;
         self.auto_install |= other.auto_install;
+        self.capture_mappings |= other.capture_mappings;
     }
 }
 
@@ -87,6 +90,9 @@ pub(crate) fn toml_deprecated_keys(contents: &str) -> DeprecatedKeysSeen {
         auto_install: value
             .as_table()
             .is_some_and(|table| table.contains_key("autoInstall")),
+        capture_mappings: value
+            .as_table()
+            .is_some_and(|table| table.contains_key("captureMappings")),
     }
 }
 
@@ -107,6 +113,7 @@ pub(crate) fn json_deprecated_keys(value: &JsonValue) -> DeprecatedKeysSeen {
         auto_install: value
             .as_object()
             .is_some_and(|object| object.contains_key("autoInstall")),
+        capture_mappings: false,
     }
 }
 
@@ -123,18 +130,25 @@ mod tests {
         let mut seen = DeprecatedKeysSeen {
             root_markers: true,
             auto_install: true,
+            capture_mappings: true,
         };
         seen.merge(DeprecatedKeysSeen::default());
         assert!(seen.root_markers, "a later clean layer must not clear this");
         assert!(seen.auto_install, "a later clean layer must not clear this");
+        assert!(
+            seen.capture_mappings,
+            "a later clean layer must not clear this"
+        );
 
         // And it must still pick flags UP from a later layer.
         let mut none = DeprecatedKeysSeen::default();
         none.merge(DeprecatedKeysSeen {
             root_markers: false,
             auto_install: true,
+            capture_mappings: true,
         });
         assert!(none.auto_install);
+        assert!(none.capture_mappings);
         assert!(!none.root_markers);
     }
 
@@ -142,6 +156,25 @@ mod tests {
     fn toml_detects_the_deprecated_top_level_auto_install() {
         assert!(toml_deprecated_keys("autoInstall = true").auto_install);
         assert!(toml_deprecated_keys("autoInstall = false").auto_install);
+    }
+
+    #[test]
+    fn toml_distinguishes_deprecated_and_canonical_capture_mappings() {
+        let deprecated = toml_deprecated_keys(
+            r#"
+            [captureMappings._.highlights]
+            variable = "variable"
+            "#,
+        );
+        assert!(deprecated.capture_mappings);
+
+        let canonical = toml_deprecated_keys(
+            r#"
+            [features."textDocument/semanticTokens".captureMappings._]
+            variable = "variable"
+            "#,
+        );
+        assert!(!canonical.capture_mappings);
     }
 
     #[test]

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -64,6 +64,14 @@ pub(crate) const AUTO_INSTALL_DEPRECATION_NOTICE: &str = "kakehashi: the top-lev
      `base` inherits nothing from `_`, so give those an explicit value. The \
      top-level key still works for now but may be removed in a future release.";
 
+/// User-facing text for the one-per-session top-level `captureMappings`
+/// notice. The dotted path is usable for both TOML and JSON configuration.
+pub(crate) const CAPTURE_MAPPINGS_DEPRECATION_NOTICE: &str = "kakehashi: the top-level `captureMappings` config key is deprecated; move highlight mappings to \
+     `features.textDocument/semanticTokens.captureMappings` and remove the \
+     intermediate `highlights` key. The top-level key still works for now but \
+     may be removed in a future release; its unused `folds` mappings have no \
+     replacement.";
+
 /// Which deprecated keys the raw TOML text spells.
 ///
 /// Returns all-false for unparseable input: this is a best-effort migration

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -113,7 +113,9 @@ pub(crate) fn json_deprecated_keys(value: &JsonValue) -> DeprecatedKeysSeen {
         auto_install: value
             .as_object()
             .is_some_and(|object| object.contains_key("autoInstall")),
-        capture_mappings: false,
+        capture_mappings: value
+            .as_object()
+            .is_some_and(|object| object.contains_key("captureMappings")),
     }
 }
 
@@ -217,6 +219,23 @@ rootMarkers = [".git"]
             "languages": { "_": { "autoInstall": true } }
         });
         assert!(!json_deprecated_keys(&canonical).auto_install);
+    }
+
+    #[test]
+    fn json_distinguishes_deprecated_and_canonical_capture_mappings() {
+        let deprecated = serde_json::json!({
+            "captureMappings": { "_": { "highlights": { "variable": "variable" } } }
+        });
+        assert!(json_deprecated_keys(&deprecated).capture_mappings);
+
+        let canonical = serde_json::json!({
+            "features": {
+                "textDocument/semanticTokens": {
+                    "captureMappings": { "_": { "variable": "variable" } }
+                }
+            }
+        });
+        assert!(!json_deprecated_keys(&canonical).capture_mappings);
     }
 
     #[test]

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -422,10 +422,26 @@ pub(crate) fn merge_workspace_settings(
     base: Option<RawWorkspaceSettings>,
     overlay: Option<RawWorkspaceSettings>,
 ) -> Option<RawWorkspaceSettings> {
-    let base = base.map(normalize_deprecated_capture_mappings);
-    let overlay = overlay.map(normalize_deprecated_capture_mappings);
     match (base, overlay) {
-        (Some(base), Some(overlay)) => {
+        (Some(base), Some(mut overlay)) => {
+            let mut base = normalize_deprecated_capture_mappings(base);
+            let base_capture_mappings = take_semantic_token_capture_mappings(&mut base.features);
+            let legacy_capture_mappings = overlay
+                .capture_mappings
+                .take()
+                .and_then(legacy_capture_mappings_to_semantic);
+            let canonical_capture_mappings =
+                take_semantic_token_capture_mappings(&mut overlay.features);
+            let capture_mappings = merge_semantic_token_capture_mappings(
+                merge_semantic_token_capture_mappings(
+                    base_capture_mappings,
+                    legacy_capture_mappings,
+                ),
+                canonical_capture_mappings,
+            );
+            let mut features = merge_features(base.features, overlay.features);
+            set_semantic_token_capture_mappings(&mut features, capture_mappings);
+
             let merged = RawWorkspaceSettings {
                 search_paths: overlay.search_paths.or(base.search_paths),
                 languages: merge_languages(base.languages, overlay.languages),
@@ -434,7 +450,7 @@ pub(crate) fn merge_workspace_settings(
                 diagnostics_debounce_ms: overlay
                     .diagnostics_debounce_ms
                     .or(base.diagnostics_debounce_ms),
-                features: merge_features(base.features, overlay.features),
+                features,
                 language_servers: merge_language_servers(
                     base.language_servers,
                     overlay.language_servers,
@@ -442,8 +458,33 @@ pub(crate) fn merge_workspace_settings(
             };
             Some(merged)
         }
-        (base, overlay) => base.or(overlay),
+        (base, overlay) => base.or(overlay).map(normalize_deprecated_capture_mappings),
     }
+}
+
+fn take_semantic_token_capture_mappings(
+    features: &mut Option<FeatureSettings>,
+) -> Option<SemanticTokenCaptureMappings> {
+    features
+        .as_mut()?
+        .text_document_semantic_tokens
+        .as_mut()?
+        .capture_mappings
+        .take()
+}
+
+fn set_semantic_token_capture_mappings(
+    features: &mut Option<FeatureSettings>,
+    capture_mappings: Option<SemanticTokenCaptureMappings>,
+) {
+    let Some(capture_mappings) = capture_mappings else {
+        return;
+    };
+    features
+        .get_or_insert_default()
+        .text_document_semantic_tokens
+        .get_or_insert_default()
+        .capture_mappings = Some(capture_mappings);
 }
 
 fn merge_features(
@@ -2250,6 +2291,61 @@ mod tests {
         assert!(
             semantic_token_capture_mappings(&merged).is_empty(),
             "an explicit empty captureMappings should clear every language entry"
+        );
+    }
+
+    #[test]
+    fn legacy_root_clear_precedes_canonical_entries_in_the_same_layer() {
+        use crate::config::defaults::default_settings;
+
+        let overlay: RawWorkspaceSettings = toml::from_str(
+            r#"
+            captureMappings = {}
+
+            [features."textDocument/semanticTokens".captureMappings._]
+            custom = "keyword"
+        "#,
+        )
+        .expect("should parse");
+
+        let merged = merge_workspace_settings(Some(default_settings()), Some(overlay))
+            .expect("two settings merge");
+        let mappings = semantic_token_capture_mappings(&merged);
+
+        assert_eq!(mappings.len(), 1);
+        assert_eq!(
+            mappings[WILDCARD_KEY],
+            HashMap::from([("custom".to_string(), "keyword".to_string())])
+        );
+    }
+
+    #[test]
+    fn legacy_language_clear_precedes_canonical_entries_in_the_same_layer() {
+        let base: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [features."textDocument/semanticTokens".captureMappings.rust]
+            old_one = "variable"
+            old_two = "function"
+        "#,
+        )
+        .expect("should parse");
+        let overlay: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [captureMappings.rust]
+            highlights = {}
+
+            [features."textDocument/semanticTokens".captureMappings.rust]
+            fresh = "keyword"
+        "#,
+        )
+        .expect("should parse");
+
+        let merged =
+            merge_workspace_settings(Some(base), Some(overlay)).expect("two settings merge");
+
+        assert_eq!(
+            semantic_token_capture_mappings(&merged)["rust"],
+            HashMap::from([("fresh".to_string(), "keyword".to_string())])
         );
     }
 

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -815,10 +815,6 @@ mod tests {
                             ("variable.builtin".to_string(), "base.variable".to_string()),
                             ("function.builtin".to_string(), "base.function".to_string()),
                         ])),
-                        folds: Some(HashMap::from([(
-                            "fold.comment".to_string(),
-                            "base.comment".to_string(),
-                        )])),
                     },
                 ),
                 (
@@ -898,8 +894,7 @@ mod tests {
             ])),
             capture_mappings: Some(HashMap::from([
                 (
-                    // shared key: _ — overlay overrides variable.builtin, adds type.builtin;
-                    //   adds folds fold.function
+                    // shared key: _ — overlay overrides variable.builtin and adds type.builtin
                     "_".to_string(),
                     QueryTypeMappings {
                         highlights: Some(HashMap::from([
@@ -909,10 +904,6 @@ mod tests {
                             ),
                             ("type.builtin".to_string(), "overlay.type".to_string()),
                         ])),
-                        folds: Some(HashMap::from([(
-                            "fold.function".to_string(),
-                            "overlay.function".to_string(),
-                        )])),
                     },
                 ),
                 (
@@ -2242,54 +2233,6 @@ mod tests {
         assert!(
             semantic_token_capture_mappings(&merged)[WILDCARD_KEY].is_empty(),
             "an explicit empty highlights map should clear the defaults"
-        );
-    }
-
-    /// The legacy `folds` table never had a consumer and has no semantic-token
-    /// counterpart; normalizing the deprecated shape keeps only highlights.
-    #[test]
-    fn deprecated_folds_do_not_leak_into_semantic_token_mappings() {
-        let base: RawWorkspaceSettings = toml::from_str(
-            r#"
-            [captureMappings._.folds]
-            "comment" = "comment"
-        "#,
-        )
-        .expect("should parse");
-        let overlay: RawWorkspaceSettings = toml::from_str(
-            r#"
-            [captureMappings._.highlights]
-            "keyword" = "keyword"
-        "#,
-        )
-        .expect("should parse");
-
-        let merged =
-            merge_workspace_settings(Some(base), Some(overlay)).expect("two settings merge");
-        let wildcard = &semantic_token_capture_mappings(&merged)[WILDCARD_KEY];
-
-        assert_eq!(wildcard["keyword"], "keyword");
-        assert!(!wildcard.contains_key("comment"));
-    }
-
-    #[test]
-    fn deprecated_folds_only_overlay_does_not_clear_highlight_mappings() {
-        use crate::config::defaults::default_settings;
-
-        let folds_only: RawWorkspaceSettings = toml::from_str(
-            r#"
-            [captureMappings.rust.folds]
-            comment = "comment"
-            "#,
-        )
-        .expect("legacy folds should still parse during migration");
-
-        let merged = merge_workspace_settings(Some(default_settings()), Some(folds_only))
-            .expect("two settings merge");
-        assert_eq!(
-            semantic_token_capture_mappings(&merged)[WILDCARD_KEY]["variable.builtin"],
-            "variable.defaultLibrary",
-            "an unused folds-only layer must not become an explicit root clear"
         );
     }
 

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -2094,6 +2094,61 @@ mod tests {
         );
     }
 
+    #[test]
+    fn canonical_capture_mappings_override_legacy_mappings_in_the_same_layer() {
+        let settings: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [captureMappings._.highlights]
+            shared = "legacy"
+            legacy_only = "legacy"
+
+            [features."textDocument/semanticTokens".captureMappings._]
+            shared = "canonical"
+            canonical_only = "canonical"
+            "#,
+        )
+        .expect("both spellings should parse during migration");
+
+        let normalized = merge_workspace_settings(Some(settings), None).expect("one layer");
+        let mappings = &semantic_token_capture_mappings(&normalized)[WILDCARD_KEY];
+        assert_eq!(mappings["shared"], "canonical");
+        assert_eq!(mappings["legacy_only"], "legacy");
+        assert_eq!(mappings["canonical_only"], "canonical");
+    }
+
+    #[test]
+    fn higher_layer_wins_across_legacy_and_canonical_spellings() {
+        let legacy: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [captureMappings._.highlights]
+            shared = "legacy"
+            "#,
+        )
+        .expect("legacy settings");
+        let canonical: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [features."textDocument/semanticTokens".captureMappings._]
+            shared = "canonical"
+            "#,
+        )
+        .expect("canonical settings");
+
+        let canonical_overlay =
+            merge_workspace_settings(Some(legacy.clone()), Some(canonical.clone()))
+                .expect("two layers");
+        assert_eq!(
+            semantic_token_capture_mappings(&canonical_overlay)[WILDCARD_KEY]["shared"],
+            "canonical"
+        );
+
+        let legacy_overlay =
+            merge_workspace_settings(Some(canonical), Some(legacy)).expect("two layers");
+        assert_eq!(
+            semantic_token_capture_mappings(&legacy_overlay)[WILDCARD_KEY]["shared"],
+            "legacy"
+        );
+    }
+
     /// An explicit empty `cmd` says "this server has no command", not "inherit
     /// the wildcard's". Same for `languages`: a list the layer wrote is the
     /// list, empty or not. Omitting the key is what inherits.

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -532,11 +532,13 @@ pub(crate) fn merge_semantic_token_capture_mappings(
 
 pub(crate) fn legacy_capture_mappings_to_semantic(
     mappings: CaptureMappings,
-) -> SemanticTokenCaptureMappings {
-    mappings
+) -> Option<SemanticTokenCaptureMappings> {
+    let root_was_empty = mappings.is_empty();
+    let mappings = mappings
         .into_iter()
         .filter_map(|(language, entry)| entry.highlights.map(|mapping| (language, mapping)))
-        .collect()
+        .collect::<SemanticTokenCaptureMappings>();
+    (root_was_empty || !mappings.is_empty()).then_some(mappings)
 }
 
 fn normalize_deprecated_capture_mappings(
@@ -545,7 +547,9 @@ fn normalize_deprecated_capture_mappings(
     let Some(legacy) = settings.capture_mappings.take() else {
         return settings;
     };
-    let legacy = legacy_capture_mappings_to_semantic(legacy);
+    let Some(legacy) = legacy_capture_mappings_to_semantic(legacy) else {
+        return settings;
+    };
     let semantic_tokens = settings
         .features
         .get_or_insert_default()
@@ -2266,6 +2270,27 @@ mod tests {
 
         assert_eq!(wildcard["keyword"], "keyword");
         assert!(!wildcard.contains_key("comment"));
+    }
+
+    #[test]
+    fn deprecated_folds_only_overlay_does_not_clear_highlight_mappings() {
+        use crate::config::defaults::default_settings;
+
+        let folds_only: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [captureMappings.rust.folds]
+            comment = "comment"
+            "#,
+        )
+        .expect("legacy folds should still parse during migration");
+
+        let merged = merge_workspace_settings(Some(default_settings()), Some(folds_only))
+            .expect("two settings merge");
+        assert_eq!(
+            semantic_token_capture_mappings(&merged)[WILDCARD_KEY]["variable.builtin"],
+            "variable.defaultLibrary",
+            "an unused folds-only layer must not become an explicit root clear"
+        );
     }
 
     /// The whole map clears too, so a layer can drop every language's mappings.

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -1,9 +1,9 @@
 use super::settings::{
     AggregationConfig, BridgeLanguageConfig, BridgeServerConfig, DebounceFeatureSettings,
     FeatureSettings, LanguageSettings, LayerAggregationConfig, LayersConfig,
-    LogMessageFeatureSettings, QueryTypeMappings,
+    LogMessageFeatureSettings, SemanticTokenCaptureMappings, SemanticTokensFeatureSettings,
 };
-use super::{CaptureMapping, CaptureMappings, RawWorkspaceSettings, WILDCARD_KEY};
+use super::{CaptureMappings, RawWorkspaceSettings, WILDCARD_KEY};
 use std::collections::{HashMap, HashSet};
 
 /// Resolve a key from a map with wildcard fallback and merging.
@@ -422,15 +422,14 @@ pub(crate) fn merge_workspace_settings(
     base: Option<RawWorkspaceSettings>,
     overlay: Option<RawWorkspaceSettings>,
 ) -> Option<RawWorkspaceSettings> {
+    let base = base.map(normalize_deprecated_capture_mappings);
+    let overlay = overlay.map(normalize_deprecated_capture_mappings);
     match (base, overlay) {
         (Some(base), Some(overlay)) => {
             let merged = RawWorkspaceSettings {
                 search_paths: overlay.search_paths.or(base.search_paths),
                 languages: merge_languages(base.languages, overlay.languages),
-                capture_mappings: merge_capture_mappings(
-                    base.capture_mappings,
-                    overlay.capture_mappings,
-                ),
+                capture_mappings: None,
                 auto_install: overlay.auto_install.or(base.auto_install),
                 diagnostics_debounce_ms: overlay
                     .diagnostics_debounce_ms
@@ -453,6 +452,10 @@ fn merge_features(
 ) -> Option<FeatureSettings> {
     match (base, overlay) {
         (Some(base), Some(overlay)) => Some(FeatureSettings {
+            text_document_semantic_tokens: merge_semantic_token_feature_settings(
+                base.text_document_semantic_tokens,
+                overlay.text_document_semantic_tokens,
+            ),
             text_document_publish_diagnostics: match (
                 base.text_document_publish_diagnostics,
                 overlay.text_document_publish_diagnostics,
@@ -482,6 +485,77 @@ fn merge_features(
         }),
         (base, overlay) => overlay.or(base),
     }
+}
+
+fn merge_semantic_token_feature_settings(
+    base: Option<SemanticTokensFeatureSettings>,
+    overlay: Option<SemanticTokensFeatureSettings>,
+) -> Option<SemanticTokensFeatureSettings> {
+    match (base, overlay) {
+        (Some(base), Some(overlay)) => Some(SemanticTokensFeatureSettings {
+            capture_mappings: merge_semantic_token_capture_mappings(
+                base.capture_mappings,
+                overlay.capture_mappings,
+            ),
+        }),
+        (base, overlay) => overlay.or(base),
+    }
+}
+
+pub(crate) fn merge_semantic_token_capture_mappings(
+    base: Option<SemanticTokenCaptureMappings>,
+    overlay: Option<SemanticTokenCaptureMappings>,
+) -> Option<SemanticTokenCaptureMappings> {
+    match (base, overlay) {
+        (None, None) => None,
+        (Some(mappings), None) | (None, Some(mappings)) => Some(mappings),
+        (Some(_), Some(overlay)) if overlay.is_empty() => Some(SemanticTokenCaptureMappings::new()),
+        (Some(mut base), Some(overlay)) => {
+            for (language, overlay_mappings) in overlay {
+                match base.entry(language) {
+                    std::collections::hash_map::Entry::Occupied(mut entry) => {
+                        if overlay_mappings.is_empty() {
+                            entry.get_mut().clear();
+                        } else {
+                            entry.get_mut().extend(overlay_mappings);
+                        }
+                    }
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        entry.insert(overlay_mappings);
+                    }
+                }
+            }
+            Some(base)
+        }
+    }
+}
+
+pub(crate) fn legacy_capture_mappings_to_semantic(
+    mappings: CaptureMappings,
+) -> SemanticTokenCaptureMappings {
+    mappings
+        .into_iter()
+        .filter_map(|(language, entry)| entry.highlights.map(|mapping| (language, mapping)))
+        .collect()
+}
+
+fn normalize_deprecated_capture_mappings(
+    mut settings: RawWorkspaceSettings,
+) -> RawWorkspaceSettings {
+    let Some(legacy) = settings.capture_mappings.take() else {
+        return settings;
+    };
+    let legacy = legacy_capture_mappings_to_semantic(legacy);
+    let semantic_tokens = settings
+        .features
+        .get_or_insert_default()
+        .text_document_semantic_tokens
+        .get_or_insert_default();
+    semantic_tokens.capture_mappings = merge_semantic_token_capture_mappings(
+        Some(legacy),
+        semantic_tokens.capture_mappings.take(),
+    );
+    settings
 }
 
 fn merge_languages(
@@ -519,64 +593,6 @@ fn merge_language_servers(
                     .or_insert(overlay_config);
             }
             Some(base_servers)
-        }
-    }
-}
-
-/// Deep merge two optional capture-mapping maps.
-///
-/// Mirrors [`merge_bridge_maps`]: an empty overlay map (`Some({})`) clears the
-/// base (empty-means-clear); otherwise per-language entries merge field by
-/// field via [`merge_query_type_mappings`].
-fn merge_capture_mappings(
-    base: Option<CaptureMappings>,
-    overlay: Option<CaptureMappings>,
-) -> Option<CaptureMappings> {
-    match (base, overlay) {
-        (None, None) => None,
-        (Some(mappings), None) | (None, Some(mappings)) => Some(mappings),
-        (Some(_), Some(overlay)) if overlay.is_empty() => Some(CaptureMappings::new()),
-        (Some(mut base), Some(overlay)) => {
-            for (lang, overlay_mappings) in overlay {
-                base.entry(lang)
-                    .and_modify(|base_mappings| {
-                        *base_mappings =
-                            merge_query_type_mappings(base_mappings, &overlay_mappings);
-                    })
-                    .or_insert(overlay_mappings);
-            }
-            Some(base)
-        }
-    }
-}
-
-/// Field-level merge of one language's capture mappings. The two query kinds
-/// are independent: writing `highlights` says nothing about `folds`.
-fn merge_query_type_mappings(
-    base: &QueryTypeMappings,
-    overlay: &QueryTypeMappings,
-) -> QueryTypeMappings {
-    QueryTypeMappings {
-        highlights: merge_capture_mapping(base.highlights.as_ref(), overlay.highlights.as_ref()),
-        folds: merge_capture_mapping(base.folds.as_ref(), overlay.folds.as_ref()),
-    }
-}
-
-/// Deep merge one query kind's capture names. Empty-means-clear, then
-/// per-capture override — the value is a plain string, so an entry the overlay
-/// names wins outright.
-fn merge_capture_mapping(
-    base: Option<&CaptureMapping>,
-    overlay: Option<&CaptureMapping>,
-) -> Option<CaptureMapping> {
-    match (base, overlay) {
-        (None, None) => None,
-        (Some(mapping), None) | (None, Some(mapping)) => Some(mapping.clone()),
-        (Some(_), Some(overlay)) if overlay.is_empty() => Some(CaptureMapping::new()),
-        (Some(base), Some(overlay)) => {
-            let mut merged = base.clone();
-            merged.extend(overlay.iter().map(|(k, v)| (k.clone(), v.clone())));
-            Some(merged)
         }
     }
 }
@@ -669,6 +685,17 @@ mod tests {
     use crate::config::QueryTypeMappings;
     use crate::config::settings;
     use std::collections::HashMap;
+
+    fn semantic_token_capture_mappings(
+        settings: &RawWorkspaceSettings,
+    ) -> &settings::SemanticTokenCaptureMappings {
+        settings
+            .features
+            .as_ref()
+            .and_then(|features| features.text_document_semantic_tokens.as_ref())
+            .and_then(|semantic_tokens| semantic_tokens.capture_mappings.as_ref())
+            .expect("semantic-token capture mappings")
+    }
 
     // ========================================================================
     // merge_workspace_settings: Option combinator tests
@@ -2033,9 +2060,9 @@ mod tests {
         // Get defaults (which have markup.strong = "")
         let defaults = default_settings();
 
-        // Verify defaults have empty string for markup.strong
+        // Verify defaults have empty string for markup.strong.
         assert_eq!(
-            defaults.capture_mappings.as_ref().unwrap()[WILDCARD_KEY].highlights()["markup.strong"],
+            semantic_token_capture_mappings(&defaults)[WILDCARD_KEY]["markup.strong"],
             "",
             "Defaults should suppress markup.strong with empty string"
         );
@@ -2047,21 +2074,21 @@ mod tests {
 
         // After merge, user's "keyword" should override default's ""
         assert_eq!(
-            merged.capture_mappings.as_ref().unwrap()[WILDCARD_KEY].highlights()["markup.strong"],
+            semantic_token_capture_mappings(&merged)[WILDCARD_KEY]["markup.strong"],
             "keyword",
             "User's markup.strong = 'keyword' should override default's ''"
         );
 
         // Also verify other user mappings are present
         assert_eq!(
-            merged.capture_mappings.as_ref().unwrap()[WILDCARD_KEY].highlights()["markup.heading.1"],
+            semantic_token_capture_mappings(&merged)[WILDCARD_KEY]["markup.heading.1"],
             "class",
             "User's markup.heading.1 mapping should be present"
         );
 
         // Verify other defaults are still present
         assert_eq!(
-            merged.capture_mappings.as_ref().unwrap()[WILDCARD_KEY].highlights()["variable.builtin"],
+            semantic_token_capture_mappings(&merged)[WILDCARD_KEY]["variable.builtin"],
             "variable.defaultLibrary",
             "Default variable.builtin mapping should be inherited"
         );
@@ -2154,18 +2181,15 @@ mod tests {
             .expect("two settings merge");
 
         assert!(
-            merged.capture_mappings.as_ref().unwrap()[WILDCARD_KEY]
-                .highlights()
-                .is_empty(),
+            semantic_token_capture_mappings(&merged)[WILDCARD_KEY].is_empty(),
             "an explicit empty highlights map should clear the defaults"
         );
     }
 
-    /// Clearing one query kind must not disturb the other: `folds` is
-    /// `#[serde(default)]`, so a layer that writes only `highlights` says
-    /// nothing about folds and must leave them alone.
+    /// The legacy `folds` table never had a consumer and has no semantic-token
+    /// counterpart; normalizing the deprecated shape keeps only highlights.
     #[test]
-    fn capture_mappings_written_highlights_leave_folds_alone() {
+    fn deprecated_folds_do_not_leak_into_semantic_token_mappings() {
         let base: RawWorkspaceSettings = toml::from_str(
             r#"
             [captureMappings._.folds]
@@ -2183,14 +2207,10 @@ mod tests {
 
         let merged =
             merge_workspace_settings(Some(base), Some(overlay)).expect("two settings merge");
-        let wildcard = &merged.capture_mappings.as_ref().unwrap()[WILDCARD_KEY];
+        let wildcard = &semantic_token_capture_mappings(&merged)[WILDCARD_KEY];
 
-        assert_eq!(
-            wildcard.folds.as_ref().unwrap()["comment"],
-            "comment",
-            "writing highlights must not clear folds"
-        );
-        assert_eq!(wildcard.highlights()["keyword"], "keyword");
+        assert_eq!(wildcard["keyword"], "keyword");
+        assert!(!wildcard.contains_key("comment"));
     }
 
     /// The whole map clears too, so a layer can drop every language's mappings.
@@ -2205,7 +2225,7 @@ mod tests {
             .expect("two settings merge");
 
         assert!(
-            merged.capture_mappings.as_ref().unwrap().is_empty(),
+            semantic_token_capture_mappings(&merged).is_empty(),
             "an explicit empty captureMappings should clear every language entry"
         );
     }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -655,21 +655,13 @@ pub(crate) fn on_type_formatting_trigger_union(
     Some((first, iter.collect()))
 }
 
-/// Custom mappings from Tree-sitter capture names to semantic token types, per query kind.
-///
-/// Both fields are optional so that omitting one and writing an empty one say
-/// different things: omit to inherit the layer below, write `{}` to clear it.
-/// A layer that configures only `highlights` must not silently drop the folds
-/// a lower layer supplied, which a non-optional field could not express.
+/// Deprecated wrapper around semantic-token highlight mappings.
 #[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct QueryTypeMappings {
     /// Capture mappings for highlights queries. Omit to inherit; `{}` clears.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub highlights: Option<CaptureMapping>,
-    /// Capture mappings for folds queries. Omit to inherit; `{}` clears.
-    /// Reserved for future folding range support — populated and merged but not yet consumed by analysis.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub folds: Option<CaptureMapping>,
 }
 
 /// The empty map an unset [`QueryTypeMappings`] field reads as.
@@ -1579,6 +1571,20 @@ mod tests {
         snap_settings.bind(|| {
             insta::assert_json_snapshot!(settings.capture_mappings);
         });
+    }
+
+    #[test]
+    fn legacy_folds_capture_mappings_are_rejected() {
+        let result = toml::from_str::<RawWorkspaceSettings>(
+            r#"
+            [captureMappings._.folds]
+            comment = "comment"
+            "#,
+        );
+        assert!(
+            result.is_err(),
+            "the never-consumed folds field was removed"
+        );
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1180,18 +1180,24 @@ mod tests {
     }
 
     #[test]
-    fn log_message_level_rejects_unknown_values_and_fields() {
+    fn log_message_level_rejects_unknown_values_but_tolerates_unknown_fields() {
         assert!(
             toml::from_str::<RawWorkspaceSettings>(
                 "[features.\"window/logMessage\"]\nlogLevel = \"debug\""
             )
             .is_err()
         );
-        assert!(
-            toml::from_str::<RawWorkspaceSettings>(
-                "[features.\"window/logMessage\"]\nlevel = \"info\""
-            )
-            .is_err()
+        let raw = toml::from_str::<RawWorkspaceSettings>(
+            "[features.\"window/logMessage\"]\nlevel = \"info\"\nlogLevel = \"warning\"",
+        );
+        assert_eq!(
+            raw.unwrap()
+                .features
+                .unwrap()
+                .window_log_message
+                .unwrap()
+                .log_level,
+            Some(LogMessageLevel::Warning)
         );
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -685,6 +685,13 @@ impl QueryTypeMappings {
 
 pub type CaptureMappings = HashMap<String, QueryTypeMappings>;
 
+/// Per-language Tree-sitter capture names mapped to LSP semantic-token roles.
+///
+/// Unlike the deprecated top-level [`CaptureMappings`] shape, the semantic
+/// token feature already supplies the consumer context, so there is no nested
+/// query-kind key such as `highlights`.
+pub type SemanticTokenCaptureMappings = HashMap<String, CaptureMapping>;
+
 /// Query type for tree-sitter query files.
 ///
 /// Used in the unified `queries` field to specify what kind of query a file contains.
@@ -876,9 +883,20 @@ pub struct LogMessageFeatureSettings {
     pub log_level: Option<LogMessageLevel>,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SemanticTokensFeatureSettings {
+    /// Per-language capture-to-token mappings. Omit to inherit; `{}` clears
+    /// every language mapping in the layer below.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capture_mappings: Option<SemanticTokenCaptureMappings>,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct FeatureSettings {
+    #[serde(rename = "textDocument/semanticTokens")]
+    pub text_document_semantic_tokens: Option<SemanticTokensFeatureSettings>,
     #[serde(rename = "textDocument/publishDiagnostics")]
     pub text_document_publish_diagnostics: Option<DebounceFeatureSettings>,
     #[serde(rename = "window/logMessage")]
@@ -894,7 +912,11 @@ impl Serialize for FeatureSettings {
     {
         use serde::ser::SerializeMap;
 
-        let mut map = serializer.serialize_map(Some(3))?;
+        let mut map = serializer.serialize_map(Some(4))?;
+        map.serialize_entry(
+            "textDocument/semanticTokens",
+            &self.text_document_semantic_tokens,
+        )?;
         map.serialize_entry(
             "textDocument/publishDiagnostics",
             &self.text_document_publish_diagnostics,

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -811,7 +811,7 @@ pub const DEFAULT_PUBLISH_DIAGNOSTICS_MAX_WAIT_MS: u64 = 1000;
 pub const MAX_FEATURE_TIMING_MS: u64 = 86_400_000;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct DebounceFeatureSettings {
     #[schemars(range(max = 86_400_000))]
     pub debounce_ms: Option<u64>,
@@ -872,13 +872,13 @@ impl LogMessageLevel {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct LogMessageFeatureSettings {
     pub log_level: Option<LogMessageLevel>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct SemanticTokensFeatureSettings {
     /// Per-language capture-to-token mappings. Omit to inherit; `{}` clears
     /// every language mapping in the layer below.
@@ -887,7 +887,6 @@ pub struct SemanticTokensFeatureSettings {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
 pub struct FeatureSettings {
     #[serde(rename = "textDocument/semanticTokens")]
     pub text_document_semantic_tokens: Option<SemanticTokensFeatureSettings>,

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -657,7 +657,6 @@ pub(crate) fn on_type_formatting_trigger_union(
 
 /// Deprecated wrapper around semantic-token highlight mappings.
 #[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq, Eq, JsonSchema)]
-#[serde(deny_unknown_fields)]
 pub struct QueryTypeMappings {
     /// Capture mappings for highlights queries. Omit to inherit; `{}` clears.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1574,16 +1573,23 @@ mod tests {
     }
 
     #[test]
-    fn legacy_folds_capture_mappings_are_rejected() {
-        let result = toml::from_str::<RawWorkspaceSettings>(
+    fn legacy_folds_does_not_discard_sibling_highlights() {
+        let settings = toml::from_str::<RawWorkspaceSettings>(
             r#"
             [captureMappings._.folds]
             comment = "comment"
+
+            [captureMappings._.highlights]
+            variable = "variable"
             "#,
-        );
-        assert!(
-            result.is_err(),
-            "the never-consumed folds field was removed"
+        )
+        .expect("unknown legacy query kinds should follow the normal tolerant parser policy");
+        assert_eq!(
+            settings.capture_mappings.expect("legacy mappings")["_"]
+                .highlights
+                .as_ref()
+                .expect("highlights")["variable"],
+            "variable"
         );
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -788,9 +788,12 @@ pub struct RawWorkspaceSettings {
     /// Per-language configuration (parser paths, queries, bridge filters, base inheritance).
     #[serde(default)]
     pub languages: HashMap<String, LanguageSettings>,
-    /// Custom mappings from Tree-sitter capture names to semantic token types.
-    /// Omit to inherit the layer below; `{}` clears every language's entry.
+    /// Deprecated: use
+    /// `features["textDocument/semanticTokens"].captureMappings` instead. This
+    /// legacy shape remains accepted during migration; only its `highlights`
+    /// entries are consumed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("deprecated" = true))]
     pub capture_mappings: Option<CaptureMappings>,
     /// Deprecated: use `languages._.autoInstall` (and per-language
     /// `languages.<lang>.autoInstall`) instead. Whether to automatically
@@ -1259,9 +1262,19 @@ mod tests {
             props.get("diagnosticsDebounceMs").is_some(),
             "missing diagnosticsDebounceMs"
         );
+        let legacy_capture_mappings = props
+            .get("captureMappings")
+            .expect("missing captureMappings");
+        assert_eq!(
+            legacy_capture_mappings.get("deprecated"),
+            Some(&serde_json::Value::Bool(true))
+        );
         assert!(
-            props.get("captureMappings").is_some(),
-            "missing captureMappings"
+            legacy_capture_mappings["description"]
+                .as_str()
+                .is_some_and(|description| description
+                    .contains("features[\"textDocument/semanticTokens\"].captureMappings")),
+            "deprecated schema property should name its replacement"
         );
         assert!(
             props.get("languageServers").is_some(),

--- a/src/config/snapshots/kakehashi__config__merge__tests__merge_workspace_settings_all_fields.snap
+++ b/src/config/snapshots/kakehashi__config__merge__tests__merge_workspace_settings_all_fields.snap
@@ -47,32 +47,28 @@ expression: result
       "autoInstall": null
     }
   },
-  "captureMappings": {
-    "_": {
-      "highlights": {
-        "function.builtin": "base.function",
-        "type.builtin": "overlay.type",
-        "variable.builtin": "overlay.variable"
-      },
-      "folds": {
-        "fold.comment": "base.comment",
-        "fold.function": "overlay.function"
-      }
-    },
-    "lua": {
-      "highlights": {
-        "keyword": "base.keyword"
-      }
-    },
-    "rust": {
-      "highlights": {
-        "type.builtin": "rust.type"
-      }
-    }
-  },
   "autoInstall": false,
   "diagnosticsDebounceMs": null,
-  "features": null,
+  "features": {
+    "textDocument/publishDiagnostics": null,
+    "textDocument/semanticTokens": {
+      "captureMappings": {
+        "_": {
+          "function.builtin": "base.function",
+          "type.builtin": "overlay.type",
+          "variable.builtin": "overlay.variable"
+        },
+        "lua": {
+          "keyword": "base.keyword"
+        },
+        "rust": {
+          "type.builtin": "rust.type"
+        }
+      }
+    },
+    "window/logMessage": null,
+    "workspace/diagnostic/refresh": null
+  },
   "languageServers": {
     "lua-language-server": {
       "cmd": [

--- a/src/config/unknown_keys.rs
+++ b/src/config/unknown_keys.rs
@@ -54,7 +54,7 @@ pub(crate) const KNOWN_BRIDGE_SERVER_SETTING_KEYS: &[&str] = &[
     "workspaceMarkers",
 ];
 
-pub(crate) const KNOWN_CAPTURE_MAPPINGS_SETTING_KEYS: &[&str] = &["folds", "highlights"];
+pub(crate) const KNOWN_CAPTURE_MAPPINGS_SETTING_KEYS: &[&str] = &["highlights"];
 
 pub(crate) const KNOWN_LANGUAGE_SETTING_KEYS: &[&str] = &[
     "aliases",

--- a/src/config/unknown_keys.rs
+++ b/src/config/unknown_keys.rs
@@ -78,6 +78,15 @@ pub(crate) fn sort_and_dedup_unknown_keys(unknown_keys: &mut Vec<String>) {
     unknown_keys.dedup();
 }
 
+pub(crate) fn unknown_toml_workspace_setting_keys(contents: &str) -> Vec<String> {
+    let Ok(value) = toml::from_str::<Value>(contents) else {
+        return Vec::new();
+    };
+    let mut keys = unknown_workspace_setting_keys(&value);
+    sort_and_dedup_unknown_keys(&mut keys);
+    keys
+}
+
 fn unknown_object_keys(path: &str, value: &Value, known_keys: &[&str]) -> Vec<String> {
     let Some(object) = value.as_object() else {
         return Vec::new();

--- a/src/config/unknown_keys.rs
+++ b/src/config/unknown_keys.rs
@@ -7,11 +7,6 @@
 //! with the answer is that caller's policy — the former rejects the update, the
 //! latter warns.
 //!
-//! The walk does not cover `features`: `FeatureSettings` and its children carry
-//! `deny_unknown_fields`, so an unknown key there fails typed deserialization
-//! before any of this runs. That makes it fatal on a config file, unlike every
-//! other unknown key, which is a wrinkle worth removing rather than a design.
-
 use serde_json::Value;
 
 pub(crate) const KNOWN_WORKSPACE_SETTING_KEYS: &[&str] = &[
@@ -30,6 +25,12 @@ pub(crate) const KNOWN_FEATURE_SETTING_KEYS: &[&str] = &[
     "window/logMessage",
     "workspace/diagnostic/refresh",
 ];
+
+pub(crate) const KNOWN_DEBOUNCE_FEATURE_SETTING_KEYS: &[&str] = &["debounceMs", "maxWaitMs"];
+
+pub(crate) const KNOWN_LOG_MESSAGE_FEATURE_SETTING_KEYS: &[&str] = &["logLevel"];
+
+pub(crate) const KNOWN_SEMANTIC_TOKENS_FEATURE_SETTING_KEYS: &[&str] = &["captureMappings"];
 
 pub(crate) const KNOWN_AGGREGATION_SETTING_KEYS: &[&str] = &[
     "maxFanOut",
@@ -149,9 +150,51 @@ pub(crate) fn unknown_workspace_setting_keys(settings: &Value) -> Vec<String> {
 
     append_unknown_bridge_server_setting_keys(object, &mut unknown_keys);
     append_unknown_capture_mappings_setting_keys(object, &mut unknown_keys);
+    append_unknown_feature_setting_keys(object, &mut unknown_keys);
     append_unknown_language_setting_keys(object, &mut unknown_keys);
 
     unknown_keys
+}
+
+fn append_unknown_feature_setting_keys(
+    object: &serde_json::Map<String, Value>,
+    unknown_keys: &mut Vec<String>,
+) {
+    let Some(features) = object.get("features").and_then(Value::as_object) else {
+        return;
+    };
+
+    unknown_keys.extend(
+        features
+            .keys()
+            .filter(|key| !KNOWN_FEATURE_SETTING_KEYS.contains(&key.as_str()))
+            .map(|key| format!("features.{key}")),
+    );
+
+    for (feature, known_keys) in [
+        (
+            "textDocument/semanticTokens",
+            KNOWN_SEMANTIC_TOKENS_FEATURE_SETTING_KEYS,
+        ),
+        (
+            "textDocument/publishDiagnostics",
+            KNOWN_DEBOUNCE_FEATURE_SETTING_KEYS,
+        ),
+        ("window/logMessage", KNOWN_LOG_MESSAGE_FEATURE_SETTING_KEYS),
+        (
+            "workspace/diagnostic/refresh",
+            KNOWN_DEBOUNCE_FEATURE_SETTING_KEYS,
+        ),
+    ] {
+        let Some(value) = features.get(feature) else {
+            continue;
+        };
+        unknown_keys.extend(unknown_object_keys(
+            &format!("features.{feature}"),
+            value,
+            known_keys,
+        ));
+    }
 }
 
 fn append_unknown_bridge_server_setting_keys(
@@ -299,9 +342,10 @@ fn append_unknown_layers_keys(
 mod tests {
     use super::*;
     use crate::config::settings::{
-        AggregationConfig, BridgeLanguageConfig, BridgeServerConfig, FeatureSettings,
-        LanguageSettings, LayerAggregationConfig, LayersConfig, QueryItem, QueryTypeMappings,
-        RawWorkspaceSettings,
+        AggregationConfig, BridgeLanguageConfig, BridgeServerConfig, DebounceFeatureSettings,
+        FeatureSettings, LanguageSettings, LayerAggregationConfig, LayersConfig,
+        LogMessageFeatureSettings, QueryItem, QueryTypeMappings, RawWorkspaceSettings,
+        SemanticTokensFeatureSettings,
     };
     use std::collections::BTreeSet;
 
@@ -333,6 +377,22 @@ mod tests {
     #[test]
     fn known_feature_setting_keys_match_schema_properties() {
         assert_known_keys_match_schema::<FeatureSettings>(KNOWN_FEATURE_SETTING_KEYS, &[]);
+    }
+
+    #[test]
+    fn known_feature_child_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<SemanticTokensFeatureSettings>(
+            KNOWN_SEMANTIC_TOKENS_FEATURE_SETTING_KEYS,
+            &[],
+        );
+        assert_known_keys_match_schema::<DebounceFeatureSettings>(
+            KNOWN_DEBOUNCE_FEATURE_SETTING_KEYS,
+            &[],
+        );
+        assert_known_keys_match_schema::<LogMessageFeatureSettings>(
+            KNOWN_LOG_MESSAGE_FEATURE_SETTING_KEYS,
+            &[],
+        );
     }
 
     #[test]
@@ -375,6 +435,39 @@ mod tests {
         }));
 
         assert_eq!(unknown, ["captureMappings._.folds"]);
+    }
+
+    #[test]
+    fn feature_typos_use_the_common_unknown_key_path() {
+        let unknown = unknown_workspace_setting_keys(&serde_json::json!({
+            "features": {
+                "textDocument/semanticToken": {},
+                "textDocument/semanticTokens": {
+                    "captureMapping": {},
+                    "captureMappings": { "_": { "variable": "variable" } }
+                },
+                "textDocument/publishDiagnostics": {
+                    "debounceMS": 1
+                },
+                "window/logMessage": {
+                    "level": "debug"
+                },
+                "workspace/diagnostic/refresh": {
+                    "maxWaitMS": 1
+                }
+            }
+        }));
+
+        assert_eq!(
+            unknown,
+            [
+                "features.textDocument/semanticToken",
+                "features.textDocument/semanticTokens.captureMapping",
+                "features.textDocument/publishDiagnostics.debounceMS",
+                "features.window/logMessage.level",
+                "features.workspace/diagnostic/refresh.maxWaitMS",
+            ]
+        );
     }
 
     #[test]

--- a/src/config/unknown_keys.rs
+++ b/src/config/unknown_keys.rs
@@ -25,6 +25,7 @@ pub(crate) const KNOWN_WORKSPACE_SETTING_KEYS: &[&str] = &[
 ];
 
 pub(crate) const KNOWN_FEATURE_SETTING_KEYS: &[&str] = &[
+    "textDocument/semanticTokens",
     "textDocument/publishDiagnostics",
     "window/logMessage",
     "workspace/diagnostic/refresh",

--- a/src/config/unknown_keys.rs
+++ b/src/config/unknown_keys.rs
@@ -97,6 +97,13 @@ pub(crate) fn is_workspace_setting_key_or_typo(key: &str) -> bool {
             .any(|known_key| is_one_edit_apart(key, known_key))
 }
 
+pub(crate) fn is_feature_setting_key_or_typo(key: &str) -> bool {
+    KNOWN_FEATURE_SETTING_KEYS.contains(&key)
+        || KNOWN_FEATURE_SETTING_KEYS
+            .iter()
+            .any(|known_key| is_one_edit_apart(key, known_key))
+}
+
 fn is_one_edit_apart(candidate: &str, known: &str) -> bool {
     let candidate = candidate.as_bytes();
     let known = known.as_bytes();
@@ -405,6 +412,15 @@ mod tests {
         assert!(!is_workspace_setting_key_or_typo("editor"));
         assert!(!is_workspace_setting_key_or_typo("files"));
         assert!(!is_workspace_setting_key_or_typo("workbench"));
+    }
+
+    #[test]
+    fn feature_sibling_filter_matches_feature_keys_and_typos_only() {
+        assert!(is_feature_setting_key_or_typo(
+            "textDocument/semanticTokens"
+        ));
+        assert!(is_feature_setting_key_or_typo("textDocument/semanticToken"));
+        assert!(!is_feature_setting_key_or_typo("someOtherClientFeature"));
     }
 
     #[test]

--- a/src/config/unknown_keys.rs
+++ b/src/config/unknown_keys.rs
@@ -364,6 +364,20 @@ mod tests {
     }
 
     #[test]
+    fn removed_legacy_folds_uses_the_common_unknown_key_path() {
+        let unknown = unknown_workspace_setting_keys(&serde_json::json!({
+            "captureMappings": {
+                "_": {
+                    "folds": { "comment": "comment" },
+                    "highlights": { "variable": "variable" }
+                }
+            }
+        }));
+
+        assert_eq!(unknown, ["captureMappings._.folds"]);
+    }
+
+    #[test]
     fn known_language_setting_keys_match_schema_properties() {
         assert_known_keys_match_schema::<LanguageSettings>(KNOWN_LANGUAGE_SETTING_KEYS, &[]);
     }

--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -60,14 +60,17 @@ impl std::error::Error for UserConfigError {
 
 /// User configuration plus metadata gathered from the same read.
 ///
-/// `deprecated_keys` is detected from the very bytes that were parsed (not a
-/// second read), so it cannot disagree with `settings` under a concurrent file
-/// edit. Parsing collapses deprecated and canonical spellings, so these flags
-/// are the only way to know a deprecated key was used.
+/// `deprecated_keys` and `unknown_keys` are detected from the very bytes that
+/// were parsed (not a second read), so they cannot disagree with `settings`
+/// under a concurrent file edit. Parsing collapses deprecated and canonical
+/// spellings, so the former flags are the only way to know a deprecated key was
+/// used.
 #[derive(Debug)]
 pub(crate) struct UserConfig {
     pub(crate) settings: RawWorkspaceSettings,
     pub(crate) deprecated_keys: crate::config::deprecation::DeprecatedKeysSeen,
+    /// Unknown keys detected from the same bytes used to parse `settings`.
+    pub(crate) unknown_keys: Vec<String>,
     /// The file these settings were read from. Reported rather than re-derived
     /// by the caller, so a relative path inside this layer is anchored to the
     /// directory actually read — not to whatever `user_config_path()` would
@@ -153,6 +156,7 @@ pub fn load_user_config() -> UserConfigResult<Option<UserConfig>> {
     };
 
     let deprecated_keys = crate::config::deprecation::toml_deprecated_keys(&contents);
+    let unknown_keys = crate::config::unknown_keys::unknown_toml_workspace_setting_keys(&contents);
     let settings = toml::from_str::<RawWorkspaceSettings>(&contents).map_err(|e| {
         UserConfigError::ParseError {
             path: path.clone(),
@@ -163,6 +167,7 @@ pub fn load_user_config() -> UserConfigResult<Option<UserConfig>> {
     Ok(Some(UserConfig {
         settings,
         deprecated_keys,
+        unknown_keys,
         path,
     }))
 }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -25,5 +25,8 @@ pub(crate) use ingress_order::current_writer_ticket;
 pub use lsp_impl::Kakehashi;
 pub(crate) use request_id::current_upstream_id;
 pub use request_id::{CancelForwarder, RequestIdCapture};
-pub(crate) use settings::{SettingsEvent, SettingsEventKind, SettingsSource, load_settings};
+pub(crate) use settings::{
+    SettingsEvent, SettingsEventKind, SettingsSource, load_settings,
+    load_settings_with_client_layers,
+};
 pub use wire_repair::repair_inbound_frames;

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -338,10 +338,10 @@ pub struct Kakehashi {
     cache: std::sync::Arc<CacheCoordinator>,
     /// Consolidated settings, capabilities, and workspace root management
     settings_manager: std::sync::Arc<SettingsManager>,
-    /// Client-supplied settings kept separate from the merged effective
-    /// snapshot so a workspace-root change can reload project configuration
-    /// without carrying values from the previous project forward.
-    client_settings_override: arc_swap::ArcSwapOption<RawWorkspaceSettings>,
+    /// Ordered client-supplied settings layers kept separate from the merged
+    /// effective snapshot so a workspace-root change can replay clears as well
+    /// as values without carrying the previous project's layer forward.
+    client_settings_overrides: std::sync::RwLock<Vec<RawWorkspaceSettings>>,
     /// Isolated coordinator for parser auto-installation
     auto_install: AutoInstallManager,
     /// Bridge coordinator for downstream LS pool and node tracking
@@ -494,7 +494,7 @@ impl Kakehashi {
             documents: std::sync::Arc::new(DocumentStore::new()),
             cache: std::sync::Arc::new(CacheCoordinator::new()),
             settings_manager: std::sync::Arc::new(SettingsManager::new()),
-            client_settings_override: arc_swap::ArcSwapOption::empty(),
+            client_settings_overrides: std::sync::RwLock::new(Vec::new()),
             auto_install,
             bridge: std::sync::Arc::new(bridge),
             synthetic_diagnostics: std::sync::Arc::new(SyntheticDiagnosticsManager::new()),

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -342,6 +342,9 @@ pub struct Kakehashi {
     /// effective snapshot so a workspace-root change can replay clears as well
     /// as values without carrying the previous project's layer forward.
     client_settings_overrides: std::sync::RwLock<Vec<RawWorkspaceSettings>>,
+    /// Explicit config layers retained after their single allowed read, so a
+    /// workspace-root change can replay relative client layers above them.
+    explicit_config: std::sync::OnceLock<Option<crate::lsp::settings::ExplicitConfig>>,
     /// Isolated coordinator for parser auto-installation
     auto_install: AutoInstallManager,
     /// Bridge coordinator for downstream LS pool and node tracking
@@ -495,6 +498,7 @@ impl Kakehashi {
             cache: std::sync::Arc::new(CacheCoordinator::new()),
             settings_manager: std::sync::Arc::new(SettingsManager::new()),
             client_settings_overrides: std::sync::RwLock::new(Vec::new()),
+            explicit_config: std::sync::OnceLock::new(),
             auto_install,
             bridge: std::sync::Arc::new(bridge),
             synthetic_diagnostics: std::sync::Arc::new(SyntheticDiagnosticsManager::new()),

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -414,6 +414,15 @@ impl Kakehashi {
                 .show_warning(crate::config::deprecation::AUTO_INSTALL_DEPRECATION_NOTICE)
                 .await;
         }
+        if settings_outcome.deprecated_keys.capture_mappings
+            && self
+                .settings_manager
+                .claim_capture_mappings_deprecation_warning()
+        {
+            self.notifier()
+                .show_warning(crate::config::deprecation::CAPTURE_MAPPINGS_DEPRECATION_NOTICE)
+                .await;
+        }
         // Same shape for the empty-container rule change: what the layers said
         // still parses, and now means something else.
         if let Some(notice) =

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -297,6 +297,11 @@ impl Kakehashi {
         {
             return Err(configuration_load_error(error));
         }
+        let _ = self.explicit_config.set(
+            explicit_config
+                .as_ref()
+                .map(crate::lsp::settings::ExplicitConfig::for_replay),
+        );
 
         let position_encoding = host_position_encoding(&params.capabilities);
         // Store client capabilities for LSP compliance checks (e.g., refresh support).

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -465,11 +465,13 @@ impl Kakehashi {
             };
             (raw_settings, settings)
         };
-        self.client_settings_override.store(
-            initialization_options
-                .and_then(|value| serde_json::from_value(value).ok())
-                .map(std::sync::Arc::new),
-        );
+        *self
+            .client_settings_overrides
+            .write()
+            .expect("client settings overrides lock poisoned") = initialization_options
+            .and_then(|value| serde_json::from_value(value).ok())
+            .into_iter()
+            .collect();
         // Derive the onTypeFormatting trigger union before settings move into
         // apply_raw_settings: kakehashi cannot know downstream trigger
         // characters at initialize time (servers spawn lazily), so the

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -443,6 +443,7 @@ impl Kakehashi {
         // for zero-config experience. Use default_settings() instead of RawWorkspaceSettings::default()
         // because the derived Default creates empty capture_mappings while default_settings() includes
         // the full default capture_mappings (markup.strong → "", etc.)
+        let initialization_merge_was_accepted = settings_outcome.settings.is_some();
         let (raw_settings, settings) = if let Some(s) = settings_outcome.settings {
             (
                 settings_outcome
@@ -473,7 +474,9 @@ impl Kakehashi {
         *self
             .client_settings_overrides
             .write()
-            .expect("client settings overrides lock poisoned") = initialization_options
+            .expect("client settings overrides lock poisoned") = initialization_merge_was_accepted
+            .then_some(initialization_options)
+            .flatten()
             .and_then(|value| serde_json::from_value(value).ok())
             .into_iter()
             .collect();

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -425,8 +425,7 @@ impl Kakehashi {
         }
         // Same shape for the empty-container rule change: what the layers said
         // still parses, and now means something else.
-        if let Some(notice) =
-            crate::lsp::settings::emptied_container_notice(settings_outcome.raw_settings.as_ref())
+        if let Some(notice) = settings_outcome.empty_container_notice.as_deref()
             && self
                 .settings_manager
                 .claim_empty_container_migration_warning()

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -404,6 +404,9 @@ impl Kakehashi {
                 return;
             }
         };
+        // Retain the authored relative paths for a future workspace-root
+        // reload; the copy applied below is anchored to the root current now.
+        let replay_layer = parsed.clone();
 
         // Snapshot read, derivation, and publication must share the same reload
         // transaction as post-install search-path updates, or either path can
@@ -467,7 +470,7 @@ impl Kakehashi {
                 self.client_settings_overrides
                     .write()
                     .expect("client settings overrides lock poisoned")
-                    .push(parsed);
+                    .push(replay_layer);
                 let warnings = Self::misconfigured_settings_warnings(&settings);
                 self.apply_raw_settings_locked(&reload, merged_ts, settings)
                     .await;

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -337,6 +337,15 @@ impl Kakehashi {
                 .show_warning(crate::config::deprecation::AUTO_INSTALL_DEPRECATION_NOTICE)
                 .await;
         }
+        if pushed_deprecated_keys.capture_mappings
+            && self
+                .settings_manager
+                .claim_capture_mappings_deprecation_warning()
+        {
+            self.notifier()
+                .show_warning(crate::config::deprecation::CAPTURE_MAPPINGS_DEPRECATION_NOTICE)
+                .await;
+        }
 
         if uses_deprecated_unwrapped_shape
             && self

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -1,7 +1,7 @@
 //! didChangeConfiguration notification handler for Kakehashi.
 
 use crate::config::unknown_keys::{
-    KNOWN_FEATURE_SETTING_KEYS, is_workspace_setting_key_or_typo, sort_and_dedup_unknown_keys,
+    is_feature_setting_key_or_typo, is_workspace_setting_key_or_typo, sort_and_dedup_unknown_keys,
     unknown_workspace_setting_keys,
 };
 use serde_json::Value;
@@ -62,8 +62,7 @@ fn kakehashi_targeted_payload(object: serde_json::Map<String, Value>) -> serde_j
             if key == "features"
                 && let Some(features) = value.as_object_mut()
             {
-                features
-                    .retain(|feature, _| KNOWN_FEATURE_SETTING_KEYS.contains(&feature.as_str()));
+                features.retain(|feature, _| is_feature_setting_key_or_typo(feature));
             }
             Some((key, value))
         })
@@ -93,9 +92,9 @@ fn format_rejected_keys(keys: &[String]) -> String {
 fn is_kakehashi_workspace_entry(key: &str, value: &Value) -> bool {
     if key == "features" {
         return value.as_object().is_some_and(|features| {
-            KNOWN_FEATURE_SETTING_KEYS
-                .iter()
-                .any(|key| features.contains_key(*key))
+            features
+                .keys()
+                .any(|feature| is_feature_setting_key_or_typo(feature))
         });
     }
     is_workspace_setting_key_or_typo(key)
@@ -635,6 +634,29 @@ mod tests {
             unknown_keys,
             ["features.textDocument/semanticTokens.captureMapping"]
         );
+    }
+
+    #[test]
+    fn settings_payload_rejects_semantic_tokens_feature_method_typo() {
+        let (payload, unknown_keys) = settings_payload(serde_json::json!({
+            "features": {
+                "textDocument/semanticToken": {
+                    "captureMappings": {}
+                }
+            }
+        }));
+
+        assert_eq!(
+            payload,
+            serde_json::json!({
+                "features": {
+                    "textDocument/semanticToken": {
+                        "captureMappings": {}
+                    }
+                }
+            })
+        );
+        assert_eq!(unknown_keys, ["features.textDocument/semanticToken"]);
     }
 
     #[test]

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -612,6 +612,32 @@ mod tests {
     }
 
     #[test]
+    fn settings_payload_rejects_unknown_semantic_tokens_feature_key() {
+        let (payload, unknown_keys) = settings_payload(serde_json::json!({
+            "features": {
+                "textDocument/semanticTokens": {
+                    "captureMapping": {}
+                }
+            }
+        }));
+
+        assert_eq!(
+            payload,
+            serde_json::json!({
+                "features": {
+                    "textDocument/semanticTokens": {
+                        "captureMapping": {}
+                    }
+                }
+            })
+        );
+        assert_eq!(
+            unknown_keys,
+            ["features.textDocument/semanticTokens.captureMapping"]
+        );
+    }
+
+    #[test]
     fn settings_payload_keeps_unwrapped_log_message_feature() {
         let features = serde_json::json!({
             "window/logMessage": {

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -464,11 +464,10 @@ impl Kakehashi {
                 // Remembered under the same reload transaction that publishes
                 // the merged settings, so a concurrent workspace-root change
                 // cannot rebuild the layers from a half-updated override.
-                let client_override = self.client_settings_override.load_full();
-                let merged_override =
-                    merge_workspace_settings(client_override.as_deref().cloned(), Some(parsed));
-                self.client_settings_override
-                    .store(merged_override.map(std::sync::Arc::new));
+                self.client_settings_overrides
+                    .write()
+                    .expect("client settings overrides lock poisoned")
+                    .push(parsed);
                 let warnings = Self::misconfigured_settings_warnings(&settings);
                 self.apply_raw_settings_locked(&reload, merged_ts, settings)
                     .await;

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -2,8 +2,8 @@
 
 use tower_lsp_server::ls_types::DidChangeWorkspaceFoldersParams;
 
-use crate::config::{WorkspaceSettings, merge_workspace_settings};
-use crate::lsp::load_settings;
+use crate::config::WorkspaceSettings;
+use crate::lsp::load_settings_with_client_layers;
 
 use super::super::{Kakehashi, lifecycle::config_root_after_folder_change, lock_settings_reload};
 
@@ -94,9 +94,9 @@ impl Kakehashi {
             .read()
             .expect("client settings overrides lock poisoned")
             .clone();
-        let outcome = load_settings(
+        let outcome = load_settings_with_client_layers(
             root_path.as_deref(),
-            None,
+            client_overrides,
             self.home_dir.as_deref(),
             |var| std::env::var(var).ok(),
             // The branch above returned for every session that has one.
@@ -119,15 +119,9 @@ impl Kakehashi {
         {
             self.notifier().show_warning(notice).await;
         }
-        let raw = client_overrides.into_iter().fold(
-            outcome
-                .raw_settings
-                .unwrap_or_else(crate::config::defaults::default_settings),
-            |base, overlay| {
-                merge_workspace_settings(Some(base), Some(overlay))
-                    .expect("merging two client settings layers must produce settings")
-            },
-        );
+        let raw = outcome
+            .raw_settings
+            .unwrap_or_else(crate::config::defaults::default_settings);
         match WorkspaceSettings::try_from_settings(
             &raw,
             self.home_dir.as_deref(),

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -103,6 +103,15 @@ impl Kakehashi {
             None,
         );
         self.notifier().log_settings_events(&outcome.events).await;
+        if outcome.deprecated_keys.capture_mappings
+            && self
+                .settings_manager
+                .claim_capture_mappings_deprecation_warning()
+        {
+            self.notifier()
+                .show_warning(crate::config::deprecation::CAPTURE_MAPPINGS_DEPRECATION_NOTICE)
+                .await;
+        }
         let raw = outcome
             .raw_settings
             .unwrap_or_else(crate::config::defaults::default_settings);

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -112,6 +112,13 @@ impl Kakehashi {
                 .show_warning(crate::config::deprecation::CAPTURE_MAPPINGS_DEPRECATION_NOTICE)
                 .await;
         }
+        if let Some(notice) = outcome.empty_container_notice.as_deref()
+            && self
+                .settings_manager
+                .claim_empty_container_migration_warning()
+        {
+            self.notifier().show_warning(notice).await;
+        }
         let raw = outcome
             .raw_settings
             .unwrap_or_else(crate::config::defaults::default_settings);

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -73,18 +73,6 @@ impl Kakehashi {
             self.settings_manager.folderless_root_path(),
         );
 
-        // An explicit `--config-file` replaces the whole config-file stack, so
-        // the project layer at the workspace root is never consulted and no
-        // file layer can change when the root does. Those files are also read
-        // exactly once by contract, which leaves this reload nothing to read
-        // and only initialize's settings events to re-emit. Refreshing the root
-        // — which still anchors relative paths — and stopping there is the whole
-        // of it.
-        if crate::config::expand::config_file_override().is_some() {
-            self.settings_manager.set_root_path(root_path);
-            return;
-        }
-
         // The root stays local until the settings derived from it are the ones
         // in effect. Publishing it earlier would leave a rejected reload with
         // the new root over the old snapshot, so the next pushed layer would
@@ -99,8 +87,10 @@ impl Kakehashi {
             client_overrides,
             self.home_dir.as_deref(),
             |var| std::env::var(var).ok(),
-            // The branch above returned for every session that has one.
-            None,
+            // Explicit files are never re-read. Initialize retained their
+            // already-parsed, already-anchored layers specifically for this
+            // replay; only client-relative layers move with the workspace.
+            self.explicit_config.get().cloned().flatten(),
         );
         self.notifier().log_settings_events(&outcome.events).await;
         if outcome.deprecated_keys.capture_mappings

--- a/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_workspace_folders.rs
@@ -2,8 +2,8 @@
 
 use tower_lsp_server::ls_types::DidChangeWorkspaceFoldersParams;
 
-use crate::config::WorkspaceSettings;
-use crate::lsp::{SettingsSource, load_settings};
+use crate::config::{WorkspaceSettings, merge_workspace_settings};
+use crate::lsp::load_settings;
 
 use super::super::{Kakehashi, lifecycle::config_root_after_folder_change, lock_settings_reload};
 
@@ -89,14 +89,14 @@ impl Kakehashi {
         // in effect. Publishing it earlier would leave a rejected reload with
         // the new root over the old snapshot, so the next pushed layer would
         // anchor to a workspace the settings in effect know nothing about.
-        let client_override = self.client_settings_override.load_full();
+        let client_overrides = self
+            .client_settings_overrides
+            .read()
+            .expect("client settings overrides lock poisoned")
+            .clone();
         let outcome = load_settings(
             root_path.as_deref(),
-            client_override.as_deref().and_then(|settings| {
-                serde_json::to_value(settings)
-                    .ok()
-                    .map(|value| (SettingsSource::InitializationOptions, value))
-            }),
+            None,
             self.home_dir.as_deref(),
             |var| std::env::var(var).ok(),
             // The branch above returned for every session that has one.
@@ -119,9 +119,15 @@ impl Kakehashi {
         {
             self.notifier().show_warning(notice).await;
         }
-        let raw = outcome
-            .raw_settings
-            .unwrap_or_else(crate::config::defaults::default_settings);
+        let raw = client_overrides.into_iter().fold(
+            outcome
+                .raw_settings
+                .unwrap_or_else(crate::config::defaults::default_settings),
+            |base, overlay| {
+                merge_workspace_settings(Some(base), Some(overlay))
+                    .expect("merging two client settings layers must produce settings")
+            },
+        );
         match WorkspaceSettings::try_from_settings(
             &raw,
             self.home_dir.as_deref(),

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -1918,6 +1918,44 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_load_toml_file_warns_about_folds_without_discarding_highlights() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("legacy-folds.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [captureMappings._.folds]
+            comment = "comment"
+
+            [captureMappings._.highlights]
+            variable = "variable"
+            "#,
+        )
+        .unwrap();
+
+        let mut events = Vec::new();
+        let mut ignored_deprecation = DeprecatedKeysSeen::default();
+        let settings = load_toml_file(&path, &mut events, &mut ignored_deprecation)
+            .expect("an unknown key should not reject an explicit config file")
+            .expect("settings");
+
+        assert!(
+            events
+                .iter()
+                .any(|event| event.kind == SettingsEventKind::Warning
+                    && event.message.contains("captureMappings._.folds")),
+            "the removed key should use the common file warning policy: {events:?}"
+        );
+        assert_eq!(
+            settings.capture_mappings.expect("legacy mappings")["_"]
+                .highlights
+                .as_ref()
+                .expect("highlights")["variable"],
+            "variable"
+        );
+    }
+
     /// Records, rather than endorses, an inconsistency: `FeatureSettings` and
     /// its children carry `deny_unknown_fields`, so an unknown key *inside*
     /// `features` fails typed deserialization and is fatal — while the same

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -575,11 +575,14 @@ fn emptied_container_names(settings: &RawWorkspaceSettings) -> Vec<String> {
         Some(mappings) if mappings.is_empty() => {
             named.push("features.\"textDocument/semanticTokens\".captureMappings".to_string())
         }
-        Some(mappings) => named.extend(mappings.iter().filter_map(|(lang, mappings)| {
+        Some(mappings) => named.extend(
             mappings
-                .is_empty()
-                .then(|| format!("features.\"textDocument/semanticTokens\".captureMappings.{lang}"))
-        })),
+                .iter()
+                .filter(|(_, mappings)| mappings.is_empty())
+                .map(|(lang, _)| {
+                    format!("features.\"textDocument/semanticTokens\".captureMappings.{lang}")
+                }),
+        ),
         None => {}
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -70,6 +70,9 @@ pub struct SettingsLoadOutcome {
     /// Which deprecated keys the loaded layers spelled — see
     /// [`DeprecatedKeysSeen`] for why this is not an `events` entry.
     pub(crate) deprecated_keys: DeprecatedKeysSeen,
+    /// First migration notice produced by an authored layer before merge-time
+    /// normalization erases its legacy spelling.
+    pub(crate) empty_container_notice: Option<String>,
 }
 
 /// Fold configuration layers into the settings they describe, lowest
@@ -424,6 +427,12 @@ pub fn load_settings(
             settings
         });
 
+    let empty_container_notice = config_layers
+        .iter()
+        .filter_map(Option::as_ref)
+        .chain(override_settings.as_ref())
+        .find_map(|settings| emptied_container_notice(Some(settings)));
+
     // Merge all layers: defaults < config_layers < override (later layers override earlier)
     let mut layers = vec![defaults];
     layers.extend(config_layers);
@@ -437,6 +446,7 @@ pub fn load_settings(
         raw_settings,
         events,
         deprecated_keys,
+        empty_container_notice,
     }
 }
 
@@ -947,6 +957,30 @@ mod tests {
             emptied_container_notice(Some(&inheriting)).is_none(),
             "omitting the keys is the inheriting spelling and must stay quiet"
         );
+    }
+
+    #[test]
+    fn load_settings_preserves_legacy_empty_mapping_notice_before_normalization() {
+        let outcome = load_settings(
+            None,
+            Some((
+                SettingsSource::InitializationOptions,
+                serde_json::json!({ "captureMappings": {} }),
+            )),
+            None,
+            |_| None,
+            Some(ExplicitConfig {
+                layers: Vec::new(),
+                events: Vec::new(),
+                deprecated_keys: DeprecatedKeysSeen::default(),
+                fatal_error: None,
+            }),
+        );
+
+        let notice = outcome
+            .empty_container_notice
+            .expect("normalization must not erase the authored empty-container signal");
+        assert!(notice.contains("captureMappings"), "{notice}");
     }
 
     #[test]

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -141,28 +141,21 @@ pub(crate) fn load_explicit_config(
     Some(read_explicit_layers(files, home, env_fn))
 }
 
-/// Keys in a TOML config file that kakehashi does not recognise.
-///
-/// Reuses the walker the `workspace/didChangeConfiguration` path uses, via a
-/// JSON round-trip, so both routes judge a key by the same schema. An empty
-/// result when the TOML cannot be re-read as a generic value is deliberate:
-/// this only ever *reports*, so a limitation of the conversion must not be
-/// louder than the settings it is describing.
-fn unknown_config_keys(contents: &str) -> Vec<String> {
-    let Ok(value) = toml::from_str::<Value>(contents) else {
-        return Vec::new();
-    };
-    let mut keys = crate::config::unknown_keys::unknown_workspace_setting_keys(&value);
-    crate::config::unknown_keys::sort_and_dedup_unknown_keys(&mut keys);
-    keys
-}
-
 fn append_unknown_config_key_warnings(
     contents: &str,
     config_path: &Path,
     events: &mut Vec<SettingsEvent>,
 ) {
-    for key in unknown_config_keys(contents) {
+    let keys = crate::config::unknown_keys::unknown_toml_workspace_setting_keys(contents);
+    append_unknown_key_warnings(&keys, config_path, events);
+}
+
+fn append_unknown_key_warnings(
+    unknown_keys: &[String],
+    config_path: &Path,
+    events: &mut Vec<SettingsEvent>,
+) {
+    for key in unknown_keys {
         events.push(SettingsEvent::warning(format!(
             "Unknown configuration key in {}: {key}",
             config_path.display()
@@ -643,6 +636,7 @@ fn load_user_config_with_events(
             events.push(SettingsEvent::info(
                 "Loaded user config from XDG_CONFIG_HOME",
             ));
+            append_unknown_key_warnings(&config.unknown_keys, &config.path, events);
             deprecated_keys.merge(config.deprecated_keys);
             Some((config.settings, config.path))
         }
@@ -2316,6 +2310,56 @@ mod tests {
                         .message
                         .contains("features.textDocument/publishDiagnostics.futureOption")),
             "the ignored key and workspace file should be named: {events:?}"
+        );
+        assert_eq!(
+            settings
+                .features
+                .expect("features")
+                .text_document_publish_diagnostics
+                .expect("publish diagnostics")
+                .debounce_ms,
+            Some(12)
+        );
+    }
+
+    #[test]
+    #[serial(xdg_env)]
+    fn load_user_config_warns_about_unknown_feature_key_without_discarding_siblings() {
+        let original_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+        let dir = TempDir::new().unwrap();
+        let config_dir = dir.path().join("kakehashi");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        let config_path = config_dir.join("kakehashi.toml");
+        std::fs::write(
+            &config_path,
+            "[features.\"textDocument/publishDiagnostics\"]\ndebounceMs = 12\nfutureOption = 1\n",
+        )
+        .unwrap();
+        // SAFETY: serial(xdg_env) prevents concurrent mutation in this test module.
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", dir.path()) };
+
+        let mut events = Vec::new();
+        let mut deprecated_keys = DeprecatedKeysSeen::default();
+        let loaded = load_user_config_with_events(&mut events, &mut deprecated_keys);
+
+        // SAFETY: serial(xdg_env) prevents concurrent mutation in this test module.
+        unsafe {
+            match original_xdg {
+                Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+
+        let settings = loaded.expect("user config").0;
+        assert!(
+            events
+                .iter()
+                .any(|event| event.kind == SettingsEventKind::Warning
+                    && event.message.contains(&config_path.display().to_string())
+                    && event
+                        .message
+                        .contains("features.textDocument/publishDiagnostics.futureOption")),
+            "the ignored key and user config should be named: {events:?}"
         );
         assert_eq!(
             settings

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -427,11 +427,12 @@ pub fn load_settings(
             settings
         });
 
-    let empty_container_notice = config_layers
-        .iter()
-        .filter_map(Option::as_ref)
-        .chain(override_settings.as_ref())
-        .find_map(|settings| emptied_container_notice(Some(settings)));
+    let empty_container_notice = empty_container_notice_for_layers(
+        config_layers
+            .iter()
+            .filter_map(Option::as_ref)
+            .chain(override_settings.as_ref()),
+    );
 
     // Merge all layers: defaults < config_layers < override (later layers override earlier)
     let mut layers = vec![defaults];
@@ -475,7 +476,29 @@ pub fn load_settings(
 /// spelling it names is also the one the documentation now recommends for
 /// "this entry has none": worth explaining once, not worth nagging about.
 pub(crate) fn emptied_container_notice(settings: Option<&RawWorkspaceSettings>) -> Option<String> {
-    let settings = settings?;
+    empty_container_notice_for_layers(settings)
+}
+
+fn empty_container_notice_for_layers<'a>(
+    layers: impl IntoIterator<Item = &'a RawWorkspaceSettings>,
+) -> Option<String> {
+    let mut named = layers
+        .into_iter()
+        .flat_map(emptied_container_names)
+        .collect::<Vec<_>>();
+    if named.is_empty() {
+        return None;
+    }
+    named.sort_unstable();
+    named.dedup();
+    Some(format!(
+        "kakehashi: an empty list or map now clears the layer below rather than \
+         deferring to it — omit the key to inherit. Affected: {}",
+        named.join(", ")
+    ))
+}
+
+fn emptied_container_names(settings: &RawWorkspaceSettings) -> Vec<String> {
     let mut named: Vec<String> = Vec::new();
 
     if let Some(servers) = settings.language_servers.as_ref() {
@@ -499,15 +522,7 @@ pub(crate) fn emptied_container_notice(settings: Option<&RawWorkspaceSettings>) 
         None => {}
     }
 
-    if named.is_empty() {
-        return None;
-    }
-    named.sort_unstable();
-    Some(format!(
-        "kakehashi: an empty list or map now clears the layer below rather than \
-         deferring to it — omit the key to inherit. Affected: {}",
-        named.join(", ")
-    ))
+    named
 }
 
 /// Expand and validate the fully merged configuration, `initializationOptions`
@@ -960,7 +975,14 @@ mod tests {
     }
 
     #[test]
-    fn load_settings_preserves_legacy_empty_mapping_notice_before_normalization() {
+    fn load_settings_aggregates_empty_notices_before_normalization() {
+        let lower_layer: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [languageServers.empty]
+            cmd = []
+            "#,
+        )
+        .expect("lower layer");
         let outcome = load_settings(
             None,
             Some((
@@ -970,7 +992,7 @@ mod tests {
             None,
             |_| None,
             Some(ExplicitConfig {
-                layers: Vec::new(),
+                layers: vec![Some(lower_layer)],
                 events: Vec::new(),
                 deprecated_keys: DeprecatedKeysSeen::default(),
                 fatal_error: None,
@@ -981,6 +1003,7 @@ mod tests {
             .empty_container_notice
             .expect("normalization must not erase the authored empty-container signal");
         assert!(notice.contains("captureMappings"), "{notice}");
+        assert!(notice.contains("languageServers.empty"), "{notice}");
     }
 
     #[test]

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -1956,30 +1956,39 @@ mod tests {
         );
     }
 
-    /// Records, rather than endorses, an inconsistency: `FeatureSettings` and
-    /// its children carry `deny_unknown_fields`, so an unknown key *inside*
-    /// `features` fails typed deserialization and is fatal — while the same
-    /// mistake anywhere else is a warning. Pinned so that changing it is a
-    /// deliberate act with a test to update, not a silent drift.
     #[test]
-    fn test_load_toml_file_unknown_feature_key_is_fatal_today() {
+    fn test_load_toml_file_warns_about_unknown_feature_key_without_discarding_siblings() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("feature-typo.toml");
         std::fs::write(
             &path,
-            "[features.\"textDocument/publishDiagnostics\"]\nfutureOption = 1\n",
+            "[features.\"textDocument/publishDiagnostics\"]\ndebounceMs = 12\nfutureOption = 1\n",
         )
         .unwrap();
 
         let mut events = Vec::new();
         let mut ignored_deprecation = DeprecatedKeysSeen::default();
-        let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
+        let settings = load_toml_file(&path, &mut events, &mut ignored_deprecation)
+            .expect("an unknown feature key should use the common file policy")
+            .expect("settings");
 
-        let message = result
-            .expect_err("today an unknown key under `features` is fatal, unlike anywhere else");
         assert!(
-            message.contains("futureOption"),
-            "the rejected key must be named: {message}"
+            events
+                .iter()
+                .any(|event| event.kind == SettingsEventKind::Warning
+                    && event
+                        .message
+                        .contains("features.textDocument/publishDiagnostics.futureOption")),
+            "the ignored key should be named in a warning: {events:?}"
+        );
+        assert_eq!(
+            settings
+                .features
+                .expect("features")
+                .text_document_publish_diagnostics
+                .expect("publish diagnostics")
+                .debounce_ms,
+            Some(12)
         );
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -754,12 +754,6 @@ fn load_toml_file(
     // Warn rather than reject: a key kakehashi does not recognise may be a
     // typo, but it may equally be one this version has not learned yet, and
     // refusing to start over it would make the file version-locked.
-    //
-    // Not reached for a key inside `features`: those structs carry
-    // `deny_unknown_fields`, so the parse above already failed and this file is
-    // fatal. Inconsistent with the rule stated here, pre-existing, and pinned
-    // by `test_load_toml_file_unknown_feature_key_is_fatal_today` so a future
-    // change to it is a deliberate one.
     for key in unknown_config_keys(&contents) {
         events.push(SettingsEvent::warning(format!(
             "Unknown configuration key in {}: {key}",

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -566,6 +566,23 @@ fn emptied_container_names(settings: &RawWorkspaceSettings) -> Vec<String> {
         None => {}
     }
 
+    let canonical = settings
+        .features
+        .as_ref()
+        .and_then(|features| features.text_document_semantic_tokens.as_ref())
+        .and_then(|semantic_tokens| semantic_tokens.capture_mappings.as_ref());
+    match canonical {
+        Some(mappings) if mappings.is_empty() => {
+            named.push("features.\"textDocument/semanticTokens\".captureMappings".to_string())
+        }
+        Some(mappings) => named.extend(mappings.iter().filter_map(|(lang, mappings)| {
+            mappings
+                .is_empty()
+                .then(|| format!("features.\"textDocument/semanticTokens\".captureMappings.{lang}"))
+        })),
+        None => {}
+    }
+
     named
 }
 
@@ -1086,6 +1103,28 @@ mod tests {
             emptied_container_notice(Some(&inheriting)).is_none(),
             "omitting the keys is the inheriting spelling and must stay quiet"
         );
+
+        let canonical_root: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [features."textDocument/semanticTokens"]
+            captureMappings = {}
+            "#,
+        )
+        .expect("canonical root clear");
+        let message = emptied_container_notice(Some(&canonical_root)).expect("root notice");
+        assert!(
+            message.contains("features.\"textDocument/semanticTokens\".captureMappings"),
+            "{message}"
+        );
+
+        let canonical_language: RawWorkspaceSettings = toml::from_str(
+            r#"
+            [features."textDocument/semanticTokens".captureMappings.rust]
+            "#,
+        )
+        .expect("canonical language clear");
+        let message = emptied_container_notice(Some(&canonical_language)).expect("entry notice");
+        assert!(message.contains("captureMappings.rust"), "{message}");
     }
 
     #[test]

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -116,6 +116,7 @@ const MAX_CONFIG_FILE_BYTES: u64 = 8 * 1024 * 1024;
 /// second time. (Naming a stream is not a supported workflow — one with no
 /// writer will simply block initialization — but reading once is what keeps the
 /// failure mode that of the path the user chose.)
+#[derive(Clone)]
 pub(crate) struct ExplicitConfig {
     layers: Vec<Option<RawWorkspaceSettings>>,
     events: Vec<SettingsEvent>,
@@ -123,6 +124,19 @@ pub(crate) struct ExplicitConfig {
     /// Why this configuration cannot be used, if it cannot. `initialize` must
     /// reject the session when this is set.
     pub(crate) fatal_error: Option<String>,
+}
+
+impl ExplicitConfig {
+    /// Retain the already-read layers for workspace-root replay without
+    /// pretending the files were read again or re-emitting their load events.
+    pub(crate) fn for_replay(&self) -> Self {
+        Self {
+            layers: self.layers.clone(),
+            events: Vec::new(),
+            deprecated_keys: self.deprecated_keys,
+            fatal_error: None,
+        }
+    }
 }
 
 /// Read and judge the `--config-file` inputs, or `None` if there are none.

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -447,7 +447,7 @@ pub fn load_settings(
 ///
 /// - an empty `cmd` or `languages` used to defer to the `_` wildcard's list;
 ///   it now says the entry has none, and omitting the key is what inherits;
-/// - an empty `captureMappings`, `highlights`, or `folds` used to be a no-op —
+/// - an empty `captureMappings` or `highlights` used to be a no-op —
 ///   the merge only extended — and now clears the layer below, which for a
 ///   top-level `captureMappings = {}` means every built-in mapping.
 ///
@@ -483,8 +483,7 @@ pub(crate) fn emptied_container_notice(settings: Option<&RawWorkspaceSettings>) 
     match settings.capture_mappings.as_ref() {
         Some(mappings) if mappings.is_empty() => named.push("captureMappings".to_string()),
         Some(mappings) => named.extend(mappings.iter().filter_map(|(lang, entry)| {
-            let cleared = entry.highlights.as_ref().is_some_and(|m| m.is_empty())
-                || entry.folds.as_ref().is_some_and(|m| m.is_empty());
+            let cleared = entry.highlights.as_ref().is_some_and(|m| m.is_empty());
             cleared.then(|| format!("captureMappings.{lang}"))
         })),
         None => {}

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -157,6 +157,19 @@ fn unknown_config_keys(contents: &str) -> Vec<String> {
     keys
 }
 
+fn append_unknown_config_key_warnings(
+    contents: &str,
+    config_path: &Path,
+    events: &mut Vec<SettingsEvent>,
+) {
+    for key in unknown_config_keys(contents) {
+        events.push(SettingsEvent::warning(format!(
+            "Unknown configuration key in {}: {key}",
+            config_path.display()
+        )));
+    }
+}
+
 /// The explicit layers merged with nothing beneath them — the subject of the
 /// strict gate.
 ///
@@ -754,12 +767,7 @@ fn load_toml_file(
     // Warn rather than reject: a key kakehashi does not recognise may be a
     // typo, but it may equally be one this version has not learned yet, and
     // refusing to start over it would make the file version-locked.
-    for key in unknown_config_keys(&contents) {
-        events.push(SettingsEvent::warning(format!(
-            "Unknown configuration key in {}: {key}",
-            path.display()
-        )));
-    }
+    append_unknown_config_key_warnings(&contents, path, events);
 
     events.push(SettingsEvent::info(format!(
         "Successfully loaded {}",
@@ -825,6 +833,7 @@ fn load_toml_settings(
     )));
 
     deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
+    append_unknown_config_key_warnings(&contents, &config_path, events);
     match toml::from_str::<RawWorkspaceSettings>(&contents) {
         Ok(settings) => {
             events.push(SettingsEvent::info("Successfully loaded kakehashi.toml"));
@@ -2280,6 +2289,42 @@ mod tests {
         assert!(
             used_deprecated.root_markers,
             "rootMarkers should set the flag"
+        );
+    }
+
+    #[test]
+    fn load_toml_settings_warns_about_unknown_feature_key_without_discarding_siblings() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("kakehashi.toml");
+        std::fs::write(
+            &config_path,
+            "[features.\"textDocument/publishDiagnostics\"]\ndebounceMs = 12\nfutureOption = 1\n",
+        )
+        .unwrap();
+
+        let mut events = Vec::new();
+        let mut deprecated_keys = DeprecatedKeysSeen::default();
+        let settings = load_toml_settings(Some(dir.path()), &mut events, &mut deprecated_keys)
+            .expect("an unknown feature key should not reject a workspace config");
+
+        assert!(
+            events
+                .iter()
+                .any(|event| event.kind == SettingsEventKind::Warning
+                    && event.message.contains(&config_path.display().to_string())
+                    && event
+                        .message
+                        .contains("features.textDocument/publishDiagnostics.futureOption")),
+            "the ignored key and workspace file should be named: {events:?}"
+        );
+        assert_eq!(
+            settings
+                .features
+                .expect("features")
+                .text_document_publish_diagnostics
+                .expect("publish diagnostics")
+                .debounce_ms,
+            Some(12)
         );
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -366,6 +366,46 @@ pub fn load_settings(
     env_fn: impl Fn(&str) -> Option<String>,
     explicit: Option<ExplicitConfig>,
 ) -> SettingsLoadOutcome {
+    load_settings_impl(
+        root_path,
+        ClientSettingsLayers::Serialized(override_settings),
+        home,
+        env_fn,
+        explicit,
+    )
+}
+
+/// Reload settings while replaying already parsed client layers in their
+/// original order. Keeping the layers distinct preserves non-associative clear
+/// operations across workspace-root changes.
+pub(crate) fn load_settings_with_client_layers(
+    root_path: Option<&Path>,
+    client_layers: Vec<RawWorkspaceSettings>,
+    home: Option<&str>,
+    env_fn: impl Fn(&str) -> Option<String>,
+    explicit: Option<ExplicitConfig>,
+) -> SettingsLoadOutcome {
+    load_settings_impl(
+        root_path,
+        ClientSettingsLayers::Parsed(client_layers),
+        home,
+        env_fn,
+        explicit,
+    )
+}
+
+enum ClientSettingsLayers {
+    Serialized(Option<(SettingsSource, Value)>),
+    Parsed(Vec<RawWorkspaceSettings>),
+}
+
+fn load_settings_impl(
+    root_path: Option<&Path>,
+    client_layers: ClientSettingsLayers,
+    home: Option<&str>,
+    env_fn: impl Fn(&str) -> Option<String>,
+    explicit: Option<ExplicitConfig>,
+) -> SettingsLoadOutcome {
     let env_fn = crate::config::expand::with_kakehashi_defaults(env_fn);
     let mut events = Vec::new();
     let mut deprecated_keys = DeprecatedKeysSeen::default();
@@ -414,30 +454,34 @@ pub fn load_settings(
         ]
     };
 
-    // Layer 4: Override settings from initialization options or client configuration.
+    // Layers 4+: Override settings from initialization options or client configuration.
     //
     // Client-supplied paths are workspace-local: the client knows the workspace
     // it opened, not the directory the server was launched from.
-    let override_settings = override_settings
-        .and_then(|(source, value)| {
-            parse_override_settings(source, value, &mut events, &mut deprecated_keys)
-        })
-        .map(|mut settings| {
-            let _ = anchor_settings_paths(&mut settings, root_path);
-            settings
-        });
+    let mut client_layers = match client_layers {
+        ClientSettingsLayers::Serialized(settings) => settings
+            .and_then(|(source, value)| {
+                parse_override_settings(source, value, &mut events, &mut deprecated_keys)
+            })
+            .into_iter()
+            .collect(),
+        ClientSettingsLayers::Parsed(settings) => settings,
+    };
+    for settings in &mut client_layers {
+        let _ = anchor_settings_paths(settings, root_path);
+    }
 
     let empty_container_notice = empty_container_notice_for_layers(
         config_layers
             .iter()
             .filter_map(Option::as_ref)
-            .chain(override_settings.as_ref()),
+            .chain(client_layers.iter()),
     );
 
-    // Merge all layers: defaults < config_layers < override (later layers override earlier)
+    // Merge all layers: defaults < config layers < client layers.
     let mut layers = vec![defaults];
     layers.extend(config_layers);
-    layers.push(override_settings);
+    layers.extend(client_layers.into_iter().map(Some));
     let merged = fold_layers(layers);
     let raw_settings = merged.clone();
     let settings = expand_merged_settings(merged, home, &env_fn, &mut events);
@@ -925,6 +969,76 @@ mod tests {
         // SAFETY: #[serial(xdg_env)] prevents concurrent modification.
         unsafe { std::env::set_var("XDG_CONFIG_HOME", config_home) };
         f()
+    }
+
+    #[test]
+    #[serial(xdg_env)]
+    fn replayed_client_layers_are_anchored_to_the_reloaded_root() {
+        let config_home = TempDir::new().expect("config home");
+        let root = TempDir::new().expect("workspace root");
+        let client_layer = RawWorkspaceSettings {
+            search_paths: Some(vec!["relative-parser".to_string()]),
+            ..Default::default()
+        };
+
+        let outcome = with_xdg_config_home(config_home.path(), || {
+            load_settings_with_client_layers(
+                Some(root.path()),
+                vec![client_layer],
+                None,
+                crate::config::make_env(&[]),
+                None,
+            )
+        });
+
+        assert_eq!(
+            outcome.raw_settings.expect("merged settings").search_paths,
+            Some(vec![
+                root.path()
+                    .join("relative-parser")
+                    .to_string_lossy()
+                    .into_owned()
+            ])
+        );
+    }
+
+    #[test]
+    #[serial(xdg_env)]
+    fn replayed_client_layers_replace_invalid_lower_values_before_validation() {
+        let config_home = TempDir::new().expect("config home");
+        let root = TempDir::new().expect("workspace root");
+        std::fs::write(
+            root.path().join("kakehashi.toml"),
+            "searchPaths = [\"$MISSING_PROJECT_PATH\"]\n",
+        )
+        .expect("project config");
+        let client_layer = RawWorkspaceSettings {
+            search_paths: Some(vec!["client-parser".to_string()]),
+            ..Default::default()
+        };
+
+        let outcome = with_xdg_config_home(config_home.path(), || {
+            load_settings_with_client_layers(
+                Some(root.path()),
+                vec![client_layer],
+                None,
+                crate::config::make_env(&[]),
+                None,
+            )
+        });
+
+        assert!(
+            outcome.settings.is_some(),
+            "client layer should repair base"
+        );
+        assert!(
+            outcome
+                .events
+                .iter()
+                .all(|event| !event.message.contains("Invalid configuration")),
+            "only the fully merged layers should be validated: {:?}",
+            outcome.events
+        );
     }
 
     /// A user config file at `<config_home>/kakehashi/kakehashi.toml`, returning

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -76,6 +76,7 @@ pub(crate) struct SettingsManager {
     /// which path (initialize or didChangeConfiguration) first sees it.
     root_markers_deprecation_warned: AtomicBool,
     auto_install_deprecation_warned: AtomicBool,
+    capture_mappings_deprecation_warned: AtomicBool,
     /// Latches once an unwrapped runtime `workspace/didChangeConfiguration`
     /// payload has been warned about. Unlike `rootMarkers`, this applies only to
     /// client-pushed runtime settings, not initializationOptions or TOML files.
@@ -133,6 +134,7 @@ impl SettingsManager {
             client_capabilities: OnceLock::new(),
             root_markers_deprecation_warned: AtomicBool::new(false),
             auto_install_deprecation_warned: AtomicBool::new(false),
+            capture_mappings_deprecation_warned: AtomicBool::new(false),
             unwrapped_didchange_deprecation_warned: AtomicBool::new(false),
             empty_container_migration_warned: AtomicBool::new(false),
         }
@@ -155,6 +157,14 @@ impl SettingsManager {
     pub(crate) fn claim_auto_install_deprecation_warning(&self) -> bool {
         !self
             .auto_install_deprecation_warned
+            .swap(true, Ordering::Relaxed)
+    }
+
+    /// Claim the one-per-session slot for the deprecated top-level
+    /// `captureMappings` key.
+    pub(crate) fn claim_capture_mappings_deprecation_warning(&self) -> bool {
+        !self
+            .capture_mappings_deprecation_warned
             .swap(true, Ordering::Relaxed)
     }
 
@@ -834,6 +844,13 @@ mod tests {
     }
 
     #[test]
+    fn claim_capture_mappings_deprecation_warning_is_true_exactly_once() {
+        let manager = SettingsManager::new();
+        assert!(manager.claim_capture_mappings_deprecation_warning());
+        assert!(!manager.claim_capture_mappings_deprecation_warning());
+    }
+
+    #[test]
     fn deprecation_claim_slots_are_independent() {
         // A config carrying both deprecated keys must warn about both; one
         // shared latch would silently drop the second notice.
@@ -844,6 +861,10 @@ mod tests {
             "claiming rootMarkers must not consume the autoInstall slot"
         );
         assert!(manager.claim_unwrapped_didchange_deprecation_warning());
+        assert!(
+            manager.claim_capture_mappings_deprecation_warning(),
+            "claiming other deprecations must not consume the captureMappings slot"
+        );
     }
 
     #[test]

--- a/tests/e2e/e2e_config_file.rs
+++ b/tests/e2e/e2e_config_file.rs
@@ -54,6 +54,10 @@ fn query_effective_settings(client: &mut LspClient) -> serde_json::Value {
         .clone()
 }
 
+fn semantic_token_capture_mappings(settings: &Value) -> &Value {
+    &settings["features"]["textDocument/semanticTokens"]["captureMappings"]
+}
+
 /// Poll effective settings until `predicate` returns true, or panic after timeout.
 ///
 /// Use after `didChangeConfiguration` to avoid fixed sleeps. Polls every 100ms for
@@ -766,7 +770,7 @@ fn test_config_file_deep_merge_capture_mappings_with_init_options() {
         }),
     );
 
-    let highlights = &settings["captureMappings"]["_"]["highlights"];
+    let highlights = &semantic_token_capture_mappings(&settings)["_"];
 
     assert_eq!(
         highlights["variable.builtin"],
@@ -1375,7 +1379,8 @@ fn test_did_change_configuration_warns_on_nested_capture_mapping_unknown_keys() 
         .env_remove("KAKEHASHI_DATA_DIR")
         .build();
 
-    let initial_capture_mappings = get_effective_settings(&mut client)["captureMappings"].clone();
+    let initial_settings = get_effective_settings(&mut client);
+    let initial_capture_mappings = semantic_token_capture_mappings(&initial_settings).clone();
 
     client.send_notification(
         "workspace/didChangeConfiguration",
@@ -1413,7 +1418,8 @@ fn test_did_change_configuration_warns_on_nested_capture_mapping_unknown_keys() 
         "nested capture mapping unknown-key update must not also log success; got: {unexpected_success:?}"
     );
 
-    let updated_capture_mappings = query_effective_settings(&mut client)["captureMappings"].clone();
+    let updated_settings = query_effective_settings(&mut client);
+    let updated_capture_mappings = semantic_token_capture_mappings(&updated_settings).clone();
     assert_eq!(
         updated_capture_mappings, initial_capture_mappings,
         "nested capture mapping unknown-key update should leave captureMappings unchanged",

--- a/tests/e2e/e2e_config_file.rs
+++ b/tests/e2e/e2e_config_file.rs
@@ -739,7 +739,7 @@ fn test_config_file_deep_merge_languages_from_two_files() {
     );
 }
 
-/// Deep merge: captureMappings from config file + initializationOptions.
+/// Deep merge: canonical semantic-token mappings from config file + initializationOptions.
 #[test]
 fn test_config_file_deep_merge_capture_mappings_with_init_options() {
     let dir = TempDir::new().unwrap();
@@ -747,7 +747,7 @@ fn test_config_file_deep_merge_capture_mappings_with_init_options() {
     let config = dir.path().join("capture.toml");
     std::fs::write(
         &config,
-        "[captureMappings._.highlights]\n\"variable.builtin\" = \"from.file\"\n",
+        "[features.\"textDocument/semanticTokens\".captureMappings._]\n\"variable.builtin\" = \"from.file\"\n",
     )
     .unwrap();
 
@@ -760,10 +760,12 @@ fn test_config_file_deep_merge_capture_mappings_with_init_options() {
     let settings = get_effective_settings_with_init_options(
         &mut client,
         json!({
-            "captureMappings": {
-                "_": {
-                    "highlights": {
+            "features": {
+                "textDocument/semanticTokens": {
+                    "captureMappings": {
+                        "_": {
                         "function.builtin": "from.init"
+                        }
                     }
                 }
             }

--- a/tests/e2e/e2e_deprecation_warning.rs
+++ b/tests/e2e/e2e_deprecation_warning.rs
@@ -1,8 +1,8 @@
 //! E2E tests for the one-per-session config deprecation notices
-//! (`rootMarkers`, the top-level `autoInstall`, and the unwrapped
+//! (`rootMarkers`, top-level `autoInstall`/`captureMappings`, and the unwrapped
 //! `didChangeConfiguration` shape).
 //!
-//! The `rootMarkers` and `autoInstall` notices can each be surfaced by
+//! The key-deprecation notices can each be surfaced by
 //! `initialize` OR by `workspace/didChangeConfiguration`, sharing one
 //! session-scoped claim guard so each fires at most once however often config
 //! keeps carrying the key. The unwrapped-shape notice is didChange-only — there
@@ -94,6 +94,36 @@ fn flat_didchange_config(auto_install: bool) -> Value {
 
 fn wrapped_didchange_config(auto_install: bool) -> Value {
     json!({ "settings": { "kakehashi": { "autoInstall": auto_install } } })
+}
+
+fn is_capture_mappings_deprecation_notice(params: &Value) -> bool {
+    params["message"].as_str().is_some_and(|message| {
+        message.contains("captureMappings") && message.contains("deprecated")
+    })
+}
+
+fn canonical_capture_mappings(value: &str) -> Value {
+    json!({
+        "settings": {
+            "kakehashi": {
+                "features": {
+                    "textDocument/semanticTokens": {
+                        "captureMappings": { "_": { "variable": value } }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn legacy_capture_mappings(value: &str) -> Value {
+    json!({
+        "settings": {
+            "kakehashi": {
+                "captureMappings": { "_": { "highlights": { "variable": value } } }
+            }
+        }
+    })
 }
 
 fn query_effective_settings(client: &mut LspClient) -> Value {
@@ -487,6 +517,134 @@ fn e2e_auto_install_deprecation_warns_at_initialize_and_not_again_on_didchange()
     assert_eq!(
         method, "window/logMessage",
         "initialize must have claimed the session's only slot; got: {params:?}"
+    );
+
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn e2e_capture_mappings_deprecation_warns_once_and_ignores_canonical_shape() {
+    let config_dir = tempfile::TempDir::new().expect("temp config dir");
+    let config_path = config_dir.path().join("kakehashi.toml");
+    std::fs::write(&config_path, "").expect("write empty config");
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("utf-8 temp path"))
+        .build();
+
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        canonical_capture_mappings("canonical"),
+    );
+    let (method, params) = client
+        .wait_for_notification_where(&["window/showMessage", "window/logMessage"], TIMEOUT, |p| {
+            is_capture_mappings_deprecation_notice(p) || is_config_updated(p)
+        })
+        .expect("canonical reconfig should log success");
+    assert_eq!(
+        method, "window/logMessage",
+        "canonical capture mappings must not warn; got: {params:?}"
+    );
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        legacy_capture_mappings("legacy"),
+    );
+    let (_, notice) = client
+        .wait_for_notification_where(
+            &["window/showMessage"],
+            TIMEOUT,
+            is_capture_mappings_deprecation_notice,
+        )
+        .expect("legacy capture mappings should warn");
+    assert_eq!(notice["type"].as_i64(), Some(2));
+    client
+        .wait_for_notification_where(&["window/logMessage"], TIMEOUT, is_config_updated)
+        .expect("legacy reconfig should still apply");
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        legacy_capture_mappings("legacy-again"),
+    );
+    let (method, params) = client
+        .wait_for_notification_where(&["window/showMessage", "window/logMessage"], TIMEOUT, |p| {
+            is_capture_mappings_deprecation_notice(p) || is_config_updated(p)
+        })
+        .expect("second legacy reconfig should log success");
+    assert_eq!(
+        method, "window/logMessage",
+        "the session must not warn twice; got: {params:?}"
+    );
+
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn e2e_capture_mappings_initialize_warning_claims_didchange_slot() {
+    let config_dir = tempfile::TempDir::new().expect("temp config dir");
+    let config_path = config_dir.path().join("kakehashi.toml");
+    std::fs::write(
+        &config_path,
+        "[captureMappings._.highlights]\nvariable = \"variable\"\n",
+    )
+    .expect("write legacy config");
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("utf-8 temp path"))
+        .build();
+
+    let initialize_id = client.send_request_async(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {}
+        }),
+    );
+    let (_response, watched) = client
+        .receive_response_for_id_watching_notifications(initialize_id, &["window/showMessage"]);
+    let mut notice = watched
+        .into_iter()
+        .find(|(_, params)| is_capture_mappings_deprecation_notice(params));
+    client.send_notification("initialized", json!({}));
+    if notice.is_none() {
+        notice = client.wait_for_notification_where(
+            &["window/showMessage"],
+            TIMEOUT,
+            is_capture_mappings_deprecation_notice,
+        );
+    }
+    let (_, notice) = notice.expect("legacy config file should warn at initialize");
+    assert_eq!(notice["type"].as_i64(), Some(2));
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        legacy_capture_mappings("runtime"),
+    );
+    let (method, params) = client
+        .wait_for_notification_where(&["window/showMessage", "window/logMessage"], TIMEOUT, |p| {
+            is_capture_mappings_deprecation_notice(p) || is_config_updated(p)
+        })
+        .expect("runtime update should log success");
+    assert_eq!(
+        method, "window/logMessage",
+        "initialize must have consumed the shared warning slot; got: {params:?}"
     );
 
     let _ = client.send_request("shutdown", json!(null));

--- a/tests/e2e/e2e_semantic.rs
+++ b/tests/e2e/e2e_semantic.rs
@@ -439,11 +439,13 @@ fn test_semantic_tokens_markdown_inline_bold() {
                 }
             },
             "initializationOptions": {
-                "captureMappings": {
-                    "_": {
-                        "highlights": {
+                "features": {
+                    "textDocument/semanticTokens": {
+                        "captureMappings": {
+                            "_": {
                             "markup.strong": "keyword",
                             "markup.heading.1": "class"
+                            }
                         }
                     }
                 }

--- a/tests/e2e/e2e_semantic_blockquote.rs
+++ b/tests/e2e/e2e_semantic_blockquote.rs
@@ -109,15 +109,25 @@ fn build_token_snapshot(tokens: &[DecodedToken], content: &str) -> Vec<serde_jso
         .collect()
 }
 
-/// E2E test: blockquote multiline injection with full captureMappings.
+fn semantic_token_initialization_options(mappings: serde_json::Value) -> serde_json::Value {
+    json!({
+        "features": {
+            "textDocument/semanticTokens": {
+                "captureMappings": { "_": mappings }
+            }
+        }
+    })
+}
+
+/// E2E test: blockquote multiline injection with full semantic-token mappings.
 ///
-/// Uses a comprehensive captureMappings config (matching typical user configs) with
+/// Uses a comprehensive canonical mapping config (matching typical user configs) with
 /// both heading and code block examples in a single document.
 #[test]
 fn test_blockquote_multiline_support_with_full_config() {
     let mut client = LspClient::new();
 
-    // User's EXACT captureMappings config
+    // A representative canonical semantic-token mapping config.
     client.send_request(
         "initialize",
         json!({
@@ -134,10 +144,7 @@ fn test_blockquote_multiline_support_with_full_config() {
                     }
                 }
             },
-            "initializationOptions": {
-                "captureMappings": {
-                    "_": {
-                        "highlights": {
+            "initializationOptions": semantic_token_initialization_options(json!({
                             "markup.heading": "class",
                             "markup.heading.1": "class",
                             "markup.heading.2": "class",
@@ -159,10 +166,7 @@ fn test_blockquote_multiline_support_with_full_config() {
                             "markup.strikethrough": "keyword.deprecated",
                             "markup.strong": "keyword",
                             "markup.underline": "keyword"
-                        }
-                    }
-                }
-            }
+            }))
         }),
     );
     client.send_notification("initialized", json!({}));
@@ -284,17 +288,11 @@ fn test_blockquote_multiline_injection_token_prefix() {
                     }
                 }
             },
-            "initializationOptions": {
-                "captureMappings": {
-                    "_": {
-                        "highlights": {
+            "initializationOptions": semantic_token_initialization_options(json!({
                             "markup.quote": "keyword",
                             "markup.raw.block": "string",
                             "markup.raw": "string"
-                        }
-                    }
-                }
-            }
+            }))
         }),
     );
     client.send_notification("initialized", json!({}));
@@ -410,16 +408,10 @@ fn test_blockquote_heading_host_token_preservation() {
                     }
                 }
             },
-            "initializationOptions": {
-                "captureMappings": {
-                    "_": {
-                        "highlights": {
+            "initializationOptions": semantic_token_initialization_options(json!({
                             "markup.heading.1": "class",
                             "markup.quote": "keyword"
-                        }
-                    }
-                }
-            }
+            }))
         }),
     );
     client.send_notification("initialized", json!({}));
@@ -528,16 +520,10 @@ fn test_blockquote_heading_multiline_support_prefix_type() {
                     }
                 }
             },
-            "initializationOptions": {
-                "captureMappings": {
-                    "_": {
-                        "highlights": {
+            "initializationOptions": semantic_token_initialization_options(json!({
                             "markup.heading.1": "class",
                             "markup.quote": "keyword"
-                        }
-                    }
-                }
-            }
+            }))
         }),
     );
     client.send_notification("initialized", json!({}));
@@ -643,15 +629,9 @@ fn test_blockquote_injection_tokens() {
                     }
                 }
             },
-            "initializationOptions": {
-                "captureMappings": {
-                    "_": {
-                        "highlights": {
+            "initializationOptions": semantic_token_initialization_options(json!({
                             "markup.quote": "string"
-                        }
-                    }
-                }
-            }
+            }))
         }),
     );
     client.send_notification("initialized", json!({}));
@@ -850,18 +830,12 @@ fn test_blockquote_shortcut_link_uniform_highlight() {
                     }
                 }
             },
-            "initializationOptions": {
-                "captureMappings": {
-                    "_": {
-                        "highlights": {
+            "initializationOptions": semantic_token_initialization_options(json!({
                             "markup.quote": "string",
                             "markup.link": "",
                             "markup.link.label": "keyword",
                             "markup.heading.1": "class"
-                        }
-                    }
-                }
-            }
+            }))
         }),
     );
     client.send_notification("initialized", json!({}));
@@ -969,10 +943,7 @@ fn init_client_with_full_config(client: &mut LspClient) {
                     }
                 }
             },
-            "initializationOptions": {
-                "captureMappings": {
-                    "_": {
-                        "highlights": {
+            "initializationOptions": semantic_token_initialization_options(json!({
                             "markup.heading": "class",
                             "markup.heading.1": "class",
                             "markup.heading.2": "class",
@@ -994,10 +965,7 @@ fn init_client_with_full_config(client: &mut LspClient) {
                             "markup.strikethrough": "keyword.deprecated",
                             "markup.strong": "keyword",
                             "markup.underline": "keyword"
-                        }
-                    }
-                }
-            }
+            }))
         }),
     );
     client.send_notification("initialized", json!({}));

--- a/tests/e2e/e2e_workspace_folder_config.rs
+++ b/tests/e2e/e2e_workspace_folder_config.rs
@@ -13,6 +13,7 @@
 use crate::helpers::lsp_client::LspClient;
 use crate::helpers::lsp_polling::poll_until;
 use serde_json::json;
+use std::time::Duration;
 use tempfile::TempDir;
 
 /// A directory holding a project config whose `searchPaths` names it.
@@ -70,6 +71,55 @@ fn poll_search_paths(client: &mut LspClient, expected: serde_json::Value, msg: &
         settled.is_some(),
         "{msg}; last seen: {}",
         query_effective_settings(client)["searchPaths"]
+    );
+}
+
+#[test]
+fn test_folder_change_warns_for_legacy_capture_mappings() {
+    let original = project_dir("original");
+    let legacy = project_dir("legacy");
+    std::fs::write(
+        legacy.path().join("kakehashi.toml"),
+        "searchPaths = [\"/legacy\"]\n[captureMappings._.highlights]\nvariable = \"variable\"\n",
+    )
+    .unwrap();
+
+    let mut client = LspClient::builder()
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "workspaceFolders": [folder(&original, "original")],
+            "capabilities": {}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    client.send_notification(
+        "workspace/didChangeWorkspaceFolders",
+        json!({
+            "event": {
+                "added": [folder(&legacy, "legacy")],
+                "removed": [folder(&original, "original")],
+            }
+        }),
+    );
+
+    let (_, params) = client
+        .wait_for_notification_where(&["window/showMessage"], Duration::from_secs(15), |params| {
+            params["message"].as_str().is_some_and(|message| {
+                message.contains("captureMappings") && message.contains("deprecated")
+            })
+        })
+        .expect("the newly selected legacy project config should warn");
+    assert_eq!(params["type"].as_i64(), Some(2));
+    poll_search_paths(
+        &mut client,
+        json!(["/legacy"]),
+        "the legacy project config should still apply",
     );
 }
 

--- a/tests/e2e/e2e_workspace_folder_config.rs
+++ b/tests/e2e/e2e_workspace_folder_config.rs
@@ -662,3 +662,54 @@ fn test_folder_change_reanchors_relative_runtime_paths_with_explicit_config() {
         "explicit config sessions should replay runtime paths against the new root",
     );
 }
+
+#[test]
+fn test_folder_change_does_not_replay_discarded_initialization_options() {
+    let primary = project_dir("from-primary");
+    let secondary = project_dir("from-secondary");
+    let config_dir = tempfile::TempDir::new().expect("config temp dir");
+    let config_path = config_dir.path().join("explicit.toml");
+    std::fs::write(&config_path, "searchPaths = []\n").expect("explicit config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("UTF-8 config path"))
+        .env_remove("KAKEHASHI_TEST_UNDEFINED")
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "workspaceFolders": [
+                folder(&primary, "primary"),
+                folder(&secondary, "secondary"),
+            ],
+            "initializationOptions": {
+                "searchPaths": ["$KAKEHASHI_TEST_UNDEFINED/path"]
+            },
+            "capabilities": {}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    client.send_notification(
+        "workspace/didChangeWorkspaceFolders",
+        json!({
+            "event": {
+                "added": [],
+                "removed": [folder(&primary, "primary")],
+            }
+        }),
+    );
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": { "kakehashi": { "searchPaths": ["relative-parser"] } } }),
+    );
+    poll_search_paths(
+        &mut client,
+        json!([secondary.path().join("relative-parser")]),
+        "discarded initialization options must not pin later pushes to the old root",
+    );
+}

--- a/tests/e2e/e2e_workspace_folder_config.rs
+++ b/tests/e2e/e2e_workspace_folder_config.rs
@@ -561,3 +561,51 @@ fn test_folder_change_preserves_capture_mapping_clear_before_later_addition() {
         "the earlier clear must still suppress lower-layer mappings: {settings}"
     );
 }
+
+#[test]
+fn test_folder_change_reanchors_relative_runtime_paths() {
+    let primary = project_dir("from-primary");
+    let secondary = project_dir("from-secondary");
+
+    let mut client = LspClient::builder()
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "workspaceFolders": [
+                folder(&primary, "primary"),
+                folder(&secondary, "secondary"),
+            ],
+            "capabilities": {}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": { "kakehashi": { "searchPaths": ["relative-parser"] } } }),
+    );
+    poll_search_paths(
+        &mut client,
+        json!([primary.path().join("relative-parser")]),
+        "runtime paths should initially anchor to the current root",
+    );
+
+    client.send_notification(
+        "workspace/didChangeWorkspaceFolders",
+        json!({
+            "event": {
+                "added": [],
+                "removed": [folder(&primary, "primary")],
+            }
+        }),
+    );
+    poll_search_paths(
+        &mut client,
+        json!([secondary.path().join("relative-parser")]),
+        "replayed runtime paths should anchor to the newly selected root",
+    );
+}

--- a/tests/e2e/e2e_workspace_folder_config.rs
+++ b/tests/e2e/e2e_workspace_folder_config.rs
@@ -123,6 +123,54 @@ fn test_folder_change_warns_for_legacy_capture_mappings() {
     );
 }
 
+#[test]
+fn test_folder_change_preserves_empty_mapping_migration_notice() {
+    let original = project_dir("original");
+    let legacy = project_dir("legacy-empty");
+    std::fs::write(
+        legacy.path().join("kakehashi.toml"),
+        "searchPaths = [\"/legacy-empty\"]\ncaptureMappings = {}\n",
+    )
+    .unwrap();
+
+    let mut client = LspClient::builder()
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "workspaceFolders": [folder(&original, "original")],
+            "capabilities": {}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+    client.send_notification(
+        "workspace/didChangeWorkspaceFolders",
+        json!({
+            "event": {
+                "added": [folder(&legacy, "legacy")],
+                "removed": [folder(&original, "original")],
+            }
+        }),
+    );
+
+    let (_, params) = client
+        .wait_for_notification_where(&["window/showMessage"], Duration::from_secs(15), |params| {
+            params["message"].as_str().is_some_and(|message| {
+                message.contains("empty list or map") && message.contains("captureMappings")
+            })
+        })
+        .expect("the authored empty mapping should retain its migration notice");
+    assert_eq!(params["type"].as_i64(), Some(2));
+    poll_search_paths(
+        &mut client,
+        json!(["/legacy-empty"]),
+        "the empty mapping project config should still apply",
+    );
+}
+
 /// Removing the last workspace folder must not leave the session rootless when
 /// the client named another root.
 ///

--- a/tests/e2e/e2e_workspace_folder_config.rs
+++ b/tests/e2e/e2e_workspace_folder_config.rs
@@ -484,3 +484,80 @@ fn test_folder_change_preserves_client_layers() {
         "the client layers must survive a project-layer reload: {settings}"
     );
 }
+
+/// Client updates are replayed as ordered layers after a project reload. An
+/// explicit root clear cannot be collapsed into a later non-empty map: doing
+/// so would let defaults or the newly selected project reappear.
+#[test]
+fn test_folder_change_preserves_capture_mapping_clear_before_later_addition() {
+    let primary = project_dir("from-primary");
+    let secondary = project_dir("from-secondary");
+
+    let mut client = LspClient::builder()
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "workspaceFolders": [
+                folder(&primary, "primary"),
+                folder(&secondary, "secondary"),
+            ],
+            "capabilities": {}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": { "kakehashi": {
+                "features": { "textDocument/semanticTokens": { "captureMappings": {} } }
+            } }
+        }),
+    );
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": { "kakehashi": {
+                "features": { "textDocument/semanticTokens": { "captureMappings": {
+                    "rust": { "comment": "comment" }
+                } } }
+            } }
+        }),
+    );
+
+    let expected = json!({ "rust": { "comment": "comment" } });
+    let pushed = poll_until(20, 100, || {
+        let settings = query_effective_settings(&mut client);
+        (settings["features"]["textDocument/semanticTokens"]["captureMappings"] == expected)
+            .then_some(settings)
+    });
+    assert!(
+        pushed.is_some(),
+        "precondition: clear then add should apply"
+    );
+
+    client.send_notification(
+        "workspace/didChangeWorkspaceFolders",
+        json!({
+            "event": {
+                "added": [],
+                "removed": [folder(&primary, "primary")],
+            }
+        }),
+    );
+    poll_search_paths(
+        &mut client,
+        json!(["/from-secondary"]),
+        "the project layer should follow the new root",
+    );
+
+    let settings = query_effective_settings(&mut client);
+    assert_eq!(
+        settings["features"]["textDocument/semanticTokens"]["captureMappings"], expected,
+        "the earlier clear must still suppress lower-layer mappings: {settings}"
+    );
+}

--- a/tests/e2e/e2e_workspace_folder_config.rs
+++ b/tests/e2e/e2e_workspace_folder_config.rs
@@ -609,3 +609,56 @@ fn test_folder_change_reanchors_relative_runtime_paths() {
         "replayed runtime paths should anchor to the newly selected root",
     );
 }
+
+#[test]
+fn test_folder_change_reanchors_relative_runtime_paths_with_explicit_config() {
+    let primary = project_dir("from-primary");
+    let secondary = project_dir("from-secondary");
+    let config_dir = tempfile::TempDir::new().expect("config temp dir");
+    let config_path = config_dir.path().join("explicit.toml");
+    std::fs::write(&config_path, "searchPaths = []\n").expect("explicit config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("UTF-8 config path"))
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "workspaceFolders": [
+                folder(&primary, "primary"),
+                folder(&secondary, "secondary"),
+            ],
+            "capabilities": {}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": { "kakehashi": { "searchPaths": ["relative-parser"] } } }),
+    );
+    poll_search_paths(
+        &mut client,
+        json!([primary.path().join("relative-parser")]),
+        "runtime paths should initially anchor to the current root",
+    );
+
+    client.send_notification(
+        "workspace/didChangeWorkspaceFolders",
+        json!({
+            "event": {
+                "added": [],
+                "removed": [folder(&primary, "primary")],
+            }
+        }),
+    );
+    poll_search_paths(
+        &mut client,
+        json!([secondary.path().join("relative-parser")]),
+        "explicit config sessions should replay runtime paths against the new root",
+    );
+}

--- a/tests/integration/test_cli.rs
+++ b/tests/integration/test_cli.rs
@@ -275,7 +275,7 @@ fn test_config_init_emits_no_auto_install_spelling() {
     );
 }
 
-/// Test that config init includes captureMappings in output
+/// Test that config init emits only the canonical semantic-token mappings.
 #[test]
 fn test_config_init_includes_capture_mappings() {
     let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
@@ -285,10 +285,14 @@ fn test_config_init_includes_capture_mappings() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // Should contain captureMappings section
     assert!(
-        stdout.contains("[captureMappings._.highlights]"),
-        "Should contain captureMappings section. Got: {}",
+        stdout.contains("[features.\"textDocument/semanticTokens\".captureMappings._]"),
+        "Should contain canonical captureMappings section. Got: {}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("[captureMappings."),
+        "Must not emit the deprecated top-level captureMappings section. Got: {}",
         stdout
     );
 

--- a/tests/integration/test_cli.rs
+++ b/tests/integration/test_cli.rs
@@ -295,6 +295,13 @@ fn test_config_init_includes_capture_mappings() {
         "Must not emit the deprecated top-level captureMappings section. Got: {}",
         stdout
     );
+    let parsed: toml::Value = toml::from_str(&stdout).expect("config init should emit valid TOML");
+    assert!(
+        parsed
+            .as_table()
+            .is_some_and(|settings| !settings.contains_key("captureMappings")),
+        "Must not emit deprecated top-level captureMappings in any TOML form. Got: {stdout}"
+    );
 
     // Should contain variable mapping
     assert!(

--- a/tests/integration/test_cli.rs
+++ b/tests/integration/test_cli.rs
@@ -607,6 +607,30 @@ fn test_config_schema_outputs_valid_json_to_stdout() {
         "Should have autoInstall property. Got: {}",
         stdout
     );
+    assert_eq!(
+        schema.pointer("/properties/captureMappings/deprecated"),
+        Some(&serde_json::json!(true)),
+        "legacy captureMappings should be marked deprecated"
+    );
+    assert!(
+        schema
+            .pointer("/$defs/FeatureSettings/properties/textDocument~1semanticTokens")
+            .is_some(),
+        "features should advertise textDocument/semanticTokens"
+    );
+    assert_eq!(
+        schema.pointer(
+            "/$defs/SemanticTokensFeatureSettings/properties/captureMappings/additionalProperties/additionalProperties/type"
+        ),
+        Some(&serde_json::json!("string")),
+        "canonical language entries should map captures directly to token roles"
+    );
+    assert!(
+        schema
+            .pointer("/$defs/QueryTypeMappings/properties/folds")
+            .is_none(),
+        "the never-consumed legacy folds field should not be advertised"
+    );
 }
 
 /// Test that config --help shows schema action


### PR DESCRIPTION
## Summary

- move capture mappings to `features."textDocument/semanticTokens".captureMappings`
- keep the top-level `captureMappings` shape readable as deprecated input with a once-per-session migration warning
- remove the never-consumed `folds` field from the schema while applying the same source-specific unknown-key policy as other unrecognized fields
- validate nested `features` keys through the common unknown-key policy, preserving recognized siblings in tolerant sources
- preserve valid sibling `highlights` when tolerant sources contain removed `folds`; runtime pushes still reject unknown keys
- preserve clear semantics and relative client paths when settings are replayed after workspace-root changes
- document merge/empty-map semantics and that `kakehashi/captures/*` remains raw

## Validation

- `make check`
- `cargo test --lib --quiet` (3553 passed, 2 ignored)
- focused removed-folds parser, file-policy, schema, and runtime-push tests
- workspace-folder configuration E2E module (12 passed)
- latest-head GitHub CI and Greptile review passed
- multi-perspective local review and Codex convergence review passed; all actionable review threads resolved; CodeRabbit skipped the latest head because the PR remains draft

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added semantic-token capture mappings under `features.textDocument/semanticTokens.captureMappings`.
  * Added per-language mappings, wildcard inheritance, overrides, and empty-map clearing.
  * Improved configuration merging across workspace folders and runtime updates.

* **Bug Fixes**
  * Unknown feature settings now produce warnings while preserving valid sibling settings.
  * Legacy `folds` entries are handled without discarding valid configuration.

* **Documentation**
  * Updated configuration and architecture guidance with the new format and migration details.

* **Deprecations**
  * Added one-time warnings for the former top-level `captureMappings` configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->