### PR TITLE
chore(release): bump version to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "kakehashi"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "arc-swap",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kakehashi"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 # std's inherent `File::lock` (src/install/queries.rs) is stable from 1.89; the
 # 2024 edition alone would only require 1.85. Declared so an older toolchain


### PR DESCRIPTION
## Summary

Bump the crate version from 0.10.0 to 0.11.0. This PR rolls up everything merged since the v0.10.0 release (2026-08-10). Merging this PR is the v0.11.0 release point: the merge commit will be tagged `v0.11.0` and published as a GitHub release.

## User-facing changes since v0.10.0

### Bridge routing protocol (`kakehashi/bridge/routing`)
- #997 — ADR: downstream routing delegation. A downstream server that advertises `capabilities.experimental.kakehashi.bridgeRouting` can answer a kakehashi-initiated `kakehashi/bridge/routing` request to suppress a bridged document's `didOpen` per server (`enabled: false`) and override workspace-root resolution (`workspaceFolders`). Supersedes and **deletes** the never-implemented `workspace-resolver` / `lua-host-api` ADRs.
- #1002 — Prerequisites: framing size ceilings on downstream connections (hostile `Content-Length` can no longer abort the process), `kakehashi/bridge/routing` exempt from the `aggregation."_"` wildcard, and a new per-server `forceStart` key that starts a server when configuration is applied instead of waiting for a document (policy servers with `languages = []`, `preferSharedInstance` warm-up).
- #1008 — Negotiate the routing capability in the downstream `initialize` handshake; downgrade after `MethodNotFound`.
- #1010 — Issue routing requests to negotiated connections only; fail open on provider errors; apply `enabled: false` before the first host `didOpen` under a bounded routing deadline.
- #1011 — Apply the routing answer to the complete host-provider candidate set before eager opening; an advertising provider can suppress sibling providers; per-connection decisions are cached.
- #1012 — Apply routed `workspaceFolders` to shared host-provider connections before `didOpen` / the first lazy host request.
- #1013 — Route virtual (injection) documents too, passing the opaque virtual URI plus the host document identity.
- #1014 — Remaining `workspaceFolders` semantics: `null` falls back to the client's workspace folders; `[]` records a rootless shared-instance route; decisions stay scoped to host URI and server.

### Queries & injections
- #1016 — Runtime directive support: Neovim-compatible `#gsub!` for dynamic capture text and injection languages, and `#offset!` / `#trim!` range metadata applied consistently across captures, semantic tokens, injections, selection ranges, and native node consumers (incl. `injection.combined`, nested included ranges, UTF-8/UTF-16 mapping). nvim-treesitter queries no longer select the wrong text/range or resolve the wrong injected language.
- #1003 — Injection region selection uses the **effective** post-`#offset!` span, not the raw `@injection.content` node. Fixes requests at a trimmed frontmatter's closing `---` being dispatched into the YAML server at virtual EOF, trimmed regions shadowing their neighbours, and widened regions leaving bytes that belonged to no region (#996 item 1).
- #998 — Caret-shaped requests (completion, signature help, …) at the **end** of a mid-line-ending injection region now resolve to that region instead of silently dropping the injected language's server. Also: positions past the region's host end abort with null instead of forwarding beyond-EOF coordinates; over-long `character` clamps to line end and past-EOF `line` is rejected; `prepareRename` fallback is bounds-checked.
- #1015 — Multiline host tokens whose span exactly matches an active injection region (e.g. TypeScript JSDoc comments) keep their host highlighting in the gaps not covered by injected tokens, with or without `multilineTokenSupport`.

### Configuration
- #1017 — Capture mappings move to `features."textDocument/semanticTokens".captureMappings`. The top-level `captureMappings` shape is still read as **deprecated** input with a once-per-session migration warning. The never-consumed `folds` field is removed from the schema; nested `features` keys go through the common unknown-key policy (tolerant sources keep recognised siblings, runtime pushes still reject). Clear semantics and relative client paths survive settings replay after workspace-root changes.
- #995 — Remove the unused `experimental.kakehashi.wrappedDidChangeConfigurationSettings` capability from the `initialize` response (no client reads it; wrapped and unwrapped `settings.kakehashi` payloads are both still accepted).

### Bridge fixes
- #993 — A `preferSharedInstance` server's marker-less documents (`untitled:` buffers, files with no marker up the tree) now join the shared instance instead of forking a second fallback process that never sees the real buffers. Also normalised root identity (trailing slash / percent-encoding no longer fork per-root processes), a tiered served-root proof for the incapable-shared divert, and re-open repair when a palette reconnect changes the connection key.

### Performance
- #903 — Cooperatively cancel parse and injection-snapshot work for obsolete document versions on `didChange` / `didClose` (`rust_xlarge/cancel_burst` −10% paired median); the latest version always gets fresh tokens, no debounce or skipped requests.

### CLI
- #1004 — `language uninstall --all` no longer swallows discovery I/O errors: a directory-level failure aborts before removing anything; a per-entry failure is named, skipped, and exits non-zero; dangling parser symlinks are now discoverable and removable (fixes #953).

## Not user-facing

- #991 — ADR: bridge client control protocol (`kakehashi/bridge/client/*`) — design only; sibling ls-bridge ADRs amended.
- #1001 — ADRs re-classified into contract / invariant / mechanism (closes #999); reorganisation and deletion only.
- #1000 — Dev build loop: dev debuginfo → `line-tables-only`, 59 test binaries → 2 (`tests/e2e`, `tests/integration`); `cargo build` after an edit 22–36s → ~4–7s, `clippy --all-targets` → ~6s; `scripts/test_e2e_parallel.sh` → `scripts/test_e2e.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the package to version 0.11.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->