### PR TITLE
chore(release): bump version to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "kakehashi"
-version = "0.11.0"
+version = "1.0.0"
 dependencies = [
  "arc-swap",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kakehashi"
-version = "0.11.0"
+version = "1.0.0"
 edition = "2024"
 # std's inherent `File::lock` (src/install/queries.rs) is stable from 1.89; the
 # 2024 edition alone would only require 1.85. Declared so an older toolchain


### PR DESCRIPTION
## Summary

Bump the crate version from 0.11.0 to 1.0.0 — the first stable major release. This PR rolls up everything merged since the v0.11.0 release (2026-08-19). Merging this PR is the v1.0.0 release point: the merge commit will be tagged `v1.0.0` and published as a GitHub release.

## What v1.0.0 means

- **Stability commitment.** The configuration surface, the `kakehashi/*` custom methods, and the bridge protocols shipped through v0.11.0 are now the stable v1 contract.
- **Deprecation schedule is enforced, not prose.** Every compatibility path deprecated during v0 now declares its removal major (v2) in code; a build at or after the removal major fails until the path is actually removed (#1019, `docs/architecture-decisions/deprecation-removal-deadlines.md`). All v0-deprecated shapes keep working throughout v1.

## Deprecated compatibility paths (accepted in v1, removed in v2.0.0)

| Deprecated | Use instead |
| --- | --- |
| `languageServers.*.rootMarkers` | `languageServers.*.workspaceMarkers` |
| Top-level `autoInstall` | `languages._.autoInstall` (override per language with `languages.<lang>.autoInstall`) |
| Top-level `captureMappings` | `features."textDocument/semanticTokens".captureMappings` |
| `languages.*.aliases` | `base` on each derived language entry |
| Unwrapped `workspace/didChangeConfiguration` settings | Wrap runtime settings in the notification's `settings.kakehashi` object |

Each still emits a once-per-session migration notice naming the v2 deadline.

## User-facing changes since v0.11.0

- #1019 — Deprecation removal deadlines: compile-time deadline declarations for every retained v0 compatibility path, runtime notices derived from the declarations (each now names the v2 removal), concrete TOML/JSON migration examples for `languages.*.aliases` (reserved `_` and self-aliases excluded, in-place edits to avoid duplicate keys), deprecated keys exposed-but-hidden in the JSON Schema as `deprecated`, and a schema declaration making the canonical and deprecated marker spellings (`workspaceMarkers` / `rootMarkers`) mutually exclusive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package to version 1.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->