### PR TITLE
feat(config): compose base config files

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -816,8 +816,10 @@ Composition is intentionally one level deep: a base file cannot contain
 `baseConfigFiles`. For an explicit `--config-file` entry that mistake rejects
 startup; for an implicitly discovered user or project entry it is warned about
 and that base file is skipped, following the owning entry's existing strict or
-tolerant loading policy. A missing base file is an optional layer and is
-skipped with a warning. Files are re-read only when their entry normally is:
+tolerant loading policy. An entry can name at most 64 base files; an explicit
+entry above the limit rejects startup, while an implicit entry warns and loads
+only the first 64. A missing base file is an optional layer and is skipped with
+a warning. Files are re-read only when their entry normally is:
 an explicit stack is retained for the session, while implicit user/project
 entries and their bases are reloaded after a workspace-root change.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,10 +106,13 @@ Parsers are stored in `{data_dir}/parser/` and queries in `{data_dir}/queries/`.
 
 ## Configuration
 
-Configuration is provided via LSP `initializationOptions`. All options are optional.
+Configuration can be provided through TOML entry files or LSP
+`initializationOptions`. All workspace-setting fields are optional.
 
-This section is a practical reference. For the canonical field list and types,
-see `kakehashi config schema`.
+This section is a practical reference. `kakehashi config schema` emits the
+canonical TOML entry-file field list and types; it additionally includes
+file-loader metadata such as `baseConfigFiles`, which is not accepted as a
+live LSP setting.
 
 ### Configuration Options
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -772,6 +772,46 @@ kakehashi --config-file /path/to/base.toml --config-file /path/to/overrides.toml
 kakehashi --config-file /path/to/empty.toml
 ```
 
+Each file selected directly — the discovered user file, the discovered project
+file, and every `--config-file` argument — is a configuration **entry**. An
+entry can prepend lower-precedence files with `baseConfigFiles`:
+
+```toml
+# kakehashi.toml
+baseConfigFiles = [
+  "$HOME/.config/kakehashi/languages.toml",
+  "$HOME/.config/kakehashi/servers.toml",
+]
+
+# Settings in this file override both base files.
+diagnosticsDebounceMs = 250
+```
+
+This entry is merged as if the base files had appeared immediately before it:
+
+```bash
+kakehashi \
+  --config-file "$HOME/.config/kakehashi/languages.toml" \
+  --config-file "$HOME/.config/kakehashi/servers.toml" \
+  --config-file ./kakehashi.toml
+```
+
+The comparison describes the local layer order. Implicit discovery still
+loads both ordinary entries, so the complete order is programmed defaults →
+user base files → user file → project base files → project file → client
+settings. `baseConfigFiles` values expand `$VAR`, `${VAR}`, and `~`; a relative
+value resolves against the entry file's directory. Each base file's own
+relative setting paths resolve against that base file's directory.
+
+Composition is intentionally one level deep: a base file cannot contain
+`baseConfigFiles`. For an explicit `--config-file` entry that mistake rejects
+startup; for an implicitly discovered user or project entry it is warned about
+and that base file is skipped, following the owning entry's existing strict or
+tolerant loading policy. A missing base file is an optional layer and is
+skipped with a warning. Files are re-read only when their entry normally is:
+an explicit stack is retained for the session, while implicit user/project
+entries and their bases are reloaded after a workspace-root change.
+
 When `--config-file` is specified:
 - Default user config (`~/.config/kakehashi/kakehashi.toml`) is **skipped**
 - Default project config (`./kakehashi.toml`) is **skipped**

--- a/docs/README.md
+++ b/docs/README.md
@@ -225,6 +225,7 @@ Path fields support environment variable expansion and tilde (`~`) expansion, ma
 - `searchPaths[*]`
 - `languages[*].parser`
 - `languages[*].queries[*].path`
+- `baseConfigFiles[*]` (TOML entry files only)
 
 **Relative paths** resolve against the configuration source that supplied them, rather than against the directory the server process was launched from:
 
@@ -799,9 +800,10 @@ kakehashi \
 The comparison describes the local layer order. Implicit discovery still
 loads both ordinary entries, so the complete order is programmed defaults →
 user base files → user file → project base files → project file → client
-settings. `baseConfigFiles` values expand `$VAR`, `${VAR}`, and `~`; a relative
-value resolves against the entry file's directory. Each base file's own
-relative setting paths resolve against that base file's directory.
+settings. `baseConfigFiles` values use the same expansion syntax described
+above, including `$$` for a literal dollar sign; a relative value resolves
+against the entry file's directory. Each base file's own relative setting
+paths resolve against that base file's directory.
 
 Composition is intentionally one level deep: a base file cannot contain
 `baseConfigFiles`. For an explicit `--config-file` entry that mistake rejects

--- a/docs/README.md
+++ b/docs/README.md
@@ -874,7 +874,8 @@ When `--config-file` is specified:
 Implicitly discovered configuration is deliberately laxer. A
 `~/.config/kakehashi/kakehashi.toml` or `./kakehashi.toml` that fails to parse
 is reported as a warning and skipped, so a stray file cannot stop the server
-from starting. Only paths you name explicitly are strict.
+from starting. Only directly selected `--config-file` entries and the bases
+they name use the strict policy.
 
 ## CLI Commands
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -823,8 +823,9 @@ startup; for an implicitly discovered user or project entry it is warned about
 and that base file is skipped, following the owning entry's existing strict or
 tolerant loading policy. An entry can name at most 64 base files; an explicit
 entry above the limit rejects startup, while an implicit entry warns and loads
-only the first 64. A missing base file is an optional layer and is skipped with
-a warning. Files are re-read only when their entry normally is:
+only the first 64. A missing base file is skipped without aborting startup, but
+the skip is surfaced as a visible warning. Files are re-read only when their
+entry normally is:
 an explicit stack is retained for the session, while implicit user/project
 entries and their bases are reloaded after a workspace-root change.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -233,7 +233,9 @@ Path fields support environment variable expansion and tilde (`~`) expansion, ma
 uses a separate file-loader pipeline: kakehashi expands the value first, then
 anchors the expanded result to the entry file's directory if it is relative.
 It leaves `.` and `..` for the operating system to resolve when the file is
-opened, rather than folding them lexically as setting paths do.
+opened, rather than folding them lexically as setting paths do. Named-home
+syntax such as `~alice/base.toml` is not supported; use `~` for the current
+user or give an absolute path.
 
 **Relative paths** resolve against the configuration source that supplied them, rather than against the directory the server process was launched from:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -221,11 +221,16 @@ Path fields support environment variable expansion and tilde (`~`) expansion, ma
 - `~` — expands to the user's home directory
 - `$$` — produces a literal `$` (escape mechanism)
 
-**Supported fields:**
+**Supported settings-path fields:**
 - `searchPaths[*]`
 - `languages[*].parser`
 - `languages[*].queries[*].path`
-- `baseConfigFiles[*]` (TOML entry files only)
+
+`baseConfigFiles[*]` in a TOML entry accepts the same expansion syntax, but it
+uses a separate file-loader pipeline: kakehashi expands the value first, then
+anchors the expanded result to the entry file's directory if it is relative.
+It leaves `.` and `..` for the operating system to resolve when the file is
+opened, rather than folding them lexically as setting paths do.
 
 **Relative paths** resolve against the configuration source that supplied them, rather than against the directory the server process was launched from:
 
@@ -241,7 +246,9 @@ The **workspace root** is the first `workspaceFolders` entry, or the deprecated 
 
 The root is re-selected the same way whenever the client sends `workspace/didChangeWorkspaceFolders`, and the project `kakehashi.toml` is re-read at the new root. One rung differs there: a folder change never falls back to the working directory. Removing the last folder falls back to `rootUri`, then the deprecated `rootPath`, and otherwise leaves the session with no project layer — closing a folder must not silently adopt the configuration of whichever directory the server happens to have been launched from. A `--config-file` session keeps its config-file stack regardless, since those files are read exactly once.
 
-Resolution is two steps: a relative value is rebased onto its source directory, and then **every** value — rebased or not — goes through the variable and tilde expansion described above.
+Resolution for these setting paths is two steps: a relative value is rebased
+onto its source directory, and then **every** value — rebased or not — goes
+through the variable and tilde expansion described above.
 
 A value beginning with `/`, `~`, or `$` skips the *rebasing* step only; it already says where it lives, and it is still expanded afterwards. On Windows a rooted path is likewise not rebased, whether it names a drive (`C:\parsers`) or not (`\parsers`, which means the current drive). This covers three cases worth calling out:
 

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -458,8 +458,6 @@ fn load_settings(root, override_settings, home, env_fn, explicit) -> SettingsLoa
 
 ## Implementation Phases
 
-**Overall Progress**: Phases 1-3 completed. Core configuration loading infrastructure is in place. Remaining work: CLI options and end-to-end testing.
-
 ### Phase 1: Query Configuration Schema (Completed - Sprint 118, PBI-151)
 - [x] Add `QueryItem` struct with `path` (required) and `kind` (optional) fields
 - [x] Add `queries: Option<Vec<QueryItem>>` field to `LanguageSettings`

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -87,7 +87,7 @@ the discovered project file, or one `--config-file` argument. An entry may name
 `baseConfigFiles`, which are expanded immediately before that entry in listed
 order. Consequently the implicit order is:
 
-```
+```text
 defaults
 < user bases < user entry
 < project bases < project entry
@@ -96,7 +96,7 @@ defaults
 
 For multiple explicit arguments, each entry expands in place:
 
-```
+```text
 bases(a) < a < bases(b) < b
 ```
 

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -107,14 +107,16 @@ not get a separate merge algorithm.
 `baseConfigFiles` is file-loader metadata, not workspace settings. It appears
 in the generated TOML schema but is not accepted as a live filesystem-loading
 directive from `initializationOptions` or
-`workspace/didChangeConfiguration`. Values use the same `$VAR`, `${VAR}`, and
-`~` expansion syntax as setting paths, then relative values anchor to the entry
-file's directory. Settings inside each base still anchor to that base file's
-own directory before the merge.
+`workspace/didChangeConfiguration`. Values use the same `$VAR`, `${VAR}`, `~`,
+and `$$` literal-dollar expansion syntax as setting paths, then relative values
+anchor to the entry file's directory. Settings inside each base still anchor
+to that base file's own directory before the merge.
 
 Base files cannot name more base files in this first version. An explicit entry
 rejects that mistake; an implicit user/project entry warns and skips the
 offending base, preserving the strictness of the source that owns the entry.
+An entry may name at most 64 bases: explicit overflow rejects the entry, while
+implicit overflow warns once and loads the first 64.
 This leaves a backward-compatible route to recursive composition later without
 requiring cycle identity, depth, or duplicate-traversal rules now.
 

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -315,8 +315,10 @@ The top-level spelling is accepted through v1 and removed in v2.
 
 ### File Loading Behavior
 
-Strictness follows *how the path was chosen*, not what went wrong with it. A
-path the user typed carries intent; a path kakehashi went looking for does not.
+Strictness is owned by the directly selected entry. A `--config-file` entry and
+the base files it names are strict; an implicitly discovered user or project
+entry and its base files are tolerant. The spelling of a base path does not
+change that policy.
 
 1. **Implicitly discovered files degrade quietly**
    - User config doesn't exist: proceed with empty user config

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -80,6 +80,44 @@ queries = [
    - Purpose: Per-session overrides from the editor/client configuration
    - Note: Runtime changes via `didChangeConfiguration` re-trigger the merge process
 
+### File Entry Composition
+
+Every directly selected TOML file is an **entry**: the discovered user file,
+the discovered project file, or one `--config-file` argument. An entry may name
+`baseConfigFiles`, which are expanded immediately before that entry in listed
+order. Consequently the implicit order is:
+
+```
+defaults
+< user bases < user entry
+< project bases < project entry
+< client layers
+```
+
+For multiple explicit arguments, each entry expands in place:
+
+```
+bases(a) < a < bases(b) < b
+```
+
+This is the same ordered layer sequence repeated `--config-file` arguments
+would produce. It deliberately reuses the existing left fold; base settings do
+not get a separate merge algorithm.
+
+`baseConfigFiles` is file-loader metadata, not workspace settings. It appears
+in the generated TOML schema but is not accepted as a live filesystem-loading
+directive from `initializationOptions` or
+`workspace/didChangeConfiguration`. Values use the same `$VAR`, `${VAR}`, and
+`~` expansion syntax as setting paths, then relative values anchor to the entry
+file's directory. Settings inside each base still anchor to that base file's
+own directory before the merge.
+
+Base files cannot name more base files in this first version. An explicit entry
+rejects that mistake; an implicit user/project entry warns and skips the
+offending base, preserving the strictness of the source that owns the entry.
+This leaves a backward-compatible route to recursive composition later without
+requiring cycle identity, depth, or duplicate-traversal rules now.
+
 ### Path Anchoring Precedes the Merge
 
 Relative path fields (`searchPaths`, `languages[*].parser`,
@@ -406,7 +444,7 @@ fn load_settings(root, override_settings, home, env_fn, explicit) -> SettingsLoa
 - **Complexity increase**: Four config sources to understand and debug
 - **Arrays replace, not merge**: `queries` arrays are replaced entirely, not concatenated; overriding one query type requires repeating all
 - **No "unset" mechanism for scalars**: a later layer can override a scalar but not return it to unset. Map- and list-valued settings do have one — an explicit empty container clears the layer below (see the merge algorithm above).
-- **File I/O at startup**: Reading the config files adds latency (minimal in practice) — two implicit files, or however many `--config-file` arguments were given
+- **File I/O at startup**: Reading the config files adds latency (minimal in practice) — two implicit entries plus their base files, or however many explicit entries and base files were given
 - **Relative paths changed meaning**: a relative value in an existing config file now resolves against that file's directory rather than wherever the server happened to be launched. Intended (it is the point of the change), but it silently relocates a user config written to be per-project — most visibly a `searchPaths` entry, whose misses are logged at debug level rather than as an error
 - **Infrastructure-integration gap**: Phases 1-3 (Sprints 118-120) built infrastructure (schema, merging, user config loading) but delivered ZERO user value until Sprint 124 wired APIs into application. Lesson: infrastructure sprints must be followed by integration sprints within 1-2 sprints to realize value.
 
@@ -449,6 +487,13 @@ fn load_settings(root, override_settings, home, env_fn, explicit) -> SettingsLoa
 - [ ] Integration tests loading actual files from XDG and project paths
 - [ ] E2E Neovim tests verifying InitializationOptions override file-based config
 
+### Phase 6: File Composition (Completed)
+- [x] Let user, project, and explicit entries prepend `baseConfigFiles`
+- [x] Preserve each base file's own relative-path anchor
+- [x] Keep composition non-recursive and reject or skip nested declarations
+- [x] Advertise the file-only field in `config schema`
+- [x] Cover explicit composition through an LSP-process E2E test
+
 ## Alternatives Considered
 
 ### 1. Shallow merge for `languages` HashMap (current implementation)
@@ -465,8 +510,13 @@ fn load_settings(root, override_settings, home, env_fn, explicit) -> SettingsLoa
 
 ### 3. Single config file with includes
 - Pro: Simpler loading logic
-- Con: Requires inventing include syntax; less conventional
-- Decision: Rejected; layered files are standard in the ecosystem
+- Pro: Lets an editor launch kakehashi normally without repeating a shared
+  `--config-file` list in client configuration
+- Con: Recursive includes would require cycle, depth, and duplicate-read rules
+- Decision: **Accepted as one-level `baseConfigFiles` composition** after
+  repeated `--config-file` established the layer semantics. Each directly
+  selected entry expands its bases in place and then uses the existing ordered
+  merge; base files cannot include more files.
 
 ### 4. Environment variable overrides
 - Pro: Easy CI/CD integration

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,10 +17,9 @@ pub(crate) use merge::{
     is_server_spawnable, merge_bridge_language_configs, merge_bridge_server_configs,
     merge_layer_aggregation_configs, merge_workspace_settings, resolve_with_wildcard,
 };
-pub(crate) use settings::{CaptureMappings, DEFAULT_DEBOUNCE_MS};
+pub(crate) use settings::{CaptureMappings, ConfigFileSettings, DEFAULT_DEBOUNCE_MS};
 // Raw and effective settings share this type, so converting between them no
 // longer names it; only the tests that build fixtures do.
-pub(crate) use settings::ConfigFileSettings;
 #[cfg(test)]
 pub(crate) use settings::QueryTypeMappings;
 pub use settings::{LanguageSettings, RawWorkspaceSettings, WorkspaceSettings, json_schema};

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,7 @@ pub(crate) use merge::{
 pub(crate) use settings::{CaptureMappings, DEFAULT_DEBOUNCE_MS};
 // Raw and effective settings share this type, so converting between them no
 // longer names it; only the tests that build fixtures do.
+pub(crate) use settings::ConfigFileSettings;
 #[cfg(test)]
 pub(crate) use settings::QueryTypeMappings;
 pub use settings::{LanguageSettings, RawWorkspaceSettings, WorkspaceSettings, json_schema};

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,9 @@ pub(crate) use merge::{
     is_server_spawnable, merge_bridge_language_configs, merge_bridge_server_configs,
     merge_layer_aggregation_configs, merge_workspace_settings, resolve_with_wildcard,
 };
-pub(crate) use settings::{CaptureMappings, ConfigFileSettings, DEFAULT_DEBOUNCE_MS};
+pub(crate) use settings::{
+    CaptureMappings, ConfigFileSettings, DEFAULT_DEBOUNCE_MS, MAX_BASE_CONFIG_FILES_PER_ENTRY,
+};
 // Raw and effective settings share this type, so converting between them no
 // longer names it; only the tests that build fixtures do.
 #[cfg(test)]

--- a/src/config/expand.rs
+++ b/src/config/expand.rs
@@ -124,7 +124,7 @@ impl std::error::Error for ExpandErrors {}
 ///
 /// `home` is the pre-computed home directory (from `dirs::home_dir()`),
 /// passed in so the caller computes it once for all paths.
-pub(super) fn expand_path(
+pub(crate) fn expand_path(
     input: &str,
     home: Option<&str>,
     env_fn: impl Fn(&str) -> Option<String>,

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -807,7 +807,8 @@ pub(crate) struct ConfigFileSettings {
     /// Lower-precedence TOML files loaded before this directly selected entry.
     /// A base file cannot declare further base files.
     #[serde(default)]
-    pub(crate) base_config_files: Vec<String>,
+    #[schemars(with = "Vec<String>")]
+    pub(crate) base_config_files: Option<Vec<String>>,
     #[serde(flatten)]
     pub(crate) settings: RawWorkspaceSettings,
 }
@@ -1344,6 +1345,12 @@ mod tests {
         assert!(!field.is_null(), "file schema must expose baseConfigFiles");
         assert_eq!(field["type"], "array");
         assert_eq!(field["items"]["type"], "string");
+        assert!(
+            value["required"]
+                .as_array()
+                .is_none_or(|required| !required.iter().any(|key| key == "baseConfigFiles")),
+            "baseConfigFiles is optional on entry files"
+        );
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -983,9 +983,9 @@ impl FeatureSettings {
     }
 }
 
-/// Generate JSON Schema for the workspace configuration.
+/// Generate JSON Schema for a TOML configuration file.
 pub fn json_schema() -> schemars::Schema {
-    schemars::schema_for!(RawWorkspaceSettings)
+    schemars::schema_for!(ConfigFileSettings)
 }
 
 // Domain types - used throughout the application and also exposed in JSON Schema
@@ -1332,6 +1332,16 @@ mod tests {
                 "missing $defs entry: {expected}"
             );
         }
+    }
+
+    #[test]
+    fn config_file_schema_advertises_base_config_files() {
+        let value = serde_json::to_value(json_schema()).expect("schema JSON");
+        let field = &value["properties"]["baseConfigFiles"];
+
+        assert!(!field.is_null(), "file schema must expose baseConfigFiles");
+        assert_eq!(field["type"], "array");
+        assert_eq!(field["items"]["type"], "string");
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -802,8 +802,9 @@ pub struct RawWorkspaceSettings {
 /// Live LSP settings deserialize as [`RawWorkspaceSettings`] directly, so
 /// clients cannot use `baseConfigFiles` to make the server read local files.
 ///
-/// At 8 MiB per file, 64 bases cap one entry's retained explicit input at
-/// 512 MiB while leaving ample room for ordinary hand-written composition.
+/// At 8 MiB per file, 64 bases cap base-file input read per entry at 512 MiB
+/// (520 MiB including the entry) while leaving ample room for ordinary
+/// hand-written composition.
 pub(crate) const MAX_BASE_CONFIG_FILES_PER_ENTRY: usize = 64;
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1355,7 +1355,10 @@ mod tests {
         assert!(!field.is_null(), "file schema must expose baseConfigFiles");
         assert_eq!(field["type"], "array");
         assert_eq!(field["items"]["type"], "string");
-        assert_eq!(field["maxItems"], 64);
+        assert_eq!(
+            field["maxItems"].as_u64(),
+            Some(MAX_BASE_CONFIG_FILES_PER_ENTRY as u64)
+        );
         assert!(
             field.get("default").is_none(),
             "an optional array must not advertise null as a schema-invalid default: {field}"

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -801,6 +801,11 @@ pub struct RawWorkspaceSettings {
 ///
 /// Live LSP settings deserialize as [`RawWorkspaceSettings`] directly, so
 /// clients cannot use `baseConfigFiles` to make the server read local files.
+///
+/// At 8 MiB per file, 64 bases cap one entry's retained explicit input at
+/// 512 MiB while leaving ample room for ordinary hand-written composition.
+pub(crate) const MAX_BASE_CONFIG_FILES_PER_ENTRY: usize = 64;
+
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ConfigFileSettings {
@@ -811,6 +816,7 @@ pub(crate) struct ConfigFileSettings {
     // `default` alone would emit; this input-only envelope is never serialized.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(with = "Vec<String>")]
+    #[schemars(length(max = MAX_BASE_CONFIG_FILES_PER_ENTRY))]
     pub(crate) base_config_files: Option<Vec<String>>,
     #[serde(flatten)]
     pub(crate) settings: RawWorkspaceSettings,
@@ -1348,6 +1354,7 @@ mod tests {
         assert!(!field.is_null(), "file schema must expose baseConfigFiles");
         assert_eq!(field["type"], "array");
         assert_eq!(field["items"]["type"], "string");
+        assert_eq!(field["maxItems"], 64);
         assert!(
             field.get("default").is_none(),
             "an optional array must not advertise null as a schema-invalid default: {field}"

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -802,9 +802,9 @@ pub struct RawWorkspaceSettings {
 /// Live LSP settings deserialize as [`RawWorkspaceSettings`] directly, so
 /// clients cannot use `baseConfigFiles` to make the server read local files.
 ///
-/// At 8 MiB per file, 64 bases cap base-file input read per entry at 512 MiB
-/// (520 MiB including the entry) while leaving ample room for ordinary
-/// hand-written composition.
+/// With at most 8 MiB of accepted content per base, 64 bases cap accepted base
+/// content per entry at 512 MiB while leaving ample room for ordinary
+/// hand-written composition. Parsed allocations can be larger.
 pub(crate) const MAX_BASE_CONFIG_FILES_PER_ENTRY: usize = 64;
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -804,6 +804,8 @@ pub struct RawWorkspaceSettings {
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ConfigFileSettings {
+    /// Lower-precedence TOML files loaded before this directly selected entry.
+    /// A base file cannot declare further base files.
     #[serde(default)]
     pub(crate) base_config_files: Vec<String>,
     #[serde(flatten)]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -806,7 +806,10 @@ pub struct RawWorkspaceSettings {
 pub(crate) struct ConfigFileSettings {
     /// Lower-precedence TOML files loaded before this directly selected entry.
     /// A base file cannot declare further base files.
-    #[serde(default)]
+    // `with = Vec<_>` makes schemars lose Option's optionality. This serde pair
+    // restores it without advertising the schema-invalid `default: null` that
+    // `default` alone would emit; this input-only envelope is never serialized.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(with = "Vec<String>")]
     pub(crate) base_config_files: Option<Vec<String>>,
     #[serde(flatten)]
@@ -1345,6 +1348,10 @@ mod tests {
         assert!(!field.is_null(), "file schema must expose baseConfigFiles");
         assert_eq!(field["type"], "array");
         assert_eq!(field["items"]["type"], "string");
+        assert!(
+            field.get("default").is_none(),
+            "an optional array must not advertise null as a schema-invalid default: {field}"
+        );
         assert!(
             value["required"]
                 .as_array()

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -797,6 +797,19 @@ pub struct RawWorkspaceSettings {
     pub language_servers: Option<HashMap<String, BridgeServerConfig>>,
 }
 
+/// Settings and composition metadata accepted only from a TOML config file.
+///
+/// Live LSP settings deserialize as [`RawWorkspaceSettings`] directly, so
+/// clients cannot use `baseConfigFiles` to make the server read local files.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ConfigFileSettings {
+    #[serde(default)]
+    pub(crate) base_config_files: Vec<String>,
+    #[serde(flatten)]
+    pub(crate) settings: RawWorkspaceSettings,
+}
+
 pub const DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_DEBOUNCE_MS: u64 = 100;
 pub const DEFAULT_WORKSPACE_DIAGNOSTIC_REFRESH_MAX_WAIT_MS: u64 = 1000;
 pub const DEFAULT_PUBLISH_DIAGNOSTICS_DEBOUNCE_MS: u64 = 100;

--- a/src/config/unknown_keys.rs
+++ b/src/config/unknown_keys.rs
@@ -400,6 +400,20 @@ mod tests {
     }
 
     #[test]
+    fn config_file_keys_accept_base_config_files_but_still_flag_typos() {
+        assert!(unknown_toml_config_file_keys("baseConfigFiles = [\"base.toml\"]\n").is_empty());
+        assert_eq!(
+            unknown_toml_config_file_keys("baseConfigFile = \"base.toml\"\n"),
+            ["baseConfigFile"]
+        );
+        assert_eq!(
+            unknown_toml_workspace_setting_keys("baseConfigFiles = [\"base.toml\"]\n"),
+            ["baseConfigFiles"],
+            "the exemption must remain limited to file validation"
+        );
+    }
+
+    #[test]
     fn known_feature_setting_keys_match_schema_properties() {
         assert_known_keys_match_schema::<FeatureSettings>(KNOWN_FEATURE_SETTING_KEYS, &[]);
     }

--- a/src/config/unknown_keys.rs
+++ b/src/config/unknown_keys.rs
@@ -87,6 +87,12 @@ pub(crate) fn unknown_toml_workspace_setting_keys(contents: &str) -> Vec<String>
     keys
 }
 
+pub(crate) fn unknown_toml_config_file_keys(contents: &str) -> Vec<String> {
+    let mut keys = unknown_toml_workspace_setting_keys(contents);
+    keys.retain(|key| key != "baseConfigFiles");
+    keys
+}
+
 fn unknown_object_keys(path: &str, value: &Value, known_keys: &[&str]) -> Vec<String> {
     let Some(object) = value.as_object() else {
         return Vec::new();

--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -4,7 +4,7 @@
 //! User config location: $XDG_CONFIG_HOME/kakehashi/kakehashi.toml
 //! Fallback: ~/.config/kakehashi/kakehashi.toml
 
-use crate::config::RawWorkspaceSettings;
+use crate::config::{ConfigFileSettings, RawWorkspaceSettings};
 use log::warn;
 use std::path::PathBuf;
 
@@ -68,6 +68,7 @@ impl std::error::Error for UserConfigError {
 #[derive(Debug)]
 pub(crate) struct UserConfig {
     pub(crate) settings: RawWorkspaceSettings,
+    pub(crate) base_config_files: Vec<String>,
     pub(crate) deprecated_keys: crate::config::deprecation::DeprecatedKeysSeen,
     /// Unknown keys detected from the same bytes used to parse `settings`.
     pub(crate) unknown_keys: Vec<String>,
@@ -156,8 +157,10 @@ pub fn load_user_config() -> UserConfigResult<Option<UserConfig>> {
     };
 
     let deprecated_keys = crate::config::deprecation::toml_deprecated_keys(&contents);
-    let unknown_keys = crate::config::unknown_keys::unknown_toml_workspace_setting_keys(&contents);
-    let settings = toml::from_str::<RawWorkspaceSettings>(&contents).map_err(|e| {
+    let mut unknown_keys =
+        crate::config::unknown_keys::unknown_toml_workspace_setting_keys(&contents);
+    unknown_keys.retain(|key| key != "baseConfigFiles");
+    let document = toml::from_str::<ConfigFileSettings>(&contents).map_err(|e| {
         UserConfigError::ParseError {
             path: path.clone(),
             source: e,
@@ -165,7 +168,8 @@ pub fn load_user_config() -> UserConfigResult<Option<UserConfig>> {
     })?;
 
     Ok(Some(UserConfig {
-        settings,
+        settings: document.settings,
+        base_config_files: document.base_config_files,
         deprecated_keys,
         unknown_keys,
         path,

--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -157,9 +157,7 @@ pub fn load_user_config() -> UserConfigResult<Option<UserConfig>> {
     };
 
     let deprecated_keys = crate::config::deprecation::toml_deprecated_keys(&contents);
-    let mut unknown_keys =
-        crate::config::unknown_keys::unknown_toml_workspace_setting_keys(&contents);
-    unknown_keys.retain(|key| key != "baseConfigFiles");
+    let unknown_keys = crate::config::unknown_keys::unknown_toml_config_file_keys(&contents);
     let document = toml::from_str::<ConfigFileSettings>(&contents).map_err(|e| {
         UserConfigError::ParseError {
             path: path.clone(),

--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -68,7 +68,7 @@ impl std::error::Error for UserConfigError {
 #[derive(Debug)]
 pub(crate) struct UserConfig {
     pub(crate) settings: RawWorkspaceSettings,
-    pub(crate) base_config_files: Vec<String>,
+    pub(crate) base_config_files: Option<Vec<String>>,
     pub(crate) deprecated_keys: crate::config::deprecation::DeprecatedKeysSeen,
     /// Unknown keys detected from the same bytes used to parse `settings`.
     pub(crate) unknown_keys: Vec<String>,

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -286,8 +286,8 @@ impl<'a> ClientNotifier<'a> {
     ///
     /// Settings events are emitted during configuration loading and include
     /// informational messages and warnings about configuration issues.
-    /// Error events use `window/showMessage` so they appear as visible
-    /// notifications in the editor, not just in the output panel.
+    /// Actionable warnings and errors use `window/showMessage` so they appear
+    /// as visible notifications in the editor, not just in the output panel.
     pub(crate) async fn log_settings_events(&self, events: &[SettingsEvent]) {
         for event in events {
             match event.kind {
@@ -298,6 +298,11 @@ impl<'a> ClientNotifier<'a> {
                 }
                 SettingsEventKind::Warning => {
                     self.log(MessageType::WARNING, event.message.as_str()).await;
+                }
+                SettingsEventKind::ShowWarning => {
+                    self.client
+                        .show_message(MessageType::WARNING, event.message.clone())
+                        .await;
                 }
                 SettingsEventKind::Info => {
                     self.log(MessageType::INFO, event.message.as_str()).await;

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -4,6 +4,7 @@ use crate::config::{
     RawWorkspaceSettings, WorkspaceSettings, defaults::default_settings, load_user_config,
     merge_workspace_settings,
 };
+use serde::Deserialize;
 use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -108,6 +109,29 @@ fn fold_layers(
 /// process died rather than reporting a bad path.
 const MAX_CONFIG_FILE_BYTES: u64 = 8 * 1024 * 1024;
 
+/// A file-backed configuration entry.
+///
+/// `baseConfigFiles` belongs to the file loader, not to live workspace
+/// settings. Keeping it outside [`RawWorkspaceSettings`] prevents clients from
+/// trying to add filesystem layers through `initializationOptions` or
+/// `workspace/didChangeConfiguration`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ConfigFileDocument {
+    #[serde(default)]
+    base_config_files: Vec<String>,
+    #[serde(flatten)]
+    settings: RawWorkspaceSettings,
+}
+
+impl std::ops::Deref for ConfigFileDocument {
+    type Target = RawWorkspaceSettings;
+
+    fn deref(&self) -> &Self::Target {
+        &self.settings
+    }
+}
+
 /// The `--config-file` inputs, read and judged exactly once.
 ///
 /// Read *once* is a contract, not an optimisation. A file replaced between two
@@ -159,8 +183,12 @@ fn append_unknown_config_key_warnings(
     contents: &str,
     config_path: &Path,
     events: &mut Vec<SettingsEvent>,
+    allow_base_config_files: bool,
 ) {
-    let keys = crate::config::unknown_keys::unknown_toml_workspace_setting_keys(contents);
+    let mut keys = crate::config::unknown_keys::unknown_toml_workspace_setting_keys(contents);
+    if allow_base_config_files {
+        keys.retain(|key| key != "baseConfigFiles");
+    }
     append_unknown_key_warnings(&keys, config_path, events);
 }
 
@@ -230,6 +258,93 @@ fn config_file_base(path: &Path) -> std::io::Result<PathBuf> {
     })
 }
 
+fn resolve_base_config_paths(
+    entry_path: &Path,
+    base_config_files: &[String],
+    home: Option<&str>,
+    env_fn: impl Fn(&str) -> Option<String>,
+) -> Result<Vec<PathBuf>, String> {
+    if base_config_files.is_empty() {
+        return Ok(Vec::new());
+    }
+    let entry_base = config_file_base(entry_path).map_err(|error| {
+        format!(
+            "Failed to resolve the directory of {}: {error}",
+            entry_path.display()
+        )
+    })?;
+
+    base_config_files
+        .iter()
+        .map(|configured| {
+            let expanded =
+                crate::config::expand::expand_path(configured, home, &env_fn).map_err(|error| {
+                    format!(
+                        "Failed to expand baseConfigFiles entry in {}: {error}",
+                        entry_path.display()
+                    )
+                })?;
+            if crate::config::paths::is_drive_relative(&expanded) {
+                return Err(format!(
+                    "Failed to resolve baseConfigFiles entry {configured:?} in {}: path names a \
+                     drive but no root; give the path in full",
+                    entry_path.display()
+                ));
+            }
+            let path = PathBuf::from(expanded);
+            Ok(if path.has_root() || path.is_absolute() {
+                path
+            } else {
+                entry_base.join(path)
+            })
+        })
+        .collect()
+}
+
+fn validate_and_anchor_explicit_layer(
+    layer: &mut Option<RawWorkspaceSettings>,
+    path: &Path,
+    home: Option<&str>,
+    env_fn: impl Fn(&str) -> Option<String>,
+) -> Result<(), String> {
+    let Some(raw_settings) = layer.as_mut() else {
+        return Ok(());
+    };
+
+    if let Err(errs) = WorkspaceSettings::try_from_settings(raw_settings, home, &env_fn)
+        && let Some(details) = errs.path_error_summary()
+    {
+        return Err(format!(
+            "Path expansion failed in {}: {details}",
+            path.display()
+        ));
+    }
+
+    let base = config_file_base(path).map_err(|error| {
+        format!(
+            "Failed to resolve the directory of {}: {error}",
+            path.display()
+        )
+    })?;
+    let unanchored = anchor_settings_paths(raw_settings, Some(&base));
+    if unanchored.is_empty() {
+        return Ok(());
+    }
+
+    Err(format!(
+        "Cannot resolve {} in {} against that file's directory, so {} would silently resolve \
+         against the working directory instead. Either the directory's name is not valid UTF-8, \
+         or the path names a drive without a root (`C:lib`); write the path in full to fix it.",
+        if unanchored.len() == 1 {
+            "a path".to_string()
+        } else {
+            format!("{} paths", unanchored.len())
+        },
+        path.display(),
+        unanchored.join(", ")
+    ))
+}
+
 /// The body of [`load_explicit_config`], taking the paths directly so it can be
 /// exercised without the process-global `--config-file` override.
 fn read_explicit_layers(
@@ -246,7 +361,7 @@ fn read_explicit_layers(
     let mut fatal_error = None;
     let mut layers = Vec::with_capacity(files.len());
 
-    for path in files {
+    for entry_path in files {
         // The verdict cannot change once a layer has failed, and reading on is
         // not free: a later path could be a FIFO that blocks forever, so an
         // already-doomed session would hang instead of reporting the failure it
@@ -254,90 +369,57 @@ fn read_explicit_layers(
         if fatal_error.is_some() {
             break;
         }
-        let mut layer = match load_toml_file(path, &mut events, &mut deprecated_keys) {
-            Ok(layer) => layer,
+        let entry = match load_toml_file(entry_path, &mut events, &mut deprecated_keys) {
+            Ok(entry) => entry,
             Err(message) => {
                 events.push(SettingsEvent::error(message.clone()));
                 fatal_error.get_or_insert(message);
-                None
+                break;
             }
         };
-        // Judging a layer in isolation also resolves its language `base`
-        // chains, so a cycle an overlay later removes is still warned about
-        // once here. Accepted: the alternative is threading a "stay quiet"
-        // flag through base resolution to silence a warning that names a
-        // real cycle in a file the user wrote.
-        //
-        // Judge each layer's *paths* on its own so a later layer cannot
-        // mask an earlier one's undefined variable: path fields are
-        // replaced wholesale by the overlay, so the merged result would
-        // never mention the mistake. Cross-field invariants are excluded
-        // here (see `ExpandErrors::path_error_summary`) — their operands
-        // merge independently, so they are only meaningful once every
-        // layer has been folded together, and `expand_merged_settings`
-        // catches them there.
-        //
-        // Judged *before* anchoring, so the value the error quotes is the one
-        // the user can find in their file. The verdict is the same either way:
-        // anchoring cannot introduce an expansion error, since it prepends an
-        // absolute base whose own `$` it escapes, and cannot remove one, since
-        // it declines to fold a value carrying a variable. So this costs
-        // nothing and reads better.
-        if let Some(raw_settings) = layer.as_ref()
-            && let Err(errs) = WorkspaceSettings::try_from_settings(raw_settings, home, &env_fn)
-            && let Some(details) = errs.path_error_summary()
-        {
-            let message = format!("Path expansion failed in {}: {details}", path.display());
-            events.push(SettingsEvent::error(message.clone()));
-            fatal_error.get_or_insert(message);
-        }
-        // Anchor each file's relative paths to that file's own directory, so
-        // `--config-file base.toml --config-file team/overrides.toml` reads
-        // `./queries` as relative to whichever file wrote it.
-        //
-        // Failing to anchor is fatal rather than skipped, both when the
-        // directory cannot be resolved and when it cannot be represented in a
-        // `String` path field: falling through would silently resolve that
-        // layer's paths against the working directory, which is the
-        // launch-directory dependence this anchoring exists to remove. The
-        // layers that degrade instead of failing are the implicit ones, whose
-        // contract has always been to fall back rather than abort.
-        //
-        // An unusable directory is only reported when the layer actually has
-        // something to anchor. A file naming only absolute paths does not care
-        // where it lives, and rejecting the session over it would be a failure
-        // the user cannot act on.
-        if let Some(raw_settings) = layer.as_mut() {
-            match config_file_base(path) {
-                Ok(base) => {
-                    let unanchored = anchor_settings_paths(raw_settings, Some(&base));
-                    if !unanchored.is_empty() {
-                        let message = format!(
-                            "Cannot resolve {} in {} against that file's directory, so {} would \
-                             silently resolve against the working directory instead. Either the \
-                             directory's name is not valid UTF-8, or the path names a drive \
-                             without a root (`C:lib`); write the path in full to fix it.",
-                            if unanchored.len() == 1 {
-                                "a path".to_string()
-                            } else {
-                                format!("{} paths", unanchored.len())
-                            },
-                            path.display(),
-                            unanchored.join(", ")
-                        );
-                        events.push(SettingsEvent::error(message.clone()));
-                        fatal_error.get_or_insert(message);
-                    }
-                }
-                Err(error) => {
-                    let message = format!(
-                        "Failed to resolve the directory of {}: {error}",
-                        path.display()
-                    );
+        let Some(entry) = entry else {
+            layers.push(None);
+            continue;
+        };
+        let base_paths =
+            match resolve_base_config_paths(entry_path, &entry.base_config_files, home, &env_fn) {
+                Ok(paths) => paths,
+                Err(message) => {
                     events.push(SettingsEvent::error(message.clone()));
-                    fatal_error.get_or_insert(message);
+                    fatal_error = Some(message);
+                    break;
                 }
+            };
+
+        for base_path in base_paths {
+            let base = match load_base_toml_file(&base_path, &mut events, &mut deprecated_keys) {
+                Ok(base) => base,
+                Err(message) => {
+                    events.push(SettingsEvent::error(message.clone()));
+                    fatal_error = Some(message);
+                    break;
+                }
+            };
+            let mut layer = base.map(|document| document.settings);
+            if let Err(message) =
+                validate_and_anchor_explicit_layer(&mut layer, &base_path, home, &env_fn)
+            {
+                events.push(SettingsEvent::error(message.clone()));
+                fatal_error = Some(message);
+                break;
             }
+            layers.push(layer);
+        }
+        if fatal_error.is_some() {
+            break;
+        }
+
+        let mut layer = Some(entry.settings);
+        if let Err(message) =
+            validate_and_anchor_explicit_layer(&mut layer, entry_path, home, &env_fn)
+        {
+            events.push(SettingsEvent::error(message.clone()));
+            fatal_error = Some(message);
         }
         layers.push(layer);
     }
@@ -685,7 +767,24 @@ fn load_toml_file(
     path: &Path,
     events: &mut Vec<SettingsEvent>,
     deprecated_keys: &mut DeprecatedKeysSeen,
-) -> Result<Option<RawWorkspaceSettings>, String> {
+) -> Result<Option<ConfigFileDocument>, String> {
+    load_toml_file_impl(path, events, deprecated_keys, true)
+}
+
+fn load_base_toml_file(
+    path: &Path,
+    events: &mut Vec<SettingsEvent>,
+    deprecated_keys: &mut DeprecatedKeysSeen,
+) -> Result<Option<ConfigFileDocument>, String> {
+    load_toml_file_impl(path, events, deprecated_keys, false)
+}
+
+fn load_toml_file_impl(
+    path: &Path,
+    events: &mut Vec<SettingsEvent>,
+    deprecated_keys: &mut DeprecatedKeysSeen,
+    allow_base_config_files: bool,
+) -> Result<Option<ConfigFileDocument>, String> {
     // Classify by opening, not by probing first: a separate `exists` check
     // would answer for a different moment than the open, and would have to
     // decide what "no" means without the kernel's reason for it. `NotFound` is
@@ -767,7 +866,7 @@ fn load_toml_file(
     let contents = String::from_utf8(bytes)
         .map_err(|err| format!("Failed to read {}: {}", path.display(), err))?;
     deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
-    let settings = toml::from_str::<RawWorkspaceSettings>(&contents)
+    let settings = toml::from_str::<ConfigFileDocument>(&contents)
         .map_err(|err| format!("Failed to parse {}: {}", path.display(), err))?;
 
     // Serde drops an unrecognised field silently, so `autoInstal = false` reads
@@ -775,7 +874,7 @@ fn load_toml_file(
     // Warn rather than reject: a key kakehashi does not recognise may be a
     // typo, but it may equally be one this version has not learned yet, and
     // refusing to start over it would make the file version-locked.
-    append_unknown_config_key_warnings(&contents, path, events);
+    append_unknown_config_key_warnings(&contents, path, events, allow_base_config_files);
 
     events.push(SettingsEvent::info(format!(
         "Successfully loaded {}",
@@ -841,7 +940,7 @@ fn load_toml_settings(
     )));
 
     deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
-    append_unknown_config_key_warnings(&contents, &config_path, events);
+    append_unknown_config_key_warnings(&contents, &config_path, events, false);
     match toml::from_str::<RawWorkspaceSettings>(&contents) {
         Ok(settings) => {
             events.push(SettingsEvent::info("Successfully loaded kakehashi.toml"));
@@ -1901,6 +2000,40 @@ mod tests {
         );
     }
 
+    #[test]
+    fn explicit_entry_prepends_its_base_config_files() {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path().join("base.toml");
+        let entry = dir.path().join("kakehashi.toml");
+        std::fs::write(&base, "autoInstall = false\n").unwrap();
+        std::fs::write(
+            &entry,
+            "baseConfigFiles = [\"base.toml\"]\nautoInstall = true\n",
+        )
+        .unwrap();
+
+        let explicit = read_explicit_layers(
+            std::slice::from_ref(&entry),
+            None,
+            crate::config::make_env(&[]),
+        );
+
+        assert!(
+            explicit.fatal_error.is_none(),
+            "the entry and its base are valid: {:?}",
+            explicit.fatal_error
+        );
+        assert_eq!(explicit.layers.len(), 2, "base then entry");
+        assert_eq!(
+            explicit.layers[0].as_ref().unwrap().auto_install,
+            Some(false)
+        );
+        assert_eq!(
+            explicit.layers[1].as_ref().unwrap().auto_install,
+            Some(true)
+        );
+    }
+
     /// A typo is reported rather than silently read as "not specified", which
     /// is what serde does with an unrecognised field. It stays a warning: an
     /// unrecognised key may be a mistake, or may be one a newer kakehashi
@@ -1949,7 +2082,8 @@ mod tests {
         let mut ignored_deprecation = DeprecatedKeysSeen::default();
         let settings = load_toml_file(&path, &mut events, &mut ignored_deprecation)
             .expect("an unknown key should not reject an explicit config file")
-            .expect("settings");
+            .expect("settings")
+            .settings;
 
         assert!(
             events
@@ -1981,7 +2115,8 @@ mod tests {
         let mut ignored_deprecation = DeprecatedKeysSeen::default();
         let settings = load_toml_file(&path, &mut events, &mut ignored_deprecation)
             .expect("an unknown feature key should use the common file policy")
-            .expect("settings");
+            .expect("settings")
+            .settings;
 
         assert!(
             events

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -1527,6 +1527,14 @@ mod tests {
             outcome
                 .events
                 .iter()
+                .any(|event| event.message.contains("missing-63.toml")),
+            "the 64th base must still be attempted: {:?}",
+            outcome.events
+        );
+        assert!(
+            outcome
+                .events
+                .iter()
                 .all(|event| !event.message.contains("missing-64.toml")),
             "the 65th base must not be touched: {:?}",
             outcome.events
@@ -2657,6 +2665,39 @@ mod tests {
                 .all(|event| !event.message.contains("Config file not found")),
             "the invalid entry must fail before reading any base: {:?}",
             explicit.events
+        );
+    }
+
+    #[test]
+    fn explicit_entry_accepts_exactly_the_base_file_limit() {
+        let dir = TempDir::new().unwrap();
+        let entry = dir.path().join("entry.toml");
+        let configured = std::iter::repeat_n("\"missing.toml\"", 64)
+            .collect::<Vec<_>>()
+            .join(", ");
+        std::fs::write(
+            &entry,
+            format!("baseConfigFiles = [{configured}]\ndiagnosticsDebounceMs = 777\n"),
+        )
+        .unwrap();
+
+        let explicit = read_explicit_layers(
+            std::slice::from_ref(&entry),
+            None,
+            crate::config::make_env(&[]),
+        );
+
+        assert!(explicit.fatal_error.is_none(), "{:?}", explicit.fatal_error);
+        assert_eq!(explicit.layers.len(), 65, "64 bases followed by the entry");
+        assert_eq!(
+            explicit
+                .layers
+                .last()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .diagnostics_debounce_ms,
+            Some(777)
         );
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -1006,10 +1006,10 @@ fn load_toml_settings(
         config_path.display()
     )));
 
-    deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
-    append_unknown_config_key_warnings(&contents, &config_path, events);
     match toml::from_str::<ConfigFileSettings>(&contents) {
         Ok(settings) => {
+            deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
+            append_unknown_config_key_warnings(&contents, &config_path, events);
             events.push(SettingsEvent::info("Successfully loaded kakehashi.toml"));
             Some(settings)
         }
@@ -1479,6 +1479,46 @@ mod tests {
                 event.kind == SettingsEventKind::Warning
                     && event.message.contains("Failed to parse")
                     && event.message.contains(&invalid.display().to_string())
+            }),
+            "the actual parse failure remains visible: {:?}",
+            outcome.events
+        );
+    }
+
+    #[test]
+    #[serial(xdg_env)]
+    fn invalid_implicit_project_entry_does_not_leak_parse_side_effects() {
+        let config_home = TempDir::new().expect("config home");
+        let project = TempDir::new().expect("project");
+        std::fs::write(
+            project.path().join("kakehashi.toml"),
+            "baseConfigFiles = 42\nautoInstall = false\nunknownTypo = true\n",
+        )
+        .unwrap();
+
+        let outcome = with_xdg_config_home(config_home.path(), || {
+            load_settings(
+                Some(project.path()),
+                None,
+                None,
+                crate::config::make_env(&[]),
+                None,
+            )
+        });
+
+        assert!(!outcome.deprecated_keys.auto_install);
+        assert!(
+            outcome.events.iter().all(|event| {
+                !event.message.contains("Unknown configuration key")
+                    && !event.message.contains("Successfully loaded")
+            }),
+            "a discarded entry must emit only its parse failure: {:?}",
+            outcome.events
+        );
+        assert!(
+            outcome.events.iter().any(|event| {
+                event.kind == SettingsEventKind::Warning
+                    && event.message.contains("Failed to parse kakehashi.toml")
             }),
             "the actual parse failure remains visible: {:?}",
             outcome.events

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -319,6 +319,14 @@ fn validate_and_anchor_explicit_layer(
     ))
 }
 
+fn missing_base_config_warning(base_path: &Path, entry_path: &Path) -> SettingsEvent {
+    SettingsEvent::show_warning(format!(
+        "Base config file not found; skipping {} (referenced from {})",
+        base_path.display(),
+        entry_path.display()
+    ))
+}
+
 /// The body of [`load_explicit_config`], taking the paths directly so it can be
 /// exercised without the process-global `--config-file` override.
 fn read_explicit_layers(
@@ -410,11 +418,7 @@ fn read_explicit_layers(
                 }
             };
             let Some(base) = base else {
-                events.extend(
-                    base_events
-                        .into_iter()
-                        .map(|event| SettingsEvent::show_warning(event.message)),
-                );
+                events.push(missing_base_config_warning(&base_path, entry_path));
                 layers.push(None);
                 continue;
             };
@@ -798,11 +802,7 @@ fn expand_implicit_file_entry(
             }
         };
         let Some(base) = base else {
-            events.extend(
-                base_events
-                    .into_iter()
-                    .map(|event| SettingsEvent::show_warning(event.message)),
-            );
+            events.push(missing_base_config_warning(&base_path, entry_path));
             layers.push(None);
             continue;
         };

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -794,10 +794,19 @@ fn expand_implicit_file_entry(
             )));
             continue;
         }
-        events.extend(base_events);
-        deprecated_keys.merge(base_deprecated_keys);
         let mut settings = base.settings;
         let _ = anchor_settings_paths(&mut settings, base_path.parent());
+        if let Err(errs) = WorkspaceSettings::try_from_settings(&settings, home, &env_fn)
+            && let Some(details) = errs.path_error_summary()
+        {
+            events.push(SettingsEvent::warning(format!(
+                "Path expansion failed in {}: {details}; skipping base file",
+                base_path.display()
+            )));
+            continue;
+        }
+        events.extend(base_events);
+        deprecated_keys.merge(base_deprecated_keys);
         layers.push(Some(settings));
     }
 
@@ -1413,6 +1422,51 @@ mod tests {
                     && event.message.contains("~bob/base.toml")
             }),
             "an unsupported named home must be skipped without literal rebasing: {:?}",
+            outcome.events
+        );
+    }
+
+    #[test]
+    #[serial(xdg_env)]
+    fn project_entry_skips_a_base_with_an_unexpandable_setting_path() {
+        let config_home = TempDir::new().expect("config home");
+        let project = TempDir::new().expect("project");
+        let base = project.path().join("base.toml");
+        std::fs::write(
+            &base,
+            "searchPaths = [\"$MISSING_KAKEHASHI_TEST_VAR/parsers\"]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            project.path().join("kakehashi.toml"),
+            "baseConfigFiles = [\"base.toml\"]\ndiagnosticsDebounceMs = 777\n",
+        )
+        .unwrap();
+
+        let outcome = with_xdg_config_home(config_home.path(), || {
+            load_settings(
+                Some(project.path()),
+                None,
+                None,
+                crate::config::make_env(&[]),
+                None,
+            )
+        });
+
+        assert_eq!(
+            outcome
+                .settings
+                .expect("an invalid base must not discard the owning entry")
+                .diagnostics_debounce_ms,
+            777
+        );
+        assert!(
+            outcome.events.iter().any(|event| {
+                event.kind == SettingsEventKind::Warning
+                    && event.message.contains(&base.display().to_string())
+                    && event.message.contains("MISSING_KAKEHASHI_TEST_VAR")
+            }),
+            "the skipped base and its path error must be visible: {:?}",
             outcome.events
         );
     }

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -1958,7 +1958,11 @@ mod tests {
         let config_home = TempDir::new().expect("config home");
         let files = TempDir::new().expect("config files");
         let base = files.path().join("base.toml");
-        std::fs::write(&base, "diagnosticsDebounceMs = 777\n").unwrap();
+        std::fs::write(
+            &base,
+            "diagnosticsDebounceMs = 777\nsearchPaths = [\"/must-not-load\"]\n",
+        )
+        .unwrap();
 
         let outcome = with_xdg_config_home(config_home.path(), || {
             load_settings(
@@ -1976,12 +1980,18 @@ mod tests {
             )
         });
 
+        let settings = outcome
+            .settings
+            .expect("ordinary initialization options remain valid");
         assert_eq!(
-            outcome
-                .settings
-                .expect("ordinary initialization options remain valid")
-                .diagnostics_debounce_ms,
-            333,
+            settings.diagnostics_debounce_ms, 333,
+            "ordinary live settings must still apply"
+        );
+        assert!(
+            settings
+                .search_paths
+                .iter()
+                .all(|path| path != "/must-not-load"),
             "live LSP settings must not initiate local file loading"
         );
     }

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -858,7 +858,7 @@ fn load_toml_file(
     // the only answer that can mean the optional-overlay case; everything else
     // — a denied ancestor directory, a path that is a directory — is a file the
     // user named and cannot use.
-    let file = match fs::File::open(path) {
+    let file = match open_config_file(path) {
         Ok(file) => file,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
             // Opening follows symlinks, so a link whose target is gone also
@@ -909,6 +909,16 @@ fn load_toml_file(
         }
     };
 
+    let metadata = file
+        .metadata()
+        .map_err(|err| format!("Failed to inspect {}: {}", path.display(), err))?;
+    if !metadata.is_file() {
+        return Err(format!(
+            "Failed to read {}: not a regular file",
+            path.display()
+        ));
+    }
+
     events.push(SettingsEvent::info(format!(
         "Loading config file: {}",
         path.display()
@@ -948,6 +958,20 @@ fn load_toml_file(
         path.display()
     )));
     Ok(Some(settings))
+}
+
+fn open_config_file(path: &Path) -> std::io::Result<fs::File> {
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        // Opening a FIFO for reading normally waits for a writer before the
+        // file type can be inspected. O_NONBLOCK makes that open immediate;
+        // regular files retain their ordinary read semantics.
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(nix::libc::O_NONBLOCK);
+    }
+    options.open(path)
 }
 
 fn read_workspace_toml_contents(
@@ -3033,6 +3057,46 @@ mod tests {
         assert!(
             message.contains("configuration limit"),
             "size must outrank the encoding error the cutoff invented: {message}"
+        );
+    }
+
+    /// Device nodes, pipes, and sockets are not configuration files. Rejecting
+    /// them also prevents a workspace-controlled FIFO from blocking an LSP
+    /// settings reload indefinitely.
+    #[cfg(unix)]
+    #[test]
+    fn test_load_toml_file_rejects_non_regular_files() {
+        let path = Path::new("/dev/null");
+        let mut events = Vec::new();
+        let mut ignored_deprecation = DeprecatedKeysSeen::default();
+
+        let result = load_toml_file(path, &mut events, &mut ignored_deprecation);
+
+        let message = result.expect_err("a device node must not be parsed as a config file");
+        assert!(
+            message.contains("not a regular file") && message.contains("/dev/null"),
+            "the path and reason must be reported: {message}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_load_toml_file_rejects_fifo_without_waiting_for_a_writer() {
+        use nix::sys::stat::Mode;
+        use nix::unistd::mkfifo;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("blocking.toml");
+        mkfifo(&path, Mode::S_IRUSR | Mode::S_IWUSR).unwrap();
+        let mut events = Vec::new();
+        let mut ignored_deprecation = DeprecatedKeysSeen::default();
+
+        let result = load_toml_file(&path, &mut events, &mut ignored_deprecation);
+
+        let message = result.expect_err("a FIFO must not be read as a config file");
+        assert!(
+            message.contains("not a regular file") && message.contains(&path.display().to_string()),
+            "the path and reason must be reported: {message}"
         );
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -1343,6 +1343,71 @@ mod tests {
         );
     }
 
+    fn assert_implicit_nested_base_is_skipped(nested_declaration: &str) {
+        let config_home = TempDir::new().expect("config home");
+        let project = TempDir::new().expect("project");
+        std::fs::write(
+            project.path().join("valid.toml"),
+            "diagnosticsDebounceMs = 444\n",
+        )
+        .unwrap();
+        std::fs::write(
+            project.path().join("nested.toml"),
+            format!("{nested_declaration}\ndiagnosticsDebounceMs = 555\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            project.path().join("kakehashi.toml"),
+            "baseConfigFiles = [\"valid.toml\", \"nested.toml\"]\nsearchPaths = [\"./entry\"]\n",
+        )
+        .unwrap();
+
+        let outcome = with_xdg_config_home(config_home.path(), || {
+            load_settings(
+                Some(project.path()),
+                None,
+                None,
+                crate::config::make_env(&[]),
+                None,
+            )
+        });
+
+        let settings = outcome.settings.expect("valid sibling and entry survive");
+        assert_eq!(
+            settings.diagnostics_debounce_ms, 444,
+            "the nested base must not override its valid sibling"
+        );
+        assert_eq!(
+            settings.search_paths,
+            vec![project.path().join("entry").to_string_lossy().into_owned()],
+            "the owning entry must still apply"
+        );
+        let nested = project.path().join("nested.toml");
+        let entry = project.path().join("kakehashi.toml");
+        assert!(
+            outcome.events.iter().any(|event| {
+                event.kind == SettingsEventKind::Warning
+                    && event.message.contains("baseConfigFiles")
+                    && event.message.contains(&nested.display().to_string())
+                    && event.message.contains(&entry.display().to_string())
+            }),
+            "the skipped nested declaration must name both files: {:?}",
+            outcome.events
+        );
+    }
+
+    #[test]
+    #[serial(xdg_env)]
+    fn implicit_base_cannot_name_more_base_files() {
+        assert_implicit_nested_base_is_skipped("baseConfigFiles = [\"deeper.toml\"]");
+    }
+
+    #[test]
+    #[serial(xdg_env)]
+    fn implicit_base_cannot_declare_an_empty_base_list() {
+        assert_implicit_nested_base_is_skipped("baseConfigFiles = []");
+    }
+
     /// A `--config-file` given as a bare filename anchors to the working
     /// directory, and one with no parent at all is an error rather than a base
     /// of "nowhere" — otherwise an unanchored layer would be indistinguishable

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -354,15 +354,19 @@ fn read_explicit_layers(
             layers.push(None);
             continue;
         };
-        let base_paths =
-            match resolve_base_config_paths(entry_path, &entry.base_config_files, home, &env_fn) {
-                Ok(paths) => paths,
-                Err(message) => {
-                    events.push(SettingsEvent::error(message.clone()));
-                    fatal_error = Some(message);
-                    break;
-                }
-            };
+        let base_paths = match resolve_base_config_paths(
+            entry_path,
+            entry.base_config_files.as_deref().unwrap_or_default(),
+            home,
+            &env_fn,
+        ) {
+            Ok(paths) => paths,
+            Err(message) => {
+                events.push(SettingsEvent::error(message.clone()));
+                fatal_error = Some(message);
+                break;
+            }
+        };
 
         for base_path in base_paths {
             let base = match load_toml_file(&base_path, &mut events, &mut deprecated_keys) {
@@ -374,7 +378,7 @@ fn read_explicit_layers(
                 }
             };
             if let Some(base) = base.as_ref()
-                && !base.base_config_files.is_empty()
+                && base.base_config_files.is_some()
             {
                 let message = format!(
                     "baseConfigFiles is only allowed in an entry config file; {} was included \
@@ -705,14 +709,18 @@ fn expand_implicit_file_entry(
     events: &mut Vec<SettingsEvent>,
     deprecated_keys: &mut DeprecatedKeysSeen,
 ) -> Vec<Option<RawWorkspaceSettings>> {
-    let base_paths =
-        match resolve_base_config_paths(entry_path, &entry.base_config_files, home, &env_fn) {
-            Ok(paths) => paths,
-            Err(message) => {
-                events.push(SettingsEvent::warning(message));
-                Vec::new()
-            }
-        };
+    let base_paths = match resolve_base_config_paths(
+        entry_path,
+        entry.base_config_files.as_deref().unwrap_or_default(),
+        home,
+        &env_fn,
+    ) {
+        Ok(paths) => paths,
+        Err(message) => {
+            events.push(SettingsEvent::warning(message));
+            Vec::new()
+        }
+    };
     let mut layers = Vec::with_capacity(base_paths.len() + 1);
     for base_path in base_paths {
         let base = match load_toml_file(&base_path, events, deprecated_keys) {
@@ -726,7 +734,7 @@ fn expand_implicit_file_entry(
             layers.push(None);
             continue;
         };
-        if !base.base_config_files.is_empty() {
+        if base.base_config_files.is_some() {
             events.push(SettingsEvent::warning(format!(
                 "baseConfigFiles is only allowed in an entry config file; {} was included from {}",
                 base_path.display(),
@@ -2149,6 +2157,26 @@ mod tests {
         assert!(message.contains("baseConfigFiles"), "{message}");
         assert!(message.contains(&base.display().to_string()), "{message}");
         assert!(message.contains(&entry.display().to_string()), "{message}");
+    }
+
+    #[test]
+    fn explicit_base_config_file_cannot_declare_an_empty_base_list() {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path().join("base.toml");
+        let entry = dir.path().join("kakehashi.toml");
+        std::fs::write(&base, "baseConfigFiles = []\n").unwrap();
+        std::fs::write(&entry, "baseConfigFiles = [\"base.toml\"]\n").unwrap();
+
+        let explicit = read_explicit_layers(
+            std::slice::from_ref(&entry),
+            None,
+            crate::config::make_env(&[]),
+        );
+
+        assert!(
+            explicit.fatal_error.is_some(),
+            "declaring the field is forbidden in a base file, even when it is empty"
+        );
     }
 
     #[test]

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -175,12 +175,9 @@ fn append_unknown_config_key_warnings(
     contents: &str,
     config_path: &Path,
     events: &mut Vec<SettingsEvent>,
-    allow_base_config_files: bool,
 ) {
     let mut keys = crate::config::unknown_keys::unknown_toml_workspace_setting_keys(contents);
-    if allow_base_config_files {
-        keys.retain(|key| key != "baseConfigFiles");
-    }
+    keys.retain(|key| key != "baseConfigFiles");
     append_unknown_key_warnings(&keys, config_path, events);
 }
 
@@ -384,7 +381,7 @@ fn read_explicit_layers(
             };
 
         for base_path in base_paths {
-            let base = match load_base_toml_file(&base_path, &mut events, &mut deprecated_keys) {
+            let base = match load_toml_file(&base_path, &mut events, &mut deprecated_keys) {
                 Ok(base) => base,
                 Err(message) => {
                     events.push(SettingsEvent::error(message.clone()));
@@ -392,6 +389,19 @@ fn read_explicit_layers(
                     break;
                 }
             };
+            if let Some(base) = base.as_ref()
+                && !base.base_config_files.is_empty()
+            {
+                let message = format!(
+                    "baseConfigFiles is only allowed in an entry config file; {} was included \
+                     from {}",
+                    base_path.display(),
+                    entry_path.display()
+                );
+                events.push(SettingsEvent::error(message.clone()));
+                fatal_error = Some(message);
+                break;
+            }
             let mut layer = base.map(|document| document.settings);
             if let Err(message) =
                 validate_and_anchor_explicit_layer(&mut layer, &base_path, home, &env_fn)
@@ -760,23 +770,6 @@ fn load_toml_file(
     events: &mut Vec<SettingsEvent>,
     deprecated_keys: &mut DeprecatedKeysSeen,
 ) -> Result<Option<ConfigFileDocument>, String> {
-    load_toml_file_impl(path, events, deprecated_keys, true)
-}
-
-fn load_base_toml_file(
-    path: &Path,
-    events: &mut Vec<SettingsEvent>,
-    deprecated_keys: &mut DeprecatedKeysSeen,
-) -> Result<Option<ConfigFileDocument>, String> {
-    load_toml_file_impl(path, events, deprecated_keys, false)
-}
-
-fn load_toml_file_impl(
-    path: &Path,
-    events: &mut Vec<SettingsEvent>,
-    deprecated_keys: &mut DeprecatedKeysSeen,
-    allow_base_config_files: bool,
-) -> Result<Option<ConfigFileDocument>, String> {
     // Classify by opening, not by probing first: a separate `exists` check
     // would answer for a different moment than the open, and would have to
     // decide what "no" means without the kernel's reason for it. `NotFound` is
@@ -866,7 +859,7 @@ fn load_toml_file_impl(
     // Warn rather than reject: a key kakehashi does not recognise may be a
     // typo, but it may equally be one this version has not learned yet, and
     // refusing to start over it would make the file version-locked.
-    append_unknown_config_key_warnings(&contents, path, events, allow_base_config_files);
+    append_unknown_config_key_warnings(&contents, path, events);
 
     events.push(SettingsEvent::info(format!(
         "Successfully loaded {}",
@@ -932,7 +925,7 @@ fn load_toml_settings(
     )));
 
     deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
-    append_unknown_config_key_warnings(&contents, &config_path, events, false);
+    append_unknown_config_key_warnings(&contents, &config_path, events);
     match toml::from_str::<RawWorkspaceSettings>(&contents) {
         Ok(settings) => {
             events.push(SettingsEvent::info("Successfully loaded kakehashi.toml"));
@@ -2025,6 +2018,30 @@ mod tests {
             explicit.layers[1].as_ref().unwrap().auto_install,
             Some(true)
         );
+    }
+
+    #[test]
+    fn explicit_base_config_file_cannot_name_more_base_files() {
+        let dir = TempDir::new().unwrap();
+        let nested = dir.path().join("nested.toml");
+        let base = dir.path().join("base.toml");
+        let entry = dir.path().join("kakehashi.toml");
+        std::fs::write(&nested, "autoInstall = false\n").unwrap();
+        std::fs::write(&base, "baseConfigFiles = [\"nested.toml\"]\n").unwrap();
+        std::fs::write(&entry, "baseConfigFiles = [\"base.toml\"]\n").unwrap();
+
+        let explicit = read_explicit_layers(
+            std::slice::from_ref(&entry),
+            None,
+            crate::config::make_env(&[]),
+        );
+
+        let message = explicit
+            .fatal_error
+            .expect("baseConfigFiles in a base file must be rejected");
+        assert!(message.contains("baseConfigFiles"), "{message}");
+        assert!(message.contains(&base.display().to_string()), "{message}");
+        assert!(message.contains(&entry.display().to_string()), "{message}");
     }
 
     /// A typo is reported rather than silently read as "not specified", which

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -736,7 +736,9 @@ fn expand_implicit_file_entry(
                     continue;
                 }
             };
-        let base = match load_toml_file(&base_path, events, deprecated_keys) {
+        let mut base_events = Vec::new();
+        let mut base_deprecated_keys = DeprecatedKeysSeen::default();
+        let base = match load_toml_file(&base_path, &mut base_events, &mut base_deprecated_keys) {
             Ok(base) => base,
             Err(message) => {
                 events.push(SettingsEvent::warning(message));
@@ -744,6 +746,7 @@ fn expand_implicit_file_entry(
             }
         };
         let Some(base) = base else {
+            events.extend(base_events);
             layers.push(None);
             continue;
         };
@@ -755,6 +758,8 @@ fn expand_implicit_file_entry(
             )));
             continue;
         }
+        events.extend(base_events);
+        deprecated_keys.merge(base_deprecated_keys);
         let mut settings = base.settings;
         let _ = anchor_settings_paths(&mut settings, base_path.parent());
         layers.push(Some(settings));
@@ -1353,7 +1358,7 @@ mod tests {
         .unwrap();
         std::fs::write(
             project.path().join("nested.toml"),
-            format!("{nested_declaration}\ndiagnosticsDebounceMs = 555\n"),
+            format!("{nested_declaration}\nautoInstall = false\ndiagnosticsDebounceMs = 555\n"),
         )
         .unwrap();
         std::fs::write(
@@ -1394,6 +1399,19 @@ mod tests {
             "the skipped nested declaration must name both files: {:?}",
             outcome.events
         );
+        assert!(
+            !outcome.deprecated_keys.auto_install,
+            "a skipped base must not trigger migration notices"
+        );
+        assert!(
+            outcome.events.iter().all(|event| {
+                event.kind != SettingsEventKind::Info
+                    || !event.message.starts_with("Successfully loaded")
+                    || !event.message.contains(&nested.display().to_string())
+            }),
+            "a skipped base must not be reported as successfully loaded: {:?}",
+            outcome.events
+        );
     }
 
     #[test]
@@ -1406,6 +1424,42 @@ mod tests {
     #[serial(xdg_env)]
     fn implicit_base_cannot_declare_an_empty_base_list() {
         assert_implicit_nested_base_is_skipped("baseConfigFiles = []");
+    }
+
+    #[test]
+    #[serial(xdg_env)]
+    fn invalid_implicit_base_does_not_leak_deprecation_state() {
+        let config_home = TempDir::new().expect("config home");
+        let project = TempDir::new().expect("project");
+        let invalid = project.path().join("invalid.toml");
+        std::fs::write(&invalid, "baseConfigFiles = 42\nautoInstall = false\n").unwrap();
+        std::fs::write(
+            project.path().join("kakehashi.toml"),
+            "baseConfigFiles = [\"invalid.toml\"]\ndiagnosticsDebounceMs = 777\n",
+        )
+        .unwrap();
+
+        let outcome = with_xdg_config_home(config_home.path(), || {
+            load_settings(
+                Some(project.path()),
+                None,
+                None,
+                crate::config::make_env(&[]),
+                None,
+            )
+        });
+
+        assert_eq!(outcome.settings.unwrap().diagnostics_debounce_ms, 777);
+        assert!(!outcome.deprecated_keys.auto_install);
+        assert!(
+            outcome.events.iter().any(|event| {
+                event.kind == SettingsEventKind::Warning
+                    && event.message.contains("Failed to parse")
+                    && event.message.contains(&invalid.display().to_string())
+            }),
+            "the actual parse failure remains visible: {:?}",
+            outcome.events
+        );
     }
 
     #[test]

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -1,10 +1,9 @@
 use crate::config::deprecation::DeprecatedKeysSeen;
 use crate::config::paths::anchor_settings_paths;
 use crate::config::{
-    RawWorkspaceSettings, WorkspaceSettings, defaults::default_settings, load_user_config,
-    merge_workspace_settings,
+    ConfigFileSettings, RawWorkspaceSettings, WorkspaceSettings, defaults::default_settings,
+    load_user_config, merge_workspace_settings,
 };
-use serde::Deserialize;
 use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -108,21 +107,6 @@ fn fold_layers(
 /// endless source — `/dev/zero`, most obviously — would allocate until the
 /// process died rather than reporting a bad path.
 const MAX_CONFIG_FILE_BYTES: u64 = 8 * 1024 * 1024;
-
-/// A file-backed configuration entry.
-///
-/// `baseConfigFiles` belongs to the file loader, not to live workspace
-/// settings. Keeping it outside [`RawWorkspaceSettings`] prevents clients from
-/// trying to add filesystem layers through `initializationOptions` or
-/// `workspace/didChangeConfiguration`.
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ConfigFileDocument {
-    #[serde(default)]
-    base_config_files: Vec<String>,
-    #[serde(flatten)]
-    settings: RawWorkspaceSettings,
-}
 
 /// The `--config-file` inputs, read and judged exactly once.
 ///
@@ -769,7 +753,7 @@ fn load_toml_file(
     path: &Path,
     events: &mut Vec<SettingsEvent>,
     deprecated_keys: &mut DeprecatedKeysSeen,
-) -> Result<Option<ConfigFileDocument>, String> {
+) -> Result<Option<ConfigFileSettings>, String> {
     // Classify by opening, not by probing first: a separate `exists` check
     // would answer for a different moment than the open, and would have to
     // decide what "no" means without the kernel's reason for it. `NotFound` is
@@ -851,7 +835,7 @@ fn load_toml_file(
     let contents = String::from_utf8(bytes)
         .map_err(|err| format!("Failed to read {}: {}", path.display(), err))?;
     deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
-    let settings = toml::from_str::<ConfigFileDocument>(&contents)
+    let settings = toml::from_str::<ConfigFileSettings>(&contents)
         .map_err(|err| format!("Failed to parse {}: {}", path.display(), err))?;
 
     // Serde drops an unrecognised field silently, so `autoInstal = false` reads

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -160,8 +160,7 @@ fn append_unknown_config_key_warnings(
     config_path: &Path,
     events: &mut Vec<SettingsEvent>,
 ) {
-    let mut keys = crate::config::unknown_keys::unknown_toml_workspace_setting_keys(contents);
-    keys.retain(|key| key != "baseConfigFiles");
+    let keys = crate::config::unknown_keys::unknown_toml_config_file_keys(contents);
     append_unknown_key_warnings(&keys, config_path, events);
 }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -12,6 +12,8 @@ use std::path::{Path, PathBuf};
 pub enum SettingsEventKind {
     Info,
     Warning,
+    /// Actionable non-fatal issue surfaced via `window/showMessage`.
+    ShowWarning,
     /// Hard error normally surfaced via `window/showMessage`.
     ///
     /// Fatal explicit-config errors instead reject initialization before
@@ -37,6 +39,13 @@ impl SettingsEvent {
     pub fn warning(message: impl Into<String>) -> Self {
         Self {
             kind: SettingsEventKind::Warning,
+            message: message.into(),
+        }
+    }
+
+    pub fn show_warning(message: impl Into<String>) -> Self {
+        Self {
+            kind: SettingsEventKind::ShowWarning,
             message: message.into(),
         }
     }
@@ -736,7 +745,7 @@ fn expand_implicit_file_entry(
 ) -> Vec<Option<RawWorkspaceSettings>> {
     let configured_bases = entry.base_config_files.as_deref().unwrap_or_default();
     let configured_bases = if configured_bases.len() > MAX_BASE_CONFIG_FILES_PER_ENTRY {
-        events.push(SettingsEvent::warning(format!(
+        events.push(SettingsEvent::show_warning(format!(
             "{} lists {} baseConfigFiles entries; at most {} are loaded per entry; skipping the \
              remainder",
             entry_path.display(),
@@ -751,7 +760,7 @@ fn expand_implicit_file_entry(
         Ok(base) => Some(base),
         Err(message) => {
             if !configured_bases.is_empty() {
-                events.push(SettingsEvent::warning(format!(
+                events.push(SettingsEvent::show_warning(format!(
                     "Failed to resolve the directory of {}: {message}",
                     entry_path.display()
                 )));
@@ -768,7 +777,7 @@ fn expand_implicit_file_entry(
             match resolve_base_config_path(entry_path, entry_base, configured, home, &env_fn) {
                 Ok(path) => path,
                 Err(message) => {
-                    events.push(SettingsEvent::warning(message));
+                    events.push(SettingsEvent::show_warning(message));
                     continue;
                 }
             };
@@ -777,7 +786,7 @@ fn expand_implicit_file_entry(
         let base = match load_toml_file(&base_path, &mut base_events, &mut base_deprecated_keys) {
             Ok(base) => base,
             Err(message) => {
-                events.push(SettingsEvent::warning(message));
+                events.push(SettingsEvent::show_warning(message));
                 continue;
             }
         };
@@ -787,7 +796,7 @@ fn expand_implicit_file_entry(
             continue;
         };
         if base.base_config_files.is_some() {
-            events.push(SettingsEvent::warning(format!(
+            events.push(SettingsEvent::show_warning(format!(
                 "baseConfigFiles is only allowed in an entry config file; {} was included from {}",
                 base_path.display(),
                 entry_path.display()
@@ -799,7 +808,7 @@ fn expand_implicit_file_entry(
         if let Err(errs) = WorkspaceSettings::try_from_settings(&settings, home, &env_fn)
             && let Some(details) = errs.path_error_summary()
         {
-            events.push(SettingsEvent::warning(format!(
+            events.push(SettingsEvent::show_warning(format!(
                 "Path expansion failed in {}: {details}; skipping base file",
                 base_path.display()
             )));
@@ -1408,7 +1417,7 @@ mod tests {
         );
         assert!(
             outcome.events.iter().any(|event| {
-                event.kind == SettingsEventKind::Warning
+                event.kind == SettingsEventKind::ShowWarning
                     && event.message.contains("Failed to expand baseConfigFiles")
                     && event.message.contains("MISSING_KAKEHASHI_TEST_VAR")
             }),
@@ -1417,7 +1426,7 @@ mod tests {
         );
         assert!(
             outcome.events.iter().any(|event| {
-                event.kind == SettingsEventKind::Warning
+                event.kind == SettingsEventKind::ShowWarning
                     && event.message.contains("~username is not supported")
                     && event.message.contains("~bob/base.toml")
             }),
@@ -1462,7 +1471,7 @@ mod tests {
         );
         assert!(
             outcome.events.iter().any(|event| {
-                event.kind == SettingsEventKind::Warning
+                event.kind == SettingsEventKind::ShowWarning
                     && event.message.contains(&base.display().to_string())
                     && event.message.contains("MISSING_KAKEHASHI_TEST_VAR")
             }),
@@ -1514,7 +1523,7 @@ mod tests {
         let entry = project.path().join("kakehashi.toml");
         assert!(
             outcome.events.iter().any(|event| {
-                event.kind == SettingsEventKind::Warning
+                event.kind == SettingsEventKind::ShowWarning
                     && event.message.contains("baseConfigFiles")
                     && event.message.contains(&nested.display().to_string())
                     && event.message.contains(&entry.display().to_string())
@@ -1576,7 +1585,7 @@ mod tests {
         assert!(!outcome.deprecated_keys.auto_install);
         assert!(
             outcome.events.iter().any(|event| {
-                event.kind == SettingsEventKind::Warning
+                event.kind == SettingsEventKind::ShowWarning
                     && event.message.contains("Failed to parse")
                     && event.message.contains(&invalid.display().to_string())
             }),
@@ -1656,7 +1665,7 @@ mod tests {
         assert_eq!(outcome.settings.unwrap().diagnostics_debounce_ms, 777);
         assert!(
             outcome.events.iter().any(|event| {
-                event.kind == SettingsEventKind::Warning
+                event.kind == SettingsEventKind::ShowWarning
                     && event.message.contains("65")
                     && event.message.contains("at most 64")
             }),

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -230,30 +230,6 @@ fn config_file_base(path: &Path) -> std::io::Result<PathBuf> {
     })
 }
 
-fn resolve_base_config_paths(
-    entry_path: &Path,
-    base_config_files: &[String],
-    home: Option<&str>,
-    env_fn: impl Fn(&str) -> Option<String>,
-) -> Result<Vec<PathBuf>, String> {
-    if base_config_files.is_empty() {
-        return Ok(Vec::new());
-    }
-    let entry_base = config_file_base(entry_path).map_err(|error| {
-        format!(
-            "Failed to resolve the directory of {}: {error}",
-            entry_path.display()
-        )
-    })?;
-
-    base_config_files
-        .iter()
-        .map(|configured| {
-            resolve_base_config_path(entry_path, &entry_base, configured, home, &env_fn)
-        })
-        .collect()
-}
-
 fn resolve_base_config_path(
     entry_path: &Path,
     entry_base: &Path,
@@ -363,21 +339,37 @@ fn read_explicit_layers(
             layers.push(None);
             continue;
         };
-        let base_paths = match resolve_base_config_paths(
-            entry_path,
-            entry.base_config_files.as_deref().unwrap_or_default(),
-            home,
-            &env_fn,
-        ) {
-            Ok(paths) => paths,
-            Err(message) => {
-                events.push(SettingsEvent::error(message.clone()));
-                fatal_error = Some(message);
-                break;
+        let configured_bases = entry.base_config_files.as_deref().unwrap_or_default();
+        let entry_base = if configured_bases.is_empty() {
+            None
+        } else {
+            match config_file_base(entry_path) {
+                Ok(base) => Some(base),
+                Err(error) => {
+                    let message = format!(
+                        "Failed to resolve the directory of {}: {error}",
+                        entry_path.display()
+                    );
+                    events.push(SettingsEvent::error(message.clone()));
+                    fatal_error = Some(message);
+                    break;
+                }
             }
         };
 
-        for base_path in base_paths {
+        for configured in configured_bases {
+            let entry_base = entry_base
+                .as_deref()
+                .expect("a non-empty base list has a resolved entry directory");
+            let base_path =
+                match resolve_base_config_path(entry_path, entry_base, configured, home, &env_fn) {
+                    Ok(path) => path,
+                    Err(message) => {
+                        events.push(SettingsEvent::error(message.clone()));
+                        fatal_error = Some(message);
+                        break;
+                    }
+                };
             let base = match load_toml_file(&base_path, &mut events, &mut deprecated_keys) {
                 Ok(base) => base,
                 Err(message) => {
@@ -2307,6 +2299,36 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(values, vec![Some(101), Some(102), Some(201), Some(202)]);
+    }
+
+    #[test]
+    fn explicit_base_files_report_the_first_failure_in_listed_order() {
+        let dir = TempDir::new().unwrap();
+        let malformed = dir.path().join("malformed.toml");
+        let entry = dir.path().join("entry.toml");
+        std::fs::write(&malformed, "not valid TOML = [\n").unwrap();
+        std::fs::write(
+            &entry,
+            "baseConfigFiles = [\"malformed.toml\", \"$MISSING_KAKEHASHI_TEST_VAR/later.toml\"]\n",
+        )
+        .unwrap();
+
+        let explicit = read_explicit_layers(
+            std::slice::from_ref(&entry),
+            None,
+            crate::config::make_env(&[]),
+        );
+
+        let message = explicit.fatal_error.expect("the first base is malformed");
+        assert!(
+            message.contains(&malformed.display().to_string()),
+            "{message}"
+        );
+        assert!(message.contains("Failed to parse"), "{message}");
+        assert!(
+            !message.contains("MISSING_KAKEHASHI_TEST_VAR"),
+            "a later path error must not mask the first base failure: {message}"
+        );
     }
 
     /// A typo is reported rather than silently read as "not specified", which

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -1,8 +1,8 @@
 use crate::config::deprecation::DeprecatedKeysSeen;
 use crate::config::paths::anchor_settings_paths;
 use crate::config::{
-    ConfigFileSettings, RawWorkspaceSettings, WorkspaceSettings, defaults::default_settings,
-    load_user_config, merge_workspace_settings,
+    ConfigFileSettings, MAX_BASE_CONFIG_FILES_PER_ENTRY, RawWorkspaceSettings, WorkspaceSettings,
+    defaults::default_settings, load_user_config, merge_workspace_settings,
 };
 use serde_json::Value;
 use std::fs;
@@ -340,6 +340,17 @@ fn read_explicit_layers(
             continue;
         };
         let configured_bases = entry.base_config_files.as_deref().unwrap_or_default();
+        if configured_bases.len() > MAX_BASE_CONFIG_FILES_PER_ENTRY {
+            let message = format!(
+                "{} lists {} baseConfigFiles entries; at most {} are allowed per entry",
+                entry_path.display(),
+                configured_bases.len(),
+                MAX_BASE_CONFIG_FILES_PER_ENTRY
+            );
+            events.push(SettingsEvent::error(message.clone()));
+            fatal_error = Some(message);
+            break;
+        }
         let entry_base = if configured_bases.is_empty() {
             None
         } else {
@@ -711,6 +722,18 @@ fn expand_implicit_file_entry(
     deprecated_keys: &mut DeprecatedKeysSeen,
 ) -> Vec<Option<RawWorkspaceSettings>> {
     let configured_bases = entry.base_config_files.as_deref().unwrap_or_default();
+    let configured_bases = if configured_bases.len() > MAX_BASE_CONFIG_FILES_PER_ENTRY {
+        events.push(SettingsEvent::warning(format!(
+            "{} lists {} baseConfigFiles entries; at most {} are loaded per entry; skipping the \
+             remainder",
+            entry_path.display(),
+            configured_bases.len(),
+            MAX_BASE_CONFIG_FILES_PER_ENTRY
+        )));
+        &configured_bases[..MAX_BASE_CONFIG_FILES_PER_ENTRY]
+    } else {
+        configured_bases
+    };
     let entry_base = match config_file_base(entry_path) {
         Ok(base) => Some(base),
         Err(message) => {
@@ -1458,6 +1481,54 @@ mod tests {
                     && event.message.contains(&invalid.display().to_string())
             }),
             "the actual parse failure remains visible: {:?}",
+            outcome.events
+        );
+    }
+
+    #[test]
+    #[serial(xdg_env)]
+    fn implicit_entry_skips_base_files_beyond_the_limit() {
+        let config_home = TempDir::new().expect("config home");
+        let project = TempDir::new().expect("project");
+        std::fs::write(
+            project.path().join("base.toml"),
+            "diagnosticsDebounceMs = 777\n",
+        )
+        .unwrap();
+        let mut configured = vec!["\"base.toml\"".to_string()];
+        configured.extend((1..=64).map(|index| format!("\"missing-{index}.toml\"")));
+        std::fs::write(
+            project.path().join("kakehashi.toml"),
+            format!("baseConfigFiles = [{}]\n", configured.join(", ")),
+        )
+        .unwrap();
+
+        let outcome = with_xdg_config_home(config_home.path(), || {
+            load_settings(
+                Some(project.path()),
+                None,
+                None,
+                crate::config::make_env(&[]),
+                None,
+            )
+        });
+
+        assert_eq!(outcome.settings.unwrap().diagnostics_debounce_ms, 777);
+        assert!(
+            outcome.events.iter().any(|event| {
+                event.kind == SettingsEventKind::Warning
+                    && event.message.contains("65")
+                    && event.message.contains("at most 64")
+            }),
+            "overflow must produce one actionable warning: {:?}",
+            outcome.events
+        );
+        assert!(
+            outcome
+                .events
+                .iter()
+                .all(|event| !event.message.contains("missing-64.toml")),
+            "the 65th base must not be touched: {:?}",
             outcome.events
         );
     }
@@ -2558,6 +2629,34 @@ mod tests {
         assert!(
             !message.contains("MISSING_KAKEHASHI_TEST_VAR"),
             "a later path error must not mask the first base failure: {message}"
+        );
+    }
+
+    #[test]
+    fn explicit_entry_rejects_too_many_base_files() {
+        let dir = TempDir::new().unwrap();
+        let entry = dir.path().join("entry.toml");
+        let configured = std::iter::repeat_n("\"missing.toml\"", 65)
+            .collect::<Vec<_>>()
+            .join(", ");
+        std::fs::write(&entry, format!("baseConfigFiles = [{configured}]\n")).unwrap();
+
+        let explicit = read_explicit_layers(
+            std::slice::from_ref(&entry),
+            None,
+            crate::config::make_env(&[]),
+        );
+
+        let message = explicit.fatal_error.expect("the list exceeds its bound");
+        assert!(message.contains("65"), "{message}");
+        assert!(message.contains("at most 64"), "{message}");
+        assert!(
+            explicit
+                .events
+                .iter()
+                .all(|event| !event.message.contains("Config file not found")),
+            "the invalid entry must fail before reading any base: {:?}",
+            explicit.events
         );
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -1885,6 +1885,40 @@ mod tests {
         );
     }
 
+    #[test]
+    #[serial(xdg_env)]
+    fn initialization_options_cannot_load_base_config_files() {
+        let config_home = TempDir::new().expect("config home");
+        let files = TempDir::new().expect("config files");
+        let base = files.path().join("base.toml");
+        std::fs::write(&base, "diagnosticsDebounceMs = 777\n").unwrap();
+
+        let outcome = with_xdg_config_home(config_home.path(), || {
+            load_settings(
+                None,
+                Some((
+                    SettingsSource::InitializationOptions,
+                    serde_json::json!({
+                        "baseConfigFiles": [base],
+                        "diagnosticsDebounceMs": 333,
+                    }),
+                )),
+                None,
+                crate::config::make_env(&[]),
+                None,
+            )
+        });
+
+        assert_eq!(
+            outcome
+                .settings
+                .expect("ordinary initialization options remain valid")
+                .diagnostics_debounce_ms,
+            333,
+            "live LSP settings must not initiate local file loading"
+        );
+    }
+
     /// User config loading logs appropriate events.
     #[test]
     #[serial(xdg_env)]

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -815,7 +815,15 @@ fn expand_implicit_file_entry(
             continue;
         }
         let mut settings = base.settings;
-        let _ = anchor_settings_paths(&mut settings, base_path.parent());
+        let unanchored = anchor_settings_paths(&mut settings, base_path.parent());
+        if !unanchored.is_empty() {
+            events.push(SettingsEvent::show_warning(format!(
+                "Cannot resolve paths in {} against that file's directory: {}; skipping base file",
+                base_path.display(),
+                unanchored.join(", ")
+            )));
+            continue;
+        }
         if let Err(errs) = WorkspaceSettings::try_from_settings(&settings, home, &env_fn)
             && let Some(details) = errs.path_error_summary()
         {
@@ -1442,6 +1450,59 @@ mod tests {
                     && event.message.contains("~bob/base.toml")
             }),
             "an unsupported named home must be skipped without literal rebasing: {:?}",
+            outcome.events
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial(xdg_env)]
+    fn project_entry_skips_base_under_non_unicode_directory() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let config_home = TempDir::new().expect("config home");
+        let parent = TempDir::new().expect("project parent");
+        let project = parent.path().join(OsStr::from_bytes(b"project-\xFF"));
+        if std::fs::create_dir(&project).is_err() {
+            eprintln!(
+                "skipping: this filesystem rejects non-UTF-8 directory names, so the case under \
+                 test cannot be constructed here"
+            );
+            return;
+        }
+        let base = project.join("base.toml");
+        std::fs::write(&base, "searchPaths = [\"./parsers\"]\n").unwrap();
+        std::fs::write(
+            project.join("kakehashi.toml"),
+            "baseConfigFiles = [\"base.toml\"]\ndiagnosticsDebounceMs = 777\n",
+        )
+        .unwrap();
+
+        let outcome = with_xdg_config_home(config_home.path(), || {
+            load_settings(
+                Some(&project),
+                None,
+                None,
+                crate::config::make_env(&[]),
+                None,
+            )
+        });
+
+        let settings = outcome.settings.expect("the entry remains valid");
+        assert_eq!(settings.diagnostics_debounce_ms, 777);
+        assert!(
+            !settings.search_paths.iter().any(|path| path == "./parsers"),
+            "the unanchorable base must be skipped: {:?}",
+            settings.search_paths
+        );
+        assert!(
+            outcome.events.iter().any(|event| {
+                event.kind == SettingsEventKind::ShowWarning
+                    && event.message.contains(&base.display().to_string())
+                    && event.message.contains("./parsers")
+            }),
+            "the skipped base must remain visible: {:?}",
             outcome.events
         );
     }

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -381,9 +381,13 @@ fn read_explicit_layers(
                         break;
                     }
                 };
-            let base = match load_toml_file(&base_path, &mut events, &mut deprecated_keys) {
+            let mut base_events = Vec::new();
+            let mut base_deprecated_keys = DeprecatedKeysSeen::default();
+            let base = match load_toml_file(&base_path, &mut base_events, &mut base_deprecated_keys)
+            {
                 Ok(base) => base,
                 Err(message) => {
+                    events.extend(base_events);
                     events.push(SettingsEvent::error(message.clone()));
                     fatal_error = Some(message);
                     break;
@@ -410,6 +414,8 @@ fn read_explicit_layers(
                 fatal_error = Some(message);
                 break;
             }
+            events.extend(base_events);
+            deprecated_keys.merge(base_deprecated_keys);
             layers.push(layer);
         }
         if fatal_error.is_some() {
@@ -2578,7 +2584,11 @@ mod tests {
         let base = dir.path().join("base.toml");
         let entry = dir.path().join("kakehashi.toml");
         std::fs::write(&nested, "autoInstall = false\n").unwrap();
-        std::fs::write(&base, "baseConfigFiles = [\"nested.toml\"]\n").unwrap();
+        std::fs::write(
+            &base,
+            "baseConfigFiles = [\"nested.toml\"]\nautoInstall = false\nunknownTypo = true\n",
+        )
+        .unwrap();
         std::fs::write(&entry, "baseConfigFiles = [\"base.toml\"]\n").unwrap();
 
         let explicit = read_explicit_layers(
@@ -2593,6 +2603,19 @@ mod tests {
         assert!(message.contains("baseConfigFiles"), "{message}");
         assert!(message.contains(&base.display().to_string()), "{message}");
         assert!(message.contains(&entry.display().to_string()), "{message}");
+        assert!(
+            !explicit.deprecated_keys.auto_install,
+            "a rejected base must not trigger migration notices"
+        );
+        assert!(
+            explicit.events.iter().all(|event| {
+                !event.message.contains("unknownTypo")
+                    && (!event.message.starts_with("Successfully loaded")
+                        || !event.message.contains(&base.display().to_string()))
+            }),
+            "a rejected base must not leak parse side effects: {:?}",
+            explicit.events
+        );
     }
 
     #[test]

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -1408,6 +1408,73 @@ mod tests {
         assert_implicit_nested_base_is_skipped("baseConfigFiles = []");
     }
 
+    #[test]
+    #[serial(xdg_env)]
+    fn implicit_base_is_read_again_on_settings_reload() {
+        let config_home = TempDir::new().expect("config home");
+        let project = TempDir::new().expect("project");
+        let base = project.path().join("base.toml");
+        std::fs::write(&base, "diagnosticsDebounceMs = 111\n").unwrap();
+        std::fs::write(
+            project.path().join("kakehashi.toml"),
+            "baseConfigFiles = [\"base.toml\"]\n",
+        )
+        .unwrap();
+
+        let initial = with_xdg_config_home(config_home.path(), || {
+            load_settings(
+                Some(project.path()),
+                None,
+                None,
+                crate::config::make_env(&[]),
+                None,
+            )
+        });
+        assert_eq!(initial.settings.unwrap().diagnostics_debounce_ms, 111);
+
+        std::fs::write(&base, "diagnosticsDebounceMs = 222\n").unwrap();
+        let reloaded = with_xdg_config_home(config_home.path(), || {
+            load_settings(
+                Some(project.path()),
+                None,
+                None,
+                crate::config::make_env(&[]),
+                None,
+            )
+        });
+        assert_eq!(reloaded.settings.unwrap().diagnostics_debounce_ms, 222);
+    }
+
+    #[test]
+    fn explicit_base_replay_keeps_the_initial_snapshot() {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path().join("base.toml");
+        let entry = dir.path().join("entry.toml");
+        std::fs::write(&base, "diagnosticsDebounceMs = 111\n").unwrap();
+        std::fs::write(&entry, "baseConfigFiles = [\"base.toml\"]\n").unwrap();
+        let explicit = read_explicit_layers(
+            std::slice::from_ref(&entry),
+            None,
+            crate::config::make_env(&[]),
+        );
+        assert!(explicit.fatal_error.is_none());
+
+        std::fs::write(&base, "diagnosticsDebounceMs = 222\n").unwrap();
+        let replayed = load_settings(
+            None,
+            None,
+            None,
+            crate::config::make_env(&[]),
+            Some(explicit.for_replay()),
+        );
+
+        assert_eq!(replayed.settings.unwrap().diagnostics_debounce_ms, 111);
+        assert!(
+            replayed.events.is_empty(),
+            "replay must not pretend the retained files were loaded again"
+        );
+    }
+
     /// A `--config-file` given as a bare filename anchors to the working
     /// directory, and one with no parent at all is an error rather than a base
     /// of "nowhere" — otherwise an unanchored layer would be indistinguishable

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -249,28 +249,38 @@ fn resolve_base_config_paths(
     base_config_files
         .iter()
         .map(|configured| {
-            let expanded =
-                crate::config::expand::expand_path(configured, home, &env_fn).map_err(|error| {
-                    format!(
-                        "Failed to expand baseConfigFiles entry in {}: {error}",
-                        entry_path.display()
-                    )
-                })?;
-            if crate::config::paths::is_drive_relative(&expanded) {
-                return Err(format!(
-                    "Failed to resolve baseConfigFiles entry {configured:?} in {}: path names a \
-                     drive but no root; give the path in full",
-                    entry_path.display()
-                ));
-            }
-            let path = PathBuf::from(expanded);
-            Ok(if path.has_root() || path.is_absolute() {
-                path
-            } else {
-                entry_base.join(path)
-            })
+            resolve_base_config_path(entry_path, &entry_base, configured, home, &env_fn)
         })
         .collect()
+}
+
+fn resolve_base_config_path(
+    entry_path: &Path,
+    entry_base: &Path,
+    configured: &str,
+    home: Option<&str>,
+    env_fn: impl Fn(&str) -> Option<String>,
+) -> Result<PathBuf, String> {
+    let expanded =
+        crate::config::expand::expand_path(configured, home, env_fn).map_err(|error| {
+            format!(
+                "Failed to expand baseConfigFiles entry in {}: {error}",
+                entry_path.display()
+            )
+        })?;
+    if crate::config::paths::is_drive_relative(&expanded) {
+        return Err(format!(
+            "Failed to resolve baseConfigFiles entry {configured:?} in {}: path names a drive \
+             but no root; give the path in full",
+            entry_path.display()
+        ));
+    }
+    let path = PathBuf::from(expanded);
+    Ok(if path.has_root() || path.is_absolute() {
+        path
+    } else {
+        entry_base.join(path)
+    })
 }
 
 fn validate_and_anchor_explicit_layer(
@@ -708,20 +718,32 @@ fn expand_implicit_file_entry(
     events: &mut Vec<SettingsEvent>,
     deprecated_keys: &mut DeprecatedKeysSeen,
 ) -> Vec<Option<RawWorkspaceSettings>> {
-    let base_paths = match resolve_base_config_paths(
-        entry_path,
-        entry.base_config_files.as_deref().unwrap_or_default(),
-        home,
-        &env_fn,
-    ) {
-        Ok(paths) => paths,
+    let configured_bases = entry.base_config_files.as_deref().unwrap_or_default();
+    let entry_base = match config_file_base(entry_path) {
+        Ok(base) => Some(base),
         Err(message) => {
-            events.push(SettingsEvent::warning(message));
-            Vec::new()
+            if !configured_bases.is_empty() {
+                events.push(SettingsEvent::warning(format!(
+                    "Failed to resolve the directory of {}: {message}",
+                    entry_path.display()
+                )));
+            }
+            None
         }
     };
-    let mut layers = Vec::with_capacity(base_paths.len() + 1);
-    for base_path in base_paths {
+    let mut layers = Vec::with_capacity(configured_bases.len() + 1);
+    for configured in configured_bases {
+        let Some(entry_base) = entry_base.as_deref() else {
+            break;
+        };
+        let base_path =
+            match resolve_base_config_path(entry_path, entry_base, configured, home, &env_fn) {
+                Ok(path) => path,
+                Err(message) => {
+                    events.push(SettingsEvent::warning(message));
+                    continue;
+                }
+            };
         let base = match load_toml_file(&base_path, events, deprecated_keys) {
             Ok(base) => base,
             Err(message) => {
@@ -1276,6 +1298,56 @@ mod tests {
                     .to_string_lossy()
                     .into_owned()
             ]
+        );
+    }
+
+    #[test]
+    #[serial(xdg_env)]
+    fn project_entry_skips_only_an_unexpandable_base_config_path() {
+        let config_home = TempDir::new().expect("config home");
+        let project = TempDir::new().expect("project");
+        std::fs::write(
+            project.path().join("valid.toml"),
+            "searchPaths = [\"./parsers\"]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            project.path().join("kakehashi.toml"),
+            "baseConfigFiles = [\"valid.toml\", \"$MISSING_KAKEHASHI_TEST_VAR/base.toml\"]\ndiagnosticsDebounceMs = 777\n",
+        )
+        .unwrap();
+
+        let outcome = with_xdg_config_home(config_home.path(), || {
+            load_settings(
+                Some(project.path()),
+                None,
+                None,
+                crate::config::make_env(&[]),
+                None,
+            )
+        });
+
+        let settings = outcome.settings.expect("the entry remains valid");
+        assert_eq!(settings.diagnostics_debounce_ms, 777);
+        assert_eq!(
+            settings.search_paths,
+            vec![
+                project
+                    .path()
+                    .join("parsers")
+                    .to_string_lossy()
+                    .into_owned()
+            ],
+            "an unusable optional base must not discard valid sibling bases"
+        );
+        assert!(
+            outcome.events.iter().any(|event| {
+                event.kind == SettingsEventKind::Warning
+                    && event.message.contains("Failed to expand baseConfigFiles")
+                    && event.message.contains("MISSING_KAKEHASHI_TEST_VAR")
+            }),
+            "the skipped base must remain visible: {:?}",
+            outcome.events
         );
     }
 

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -2151,6 +2151,65 @@ mod tests {
         assert!(message.contains(&entry.display().to_string()), "{message}");
     }
 
+    #[test]
+    fn explicit_base_config_files_expand_environment_paths() {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path().join("base.toml");
+        let entry_dir = TempDir::new().unwrap();
+        let entry = entry_dir.path().join("kakehashi.toml");
+        std::fs::write(&base, "autoInstall = false\n").unwrap();
+        std::fs::write(&entry, "baseConfigFiles = [\"$HOME/base.toml\"]\n").unwrap();
+        let home = dir.path().to_string_lossy().into_owned();
+
+        let explicit = read_explicit_layers(
+            std::slice::from_ref(&entry),
+            Some(&home),
+            crate::config::make_env(&[("HOME", &home)]),
+        );
+
+        assert!(explicit.fatal_error.is_none(), "{:?}", explicit.fatal_error);
+        assert_eq!(explicit.layers.len(), 2);
+        assert_eq!(
+            explicit.layers[0].as_ref().unwrap().auto_install,
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn explicit_entries_expand_bases_in_argument_order() {
+        let dir = TempDir::new().unwrap();
+        let base_a = dir.path().join("base-a.toml");
+        let entry_a = dir.path().join("entry-a.toml");
+        let base_b = dir.path().join("base-b.toml");
+        let entry_b = dir.path().join("entry-b.toml");
+        std::fs::write(&base_a, "diagnosticsDebounceMs = 101\n").unwrap();
+        std::fs::write(
+            &entry_a,
+            "baseConfigFiles = [\"base-a.toml\"]\ndiagnosticsDebounceMs = 102\n",
+        )
+        .unwrap();
+        std::fs::write(&base_b, "diagnosticsDebounceMs = 201\n").unwrap();
+        std::fs::write(
+            &entry_b,
+            "baseConfigFiles = [\"base-b.toml\"]\ndiagnosticsDebounceMs = 202\n",
+        )
+        .unwrap();
+
+        let explicit =
+            read_explicit_layers(&[entry_a, entry_b], None, crate::config::make_env(&[]));
+
+        let values = explicit
+            .layers
+            .iter()
+            .map(|layer| {
+                layer
+                    .as_ref()
+                    .and_then(|layer| layer.diagnostics_debounce_ms)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(values, vec![Some(101), Some(102), Some(201), Some(202)]);
+    }
+
     /// A typo is reported rather than silently read as "not specified", which
     /// is what serde does with an unrecognised field. It stays a warning: an
     /// unrecognised key may be a mistake, or may be one a newer kakehashi

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -124,14 +124,6 @@ struct ConfigFileDocument {
     settings: RawWorkspaceSettings,
 }
 
-impl std::ops::Deref for ConfigFileDocument {
-    type Target = RawWorkspaceSettings;
-
-    fn deref(&self) -> &Self::Target {
-        &self.settings
-    }
-}
-
 /// The `--config-file` inputs, read and judged exactly once.
 ///
 /// Read *once* is a contract, not an optimisation. A file replaced between two
@@ -1877,6 +1869,7 @@ mod tests {
         assert_eq!(
             settings
                 .expect("present file should yield a layer")
+                .settings
                 .auto_install,
             Some(false)
         );

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -518,14 +518,19 @@ fn load_settings_impl(
         let mut layers =
             load_user_config_with_events(home, &env_fn, &mut events, &mut deprecated_keys);
         // Layer 3: Project config from root_path/kakehashi.toml
-        layers.push(
-            load_toml_settings(root_path, &mut events, &mut deprecated_keys).map(|mut settings| {
-                // `load_toml_settings` reads `root_path/kakehashi.toml`, so the
-                // file's directory is `root_path` itself.
-                let _ = anchor_settings_paths(&mut settings, root_path);
-                settings
-            }),
-        );
+        if let Some(project) = load_toml_settings(root_path, &mut events, &mut deprecated_keys) {
+            let entry_path = root_path
+                .expect("a loaded project config has a root")
+                .join("kakehashi.toml");
+            layers.extend(expand_implicit_file_entry(
+                project,
+                &entry_path,
+                home,
+                &env_fn,
+                &mut events,
+                &mut deprecated_keys,
+            ));
+        }
         layers
     };
 
@@ -943,7 +948,7 @@ fn load_toml_settings(
     root_path: Option<&Path>,
     events: &mut Vec<SettingsEvent>,
     deprecated_keys: &mut DeprecatedKeysSeen,
-) -> Option<RawWorkspaceSettings> {
+) -> Option<ConfigFileSettings> {
     let root = root_path?;
     let config_path = root.join("kakehashi.toml");
     let contents = read_workspace_toml_contents(&config_path, events)?;
@@ -954,7 +959,7 @@ fn load_toml_settings(
 
     deprecated_keys.merge(crate::config::deprecation::toml_deprecated_keys(&contents));
     append_unknown_config_key_warnings(&contents, &config_path, events);
-    match toml::from_str::<RawWorkspaceSettings>(&contents) {
+    match toml::from_str::<ConfigFileSettings>(&contents) {
         Ok(settings) => {
             events.push(SettingsEvent::info("Successfully loaded kakehashi.toml"));
             Some(settings)
@@ -1219,6 +1224,51 @@ mod tests {
         assert_eq!(
             settings.search_paths,
             vec![user_dir.join("parsers").to_string_lossy().into_owned()]
+        );
+    }
+
+    #[test]
+    #[serial(xdg_env)]
+    fn project_entry_prepends_its_base_config_files_after_user_config() {
+        let config_home = TempDir::new().expect("config home");
+        write_user_config(config_home.path(), "diagnosticsDebounceMs = 250\n");
+        let project = TempDir::new().expect("project");
+        std::fs::write(
+            project.path().join("base.toml"),
+            "autoInstall = false\nsearchPaths = [\"./parsers\"]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            project.path().join("kakehashi.toml"),
+            "baseConfigFiles = [\"base.toml\"]\nautoInstall = true\n",
+        )
+        .unwrap();
+
+        let outcome = with_xdg_config_home(config_home.path(), || {
+            load_settings(
+                Some(project.path()),
+                None,
+                None,
+                crate::config::make_env(&[]),
+                None,
+            )
+        });
+
+        let settings = outcome.settings.expect("valid composed project config");
+        assert!(
+            settings.auto_install,
+            "the project entry must override its base"
+        );
+        assert_eq!(settings.diagnostics_debounce_ms, 250, "user layer survives");
+        assert_eq!(
+            settings.search_paths,
+            vec![
+                project
+                    .path()
+                    .join("parsers")
+                    .to_string_lossy()
+                    .into_owned()
+            ]
         );
     }
 
@@ -2515,7 +2565,8 @@ mod tests {
         let mut events = Vec::new();
         let mut deprecated_keys = DeprecatedKeysSeen::default();
         let settings = load_toml_settings(Some(dir.path()), &mut events, &mut deprecated_keys)
-            .expect("an unknown feature key should not reject a workspace config");
+            .expect("an unknown feature key should not reject a workspace config")
+            .settings;
 
         assert!(
             events

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -515,31 +515,18 @@ fn load_settings_impl(
         deprecated_keys.merge(explicit.deprecated_keys);
         explicit.layers
     } else {
-        vec![
-            // Layer 2: User config from XDG_CONFIG_HOME (~/.config/kakehashi/kakehashi.toml)
-            //
-            // A base that cannot be represented leaves values as written, which
-            // is the pre-#732 meaning. Deliberately not fatal here: an implicit
-            // layer's contract is to degrade rather than take the session down,
-            // and `anchor_settings_paths` warns about what it skipped. Same for
-            // a `parent()` of `None`, which the explicit layer treats as fatal —
-            // `user_config_path` always answers an absolute path ending
-            // `kakehashi/kakehashi.toml`, so the two rules cannot actually
-            // disagree about any real path.
-            load_user_config_with_events(&mut events, &mut deprecated_keys).map(
-                |(mut settings, path)| {
-                    let _ = anchor_settings_paths(&mut settings, path.parent());
-                    settings
-                },
-            ),
-            // Layer 3: Project config from root_path/kakehashi.toml
+        let mut layers =
+            load_user_config_with_events(home, &env_fn, &mut events, &mut deprecated_keys);
+        // Layer 3: Project config from root_path/kakehashi.toml
+        layers.push(
             load_toml_settings(root_path, &mut events, &mut deprecated_keys).map(|mut settings| {
                 // `load_toml_settings` reads `root_path/kakehashi.toml`, so the
                 // file's directory is `root_path` itself.
                 let _ = anchor_settings_paths(&mut settings, root_path);
                 settings
             }),
-        ]
+        );
+        layers
     };
 
     // Layers 4+: Override settings from initialization options or client configuration.
@@ -705,14 +692,61 @@ fn expand_merged_settings(
     })
 }
 
-/// Load user config and add appropriate events to the events vector.
-///
-/// Reports the file it was read from alongside the settings, so the caller can
-/// anchor the layer's relative paths to that file's directory.
-fn load_user_config_with_events(
+fn expand_implicit_file_entry(
+    entry: ConfigFileSettings,
+    entry_path: &Path,
+    home: Option<&str>,
+    env_fn: impl Fn(&str) -> Option<String>,
     events: &mut Vec<SettingsEvent>,
     deprecated_keys: &mut DeprecatedKeysSeen,
-) -> Option<(RawWorkspaceSettings, PathBuf)> {
+) -> Vec<Option<RawWorkspaceSettings>> {
+    let base_paths =
+        match resolve_base_config_paths(entry_path, &entry.base_config_files, home, &env_fn) {
+            Ok(paths) => paths,
+            Err(message) => {
+                events.push(SettingsEvent::warning(message));
+                Vec::new()
+            }
+        };
+    let mut layers = Vec::with_capacity(base_paths.len() + 1);
+    for base_path in base_paths {
+        let base = match load_toml_file(&base_path, events, deprecated_keys) {
+            Ok(base) => base,
+            Err(message) => {
+                events.push(SettingsEvent::warning(message));
+                continue;
+            }
+        };
+        let Some(base) = base else {
+            layers.push(None);
+            continue;
+        };
+        if !base.base_config_files.is_empty() {
+            events.push(SettingsEvent::warning(format!(
+                "baseConfigFiles is only allowed in an entry config file; {} was included from {}",
+                base_path.display(),
+                entry_path.display()
+            )));
+            continue;
+        }
+        let mut settings = base.settings;
+        let _ = anchor_settings_paths(&mut settings, base_path.parent());
+        layers.push(Some(settings));
+    }
+
+    let mut settings = entry.settings;
+    let _ = anchor_settings_paths(&mut settings, entry_path.parent());
+    layers.push(Some(settings));
+    layers
+}
+
+/// Load the user entry and expand its file-local base layers.
+fn load_user_config_with_events(
+    home: Option<&str>,
+    env_fn: impl Fn(&str) -> Option<String>,
+    events: &mut Vec<SettingsEvent>,
+    deprecated_keys: &mut DeprecatedKeysSeen,
+) -> Vec<Option<RawWorkspaceSettings>> {
     match load_user_config() {
         Ok(Some(config)) => {
             events.push(SettingsEvent::info(
@@ -720,18 +754,28 @@ fn load_user_config_with_events(
             ));
             append_unknown_key_warnings(&config.unknown_keys, &config.path, events);
             deprecated_keys.merge(config.deprecated_keys);
-            Some((config.settings, config.path))
+            expand_implicit_file_entry(
+                ConfigFileSettings {
+                    base_config_files: config.base_config_files,
+                    settings: config.settings,
+                },
+                &config.path,
+                home,
+                env_fn,
+                events,
+                deprecated_keys,
+            )
         }
         Ok(None) => {
             // No user config file exists - this is fine (zero-config experience)
-            None
+            Vec::new()
         }
         Err(err) => {
             events.push(SettingsEvent::warning(format!(
                 "Failed to load user config: {}",
                 err
             )));
-            None
+            Vec::new()
         }
     }
 }
@@ -1147,6 +1191,35 @@ mod tests {
         std::fs::create_dir_all(&dir).expect("failed to create user config dir");
         std::fs::write(dir.join("kakehashi.toml"), contents).expect("failed to write user config");
         dir
+    }
+
+    #[test]
+    #[serial(xdg_env)]
+    fn user_entry_prepends_its_base_config_files() {
+        let config_home = TempDir::new().expect("config home");
+        let user_dir = write_user_config(
+            config_home.path(),
+            "baseConfigFiles = [\"base.toml\"]\nautoInstall = true\n",
+        );
+        std::fs::write(
+            user_dir.join("base.toml"),
+            "autoInstall = false\nsearchPaths = [\"./parsers\"]\n",
+        )
+        .unwrap();
+
+        let outcome = with_xdg_config_home(config_home.path(), || {
+            load_settings(None, None, None, crate::config::make_env(&[]), None)
+        });
+
+        let settings = outcome.settings.expect("valid composed user config");
+        assert!(
+            settings.auto_install,
+            "the user entry must override its base"
+        );
+        assert_eq!(
+            settings.search_paths,
+            vec![user_dir.join("parsers").to_string_lossy().into_owned()]
+        );
     }
 
     /// A `--config-file` given as a bare filename anchors to the working
@@ -2483,7 +2556,12 @@ mod tests {
 
         let mut events = Vec::new();
         let mut deprecated_keys = DeprecatedKeysSeen::default();
-        let loaded = load_user_config_with_events(&mut events, &mut deprecated_keys);
+        let loaded = load_user_config_with_events(
+            None,
+            crate::config::make_env(&[]),
+            &mut events,
+            &mut deprecated_keys,
+        );
 
         // SAFETY: serial(xdg_env) prevents concurrent mutation in this test module.
         unsafe {
@@ -2493,7 +2571,7 @@ mod tests {
             }
         }
 
-        let settings = loaded.expect("user config").0;
+        let settings = loaded.into_iter().flatten().next().expect("user config");
         assert!(
             events
                 .iter()

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -409,9 +409,16 @@ fn read_explicit_layers(
                     break;
                 }
             };
-            if let Some(base) = base.as_ref()
-                && base.base_config_files.is_some()
-            {
+            let Some(base) = base else {
+                events.extend(
+                    base_events
+                        .into_iter()
+                        .map(|event| SettingsEvent::show_warning(event.message)),
+                );
+                layers.push(None);
+                continue;
+            };
+            if base.base_config_files.is_some() {
                 let message = format!(
                     "baseConfigFiles is only allowed in an entry config file; {} was included \
                      from {}",
@@ -422,7 +429,7 @@ fn read_explicit_layers(
                 fatal_error = Some(message);
                 break;
             }
-            let mut layer = base.map(|document| document.settings);
+            let mut layer = Some(base.settings);
             if let Err(message) =
                 validate_and_anchor_explicit_layer(&mut layer, &base_path, home, &env_fn)
             {
@@ -791,7 +798,11 @@ fn expand_implicit_file_entry(
             }
         };
         let Some(base) = base else {
-            events.extend(base_events);
+            events.extend(
+                base_events
+                    .into_iter()
+                    .map(|event| SettingsEvent::show_warning(event.message)),
+            );
             layers.push(None);
             continue;
         };
@@ -1413,7 +1424,7 @@ mod tests {
                     .to_string_lossy()
                     .into_owned()
             ],
-            "an unusable optional base must not discard valid sibling bases"
+            "an unusable base must not discard valid sibling bases"
         );
         assert!(
             outcome.events.iter().any(|event| {

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -251,6 +251,13 @@ fn resolve_base_config_path(
             entry_path.display()
         ));
     }
+    if expanded.starts_with('~') {
+        return Err(format!(
+            "Failed to resolve baseConfigFiles entry {configured:?} in {}: ~username is not \
+             supported; use ~ for the current user or an absolute path",
+            entry_path.display()
+        ));
+    }
     let path = PathBuf::from(expanded);
     Ok(if path.has_root() || path.is_absolute() {
         path
@@ -1363,7 +1370,7 @@ mod tests {
         .unwrap();
         std::fs::write(
             project.path().join("kakehashi.toml"),
-            "baseConfigFiles = [\"valid.toml\", \"$MISSING_KAKEHASHI_TEST_VAR/base.toml\"]\ndiagnosticsDebounceMs = 777\n",
+            "baseConfigFiles = [\"valid.toml\", \"$MISSING_KAKEHASHI_TEST_VAR/base.toml\", \"~bob/base.toml\"]\ndiagnosticsDebounceMs = 777\n",
         )
         .unwrap();
 
@@ -1397,6 +1404,15 @@ mod tests {
                     && event.message.contains("MISSING_KAKEHASHI_TEST_VAR")
             }),
             "the skipped base must remain visible: {:?}",
+            outcome.events
+        );
+        assert!(
+            outcome.events.iter().any(|event| {
+                event.kind == SettingsEventKind::Warning
+                    && event.message.contains("~username is not supported")
+                    && event.message.contains("~bob/base.toml")
+            }),
+            "an unsupported named home must be skipped without literal rebasing: {:?}",
             outcome.events
         );
     }
@@ -2660,6 +2676,25 @@ mod tests {
             explicit.layers[0].as_ref().unwrap().auto_install,
             Some(false)
         );
+    }
+
+    #[test]
+    fn explicit_base_config_files_reject_unsupported_named_tilde() {
+        let dir = TempDir::new().unwrap();
+        let entry = dir.path().join("kakehashi.toml");
+        std::fs::write(&entry, "baseConfigFiles = [\"~bob/base.toml\"]\n").unwrap();
+
+        let explicit = read_explicit_layers(
+            std::slice::from_ref(&entry),
+            None,
+            crate::config::make_env(&[]),
+        );
+
+        let message = explicit
+            .fatal_error
+            .expect("named-home expansion is unsupported and must not be rebased literally");
+        assert!(message.contains("~username is not supported"), "{message}");
+        assert!(message.contains("~bob/base.toml"), "{message}");
     }
 
     #[test]

--- a/tests/e2e/e2e_config_file.rs
+++ b/tests/e2e/e2e_config_file.rs
@@ -669,6 +669,15 @@ fn test_implicit_missing_base_is_shown_as_a_warning() {
         .expect("the missing base must be reported");
     assert_eq!(report.0, "window/showMessage", "report: {report:?}");
     assert_eq!(report.1["type"], json!(2), "report: {report:?}");
+    assert_eq!(
+        report.1["message"],
+        json!(format!(
+            "Base config file not found; skipping {} (referenced from {})",
+            missing.display(),
+            dir.path().join("kakehashi.toml").display()
+        )),
+        "report: {report:?}"
+    );
 }
 
 /// The initialize error is the *only* client-facing report of a fatal config

--- a/tests/e2e/e2e_config_file.rs
+++ b/tests/e2e/e2e_config_file.rs
@@ -587,6 +587,51 @@ fn test_implicit_project_config_parse_failure_is_not_fatal() {
     );
 }
 
+#[test]
+fn test_implicit_base_path_failure_is_shown_as_a_warning() {
+    let dir = TempDir::new().unwrap();
+    let base = dir.path().join("base.toml");
+    std::fs::write(
+        &base,
+        "searchPaths = [\"$MISSING_KAKEHASHI_TEST_VAR/parsers\"]\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("kakehashi.toml"),
+        "baseConfigFiles = [\"base.toml\"]\nautoInstall = false\n",
+    )
+    .unwrap();
+    let mut client = LspClient::builder()
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .env_remove("MISSING_KAKEHASHI_TEST_VAR")
+        .build();
+
+    let initialize_id = client.send_request_async(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": format!("file://{}", dir.path().display()),
+            "capabilities": {}
+        }),
+    );
+    let (response, watched) = client.receive_response_for_id_watching_notifications(
+        initialize_id,
+        &["window/showMessage", "window/logMessage"],
+    );
+
+    assert!(response.get("result").is_some(), "initialize: {response}");
+    let report = watched
+        .iter()
+        .find(|(_, params)| {
+            params["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("MISSING_KAKEHASHI_TEST_VAR"))
+        })
+        .expect("the skipped base must be reported");
+    assert_eq!(report.0, "window/showMessage", "report: {report:?}");
+    assert_eq!(report.1["type"], json!(2), "report: {report:?}");
+}
+
 /// The initialize error is the *only* client-facing report of a fatal config
 /// failure. Without this the early return in `initialize_impl` could drift back
 /// below `log_settings_events` and the user would get a `window/showMessage`

--- a/tests/e2e/e2e_config_file.rs
+++ b/tests/e2e/e2e_config_file.rs
@@ -157,6 +157,39 @@ fn test_config_file_two_files_merge_in_order() {
     );
 }
 
+#[test]
+fn test_config_file_entry_loads_base_config_files() {
+    let dir = TempDir::new().unwrap();
+    let base = dir.path().join("base.toml");
+    let entry = dir.path().join("kakehashi.toml");
+    std::fs::write(
+        &base,
+        "autoInstall = false\nsearchPaths = [\"./parsers\"]\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &entry,
+        "baseConfigFiles = [\"$HOME/base.toml\"]\nautoInstall = true\n",
+    )
+    .unwrap();
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(entry.to_str().unwrap())
+        .env("HOME", dir.path().to_string_lossy())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let settings = get_effective_settings(&mut client);
+
+    assert_eq!(settings["autoInstall"], json!(true), "entry overrides base");
+    assert_eq!(
+        settings["searchPaths"],
+        json!([dir.path().join("parsers").to_string_lossy()]),
+        "the base layer keeps its own relative-path anchor"
+    );
+}
+
 /// An absent explicit config file is an optional layer, not a startup failure:
 /// layered invocations rely on the overlay being allowed to not exist, and a
 /// relative path resolves against the editor's working directory.

--- a/tests/e2e/e2e_config_file.rs
+++ b/tests/e2e/e2e_config_file.rs
@@ -632,6 +632,45 @@ fn test_implicit_base_path_failure_is_shown_as_a_warning() {
     assert_eq!(report.1["type"], json!(2), "report: {report:?}");
 }
 
+#[test]
+fn test_implicit_missing_base_is_shown_as_a_warning() {
+    let dir = TempDir::new().unwrap();
+    let missing = dir.path().join("missing.toml");
+    std::fs::write(
+        dir.path().join("kakehashi.toml"),
+        "baseConfigFiles = [\"missing.toml\"]\nautoInstall = false\n",
+    )
+    .unwrap();
+    let mut client = LspClient::builder()
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let initialize_id = client.send_request_async(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": format!("file://{}", dir.path().display()),
+            "capabilities": {}
+        }),
+    );
+    let (response, watched) = client.receive_response_for_id_watching_notifications(
+        initialize_id,
+        &["window/showMessage", "window/logMessage"],
+    );
+
+    assert!(response.get("result").is_some(), "initialize: {response}");
+    let report = watched
+        .iter()
+        .find(|(_, params)| {
+            params["message"]
+                .as_str()
+                .is_some_and(|message| message.contains(&missing.display().to_string()))
+        })
+        .expect("the missing base must be reported");
+    assert_eq!(report.0, "window/showMessage", "report: {report:?}");
+    assert_eq!(report.1["type"], json!(2), "report: {report:?}");
+}
+
 /// The initialize error is the *only* client-facing report of a fatal config
 /// failure. Without this the early return in `initialize_impl` could drift back
 /// below `log_settings_events` and the user would get a `window/showMessage`


### PR DESCRIPTION
## Summary

- add TOML-only `baseConfigFiles` composition for user, project, and explicit config entries
- merge bases in listed order before their owning entry, with environment/tilde expansion and per-file path anchoring
- keep composition one level deep and cap each entry at 64 bases
- preserve strict explicit snapshots and tolerant, reloadable implicit sources
- expose the field in `kakehashi config schema` and document the contract in the configuration ADR and README

## Validation

- `cargo test --lib --quiet` (3579 passed, 2 ignored)
- `cargo test --test integration test_config_schema --quiet` (7 passed)
- `cargo test --features e2e --test e2e e2e_config_file:: --quiet` (37 passed)
- `make check`
- `git diff --check`

## Risk

The main risk is source ordering and error-policy drift across explicit, user, project, and live-client ingress. Focused tests cover ordering, nested declarations, path expansion, 64/65 boundaries, reload/replay lifetime, discarded-source side effects, and the file-only LSP boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - TOML configuration files can include up to 64 base configuration files.
  - Base files support environment-variable and tilde expansion, relative paths, ordered merging, and overrides by the declaring file.
  - Base-file composition is limited to one level for predictable loading.
  - Explicit configuration errors stop loading, while missing or invalid implicit bases are skipped with visible warnings.
  - Unsupported named-home paths are rejected.
  - Actionable configuration warnings now appear as editor notifications.

- **Documentation**
  - Updated configuration guidance to explain supported formats, precedence, path handling, limits, and reload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->