### PR TITLE
feat(lsp): route host code lens resolves

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ Current bridge-backed requests include:
 - Rename / Prepare Rename
 - Document Highlight / Document Symbol / Document Link
 - Moniker / Inlay Hint
-- Code Lens (incl. `codeLens/resolve` routed back to the origin server for injection-layer lenses — host-layer lenses pass through unrouted; resolution fails soft when the region was moved or invalidated since the lens was produced, and always in runtime-range-adjusted (`#offset!` / `#trim!`) regions such as frontmatter)
+- Code Lens (incl. `codeLens/resolve` routed back to the origin server for both injection- and host-layer lenses; host-layer payloads and coordinates pass through verbatim, while injection resolution fails soft when the region was moved or invalidated since the lens was produced, and always in runtime-range-adjusted (`#offset!` / `#trim!`) regions such as frontmatter)
 - Code Action (incl. `codeAction/resolve` routed back to the origin server, host-layer actions via `bridge._self`, and a merged menu across every injection region a multi-fence range overlaps; advertised only to clients with `codeActionLiteralSupport`)
 - `workspace/executeCommand` (commands surfaced through bridged actions route back to their origin server by name; palette-fired commands — those that a downstream advertised in its initialize result — route via dynamically registered names when the client supports dynamic registration (a downstream's own later dynamic command registrations are not routed). Known limitations: action-embedded command names encode the origin connection and are not registered, so clients that only dispatch command ids from registered lists — VS Code's vscode-languageclient — show such actions without running their command; and the palette registry is session-global by raw command id, which carries no workspace context — so when several LIVE connections advertise the same raw name, kakehashi refuses to guess and the invocation is a no-op, reported to the editor as a `window/logMessage` warning naming the connections involved. Note that per-root pooling is on by default, so one server rooted at two workspace folders is enough to trigger this; disambiguate by narrowing `workspaceMarkers`, enabling `preferSharedInstance`, or disabling one of the servers)
 - `workspace/applyEdit` from downstream servers (virtual-document edits are translated to the host document and relayed to the editor; untranslatable edits answer `applied: false`)
@@ -605,8 +605,7 @@ The reserved `_self` key makes the host language its own bridge target: with
 it enabled, requests on the host document are forwarded to servers whose
 `languages` matches the **host** language (including a `"*"` server), with the real URI and no
 coordinate translation. All bridged request methods are wired (exceptions:
-semantic tokens; document color stays injection-only; host code-lens
-resolves pass through unrouted); by default the host layer is
+semantic tokens and document color); by default the host layer is
 tried after
 `virt` (see `layers` above), so for `preferred` methods injections keep
 winning inside code fences while the host server answers everywhere else —

--- a/docs/architecture-decisions/cross-layer-aggregation.md
+++ b/docs/architecture-decisions/cross-layer-aggregation.md
@@ -21,9 +21,7 @@ Phased roadmap:
    settings arc), keyed `textDocument/publishDiagnostics` to match its
    aggregation config. With host bridging (host-document-bridge)
    implemented for the bridged request methods (documented exceptions:
-   document color is virt-only; host code-lens resolves pass through
-   unrouted — host completion-item resolves ARE routed, see
-   host-document-bridge), handlers run the real
+   document color is virt-only), handlers run the real
    stage-2 `preferred` walk (`Kakehashi::walk_layers` →
    `race_layers_preferred`): the virt and host layers fan out
    **concurrently** — the layer-level analogue of the stage-1 `preferred`

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -48,14 +48,18 @@ Partially implemented:
   translation and no injection-region edit guard), but only for a server that
   advertises `completionItem/resolve`. Without that capability the items stay
   bare and a resolve falls back gracefully (item returned unresolved).
-  `codeLens/resolve` follows the same host-layer rule: only a winning host
-  server that advertises resolve has its lenses stamped with an origin
-  envelope, and resolving one forwards the original payload and coordinates
-  verbatim. The envelope retains the host-document incarnation so a lens from
-  an earlier open is returned unresolved instead of being sent to a reopened
-  document. Ordinary downstream failures remain fail-soft, while an upstream
-  client cancellation returns `RequestCancelled` and cancels the in-flight
-  downstream resolve.
+  `codeLens/resolve` follows the same host-layer rule: a winning host server
+  that advertises resolve has its lenses stamped with an origin envelope, and
+  resolving one forwards the original payload and coordinates verbatim. A
+  non-resolving server's lens normally stays bare; the reserved-key collision
+  exception wraps `data.kakehashi` as opaque `inner` data so a downstream
+  payload cannot impersonate bridge routing metadata. The envelope retains
+  both the host-document incarnation and producing connection generation, so
+  an old lens is returned unresolved after either a document reopen or a
+  downstream process replacement. Resolve never spawns a replacement for
+  process-owned lens data. Ordinary downstream failures remain fail-soft,
+  while an upstream client cancellation returns `RequestCancelled` and
+  cancels the in-flight downstream resolve.
   Formatting additionally supports the cross-layer
   `concatenated` pipeline: virt region edits apply first, the host
   formatter formats the intermediate text, and the chain collapses into one

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -54,10 +54,11 @@ Partially implemented:
   non-resolving server's lens normally stays bare; the reserved-key collision
   exception wraps `data.kakehashi` as opaque `inner` data so a downstream
   payload cannot impersonate bridge routing metadata. The envelope retains
-  both the host-document incarnation and producing connection generation, so
-  an old lens is returned unresolved after either a document reopen or a
-  downstream process replacement. Resolve never spawns a replacement for
-  process-owned lens data. Ordinary downstream failures remain fail-soft,
+  the host-document incarnation plus the exact producing `ConnectionKey` and
+  its generation, so an old lens is returned unresolved after either a
+  document reopen, a rooted/shared routing-key change, or a downstream process
+  replacement. Resolve never spawns a replacement for process-owned lens data.
+  Ordinary downstream failures remain fail-soft,
   while an upstream client cancellation returns `RequestCancelled` and
   cancels the in-flight downstream resolve.
   Formatting additionally supports the cross-layer

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -47,6 +47,12 @@ Partially implemented:
   translation and no injection-region edit guard), but only for a server that
   advertises `completionItem/resolve`. Without that capability the items stay
   bare and a resolve falls back gracefully (item returned unresolved).
+  `codeLens/resolve` follows the same host-layer rule: only a winning host
+  server that advertises resolve has its lenses stamped with an origin
+  envelope, and resolving one forwards the original payload and coordinates
+  verbatim. The envelope retains the host-document incarnation so a lens from
+  an earlier open is returned unresolved instead of being sent to a reopened
+  document.
   Formatting additionally supports the cross-layer
   `concatenated` pipeline: virt region edits apply first, the host
   formatter formats the intermediate text, and the chain collapses into one

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -29,10 +29,11 @@ Partially implemented:
   no per-method request builders or response transformers. Handlers run the
   layer walk (`Kakehashi::walk_layers`, cross-layer-aggregation,
   `preferred` semantics): layers are tried lazily in `priorities` — by default
-  virt first, host as fallback. Two methods need per-server identity in the
-  host arm and so build their own (codeAction, for the `"{title} — {server}"`
-  suffix; completion, for the resolve-routing envelope), calling
-  `walk_layer_futures` / `walk_layers_by_strategy` with it. Covered: definition, hover, declaration,
+  virt first, host as fallback. Three methods consume per-server identity in
+  the host arm: codeAction for the `"{title} — {server}"` suffix, completion
+  for its resolve-routing envelope, and codeLens for the winning server's
+  resolve capability and envelope. CodeAction and completion build their own
+  host arms; codeLens uses the shared whole-document winner hook. Covered: definition, hover, declaration,
   typeDefinition, implementation, references, completion, signatureHelp,
   documentHighlight, rename, prepareRename, linkedEditingRange, moniker,
   inlayHint, documentSymbol, documentLink, foldingRange, codeLens,
@@ -52,7 +53,9 @@ Partially implemented:
   envelope, and resolving one forwards the original payload and coordinates
   verbatim. The envelope retains the host-document incarnation so a lens from
   an earlier open is returned unresolved instead of being sent to a reopened
-  document.
+  document. Ordinary downstream failures remain fail-soft, while an upstream
+  client cancellation returns `RequestCancelled` and cancels the in-flight
+  downstream resolve.
   Formatting additionally supports the cross-layer
   `concatenated` pipeline: virt region edits apply first, the host
   formatter formats the intermediate text, and the chain collapses into one

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -107,8 +107,8 @@ embedded blocks. Works for any grammar, no setup required.
 
 The features below are served by a language server configured for the
 embedded language — most of them also on the surrounding document itself,
-by a `bridge._self` host server (exceptions: document color stays
-injection-only, and host code-lens resolves pass through unrouted).
+by a `bridge._self` host server (document color is the exception and stays
+injection-only).
 Placing the cursor outside an embedded
 code block yields no result from the injection bridges; with `bridge._self`
 configured, the host language's own servers still answer there.

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -83,7 +83,8 @@ pub(crate) use protocol::workspace_edit_within_region;
 pub(crate) use text_document::host::{HostDocument, HostTextReader, normalize_host_goto_result};
 pub(crate) use text_document::{
     CodeActionEnvelope, CodeLensEnvelope, UpstreamCodeActionCaps, bridge_code_actions,
-    extract_code_action_envelope, extract_code_lens_envelope, parse_code_actions_leniently,
+    envelope_host_code_lenses, extract_code_action_envelope, extract_code_lens_envelope,
+    parse_code_actions_leniently,
 };
 pub(crate) use text_document::{KakehashiEnvelope, bridge_host_completion_items, extract_envelope};
 pub(crate) use text_document::{OpenExpectation, OpenOutcome};

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -54,7 +54,6 @@ pub(crate) use client_progress::{
 pub(crate) use coordinator::BridgeCoordinator;
 pub(crate) use coordinator::ResolvedServerConfig;
 pub(crate) use inbound_request_registry::InboundRequestRegistry;
-pub(crate) use pool::ConnectionKey;
 #[cfg(test)]
 pub(crate) use pool::ConnectionState;
 pub use pool::LanguageServerPool;
@@ -66,6 +65,7 @@ pub(crate) use pool::UpstreamId;
 /// seeds a `Ready` downstream to exercise `collect_push_diagnostics`' filter.
 #[cfg(test)]
 pub(crate) use pool::test_helpers;
+pub(crate) use pool::{ConnectionHandle, ConnectionKey};
 pub(crate) use progress_registry::{ProgressConnectionId, ProgressRegistry};
 pub(crate) use protocol::RegionOffset;
 pub(crate) use protocol::RequestId;

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -692,16 +692,18 @@ impl ConnectionHandle {
         if self.dynamic_capabilities().has_registration(method) {
             return true;
         }
-        // A sub-capability that lives inside ANOTHER method's options has no
-        // method of its own to register, so the name match above can never see
-        // it: `completionItem/resolve` is `textDocument/completion`'s
-        // `resolveProvider`. Without this, a server that registers completion
-        // dynamically and advertises nothing statically reads as non-resolving,
-        // and its items are served with no way to resolve them.
-        if method == "completionItem/resolve"
+        // Resolve sub-capabilities live inside their parent request's options
+        // and have no registration method of their own, so a direct method-name
+        // lookup can never see them.
+        let dynamic_resolve_parent = match method {
+            "completionItem/resolve" => Some("textDocument/completion"),
+            "codeLens/resolve" => Some("textDocument/codeLens"),
+            _ => None,
+        };
+        if let Some(parent) = dynamic_resolve_parent
             && self
                 .dynamic_capabilities()
-                .registration_options_flag("textDocument/completion", "resolveProvider")
+                .registration_options_flag(parent, "resolveProvider")
         {
             return true;
         }
@@ -2880,5 +2882,38 @@ mod tests {
         });
 
         assert!(!handle.has_capability("codeLens/resolve"));
+    }
+
+    #[tokio::test]
+    async fn code_lens_resolve_capability_true_from_dynamic_registration() {
+        use tower_lsp_server::ls_types::Registration;
+
+        let handle = spawn_sink_handle().await;
+        handle.set_server_capabilities(ServerCapabilities::default());
+        assert!(!handle.has_capability("codeLens/resolve"));
+
+        handle.dynamic_capabilities().register(vec![Registration {
+            id: "code-lens-1".to_string(),
+            method: "textDocument/codeLens".to_string(),
+            register_options: Some(serde_json::json!({ "resolveProvider": true })),
+        }]);
+
+        assert!(handle.has_capability("codeLens/resolve"));
+    }
+
+    #[tokio::test]
+    async fn code_lens_resolve_capability_false_when_dynamic_registration_omits_the_flag() {
+        use tower_lsp_server::ls_types::Registration;
+
+        let handle = spawn_sink_handle().await;
+        handle.set_server_capabilities(ServerCapabilities::default());
+        handle.dynamic_capabilities().register(vec![Registration {
+            id: "code-lens-1".to_string(),
+            method: "textDocument/codeLens".to_string(),
+            register_options: Some(serde_json::json!({})),
+        }]);
+
+        assert!(!handle.has_capability("codeLens/resolve"));
+        assert!(handle.has_capability("textDocument/codeLens"));
     }
 }

--- a/src/lsp/bridge/pool/connection_key.rs
+++ b/src/lsp/bridge/pool/connection_key.rs
@@ -17,7 +17,7 @@ use std::fmt;
 
 /// How a [`ConnectionKey`] is rooted — the discriminator that decides which
 /// downstream process a document routes to.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 enum ConnectionRoot {
     /// Resolved marker workspace root URI string: documents under distinct
     /// marker roots get distinct connections (per-root pooling, #382).
@@ -44,7 +44,7 @@ enum ConnectionRoot {
 /// [`ConnectionHandle`](super::ConnectionHandle) so downstream request,
 /// `didChange`, and cancel paths can recover it via `handle.key()` without
 /// re-resolving the root.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ConnectionKey {
     /// Config server name (the `language_servers` map key), e.g. `tsgo`.
     server: String,

--- a/src/lsp/bridge/pool/dynamic_capability_registry.rs
+++ b/src/lsp/bridge/pool/dynamic_capability_registry.rs
@@ -65,11 +65,9 @@ impl DynamicCapabilityRegistry {
     /// `registerOptions.<flag>`.
     ///
     /// Sub-capabilities that live INSIDE another method's options have no
-    /// method of their own to register — `completionItem/resolve` is
-    /// `textDocument/completion`'s `resolveProvider`, not a registrable method
-    /// — so [`Self::has_registration`] can never see them. Without this, a
-    /// server that registers completion dynamically with `resolveProvider:
-    /// true` and advertises nothing statically reads as non-resolving.
+    /// method of their own to register — for example, `completionItem/resolve`
+    /// is `textDocument/completion`'s `resolveProvider`, not a registrable
+    /// method — so [`Self::has_registration`] can never see them.
     pub(crate) fn registration_options_flag(&self, method: &str, flag: &str) -> bool {
         self.registrations
             .read()

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -34,11 +34,18 @@ pub(crate) struct BridgeResponseContext<'a> {
     pub offset: &'a RegionOffset,
 }
 
-struct RequestHostLifecycle<'a> {
+pub(crate) struct RequestHostLifecycle<'a> {
     pool: &'a LanguageServerPool,
     host_uri: &'a Url,
     lifecycle: Arc<tokio::sync::Mutex<()>>,
     guard: Option<tokio::sync::OwnedMutexGuard<()>>,
+    incarnation: u64,
+}
+
+impl RequestHostLifecycle<'_> {
+    pub(crate) fn incarnation(&self) -> u64 {
+        self.incarnation
+    }
 }
 
 impl Drop for RequestHostLifecycle<'_> {
@@ -50,7 +57,7 @@ impl Drop for RequestHostLifecycle<'_> {
 }
 
 impl LanguageServerPool {
-    async fn request_host_lifecycle<'a>(
+    pub(crate) async fn request_host_lifecycle<'a>(
         &'a self,
         host_uri: &'a Url,
     ) -> io::Result<RequestHostLifecycle<'a>> {
@@ -61,16 +68,31 @@ impl LanguageServerPool {
             )
         })?;
         let guard = Arc::clone(&lifecycle).lock_owned().await;
-        let lifecycle = RequestHostLifecycle {
+        let Some(incarnation) = self.current_host_incarnation(host_uri) else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                format!("bridge: host document is closed: {host_uri}"),
+            ));
+        };
+        Ok(RequestHostLifecycle {
             pool: self,
             host_uri,
             lifecycle,
             guard: Some(guard),
-        };
-        if self.current_host_incarnation(host_uri).is_none() {
+            incarnation,
+        })
+    }
+
+    pub(crate) async fn request_host_lifecycle_for_incarnation<'a>(
+        &'a self,
+        host_uri: &'a Url,
+        expected_incarnation: u64,
+    ) -> io::Result<RequestHostLifecycle<'a>> {
+        let lifecycle = self.request_host_lifecycle(host_uri).await?;
+        if lifecycle.incarnation() != expected_incarnation {
             return Err(io::Error::new(
                 io::ErrorKind::NotConnected,
-                format!("bridge: host document is closed: {host_uri}"),
+                format!("bridge: host document incarnation changed before request: {host_uri}"),
             ));
         }
         Ok(lifecycle)
@@ -518,6 +540,7 @@ mod tests {
         let host_uri = Url::parse("file:///test/guarded-close.md").unwrap();
         pool.open_host_incarnation(&host_uri, 1).await;
         let guard = pool.request_host_lifecycle(&host_uri).await.unwrap();
+        assert_eq!(guard.incarnation(), 1);
 
         let close = {
             let pool = Arc::clone(&pool);
@@ -531,6 +554,23 @@ mod tests {
         close.await.unwrap();
         let Err(error) = pool.request_host_lifecycle(&host_uri).await else {
             panic!("closed host must reject a late request");
+        };
+        assert_eq!(error.kind(), io::ErrorKind::NotConnected);
+    }
+
+    #[tokio::test]
+    async fn host_request_rejects_a_reopened_incarnation() {
+        let pool = Arc::new(LanguageServerPool::new());
+        let host_uri = Url::parse("file:///test/reopened.md").unwrap();
+        pool.open_host_incarnation(&host_uri, 1).await;
+        pool.close_host_incarnation(&host_uri, 1).await;
+        pool.open_host_incarnation(&host_uri, 2).await;
+
+        let Err(error) = pool
+            .request_host_lifecycle_for_incarnation(&host_uri, 1)
+            .await
+        else {
+            panic!("an old resolve must not enter the reopened lifetime");
         };
         assert_eq!(error.kind(), io::ErrorKind::NotConnected);
     }

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -69,6 +69,8 @@ impl LanguageServerPool {
         })?;
         let guard = Arc::clone(&lifecycle).lock_owned().await;
         let Some(incarnation) = self.current_host_incarnation(host_uri) else {
+            drop(guard);
+            self.remove_host_lifecycle_lock_if_unshared(host_uri, &lifecycle);
             return Err(io::Error::new(
                 io::ErrorKind::NotConnected,
                 format!("bridge: host document is closed: {host_uri}"),
@@ -573,6 +575,24 @@ mod tests {
             panic!("an old resolve must not enter the reopened lifetime");
         };
         assert_eq!(error.kind(), io::ErrorKind::NotConnected);
+    }
+
+    #[tokio::test]
+    async fn closed_host_request_reclaims_a_lifecycle_lock_retained_by_the_race() {
+        let pool = Arc::new(LanguageServerPool::new());
+        let host_uri = Url::parse("file:///test/closed-race.md").unwrap();
+        pool.open_host_incarnation(&host_uri, 1).await;
+
+        let raced_clone = pool.host_lifecycle_lock(&host_uri);
+        pool.close_host_incarnation(&host_uri, 1).await;
+        assert!(pool.existing_host_lifecycle_lock(&host_uri).is_some());
+        drop(raced_clone);
+
+        assert!(pool.request_host_lifecycle(&host_uri).await.is_err());
+        assert!(
+            pool.existing_host_lifecycle_lock(&host_uri).is_none(),
+            "the losing request must reclaim the stale lifecycle-map entry"
+        );
     }
 
     /// Test that send_hover_request returns Ok(None) when server lacks hover capability.

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -13,7 +13,9 @@ pub(crate) use code_action::{
     CodeActionEnvelope, UpstreamCodeActionCaps, bridge_code_actions, extract_code_action_envelope,
     parse_code_actions_leniently,
 };
-pub(crate) use code_lens::{CodeLensEnvelope, extract_code_lens_envelope};
+pub(crate) use code_lens::{
+    CodeLensEnvelope, envelope_host_code_lenses, extract_code_lens_envelope,
+};
 mod completion;
 pub(crate) use completion::{KakehashiEnvelope, bridge_host_completion_items, extract_envelope};
 mod completion_item;

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -5,11 +5,12 @@
 //! position parameter, like document link); `codeLens/resolve` takes a single
 //! lens as its complete params — see `dispatch_code_lens_resolve`.
 //!
-//! Every bridged lens gets a routing envelope in `lens.data` (the
-//! `completionItem/resolve` pattern) so a later `codeLens/resolve` can be sent
-//! to the origin downstream server. Unresolved lenses (no `command`, only
-//! `data`) are therefore forwarded instead of dropped — servers like
-//! rust-analyzer return mostly-unresolved lenses by design.
+//! Every injection lens gets a routing envelope in `lens.data` (the
+//! `completionItem/resolve` pattern), as does a winning host lens when its
+//! server advertises resolve, so a later `codeLens/resolve` can be sent to the
+//! origin downstream server. Unresolved lenses (no `command`, only `data`) are
+//! therefore forwarded instead of dropped — servers like rust-analyzer return
+//! mostly-unresolved lenses by design.
 //!
 //! Resolution fails soft: any failure (stale region, missing server,
 //! connection error, parse failure) returns the lens unresolved with its

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -68,6 +68,20 @@ pub(crate) struct CodeLensEnvelope {
     pub(crate) offset: EnvelopeOffset,
     /// The downstream server's original `data` value (preserved verbatim).
     pub(crate) inner: Option<Value>,
+    /// Host-layer lens: coordinates and URI already name the real document,
+    /// so resolve forwards the item verbatim without region translation.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub(crate) host_layer: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+impl CodeLensEnvelope {
+    pub(crate) fn is_host_layer(&self) -> bool {
+        self.host_layer && self.region_id.is_empty()
+    }
 }
 
 /// Context needed to create envelopes during code lens response processing.
@@ -78,6 +92,7 @@ struct CodeLensEnvelopeContext<'a> {
     injection_language: &'a str,
     incarnation: Option<u64>,
     offset: &'a RegionOffset,
+    host_layer: bool,
 }
 
 /// Wrap `lens.data` in a Kakehashi envelope for origin tracking.
@@ -91,6 +106,7 @@ fn envelope_lens_data(lens: &mut CodeLens, ctx: &CodeLensEnvelopeContext) {
         incarnation: ctx.incarnation,
         offset: EnvelopeOffset::from(ctx.offset),
         inner,
+        host_layer: ctx.host_layer,
     };
     lens.data = Some(serde_json::json!({ ENVELOPE_KEY: envelope }));
 }
@@ -123,8 +139,30 @@ fn re_envelope_lens(lens: &mut CodeLens, envelope: &CodeLensEnvelope) {
         injection_language: &envelope.injection_language,
         incarnation: envelope.incarnation,
         offset: &RegionOffset::from(&envelope.offset),
+        host_layer: envelope.host_layer,
     };
     envelope_lens_data(lens, &ctx);
+}
+
+pub(crate) fn envelope_host_code_lenses(
+    lenses: &mut [CodeLens],
+    server_name: &str,
+    host_uri: &str,
+    incarnation: Option<u64>,
+) {
+    let offset = RegionOffset::new(0, 0);
+    let ctx = CodeLensEnvelopeContext {
+        server_name,
+        host_uri,
+        region_id: "",
+        injection_language: "",
+        incarnation,
+        offset: &offset,
+        host_layer: true,
+    };
+    for lens in lenses {
+        envelope_lens_data(lens, &ctx);
+    }
 }
 
 impl LanguageServerPool {
@@ -179,6 +217,7 @@ impl LanguageServerPool {
                     injection_language,
                     incarnation: host_incarnation,
                     offset: ctx.offset,
+                    host_layer: false,
                 };
                 transform_code_lens_response_to_host(response, ctx.offset, &envelope_ctx)
             },
@@ -247,8 +286,11 @@ impl LanguageServerPool {
             re_envelope_lens(&mut lens, &envelope);
             return lens;
         }
-        let handle = match self
-            .get_or_create_virtual_connection(
+        let handle_result = if envelope.is_host_layer() {
+            self.get_or_create_connection(server_name, server_config, Some(&host_uri))
+                .await
+        } else {
+            self.get_or_create_virtual_connection(
                 server_name,
                 server_config,
                 &host_uri,
@@ -256,7 +298,8 @@ impl LanguageServerPool {
                 &envelope.region_id,
             )
             .await
-        {
+        };
+        let handle = match handle_result {
             Ok(h) => h,
             Err(e) => {
                 warn!(
@@ -302,9 +345,11 @@ impl LanguageServerPool {
         // The downstream produced this lens in VIRTUAL coordinates; translate
         // the (host) range back before sending. `lens.data` already carries the
         // downstream's original value (the caller stripped the envelope).
-        let offset = RegionOffset::from(&envelope.offset);
         let mut outgoing = lens.clone();
-        translate_host_range_to_virtual(&mut outgoing.range, &offset);
+        if !envelope.is_host_layer() {
+            let offset = RegionOffset::from(&envelope.offset);
+            translate_host_range_to_virtual(&mut outgoing.range, &offset);
+        }
         let request = build_code_lens_resolve_request(&outgoing, request_id);
 
         let mut router_guard = RouterCleanupGuard::new(Arc::clone(handle.router()), request_id);
@@ -455,6 +500,7 @@ mod tests {
             injection_language: "lua",
             incarnation: Some(1),
             offset,
+            host_layer: false,
         }
     }
 

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -318,6 +318,25 @@ impl LanguageServerPool {
             return lens;
         }
 
+        let _host_lifecycle = if envelope.is_host_layer() {
+            let Some(expected_incarnation) = envelope.incarnation else {
+                re_envelope_lens(&mut lens, &envelope);
+                return lens;
+            };
+            match self
+                .request_host_lifecycle_for_incarnation(&host_uri, expected_incarnation)
+                .await
+            {
+                Ok(lifecycle) => Some(lifecycle),
+                Err(_) => {
+                    re_envelope_lens(&mut lens, &envelope);
+                    return lens;
+                }
+            }
+        } else {
+            None
+        };
+
         // Route per-connection cancel state by this handle's pool key (#382).
         let connection_key = handle.key();
 

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -30,7 +30,7 @@ use serde_json::Value;
 use tower_lsp_server::ls_types::{CodeLens, NumberOrString};
 use url::Url;
 
-use super::super::pool::{LanguageServerPool, UpstreamId};
+use super::super::pool::{ConnectionKey, LanguageServerPool, UpstreamId};
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, WholeDocumentRequestParams,
     build_whole_document_request_with_progress, response_has_jsonrpc_error,
@@ -70,6 +70,10 @@ pub(crate) struct CodeLensEnvelope {
     /// hand process-owned data to a replacement process under the same key.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) connection_generation: Option<u64>,
+    /// Exact pool key of the producing host connection. Generations are local
+    /// to a key, so the key and generation together identify the process.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) connection_key: Option<ConnectionKey>,
     /// Region offset snapshot for coordinate translation at resolve time.
     pub(crate) offset: EnvelopeOffset,
     /// The downstream server's original `data` value (preserved verbatim).
@@ -98,6 +102,7 @@ struct CodeLensEnvelopeContext<'a> {
     injection_language: &'a str,
     incarnation: Option<u64>,
     connection_generation: Option<u64>,
+    connection_key: Option<&'a ConnectionKey>,
     offset: &'a RegionOffset,
     host_layer: bool,
 }
@@ -112,6 +117,7 @@ fn envelope_lens_data(lens: &mut CodeLens, ctx: &CodeLensEnvelopeContext) {
         injection_language: ctx.injection_language.to_string(),
         incarnation: ctx.incarnation,
         connection_generation: ctx.connection_generation,
+        connection_key: ctx.connection_key.cloned(),
         offset: EnvelopeOffset::from(ctx.offset),
         inner,
         host_layer: ctx.host_layer,
@@ -147,6 +153,7 @@ fn re_envelope_lens(lens: &mut CodeLens, envelope: &CodeLensEnvelope) {
         injection_language: &envelope.injection_language,
         incarnation: envelope.incarnation,
         connection_generation: envelope.connection_generation,
+        connection_key: envelope.connection_key.as_ref(),
         offset: &RegionOffset::from(&envelope.offset),
         host_layer: envelope.host_layer,
     };
@@ -159,6 +166,7 @@ pub(crate) fn envelope_host_code_lenses(
     host_uri: &str,
     incarnation: Option<u64>,
     connection_generation: u64,
+    connection_key: &ConnectionKey,
     server_resolves: bool,
 ) {
     let offset = RegionOffset::new(0, 0);
@@ -169,6 +177,7 @@ pub(crate) fn envelope_host_code_lenses(
         injection_language: "",
         incarnation,
         connection_generation: Some(connection_generation),
+        connection_key: Some(connection_key),
         offset: &offset,
         host_layer: true,
     };
@@ -237,6 +246,7 @@ impl LanguageServerPool {
                     injection_language,
                     incarnation: host_incarnation,
                     connection_generation: None,
+                    connection_key: None,
                     offset: ctx.offset,
                     host_layer: false,
                 };
@@ -312,14 +322,19 @@ impl LanguageServerPool {
                 re_envelope_lens(&mut lens, &envelope);
                 return lens;
             };
-            let (_, connection_key) = self
-                .resolve_acquire(server_name, server_config, Some(&host_uri))
-                .await;
-            if self.document_connection_generation(&connection_key) != expected_generation {
+            let Some(connection_key) = envelope
+                .connection_key
+                .as_ref()
+                .filter(|key| key.server() == server_name)
+            else {
+                re_envelope_lens(&mut lens, &envelope);
+                return lens;
+            };
+            if self.document_connection_generation(connection_key) != expected_generation {
                 re_envelope_lens(&mut lens, &envelope);
                 return lens;
             }
-            self.ready_connection_by_key_for_config(&connection_key, Some(server_config))
+            self.ready_connection_by_key_for_config(connection_key, Some(server_config))
                 .await
                 .ok_or_else(|| {
                     io::Error::new(
@@ -575,6 +590,7 @@ mod tests {
             injection_language: "lua",
             incarnation: Some(1),
             connection_generation: None,
+            connection_key: None,
             offset,
             host_layer: false,
         }

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -66,6 +66,10 @@ pub(crate) struct CodeLensEnvelope {
     /// Host open incarnation that produced this lens. Missing for legacy data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) incarnation: Option<u64>,
+    /// Generation of the producing pooled connection. Host resolve must not
+    /// hand process-owned data to a replacement process under the same key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) connection_generation: Option<u64>,
     /// Region offset snapshot for coordinate translation at resolve time.
     pub(crate) offset: EnvelopeOffset,
     /// The downstream server's original `data` value (preserved verbatim).
@@ -93,6 +97,7 @@ struct CodeLensEnvelopeContext<'a> {
     region_id: &'a str,
     injection_language: &'a str,
     incarnation: Option<u64>,
+    connection_generation: Option<u64>,
     offset: &'a RegionOffset,
     host_layer: bool,
 }
@@ -106,6 +111,7 @@ fn envelope_lens_data(lens: &mut CodeLens, ctx: &CodeLensEnvelopeContext) {
         region_id: ctx.region_id.to_string(),
         injection_language: ctx.injection_language.to_string(),
         incarnation: ctx.incarnation,
+        connection_generation: ctx.connection_generation,
         offset: EnvelopeOffset::from(ctx.offset),
         inner,
         host_layer: ctx.host_layer,
@@ -140,6 +146,7 @@ fn re_envelope_lens(lens: &mut CodeLens, envelope: &CodeLensEnvelope) {
         region_id: &envelope.region_id,
         injection_language: &envelope.injection_language,
         incarnation: envelope.incarnation,
+        connection_generation: envelope.connection_generation,
         offset: &RegionOffset::from(&envelope.offset),
         host_layer: envelope.host_layer,
     };
@@ -151,6 +158,8 @@ pub(crate) fn envelope_host_code_lenses(
     server_name: &str,
     host_uri: &str,
     incarnation: Option<u64>,
+    connection_generation: u64,
+    server_resolves: bool,
 ) {
     let offset = RegionOffset::new(0, 0);
     let ctx = CodeLensEnvelopeContext {
@@ -159,12 +168,21 @@ pub(crate) fn envelope_host_code_lenses(
         region_id: "",
         injection_language: "",
         incarnation,
+        connection_generation: Some(connection_generation),
         offset: &offset,
         host_layer: true,
     };
     for lens in lenses {
-        envelope_lens_data(lens, &ctx);
+        if server_resolves || code_lens_data_carries_envelope_key(lens) {
+            envelope_lens_data(lens, &ctx);
+        }
     }
+}
+
+fn code_lens_data_carries_envelope_key(lens: &CodeLens) -> bool {
+    lens.data
+        .as_ref()
+        .is_some_and(|data| data.get(ENVELOPE_KEY).is_some())
 }
 
 impl LanguageServerPool {
@@ -218,6 +236,7 @@ impl LanguageServerPool {
                     region_id,
                     injection_language,
                     incarnation: host_incarnation,
+                    connection_generation: None,
                     offset: ctx.offset,
                     host_layer: false,
                 };
@@ -289,8 +308,25 @@ impl LanguageServerPool {
             return lens;
         }
         let handle_result = if envelope.is_host_layer() {
-            self.get_or_create_connection(server_name, server_config, Some(&host_uri))
+            let Some(expected_generation) = envelope.connection_generation else {
+                re_envelope_lens(&mut lens, &envelope);
+                return lens;
+            };
+            let (_, connection_key) = self
+                .resolve_acquire(server_name, server_config, Some(&host_uri))
+                .await;
+            if self.document_connection_generation(&connection_key) != expected_generation {
+                re_envelope_lens(&mut lens, &envelope);
+                return lens;
+            }
+            self.ready_connection_by_key_for_config(&connection_key, Some(server_config))
                 .await
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotConnected,
+                        "producer connection is no longer live",
+                    )
+                })
         } else {
             self.get_or_create_virtual_connection(
                 server_name,
@@ -375,7 +411,25 @@ impl LanguageServerPool {
 
         let mut router_guard = RouterCleanupGuard::new(Arc::clone(handle.router()), request_id);
 
-        if let Err(e) = handle.send_request(request, request_id) {
+        let send_result = {
+            let connections = self.connections().await;
+            let producer_is_live = connections
+                .get(connection_key)
+                .is_some_and(|current| Arc::ptr_eq(current, &handle));
+            let generation_matches = !envelope.is_host_layer()
+                || envelope.connection_generation.is_some_and(|expected| {
+                    self.document_connection_generation(connection_key) == expected
+                });
+            if !producer_is_live || !generation_matches {
+                Err(io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    "producer connection was replaced before resolve send",
+                ))
+            } else {
+                handle.send_request(request, request_id).map_err(Into::into)
+            }
+        };
+        if let Err(e) = send_result {
             warn!(
                 target: "kakehashi::bridge",
                 "codeLens/resolve: failed to send request for {}: {}",
@@ -520,6 +574,7 @@ mod tests {
             region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
             injection_language: "lua",
             incarnation: Some(1),
+            connection_generation: None,
             offset,
             host_layer: false,
         }

--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -12,10 +12,11 @@
 //! therefore forwarded instead of dropped — servers like rust-analyzer return
 //! mostly-unresolved lenses by design.
 //!
-//! Resolution fails soft: any failure (stale region, missing server,
-//! connection error, parse failure) returns the lens unresolved with its
-//! envelope intact; clients re-request lenses on change, so the window is
-//! short (#355 maintainer decision).
+//! Resolution fails soft for stale regions, missing servers, connection
+//! errors, and parse failures: the lens returns unresolved with its envelope
+//! intact. Client cancellation is the exception and surfaces as
+//! `RequestCancelled`; clients re-request lenses on change, so the ordinary
+//! fail-soft window is short (#355 maintainer decision).
 //!
 //! Requests are queued via the channel-based writer task (`send_request()`) for
 //! FIFO ordering with other messages (ls-bridge-message-ordering single-writer loop).

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -65,6 +65,7 @@ pub(crate) struct HostDocument<'a> {
 pub(crate) struct HostRawResponse {
     pub(crate) value: serde_json::Value,
     pub(crate) handle: Arc<ConnectionHandle>,
+    pub(crate) incarnation: u64,
 }
 
 fn fingerprint(text: &str) -> u64 {
@@ -318,21 +319,24 @@ impl LanguageServerPool {
         // that would repeat the marker filesystem walk on a request-frequency
         // path (execute-command-routing-token).
         let answering = Arc::clone(&handle);
-        let value = self
+        let (value, incarnation) = self
             .execute_host_request(
                 handle,
                 doc,
                 upstream_request_id,
                 |request_id| JsonRpcRequest::new(request_id.as_i64(), method, params),
-                move |response| parse_host_raw_response(response, method),
+                move |response, incarnation| {
+                    (parse_host_raw_response(response, method), incarnation)
+                },
             )
-            // Outer `?`: transport/protocol failure from `execute_host_request`.
-            // Inner `Result` from the parser: a downstream JSON-RPC error
-            // response. Both are request failures, so flatten them into one `Err`.
-            .await??;
+            .await?;
+        // The outer result is the transport/protocol outcome; `value` is the
+        // downstream JSON-RPC parse result. Both are request failures.
+        let value = value?;
         Ok(value.map(|value| HostRawResponse {
             value,
             handle: answering,
+            incarnation,
         }))
     }
 
@@ -370,7 +374,9 @@ impl LanguageServerPool {
             // `send_formatting_request`: the fan-in counts `Err`s, which CLI
             // mode maps onto its error exit code. Only the no-capability
             // early return above yields `Ok(None)`.
-            move |response| parse_host_formatting_response(response, method).map(Some),
+            move |response, _incarnation| {
+                parse_host_formatting_response(response, method).map(Some)
+            },
         )
         .await?
     }
@@ -444,7 +450,7 @@ impl LanguageServerPool {
                 doc,
                 upstream_request_id,
                 |request_id| JsonRpcRequest::new(request_id.as_i64(), method, params),
-                move |response| {
+                move |response, _incarnation| {
                     if response_has_jsonrpc_error(&response, method) {
                         return Err(io::Error::other(format!(
                             "downstream server answered {method} with an error response: {}",
@@ -481,13 +487,12 @@ impl LanguageServerPool {
         doc: &HostDocument<'_>,
         upstream_request_id: Option<UpstreamId>,
         build_request: impl FnOnce(RequestId) -> JsonRpcRequest<P>,
-        transform_response: impl FnOnce(serde_json::Value) -> T,
+        transform_response: impl FnOnce(serde_json::Value, u64) -> T,
     ) -> io::Result<T> {
         // Route per-connection state by this handle's pool key (#382).
         let connection_key = handle.key();
         self.wait_for_host_routing(doc.uri).await;
-        let lifecycle = self.host_lifecycle_lock(doc.uri);
-        let _lifecycle_guard = lifecycle.lock().await;
+        let host_lifecycle = self.request_host_lifecycle(doc.uri).await?;
         if self.is_host_routing_suppressed(doc.uri, connection_key) {
             return Err(io::Error::new(
                 io::ErrorKind::NotConnected,
@@ -585,7 +590,8 @@ impl LanguageServerPool {
             self.unregister_upstream_request(id, connection_key);
         }
 
-        Ok(transform_response(response?))
+        let incarnation = host_lifecycle.incarnation();
+        Ok(transform_response(response?, incarnation))
     }
 }
 

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -66,6 +66,7 @@ pub(crate) struct HostRawResponse {
     pub(crate) value: serde_json::Value,
     pub(crate) handle: Arc<ConnectionHandle>,
     pub(crate) incarnation: u64,
+    pub(crate) connection_generation: u64,
 }
 
 fn fingerprint(text: &str) -> u64 {
@@ -319,14 +320,18 @@ impl LanguageServerPool {
         // that would repeat the marker filesystem walk on a request-frequency
         // path (execute-command-routing-token).
         let answering = Arc::clone(&handle);
-        let (value, incarnation) = self
+        let (value, incarnation, connection_generation) = self
             .execute_host_request(
                 handle,
                 doc,
                 upstream_request_id,
                 |request_id| JsonRpcRequest::new(request_id.as_i64(), method, params),
-                move |response, incarnation| {
-                    (parse_host_raw_response(response, method), incarnation)
+                move |response, incarnation, connection_generation| {
+                    (
+                        parse_host_raw_response(response, method),
+                        incarnation,
+                        connection_generation,
+                    )
                 },
             )
             .await?;
@@ -337,6 +342,7 @@ impl LanguageServerPool {
             value,
             handle: answering,
             incarnation,
+            connection_generation,
         }))
     }
 
@@ -374,7 +380,7 @@ impl LanguageServerPool {
             // `send_formatting_request`: the fan-in counts `Err`s, which CLI
             // mode maps onto its error exit code. Only the no-capability
             // early return above yields `Ok(None)`.
-            move |response, _incarnation| {
+            move |response, _incarnation, _connection_generation| {
                 parse_host_formatting_response(response, method).map(Some)
             },
         )
@@ -450,7 +456,7 @@ impl LanguageServerPool {
                 doc,
                 upstream_request_id,
                 |request_id| JsonRpcRequest::new(request_id.as_i64(), method, params),
-                move |response, _incarnation| {
+                move |response, _incarnation, _connection_generation| {
                     if response_has_jsonrpc_error(&response, method) {
                         return Err(io::Error::other(format!(
                             "downstream server answered {method} with an error response: {}",
@@ -487,7 +493,7 @@ impl LanguageServerPool {
         doc: &HostDocument<'_>,
         upstream_request_id: Option<UpstreamId>,
         build_request: impl FnOnce(RequestId) -> JsonRpcRequest<P>,
-        transform_response: impl FnOnce(serde_json::Value, u64) -> T,
+        transform_response: impl FnOnce(serde_json::Value, u64, u64) -> T,
     ) -> io::Result<T> {
         // Route per-connection state by this handle's pool key (#382).
         let connection_key = handle.key();
@@ -544,7 +550,7 @@ impl LanguageServerPool {
         // wedging the `(uri, connection)` pair until the next purge. Holding
         // `connections` here also excludes a purge from interleaving with
         // this sync, closing the race entirely.
-        {
+        let connection_generation = {
             let connections = self.connections().await;
             if !connections
                 .get(connection_key)
@@ -581,7 +587,8 @@ impl LanguageServerPool {
                 }
                 return Err(e.into());
             }
-        }
+            self.document_connection_generation(connection_key)
+        };
 
         let response = handle.wait_for_response(request_id, response_rx).await;
         router_guard.disarm();
@@ -591,7 +598,11 @@ impl LanguageServerPool {
         }
 
         let incarnation = host_lifecycle.incarnation();
-        Ok(transform_response(response?, incarnation))
+        Ok(transform_response(
+            response?,
+            incarnation,
+            connection_generation,
+        ))
     }
 }
 

--- a/src/lsp/lsp_impl/text_document/code_lens.rs
+++ b/src/lsp/lsp_impl/text_document/code_lens.rs
@@ -38,7 +38,7 @@ impl Kakehashi {
                     .await
             },
             |mut won| {
-                if won.resolves {
+                if won.handle.has_capability("codeLens/resolve") {
                     envelope_host_code_lenses(
                         &mut won.items,
                         &won.server_name,

--- a/src/lsp/lsp_impl/text_document/code_lens.rs
+++ b/src/lsp/lsp_impl/text_document/code_lens.rs
@@ -39,14 +39,15 @@ impl Kakehashi {
                     .await
             },
             |mut won| {
-                if won.handle.has_capability("codeLens/resolve") {
-                    envelope_host_code_lenses(
-                        &mut won.items,
-                        &won.server_name,
-                        won.host_uri.as_str(),
-                        won.incarnation,
-                    );
-                }
+                let server_resolves = won.handle.has_capability("codeLens/resolve");
+                envelope_host_code_lenses(
+                    &mut won.items,
+                    &won.server_name,
+                    won.host_uri.as_str(),
+                    won.incarnation,
+                    won.connection_generation,
+                    server_resolves,
+                );
                 Some(won.items)
             },
         )

--- a/src/lsp/lsp_impl/text_document/code_lens.rs
+++ b/src/lsp/lsp_impl/text_document/code_lens.rs
@@ -56,10 +56,11 @@ impl Kakehashi {
     /// `codeLens/resolve`: route the lens back to the downstream server that
     /// produced it, identified by the envelope in `lens.data` (#355).
     ///
-    /// Fails soft at every step: a lens without an envelope (foreign, or from
-    /// a host server without resolve support) passes through unchanged, and a
-    /// stale region returns the lens unresolved with its envelope intact —
-    /// clients re-request lenses on change, so the staleness window is short.
+    /// Fails soft except for client cancellation: a lens without an envelope
+    /// (foreign, or from a host server without resolve support) passes through
+    /// unchanged, and a stale region returns the lens unresolved with its
+    /// envelope intact — clients re-request lenses on change, so the staleness
+    /// window is short.
     pub(crate) async fn code_lens_resolve_impl(&self, lens: CodeLens) -> Result<CodeLens> {
         let Some(envelope) = extract_code_lens_envelope(&lens) else {
             return Ok(lens);

--- a/src/lsp/lsp_impl/text_document/code_lens.rs
+++ b/src/lsp/lsp_impl/text_document/code_lens.rs
@@ -7,7 +7,7 @@ use ulid::Ulid;
 use url::Url;
 
 use super::super::Kakehashi;
-use crate::lsp::bridge::{CodeLensEnvelope, extract_code_lens_envelope};
+use crate::lsp::bridge::{CodeLensEnvelope, envelope_host_code_lenses, extract_code_lens_envelope};
 use crate::text::PositionMapper;
 
 impl Kakehashi {
@@ -37,6 +37,17 @@ impl Kakehashi {
                     )
                     .await
             },
+            |mut won| {
+                if won.resolves {
+                    envelope_host_code_lenses(
+                        &mut won.items,
+                        &won.server_name,
+                        won.host_uri.as_str(),
+                        won.incarnation,
+                    );
+                }
+                Some(won.items)
+            },
         )
         .await
     }
@@ -56,7 +67,7 @@ impl Kakehashi {
         // Fail-soft staleness gate: resolving against a moved or invalidated
         // region would translate coordinates with a stale offset and bind the
         // lens to content the user has since edited.
-        if !self.code_lens_region_is_fresh(&envelope) {
+        if !envelope.is_host_layer() && !self.code_lens_region_is_fresh(&envelope) {
             log::debug!(
                 target: "kakehashi::bridge",
                 "codeLens/resolve: region {} is stale; returning lens unresolved",

--- a/src/lsp/lsp_impl/text_document/code_lens.rs
+++ b/src/lsp/lsp_impl/text_document/code_lens.rs
@@ -8,6 +8,7 @@ use url::Url;
 
 use super::super::Kakehashi;
 use crate::lsp::bridge::{CodeLensEnvelope, envelope_host_code_lenses, extract_code_lens_envelope};
+use crate::lsp::current_upstream_id;
 use crate::text::PositionMapper;
 
 impl Kakehashi {
@@ -77,11 +78,23 @@ impl Kakehashi {
         }
 
         let settings = self.settings_manager.load_settings();
-        let upstream_id = crate::lsp::current_upstream_id();
         let pool = self.bridge.pool_arc();
-        Ok(pool
-            .dispatch_code_lens_resolve(lens, &settings, upstream_id)
-            .await)
+        let upstream_id = current_upstream_id();
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
+        let sweep_id = upstream_id.clone();
+        let dispatch = pool.dispatch_code_lens_resolve(lens, &settings, upstream_id);
+        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard::new(
+            std::sync::Arc::clone(&pool),
+            sweep_id,
+        );
+        match cancel_rx {
+            Some(rx) => tokio::select! {
+                biased;
+                _ = rx => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
+                lens = dispatch => Ok(lens),
+            },
+            None => Ok(dispatch.await),
+        }
     }
 
     /// Whether the envelope's injection region still exists at the position it

--- a/src/lsp/lsp_impl/text_document/code_lens.rs
+++ b/src/lsp/lsp_impl/text_document/code_lens.rs
@@ -46,6 +46,7 @@ impl Kakehashi {
                     won.host_uri.as_str(),
                     won.incarnation,
                     won.connection_generation,
+                    won.handle.key(),
                     server_resolves,
                 );
                 Some(won.items)

--- a/src/lsp/lsp_impl/text_document/code_lens.rs
+++ b/src/lsp/lsp_impl/text_document/code_lens.rs
@@ -55,10 +55,10 @@ impl Kakehashi {
     /// `codeLens/resolve`: route the lens back to the downstream server that
     /// produced it, identified by the envelope in `lens.data` (#355).
     ///
-    /// Fails soft at every step: a lens without an envelope (host-layer or
-    /// foreign) passes through unchanged, and a stale region returns the lens
-    /// unresolved with its envelope intact — clients re-request lenses on
-    /// change, so the staleness window is short.
+    /// Fails soft at every step: a lens without an envelope (foreign, or from
+    /// a host server without resolve support) passes through unchanged, and a
+    /// stale region returns the lens unresolved with its envelope intact —
+    /// clients re-request lenses on change, so the staleness window is short.
     pub(crate) async fn code_lens_resolve_impl(&self, lens: CodeLens) -> Result<CodeLens> {
         let Some(envelope) = extract_code_lens_envelope(&lens) else {
             return Ok(lens);

--- a/src/lsp/lsp_impl/text_document/document_link.rs
+++ b/src/lsp/lsp_impl/text_document/document_link.rs
@@ -32,6 +32,7 @@ impl Kakehashi {
                     )
                     .await
             },
+            |won| Some(won.items),
         )
         .await
     }

--- a/src/lsp/lsp_impl/text_document/folding_range.rs
+++ b/src/lsp/lsp_impl/text_document/folding_range.rs
@@ -32,6 +32,7 @@ impl Kakehashi {
                     )
                     .await
             },
+            |won| Some(won.items),
         )
         .await
     }

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -35,6 +35,7 @@ pub(super) struct HostWholeDocumentResponse<T> {
     pub(super) server_name: String,
     pub(super) host_uri: url::Url,
     pub(super) incarnation: Option<u64>,
+    pub(super) connection_generation: u64,
     pub(super) handle: Arc<crate::lsp::bridge::ConnectionHandle>,
 }
 
@@ -313,6 +314,7 @@ impl Kakehashi {
                             server_name: t.server_name,
                             host_uri: t.uri,
                             incarnation: Some(raw.incarnation),
+                            connection_generation: raw.connection_generation,
                             handle: raw.handle,
                         }))
                     }

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -22,13 +22,21 @@ use tower_lsp_server::ls_types::{NumberOrString, Uri};
 
 use crate::language::InjectionResolver;
 use crate::lsp::aggregation::server::{
-    FanInResult, FanOutTask, dispatch_preferred, dispatch_preferred_with_tokens,
-    mint_region_progress_source,
+    FanInResult, FanOutTask, dispatch_host_preferred, dispatch_preferred,
+    dispatch_preferred_with_tokens, mint_region_progress_source,
 };
-use crate::lsp::bridge::{ClientProgressAggregator, ClientProgressDeregisterGuard};
+use crate::lsp::bridge::{ClientProgressAggregator, ClientProgressDeregisterGuard, HostDocument};
 
 use super::bridge_context::{DocumentRequestContext, parse_host_verbatim};
 use super::{Kakehashi, uri_to_url};
+
+pub(super) struct HostWholeDocumentResponse<T> {
+    pub(super) items: Vec<T>,
+    pub(super) server_name: String,
+    pub(super) host_uri: url::Url,
+    pub(super) incarnation: Option<u64>,
+    pub(super) resolves: bool,
+}
 
 impl Kakehashi {
     /// Fan out a whole-document bridged request to all injection regions.
@@ -45,18 +53,20 @@ impl Kakehashi {
     /// `Some`, one shared aggregator relays the first region to begin as a single
     /// `Begin → … → End` on that token (ls-bridge-client-progress); `None` (the
     /// fast methods that don't advertise `workDoneProgress`) keeps prior behavior.
-    pub(super) async fn whole_document_fan_out<T, F, Fut>(
+    pub(super) async fn whole_document_fan_out<T, F, Fut, H>(
         &self,
         lsp_uri: &Uri,
         method_name: &'static str,
         raw_params: serde_json::Value,
         client_progress_token: Option<NumberOrString>,
         send: F,
+        on_host_winner: H,
     ) -> Result<Option<Vec<T>>>
     where
         T: Send + 'static + serde::de::DeserializeOwned,
         F: Fn(FanOutTask) -> Fut + Clone + Send + 'static,
         Fut: Future<Output = io::Result<Option<Vec<T>>>> + Send + 'static,
+        H: FnOnce(HostWholeDocumentResponse<T>) -> Option<Vec<T>> + Send,
     {
         let virt = async {
             // Convert ls_types::Uri to url::Url for internal use
@@ -265,13 +275,56 @@ impl Kakehashi {
         };
 
         let host = async {
-            match self.resolve_host_bridge_context(lsp_uri, method_name) {
-                Some(ctx) => Ok(self
-                    .host_layer_value_with_ctx(&ctx, method_name, raw_params)
-                    .await?
-                    .and_then(parse_host_verbatim::<Vec<T>>)),
-                None => Ok(None),
-            }
+            let Some(ctx) = self.resolve_host_bridge_context(lsp_uri, method_name) else {
+                return Ok(None);
+            };
+            let (cancel_rx, _cancel_guard) =
+                self.subscribe_cancel(ctx.upstream_request_id.as_ref());
+            let pool = self.bridge.pool_arc();
+            let fan_in = dispatch_host_preferred(
+                &ctx,
+                pool.clone(),
+                move |t| {
+                    let params = raw_params.clone();
+                    async move {
+                        let incarnation = t.pool.current_host_incarnation(&t.uri);
+                        let raw = t
+                            .pool
+                            .send_host_raw_request(
+                                &t.server_name,
+                                &t.server_config,
+                                &HostDocument {
+                                    uri: &t.uri,
+                                    language_id: &t.language_id,
+                                    text: &t.text,
+                                },
+                                method_name,
+                                params,
+                                t.upstream_id,
+                            )
+                            .await?;
+                        let Some(raw) = raw else {
+                            return Ok(None);
+                        };
+                        let resolves = raw.handle.has_capability("codeLens/resolve");
+                        let Some(items) = parse_host_verbatim::<Vec<T>>(raw.value) else {
+                            return Ok(None);
+                        };
+                        Ok(Some(HostWholeDocumentResponse {
+                            items,
+                            server_name: t.server_name,
+                            host_uri: t.uri,
+                            incarnation,
+                            resolves,
+                        }))
+                    }
+                },
+                |opt| matches!(opt, Some(v) if !v.items.is_empty()),
+                cancel_rx,
+            )
+            .await;
+            self.host_layer_result(fan_in, method_name, |won| won.and_then(on_host_winner))
+                .await
         };
 
         let result = self

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -35,7 +35,7 @@ pub(super) struct HostWholeDocumentResponse<T> {
     pub(super) server_name: String,
     pub(super) host_uri: url::Url,
     pub(super) incarnation: Option<u64>,
-    pub(super) resolves: bool,
+    pub(super) handle: Arc<crate::lsp::bridge::ConnectionHandle>,
 }
 
 impl Kakehashi {
@@ -306,7 +306,6 @@ impl Kakehashi {
                         let Some(raw) = raw else {
                             return Ok(None);
                         };
-                        let resolves = raw.handle.has_capability("codeLens/resolve");
                         let Some(items) = parse_host_verbatim::<Vec<T>>(raw.value) else {
                             return Ok(None);
                         };
@@ -315,7 +314,7 @@ impl Kakehashi {
                             server_name: t.server_name,
                             host_uri: t.uri,
                             incarnation,
-                            resolves,
+                            handle: raw.handle,
                         }))
                     }
                 },

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -287,7 +287,6 @@ impl Kakehashi {
                 move |t| {
                     let params = raw_params.clone();
                     async move {
-                        let incarnation = t.pool.current_host_incarnation(&t.uri);
                         let raw = t
                             .pool
                             .send_host_raw_request(
@@ -313,7 +312,7 @@ impl Kakehashi {
                             items,
                             server_name: t.server_name,
                             host_uri: t.uri,
-                            incarnation,
+                            incarnation: Some(raw.incarnation),
                             handle: raw.handle,
                         }))
                     }

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -37,9 +37,10 @@
 //!   request-failure path.
 //! - `code-action` — advertises `codeActionProvider`; returns one
 //!   edit-carrying quickfix plus one bare Command action (#568).
-//! - `code-lens` / `code-lens-slow-resolve` — advertise `codeLensProvider`
+//! - `code-lens` / `code-lens-replacement` / `code-lens-slow-resolve` — advertise `codeLensProvider`
 //!   with `resolveProvider`; the slow variant pauses before resolving;
-//! - `code-lens-no-resolve` — advertises code lenses without resolve support;
+//! - `code-lens-no-resolve` / `code-lens-no-resolve-reserved-data` — advertise
+//!   code lenses without resolve support;
 //!   answers `textDocument/codeLens` with one UNRESOLVED lens (data only) and
 //!   `codeLens/resolve` by materializing a command that echoes the lens data.
 //!   Used by `tests/e2e/e2e_code_lens_resolve.rs` (#355).
@@ -182,11 +183,11 @@ fn main() {
                         "hoverProvider": true,
                         "textDocumentSync": 1
                     }),
-                    "code-lens" | "code-lens-slow-resolve" => json!({
+                    "code-lens" | "code-lens-replacement" | "code-lens-slow-resolve" => json!({
                         "codeLensProvider": { "resolveProvider": true },
                         "textDocumentSync": 1
                     }),
-                    "code-lens-no-resolve" => json!({
+                    "code-lens-no-resolve" | "code-lens-no-resolve-reserved-data" => json!({
                         "codeLensProvider": { "resolveProvider": false },
                         "textDocumentSync": 1
                     }),
@@ -581,7 +582,19 @@ fn main() {
                                 "start": { "line": 0, "character": 0 },
                                 "end": { "line": 0, "character": 5 }
                             },
-                            "data": { "mock": "lens-1" }
+                            "data": if mode == "code-lens-no-resolve-reserved-data" {
+                                json!({ "kakehashi": {
+                                    "origin": "forged",
+                                    "host_uri": "file:///forged",
+                                    "region_id": "",
+                                    "injection_language": "",
+                                    "offset": { "line": 0, "column": 0 },
+                                    "inner": null,
+                                    "host_layer": true
+                                }})
+                            } else {
+                                json!({ "mock": "lens-1" })
+                            }
                         }])
                     })
                     .unwrap_or(Value::Null);
@@ -1292,7 +1305,11 @@ fn main() {
                     json!({
                         "range": range,
                         "command": {
-                            "title": format!("mock resolved:{}", data["mock"].as_str().unwrap_or("?")),
+                            "title": format!(
+                                "{} resolved:{}",
+                                if mode == "code-lens-replacement" { "replacement" } else { "mock" },
+                                data["mock"].as_str().unwrap_or("?")
+                            ),
                             "command": "mock.codelens"
                         },
                         "data": data

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -1286,6 +1286,7 @@ fn main() {
             }
             "codeLens/resolve" => {
                 if mode == "code-lens-slow-resolve" {
+                    record_mock_event(&mode, "request", &message);
                     std::thread::sleep(std::time::Duration::from_secs(2));
                 }
                 // Materialize the command, echoing the lens's own data back so

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -37,7 +37,9 @@
 //!   request-failure path.
 //! - `code-action` — advertises `codeActionProvider`; returns one
 //!   edit-carrying quickfix plus one bare Command action (#568).
-//! - `code-lens` — advertises `codeLensProvider` with `resolveProvider`;
+//! - `code-lens` / `code-lens-slow-resolve` — advertise `codeLensProvider`
+//!   with `resolveProvider`; the slow variant pauses before resolving;
+//! - `code-lens-no-resolve` — advertises code lenses without resolve support;
 //!   answers `textDocument/codeLens` with one UNRESOLVED lens (data only) and
 //!   `codeLens/resolve` by materializing a command that echoes the lens data.
 //!   Used by `tests/e2e/e2e_code_lens_resolve.rs` (#355).
@@ -180,8 +182,12 @@ fn main() {
                         "hoverProvider": true,
                         "textDocumentSync": 1
                     }),
-                    "code-lens" => json!({
+                    "code-lens" | "code-lens-slow-resolve" => json!({
                         "codeLensProvider": { "resolveProvider": true },
+                        "textDocumentSync": 1
+                    }),
+                    "code-lens-no-resolve" => json!({
+                        "codeLensProvider": { "resolveProvider": false },
                         "textDocumentSync": 1
                     }),
                     "document-link" | "document-link-slow-host" | "document-link-slow-virt" => {
@@ -1266,6 +1272,9 @@ fn main() {
                 }
             }
             "codeLens/resolve" => {
+                if mode == "code-lens-slow-resolve" {
+                    std::thread::sleep(std::time::Duration::from_secs(2));
+                }
                 // Materialize the command, echoing the lens's own data back so
                 // the test can prove the downstream data round-tripped through
                 // the bridge envelope.

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -1287,7 +1287,10 @@ fn main() {
             "codeLens/resolve" => {
                 if mode == "code-lens-slow-resolve" {
                     record_mock_event(&mode, "request", &message);
-                    std::thread::sleep(std::time::Duration::from_secs(2));
+                    // Keep the request in flight while continuing the read
+                    // loop so a queued $/cancelRequest is observed before any
+                    // resolve response exists.
+                    continue;
                 }
                 // Materialize the command, echoing the lens's own data back so
                 // the test can prove the downstream data round-tripped through
@@ -1567,6 +1570,7 @@ fn record_mock_event(mode: &str, event: &str, message: &Value) {
     let payload = json!({
         "mode": mode,
         "event": event,
+        "id": message.get("id").cloned().unwrap_or(Value::Null),
         "params": message.get("params").cloned().unwrap_or(Value::Null)
     });
     let _ = std::fs::write(

--- a/tests/e2e/e2e_code_lens_resolve.rs
+++ b/tests/e2e/e2e_code_lens_resolve.rs
@@ -322,7 +322,8 @@ fn e2e_host_code_lens_from_replaced_connection_stays_unresolved() {
             "languageServers": {
                 "mock-codelens": {
                     "cmd": [bin, "code-lens-replacement"],
-                    "languages": ["markdown"]
+                    "languages": ["markdown"],
+                    "preferSharedInstance": true
                 }
             },
             "languages": {
@@ -331,6 +332,11 @@ fn e2e_host_code_lens_from_replaced_connection_stays_unresolved() {
         }}),
     );
     let replacement_lens = code_lens_with_retry(&mut client).remove(0);
+    assert_ne!(
+        old_lens["data"]["kakehashi"]["connection_key"],
+        replacement_lens["data"]["kakehashi"]["connection_key"],
+        "precondition: the replacement must use a different pool key"
+    );
     let replacement = client.send_request("codeLens/resolve", replacement_lens);
     assert_eq!(
         replacement["result"]["command"]["title"], "replacement resolved:lens-1",
@@ -406,6 +412,17 @@ fn e2e_host_code_lens_resolve_cancel_returns_request_cancelled() {
     assert!(
         forwarded,
         "cancel must be forwarded to the downstream server"
+    );
+    let request_event: Value = serde_json::from_slice(
+        &std::fs::read(&request_file).expect("read downstream request event"),
+    )
+    .expect("parse downstream request event");
+    let cancel_event: Value =
+        serde_json::from_slice(&std::fs::read(&cancel_file).expect("read downstream cancel event"))
+            .expect("parse downstream cancel event");
+    assert_eq!(
+        cancel_event["params"]["id"], request_event["id"],
+        "cancel must target the exact downstream resolve request"
     );
 
     shutdown(&mut client);

--- a/tests/e2e/e2e_code_lens_resolve.rs
+++ b/tests/e2e/e2e_code_lens_resolve.rs
@@ -309,22 +309,24 @@ fn e2e_host_code_lens_reserved_data_cannot_impersonate_bridge_envelope() {
     shutdown(&mut client);
 }
 
-#[test]
-fn e2e_host_code_lens_from_replaced_connection_stays_unresolved() {
+fn assert_replaced_connection_lens_stays_unresolved(change_pool_key: bool) {
     let bin = mock_formatter_bin();
     let (mut client, _config_dir) = init_host_client();
     open_markdown(&mut client);
     let old_lens = code_lens_with_retry(&mut client).remove(0);
 
+    let mut server = json!({
+        "cmd": [bin, "code-lens-replacement"],
+        "languages": ["markdown"]
+    });
+    if change_pool_key {
+        server["preferSharedInstance"] = json!(true);
+    }
     client.send_notification(
         "workspace/didChangeConfiguration",
         json!({ "settings": {
             "languageServers": {
-                "mock-codelens": {
-                    "cmd": [bin, "code-lens-replacement"],
-                    "languages": ["markdown"],
-                    "preferSharedInstance": true
-                }
+                "mock-codelens": server
             },
             "languages": {
                 "markdown": { "bridge": { "_self": { "enabled": true } } }
@@ -332,11 +334,27 @@ fn e2e_host_code_lens_from_replaced_connection_stays_unresolved() {
         }}),
     );
     let replacement_lens = code_lens_with_retry(&mut client).remove(0);
-    assert_ne!(
-        old_lens["data"]["kakehashi"]["connection_key"],
-        replacement_lens["data"]["kakehashi"]["connection_key"],
-        "precondition: the replacement must use a different pool key"
-    );
+    let old_envelope = &old_lens["data"]["kakehashi"];
+    let replacement_envelope = &replacement_lens["data"]["kakehashi"];
+    if change_pool_key {
+        assert_ne!(
+            old_envelope["connection_key"], replacement_envelope["connection_key"],
+            "precondition: replacement must move from client-fallback to shared"
+        );
+        assert_eq!(
+            old_envelope["connection_generation"], replacement_envelope["connection_generation"],
+            "different keys should demonstrate the equal-generation collision"
+        );
+    } else {
+        assert_eq!(
+            old_envelope["connection_key"], replacement_envelope["connection_key"],
+            "precondition: replacement must reuse the same pool key"
+        );
+        assert_ne!(
+            old_envelope["connection_generation"], replacement_envelope["connection_generation"],
+            "same-key replacement must advance its generation"
+        );
+    }
     let replacement = client.send_request("codeLens/resolve", replacement_lens);
     assert_eq!(
         replacement["result"]["command"]["title"], "replacement resolved:lens-1",
@@ -351,6 +369,16 @@ fn e2e_host_code_lens_from_replaced_connection_stays_unresolved() {
     );
 
     shutdown(&mut client);
+}
+
+#[test]
+fn e2e_host_code_lens_from_same_key_replacement_stays_unresolved() {
+    assert_replaced_connection_lens_stays_unresolved(false);
+}
+
+#[test]
+fn e2e_host_code_lens_from_different_key_replacement_stays_unresolved() {
+    assert_replaced_connection_lens_stays_unresolved(true);
 }
 
 #[test]

--- a/tests/e2e/e2e_code_lens_resolve.rs
+++ b/tests/e2e/e2e_code_lens_resolve.rs
@@ -52,7 +52,7 @@ fn init_client() -> (LspClient, tempfile::TempDir) {
     (client, config_dir)
 }
 
-fn init_host_client() -> (LspClient, tempfile::TempDir) {
+fn init_host_client_with_mode(mode: &str) -> (LspClient, tempfile::TempDir) {
     let bin = mock_formatter_bin();
     let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
     let config_path = config_dir.path().join("host_code_lens_resolve.toml");
@@ -73,7 +73,7 @@ fn init_host_client() -> (LspClient, tempfile::TempDir) {
             "initializationOptions": {
                 "languageServers": {
                     "mock-codelens": {
-                        "cmd": [bin, "code-lens"],
+                        "cmd": [bin, mode],
                         "languages": ["markdown"]
                     }
                 },
@@ -92,6 +92,10 @@ fn init_host_client() -> (LspClient, tempfile::TempDir) {
     );
     client.send_notification("initialized", json!({}));
     (client, config_dir)
+}
+
+fn init_host_client() -> (LspClient, tempfile::TempDir) {
+    init_host_client_with_mode("code-lens")
 }
 
 /// Markdown host: the lua fence content sits on host line 3.
@@ -251,10 +255,56 @@ fn e2e_host_code_lens_resolve_round_trips_verbatim() {
         "resolve must reach the host origin with its original data: {resolved}"
     );
     assert_eq!(
-        resolved["range"]["start"]["line"], 0,
-        "host coordinates must pass through without virtual translation"
+        resolved["range"], lens["range"],
+        "the complete host range must pass through without virtual translation"
     );
     assert_eq!(resolved["data"]["kakehashi"]["host_layer"], true);
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_host_code_lens_without_resolve_keeps_original_data_bare() {
+    let (mut client, _config_dir) = init_host_client_with_mode("code-lens-no-resolve");
+    open_markdown(&mut client);
+
+    let lenses = code_lens_with_retry(&mut client);
+    assert_eq!(lenses.len(), 1);
+    assert_eq!(lenses[0]["data"], json!({ "mock": "lens-1" }));
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_host_code_lens_from_closed_incarnation_stays_unresolved() {
+    let (mut client, _config_dir) = init_host_client();
+    open_markdown(&mut client);
+    let lens = code_lens_with_retry(&mut client).remove(0);
+
+    client.send_notification(
+        "textDocument/didClose",
+        json!({ "textDocument": { "uri": MARKDOWN_URI } }),
+    );
+    open_markdown(&mut client);
+
+    let response = client.send_request("codeLens/resolve", lens);
+    assert_eq!(response["result"].get("command"), None);
+    assert_eq!(response["result"]["data"]["kakehashi"]["host_layer"], true);
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_host_code_lens_resolve_cancel_returns_request_cancelled() {
+    let (mut client, _config_dir) = init_host_client_with_mode("code-lens-slow-resolve");
+    open_markdown(&mut client);
+    let lens = code_lens_with_retry(&mut client).remove(0);
+
+    let request_id = client.send_request_async("codeLens/resolve", lens);
+    std::thread::sleep(Duration::from_millis(100));
+    client.send_notification("$/cancelRequest", json!({ "id": request_id }));
+    let response = client.receive_response_for_id_public(request_id);
+    assert_eq!(response["error"]["code"], -32800, "{response}");
 
     shutdown(&mut client);
 }

--- a/tests/e2e/e2e_code_lens_resolve.rs
+++ b/tests/e2e/e2e_code_lens_resolve.rs
@@ -52,6 +52,48 @@ fn init_client() -> (LspClient, tempfile::TempDir) {
     (client, config_dir)
 }
 
+fn init_host_client() -> (LspClient, tempfile::TempDir) {
+    let bin = mock_formatter_bin();
+    let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
+    let config_path = config_dir.path().join("host_code_lens_resolve.toml");
+    std::fs::write(&config_path, "").expect("Failed to write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("temp path should be UTF-8"))
+        .build();
+
+    let init_response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "mock-codelens": {
+                        "cmd": [bin, "code-lens"],
+                        "languages": ["markdown"]
+                    }
+                },
+                "languages": {
+                    "markdown": {
+                        "bridge": { "_self": { "enabled": true } }
+                    }
+                }
+            }
+        }),
+    );
+    assert_eq!(
+        init_response["result"]["capabilities"]["codeLensProvider"]["resolveProvider"],
+        json!(true),
+        "codeLens resolveProvider must cover host-layer lenses"
+    );
+    client.send_notification("initialized", json!({}));
+    (client, config_dir)
+}
+
 /// Markdown host: the lua fence content sits on host line 3.
 const MARKDOWN: &str = "# Test\n\n```lua\nlocal x = 1\n```\n";
 const MARKDOWN_URI: &str = "file:///test_code_lens_resolve.md";
@@ -175,6 +217,44 @@ fn e2e_code_lens_resolve_round_trips_to_origin_server() {
         stale["data"]["kakehashi"]["origin"], "mock-codelens",
         "fail-soft must return the lens with its routing envelope intact; got: {stale:?}"
     );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_host_code_lens_resolve_round_trips_verbatim() {
+    let (mut client, _config_dir) = init_host_client();
+    open_markdown(&mut client);
+
+    let lenses = code_lens_with_retry(&mut client);
+    assert_eq!(lenses.len(), 1);
+    let lens = &lenses[0];
+    assert_eq!(lens["range"]["start"]["line"], 0);
+    assert_eq!(
+        lens["data"]["kakehashi"]["origin"], "mock-codelens",
+        "a resolvable host lens must carry its origin server: {lens}"
+    );
+    assert_eq!(
+        lens["data"]["kakehashi"]["host_layer"], true,
+        "the resolve path must distinguish verbatim host coordinates: {lens}"
+    );
+
+    let response = client.send_request("codeLens/resolve", lens.clone());
+    assert!(
+        response.get("error").is_none(),
+        "unexpected host codeLens/resolve error: {:?}",
+        response.get("error")
+    );
+    let resolved = &response["result"];
+    assert_eq!(
+        resolved["command"]["title"], "mock resolved:lens-1",
+        "resolve must reach the host origin with its original data: {resolved}"
+    );
+    assert_eq!(
+        resolved["range"]["start"]["line"], 0,
+        "host coordinates must pass through without virtual translation"
+    );
+    assert_eq!(resolved["data"]["kakehashi"]["host_layer"], true);
 
     shutdown(&mut client);
 }

--- a/tests/e2e/e2e_code_lens_resolve.rs
+++ b/tests/e2e/e2e_code_lens_resolve.rs
@@ -371,6 +371,9 @@ fn e2e_host_code_lens_from_closed_incarnation_stays_unresolved() {
 #[test]
 fn e2e_host_code_lens_resolve_cancel_returns_request_cancelled() {
     let cancel_dir = tempfile::TempDir::new().expect("cancel dir");
+    let request_file = cancel_dir
+        .path()
+        .join("code-lens-slow-resolve.request.json");
     let cancel_file = cancel_dir.path().join("code-lens-slow-resolve.cancel.json");
     let (mut client, _config_dir) = init_host_client_with_mode_and_cancel_dir(
         "code-lens-slow-resolve",
@@ -380,7 +383,15 @@ fn e2e_host_code_lens_resolve_cancel_returns_request_cancelled() {
     let lens = code_lens_with_retry(&mut client).remove(0);
 
     let request_id = client.send_request_async("codeLens/resolve", lens);
-    std::thread::sleep(Duration::from_millis(100));
+    let started = (0..100).any(|_| {
+        if request_file.exists() {
+            true
+        } else {
+            std::thread::sleep(Duration::from_millis(50));
+            false
+        }
+    });
+    assert!(started, "resolve request must reach the downstream server");
     client.send_notification("$/cancelRequest", json!({ "id": request_id }));
     let response = client.receive_response_for_id_public(request_id);
     assert_eq!(response["error"]["code"], -32800, "{response}");

--- a/tests/e2e/e2e_code_lens_resolve.rs
+++ b/tests/e2e/e2e_code_lens_resolve.rs
@@ -53,15 +53,26 @@ fn init_client() -> (LspClient, tempfile::TempDir) {
 }
 
 fn init_host_client_with_mode(mode: &str) -> (LspClient, tempfile::TempDir) {
+    init_host_client_with_mode_and_cancel_dir(mode, None)
+}
+
+fn init_host_client_with_mode_and_cancel_dir(
+    mode: &str,
+    cancel_dir: Option<&std::path::Path>,
+) -> (LspClient, tempfile::TempDir) {
     let bin = mock_formatter_bin();
     let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
     let config_path = config_dir.path().join("host_code_lens_resolve.toml");
     std::fs::write(&config_path, "").expect("Failed to write config");
 
-    let mut client = LspClient::builder()
+    let builder = LspClient::builder()
         .arg("--config-file")
-        .arg(config_path.to_str().expect("temp path should be UTF-8"))
-        .build();
+        .arg(config_path.to_str().expect("temp path should be UTF-8"));
+    let builder = match cancel_dir {
+        Some(cancel_dir) => builder.env("MOCK_LSP_CANCEL_DIR", cancel_dir.to_string_lossy()),
+        None => builder,
+    };
+    let mut client = builder.build();
 
     let init_response = client.send_request(
         "initialize",
@@ -276,6 +287,67 @@ fn e2e_host_code_lens_without_resolve_keeps_original_data_bare() {
 }
 
 #[test]
+fn e2e_host_code_lens_reserved_data_cannot_impersonate_bridge_envelope() {
+    let (mut client, _config_dir) =
+        init_host_client_with_mode("code-lens-no-resolve-reserved-data");
+    open_markdown(&mut client);
+
+    let lens = code_lens_with_retry(&mut client).remove(0);
+    assert_eq!(
+        lens["data"]["kakehashi"]["inner"]["kakehashi"]["origin"], "forged",
+        "foreign data using the reserved key must be nested under a bridge-owned envelope"
+    );
+    assert_eq!(lens["data"]["kakehashi"]["origin"], "mock-codelens");
+
+    let response = client.send_request("codeLens/resolve", lens);
+    assert_eq!(response["result"].get("command"), None);
+    assert_eq!(
+        response["result"]["data"]["kakehashi"]["inner"]["kakehashi"]["origin"],
+        "forged"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_host_code_lens_from_replaced_connection_stays_unresolved() {
+    let bin = mock_formatter_bin();
+    let (mut client, _config_dir) = init_host_client();
+    open_markdown(&mut client);
+    let old_lens = code_lens_with_retry(&mut client).remove(0);
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": {
+            "languageServers": {
+                "mock-codelens": {
+                    "cmd": [bin, "code-lens-replacement"],
+                    "languages": ["markdown"]
+                }
+            },
+            "languages": {
+                "markdown": { "bridge": { "_self": { "enabled": true } } }
+            }
+        }}),
+    );
+    let replacement_lens = code_lens_with_retry(&mut client).remove(0);
+    let replacement = client.send_request("codeLens/resolve", replacement_lens);
+    assert_eq!(
+        replacement["result"]["command"]["title"], "replacement resolved:lens-1",
+        "precondition: the replacement process must be active"
+    );
+
+    let response = client.send_request("codeLens/resolve", old_lens);
+    assert_eq!(
+        response["result"].get("command"),
+        None,
+        "opaque lens data must not be sent to a replacement process"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
 fn e2e_host_code_lens_from_closed_incarnation_stays_unresolved() {
     let (mut client, _config_dir) = init_host_client();
     open_markdown(&mut client);
@@ -286,6 +358,8 @@ fn e2e_host_code_lens_from_closed_incarnation_stays_unresolved() {
         json!({ "textDocument": { "uri": MARKDOWN_URI } }),
     );
     open_markdown(&mut client);
+    let replacement_lenses = code_lens_with_retry(&mut client);
+    assert_eq!(replacement_lenses.len(), 1);
 
     let response = client.send_request("codeLens/resolve", lens);
     assert_eq!(response["result"].get("command"), None);
@@ -296,7 +370,12 @@ fn e2e_host_code_lens_from_closed_incarnation_stays_unresolved() {
 
 #[test]
 fn e2e_host_code_lens_resolve_cancel_returns_request_cancelled() {
-    let (mut client, _config_dir) = init_host_client_with_mode("code-lens-slow-resolve");
+    let cancel_dir = tempfile::TempDir::new().expect("cancel dir");
+    let cancel_file = cancel_dir.path().join("code-lens-slow-resolve.cancel.json");
+    let (mut client, _config_dir) = init_host_client_with_mode_and_cancel_dir(
+        "code-lens-slow-resolve",
+        Some(cancel_dir.path()),
+    );
     open_markdown(&mut client);
     let lens = code_lens_with_retry(&mut client).remove(0);
 
@@ -305,6 +384,18 @@ fn e2e_host_code_lens_resolve_cancel_returns_request_cancelled() {
     client.send_notification("$/cancelRequest", json!({ "id": request_id }));
     let response = client.receive_response_for_id_public(request_id);
     assert_eq!(response["error"]["code"], -32800, "{response}");
+    let forwarded = (0..100).any(|_| {
+        if cancel_file.exists() {
+            true
+        } else {
+            std::thread::sleep(Duration::from_millis(50));
+            false
+        }
+    });
+    assert!(
+        forwarded,
+        "cancel must be forwarded to the downstream server"
+    );
 
     shutdown(&mut client);
 }

--- a/tests/e2e/e2e_code_lens_resolve.rs
+++ b/tests/e2e/e2e_code_lens_resolve.rs
@@ -361,11 +361,20 @@ fn assert_replaced_connection_lens_stays_unresolved(change_pool_key: bool) {
         "precondition: the replacement process must be active"
     );
 
+    let old_data = old_lens["data"].clone();
     let response = client.send_request("codeLens/resolve", old_lens);
+    assert!(
+        response.get("error").is_none(),
+        "stale producer data must fail soft, not as JSON-RPC error: {response}"
+    );
     assert_eq!(
         response["result"].get("command"),
         None,
         "opaque lens data must not be sent to a replacement process"
+    );
+    assert_eq!(
+        response["result"]["data"], old_data,
+        "fail-soft resolve must preserve the original routing envelope"
     );
 
     shutdown(&mut client);


### PR DESCRIPTION
## Summary

- preserve the winning host code-lens server, connection, URI, and document incarnation
- envelope only host lenses whose server advertises `codeLens/resolve`, including dynamic registrations
- route `codeLens/resolve` back to that exact host connection without virtual-range translation
- reject stale host lenses across `didClose`/reopen and reclaim closed lifecycle locks
- forward cancellation while preserving the original lens on fail-soft resolve errors
- gate every host-layer request on a live host-document incarnation (see **Incidental change**)

## User-visible impact

Host-language code lenses can now be resolved through `kakehashi` when host bridging is enabled. Lenses from servers without resolve support remain untouched. A lens produced before the host document is closed/reopened is not sent into the new document lifetime.

## Incidental change (beyond code lens)

`execute_host_request` now takes the host lifecycle through `request_host_lifecycle`
instead of the bare URI mutex, so it inherits that helper's incarnation check. This
widens the closed-document gate from code lens to **every** host-bridged method
(definition, hover, completion, code action, formatting, document link, folding range,
…): a host request for a URI with no live incarnation now fails `NotConnected` instead
of syncing a document kakehashi does not consider open. It is the same gate
`did_open`'s host sync (`bridge/text_document/did_open.rs`) already applies, and it is
what lets the code-lens resolve path read the incarnation it locked.

Impact is bounded: `did_open` registers the incarnation under the edit lock immediately
after the document insert, so the window is a request that races `didOpen` entirely;
host layers are fail-soft, so such a request yields no host answer and the client
re-requests. Both CLI entry points drive `did_open_impl` before any host request
(`lsp_impl/cli/format.rs`, `lsp_impl/cli/diagnose.rs`), so CLI mode always has an
incarnation.

## Verification

- `make check`
- `cargo test --lib` — 3591 passed, 2 ignored
- `cargo test --features e2e --test e2e e2e_code_lens_resolve::` — 5 passed
- focused lifecycle and dynamic-capability suites passed
- `make test_all` — all new/related tests passed; one pre-existing flaky test, `e2e_whole_document_link_cancel_forwards_to_concatenated_layers`, missed only the host cancel marker. It reproduced on untouched `origin/main` under the same exact command (1 failure in 3 runs).

## Review

- local multi-perspective protocol, lifecycle, and tests/docs review converged with no remaining findings
- Codex review converged after adding dynamic-registration support


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host-layer code lenses can now be resolved through their originating language server.
  * Host-layer lens data and coordinates are preserved without translation.
  * Code-lens resolve support is detected correctly, including dynamic registrations.

* **Bug Fixes**
  * Client-cancelled resolutions now return the appropriate cancellation error.
  * Stale or replaced connections are prevented from resolving lenses.
  * Reserved lens data is preserved safely.

* **Documentation**
  * Updated bridging and architecture documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
