### PR TITLE
feat(bridge): forward unimplemented methods to host servers on explicit config

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -624,8 +624,9 @@ forwarded to the host servers when you name it explicitly under
 `_self.aggregation`. Whether it goes out as a request or a notification
 follows what the client sent; a request is answered with the first non-empty
 downstream result in `priorities` order, a notification reaches every
-listed server. Params travel verbatim (real URI), the result comes back
-untouched, and the downstream server's advertised capabilities are not
+listed server. Params travel verbatim (real URI; only the progress tokens
+are stripped, since kakehashi relays no downstream progress), the result
+comes back untouched, and the downstream server's advertised capabilities are not
 checked — a server that does not implement the method answers
 `MethodNotFound` itself.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -616,6 +616,34 @@ wildcard — a server listing the host language is a *capability*, not consent
 to use it. `_self.aggregation` (priorities/strategy/maxFanOut) inherits from
 `_` as usual.
 
+**Forwarding methods kakehashi does not implement:**
+
+A method kakehashi has no handler for (say `textDocument/inlineCompletion`
+for a Copilot server, or a vendor-specific request or notification) is
+forwarded to the host servers when you name it explicitly under
+`_self.aggregation`. Whether it goes out as a request or a notification
+follows what the client sent; a request is answered with the first non-empty
+downstream result in `priorities` order, a notification reaches every
+listed server. Params travel verbatim (real URI), the result comes back
+untouched, and the downstream server's advertised capabilities are not
+checked — a server that does not implement the method answers
+`MethodNotFound` itself.
+
+```toml
+[languages.markdown.bridge._self]
+enabled = true
+
+[languages.markdown.bridge._self.aggregation."textDocument/inlineCompletion"]
+priorities = ["copilot"]             # strategy must stay "preferred" (the default)
+```
+
+Limits: only the method's literal key opts in (the `_` method wildcard does
+not), `params.textDocument.uri` must name an open document (it picks the
+host), the host layer only (no injection regions), `"concatenated"` is
+rejected (results of unknown shape cannot be merged), and kakehashi
+advertises nothing for the method in its `ServerCapabilities` — a client that
+gates on them must be told to send anyway.
+
 **Aggregation Configuration:**
 
 When multiple language servers can handle the same injection language, `aggregation` controls which server's response is preferred. Each entry contains:

--- a/docs/README.md
+++ b/docs/README.md
@@ -634,7 +634,7 @@ checked — a server that does not implement the method answers
 enabled = true
 
 [languages.markdown.bridge._self.aggregation."textDocument/inlineCompletion"]
-priorities = ["copilot"]             # strategy must stay "preferred" (the default)
+priorities = ["copilot"]             # the entry's own strategy must be "preferred" (default)
 ```
 
 Limits: only the method's literal key opts in (the `_` method wildcard does

--- a/docs/README.md
+++ b/docs/README.md
@@ -624,7 +624,7 @@ forwarded to the host servers when you name it explicitly under
 `_self.aggregation`. Whether it goes out as a request or a notification
 follows what the client sent; a request is answered with the first non-empty
 downstream result in `priorities` order, a notification reaches every
-listed server. Params travel verbatim (real URI; only the progress tokens
+selected server (the `priorities` allowlist, capped by `maxFanOut`). Params travel verbatim (real URI; only the progress tokens
 are stripped, since kakehashi relays no downstream progress), the result
 comes back untouched, and the downstream server's advertised capabilities are not
 checked — a server that does not implement the method answers

--- a/docs/README.md
+++ b/docs/README.md
@@ -639,10 +639,13 @@ priorities = ["copilot"]             # the entry's own strategy must be "preferr
 
 Limits: only the method's literal key opts in (the `_` method wildcard does
 not), `params.textDocument.uri` must name an open document (it picks the
-host), the host layer only (no injection regions), `"concatenated"` is
-rejected (results of unknown shape cannot be merged), and kakehashi
-advertises nothing for the method in its `ServerCapabilities` — a client that
-gates on them must be told to send anyway.
+host), the host layer only (no injection regions), `"concatenated"` on the
+entry itself is rejected (results of unknown shape cannot be merged), the
+bridge-owned lifecycle/sync methods (`shutdown`, `textDocument/didClose`, …)
+are never forwarded, and kakehashi advertises nothing for the method in its
+`ServerCapabilities` — a client that gates on them must be told to send
+anyway. A server answering `MethodNotFound` counts as an empty answer; any
+other downstream failure surfaces as one log warning per request.
 
 **Aggregation Configuration:**
 

--- a/docs/architecture-decisions/custom-method-host-forwarding.md
+++ b/docs/architecture-decisions/custom-method-host-forwarding.md
@@ -85,8 +85,11 @@ priorities = ["copilot"]
   re-reads the document's current text at sync time, and is dropped if the
   document was closed while it waited. That wait is not the client's:
   the notification's ingress handling completes once delivery is handed
-  off, so a burst of forwarded notifications against a slow-starting
-  server cannot stall the other messages behind it.
+  off (under a bound on deliveries in flight; past it the handler waits
+  for a slot), so a burst of forwarded notifications against a
+  slow-starting server cannot stall the other messages behind it. No
+  order is promised between forwarded notifications, even to one server:
+  their handlers already run concurrently, as every non-sync message's do.
 - **Startup.** A forwarded request follows the host-request policy and
   fails fast (empty) on a server still initializing — the next request gets
   it. A forwarded notification instead waits through initialization, within

--- a/docs/architecture-decisions/custom-method-host-forwarding.md
+++ b/docs/architecture-decisions/custom-method-host-forwarding.md
@@ -73,9 +73,10 @@ priorities = ["copilot"]
 - **Request vs. notification follows the wire.** A message with an `id` is
   forwarded as a request and answered with the first non-empty downstream
   `result` in `priorities` order (`preferred`, with the host layer's
-  emptiness rule: `null`, `[]`, `{}`, and the known empty-list envelopes
-  such as `{"items": []}` count as empty); an all-empty or all-failed
-  fan-out answers `null`. A message without an `id` is forwarded as a
+  emptiness rule: `null`, `[]`, and the known empty-list envelopes such as
+  `{"items": []}` count as empty — a bare `{}` does not, it is a result);
+  an all-empty or all-failed fan-out answers `null`. A response carrying
+  neither `result` nor `error` is a failed contribution on this path. A message without an `id` is forwarded as a
   notification to **every** selected server, each delivered independently.
 - **Ordering.** Forwarded requests are not sequenced behind pending
   `didChange` tickets (the same as hover and definition) and sync the text

--- a/docs/architecture-decisions/custom-method-host-forwarding.md
+++ b/docs/architecture-decisions/custom-method-host-forwarding.md
@@ -83,7 +83,8 @@ priorities = ["copilot"]
   snapshotted at dispatch, as typed host methods do. A forwarded
   notification, which may wait through a server's initialization first,
   re-reads the document's current text at sync time, and is dropped if the
-  document was closed while it waited. That wait is not the client's:
+  document was closed while it waited — including a close followed by a
+  reopen of the same URI, which is a different document. That wait is not the client's:
   the notification's ingress handling completes once delivery is handed
   off, so a burst of forwarded notifications against a slow-starting
   server cannot stall the other messages behind it. Deliveries in flight

--- a/docs/architecture-decisions/custom-method-host-forwarding.md
+++ b/docs/architecture-decisions/custom-method-host-forwarding.md
@@ -87,8 +87,16 @@ priorities = ["copilot"]
   ignored, as the typed verbatim host methods ignore it, so one wildcard
   line written for diagnostics cannot break every forwarded method. An
   entry that itself sets `strategy = "concatenated"` is a configuration
-  error: the request is answered with `InvalidParams` naming the method,
-  and a notification is dropped with a warning.
+  error: the request is answered with `RequestFailed` (-32803; the request
+  was well-formed, the server cannot serve it) naming the method, and a
+  notification is dropped with a warning.
+- **Reserved methods.** The bridge-owned lifecycle and sync methods
+  (`initialize`, `shutdown`, `exit`, the `textDocument/did*` sync family,
+  the other notifications kakehashi handles itself) and the `$/` and
+  `kakehashi/` namespaces are never forwarded, even when an entry names
+  them: a request is answered `RequestFailed`, a notification is dropped
+  with a warning. The forwarding methods can be called directly, so this
+  holds in the handler, not only in the fallback dispatch.
 - **Cancellation.** A forwarded request joins the upstream-id registry, so a
   client `$/cancelRequest` reaches the downstream servers exactly as it does
   for typed host methods.

--- a/docs/architecture-decisions/custom-method-host-forwarding.md
+++ b/docs/architecture-decisions/custom-method-host-forwarding.md
@@ -1,0 +1,165 @@
+# Custom Method Host Forwarding
+
+**Related Decisions**:
+- [host-document-bridge](host-document-bridge.md) — the `_self` layer whose `enabled` gate, server selection, and aggregation map this decision reuses verbatim
+- [aggregation-priorities-wildcard](aggregation-priorities-wildcard.md) — the ordered-allowlist `priorities` semantics that pick the receiving servers
+- [language-server-bridge-request-strategies](language-server-bridge-request-strategies.md) — the `preferred` strategy, the only one a method of unknown shape can use
+- [ls-bridge-message-ordering](ls-bridge-message-ordering.md) — cancel forwarding and the upstream-id registry the forwarded request joins
+- [cross-layer-aggregation](cross-layer-aggregation.md) — the virt/host/native walk that forwarded methods deliberately do **not** join (host only)
+
+## Implementation Status
+
+Implemented. The fallback dispatch lives in `src/lsp/custom_method_forward.rs`
+(`CustomMethodForwarder`), the handlers in
+`src/lsp/lsp_impl/custom_method_forward.rs`, and the gate-free host sends in
+`src/lsp/bridge/text_document/host.rs`.
+
+## Context
+
+Kakehashi implements a fixed set of LSP methods. A client that speaks a method
+outside that set — `textDocument/inlineCompletion` to a Copilot server, a
+vendor-specific `$/…`-free custom request, or a custom notification — gets
+`MethodNotFound` from the JSON-RPC router and the downstream server never
+hears about it, even when the user has a server configured that answers it.
+
+Adding one typed handler per such method does not scale: the parameter and
+result shapes are unknown to kakehashi, and the set is open-ended. What *is*
+known for every JSON-RPC message is whether it is a request (has `id`) or a
+notification, and — for the textDocument family — which host document it
+concerns (`params.textDocument.uri`).
+
+The host layer (host-document-bridge) already forwards the client's params
+verbatim with the real URI and returns the downstream `result` untranslated.
+That path is shape-agnostic by construction; it only lacked a way in for
+methods kakehashi has no handler for.
+
+## Decision
+
+A method kakehashi does not implement is forwarded to the host document's
+servers when, and only when, the user has written an **explicit** aggregation
+entry for it under `bridge._self`:
+
+```toml
+[languages.markdown.bridge._self]
+enabled = true
+
+[languages.markdown.bridge._self.aggregation."textDocument/inlineCompletion"]
+priorities = ["copilot"]
+# strategy defaults to "preferred"; "concatenated" is rejected for forwarded
+# methods (the result shape is unknown, so nothing can be merged).
+```
+
+### Contract
+
+- **Eligibility.** Three conditions, all required: kakehashi has no handler
+  for the method; `params.textDocument.uri` names an open host document whose
+  language has `bridge._self.enabled = true`; and the method name appears as
+  a **literal key** of that language's `bridge._self.aggregation` map
+  (inherited through the `bridge._` wildcard like any other aggregation
+  field). The `"_"` method wildcard does not make a method eligible — it
+  would turn every typo into a downstream round trip. An ineligible request
+  keeps today's `MethodNotFound`; an ineligible notification is dropped
+  silently, as the router already does.
+- **Request vs. notification follows the wire.** A message with an `id` is
+  forwarded as a request and answered with the first non-empty downstream
+  `result` in `priorities` order (`preferred`); an all-empty or all-failed
+  fan-out answers `null`. A message without an `id` is forwarded as a
+  notification to **every** selected server, in priority order.
+- **Verbatim params, verbatim result.** Host-layer rules apply unchanged:
+  real URI, real coordinates, no translation either way, progress tokens
+  stripped (the bridge does not relay downstream progress).
+- **Host only.** Injection regions are not consulted. A custom method's
+  params cannot be re-targeted at a virtual document without knowing which
+  fields are positions, so the virt layer is out of scope (see Consequences).
+- **Capabilities are not consulted.** Unlike the typed host methods, the
+  forward does not require the server to advertise anything. A server that
+  does not implement the method is expected to answer `MethodNotFound`
+  itself, which the fan-in counts as a failed (empty) contribution. Kakehashi
+  likewise advertises nothing to the client for forwarded methods; a client
+  that gates on `ServerCapabilities` must be told to send anyway.
+- **Strategy.** `preferred` only. An explicit `strategy = "concatenated"`
+  on a forwarded method is a configuration error: the request is answered
+  with `InvalidParams` naming the method, and a notification is dropped with
+  a warning.
+- **Cancellation.** A forwarded request joins the upstream-id registry, so a
+  client `$/cancelRequest` reaches the downstream servers exactly as it does
+  for typed host methods.
+
+### Invariants
+
+- Forwarding must never shadow a handler kakehashi has. The dispatch learns
+  "no handler" from the router's own `MethodNotFound` answer for requests,
+  so the set of built-in request names is never duplicated in a list that
+  could drift. Notifications get no such answer (the router drops unknown
+  ones silently), so the notifications kakehashi **implements** are named
+  once, next to the implementation, and excluded; an unimplemented standard
+  notification is as forwardable as a custom one.
+- A forwarded message must see the host document already synced on the
+  receiving server: the send happens under the same per-document host
+  lifecycle lock and after the same `didOpen`/`didChange` reconciliation as
+  every typed host request, or the downstream server answers about a
+  document it never opened.
+- The upstream id is bound to the downstream request under the same registry
+  the cancel path reads; the forward adds no second bookkeeping.
+
+## Consequences
+
+### Positive
+
+- Any request/notification a host-capable server understands becomes usable
+  through kakehashi with two lines of config and no release.
+- No per-method code: the existing host layer carries the whole feature.
+- Built-in methods are unaffected by construction (router-first dispatch).
+
+### Negative
+
+- Host only. A Copilot-style server configured for an injection language
+  cannot be reached this way; doing so needs a declared position schema per
+  method (a `positions = ["position"]`-style annotation with response-side
+  inverse mapping), deferred until a concrete need appears.
+- No capability advertisement. Clients that consult `ServerCapabilities`
+  before sending (most editors do for standard methods such as
+  `inlineCompletion`) need a client-side override; a future `capability`
+  field on the aggregation entry, merged into `ServerCapabilities` as raw
+  JSON, would close this without guessing the method→capability mapping.
+- `concatenated` is unavailable; merging needs a known result shape.
+- A request whose params carry no `textDocument.uri` cannot be routed and is
+  answered `InvalidParams` — the forward is intentionally limited to the
+  document-scoped family rather than inventing a default target.
+
+### Neutral
+
+- The forward is exposed as the explicit methods `kakehashi/forward/request`
+  and `kakehashi/forward/notification` with params `{ "method", "params" }`;
+  the fallback dispatch rewrites an unhandled message into these. A client
+  may call them directly; eligibility is checked identically either way.
+
+## Alternatives Considered
+
+### A. Per-method typed handlers (`inline_completion` etc.)
+
+Rejected: every new method is a release, and the shapes kakehashi would have
+to model are exactly the ones it has no use for.
+
+### B. A hand-maintained list of built-in request names in the dispatch
+
+Rejected: the list would drift from the router the moment a handler is added
+or removed, and the failure mode (a built-in silently forwarded, or a custom
+method silently dropped) is invisible until a user hits it. Asking the router
+and acting on its `MethodNotFound` answer costs one extra in-process call only
+for unhandled methods.
+
+### C. Forward whenever `_self.enabled = true`, no per-method entry
+
+Rejected: a wildcard forward turns every client typo and every unsupported
+standard method into a downstream round trip, and makes the `"_"` aggregation
+wildcard (which legitimately sets `priorities` for all typed methods) an
+accidental opt-in.
+
+### D. Virt-layer support via heuristic position translation
+
+Rejected for now: guessing which fields are positions from their names works
+for the request (`position`, `range`) but not for the response, whose shape is
+unknown; an untranslated `InlineCompletionItem.range` would corrupt the
+client's buffer. A declared schema is the right shape for that feature and is
+deferred.

--- a/docs/architecture-decisions/custom-method-host-forwarding.md
+++ b/docs/architecture-decisions/custom-method-host-forwarding.md
@@ -108,13 +108,18 @@ priorities = ["copilot"]
   error: the request is answered with `RequestFailed` (-32803; the request
   was well-formed, the server cannot serve it) naming the method, and a
   notification is dropped with a warning.
-- **Reserved methods.** The bridge-owned lifecycle and sync methods
-  (`initialize`, `shutdown`, `exit`, the `textDocument/did*` sync family,
-  the other notifications kakehashi handles itself) and the `$/` and
-  `kakehashi/` namespaces are never forwarded, even when an entry names
-  them: a request is answered `RequestFailed`, a notification is dropped
-  with a warning. The forwarding methods can be called directly, so this
-  holds in the handler, not only in the fallback dispatch.
+- **Reserved methods.** The bridge-owned lifecycle, sync, and routing
+  methods (`initialize`, `shutdown`, `exit`, the `textDocument/did*` and
+  `notebookDocument/*` sync families, `workspace/executeCommand`, the other
+  notifications kakehashi handles itself) and the `$/` and `kakehashi/`
+  namespaces are never forwarded, even when an entry names them: a request
+  is answered `RequestFailed`, a notification is dropped with a warning.
+  The forwarding methods can be called directly, so this holds in the
+  handler, not only in the fallback dispatch. A direct call may still name
+  a typed method kakehashi implements (say `textDocument/hover` with an
+  entry written to tune its priorities); it is then sent blind to the host
+  layer alone — the caller asked for exactly that, and the set of typed
+  methods is what this decision refuses to enumerate.
 - **Cancellation.** A forwarded request joins the upstream-id registry, so a
   client `$/cancelRequest` reaches the downstream servers exactly as it does
   for typed host methods.

--- a/docs/architecture-decisions/custom-method-host-forwarding.md
+++ b/docs/architecture-decisions/custom-method-host-forwarding.md
@@ -77,8 +77,11 @@ priorities = ["copilot"]
   fan-out answers `null`. A message without an `id` is forwarded as a
   notification to **every** selected server, each delivered independently.
 - **Ordering.** Forwarded requests are not sequenced behind pending
-  `didChange` tickets (the same as hover and definition); the host text
-  synced before the send is the document's current text at that moment.
+  `didChange` tickets (the same as hover and definition) and sync the text
+  snapshotted at dispatch, as typed host methods do. A forwarded
+  notification, which may wait through a server's initialization first,
+  re-reads the document's current text at sync time, and is dropped if the
+  document was closed while it waited.
 - **Startup.** A forwarded request follows the host-request policy and
   fails fast (empty) on a server still initializing — the next request gets
   it. A forwarded notification instead waits through initialization, within

--- a/docs/architecture-decisions/custom-method-host-forwarding.md
+++ b/docs/architecture-decisions/custom-method-host-forwarding.md
@@ -82,10 +82,13 @@ priorities = ["copilot"]
   itself, which the fan-in counts as a failed (empty) contribution. Kakehashi
   likewise advertises nothing to the client for forwarded methods; a client
   that gates on `ServerCapabilities` must be told to send anyway.
-- **Strategy.** `preferred` only. An explicit `strategy = "concatenated"`
-  on a forwarded method is a configuration error: the request is answered
-  with `InvalidParams` naming the method, and a notification is dropped with
-  a warning.
+- **Strategy.** `preferred` only, judged on the entry's **own** `strategy`
+  field: a `concatenated` inherited from the `"_"` method wildcard is
+  ignored, as the typed verbatim host methods ignore it, so one wildcard
+  line written for diagnostics cannot break every forwarded method. An
+  entry that itself sets `strategy = "concatenated"` is a configuration
+  error: the request is answered with `InvalidParams` naming the method,
+  and a notification is dropped with a warning.
 - **Cancellation.** A forwarded request joins the upstream-id registry, so a
   client `$/cancelRequest` reaches the downstream servers exactly as it does
   for typed host methods.

--- a/docs/architecture-decisions/custom-method-host-forwarding.md
+++ b/docs/architecture-decisions/custom-method-host-forwarding.md
@@ -60,8 +60,9 @@ priorities = ["copilot"]
   keys too; today those name only router-handled methods). The `"_"`
   method wildcard does not make a method eligible — it would turn every
   typo into a downstream round trip. An ineligible request keeps today's
-  `MethodNotFound`; an ineligible notification is not forwarded (logged at
-  debug; a malformed or misconfigured one at warn).
+  `MethodNotFound`; an ineligible notification is not forwarded — silently
+  when no configuration names the method at all, otherwise logged at debug
+  (a malformed or misconfigured one at warn).
 - **Eligible but empty.** An eligible entry with `priorities = []` or
   `maxFanOut = 0` selects no server: a request answers `null`, a
   notification goes nowhere — the per-method kill switch

--- a/docs/architecture-decisions/custom-method-host-forwarding.md
+++ b/docs/architecture-decisions/custom-method-host-forwarding.md
@@ -51,10 +51,12 @@ priorities = ["copilot"]
 
 ### Contract
 
-- **Eligibility.** Three conditions, all required: kakehashi has no handler
+- **Eligibility.** Four conditions, all required: kakehashi has no handler
   for the method; `params.textDocument.uri` names an open host document whose
-  language has `bridge._self.enabled = true`; and the method name appears as
-  a **literal key** of that language's `bridge._self.aggregation` map
+  language has `bridge._self.enabled = true`; some configured server lists
+  that language (the host layer exists at all — without one there is no
+  target to be eligible for); and the method name appears as a **literal
+  key** of that language's `bridge._self.aggregation` map
   (inherited through the `bridge._` wildcard like any other aggregation
   field — which means the shipped defaults and `languages._` contribute
   keys too; today those name only router-handled methods). The `"_"`

--- a/docs/architecture-decisions/custom-method-host-forwarding.md
+++ b/docs/architecture-decisions/custom-method-host-forwarding.md
@@ -75,8 +75,10 @@ priorities = ["copilot"]
 - **Request vs. notification follows the wire.** A message with an `id` is
   forwarded as a request and answered with the first non-empty downstream
   `result` in `priorities` order (`preferred`, with the host layer's
-  emptiness rule: `null`, `[]`, and the known empty-list envelopes such as
-  `{"items": []}` count as empty — a bare `{}` does not, it is a result);
+  emptiness rule for unknown shapes: `null`, `[]`, and an object that is
+  nothing but a canonical empty-list envelope such as `{"items": []}` count
+  as empty — a bare `{}` or an envelope carrying any other member, say
+  `{"items": [], "cursor": "…"}`, is a result);
   an all-empty or all-failed fan-out answers `null`. A response carrying
   neither `result` nor `error` is a failed contribution on this path. A message without an `id` is forwarded as a
   notification to **every** selected server, each delivered independently.

--- a/docs/architecture-decisions/custom-method-host-forwarding.md
+++ b/docs/architecture-decisions/custom-method-host-forwarding.md
@@ -9,7 +9,7 @@
 
 ## Implementation Status
 
-Implemented. The fallback dispatch lives in `src/lsp/custom_method_forward.rs`
+Implemented. The fallback dispatch lives in `src/lsp/custom_method_forwarder.rs`
 (`CustomMethodForwarder`), the handlers in
 `src/lsp/lsp_impl/custom_method_forward.rs`, and the gate-free host sends in
 `src/lsp/bridge/text_document/host.rs`.

--- a/docs/architecture-decisions/custom-method-host-forwarding.md
+++ b/docs/architecture-decisions/custom-method-host-forwarding.md
@@ -82,7 +82,10 @@ priorities = ["copilot"]
   snapshotted at dispatch, as typed host methods do. A forwarded
   notification, which may wait through a server's initialization first,
   re-reads the document's current text at sync time, and is dropped if the
-  document was closed while it waited.
+  document was closed while it waited. That wait is not the client's:
+  the notification's ingress handling completes once delivery is handed
+  off, so a burst of forwarded notifications against a slow-starting
+  server cannot stall the other messages behind it.
 - **Startup.** A forwarded request follows the host-request policy and
   fails fast (empty) on a server still initializing — the next request gets
   it. A forwarded notification instead waits through initialization, within

--- a/docs/architecture-decisions/custom-method-host-forwarding.md
+++ b/docs/architecture-decisions/custom-method-host-forwarding.md
@@ -56,15 +56,29 @@ priorities = ["copilot"]
   language has `bridge._self.enabled = true`; and the method name appears as
   a **literal key** of that language's `bridge._self.aggregation` map
   (inherited through the `bridge._` wildcard like any other aggregation
-  field). The `"_"` method wildcard does not make a method eligible — it
-  would turn every typo into a downstream round trip. An ineligible request
-  keeps today's `MethodNotFound`; an ineligible notification is dropped
-  silently, as the router already does.
+  field — which means the shipped defaults and `languages._` contribute
+  keys too; today those name only router-handled methods). The `"_"`
+  method wildcard does not make a method eligible — it would turn every
+  typo into a downstream round trip. An ineligible request keeps today's
+  `MethodNotFound`; an ineligible notification is not forwarded (logged at
+  debug; a malformed or misconfigured one at warn).
+- **Eligible but empty.** An eligible entry with `priorities = []` or
+  `maxFanOut = 0` selects no server: a request answers `null`, a
+  notification goes nowhere — the per-method kill switch
+  (aggregation-priorities-wildcard) behaves as it does for typed methods.
+- **Routing key, not a restriction.** `params.textDocument.uri` is read to
+  pick the host document; the params are otherwise not inspected, so a
+  client can route any params shape by including that member.
 - **Request vs. notification follows the wire.** A message with an `id` is
   forwarded as a request and answered with the first non-empty downstream
-  `result` in `priorities` order (`preferred`); an all-empty or all-failed
+  `result` in `priorities` order (`preferred`, with the host layer's
+  emptiness rule: `null`, `[]`, `{}`, and the known empty-list envelopes
+  such as `{"items": []}` count as empty); an all-empty or all-failed
   fan-out answers `null`. A message without an `id` is forwarded as a
-  notification to **every** selected server, in priority order.
+  notification to **every** selected server, each delivered independently.
+- **Ordering.** Forwarded requests are not sequenced behind pending
+  `didChange` tickets (the same as hover and definition); the host text
+  synced before the send is the document's current text at that moment.
 - **Startup.** A forwarded request follows the host-request policy and
   fails fast (empty) on a server still initializing — the next request gets
   it. A forwarded notification instead waits through initialization, within
@@ -105,22 +119,27 @@ priorities = ["copilot"]
   client `$/cancelRequest` reaches the downstream servers exactly as it does
   for typed host methods.
 
-### Invariants
+## Invariants
 
-- Forwarding must never shadow a handler kakehashi has. The dispatch learns
-  "no handler" from the router's own `MethodNotFound` answer for requests,
-  so the set of built-in request names is never duplicated in a list that
-  could drift. Notifications get no such answer (the router drops unknown
-  ones silently), so the notifications kakehashi **implements** are named
-  once, next to the implementation, and excluded; an unimplemented standard
-  notification is as forwardable as a custom one.
-- A forwarded message must see the host document already synced on the
-  receiving server: the send happens under the same per-document host
-  lifecycle lock and after the same `didOpen`/`didChange` reconciliation as
-  every typed host request, or the downstream server answers about a
-  document it never opened.
-- The upstream id is bound to the downstream request under the same registry
-  the cancel path reads; the forward adds no second bookkeeping.
+> The invariants below are normative; the mechanisms that satisfy them are
+> deliberately unspecified.
+
+- Forwarding never shadows a handler kakehashi has. For requests the
+  router's own answer is the authority on "no handler", so no list of
+  built-in request names exists to drift; notifications get no such answer,
+  so the ones kakehashi handles are named exactly once, beside their
+  implementation. An unimplemented standard notification is as forwardable
+  as a custom one.
+- A forwarded message reaches a server only after that server has the host
+  document open at the text kakehashi considers current, under the same
+  ordering guarantees as every typed host request; otherwise the server
+  answers about a document it never opened, or about rolled-back text.
+- A forwarded request is cancellable by the client's `$/cancelRequest`
+  through the same path as a typed host request; no second bookkeeping.
+- The misconfiguration surface is the request: `concatenated` or a reserved
+  method fails the request that hits it rather than a settings-apply
+  warning, because the set of built-in methods the warning would have to
+  exclude is exactly what this decision refuses to enumerate.
 
 ## Consequences
 
@@ -146,6 +165,9 @@ priorities = ["copilot"]
 - A request whose params carry no `textDocument.uri` cannot be routed and is
   answered `InvalidParams` — the forward is intentionally limited to the
   document-scoped family rather than inventing a default target.
+- When every selected server fails for a reason other than declining the
+  method, the client sees `null` plus one `window/logMessage` warning per
+  request, not the downstream error.
 
 ### Neutral
 

--- a/docs/architecture-decisions/custom-method-host-forwarding.md
+++ b/docs/architecture-decisions/custom-method-host-forwarding.md
@@ -79,9 +79,13 @@ priorities = ["copilot"]
 - **Capabilities are not consulted.** Unlike the typed host methods, the
   forward does not require the server to advertise anything. A server that
   does not implement the method is expected to answer `MethodNotFound`
-  itself, which the fan-in counts as a failed (empty) contribution. Kakehashi
-  likewise advertises nothing to the client for forwarded methods; a client
-  that gates on `ServerCapabilities` must be told to send anyway.
+  itself; that answer is an empty contribution (logged at debug, not a
+  counted failure — it is the contract's normal decline, and a counted
+  failure would warn the client on every keystroke). Any other downstream
+  error is a counted failure, surfaced once per request as a client
+  warning when no server answered. Kakehashi likewise advertises nothing to
+  the client for forwarded methods; a client that gates on
+  `ServerCapabilities` must be told to send anyway.
 - **Strategy.** `preferred` only, judged on the entry's **own** `strategy`
   field: a `concatenated` inherited from the `"_"` method wildcard is
   ignored, as the typed verbatim host methods ignore it, so one wildcard

--- a/docs/architecture-decisions/custom-method-host-forwarding.md
+++ b/docs/architecture-decisions/custom-method-host-forwarding.md
@@ -85,9 +85,11 @@ priorities = ["copilot"]
   re-reads the document's current text at sync time, and is dropped if the
   document was closed while it waited. That wait is not the client's:
   the notification's ingress handling completes once delivery is handed
-  off (under a bound on deliveries in flight; past it the handler waits
-  for a slot), so a burst of forwarded notifications against a
-  slow-starting server cannot stall the other messages behind it. No
+  off, so a burst of forwarded notifications against a slow-starting
+  server cannot stall the other messages behind it. Deliveries in flight
+  are bounded; past the bound a notification is dropped with a warning
+  rather than queued — waiting for a slot would move the stall back into
+  the handler. No
   order is promised between forwarded notifications, even to one server:
   their handlers already run concurrently, as every non-sync message's do.
 - **Startup.** A forwarded request follows the host-request policy and

--- a/docs/architecture-decisions/custom-method-host-forwarding.md
+++ b/docs/architecture-decisions/custom-method-host-forwarding.md
@@ -65,6 +65,11 @@ priorities = ["copilot"]
   `result` in `priorities` order (`preferred`); an all-empty or all-failed
   fan-out answers `null`. A message without an `id` is forwarded as a
   notification to **every** selected server, in priority order.
+- **Startup.** A forwarded request follows the host-request policy and
+  fails fast (empty) on a server still initializing — the next request gets
+  it. A forwarded notification instead waits through initialization, within
+  the initialization bound (ls-bridge-timeout-hierarchy Tier 0): a request
+  is naturally retried, a dropped notification is gone.
 - **Verbatim params, verbatim result.** Host-layer rules apply unchanged:
   real URI, real coordinates, no translation either way, progress tokens
   stripped (the bridge does not relay downstream progress).

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -340,6 +340,14 @@ types.
 > `kakehashi/internal/*` methods are not part of this public surface and are not
 > documented here.
 
+Two further methods carry the forwarding of methods kakehashi does not
+implement (see "Forwarding methods kakehashi does not implement" in the
+configuration reference): `kakehashi/forward/request` and
+`kakehashi/forward/notification`, both with params `{ "method": "<name>",
+"params": <original params> }`. kakehashi issues them itself for an
+unhandled message; a client may also call them directly, under the same
+eligibility rules.
+
 ### `NodeInfo`
 
 ```typescript

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -622,4 +622,7 @@ results pass through, while injection-layer code actions (and applyEdit
 requests that also touch a virtual document) constrain host-URI edits to
 the region.
 The surrounding host document can be bridged to the host language's own
-servers via `bridge._self` (host-document-bridge).
+servers via `bridge._self` (host-document-bridge). Methods kakehashi does not
+implement can still reach those host servers when named explicitly under
+`bridge._self.aggregation` — see "Forwarding methods kakehashi does not
+implement" in the configuration reference.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1557,7 +1557,8 @@ fn run_lsp_server() {
 async fn serve_lsp() {
     use env_logger::Builder;
     use kakehashi::lsp::{
-        CancelForwarder, IngressOrderGate, Kakehashi, LanguageServerPool, RequestIdCapture,
+        CancelForwarder, CustomMethodForwarder, FORWARD_NOTIFICATION_METHOD,
+        FORWARD_REQUEST_METHOD, IngressOrderGate, Kakehashi, LanguageServerPool, RequestIdCapture,
         repair_inbound_frames,
     };
     use std::sync::Arc;
@@ -1755,6 +1756,13 @@ async fn serve_lsp() {
         "kakehashi/node/fieldNameForNamedChild",
         Kakehashi::kakehashi_node_field_name_for_named_child,
     )
+    // custom-method-host-forwarding: the explicit forwarding methods the
+    // CustomMethodForwarder below rewrites unhandled messages into.
+    .custom_method(FORWARD_REQUEST_METHOD, Kakehashi::forward_custom_request)
+    .custom_method(
+        FORWARD_NOTIFICATION_METHOD,
+        Kakehashi::forward_custom_notification,
+    )
     .finish();
 
     // Reap downstream servers when the editor terminates this process without
@@ -1763,6 +1771,14 @@ async fn serve_lsp() {
     // session indefinitely.
     #[cfg(unix)]
     service.inner().spawn_termination_cleanup();
+
+    // Innermost wrapper: re-issue requests the router answers MethodNotFound
+    // (and notifications kakehashi does not implement) as the forwarding
+    // methods, so a configured host server can answer methods kakehashi has
+    // no handler for (custom-method-host-forwarding). Sits inside
+    // RequestIdCapture so the forwarded request keeps its upstream id and
+    // cancel path.
+    let service = CustomMethodForwarder::new(service);
 
     // Wrap service with RequestIdCapture to:
     // 1. Capture upstream request IDs (for ls-bridge-server-pool-coordination bridge requests)

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1778,7 +1778,8 @@ async fn serve_lsp() {
     // no handler for (custom-method-host-forwarding). Sits inside
     // RequestIdCapture so the forwarded request keeps its upstream id and
     // cancel path.
-    let service = CustomMethodForwarder::new(service);
+    let custom_method_gate = service.inner().custom_method_gate();
+    let service = CustomMethodForwarder::new(service, custom_method_gate);
 
     // Wrap service with RequestIdCapture to:
     // 1. Capture upstream request IDs (for ls-bridge-server-pool-coordination bridge requests)

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1096,6 +1096,28 @@ impl LanguageSettings {
             .unwrap_or_else(ResolvedAggregationConfig::with_defaults)
     }
 
+    /// Whether `method` has a **literal** entry in the host bridge target's
+    /// aggregation map (`bridge._self`, wildcard-merged from `bridge._`).
+    ///
+    /// This is the opt-in for forwarding a method kakehashi does not
+    /// implement (custom-method-host-forwarding): only a method the user
+    /// named explicitly is forwarded, so the `"_"` METHOD wildcard — which
+    /// legitimately sets `priorities` for every typed method — never turns
+    /// an unknown or mistyped method into a downstream round trip.
+    pub(crate) fn has_explicit_host_aggregation(&self, method: &str) -> bool {
+        self.bridge
+            .as_ref()
+            .and_then(|map| {
+                crate::config::resolve_with_wildcard(
+                    map,
+                    HOST_BRIDGE_KEY,
+                    crate::config::merge_bridge_language_configs,
+                )
+            })
+            .and_then(|cfg| cfg.aggregation)
+            .is_some_and(|aggregation| aggregation.contains_key(method))
+    }
+
     /// Check if a language is allowed for bridging based on the bridge filter.
     ///
     /// Returns:
@@ -2919,6 +2941,59 @@ kind = "locals""#;
         };
         let agg = settings.resolve_host_aggregation("textDocument/definition");
         assert_eq!(agg.priorities, vec!["marksman".to_string()]);
+    }
+
+    #[test]
+    fn host_forwarding_requires_a_literal_method_entry() {
+        // custom-method-host-forwarding: a method is forwardable only when its
+        // name is a literal key of `_self.aggregation` — reachable through the
+        // bridge `_` wildcard, but never through the `"_"` METHOD wildcard.
+        let entry = |method: &str| {
+            HashMap::from([(
+                method.to_string(),
+                AggregationConfig {
+                    priorities: Some(vec!["copilot".to_string()]),
+                    ..Default::default()
+                },
+            )])
+        };
+        let settings = LanguageSettings {
+            bridge: Some(HashMap::from([
+                (
+                    HOST_BRIDGE_KEY.to_string(),
+                    BridgeLanguageConfig {
+                        enabled: Some(true),
+                        aggregation: Some(entry("textDocument/inlineCompletion")),
+                    },
+                ),
+                (
+                    WILDCARD_KEY.to_string(),
+                    BridgeLanguageConfig {
+                        enabled: None,
+                        aggregation: Some(
+                            entry("custom/fromWildcard")
+                                .into_iter()
+                                .chain(entry("_"))
+                                .collect(),
+                        ),
+                    },
+                ),
+            ])),
+            ..Default::default()
+        };
+        assert!(settings.has_explicit_host_aggregation("textDocument/inlineCompletion"));
+        assert!(
+            settings.has_explicit_host_aggregation("custom/fromWildcard"),
+            "bridge-key wildcard `_` contributes method entries to `_self`"
+        );
+        assert!(
+            !settings.has_explicit_host_aggregation("custom/unlisted"),
+            "the `_` METHOD wildcard must not make every method forwardable"
+        );
+        assert!(
+            !LanguageSettings::default().has_explicit_host_aggregation("custom/unlisted"),
+            "no bridge map at all: nothing is forwardable"
+        );
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1113,7 +1113,26 @@ impl LanguageSettings {
         &self,
         method: &str,
     ) -> Option<AggregationConfig> {
-        self.explicit_host_aggregation()?.remove(method)
+        // Mirrors `merge_bridge_language_configs` for ONE key without cloning
+        // the whole map: `_self` over `_`, field-merged where both name the
+        // method, and an explicit empty `_self.aggregation = {}` clearing the
+        // inherited entries. This runs per eligible request.
+        let map = self.bridge.as_ref()?;
+        let aggregation_of = |key: &str| map.get(key).and_then(|cfg| cfg.aggregation.as_ref());
+        let own_map = aggregation_of(HOST_BRIDGE_KEY);
+        let inherited_map = aggregation_of(crate::config::WILDCARD_KEY);
+        if own_map.is_some_and(HashMap::is_empty) {
+            return None;
+        }
+        let own = own_map.and_then(|agg| agg.get(method));
+        let inherited = inherited_map.and_then(|agg| agg.get(method));
+        match (inherited, own) {
+            (None, None) => None,
+            (Some(base), Some(overlay)) => Some(crate::config::merge::merge_aggregation_configs(
+                base, overlay,
+            )),
+            (base, overlay) => overlay.or(base).cloned(),
+        }
     }
 
     /// The literal method keys of the host bridge target's aggregation map
@@ -3039,6 +3058,104 @@ kind = "locals""#;
                 .explicit_host_aggregation_entry("custom/unlisted")
                 .is_some(),
             "no bridge map at all: nothing is forwardable"
+        );
+    }
+
+    #[test]
+    fn explicit_host_entry_mirrors_the_map_merge_for_one_key() {
+        let entry = |strategy: Option<AggregationStrategy>, priorities: Option<Vec<&str>>| {
+            AggregationConfig {
+                strategy,
+                priorities: priorities.map(|p| p.into_iter().map(String::from).collect()),
+                ..Default::default()
+            }
+        };
+        let settings = LanguageSettings {
+            bridge: Some(HashMap::from([
+                (
+                    HOST_BRIDGE_KEY.to_string(),
+                    BridgeLanguageConfig {
+                        enabled: Some(true),
+                        aggregation: Some(HashMap::from([(
+                            "custom/both".to_string(),
+                            entry(None, Some(vec!["own"])),
+                        )])),
+                    },
+                ),
+                (
+                    WILDCARD_KEY.to_string(),
+                    BridgeLanguageConfig {
+                        enabled: None,
+                        aggregation: Some(HashMap::from([
+                            (
+                                "custom/both".to_string(),
+                                entry(Some(AggregationStrategy::Concatenated), Some(vec!["inh"])),
+                            ),
+                            (
+                                "custom/inherited".to_string(),
+                                entry(None, Some(vec!["inh"])),
+                            ),
+                        ])),
+                    },
+                ),
+            ])),
+            ..Default::default()
+        };
+        let both = settings
+            .explicit_host_aggregation_entry("custom/both")
+            .unwrap();
+        assert_eq!(
+            both.priorities,
+            Some(vec!["own".to_string()]),
+            "own field wins"
+        );
+        assert_eq!(
+            both.strategy,
+            Some(AggregationStrategy::Concatenated),
+            "unset own field inherits from the bridge-key wildcard's entry"
+        );
+        assert!(
+            settings
+                .explicit_host_aggregation_entry("custom/inherited")
+                .is_some()
+        );
+        // Matches the full map merge exactly.
+        let merged = crate::config::resolve_with_wildcard(
+            settings.bridge.as_ref().unwrap(),
+            HOST_BRIDGE_KEY,
+            crate::config::merge_bridge_language_configs,
+        )
+        .and_then(|cfg| cfg.aggregation)
+        .unwrap();
+        assert_eq!(merged.get("custom/both"), Some(&both));
+
+        // An explicit empty `_self.aggregation = {}` clears inherited entries.
+        let cleared = LanguageSettings {
+            bridge: Some(HashMap::from([
+                (
+                    HOST_BRIDGE_KEY.to_string(),
+                    BridgeLanguageConfig {
+                        enabled: Some(true),
+                        aggregation: Some(HashMap::new()),
+                    },
+                ),
+                (
+                    WILDCARD_KEY.to_string(),
+                    BridgeLanguageConfig {
+                        enabled: None,
+                        aggregation: Some(HashMap::from([(
+                            "custom/inherited".to_string(),
+                            entry(None, None),
+                        )])),
+                    },
+                ),
+            ])),
+            ..Default::default()
+        };
+        assert!(
+            cleared
+                .explicit_host_aggregation_entry("custom/inherited")
+                .is_none()
         );
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -126,6 +126,8 @@ pub struct BridgeLanguageConfig {
     /// Omit to inherit from wildcard (defaults to true).
     pub enabled: Option<bool>,
     /// Per-method aggregation config. Key = LSP method name or "_" for default.
+    /// Under `_self`, a key naming a method kakehashi does not implement
+    /// forwards that method to the host servers (custom-method-host-forwarding).
     pub aggregation: Option<HashMap<String, AggregationConfig>>,
 }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1098,32 +1098,22 @@ impl LanguageSettings {
             .unwrap_or_else(ResolvedAggregationConfig::with_defaults)
     }
 
-    /// Whether `method` has a **literal** entry in the host bridge target's
-    /// aggregation map (`bridge._self`, wildcard-merged from `bridge._`).
-    ///
-    /// This is the opt-in for forwarding a method kakehashi does not
-    /// implement (custom-method-host-forwarding): only a method the user
-    /// named explicitly is forwarded, so the `"_"` METHOD wildcard — which
+    /// The literal `bridge._self.aggregation` entry for `method`, as written
+    /// (wildcard-merged from `bridge._` at the map level, but NOT field-merged
+    /// with the `"_"` method wildcard). Its `strategy` is therefore the one
+    /// the entry sets **itself**: a forwarded method can only run `preferred`,
+    /// and an inherited `concatenated` (set once under `_` for the typed
+    /// methods that honor it) must not poison every forwarded method, just
+    /// as the typed verbatim paths ignore it (custom-method-host-forwarding).
+    /// Presence is the opt-in for forwarding: only a method the user named
+    /// explicitly is forwarded, so the `"_"` METHOD wildcard — which
     /// legitimately sets `priorities` for every typed method — never turns
     /// an unknown or mistyped method into a downstream round trip.
-    pub(crate) fn has_explicit_host_aggregation(&self, method: &str) -> bool {
-        self.explicit_host_aggregation()
-            .is_some_and(|aggregation| aggregation.contains_key(method))
-    }
-
-    /// The `strategy` a literal `bridge._self.aggregation` entry for `method`
-    /// sets **itself** — not the one it would inherit from the `"_"` method
-    /// wildcard. A forwarded method can only run `preferred`; an inherited
-    /// `concatenated` (set once under `_` for the typed methods that honor
-    /// it) must not poison every forwarded method, just as the typed
-    /// verbatim paths ignore it (custom-method-host-forwarding).
-    pub(crate) fn explicit_host_aggregation_strategy(
+    pub(crate) fn explicit_host_aggregation_entry(
         &self,
         method: &str,
-    ) -> Option<AggregationStrategy> {
-        self.explicit_host_aggregation()?
-            .get(method)
-            .and_then(|entry| entry.strategy)
+    ) -> Option<AggregationConfig> {
+        self.explicit_host_aggregation()?.remove(method)
     }
 
     /// The literal method keys of the host bridge target's aggregation map
@@ -3027,17 +3017,27 @@ kind = "locals""#;
             ])),
             ..Default::default()
         };
-        assert!(settings.has_explicit_host_aggregation("textDocument/inlineCompletion"));
         assert!(
-            settings.has_explicit_host_aggregation("custom/fromWildcard"),
+            settings
+                .explicit_host_aggregation_entry("textDocument/inlineCompletion")
+                .is_some()
+        );
+        assert!(
+            settings
+                .explicit_host_aggregation_entry("custom/fromWildcard")
+                .is_some(),
             "bridge-key wildcard `_` contributes method entries to `_self`"
         );
         assert!(
-            !settings.has_explicit_host_aggregation("custom/unlisted"),
+            !settings
+                .explicit_host_aggregation_entry("custom/unlisted")
+                .is_some(),
             "the `_` METHOD wildcard must not make every method forwardable"
         );
         assert!(
-            !LanguageSettings::default().has_explicit_host_aggregation("custom/unlisted"),
+            !LanguageSettings::default()
+                .explicit_host_aggregation_entry("custom/unlisted")
+                .is_some(),
             "no bridge map at all: nothing is forwardable"
         );
     }
@@ -3071,12 +3071,16 @@ kind = "locals""#;
             ..Default::default()
         };
         assert_eq!(
-            settings.explicit_host_aggregation_strategy("custom/plain"),
+            settings
+                .explicit_host_aggregation_entry("custom/plain")
+                .and_then(|e| e.strategy),
             None,
             "the `_` method wildcard's strategy is not the entry's own"
         );
         assert_eq!(
-            settings.explicit_host_aggregation_strategy("custom/merged"),
+            settings
+                .explicit_host_aggregation_entry("custom/merged")
+                .and_then(|e| e.strategy),
             Some(AggregationStrategy::Concatenated)
         );
         assert_eq!(

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1105,6 +1105,15 @@ impl LanguageSettings {
     /// legitimately sets `priorities` for every typed method — never turns
     /// an unknown or mistyped method into a downstream round trip.
     pub(crate) fn has_explicit_host_aggregation(&self, method: &str) -> bool {
+        self.explicit_host_aggregation()
+            .is_some_and(|aggregation| aggregation.contains_key(method))
+    }
+
+    /// The literal method keys of the host bridge target's aggregation map
+    /// (`bridge._self`, wildcard-merged from `bridge._`), `"_"` included —
+    /// callers wanting forwardable methods filter it; see
+    /// [`Self::has_explicit_host_aggregation`].
+    fn explicit_host_aggregation(&self) -> Option<HashMap<String, AggregationConfig>> {
         self.bridge
             .as_ref()
             .and_then(|map| {
@@ -1115,7 +1124,6 @@ impl LanguageSettings {
                 )
             })
             .and_then(|cfg| cfg.aggregation)
-            .is_some_and(|aggregation| aggregation.contains_key(method))
     }
 
     /// Check if a language is allowed for bridging based on the bridge filter.
@@ -1153,6 +1161,22 @@ pub struct WorkspaceSettings {
     pub diagnostics_debounce_ms: u64,
     pub features: ResolvedFeatureSettings,
     pub language_servers: HashMap<String, BridgeServerConfig>,
+}
+
+impl WorkspaceSettings {
+    /// Every method some language names literally under
+    /// `bridge._self.aggregation` — the set of methods that could be
+    /// forwarded for SOME document (custom-method-host-forwarding). A
+    /// superset filter for the dispatch layer, which has no document in hand:
+    /// per-document eligibility is decided again at forward time.
+    pub(crate) fn host_forwardable_methods(&self) -> std::collections::HashSet<String> {
+        self.languages
+            .values()
+            .filter_map(LanguageSettings::explicit_host_aggregation)
+            .flat_map(|aggregation| aggregation.into_keys())
+            .filter(|method| method != crate::config::WILDCARD_KEY)
+            .collect()
+    }
 }
 
 impl Default for WorkspaceSettings {
@@ -2993,6 +3017,40 @@ kind = "locals""#;
         assert!(
             !LanguageSettings::default().has_explicit_host_aggregation("custom/unlisted"),
             "no bridge map at all: nothing is forwardable"
+        );
+    }
+
+    #[test]
+    fn host_forwardable_methods_unions_literal_entries_across_languages() {
+        let lang = |method: &str| LanguageSettings {
+            bridge: Some(HashMap::from([(
+                HOST_BRIDGE_KEY.to_string(),
+                BridgeLanguageConfig {
+                    enabled: Some(true),
+                    aggregation: Some(HashMap::from([
+                        (method.to_string(), AggregationConfig::default()),
+                        ("_".to_string(), AggregationConfig::default()),
+                    ])),
+                },
+            )])),
+            ..Default::default()
+        };
+        let settings = WorkspaceSettings {
+            languages: HashMap::from([
+                ("markdown".to_string(), lang("custom/a")),
+                ("python".to_string(), lang("custom/b")),
+                ("rust".to_string(), LanguageSettings::default()),
+            ]),
+            ..Default::default()
+        };
+        let methods = settings.host_forwardable_methods();
+        assert_eq!(
+            methods,
+            ["custom/a", "custom/b"]
+                .into_iter()
+                .map(String::from)
+                .collect::<std::collections::HashSet<_>>(),
+            "every language's literal entries, never the `_` method wildcard"
         );
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1109,6 +1109,21 @@ impl LanguageSettings {
             .is_some_and(|aggregation| aggregation.contains_key(method))
     }
 
+    /// The `strategy` a literal `bridge._self.aggregation` entry for `method`
+    /// sets **itself** — not the one it would inherit from the `"_"` method
+    /// wildcard. A forwarded method can only run `preferred`; an inherited
+    /// `concatenated` (set once under `_` for the typed methods that honor
+    /// it) must not poison every forwarded method, just as the typed
+    /// verbatim paths ignore it (custom-method-host-forwarding).
+    pub(crate) fn explicit_host_aggregation_strategy(
+        &self,
+        method: &str,
+    ) -> Option<AggregationStrategy> {
+        self.explicit_host_aggregation()?
+            .get(method)
+            .and_then(|entry| entry.strategy)
+    }
+
     /// The literal method keys of the host bridge target's aggregation map
     /// (`bridge._self`, wildcard-merged from `bridge._`), `"_"` included —
     /// callers wanting forwardable methods filter it; see
@@ -3017,6 +3032,50 @@ kind = "locals""#;
         assert!(
             !LanguageSettings::default().has_explicit_host_aggregation("custom/unlisted"),
             "no bridge map at all: nothing is forwardable"
+        );
+    }
+
+    #[test]
+    fn explicit_host_strategy_ignores_the_method_wildcard() {
+        let settings = LanguageSettings {
+            bridge: Some(HashMap::from([(
+                HOST_BRIDGE_KEY.to_string(),
+                BridgeLanguageConfig {
+                    enabled: Some(true),
+                    aggregation: Some(HashMap::from([
+                        ("custom/plain".to_string(), AggregationConfig::default()),
+                        (
+                            "custom/merged".to_string(),
+                            AggregationConfig {
+                                strategy: Some(AggregationStrategy::Concatenated),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "_".to_string(),
+                            AggregationConfig {
+                                strategy: Some(AggregationStrategy::Concatenated),
+                                ..Default::default()
+                            },
+                        ),
+                    ])),
+                },
+            )])),
+            ..Default::default()
+        };
+        assert_eq!(
+            settings.explicit_host_aggregation_strategy("custom/plain"),
+            None,
+            "the `_` method wildcard's strategy is not the entry's own"
+        );
+        assert_eq!(
+            settings.explicit_host_aggregation_strategy("custom/merged"),
+            Some(AggregationStrategy::Concatenated)
+        );
+        assert_eq!(
+            settings.resolve_host_aggregation("custom/plain").strategy,
+            AggregationStrategy::Concatenated,
+            "contrast: the resolved strategy does inherit"
         );
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1189,6 +1189,11 @@ impl WorkspaceSettings {
     pub(crate) fn host_forwardable_methods(&self) -> std::collections::HashSet<String> {
         self.languages
             .values()
+            // Without the `_self.enabled = true` opt-in nothing forwards, and
+            // the opt-in is what keeps the shipped `bridge._` defaults
+            // (diagnostics, codeAction) from opening the gate for every
+            // language out of the box.
+            .filter(|language| language.is_host_bridging_enabled())
             .filter_map(LanguageSettings::explicit_host_aggregation)
             .flat_map(|aggregation| aggregation.into_keys())
             .filter(|method| method != crate::config::WILDCARD_KEY)
@@ -3079,6 +3084,37 @@ kind = "locals""#;
             AggregationStrategy::Concatenated,
             "contrast: the resolved strategy does inherit"
         );
+    }
+
+    #[test]
+    fn host_forwardable_methods_is_empty_without_host_opt_in() {
+        // The shipped defaults name diagnostics/codeAction under `bridge._`;
+        // without `_self.enabled = true` they must not open the gate.
+        let shipped = crate::config::WorkspaceSettings::try_from_settings(
+            &crate::config::defaults::default_settings(),
+            None,
+            crate::config::expand::with_kakehashi_defaults(|_| None),
+        )
+        .expect("shipped defaults resolve");
+        assert!(shipped.host_forwardable_methods().is_empty());
+        let not_opted_in = LanguageSettings {
+            bridge: Some(HashMap::from([(
+                WILDCARD_KEY.to_string(),
+                BridgeLanguageConfig {
+                    enabled: Some(true),
+                    aggregation: Some(HashMap::from([(
+                        "custom/a".to_string(),
+                        AggregationConfig::default(),
+                    )])),
+                },
+            )])),
+            ..Default::default()
+        };
+        let settings = WorkspaceSettings {
+            languages: HashMap::from([("markdown".to_string(), not_opted_in)]),
+            ..Default::default()
+        };
+        assert!(settings.host_forwardable_methods().is_empty());
     }
 
     #[test]

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -12,6 +12,7 @@ mod text_sync;
 mod wire_repair;
 
 mod aggregation;
+mod custom_method_forward;
 mod ingress_order;
 mod lsp_impl;
 mod progress;
@@ -20,9 +21,13 @@ mod semantic_request_tracker;
 mod settings;
 
 pub use bridge::LanguageServerPool;
+pub use custom_method_forward::CustomMethodForwarder;
 pub use ingress_order::IngressOrderGate;
 pub(crate) use ingress_order::current_writer_ticket;
 pub use lsp_impl::Kakehashi;
+pub use lsp_impl::custom_method_forward::{
+    FORWARD_NOTIFICATION_METHOD, FORWARD_REQUEST_METHOD, ForwardParams,
+};
 pub(crate) use request_id::current_upstream_id;
 pub use request_id::{CancelForwarder, RequestIdCapture};
 pub(crate) use settings::{

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -12,7 +12,7 @@ mod text_sync;
 mod wire_repair;
 
 mod aggregation;
-mod custom_method_forward;
+mod custom_method_forwarder;
 mod ingress_order;
 mod lsp_impl;
 mod progress;
@@ -21,13 +21,11 @@ mod semantic_request_tracker;
 mod settings;
 
 pub use bridge::LanguageServerPool;
-pub use custom_method_forward::CustomMethodForwarder;
+pub use custom_method_forwarder::CustomMethodForwarder;
 pub use ingress_order::IngressOrderGate;
 pub(crate) use ingress_order::current_writer_ticket;
 pub use lsp_impl::Kakehashi;
-pub use lsp_impl::custom_method_forward::{
-    FORWARD_NOTIFICATION_METHOD, FORWARD_REQUEST_METHOD, ForwardParams,
-};
+pub use lsp_impl::custom_method_forward::{FORWARD_NOTIFICATION_METHOD, FORWARD_REQUEST_METHOD};
 pub(crate) use request_id::current_upstream_id;
 pub use request_id::{CancelForwarder, RequestIdCapture};
 pub(crate) use settings::{

--- a/src/lsp/aggregation/server.rs
+++ b/src/lsp/aggregation/server.rs
@@ -13,6 +13,6 @@ pub(crate) use dispatch::{
 pub(crate) use fan_in::FanInResult;
 pub(crate) use fan_out::FanOutTask;
 pub(crate) use host_dispatch::{
-    HostFanOutTask, dispatch_host_concatenated, dispatch_host_preferred,
+    HostFanOutTask, dispatch_host_concatenated, dispatch_host_preferred, select_host_servers,
 };
 pub(crate) use priority::{expand_priorities, truncate_entries};

--- a/src/lsp/aggregation/server/host_dispatch.rs
+++ b/src/lsp/aggregation/server/host_dispatch.rs
@@ -171,6 +171,7 @@ mod tests {
             strategy: AggregationStrategy::Preferred,
             max_fan_out,
             upstream_request_id: None,
+            incarnation: 0,
         }
     }
 

--- a/src/lsp/aggregation/server/host_dispatch.rs
+++ b/src/lsp/aggregation/server/host_dispatch.rs
@@ -138,3 +138,67 @@ where
     }
     (join_set, entries)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::settings::AggregationStrategy;
+
+    fn config(name: &str) -> ResolvedServerConfig {
+        ResolvedServerConfig {
+            server_name: name.to_string(),
+            config: Arc::new(BridgeServerConfig {
+                cmd: Some(vec![name.to_string()]),
+                languages: None,
+                initialization_options: None,
+                workspace_markers: None,
+                on_type_formatting_triggers: None,
+                prefer_shared_instance: None,
+                force_start: None,
+                enabled: None,
+                settings: None,
+            }),
+        }
+    }
+
+    fn ctx(priorities: &[&str], max_fan_out: Option<usize>) -> HostRequestContext {
+        HostRequestContext {
+            uri: url::Url::parse("file:///doc.md").unwrap(),
+            language_id: "markdown".to_string(),
+            text: Arc::from("# doc"),
+            configs: vec![config("a"), config("b"), config("c")],
+            priorities: priorities.iter().map(|p| (*p).to_string()).collect(),
+            strategy: AggregationStrategy::Preferred,
+            max_fan_out,
+            upstream_request_id: None,
+        }
+    }
+
+    fn names(selected: &[ResolvedServerConfig]) -> Vec<&str> {
+        selected.iter().map(|c| c.server_name.as_str()).collect()
+    }
+
+    /// The delivery plan a forwarded notification follows
+    /// (custom-method-host-forwarding): walk order, `"*"` expansion, the
+    /// `maxFanOut` cap, and the `[]` kill switch — pinned here because the
+    /// e2e can only observe arrivals, never a delivery that did NOT happen.
+    #[test]
+    fn select_host_servers_follows_priorities_cap_and_kill_switch() {
+        assert_eq!(
+            names(&select_host_servers(&ctx(&["b", "a"], None))),
+            ["b", "a"]
+        );
+        assert_eq!(
+            names(&select_host_servers(&ctx(&["b", "a"], Some(1)))),
+            ["b"],
+            "maxFanOut = 1 keeps only the first in priority order"
+        );
+        assert_eq!(
+            names(&select_host_servers(&ctx(&["c", "*"], None))),
+            ["c", "a", "b"],
+            "`*` expands to the unlisted rest"
+        );
+        assert!(select_host_servers(&ctx(&[], None)).is_empty());
+        assert!(select_host_servers(&ctx(&["b", "a"], Some(0))).is_empty());
+    }
+}

--- a/src/lsp/aggregation/server/host_dispatch.rs
+++ b/src/lsp/aggregation/server/host_dispatch.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use tokio::task::JoinSet;
 
 use crate::config::settings::BridgeServerConfig;
-use crate::lsp::bridge::{LanguageServerPool, UpstreamId};
+use crate::lsp::bridge::{LanguageServerPool, ResolvedServerConfig, UpstreamId};
 use crate::lsp::lsp_impl::bridge_context::HostRequestContext;
 use crate::lsp::request_id::CancelReceiver;
 
@@ -78,6 +78,21 @@ where
     let (mut join_set, entries) = host_fan_out(ctx, pool, f);
     let ordering = entry_names(&entries);
     concatenated::concatenated(&mut join_set, &ordering, cancel_rx, log_target, panic_sink).await
+}
+
+/// The host servers a request over `ctx` fans out to: allowlist + `"*"`
+/// expansion against `ctx.configs`, `max_fan_out`-truncated, in walk order
+/// (aggregation-priorities-wildcard).
+///
+/// Exposed for senders that have no fan-in — a forwarded notification
+/// (custom-method-host-forwarding) goes to every selected server and
+/// collects nothing — so they select exactly the servers a request would.
+pub(crate) fn select_host_servers(ctx: &HostRequestContext) -> Vec<ResolvedServerConfig> {
+    let entries = truncate_entries(
+        expand_priorities(&ctx.priorities, &ctx.configs),
+        ctx.max_fan_out,
+    );
+    super::fan_out::select_servers(&ctx.configs, &entries)
 }
 
 /// Shared host fan-out: allowlist + `"*"` expansion against `ctx.configs`,

--- a/src/lsp/aggregation/server/host_dispatch.rs
+++ b/src/lsp/aggregation/server/host_dispatch.rs
@@ -33,6 +33,8 @@ pub(crate) struct HostFanOutTask {
     pub(crate) language_id: String,
     pub(crate) text: Arc<str>,
     pub(crate) upstream_id: Option<UpstreamId>,
+    /// The document incarnation the context was resolved against.
+    pub(crate) incarnation: u64,
 }
 
 /// Host-bridge aggregation entry point using the preferred strategy.
@@ -127,6 +129,7 @@ where
             language_id: ctx.language_id.clone(),
             text: Arc::clone(&ctx.text),
             upstream_id: ctx.upstream_request_id.clone(),
+            incarnation: ctx.incarnation,
         };
         let fut = f(task);
         join_set.spawn(async move {

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -80,7 +80,9 @@ pub(crate) use protocol::translate_virtual_range_to_host;
 pub(crate) use protocol::workspace_edit_has_effect;
 pub(crate) use protocol::workspace_edit_preserves_line_prefixes;
 pub(crate) use protocol::workspace_edit_within_region;
-pub(crate) use text_document::host::{HostDocument, HostTextReader, normalize_host_goto_result};
+pub(crate) use text_document::host::{
+    CapabilityGate, HostDocument, HostTextReader, normalize_host_goto_result,
+};
 pub(crate) use text_document::{
     CodeActionEnvelope, CodeLensEnvelope, UpstreamCodeActionCaps, bridge_code_actions,
     extract_code_action_envelope, extract_code_lens_envelope, parse_code_actions_leniently,

--- a/src/lsp/bridge/protocol/jsonrpc.rs
+++ b/src/lsp/bridge/protocol/jsonrpc.rs
@@ -5,6 +5,7 @@
 
 use log::warn;
 use serde::Serialize;
+use std::borrow::Cow;
 
 /// Detect a JSON-RPC error response so transformers can short-circuit.
 ///
@@ -57,16 +58,16 @@ pub(crate) fn jsonrpc_error_summary(response: &serde_json::Value) -> String {
 pub(crate) struct JsonRpcRequest<P> {
     jsonrpc: &'static str,
     id: i64,
-    method: &'static str,
+    method: Cow<'static, str>,
     params: P,
 }
 
 impl<P> JsonRpcRequest<P> {
-    pub(crate) fn new(id: i64, method: &'static str, params: P) -> Self {
+    pub(crate) fn new(id: i64, method: impl Into<Cow<'static, str>>, params: P) -> Self {
         Self {
             jsonrpc: "2.0",
             id,
-            method,
+            method: method.into(),
             params,
         }
     }
@@ -76,15 +77,15 @@ impl<P> JsonRpcRequest<P> {
 #[derive(Debug, Serialize)]
 pub(crate) struct JsonRpcNotification<P> {
     jsonrpc: &'static str,
-    method: &'static str,
+    method: Cow<'static, str>,
     params: P,
 }
 
 impl<P> JsonRpcNotification<P> {
-    pub(crate) fn new(method: &'static str, params: P) -> Self {
+    pub(crate) fn new(method: impl Into<Cow<'static, str>>, params: P) -> Self {
         Self {
             jsonrpc: "2.0",
-            method,
+            method: method.into(),
             params,
         }
     }

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -67,10 +67,14 @@ pub(crate) struct OpenExpectation<'a> {
     pub(crate) expected_connection: Option<ConnectionKey>,
 }
 
-struct LifecycleCleanup<'a> {
-    pool: &'a LanguageServerPool,
-    host_uri: &'a url::Url,
-    lifecycle: &'a Arc<tokio::sync::Mutex<()>>,
+/// Drops a lifecycle-lock entry this caller may have created for a document
+/// that turns out to be closed: `host_lifecycle_lock` inserts on demand, and
+/// a late caller racing `didClose` would otherwise leave an orphan entry
+/// behind for every closed URI it touched.
+pub(super) struct LifecycleCleanup<'a> {
+    pub(super) pool: &'a LanguageServerPool,
+    pub(super) host_uri: &'a url::Url,
+    pub(super) lifecycle: &'a Arc<tokio::sync::Mutex<()>>,
 }
 
 impl Drop for LifecycleCleanup<'_> {

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -498,6 +498,7 @@ impl LanguageServerPool {
             uri: host_uri,
             language_id,
             text,
+            incarnation: None,
         };
         if let Err(e) = super::host::sync_host_document(
             &mut sender,

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -414,6 +414,7 @@ impl LanguageServerPool {
         server_config: &BridgeServerConfig,
         doc: &HostDocument<'_>,
         live_text_reader: Option<&HostTextReader>,
+        incarnation: Option<u64>,
         method: &str,
         mut params: serde_json::Value,
     ) -> io::Result<()> {
@@ -439,11 +440,16 @@ impl LanguageServerPool {
         let _lifecycle_guard = lifecycle.lock().await;
         // The waits above can outlive the document: once closed, a sync here
         // would re-open it downstream from the stale snapshot with nothing
-        // left to close it. Checked UNDER the lifecycle lock, which the
-        // downstream close also takes, so a close cannot slip between this
-        // check and the send; and the snapshot is never used as a fallback
-        // on this path — the reader answering `None` is the document gone.
-        if live_text_reader.is_some_and(|reader| reader().is_none()) {
+        // left to close it — and a close-then-reopen of the same URI would
+        // deliver a message meant for the old document into the new one.
+        // Checked UNDER the lifecycle lock, which the downstream close also
+        // takes, so neither can slip between this check and the send: the
+        // incarnation must still be the one the message was resolved
+        // against, and the reader must still find a document. The snapshot
+        // is never used as a fallback on this path.
+        if self.current_host_incarnation(doc.uri) != incarnation
+            || live_text_reader.is_some_and(|reader| reader().is_none())
+        {
             return Err(io::Error::new(
                 io::ErrorKind::NotConnected,
                 "host document closed while waiting for the server",

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -416,19 +416,21 @@ impl LanguageServerPool {
             )
             .await?;
         let connection_key = handle.key();
-        // The wait above can outlive the document: once closed, a sync here
+        self.wait_for_host_routing(doc.uri).await;
+        let lifecycle = self.host_lifecycle_lock(doc.uri);
+        let _lifecycle_guard = lifecycle.lock().await;
+        // The waits above can outlive the document: once closed, a sync here
         // would re-open it downstream from the stale snapshot with nothing
-        // left to close it. The reader answering `None` is that signal
-        // (narrows the window; the sync itself keeps the snapshot fallback).
+        // left to close it. Checked UNDER the lifecycle lock, which the
+        // downstream close also takes, so a close cannot slip between this
+        // check and the send; and the snapshot is never used as a fallback
+        // on this path — the reader answering `None` is the document gone.
         if live_text_reader.is_some_and(|reader| reader().is_none()) {
             return Err(io::Error::new(
                 io::ErrorKind::NotConnected,
                 "host document closed while waiting for the server",
             ));
         }
-        self.wait_for_host_routing(doc.uri).await;
-        let lifecycle = self.host_lifecycle_lock(doc.uri);
-        let _lifecycle_guard = lifecycle.lock().await;
         if self.is_host_routing_suppressed(doc.uri, connection_key) {
             return Err(io::Error::new(
                 io::ErrorKind::NotConnected,

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -367,7 +367,7 @@ impl LanguageServerPool {
                         // member (long-standing leniency); an arbitrary
                         // forwarded method gets JSON-RPC's strict reading —
                         // that is a broken server, counted as a failure.
-                        if response.get("result").is_none() && response.get("error").is_none() {
+                        if lacks_result_and_error(&response) {
                             return Err(io::Error::other(format!(
                                 "[{server}] answered {method:?} with neither result nor error"
                             )));
@@ -776,6 +776,12 @@ fn host_url_to_lsp_uri(uri: &Url) -> io::Result<Uri> {
 /// Strip the JSON-RPC envelope: `Err` for an error response (a request
 /// failure), `Ok(None)` for a `null` or absent result, and `Ok(Some(result))`
 /// with the bare `result` value otherwise.
+/// A response with neither a `result` member nor a non-null `error` object:
+/// JSON-RPC requires one of the two, and `"error": null` is not an error.
+fn lacks_result_and_error(response: &serde_json::Value) -> bool {
+    response.get("result").is_none() && response.get("error").is_none_or(serde_json::Value::is_null)
+}
+
 /// Whether a downstream response is a JSON-RPC `MethodNotFound` (-32601):
 /// the server's own way of saying it does not implement the method.
 fn declines_method(response: &serde_json::Value) -> bool {
@@ -1146,6 +1152,22 @@ mod tests {
             "result": { "kind": "full" }
         });
         assert!(parse_host_diagnostic_response(response, "textDocument/diagnostic").is_err());
+    }
+
+    #[test]
+    fn lacks_result_and_error_treats_null_error_as_absent() {
+        assert!(lacks_result_and_error(
+            &serde_json::json!({ "jsonrpc": "2.0", "id": 1 })
+        ));
+        assert!(lacks_result_and_error(&serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "error": null
+        })));
+        assert!(!lacks_result_and_error(&serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "result": null
+        })));
+        assert!(!lacks_result_and_error(&serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "error": { "code": -32603, "message": "x" }
+        })));
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -312,6 +312,7 @@ impl LanguageServerPool {
     ///
     /// `gate` decides whether the server's advertised capabilities are
     /// consulted first ([`CapabilityGate`]).
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn send_host_raw_request(
         &self,
         server_name: &str,
@@ -335,7 +336,9 @@ impl LanguageServerPool {
         // that would repeat the marker filesystem walk on a request-frequency
         // path (execute-command-routing-token).
         let answering = Arc::clone(&handle);
-        let server = server_name.to_owned();
+        // Only the blind decline log names the server; keep the typed hot
+        // path allocation-free.
+        let server = (gate == CapabilityGate::Blind).then(|| server_name.to_owned());
         let value = self
             .execute_host_request(
                 handle,
@@ -351,7 +354,7 @@ impl LanguageServerPool {
                     // server would warn on every keystroke and flood the
                     // client log. An ADVERTISED method answered
                     // MethodNotFound is a genuine failure and stays one.
-                    if gate == CapabilityGate::Blind && declines_method(&response) {
+                    if let Some(server) = server.filter(|_| declines_method(&response)) {
                         log::debug!(
                             target: "kakehashi::bridge",
                             "[{server}] does not implement {method:?} (MethodNotFound); \

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -354,13 +354,24 @@ impl LanguageServerPool {
                     // server would warn on every keystroke and flood the
                     // client log. An ADVERTISED method answered
                     // MethodNotFound is a genuine failure and stays one.
-                    if let Some(server) = server.filter(|_| declines_method(&response)) {
-                        log::debug!(
-                            target: "kakehashi::bridge",
-                            "[{server}] does not implement {method:?} (MethodNotFound); \
-                             treated as an empty answer"
-                        );
-                        return Ok(None);
+                    if let Some(server) = server.as_deref() {
+                        if declines_method(&response) {
+                            log::debug!(
+                                target: "kakehashi::bridge",
+                                "[{server}] does not implement {method:?} (MethodNotFound); \
+                                 treated as an empty answer"
+                            );
+                            return Ok(None);
+                        }
+                        // The typed raw path tolerates a response with neither
+                        // member (long-standing leniency); an arbitrary
+                        // forwarded method gets JSON-RPC's strict reading —
+                        // that is a broken server, counted as a failure.
+                        if response.get("result").is_none() && response.get("error").is_none() {
+                            return Err(io::Error::other(format!(
+                                "[{server}] answered {method:?} with neither result nor error"
+                            )));
+                        }
                     }
                     parse_host_raw_response(response, method)
                 },

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -811,10 +811,17 @@ fn lacks_result_and_error(response: &serde_json::Value) -> bool {
 /// the server's own way of saying it does not implement the method.
 fn declines_method(response: &serde_json::Value) -> bool {
     const METHOD_NOT_FOUND: i64 = -32601;
-    response
-        .pointer("/error/code")
-        .and_then(serde_json::Value::as_i64)
-        .is_some_and(|code| code == METHOD_NOT_FOUND)
+    // A well-formed decline only: an error object with the code and its
+    // required `message`, and no `result` beside it. Anything malformed
+    // falls through to the strict parse and counts as a failure.
+    response.get("result").is_none()
+        && response
+            .pointer("/error/code")
+            .and_then(serde_json::Value::as_i64)
+            .is_some_and(|code| code == METHOD_NOT_FOUND)
+        && response
+            .pointer("/error/message")
+            .is_some_and(serde_json::Value::is_string)
 }
 
 fn parse_host_raw_response(
@@ -1207,6 +1214,14 @@ mod tests {
         })));
         assert!(!declines_method(&serde_json::json!({
             "jsonrpc": "2.0", "id": 1, "result": null
+        })));
+        // Malformed declines are failures, not quiet empties.
+        assert!(!declines_method(&serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "error": { "code": -32601 }
+        })));
+        assert!(!declines_method(&serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "result": 1,
+            "error": { "code": -32601, "message": "Method not found" }
         })));
     }
 

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -814,7 +814,8 @@ fn declines_method(response: &serde_json::Value) -> bool {
     // A well-formed decline only: an error object with the code and its
     // required `message`, and no `result` beside it. Anything malformed
     // falls through to the strict parse and counts as a failure.
-    response.get("result").is_none()
+    response.get("jsonrpc").and_then(serde_json::Value::as_str) == Some("2.0")
+        && response.get("result").is_none()
         && response
             .pointer("/error/code")
             .and_then(serde_json::Value::as_i64)
@@ -1218,6 +1219,12 @@ mod tests {
         // Malformed declines are failures, not quiet empties.
         assert!(!declines_method(&serde_json::json!({
             "jsonrpc": "2.0", "id": 1, "error": { "code": -32601 }
+        })));
+        assert!(!declines_method(&serde_json::json!({
+            "id": 1, "error": { "code": -32601, "message": "Method not found" }
+        })));
+        assert!(!declines_method(&serde_json::json!({
+            "jsonrpc": "1.0", "id": 1, "error": { "code": -32601, "message": "Method not found" }
         })));
         assert!(!declines_method(&serde_json::json!({
             "jsonrpc": "2.0", "id": 1, "result": 1,

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -34,7 +34,7 @@ use url::Url;
 use super::super::actor::RouterCleanupGuard;
 use super::super::pool::{
     ConnectionHandle, ConnectionHandleSender, ConnectionKey, HostDocSyncState, LanguageServerPool,
-    MessageSender, UpstreamId,
+    MessageSender, NotificationSendResult, UpstreamId,
 };
 use super::super::protocol::{
     JsonRpcNotification, JsonRpcRequest, RequestId, jsonrpc_error_summary,
@@ -334,6 +334,110 @@ impl LanguageServerPool {
             value,
             handle: answering,
         }))
+    }
+
+    /// Send a request for a method kakehashi does not implement
+    /// (custom-method-host-forwarding). Identical to
+    /// [`Self::send_host_raw_request`] except that the server's advertised
+    /// capabilities are **not** consulted: the method is unknown to
+    /// kakehashi, so it has no capability to look up, and the contract is
+    /// that a server not implementing it answers `MethodNotFound` itself —
+    /// which surfaces here as the `Err` of a downstream error response.
+    pub(crate) async fn send_host_custom_request(
+        &self,
+        server_name: &str,
+        server_config: &BridgeServerConfig,
+        doc: &HostDocument<'_>,
+        method: &str,
+        mut params: serde_json::Value,
+        upstream_request_id: Option<UpstreamId>,
+    ) -> io::Result<Option<serde_json::Value>> {
+        strip_progress_tokens(&mut params);
+        let handle = self
+            .get_or_create_connection(server_name, server_config, Some(doc.uri))
+            .await?;
+        self.execute_host_request(
+            handle,
+            doc,
+            upstream_request_id,
+            |request_id| JsonRpcRequest::new(request_id.as_i64(), method.to_owned(), params),
+            move |response| parse_host_raw_response(response, method),
+        )
+        .await?
+    }
+
+    /// Send a notification for a method kakehashi does not implement
+    /// (custom-method-host-forwarding) with the upstream params forwarded
+    /// verbatim, after syncing the host document to the server.
+    ///
+    /// The sync is what distinguishes this from a bare
+    /// `handle.send_notification`: a notification about a document the
+    /// server never opened is a protocol nuisance at best. It therefore
+    /// follows the lock discipline of [`Self::execute_host_request`] —
+    /// routing wait, per-document lifecycle lock, suppression check, live
+    /// handle check, then sync and send under the `connections` →
+    /// `host_documents` order — minus the request bookkeeping a
+    /// notification has no use for. Unlike [`Self::notify_host_will_save`],
+    /// this may spawn the connection: the user asked for this method to
+    /// reach this server, exactly as a request would. And unlike the
+    /// request path it **waits through initialization** (Tier 0 bound,
+    /// ls-bridge-timeout-hierarchy): a request that fails fast is retried
+    /// by the next keystroke, but a dropped notification is gone.
+    pub(crate) async fn send_host_custom_notification(
+        &self,
+        server_name: &str,
+        server_config: &BridgeServerConfig,
+        doc: &HostDocument<'_>,
+        method: &str,
+        mut params: serde_json::Value,
+    ) -> io::Result<()> {
+        strip_progress_tokens(&mut params);
+        let handle = self
+            .get_or_create_connection_wait_ready(
+                server_name,
+                server_config,
+                Some(doc.uri),
+                std::time::Duration::from_secs(super::super::pool::INIT_TIMEOUT_SECS),
+            )
+            .await?;
+        let connection_key = handle.key();
+        self.wait_for_host_routing(doc.uri).await;
+        let lifecycle = self.host_lifecycle_lock(doc.uri);
+        let _lifecycle_guard = lifecycle.lock().await;
+        if self.is_host_routing_suppressed(doc.uri, connection_key) {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                format!("host document routing disabled on {connection_key}"),
+            ));
+        }
+        self.apply_host_routing_workspace_folders(doc.uri, connection_key.server(), &handle)
+            .await
+            .map_err(|error| {
+                io::Error::new(
+                    error.kind(),
+                    format!("failed to apply host routing workspace folders: {error}"),
+                )
+            })?;
+
+        let connections = self.connections().await;
+        if !connections
+            .get(connection_key)
+            .is_some_and(|current| Arc::ptr_eq(current, &handle))
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                format!("connection to {connection_key} was replaced during host sync"),
+            ));
+        }
+        let mut docs = self.host_documents().await;
+        let mut sender = ConnectionHandleSender(&handle);
+        sync_host_document(&mut sender, &mut docs, doc, None, connection_key).await?;
+        match handle.send_notification(JsonRpcNotification::new(method.to_owned(), params)) {
+            NotificationSendResult::Queued => Ok(()),
+            other => Err(io::Error::other(format!(
+                "failed to queue {method} for {connection_key}: {other:?}"
+            ))),
+        }
     }
 
     /// Send a host formatting request. Unlike [`Self::send_host_raw_request`],

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -408,13 +408,14 @@ impl LanguageServerPool {
     /// sync runs; `live_text_reader` lets the sync send the document's
     /// current text instead of rolling the server back to the snapshot
     /// (the eager re-sync closes the same window the same way, #422).
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn send_host_custom_notification(
         &self,
         server_name: &str,
         server_config: &BridgeServerConfig,
         doc: &HostDocument<'_>,
         live_text_reader: Option<&HostTextReader>,
-        incarnation: Option<u64>,
+        incarnation: u64,
         method: &str,
         mut params: serde_json::Value,
     ) -> io::Result<()> {
@@ -447,7 +448,7 @@ impl LanguageServerPool {
         // incarnation must still be the one the message was resolved
         // against, and the reader must still find a document. The snapshot
         // is never used as a fallback on this path.
-        if self.current_host_incarnation(doc.uri) != incarnation
+        if self.current_host_incarnation(doc.uri) != Some(incarnation)
             || live_text_reader.is_some_and(|reader| reader().is_none())
         {
             return Err(io::Error::new(

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -301,7 +301,7 @@ impl LanguageServerPool {
         server_name: &str,
         server_config: &BridgeServerConfig,
         doc: &HostDocument<'_>,
-        method: &'static str,
+        method: &str,
         mut params: serde_json::Value,
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Option<HostRawResponse>> {
@@ -323,7 +323,7 @@ impl LanguageServerPool {
                 handle,
                 doc,
                 upstream_request_id,
-                |request_id| JsonRpcRequest::new(request_id.as_i64(), method, params),
+                |request_id| JsonRpcRequest::new(request_id.as_i64(), method.to_owned(), params),
                 move |response| parse_host_raw_response(response, method),
             )
             // Outer `?`: transport/protocol failure from `execute_host_request`.
@@ -618,7 +618,7 @@ fn host_url_to_lsp_uri(uri: &Url) -> io::Result<Uri> {
 /// with the bare `result` value otherwise.
 fn parse_host_raw_response(
     mut response: serde_json::Value,
-    method: &'static str,
+    method: &str,
 ) -> io::Result<Option<serde_json::Value>> {
     // A downstream JSON-RPC error response is a request failure, not "no
     // result" — propagate it as `Err` so a request-error sink can surface it

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -416,6 +416,16 @@ impl LanguageServerPool {
             )
             .await?;
         let connection_key = handle.key();
+        // The wait above can outlive the document: once closed, a sync here
+        // would re-open it downstream from the stale snapshot with nothing
+        // left to close it. The reader answering `None` is that signal
+        // (narrows the window; the sync itself keeps the snapshot fallback).
+        if live_text_reader.is_some_and(|reader| reader().is_none()) {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "host document closed while waiting for the server",
+            ));
+        }
         self.wait_for_host_routing(doc.uri).await;
         let lifecycle = self.host_lifecycle_lock(doc.uri);
         let _lifecycle_guard = lifecycle.lock().await;

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -42,6 +42,19 @@ use super::super::protocol::{
 };
 use crate::config::settings::BridgeServerConfig;
 
+/// Whether a host raw request consults the server's advertised capabilities
+/// before it is sent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CapabilityGate {
+    /// The typed host methods: a server that does not advertise the method
+    /// is skipped (`Ok(None)`), never asked.
+    Advertised,
+    /// Forwarded methods (custom-method-host-forwarding): kakehashi has no
+    /// capability to look up for them, so the server is asked regardless
+    /// and its own `MethodNotFound` is the decline.
+    Blind,
+}
+
 /// The host document a request operates on: real URI, host language id, and
 /// the current host text (verbatim).
 pub(crate) struct HostDocument<'a> {
@@ -296,6 +309,9 @@ impl LanguageServerPool {
     /// the next request gets it) — the policy every interactive host-bridged
     /// method wants. The diagnostic path, which must instead wait through
     /// initialization, uses the dedicated [`Self::send_host_diagnostic_request`].
+    ///
+    /// `gate` decides whether the server's advertised capabilities are
+    /// consulted first ([`CapabilityGate`]).
     pub(crate) async fn send_host_raw_request(
         &self,
         server_name: &str,
@@ -304,12 +320,13 @@ impl LanguageServerPool {
         method: &str,
         mut params: serde_json::Value,
         upstream_request_id: Option<UpstreamId>,
+        gate: CapabilityGate,
     ) -> io::Result<Option<HostRawResponse>> {
         strip_progress_tokens(&mut params);
         let handle = self
             .get_or_create_connection(server_name, server_config, Some(doc.uri))
             .await?;
-        if !handle.has_capability(method) {
+        if gate == CapabilityGate::Advertised && !handle.has_capability(method) {
             return Ok(None);
         }
         // Carried out with the response so a caller that must name this exact
@@ -318,13 +335,32 @@ impl LanguageServerPool {
         // that would repeat the marker filesystem walk on a request-frequency
         // path (execute-command-routing-token).
         let answering = Arc::clone(&handle);
+        let server = server_name.to_owned();
         let value = self
             .execute_host_request(
                 handle,
                 doc,
                 upstream_request_id,
                 |request_id| JsonRpcRequest::new(request_id.as_i64(), method.to_owned(), params),
-                move |response| parse_host_raw_response(response, method),
+                move |response| {
+                    // Under the blind gate, MethodNotFound is the contract's
+                    // expected decline: nothing was advertised, the server
+                    // does not implement the method, it says so. An empty
+                    // contribution at debug, not a counted failure —
+                    // otherwise a priorities list with one non-implementing
+                    // server would warn on every keystroke and flood the
+                    // client log. An ADVERTISED method answered
+                    // MethodNotFound is a genuine failure and stays one.
+                    if gate == CapabilityGate::Blind && declines_method(&response) {
+                        log::debug!(
+                            target: "kakehashi::bridge",
+                            "[{server}] does not implement {method:?} (MethodNotFound); \
+                             treated as an empty answer"
+                        );
+                        return Ok(None);
+                    }
+                    parse_host_raw_response(response, method)
+                },
             )
             // Outer `?`: transport/protocol failure from `execute_host_request`.
             // Inner `Result` from the parser: a downstream JSON-RPC error
@@ -334,52 +370,6 @@ impl LanguageServerPool {
             value,
             handle: answering,
         }))
-    }
-
-    /// Send a request for a method kakehashi does not implement
-    /// (custom-method-host-forwarding). Identical to
-    /// [`Self::send_host_raw_request`] except that the server's advertised
-    /// capabilities are **not** consulted: the method is unknown to
-    /// kakehashi, so it has no capability to look up, and the contract is
-    /// that a server not implementing it answers `MethodNotFound` itself —
-    /// which surfaces here as the `Err` of a downstream error response.
-    pub(crate) async fn send_host_custom_request(
-        &self,
-        server_name: &str,
-        server_config: &BridgeServerConfig,
-        doc: &HostDocument<'_>,
-        method: &str,
-        mut params: serde_json::Value,
-        upstream_request_id: Option<UpstreamId>,
-    ) -> io::Result<Option<serde_json::Value>> {
-        strip_progress_tokens(&mut params);
-        let handle = self
-            .get_or_create_connection(server_name, server_config, Some(doc.uri))
-            .await?;
-        let server = server_name.to_owned();
-        self.execute_host_request(
-            handle,
-            doc,
-            upstream_request_id,
-            |request_id| JsonRpcRequest::new(request_id.as_i64(), method.to_owned(), params),
-            move |response| {
-                // The contract's expected decline: nothing was advertised, the
-                // server does not implement the method, it says so. An empty
-                // contribution at debug, not a counted failure — otherwise a
-                // priorities list with one non-implementing server would warn
-                // on every keystroke and flood the client log.
-                if declines_method(&response) {
-                    log::debug!(
-                        target: "kakehashi::bridge",
-                        "[{server}] does not implement {method:?} (MethodNotFound); \
-                         treated as an empty answer"
-                    );
-                    return Ok(None);
-                }
-                parse_host_raw_response(response, method)
-            },
-        )
-        .await?
     }
 
     /// Send a notification for a method kakehashi does not implement

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -429,6 +429,13 @@ impl LanguageServerPool {
         let connection_key = handle.key();
         self.wait_for_host_routing(doc.uri).await;
         let lifecycle = self.host_lifecycle_lock(doc.uri);
+        // Whatever path returns below: if the document is gone, the lock
+        // entry this call may just have re-created goes with it.
+        let _cleanup = super::did_open::LifecycleCleanup {
+            pool: self,
+            host_uri: doc.uri,
+            lifecycle: &lifecycle,
+        };
         let _lifecycle_guard = lifecycle.lock().await;
         // The waits above can outlive the document: once closed, a sync here
         // would re-open it downstream from the stale snapshot with nothing

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -61,6 +61,12 @@ pub(crate) struct HostDocument<'a> {
     pub(crate) uri: &'a Url,
     pub(crate) language_id: &'a str,
     pub(crate) text: &'a str,
+    /// The document incarnation the caller resolved against, when it wants
+    /// the send refused once that incarnation is gone (closed, or closed
+    /// and reopened): checked under the host lifecycle lock before the sync
+    /// (custom-method-host-forwarding). `None` keeps the typed host paths'
+    /// long-standing behavior of syncing whatever is there.
+    pub(crate) incarnation: Option<u64>,
 }
 
 /// A raw host-server response plus the very connection that answered it.
@@ -415,7 +421,6 @@ impl LanguageServerPool {
         server_config: &BridgeServerConfig,
         doc: &HostDocument<'_>,
         live_text_reader: Option<&HostTextReader>,
-        incarnation: u64,
         method: &str,
         mut params: serde_json::Value,
     ) -> io::Result<()> {
@@ -448,7 +453,9 @@ impl LanguageServerPool {
         // incarnation must still be the one the message was resolved
         // against, and the reader must still find a document. The snapshot
         // is never used as a fallback on this path.
-        if self.current_host_incarnation(doc.uri) != Some(incarnation)
+        if doc
+            .incarnation
+            .is_some_and(|expected| self.current_host_incarnation(doc.uri) != Some(expected))
             || live_text_reader.is_some_and(|reader| reader().is_none())
         {
             return Err(io::Error::new(
@@ -647,7 +654,25 @@ impl LanguageServerPool {
         let connection_key = handle.key();
         self.wait_for_host_routing(doc.uri).await;
         let lifecycle = self.host_lifecycle_lock(doc.uri);
+        // If the document is gone by the time we return, the lock entry this
+        // call may have re-created goes with it.
+        let _cleanup = super::did_open::LifecycleCleanup {
+            pool: self,
+            host_uri: doc.uri,
+            lifecycle: &lifecycle,
+        };
         let _lifecycle_guard = lifecycle.lock().await;
+        // A caller bound to an incarnation asked not to resurrect a document
+        // that closed (or closed and reopened) while it waited above; checked
+        // under the lifecycle lock the close path also takes.
+        if let Some(expected) = doc.incarnation
+            && self.current_host_incarnation(doc.uri) != Some(expected)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "host document closed while waiting for the server",
+            ));
+        }
         if self.is_host_routing_suppressed(doc.uri, connection_key) {
             return Err(io::Error::new(
                 io::ErrorKind::NotConnected,
@@ -1205,6 +1230,7 @@ mod tests {
             uri,
             language_id: "markdown",
             text,
+            incarnation: None,
         }
     }
 

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -356,12 +356,28 @@ impl LanguageServerPool {
         let handle = self
             .get_or_create_connection(server_name, server_config, Some(doc.uri))
             .await?;
+        let server = server_name.to_owned();
         self.execute_host_request(
             handle,
             doc,
             upstream_request_id,
             |request_id| JsonRpcRequest::new(request_id.as_i64(), method.to_owned(), params),
-            move |response| parse_host_raw_response(response, method),
+            move |response| {
+                // The contract's expected decline: nothing was advertised, the
+                // server does not implement the method, it says so. An empty
+                // contribution at debug, not a counted failure — otherwise a
+                // priorities list with one non-implementing server would warn
+                // on every keystroke and flood the client log.
+                if declines_method(&response) {
+                    log::debug!(
+                        target: "kakehashi::bridge",
+                        "[{server}] does not implement {method:?} (MethodNotFound); \
+                         treated as an empty answer"
+                    );
+                    return Ok(None);
+                }
+                parse_host_raw_response(response, method)
+            },
         )
         .await?
     }
@@ -720,6 +736,16 @@ fn host_url_to_lsp_uri(uri: &Url) -> io::Result<Uri> {
 /// Strip the JSON-RPC envelope: `Err` for an error response (a request
 /// failure), `Ok(None)` for a `null` or absent result, and `Ok(Some(result))`
 /// with the bare `result` value otherwise.
+/// Whether a downstream response is a JSON-RPC `MethodNotFound` (-32601):
+/// the server's own way of saying it does not implement the method.
+fn declines_method(response: &serde_json::Value) -> bool {
+    const METHOD_NOT_FOUND: i64 = -32601;
+    response
+        .pointer("/error/code")
+        .and_then(serde_json::Value::as_i64)
+        .is_some_and(|code| code == METHOD_NOT_FOUND)
+}
+
 fn parse_host_raw_response(
     mut response: serde_json::Value,
     method: &str,
@@ -1080,6 +1106,21 @@ mod tests {
             "result": { "kind": "full" }
         });
         assert!(parse_host_diagnostic_response(response, "textDocument/diagnostic").is_err());
+    }
+
+    #[test]
+    fn declines_method_matches_only_method_not_found() {
+        assert!(declines_method(&serde_json::json!({
+            "jsonrpc": "2.0", "id": 1,
+            "error": { "code": -32601, "message": "Method not found" }
+        })));
+        assert!(!declines_method(&serde_json::json!({
+            "jsonrpc": "2.0", "id": 1,
+            "error": { "code": -32603, "message": "boom" }
+        })));
+        assert!(!declines_method(&serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "result": null
+        })));
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -34,7 +34,7 @@ use url::Url;
 use super::super::actor::RouterCleanupGuard;
 use super::super::pool::{
     ConnectionHandle, ConnectionHandleSender, ConnectionKey, HostDocSyncState, LanguageServerPool,
-    MessageSender, NotificationSendResult, UpstreamId,
+    MessageSender, UpstreamId,
 };
 use super::super::protocol::{
     JsonRpcNotification, JsonRpcRequest, RequestId, jsonrpc_error_summary,
@@ -399,11 +399,17 @@ impl LanguageServerPool {
     /// request path it **waits through initialization** (Tier 0 bound,
     /// ls-bridge-timeout-hierarchy): a request that fails fast is retried
     /// by the next keystroke, but a dropped notification is gone.
+    ///
+    /// Because of that wait, `doc.text` can be seconds old by the time the
+    /// sync runs; `live_text_reader` lets the sync send the document's
+    /// current text instead of rolling the server back to the snapshot
+    /// (the eager re-sync closes the same window the same way, #422).
     pub(crate) async fn send_host_custom_notification(
         &self,
         server_name: &str,
         server_config: &BridgeServerConfig,
         doc: &HostDocument<'_>,
+        live_text_reader: Option<&HostTextReader>,
         method: &str,
         mut params: serde_json::Value,
     ) -> io::Result<()> {
@@ -447,13 +453,17 @@ impl LanguageServerPool {
         }
         let mut docs = self.host_documents().await;
         let mut sender = ConnectionHandleSender(&handle);
-        sync_host_document(&mut sender, &mut docs, doc, None, connection_key).await?;
-        match handle.send_notification(JsonRpcNotification::new(method.to_owned(), params)) {
-            NotificationSendResult::Queued => Ok(()),
-            other => Err(io::Error::other(format!(
-                "failed to queue {method} for {connection_key}: {other:?}"
-            ))),
-        }
+        sync_host_document(
+            &mut sender,
+            &mut docs,
+            doc,
+            live_text_reader.map(|reader| reader.as_ref()),
+            connection_key,
+        )
+        .await?;
+        sender
+            .send_notification(JsonRpcNotification::new(method.to_owned(), params))
+            .await
     }
 
     /// Send a host formatting request. Unlike [`Self::send_host_raw_request`],

--- a/src/lsp/custom_method_forward.rs
+++ b/src/lsp/custom_method_forward.rs
@@ -168,6 +168,9 @@ mod tests {
     use std::sync::Mutex as StdMutex;
     use tower_lsp_server::jsonrpc::{Error, Id};
 
+    /// LSP `ServerNotInitialized`; tower-lsp-server 0.23 has no named variant.
+    const SERVER_NOT_INITIALIZED: ErrorCode = ErrorCode::ServerError(-32002);
+
     /// Inner service that answers `known/method` and records every call;
     /// anything else gets the router's `MethodNotFound` (requests) or
     /// silence (notifications).
@@ -307,6 +310,68 @@ mod tests {
         assert_eq!(methods(&router), ["$/unknown"]);
     }
 
+    #[test]
+    fn plan_classifies_by_namespace_id_and_handled_set() {
+        let req = |method: &'static str| request(method, 1);
+        let note = |method: &'static str| notification(method);
+        assert_eq!(
+            plan(&req("custom/echo"), configured),
+            Plan::ProbeThenForward
+        );
+        assert_eq!(
+            plan(&note("custom/ping"), configured),
+            Plan::ForwardNotification
+        );
+        assert_eq!(
+            plan(&note("textDocument/didOpen"), configured),
+            Plan::PassThrough
+        );
+        assert_eq!(plan(&req("$/anything"), configured), Plan::PassThrough);
+        assert_eq!(plan(&req("kakehashi/node"), configured), Plan::PassThrough);
+        assert_eq!(
+            plan(&req("custom/echo"), |_: &str| false),
+            Plan::PassThrough
+        );
+        assert_eq!(
+            plan(&note("custom/ping"), |_: &str| false),
+            Plan::PassThrough
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_answering_method_not_found_is_not_forwarded_again() {
+        /// Router whose forward handler itself declines (the handler's
+        /// NotForwardable answer): exactly one forward, then the client
+        /// gets that MethodNotFound.
+        #[derive(Clone, Default)]
+        struct Declining {
+            calls: Arc<StdMutex<Vec<String>>>,
+        }
+        impl Service<Request> for Declining {
+            type Response = Option<Response>;
+            type Error = std::convert::Infallible;
+            type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+            fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+            fn call(&mut self, req: Request) -> Self::Future {
+                self.calls.lock().unwrap().push(req.method().to_owned());
+                let (_, id, _) = req.into_parts();
+                std::future::ready(Ok(
+                    id.map(|id| Response::from_error(id, Error::method_not_found()))
+                ))
+            }
+        }
+        let router = Declining::default();
+        let mut svc = CustomMethodForwarder::new(router.clone(), configured);
+        let response = svc.call(request("custom/echo", 1)).await.unwrap().unwrap();
+        assert_eq!(response.error().unwrap().code, ErrorCode::MethodNotFound);
+        assert_eq!(
+            *router.calls.lock().unwrap(),
+            ["custom/echo", FORWARD_REQUEST_METHOD]
+        );
+    }
+
     #[tokio::test]
     async fn unconfigured_methods_pass_through_without_a_forward() {
         // The gate says no: the router's MethodNotFound stands and no second
@@ -352,9 +417,9 @@ mod tests {
             }
             fn call(&mut self, req: Request) -> Self::Future {
                 let (_, id, _) = req.into_parts();
-                std::future::ready(Ok(id.map(|id| {
-                    Response::from_error(id, Error::new(ErrorCode::ServerError(-32002)))
-                })))
+                std::future::ready(Ok(
+                    id.map(|id| Response::from_error(id, Error::new(SERVER_NOT_INITIALIZED)))
+                ))
             }
         }
         let mut svc = CustomMethodForwarder::new(Uninitialized, configured);

--- a/src/lsp/custom_method_forward.rs
+++ b/src/lsp/custom_method_forward.rs
@@ -1,0 +1,327 @@
+//! Fallback dispatch for custom-method-host-forwarding.
+//!
+//! Sits directly around the `LspService`. A request the router answers with
+//! `MethodNotFound` is re-issued as `kakehashi/forward/request`; a
+//! notification kakehashi does not implement is issued as
+//! `kakehashi/forward/notification`. Both carry `{ "method", "params" }` and
+//! keep the original `id`, so the handler decides eligibility from
+//! configuration and the client sees either the forwarded answer or the
+//! router's original `MethodNotFound`.
+//!
+//! Built-in methods are never shadowed: requests are dispatched to the router
+//! first and only its own "no handler" answer triggers the forward; the
+//! notifications kakehashi implements are excluded by name
+//! ([`HANDLED_NOTIFICATIONS`]).
+//!
+//! The inner service is shared behind a `std::sync::Mutex` because the
+//! forward needs it again after the first answer arrives, inside the response
+//! future, where `&mut self` is gone. The lock is only ever held
+//! synchronously — around `poll_ready`/`call`, never across an await — so it
+//! cannot deadlock, and the first dispatch of every message still happens
+//! synchronously in [`Service::call`], in wire order, exactly as before.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+
+use tower::Service;
+use tower_lsp_server::jsonrpc::{ErrorCode, Request, Response};
+
+use crate::lsp::lsp_impl::HANDLED_NOTIFICATIONS;
+use crate::lsp::lsp_impl::custom_method_forward::{
+    FORWARD_NOTIFICATION_METHOD, FORWARD_REQUEST_METHOD,
+};
+
+/// Re-issues unhandled requests and notifications as the forwarding methods.
+pub struct CustomMethodForwarder<S> {
+    inner: Arc<Mutex<S>>,
+}
+
+impl<S> CustomMethodForwarder<S> {
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(inner)),
+        }
+    }
+}
+
+/// What the forwarder does with one inbound message.
+#[derive(Debug, PartialEq, Eq)]
+enum Plan {
+    /// Hand to the router as-is: reserved namespaces, handled
+    /// notifications, and the forwarding methods themselves.
+    PassThrough,
+    /// Dispatch as-is; if the router answers `MethodNotFound`, dispatch the
+    /// rewritten request.
+    ProbeThenForward,
+    /// Dispatch the rewritten notification instead of the original (which
+    /// the router would drop).
+    ForwardNotification,
+}
+
+fn plan(req: &Request) -> Plan {
+    let method = req.method();
+    // `$/` is the protocol's own namespace (cancel, progress, trace) and
+    // `kakehashi/` is ours; neither is anyone's custom method.
+    if method.starts_with("$/") || method.starts_with("kakehashi/") {
+        return Plan::PassThrough;
+    }
+    if req.id().is_some() {
+        Plan::ProbeThenForward
+    } else if HANDLED_NOTIFICATIONS.contains(&method) {
+        Plan::PassThrough
+    } else {
+        Plan::ForwardNotification
+    }
+}
+
+/// Wrap `req` into the forwarding envelope under `forward_method`, keeping
+/// its id (if any).
+fn rewrite(req: &Request, forward_method: &'static str) -> Request {
+    let params = serde_json::json!({
+        "method": req.method(),
+        "params": req.params().cloned().unwrap_or(serde_json::Value::Null),
+    });
+    let builder = Request::build(forward_method).params(params);
+    match req.id() {
+        Some(id) => builder.id(id.clone()).finish(),
+        None => builder.finish(),
+    }
+}
+
+fn is_method_not_found(response: &Option<Response>) -> bool {
+    response
+        .as_ref()
+        .and_then(Response::error)
+        .is_some_and(|error| error.code == ErrorCode::MethodNotFound)
+}
+
+impl<S> Service<Request> for CustomMethodForwarder<S>
+where
+    S: Service<Request, Response = Option<Response>> + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        lock(&self.inner).poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        match plan(&req) {
+            Plan::PassThrough => Box::pin(lock(&self.inner).call(req)),
+            Plan::ForwardNotification => {
+                let forwarded = rewrite(&req, FORWARD_NOTIFICATION_METHOD);
+                Box::pin(lock(&self.inner).call(forwarded))
+            }
+            Plan::ProbeThenForward => {
+                let forwarded = rewrite(&req, FORWARD_REQUEST_METHOD);
+                let probe = lock(&self.inner).call(req);
+                let inner = Arc::clone(&self.inner);
+                Box::pin(async move {
+                    let response = probe.await?;
+                    if !is_method_not_found(&response) {
+                        return Ok(response);
+                    }
+                    // No `poll_ready` here: the probe was admitted through the
+                    // normal `poll_ready`, and the service cannot have gone
+                    // back to initializing since, so calling directly is
+                    // sound — and the inner `poll_ready` registers no waker
+                    // while initializing, so awaiting it here could hang.
+                    let forward = lock(&inner).call(forwarded);
+                    forward.await
+                })
+            }
+        }
+    }
+}
+
+fn lock<S>(inner: &Mutex<S>) -> std::sync::MutexGuard<'_, S> {
+    // The guard is never held across an await, so a poisoned lock can only
+    // mean a panic inside `poll_ready`/`call` themselves; keep serving.
+    inner
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+    use tower_lsp_server::jsonrpc::{Error, Id};
+
+    /// Inner service that answers `known/method` and records every call;
+    /// anything else gets the router's `MethodNotFound` (requests) or
+    /// silence (notifications).
+    #[derive(Clone, Default)]
+    struct Router {
+        calls: Arc<StdMutex<Vec<Request>>>,
+    }
+
+    impl Service<Request> for Router {
+        type Response = Option<Response>;
+        type Error = std::convert::Infallible;
+        type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: Request) -> Self::Future {
+            self.calls.lock().unwrap().push(req.clone());
+            let known = matches!(
+                req.method(),
+                "known/method" | FORWARD_REQUEST_METHOD | FORWARD_NOTIFICATION_METHOD
+            );
+            let (method, id, _) = req.into_parts();
+            std::future::ready(Ok(id.map(|id| {
+                if known {
+                    Response::from_ok(id, serde_json::json!({ "answered": method }))
+                } else {
+                    let mut error = Error::method_not_found();
+                    error.data = Some(serde_json::Value::String(method.into_owned()));
+                    Response::from_error(id, error)
+                }
+            })))
+        }
+    }
+
+    fn request(method: &'static str, id: i64) -> Request {
+        Request::build(method)
+            .id(id)
+            .params(serde_json::json!({ "textDocument": { "uri": "file:///a.md" } }))
+            .finish()
+    }
+
+    fn notification(method: &'static str) -> Request {
+        Request::build(method)
+            .params(serde_json::json!({ "n": 1 }))
+            .finish()
+    }
+
+    async fn drive(router: &Router, req: Request) -> Option<Response> {
+        let mut svc = CustomMethodForwarder::new(router.clone());
+        std::future::poll_fn(|cx| svc.poll_ready(cx)).await.unwrap();
+        svc.call(req).await.unwrap()
+    }
+
+    fn methods(router: &Router) -> Vec<String> {
+        router
+            .calls
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|r| r.method().to_owned())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn handled_request_is_answered_by_the_router_alone() {
+        let router = Router::default();
+        let response = drive(&router, request("known/method", 1)).await.unwrap();
+        assert_eq!(response.result().unwrap()["answered"], "known/method");
+        assert_eq!(methods(&router), ["known/method"]);
+    }
+
+    #[tokio::test]
+    async fn unhandled_request_is_forwarded_with_its_id_and_params() {
+        let router = Router::default();
+        let response = drive(&router, request("custom/echo", 7)).await.unwrap();
+        assert_eq!(response.id(), &Id::Number(7));
+        assert_eq!(
+            response.result().unwrap()["answered"],
+            FORWARD_REQUEST_METHOD
+        );
+        assert_eq!(methods(&router), ["custom/echo", FORWARD_REQUEST_METHOD]);
+        let forwarded = router.calls.lock().unwrap()[1].clone();
+        assert_eq!(forwarded.id(), Some(&Id::Number(7)));
+        assert_eq!(
+            forwarded.params().unwrap(),
+            &serde_json::json!({
+                "method": "custom/echo",
+                "params": { "textDocument": { "uri": "file:///a.md" } }
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn unhandled_notification_is_forwarded_instead_of_dropped() {
+        let router = Router::default();
+        assert!(drive(&router, notification("custom/ping")).await.is_none());
+        assert_eq!(methods(&router), [FORWARD_NOTIFICATION_METHOD]);
+        let forwarded = router.calls.lock().unwrap()[0].clone();
+        assert_eq!(forwarded.id(), None);
+        assert_eq!(
+            forwarded.params().unwrap(),
+            &serde_json::json!({ "method": "custom/ping", "params": { "n": 1 } })
+        );
+    }
+
+    #[tokio::test]
+    async fn handled_notifications_and_reserved_namespaces_pass_through() {
+        for method in [
+            "textDocument/didOpen",
+            "exit",
+            "$/cancelRequest",
+            "$/setTrace",
+            "kakehashi/captures",
+        ] {
+            let router = Router::default();
+            drive(&router, notification(method)).await;
+            assert_eq!(
+                methods(&router),
+                [method],
+                "{method} must reach the router as-is"
+            );
+        }
+        // A `$/` request that the router does not know is NOT forwarded either.
+        let router = Router::default();
+        let response = drive(&router, request("$/unknown", 3)).await.unwrap();
+        assert_eq!(response.error().unwrap().code, ErrorCode::MethodNotFound);
+        assert_eq!(methods(&router), ["$/unknown"]);
+    }
+
+    #[tokio::test]
+    async fn forwarding_methods_called_directly_are_not_rewrapped() {
+        let router = Router::default();
+        let response = drive(&router, request(FORWARD_REQUEST_METHOD, 1))
+            .await
+            .unwrap();
+        assert_eq!(
+            response.result().unwrap()["answered"],
+            FORWARD_REQUEST_METHOD
+        );
+        assert_eq!(methods(&router), [FORWARD_REQUEST_METHOD]);
+    }
+
+    #[tokio::test]
+    async fn non_method_not_found_errors_are_returned_verbatim() {
+        /// Answers every request with `ServerNotInitialized` (-32002).
+        #[derive(Clone)]
+        struct Uninitialized;
+        impl Service<Request> for Uninitialized {
+            type Response = Option<Response>;
+            type Error = std::convert::Infallible;
+            type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+            fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+            fn call(&mut self, req: Request) -> Self::Future {
+                let (_, id, _) = req.into_parts();
+                std::future::ready(Ok(id.map(|id| {
+                    Response::from_error(id, Error::new(ErrorCode::ServerError(-32002)))
+                })))
+            }
+        }
+        let mut svc = CustomMethodForwarder::new(Uninitialized);
+        let response = svc.call(request("custom/echo", 1)).await.unwrap().unwrap();
+        assert_eq!(
+            response.error().unwrap().code,
+            ErrorCode::ServerError(-32002)
+        );
+    }
+}

--- a/src/lsp/custom_method_forward.rs
+++ b/src/lsp/custom_method_forward.rs
@@ -286,6 +286,7 @@ mod tests {
         for method in [
             "textDocument/didOpen",
             "exit",
+            "window/workDoneProgress/cancel",
             "$/cancelRequest",
             "$/setTrace",
             "kakehashi/captures",

--- a/src/lsp/custom_method_forward.rs
+++ b/src/lsp/custom_method_forward.rs
@@ -13,6 +13,12 @@
 //! notifications kakehashi implements are excluded by name
 //! ([`HANDLED_NOTIFICATIONS`]).
 //!
+//! A gate predicate (`Kakehashi::custom_method_gate`) answers "could this
+//! method be forwarded for some document under the current settings?" before
+//! anything is cloned: the forward envelope needs the params, which the
+//! router consumes, so without the gate every standard request would pay a
+//! deep params clone for a forward that never happens.
+//!
 //! The inner service is shared behind a `std::sync::Mutex` because the
 //! forward needs it again after the first answer arrives, inside the response
 //! future, where `&mut self` is gone. The lock is only ever held
@@ -34,14 +40,18 @@ use crate::lsp::lsp_impl::custom_method_forward::{
 };
 
 /// Re-issues unhandled requests and notifications as the forwarding methods.
-pub struct CustomMethodForwarder<S> {
+pub struct CustomMethodForwarder<S, G> {
     inner: Arc<Mutex<S>>,
+    /// "Could this method be forwarded for some document?" — a superset
+    /// filter; per-document eligibility is the handler's job.
+    is_forwardable: G,
 }
 
-impl<S> CustomMethodForwarder<S> {
-    pub fn new(inner: S) -> Self {
+impl<S, G> CustomMethodForwarder<S, G> {
+    pub fn new(inner: S, is_forwardable: G) -> Self {
         Self {
             inner: Arc::new(Mutex::new(inner)),
+            is_forwardable,
         }
     }
 }
@@ -60,11 +70,13 @@ enum Plan {
     ForwardNotification,
 }
 
-fn plan(req: &Request) -> Plan {
+fn plan(req: &Request, is_forwardable: impl Fn(&str) -> bool) -> Plan {
     let method = req.method();
     // `$/` is the protocol's own namespace (cancel, progress, trace) and
-    // `kakehashi/` is ours; neither is anyone's custom method.
-    if method.starts_with("$/") || method.starts_with("kakehashi/") {
+    // `kakehashi/` is ours; neither is anyone's custom method. A method no
+    // configuration names is not one either — and that check is what keeps
+    // the standard methods off the clone-then-probe path.
+    if method.starts_with("$/") || method.starts_with("kakehashi/") || !is_forwardable(method) {
         return Plan::PassThrough;
     }
     if req.id().is_some() {
@@ -97,11 +109,12 @@ fn is_method_not_found(response: &Option<Response>) -> bool {
         .is_some_and(|error| error.code == ErrorCode::MethodNotFound)
 }
 
-impl<S> Service<Request> for CustomMethodForwarder<S>
+impl<S, G> Service<Request> for CustomMethodForwarder<S, G>
 where
     S: Service<Request, Response = Option<Response>> + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Send + 'static,
+    G: Fn(&str) -> bool,
 {
     type Response = S::Response;
     type Error = S::Error;
@@ -112,7 +125,7 @@ where
     }
 
     fn call(&mut self, req: Request) -> Self::Future {
-        match plan(&req) {
+        match plan(&req, &self.is_forwardable) {
             Plan::PassThrough => Box::pin(lock(&self.inner).call(req)),
             Plan::ForwardNotification => {
                 let forwarded = rewrite(&req, FORWARD_NOTIFICATION_METHOD);
@@ -203,8 +216,15 @@ mod tests {
             .finish()
     }
 
+    /// The configured forward methods in these tests: anything under
+    /// `custom/`, plus the handled/reserved names so the exclusion rules —
+    /// not the gate — are what the pass-through assertions exercise.
+    fn configured(method: &str) -> bool {
+        method.starts_with("custom/") || !method.starts_with("known/")
+    }
+
     async fn drive(router: &Router, req: Request) -> Option<Response> {
-        let mut svc = CustomMethodForwarder::new(router.clone());
+        let mut svc = CustomMethodForwarder::new(router.clone(), configured);
         std::future::poll_fn(|cx| svc.poll_ready(cx)).await.unwrap();
         svc.call(req).await.unwrap()
     }
@@ -286,6 +306,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unconfigured_methods_pass_through_without_a_forward() {
+        // The gate says no: the router's MethodNotFound stands and no second
+        // dispatch happens — the standard-method hot path.
+        let router = Router::default();
+        let mut svc = CustomMethodForwarder::new(router.clone(), |_: &str| false);
+        let response = svc.call(request("custom/echo", 1)).await.unwrap().unwrap();
+        assert_eq!(response.error().unwrap().code, ErrorCode::MethodNotFound);
+        assert_eq!(methods(&router), ["custom/echo"]);
+        assert!(
+            svc.call(notification("custom/ping"))
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(methods(&router), ["custom/echo", "custom/ping"]);
+    }
+
+    #[tokio::test]
     async fn forwarding_methods_called_directly_are_not_rewrapped() {
         let router = Router::default();
         let response = drive(&router, request(FORWARD_REQUEST_METHOD, 1))
@@ -317,7 +355,7 @@ mod tests {
                 })))
             }
         }
-        let mut svc = CustomMethodForwarder::new(Uninitialized);
+        let mut svc = CustomMethodForwarder::new(Uninitialized, configured);
         let response = svc.call(request("custom/echo", 1)).await.unwrap().unwrap();
         assert_eq!(
             response.error().unwrap().code,

--- a/src/lsp/custom_method_forward.rs
+++ b/src/lsp/custom_method_forward.rs
@@ -32,6 +32,8 @@ use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
 use tower::Service;
+
+use crate::error::LockResultExt;
 use tower_lsp_server::jsonrpc::{ErrorCode, Request, Response};
 
 use crate::lsp::lsp_impl::HANDLED_NOTIFICATIONS;
@@ -155,10 +157,9 @@ where
 
 fn lock<S>(inner: &Mutex<S>) -> std::sync::MutexGuard<'_, S> {
     // The guard is never held across an await, so a poisoned lock can only
-    // mean a panic inside `poll_ready`/`call` themselves; keep serving.
-    inner
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
+    // mean a panic inside `poll_ready`/`call` themselves; keep serving, but
+    // say so — that panic is exactly the event worth seeing in the log.
+    inner.lock().recover_poison("CustomMethodForwarder::inner")
 }
 
 #[cfg(test)]

--- a/src/lsp/custom_method_forwarder.rs
+++ b/src/lsp/custom_method_forwarder.rs
@@ -5,8 +5,8 @@
 //! notification kakehashi does not implement is issued as
 //! `kakehashi/forward/notification`. Both carry `{ "method", "params" }` and
 //! keep the original `id`, so the handler decides eligibility from
-//! configuration and the client sees either the forwarded answer or the
-//! router's original `MethodNotFound`.
+//! configuration and the client sees either the forwarded answer or a
+//! `MethodNotFound` (the handler's own, wire-equivalent to the router's).
 //!
 //! Built-in methods are never shadowed: requests are dispatched to the router
 //! first and only its own "no handler" answer triggers the forward; the
@@ -142,11 +142,14 @@ where
                     if !is_method_not_found(&response) {
                         return Ok(response);
                     }
-                    // No `poll_ready` here: the probe was admitted through the
-                    // normal `poll_ready`, and the service cannot have gone
-                    // back to initializing since, so calling directly is
-                    // sound — and the inner `poll_ready` registers no waker
-                    // while initializing, so awaiting it here could hang.
+                    // No `poll_ready` here — a deliberate bend of the tower
+                    // contract: the probe was admitted through the normal
+                    // `poll_ready`, and the service cannot have gone back to
+                    // initializing since, so calling directly is sound (after
+                    // `exit` the inner call answers with its exited error,
+                    // which propagates like any other). Awaiting the inner
+                    // `poll_ready` instead could hang: it registers no waker
+                    // while initializing.
                     let forward = lock(&inner).call(forwarded);
                     forward.await
                 })

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -2,6 +2,7 @@ mod apply_edit_translation;
 pub(crate) mod bridge_context;
 mod cli;
 mod coordinator;
+pub(crate) mod custom_method_forward;
 pub(crate) use coordinator::DiagnosticPublisher;
 pub(crate) mod kakehashi;
 mod lifecycle;
@@ -54,6 +55,26 @@ use super::auto_install::{AutoInstallManager, InstallingLanguages};
 use super::cache::CacheCoordinator;
 use super::debounced_diagnostics::DebouncedDiagnosticsManager;
 use super::synthetic_diagnostics::SyntheticDiagnosticsManager;
+
+/// The client notifications `Kakehashi`'s `LanguageServer` impl handles.
+///
+/// custom-method-host-forwarding must never shadow a handler kakehashi has.
+/// Requests learn "no handler" from the router's own `MethodNotFound`
+/// answer; notifications get no answer (the router drops unknown ones
+/// silently), so the implemented ones are named here, next to the impl
+/// below, and the forwarder leaves them alone. Keep this in step with the
+/// `async fn` notifications in `impl LanguageServer for Kakehashi`.
+pub(crate) const HANDLED_NOTIFICATIONS: &[&str] = &[
+    "initialized",
+    "exit",
+    "textDocument/didOpen",
+    "textDocument/didChange",
+    "textDocument/willSave",
+    "textDocument/didSave",
+    "textDocument/didClose",
+    "workspace/didChangeConfiguration",
+    "workspace/didChangeWorkspaceFolders",
+];
 
 pub(super) fn uri_to_url(uri: &Uri) -> std::result::Result<Url, url::ParseError> {
     Url::parse(uri.as_str())

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -68,7 +68,7 @@ use super::synthetic_diagnostics::SyntheticDiagnosticsManager;
 /// `exit` by the `LspService` itself and `window/workDoneProgress/cancel`
 /// by `RequestIdCapture` (ls-bridge-work-done-progress routes it to the
 /// token's owner; a verbatim fan-out would deliver it twice).
-/// `handled_notifications_match_the_router` pins the trait part.
+/// `handled_notifications_match_the_language_server_impl` pins the trait part.
 pub(crate) const HANDLED_NOTIFICATIONS: &[&str] = &[
     "initialized",
     "exit",

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -56,17 +56,23 @@ use super::cache::CacheCoordinator;
 use super::debounced_diagnostics::DebouncedDiagnosticsManager;
 use super::synthetic_diagnostics::SyntheticDiagnosticsManager;
 
-/// The client notifications `Kakehashi`'s `LanguageServer` impl handles.
+/// The client notifications kakehashi handles itself.
 ///
 /// custom-method-host-forwarding must never shadow a handler kakehashi has.
 /// Requests learn "no handler" from the router's own `MethodNotFound`
-/// answer; notifications get no answer (the router drops unknown ones
-/// silently), so the implemented ones are named here, next to the impl
-/// below, and the forwarder leaves them alone. Keep this in step with the
-/// `async fn` notifications in `impl LanguageServer for Kakehashi`.
+/// answer; notifications get no answer (the router runs a logging default
+/// for standard ones it knows and drops the rest), so the handled ones are
+/// named here, next to the impl below, and the forwarder leaves them alone.
+/// Keep this in step with the `async fn` notifications in
+/// `impl LanguageServer for Kakehashi`, plus the two handled outside it:
+/// `exit` by the `LspService` itself and `window/workDoneProgress/cancel`
+/// by `RequestIdCapture` (ls-bridge-work-done-progress routes it to the
+/// token's owner; a verbatim fan-out would deliver it twice).
+/// `handled_notifications_match_the_router` pins the trait part.
 pub(crate) const HANDLED_NOTIFICATIONS: &[&str] = &[
     "initialized",
     "exit",
+    "window/workDoneProgress/cancel",
     "textDocument/didOpen",
     "textDocument/didChange",
     "textDocument/willSave",
@@ -75,6 +81,21 @@ pub(crate) const HANDLED_NOTIFICATIONS: &[&str] = &[
     "workspace/didChangeConfiguration",
     "workspace/didChangeWorkspaceFolders",
 ];
+
+/// Methods a forward must never carry, configured or not
+/// (custom-method-host-forwarding): the connection lifecycle and document
+/// sync that the bridge owns. A forwarded `shutdown` would kill a shared
+/// server; a forwarded `textDocument/didClose` would desync the bridge's
+/// own record of what the server has open. The dispatch layer never
+/// rewrites these (built-ins answer for themselves, handled notifications
+/// are excluded by name), but `kakehashi/forward/*` can be called directly,
+/// so the handler refuses them too.
+pub(crate) fn is_reserved_method(method: &str) -> bool {
+    method.starts_with("$/")
+        || method.starts_with("kakehashi/")
+        || matches!(method, "initialize" | "shutdown")
+        || HANDLED_NOTIFICATIONS.contains(&method)
+}
 
 pub(super) fn uri_to_url(uri: &Uri) -> std::result::Result<Url, url::ParseError> {
     Url::parse(uri.as_str())

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -83,8 +83,8 @@ pub(crate) const HANDLED_NOTIFICATIONS: &[&str] = &[
 ];
 
 /// Methods a forward must never carry, configured or not
-/// (custom-method-host-forwarding): the connection lifecycle and document
-/// sync that the bridge owns. A forwarded `shutdown` would kill a shared
+/// (custom-method-host-forwarding): the connection lifecycle, document
+/// sync, and command routing that the bridge owns. A forwarded `shutdown` would kill a shared
 /// server; a forwarded `textDocument/didClose` would desync the bridge's
 /// own record of what the server has open. The dispatch layer never
 /// rewrites these (built-ins answer for themselves, handled notifications
@@ -93,7 +93,13 @@ pub(crate) const HANDLED_NOTIFICATIONS: &[&str] = &[
 pub(crate) fn is_reserved_method(method: &str) -> bool {
     method.starts_with("$/")
         || method.starts_with("kakehashi/")
-        || matches!(method, "initialize" | "shutdown")
+        // The notebook sync family is the same contract as textDocument/did*
+        // for a document kind the bridge never tracks: a forwarded open
+        // would never be re-synced or closed.
+        || method.starts_with("notebookDocument/")
+        // executeCommand routing decides WHICH server owns a command
+        // (execute-command-routing-token); a blind fan-out would defeat it.
+        || matches!(method, "initialize" | "shutdown" | "workspace/executeCommand")
         || HANDLED_NOTIFICATIONS.contains(&method)
 }
 

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -455,6 +455,13 @@ pub struct Kakehashi {
     /// cancels obsolete work. Entries are removed by a pointer-checked winner
     /// guard, so an old winner cannot erase its successor's marker.
     #[allow(clippy::type_complexity)]
+    /// In-flight forwarded-notification deliveries
+    /// (custom-method-host-forwarding): each may wait through a server's
+    /// initialization, so they run detached from the ingress handler but
+    /// under this bound — past it the handler waits for a slot instead of
+    /// piling up unbounded tasks.
+    forward_delivery_slots: std::sync::Arc<tokio::sync::Semaphore>,
+    #[allow(clippy::type_complexity)]
     captures_walk_inflight: dashmap::DashMap<
         (Url, String, bool),
         std::sync::Arc<kakehashi::captures::CapturesWalkFlight>,
@@ -560,6 +567,9 @@ impl Kakehashi {
             home_dir: dirs::home_dir().map(|p| p.to_string_lossy().into_owned()),
             captures_cache: dashmap::DashMap::new(),
             captures_walk_cache: dashmap::DashMap::new(),
+            forward_delivery_slots: std::sync::Arc::new(tokio::sync::Semaphore::new(
+                custom_method_forward::MAX_IN_FLIGHT_DELIVERIES,
+            )),
             captures_walk_inflight: dashmap::DashMap::new(),
             captures_match_cache: std::sync::Arc::new(
                 kakehashi::captures_match_cache::CapturesMatchCache::new(),

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -458,8 +458,8 @@ pub struct Kakehashi {
     /// In-flight forwarded-notification deliveries
     /// (custom-method-host-forwarding): each may wait through a server's
     /// initialization, so they run detached from the ingress handler but
-    /// under this bound — past it the handler waits for a slot instead of
-    /// piling up unbounded tasks.
+    /// under this bound — past it a notification is dropped (warned), never
+    /// queued: waiting for a slot would stall the ingress handler instead.
     forward_delivery_slots: std::sync::Arc<tokio::sync::Semaphore>,
     #[allow(clippy::type_complexity)]
     captures_walk_inflight: dashmap::DashMap<

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -1100,6 +1100,68 @@ impl LanguageServer for Kakehashi {
 
 #[cfg(test)]
 mod tests {
+    /// Pins [`super::HANDLED_NOTIFICATIONS`] to the notification handlers in
+    /// `impl LanguageServer for Kakehashi`: a handler added without a list
+    /// entry would be silently diverted to the forwarder, and a list entry
+    /// without a handler would shield a method nobody serves. Source-scanned
+    /// because tower-lsp registers a logging default for every standard
+    /// notification, so the router cannot tell "ours" from "default".
+    #[test]
+    fn handled_notifications_match_the_language_server_impl() {
+        const SOURCE: &str = include_str!("lsp_impl.rs");
+        let start = SOURCE
+            .find("impl LanguageServer for Kakehashi {")
+            .expect("the LanguageServer impl lives in this file");
+        let body = &SOURCE[start..];
+        let end = body.find("\n}\n").expect("impl block closes");
+        let body = &body[..end];
+        // A notification handler returns `()`: no `->` between `)` and `{`.
+        let re = regex::Regex::new(r"async fn (\w+)\s*\(([^)]*)\)\s*(->)?").unwrap();
+        let implemented: std::collections::BTreeSet<&str> = re
+            .captures_iter(body)
+            .filter(|caps| caps.get(3).is_none())
+            .map(|caps| caps.get(1).unwrap().as_str())
+            .collect();
+
+        // Handler name → wire method, for the entries the impl owns. `exit`
+        // (LspService) and `window/workDoneProgress/cancel` (RequestIdCapture)
+        // are handled outside the impl and are listed for that reason.
+        let owned_elsewhere = ["exit", "window/workDoneProgress/cancel"];
+        let table = [
+            ("initialized", "initialized"),
+            ("did_open", "textDocument/didOpen"),
+            ("did_change", "textDocument/didChange"),
+            ("will_save", "textDocument/willSave"),
+            ("did_save", "textDocument/didSave"),
+            ("did_close", "textDocument/didClose"),
+            (
+                "did_change_configuration",
+                "workspace/didChangeConfiguration",
+            ),
+            (
+                "did_change_workspace_folders",
+                "workspace/didChangeWorkspaceFolders",
+            ),
+        ];
+        let mapped: std::collections::BTreeSet<&str> = implemented
+            .iter()
+            .map(|name| {
+                table
+                    .iter()
+                    .find(|(handler, _)| handler == name)
+                    .map(|(_, method)| *method)
+                    .unwrap_or_else(|| {
+                        panic!("notification handler `{name}` has no HANDLED_NOTIFICATIONS entry")
+                    })
+            })
+            .collect();
+        let listed: std::collections::BTreeSet<&str> = super::HANDLED_NOTIFICATIONS
+            .iter()
+            .copied()
+            .filter(|method| !owned_elsewhere.contains(method))
+            .collect();
+        assert_eq!(mapped, listed);
+    }
     use super::*;
     use crate::lsp::auto_install::InstallingLanguagesExt;
 

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -347,6 +347,30 @@ pub(crate) fn is_empty_layer_value(value: &serde_json::Value) -> bool {
     false
 }
 
+/// Emptiness for a forwarded method of unknown shape
+/// (custom-method-host-forwarding): `null`, `[]`, and an object that is
+/// nothing but a canonical empty-list envelope — list fields all empty and
+/// no other member (besides `isIncomplete`). Anything else is a result: the
+/// typed heuristics would read `{"items": [], "cursor": "abc"}` as empty and
+/// let a lower-priority server mask a real, metadata-bearing answer.
+pub(crate) fn is_empty_forwarded_value(value: &serde_json::Value) -> bool {
+    const LIST_KEYS: [&str; 3] = ["items", "signatures", "ranges"];
+    match value {
+        serde_json::Value::Null => true,
+        serde_json::Value::Array(items) => items.is_empty(),
+        serde_json::Value::Object(object) => {
+            !object.is_empty()
+                && object.iter().all(|(key, member)| {
+                    (key == "isIncomplete" && member == &serde_json::Value::Bool(false))
+                        || (LIST_KEYS.contains(&key.as_str())
+                            && member.as_array().is_some_and(Vec::is_empty))
+                })
+                && object.keys().any(|key| LIST_KEYS.contains(&key.as_str()))
+        }
+        _ => false,
+    }
+}
+
 fn is_empty_host_layer_value(request_method: &str, value: &serde_json::Value) -> bool {
     if request_method == "textDocument/rename" {
         // This is intentionally stricter than is_empty_layer_value: rename
@@ -1333,7 +1357,15 @@ impl Kakehashi {
                         .map(|raw| raw.map(|raw| raw.value))
                 }
             },
-            |opt| matches!(opt, Some(v) if !is_empty_host_layer_value(request_method, v)),
+            |opt| match (gate, opt) {
+                (_, None) => false,
+                (crate::lsp::bridge::CapabilityGate::Blind, Some(v)) => {
+                    !is_empty_forwarded_value(v)
+                }
+                (crate::lsp::bridge::CapabilityGate::Advertised, Some(v)) => {
+                    !is_empty_host_layer_value(request_method, v)
+                }
+            },
             cancel_rx,
         )
         .await;
@@ -2270,6 +2302,32 @@ mod tests {
                 "newUri": "file:///new.md"
             }]
         })));
+    }
+
+    #[test]
+    fn forwarded_emptiness_keeps_metadata_bearing_objects() {
+        use serde_json::json;
+        for empty in [
+            json!(null),
+            json!([]),
+            json!({ "items": [] }),
+            json!({ "items": [], "isIncomplete": false }),
+            json!({ "signatures": [], "ranges": [] }),
+        ] {
+            assert!(is_empty_forwarded_value(&empty), "{empty}");
+        }
+        for result in [
+            json!({}),
+            json!({ "items": [], "cursor": "abc" }),
+            json!({ "items": [], "isIncomplete": true }),
+            json!({ "items": [1] }),
+            json!({ "total": 0 }),
+            json!("text"),
+            json!(0),
+            json!(false),
+        ] {
+            assert!(!is_empty_forwarded_value(&result), "{result}");
+        }
     }
 
     #[test]

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1345,6 +1345,12 @@ impl Kakehashi {
                                 uri: &t.uri,
                                 language_id: &t.language_id,
                                 text: &t.text,
+                                // A forwarded method is bound to the document
+                                // it was resolved against: never resurrect a
+                                // closed one. The typed methods keep their
+                                // long-standing unbound behavior.
+                                incarnation: (gate == crate::lsp::bridge::CapabilityGate::Blind)
+                                    .then_some(t.incarnation),
                             },
                             &method,
                             params,

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1259,16 +1259,19 @@ impl Kakehashi {
     pub(crate) async fn host_layer_value_with_ctx(
         &self,
         ctx: &HostRequestContext,
-        request_method: &'static str,
+        request_method: &str,
         params: serde_json::Value,
     ) -> tower_lsp_server::jsonrpc::Result<Option<serde_json::Value>> {
         let (cancel_rx, _cancel_guard) = self.subscribe_cancel(ctx.upstream_request_id.as_ref());
         let pool = self.bridge.pool_arc();
+        // Shared across the per-server tasks, which must be `'static`.
+        let method: std::sync::Arc<str> = request_method.into();
         let result = crate::lsp::aggregation::server::dispatch_host_preferred(
             ctx,
             pool.clone(),
             move |t| {
                 let params = params.clone();
+                let method = std::sync::Arc::clone(&method);
                 async move {
                     t.pool
                         .send_host_raw_request(
@@ -1279,7 +1282,7 @@ impl Kakehashi {
                                 language_id: &t.language_id,
                                 text: &t.text,
                             },
-                            request_method,
+                            &method,
                             params,
                             t.upstream_id,
                         )

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -227,6 +227,10 @@ pub(crate) struct HostRequestContext {
     pub(crate) max_fan_out: Option<usize>,
     /// The upstream JSON-RPC request ID for cancel forwarding.
     pub(crate) upstream_request_id: Option<UpstreamId>,
+    /// The document incarnation `text` was read from: a later close-and-reopen
+    /// of the same URI is a different document, which a message resolved
+    /// against this one must not reach (custom-method-host-forwarding).
+    pub(crate) incarnation: u64,
 }
 
 /// Document context plus a cursor position.
@@ -1213,7 +1217,10 @@ impl Kakehashi {
         // request (hover / definition / formatting / will-save / diagnostics) would
         // bail to `None` for the whole reparse window after each edit, even though
         // it forwards the real URI + text verbatim and depends on no tree.
-        let text = self.documents.get(&uri)?.text_arc();
+        let (text, incarnation) = {
+            let document = self.documents.get(&uri)?;
+            (document.text_arc(), document.incarnation())
+        };
         let language_name = self.document_language(&uri)?;
 
         let settings = self.settings_manager.load_settings();
@@ -1250,6 +1257,7 @@ impl Kakehashi {
             strategy: agg.strategy,
             max_fan_out: agg.max_fan_out,
             upstream_request_id: current_upstream_id(),
+            incarnation,
         })
     }
 

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1209,6 +1209,19 @@ impl Kakehashi {
         lsp_uri: &Uri,
         method_name: &str,
     ) -> Option<HostRequestContext> {
+        let settings = self.settings_manager.load_settings();
+        self.resolve_host_bridge_context_in(&settings, lsp_uri, method_name)
+    }
+
+    /// [`Self::resolve_host_bridge_context`] against a settings snapshot the
+    /// caller already holds, so eligibility it decided from that snapshot
+    /// and the routing resolved here cannot straddle a settings reload.
+    pub(crate) fn resolve_host_bridge_context_in(
+        &self,
+        settings: &std::sync::Arc<crate::config::WorkspaceSettings>,
+        lsp_uri: &Uri,
+        method_name: &str,
+    ) -> Option<HostRequestContext> {
         let uri = uri_to_url(lsp_uri).ok()?;
         // Host tier needs only the text, never the parse tree
         // (parse-decoupled-document-lifecycle ADR): read `text_arc()` directly
@@ -1223,7 +1236,6 @@ impl Kakehashi {
         };
         let language_name = self.document_language(&uri)?;
 
-        let settings = self.settings_manager.load_settings();
         let lang_settings = settings.resolve_host_language_settings(&language_name)?;
         if !lang_settings.is_host_bridging_enabled() {
             log::debug!(
@@ -1236,7 +1248,7 @@ impl Kakehashi {
 
         let configs = self
             .bridge
-            .cached_host_configs_for_language(&settings, &language_name);
+            .cached_host_configs_for_language(settings, &language_name);
         if configs.is_empty() {
             log::debug!(
                 "{}: no host-capable server configured for {}",

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1256,11 +1256,31 @@ impl Kakehashi {
     /// Dispatch a host bridge request over a resolved [`HostRequestContext`]:
     /// the upstream `params` are forwarded verbatim (real URI, real
     /// coordinates) and the raw `result` value comes back untranslated.
+    /// Servers that do not advertise the method are skipped.
     pub(crate) async fn host_layer_value_with_ctx(
         &self,
         ctx: &HostRequestContext,
         request_method: &str,
         params: serde_json::Value,
+    ) -> tower_lsp_server::jsonrpc::Result<Option<serde_json::Value>> {
+        self.host_layer_value_gated(
+            ctx,
+            request_method,
+            params,
+            crate::lsp::bridge::CapabilityGate::Advertised,
+        )
+        .await
+    }
+
+    /// [`Self::host_layer_value_with_ctx`] with the capability gate chosen
+    /// by the caller: the forwarded methods
+    /// (custom-method-host-forwarding) ask every selected server blind.
+    pub(crate) async fn host_layer_value_gated(
+        &self,
+        ctx: &HostRequestContext,
+        request_method: &str,
+        params: serde_json::Value,
+        gate: crate::lsp::bridge::CapabilityGate,
     ) -> tower_lsp_server::jsonrpc::Result<Option<serde_json::Value>> {
         let (cancel_rx, _cancel_guard) = self.subscribe_cancel(ctx.upstream_request_id.as_ref());
         let pool = self.bridge.pool_arc();
@@ -1285,6 +1305,7 @@ impl Kakehashi {
                             &method,
                             params,
                             t.upstream_id,
+                            gate,
                         )
                         .await
                         // This generic raw walk relays the value verbatim; only

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -418,6 +418,7 @@ impl DiagnosticSnapshotPreparer {
                 strategy: agg.strategy,
                 max_fan_out: agg.max_fan_out,
                 upstream_request_id: None,
+                incarnation: snapshot.incarnation(),
             })
         });
 

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -319,6 +319,7 @@ impl Kakehashi {
                 uri: &ctx.uri,
                 language_id: &ctx.language_id,
                 text: &ctx.text,
+                incarnation: Some(incarnation),
             };
             let deliveries = servers.iter().map(|server| {
                 let pool = std::sync::Arc::clone(&pool);
@@ -333,7 +334,6 @@ impl Kakehashi {
                             &server.config,
                             doc,
                             Some(live_text_reader),
-                            incarnation,
                             method,
                             payload,
                         )

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -290,24 +290,42 @@ impl Kakehashi {
             language_id: &ctx.language_id,
             text: &ctx.text,
         };
-        for server in select_host_servers(&ctx) {
-            if let Err(error) = pool
-                .send_host_custom_notification(
-                    &server.server_name,
-                    &server.config,
-                    &doc,
-                    &params.method,
-                    params.params.clone(),
-                )
-                .await
-            {
-                log::warn!(
-                    "{:?}: notification not delivered to {}: {error}",
-                    params.method,
-                    server.server_name
-                );
+        // Current text at sync time, not the snapshot taken before the
+        // per-server initialization wait (same lock-order reasoning as the
+        // reader in `debounced_diagnostics`: read and dropped inside the
+        // closure, never held across an await).
+        let documents = std::sync::Arc::clone(&self.documents);
+        let reader_uri = ctx.uri.clone();
+        let live_text_reader: crate::lsp::bridge::HostTextReader =
+            std::sync::Arc::new(move || documents.get(&reader_uri).map(|doc| doc.text_arc()));
+        // Every selected server independently: one server's initialization
+        // wait must not hold back delivery to the others.
+        let deliveries = select_host_servers(&ctx).into_iter().map(|server| {
+            let pool = std::sync::Arc::clone(&pool);
+            let doc = &doc;
+            let method = &params.method;
+            let payload = params.params.clone();
+            let live_text_reader = &live_text_reader;
+            async move {
+                if let Err(error) = pool
+                    .send_host_custom_notification(
+                        &server.server_name,
+                        &server.config,
+                        doc,
+                        Some(live_text_reader),
+                        method,
+                        payload,
+                    )
+                    .await
+                {
+                    log::warn!(
+                        "{method:?}: notification not delivered to {}: {error}",
+                        server.server_name
+                    );
+                }
             }
-        }
+        });
+        futures::future::join_all(deliveries).await;
     }
 }
 

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -275,6 +275,12 @@ impl Kakehashi {
         let live_text_reader: crate::lsp::bridge::HostTextReader =
             std::sync::Arc::new(move || documents.get(&reader_uri).map(|doc| doc.text_arc()));
         let servers = select_host_servers(&ctx);
+        if servers.is_empty() {
+            // The kill switch (`priorities = []`, `maxFanOut = 0`): nothing
+            // to deliver, so no permit and no task — a burst of these must
+            // not crowd out notifications that do have servers.
+            return;
+        }
         let ForwardParams { method, params } = params;
         // Detached: a delivery may wait through a server's initialization,
         // and a notification handler that waited with it would hold one of

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -260,11 +260,6 @@ impl Kakehashi {
             }
         };
         let pool = self.bridge.pool_arc();
-        let doc = HostDocument {
-            uri: &ctx.uri,
-            language_id: &ctx.language_id,
-            text: &ctx.text,
-        };
         // Current text at sync time, not the snapshot taken before the
         // per-server initialization wait (same lock-order reasoning as the
         // reader in `debounced_diagnostics`: read and dropped inside the
@@ -273,34 +268,48 @@ impl Kakehashi {
         let reader_uri = ctx.uri.clone();
         let live_text_reader: crate::lsp::bridge::HostTextReader =
             std::sync::Arc::new(move || documents.get(&reader_uri).map(|doc| doc.text_arc()));
-        // Every selected server independently: one server's initialization
-        // wait must not hold back delivery to the others.
-        let deliveries = select_host_servers(&ctx).into_iter().map(|server| {
-            let pool = std::sync::Arc::clone(&pool);
-            let doc = &doc;
-            let method = &params.method;
-            let payload = params.params.clone();
-            let live_text_reader = &live_text_reader;
-            async move {
-                if let Err(error) = pool
-                    .send_host_custom_notification(
-                        &server.server_name,
-                        &server.config,
-                        doc,
-                        Some(live_text_reader),
-                        method,
-                        payload,
-                    )
-                    .await
-                {
-                    log::warn!(
-                        "{method:?}: notification not delivered to {}: {error}",
-                        server.server_name
-                    );
+        let servers = select_host_servers(&ctx);
+        let ForwardParams { method, params } = params;
+        // Detached: a delivery may wait through a server's initialization,
+        // and a notification handler that waited with it would hold one of
+        // the bounded ingress slots for that long — a burst against a slow
+        // server could then stall didChange/didClose for everyone. The
+        // handler returns once the work is handed off; each delivery logs
+        // its own failure. Every selected server runs independently, so one
+        // server's wait never holds back delivery to the others.
+        tokio::spawn(async move {
+            let doc = HostDocument {
+                uri: &ctx.uri,
+                language_id: &ctx.language_id,
+                text: &ctx.text,
+            };
+            let deliveries = servers.iter().map(|server| {
+                let pool = std::sync::Arc::clone(&pool);
+                let doc = &doc;
+                let method = &method;
+                let payload = params.clone();
+                let live_text_reader = &live_text_reader;
+                async move {
+                    if let Err(error) = pool
+                        .send_host_custom_notification(
+                            &server.server_name,
+                            &server.config,
+                            doc,
+                            Some(live_text_reader),
+                            method,
+                            payload,
+                        )
+                        .await
+                    {
+                        log::warn!(
+                            "{method:?}: notification not delivered to {}: {error}",
+                            server.server_name
+                        );
+                    }
                 }
-            }
+            });
+            futures::future::join_all(deliveries).await;
         });
-        futures::future::join_all(deliveries).await;
     }
 }
 

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -136,7 +136,7 @@ fn text_document_uri(params: &Value) -> std::result::Result<(Uri, Url), Rejectio
 /// Per-settings-generation cache behind [`Kakehashi::custom_method_gate`].
 struct ForwardableMethods {
     generation: u64,
-    methods: std::sync::Arc<std::collections::HashSet<String>>,
+    methods: std::collections::HashSet<String>,
 }
 
 impl Kakehashi {
@@ -150,23 +150,24 @@ impl Kakehashi {
         let settings_manager = std::sync::Arc::clone(&self.settings_manager);
         let cache = std::sync::Arc::new(std::sync::Mutex::new(None::<ForwardableMethods>));
         move |method: &str| {
-            let snapshot = settings_manager.load_settings_pair();
+            // Generation first (one atomic load, no Arc clone); the full
+            // snapshot is loaded only on a miss. A store between the two
+            // loads just recomputes once more on the next message.
+            let generation = settings_manager.settings_generation();
             let mut cache = cache.lock().recover_poison("custom_method_gate cache");
-            let current = match cache.as_ref() {
-                Some(cached) if cached.generation == snapshot.generation => {
-                    std::sync::Arc::clone(&cached.methods)
-                }
+            // The lookup itself runs under the guard: a set probe is cheaper
+            // than the Arc round trip that releasing first would cost.
+            match cache.as_ref() {
+                Some(cached) if cached.generation == generation => cached.methods.contains(method),
                 _ => {
-                    let methods = std::sync::Arc::new(snapshot.settings.host_forwardable_methods());
-                    *cache = Some(ForwardableMethods {
+                    let snapshot = settings_manager.load_settings_pair();
+                    let fresh = cache.insert(ForwardableMethods {
                         generation: snapshot.generation,
-                        methods: std::sync::Arc::clone(&methods),
+                        methods: snapshot.settings.host_forwardable_methods(),
                     });
-                    methods
+                    fresh.methods.contains(method)
                 }
-            };
-            drop(cache);
-            current.contains(method)
+            }
         }
     }
 

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -20,6 +20,7 @@ use super::bridge_context::{HostRequestContext, UpstreamRegistrySweepGuard, is_e
 use super::uri_to_url;
 use super::{Kakehashi, is_reserved_method};
 use crate::config::settings::AggregationStrategy;
+use crate::error::LockResultExt;
 use crate::lsp::aggregation::server::{dispatch_host_preferred, select_host_servers};
 use crate::lsp::bridge::HostDocument;
 
@@ -150,9 +151,7 @@ impl Kakehashi {
         let cache = std::sync::Arc::new(std::sync::Mutex::new(None::<ForwardableMethods>));
         move |method: &str| {
             let snapshot = settings_manager.load_settings_pair();
-            let mut cache = cache
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let mut cache = cache.lock().recover_poison("custom_method_gate cache");
             let current = match cache.as_ref() {
                 Some(cached) if cached.generation == snapshot.generation => {
                     std::sync::Arc::clone(&cached.methods)

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -82,7 +82,45 @@ fn text_document_uri(params: &Value) -> Option<Uri> {
         .and_then(|raw| raw.parse::<Uri>().ok())
 }
 
+/// Per-settings-generation cache behind [`Kakehashi::custom_method_gate`].
+struct ForwardableMethods {
+    generation: u64,
+    methods: std::sync::Arc<std::collections::HashSet<String>>,
+}
+
 impl Kakehashi {
+    /// A predicate for the dispatch layer: could `method` be forwarded for
+    /// SOME document under the current settings? The forwarder consults it
+    /// before cloning a request's params, so the standard methods — the hot
+    /// path — never pay for a forward that cannot happen. Recomputed only
+    /// when the settings generation moves; otherwise one atomic load, one
+    /// lock, one hash lookup.
+    pub fn custom_method_gate(&self) -> impl Fn(&str) -> bool + Send + Sync + Clone + 'static {
+        let settings_manager = std::sync::Arc::clone(&self.settings_manager);
+        let cache = std::sync::Arc::new(std::sync::Mutex::new(None::<ForwardableMethods>));
+        move |method: &str| {
+            let snapshot = settings_manager.load_settings_pair();
+            let mut cache = cache
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let current = match cache.as_ref() {
+                Some(cached) if cached.generation == snapshot.generation => {
+                    std::sync::Arc::clone(&cached.methods)
+                }
+                _ => {
+                    let methods = std::sync::Arc::new(snapshot.settings.host_forwardable_methods());
+                    *cache = Some(ForwardableMethods {
+                        generation: snapshot.generation,
+                        methods: std::sync::Arc::clone(&methods),
+                    });
+                    methods
+                }
+            };
+            drop(cache);
+            current.contains(method)
+        }
+    }
+
     /// Resolve the host servers a forwarded message goes to, or why it
     /// does not go anywhere.
     fn resolve_forward_target(

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -142,25 +142,28 @@ impl Kakehashi {
         let language = self
             .document_language(&url)
             .ok_or(Rejection::NotForwardable("document is not open"))?;
-        let explicit = self
-            .settings_manager
-            .load_settings()
+        let settings = self.settings_manager.load_settings();
+        let Some(lang_settings) = settings
             .resolve_host_language_settings(&language)
-            .is_some_and(|settings| settings.has_explicit_host_aggregation(&params.method));
-        if !explicit {
+            .filter(|settings| settings.has_explicit_host_aggregation(&params.method))
+        else {
             return Err(Rejection::NotForwardable(
                 "no literal bridge._self.aggregation entry for the method",
             ));
+        };
+        // Only the entry's OWN strategy counts: an inherited `concatenated`
+        // from the `_` method wildcard is ignored here exactly as the typed
+        // verbatim host paths ignore it.
+        if let Some(strategy) = lang_settings
+            .explicit_host_aggregation_strategy(&params.method)
+            .filter(|strategy| *strategy != AggregationStrategy::Preferred)
+        {
+            return Err(Rejection::UnsupportedStrategy(strategy));
         }
-        let ctx = self
-            .resolve_host_bridge_context(&lsp_uri, &params.method)
+        self.resolve_host_bridge_context(&lsp_uri, &params.method)
             .ok_or(Rejection::NotForwardable(
-                "host bridging is not opted in for the document's language, or no server handles it",
-            ))?;
-        if ctx.strategy != AggregationStrategy::Preferred {
-            return Err(Rejection::UnsupportedStrategy(ctx.strategy));
-        }
-        Ok(ctx)
+                "host bridge context unavailable (see the preceding debug line)",
+            ))
     }
 
     /// `kakehashi/forward/request`: forward a request kakehashi does not

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -15,9 +15,9 @@ use serde_json::Value;
 use tower_lsp_server::jsonrpc::{Error, Result};
 use tower_lsp_server::ls_types::Uri;
 
-use super::Kakehashi;
 use super::bridge_context::{HostRequestContext, UpstreamRegistrySweepGuard, is_empty_layer_value};
 use super::uri_to_url;
+use super::{Kakehashi, is_reserved_method};
 use crate::config::settings::AggregationStrategy;
 use crate::lsp::aggregation::server::{dispatch_host_preferred, select_host_servers};
 use crate::lsp::bridge::HostDocument;
@@ -52,6 +52,9 @@ enum Rejection {
     /// A strategy other than `preferred`: results of unknown shape cannot
     /// be merged, so the entry is a configuration error.
     UnsupportedStrategy(AggregationStrategy),
+    /// Lifecycle or sync method the bridge owns ([`is_reserved_method`]);
+    /// refused even when configured.
+    Reserved,
 }
 
 impl Rejection {
@@ -69,6 +72,10 @@ impl Rejection {
             Self::UnsupportedStrategy(strategy) => Error::invalid_params(format!(
                 "{method}: bridge._self.aggregation strategy {strategy:?} is not supported for \
                  forwarded methods; only `preferred` can combine results of unknown shape"
+            )),
+            Self::Reserved => Error::invalid_params(format!(
+                "{method}: lifecycle and document-sync methods are owned by the bridge and \
+                 are never forwarded"
             )),
         }
     }
@@ -127,6 +134,9 @@ impl Kakehashi {
         &self,
         params: &ForwardParams,
     ) -> std::result::Result<HostRequestContext, Rejection> {
+        if is_reserved_method(&params.method) {
+            return Err(Rejection::Reserved);
+        }
         let lsp_uri = text_document_uri(&params.params).ok_or(Rejection::NoTextDocument)?;
         let url = uri_to_url(&lsp_uri).map_err(|_| Rejection::NoTextDocument)?;
         let language = self
@@ -274,6 +284,23 @@ mod tests {
     }
 
     #[test]
+    fn reserved_methods_cover_lifecycle_sync_and_namespaces() {
+        for method in [
+            "initialize",
+            "shutdown",
+            "exit",
+            "textDocument/didClose",
+            "window/workDoneProgress/cancel",
+            "$/cancelRequest",
+            "kakehashi/forward/request",
+        ] {
+            assert!(is_reserved_method(method), "{method} must be reserved");
+        }
+        assert!(!is_reserved_method("textDocument/inlineCompletion"));
+        assert!(!is_reserved_method("custom/ping"));
+    }
+
+    #[test]
     fn rejections_map_to_the_contracted_error_codes() {
         use tower_lsp_server::jsonrpc::ErrorCode;
         assert_eq!(
@@ -287,6 +314,10 @@ mod tests {
             Rejection::UnsupportedStrategy(AggregationStrategy::Concatenated)
                 .into_error("custom/x")
                 .code,
+            ErrorCode::InvalidParams
+        );
+        assert_eq!(
+            Rejection::Reserved.into_error("shutdown").code,
             ErrorCode::InvalidParams
         );
     }

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -192,32 +192,34 @@ impl Kakehashi {
         if is_reserved_method(&params.method) {
             return Err(Rejection::Reserved);
         }
-        let (lsp_uri, url) = text_document_uri(&params.params)?;
-        let language = self
-            .document_language(&url)
-            .ok_or(Rejection::NotForwardable("document is not open"))?;
+        let (lsp_uri, _url) = text_document_uri(&params.params)?;
+        // One settings snapshot for both the eligibility decision and the
+        // routing, and the language taken from the resolved context itself:
+        // a settings reload or a close-and-reopen between two reads could
+        // otherwise authorize under one configuration and route under another.
         let settings = self.settings_manager.load_settings();
-        let Some(lang_settings) = settings
-            .resolve_host_language_settings(&language)
-            .filter(|settings| settings.has_explicit_host_aggregation(&params.method))
-        else {
-            return Err(Rejection::NotForwardable(
+        let ctx = self
+            .resolve_host_bridge_context_in(&settings, &lsp_uri, &params.method)
+            .ok_or(Rejection::NotForwardable(
+                "document not open, host bridging not opted in for its language, or no \
+                 host-capable server (see the preceding debug line)",
+            ))?;
+        let entry = settings
+            .resolve_host_language_settings(&ctx.language_id)
+            .and_then(|lang| lang.explicit_host_aggregation_entry(&params.method))
+            .ok_or(Rejection::NotForwardable(
                 "no literal bridge._self.aggregation entry for the method",
-            ));
-        };
+            ))?;
         // Only the entry's OWN strategy counts: an inherited `concatenated`
         // from the `_` method wildcard is ignored here exactly as the typed
         // verbatim host paths ignore it.
-        if let Some(strategy) = lang_settings
-            .explicit_host_aggregation_strategy(&params.method)
+        if let Some(strategy) = entry
+            .strategy
             .filter(|strategy| *strategy != AggregationStrategy::Preferred)
         {
             return Err(Rejection::UnsupportedStrategy(strategy));
         }
-        self.resolve_host_bridge_context(&lsp_uri, &params.method)
-            .ok_or(Rejection::NotForwardable(
-                "host bridge context unavailable (see the preceding debug line)",
-            ))
+        Ok(ctx)
     }
 
     /// `kakehashi/forward/request`: forward a request kakehashi does not

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -339,10 +339,21 @@ impl Kakehashi {
                         )
                         .await
                     {
-                        log::warn!(
-                            "{method:?}: notification not delivered to {}: {error}",
-                            server.server_name
-                        );
+                        // NotConnected is the expected race — the document
+                        // closed (or its routing was switched off) while the
+                        // delivery waited — not a broken server; keep it out
+                        // of the warning stream.
+                        if error.kind() == std::io::ErrorKind::NotConnected {
+                            log::debug!(
+                                "{method:?}: notification not delivered to {}: {error}",
+                                server.server_name
+                            );
+                        } else {
+                            log::warn!(
+                                "{method:?}: notification not delivered to {}: {error}",
+                                server.server_name
+                            );
+                        }
                     }
                 }
             });

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -125,11 +125,17 @@ fn text_document_uri(params: &Value) -> std::result::Result<(Uri, Url), Rejectio
         .pointer("/textDocument/uri")
         .and_then(Value::as_str)
         .ok_or(Rejection::NoTextDocument)?;
-    let lsp_uri = raw
-        .parse::<Uri>()
-        .map_err(|_| Rejection::InvalidTextDocumentUri(raw.to_owned()))?;
-    let url =
-        uri_to_url(&lsp_uri).map_err(|_| Rejection::InvalidTextDocumentUri(raw.to_owned()))?;
+    // Echoed back in the error message: bound it, the sender has the value.
+    let quoted = || {
+        const ECHO_LIMIT: usize = 128;
+        let mut shown: String = raw.chars().take(ECHO_LIMIT).collect();
+        if raw.chars().nth(ECHO_LIMIT).is_some() {
+            shown.push('…');
+        }
+        Rejection::InvalidTextDocumentUri(shown)
+    };
+    let lsp_uri = raw.parse::<Uri>().map_err(|_| quoted())?;
+    let url = uri_to_url(&lsp_uri).map_err(|_| quoted())?;
     Ok((lsp_uri, url))
 }
 
@@ -337,6 +343,16 @@ mod tests {
         assert_eq!(
             text_document_uri(&params).unwrap_err(),
             Rejection::InvalidTextDocumentUri("not a uri".to_owned())
+        );
+        let huge = format!("not a uri {}", "x".repeat(10_000));
+        let params = serde_json::json!({ "textDocument": { "uri": huge } });
+        let Rejection::InvalidTextDocumentUri(shown) = text_document_uri(&params).unwrap_err()
+        else {
+            panic!("malformed");
+        };
+        assert!(
+            shown.chars().count() <= 129 && shown.ends_with('…'),
+            "{shown}"
         );
         assert_eq!(
             Rejection::InvalidTextDocumentUri("x".into())

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -16,13 +16,13 @@ use tower_lsp_server::jsonrpc::{Error, ErrorCode, Result};
 use tower_lsp_server::ls_types::Uri;
 use url::Url;
 
-use super::bridge_context::{HostRequestContext, UpstreamRegistrySweepGuard, is_empty_layer_value};
+use super::bridge_context::{HostRequestContext, UpstreamRegistrySweepGuard};
 use super::uri_to_url;
 use super::{Kakehashi, is_reserved_method};
 use crate::config::settings::AggregationStrategy;
 use crate::error::LockResultExt;
-use crate::lsp::aggregation::server::{dispatch_host_preferred, select_host_servers};
-use crate::lsp::bridge::HostDocument;
+use crate::lsp::aggregation::server::select_host_servers;
+use crate::lsp::bridge::{CapabilityGate, HostDocument};
 
 /// Wire name of the request-forwarding method.
 pub const FORWARD_REQUEST_METHOD: &str = "kakehashi/forward/request";
@@ -225,39 +225,8 @@ impl Kakehashi {
             self.bridge.pool_arc(),
             ctx.upstream_request_id.clone(),
         );
-        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(ctx.upstream_request_id.as_ref());
-        let pool = self.bridge.pool_arc();
-        let method: std::sync::Arc<str> = params.method.as_str().into();
-        let raw_params = params.params;
-        let result = dispatch_host_preferred(
-            &ctx,
-            pool.clone(),
-            move |t| {
-                let params = raw_params.clone();
-                let method = std::sync::Arc::clone(&method);
-                async move {
-                    t.pool
-                        .send_host_custom_request(
-                            &t.server_name,
-                            &t.server_config,
-                            &HostDocument {
-                                uri: &t.uri,
-                                language_id: &t.language_id,
-                                text: &t.text,
-                            },
-                            &method,
-                            params,
-                            t.upstream_id,
-                        )
-                        .await
-                }
-            },
-            |opt| matches!(opt, Some(v) if !is_empty_layer_value(v)),
-            cancel_rx,
-        )
-        .await;
         let value = self
-            .host_layer_result(result, &params.method, |value| value)
+            .host_layer_value_gated(&ctx, &params.method, params.params, CapabilityGate::Blind)
             .await?;
         Ok(value.unwrap_or(Value::Null))
     }

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -283,15 +283,18 @@ impl Kakehashi {
         // handler returns once the work is handed off; each delivery logs
         // its own failure. Every selected server runs independently, so one
         // server's wait never holds back delivery to the others. Deliveries
-        // are bounded by `MAX_IN_FLIGHT_DELIVERIES`; past that the handler
-        // waits for a slot — backpressure rather than unbounded tasks.
+        // are bounded by `MAX_IN_FLIGHT_DELIVERIES`; past that the
+        // notification is dropped with a warning. Awaiting a slot here would
+        // move the stall back into the ingress handler (every slot held by a
+        // handler waiting on a delivery), so overflow must not block.
         // Ordering across notifications is not preserved: handlers already
         // run concurrently, so none was promised (ADR: Ordering).
-        let Ok(permit) = std::sync::Arc::clone(&self.forward_delivery_slots)
-            .acquire_owned()
-            .await
+        let Ok(permit) = std::sync::Arc::clone(&self.forward_delivery_slots).try_acquire_owned()
         else {
-            // Only a closed semaphore fails, and this one is never closed.
+            log::warn!(
+                "{method:?}: notification dropped: {MAX_IN_FLIGHT_DELIVERIES} forwarded \
+                 notifications are already waiting on their servers"
+            );
             return;
         };
         tokio::spawn(async move {

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -270,13 +270,18 @@ impl Kakehashi {
         // per-server initialization wait (same lock-order reasoning as the
         // reader in `debounced_diagnostics`: read and dropped inside the
         // closure, never held across an await).
+        // Bound to the incarnation the context was read from: a
+        // close-and-reopen of the same URI while a delivery waits is a
+        // different document and reads as "gone".
         let documents = std::sync::Arc::clone(&self.documents);
         let reader_uri = ctx.uri.clone();
-        let live_text_reader: crate::lsp::bridge::HostTextReader =
-            std::sync::Arc::new(move || documents.get(&reader_uri).map(|doc| doc.text_arc()));
-        // The document this message was resolved against; a close-and-reopen
-        // of the same URI while a delivery waits must not receive it.
-        let incarnation = pool.current_host_incarnation(&ctx.uri);
+        let incarnation = ctx.incarnation;
+        let live_text_reader: crate::lsp::bridge::HostTextReader = std::sync::Arc::new(move || {
+            documents
+                .get(&reader_uri)
+                .filter(|doc| doc.incarnation() == incarnation)
+                .map(|doc| doc.text_arc())
+        });
         let servers = select_host_servers(&ctx);
         if servers.is_empty() {
             // The kill switch (`priorities = []`, `maxFanOut = 0`): nothing

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tower_lsp_server::jsonrpc::{Error, ErrorCode, Result};
 use tower_lsp_server::ls_types::Uri;
+use url::Url;
 
 use super::bridge_context::{HostRequestContext, UpstreamRegistrySweepGuard, is_empty_layer_value};
 use super::uri_to_url;
@@ -44,6 +45,9 @@ enum Rejection {
     /// pick servers for. `InvalidParams` — the method IS forwardable, the
     /// call is malformed for it.
     NoTextDocument,
+    /// `textDocument.uri` is present but not an absolute URI kakehashi can
+    /// key a document by. `InvalidParams`, with the offending value.
+    InvalidTextDocumentUri(String),
     /// Not opted in: unknown document, host bridging off for its language,
     /// no literal aggregation entry, or no host-capable server. For a
     /// request this keeps the router's `MethodNotFound` — from the client's
@@ -72,35 +76,60 @@ fn request_failed(message: String) -> Error {
 }
 
 impl Rejection {
+    /// Human-readable reason, without the method (callers prefix it).
+    fn describe(&self) -> String {
+        match self {
+            Self::NoTextDocument => {
+                "forwarding needs params.textDocument.uri to pick a host document".to_owned()
+            }
+            Self::InvalidTextDocumentUri(raw) => {
+                format!("params.textDocument.uri {raw:?} is not an absolute URI")
+            }
+            Self::NotForwardable(reason) => (*reason).to_owned(),
+            Self::UnsupportedStrategy(strategy) => format!(
+                "bridge._self.aggregation strategy {strategy:?} is not supported for forwarded \
+                 methods; only `preferred` can combine results of unknown shape"
+            ),
+            Self::Reserved => {
+                "lifecycle and document-sync methods are owned by the bridge and are never \
+                 forwarded"
+                    .to_owned()
+            }
+        }
+    }
+
+    /// The JSON-RPC error a request gets. Pure: logging is the caller's.
     fn into_error(self, method: &str) -> Error {
         match self {
-            Self::NoTextDocument => Error::invalid_params(format!(
-                "{method}: forwarding needs params.textDocument.uri to pick a host document"
-            )),
-            Self::NotForwardable(reason) => {
-                log::debug!("{method}: not forwarded: {reason}");
+            Self::NoTextDocument | Self::InvalidTextDocumentUri(_) => {
+                Error::invalid_params(format!("{method}: {}", self.describe()))
+            }
+            Self::NotForwardable(_) => {
                 let mut error = Error::method_not_found();
                 error.data = Some(Value::String(method.to_owned()));
                 error
             }
-            Self::UnsupportedStrategy(strategy) => request_failed(format!(
-                "{method}: bridge._self.aggregation strategy {strategy:?} is not supported for \
-                 forwarded methods; only `preferred` can combine results of unknown shape"
-            )),
-            Self::Reserved => request_failed(format!(
-                "{method}: lifecycle and document-sync methods are owned by the bridge and \
-                 are never forwarded"
-            )),
+            Self::UnsupportedStrategy(_) | Self::Reserved => {
+                request_failed(format!("{method}: {}", self.describe()))
+            }
         }
     }
 }
 
-/// `params.textDocument.uri`, the one field the forward reads.
-fn text_document_uri(params: &Value) -> Option<Uri> {
-    params
+/// `params.textDocument.uri`, the one field the forward reads, as both the
+/// wire `Uri` (forwarded verbatim) and the `Url` the document store is keyed
+/// by. Absent and malformed are told apart so the client learns which.
+fn text_document_uri(params: &Value) -> std::result::Result<(Uri, Url), Rejection> {
+    let raw = params
         .pointer("/textDocument/uri")
         .and_then(Value::as_str)
-        .and_then(|raw| raw.parse::<Uri>().ok())
+        .ok_or(Rejection::NoTextDocument)?;
+    let lsp_uri = raw
+        .parse::<Uri>()
+        .map_err(|_| Rejection::InvalidTextDocumentUri(raw.to_owned()))?;
+    let url =
+        uri_to_url(&lsp_uri).map_err(|_| Rejection::InvalidTextDocumentUri(raw.to_owned()))?;
+    Ok((lsp_uri, url))
 }
 
 /// Per-settings-generation cache behind [`Kakehashi::custom_method_gate`].
@@ -151,8 +180,7 @@ impl Kakehashi {
         if is_reserved_method(&params.method) {
             return Err(Rejection::Reserved);
         }
-        let lsp_uri = text_document_uri(&params.params).ok_or(Rejection::NoTextDocument)?;
-        let url = uri_to_url(&lsp_uri).map_err(|_| Rejection::NoTextDocument)?;
+        let (lsp_uri, url) = text_document_uri(&params.params)?;
         let language = self
             .document_language(&url)
             .ok_or(Rejection::NotForwardable("document is not open"))?;
@@ -184,9 +212,12 @@ impl Kakehashi {
     /// implement to the host servers and answer with the first non-empty
     /// downstream result (`preferred`), or `null`.
     pub async fn forward_custom_request(&self, params: ForwardParams) -> Result<Value> {
-        let ctx = self
-            .resolve_forward_target(&params)
-            .map_err(|rejection| rejection.into_error(&params.method))?;
+        let ctx = self.resolve_forward_target(&params).map_err(|rejection| {
+            if let Rejection::NotForwardable(reason) = &rejection {
+                log::debug!("{:?}: not forwarded: {reason}", params.method);
+            }
+            rejection.into_error(&params.method)
+        })?;
 
         // Standalone host dispatch (no layer race): the RAII sweep clears
         // the upstream-registry entries an aborted per-server task may not
@@ -236,17 +267,19 @@ impl Kakehashi {
     /// does not implement to **every** selected host server, in priority
     /// order. Nothing comes back; failures are logged per server.
     pub async fn forward_custom_notification(&self, params: ForwardParams) {
+        // `{:?}` on the method: it is a client-controlled string going to a
+        // line-oriented log.
         let ctx = match self.resolve_forward_target(&params) {
             Ok(ctx) => ctx,
             Err(Rejection::NotForwardable(reason)) => {
-                log::debug!("{}: notification not forwarded: {reason}", params.method);
+                log::debug!("{:?}: notification not forwarded: {reason}", params.method);
                 return;
             }
             Err(rejection) => {
                 log::warn!(
-                    "{}: notification dropped: {}",
+                    "{:?}: notification dropped: {}",
                     params.method,
-                    rejection.into_error(&params.method).message
+                    rejection.describe()
                 );
                 return;
             }
@@ -269,7 +302,7 @@ impl Kakehashi {
                 .await
             {
                 log::warn!(
-                    "{}: notification not delivered to {}: {error}",
+                    "{:?}: notification not delivered to {}: {error}",
                     params.method,
                     server.server_name
                 );
@@ -294,10 +327,36 @@ mod tests {
     fn text_document_uri_reads_only_the_standard_location() {
         assert!(
             text_document_uri(&serde_json::json!({ "textDocument": { "uri": "file:///a.md" } }))
-                .is_some()
+                .is_ok()
         );
-        assert!(text_document_uri(&serde_json::json!({ "uri": "file:///a.md" })).is_none());
-        assert!(text_document_uri(&Value::Null).is_none());
+        for params in [
+            serde_json::json!({ "uri": "file:///a.md" }),
+            Value::Null,
+            serde_json::json!(5),
+            serde_json::json!([]),
+            serde_json::json!({ "textDocument": { "uri": 7 } }),
+        ] {
+            assert_eq!(
+                text_document_uri(&params).unwrap_err(),
+                Rejection::NoTextDocument,
+                "{params}"
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_text_document_uri_is_reported_as_such() {
+        let params = serde_json::json!({ "textDocument": { "uri": "not a uri" } });
+        assert_eq!(
+            text_document_uri(&params).unwrap_err(),
+            Rejection::InvalidTextDocumentUri("not a uri".to_owned())
+        );
+        assert_eq!(
+            Rejection::InvalidTextDocumentUri("x".into())
+                .into_error("custom/x")
+                .code,
+            ErrorCode::InvalidParams
+        );
     }
 
     #[test]

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -354,6 +354,8 @@ mod tests {
             "exit",
             "textDocument/didClose",
             "window/workDoneProgress/cancel",
+            "notebookDocument/didOpen",
+            "workspace/executeCommand",
             "$/cancelRequest",
             "kakehashi/forward/request",
         ] {

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -26,6 +26,12 @@ use crate::lsp::bridge::{CapabilityGate, HostDocument};
 
 /// Wire name of the request-forwarding method.
 pub const FORWARD_REQUEST_METHOD: &str = "kakehashi/forward/request";
+/// Bound on forwarded-notification deliveries in flight at once — one
+/// delivery per notification, each fanning out to its servers. Matches the
+/// ingress concurrency cap, so a flood cannot hold more memory in waiting
+/// deliveries than it could in waiting handlers.
+pub(crate) const MAX_IN_FLIGHT_DELIVERIES: usize = 64;
+
 /// Wire name of the notification-forwarding method.
 pub const FORWARD_NOTIFICATION_METHOD: &str = "kakehashi/forward/notification";
 
@@ -276,8 +282,20 @@ impl Kakehashi {
         // server could then stall didChange/didClose for everyone. The
         // handler returns once the work is handed off; each delivery logs
         // its own failure. Every selected server runs independently, so one
-        // server's wait never holds back delivery to the others.
+        // server's wait never holds back delivery to the others. Deliveries
+        // are bounded by `MAX_IN_FLIGHT_DELIVERIES`; past that the handler
+        // waits for a slot — backpressure rather than unbounded tasks.
+        // Ordering across notifications is not preserved: handlers already
+        // run concurrently, so none was promised (ADR: Ordering).
+        let Ok(permit) = std::sync::Arc::clone(&self.forward_delivery_slots)
+            .acquire_owned()
+            .await
+        else {
+            // Only a closed semaphore fails, and this one is never closed.
+            return;
+        };
         tokio::spawn(async move {
+            let _permit = permit;
             let doc = HostDocument {
                 uri: &ctx.uri,
                 language_id: &ctx.language_id,

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -274,6 +274,9 @@ impl Kakehashi {
         let reader_uri = ctx.uri.clone();
         let live_text_reader: crate::lsp::bridge::HostTextReader =
             std::sync::Arc::new(move || documents.get(&reader_uri).map(|doc| doc.text_arc()));
+        // The document this message was resolved against; a close-and-reopen
+        // of the same URI while a delivery waits must not receive it.
+        let incarnation = pool.current_host_incarnation(&ctx.uri);
         let servers = select_host_servers(&ctx);
         if servers.is_empty() {
             // The kill switch (`priorities = []`, `maxFanOut = 0`): nothing
@@ -323,6 +326,7 @@ impl Kakehashi {
                             &server.config,
                             doc,
                             Some(live_text_reader),
+                            incarnation,
                             method,
                             payload,
                         )

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -1,0 +1,255 @@
+//! Handlers for custom-method-host-forwarding: `kakehashi/forward/request`
+//! and `kakehashi/forward/notification`.
+//!
+//! A method kakehashi does not implement reaches these through
+//! [`crate::lsp::CustomMethodForwarder`], rewritten into
+//! `{ "method", "params" }`; a client may also call them directly. Either
+//! way the same eligibility applies: the host document named by
+//! `params.textDocument.uri` must have `bridge._self.enabled = true` and a
+//! **literal** `bridge._self.aggregation` entry for the method. The params
+//! go to the host servers verbatim — real URI, no translation — and the
+//! first non-empty `result` in priority order comes back untouched.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tower_lsp_server::jsonrpc::{Error, Result};
+use tower_lsp_server::ls_types::Uri;
+
+use super::Kakehashi;
+use super::bridge_context::{HostRequestContext, UpstreamRegistrySweepGuard, is_empty_layer_value};
+use super::uri_to_url;
+use crate::config::settings::AggregationStrategy;
+use crate::lsp::aggregation::server::{dispatch_host_preferred, select_host_servers};
+use crate::lsp::bridge::HostDocument;
+
+/// Wire name of the request-forwarding method.
+pub const FORWARD_REQUEST_METHOD: &str = "kakehashi/forward/request";
+/// Wire name of the notification-forwarding method.
+pub const FORWARD_NOTIFICATION_METHOD: &str = "kakehashi/forward/notification";
+
+/// Params of both forwarding methods: the original method name and its
+/// params, verbatim.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ForwardParams {
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+}
+
+/// Why a message is not forwarded. Requests answer with the JSON-RPC error
+/// each variant maps to; notifications log and drop.
+#[derive(Debug, PartialEq, Eq)]
+enum Rejection {
+    /// No `textDocument.uri` in the params: there is no host document to
+    /// pick servers for. `InvalidParams` — the method IS forwardable, the
+    /// call is malformed for it.
+    NoTextDocument,
+    /// Not opted in: unknown document, host bridging off for its language,
+    /// no literal aggregation entry, or no host-capable server. For a
+    /// request this keeps the router's `MethodNotFound` — from the client's
+    /// side nothing changed.
+    NotForwardable(&'static str),
+    /// A strategy other than `preferred`: results of unknown shape cannot
+    /// be merged, so the entry is a configuration error.
+    UnsupportedStrategy(AggregationStrategy),
+}
+
+impl Rejection {
+    fn into_error(self, method: &str) -> Error {
+        match self {
+            Self::NoTextDocument => Error::invalid_params(format!(
+                "{method}: forwarding needs params.textDocument.uri to pick a host document"
+            )),
+            Self::NotForwardable(reason) => {
+                log::debug!("{method}: not forwarded: {reason}");
+                let mut error = Error::method_not_found();
+                error.data = Some(Value::String(method.to_owned()));
+                error
+            }
+            Self::UnsupportedStrategy(strategy) => Error::invalid_params(format!(
+                "{method}: bridge._self.aggregation strategy {strategy:?} is not supported for \
+                 forwarded methods; only `preferred` can combine results of unknown shape"
+            )),
+        }
+    }
+}
+
+/// `params.textDocument.uri`, the one field the forward reads.
+fn text_document_uri(params: &Value) -> Option<Uri> {
+    params
+        .pointer("/textDocument/uri")
+        .and_then(Value::as_str)
+        .and_then(|raw| raw.parse::<Uri>().ok())
+}
+
+impl Kakehashi {
+    /// Resolve the host servers a forwarded message goes to, or why it
+    /// does not go anywhere.
+    fn resolve_forward_target(
+        &self,
+        params: &ForwardParams,
+    ) -> std::result::Result<HostRequestContext, Rejection> {
+        let lsp_uri = text_document_uri(&params.params).ok_or(Rejection::NoTextDocument)?;
+        let url = uri_to_url(&lsp_uri).map_err(|_| Rejection::NoTextDocument)?;
+        let language = self
+            .document_language(&url)
+            .ok_or(Rejection::NotForwardable("document is not open"))?;
+        let explicit = self
+            .settings_manager
+            .load_settings()
+            .resolve_host_language_settings(&language)
+            .is_some_and(|settings| settings.has_explicit_host_aggregation(&params.method));
+        if !explicit {
+            return Err(Rejection::NotForwardable(
+                "no literal bridge._self.aggregation entry for the method",
+            ));
+        }
+        let ctx = self
+            .resolve_host_bridge_context(&lsp_uri, &params.method)
+            .ok_or(Rejection::NotForwardable(
+                "host bridging is not opted in for the document's language, or no server handles it",
+            ))?;
+        if ctx.strategy != AggregationStrategy::Preferred {
+            return Err(Rejection::UnsupportedStrategy(ctx.strategy));
+        }
+        Ok(ctx)
+    }
+
+    /// `kakehashi/forward/request`: forward a request kakehashi does not
+    /// implement to the host servers and answer with the first non-empty
+    /// downstream result (`preferred`), or `null`.
+    pub async fn forward_custom_request(&self, params: ForwardParams) -> Result<Value> {
+        let ctx = self
+            .resolve_forward_target(&params)
+            .map_err(|rejection| rejection.into_error(&params.method))?;
+
+        // Standalone host dispatch (no layer race): the RAII sweep clears
+        // the upstream-registry entries an aborted per-server task may not
+        // reach itself — same discipline as willSaveWaitUntil.
+        let _sweep = UpstreamRegistrySweepGuard::new(
+            self.bridge.pool_arc(),
+            ctx.upstream_request_id.clone(),
+        );
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(ctx.upstream_request_id.as_ref());
+        let pool = self.bridge.pool_arc();
+        let method: std::sync::Arc<str> = params.method.as_str().into();
+        let raw_params = params.params;
+        let result = dispatch_host_preferred(
+            &ctx,
+            pool.clone(),
+            move |t| {
+                let params = raw_params.clone();
+                let method = std::sync::Arc::clone(&method);
+                async move {
+                    t.pool
+                        .send_host_custom_request(
+                            &t.server_name,
+                            &t.server_config,
+                            &HostDocument {
+                                uri: &t.uri,
+                                language_id: &t.language_id,
+                                text: &t.text,
+                            },
+                            &method,
+                            params,
+                            t.upstream_id,
+                        )
+                        .await
+                }
+            },
+            |opt| matches!(opt, Some(v) if !is_empty_layer_value(v)),
+            cancel_rx,
+        )
+        .await;
+        let value = self
+            .host_layer_result(result, &params.method, |value| value)
+            .await?;
+        Ok(value.unwrap_or(Value::Null))
+    }
+
+    /// `kakehashi/forward/notification`: forward a notification kakehashi
+    /// does not implement to **every** selected host server, in priority
+    /// order. Nothing comes back; failures are logged per server.
+    pub async fn forward_custom_notification(&self, params: ForwardParams) {
+        let ctx = match self.resolve_forward_target(&params) {
+            Ok(ctx) => ctx,
+            Err(Rejection::NotForwardable(reason)) => {
+                log::debug!("{}: notification not forwarded: {reason}", params.method);
+                return;
+            }
+            Err(rejection) => {
+                log::warn!(
+                    "{}: notification dropped: {}",
+                    params.method,
+                    rejection.into_error(&params.method).message
+                );
+                return;
+            }
+        };
+        let pool = self.bridge.pool_arc();
+        let doc = HostDocument {
+            uri: &ctx.uri,
+            language_id: &ctx.language_id,
+            text: &ctx.text,
+        };
+        for server in select_host_servers(&ctx) {
+            if let Err(error) = pool
+                .send_host_custom_notification(
+                    &server.server_name,
+                    &server.config,
+                    &doc,
+                    &params.method,
+                    params.params.clone(),
+                )
+                .await
+            {
+                log::warn!(
+                    "{}: notification not delivered to {}: {error}",
+                    params.method,
+                    server.server_name
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forward_params_default_params_to_null() {
+        let parsed: ForwardParams =
+            serde_json::from_value(serde_json::json!({ "method": "custom/x" })).unwrap();
+        assert_eq!(parsed.method, "custom/x");
+        assert_eq!(parsed.params, Value::Null);
+    }
+
+    #[test]
+    fn text_document_uri_reads_only_the_standard_location() {
+        assert!(
+            text_document_uri(&serde_json::json!({ "textDocument": { "uri": "file:///a.md" } }))
+                .is_some()
+        );
+        assert!(text_document_uri(&serde_json::json!({ "uri": "file:///a.md" })).is_none());
+        assert!(text_document_uri(&Value::Null).is_none());
+    }
+
+    #[test]
+    fn rejections_map_to_the_contracted_error_codes() {
+        use tower_lsp_server::jsonrpc::ErrorCode;
+        assert_eq!(
+            Rejection::NoTextDocument.into_error("custom/x").code,
+            ErrorCode::InvalidParams
+        );
+        let not_found = Rejection::NotForwardable("why").into_error("custom/x");
+        assert_eq!(not_found.code, ErrorCode::MethodNotFound);
+        assert_eq!(not_found.data, Some(Value::String("custom/x".into())));
+        assert_eq!(
+            Rejection::UnsupportedStrategy(AggregationStrategy::Concatenated)
+                .into_error("custom/x")
+                .code,
+            ErrorCode::InvalidParams
+        );
+    }
+}

--- a/src/lsp/lsp_impl/custom_method_forward.rs
+++ b/src/lsp/lsp_impl/custom_method_forward.rs
@@ -12,7 +12,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tower_lsp_server::jsonrpc::{Error, Result};
+use tower_lsp_server::jsonrpc::{Error, ErrorCode, Result};
 use tower_lsp_server::ls_types::Uri;
 
 use super::bridge_context::{HostRequestContext, UpstreamRegistrySweepGuard, is_empty_layer_value};
@@ -57,6 +57,20 @@ enum Rejection {
     Reserved,
 }
 
+/// LSP `RequestFailed` (3.17+): the request was well-formed but cannot be
+/// served — here, for a configuration or policy reason the client did not
+/// cause. tower-lsp-server 0.23 has no named variant. Distinct from
+/// `InvalidParams`, which would tell the client to fix its request.
+const REQUEST_FAILED: ErrorCode = ErrorCode::ServerError(-32803);
+
+fn request_failed(message: String) -> Error {
+    Error {
+        code: REQUEST_FAILED,
+        message: message.into(),
+        data: None,
+    }
+}
+
 impl Rejection {
     fn into_error(self, method: &str) -> Error {
         match self {
@@ -69,11 +83,11 @@ impl Rejection {
                 error.data = Some(Value::String(method.to_owned()));
                 error
             }
-            Self::UnsupportedStrategy(strategy) => Error::invalid_params(format!(
+            Self::UnsupportedStrategy(strategy) => request_failed(format!(
                 "{method}: bridge._self.aggregation strategy {strategy:?} is not supported for \
                  forwarded methods; only `preferred` can combine results of unknown shape"
             )),
-            Self::Reserved => Error::invalid_params(format!(
+            Self::Reserved => request_failed(format!(
                 "{method}: lifecycle and document-sync methods are owned by the bridge and \
                  are never forwarded"
             )),
@@ -305,7 +319,6 @@ mod tests {
 
     #[test]
     fn rejections_map_to_the_contracted_error_codes() {
-        use tower_lsp_server::jsonrpc::ErrorCode;
         assert_eq!(
             Rejection::NoTextDocument.into_error("custom/x").code,
             ErrorCode::InvalidParams
@@ -313,15 +326,17 @@ mod tests {
         let not_found = Rejection::NotForwardable("why").into_error("custom/x");
         assert_eq!(not_found.code, ErrorCode::MethodNotFound);
         assert_eq!(not_found.data, Some(Value::String("custom/x".into())));
+        // Config/policy refusals are RequestFailed: the client's request was
+        // well-formed, so InvalidParams would send it fixing the wrong side.
         assert_eq!(
             Rejection::UnsupportedStrategy(AggregationStrategy::Concatenated)
                 .into_error("custom/x")
                 .code,
-            ErrorCode::InvalidParams
+            ErrorCode::ServerError(-32803)
         );
         assert_eq!(
             Rejection::Reserved.into_error("shutdown").code,
-            ErrorCode::InvalidParams
+            ErrorCode::ServerError(-32803)
         );
     }
 }

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -35,8 +35,9 @@ use crate::lsp::aggregation::server::{
     dispatch_host_preferred, dispatch_preferred,
 };
 use crate::lsp::bridge::{
-    CodeActionEnvelope, HostDocument, RegionOffset, UpstreamCodeActionCaps, bridge_code_actions,
-    extract_code_action_envelope, parse_code_actions_leniently, region_host_end,
+    CapabilityGate, CodeActionEnvelope, HostDocument, RegionOffset, UpstreamCodeActionCaps,
+    bridge_code_actions, extract_code_action_envelope, parse_code_actions_leniently,
+    region_host_end,
 };
 
 const METHOD: &str = "textDocument/codeAction";
@@ -502,6 +503,7 @@ impl Kakehashi {
                         METHOD,
                         params,
                         t.upstream_id,
+                        CapabilityGate::Advertised,
                     )
                     .await?;
                 let Some(raw) = raw else {

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -499,6 +499,7 @@ impl Kakehashi {
                             uri: &t.uri,
                             language_id: &t.language_id,
                             text: &t.text,
+                            incarnation: None,
                         },
                         METHOD,
                         params,

--- a/src/lsp/lsp_impl/text_document/completion.rs
+++ b/src/lsp/lsp_impl/text_document/completion.rs
@@ -87,6 +87,7 @@ impl Kakehashi {
                             uri: &t.uri,
                             language_id: &t.language_id,
                             text: &t.text,
+                            incarnation: None,
                         },
                         METHOD,
                         params,

--- a/src/lsp/lsp_impl/text_document/completion.rs
+++ b/src/lsp/lsp_impl/text_document/completion.rs
@@ -22,7 +22,7 @@ use super::super::Kakehashi;
 use crate::lsp::aggregation::server::{
     HostFanOutTask, dispatch_host_preferred, dispatch_preferred,
 };
-use crate::lsp::bridge::{HostDocument, bridge_host_completion_items};
+use crate::lsp::bridge::{CapabilityGate, HostDocument, bridge_host_completion_items};
 use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
 
 const METHOD: &str = "textDocument/completion";
@@ -91,6 +91,7 @@ impl Kakehashi {
                         METHOD,
                         params,
                         t.upstream_id,
+                        CapabilityGate::Advertised,
                     )
                     .await?;
                 let Some(raw) = raw else {

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -755,6 +755,7 @@ async fn send_host_diagnostic_fan_out_request(
                 uri: &t.uri,
                 language_id: &t.language_id,
                 text: &t.text,
+                incarnation: None,
             },
             serde_json::json!({ "textDocument": { "uri": t.uri.as_str() } }),
             t.upstream_id,

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -919,6 +919,7 @@ print("hello")
                 strategy: AggregationStrategy::Concatenated,
                 max_fan_out: None,
                 upstream_request_id: None,
+                incarnation: 0,
             }),
             layer_cfg: ResolvedLayerConfig {
                 priorities: vec![LayerSource::Host],
@@ -1035,6 +1036,7 @@ print("hello")
                 strategy: AggregationStrategy::Concatenated,
                 max_fan_out: None,
                 upstream_request_id: None,
+                incarnation: 0,
             }),
             layer_cfg: ResolvedLayerConfig {
                 priorities: vec![LayerSource::Host],

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -528,6 +528,7 @@ impl Kakehashi {
                                 uri: &t.uri,
                                 language_id: &t.language_id,
                                 text: &t.text,
+                                incarnation: None,
                             },
                             "textDocument/formatting",
                             params,

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -159,6 +159,10 @@ fn main() {
     // answered, the baseline demonstrably exists — a later baseline-less full
     // request means a pull LOST it and is re-fetching.
     let mut unchanged_answered = false;
+    // `custom-echo` mode: every `custom/*` notification received, in order,
+    // reported back by the next `custom/*` request so a test can prove a
+    // forwarded notification reached this server (custom-method-host-forwarding).
+    let mut custom_notifications: Vec<Value> = Vec::new();
 
     while let Some(message) = read_message(&mut reader) {
         let method = message
@@ -167,6 +171,34 @@ fn main() {
             .unwrap_or_default();
         let id = message.get("id").cloned();
         append_wire_log(method, &message);
+
+        // `custom-echo`: answer any `custom/*` request with what arrived —
+        // the method, the params verbatim, whether the referenced document
+        // was opened here first, and the notifications recorded so far. The
+        // mode advertises NO capability for these methods: the bridge must
+        // forward them blind.
+        if mode == "custom-echo" && method.starts_with("custom/") {
+            let params = message.get("params").cloned().unwrap_or(Value::Null);
+            if id.is_some() {
+                let opened = params
+                    .pointer("/textDocument/uri")
+                    .and_then(Value::as_str)
+                    .is_some_and(|uri| documents.contains_key(uri));
+                respond(
+                    &mut writer,
+                    id,
+                    json!({
+                        "method": method,
+                        "params": params,
+                        "opened": opened,
+                        "notifications": custom_notifications,
+                    }),
+                );
+            } else {
+                custom_notifications.push(json!({ "method": method, "params": params }));
+            }
+            continue;
+        }
 
         match method {
             "initialize" => {
@@ -180,6 +212,7 @@ fn main() {
                         "hoverProvider": true,
                         "textDocumentSync": 1
                     }),
+                    "custom-echo" => json!({ "textDocumentSync": 1 }),
                     "code-lens" => json!({
                         "codeLensProvider": { "resolveProvider": true },
                         "textDocumentSync": 1

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -181,6 +181,9 @@ fn main() {
         // methods and says so the JSON-RPC way — the decline the forward's
         // capability-blind fan-in must treat as an empty contribution.
         if mode == "custom-decline" && method.starts_with("custom/") {
+            // Logged under its own name so a test can tell this server's
+            // receipt from an echo server's in the shared wire log.
+            append_wire_log(&format!("custom-decline:{method}"), &message);
             respond_error(&mut writer, id, -32601, "Method not found");
             continue;
         }

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -177,6 +177,13 @@ fn main() {
         // was opened here first, and the notifications recorded so far. The
         // mode advertises NO capability for these methods: the bridge must
         // forward them blind.
+        // `custom-decline`: a server that implements none of the custom
+        // methods and says so the JSON-RPC way — the decline the forward's
+        // capability-blind fan-in must treat as an empty contribution.
+        if mode == "custom-decline" && method.starts_with("custom/") {
+            respond_error(&mut writer, id, -32601, "Method not found");
+            continue;
+        }
         if mode == "custom-echo" && method.starts_with("custom/") {
             let params = message.get("params").cloned().unwrap_or(Value::Null);
             if id.is_some() {
@@ -212,7 +219,7 @@ fn main() {
                         "hoverProvider": true,
                         "textDocumentSync": 1
                     }),
-                    "custom-echo" => json!({ "textDocumentSync": 1 }),
+                    "custom-echo" | "custom-decline" => json!({ "textDocumentSync": 1 }),
                     "code-lens" => json!({
                         "codeLensProvider": { "resolveProvider": true },
                         "textDocumentSync": 1

--- a/tests/e2e/e2e_custom_method_forward.rs
+++ b/tests/e2e/e2e_custom_method_forward.rs
@@ -28,6 +28,12 @@ priorities = ["mock-host"]
 [languages.markdown.bridge._self.aggregation."custom/merged"]
 priorities = ["mock-host"]
 strategy = "concatenated"
+
+# Inherited by every method entry above that sets no strategy of its own.
+# The typed host methods ignore an inherited `concatenated`; so must the
+# forward, or this one line would break every forwarded method.
+[languages.markdown.bridge._self.aggregation._]
+strategy = "concatenated"
 "#;
 
 fn init_client(config_toml: &str) -> (LspClient, tempfile::TempDir) {

--- a/tests/e2e/e2e_custom_method_forward.rs
+++ b/tests/e2e/e2e_custom_method_forward.rs
@@ -242,46 +242,33 @@ maxFanOut = 1
         "every listed server receives the notification, not only the first"
     );
 
+    // maxFanOut: the positive half is observable here (mock-b, first in
+    // priorities, receives the capped ping); the negative half — mock-a
+    // never receives it — cannot be, since forwarded notifications carry no
+    // ordering promise and "not arrived yet" is indistinguishable from
+    // "never sent". The delivery plan itself is pinned by the unit test
+    // `select_host_servers_follows_priorities_cap_and_kill_switch`.
     let capped = json!({ "textDocument": { "uri": MARKDOWN_URI }, "n": 2 });
     session
         .client
         .send_notification("custom/capped", capped.clone());
-    // A second uncapped ping after the capped one. Forwarded notifications
-    // carry no ordering promise, so the marker is not a fence; it is a
-    // later-sent message whose arrival at mock-a makes a wrongly fanned-out
-    // capped ping — dispatched earlier, to the same server — overwhelmingly
-    // likely to have arrived too, which "not arrived yet" could otherwise
-    // hide. Arrival sets are compared, not sequences.
-    let marker = json!({ "textDocument": { "uri": MARKDOWN_URI }, "n": 3 });
-    session
-        .client
-        .send_notification("custom/ping", marker.clone());
     let expected_capped = json!({ "method": "custom/capped", "params": capped });
-    let expected_marker = json!({ "method": "custom/ping", "params": marker });
-    let sorted = |items: &[&Value]| -> Vec<String> {
-        let mut v: Vec<String> = items.iter().map(|i| i.to_string()).collect();
-        v.sort();
-        v
-    };
-    let settled = |session: &mut Session, echo: &str| -> Vec<String> {
-        for _ in 0..300 {
-            let seen = session.notifications_seen_by(echo);
-            if let Some(items) = seen.as_array().filter(|n| n.contains(&expected_marker)) {
-                return sorted(&items.iter().collect::<Vec<_>>());
-            }
-            std::thread::sleep(std::time::Duration::from_millis(20));
+    for _ in 0..300 {
+        let seen = session.notifications_seen_by("custom/echoB");
+        if seen
+            .as_array()
+            .is_some_and(|n| n.contains(&expected_capped))
+        {
+            break;
         }
-        panic!("{echo}: marker ping never arrived");
-    };
-    assert_eq!(
-        settled(&mut session, "custom/echoB"),
-        sorted(&[&expected_ping[0], &expected_capped, &expected_marker]),
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    assert!(
+        session
+            .notifications_seen_by("custom/echoB")
+            .as_array()
+            .is_some_and(|n| n.contains(&expected_capped)),
         "mock-b is first in priorities: the one server under maxFanOut = 1"
-    );
-    assert_eq!(
-        settled(&mut session, "custom/echoA"),
-        sorted(&[&expected_ping[0], &expected_marker]),
-        "maxFanOut = 1 must stop the capped notification at the first server"
     );
 
     session.shutdown();

--- a/tests/e2e/e2e_custom_method_forward.rs
+++ b/tests/e2e/e2e_custom_method_forward.rs
@@ -325,7 +325,7 @@ priorities = ["mock-decline"]
             if session
                 .wire_methods()
                 .iter()
-                .any(|m| m == "custom/nobody-implements")
+                .any(|m| m == "custom-decline:custom/nobody-implements")
             {
                 Some(())
             } else {
@@ -336,21 +336,27 @@ priorities = ["mock-decline"]
         .is_some();
     assert!(declined, "the declining server never came up");
 
-    let echoes = |session: &Session| {
+    // The declining mock logs its receipts under its own name, so each
+    // server's receipt is told apart in the shared wire log.
+    let count = |session: &Session, entry: &str| {
         session
             .wire_methods()
             .iter()
-            .filter(|m| *m == "custom/echo")
+            .filter(|m| *m == entry)
             .count()
     };
-    let before = echoes(&session);
+    let (echo_before, decline_before) = (
+        count(&session, "custom/echo"),
+        count(&session, "custom-decline:custom/echo"),
+    );
     let result = session.echo_until_answered("custom/echo", params);
     assert_eq!(
         result["method"], "custom/echo",
         "the lower-priority server's answer wins over the decline"
     );
     assert!(
-        echoes(&session) - before >= 2,
+        count(&session, "custom/echo") > echo_before
+            && count(&session, "custom-decline:custom/echo") > decline_before,
         "both servers must have been asked (capability-blind); wire: {:?}",
         session.wire_methods()
     );

--- a/tests/e2e/e2e_custom_method_forward.rs
+++ b/tests/e2e/e2e_custom_method_forward.rs
@@ -1,0 +1,248 @@
+//! E2E tests for custom-method-host-forwarding: a method kakehashi does not
+//! implement is forwarded to the host document's servers when — and only
+//! when — `bridge._self.aggregation` names it explicitly. Requests get the
+//! first non-empty downstream result; notifications fan out to every
+//! selected server. The `custom-echo` mock advertises no capability for the
+//! methods, so a successful echo also proves the forward is capability-blind.
+
+use crate::helpers::lsp_client::LspClient;
+use serde_json::{Value, json};
+
+fn mock_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_mock-lsp-formatter")
+}
+
+const MARKDOWN: &str = "# Title\n\nprose\n";
+const MARKDOWN_URI: &str = "file:///test_custom_forward.md";
+
+const FORWARDING_CONFIG: &str = r#"
+[languages.markdown.bridge._self]
+enabled = true
+
+[languages.markdown.bridge._self.aggregation."custom/echo"]
+priorities = ["mock-host"]
+
+[languages.markdown.bridge._self.aggregation."custom/ping"]
+priorities = ["mock-host"]
+
+[languages.markdown.bridge._self.aggregation."custom/merged"]
+priorities = ["mock-host"]
+strategy = "concatenated"
+"#;
+
+fn init_client(config_toml: &str) -> (LspClient, tempfile::TempDir) {
+    let config_dir = tempfile::TempDir::new().expect("config dir");
+    let config_path = config_dir.path().join("custom_forward.toml");
+    std::fs::write(&config_path, config_toml).expect("write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("temp path should be UTF-8"))
+        .build();
+    let _init = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "mock-host": {
+                        "cmd": [mock_bin(), "custom-echo"],
+                        "languages": ["markdown"]
+                    }
+                }
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": MARKDOWN_URI,
+                "languageId": "markdown",
+                "version": 1,
+                "text": MARKDOWN
+            }
+        }),
+    );
+    (client, config_dir)
+}
+
+fn shutdown(client: &mut LspClient) {
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+fn error_code(response: &Value) -> Option<i64> {
+    response.pointer("/error/code").and_then(Value::as_i64)
+}
+
+/// Send `custom/echo` until the host server answers. Like every host
+/// request, the forward fails fast while the downstream is still
+/// initializing (an empty result; "the next request gets it"), and didOpen
+/// is what spawned it, so the first probes after open may come back `null`.
+fn echo_until_answered(client: &mut LspClient, params: Value) -> Value {
+    for _ in 0..300 {
+        let response = client.send_request("custom/echo", params.clone());
+        assert!(
+            response.get("error").is_none(),
+            "forwarded request must not error; got {response}"
+        );
+        if !response["result"].is_null() {
+            return response["result"].clone();
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    panic!("host server never answered custom/echo");
+}
+
+#[test]
+fn e2e_custom_request_is_forwarded_verbatim_to_the_host_server() {
+    let (mut client, _config_dir) = init_client(FORWARDING_CONFIG);
+
+    let params = json!({
+        "textDocument": { "uri": MARKDOWN_URI },
+        "position": { "line": 2, "character": 1 },
+        "extra": { "nested": [1, 2, 3] }
+    });
+    let result = echo_until_answered(&mut client, params.clone());
+    assert_eq!(result["method"], "custom/echo");
+    assert_eq!(
+        result["params"], params,
+        "params must reach the server verbatim (real URI, no translation)"
+    );
+    assert_eq!(
+        result["opened"], true,
+        "the host document must be synced to the server before the request"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_custom_notification_is_forwarded_to_the_host_server() {
+    let (mut client, _config_dir) = init_client(FORWARDING_CONFIG);
+
+    let ping = json!({ "textDocument": { "uri": MARKDOWN_URI }, "n": 7 });
+    client.send_notification("custom/ping", ping.clone());
+
+    // The notification and the probe request are independent handler tasks,
+    // so the probe may overtake the notification; poll until it shows up.
+    let mut recorded = Value::Null;
+    for _ in 0..300 {
+        let result = echo_until_answered(
+            &mut client,
+            json!({ "textDocument": { "uri": MARKDOWN_URI } }),
+        );
+        recorded = result["notifications"].clone();
+        if recorded.as_array().is_some_and(|n| !n.is_empty()) {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    assert_eq!(
+        recorded,
+        json!([{ "method": "custom/ping", "params": ping }]),
+        "the notification must reach the host server exactly once, verbatim"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_unlisted_custom_request_keeps_method_not_found() {
+    let (mut client, _config_dir) = init_client(FORWARDING_CONFIG);
+
+    let response = client.send_request(
+        "custom/unlisted",
+        json!({ "textDocument": { "uri": MARKDOWN_URI } }),
+    );
+    assert_eq!(
+        error_code(&response),
+        Some(-32601),
+        "a method without a literal aggregation entry is not forwarded; got {response}"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_custom_request_without_host_opt_in_keeps_method_not_found() {
+    // The aggregation entry exists but `_self.enabled` does not: the host
+    // layer is off, so nothing is forwarded and the router's answer stands.
+    let (mut client, _config_dir) = init_client(
+        r#"
+[languages.markdown.bridge._self.aggregation."custom/echo"]
+priorities = ["mock-host"]
+"#,
+    );
+
+    let response = client.send_request(
+        "custom/echo",
+        json!({ "textDocument": { "uri": MARKDOWN_URI } }),
+    );
+    assert_eq!(error_code(&response), Some(-32601), "got {response}");
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_custom_request_without_text_document_is_invalid_params() {
+    let (mut client, _config_dir) = init_client(FORWARDING_CONFIG);
+
+    let response = client.send_request("custom/echo", json!({ "no": "document" }));
+    assert_eq!(
+        error_code(&response),
+        Some(-32602),
+        "a forwardable method needs textDocument.uri to pick a host; got {response}"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_concatenated_strategy_on_a_forwarded_request_is_invalid_params() {
+    let (mut client, _config_dir) = init_client(FORWARDING_CONFIG);
+
+    let response = client.send_request(
+        "custom/merged",
+        json!({ "textDocument": { "uri": MARKDOWN_URI } }),
+    );
+    assert_eq!(
+        error_code(&response),
+        Some(-32602),
+        "only `preferred` can combine results of unknown shape; got {response}"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_built_in_method_is_not_shadowed_by_forwarding() {
+    // `textDocument/hover` has a handler; the router answers it (empty here,
+    // since the mock advertises no hoverProvider) and the forward never runs.
+    let (mut client, _config_dir) = init_client(
+        r#"
+[languages.markdown.bridge._self]
+enabled = true
+
+[languages.markdown.bridge._self.aggregation."textDocument/hover"]
+priorities = ["mock-host"]
+"#,
+    );
+
+    let response = client.send_request(
+        "textDocument/hover",
+        json!({
+            "textDocument": { "uri": MARKDOWN_URI },
+            "position": { "line": 0, "character": 0 }
+        }),
+    );
+    assert!(response.get("error").is_none(), "got {response}");
+    assert_eq!(response["result"], Value::Null);
+
+    shutdown(&mut client);
+}

--- a/tests/e2e/e2e_custom_method_forward.rs
+++ b/tests/e2e/e2e_custom_method_forward.rs
@@ -336,8 +336,10 @@ priorities = ["mock-decline"]
         .is_some();
     assert!(declined, "the declining server never came up");
 
-    // The declining mock logs its receipts under its own name, so each
-    // server's receipt is told apart in the shared wire log.
+    // The declining mock logs its receipts under its own name (in addition
+    // to the generic line every mock writes), so each server's receipt is
+    // told apart in the shared wire log: echo receipts = generic lines minus
+    // the decline server's own.
     let count = |session: &Session, entry: &str| {
         session
             .wire_methods()
@@ -345,19 +347,24 @@ priorities = ["mock-decline"]
             .filter(|m| *m == entry)
             .count()
     };
-    let (echo_before, decline_before) = (
-        count(&session, "custom/echo"),
-        count(&session, "custom-decline:custom/echo"),
-    );
-    let result = session.echo_until_answered("custom/echo", params);
+    let receipts = |session: &Session| {
+        let declined = count(session, "custom-decline:custom/echo");
+        (count(session, "custom/echo") - declined, declined)
+    };
+    // Warm the echo server too, so the probe below is a single request
+    // against two ready servers — one upstream request, two receipts.
+    session.echo_until_answered("custom/echo", params.clone());
+    let (echo_before, decline_before) = receipts(&session);
+    let response = session.client.send_request("custom/echo", params);
     assert_eq!(
-        result["method"], "custom/echo",
-        "the lower-priority server's answer wins over the decline"
+        response["result"]["method"], "custom/echo",
+        "the lower-priority server's answer wins over the decline; got {response}"
     );
-    assert!(
-        count(&session, "custom/echo") > echo_before
-            && count(&session, "custom-decline:custom/echo") > decline_before,
-        "both servers must have been asked (capability-blind); wire: {:?}",
+    let (echo_after, decline_after) = receipts(&session);
+    assert_eq!(
+        (echo_after - echo_before, decline_after - decline_before),
+        (1, 1),
+        "one request must reach both servers (capability-blind fan-out); wire: {:?}",
         session.wire_methods()
     );
 

--- a/tests/e2e/e2e_custom_method_forward.rs
+++ b/tests/e2e/e2e_custom_method_forward.rs
@@ -15,6 +15,11 @@ fn mock_bin() -> &'static str {
 const MARKDOWN: &str = "# Title\n\nprose\n";
 const MARKDOWN_URI: &str = "file:///test_custom_forward.md";
 
+const METHOD_NOT_FOUND: i64 = -32601;
+const INVALID_PARAMS: i64 = -32602;
+/// LSP `RequestFailed`: well-formed request, refused for a server-side reason.
+const REQUEST_FAILED: i64 = -32803;
+
 const FORWARDING_CONFIG: &str = r#"
 [languages.markdown.bridge._self]
 enabled = true
@@ -36,14 +41,39 @@ strategy = "concatenated"
 strategy = "concatenated"
 "#;
 
-fn init_client(config_toml: &str) -> (LspClient, tempfile::TempDir) {
+/// One `custom-echo` mock per name, all host candidates for markdown.
+fn language_servers(names: &[&str]) -> Value {
+    let mut servers = serde_json::Map::new();
+    for name in names {
+        servers.insert(
+            (*name).to_owned(),
+            json!({ "cmd": [mock_bin(), "custom-echo"], "languages": ["markdown"] }),
+        );
+    }
+    Value::Object(servers)
+}
+
+struct Session {
+    client: LspClient,
+    _config_dir: tempfile::TempDir,
+    wire_log: std::path::PathBuf,
+}
+
+fn init_session(config_toml: &str, servers: &[&str]) -> Session {
     let config_dir = tempfile::TempDir::new().expect("config dir");
     let config_path = config_dir.path().join("custom_forward.toml");
     std::fs::write(&config_path, config_toml).expect("write config");
+    // Every mock appends `method\turi` per inbound message here, so a test
+    // can assert what did — and did not — reach the downstream servers.
+    let wire_log = config_dir.path().join("mock_wire.log");
 
     let mut client = LspClient::builder()
         .arg("--config-file")
         .arg(config_path.to_str().expect("temp path should be UTF-8"))
+        .env(
+            "MOCK_LSP_WIRE_LOG",
+            wire_log.to_str().expect("temp path should be UTF-8"),
+        )
         .build();
     let _init = client.send_request(
         "initialize",
@@ -52,14 +82,7 @@ fn init_client(config_toml: &str) -> (LspClient, tempfile::TempDir) {
             "rootUri": null,
             "capabilities": {},
             "workspaceFolders": null,
-            "initializationOptions": {
-                "languageServers": {
-                    "mock-host": {
-                        "cmd": [mock_bin(), "custom-echo"],
-                        "languages": ["markdown"]
-                    }
-                }
-            }
+            "initializationOptions": { "languageServers": language_servers(servers) }
         }),
     );
     client.send_notification("initialized", json!({}));
@@ -74,52 +97,87 @@ fn init_client(config_toml: &str) -> (LspClient, tempfile::TempDir) {
             }
         }),
     );
-    (client, config_dir)
+    Session {
+        client,
+        _config_dir: config_dir,
+        wire_log,
+    }
 }
 
-fn shutdown(client: &mut LspClient) {
-    let _ = client.send_request("shutdown", json!(null));
-    client.send_notification("exit", json!(null));
+fn init_client(config_toml: &str) -> Session {
+    init_session(config_toml, &["mock-host"])
 }
 
-const METHOD_NOT_FOUND: i64 = -32601;
-const INVALID_PARAMS: i64 = -32602;
-/// LSP `RequestFailed`: well-formed request, refused for a server-side reason.
-const REQUEST_FAILED: i64 = -32803;
+impl Session {
+    fn shutdown(&mut self) {
+        let _ = self.client.send_request("shutdown", json!(null));
+        self.client.send_notification("exit", json!(null));
+    }
+
+    /// Methods the mocks received, in arrival order.
+    fn wire_methods(&self) -> Vec<String> {
+        std::fs::read_to_string(&self.wire_log)
+            .unwrap_or_default()
+            .lines()
+            .filter_map(|line| line.split('\t').next().map(str::to_owned))
+            .collect()
+    }
+
+    /// Send `method` (an echo method) until the host server answers. Like
+    /// every host request, the forward fails fast while the downstream is
+    /// still initializing (an empty result; "the next request gets it"), and
+    /// didOpen is what spawned it, so the first probes after open may come
+    /// back `null`.
+    fn echo_until_answered(&mut self, method: &str, params: Value) -> Value {
+        for _ in 0..300 {
+            let response = self.client.send_request(method, params.clone());
+            assert!(
+                response.get("error").is_none(),
+                "forwarded request must not error; got {response}"
+            );
+            if !response["result"].is_null() {
+                return response["result"].clone();
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        panic!("host server never answered {method}");
+    }
+
+    /// Poll `echo_method` until the server behind it reports at least one
+    /// recorded notification (the notification and the probe are independent
+    /// handler tasks, so the probe may overtake), returning the list. Bounded:
+    /// the first call already waited for the server, later ones answer at once.
+    fn notifications_seen_by(&mut self, echo_method: &str) -> Value {
+        let params = json!({ "textDocument": { "uri": MARKDOWN_URI } });
+        let mut recorded =
+            self.echo_until_answered(echo_method, params.clone())["notifications"].clone();
+        for _ in 0..100 {
+            if recorded.as_array().is_some_and(|n| !n.is_empty()) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            recorded =
+                self.client.send_request(echo_method, params.clone())["result"]["notifications"]
+                    .clone();
+        }
+        recorded
+    }
+}
 
 fn error_code(response: &Value) -> Option<i64> {
     response.pointer("/error/code").and_then(Value::as_i64)
 }
 
-/// Send `custom/echo` until the host server answers. Like every host
-/// request, the forward fails fast while the downstream is still
-/// initializing (an empty result; "the next request gets it"), and didOpen
-/// is what spawned it, so the first probes after open may come back `null`.
-fn echo_until_answered(client: &mut LspClient, params: Value) -> Value {
-    for _ in 0..300 {
-        let response = client.send_request("custom/echo", params.clone());
-        assert!(
-            response.get("error").is_none(),
-            "forwarded request must not error; got {response}"
-        );
-        if !response["result"].is_null() {
-            return response["result"].clone();
-        }
-        std::thread::sleep(std::time::Duration::from_millis(50));
-    }
-    panic!("host server never answered custom/echo");
-}
-
 #[test]
 fn e2e_custom_request_is_forwarded_verbatim_to_the_host_server() {
-    let (mut client, _config_dir) = init_client(FORWARDING_CONFIG);
+    let mut session = init_client(FORWARDING_CONFIG);
 
     let params = json!({
         "textDocument": { "uri": MARKDOWN_URI },
         "position": { "line": 2, "character": 1 },
         "extra": { "nested": [1, 2, 3] }
     });
-    let result = echo_until_answered(&mut client, params.clone());
+    let result = session.echo_until_answered("custom/echo", params.clone());
     assert_eq!(result["method"], "custom/echo");
     assert_eq!(
         result["params"], params,
@@ -130,44 +188,89 @@ fn e2e_custom_request_is_forwarded_verbatim_to_the_host_server() {
         "the host document must be synced to the server before the request"
     );
 
-    shutdown(&mut client);
+    session.shutdown();
 }
 
 #[test]
 fn e2e_custom_notification_is_forwarded_to_the_host_server() {
-    let (mut client, _config_dir) = init_client(FORWARDING_CONFIG);
+    let mut session = init_client(FORWARDING_CONFIG);
 
     let ping = json!({ "textDocument": { "uri": MARKDOWN_URI }, "n": 7 });
-    client.send_notification("custom/ping", ping.clone());
+    session
+        .client
+        .send_notification("custom/ping", ping.clone());
 
-    // The notification and the probe request are independent handler tasks,
-    // so the probe may overtake the notification; poll until it shows up.
-    let mut recorded = Value::Null;
+    assert_eq!(
+        session.notifications_seen_by("custom/echo"),
+        json!([{ "method": "custom/ping", "params": ping }]),
+        "the notification must reach the host server exactly once, verbatim"
+    );
+
+    session.shutdown();
+}
+
+#[test]
+fn e2e_custom_notification_reaches_every_listed_server_unless_capped() {
+    const TWO_SERVERS: &str = r#"
+[languages.markdown.bridge._self]
+enabled = true
+
+# One private echo per server, so each server's record can be read alone.
+[languages.markdown.bridge._self.aggregation."custom/echoA"]
+priorities = ["mock-a"]
+[languages.markdown.bridge._self.aggregation."custom/echoB"]
+priorities = ["mock-b"]
+
+[languages.markdown.bridge._self.aggregation."custom/ping"]
+priorities = ["mock-b", "mock-a"]
+
+[languages.markdown.bridge._self.aggregation."custom/capped"]
+priorities = ["mock-b", "mock-a"]
+maxFanOut = 1
+"#;
+    let mut session = init_session(TWO_SERVERS, &["mock-a", "mock-b"]);
+
+    let ping = json!({ "textDocument": { "uri": MARKDOWN_URI }, "n": 1 });
+    session
+        .client
+        .send_notification("custom/ping", ping.clone());
+    let expected_ping = json!([{ "method": "custom/ping", "params": ping }]);
+    assert_eq!(session.notifications_seen_by("custom/echoB"), expected_ping);
+    assert_eq!(
+        session.notifications_seen_by("custom/echoA"),
+        expected_ping,
+        "every listed server receives the notification, not only the first"
+    );
+
+    let capped = json!({ "textDocument": { "uri": MARKDOWN_URI }, "n": 2 });
+    session
+        .client
+        .send_notification("custom/capped", capped.clone());
+    let expected_capped = json!({ "method": "custom/capped", "params": capped });
+    // mock-b is first in priorities and the only one under maxFanOut = 1;
+    // once it has the capped ping, mock-a must still show only the first.
     for _ in 0..300 {
-        let result = echo_until_answered(
-            &mut client,
-            json!({ "textDocument": { "uri": MARKDOWN_URI } }),
-        );
-        recorded = result["notifications"].clone();
-        if recorded.as_array().is_some_and(|n| !n.is_empty()) {
+        let b = session.notifications_seen_by("custom/echoB");
+        if b.as_array().is_some_and(|n| n.len() >= 2) {
+            assert_eq!(b[1], expected_capped);
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(20));
     }
     assert_eq!(
-        recorded,
-        json!([{ "method": "custom/ping", "params": ping }]),
-        "the notification must reach the host server exactly once, verbatim"
+        session.notifications_seen_by("custom/echoA"),
+        expected_ping,
+        "maxFanOut = 1 must stop the notification at the first server"
     );
 
-    shutdown(&mut client);
+    session.shutdown();
 }
 
 #[test]
 fn e2e_unlisted_custom_request_keeps_method_not_found() {
-    let (mut client, _config_dir) = init_client(FORWARDING_CONFIG);
+    let mut session = init_client(FORWARDING_CONFIG);
 
-    let response = client.send_request(
+    let response = session.client.send_request(
         "custom/unlisted",
         json!({ "textDocument": { "uri": MARKDOWN_URI } }),
     );
@@ -177,21 +280,42 @@ fn e2e_unlisted_custom_request_keeps_method_not_found() {
         "a method without a literal aggregation entry is not forwarded; got {response}"
     );
 
-    shutdown(&mut client);
+    session.shutdown();
+}
+
+#[test]
+fn e2e_custom_request_for_an_unopened_document_keeps_method_not_found() {
+    let mut session = init_client(FORWARDING_CONFIG);
+
+    let response = session.client.send_request(
+        "custom/echo",
+        json!({ "textDocument": { "uri": "file:///never_opened.md" } }),
+    );
+    assert_eq!(
+        error_code(&response),
+        Some(METHOD_NOT_FOUND),
+        "only an open host document has servers to forward to; got {response}"
+    );
+    assert!(
+        !session.wire_methods().iter().any(|m| m == "custom/echo"),
+        "nothing must reach the downstream for an unopened document"
+    );
+
+    session.shutdown();
 }
 
 #[test]
 fn e2e_custom_request_without_host_opt_in_keeps_method_not_found() {
     // The aggregation entry exists but `_self.enabled` does not: the host
     // layer is off, so nothing is forwarded and the router's answer stands.
-    let (mut client, _config_dir) = init_client(
+    let mut session = init_client(
         r#"
 [languages.markdown.bridge._self.aggregation."custom/echo"]
 priorities = ["mock-host"]
 "#,
     );
 
-    let response = client.send_request(
+    let response = session.client.send_request(
         "custom/echo",
         json!({ "textDocument": { "uri": MARKDOWN_URI } }),
     );
@@ -201,28 +325,31 @@ priorities = ["mock-host"]
         "got {response}"
     );
 
-    shutdown(&mut client);
+    session.shutdown();
 }
 
 #[test]
 fn e2e_custom_request_without_text_document_is_invalid_params() {
-    let (mut client, _config_dir) = init_client(FORWARDING_CONFIG);
+    let mut session = init_client(FORWARDING_CONFIG);
 
-    let response = client.send_request("custom/echo", json!({ "no": "document" }));
-    assert_eq!(
-        error_code(&response),
-        Some(INVALID_PARAMS),
-        "a forwardable method needs textDocument.uri to pick a host; got {response}"
-    );
+    for params in [json!({ "no": "document" }), json!(null), json!(5)] {
+        let response = session.client.send_request("custom/echo", params.clone());
+        assert_eq!(
+            error_code(&response),
+            Some(INVALID_PARAMS),
+            "a forwardable method needs textDocument.uri to pick a host; params {params}, got \
+             {response}"
+        );
+    }
 
-    shutdown(&mut client);
+    session.shutdown();
 }
 
 #[test]
 fn e2e_concatenated_strategy_on_a_forwarded_request_is_request_failed() {
-    let (mut client, _config_dir) = init_client(FORWARDING_CONFIG);
+    let mut session = init_client(FORWARDING_CONFIG);
 
-    let response = client.send_request(
+    let response = session.client.send_request(
         "custom/merged",
         json!({ "textDocument": { "uri": MARKDOWN_URI } }),
     );
@@ -232,24 +359,71 @@ fn e2e_concatenated_strategy_on_a_forwarded_request_is_request_failed() {
         "only `preferred` can combine results of unknown shape; got {response}"
     );
 
-    shutdown(&mut client);
+    session.shutdown();
+}
+
+#[test]
+fn e2e_reserved_method_is_refused_even_when_configured() {
+    let mut session = init_client(
+        r#"
+[languages.markdown.bridge._self]
+enabled = true
+
+[languages.markdown.bridge._self.aggregation."custom/echo"]
+priorities = ["mock-host"]
+
+[languages.markdown.bridge._self.aggregation."shutdown"]
+priorities = ["mock-host"]
+"#,
+    );
+    // Make sure the server is up, so a leaked shutdown would be observable.
+    session.echo_until_answered(
+        "custom/echo",
+        json!({ "textDocument": { "uri": MARKDOWN_URI } }),
+    );
+
+    let response = session.client.send_request(
+        "kakehashi/forward/request",
+        json!({ "method": "shutdown", "params": { "textDocument": { "uri": MARKDOWN_URI } } }),
+    );
+    assert_eq!(
+        error_code(&response),
+        Some(REQUEST_FAILED),
+        "got {response}"
+    );
+    assert!(
+        !session.wire_methods().iter().any(|m| m == "shutdown"),
+        "a forwarded shutdown must never reach a downstream server"
+    );
+
+    session.shutdown();
 }
 
 #[test]
 fn e2e_built_in_method_is_not_shadowed_by_forwarding() {
-    // `textDocument/hover` has a handler; the router answers it (empty here,
-    // since the mock advertises no hoverProvider) and the forward never runs.
-    let (mut client, _config_dir) = init_client(
+    // `textDocument/hover` has a handler; the router answers it and the
+    // forward never runs — proven by the mock's wire log, not by the answer
+    // (the mock answers hover and a forwarded hover alike, so the response
+    // alone could not tell a shadowed router from a working one).
+    let mut session = init_client(
         r#"
 [languages.markdown.bridge._self]
 enabled = true
+
+[languages.markdown.bridge._self.aggregation."custom/echo"]
+priorities = ["mock-host"]
 
 [languages.markdown.bridge._self.aggregation."textDocument/hover"]
 priorities = ["mock-host"]
 "#,
     );
+    // The server is up and has the document: a forward WOULD reach it now.
+    session.echo_until_answered(
+        "custom/echo",
+        json!({ "textDocument": { "uri": MARKDOWN_URI } }),
+    );
 
-    let response = client.send_request(
+    let response = session.client.send_request(
         "textDocument/hover",
         json!({
             "textDocument": { "uri": MARKDOWN_URI },
@@ -257,7 +431,19 @@ priorities = ["mock-host"]
         }),
     );
     assert!(response.get("error").is_none(), "got {response}");
-    assert_eq!(response["result"], Value::Null);
+    assert_eq!(
+        response["result"],
+        Value::Null,
+        "the mock advertises no hoverProvider, so the typed host path skips it"
+    );
+    assert!(
+        !session
+            .wire_methods()
+            .iter()
+            .any(|m| m == "textDocument/hover"),
+        "hover must be answered by kakehashi's handler, never forwarded blind; wire: {:?}",
+        session.wire_methods()
+    );
 
-    shutdown(&mut client);
+    session.shutdown();
 }

--- a/tests/e2e/e2e_custom_method_forward.rs
+++ b/tests/e2e/e2e_custom_method_forward.rs
@@ -246,21 +246,73 @@ maxFanOut = 1
     session
         .client
         .send_notification("custom/capped", capped.clone());
+    // A second uncapped ping after the capped one. Each server's deliveries
+    // arrive in send order, so once mock-a shows this marker, a wrongly
+    // fanned-out capped ping would already be visible before it — "not
+    // arrived yet" cannot fake a pass.
+    let marker = json!({ "textDocument": { "uri": MARKDOWN_URI }, "n": 3 });
+    session
+        .client
+        .send_notification("custom/ping", marker.clone());
     let expected_capped = json!({ "method": "custom/capped", "params": capped });
-    // mock-b is first in priorities and the only one under maxFanOut = 1;
-    // once it has the capped ping, mock-a must still show only the first.
-    for _ in 0..300 {
-        let b = session.notifications_seen_by("custom/echoB");
-        if b.as_array().is_some_and(|n| n.len() >= 2) {
-            assert_eq!(b[1], expected_capped);
-            break;
+    let expected_marker = json!({ "method": "custom/ping", "params": marker });
+    let settled = |session: &mut Session, echo: &str| -> Value {
+        for _ in 0..300 {
+            let seen = session.notifications_seen_by(echo);
+            if seen
+                .as_array()
+                .is_some_and(|n| n.last() == Some(&expected_marker))
+            {
+                return seen;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
         }
-        std::thread::sleep(std::time::Duration::from_millis(20));
-    }
+        panic!("{echo}: marker ping never arrived");
+    };
     assert_eq!(
-        session.notifications_seen_by("custom/echoA"),
-        expected_ping,
-        "maxFanOut = 1 must stop the notification at the first server"
+        settled(&mut session, "custom/echoB"),
+        json!([expected_ping[0], expected_capped, expected_marker]),
+        "mock-b is first in priorities: the one server under maxFanOut = 1"
+    );
+    assert_eq!(
+        settled(&mut session, "custom/echoA"),
+        json!([expected_ping[0], expected_marker]),
+        "maxFanOut = 1 must stop the capped notification at the first server"
+    );
+
+    session.shutdown();
+}
+
+#[test]
+fn e2e_empty_priorities_answer_null_without_forwarding() {
+    // The per-method kill switch: eligible, selects nobody. A request
+    // answers null (no error, no downstream traffic), as for typed methods.
+    let mut session = init_client(
+        r#"
+[languages.markdown.bridge._self]
+enabled = true
+
+[languages.markdown.bridge._self.aggregation."custom/echo"]
+priorities = ["mock-host"]
+
+[languages.markdown.bridge._self.aggregation."custom/nobody"]
+priorities = []
+"#,
+    );
+    session.echo_until_answered(
+        "custom/echo",
+        json!({ "textDocument": { "uri": MARKDOWN_URI } }),
+    );
+
+    let response = session.client.send_request(
+        "custom/nobody",
+        json!({ "textDocument": { "uri": MARKDOWN_URI } }),
+    );
+    assert!(response.get("error").is_none(), "got {response}");
+    assert_eq!(response["result"], Value::Null);
+    assert!(
+        !session.wire_methods().iter().any(|m| m == "custom/nobody"),
+        "an empty allowlist must reach no server"
     );
 
     session.shutdown();

--- a/tests/e2e/e2e_custom_method_forward.rs
+++ b/tests/e2e/e2e_custom_method_forward.rs
@@ -82,6 +82,11 @@ fn shutdown(client: &mut LspClient) {
     client.send_notification("exit", json!(null));
 }
 
+const METHOD_NOT_FOUND: i64 = -32601;
+const INVALID_PARAMS: i64 = -32602;
+/// LSP `RequestFailed`: well-formed request, refused for a server-side reason.
+const REQUEST_FAILED: i64 = -32803;
+
 fn error_code(response: &Value) -> Option<i64> {
     response.pointer("/error/code").and_then(Value::as_i64)
 }
@@ -168,7 +173,7 @@ fn e2e_unlisted_custom_request_keeps_method_not_found() {
     );
     assert_eq!(
         error_code(&response),
-        Some(-32601),
+        Some(METHOD_NOT_FOUND),
         "a method without a literal aggregation entry is not forwarded; got {response}"
     );
 
@@ -190,7 +195,11 @@ priorities = ["mock-host"]
         "custom/echo",
         json!({ "textDocument": { "uri": MARKDOWN_URI } }),
     );
-    assert_eq!(error_code(&response), Some(-32601), "got {response}");
+    assert_eq!(
+        error_code(&response),
+        Some(METHOD_NOT_FOUND),
+        "got {response}"
+    );
 
     shutdown(&mut client);
 }
@@ -202,7 +211,7 @@ fn e2e_custom_request_without_text_document_is_invalid_params() {
     let response = client.send_request("custom/echo", json!({ "no": "document" }));
     assert_eq!(
         error_code(&response),
-        Some(-32602),
+        Some(INVALID_PARAMS),
         "a forwardable method needs textDocument.uri to pick a host; got {response}"
     );
 
@@ -210,7 +219,7 @@ fn e2e_custom_request_without_text_document_is_invalid_params() {
 }
 
 #[test]
-fn e2e_concatenated_strategy_on_a_forwarded_request_is_invalid_params() {
+fn e2e_concatenated_strategy_on_a_forwarded_request_is_request_failed() {
     let (mut client, _config_dir) = init_client(FORWARDING_CONFIG);
 
     let response = client.send_request(
@@ -219,7 +228,7 @@ fn e2e_concatenated_strategy_on_a_forwarded_request_is_invalid_params() {
     );
     assert_eq!(
         error_code(&response),
-        Some(-32602),
+        Some(REQUEST_FAILED),
         "only `preferred` can combine results of unknown shape; got {response}"
     );
 

--- a/tests/e2e/e2e_custom_method_forward.rs
+++ b/tests/e2e/e2e_custom_method_forward.rs
@@ -175,13 +175,23 @@ fn e2e_custom_request_is_forwarded_verbatim_to_the_host_server() {
     let params = json!({
         "textDocument": { "uri": MARKDOWN_URI },
         "position": { "line": 2, "character": 1 },
-        "extra": { "nested": [1, 2, 3] }
+        "extra": { "nested": [1, 2, 3] },
+        // The one exception to verbatim: progress tokens are stripped, since
+        // kakehashi relays no downstream progress.
+        "workDoneToken": "wd-1",
+        "partialResultToken": "pr-1"
     });
     let result = session.echo_until_answered("custom/echo", params.clone());
     assert_eq!(result["method"], "custom/echo");
+    let mut expected = params.clone();
+    expected.as_object_mut().unwrap().remove("workDoneToken");
+    expected
+        .as_object_mut()
+        .unwrap()
+        .remove("partialResultToken");
     assert_eq!(
-        result["params"], params,
-        "params must reach the server verbatim (real URI, no translation)"
+        result["params"], expected,
+        "params must reach the server verbatim (real URI, no translation) minus progress tokens"
     );
     assert_eq!(
         result["opened"], true,

--- a/tests/e2e/e2e_custom_method_forward.rs
+++ b/tests/e2e/e2e_custom_method_forward.rs
@@ -41,13 +41,20 @@ strategy = "concatenated"
 strategy = "concatenated"
 "#;
 
-/// One `custom-echo` mock per name, all host candidates for markdown.
+/// One mock per name, all host candidates for markdown. Names containing
+/// `decline` run the `custom-decline` mode (answers every `custom/*` request
+/// with MethodNotFound); the rest run `custom-echo`.
 fn language_servers(names: &[&str]) -> Value {
     let mut servers = serde_json::Map::new();
     for name in names {
+        let mode = if name.contains("decline") {
+            "custom-decline"
+        } else {
+            "custom-echo"
+        };
         servers.insert(
             (*name).to_owned(),
-            json!({ "cmd": [mock_bin(), "custom-echo"], "languages": ["markdown"] }),
+            json!({ "cmd": [mock_bin(), mode], "languages": ["markdown"] }),
         );
     }
     Value::Object(servers)
@@ -279,6 +286,73 @@ maxFanOut = 1
             .as_array()
             .is_some_and(|n| n.contains(&expected_capped)),
         "mock-b is first in priorities: the one server under maxFanOut = 1"
+    );
+
+    session.shutdown();
+}
+
+#[test]
+fn e2e_request_falls_through_a_declining_server_to_the_next() {
+    // preferred fan-in over two servers: the higher-priority one declines
+    // (MethodNotFound), the lower one answers — the answer must win, and a
+    // decline must not turn into an error.
+    let mut session = init_session(
+        r#"
+[languages.markdown.bridge._self]
+enabled = true
+
+[languages.markdown.bridge._self.aggregation."custom/echo"]
+priorities = ["mock-decline", "mock-host"]
+
+[languages.markdown.bridge._self.aggregation."custom/nobody-implements"]
+priorities = ["mock-decline"]
+"#,
+        &["mock-decline", "mock-host"],
+    );
+
+    let params = json!({ "textDocument": { "uri": MARKDOWN_URI } });
+    // Warm the declining server first (a request fails fast while it
+    // initializes, which would let the echo win without a fall-through ever
+    // happening): a method only it is listed for, until it shows on the wire.
+    // Every selected server declining is null, never an error.
+    let declined = (0..300)
+        .find_map(|_| {
+            let response = session
+                .client
+                .send_request("custom/nobody-implements", params.clone());
+            assert!(response.get("error").is_none(), "got {response}");
+            assert_eq!(response["result"], Value::Null);
+            if session
+                .wire_methods()
+                .iter()
+                .any(|m| m == "custom/nobody-implements")
+            {
+                Some(())
+            } else {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                None
+            }
+        })
+        .is_some();
+    assert!(declined, "the declining server never came up");
+
+    let echoes = |session: &Session| {
+        session
+            .wire_methods()
+            .iter()
+            .filter(|m| *m == "custom/echo")
+            .count()
+    };
+    let before = echoes(&session);
+    let result = session.echo_until_answered("custom/echo", params);
+    assert_eq!(
+        result["method"], "custom/echo",
+        "the lower-priority server's answer wins over the decline"
+    );
+    assert!(
+        echoes(&session) - before >= 2,
+        "both servers must have been asked (capability-blind); wire: {:?}",
+        session.wire_methods()
     );
 
     session.shutdown();

--- a/tests/e2e/e2e_custom_method_forward.rs
+++ b/tests/e2e/e2e_custom_method_forward.rs
@@ -246,24 +246,28 @@ maxFanOut = 1
     session
         .client
         .send_notification("custom/capped", capped.clone());
-    // A second uncapped ping after the capped one. Each server's deliveries
-    // arrive in send order, so once mock-a shows this marker, a wrongly
-    // fanned-out capped ping would already be visible before it — "not
-    // arrived yet" cannot fake a pass.
+    // A second uncapped ping after the capped one. Forwarded notifications
+    // carry no ordering promise, so the marker is not a fence; it is a
+    // later-sent message whose arrival at mock-a makes a wrongly fanned-out
+    // capped ping — dispatched earlier, to the same server — overwhelmingly
+    // likely to have arrived too, which "not arrived yet" could otherwise
+    // hide. Arrival sets are compared, not sequences.
     let marker = json!({ "textDocument": { "uri": MARKDOWN_URI }, "n": 3 });
     session
         .client
         .send_notification("custom/ping", marker.clone());
     let expected_capped = json!({ "method": "custom/capped", "params": capped });
     let expected_marker = json!({ "method": "custom/ping", "params": marker });
-    let settled = |session: &mut Session, echo: &str| -> Value {
+    let sorted = |items: &[&Value]| -> Vec<String> {
+        let mut v: Vec<String> = items.iter().map(|i| i.to_string()).collect();
+        v.sort();
+        v
+    };
+    let settled = |session: &mut Session, echo: &str| -> Vec<String> {
         for _ in 0..300 {
             let seen = session.notifications_seen_by(echo);
-            if seen
-                .as_array()
-                .is_some_and(|n| n.last() == Some(&expected_marker))
-            {
-                return seen;
+            if let Some(items) = seen.as_array().filter(|n| n.contains(&expected_marker)) {
+                return sorted(&items.iter().collect::<Vec<_>>());
             }
             std::thread::sleep(std::time::Duration::from_millis(20));
         }
@@ -271,12 +275,12 @@ maxFanOut = 1
     };
     assert_eq!(
         settled(&mut session, "custom/echoB"),
-        json!([expected_ping[0], expected_capped, expected_marker]),
+        sorted(&[&expected_ping[0], &expected_capped, &expected_marker]),
         "mock-b is first in priorities: the one server under maxFanOut = 1"
     );
     assert_eq!(
         settled(&mut session, "custom/echoA"),
-        json!([expected_ping[0], expected_marker]),
+        sorted(&[&expected_ping[0], &expected_marker]),
         "maxFanOut = 1 must stop the capped notification at the first server"
     );
 

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -22,6 +22,7 @@ mod e2e_code_lens_resolve;
 mod e2e_concatenated_formatting;
 mod e2e_config_file;
 mod e2e_config_relative_paths;
+mod e2e_custom_method_forward;
 mod e2e_data_dir;
 mod e2e_deprecation_warning;
 mod e2e_didchange_forwarding;


### PR DESCRIPTION
## Summary

Methods kakehashi does not implement — `textDocument/inlineCompletion` for a Copilot server, vendor custom requests, custom notifications — are now forwarded to the host document's `bridge._self` servers when the user names them explicitly:

```toml
[languages.markdown.bridge._self]
enabled = true

[languages.markdown.bridge._self.aggregation."textDocument/inlineCompletion"]
priorities = ["copilot"]
```

Design record: `docs/architecture-decisions/custom-method-host-forwarding.md`.

### How it works
- **Dispatch** (`src/lsp/custom_method_forwarder.rs`): an innermost tower middleware. A settings-gated predicate (methods some opted-in language names literally; cached per settings generation) decides whether a message is even a candidate, so standard traffic is untouched. A candidate request is dispatched to the router first and re-issued as `kakehashi/forward/request` only on the router's own `MethodNotFound`; a candidate notification kakehashi does not handle becomes `kakehashi/forward/notification`. Built-ins are never shadowed — the router is the authority for requests, `HANDLED_NOTIFICATIONS` (pinned to the `LanguageServer` impl by a source-scan test) for notifications.
- **Handler** (`src/lsp/lsp_impl/custom_method_forward.rs`): eligibility from one settings snapshot and one document read (open host document, `_self.enabled`, a host-capable server, a literal entry, `preferred` on the entry's own field, not a reserved lifecycle/sync/routing method). Requests forward params verbatim through the shared host layer with `CapabilityGate::Blind` (no capability check; a downstream `MethodNotFound` is a quiet decline; malformed envelopes count as failures; emptiness judged strictly for unknown shapes). Notifications fan out to every selected server concurrently on a detached, bounded task, wait through server initialization, re-read current text at sync time, and are dropped if the document closed (or closed-and-reopened) while they waited.
- **Errors**: ineligible → `MethodNotFound` (as today); missing/malformed `textDocument.uri` → `InvalidParams`; unsupported strategy or reserved method → `RequestFailed` (-32803).
- **Limits** (documented): host layer only; no capability advertisement to the client; `concatenated` rejected; no ordering promise between forwarded notifications.

### Tests
- 12 e2e tests (`tests/e2e/e2e_custom_method_forward.rs`) with new `custom-echo` / `custom-decline` mock modes: verbatim forwarding (minus progress tokens), notification delivery and per-server fan-out, fall-through across a declining server, kill-switch entries, reserved-method refusal, unopened documents, and a wire-log proof that built-in hover is never forwarded.
- Unit tests for the middleware plan/probe, the gate, config lookups, the delivery plan, emptiness, and decline-envelope validation.

### Follow-ups (pre-existing, not widened here)
- `execute_host_request` holds the per-URI lifecycle lock across the downstream response for every typed host request, and typed host requests can re-sync a document that closed while they waited for routing/connection. Forwarded paths now carry an incarnation check; the typed paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added opt-in forwarding for explicitly configured, unsupported LSP methods to host language servers.
  - Requests return the first non-empty result; notifications reach all selected servers.
  - Preserves parameters while supporting prioritization, fan-out limits, cancellation, and lifecycle safety.
  - Protects built-in and reserved methods from forwarding.

- **Documentation**
  - Documented configuration, routing behavior, limitations, error handling, and design decisions.

- **Tests**
  - Added comprehensive unit and end-to-end coverage for forwarding, validation, prioritization, notifications, and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->