### PR TITLE
feat(config): enforce deprecation removal deadlines

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,17 @@
+use std::{env, fs, path::PathBuf};
+
+fn main() {
+    println!("cargo::rerun-if-changed=Cargo.toml");
+
+    let package_major = env::var("CARGO_PKG_VERSION_MAJOR")
+        .expect("Cargo must provide CARGO_PKG_VERSION_MAJOR")
+        .parse::<u64>()
+        .expect("Cargo package major version must fit in u64");
+    let output = PathBuf::from(env::var_os("OUT_DIR").expect("Cargo must provide OUT_DIR"))
+        .join("package_version.rs");
+    fs::write(
+        output,
+        format!("pub(crate) const PACKAGE_MAJOR: u64 = {package_major};\n"),
+    )
+    .expect("package version module must be writable");
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -302,7 +302,7 @@ Per-language configuration. Usually not needed as kakehashi auto-detects languag
 | `queries` | Array of query configurations with `path` and `kind` (highlights, bindings, injections) |
 | `bridge` | Per-injection-language bridge filter and aggregation settings |
 | `autoInstall` | Whether missing parsers/queries for this language may be auto-installed |
-| `aliases` | Deprecated alternative language IDs. Prefer `base` on the derived language instead. |
+| `aliases` | Deprecated alternative language IDs, supported through v1 and removed in v2. Prefer `base` on the derived language instead. |
 
 ##### `languages[*].autoInstall`
 
@@ -462,11 +462,12 @@ Remap Tree-sitter capture names to LSP semantic token types. Use `_` as a wildca
 ```
 
 The former top-level `captureMappings.<language>.highlights` shape remains
-accepted for migration, but is deprecated. If both spellings occur in one
-layer, the feature-scoped value wins for duplicate capture names; otherwise
-their entries are combined. In the legacy spelling, `captureMappings = {}`
-clears the inherited root and `highlights = {}` under a
-`[captureMappings.<language>]` table clears that language's inherited entry.
+accepted for migration through v1, but is deprecated and will be removed in
+v2. If both spellings occur in one layer, the feature-scoped value wins for
+duplicate capture names; otherwise their entries are combined. In the legacy
+spelling, `captureMappings = {}` clears the inherited root and `highlights = {}`
+under a `[captureMappings.<language>]` table clears that language's inherited
+entry.
 The clear is applied before canonical entries in the same layer are added. The
 old `folds` table was unused and has no
 replacement. It is absent from the schema and has no effect. Like another
@@ -531,10 +532,10 @@ Configure language servers for bridging LSP requests in injection regions.
 
 > **Migration note**: `workspaceMarkers` was previously named `rootMarkers`
 > (aligning with the LSP spec's `workspaceFolders`). The old `rootMarkers` key
-> still works as a deprecated alias, so existing configs need no change; new
-> configs should prefer `workspaceMarkers`. When a config still uses
-> `rootMarkers`, kakehashi shows a one-time deprecation notice per session as a
-> visible `window/showMessage` popup.
+> remains accepted through v1 but will be removed in v2, so existing configs
+> must migrate to `workspaceMarkers` before upgrading to v2. When a config
+> still uses `rootMarkers`, kakehashi shows a one-time deprecation notice per
+> session as a visible `window/showMessage` popup.
 
 A `languageServers._` wildcard entry supplies defaults that every server
 inherits field-by-field (wildcard-config-inheritance) — e.g. set

--- a/docs/README.md
+++ b/docs/README.md
@@ -284,7 +284,7 @@ is itself resolved by language name and so must follow it too.
 **Deprecated:** use [`languages[*].autoInstall`](#languagesautoinstall) instead.
 The top-level key still works — it answers whenever no per-language value is
 set — but kakehashi shows a one-time migration notice when it is present, and
-it may be removed in a future release.
+it will be removed in kakehashi v2.
 
 Move `autoInstall = true` to `[languages._] autoInstall = true` — equivalent in
 every case but one, see the migration caveat under

--- a/docs/README.md
+++ b/docs/README.md
@@ -302,7 +302,7 @@ Per-language configuration. Usually not needed as kakehashi auto-detects languag
 | `queries` | Array of query configurations with `path` and `kind` (highlights, bindings, injections) |
 | `bridge` | Per-injection-language bridge filter and aggregation settings |
 | `autoInstall` | Whether missing parsers/queries for this language may be auto-installed |
-| `aliases` | Deprecated alternative language IDs, supported through v1 and removed in v2. Prefer `base` on the derived language instead. |
+| `aliases` | Deprecated and ignored alternative language IDs. The field is accepted for migration warnings through v1 and removed in v2; use `base` on each derived language instead. |
 
 ##### `languages[*].autoInstall`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -196,6 +196,33 @@ default `info` forwards Error, Warning, and Info while suppressing LSP `Log` and
 }
 ```
 
+### Live configuration updates
+
+When pushing configuration with `workspace/didChangeConfiguration`, put
+kakehashi's settings below `settings.kakehashi`:
+
+```json
+{
+  "settings": {
+    "kakehashi": {
+      "searchPaths": ["/path/to/kakehashi-data"]
+    }
+  }
+}
+```
+
+The older flat shape below is deprecated. It remains accepted through v1 and
+is removed in v2, so clients must migrate to the wrapper above before upgrading
+to v2.
+
+```json
+{
+  "settings": {
+    "searchPaths": ["/path/to/kakehashi-data"]
+  }
+}
+```
+
 ### Environment Variable Expansion
 
 Path fields support environment variable expansion and tilde (`~`) expansion, making configurations portable across machines.

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,7 +108,8 @@ Parsers are stored in `{data_dir}/parser/` and queries in `{data_dir}/queries/`.
 
 Configuration is provided via LSP `initializationOptions`. All options are optional.
 
-This section is a practical reference. For the exhaustive field list and types, see `kakehashi config schema`.
+This section is a practical reference. For the canonical field list and types,
+see `kakehashi config schema`.
 
 ### Configuration Options
 
@@ -211,18 +212,6 @@ kakehashi's settings below `settings.kakehashi`:
 }
 ```
 
-The older flat shape below is deprecated. It remains accepted through v1 and
-is removed in v2, so clients must migrate to the wrapper above before upgrading
-to v2.
-
-```json
-{
-  "settings": {
-    "searchPaths": ["/path/to/kakehashi-data"]
-  }
-}
-```
-
 ### Environment Variable Expansion
 
 Path fields support environment variable expansion and tilde (`~`) expansion, making configurations portable across machines.
@@ -306,18 +295,6 @@ given an explicit path is loaded as-is, so an `; inherits:` line in it is inert
 absent. Inherit only from queries that follow the implicit layout, whose parent
 is itself resolved by language name and so must follow it too.
 
-#### `autoInstall` (deprecated)
-
-**Deprecated:** use [`languages[*].autoInstall`](#languagesautoinstall) instead.
-The top-level key still works — it answers whenever no per-language value is
-set — but kakehashi shows a one-time migration notice when it is present, and
-it will be removed in kakehashi v2.
-
-Move `autoInstall = true` to `[languages._] autoInstall = true` — equivalent in
-every case but one, see the migration caveat under
-[`languages[*].autoInstall`](#languagesautoinstall) — then override per language
-as needed.
-
 #### `languages`
 
 Per-language configuration. Usually not needed as kakehashi auto-detects languages.
@@ -329,7 +306,6 @@ Per-language configuration. Usually not needed as kakehashi auto-detects languag
 | `queries` | Array of query configurations with `path` and `kind` (highlights, bindings, injections) |
 | `bridge` | Per-injection-language bridge filter and aggregation settings |
 | `autoInstall` | Whether missing parsers/queries for this language may be auto-installed |
-| `aliases` | Deprecated and ignored alternative language IDs. The field is accepted for migration warnings through v1 and removed in v2; use `base` on each derived language instead. |
 
 ##### `languages[*].autoInstall`
 
@@ -337,11 +313,11 @@ Whether kakehashi may download and install a missing parser/queries for this
 language when a file is opened.
 
 Resolved most-specific-wins: the language's own value, then each entry in its
-`base` chain, then the `"_"` wildcard's, then the deprecated top-level
-`autoInstall`, defaulting to `true`. Unset is the default at every level, so a
-language inherits through `base` and `"_"` exactly like the other fields — for
-example `[languages.rmd] base = "markdown"` picks up markdown's `autoInstall`
-before `"_"` is consulted.
+`base` chain, then the `"_"` wildcard's, defaulting to `true`. Unset is the
+default at every documented level, so a language inherits through `base` and
+`"_"` exactly like the other fields — for example
+`[languages.rmd] base = "markdown"` picks up markdown's `autoInstall` before
+`"_"` is consulted.
 
 **Which name to use.** The key names the language kakehashi would *install*, not
 the token in your document. A host document uses the `languageId` your editor
@@ -378,23 +354,6 @@ points at the config that decided it. For a language with no entry of its own it
 names the exact key (`` `languages._.autoInstall` is false ``); for one that
 does have an entry it names the overriding key and the places the value may have
 come from, since `base`-chain and `_` inheritance are folded together by then.
-
-**Migration caveat:** moving the top-level key to `[languages._]` is
-equivalence-preserving for every language *except* one whose `base` chain
-terminates before reaching `"_"` — a self-referential `base`
-(`[languages.foo] base = "foo"`) or a cycle that never visits `"_"`. Such a
-language inherits nothing from `"_"` — by design, for every field — so it falls
-through to the top-level default instead. (A chain that *does* reach `"_"`,
-including one that gets there via an explicit `[languages._] base`, inherits
-normally.) Give those
-languages an explicit `autoInstall` when migrating.
-
-**Precedence note:** a `languages.*.autoInstall` value outranks the top-level
-`autoInstall` even when the top-level one is set at a higher-precedence source.
-That is deliberate — the top-level key is only a fallback for an unset
-per-language value — but it means moving the key to `[languages._]` in a
-low-precedence file will shadow a top-level `autoInstall` pushed via
-`initializationOptions`. Prefer setting one or the other, not both.
 
 ##### `languages[*].base`
 
@@ -488,21 +447,6 @@ Remap Tree-sitter capture names to LSP semantic token types. Use `_` as a wildca
 }
 ```
 
-The former top-level `captureMappings.<language>.highlights` shape remains
-accepted for migration through v1, but is deprecated and will be removed in
-v2. If both spellings occur in one layer, the feature-scoped value wins for
-duplicate capture names; otherwise their entries are combined. In the legacy
-spelling, `captureMappings = {}` clears the inherited root and `highlights = {}`
-under a `[captureMappings.<language>]` table clears that language's inherited
-entry.
-The clear is applied before canonical entries in the same layer are added. The
-old `folds` table was unused and has no
-replacement. It is absent from the schema and has no effect. Like another
-unrecognized key, it is ignored where the configuration source tolerates
-unknown keys and causes a pushed runtime update to be rejected by that
-ingress's existing unknown-key policy; valid siblings such as `highlights` are
-not discarded merely because `folds` is present.
-
 ### Bridge Configuration
 
 #### `languageServers`
@@ -552,17 +496,10 @@ Configure language servers for bridging LSP requests in injection regions.
 | `cmd` | Command and arguments to start the language server |
 | `languages` | Languages this server handles. The element `"*"` means **any language**, for servers that are not tied to one (spell/grammar/typo checkers, AI completion) — see below. |
 | `initializationOptions` | Optional initialization options forwarded during the downstream server's `initialize` request |
-| `workspaceMarkers` | Marker files/directories locating the workspace root the server is initialized with, following Neovim's `vim.fs.root` `(string\|string[])[]` shape. (The pre-rename key `rootMarkers` is still accepted as a deprecated alias.) Entries are tried **in list order** (earlier = higher priority): each entry is searched up the triggering document's ancestors nearest-first before the next entry is tried, so a higher-priority marker in a far ancestor outranks a lower-priority one sitting next to the document. A **nested array** is one equal-priority group where the nearest ancestor containing any of its names wins — e.g. `[["stylua.toml", ".luarc.json"], ".git"]` means "nearest of stylua.toml/.luarc.json, otherwise .git". The first matching entry's directory becomes the server's `rootUri` and sole workspace folder. Default: `[".git"]`. No marker hit falls back to the client-supplied root; an explicit `[]` disables the search. The connection pool is keyed by `(server, resolved root)`, so in a multi-root monorepo documents under different marker roots get their own downstream process, each rooted correctly; documents sharing a root (or the no-marker fallback) share one process. Trade-off: process count grows with the number of distinct roots opened, and there is currently no idle-eviction — a long session touching many roots keeps one process per root alive until shutdown. Servers that operate purely on `workspaceFolders` can opt out of this growth with `preferSharedInstance` (below). |
+| `workspaceMarkers` | Marker files/directories locating the workspace root the server is initialized with, following Neovim's `vim.fs.root` `(string\|string[])[]` shape. Entries are tried **in list order** (earlier = higher priority): each entry is searched up the triggering document's ancestors nearest-first before the next entry is tried, so a higher-priority marker in a far ancestor outranks a lower-priority one sitting next to the document. A **nested array** is one equal-priority group where the nearest ancestor containing any of its names wins — e.g. `[["stylua.toml", ".luarc.json"], ".git"]` means "nearest of stylua.toml/.luarc.json, otherwise .git". The first matching entry's directory becomes the server's `rootUri` and sole workspace folder. Default: `[".git"]`. No marker hit falls back to the client-supplied root; an explicit `[]` disables the search. The connection pool is keyed by `(server, resolved root)`, so in a multi-root monorepo documents under different marker roots get their own downstream process, each rooted correctly; documents sharing a root (or the no-marker fallback) share one process. Trade-off: process count grows with the number of distinct roots opened, and there is currently no idle-eviction — a long session touching many roots keeps one process per root alive until shutdown. Servers that operate purely on `workspaceFolders` can opt out of this growth with `preferSharedInstance` (below). |
 | `onTypeFormattingTriggers` | Trigger characters for bridged `textDocument/onTypeFormatting` (e.g. `["}", ";"]`). kakehashi advertises the sorted union across all servers at initialize and forwards a request to a downstream server only when that server's own capabilities declare the typed character. Unset everywhere (default) → the capability is not advertised. |
 | `forceStart` | Start this server as soon as configuration is applied, instead of waiting for a document that routes to it. Default `false`. With no triggering document there is no marker root to walk, so the connection is keyed the way any document-less acquire is — the shared connection for a `preferSharedInstance` server, the client-root fallback otherwise. That is also the honest scope of the warm-up: documents under marker roots resolve *marker* keys and will not reuse it, so setting this on an ordinary per-root server pre-spawns a process most documents bypass. It earns its keep for `preferSharedInstance` servers, marker-less workspaces, and a server that no document would ever start (`languages = []`). Within a session the flag is one-way: a reload that flips it to `false` never stops an already-running server, and deleting the entry is what stops one. It also starts a server rather than supervising it — a warm-up that crashes stays down until configuration is applied again, since a server no document routes to has no request that would notice. |
 | `preferSharedInstance` | Prefer reusing **one** downstream process across every workspace root for this server instead of the default one-process-per-marker-root (above). Default `false`. It is a *preference*, honored only when the downstream server advertises `workspace.workspaceFolders.{supported, changeNotifications}`: when it does, kakehashi routes all roots to a single connection and announces each new root with `workspace/didChangeWorkspaceFolders`; when it does not, kakehashi logs once and silently falls back to the per-root-instance model for marker-rooted documents (marker-less documents — e.g. non-file URIs like an editor's `untitled:` scratch buffers — stay on the shared connection: they bring no marker root, so the missing capability never blocks them; on capable servers the client workspace is announced on their behalf). Because that fallback is universal, a blanket `languageServers._.preferSharedInstance = true` is safe across a mixed set of servers. Use it to bound process count and get cross-root navigation for servers that key purely off `workspaceFolders`; leave it `false` for servers needing per-root isolation (per-root virtualenv, conflicting tool/package versions) or that key behavior off the immutable `rootUri`. Note: removal/idle-eviction of folders is not modeled yet — the set only grows. |
-
-> **Migration note**: `workspaceMarkers` was previously named `rootMarkers`
-> (aligning with the LSP spec's `workspaceFolders`). The old `rootMarkers` key
-> remains accepted through v1 but will be removed in v2, so existing configs
-> must migrate to `workspaceMarkers` before upgrading to v2. When a config
-> still uses `rootMarkers`, kakehashi shows a one-time deprecation notice per
-> session as a visible `window/showMessage` popup.
 
 A `languageServers._` wildcard entry supplies defaults that every server
 inherits field-by-field (wildcard-config-inheritance) — e.g. set

--- a/docs/architecture-decisions/base-language-inheritance.md
+++ b/docs/architecture-decisions/base-language-inheritance.md
@@ -131,7 +131,9 @@ through v1 so the server can emit a client-visible migration warning. It is
 removed from the configuration schema and parser in v2, in accordance with
 deprecation-removal-deadlines.
 
-**Migration**: Each `aliases = ["x", "y"]` on language `L` becomes:
+**Migration**: Each distinct alias other than the reserved `_` key or `L`
+itself becomes a derived language. Remove `_` and self-aliases without creating
+`base` entries. For example, `aliases = ["x", "y"]` on language `L` becomes:
 
 ```toml
 [languages.x]

--- a/docs/architecture-decisions/base-language-inheritance.md
+++ b/docs/architecture-decisions/base-language-inheritance.md
@@ -133,7 +133,9 @@ deprecation-removal-deadlines.
 
 **Migration**: Each distinct alias other than the reserved `_` key or `L`
 itself becomes a derived language. Remove `_` and self-aliases without creating
-`base` entries. For example, `aliases = ["x", "y"]` on language `L` becomes:
+`base` entries. If the alias already has a language entry, add or update `base`
+in that entry rather than declaring the table or object key a second time. For
+example, `aliases = ["x", "y"]` on language `L` becomes:
 
 ```toml
 [languages.x]

--- a/docs/architecture-decisions/base-language-inheritance.md
+++ b/docs/architecture-decisions/base-language-inheritance.md
@@ -123,9 +123,13 @@ first-line normalization with base fallback. This keeps configured injection
 keys authoritative while still canonicalizing unconfigured aliases such as
 `py` -> `python` without requiring a parser to be loaded.
 
-### Removed: `aliases` Field
+### Removed behavior and staged removal: `aliases` Field
 
-The `aliases` field is removed from language configuration with a deprecation warning. When `aliases` is still present, the server emits a client-visible warning with migration guidance.
+Alias resolution is removed: retained `aliases` values no longer register
+alternative language IDs. The input field itself remains accepted and ignored
+through v1 so the server can emit a client-visible migration warning. It is
+removed from the configuration schema and parser in v2, in accordance with
+[Deprecation removal deadlines](deprecation-removal-deadlines.md).
 
 **Migration**: Each `aliases = ["x", "y"]` on language `L` becomes:
 

--- a/docs/architecture-decisions/base-language-inheritance.md
+++ b/docs/architecture-decisions/base-language-inheritance.md
@@ -129,7 +129,7 @@ Alias resolution is removed: retained `aliases` values no longer register
 alternative language IDs. The input field itself remains accepted and ignored
 through v1 so the server can emit a client-visible migration warning. It is
 removed from the configuration schema and parser in v2, in accordance with
-[Deprecation removal deadlines](deprecation-removal-deadlines.md).
+deprecation-removal-deadlines.
 
 **Migration**: Each `aliases = ["x", "y"]` on language `L` becomes:
 

--- a/docs/architecture-decisions/base-language-inheritance.md
+++ b/docs/architecture-decisions/base-language-inheritance.md
@@ -210,6 +210,7 @@ base = "L"
 - [language-detection-fallback-chain](language-detection-fallback-chain.md): Language detection fallback chain (alias resolution replaced by base resolution)
 - [configuration-merging-strategy](configuration-merging-strategy.md): Cross-layer configuration merging (base chain operates after layer merging)
 - [wildcard-config-inheritance](wildcard-config-inheritance.md): Wildcard config inheritance (`base` generalizes `_` inheritance)
+- [deprecation-removal-deadlines](deprecation-removal-deadlines.md): Compile-time removal boundary for the retained `aliases` input field
 
 ## Appendix: Configuration Examples
 

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -193,6 +193,7 @@ normally per key, but the two keys are then read in specificity order, not sourc
 order. This is why `default_settings()` (merge layer 1) and the `config init`
 template both leave `languages._.autoInstall` unset: a built-in value there would
 silently shadow every user-supplied top-level opt-out.
+The top-level spelling is accepted through v1 and removed in v2.
 
 **Languages HashMap** (`languages`):
 - **Deep merge at language level**: Keys from later sources override same keys from earlier sources
@@ -487,3 +488,4 @@ fn load_settings(root, override_settings, home, env_fn, explicit) -> SettingsLoa
 ## Related Decisions
 
 - [wildcard-config-inheritance](wildcard-config-inheritance.md): Wildcard inheritance within a single config layer
+- [deprecation-removal-deadlines](deprecation-removal-deadlines.md): Compile-time removal boundary for the top-level `autoInstall` compatibility path

--- a/docs/architecture-decisions/deprecation-removal-deadlines.md
+++ b/docs/architecture-decisions/deprecation-removal-deadlines.md
@@ -19,10 +19,11 @@ reviewable deadline instead of inheriting that schedule accidentally.
 
 ## Decision
 
-Every retained compatibility path declares both the major version in which it
-was deprecated and the major version in which it must be removed. A build at or
-after the removal major fails while that declaration remains, naming the
-expired compatibility path and its deadline.
+Every retained path explicitly designated as deprecated declares both the major
+version in which it was deprecated and the major version in which it must be
+removed. A build at or after the removal major fails while that declaration
+remains, naming the expired compatibility path and its deadline. Compatibility
+fallbacks that are not deprecated are outside this removal policy.
 
 All compatibility paths deprecated during v0 declare v2 as their removal
 major. They remain valid in v0 and v1. A compatibility path first deprecated in

--- a/docs/architecture-decisions/deprecation-removal-deadlines.md
+++ b/docs/architecture-decisions/deprecation-removal-deadlines.md
@@ -4,6 +4,7 @@
 - [configuration-merging-strategy](configuration-merging-strategy.md)
 - [semantic-token-capture-mapping-config](semantic-token-capture-mapping-config.md)
 - [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md)
+- [base-language-inheritance](base-language-inheritance.md)
 
 ## Context
 

--- a/docs/architecture-decisions/deprecation-removal-deadlines.md
+++ b/docs/architecture-decisions/deprecation-removal-deadlines.md
@@ -1,0 +1,96 @@
+# Deprecation Removal Deadlines
+
+**Related Decisions**:
+- [configuration-merging-strategy](configuration-merging-strategy.md)
+- [semantic-token-capture-mapping-config](semantic-token-capture-mapping-config.md)
+- [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md)
+
+## Context
+
+kakehashi accepts several deprecated configuration shapes so users can migrate
+without an immediate breaking change. Those compatibility paths identify
+themselves only through prose such as "may be removed in a future release",
+which neither distinguishes the release generation that introduced a
+deprecation nor prevents an obsolete path from surviving indefinitely.
+
+The v0 compatibility paths are intentionally allowed to remain throughout v1,
+but must not ship in v2. Future deprecations need their own independently
+reviewable deadline instead of inheriting that schedule accidentally.
+
+## Decision
+
+Every retained compatibility path declares both the major version in which it
+was deprecated and the major version in which it must be removed. A build at or
+after the removal major fails while that declaration remains, naming the
+expired compatibility path and its deadline.
+
+All compatibility paths deprecated during v0 declare v2 as their removal
+major. They remain valid in v0 and v1. A compatibility path first deprecated in
+v1 uses a distinct declaration and must state its own removal major.
+
+User-facing deprecation notices state the scheduled removal major. Reaching the
+deadline removes the legacy parser, normalization, warning, tests, and deadline
+declaration together; deleting only the declaration does not satisfy the
+policy.
+
+## Invariants
+
+> The invariants below are normative; the mechanisms that satisfy them are
+> deliberately unspecified.
+
+- A release must not build at or after a compatibility path's declared removal
+  major while that path remains supported. This makes a major-version bump an
+  unavoidable deprecation inventory check.
+- Deprecations introduced in different major versions remain distinguishable
+  even when they affect the same subsystem, so one generation's deadline does
+  not force or postpone another's removal.
+- A notice and its compatibility behavior have the same deadline. Users must
+  not be promised support beyond the release in which the implementation is
+  required to disappear.
+
+## Considered Options
+
+### Record only when the path was deprecated
+
+Rejected because version metadata alone documents history but does not encode
+when compatibility must end. Rust's standard deprecation metadata also warns
+about use rather than rejecting a stale declaration.
+
+### Audit deprecations manually during a major release
+
+Rejected because the check is easy to omit and prose does not provide a
+machine-checkable inventory or boundary.
+
+### Scan source text in CI for version-shaped comments
+
+Rejected because comments and formatting are not a stable contract between the
+compatibility implementation and the check. It would also allow a local build
+to succeed while the release gate is already known to be violated.
+
+### Enforce explicit deadlines during compilation
+
+Chosen because the declaration stays beside the compatibility warning, works
+in ordinary local builds and CI, and makes the package major-version bump fail
+at the exact boundary that requires removal.
+
+## Consequences
+
+### Positive
+
+- v0 and v1 deprecations can be inventoried and scheduled independently.
+- A v2 version bump cannot silently retain any registered v0 compatibility
+  path.
+- Notices give users a concrete migration deadline.
+
+### Negative
+
+- Adding a deprecation requires choosing and maintaining a removal major.
+- A major-version bump may be blocked until several compatibility paths and
+  their tests are removed together.
+
+### Neutral
+
+- The policy does not change which deprecated configuration shapes are
+  accepted in v0 or v1.
+- Runtime handling after removal continues to follow each configuration
+  source's unknown-key policy.

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -540,6 +540,7 @@ languageServers:
 - **[bridge-routing-protocol](bridge-routing-protocol.md)**: Downstream routing delegation
   - A routing provider's `workspaceFolders` answer overrides the marker-walk root resolution
   - `forceStart` spawns eagerly — the `#shared` key with the primary-root seed for `preferSharedInstance` servers, the marker-less fallback shape otherwise
+- **[deprecation-removal-deadlines](deprecation-removal-deadlines.md)**: Compile-time removal boundary for the `rootMarkers` compatibility key
 
 ## Amendment History
 
@@ -577,8 +578,8 @@ languageServers:
   walk's URL cannot fake a mismatch).
 - **2026-07-01**: Renamed the `languageServers.*.rootMarkers` config key to
   `workspaceMarkers` (aligning with the LSP spec's `workspaceFolders`); the old
-  `rootMarkers` is accepted as a deprecated serde alias for backward
-  compatibility. The marker walk itself and the pool-keying behavior are
+  `rootMarkers` is accepted as a deprecated serde alias through v1 and removed
+  in v2. The marker walk itself and the pool-keying behavior are
   unchanged; only the config key name moved. Earlier amendment entries below
   still reference the pre-rename key as the historical record of their date.
 - **2026-06-20**: Added the per-server `preferSharedInstance` opt-in (#391): capability-gated routing to one `ConnectionKey::shared` connection across roots, a mutable per-connection `WorkspaceFolderSet`, and `workspace/didChangeWorkspaceFolders` emission ahead of `didOpen` for newly joined roots. Default stays per-root (#382); incapable servers (no `workspace.workspaceFolders.{supported, changeNotifications}`) log once and fall back to per-root.

--- a/docs/architecture-decisions/semantic-token-capture-mapping-config.md
+++ b/docs/architecture-decisions/semantic-token-capture-mapping-config.md
@@ -3,6 +3,7 @@
 **Related Decisions**:
 - [configuration-merging-strategy](configuration-merging-strategy.md)
 - [wildcard-config-inheritance](wildcard-config-inheritance.md)
+- [deprecation-removal-deadlines](deprecation-removal-deadlines.md)
 
 ## Context
 
@@ -26,7 +27,8 @@ no intermediate `highlights` key.
 
 The former top-level `captureMappings.<language>.highlights` spelling remains
 accepted during migration and produces a deprecation warning at most once per
-session. The never-consumed `folds` field is removed from the schema without a
+session. It is accepted through v1 and removed in v2. The never-consumed
+`folds` field is removed from the schema without a
 replacement and has no effect. It follows the same source-specific unknown-key
 policy as any other unrecognized field: tolerant sources ignore it, while a
 pushed runtime update carrying it is rejected. Its presence does not turn an

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -11,6 +11,27 @@
 
 use serde_json::Value as JsonValue;
 
+crate::deprecation::enforce_deprecation_deadline!(
+    name = "languageServers.*.rootMarkers",
+    deprecated_in = 0,
+    remove_in = 2,
+);
+crate::deprecation::enforce_deprecation_deadline!(
+    name = "unwrapped workspace/didChangeConfiguration settings",
+    deprecated_in = 0,
+    remove_in = 2,
+);
+crate::deprecation::enforce_deprecation_deadline!(
+    name = "top-level autoInstall",
+    deprecated_in = 0,
+    remove_in = 2,
+);
+crate::deprecation::enforce_deprecation_deadline!(
+    name = "top-level captureMappings",
+    deprecated_in = 0,
+    remove_in = 2,
+);
+
 /// Which deprecated config keys any loaded layer actually spelled.
 ///
 /// Serde collapses deprecated and canonical spellings (via `alias`, or by the
@@ -44,14 +65,14 @@ impl DeprecatedKeysSeen {
 /// User-facing text for the one-per-session `rootMarkers` deprecation notice,
 /// shared by every path that can surface it (initialize, didChangeConfiguration).
 pub(crate) const ROOT_MARKERS_DEPRECATION_NOTICE: &str = "kakehashi: the `rootMarkers` config key is deprecated; rename it to \
-     `workspaceMarkers`. `rootMarkers` still works for now but may be removed \
-     in a future release.";
+     `workspaceMarkers`. `rootMarkers` still works for now but will be removed \
+     in kakehashi v2.";
 
 /// User-facing text for runtime client-pushed configuration that still uses the
 /// old unwrapped/flat `workspace/didChangeConfiguration` shape.
 pub(crate) const UNWRAPPED_DIDCHANGE_CONFIGURATION_NOTICE: &str = "kakehashi: unwrapped `workspace/didChangeConfiguration` settings are deprecated; \
      send runtime settings in the notification's `settings.kakehashi` object. \
-     Flat didChange settings still work for now but may be removed in a future release.";
+     Flat didChange settings still work for now but will be removed in kakehashi v2.";
 
 /// User-facing text for the one-per-session top-level `autoInstall` notice.
 ///
@@ -62,7 +83,7 @@ pub(crate) const AUTO_INSTALL_DEPRECATION_NOTICE: &str = "kakehashi: the top-lev
      `languages._.autoInstall` (and override per language with \
      `languages.<lang>.autoInstall`). A language with a self-referential \
      `base` inherits nothing from `_`, so give those an explicit value. The \
-     top-level key still works for now but may be removed in a future release.";
+     top-level key still works for now but will be removed in kakehashi v2.";
 
 /// User-facing text for the one-per-session top-level `captureMappings`
 /// notice. The dotted path is usable for both TOML and JSON configuration.
@@ -70,7 +91,7 @@ pub(crate) const CAPTURE_MAPPINGS_DEPRECATION_NOTICE: &str = "kakehashi: the top
      `features.\"textDocument/semanticTokens\".captureMappings` in TOML (or \
      `features[\"textDocument/semanticTokens\"].captureMappings` in JSON) and remove the \
      intermediate `highlights` key. The top-level key still works for now but \
-     may be removed in a future release.";
+     will be removed in kakehashi v2.";
 
 /// Which deprecated keys the raw TOML text spells.
 ///

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -31,6 +31,11 @@ crate::deprecation::enforce_deprecation_deadline!(
     deprecated_in = 0,
     remove_in = 2,
 );
+crate::deprecation::enforce_deprecation_deadline!(
+    name = "languages.*.aliases",
+    deprecated_in = 0,
+    remove_in = 2,
+);
 
 /// Which deprecated config keys any loaded layer actually spelled.
 ///

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -153,7 +153,8 @@ pub(crate) fn aliases_deprecation_notice(language: &str, aliases: &[String]) -> 
     let json = serde_json::json!({ "languages": derived_languages });
     format!(
         "Language '{language}' uses deprecated 'aliases' field. \
-         Use 'base' on each derived language instead.\n\
+         Use 'base' on each derived language instead. Edit each existing language entry in \
+         place; do not add a duplicate table or object key.\n\
          TOML:\n{toml_examples}\n\
          JSON:\n{json}\n\
          {special_guidance}The 'aliases' field will be removed in kakehashi v{}.",
@@ -371,7 +372,8 @@ rootMarkers = [".git"]
         let notice = aliases_deprecation_notice("markdown", &["rmd".to_owned()]);
         let expected = format!(
             "Language 'markdown' uses deprecated 'aliases' field. Use 'base' on each derived \
-             language instead.\nTOML:\n[languages.\"rmd\"]\nbase = \"markdown\"\nJSON:\n\
+             language instead. Edit each existing language entry in place; do not add a \
+             duplicate table or object key.\nTOML:\n[languages.\"rmd\"]\nbase = \"markdown\"\nJSON:\n\
              {{\"languages\":{{\"rmd\":{{\"base\":\"markdown\"}}}}}}\n\
              The 'aliases' field will be removed in kakehashi v{}.",
             ALIASES_DEPRECATION.remove_in_major()

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -102,7 +102,15 @@ crate::deprecation::declare_deprecation!(
     deprecated_in = 0,
     remove_in = 2,
 );
-pub(crate) fn aliases_deprecation_notice(language: &str, example_alias: &str) -> String {
+pub(crate) fn aliases_deprecation_notice(language: &str, example_alias: Option<&str>) -> String {
+    let Some(example_alias) = example_alias else {
+        return format!(
+            "Language '{language}' uses an empty deprecated 'aliases' field. \
+             Remove the empty 'aliases' field. The 'aliases' field will be removed in \
+             kakehashi v{}.",
+            ALIASES_DEPRECATION.remove_in_major()
+        );
+    };
     let language_toml = toml::Value::String(language.to_owned()).to_string();
     let alias_toml = toml::Value::String(example_alias.to_owned()).to_string();
     let mut derived_languages = serde_json::Map::new();
@@ -328,7 +336,7 @@ rootMarkers = [".git"]
 
     #[test]
     fn aliases_notice_gives_valid_toml_and_json_migrations_with_declared_deadline() {
-        let notice = aliases_deprecation_notice("markdown", "rmd");
+        let notice = aliases_deprecation_notice("markdown", Some("rmd"));
         let expected = format!(
             "Language 'markdown' uses deprecated 'aliases' field. Use 'base' on each derived \
              language instead.\nTOML:\n[languages.\"rmd\"]\nbase = \"markdown\"\nJSON:\n\
@@ -341,7 +349,7 @@ rootMarkers = [".git"]
 
     #[test]
     fn aliases_notice_escapes_language_ids_in_both_migration_formats() {
-        let notice = aliases_deprecation_notice("mark\"down", "r.md\"x");
+        let notice = aliases_deprecation_notice("mark\"down", Some("r.md\"x"));
         let toml_example = notice
             .split_once("TOML:\n")
             .and_then(|(_, examples)| examples.split_once("\nJSON:\n"))
@@ -364,6 +372,18 @@ rootMarkers = [".git"]
             parsed_json["languages"]["r.md\"x"]["base"].as_str(),
             Some("mark\"down")
         );
+    }
+
+    #[test]
+    fn empty_aliases_notice_only_requests_removing_the_field() {
+        let notice = aliases_deprecation_notice("markdown", None);
+        assert!(
+            notice.contains("Remove the empty 'aliases' field"),
+            "{notice}"
+        );
+        assert!(!notice.contains("<derived>"), "{notice}");
+        assert!(!notice.contains("TOML:"), "{notice}");
+        assert!(!notice.contains("JSON:"), "{notice}");
     }
 
     #[test]

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -11,32 +11,6 @@
 
 use serde_json::Value as JsonValue;
 
-crate::deprecation::enforce_deprecation_deadline!(
-    name = "languageServers.*.rootMarkers",
-    deprecated_in = 0,
-    remove_in = 2,
-);
-crate::deprecation::enforce_deprecation_deadline!(
-    name = "unwrapped workspace/didChangeConfiguration settings",
-    deprecated_in = 0,
-    remove_in = 2,
-);
-crate::deprecation::enforce_deprecation_deadline!(
-    name = "top-level autoInstall",
-    deprecated_in = 0,
-    remove_in = 2,
-);
-crate::deprecation::enforce_deprecation_deadline!(
-    name = "top-level captureMappings",
-    deprecated_in = 0,
-    remove_in = 2,
-);
-crate::deprecation::enforce_deprecation_deadline!(
-    name = "languages.*.aliases",
-    deprecated_in = 0,
-    remove_in = 2,
-);
-
 /// Which deprecated config keys any loaded layer actually spelled.
 ///
 /// Serde collapses deprecated and canonical spellings (via `alias`, or by the
@@ -67,36 +41,76 @@ impl DeprecatedKeysSeen {
     }
 }
 
-/// User-facing text for the one-per-session `rootMarkers` deprecation notice,
-/// shared by every path that can surface it (initialize, didChangeConfiguration).
-pub(crate) const ROOT_MARKERS_DEPRECATION_NOTICE: &str = "kakehashi: the `rootMarkers` config key is deprecated; rename it to \
-     `workspaceMarkers`. `rootMarkers` still works for now but will be removed \
-     in kakehashi v2.";
+crate::deprecation::declare_deprecation_notice!(
+    /// User-facing text for the one-per-session `rootMarkers` deprecation notice,
+    /// shared by every path that can surface it (initialize, didChangeConfiguration).
+    pub(crate) const ROOT_MARKERS_DEPRECATION_NOTICE;
+    name = "languageServers.*.rootMarkers",
+    deprecated_in = 0,
+    remove_in = 2,
+    message = "kakehashi: the `rootMarkers` config key is deprecated; rename it to \
+         `workspaceMarkers`. `rootMarkers` still works for now but will be removed \
+         in kakehashi v"
+);
 
-/// User-facing text for runtime client-pushed configuration that still uses the
-/// old unwrapped/flat `workspace/didChangeConfiguration` shape.
-pub(crate) const UNWRAPPED_DIDCHANGE_CONFIGURATION_NOTICE: &str = "kakehashi: unwrapped `workspace/didChangeConfiguration` settings are deprecated; \
-     send runtime settings in the notification's `settings.kakehashi` object. \
-     Flat didChange settings still work for now but will be removed in kakehashi v2.";
+crate::deprecation::declare_deprecation_notice!(
+    /// User-facing text for runtime client-pushed configuration that still uses the
+    /// old unwrapped/flat `workspace/didChangeConfiguration` shape.
+    pub(crate) const UNWRAPPED_DIDCHANGE_CONFIGURATION_NOTICE;
+    name = "unwrapped workspace/didChangeConfiguration settings",
+    deprecated_in = 0,
+    remove_in = 2,
+    message = "kakehashi: unwrapped `workspace/didChangeConfiguration` settings are deprecated; \
+         send runtime settings in the notification's `settings.kakehashi` object. \
+         Flat didChange settings still work for now but will be removed in kakehashi v"
+);
 
-/// User-facing text for the one-per-session top-level `autoInstall` notice.
-///
-/// Dotted key paths, not TOML table syntax: this notice also fires for JSON
-/// runtime settings (`initializationOptions`, `didChangeConfiguration`), where
-/// `[languages._]` would name a shape the user cannot write.
-pub(crate) const AUTO_INSTALL_DEPRECATION_NOTICE: &str = "kakehashi: the top-level `autoInstall` config key is deprecated; move it to \
-     `languages._.autoInstall` (and override per language with \
-     `languages.<lang>.autoInstall`). A language with a self-referential \
-     `base` inherits nothing from `_`, so give those an explicit value. The \
-     top-level key still works for now but will be removed in kakehashi v2.";
+crate::deprecation::declare_deprecation_notice!(
+    /// User-facing text for the one-per-session top-level `autoInstall` notice.
+    ///
+    /// Dotted key paths, not TOML table syntax: this notice also fires for JSON
+    /// runtime settings (`initializationOptions`, `didChangeConfiguration`), where
+    /// `[languages._]` would name a shape the user cannot write.
+    pub(crate) const AUTO_INSTALL_DEPRECATION_NOTICE;
+    name = "top-level autoInstall",
+    deprecated_in = 0,
+    remove_in = 2,
+    message = "kakehashi: the top-level `autoInstall` config key is deprecated; move it to \
+         `languages._.autoInstall` (and override per language with \
+         `languages.<lang>.autoInstall`). A language with a self-referential \
+         `base` inherits nothing from `_`, so give those an explicit value. The \
+         top-level key still works for now but will be removed in kakehashi v"
+);
 
-/// User-facing text for the one-per-session top-level `captureMappings`
-/// notice. The dotted path is usable for both TOML and JSON configuration.
-pub(crate) const CAPTURE_MAPPINGS_DEPRECATION_NOTICE: &str = "kakehashi: the top-level `captureMappings` config key is deprecated; move highlight mappings to \
-     `features.\"textDocument/semanticTokens\".captureMappings` in TOML (or \
-     `features[\"textDocument/semanticTokens\"].captureMappings` in JSON) and remove the \
-     intermediate `highlights` key. The top-level key still works for now but \
-     will be removed in kakehashi v2.";
+crate::deprecation::declare_deprecation_notice!(
+    /// User-facing text for the one-per-session top-level `captureMappings`
+    /// notice. The dotted path is usable for both TOML and JSON configuration.
+    pub(crate) const CAPTURE_MAPPINGS_DEPRECATION_NOTICE;
+    name = "top-level captureMappings",
+    deprecated_in = 0,
+    remove_in = 2,
+    message = "kakehashi: the top-level `captureMappings` config key is deprecated; move highlight mappings to \
+         `features.\"textDocument/semanticTokens\".captureMappings` in TOML (or \
+         `features[\"textDocument/semanticTokens\"].captureMappings` in JSON) and remove the \
+         intermediate `highlights` key. The top-level key still works for now but \
+         will be removed in kakehashi v"
+);
+
+crate::deprecation::declare_deprecation!(
+    pub(crate) const ALIASES_DEPRECATION;
+    name = "languages.*.aliases",
+    deprecated_in = 0,
+    remove_in = 2,
+);
+pub(crate) fn aliases_deprecation_notice(language: &str, example_alias: &str) -> String {
+    format!(
+        "Language '{language}' uses deprecated 'aliases' field. \
+         Use 'base' on derived languages instead. \
+         Example: [languages.{example_alias}] base = \"{language}\". \
+         The 'aliases' field will be removed in kakehashi v{}.",
+        ALIASES_DEPRECATION.remove_in_major()
+    )
+}
 
 /// Which deprecated keys the raw TOML text spells.
 ///
@@ -301,6 +315,16 @@ rootMarkers = [".git"]
                 "v0 deprecation notice must name its removal deadline: {notice}"
             );
         }
+    }
+
+    #[test]
+    fn aliases_notice_uses_its_declared_removal_major() {
+        let notice = aliases_deprecation_notice("markdown", "rmd");
+        let expected = format!(
+            "removed in kakehashi v{}",
+            ALIASES_DEPRECATION.remove_in_major()
+        );
+        assert!(notice.contains(&expected), "{notice}");
     }
 
     #[test]

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -157,6 +157,15 @@ pub(crate) fn json_deprecated_keys(value: &JsonValue) -> DeprecatedKeysSeen {
 mod tests {
     use super::*;
 
+    fn v0_deprecation_notices() -> [&'static str; 4] {
+        [
+            ROOT_MARKERS_DEPRECATION_NOTICE,
+            UNWRAPPED_DIDCHANGE_CONFIGURATION_NOTICE,
+            AUTO_INSTALL_DEPRECATION_NOTICE,
+            CAPTURE_MAPPINGS_DEPRECATION_NOTICE,
+        ]
+    }
+
     #[test]
     fn merge_ors_flags_so_a_clean_later_layer_cannot_clear_them() {
         // The regression: `=` instead of `|=` would let a clean higher layer
@@ -282,6 +291,16 @@ rootMarkers = [".git"]
             CAPTURE_MAPPINGS_DEPRECATION_NOTICE
                 .contains("features[\"textDocument/semanticTokens\"].captureMappings")
         );
+    }
+
+    #[test]
+    fn every_v0_notice_names_the_v2_removal() {
+        for notice in v0_deprecation_notices() {
+            assert!(
+                notice.contains("removed in kakehashi v2"),
+                "v0 deprecation notice must name its removal deadline: {notice}"
+            );
+        }
     }
 
     #[test]

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -115,6 +115,28 @@ pub(crate) fn aliases_deprecation_notice(language: &str, aliases: &[String]) -> 
             ALIASES_DEPRECATION.remove_in_major()
         );
     }
+    let has_reserved_alias = aliases.contains("_");
+    let has_self_alias = aliases.contains(language);
+    let aliases = aliases
+        .into_iter()
+        .filter(|alias| *alias != "_" && *alias != language)
+        .collect::<Vec<_>>();
+    let special_guidance = match (has_reserved_alias, has_self_alias) {
+        (true, true) => {
+            "The `_` alias is reserved and must not become a base entry. \
+             A self-alias needs no base entry.\n"
+        }
+        (true, false) => "The `_` alias is reserved and must not become a base entry.\n",
+        (false, true) => "A self-alias needs no base entry.\n",
+        (false, false) => "",
+    };
+    if aliases.is_empty() {
+        return format!(
+            "Language '{language}' uses deprecated 'aliases' field. Remove the 'aliases' field. \
+             {special_guidance}The 'aliases' field will be removed in kakehashi v{}.",
+            ALIASES_DEPRECATION.remove_in_major()
+        );
+    }
     let language_toml = toml::Value::String(language.to_owned()).to_string();
     let toml_examples = aliases
         .iter()
@@ -134,7 +156,7 @@ pub(crate) fn aliases_deprecation_notice(language: &str, aliases: &[String]) -> 
          Use 'base' on each derived language instead.\n\
          TOML:\n{toml_examples}\n\
          JSON:\n{json}\n\
-         The 'aliases' field will be removed in kakehashi v{}.",
+         {special_guidance}The 'aliases' field will be removed in kakehashi v{}.",
         ALIASES_DEPRECATION.remove_in_major()
     )
 }
@@ -417,6 +439,20 @@ rootMarkers = [".git"]
         assert_eq!(
             parsed_json["languages"]["qmd"]["base"].as_str(),
             Some("markdown")
+        );
+    }
+
+    #[test]
+    fn aliases_notice_does_not_migrate_reserved_or_self_aliases() {
+        let aliases = vec!["_".to_owned(), "markdown".to_owned(), "rmd".to_owned()];
+        let notice = aliases_deprecation_notice("markdown", &aliases);
+        assert!(notice.contains("[languages.\"rmd\"]"), "{notice}");
+        assert!(!notice.contains("[languages.\"_\"]"), "{notice}");
+        assert!(!notice.contains("[languages.\"markdown\"]"), "{notice}");
+        assert!(notice.contains("`_` alias is reserved"), "{notice}");
+        assert!(
+            notice.contains("self-alias needs no base entry"),
+            "{notice}"
         );
     }
 

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -102,27 +102,37 @@ crate::deprecation::declare_deprecation!(
     deprecated_in = 0,
     remove_in = 2,
 );
-pub(crate) fn aliases_deprecation_notice(language: &str, example_alias: Option<&str>) -> String {
-    let Some(example_alias) = example_alias else {
+pub(crate) fn aliases_deprecation_notice(language: &str, aliases: &[String]) -> String {
+    let aliases = aliases
+        .iter()
+        .map(String::as_str)
+        .collect::<std::collections::BTreeSet<_>>();
+    if aliases.is_empty() {
         return format!(
             "Language '{language}' uses an empty deprecated 'aliases' field. \
              Remove the empty 'aliases' field. The 'aliases' field will be removed in \
              kakehashi v{}.",
             ALIASES_DEPRECATION.remove_in_major()
         );
-    };
+    }
     let language_toml = toml::Value::String(language.to_owned()).to_string();
-    let alias_toml = toml::Value::String(example_alias.to_owned()).to_string();
+    let toml_examples = aliases
+        .iter()
+        .map(|alias| {
+            let alias = toml::Value::String((*alias).to_owned()).to_string();
+            format!("[languages.{alias}]\nbase = {language_toml}")
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
     let mut derived_languages = serde_json::Map::new();
-    derived_languages.insert(
-        example_alias.to_owned(),
-        serde_json::json!({ "base": language }),
-    );
+    for alias in aliases {
+        derived_languages.insert(alias.to_owned(), serde_json::json!({ "base": language }));
+    }
     let json = serde_json::json!({ "languages": derived_languages });
     format!(
         "Language '{language}' uses deprecated 'aliases' field. \
          Use 'base' on each derived language instead.\n\
-         TOML:\n[languages.{alias_toml}]\nbase = {language_toml}\n\
+         TOML:\n{toml_examples}\n\
          JSON:\n{json}\n\
          The 'aliases' field will be removed in kakehashi v{}.",
         ALIASES_DEPRECATION.remove_in_major()
@@ -336,7 +346,7 @@ rootMarkers = [".git"]
 
     #[test]
     fn aliases_notice_gives_valid_toml_and_json_migrations_with_declared_deadline() {
-        let notice = aliases_deprecation_notice("markdown", Some("rmd"));
+        let notice = aliases_deprecation_notice("markdown", &["rmd".to_owned()]);
         let expected = format!(
             "Language 'markdown' uses deprecated 'aliases' field. Use 'base' on each derived \
              language instead.\nTOML:\n[languages.\"rmd\"]\nbase = \"markdown\"\nJSON:\n\
@@ -349,7 +359,7 @@ rootMarkers = [".git"]
 
     #[test]
     fn aliases_notice_escapes_language_ids_in_both_migration_formats() {
-        let notice = aliases_deprecation_notice("mark\"down", Some("r.md\"x"));
+        let notice = aliases_deprecation_notice("mark\"down", &["r.md\"x".to_owned()]);
         let toml_example = notice
             .split_once("TOML:\n")
             .and_then(|(_, examples)| examples.split_once("\nJSON:\n"))
@@ -376,7 +386,7 @@ rootMarkers = [".git"]
 
     #[test]
     fn empty_aliases_notice_only_requests_removing_the_field() {
-        let notice = aliases_deprecation_notice("markdown", None);
+        let notice = aliases_deprecation_notice("markdown", &[]);
         assert!(
             notice.contains("Remove the empty 'aliases' field"),
             "{notice}"
@@ -384,6 +394,30 @@ rootMarkers = [".git"]
         assert!(!notice.contains("<derived>"), "{notice}");
         assert!(!notice.contains("TOML:"), "{notice}");
         assert!(!notice.contains("JSON:"), "{notice}");
+    }
+
+    #[test]
+    fn aliases_notice_migrates_every_distinct_alias() {
+        let aliases = vec!["rmd".to_owned(), "qmd".to_owned(), "rmd".to_owned()];
+        let notice = aliases_deprecation_notice("markdown", &aliases);
+        assert_eq!(notice.matches("[languages.\"rmd\"]").count(), 1);
+        assert_eq!(notice.matches("[languages.\"qmd\"]").count(), 1);
+
+        let json_example = notice
+            .split_once("\nJSON:\n")
+            .and_then(|(_, rest)| rest.split_once("\nThe 'aliases' field"))
+            .map(|(json, _)| json)
+            .expect("JSON migration example");
+        let parsed_json: serde_json::Value =
+            serde_json::from_str(json_example).expect("valid JSON example");
+        assert_eq!(
+            parsed_json["languages"]["rmd"]["base"].as_str(),
+            Some("markdown")
+        );
+        assert_eq!(
+            parsed_json["languages"]["qmd"]["base"].as_str(),
+            Some("markdown")
+        );
     }
 
     #[test]

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -103,10 +103,19 @@ crate::deprecation::declare_deprecation!(
     remove_in = 2,
 );
 pub(crate) fn aliases_deprecation_notice(language: &str, example_alias: &str) -> String {
+    let language_toml = toml::Value::String(language.to_owned()).to_string();
+    let alias_toml = toml::Value::String(example_alias.to_owned()).to_string();
+    let mut derived_languages = serde_json::Map::new();
+    derived_languages.insert(
+        example_alias.to_owned(),
+        serde_json::json!({ "base": language }),
+    );
+    let json = serde_json::json!({ "languages": derived_languages });
     format!(
         "Language '{language}' uses deprecated 'aliases' field. \
-         Use 'base' on derived languages instead. \
-         Example: [languages.{example_alias}] base = \"{language}\". \
+         Use 'base' on each derived language instead.\n\
+         TOML:\n[languages.{alias_toml}]\nbase = {language_toml}\n\
+         JSON:\n{json}\n\
          The 'aliases' field will be removed in kakehashi v{}.",
         ALIASES_DEPRECATION.remove_in_major()
     )
@@ -318,13 +327,43 @@ rootMarkers = [".git"]
     }
 
     #[test]
-    fn aliases_notice_uses_its_declared_removal_major() {
+    fn aliases_notice_gives_valid_toml_and_json_migrations_with_declared_deadline() {
         let notice = aliases_deprecation_notice("markdown", "rmd");
         let expected = format!(
-            "removed in kakehashi v{}",
+            "Language 'markdown' uses deprecated 'aliases' field. Use 'base' on each derived \
+             language instead.\nTOML:\n[languages.\"rmd\"]\nbase = \"markdown\"\nJSON:\n\
+             {{\"languages\":{{\"rmd\":{{\"base\":\"markdown\"}}}}}}\n\
+             The 'aliases' field will be removed in kakehashi v{}.",
             ALIASES_DEPRECATION.remove_in_major()
         );
-        assert!(notice.contains(&expected), "{notice}");
+        assert_eq!(notice, expected);
+    }
+
+    #[test]
+    fn aliases_notice_escapes_language_ids_in_both_migration_formats() {
+        let notice = aliases_deprecation_notice("mark\"down", "r.md\"x");
+        let toml_example = notice
+            .split_once("TOML:\n")
+            .and_then(|(_, examples)| examples.split_once("\nJSON:\n"))
+            .map(|(toml, _)| toml)
+            .expect("TOML migration example");
+        let parsed_toml: toml::Value = toml::from_str(toml_example).expect("valid TOML example");
+        assert_eq!(
+            parsed_toml["languages"]["r.md\"x"]["base"].as_str(),
+            Some("mark\"down")
+        );
+
+        let json_example = notice
+            .split_once("\nJSON:\n")
+            .and_then(|(_, rest)| rest.split_once("\nThe 'aliases' field"))
+            .map(|(json, _)| json)
+            .expect("JSON migration example");
+        let parsed_json: serde_json::Value =
+            serde_json::from_str(json_example).expect("valid JSON example");
+        assert_eq!(
+            parsed_json["languages"]["r.md\"x"]["base"].as_str(),
+            Some("mark\"down")
+        );
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -369,44 +369,12 @@ impl RootMarker {
     }
 }
 
-fn add_deprecated_root_markers_schema(schema: &mut schemars::Schema) {
-    let Some(schema) = schema.as_object_mut() else {
-        return;
-    };
-    let Some(properties) = schema
-        .get_mut("properties")
-        .and_then(serde_json::Value::as_object_mut)
-    else {
-        return;
-    };
-    let Some(mut root_markers) = properties.get("workspaceMarkers").cloned() else {
-        return;
-    };
-    let Some(root_markers) = root_markers.as_object_mut() else {
-        return;
-    };
-    root_markers.insert("deprecated".to_owned(), serde_json::Value::Bool(true));
-    root_markers.insert(
-        "description".to_owned(),
-        serde_json::Value::String(
-            "Deprecated alias for `workspaceMarkers`; accepted through v1 and removed in v2."
-                .to_owned(),
-        ),
-    );
-    properties.insert("rootMarkers".to_owned(), root_markers.clone().into());
-    schema.insert(
-        "not".to_owned(),
-        serde_json::json!({ "required": ["workspaceMarkers", "rootMarkers"] }),
-    );
-}
-
 /// Configuration for a bridge language server.
 ///
 /// This is used to configure external language servers (like rust-analyzer, pyright)
 /// that kakehashi can redirect requests to for injection regions.
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-#[schemars(transform = add_deprecated_root_markers_schema)]
 pub struct BridgeServerConfig {
     /// Command array: first element is the program, rest are arguments
     /// e.g., ["rust-analyzer"] or ["pyright-langserver", "--stdio"].
@@ -451,9 +419,7 @@ pub struct BridgeServerConfig {
     /// `None` = inherit (built-in default `[".git"]`); an explicit `[]`
     /// disables the search (the client-supplied root is forwarded as-is).
     /// When no marker matches, the client-supplied root is the fallback.
-    ///
-    /// The wire key is `workspaceMarkers`; the pre-rename key `rootMarkers` is
-    /// kept as a deprecated serde alias through v1 and removed in v2.
+    // Compatibility-only v0 spelling; intentionally absent from generated docs.
     #[serde(alias = "rootMarkers")]
     pub workspace_markers: Option<Vec<RootMarker>>,
     /// Trigger characters for bridged `textDocument/onTypeFormatting` (#354).
@@ -811,19 +777,14 @@ pub struct RawWorkspaceSettings {
     /// Per-language configuration (parser paths, queries, bridge filters, base inheritance).
     #[serde(default)]
     pub languages: HashMap<String, LanguageSettings>,
-    /// Deprecated: use
-    /// `features["textDocument/semanticTokens"].captureMappings` instead. This
-    /// legacy shape remains accepted during migration; only its `highlights`
-    /// entries are consumed. It is removed in v2.
+    // Compatibility-only v0 input; intentionally absent from generated docs.
+    #[doc(hidden)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(extend("deprecated" = true))]
+    #[schemars(skip)]
     pub capture_mappings: Option<CaptureMappings>,
-    /// Deprecated: use `languages._.autoInstall` (and per-language
-    /// `languages.<lang>.autoInstall`) instead. Whether to automatically
-    /// install missing parsers and queries. Still honored when no per-language
-    /// value is set, but setting it shows a one-time migration notice. It is
-    /// removed in v2.
-    #[schemars(extend("deprecated" = true))]
+    // Compatibility-only v0 input; intentionally absent from generated docs.
+    #[doc(hidden)]
+    #[schemars(skip)]
     pub auto_install: Option<bool>,
     /// Debounce delay, in milliseconds, between a `didChange` and the diagnostic
     /// pull it triggers. Higher values cut refresh/pull volume during rapid typing
@@ -1022,9 +983,10 @@ pub fn json_schema() -> schemars::Schema {
 /// `rename_all` is load-bearing now that a field is multi-word: the config
 /// surface is camelCase throughout, and dropping it fails
 /// `known_language_setting_keys_match_schema_properties`, which compares the
-/// camelCase `KNOWN_LANGUAGE_SETTING_KEYS` against this struct's generated
-/// schema property names. (The `snake_case leak` assertions nearby only cover
-/// `RawWorkspaceSettings`' own top-level keys, not this type's.)
+/// camelCase `KNOWN_LANGUAGE_SETTING_KEYS` against this struct's canonical
+/// schema properties plus explicitly hidden compatibility inputs. (The
+/// `snake_case leak` assertions nearby only cover `RawWorkspaceSettings`' own
+/// top-level keys, not this type's.)
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct LanguageSettings {
@@ -1045,10 +1007,9 @@ pub struct LanguageSettings {
     /// (`virt`/`host`/`native`) per LSP method (`"_"` = method wildcard).
     /// Omit to use the default order `["virt", "host", "native"]`.
     pub layers: Option<LayersConfig>,
-    /// Deprecated and ignored alternative language IDs. The field remains
-    /// accepted for migration warnings through v1 and is removed in v2; use
-    /// `base` on each derived language instead.
-    #[schemars(extend("deprecated" = true))]
+    // Compatibility-only v0 input; intentionally absent from generated docs.
+    #[doc(hidden)]
+    #[schemars(skip)]
     pub aliases: Option<Vec<String>>,
     /// Whether missing parsers/queries for this language may be auto-installed.
     ///
@@ -1289,43 +1250,30 @@ mod tests {
         // Top-level properties should use camelCase (from serde renames)
         let props = value.get("properties").expect("should have properties");
         assert!(props.get("searchPaths").is_some(), "missing searchPaths");
-        let legacy_auto_install = props.get("autoInstall").expect("missing autoInstall");
-        assert_eq!(
-            legacy_auto_install.get("deprecated"),
-            Some(&serde_json::Value::Bool(true))
+        assert!(
+            props.get("autoInstall").is_none(),
+            "deprecated top-level autoInstall must not be advertised"
         );
         assert!(
             props.get("diagnosticsDebounceMs").is_some(),
             "missing diagnosticsDebounceMs"
         );
-        let legacy_capture_mappings = props
-            .get("captureMappings")
-            .expect("missing captureMappings");
-        assert_eq!(
-            legacy_capture_mappings.get("deprecated"),
-            Some(&serde_json::Value::Bool(true))
-        );
         assert!(
-            legacy_capture_mappings["description"]
-                .as_str()
-                .is_some_and(|description| description
-                    .contains("features[\"textDocument/semanticTokens\"].captureMappings")),
-            "deprecated schema property should name its replacement"
+            props.get("captureMappings").is_none(),
+            "deprecated top-level captureMappings must not be advertised"
         );
         assert!(
             props.get("languageServers").is_some(),
             "missing languageServers"
         );
-        let legacy_aliases = value["$defs"]["LanguageSettings"]["properties"]["aliases"]
-            .as_object()
-            .expect("missing languages.*.aliases");
-        assert_eq!(
-            legacy_aliases.get("deprecated"),
-            Some(&serde_json::Value::Bool(true))
+        assert!(
+            value["$defs"]["LanguageSettings"]["properties"]["aliases"].is_null(),
+            "deprecated aliases must not be advertised"
         );
-        let legacy_root_markers = value["$defs"]["BridgeServerConfig"]["properties"]["rootMarkers"]
-            .as_object()
-            .expect("missing languageServers.*.rootMarkers");
+        assert!(
+            value["$defs"]["BridgeServerConfig"]["properties"]["rootMarkers"].is_null(),
+            "deprecated rootMarkers must not be advertised"
+        );
         assert!(
             value["$defs"]["BridgeServerConfig"]["description"]
                 .as_str()
@@ -1334,21 +1282,9 @@ mod tests {
                 ),
             "BridgeServerConfig should retain its public type description"
         );
-        assert_eq!(
-            value["$defs"]["BridgeServerConfig"]["not"]["required"],
-            serde_json::json!(["workspaceMarkers", "rootMarkers"]),
-            "canonical and deprecated marker keys should be mutually exclusive"
-        );
-        assert_eq!(
-            legacy_root_markers.get("deprecated"),
-            Some(&serde_json::Value::Bool(true))
-        );
         assert!(
-            legacy_root_markers["description"]
-                .as_str()
-                .is_some_and(|description| description.contains("workspaceMarkers")
-                    && description.contains("removed in v2")),
-            "deprecated rootMarkers schema property should name replacement and deadline"
+            value["$defs"]["BridgeServerConfig"]["not"].is_null(),
+            "schema should not encode constraints for an unadvertised alias"
         );
 
         // snake_case variants must NOT appear

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -369,10 +369,6 @@ impl RootMarker {
     }
 }
 
-/// Configuration for a bridge language server.
-///
-/// This is used to configure external language servers (like rust-analyzer, pyright)
-/// that kakehashi can redirect requests to for injection regions.
 fn add_deprecated_root_markers_schema(schema: &mut schemars::Schema) {
     let Some(properties) = schema
         .as_object_mut()
@@ -398,6 +394,10 @@ fn add_deprecated_root_markers_schema(schema: &mut schemars::Schema) {
     properties.insert("rootMarkers".to_owned(), root_markers.clone().into());
 }
 
+/// Configuration for a bridge language server.
+///
+/// This is used to configure external language servers (like rust-analyzer, pyright)
+/// that kakehashi can redirect requests to for injection regions.
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 #[schemars(transform = add_deprecated_root_markers_schema)]
@@ -1320,6 +1320,14 @@ mod tests {
         let legacy_root_markers = value["$defs"]["BridgeServerConfig"]["properties"]["rootMarkers"]
             .as_object()
             .expect("missing languageServers.*.rootMarkers");
+        assert!(
+            value["$defs"]["BridgeServerConfig"]["description"]
+                .as_str()
+                .is_some_and(
+                    |description| description.contains("configure external language servers")
+                ),
+            "BridgeServerConfig should retain its public type description"
+        );
         assert_eq!(
             legacy_root_markers.get("deprecated"),
             Some(&serde_json::Value::Bool(true))

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -370,9 +370,11 @@ impl RootMarker {
 }
 
 fn add_deprecated_root_markers_schema(schema: &mut schemars::Schema) {
+    let Some(schema) = schema.as_object_mut() else {
+        return;
+    };
     let Some(properties) = schema
-        .as_object_mut()
-        .and_then(|schema| schema.get_mut("properties"))
+        .get_mut("properties")
         .and_then(serde_json::Value::as_object_mut)
     else {
         return;
@@ -392,6 +394,10 @@ fn add_deprecated_root_markers_schema(schema: &mut schemars::Schema) {
         ),
     );
     properties.insert("rootMarkers".to_owned(), root_markers.clone().into());
+    schema.insert(
+        "not".to_owned(),
+        serde_json::json!({ "required": ["workspaceMarkers", "rootMarkers"] }),
+    );
 }
 
 /// Configuration for a bridge language server.
@@ -1327,6 +1333,11 @@ mod tests {
                     |description| description.contains("configure external language servers")
                 ),
             "BridgeServerConfig should retain its public type description"
+        );
+        assert_eq!(
+            value["$defs"]["BridgeServerConfig"]["not"]["required"],
+            serde_json::json!(["workspaceMarkers", "rootMarkers"]),
+            "canonical and deprecated marker keys should be mutually exclusive"
         );
         assert_eq!(
             legacy_root_markers.get("deprecated"),

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -421,7 +421,7 @@ pub struct BridgeServerConfig {
     /// When no marker matches, the client-supplied root is the fallback.
     ///
     /// The wire key is `workspaceMarkers`; the pre-rename key `rootMarkers` is
-    /// kept as a deprecated serde alias for backward compatibility.
+    /// kept as a deprecated serde alias through v1 and removed in v2.
     #[serde(alias = "rootMarkers")]
     pub workspace_markers: Option<Vec<RootMarker>>,
     /// Trigger characters for bridged `textDocument/onTypeFormatting` (#354).
@@ -782,14 +782,15 @@ pub struct RawWorkspaceSettings {
     /// Deprecated: use
     /// `features["textDocument/semanticTokens"].captureMappings` instead. This
     /// legacy shape remains accepted during migration; only its `highlights`
-    /// entries are consumed.
+    /// entries are consumed. It is removed in v2.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(extend("deprecated" = true))]
     pub capture_mappings: Option<CaptureMappings>,
     /// Deprecated: use `languages._.autoInstall` (and per-language
     /// `languages.<lang>.autoInstall`) instead. Whether to automatically
     /// install missing parsers and queries. Still honored when no per-language
-    /// value is set, but setting it shows a one-time migration notice.
+    /// value is set, but setting it shows a one-time migration notice. It is
+    /// removed in v2.
     pub auto_install: Option<bool>,
     /// Debounce delay, in milliseconds, between a `didChange` and the diagnostic
     /// pull it triggers. Higher values cut refresh/pull volume during rapid typing
@@ -1011,7 +1012,7 @@ pub struct LanguageSettings {
     /// (`virt`/`host`/`native`) per LSP method (`"_"` = method wildcard).
     /// Omit to use the default order `["virt", "host", "native"]`.
     pub layers: Option<LayersConfig>,
-    /// Deprecated: use `base` on the derived language instead.
+    /// Deprecated: use `base` on the derived language instead. Removed in v2.
     /// Alternative languageId values that should use this parser.
     pub aliases: Option<Vec<String>>,
     /// Whether missing parsers/queries for this language may be auto-installed.

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1012,8 +1012,9 @@ pub struct LanguageSettings {
     /// (`virt`/`host`/`native`) per LSP method (`"_"` = method wildcard).
     /// Omit to use the default order `["virt", "host", "native"]`.
     pub layers: Option<LayersConfig>,
-    /// Deprecated: use `base` on the derived language instead. Removed in v2.
-    /// Alternative languageId values that should use this parser.
+    /// Deprecated and ignored alternative language IDs. The field remains
+    /// accepted for migration warnings through v1 and is removed in v2; use
+    /// `base` on each derived language instead.
     pub aliases: Option<Vec<String>>,
     /// Whether missing parsers/queries for this language may be auto-installed.
     ///

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -373,8 +373,34 @@ impl RootMarker {
 ///
 /// This is used to configure external language servers (like rust-analyzer, pyright)
 /// that kakehashi can redirect requests to for injection regions.
+fn add_deprecated_root_markers_schema(schema: &mut schemars::Schema) {
+    let Some(properties) = schema
+        .as_object_mut()
+        .and_then(|schema| schema.get_mut("properties"))
+        .and_then(serde_json::Value::as_object_mut)
+    else {
+        return;
+    };
+    let Some(mut root_markers) = properties.get("workspaceMarkers").cloned() else {
+        return;
+    };
+    let Some(root_markers) = root_markers.as_object_mut() else {
+        return;
+    };
+    root_markers.insert("deprecated".to_owned(), serde_json::Value::Bool(true));
+    root_markers.insert(
+        "description".to_owned(),
+        serde_json::Value::String(
+            "Deprecated alias for `workspaceMarkers`; accepted through v1 and removed in v2."
+                .to_owned(),
+        ),
+    );
+    properties.insert("rootMarkers".to_owned(), root_markers.clone().into());
+}
+
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
+#[schemars(transform = add_deprecated_root_markers_schema)]
 pub struct BridgeServerConfig {
     /// Command array: first element is the program, rest are arguments
     /// e.g., ["rust-analyzer"] or ["pyright-langserver", "--stdio"].
@@ -1290,6 +1316,20 @@ mod tests {
         assert_eq!(
             legacy_aliases.get("deprecated"),
             Some(&serde_json::Value::Bool(true))
+        );
+        let legacy_root_markers = value["$defs"]["BridgeServerConfig"]["properties"]["rootMarkers"]
+            .as_object()
+            .expect("missing languageServers.*.rootMarkers");
+        assert_eq!(
+            legacy_root_markers.get("deprecated"),
+            Some(&serde_json::Value::Bool(true))
+        );
+        assert!(
+            legacy_root_markers["description"]
+                .as_str()
+                .is_some_and(|description| description.contains("workspaceMarkers")
+                    && description.contains("removed in v2")),
+            "deprecated rootMarkers schema property should name replacement and deadline"
         );
 
         // snake_case variants must NOT appear

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -791,6 +791,7 @@ pub struct RawWorkspaceSettings {
     /// install missing parsers and queries. Still honored when no per-language
     /// value is set, but setting it shows a one-time migration notice. It is
     /// removed in v2.
+    #[schemars(extend("deprecated" = true))]
     pub auto_install: Option<bool>,
     /// Debounce delay, in milliseconds, between a `didChange` and the diagnostic
     /// pull it triggers. Higher values cut refresh/pull volume during rapid typing
@@ -1015,6 +1016,7 @@ pub struct LanguageSettings {
     /// Deprecated and ignored alternative language IDs. The field remains
     /// accepted for migration warnings through v1 and is removed in v2; use
     /// `base` on each derived language instead.
+    #[schemars(extend("deprecated" = true))]
     pub aliases: Option<Vec<String>>,
     /// Whether missing parsers/queries for this language may be auto-installed.
     ///
@@ -1255,7 +1257,11 @@ mod tests {
         // Top-level properties should use camelCase (from serde renames)
         let props = value.get("properties").expect("should have properties");
         assert!(props.get("searchPaths").is_some(), "missing searchPaths");
-        assert!(props.get("autoInstall").is_some(), "missing autoInstall");
+        let legacy_auto_install = props.get("autoInstall").expect("missing autoInstall");
+        assert_eq!(
+            legacy_auto_install.get("deprecated"),
+            Some(&serde_json::Value::Bool(true))
+        );
         assert!(
             props.get("diagnosticsDebounceMs").is_some(),
             "missing diagnosticsDebounceMs"
@@ -1277,6 +1283,13 @@ mod tests {
         assert!(
             props.get("languageServers").is_some(),
             "missing languageServers"
+        );
+        let legacy_aliases = value["$defs"]["LanguageSettings"]["properties"]["aliases"]
+            .as_object()
+            .expect("missing languages.*.aliases");
+        assert_eq!(
+            legacy_aliases.get("deprecated"),
+            Some(&serde_json::Value::Bool(true))
         );
 
         // snake_case variants must NOT appear

--- a/src/config/unknown_keys.rs
+++ b/src/config/unknown_keys.rs
@@ -434,10 +434,7 @@ mod tests {
 
     #[test]
     fn known_bridge_server_setting_keys_match_schema_properties_and_aliases() {
-        assert_known_keys_match_schema::<BridgeServerConfig>(
-            KNOWN_BRIDGE_SERVER_SETTING_KEYS,
-            &["rootMarkers"],
-        );
+        assert_known_keys_match_schema::<BridgeServerConfig>(KNOWN_BRIDGE_SERVER_SETTING_KEYS, &[]);
     }
 
     #[test]

--- a/src/config/unknown_keys.rs
+++ b/src/config/unknown_keys.rs
@@ -387,7 +387,10 @@ mod tests {
 
     #[test]
     fn known_workspace_setting_keys_match_schema_properties() {
-        assert_known_keys_match_schema::<RawWorkspaceSettings>(KNOWN_WORKSPACE_SETTING_KEYS, &[]);
+        assert_known_keys_match_schema::<RawWorkspaceSettings>(
+            KNOWN_WORKSPACE_SETTING_KEYS,
+            &["autoInstall", "captureMappings"],
+        );
     }
 
     #[test]
@@ -434,7 +437,10 @@ mod tests {
 
     #[test]
     fn known_bridge_server_setting_keys_match_schema_properties_and_aliases() {
-        assert_known_keys_match_schema::<BridgeServerConfig>(KNOWN_BRIDGE_SERVER_SETTING_KEYS, &[]);
+        assert_known_keys_match_schema::<BridgeServerConfig>(
+            KNOWN_BRIDGE_SERVER_SETTING_KEYS,
+            &["rootMarkers"],
+        );
     }
 
     #[test]
@@ -494,7 +500,10 @@ mod tests {
 
     #[test]
     fn known_language_setting_keys_match_schema_properties() {
-        assert_known_keys_match_schema::<LanguageSettings>(KNOWN_LANGUAGE_SETTING_KEYS, &[]);
+        assert_known_keys_match_schema::<LanguageSettings>(
+            KNOWN_LANGUAGE_SETTING_KEYS,
+            &["aliases"],
+        );
     }
 
     #[test]

--- a/src/deprecation.rs
+++ b/src/deprecation.rs
@@ -1,0 +1,48 @@
+include!(concat!(env!("OUT_DIR"), "/package_version.rs"));
+
+pub(crate) const fn removal_is_due(current_major: u64, remove_in_major: u64) -> bool {
+    current_major >= remove_in_major
+}
+
+macro_rules! enforce_deprecation_deadline {
+    (
+        name = $name:literal,
+        deprecated_in = $deprecated_in:literal,
+        remove_in = $remove_in:literal $(,)?
+    ) => {
+        const _: () = {
+            assert!(
+                $deprecated_in < $remove_in,
+                "a deprecation must precede its removal major"
+            );
+            assert!(
+                !$crate::deprecation::removal_is_due(
+                    $crate::deprecation::PACKAGE_MAJOR,
+                    $remove_in,
+                ),
+                concat!(
+                    "`",
+                    $name,
+                    "` was deprecated in v",
+                    stringify!($deprecated_in),
+                    " and must be removed before releasing v",
+                    stringify!($remove_in),
+                )
+            );
+        };
+    };
+}
+
+pub(crate) use enforce_deprecation_deadline;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn v0_deprecation_remains_valid_through_v1_and_expires_in_v2() {
+        assert!(!removal_is_due(0, 2));
+        assert!(!removal_is_due(1, 2));
+        assert!(removal_is_due(2, 2));
+    }
+}

--- a/src/deprecation.rs
+++ b/src/deprecation.rs
@@ -38,11 +38,88 @@ pub(crate) use enforce_deprecation_deadline;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::{fs, process::Command};
+
+    fn compile_fixture(version: &str) -> std::process::Output {
+        let fixture = tempfile::tempdir().expect("fixture temp dir");
+        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let deprecation_module = manifest_dir.join("src/deprecation.rs");
+        let module_path = deprecation_module
+            .to_str()
+            .expect("repository path must be valid UTF-8");
+
+        fs::create_dir(fixture.path().join("src")).expect("fixture src dir");
+        fs::copy(
+            manifest_dir.join("build.rs"),
+            fixture.path().join("build.rs"),
+        )
+        .expect("copy production build script");
+        fs::write(
+            fixture.path().join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"deprecation-deadline-fixture\"\nversion = \"{version}\"\nedition = \"2024\"\n"
+            ),
+        )
+        .expect("write fixture manifest");
+        fs::write(
+            fixture.path().join("src/lib.rs"),
+            format!(
+                r#"
+#[path = {module_path:?}]
+mod deprecation;
+
+mod policies {{
+    crate::deprecation::enforce_deprecation_deadline!(
+        name = "v0 path",
+        deprecated_in = 0,
+        remove_in = 2,
+    );
+    crate::deprecation::enforce_deprecation_deadline!(
+        name = "v1 path",
+        deprecated_in = 1,
+        remove_in = 3,
+    );
+}}
+"#
+            ),
+        )
+        .expect("write fixture library");
+
+        Command::new(env!("CARGO"))
+            .args(["check", "--offline", "--quiet"])
+            .current_dir(fixture.path())
+            .env("CARGO_TARGET_DIR", fixture.path().join("target"))
+            .output()
+            .expect("run cargo check for deadline fixture")
+    }
 
     #[test]
     fn v0_deprecation_remains_valid_through_v1_and_expires_in_v2() {
         assert!(!removal_is_due(0, 2));
         assert!(!removal_is_due(1, 2));
         assert!(removal_is_due(2, 2));
+    }
+
+    #[test]
+    fn compile_gate_tracks_cargo_major_and_keeps_generations_independent() {
+        let v1 = compile_fixture("1.0.0");
+        assert!(
+            v1.status.success(),
+            "both policies must compile in v1: {}",
+            String::from_utf8_lossy(&v1.stderr)
+        );
+
+        let v2 = compile_fixture("2.0.0");
+        assert!(!v2.status.success(), "the v0 policy must expire in v2");
+        let stderr = String::from_utf8_lossy(&v2.stderr);
+        assert!(
+            stderr
+                .contains("`v0 path` was deprecated in v0 and must be removed before releasing v2"),
+            "the failure must identify the expired policy: {stderr}"
+        );
+        assert!(
+            !stderr.contains("`v1 path` was deprecated"),
+            "the independently scheduled v1 policy must remain valid in v2: {stderr}"
+        );
     }
 }

--- a/src/deprecation.rs
+++ b/src/deprecation.rs
@@ -26,17 +26,21 @@ macro_rules! declare_deprecation {
         deprecated_in = $deprecated_in:literal,
         remove_in = $remove_in:literal $(,)?
     ) => {
-        $visibility const $policy: $crate::deprecation::Deprecation =
-            $crate::deprecation::Deprecation::new($remove_in);
+        $visibility const $policy: $crate::deprecation::Deprecation = {
+            let remove_in: u64 = $remove_in;
+            $crate::deprecation::Deprecation::new(remove_in)
+        };
         const _: () = {
+            let deprecated_in: u64 = $deprecated_in;
+            let remove_in: u64 = $remove_in;
             assert!(
-                $deprecated_in < $remove_in,
+                deprecated_in < remove_in,
                 "a deprecation must precede its removal major"
             );
             assert!(
                 !$crate::deprecation::removal_is_due(
                     $crate::deprecation::PACKAGE_MAJOR,
-                    $remove_in,
+                    remove_in,
                 ),
                 concat!(
                     "`",
@@ -62,14 +66,16 @@ macro_rules! declare_deprecation_notice {
     ) => {
         $(#[$attribute])*
         $visibility const $notice: &str = {
+            let deprecated_in: u64 = $deprecated_in;
+            let remove_in: u64 = $remove_in;
             assert!(
-                $deprecated_in < $remove_in,
+                deprecated_in < remove_in,
                 "a deprecation must precede its removal major"
             );
             assert!(
                 !$crate::deprecation::removal_is_due(
                     $crate::deprecation::PACKAGE_MAJOR,
-                    $remove_in,
+                    remove_in,
                 ),
                 concat!(
                     "`",
@@ -141,6 +147,12 @@ mod policies {{
         name = "v1 path",
         deprecated_in = 1,
         remove_in = 3,
+    );
+    crate::deprecation::declare_deprecation!(
+        const LARGE_MAJOR_POLICY;
+        name = "large major path",
+        deprecated_in = 4_294_967_296,
+        remove_in = 4_294_967_297,
     );
 }}
 "#

--- a/src/deprecation.rs
+++ b/src/deprecation.rs
@@ -57,7 +57,7 @@ mod tests {
         fs::write(
             fixture.path().join("Cargo.toml"),
             format!(
-                "[package]\nname = \"deprecation-deadline-fixture\"\nversion = \"{version}\"\nedition = \"2024\"\n"
+                "[package]\nname = \"deprecation-deadline-fixture\"\nversion = \"{version}\"\nedition = \"2024\"\n\n[workspace]\n"
             ),
         )
         .expect("write fixture manifest");

--- a/src/deprecation.rs
+++ b/src/deprecation.rs
@@ -1,15 +1,33 @@
 include!(concat!(env!("OUT_DIR"), "/package_version.rs"));
 
+#[derive(Clone, Copy)]
+pub(crate) struct Deprecation {
+    remove_in_major: u64,
+}
+
+impl Deprecation {
+    pub(crate) const fn new(remove_in_major: u64) -> Self {
+        Self { remove_in_major }
+    }
+
+    pub(crate) const fn remove_in_major(self) -> u64 {
+        self.remove_in_major
+    }
+}
+
 pub(crate) const fn removal_is_due(current_major: u64, remove_in_major: u64) -> bool {
     current_major >= remove_in_major
 }
 
-macro_rules! enforce_deprecation_deadline {
+macro_rules! declare_deprecation {
     (
+        $visibility:vis const $policy:ident;
         name = $name:literal,
         deprecated_in = $deprecated_in:literal,
         remove_in = $remove_in:literal $(,)?
     ) => {
+        $visibility const $policy: $crate::deprecation::Deprecation =
+            $crate::deprecation::Deprecation::new($remove_in);
         const _: () = {
             assert!(
                 $deprecated_in < $remove_in,
@@ -33,7 +51,42 @@ macro_rules! enforce_deprecation_deadline {
     };
 }
 
-pub(crate) use enforce_deprecation_deadline;
+macro_rules! declare_deprecation_notice {
+    (
+        $(#[$attribute:meta])*
+        $visibility:vis const $notice:ident;
+        name = $name:literal,
+        deprecated_in = $deprecated_in:literal,
+        remove_in = $remove_in:literal,
+        message = $message:literal $(,)?
+    ) => {
+        const _: () = {
+            assert!(
+                $deprecated_in < $remove_in,
+                "a deprecation must precede its removal major"
+            );
+            assert!(
+                !$crate::deprecation::removal_is_due(
+                    $crate::deprecation::PACKAGE_MAJOR,
+                    $remove_in,
+                ),
+                concat!(
+                    "`",
+                    $name,
+                    "` was deprecated in v",
+                    stringify!($deprecated_in),
+                    " and must be removed before releasing v",
+                    stringify!($remove_in),
+                )
+            );
+        };
+        $(#[$attribute])*
+        $visibility const $notice: &str =
+            concat!($message, stringify!($remove_in), ".");
+    };
+}
+
+pub(crate) use {declare_deprecation, declare_deprecation_notice};
 
 #[cfg(test)]
 mod tests {
@@ -69,12 +122,15 @@ mod tests {
 mod deprecation;
 
 mod policies {{
-    crate::deprecation::enforce_deprecation_deadline!(
+    crate::deprecation::declare_deprecation_notice!(
+        const V0_NOTICE;
         name = "v0 path",
         deprecated_in = 0,
         remove_in = 2,
+        message = "v0 path is removed in v"
     );
-    crate::deprecation::enforce_deprecation_deadline!(
+    crate::deprecation::declare_deprecation!(
+        const V1_POLICY;
         name = "v1 path",
         deprecated_in = 1,
         remove_in = 3,

--- a/src/deprecation.rs
+++ b/src/deprecation.rs
@@ -60,7 +60,8 @@ macro_rules! declare_deprecation_notice {
         remove_in = $remove_in:literal,
         message = $message:literal $(,)?
     ) => {
-        const _: () = {
+        $(#[$attribute])*
+        $visibility const $notice: &str = {
             assert!(
                 $deprecated_in < $remove_in,
                 "a deprecation must precede its removal major"
@@ -79,10 +80,8 @@ macro_rules! declare_deprecation_notice {
                     stringify!($remove_in),
                 )
             );
+            concat!($message, stringify!($remove_in), ".")
         };
-        $(#[$attribute])*
-        $visibility const $notice: &str =
-            concat!($message, stringify!($remove_in), ".");
     };
 }
 
@@ -123,6 +122,14 @@ mod deprecation;
 
 mod policies {{
     crate::deprecation::declare_deprecation_notice!(
+        #[cfg(any())]
+        const DISABLED_EXPIRED_NOTICE;
+        name = "disabled expired path",
+        deprecated_in = 0,
+        remove_in = 1,
+        message = "disabled expired path is removed in v"
+    );
+    crate::deprecation::declare_deprecation_notice!(
         const V0_NOTICE;
         name = "v0 path",
         deprecated_in = 0,
@@ -161,7 +168,7 @@ mod policies {{
         let v1 = compile_fixture("1.0.0");
         assert!(
             v1.status.success(),
-            "both policies must compile in v1: {}",
+            "enabled policies and cfg-disabled deadlines must compile in v1: {}",
             String::from_utf8_lossy(&v1.stderr)
         );
 

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -759,14 +759,9 @@ impl LanguageCoordinator {
             }
 
             if let Some(aliases) = &config.aliases {
-                let example_alias = aliases
-                    .iter()
-                    .next()
-                    .map(|a| a.as_str())
-                    .unwrap_or("<derived>");
                 let message = crate::config::deprecation::aliases_deprecation_notice(
                     lang_name,
-                    example_alias,
+                    aliases.first().map(String::as_str),
                 );
                 log::warn!(target: "kakehashi::config", "{message}");
                 config_warnings.push(message);

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -759,10 +759,8 @@ impl LanguageCoordinator {
             }
 
             if let Some(aliases) = &config.aliases {
-                let message = crate::config::deprecation::aliases_deprecation_notice(
-                    lang_name,
-                    aliases.first().map(String::as_str),
-                );
+                let message =
+                    crate::config::deprecation::aliases_deprecation_notice(lang_name, aliases);
                 log::warn!(target: "kakehashi::config", "{message}");
                 config_warnings.push(message);
             }

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -764,12 +764,9 @@ impl LanguageCoordinator {
                     .next()
                     .map(|a| a.as_str())
                     .unwrap_or("<derived>");
-                let message = format!(
-                    "Language '{}' uses deprecated 'aliases' field. \
-                     Use 'base' on derived languages instead. \
-                     Example: [languages.{}] base = \"{}\". \
-                     The 'aliases' field will be removed in kakehashi v2.",
-                    lang_name, example_alias, lang_name
+                let message = crate::config::deprecation::aliases_deprecation_notice(
+                    lang_name,
+                    example_alias,
                 );
                 log::warn!(target: "kakehashi::config", "{message}");
                 config_warnings.push(message);
@@ -2572,7 +2569,6 @@ mod tests {
                     if *level == LanguageLogLevel::Warning
                         && message.contains("deprecated 'aliases' field")
                         && message.contains("Use 'base' on derived languages instead")
-                        && message.contains("removed in kakehashi v2")
             )),
             "load_settings should emit a client-visible migration warning for deprecated aliases"
         );

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -767,7 +767,8 @@ impl LanguageCoordinator {
                 let message = format!(
                     "Language '{}' uses deprecated 'aliases' field. \
                      Use 'base' on derived languages instead. \
-                     Example: [languages.{}] base = \"{}\"",
+                     Example: [languages.{}] base = \"{}\". \
+                     The 'aliases' field will be removed in kakehashi v2.",
                     lang_name, example_alias, lang_name
                 );
                 log::warn!(target: "kakehashi::config", "{message}");
@@ -2571,6 +2572,7 @@ mod tests {
                     if *level == LanguageLogLevel::Warning
                         && message.contains("deprecated 'aliases' field")
                         && message.contains("Use 'base' on derived languages instead")
+                        && message.contains("removed in kakehashi v2")
             )),
             "load_settings should emit a client-visible migration warning for deprecated aliases"
         );

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -2568,7 +2568,7 @@ mod tests {
                 LanguageEvent::ShowMessage { level, message }
                     if *level == LanguageLogLevel::Warning
                         && message.contains("deprecated 'aliases' field")
-                        && message.contains("Use 'base' on derived languages instead")
+                        && message.contains("Use 'base' on each derived language instead")
             )),
             "load_settings should emit a client-visible migration warning for deprecated aliases"
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub(crate) mod cancel;
 pub mod cli;
 pub(crate) mod compute_pool;
 pub mod config;
+pub(crate) mod deprecation;
 pub(crate) mod document;
 pub(crate) mod error;
 pub(crate) mod experimental;

--- a/tests/integration/test_cli.rs
+++ b/tests/integration/test_cli.rs
@@ -610,14 +610,14 @@ fn test_config_schema_outputs_valid_json_to_stdout() {
         stdout
     );
     assert!(
-        props.get("autoInstall").is_some(),
-        "Should have autoInstall property. Got: {}",
+        props.get("autoInstall").is_none(),
+        "Should not advertise deprecated top-level autoInstall. Got: {}",
         stdout
     );
-    assert_eq!(
-        schema.pointer("/properties/captureMappings/deprecated"),
-        Some(&serde_json::json!(true)),
-        "legacy captureMappings should be marked deprecated"
+    assert!(
+        schema.pointer("/properties/captureMappings").is_none(),
+        "Should not advertise deprecated top-level captureMappings. Got: {}",
+        stdout
     );
     assert!(
         schema


### PR DESCRIPTION
## Summary

- declare deprecation origin/removal majors and fail compilation once a retained path reaches its removal major
- schedule every retained v0 configuration deprecation for removal in v2 while keeping future v1 policies independent
- derive runtime notice deadlines from the declarations and expose deprecated compatibility keys in JSON Schema
- document the v1 migration window, v2 removal boundary, and owning ADR relationships

## Validation

- `make check`
- `cargo test --lib --quiet` (3561 passed, 2 ignored)
- compile fixture proves v0 policies compile in v1, fail in v2, and an independent v1 policy remains valid in v2
- revise Stage 1 multi-perspective review converged to clean
- Codex MCP review converged to no actionable findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer migration guidance and notices for deprecated configuration options.
  * Added migration examples for language aliases in TOML and JSON formats.
  * Added validation for deprecation deadlines and compatibility timelines.
  * Improved configuration schema details for deprecated fields and replacements.

* **Bug Fixes**
  * Configurations using conflicting workspace marker settings are now rejected with a clear error.

* **Documentation**
  * Documented the v1 compatibility period and v2 removal timeline for legacy settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->